### PR TITLE
Remove fqdn from Summary doc struct since we don't have it in the data model

### DIFF
--- a/components/compliance-service/ingest/examples/compliance-success-tiny-report.json
+++ b/components/compliance-service/ingest/examples/compliance-success-tiny-report.json
@@ -219,5 +219,12 @@
   "environment": "DevSec Prod Beta",
   "roles": ["base_linux", "apache_linux", "linux-hardening-prod", "dot.role"],
   "recipes": ["apache_extras", "apache_extras::harden", "java::default", "nagios::fix"],
-  "end_time": "2018-10-25T10:18:41+01:00"
+  "end_time": "2018-10-25T10:18:41+01:00",
+  "policy_name": "tiny-policy-name",
+  "policy_group": "tiny-policy-group",
+  "organization_name": "tiny",
+  "source_fqdn": "api.chef.io",
+  "chef_tags": ["mylinux", "my.tag", "some=tag"],
+  "ipaddress": "192.168.56.33",
+  "fqdn": "lb-deb.example.com"
 }

--- a/components/compliance-service/reporting/relaxting/es_types.go
+++ b/components/compliance-service/reporting/relaxting/es_types.go
@@ -36,7 +36,6 @@ type ESInSpecSummary struct {
 	OrganizationName string   `json:"organization_name"`
 	SourceFQDN       string   `json:"source_fqdn"`
 	ChefTags         []string `json:"chef_tags"`
-	FQDN             string   `json:"fqdn"`
 	Projects         []string `json:"projects"`
 }
 


### PR DESCRIPTION
We don't have `fqdn` in the summary data model. By removing FQDN from the summary struct, we avoid adding a blank value in elasticsearch for every summary document.

I've also added the new fields to the tiny report we use for local dev & test.