### PR TITLE
[deployment] Don't run GC when stopping services

### DIFF
--- a/components/automate-deployment/pkg/converge/stop_mitigation.go
+++ b/components/automate-deployment/pkg/converge/stop_mitigation.go
@@ -81,7 +81,7 @@ func (r *safeServiceShutdownRunner) RunIfRequired(t target.Target, pkg habpkg.Ve
 	if !required {
 		return nil
 	}
-	logrus.Info("Restart mitigation is required.")
+	logrus.Infof("Restart mitigation is required for service %s", pkg.Name())
 	return r.run(t, pkg)
 }
 
@@ -116,7 +116,7 @@ func (r *safeServiceShutdownRunner) run(t target.Target, pkg habpkg.VersionedPac
 			logrus.WithError(err).Warn("Some reverse dependencies failed to stop")
 		}
 	}
-
+	logrus.Infof("Restart mitigation for service %s complete", pkg.Name())
 	return nil
 }
 

--- a/components/automate-deployment/pkg/depot/garbage_collect.go
+++ b/components/automate-deployment/pkg/depot/garbage_collect.go
@@ -7,6 +7,12 @@ import (
 	"github.com/chef/automate/components/automate-deployment/pkg/habpkg"
 )
 
+const (
+	ConservativeGC = "conservative"
+	AggressiveGC   = "aggressive"
+	DisabledGC     = "disabled"
+)
+
 // TODO(jaym): I'm not sure what to call this thing
 type HabCache interface {
 	TDepsForPackage(habpkg.VersionedPackage) ([]habpkg.HabPkg, error)
@@ -26,11 +32,11 @@ func NewGarbageCollector(cache HabCache) *GarbageCollector {
 
 func (gc *GarbageCollector) Collect(roots []habpkg.HabPkg, cleanupMode string) error {
 	switch cleanupMode {
-	case "conservative":
+	case ConservativeGC:
 		return gc.ConservativeCollect(roots)
-	case "aggressive":
+	case AggressiveGC:
 		return gc.AggressiveCollect(roots)
-	case "disabled":
+	case DisabledGC:
 		return nil
 	default:
 		return errors.Errorf("invalid package cleanup mode %q given to gc.Collect()", cleanupMode)
@@ -84,7 +90,7 @@ func (gc *GarbageCollector) ConservativeCollect(rootPackages []habpkg.HabPkg) er
 	if len(pkgsToDelete) > 0 {
 		logrus.WithFields(logrus.Fields{
 			"roots": rootPackages,
-			"mode":  "conservative",
+			"mode":  ConservativeGC,
 		}).Info("Cleaning up unused packages")
 	}
 
@@ -138,7 +144,7 @@ func (gc *GarbageCollector) AggressiveCollect(roots []habpkg.HabPkg) error {
 			if !loggedOnce {
 				logrus.WithFields(logrus.Fields{
 					"roots": roots,
-					"mode":  "aggressive",
+					"mode":  AggressiveGC,
 				}).Info("Cleaning up unused packages")
 				loggedOnce = true
 			}

--- a/components/automate-deployment/pkg/server/restart.go
+++ b/components/automate-deployment/pkg/server/restart.go
@@ -11,6 +11,7 @@ import (
 	api "github.com/chef/automate/api/interservice/deployment"
 	"github.com/chef/automate/components/automate-deployment/pkg/converge"
 	"github.com/chef/automate/components/automate-deployment/pkg/deployment"
+	"github.com/chef/automate/components/automate-deployment/pkg/depot"
 	"github.com/chef/automate/components/automate-deployment/pkg/target"
 )
 
@@ -151,6 +152,6 @@ func (s *server) buildStopDesiredState() (converge.DesiredState, []string) {
 	return converge.NewDesiredState(topology,
 			converge.NewSkipSupervisorState(),
 			s.deployment.CurrentReleaseManifest.ListPackages(),
-			s.getPackageCleanupMode()),
+			depot.DisabledGC),
 		servicesGoingDown
 }


### PR DESCRIPTION
Right now we use the converger to stop all services. Since the
converger is also where the package garbage collector runs, we were
deleting packages on shutdown, which seems unnecessary and just slows
down the restart.

Signed-off-by: Steven Danna <steve@chef.io>