### PR TITLE
Apply golangci-lint to config-mgmt-service and secrets-service

### DIFF
--- a/components/config-mgmt-service/backend/elastic/elastic.go
+++ b/components/config-mgmt-service/backend/elastic/elastic.go
@@ -7,15 +7,14 @@ package elastic
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/chef/automate/components/config-mgmt-service/errors"
 	"github.com/olivere/elastic"
-	log "github.com/sirupsen/logrus"
+
+	"github.com/chef/automate/components/config-mgmt-service/errors"
 )
 
 const (
@@ -289,15 +288,6 @@ func (es Backend) GetListForField(searchTerm string) ([]string, error) {
 	}
 
 	return orgs, nil
-}
-
-func logQueryPart(partToPrint interface{}, name string) {
-	part, err := json.MarshalIndent(partToPrint, "", "  ")
-	if err != nil {
-		log.Errorf("%s", err)
-	}
-	log.Debugf("\n------------------%s-(start)------------------\n%s\n------------------%s-(end)------------------\n",
-		name, string(part), name)
 }
 
 // EmptyStringIfNil asserts an interface as a string, and if that fails it returns empty string

--- a/components/config-mgmt-service/backend/elastic/nodes.go
+++ b/components/config-mgmt-service/backend/elastic/nodes.go
@@ -62,14 +62,10 @@ func (es Backend) GetNode(id string) (backend.Node, error) {
 // non-random access pagination and custom selection of how the docs are sorted.
 func (es Backend) GetInventoryNodes(ctx context.Context, start time.Time,
 	end time.Time, filters map[string][]string, cursorDate time.Time,
-	cursorID string, pageSize int, sortField string,
+	cursorID string, pageSize int, _ string,
 	ascending bool) ([]backend.InventoryNode, error) {
 
 	mainQuery := newBoolQueryFromFilters(filters)
-
-	if sortField == "" {
-		sortField = CheckinTimestamp
-	}
 
 	rangeQuery, ok := newRangeQueryTime(start, end, CheckinTimestamp)
 
@@ -83,7 +79,7 @@ func (es Backend) GetInventoryNodes(ctx context.Context, start time.Time,
 		Query(mainQuery).
 		Index(IndexNodeState).
 		Size(pageSize).
-		Sort(sortField, ascending).
+		Sort(CheckinTimestamp, ascending).
 		Sort(NodeFieldID, ascending).
 		FetchSourceContext(fetchSource)
 

--- a/components/config-mgmt-service/backend/elastic/nodes.go
+++ b/components/config-mgmt-service/backend/elastic/nodes.go
@@ -83,7 +83,7 @@ func (es Backend) GetInventoryNodes(ctx context.Context, start time.Time,
 		Query(mainQuery).
 		Index(IndexNodeState).
 		Size(pageSize).
-		Sort(CheckinTimestamp, ascending).
+		Sort(sortField, ascending).
 		Sort(NodeFieldID, ascending).
 		FetchSourceContext(fetchSource)
 
@@ -261,11 +261,11 @@ func (es Backend) GetNodesCounts(filters map[string][]string) (backend.NodesCoun
 	for _, bucket := range statusNodesBuckets {
 		switch bucket.Key {
 		case "success":
-			ns.Success = int64(bucket.DocCount)
+			ns.Success = bucket.DocCount
 		case "failure":
-			ns.Failure = int64(bucket.DocCount)
+			ns.Failure = bucket.DocCount
 		case "missing":
-			ns.Missing = int64(bucket.DocCount)
+			ns.Missing = bucket.DocCount
 		}
 	}
 

--- a/components/config-mgmt-service/backend/elastic/nodes.go
+++ b/components/config-mgmt-service/backend/elastic/nodes.go
@@ -60,6 +60,10 @@ func (es Backend) GetNode(id string) (backend.Node, error) {
 
 // GetInventoryNodes - Collect inventory nodes from elasticsearch. This function allows
 // non-random access pagination and custom selection of how the docs are sorted.
+//
+// TODO(ssd) 2019-04-23: The sortField argument is ignored in this
+// call. The linter pointed out that it was previously ignored and an
+// attempt to not ignore it caused multiple tests to fail.
 func (es Backend) GetInventoryNodes(ctx context.Context, start time.Time,
 	end time.Time, filters map[string][]string, cursorDate time.Time,
 	cursorID string, pageSize int, _ string,

--- a/components/config-mgmt-service/backend/elastic/runs.go
+++ b/components/config-mgmt-service/backend/elastic/runs.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/olivere/elastic"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/chef/automate/components/config-mgmt-service/backend"
 	"github.com/chef/automate/components/config-mgmt-service/errors"
 	"github.com/chef/automate/components/ingest-service/backend/elastic/mappings"
-	"github.com/olivere/elastic"
-	log "github.com/sirupsen/logrus"
 )
 
 // GetRun - Get a node's last run
@@ -93,12 +94,12 @@ func (es Backend) GetRunsCounts(filters map[string][]string, start string, end s
 	for _, bucket := range statusRunsBuckets {
 		switch bucket.Key {
 		case "success":
-			ns.Success = int64(bucket.DocCount)
+			ns.Success = bucket.DocCount
 		case "failure":
-			ns.Failure = int64(bucket.DocCount)
+			ns.Failure = bucket.DocCount
 		}
 
-		totalRuns += int64(bucket.DocCount)
+		totalRuns += bucket.DocCount
 	}
 
 	ns.Total = totalRuns
@@ -192,7 +193,7 @@ func (es Backend) getAllConvergeIndiceNames() ([]string, error) {
 		return []string{}, err
 	}
 
-	var names []string
+	names := make([]string, 0, len(res))
 	for name := range res {
 		names = append(names, name)
 	}

--- a/components/config-mgmt-service/backend/elastic/suggestions.go
+++ b/components/config-mgmt-service/backend/elastic/suggestions.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/chef/automate/components/config-mgmt-service/backend"
 	"github.com/olivere/elastic"
 	"github.com/schollz/closestmatch"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/chef/automate/components/config-mgmt-service/backend"
 )
 
 // GetSuggestions - get a collection of suggestions
@@ -175,7 +176,7 @@ func (es Backend) getArrayAggSuggestions(term string, text string) ([]backend.Su
 
 	finalSuggs := make([]backend.Suggestion, 0)
 	for i, sug := range suggs {
-		oneSugg := backend.Suggestion{Text: string(sug), Score: float32(len(suggs) - i)}
+		oneSugg := backend.Suggestion{Text: sug, Score: float32(len(suggs) - i)}
 		finalSuggs = append(finalSuggs, oneSugg)
 	}
 

--- a/components/config-mgmt-service/config/service.go
+++ b/components/config-mgmt-service/config/service.go
@@ -25,12 +25,12 @@ var SERVICE_NAME = "config-mgmt-service"
 
 // Service config definition
 type Service struct {
-	Name         string          `json:"name" mapstructure:"name"`
-	Version      string          `json:"version" mapstructure:"version"`
-	Host         string          `json:"host" mapstructure:"host"`
-	Port         int             `json:"port" mapstructure:"port"`
-	LogLevel     string          `json:"log_level" mapstructure:"log_level"`
-	client       backend.Client  `json:"-"`
+	Name         string `json:"name" mapstructure:"name"`
+	Version      string `json:"version" mapstructure:"version"`
+	Host         string `json:"host" mapstructure:"host"`
+	Port         int    `json:"port" mapstructure:"port"`
+	LogLevel     string `json:"log_level" mapstructure:"log_level"`
+	client       backend.Client
 	TLSConfig    certs.TLSConfig `mapstructure:"tls"`
 	serviceCerts *certs.ServiceCerts
 }

--- a/components/config-mgmt-service/grpcserver/cfg_mgmt.go
+++ b/components/config-mgmt-service/grpcserver/cfg_mgmt.go
@@ -249,7 +249,7 @@ func stringArrayToListValue(strings []string, list *gpStruct.ListValue) error {
 
 	for i, string := range strings {
 		v := &gpStruct.Value{
-			Kind: &gpStruct.Value_StringValue{string},
+			Kind: &gpStruct.Value_StringValue{StringValue: string},
 		}
 
 		list.Values[i] = v

--- a/components/secrets-service/cmd/secrets-service/commands/root.go
+++ b/components/secrets-service/cmd/secrets-service/commands/root.go
@@ -5,6 +5,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -34,9 +35,18 @@ func init() {
 	RootCmd.PersistentFlags().String("key", "", "path to key")
 	RootCmd.PersistentFlags().String("cert", "", "path to cert")
 
-	viper.BindPFlag("cert", RootCmd.PersistentFlags().Lookup("cert"))
-	viper.BindPFlag("root-cert", RootCmd.PersistentFlags().Lookup("root-cert"))
-	viper.BindPFlag("key", RootCmd.PersistentFlags().Lookup("key"))
+	bindPFlag("cert", RootCmd.PersistentFlags().Lookup("cert"))
+	bindPFlag("root-cert", RootCmd.PersistentFlags().Lookup("root-cert"))
+	bindPFlag("key", RootCmd.PersistentFlags().Lookup("key"))
+}
+
+func bindPFlag(name string, flag *pflag.Flag) {
+	err := viper.BindPFlag("cert", RootCmd.PersistentFlags().Lookup("cert"))
+	if err != nil {
+		// This is a programming error and should not happen
+		// at runtime.
+		panic("could not bind flag!")
+	}
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/components/secrets-service/cmd/secrets-service/commands/serve.go
+++ b/components/secrets-service/cmd/secrets-service/commands/serve.go
@@ -25,21 +25,20 @@ var serveCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		conf, err := configFromViper()
 		if err != nil {
-			log.WithFields(log.Fields{
-				"error": err.Error(),
-			}).Fatal("Failed to load config")
+			log.WithError(err).Fatal("Failed to load config")
 		}
 		conf.Service.SetLogLevel()
 		tlsOpts, err := conf.ReadCerts()
 		if err != nil {
-			log.WithFields(log.Fields{
-				"error": err.Error(),
-			}).Fatal("Failed to load SSL key/cert files")
+			log.WithError(err).Fatal("Failed to load SSL key/cert files")
 		}
 		connFactory := secureconn.NewFactory(*tlsOpts)
 		log.Info("Starting Secrets Services")
 
-		grpc.Spawn(conf, connFactory)
+		err = grpc.Spawn(conf, connFactory)
+		if err != nil {
+			log.WithError(err).Fatal("gRPC server failed")
+		}
 	},
 }
 

--- a/components/secrets-service/dao/filtering.go
+++ b/components/secrets-service/dao/filtering.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/chef/automate/api/external/secrets"
-	"github.com/chef/automate/components/secrets-service/utils"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"github.com/chef/automate/api/external/secrets"
+	"github.com/chef/automate/components/secrets-service/utils"
 )
 
 func mergeFilters(mergeableFilters []*secrets.Filter) ([]secrets.Filter, error) {
@@ -50,7 +51,7 @@ func buildWhereFilter(mergeableFilters []*secrets.Filter, tableAbbrev string, fi
 		return "", errors.Wrap(err, "buildWhereFilter error")
 	}
 
-	var conditions []string
+	conditions := make([]string, 0, len(filters))
 	for _, filter := range filters {
 		var newCondition string
 		var err error

--- a/components/secrets-service/dao/secrets.go
+++ b/components/secrets-service/dao/secrets.go
@@ -212,15 +212,15 @@ func decryptString(ciphertext string, key string) (*string, error) {
 }
 
 //UpdateSecret updates a secret in the db with input values
-func (secretsDb *DB) UpdateSecret(inSecret *secrets.Secret) (count int64, err error) {
+func (secretsDb *DB) UpdateSecret(inSecret *secrets.Secret) error {
 	secret, err := secretsDb.toDBSecret(inSecret)
 	if err != nil {
 		err = errors.Wrap(err, fmt.Sprintf("UpdateSecret: unable to translate secret to db struct %+v", inSecret))
-		return
+		return err
 	}
 	secret.LastModified = timeNowRef()
 
-	err = Transact(secretsDb, func(tx *DBTrans) error {
+	return Transact(secretsDb, func(tx *DBTrans) error {
 		//get list of tags from current secret
 		_, err := tx.Exec(deleteSecretTags, secret.ID)
 		if err != nil {
@@ -243,8 +243,6 @@ func (secretsDb *DB) UpdateSecret(inSecret *secrets.Secret) (count int64, err er
 		}
 		return nil
 	})
-
-	return
 }
 
 // AddSecret adds a secret to the db

--- a/components/secrets-service/dao/tags.go
+++ b/components/secrets-service/dao/tags.go
@@ -3,8 +3,9 @@ package dao
 import (
 	"encoding/json"
 
-	"github.com/chef/automate/api/external/secrets"
 	"github.com/pkg/errors"
+
+	"github.com/chef/automate/api/external/secrets"
 )
 
 type secretTag struct {
@@ -63,11 +64,13 @@ func KeyValueToRawMap(arr []*secrets.Kv) (json.RawMessage, error) {
 // RawMapToKeyValue helps convert an array of KeyValues in a Map and convert it to json
 func RawMapToKeyValue(rawJSON json.RawMessage) ([]*secrets.Kv, error) {
 	var zaMap map[string]string
-	var zaArray []*secrets.Kv
+
 	err := json.Unmarshal(rawJSON, &zaMap)
 	if err != nil {
-		return zaArray, errors.Wrap(err, "rawMapToKeyValue unable to unmarshal map")
+		return nil, errors.Wrap(err, "rawMapToKeyValue unable to unmarshal map")
 	}
+
+	zaArray := make([]*secrets.Kv, 0, len(zaMap))
 	for k, v := range zaMap {
 		zaArray = append(zaArray, &secrets.Kv{Key: k, Value: v})
 	}

--- a/components/secrets-service/server/server.go
+++ b/components/secrets-service/server/server.go
@@ -3,12 +3,13 @@ package server
 import (
 	"context"
 
+	"github.com/pkg/errors"
+	logs "github.com/sirupsen/logrus"
+
 	"github.com/chef/automate/api/external/secrets"
 	"github.com/chef/automate/components/secrets-service/dao"
 	"github.com/chef/automate/components/secrets-service/utils"
 	"github.com/chef/automate/lib/grpc/health"
-	"github.com/pkg/errors"
-	logs "github.com/sirupsen/logrus"
 )
 
 // SecretsServer is the interface to this component.
@@ -64,7 +65,7 @@ func (ss *SecretsServer) Update(ctx context.Context, in *secrets.Secret) (*secre
 		return nil, utils.FormatErrorMsg(utils.ProcessInvalid(err, "updateSecretValidation: unable to validate secret"), in.Id)
 	}
 
-	_, err = ss.secretsDb.UpdateSecret(newSecret)
+	err = ss.secretsDb.UpdateSecret(newSecret)
 	if err != nil {
 		return nil, utils.FormatErrorMsg(err, in.Id)
 	}


### PR DESCRIPTION
These are 2 of the 3 services that don't seem to be using the linter
currently. This applies the linter to those projects which will
hopefully make it a bit easier to transition to having
`go_component_static_tests` run the linter.

`ingest-service` is, I believe, likely the last service that needs to
have the linter applied to it. I have not done it here because there
are a large number of errcheck violations that need to be looked at
carefully.

Signed-off-by: Steven Danna <steve@chef.io>