### PR TITLE
Flaky tests: Adding an Elasticsearch refresh in place of a sleep

### DIFF
--- a/inspec/a2-api-integration/controls/ingest-job-scheduler.rb
+++ b/inspec/a2-api-integration/controls/ingest-job-scheduler.rb
@@ -1,5 +1,7 @@
 title 'ingest-service/JobScheduler REST API integration tests'
 
+
+
 control 'ingest-job-scheduler' do
   title 'check ingest job-scheduler endpoints'
   desc 'Verifies configuration of jobs inside the ingest scheduler'
@@ -57,6 +59,12 @@ control 'ingest-job-scheduler' do
         ENV['ELASTICSEARCH_URL'] || "http://localhost:10144"
       end
 
+      def refresh_elasticsearch()
+        request = inspec.http("#{elasticsearch_url}/_refresh")
+        failed_count = JSON.parse(request.body, symbolize_names: true)[:_shards][:failed]
+        expect(failed_count).to eq 0
+      end
+
       it 'if update has running == true, run the job' do
         # turn off missing node job
         expect(automate_api_request(
@@ -75,9 +83,7 @@ control 'ingest-job-scheduler' do
         ).to eq 200
 
         # wait for elastic search to update
-        request = inspec.http("#{elasticsearch_url}/_refresh")
-        failed_count = JSON.parse(request.body, symbolize_names: true)[:_shards][:failed]
-        expect(failed_count).to eq 0
+        refresh_elasticsearch()
 
         # turn on node missing with a day old threshold
         expect(automate_api_request(
@@ -88,9 +94,7 @@ control 'ingest-job-scheduler' do
         ).to eq 200
 
         # wait for elastic search to update
-        request = inspec.http("#{elasticsearch_url}/_refresh")
-        failed_count = JSON.parse(request.body, symbolize_names: true)[:_shards][:failed]
-        expect(failed_count).to eq 0
+        refresh_elasticsearch()
 
         # # check that the node added is missing
         expect(get_test_node.http_status).to eq 200
@@ -125,9 +129,7 @@ control 'ingest-job-scheduler' do
         ).to eq 200
 
         # wait for elastic search to update
-        request = inspec.http("#{elasticsearch_url}/_refresh")
-        failed_count = JSON.parse(request.body, symbolize_names: true)[:_shards][:failed]
-        expect(failed_count).to eq 0
+        refresh_elasticsearch()
 
         # update node missing job config with a day old threshold
         expect(automate_api_request(
@@ -138,9 +140,7 @@ control 'ingest-job-scheduler' do
         ).to eq 200
 
         # wait for elastic search to update
-        request = inspec.http("#{elasticsearch_url}/_refresh")
-        failed_count = JSON.parse(request.body, symbolize_names: true)[:_shards][:failed]
-        expect(failed_count).to eq 0
+        refresh_elasticsearch()
 
         # check that the node added is not missing
         expect(get_test_node.http_status).to eq 200


### PR DESCRIPTION
### :nut_and_bolt: Description

Testing out an Elasticsearch refresh in place of sleep. We are trying to prevent tests failing because Elasticsearch has not updated yet.
