### PR TITLE
Add chef-automate subcommands to toggle applications tab features

### DIFF
--- a/components/automate-cli/cmd/chef-automate/applications.go
+++ b/components/automate-cli/cmd/chef-automate/applications.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/chef/automate/api/config/deployment"
+	"github.com/chef/automate/api/config/event"
+	eventgw "github.com/chef/automate/api/config/event_gateway"
+	"github.com/chef/automate/api/config/gateway"
+	w "github.com/chef/automate/api/config/shared/wrappers"
+	"github.com/chef/automate/components/automate-deployment/pkg/client"
+)
+
+func init() {
+	appsSubcmd := newApplicationsRootSubcmd()
+	appsSubcmd.AddCommand(newApplicationsEnableCmd())
+	appsSubcmd.AddCommand(newApplicationsDisableCmd())
+
+	RootCmd.AddCommand(appsSubcmd)
+}
+
+func newApplicationsRootSubcmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "applications COMMAND",
+		Short:  "Manage applications visibility features",
+		Hidden: true,
+	}
+}
+
+func newApplicationsEnableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "enable",
+		Short: "Enable applications visibility features",
+		RunE:  runApplicationsEnableCmd,
+		Args:  cobra.NoArgs,
+	}
+}
+
+func newApplicationsDisableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "disable",
+		Short: "Disable applications visibility features",
+		RunE:  runApplicationsDisableCmd,
+		Args:  cobra.NoArgs,
+	}
+}
+
+func runApplicationsEnableCmd(*cobra.Command, []string) error {
+	cfg := newApplicationsToggleConfig(true)
+	if err := client.PatchAutomateConfig(configCmdFlags.timeout, cfg, writer); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runApplicationsDisableCmd(*cobra.Command, []string) error {
+	cfg := newApplicationsToggleConfig(false)
+	if err := client.PatchAutomateConfig(configCmdFlags.timeout, cfg, writer); err != nil {
+		return err
+	}
+	return nil
+}
+
+// newApplicationsToggleConfig creates an AutomateConfig data structure
+// equivalent to the following Automate config toml, with `$ENABLE` set
+// according to the `enable` argument:
+// # Gateway service configuration.
+// [gateway.v1]
+//   [gateway.v1.sys]
+//     [gateway.v1.sys.service]
+//       enable_apps_feature = $ENABLE
+// # event-service configuration.
+// [event_service.v1]
+//   [event_service.v1.sys]
+//     [event_service.v1.sys.service]
+//       enable_nats_feature = $ENABLE
+// # event-gateway
+// [event_gateway]
+//   [event_gateway.v1]
+//     [event_gateway.v1.sys]
+//       [event_gateway.v1.sys.service]
+//         enable_nats_feature = $ENABLE
+func newApplicationsToggleConfig(enable bool) *deployment.AutomateConfig {
+	return &deployment.AutomateConfig{
+		Gateway: &gateway.ConfigRequest{
+			V1: &gateway.ConfigRequest_V1{
+				Sys: &gateway.ConfigRequest_V1_System{
+					Service: &gateway.ConfigRequest_V1_System_Service{
+						EnableAppsFeature: w.Bool(enable),
+					},
+				},
+			},
+		},
+		EventService: &event.ConfigRequest{
+			V1: &event.ConfigRequest_V1{
+				Sys: &event.ConfigRequest_V1_System{
+					Service: &event.ConfigRequest_V1_System_Service{
+						EnableNatsFeature: w.Bool(enable),
+					},
+				},
+			},
+		},
+		EventGateway: &eventgw.ConfigRequest{
+			V1: &eventgw.ConfigRequest_V1{
+				Sys: &eventgw.ConfigRequest_V1_System{
+					Service: &eventgw.ConfigRequest_V1_System_Service{
+						EnableNatsFeature: w.Bool(enable),
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
### :nut_and_bolt: Description

Visibility into applications (habitat) data is currently alpha quality
and feature-flagged off by default. For architectural reasons, three
different feature toggles must be flipped to fully enable the feature on
the back-end. To make it easier for developers (and eventually users) to
test, this patch adds a CLI subcommand to toggle the feature. The
subcommand is currently hidden; we likely will unhide it in the future
to facilitate an open beta.

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

* start all services
* build components/automate-cli
* the default config for the hab studio enables all the feature flags, so you need to run `chef-automate applications disable` first. After running it, the NATS ports should not be listening, for example `netstat -an | grep LISTEN |grep 4222` should not show anything.
* Turn the applications feature back on with `chef-automate applications enable`, wait a few seconds for things to come up, then the NATS ports should be listening again and you should be able to run studio helpers like `applications_populate_database`

### :chains: Related Resources

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?