### PR TITLE
Avoid ES errors with default shell settings

### DIFF
--- a/components/automate-chef-io/content/docs/system-requirements.md
+++ b/components/automate-chef-io/content/docs/system-requirements.md
@@ -28,7 +28,6 @@ Chef Automate requires
 * `useradd`
 * `curl` or `wget`
 * The shell that starts Automate should have a # of open files max of at least 65535, 
-not 1024 which is common
 
 Commercial support for Chef Automate is available for platforms that satisfy these
 criteria.

--- a/components/automate-chef-io/content/docs/system-requirements.md
+++ b/components/automate-chef-io/content/docs/system-requirements.md
@@ -27,7 +27,7 @@ Chef Automate requires
 * `systemd` as the init system
 * `useradd`
 * `curl` or `wget`
-* The shell that starts Automate should have a # of open files max of at least 65535, 
+* The shell that starts Automate should have a max open files setting of at least 65535
 
 Commercial support for Chef Automate is available for platforms that satisfy these
 criteria.

--- a/components/automate-chef-io/content/docs/system-requirements.md
+++ b/components/automate-chef-io/content/docs/system-requirements.md
@@ -27,6 +27,8 @@ Chef Automate requires
 * `systemd` as the init system
 * `useradd`
 * `curl` or `wget`
+* The shell that starts Automate should have a # of open files max of at least 65535, 
+not 1024 which is common
 
 Commercial support for Chef Automate is available for platforms that satisfy these
 criteria.


### PR DESCRIPTION
Elasticsearch by default expects at least 65535 potential open files to be available from the kernel through the shell process it starts up in.

Signed-off-by: Steven Danna <steve@chef.io>