### PR TITLE
[CI] Remove defunct comment in Expeditor configuration

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -891,7 +891,6 @@ subscriptions:
     actions:
       - bash:.expeditor/update_habitat.sh:
           post_commit: false
-  # End of A2 Workflow Subscriptions
   - workload: schedule_triggered:chef/automate:master:nightly_tests:*
     actions:
       - trigger_pipeline:a1-migration/dev


### PR DESCRIPTION
The A2 workflow subscriptions are gone but this comment remained.

This commit will hopefully also trigger Expeditor into creating new
agents for this newly created project.

Signed-off-by: Steven Danna <steve@chef.io>