### PR TITLE
Pass GITHUB_TOKEN into the build

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -60,6 +60,10 @@ steps:
       HAB_STUDIO_SUP: false
       HAB_NONINTERACTIVE: true
     expeditor:
+      secrets:
+        GITHUB_TOKEN:
+          account: github/chef-ci
+          field: token
       executor:
         linux:
           privileged: true


### PR DESCRIPTION
The documentation build still requires a github token to build.

NB: We may require HAB_STUDIO_GITHUB_TOKEN

Signed-off-by: Steven Danna <steve@chef.io>