### PR TITLE
Dan/applications load gen

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -519,6 +519,7 @@ habitat_packages:
         - lib/stringutils/*
         - lib/tls/*
         - lib/tracing/*
+        - lib/uuid4/*
         - lib/version/*
         - Gopkg.lock
   - nodemanager-service:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1593,6 +1593,7 @@
     "github.com/stretchr/testify/suite",
     "github.com/teambition/rrule-go",
     "github.com/uber/jaeger-client-go/config",
+    "go.uber.org/atomic",
     "go.uber.org/multierr",
     "go.uber.org/zap",
     "go.uber.org/zap/zapcore",

--- a/components/applications-service/.gitignore
+++ b/components/applications-service/.gitignore
@@ -1,1 +1,2 @@
 cmd/applications-publisher/applications-publisher 
+cmd/applications-load-gen/applications-load-gen

--- a/components/applications-service/cmd/applications-load-gen/applications_load_gen.go
+++ b/components/applications-service/cmd/applications-load-gen/applications_load_gen.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/chef/automate/components/applications-service/cmd/applications-load-gen/commands"
+
+func main() {
+	commands.Execute()
+}

--- a/components/applications-service/cmd/applications-load-gen/commands/describe.go
+++ b/components/applications-service/cmd/applications-load-gen/commands/describe.go
@@ -1,0 +1,190 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/burntsushi/toml"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	//uuid "github.com/chef/automate/lib/uuid4"
+)
+
+var now = time.Now()
+
+func newDescribeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "describe",
+		Short: "explains what running a load profile will do",
+		RunE:  runDescribeCmd,
+	}
+}
+
+func runDescribeCmd(cmd *cobra.Command, args []string) error {
+	if profileFile == "" {
+		return errors.New("no profile filename given")
+	}
+
+	fmt.Printf("Reading profile %q\n", profileFile)
+
+	var profile LoadProfile
+	_, err := toml.DecodeFile(profileFile, &profile)
+	if err != nil {
+		fmt.Printf("Invalid load profile\nError: %s\n", err)
+		return err
+	}
+
+	//fmt.Printf("%+v", profile)
+
+	for i, supCfg := range profile.GeneratorCfg.Supervisors {
+		supT := profile.Templates.GetTemplate(supCfg.TemplateName)
+
+		headerStr := fmt.Sprintf("Supervisor group %d: %s", i, supCfg.Name)
+		fmt.Println(headerStr)
+		fmt.Println(strings.Repeat("=", len(headerStr)))
+		fmt.Println("")
+
+		fmt.Printf("Number of simulated supervisors: %d\n", supCfg.Count)
+		fmt.Printf("Number of services per supervisor: %d\n", len(supT.ServiceTemplates))
+
+		for _, svcT := range supT.ServiceTemplates {
+			var m MessagePrototype
+			m.SetRelease()
+			m.ApplySvcTemplate(svcT)
+			m.ApplySupCfg(supCfg)
+			fmt.Println(m.PrettyStr())
+		}
+
+	}
+
+	return nil
+}
+
+// Data elements of a message that currently exist:
+// sup-id         AUTO
+// group          hardcode to "default"
+// application    assign per-service in sup template
+// environment    <name>   The environment name of the current deployment
+// health         hardcode to 0 (OK) for now.
+// status         hardcode to 0 (RUNNING) for now
+//
+// Package Indentifier
+// --origin      parse from service name
+// --name        parse from service name
+// --version     hardcode to 1.0.0 for now
+// --release     generate from the startup time of the generator
+type MessagePrototype struct {
+	Application string
+	Environment string
+	Channel     string
+	Site        string
+	Origin      string
+	PkgName     string
+	Release     string
+}
+
+func (m *MessagePrototype) SetRelease() {
+	m.Release = now.Format("20060102150405")
+}
+
+func (m *MessagePrototype) ApplySvcTemplate(t ServiceTemplate) {
+	// TODO: make this safer
+	parts := strings.Split(t.Package, "/")
+	m.Origin = parts[0]
+	m.PkgName = parts[1]
+	m.Application = t.Application
+}
+
+func (m *MessagePrototype) ApplySupCfg(s SupervisorCfg) {
+	m.Environment = s.Environment
+	m.Channel = s.Channel
+	m.Site = s.Site
+}
+
+func (m *MessagePrototype) PrettyStr() string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("  - Package: %s/%s/%s\n", m.Origin, m.PkgName, m.Release))
+	b.WriteString(fmt.Sprintf("  - Application: %s\n", m.Application))
+	b.WriteString(fmt.Sprintf("  - Environment: %s\n", m.Environment))
+	b.WriteString(fmt.Sprintf("  - Channel: %s\n", m.Channel))
+	b.WriteString(fmt.Sprintf("  - Site: %s\n", m.Site))
+	return b.String()
+}
+
+// FIXME: move all this into pkg/ after prototyping is done
+
+type LoadProfile struct {
+	Templates    Templates    `toml:"templates"`
+	GeneratorCfg GeneratorCfg `toml:"generator"`
+}
+
+// [templates]
+//   [[templates.supervisor]]
+//     # SupervisorTemplate one
+//   [[templates.supervisor]]
+//     # SupervisorTemplate two
+type Templates struct {
+	SupervisorTemplates []SupervisorTemplate `toml:"supervisor"`
+}
+
+func (ts Templates) GetTemplate(name string) *SupervisorTemplate {
+	for _, t := range ts.SupervisorTemplates {
+		if t.Name == name {
+			return &t
+		}
+	}
+
+	return nil
+}
+
+// name = "pos_terminal"
+// [[ service ]]
+// package = "noms/pos-service-1"
+// [[ service ]]
+// package = "noms/pos-service-2"
+type SupervisorTemplate struct {
+	Name             string            `toml:"name"`
+	ServiceTemplates []ServiceTemplate `toml:"service"`
+}
+
+// [[ service ]]
+// package = "noms/pos-service-2"
+type ServiceTemplate struct {
+	Package     string `toml:"package"`
+	Application string `toml:"application"`
+}
+
+// [generator]
+//   [[generator.supervisor]]
+//     # SupervisorCfg one
+//   [[generator.supervisor]]
+//     # SupervisorCfg two
+type GeneratorCfg struct {
+	Supervisors []SupervisorCfg `toml:"supervisor"`
+}
+
+// [[generator.supervisor]]
+//   name = "pos_terminals:production1"
+//   template = "pos_terminal"
+//   count = 1000
+//   channel = "production1"
+//   [site_range]
+//     format = "restaurant-prod1-%s"
+//     count = 1000
+type SupervisorCfg struct {
+	Name         string `toml:"name"`
+	TemplateName string `toml:"template"`
+	Count        int32  `toml:"count"`
+	Channel      string `toml:"channel"`
+	Environment  string `toml:"environment"`
+	Site         string `toml:"site"`
+}
+
+//   [site_range]
+//     format = "restaurant-prod1-%s"
+//     count = 1000
+type SiteRange struct {
+	FormatStr string `toml:"format"`
+	Count     int32  `toml:"count"`
+}

--- a/components/applications-service/cmd/applications-load-gen/commands/describe.go
+++ b/components/applications-service/cmd/applications-load-gen/commands/describe.go
@@ -35,7 +35,7 @@ func runDescribeCmd(cmd *cobra.Command, args []string) error {
 	supGroups := profileCfg.BuildSupervisorGroups()
 
 	for _, supGroup := range supGroups {
-		fmt.Println(supGroup.PrettyStr())
+		fmt.Print(supGroup.PrettyStr())
 	}
 
 	return nil

--- a/components/applications-service/cmd/applications-load-gen/commands/describe.go
+++ b/components/applications-service/cmd/applications-load-gen/commands/describe.go
@@ -2,16 +2,13 @@ package commands
 
 import (
 	"fmt"
-	"strings"
-	"time"
 
 	"github.com/burntsushi/toml"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	//uuid "github.com/chef/automate/lib/uuid4"
-)
 
-var now = time.Now()
+	"github.com/chef/automate/components/applications-service/pkg/generator"
+)
 
 func newDescribeCmd() *cobra.Command {
 	return &cobra.Command{
@@ -28,163 +25,18 @@ func runDescribeCmd(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Reading profile %q\n", profileFile)
 
-	var profile LoadProfile
-	_, err := toml.DecodeFile(profileFile, &profile)
+	var profileCfg generator.LoadProfileCfg
+	_, err := toml.DecodeFile(profileFile, &profileCfg)
 	if err != nil {
 		fmt.Printf("Invalid load profile\nError: %s\n", err)
 		return err
 	}
 
-	//fmt.Printf("%+v", profile)
+	supGroups := profileCfg.BuildSupervisorGroups()
 
-	for i, supCfg := range profile.GeneratorCfg.Supervisors {
-		supT := profile.Templates.GetTemplate(supCfg.TemplateName)
-
-		headerStr := fmt.Sprintf("Supervisor group %d: %s", i, supCfg.Name)
-		fmt.Println(headerStr)
-		fmt.Println(strings.Repeat("=", len(headerStr)))
-		fmt.Println("")
-
-		fmt.Printf("Number of simulated supervisors: %d\n", supCfg.Count)
-		fmt.Printf("Number of services per supervisor: %d\n", len(supT.ServiceTemplates))
-
-		for _, svcT := range supT.ServiceTemplates {
-			var m MessagePrototype
-			m.SetRelease()
-			m.ApplySvcTemplate(svcT)
-			m.ApplySupCfg(supCfg)
-			fmt.Println(m.PrettyStr())
-		}
-
+	for _, supGroup := range supGroups {
+		fmt.Println(supGroup.PrettyStr())
 	}
 
 	return nil
-}
-
-// Data elements of a message that currently exist:
-// sup-id         AUTO
-// group          hardcode to "default"
-// application    assign per-service in sup template
-// environment    <name>   The environment name of the current deployment
-// health         hardcode to 0 (OK) for now.
-// status         hardcode to 0 (RUNNING) for now
-//
-// Package Indentifier
-// --origin      parse from service name
-// --name        parse from service name
-// --version     hardcode to 1.0.0 for now
-// --release     generate from the startup time of the generator
-type MessagePrototype struct {
-	Application string
-	Environment string
-	Channel     string
-	Site        string
-	Origin      string
-	PkgName     string
-	Release     string
-}
-
-func (m *MessagePrototype) SetRelease() {
-	m.Release = now.Format("20060102150405")
-}
-
-func (m *MessagePrototype) ApplySvcTemplate(t ServiceTemplate) {
-	// TODO: make this safer
-	parts := strings.Split(t.Package, "/")
-	m.Origin = parts[0]
-	m.PkgName = parts[1]
-	m.Application = t.Application
-}
-
-func (m *MessagePrototype) ApplySupCfg(s SupervisorCfg) {
-	m.Environment = s.Environment
-	m.Channel = s.Channel
-	m.Site = s.Site
-}
-
-func (m *MessagePrototype) PrettyStr() string {
-	var b strings.Builder
-	b.WriteString(fmt.Sprintf("  - Package: %s/%s/%s\n", m.Origin, m.PkgName, m.Release))
-	b.WriteString(fmt.Sprintf("  - Application: %s\n", m.Application))
-	b.WriteString(fmt.Sprintf("  - Environment: %s\n", m.Environment))
-	b.WriteString(fmt.Sprintf("  - Channel: %s\n", m.Channel))
-	b.WriteString(fmt.Sprintf("  - Site: %s\n", m.Site))
-	return b.String()
-}
-
-// FIXME: move all this into pkg/ after prototyping is done
-
-type LoadProfile struct {
-	Templates    Templates    `toml:"templates"`
-	GeneratorCfg GeneratorCfg `toml:"generator"`
-}
-
-// [templates]
-//   [[templates.supervisor]]
-//     # SupervisorTemplate one
-//   [[templates.supervisor]]
-//     # SupervisorTemplate two
-type Templates struct {
-	SupervisorTemplates []SupervisorTemplate `toml:"supervisor"`
-}
-
-func (ts Templates) GetTemplate(name string) *SupervisorTemplate {
-	for _, t := range ts.SupervisorTemplates {
-		if t.Name == name {
-			return &t
-		}
-	}
-
-	return nil
-}
-
-// name = "pos_terminal"
-// [[ service ]]
-// package = "noms/pos-service-1"
-// [[ service ]]
-// package = "noms/pos-service-2"
-type SupervisorTemplate struct {
-	Name             string            `toml:"name"`
-	ServiceTemplates []ServiceTemplate `toml:"service"`
-}
-
-// [[ service ]]
-// package = "noms/pos-service-2"
-type ServiceTemplate struct {
-	Package     string `toml:"package"`
-	Application string `toml:"application"`
-}
-
-// [generator]
-//   [[generator.supervisor]]
-//     # SupervisorCfg one
-//   [[generator.supervisor]]
-//     # SupervisorCfg two
-type GeneratorCfg struct {
-	Supervisors []SupervisorCfg `toml:"supervisor"`
-}
-
-// [[generator.supervisor]]
-//   name = "pos_terminals:production1"
-//   template = "pos_terminal"
-//   count = 1000
-//   channel = "production1"
-//   [site_range]
-//     format = "restaurant-prod1-%s"
-//     count = 1000
-type SupervisorCfg struct {
-	Name         string `toml:"name"`
-	TemplateName string `toml:"template"`
-	Count        int32  `toml:"count"`
-	Channel      string `toml:"channel"`
-	Environment  string `toml:"environment"`
-	Site         string `toml:"site"`
-}
-
-//   [site_range]
-//     format = "restaurant-prod1-%s"
-//     count = 1000
-type SiteRange struct {
-	FormatStr string `toml:"format"`
-	Count     int32  `toml:"count"`
 }

--- a/components/applications-service/cmd/applications-load-gen/commands/describe.go
+++ b/components/applications-service/cmd/applications-load-gen/commands/describe.go
@@ -18,19 +18,19 @@ func newDescribeCmd() *cobra.Command {
 }
 
 func runDescribeCmd(cmd *cobra.Command, args []string) error {
-	if profileFile == "" && !useDefaultProfile {
+	if rootFlags.profileFile == "" && !rootFlags.useDefaultProfile {
 		return errors.New("no profile filename given")
 	}
 
-	fmt.Printf("Reading profile %q\n", profileFile)
+	fmt.Printf("Reading profile %q\n", rootFlags.profileFile)
 
 	var profileCfg *generator.LoadProfileCfg
 	var err error
 
-	if useDefaultProfile {
+	if rootFlags.useDefaultProfile {
 		profileCfg, err = generator.BuiltinConfig()
 	} else {
-		profileCfg, err = generator.ProfileFromFile(profileFile)
+		profileCfg, err = generator.ProfileFromFile(rootFlags.profileFile)
 	}
 	if err != nil {
 		return err

--- a/components/applications-service/cmd/applications-load-gen/commands/root.go
+++ b/components/applications-service/cmd/applications-load-gen/commands/root.go
@@ -7,6 +7,7 @@ import (
 )
 
 var profileFile string
+var useDefaultProfile bool
 
 // RootCmd is the command runner.
 var RootCmd = &cobra.Command{
@@ -31,6 +32,12 @@ func init() {
 		"p",
 		"",
 		"file that configures the shape of the load to be generated",
+	)
+	RootCmd.PersistentFlags().BoolVar(
+		&useDefaultProfile,
+		"use-default-profile",
+		false,
+		"use simple builtin load profile",
 	)
 
 	RootCmd.AddCommand(newDescribeCmd())

--- a/components/applications-service/cmd/applications-load-gen/commands/root.go
+++ b/components/applications-service/cmd/applications-load-gen/commands/root.go
@@ -6,8 +6,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var profileFile string
-var useDefaultProfile bool
+var rootFlags struct {
+	profileFile       string
+	useDefaultProfile bool
+}
 
 // RootCmd is the command runner.
 var RootCmd = &cobra.Command{
@@ -27,14 +29,14 @@ func Execute() {
 func init() {
 	// global config
 	RootCmd.PersistentFlags().StringVarP(
-		&profileFile,
+		&rootFlags.profileFile,
 		"profile",
 		"p",
 		"",
 		"file that configures the shape of the load to be generated",
 	)
 	RootCmd.PersistentFlags().BoolVar(
-		&useDefaultProfile,
+		&rootFlags.useDefaultProfile,
 		"use-default-profile",
 		false,
 		"use simple builtin load profile",

--- a/components/applications-service/cmd/applications-load-gen/commands/root.go
+++ b/components/applications-service/cmd/applications-load-gen/commands/root.go
@@ -34,4 +34,5 @@ func init() {
 	)
 
 	RootCmd.AddCommand(newDescribeCmd())
+	RootCmd.AddCommand(newRunCmd())
 }

--- a/components/applications-service/cmd/applications-load-gen/commands/root.go
+++ b/components/applications-service/cmd/applications-load-gen/commands/root.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var profileFile string
+
+// RootCmd is the command runner.
+var RootCmd = &cobra.Command{
+	Use:          "applications-load-gen",
+	Short:        "Load Generator for Chef Automate Applications Service",
+	SilenceUsage: true,
+}
+
+// Execute adds all child commands to the root command sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		os.Exit(-1)
+	}
+}
+
+func init() {
+	// global config
+	RootCmd.PersistentFlags().StringVarP(
+		&profileFile,
+		"profile",
+		"p",
+		"",
+		"file that configures the shape of the load to be generated",
+	)
+
+	RootCmd.AddCommand(newDescribeCmd())
+}

--- a/components/applications-service/cmd/applications-load-gen/commands/run.go
+++ b/components/applications-service/cmd/applications-load-gen/commands/run.go
@@ -1,0 +1,67 @@
+package commands
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/burntsushi/toml"
+	"github.com/chef/automate/components/applications-service/pkg/generator"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var authToken string
+var tick int
+
+func newRunCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "run",
+		Short: "runs the load generator",
+		RunE:  runRunCmd,
+	}
+	c.PersistentFlags().StringVarP(
+		&authToken,
+		"auth-token",
+		"t",
+		"",
+		"Automate auth token",
+	)
+	c.PersistentFlags().IntVar(
+		&tick,
+		"tick",
+		30,
+		"interval between hab sup healthcheck ticks",
+	)
+
+	return c
+}
+
+func runRunCmd(cmd *cobra.Command, args []string) error {
+	if profileFile == "" {
+		return errors.New("no profile filename given")
+	}
+
+	if authToken == "" {
+		return errors.New("no auth token given")
+	}
+
+	fmt.Printf("Reading profile %q\n", profileFile)
+
+	var profileCfg generator.LoadProfileCfg
+	_, err := toml.DecodeFile(profileFile, &profileCfg)
+	if err != nil {
+		fmt.Printf("Invalid load profile\nError: %s\n", err)
+		return err
+	}
+
+	runnerCfg := &generator.RunnerConfig{
+		AuthToken: authToken,
+		Host:      "localhost",
+		Tick:      tick,
+	}
+
+	runner := profileCfg.BuildRunner()
+	runner.Run(runnerCfg)
+	runtime.Goexit() // waits for all the other threads
+	return nil
+}

--- a/components/applications-service/cmd/applications-load-gen/commands/run.go
+++ b/components/applications-service/cmd/applications-load-gen/commands/run.go
@@ -9,9 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var authToken string
-var tick int
-var verbosity int
+var runFlags struct {
+	authToken string
+	tick      int
+	verbosity int
+}
 
 func newRunCmd() *cobra.Command {
 	c := &cobra.Command{
@@ -20,20 +22,20 @@ func newRunCmd() *cobra.Command {
 		RunE:  runRunCmd,
 	}
 	c.PersistentFlags().StringVarP(
-		&authToken,
+		&runFlags.authToken,
 		"auth-token",
 		"t",
 		"",
 		"Automate auth token",
 	)
 	c.PersistentFlags().IntVar(
-		&tick,
+		&runFlags.tick,
 		"tick",
 		30,
 		"interval between hab sup healthcheck ticks",
 	)
 	c.PersistentFlags().CountVarP(
-		&verbosity,
+		&runFlags.verbosity,
 		"verbose",
 		"V",
 		"log each supervisor cycle; give twice to log every message",
@@ -43,33 +45,33 @@ func newRunCmd() *cobra.Command {
 }
 
 func runRunCmd(cmd *cobra.Command, args []string) error {
-	if profileFile == "" && !useDefaultProfile {
+	if rootFlags.profileFile == "" && !rootFlags.useDefaultProfile {
 		return errors.New("no profile filename given")
 	}
 
-	if authToken == "" {
+	if runFlags.authToken == "" {
 		return errors.New("no auth token given")
 	}
 
-	fmt.Printf("Reading profile %q\n", profileFile)
+	fmt.Printf("Reading profile %q\n", rootFlags.profileFile)
 
 	var profileCfg *generator.LoadProfileCfg
 	var err error
 
-	if useDefaultProfile {
+	if rootFlags.useDefaultProfile {
 		profileCfg, err = generator.BuiltinConfig()
 	} else {
-		profileCfg, err = generator.ProfileFromFile(profileFile)
+		profileCfg, err = generator.ProfileFromFile(rootFlags.profileFile)
 	}
 	if err != nil {
 		return err
 	}
 
 	runnerCfg := &generator.RunnerConfig{
-		AuthToken: authToken,
+		AuthToken: runFlags.authToken,
 		Host:      "localhost",
-		Tick:      tick,
-		Verbosity: verbosity,
+		Tick:      runFlags.tick,
+		Verbosity: runFlags.verbosity,
 	}
 
 	runner, err := profileCfg.BuildRunner()

--- a/components/applications-service/cmd/applications-load-gen/commands/run.go
+++ b/components/applications-service/cmd/applications-load-gen/commands/run.go
@@ -12,6 +12,7 @@ import (
 
 var authToken string
 var tick int
+var verbosity int
 
 func newRunCmd() *cobra.Command {
 	c := &cobra.Command{
@@ -31,6 +32,12 @@ func newRunCmd() *cobra.Command {
 		"tick",
 		30,
 		"interval between hab sup healthcheck ticks",
+	)
+	c.PersistentFlags().CountVarP(
+		&verbosity,
+		"verbose",
+		"V",
+		"log each supervisor cycle; give twice to log every message",
 	)
 
 	return c
@@ -58,6 +65,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 		AuthToken: authToken,
 		Host:      "localhost",
 		Tick:      tick,
+		Verbosity: verbosity,
 	}
 
 	runner := profileCfg.BuildRunner()

--- a/components/applications-service/dev/applications-load-gen/noms.toml
+++ b/components/applications-service/dev/applications-load-gen/noms.toml
@@ -47,7 +47,6 @@
     environment = "production1"
     site = "site1"
 
-
   [[generator.supervisor]]
     name = "order_mgmt:production1"
     template = "order_mgmt"

--- a/components/applications-service/dev/applications-load-gen/noms.toml
+++ b/components/applications-service/dev/applications-load-gen/noms.toml
@@ -42,7 +42,7 @@
   [[generator.supervisor]]
     name = "pos_terminals:production1"
     template = "pos_terminal"
-    count = 100
+    count = 10
     channel = "production1"
     environment = "production1"
     site = "site1"

--- a/components/applications-service/dev/applications-load-gen/noms.toml
+++ b/components/applications-service/dev/applications-load-gen/noms.toml
@@ -1,0 +1,58 @@
+################################################################################
+# Data elements of a message that currently exist:
+# sup-id         AUTO
+# group          hardcode to "default"
+# application    assign per-service in sup template
+# environment    <name>   The environment name of the current deployment
+# health         hardcode to 0 (OK) for now.
+# status         hardcode to 0 (RUNNING) for now
+# 
+# Package Indentifier
+# --origin      parse from service name 
+# --name        parse from service name 
+# --version     hardcode to 1.0.0 for now
+# --release     generate from the startup time of the generator
+
+[templates]
+  [[templates.supervisor]]
+    name = "pos_terminal"
+    [[ templates.supervisor.service ]]
+      package = "noms/pos-service-1"
+      application = "pos_terminal"
+    [[ templates.supervisor.service ]]
+      package = "noms/pos-service-2"
+      application = "pos_terminal"
+    [[ templates.supervisor.service ]]
+      package = "noms/pos-service-3"
+      application = "pos_terminal"
+
+  [[templates.supervisor]]
+    name = "order_mgmt"
+    [[ templates.supervisor.service ]]
+      package = "noms/om-service-1"
+      application = "order_mgmt"
+    [[ templates.supervisor.service ]]
+      package = "noms/om-service-2"
+      application = "order_mgmt"
+    [[ templates.supervisor.service ]]
+      package = "noms/om-service-3"
+      application = "order_mgmt"
+
+[generator]
+  [[generator.supervisor]]
+    name = "pos_terminals:production1"
+    template = "pos_terminal"
+    count = 100
+    channel = "production1"
+    environment = "production1"
+    site = "site1"
+
+
+  [[generator.supervisor]]
+    name = "order_mgmt:production1"
+    template = "order_mgmt"
+    count = 10
+    channel = "production1"
+    environment = "production1"
+    site = "site1"
+

--- a/components/applications-service/habitat/plan.sh
+++ b/components/applications-service/habitat/plan.sh
@@ -40,6 +40,7 @@ scaffolding_go_import_path="${scaffolding_go_base_path}/${scaffolding_go_repo_na
 scaffolding_go_binary_list=(
   "${scaffolding_go_import_path}/cmd/${pkg_name}"
   "${scaffolding_go_import_path}/cmd/applications-publisher"
+  "${scaffolding_go_import_path}/cmd/applications-load-gen"
 )
 
 do_prepare() {

--- a/components/applications-service/pkg/generator/builtin_config.go
+++ b/components/applications-service/pkg/generator/builtin_config.go
@@ -1,0 +1,39 @@
+package generator
+
+import (
+	"github.com/burntsushi/toml"
+	"github.com/pkg/errors"
+)
+
+const builtinConfigToml = `
+[templates]
+  [[templates.supervisor]]
+    name = "three-svc-sup"
+    [[ templates.supervisor.service ]]
+      package = "example/service-1"
+      application = "example-app"
+    [[ templates.supervisor.service ]]
+      package = "example/service-2"
+      application = "example-app"
+    [[ templates.supervisor.service ]]
+      package = "example/service-3"
+      application = "example-app"
+
+[generator]
+  [[generator.supervisor]]
+		name = "supervisors:qa"
+    template = "three-svc-sup"
+    count = 10
+    channel = "qa"
+    environment = "qa"
+    site = "site1"
+`
+
+func BuiltinConfig() (*LoadProfileCfg, error) {
+	var profileCfg LoadProfileCfg
+	_, err := toml.Decode(builtinConfigToml, &profileCfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "Oops :( The builtin load profile isn't valid")
+	}
+	return &profileCfg, nil
+}

--- a/components/applications-service/pkg/generator/config.go
+++ b/components/applications-service/pkg/generator/config.go
@@ -1,0 +1,108 @@
+package generator
+
+import (
+	"time"
+)
+
+var now = time.Now()
+
+type LoadProfileCfg struct {
+	Templates    Templates    `toml:"templates"`
+	GeneratorCfg GeneratorCfg `toml:"generator"`
+}
+
+func (l *LoadProfileCfg) BuildRunner() *LoadGenRunner {
+	return &LoadGenRunner{SupervisorGroups: l.BuildSupervisorGroups()}
+}
+
+func (l *LoadProfileCfg) BuildSupervisorGroups() []*SupervisorGroup {
+	groups := []*SupervisorGroup{}
+
+	for _, supCfg := range l.GeneratorCfg.Supervisors {
+
+		group := SupervisorGroup{Name: supCfg.Name, Count: supCfg.Count}
+
+		supT := l.Templates.GetTemplate(supCfg.TemplateName)
+
+		for _, svcT := range supT.ServiceTemplates {
+			var m MessagePrototype
+			m.SetRelease()
+			m.ApplySvcTemplate(svcT)
+			m.ApplySupCfg(supCfg)
+			group.MessagePrototypes = append(group.MessagePrototypes, &m)
+		}
+
+		groups = append(groups, &group)
+	}
+	return groups
+}
+
+// [templates]
+//   [[templates.supervisor]]
+//     # SupervisorTemplate one
+//   [[templates.supervisor]]
+//     # SupervisorTemplate two
+type Templates struct {
+	SupervisorTemplates []SupervisorTemplate `toml:"supervisor"`
+}
+
+func (ts Templates) GetTemplate(name string) *SupervisorTemplate {
+	for _, t := range ts.SupervisorTemplates {
+		if t.Name == name {
+			return &t
+		}
+	}
+
+	return nil
+}
+
+// name = "pos_terminal"
+// [[ service ]]
+// package = "noms/pos-service-1"
+// [[ service ]]
+// package = "noms/pos-service-2"
+type SupervisorTemplate struct {
+	Name             string            `toml:"name"`
+	ServiceTemplates []ServiceTemplate `toml:"service"`
+}
+
+// [[ service ]]
+// package = "noms/pos-service-2"
+type ServiceTemplate struct {
+	Package     string `toml:"package"`
+	Application string `toml:"application"`
+}
+
+// [generator]
+//   [[generator.supervisor]]
+//     # SupervisorCfg one
+//   [[generator.supervisor]]
+//     # SupervisorCfg two
+type GeneratorCfg struct {
+	Supervisors []SupervisorCfg `toml:"supervisor"`
+}
+
+// [[generator.supervisor]]
+//   name = "pos_terminals:production1"
+//   template = "pos_terminal"
+//   count = 1000
+//   channel = "production1"
+//   [site_range]
+//     format = "restaurant-prod1-%s"
+//     count = 1000
+type SupervisorCfg struct {
+	Name         string `toml:"name"`
+	TemplateName string `toml:"template"`
+	Count        int32  `toml:"count"`
+	Channel      string `toml:"channel"`
+	Environment  string `toml:"environment"`
+	Site         string `toml:"site"`
+}
+
+//   [site_range]
+//     format = "restaurant-prod1-%s"
+//     count = 1000
+type SiteRange struct {
+	FormatStr string `toml:"format"`
+	Count     int32  `toml:"count"`
+}

--- a/components/applications-service/pkg/generator/config.go
+++ b/components/applications-service/pkg/generator/config.go
@@ -2,9 +2,21 @@ package generator
 
 import (
 	"time"
+
+	"github.com/burntsushi/toml"
+	"github.com/pkg/errors"
 )
 
 var now = time.Now()
+
+func ProfileFromFile(path string) (*LoadProfileCfg, error) {
+	var profileCfg LoadProfileCfg
+	_, err := toml.DecodeFile(path, &profileCfg)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Invalid load profile %q", path)
+	}
+	return &profileCfg, nil
+}
 
 type LoadProfileCfg struct {
 	Templates    Templates    `toml:"templates"`

--- a/components/applications-service/pkg/generator/config_test.go
+++ b/components/applications-service/pkg/generator/config_test.go
@@ -1,0 +1,57 @@
+package generator
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/chef/automate/api/external/applications"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadProfileFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "TestLoadProfileFile-*.toml")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	f.WriteString(builtinConfigToml)
+	f.Close()
+
+	profileCfg, err := ProfileFromFile(f.Name())
+	require.NoError(t, err)
+
+	assert.IsType(t, &LoadProfileCfg{}, profileCfg)
+}
+
+func TestDefaultProfileIsViable(t *testing.T) {
+	profileCfg, err := BuiltinConfig()
+	require.NoError(t, err)
+	runner, err := profileCfg.BuildRunner()
+	require.NoError(t, err)
+
+	assert.Len(t, runner.SupervisorGroups, 1)
+
+	supGroup := runner.SupervisorGroups[0]
+
+	require.Len(t, supGroup.MessagePrototypes, 3)
+
+	uuid := "00000000-0000-0000-0000-000000000000"
+
+	msg := supGroup.MessagePrototypes[0].CreateMessage(uuid)
+
+	expectedRelease := now.Format("20060102150405")
+
+	expected := &applications.HabService{
+		SupervisorId: uuid,
+		Group:        "default",
+		PkgIdent: &applications.PackageIdent{
+			Origin:  "example",
+			Name:    "service-1",
+			Version: "0.1.0",
+			Release: expectedRelease,
+		},
+	}
+
+	assert.Equal(t, expected, msg)
+}

--- a/components/applications-service/pkg/generator/runner.go
+++ b/components/applications-service/pkg/generator/runner.go
@@ -165,16 +165,7 @@ func (s *SupSim) PublishAll() error {
 
 	for _, m := range s.MessagePrototypes {
 
-		msg := &applications.HabService{
-			SupervisorId: s.UUID.String(),
-			Group:        "default",
-			PkgIdent: &applications.PackageIdent{
-				Origin:  m.Origin,
-				Name:    m.PkgName,
-				Version: "0.1.0",
-				Release: m.Release,
-			},
-		}
+		msg := m.CreateMessage(s.UUID.String())
 
 		log.WithFields(log.Fields{
 			"name":          s.Name,
@@ -236,6 +227,19 @@ func (m *MessagePrototype) ApplySupCfg(s SupervisorCfg) {
 	m.Environment = s.Environment
 	m.Channel = s.Channel
 	m.Site = s.Site
+}
+
+func (m *MessagePrototype) CreateMessage(uuid string) *applications.HabService {
+	return &applications.HabService{
+		SupervisorId: uuid,
+		Group:        "default",
+		PkgIdent: &applications.PackageIdent{
+			Origin:  m.Origin,
+			Name:    m.PkgName,
+			Version: "0.1.0",
+			Release: m.Release,
+		},
+	}
 }
 
 func (m *MessagePrototype) PrettyStr() string {

--- a/components/applications-service/pkg/generator/runner.go
+++ b/components/applications-service/pkg/generator/runner.go
@@ -1,0 +1,203 @@
+package generator
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/chef/automate/api/external/applications"
+	"github.com/chef/automate/components/applications-service/pkg/nats"
+	uuid "github.com/chef/automate/lib/uuid4"
+)
+
+type RunnerConfig struct {
+	AuthToken string
+	Host      string
+	Tick      int
+}
+
+type LoadGenRunner struct {
+	SupervisorGroups []*SupervisorGroup
+}
+
+func (r *LoadGenRunner) Run(cfg *RunnerConfig) {
+	for _, g := range r.SupervisorGroups {
+		g.Run(cfg)
+	}
+}
+
+type SupervisorGroup struct {
+	Name              string
+	Count             int32
+	MessagePrototypes []*MessagePrototype
+}
+
+func (s *SupervisorGroup) PrettyStr() string {
+	var b strings.Builder
+
+	headerStr := fmt.Sprintf("Supervisor group: %s", s.Name)
+	fmt.Fprintln(&b, headerStr)
+	fmt.Fprintln(&b, strings.Repeat("=", len(headerStr)))
+
+	fmt.Fprintf(&b, "- Simulated supervisors: %d\n", s.Count)
+	fmt.Fprintf(&b, "- Services per supervisor: %d\n", len(s.MessagePrototypes))
+
+	fmt.Fprintln(&b, "")
+
+	for _, m := range s.MessagePrototypes {
+		fmt.Fprintln(&b, m.PrettyStr())
+	}
+
+	return b.String()
+}
+
+func (s *SupervisorGroup) Run(cfg *RunnerConfig) {
+	for n := int32(0); n < s.Count; n++ {
+		fmt.Printf("supervisor group %q (%d)\n", s.Name, n)
+		go s.SpawnSup(n, cfg)
+	}
+}
+
+func (s *SupervisorGroup) SpawnSup(n int32, cfg *RunnerConfig) error {
+	sup, err := NewSupSim(s.Name, n, cfg, s.MessagePrototypes)
+	if err != nil {
+		fmt.Printf("Supervisor setup failed: %s\n", err)
+		return err
+	}
+
+	err = sup.Run()
+	if err != nil {
+		fmt.Printf("Supervisor failed to run: %s\n", err)
+		return err
+	}
+
+	return nil
+}
+
+type SupSim struct {
+	Name              string
+	Idx               int32
+	Cfg               *RunnerConfig
+	UUID              uuid.UUID
+	MessagePrototypes []*MessagePrototype
+	nc                *nats.NatsClient
+}
+
+func NewSupSim(name string, idx int32, cfg *RunnerConfig, messages []*MessagePrototype) (*SupSim, error) {
+	uuid, err := uuid.NewV4()
+	if err != nil {
+		return nil, err
+	}
+	return &SupSim{
+		Name:              name,
+		UUID:              uuid,
+		Cfg:               cfg,
+		MessagePrototypes: messages,
+	}, nil
+}
+
+func (s *SupSim) Run() error {
+	url := fmt.Sprintf("nats://%s@%s:4222", s.Cfg.AuthToken, s.Cfg.Host)
+	cluster := "event-service"
+	client := fmt.Sprintf("load-generator-%s", s.UUID)
+	durable := client
+	subject := "habitat"
+
+	s.nc = nats.NewExternalClient(url, cluster, client, durable, subject)
+	s.nc.InsecureSkipVerify = true
+	err := s.nc.Connect()
+	if err != nil {
+		return err
+	}
+	defer s.nc.Close()
+	// run loadgen loop
+
+	// TODO: use logger instead
+	fmt.Printf("starting sup %s (%d) (%s)\n", s.Name, s.Idx, s.UUID)
+
+	// the ticker always waits its full time before publishing. Also we wish to
+	// splay out the simulated sups for a more even distribution of messages. So
+	// we get a random splay, publish once, then loop.
+	splay := rand.Int31n(int32(s.Cfg.Tick))
+	time.Sleep(time.Duration(splay) * time.Second)
+	s.PublishAll()
+
+	ticker := time.NewTicker(time.Duration(s.Cfg.Tick) * time.Second)
+	for _ = range ticker.C {
+		s.PublishAll()
+	}
+	return nil
+}
+
+func (s *SupSim) PublishAll() error {
+	for _, m := range s.MessagePrototypes {
+		fmt.Printf("publish messages from sup %s (%d) (%s)\n", s.Name, s.Idx, s.UUID)
+		msg := &applications.HabService{
+			SupervisorId: s.UUID.String(),
+			Group:        "default",
+			PkgIdent: &applications.PackageIdent{
+				Origin:  m.Origin,
+				Name:    m.PkgName,
+				Version: "0.1.0",
+				Release: m.Release,
+			},
+		}
+		err := s.nc.PublishHabService(msg)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Data elements of a message that currently exist:
+// sup-id         AUTO
+// group          hardcode to "default"
+// application    assign per-service in sup template
+// environment    <name>   The environment name of the current deployment
+// health         hardcode to 0 (OK) for now.
+// status         hardcode to 0 (RUNNING) for now
+//
+// Package Indentifier
+// --origin      parse from service name
+// --name        parse from service name
+// --version     hardcode to 1.0.0 for now
+// --release     generate from the startup time of the generator
+type MessagePrototype struct {
+	Application string
+	Environment string
+	Channel     string
+	Site        string
+	Origin      string
+	PkgName     string
+	Release     string
+}
+
+func (m *MessagePrototype) SetRelease() {
+	m.Release = now.Format("20060102150405")
+}
+
+func (m *MessagePrototype) ApplySvcTemplate(t ServiceTemplate) {
+	// TODO: make this safer
+	parts := strings.Split(t.Package, "/")
+	m.Origin = parts[0]
+	m.PkgName = parts[1]
+	m.Application = t.Application
+}
+
+func (m *MessagePrototype) ApplySupCfg(s SupervisorCfg) {
+	m.Environment = s.Environment
+	m.Channel = s.Channel
+	m.Site = s.Site
+}
+
+func (m *MessagePrototype) PrettyStr() string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("  - Package: %s/%s/%s\n", m.Origin, m.PkgName, m.Release))
+	b.WriteString(fmt.Sprintf("  - Application: %s\n", m.Application))
+	b.WriteString(fmt.Sprintf("  - Environment: %s\n", m.Environment))
+	b.WriteString(fmt.Sprintf("  - Channel: %s\n", m.Channel))
+	b.WriteString(fmt.Sprintf("  - Site: %s\n", m.Site))
+	return b.String()
+}

--- a/components/applications-service/pkg/generator/runner.go
+++ b/components/applications-service/pkg/generator/runner.go
@@ -124,11 +124,13 @@ func (s *SupSim) Run() error {
 	s.Stats.SupStarted()
 	defer s.Stats.SupDied()
 
-	url := fmt.Sprintf("nats://%s@%s:4222", s.Cfg.AuthToken, s.Cfg.Host)
-	cluster := "event-service"
-	client := fmt.Sprintf("load-generator-%s", s.UUID)
-	durable := client
-	subject := "habitat"
+	var (
+		url     = fmt.Sprintf("nats://%s@%s:4222", s.Cfg.AuthToken, s.Cfg.Host)
+		cluster = "event-service"
+		client  = fmt.Sprintf("load-generator-%s", s.UUID)
+		durable = client
+		subject = "habitat"
+	)
 
 	s.nc = nats.NewExternalClient(url, cluster, client, durable, subject)
 	s.nc.InsecureSkipVerify = true
@@ -172,7 +174,7 @@ func (s *SupSim) PublishAll() error {
 			"index":         s.Idx,
 			"uuid":          s.UUID.String(),
 			"service_count": len(s.MessagePrototypes),
-			"pkg_fqid":      fmt.Sprintf("%s/%s/%s/%s", m.Origin, m.PkgName, versionNumber, m.Release),
+			"pkg_fqid":      m.PkgFQID(),
 		}).Debug("publishing messages")
 
 		err := s.nc.PublishHabService(msg)
@@ -240,6 +242,10 @@ func (m *MessagePrototype) CreateMessage(uuid string) *applications.HabService {
 			Release: m.Release,
 		},
 	}
+}
+
+func (m *MessagePrototype) PkgFQID() string {
+	return fmt.Sprintf("%s/%s/%s/%s", m.Origin, m.PkgName, versionNumber, m.Release)
 }
 
 func (m *MessagePrototype) PrettyStr() string {

--- a/components/applications-service/pkg/generator/runner_stats.go
+++ b/components/applications-service/pkg/generator/runner_stats.go
@@ -1,0 +1,107 @@
+package generator
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"go.uber.org/atomic"
+)
+
+type RunnerStats struct {
+	messagesSentSuccess atomic.Uint64
+	messagesSentFailed  atomic.Uint64
+	collectionStart     time.Time
+}
+
+func (r *RunnerStats) TotalMessages() uint64 {
+	return r.messagesSentSuccess.Load() + r.messagesSentFailed.Load()
+}
+
+func (r *RunnerStats) TotalRate() float64 {
+	return float64(r.TotalMessages()) / time.Since(r.collectionStart).Seconds()
+}
+
+func NewStatsKeeper() *RunnerStatsKeeper {
+	now := time.Now()
+
+	return &RunnerStatsKeeper{
+		lifetimeStats:  &RunnerStats{collectionStart: now},
+		lastCycleStats: &RunnerStats{collectionStart: now},
+	}
+}
+
+type RunnerStatsKeeper struct {
+	supervisorsRunning atomic.Uint64
+	supervisorsFailed  atomic.Uint64
+	lifetimeStats      *RunnerStats
+	lastCycleStats     *RunnerStats
+}
+
+const statsPrintPerMinute = 2
+
+func (r *RunnerStatsKeeper) RunCollectAndPrintLoop() {
+	r.Report()
+	ticker := time.NewTicker(r.Interval())
+	for _ = range ticker.C {
+		r.Report()
+		r.ResetCycleStats()
+	}
+}
+
+func (r *RunnerStatsKeeper) Interval() time.Duration {
+	return time.Minute / statsPrintPerMinute
+}
+
+func (r *RunnerStatsKeeper) SupStarted() {
+	r.supervisorsRunning.Inc()
+}
+
+func (r *RunnerStatsKeeper) SupDied() {
+	r.supervisorsRunning.Dec()
+	r.supervisorsFailed.Inc()
+}
+
+func (r *RunnerStatsKeeper) SuccessfulPublish() {
+	r.lifetimeStats.messagesSentSuccess.Inc()
+	r.lastCycleStats.messagesSentSuccess.Inc()
+}
+
+func (r *RunnerStatsKeeper) FailedPublish() {
+	r.lifetimeStats.messagesSentFailed.Inc()
+	r.lastCycleStats.messagesSentFailed.Inc()
+}
+
+func (r *RunnerStatsKeeper) ResetCycleStats() {
+	r.lastCycleStats = &RunnerStats{collectionStart: time.Now()}
+}
+
+func (r *RunnerStatsKeeper) Report() {
+	heading := fmt.Sprintf("Load Generator Statistics %s", time.Now().Format(time.RFC3339))
+	hr := strings.Repeat("-", len(heading))
+
+	intervalSeconds := int(r.Interval().Round(time.Second).Seconds())
+
+	fmt.Printf(`
+%s
+%s
+Supervisors Running:          %d
+Supervisors Died:             %d
+Messages Sent    (lifetime):  %d
+Message Rate /s  (lifetime):  %.2f 
+Messages Sent    (last %2ds):  %d
+Message Rate /s  (last %2ds):  %.2f
+`,
+		heading,
+		hr,
+		r.supervisorsRunning.Load(),
+		r.supervisorsFailed.Load(),
+		r.lifetimeStats.TotalMessages(),
+		r.lifetimeStats.TotalRate(),
+		intervalSeconds,
+		r.lastCycleStats.TotalMessages(),
+		intervalSeconds,
+		r.lastCycleStats.TotalRate(),
+	)
+
+}


### PR DESCRIPTION
### :nut_and_bolt: Description

Adds a load generator for testing the performance of applications service data ingestion. I designed the configuration of the load generator such that we can configure it for a variety of scenarios that emulate various customers' configurations without too much repetition. For a simple traffic generation scenario, I have included a basic built-in configuration that can be activated via command line flag.

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

The generator is designed to connect to the event-gateway, so you will need to build the applications service and then start all services in the studio. After that, get a token in your shell with `T=$(get_api_token)`. Then:

* `hab pkg exec YOUR_ORIGIN/applications-service applications-load-gen describe -p components/applications-service/dev/applications-load-gen/noms.toml` -- this prints a description of what messages will be generated by the config file given. It looks like this:

```
Supervisor group: pos_terminals:production1
===========================================
- Simulated supervisors: 10
- Services per supervisor: 3

  - Package: noms/pos-service-1/20190415181629
  - Application: pos_terminal
  - Environment: production1
  - Channel: production1
  - Site: site1

  - Package: noms/pos-service-2/20190415181629
  - Application: pos_terminal
  - Environment: production1
  - Channel: production1
  - Site: site1

  - Package: noms/pos-service-3/20190415181629
  - Application: pos_terminal
  - Environment: production1
  - Channel: production1
  - Site: site1

Supervisor group: order_mgmt:production1
========================================
- Simulated supervisors: 10
- Services per supervisor: 3

  - Package: noms/om-service-1/20190415181629
  - Application: order_mgmt
  - Environment: production1
  - Channel: production1
  - Site: site1

  - Package: noms/om-service-2/20190415181629
  - Application: order_mgmt
  - Environment: production1
  - Channel: production1
  - Site: site1

  - Package: noms/om-service-3/20190415181629
  - Application: order_mgmt
  - Environment: production1
  - Channel: production1
  - Site: site1
```

* `hab pkg exec YOUR_ORIGIN/applications-service applications-load-gen run -p components/applications-service/dev/applications-load-gen/noms.toml -t $T` This prints the description and then every 30s should print a stats summary like:

```
Load Generator Statistics 2019-04-15T18:17:59Z
----------------------------------------------
Supervisors Running:          20
Supervisors Died:             0
Messages Sent    (lifetime):  180
Message Rate /s  (lifetime):  2.00 
Messages Sent    (last 30s):  60
Message Rate /s  (last 30s):  2.00
```

* If you `chef-automate dev enable-prometheus` you should see metrics that match what the load generator's stat's output say.

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?