### PR TITLE
Remove logging that was added for diagnosis

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
+++ b/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
@@ -117,9 +117,7 @@ fi
 # Update to whatever the latest version of hab that got installed is
 hab pkg binlink core/hab --force
 
-set -x
 if [[ ! -f /root/a2-iamv2-enabled ]]; then
-    echo ${iam_version}
     case "${iam_version}" in
     "v2.1")
       chef-automate iam upgrade-to-v2 --beta2.1
@@ -134,7 +132,6 @@ if [[ ! -f /root/a2-iamv2-enabled ]]; then
       ;;
     esac
 fi
-set +x
 
 if [[ "${create_admin_token}" == "true" ]]; then
     if [[ ! -f /root/admin-token.txt ]]; then


### PR DESCRIPTION
### :nut_and_bolt: Description

Cleaning up some leftover logging during setting up a new machine in the deployment farm.

### :+1: Definition of Done

A couple lines of extraneous logging removed during buildkite deployments.

### :athletic_shoe: Demo Script / Repro Steps

Can be viewed in deployment logs.

### :chains: Related Resources

PR - #78 

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
