### PR TITLE
Add 'habitat/build' pipeline (but do not use)

### DIFF
--- a/.expeditor/build.habitat.yml
+++ b/.expeditor/build.habitat.yml
@@ -1,0 +1,3 @@
+---
+origin: chef
+smart_build: true

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -771,6 +771,8 @@ pipelines:
       public: true
   - verify_private:
       description: Pull Request validation tests requiring access keys
+  - habitat/build:
+      description: Build the Habitat packages for Chef Automate
   - nightly:
       description: Nightly tests against master
       definition: .expeditor/nightly.pipeline.yml


### PR DESCRIPTION


### :nut_and_bolt: Description
Adds the new v2 Habitat build pipeline but does not leverage it. We will
be running through some tests builds on another branch, but we need to
merge the config in order to create the pipeline.

Signed-off-by: Tom Duffield <tom@chef.io>
### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
