### PR TITLE
Fix tab-selector error when clicked directly

### DIFF
--- a/components/chef-ui-library/src/molecules/chef-tab-selector/chef-tab-selector.e2e.tsx
+++ b/components/chef-ui-library/src/molecules/chef-tab-selector/chef-tab-selector.e2e.tsx
@@ -1,0 +1,31 @@
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
+
+describe('chef-tab-selector', () => {
+  let page: E2EPage;
+  let element: E2EElement;
+
+  beforeEach(async () => {
+    page = await newE2EPage();
+    await page.setContent(`
+      <chef-tab-selector value='opt2'>
+        <chef-option value='opt1'>Option 1</chef-option>
+        <chef-option value='opt2'>Option 2</chef-option>
+        <chef-option value='opt3'>Option 3</chef-option>
+      </chef-tab-selector>
+    `);
+    element = await page.find('chef-tab-selector');
+  });
+
+  it('renders', async () => {
+    expect(element).toHaveClass('hydrated');
+  });
+
+  describe('when clicked', () => {
+    it('sets value to value of clicked chef-option', async () => {
+      const option = await element.find('chef-option[value="opt1"]');
+      await option.click();
+      await page.waitForChanges();
+      expect(await element.getProperty('value')).toEqual('opt1');
+    });
+  });
+});

--- a/components/chef-ui-library/src/molecules/chef-tab-selector/chef-tab-selector.tsx
+++ b/components/chef-ui-library/src/molecules/chef-tab-selector/chef-tab-selector.tsx
@@ -62,9 +62,12 @@ export class ChefTabSelector {
   selected: HTMLChefOptionElement;
 
   @Listen('click') handleClick(event) {
-    this.value = event.target.closest('chef-option').value;
-    this.change.emit();
-    this.input.emit();
+    const option = event.target.closest('chef-option');
+    if (option) {
+      this.value = option.value;
+      this.change.emit();
+      this.input.emit();
+    }
   }
 
   componentDidLoad() {


### PR DESCRIPTION
It's possible to click on only the `chef-tab-selector` itself instead of clicking within one of its `chef-option` child elements. This commit ensures an error isn't thrown by the click handler in this scenario.

<img width="467" alt="Screen Shot 2019-04-05 at 2 37 47 AM" src="https://user-images.githubusercontent.com/479121/55637198-b88a9b80-5781-11e9-8935-0a7009a38900.png">