### PR TITLE
[Workflow] Refresh session token for workflow UI

### DIFF
--- a/components/automate-workflow-web/package.json
+++ b/components/automate-workflow-web/package.json
@@ -32,6 +32,7 @@
     "eventsource-polyfill": "^0.9.6",
     "font-awesome": "=4.7.0",
     "highlight.js": "=8.3.0",
+    "jwt-decode": "^2.2.0",
     "keymaster": "=1.6.2",
     "lodash": "=4.2.1",
     "marked": "=0.3.6",


### PR DESCRIPTION
### :nut_and_bolt: Description
To keep the session alive on A2 token get refreshed every minute. But for the workflow, there is no way to refresh to the session token.

### :+1: Definition of Done

 - Include jwt-decode npm library.
 - To make the session token consistent for both Automate 2 UI and workflow UI added refresh token logic to Workflow as well.
- Completed https://github.com/chef/a1/tree/rhass/fix-session-logout

### :athletic_shoe: Demo Script / Repro Steps
* Install Automate 2.0
```
curl https://packages.chef.io/files/current/latest/chef-automate-cli/chef-automate_linux_amd64.zip | gunzip - > chef-automate && chmod +x chef-automate && \
./chef-automate deploy --channel dev --skip-preflight --accept-terms-and-mlsa --enable-chef-server --enable-workflow
```
* Login to Workflow.
* Stay on the dashboard page.
* After about two minutes the session will logout.

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
