### PR TITLE
[deployment] Verify config settings for external data stores

### DIFF
--- a/api/config/shared/global.go
+++ b/api/config/shared/global.go
@@ -182,6 +182,20 @@ func (c *GlobalConfig) Validate() error { // nolint gocyclo
 		cfgErr.AddInvalidValue("global.v1.external.data_collector.auth.scheme", "scheme must be one of '', 'token'")
 	}
 
+	if externalES := c.GetV1().GetExternal().GetElasticsearch(); externalES.GetEnable().GetValue() {
+		nodes := externalES.GetNodes()
+		httpsNodes := make([]string, 0)
+		for _, n := range nodes {
+			ns := n.GetValue()
+			if strings.Contains(ns, "https") {
+				httpsNodes = append(httpsNodes, ns)
+			}
+		}
+		if len(httpsNodes) > 0 && len(httpsNodes) < len(nodes) {
+			cfgErr.AddInvalidValue("global.v1.external.elasticsearch.nodes", "Cannot mix http and https nodes")
+		}
+	}
+
 	if cfgErr.IsEmpty() {
 		return nil
 	}

--- a/api/config/shared/global.go
+++ b/api/config/shared/global.go
@@ -183,6 +183,7 @@ func (c *GlobalConfig) Validate() error { // nolint gocyclo
 	}
 
 	if externalES := c.GetV1().GetExternal().GetElasticsearch(); externalES.GetEnable().GetValue() {
+		// Make sure external ES nodes all either have https urls or https urls
 		nodes := externalES.GetNodes()
 		httpsNodes := make([]string, 0)
 		for _, n := range nodes {
@@ -193,6 +194,14 @@ func (c *GlobalConfig) Validate() error { // nolint gocyclo
 		}
 		if len(httpsNodes) > 0 && len(httpsNodes) < len(nodes) {
 			cfgErr.AddInvalidValue("global.v1.external.elasticsearch.nodes", "Cannot mix http and https nodes")
+		}
+
+		// Make sure that only one of root_cert or root_cert_file has been
+		// specified
+		rc := c.GetV1().GetExternal().GetElasticsearch().GetSsl().GetRootCert().GetValue()
+		rcf := c.GetV1().GetExternal().GetElasticsearch().GetSsl().GetRootCertFile().GetValue()
+		if len(rc) > 0 && len(rcf) > 0 {
+			cfgErr.AddInvalidValue("global.v1.external.elasticsearch.ssl", "Specify either global.v1.external.elasticsearch.ssl.root_cert or global.v1.external.elasticsearch.ssl.root_cert_file, but not both.")
 		}
 	}
 

--- a/api/config/shared/global.go
+++ b/api/config/shared/global.go
@@ -188,7 +188,7 @@ func (c *GlobalConfig) Validate() error { // nolint gocyclo
 		httpsNodes := make([]string, 0)
 		for _, n := range nodes {
 			ns := n.GetValue()
-			if strings.Contains(ns, "https") {
+			if strings.HasPrefix(ns, "https") {
 				httpsNodes = append(httpsNodes, ns)
 			}
 		}
@@ -243,8 +243,8 @@ func (c *GlobalConfig) Validate() error { // nolint gocyclo
 			}
 
 			// dbuser username and password
-			du := auth.GetPassword().GetSuperuser().GetUsername().GetValue()
-			dp := auth.GetPassword().GetSuperuser().GetPassword().GetValue()
+			du := auth.GetPassword().GetDbuser().GetUsername().GetValue()
+			dp := auth.GetPassword().GetDbuser().GetPassword().GetValue()
 			if du == "" {
 				cfgErr.AddMissingKey("global.v1.external.postgresql.auth.password.dbuser.username")
 			}

--- a/api/config/shared/global.go
+++ b/api/config/shared/global.go
@@ -223,7 +223,6 @@ func (c *GlobalConfig) Validate() error { // nolint gocyclo
 				}
 			}
 		}
-
 	}
 
 	if externalPG := c.GetV1().GetExternal().GetPostgresql(); externalPG.GetEnable().GetValue() {

--- a/api/config/shared/global_test.go
+++ b/api/config/shared/global_test.go
@@ -315,6 +315,30 @@ format = "json"
 		expected.AddInvalidValue("global.v1.external.elasticsearch.nodes", "Cannot mix http and https nodes")
 		assert.EqualError(t, cfgErr, expected.Error(), "")
 	})
+
+	t.Run("with both root_cert and root_cert_file set", func(t *testing.T) {
+		c := &GlobalConfig{
+			V1: &V1{
+				Fqdn: w.String("this.is.a.host"),
+				External: &External{
+					Elasticsearch: &External_Elasticsearch{
+						Enable: w.Bool(true),
+						Ssl: &External_Elasticsearch_SSL{
+							RootCert:     w.String("rootcert"),
+							RootCertFile: w.String("rootcertfile"),
+						},
+					},
+				},
+			},
+		}
+		err := c.Validate()
+		require.Error(t, err)
+		cfgErr, ok := err.(Error)
+		require.True(t, ok)
+		expected := NewInvalidConfigError()
+		expected.AddInvalidValue("global.v1.external.elasticsearch.ssl", "Specify either global.v1.external.elasticsearch.ssl.root_cert or global.v1.external.elasticsearch.ssl.root_cert_file, but not both.")
+		assert.EqualError(t, cfgErr, expected.Error(), "")
+	})
 }
 
 func loadFromToml(s string) *GlobalConfig {

--- a/api/config/shared/global_test.go
+++ b/api/config/shared/global_test.go
@@ -227,7 +227,7 @@ func TestValidate(t *testing.T) {
 		expected := NewInvalidConfigError()
 		expected.AddInvalidValue("global.v1.log.level",
 			"'trace' must be one of 'debug, 'info', 'warning', 'error', 'fatal', 'panic'")
-		assert.EqualError(t, cfgErr, expected.Error(), "")
+		assert.EqualError(t, cfgErr, expected.Error())
 	})
 
 	t.Run("with invalid log format", func(t *testing.T) {
@@ -240,7 +240,7 @@ func TestValidate(t *testing.T) {
 		require.True(t, ok)
 		expected := NewInvalidConfigError()
 		expected.AddInvalidValue("global.v1.log.format", "'xml' must be 'text' or 'json'")
-		assert.EqualError(t, cfgErr, expected.Error(), "")
+		assert.EqualError(t, cfgErr, expected.Error())
 	})
 
 	t.Run("with DefaultGlobalConfig", func(t *testing.T) {
@@ -313,7 +313,7 @@ format = "json"
 		require.True(t, ok)
 		expected := NewInvalidConfigError()
 		expected.AddInvalidValue("global.v1.external.elasticsearch.nodes", "Cannot mix http and https nodes")
-		assert.EqualError(t, cfgErr, expected.Error(), "")
+		assert.EqualError(t, cfgErr, expected.Error())
 	})
 
 	t.Run("with both root_cert and root_cert_file set", func(t *testing.T) {
@@ -337,7 +337,7 @@ format = "json"
 		require.True(t, ok)
 		expected := NewInvalidConfigError()
 		expected.AddInvalidValue("global.v1.external.elasticsearch.ssl", "Specify either global.v1.external.elasticsearch.ssl.root_cert or global.v1.external.elasticsearch.ssl.root_cert_file, but not both.")
-		assert.EqualError(t, cfgErr, expected.Error(), "")
+		assert.EqualError(t, cfgErr, expected.Error())
 	})
 
 	t.Run("with invalid auth scheme for external elasticsearch", func(t *testing.T) {
@@ -360,7 +360,7 @@ format = "json"
 		require.True(t, ok)
 		expected := NewInvalidConfigError()
 		expected.AddInvalidValue("global.v1.external.elasticsearch.auth.scheme", "Scheme should be 'basic_auth'.")
-		assert.EqualError(t, cfgErr, expected.Error(), "")
+		assert.EqualError(t, cfgErr, expected.Error())
 	})
 
 	t.Run("with external elasticsearch basic auth but no username and password set", func(t *testing.T) {
@@ -406,7 +406,7 @@ format = "json"
 		require.True(t, ok)
 		expected := NewInvalidConfigError()
 		expected.AddInvalidValue("global.v1.external.postgresql.auth.scheme", "Scheme should be 'password'.")
-		assert.EqualError(t, cfgErr, expected.Error(), "")
+		assert.EqualError(t, cfgErr, expected.Error())
 	})
 
 	t.Run("with external password auth but no superuser and dbuser username and password set", func(t *testing.T) {


### PR DESCRIPTION
### :nut_and_bolt: Description
Verify config settings for external postgres and elasticsearch.

If external elasticsearch is configured
* basic_auth is also configured,
* either the root cert or a root cert file is specified in the config, and
* elasticsearch node urls are either all http or https.

If external postgres is configured with auth, password auth is configured.

Signed-off-by: Yvonne Lam <yvonne@chef.io>

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
