### PR TITLE
Use HAB_STUDIO_SECRET_GITHUB_TOKEN

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -47,9 +47,8 @@ steps:
       executor:
         docker:
 
-  # The build technically depends on AWS access to build
-  # automate-compliance-profiles even though we don't currently have
-  # it piped in here. Further we need to build in order to run the
+  # The build depends on GitHub access to build
+  # automate-chef-io. Further we need to build in order to run the
   # integration tests.
   - label: build
     command:
@@ -61,7 +60,7 @@ steps:
       HAB_NONINTERACTIVE: true
     expeditor:
       secrets:
-        GITHUB_TOKEN:
+        HAB_STUDIO_SECRET_GITHUB_TOKEN:
           account: github/chef-ci
           field: token
       executor:


### PR DESCRIPTION
The HAB_STUDIO_SECRET_ prefix tells the habitat studio to import that
environment variable when starting the studio. Since the build happens
inside the studio, this prefix is required.

Signed-off-by: Steven Danna <steve@chef.io>