### PR TITLE
Add a test to ensure load generator code stays updated

### DIFF
--- a/components/applications-service/pkg/generator/config_test.go
+++ b/components/applications-service/pkg/generator/config_test.go
@@ -3,6 +3,8 @@ package generator
 import (
 	"io/ioutil"
 	"os"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/chef/automate/api/external/applications"
@@ -45,6 +47,9 @@ func TestDefaultProfileIsViable(t *testing.T) {
 	expected := &applications.HabService{
 		SupervisorId: uuid,
 		Group:        "default",
+		Application:  "example-app",
+		Environment:  "qa",
+		Fqdn:         "00000000-0000-0000-0000-000000000000.example",
 		PkgIdent: &applications.PackageIdent{
 			Origin:  "example",
 			Name:    "service-1",
@@ -54,4 +59,49 @@ func TestDefaultProfileIsViable(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, msg)
+
+	// Test to make sure that the generator is filling in all of the values in
+	// the messages. Use reflection to get an object we can interrogate about the
+	// struct fields; later, we'll check if the values are the zero values for
+	// those types
+	msgAsValue := reflect.ValueOf(*msg)
+
+	// These fields are expected to be the zero values for their types
+	exceptions := []string{"HealthCheck", "Status"}
+
+	for i := 0; i < msgAsValue.NumField(); i++ {
+		// Attempting to access a private struct field via reflection panics, so
+		// skip things we are not allowed to see:
+		if msgAsValue.Field(i).CanInterface() {
+			fieldName := msgAsValue.Type().Field(i).Name
+			// skip internal protobuf fields that start with "XXX_"
+			if !strings.HasPrefix(fieldName, "XXX_") {
+
+				isException := false
+				for _, exception := range exceptions {
+					if fieldName == exception {
+						isException = true
+						break
+					}
+				}
+				if isException {
+					continue
+				}
+
+				// the value of the struct field
+				fieldValue := msgAsValue.Field(i).Interface()
+				// get a zero value for that type
+				valType := msgAsValue.Field(i).Type()
+				zeroForType := reflect.Zero(valType).Interface()
+
+				// If the value of the field is the zero value, and it's not in our
+				// exceptions list, then we probably added a new field to
+				// applications.HabService and forgot to update the load generator code
+				// to match it.
+				assert.NotEqualf(t,
+					zeroForType, fieldValue,
+					"Field %q of the HabService message was set to the zero value for its type (%T); MessagePrototype.CreateMessage() may need to be updated", fieldName, fieldValue)
+			}
+		}
+	}
 }

--- a/components/applications-service/pkg/generator/runner.go
+++ b/components/applications-service/pkg/generator/runner.go
@@ -235,6 +235,11 @@ func (m *MessagePrototype) CreateMessage(uuid string) *applications.HabService {
 	return &applications.HabService{
 		SupervisorId: uuid,
 		Group:        "default",
+		HealthCheck:  applications.HealthStatus_OK,
+		Status:       applications.ServiceStatus_RUNNING,
+		Application:  m.Application,
+		Environment:  m.Environment,
+		Fqdn:         fmt.Sprintf("%s.example", uuid),
 		PkgIdent: &applications.PackageIdent{
 			Origin:  m.Origin,
 			Name:    m.PkgName,


### PR DESCRIPTION
### :nut_and_bolt: Description

If we are not actively doing load test work, we are probably gonna
forget to update the load generator when we add some new data field to
our habitat events. Add a test that can detect when a new field is added
to the applications.HabService message and we don't add code to the load
generator to fill it in.

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

Comment out one of the new lines I added in components/applications-service/pkg/generator/runner.go and you should see the test I added fail with a message like:

```
        Test:       	TestDefaultProfileIsViable
        Error Trace:    config_test.go:95
        Error:      	Should not be: ""
        Test:       	TestDefaultProfileIsViable
        Messages:   	Field "Fqdn" of the HabService message was set to the zero value for its type (string); MessagePrototype.CreateMessage() may need to be updated
```

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?