### PR TITLE
Support for unassigned reports in reporting server GetReport endpoint

### DIFF
--- a/components/compliance-service/integration_test/reporting_server_read_report_test.go
+++ b/components/compliance-service/integration_test/reporting_server_read_report_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,14 +10,7 @@ import (
 	"github.com/chef/automate/components/compliance-service/api/reporting"
 	reportingServer "github.com/chef/automate/components/compliance-service/api/reporting/server"
 	"github.com/chef/automate/components/compliance-service/reporting/relaxting"
-	"github.com/chef/automate/lib/grpc/auth_context"
 )
-
-// TODO: Move this function
-func contextWithProjects(projects []string) context.Context {
-	ctx := context.Background()
-	return auth_context.NewContext(ctx, []string{}, projects, "", "", "")
-}
 
 func TestReadReport(t *testing.T) {
 	server := reportingServer.New(&relaxting.ES2Backend{ESUrl: elasticsearchUrl})

--- a/components/compliance-service/integration_test/reporting_server_read_report_test.go
+++ b/components/compliance-service/integration_test/reporting_server_read_report_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chef/automate/lib/grpc/auth_context"
 )
 
+// TODO: Move this function
 func contextWithProjects(projects []string) context.Context {
 	ctx := context.Background()
 	return auth_context.NewContext(ctx, []string{}, projects, "", "", "")
@@ -21,34 +22,52 @@ func contextWithProjects(projects []string) context.Context {
 
 func TestReadReport(t *testing.T) {
 	server := reportingServer.New(&relaxting.ES2Backend{ESUrl: elasticsearchUrl})
-	report := relaxting.ESInSpecReport{Projects: []string{"project1", "project2"}}
-	reportIds := suite.InsertInspecReports([]*relaxting.ESInSpecReport{&report})
+	reports := []*relaxting.ESInSpecReport{
+		{
+			Projects: []string{},
+		},
+		{
+			Projects: []string{"project1", "project2"},
+		},
+	}
+	reportIds := suite.InsertInspecReports(reports)
 
 	defer suite.DeleteAllDocuments()
 
-	require.Len(t, reportIds, 1)
+	require.Len(t, reportIds, 2)
 
-	reportId := reportIds[0]
+	unassignedReportId := reportIds[0]
+	assignedReportId := reportIds[1]
 
 	successCases := []struct {
 		description     string
 		allowedProjects []string
-		expectedId      string
+		reportId        string
 	}{
 		{
-			description:     "Projects: user has access to all projects",
+			description:     "Projects: user has access to all projects accessing an assigned report",
 			allowedProjects: []string{authzConstants.AllProjectsExternalID},
-			expectedId:      reportId,
+			reportId:        assignedReportId,
 		},
 		{
-			description:     "Projects: user has access to all projects a report belongs to",
+			description:     "Projects: user has access to all projects accessing an unassigned report",
+			allowedProjects: []string{authzConstants.AllProjectsExternalID},
+			reportId:        unassignedReportId,
+		},
+		{
+			description:     "Projects: user has access to all projects a report belongs to acessing an assigned report",
 			allowedProjects: []string{"project1", "project2"},
-			expectedId:      reportId,
+			reportId:        assignedReportId,
 		},
 		{
-			description:     "Projects: user has access to one project a report belongs to",
-			allowedProjects: []string{"project1"},
-			expectedId:      reportId,
+			description:     "Projects: user has access to some projects a report belongs to accessing an assigned report",
+			allowedProjects: []string{"project1", "project3"},
+			reportId:        assignedReportId,
+		},
+		{
+			description:     "Projects: user has access to unassigned reports accessing an unassigned report",
+			allowedProjects: []string{"project1", authzConstants.UnassignedProjectID},
+			reportId:        unassignedReportId,
 		},
 	}
 
@@ -56,22 +75,44 @@ func TestReadReport(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			ctx := contextWithProjects(test.allowedProjects)
 
-			response, err := server.ReadReport(ctx, &reporting.Query{Id: reportId})
+			response, err := server.ReadReport(ctx, &reporting.Query{Id: test.reportId})
 
 			assert.NoError(t, err)
 			require.NotNil(t, response)
-			assert.Equal(t, test.expectedId, response.Id)
+			assert.Equal(t, test.reportId, response.Id)
 		})
 	}
 
-	description := "Projects: user does not have access to any projects a report belongs to"
-	allowedProjects := []string{"project3"}
-	t.Run(description, func(t *testing.T) {
-		ctx := contextWithProjects(allowedProjects)
+	failureCases := []struct {
+		description     string
+		allowedProjects []string
+		reportId        string
+	}{
+		{
+			description:     "Projects: user does not have access to any projects an assigned report belongs to",
+			allowedProjects: []string{"project3"},
+			reportId:        assignedReportId,
+		},
+		{
+			description:     "Projects: user with unassigned access accessing an assigned report",
+			allowedProjects: []string{authzConstants.UnassignedProjectID},
+			reportId:        assignedReportId,
+		},
+		{
+			description:     "Projects: user without unassigned access accessing an unassinged report",
+			allowedProjects: []string{"project1"},
+			reportId:        unassignedReportId,
+		},
+	}
 
-		response, err := server.ReadReport(ctx, &reporting.Query{Id: reportId})
+	for _, test := range failureCases {
+		t.Run(test.description, func(t *testing.T) {
+			ctx := contextWithProjects(test.allowedProjects)
 
-		assert.Error(t, err)
-		assert.Nil(t, response)
-	})
+			response, err := server.ReadReport(ctx, &reporting.Query{Id: test.reportId})
+
+			assert.Error(t, err)
+			assert.Nil(t, response)
+		})
+	}
 }

--- a/components/compliance-service/integration_test/suite_test.go
+++ b/components/compliance-service/integration_test/suite_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/chef/automate/components/nodemanager-service/api/manager"
 	nodes "github.com/chef/automate/components/nodemanager-service/api/nodes"
 	notifications "github.com/chef/automate/components/notifications-client/api"
+	"github.com/chef/automate/lib/grpc/auth_context"
+
 	"github.com/golang/mock/gomock"
 	empty "github.com/golang/protobuf/ptypes/empty"
 	"github.com/olivere/elastic"
@@ -445,4 +447,9 @@ func (nm *NodeManagerMock) GetNodeWithSecrets(ctx context.Context, in *manager.I
 func (nm *NodeManagerMock) SearchManagerNodes(ctx context.Context, in *manager.NodeQuery,
 	opts ...grpc.CallOption) (*manager.ManagerNodes, error) {
 	return &manager.ManagerNodes{}, nil
+}
+
+func contextWithProjects(projects []string) context.Context {
+	ctx := context.Background()
+	return auth_context.NewContext(ctx, []string{}, projects, "", "", "")
 }


### PR DESCRIPTION
Followup to #23 and #53. ~~Branched from #97 so that code is in here as well.~~

This updates the project work the GetReport endpoing in reporting server to handle access to unassigned reports as detailed in #66.