### PR TITLE
Add timeout to most `hab` commands

### DIFF
--- a/components/automate-deployment/pkg/target/hab_cmd_test.go
+++ b/components/automate-deployment/pkg/target/hab_cmd_test.go
@@ -21,8 +21,9 @@ func TestInstallPackage(t *testing.T) {
 		installer := target.NewHabCmd(mockExecutor, false)
 
 		mockExecutor.Expect("CombinedOutput", command.ExpectedCommand{
-			Cmd: "hab",
-			Env: []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Cmd:     "hab",
+			Env:     []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Timeout: target.HabTimeoutInstallPackage,
 			Args: []string{
 				"pkg",
 				"install",
@@ -38,8 +39,9 @@ func TestInstallPackage(t *testing.T) {
 		mockExecutor := command.NewMockExecutor(t)
 		installer := target.NewHabCmd(mockExecutor, true)
 		mockExecutor.Expect("CombinedOutput", command.ExpectedCommand{
-			Cmd: "hab",
-			Env: []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true", "HAB_FEAT_OFFLINE_INSTALL=true"},
+			Cmd:     "hab",
+			Env:     []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true", "HAB_FEAT_OFFLINE_INSTALL=true"},
+			Timeout: target.HabTimeoutInstallPackage,
 			Args: []string{
 				"pkg",
 				"install",
@@ -57,8 +59,9 @@ func TestInstallPackage(t *testing.T) {
 		mockExecutor := command.NewMockExecutor(t)
 		installer := target.NewHabCmd(mockExecutor, false)
 		mockExecutor.Expect("CombinedOutput", command.ExpectedCommand{
-			Cmd: "hab",
-			Env: []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Cmd:     "hab",
+			Timeout: target.HabTimeoutInstallPackage,
+			Env:     []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
 			Args: []string{
 				"pkg",
 				"install",
@@ -75,8 +78,9 @@ func TestInstallPackage(t *testing.T) {
 		mockExecutor := command.NewMockExecutor(t)
 		installer := target.NewHabCmd(mockExecutor, false)
 		mockExecutor.Expect("CombinedOutput", command.ExpectedCommand{
-			Cmd: "hab",
-			Env: []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Cmd:     "hab",
+			Timeout: target.HabTimeoutInstallPackage,
+			Env:     []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
 			Args: []string{
 				"pkg",
 				"install",
@@ -101,9 +105,10 @@ func TestIsInstalled(t *testing.T) {
 		installer := target.NewHabCmd(mockExecutor, false)
 
 		mockExecutor.Expect("Run", command.ExpectedCommand{
-			Cmd:  "hab",
-			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
-			Args: []string{"pkg", "path", pkgIdent},
+			Cmd:     "hab",
+			Timeout: target.HabTimeoutIsInstalled,
+			Env:     []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Args:    []string{"pkg", "path", pkgIdent},
 		}).Return(nil)
 
 		_, err := installer.IsInstalled(&pkg)
@@ -116,9 +121,10 @@ func TestIsInstalled(t *testing.T) {
 		installer := target.NewHabCmd(mockExecutor, false)
 
 		mockExecutor.Expect("Run", command.ExpectedCommand{
-			Cmd:  "hab",
-			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
-			Args: []string{"pkg", "path", pkgIdent},
+			Cmd:     "hab",
+			Timeout: target.HabTimeoutIsInstalled,
+			Env:     []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Args:    []string{"pkg", "path", pkgIdent},
 		}).Return(nil)
 
 		isInstalled, err := installer.IsInstalled(&pkg)
@@ -132,9 +138,10 @@ func TestIsInstalled(t *testing.T) {
 		installer := target.NewHabCmd(mockExecutor, false)
 
 		mockExecutor.Expect("Run", command.ExpectedCommand{
-			Cmd:  "hab",
-			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
-			Args: []string{"pkg", "path", pkgIdent},
+			Cmd:     "hab",
+			Timeout: target.HabTimeoutIsInstalled,
+			Env:     []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Args:    []string{"pkg", "path", pkgIdent},
 		}).Return(errors.New("no such package"))
 
 		isInstalled, err := installer.IsInstalled(&pkg)
@@ -154,9 +161,10 @@ func TestBinlinkPackage(t *testing.T) {
 		installer := target.NewHabCmd(mockExecutor, false)
 
 		mockExecutor.Expect("CombinedOutput", command.ExpectedCommand{
-			Cmd:  "hab",
-			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
-			Args: []string{"pkg", "binlink", "--force", pkgIdent, "some_exe"},
+			Cmd:     "hab",
+			Timeout: target.HabTimeoutDefault,
+			Env:     []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Args:    []string{"pkg", "binlink", "--force", pkgIdent, "some_exe"},
 		}).Return("test command output", nil)
 
 		_, err := installer.BinlinkPackage(&pkg, "some_exe")
@@ -169,9 +177,10 @@ func TestBinlinkPackage(t *testing.T) {
 		installer := target.NewHabCmd(mockExecutor, false)
 
 		mockExecutor.Expect("CombinedOutput", command.ExpectedCommand{
-			Cmd:  "hab",
-			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
-			Args: []string{"pkg", "binlink", "--force", pkgIdent, "some_exe"},
+			Cmd:     "hab",
+			Timeout: target.HabTimeoutDefault,
+			Env:     []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Args:    []string{"pkg", "binlink", "--force", pkgIdent, "some_exe"},
 		}).Return("test command output", errors.New("test command error"))
 
 		output, err := installer.BinlinkPackage(&pkg, "some_exe")

--- a/components/automate-deployment/pkg/target/local_target_test.go
+++ b/components/automate-deployment/pkg/target/local_target_test.go
@@ -94,10 +94,15 @@ type execMock struct {
 }
 
 func expectHabCommand(cmd string, args ...string) command.ExpectedCommand {
+	timeout := HabTimeoutDefault
+	if len(args) > 1 && args[1] == "install" {
+		timeout = HabTimeoutInstallPackage
+	}
 	return command.ExpectedCommand{
-		Cmd:  cmd,
-		Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
-		Args: args,
+		Cmd:     cmd,
+		Timeout: timeout,
+		Env:     []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+		Args:    args,
 	}
 }
 


### PR DESCRIPTION
We've recently observed `hab` to hang indefinitely at 100% CPU. We are
investigating this bug; however, it also revealed that our converge
loop does not time out hab commands at all. This adds a timeout to
most hab commands we run in the deployment service.

Signed-off-by: Steven Danna <steve@chef.io>