### PR TITLE
Enable additional static tests for apps svc and fix lint issues

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -69,9 +69,7 @@ steps:
 
   - label: "[unit] applications-service"
     command:
-      - scripts/install_golang
-      - cd components/applications-service
-      - make ci
+      - hab studio run "source .studiorc && go_component_make components/applications-service ci"
     timeout_in_minutes: 10
     retry:
       automatic:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -69,7 +69,9 @@ steps:
 
   - label: "[unit] applications-service"
     command:
-      - hab studio run "source .studiorc && go_component_unit applications-service && go_component_static_tests applications-service"
+      - scripts/install_golang
+      - cd components/applications-service
+      - make ci
     timeout_in_minutes: 10
     retry:
       automatic:

--- a/.studio/golang
+++ b/.studio/golang
@@ -259,3 +259,21 @@ function go_component_static_tests() {
 }
 # Adding auto tab complete
 complete -F _component_auto_complete go_component_static_tests
+
+document "go_component_make" <<DOC
+  Runs the given make target(s) for the given component inside the scaffolding_go_pkg_path
+DOC
+function go_component_make() {
+  [[ "$1" == "" ]] && error "Missing component name argument" && return 1;
+  setup_go_workspace
+  local component_relpath=$1
+  local component_path="$GOPATH/src/github.com/chef/automate/$component_relpath"
+  shift
+  pushd "$component_path" > /dev/null || (echo "invalid component; cannot cd to $component_path" && return 1)
+  echo "in $component_path"
+  echo "make $*"
+  make "$@"
+  local return_code=$?
+  popd > /dev/null || return 1
+  return $return_code
+}

--- a/components/applications-service/.gitignore
+++ b/components/applications-service/.gitignore
@@ -1,2 +1,3 @@
 cmd/applications-publisher/applications-publisher 
 cmd/applications-load-gen/applications-load-gen
+applications_service

--- a/components/applications-service/Makefile
+++ b/components/applications-service/Makefile
@@ -1,0 +1,43 @@
+GOFILES=$(shell go list ./... | grep -Ev '/vendor|asset\.go|proto|/integration_test' | sed 's/^_//')
+GOPATH=$(shell go env GOPATH)
+
+include ../../Makefile.common_go
+
+default: ci
+
+ci: build lint vet test
+
+review: lint vet
+
+# Utilities
+build:
+	go build cmd/applications-service/applications_service.go
+
+clean:
+	@echo "Removing artifacts..."
+	rm -f event-gateway
+
+proto:
+	cd ../../ && hab studio run 'source .studiorc; compile_go_protobuf_component event-gateway'
+
+test:
+	GOMAXPROCS=4 go test -v -cover $(GOFILES)
+
+vet:
+	go vet $(GOFILES)
+
+run:
+	go run cmd/event-gateway/event-gateway.go serve --config config.dev.toml
+
+# Etc
+edit:
+	$(EDITOR) Makefile
+
+view:
+	$(PAGER) Makefile || cat Makefile
+
+.PHONY: ci review setup clean
+.PHONY: build clean fmt lint proto test vet
+.PHONY: edit view
+.PHONY: run
+.PHONY: generate

--- a/components/applications-service/cmd/applications-publisher/main.go
+++ b/components/applications-service/cmd/applications-publisher/main.go
@@ -102,6 +102,10 @@ func main() {
 	flag.Usage = usage
 	flag.Parse()
 
+	if uniqID {
+		clientID = "applications-publisher-" + strconv.FormatInt(t.UnixNano(), 10)
+	}
+
 	if internalNats {
 		client = nats.New(
 			fmt.Sprintf("nats://0.0.0.0:%s", port),
@@ -127,10 +131,6 @@ func main() {
 	// Convert proto enums
 	event.HealthCheck = applications.HealthStatus(health)
 	event.Status = applications.ServiceStatus(status)
-
-	if uniqID {
-		clientID = "applications-publisher-" + strconv.FormatInt(t.UnixNano(), 10)
-	}
 
 	if infiniteLoop {
 		err := client.Connect()

--- a/components/applications-service/cmd/applications-service/commands/root.go
+++ b/components/applications-service/cmd/applications-service/commands/root.go
@@ -34,9 +34,20 @@ func init() {
 	RootCmd.PersistentFlags().String("key", "", "path to key")
 	RootCmd.PersistentFlags().String("cert", "", "path to cert")
 
-	viper.BindPFlag("cert", RootCmd.PersistentFlags().Lookup("cert"))
-	viper.BindPFlag("root-cert", RootCmd.PersistentFlags().Lookup("root-cert"))
-	viper.BindPFlag("key", RootCmd.PersistentFlags().Lookup("key"))
+	// https://github.com/spf13/viper/blob/7a605a50e69cd1ea431c4a1e6eebe9b287ef6de4/viper.go#L939
+	// err is non-nil when the flag doesn't exist. panic here should get caught quickly by Ci.
+	err := viper.BindPFlag("cert", RootCmd.PersistentFlags().Lookup("cert"))
+	if err != nil {
+		panic("viper configuration does not match command line flags")
+	}
+	err = viper.BindPFlag("root-cert", RootCmd.PersistentFlags().Lookup("root-cert"))
+	if err != nil {
+		panic("viper configuration does not match command line flags")
+	}
+	err = viper.BindPFlag("key", RootCmd.PersistentFlags().Lookup("key"))
+	if err != nil {
+		panic("viper configuration does not match command line flags")
+	}
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/components/applications-service/cmd/applications-service/commands/serve.go
+++ b/components/applications-service/cmd/applications-service/commands/serve.go
@@ -22,7 +22,7 @@ import (
 var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Launches applications services",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		conf, err := configFromViper()
 		if err != nil {
 			log.WithFields(log.Fields{
@@ -56,7 +56,10 @@ var serveCmd = &cobra.Command{
 			)
 
 			// Trigger NATS Subscription
-			natsClient.ConnectAndSubscribe()
+			err := natsClient.ConnectAndSubscribe()
+			if err != nil {
+				log.WithError(err).Fatal("could not connect to nats-streaming")
+			}
 
 			// Receive digested messages from the event channel and
 			// send them to the datastore for processing
@@ -96,7 +99,7 @@ var serveCmd = &cobra.Command{
 		}()
 
 		// GRPC Server
-		grpc.Spawn(conf, connFactory)
+		return grpc.Spawn(conf, connFactory)
 	},
 }
 

--- a/components/applications-service/pkg/generator/runner.go
+++ b/components/applications-service/pkg/generator/runner.go
@@ -82,7 +82,7 @@ func (s *SupervisorGroup) PrettyStr() string {
 func (s *SupervisorGroup) Run(cfg *RunnerConfig, stats *RunnerStatsKeeper) {
 	for n := int32(0); n < s.Count; n++ {
 		log.WithFields(log.Fields{"name": s.Name, "index": n}).Info("spawning supervisor")
-		go s.SpawnSup(n, cfg, stats)
+		go s.SpawnSup(n, cfg, stats) // nolint: errcheck
 	}
 }
 
@@ -148,11 +148,11 @@ func (s *SupSim) Run() error {
 	// we get a random splay, publish once, then loop.
 	splay := rand.Int31n(int32(s.Cfg.Tick))
 	time.Sleep(time.Duration(splay) * time.Second)
-	s.PublishAll()
+	s.PublishAll() // nolint: errcheck
 
 	ticker := time.NewTicker(time.Duration(s.Cfg.Tick) * time.Second)
 	for _ = range ticker.C {
-		s.PublishAll()
+		s.PublishAll() // nolint: errcheck
 	}
 	return nil
 }

--- a/components/applications-service/pkg/nats/nats.go
+++ b/components/applications-service/pkg/nats/nats.go
@@ -204,8 +204,8 @@ func (nc *NatsClient) ConnectAndPublish(msg *applications.HabService) error {
 // order to configure TLS, we are responsible for closing it.
 func (nc *NatsClient) Close() {
 	natsConn := nc.conn.NatsConn()
-	nc.conn.Close()
-	natsConn.Close()
+	nc.conn.Close()  // nolint: errcheck
+	natsConn.Close() // nolint: errcheck
 }
 
 func (nc *NatsClient) natsTLSConfig() (*tls.Config, error) {

--- a/components/applications-service/pkg/nats/publisher.go
+++ b/components/applications-service/pkg/nats/publisher.go
@@ -33,8 +33,7 @@ func (nc *NatsClient) PublishHabService(msg *applications.HabService) error {
 	if err != nil {
 		return err
 	}
-	nc.conn.Publish(nc.subject, b)
-	return nil
+	return nc.conn.Publish(nc.subject, b)
 }
 
 // PublishBytes publishes an array of bytes to the NATS server
@@ -50,6 +49,5 @@ func (nc *NatsClient) PublishBytes(b []byte) error {
 		"message": string(b),
 	}).Info("Publishing message")
 
-	nc.conn.Publish(nc.subject, b)
-	return nil
+	return nc.conn.Publish(nc.subject, b)
 }

--- a/components/applications-service/pkg/storage/postgres/hab_event.go
+++ b/components/applications-service/pkg/storage/postgres/hab_event.go
@@ -26,7 +26,7 @@ var (
 
 	timeLastEventSeen = float64(time.Now().Unix())
 
-	timeLastEventSeenCounter = promauto.NewCounterFunc(prometheus.CounterOpts{
+	_ = promauto.NewCounterFunc(prometheus.CounterOpts{
 		Name: "applications_ingest_ops_last_time",
 		Help: "Time when the last applications message was accepted for ingestion",
 	},


### PR DESCRIPTION
### :nut_and_bolt: Description

Changes applications-service to use `Makefile.common_go` stuff, which implies that we start using golangci-lint. That linter found a handful of issues, many of which are real bugs. Previously we were using the studio function `go_component_static_tests` which just runs `gofmt` so isn't very useful. We _could_ change `go_component_static_tests` to run golangci-lint, but the following projects use it:
*  config-mgmt-service
* ingest-service
* secrets-service

The other problem with the studio function is it doesn't have the same customization capabilities as the makefile approach. For example, with the makefile, it's possible to pin golangci-lint to a specific version if you need.

As far as I can tell, most devs are running the linter on their host and not the studio.  As of golangci-lint 1.15, it doesn't work very well in the studio due to a bug that breaks stuff when the CWD path has a symlink. That's fixed in 1.16, so I have a PR to upgrade us to that version: https://github.com/chef/automate/pull/110

### :+1: Definition of Done

- [x] Ci runs golangci-lint on applications service
- [x] Ci passes

### :athletic_shoe: Demo Script / Repro Steps

* click the links to see the verify (public) pipeline run, find the applications service unit tests, and un-collapse the `Running /bin/bash -e -c 'scripts/install_golang` line. You'll see that it runs `make ci` which runs `../../cache/golangci-lint-1.16.0-linux-amd64/golangci-lint run -c ../../.golangci.toml ./...`
* In the studio: `go_component_make components/applications-service/ ci` or `go_component_make components/applications-service/ lint test build` (proper handling of multiple make target args)
* Run `make ci` from the `components/applications-service/` dir of your local clone of automate

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?