### PR TITLE
[UI] Fixes Unknown service-group status/table

### DIFF
--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
@@ -75,7 +75,7 @@ chef-td {
     }
 
     &.UNKNOWN {
-      color: $chef-primary;
+      color: $chef-dark-grey;
     }
 
     &.CRITICAL {
@@ -107,7 +107,7 @@ chef-td {
     }
 
     &.UNKNOWN {
-      background: $chef-primary;
+      background: $chef-dark-grey;
     }
 
     &.CRITICAL {
@@ -147,7 +147,7 @@ chef-tr.row {
   }
 
   &>chef-td.UNKNOWN:first-child:before {
-    background: $chef-primary;
+    background: $chef-dark-grey;
   }
 
   &>chef-td.CRITICAL:first-child:before {

--- a/components/automate-ui/src/app/pipes/service-status-icon.pipe.spec.ts
+++ b/components/automate-ui/src/app/pipes/service-status-icon.pipe.spec.ts
@@ -14,8 +14,8 @@ describe('ServiceStatusIconPipe', () => {
       expect(pipe.transform('CRITICAL')).toEqual('warning');
     });
 
-    it('should convert unknown to warning', () => {
-      expect(pipe.transform('UNKNOWN')).toEqual('warning');
+    it('should convert unknown to help', () => {
+      expect(pipe.transform('UNKNOWN')).toEqual('help');
     });
 
     it('should convert missing to help', () => {

--- a/components/automate-ui/src/app/pipes/service-status-icon.pipe.ts
+++ b/components/automate-ui/src/app/pipes/service-status-icon.pipe.ts
@@ -11,9 +11,9 @@ export class ServiceStatusIconPipe implements PipeTransform {
         return 'check_circle';
 
       case 'CRITICAL':
-      case 'UNKNOWN':
         return 'warning';
 
+      case 'UNKNOWN':
       case 'DEPLOYING':
         return 'help';
 


### PR DESCRIPTION
Quick color and icon fix for the service-groups table:

## Check the UNKNOWN row!! `sample-app.acceptance`

**Before:**
<img width="1015" alt="before" src="https://user-images.githubusercontent.com/5712253/56250700-19657e00-6076-11e9-80fc-8cb6c65eeb4b.png">

**After:**

<img width="1018" alt="after" src="https://user-images.githubusercontent.com/5712253/56250633-cd1a3e00-6075-11e9-82fd-fe1a813895ac.png">

Signed-off-by: Salim Afiune <afiune@chef.io>
