### PR TITLE
List reports cleanup

### DIFF
--- a/components/compliance-service/ingest/pipeline/processor/reports_project_tagger_test.go
+++ b/components/compliance-service/ingest/pipeline/processor/reports_project_tagger_test.go
@@ -37,7 +37,7 @@ func TestReportProjectRulesMatching(t *testing.T) {
 			matching:    false,
 			report:      &relaxting.ESInSpecReport{},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{},
+				{},
 			},
 		},
 		// Environment
@@ -48,9 +48,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Environment: "production",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefEnvironmentsTag,
 							Values: []string{"production"},
 						},
@@ -65,9 +65,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Environment: "production",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefEnvironmentsTag,
 							Values: []string{"production", "dev"},
 						},
@@ -83,17 +83,17 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Roles:       []string{"south-side"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefEnvironmentsTag,
 							Values: []string{"production"},
 						},
 					},
 				},
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.RolesTag,
 							Values: []string{"north-side"},
 						},
@@ -109,13 +109,13 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Roles:       []string{"south-side"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefEnvironmentsTag,
 							Values: []string{"production"},
 						},
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.RolesTag,
 							Values: []string{"north-side"},
 						},
@@ -130,9 +130,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Environment: "Production",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefEnvironmentsTag,
 							Values: []string{"production"},
 						},
@@ -149,9 +149,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				OrganizationName: "org_1",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefOrgsTag,
 							Values: []string{"org_1"},
 						},
@@ -166,9 +166,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				OrganizationName: "Org_1",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefOrgsTag,
 							Values: []string{"org_1"},
 						},
@@ -183,9 +183,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				OrganizationName: "org_1",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefOrgsTag,
 							Values: []string{"org_2"},
 						},
@@ -200,9 +200,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				OrganizationName: "org_1",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefOrgsTag,
 							Values: []string{"org_1", "org_2"},
 						},
@@ -219,9 +219,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				SourceFQDN: "chef_server_1",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefServersTag,
 							Values: []string{"chef_server_1"},
 						},
@@ -236,9 +236,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				SourceFQDN: "Chef_server_1",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefServersTag,
 							Values: []string{"chef_server_1"},
 						},
@@ -253,9 +253,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				SourceFQDN: "Chef_server_2",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefServersTag,
 							Values: []string{"chef_server_1"},
 						},
@@ -270,9 +270,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				SourceFQDN: "chef_server_1",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefServersTag,
 							Values: []string{"chef_server_1", "chef_server_2"},
 						},
@@ -289,9 +289,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Roles: []string{"area_51"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.RolesTag,
 							Values: []string{"area_51"},
 						},
@@ -306,9 +306,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Roles: []string{"area_51", "vandenberg", "hunter army airfield"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.RolesTag,
 							Values: []string{"area_51"},
 						},
@@ -323,17 +323,17 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Roles: []string{"area_51", "vandenberg", "hunter army airfield"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.RolesTag,
 							Values: []string{"area_51"},
 						},
 					},
 				},
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.RolesTag,
 							Values: []string{"area_54"},
 						},
@@ -348,9 +348,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Roles: []string{"area_51", "vandenberg", "hunter army airfield"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.RolesTag,
 							Values: []string{"area_51", "area_54"},
 						},
@@ -365,13 +365,13 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Roles: []string{"area_51", "vandenberg", "hunter army airfield"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.RolesTag,
 							Values: []string{"area_51"},
 						},
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.RolesTag,
 							Values: []string{"area_54"},
 						},
@@ -386,9 +386,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Roles: []string{"AREA_51"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.RolesTag,
 							Values: []string{"area_51"},
 						},
@@ -403,9 +403,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Roles: []string{"area_52"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.RolesTag,
 							Values: []string{"area_51"},
 						},
@@ -420,9 +420,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Roles: []string{"area_52"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.RolesTag,
 							Values: []string{"area_51", "area_52"},
 						},
@@ -438,13 +438,13 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				Roles:       []string{"area_52", "area_49"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.RolesTag,
 							Values: []string{"area_52"},
 						},
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefEnvironmentsTag,
 							Values: []string{"production"},
 						},
@@ -462,9 +462,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				ChefTags:    []string{"area_51"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefTagsTag,
 							Values: []string{"area_51"},
 						},
@@ -480,9 +480,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				ChefTags:    []string{"area_51", "vandenberg", "hunter army airfield"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefTagsTag,
 							Values: []string{"area_51"},
 						},
@@ -498,9 +498,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				ChefTags:    []string{"AREA_51"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefTagsTag,
 							Values: []string{"area_51"},
 						},
@@ -515,9 +515,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				ChefTags: []string{"area_52"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefTagsTag,
 							Values: []string{"area_51"},
 						},
@@ -532,9 +532,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				ChefTags: []string{"area_52"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefTagsTag,
 							Values: []string{"area_51", "area_52"},
 						},
@@ -549,9 +549,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				ChefTags: []string{"area_52", "vandenberg", "hunter army airfield"},
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefTagsTag,
 							Values: []string{"area_51", "area_52"},
 						},
@@ -567,17 +567,17 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				OrganizationName: "org_1",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefTagsTag,
 							Values: []string{"area_52"},
 						},
 					},
 				},
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefOrgsTag,
 							Values: []string{"org_1"},
 						},
@@ -593,17 +593,17 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				OrganizationName: "org_2",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefTagsTag,
 							Values: []string{"area_52"},
 						},
 					},
 				},
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefOrgsTag,
 							Values: []string{"org_1"},
 						},
@@ -620,9 +620,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				PolicyGroup: "PolicyGroup",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.PolicyGroupTag,
 							Values: []string{"PolicyGroup"},
 						},
@@ -637,9 +637,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				PolicyGroup: "PolicyGroup",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.PolicyGroupTag,
 							Values: []string{"policygroup"},
 						},
@@ -654,9 +654,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				PolicyGroup: "PolicyGroup",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.PolicyGroupTag,
 							Values: []string{"area_51"},
 						},
@@ -671,9 +671,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				PolicyGroup: "area_52",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.PolicyGroupTag,
 							Values: []string{"area_51", "area_52"},
 						},
@@ -689,17 +689,17 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				OrganizationName: "org_1",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.PolicyGroupTag,
 							Values: []string{"area_52"},
 						},
 					},
 				},
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefOrgsTag,
 							Values: []string{"org_1"},
 						},
@@ -715,17 +715,17 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				OrganizationName: "org_2",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.PolicyGroupTag,
 							Values: []string{"area_52"},
 						},
 					},
 				},
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefOrgsTag,
 							Values: []string{"org_1"},
 						},
@@ -742,9 +742,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				PolicyName: "PolicyName",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.PolicyNameTag,
 							Values: []string{"PolicyName"},
 						},
@@ -759,9 +759,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				PolicyName: "PolicyGroup",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.PolicyNameTag,
 							Values: []string{"policygroup"},
 						},
@@ -776,9 +776,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				PolicyName: "area_52",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.PolicyNameTag,
 							Values: []string{"area_51"},
 						},
@@ -793,9 +793,9 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				PolicyName: "area_52",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.PolicyNameTag,
 							Values: []string{"area_51", "area_52"},
 						},
@@ -811,17 +811,17 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				OrganizationName: "org_1",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.PolicyNameTag,
 							Values: []string{"area_52"},
 						},
 					},
 				},
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefOrgsTag,
 							Values: []string{"org_1"},
 						},
@@ -837,17 +837,17 @@ func TestReportProjectRulesMatching(t *testing.T) {
 				OrganizationName: "org_2",
 			},
 			rules: []*iam_v2.ProjectRule{
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.PolicyNameTag,
 							Values: []string{"area_52"},
 						},
 					},
 				},
-				&iam_v2.ProjectRule{
+				{
 					Conditions: []*iam_v2.Condition{
-						&iam_v2.Condition{
+						{
 							Type:   rules_tags.ChefOrgsTag,
 							Values: []string{"org_1"},
 						},
@@ -911,9 +911,9 @@ func TestBundlerMatchProjectRule(t *testing.T) {
 	projectRules := map[string]*iam_v2.ProjectRules{}
 	projectRules[testProjectName] = &iam_v2.ProjectRules{
 		Rules: []*iam_v2.ProjectRule{
-			&iam_v2.ProjectRule{
+			{
 				Conditions: []*iam_v2.Condition{
-					&iam_v2.Condition{
+					{
 						Type:   rules_tags.ChefEnvironmentsTag,
 						Values: []string{environmentsName},
 					},
@@ -967,9 +967,9 @@ func TestBundlerWithScanJobReport(t *testing.T) {
 	projectRules := map[string]*iam_v2.ProjectRules{}
 	projectRules[testProjectName] = &iam_v2.ProjectRules{
 		Rules: []*iam_v2.ProjectRule{
-			&iam_v2.ProjectRule{
+			{
 				Conditions: []*iam_v2.Condition{
-					&iam_v2.Condition{
+					{
 						Type:   rules_tags.ChefEnvironmentsTag,
 						Values: []string{environmentsName},
 					},

--- a/components/compliance-service/ingest/projectupdater/manager.go
+++ b/components/compliance-service/ingest/projectupdater/manager.go
@@ -194,12 +194,12 @@ func (manager *Manager) sendFaildEvent(msg string, projectUpdateID string) {
 		},
 		Data: &_struct.Struct{
 			Fields: map[string]*_struct.Value{
-				project_update_tags.ProjectUpdateIDTag: &_struct.Value{
+				project_update_tags.ProjectUpdateIDTag: {
 					Kind: &_struct.Value_StringValue{
 						StringValue: projectUpdateID,
 					},
 				},
-				"message": &_struct.Value{
+				"message": {
 					Kind: &_struct.Value_StringValue{
 						StringValue: msg,
 					},
@@ -226,22 +226,22 @@ func (manager *Manager) sendStatusEvent(jobStatus ingestic.JobStatus) {
 		},
 		Data: &_struct.Struct{
 			Fields: map[string]*_struct.Value{
-				"Completed": &_struct.Value{
+				"Completed": {
 					Kind: &_struct.Value_BoolValue{
 						BoolValue: jobStatus.Completed,
 					},
 				},
-				"PercentageComplete": &_struct.Value{
+				"PercentageComplete": {
 					Kind: &_struct.Value_NumberValue{
 						NumberValue: float64(jobStatus.PercentageComplete),
 					},
 				},
-				"EstimatedTimeCompeleteInSec": &_struct.Value{
+				"EstimatedTimeCompeleteInSec": {
 					Kind: &_struct.Value_NumberValue{
 						NumberValue: float64(jobStatus.EstimatedEndTimeInSec),
 					},
 				},
-				project_update_tags.ProjectUpdateIDTag: &_struct.Value{
+				project_update_tags.ProjectUpdateIDTag: {
 					Kind: &_struct.Value_StringValue{
 						StringValue: manager.projectUpdateID,
 					},

--- a/components/compliance-service/integration_test/reporting_server_list_reports_test.go
+++ b/components/compliance-service/integration_test/reporting_server_list_reports_test.go
@@ -48,7 +48,7 @@ func TestListReports(t *testing.T) {
 	}{
 		{
 			description:     "Projects: user has access to all projects",
-			allowedProjects: []string{"*"},
+			allowedProjects: []string{authzConstants.AllProjectsExternalID},
 			expectedIds:     reportIds,
 		},
 		{

--- a/components/compliance-service/integration_test/reporting_server_read_report_test.go
+++ b/components/compliance-service/integration_test/reporting_server_read_report_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	authzConstants "github.com/chef/automate/components/authz-service/constants/v2"
 	"github.com/chef/automate/components/compliance-service/api/reporting"
 	reportingServer "github.com/chef/automate/components/compliance-service/api/reporting/server"
 	"github.com/chef/automate/components/compliance-service/reporting/relaxting"
@@ -36,7 +37,7 @@ func TestReadReport(t *testing.T) {
 	}{
 		{
 			description:     "Projects: user has access to all projects",
-			allowedProjects: []string{"*"},
+			allowedProjects: []string{authzConstants.AllProjectsExternalID},
 			expectedId:      reportId,
 		},
 		{

--- a/components/compliance-service/integration_test/reports_projects_update_test.go
+++ b/components/compliance-service/integration_test/reports_projects_update_test.go
@@ -42,11 +42,11 @@ func TestProjectUpdate(t *testing.T) {
 				Projects:    []string{"old_tag"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefEnvironmentsTag,
 									Values: []string{"env1"},
 								},
@@ -68,11 +68,11 @@ func TestProjectUpdate(t *testing.T) {
 				Projects:    []string{"old_tag"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefEnvironmentsTag,
 									Values: []string{"env1", "env2"},
 								},
@@ -96,15 +96,15 @@ func TestProjectUpdate(t *testing.T) {
 				Roles:       []string{"backend"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefEnvironmentsTag,
 									Values: []string{"env1"},
 								},
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.RolesTag,
 									Values: []string{"backend"},
 								},
@@ -128,15 +128,15 @@ func TestProjectUpdate(t *testing.T) {
 				Roles:       []string{"backend"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefEnvironmentsTag,
 									Values: []string{"env1"},
 								},
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.RolesTag,
 									Values: []string{"frontend"},
 								},
@@ -158,19 +158,19 @@ func TestProjectUpdate(t *testing.T) {
 				Projects:    []string{"old_tag"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefEnvironmentsTag,
 									Values: []string{"env2"},
 								},
 							},
 						},
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefEnvironmentsTag,
 									Values: []string{"env1"},
 								},
@@ -192,11 +192,11 @@ func TestProjectUpdate(t *testing.T) {
 				Projects:    []string{"old_tag"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefEnvironmentsTag,
 									Values: []string{"env2"},
 								},
@@ -204,11 +204,11 @@ func TestProjectUpdate(t *testing.T) {
 						},
 					},
 				},
-				"project3": &iam_v2.ProjectRules{
+				"project3": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefEnvironmentsTag,
 									Values: []string{"env1"},
 								},
@@ -232,11 +232,11 @@ func TestProjectUpdate(t *testing.T) {
 				Roles:       []string{"backend"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.RolesTag,
 									Values: []string{"backend"},
 								},
@@ -244,11 +244,11 @@ func TestProjectUpdate(t *testing.T) {
 						},
 					},
 				},
-				"project3": &iam_v2.ProjectRules{
+				"project3": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefEnvironmentsTag,
 									Values: []string{"env1"},
 								},
@@ -272,11 +272,11 @@ func TestProjectUpdate(t *testing.T) {
 				Roles:    []string{"area_51"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.RolesTag,
 									Values: []string{"area_51"},
 								},
@@ -298,11 +298,11 @@ func TestProjectUpdate(t *testing.T) {
 				Roles:    []string{"area_51"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.RolesTag,
 									Values: []string{"area_52"},
 								},
@@ -324,11 +324,11 @@ func TestProjectUpdate(t *testing.T) {
 				Roles:    []string{"Area_51"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.RolesTag,
 									Values: []string{"area_51"},
 								},
@@ -350,11 +350,11 @@ func TestProjectUpdate(t *testing.T) {
 				Roles:    []string{"area_51"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.RolesTag,
 									Values: []string{"area_51", "area_52"},
 								},
@@ -376,11 +376,11 @@ func TestProjectUpdate(t *testing.T) {
 				Roles:    []string{"area_51", "area_52", "area_53"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.RolesTag,
 									Values: []string{"area_51"},
 								},
@@ -402,11 +402,11 @@ func TestProjectUpdate(t *testing.T) {
 				Roles:    []string{"area_51", "area_52", "area_53"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.RolesTag,
 									Values: []string{"area_54"},
 								},
@@ -430,11 +430,11 @@ func TestProjectUpdate(t *testing.T) {
 				SourceFQDN: "chef-server.org",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefServersTag,
 									Values: []string{"chef-server.org"},
 								},
@@ -456,11 +456,11 @@ func TestProjectUpdate(t *testing.T) {
 				SourceFQDN: "chef-server2.org",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefServersTag,
 									Values: []string{"chef-server.org"},
 								},
@@ -482,11 +482,11 @@ func TestProjectUpdate(t *testing.T) {
 				SourceFQDN: "Chef-server.org",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefServersTag,
 									Values: []string{"chef-server.org"},
 								},
@@ -508,11 +508,11 @@ func TestProjectUpdate(t *testing.T) {
 				SourceFQDN: "chef-server.org",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefServersTag,
 									Values: []string{"chef-server.org", "chef-server2.org"},
 								},
@@ -536,19 +536,19 @@ func TestProjectUpdate(t *testing.T) {
 				OrganizationName: "org1",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefServersTag,
 									Values: []string{"chef-server.org"},
 								},
 							},
 						},
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefOrgsTag,
 									Values: []string{"org1"},
 								},
@@ -572,19 +572,19 @@ func TestProjectUpdate(t *testing.T) {
 				OrganizationName: "org1",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefServersTag,
 									Values: []string{"chef-server2.org"},
 								},
 							},
 						},
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefOrgsTag,
 									Values: []string{"org1"},
 								},
@@ -608,11 +608,11 @@ func TestProjectUpdate(t *testing.T) {
 				OrganizationName: "org1",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefOrgsTag,
 									Values: []string{"org1"},
 								},
@@ -634,11 +634,11 @@ func TestProjectUpdate(t *testing.T) {
 				OrganizationName: "org1",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefOrgsTag,
 									Values: []string{"org2"},
 								},
@@ -660,11 +660,11 @@ func TestProjectUpdate(t *testing.T) {
 				OrganizationName: "org1",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"old_tag": &iam_v2.ProjectRules{
+				"old_tag": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefOrgsTag,
 									Values: []string{"org1"},
 								},
@@ -688,11 +688,11 @@ func TestProjectUpdate(t *testing.T) {
 				PolicyGroup: "prod",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.PolicyGroupTag,
 									Values: []string{"prod"},
 								},
@@ -714,11 +714,11 @@ func TestProjectUpdate(t *testing.T) {
 				PolicyGroup: "prod",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.PolicyGroupTag,
 									Values: []string{"dev"},
 								},
@@ -740,11 +740,11 @@ func TestProjectUpdate(t *testing.T) {
 				PolicyGroup: "prod",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.PolicyGroupTag,
 									Values: []string{"Prod"},
 								},
@@ -766,11 +766,11 @@ func TestProjectUpdate(t *testing.T) {
 				PolicyGroup: "prod",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.PolicyGroupTag,
 									Values: []string{"prod", "dev"},
 								},
@@ -794,19 +794,19 @@ func TestProjectUpdate(t *testing.T) {
 				OrganizationName: "org1",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.PolicyGroupTag,
 									Values: []string{"prod"},
 								},
 							},
 						},
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefOrgsTag,
 									Values: []string{"org1"},
 								},
@@ -830,19 +830,19 @@ func TestProjectUpdate(t *testing.T) {
 				OrganizationName: "org1",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.PolicyGroupTag,
 									Values: []string{"dev"},
 								},
 							},
 						},
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefOrgsTag,
 									Values: []string{"org1"},
 								},
@@ -866,11 +866,11 @@ func TestProjectUpdate(t *testing.T) {
 				PolicyName: "prod",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.PolicyNameTag,
 									Values: []string{"prod"},
 								},
@@ -892,11 +892,11 @@ func TestProjectUpdate(t *testing.T) {
 				PolicyName: "prod",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.PolicyNameTag,
 									Values: []string{"dev"},
 								},
@@ -918,11 +918,11 @@ func TestProjectUpdate(t *testing.T) {
 				PolicyName: "prod",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.PolicyNameTag,
 									Values: []string{"Prod"},
 								},
@@ -944,11 +944,11 @@ func TestProjectUpdate(t *testing.T) {
 				PolicyName: "prod",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.PolicyNameTag,
 									Values: []string{"prod", "dev"},
 								},
@@ -972,19 +972,19 @@ func TestProjectUpdate(t *testing.T) {
 				OrganizationName: "org1",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.PolicyNameTag,
 									Values: []string{"prod"},
 								},
 							},
 						},
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefOrgsTag,
 									Values: []string{"org1"},
 								},
@@ -1008,15 +1008,15 @@ func TestProjectUpdate(t *testing.T) {
 				OrganizationName: "org1",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.PolicyNameTag,
 									Values: []string{"dev"},
 								},
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefOrgsTag,
 									Values: []string{"org1"},
 								},
@@ -1040,11 +1040,11 @@ func TestProjectUpdate(t *testing.T) {
 				ChefTags: []string{"area_51"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefTagsTag,
 									Values: []string{"area_51"},
 								},
@@ -1066,11 +1066,11 @@ func TestProjectUpdate(t *testing.T) {
 				ChefTags: []string{"area_51"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefTagsTag,
 									Values: []string{"area_52"},
 								},
@@ -1092,11 +1092,11 @@ func TestProjectUpdate(t *testing.T) {
 				ChefTags: []string{"Area_51"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefTagsTag,
 									Values: []string{"area_51"},
 								},
@@ -1118,11 +1118,11 @@ func TestProjectUpdate(t *testing.T) {
 				ChefTags: []string{"area_51"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefTagsTag,
 									Values: []string{"area_51", "area_52"},
 								},
@@ -1146,19 +1146,19 @@ func TestProjectUpdate(t *testing.T) {
 				OrganizationName: "org1",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefTagsTag,
 									Values: []string{"area_51"},
 								},
 							},
 						},
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefOrgsTag,
 									Values: []string{"org1"},
 								},
@@ -1182,19 +1182,19 @@ func TestProjectUpdate(t *testing.T) {
 				OrganizationName: "org1",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefTagsTag,
 									Values: []string{"area_51"},
 								},
 							},
 						},
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefOrgsTag,
 									Values: []string{"org2"},
 								},
@@ -1218,15 +1218,15 @@ func TestProjectUpdate(t *testing.T) {
 				OrganizationName: "org1",
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefTagsTag,
 									Values: []string{"area_51"},
 								},
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefOrgsTag,
 									Values: []string{"org2"},
 								},
@@ -1248,11 +1248,11 @@ func TestProjectUpdate(t *testing.T) {
 				ChefTags: []string{"area_51", "area_52", "area_53"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefTagsTag,
 									Values: []string{"area_51"},
 								},
@@ -1274,11 +1274,11 @@ func TestProjectUpdate(t *testing.T) {
 				ChefTags: []string{"area_51", "area_52", "area_53"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
-				"project9": &iam_v2.ProjectRules{
+				"project9": {
 					Rules: []*iam_v2.ProjectRule{
-						&iam_v2.ProjectRule{
+						{
 							Conditions: []*iam_v2.Condition{
-								&iam_v2.Condition{
+								{
 									Type:   rules_tags.ChefTagsTag,
 									Values: []string{"area_54"},
 								},
@@ -1359,7 +1359,7 @@ func TestErrorWhenProjectUpdateIDNotSent(t *testing.T) {
 		Published: ptypes.TimestampNow(),
 		Data: &_struct.Struct{
 			Fields: map[string]*_struct.Value{
-				project_update_tags.ProjectUpdateIDTag: &_struct.Value{
+				project_update_tags.ProjectUpdateIDTag: {
 					Kind: &_struct.Value_StringValue{
 						StringValue: "",
 					},
@@ -1387,7 +1387,7 @@ func TestStartProjectUpdateWhenIDIsSent(t *testing.T) {
 		Published: ptypes.TimestampNow(),
 		Data: &_struct.Struct{
 			Fields: map[string]*_struct.Value{
-				project_update_tags.ProjectUpdateIDTag: &_struct.Value{
+				project_update_tags.ProjectUpdateIDTag: {
 					Kind: &_struct.Value_StringValue{
 						StringValue: "TestNoErrorWhenProjectUpdateIDIsSent",
 					},
@@ -1429,7 +1429,7 @@ func TestTwoUpdateSameTimeFailureEvent(t *testing.T) {
 		Published: ptypes.TimestampNow(),
 		Data: &_struct.Struct{
 			Fields: map[string]*_struct.Value{
-				project_update_tags.ProjectUpdateIDTag: &_struct.Value{
+				project_update_tags.ProjectUpdateIDTag: {
 					Kind: &_struct.Value_StringValue{
 						StringValue: "one",
 					},
@@ -1450,7 +1450,7 @@ func TestTwoUpdateSameTimeFailureEvent(t *testing.T) {
 		Published: ptypes.TimestampNow(),
 		Data: &_struct.Struct{
 			Fields: map[string]*_struct.Value{
-				project_update_tags.ProjectUpdateIDTag: &_struct.Value{
+				project_update_tags.ProjectUpdateIDTag: {
 					Kind: &_struct.Value_StringValue{
 						StringValue: "two",
 					},

--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -700,30 +700,25 @@ func (backend *ES2Backend) GetReport(esIndex string, reportId string,
 //             latestOnly - specifies whether or not we are only interested in retrieving only the latest report
 //  return *elastic.BoolQuery
 func (backend ES2Backend) getFiltersQuery(filters map[string][]string, latestOnly bool) *elastic.BoolQuery {
-	var (
-		endTime   string
-		startTime string
-	)
-
 	utils.DeDupFilters(filters)
 
 	typeQuery := elastic.NewTypeQuery(mappings.DocType)
 
-	endTime = firstOrEmpty(filters["end_time"])
-	startTime = firstOrEmpty(filters["start_time"])
-
-	timeRangeQuery := elastic.NewRangeQuery("end_time")
-	if len(startTime) > 0 {
-		timeRangeQuery.Gte(startTime)
-	}
-	if len(endTime) > 0 {
-		timeRangeQuery.Lte(endTime)
-	}
-
 	boolQuery := elastic.NewBoolQuery()
 	boolQuery = boolQuery.Must(typeQuery)
 
-	if len(startTime) > 0 || len(endTime) > 0 {
+	if len(filters["start_time"]) > 0 || len(filters["end_time"]) > 0 {
+		endTime := firstOrEmpty(filters["end_time"])
+		startTime := firstOrEmpty(filters["start_time"])
+
+		timeRangeQuery := elastic.NewRangeQuery("end_time")
+		if len(startTime) > 0 {
+			timeRangeQuery.Gte(startTime)
+		}
+		if len(endTime) > 0 {
+			timeRangeQuery.Lte(endTime)
+		}
+
 		boolQuery = boolQuery.Must(timeRangeQuery)
 	}
 


### PR DESCRIPTION
Some tangentially related changes I had made in #53 but didn't include for clarity.

* I ran `gofmt -s -w -l` on `compliance-service`. Our linter has simplification turned off for some reason (that's the `-s`), even though `make lint` tells you to run it:
    ```
    reporting/relaxting/reports.go:711: File is not `gofmt`-ed with `-s` (gofmt)
    ```
* I rearranged some code in the report filtering to make it more clear where some values are used.
* After our meeting this morning I realized I was embedding the special value `*` in some tests, so I replaced that with the constant from `authz_service`