### PR TITLE
[CI] Move test-license-usage pipeline to nightly

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -756,9 +756,6 @@ schedules:
   - name: nightly_tests
     description: "Run nightly tests against development environment"
     cronline: "0 6 * * *"
-  - name: run_every_30_minutes
-    description: "Run every 30 minutes"
-    cronline: "*/30 * * * *"
 
 # These are our Buildkite pipelines where deploys take place
 pipelines:
@@ -897,10 +894,7 @@ subscriptions:
       - trigger_pipeline:deploy/proxy
       - trigger_pipeline:basic-a1/dev
       - trigger_pipeline:nightly
-  - workload: schedule_triggered:chef/automate:master:run_every_30_minutes:*
-    actions:
-      - trigger_pipeline:test-license-usage/dev:
-          silent: true
+      - trigger_pipeline:test-license-usage/dev
   - workload: docker_image_published:chefes/buildkite:*
     actions:
       - bash:.expeditor/update_docker_image_version_in_verify_pipeline.sh


### PR DESCRIPTION
Running this pipeline every 30 minutes interacts poorly with the
current implementation of buildkite-agent scaling. As a result, this
pipeline was keeping a large number of expensive workers online.

This change triggers the pipeline nightly, which should allow our
buildkite queues to scale down more often.

Signed-off-by: Steven Danna <steve@chef.io>
