### PR TITLE
Fixed a subset of broken links

### DIFF
--- a/.studio/secrets-service
+++ b/.studio/secrets-service
@@ -172,7 +172,7 @@ function secrets_reload_A1_data() {
   fi;
 
   # The A1 secret_key is being migrated from the deployment-service at:
-  # => https://github.com/chef/automate/blob/62a3c1be12a616a21d3e2ff2f11a9c73f8cd9844/components/automate-deployment/pkg/client/deployer.go#L1213
+  # => https://github.com/chef/automate/blob/dc2e9abeaf09ad3577e922d0e8afec9f6713cc4e/components/automate-deployment/pkg/client/deployer.go#L1433
   #
   # So here we are just writing it to the secrets-service data file as they are doing it
   if [[ ! -f $SECRETS_KEY_PATH ]]; then

--- a/components/automate-deployment/pkg/a1upgrade/a1commands.go
+++ b/components/automate-deployment/pkg/a1upgrade/a1commands.go
@@ -71,7 +71,7 @@ type EsShardsStats struct {
 
 // MaintDotFlag is the path to the file which will make A1's nginx go into
 // maintenance mode. See also:
-// https://github.com/chef/automate/blob/e1278c5fbb4478fa31b0853788cad1f6714fecf7/cookbooks/delivery/templates/default/nginx-internal.conf.erb#L146
+// https://github.com/chef/a1/blob/e1278c5fbb4478fa31b0853788cad1f6714fecf7/cookbooks/delivery/templates/default/nginx-internal.conf.erb#L146
 const MaintDotFlag = "/var/opt/delivery/delivery/etc/maint.flag"
 
 const rabbitStatsURL = "https://localhost:15672/api/queues/%2Finsights/data-collector"

--- a/components/automate-gateway/gateway_mocks/README.md
+++ b/components/automate-gateway/gateway_mocks/README.md
@@ -2,7 +2,7 @@
 
 Files in this directory are generated using a library called [mockgen]('https://github.com/golang/mock#running-mockgen'), which is part of [gomock]('https://github.com/grpc/grpc-go/blob/master/Documentation/gomock-example.md'). These generated files are used for testing the automate-gateway with mocked clients.
 
-Gomock is used for testing client-side logic. All the GRPC clients in the gateway comes from the `ClientsFactory` [interface]('https://github.com/chef/automate/blob/25c39573e4fae51ad7d84c3dbf78e106958cb25f/components/automate-gateway/gateway/clients.go#L64'). This interface has explicit definitions for all the micro-services that the gateway depends on, it is here where we dialing in to connect to those clients. Those clients contains the GRPC functions that we we need to mock so we can run our tests against the mocked version rather than the real version.
+Gomock is used for testing client-side logic. All the GRPC clients in the gateway comes from the `ClientsFactory` [interface](https://github.com/chef/automate/blob/dc2e9abeaf09ad3577e922d0e8afec9f6713cc4e/components/automate-gateway/gateway/clients.go#L81). This interface has explicit definitions for all the micro-services that the gateway depends on, it is here where we dialing in to connect to those clients. Those clients contains the GRPC functions that we we need to mock so we can run our tests against the mocked version rather than the real version.
 
 ## How to generate a new mock
 

--- a/components/es-sidecar-service/pkg/elastic/snapshot.go
+++ b/components/es-sidecar-service/pkg/elastic/snapshot.go
@@ -257,7 +257,7 @@ func (es *Elastic) GetCreateSnapshotStatus(ctx context.Context, serviceName, sna
 	// found to report status; the bytes stats included in the messages update
 	// the totals as they go so they're not reliable. This approach has proved
 	// reasonable when used for A1 upgrades in our testing. See also:
-	// https://github.com/chef/automate/blob/bb778e82e0fd289d7fcd550b2c4f2963eeba2b39/components/automate-deployment/pkg/a1upgrade/a1commands.go#L128
+	// https://github.com/chef/automate/blob/13e626b60a9ae391a2b70e9d50970b8ddb6742c8/components/automate-deployment/pkg/a1upgrade/a1commands.go#L253
 	s.ProgressPercentage = (float64(esSnapshotStatus.ShardsStats.Done) / float64(esSnapshotStatus.ShardsStats.Total)) * 100
 	s.Message = ""
 


### PR DESCRIPTION
### :nut_and_bolt: Description

These links broke because of the chef/automate -> chef/a2 global
replace that we did when moving the repository.

`components/automate-gateway/README.md` still has a few broken links
because the directions for adding a new endpoint are out of date and
refer to files that have either moved or no longer exist.

Signed-off-by: Steven Danna <steve@chef.io>

### :+1: Definition of Done

Fewer broken links than before