### PR TITLE
Checking terraform behavior, trial 3

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
+++ b/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
@@ -119,8 +119,8 @@ hab pkg binlink core/hab --force
 
 set -x
 if [[ ! -f /root/a2-iamv2-enabled ]]; then
-    echo $iam_version
-    case "$iam_version" in
+    echo ${iam_version}
+    case "${iam_version}" in
     "v2.1")
       chef-automate iam upgrade-to-v2 --beta2.1
       touch /root/a2-iamv2-enabled


### PR DESCRIPTION
So, terraform has not been taking kindly to my rather innocuous changes.
But I think I found it -- PEBKAC.
It turns out that variables in terraform need to be `${name}` rather than just `$name`.
This patch should confirm this.