### PR TITLE
Update the CS pedant config to talk to the ES gateway instead of directly to ES

### DIFF
--- a/components/automate-cs-oc-erchef/habitat/config/pedant_config.rb
+++ b/components/automate-cs-oc-erchef/habitat/config/pedant_config.rb
@@ -67,7 +67,7 @@ default_orgname nil
 # testing location, you should not specify a value for this parameter.
 # The tests will still run, albeit slower, as they will now need to
 # poll for a period to ensure they are querying committed results.
-search_server "http://localhost:10141/"
+search_server "http://localhost:10144/"
 
 search_commit_url "/_refresh"
 search_url_fmt "/chef/_search?q=X_CHEF_type_CHEF_X:%{type}%%20%{query}"


### PR DESCRIPTION
Signed-off-by: Irving Popovetsky <irving@chef.io>

### :nut_and_bolt: Description

It's my understanding that all Automate services should talk to the ES gateway instead of directly to ES.   I found this one when running pedant on an A2 server with external ES.  

### :+1: Definition of Done


### :athletic_shoe: Demo Script / Repro Steps

On an A2 with external ES:
1. run `chef-server-ctl test`,  you get 12 failures on the tests that expected to speak directly to ES
2. manually change `/hab/svc/automate-cs-oc-erchef/config/pedant_config.rb`, line 70 
```
search_server "http://localhost:10144/"
```
3. run `chef-server-ctl test` again

### :chains: Related Resources

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
