### PR TITLE
Accept chef license for inspec 4 via ENV variable

### DIFF
--- a/components/compliance-service/compliance.go
+++ b/components/compliance-service/compliance.go
@@ -99,6 +99,11 @@ func runHungJobs(ctx context.Context, scheduledJobsIds []string, schedulerServer
 func initBits(ctx context.Context, conf *config.Compliance) (db *pgdb.DB, connFactory *secureconn.Factory, esr relaxting.ES2Backend, statusSrv *statusserver.Server, err error) {
 	statusSrv = statusserver.New()
 
+	err = inspec.AcceptInspecLicense()
+	if err != nil {
+		return db, connFactory, esr, statusSrv, err
+	}
+
 	statusserver.AddMigrationUpdate(statusSrv, statusserver.MigrationLabelPG, "Initializing DB connection and schema migration...")
 	// start pg backend
 	db, err = createPGBackend(&conf.Postgres)

--- a/components/compliance-service/inspec-agent/remote/remote.go
+++ b/components/compliance-service/inspec-agent/remote/remote.go
@@ -116,7 +116,7 @@ func assembleRemoteJobConfigAndScript(job *types.InspecJob) (string, string, err
 				fi
 				exit 0
 			}
-			echo '%s' | sudo inspec exec %s --json-config=-
+			echo '%s' | sudo CHEF_LICENSE="accept-no-persist" inspec exec %s --json-config=-
 
 			modify_exit_code $?`, string(jsonConf), profilesString), inspec.BashScript, nil
 	case inspec.BackendSSMWindows, inspec.BackendAZWindows:
@@ -137,6 +137,7 @@ func assembleRemoteJobConfigAndScript(job *types.InspecJob) (string, string, err
 						if($JsonConfig -ne $null) { $JsonArgument = '--json-config="-"' }
 						Invoke-Expression -Command "echo '$JsonConfig' | $InspecBinaryLocation.bat $Command $Path $JsonArgument".Trim()
 				}
+				$env:CHEF_LICENSE="accept-no-persist"
 				Ensure-InspecInstalled
 				Invoke-InspecCommand -Command exec -Path "%s" -JsonConfig '%s'`, profilesString, string(jsonConf)), inspec.PowershellScript, nil
 	}

--- a/components/compliance-service/inspec/cli.go
+++ b/components/compliance-service/inspec/cli.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -32,8 +32,9 @@ const logSensitiveData = false
 
 func inspecShimEnv() map[string]string {
 	return map[string]string{
-		"HOME":   TmpDir,
-		"TMPDIR": TmpDir,
+		"HOME":         TmpDir,
+		"TMPDIR":       TmpDir,
+		"CHEF_LICENSE": "accept-no-persist",
 	}
 }
 
@@ -43,6 +44,14 @@ func isTimeoutSane(timeout time.Duration, max time.Duration) error {
 	}
 	if timeout > max {
 		return errors.New(fmt.Sprintf("Timeouts of more than %s should not be set for the inspec cli.", max))
+	}
+	return nil
+}
+
+func AcceptInspecLicense() error {
+	err := os.Setenv("CHEF_LICENSE", "accept-no-persist")
+	if err != nil {
+		return errors.Wrap(err, "Unable to set CHEF_LICENSE env variable")
 	}
 	return nil
 }


### PR DESCRIPTION
Tested with `chef/inspec/4.1.3/20190417211329`
With this change, we use ENV variable `CHEF_LICENSE=accept-no-persist` to prevent inspec from prompting for chef license acceptance