### PR TITLE
Minor cleanup in teams and authz services

### DIFF
--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -22,7 +22,6 @@ import (
 
 	api_v2 "github.com/chef/automate/api/interservice/authz/v2"
 	constants_v1 "github.com/chef/automate/components/authz-service/constants/v1"
-	constants "github.com/chef/automate/components/authz-service/constants/v2"
 	constants_v2 "github.com/chef/automate/components/authz-service/constants/v2"
 	"github.com/chef/automate/components/authz-service/engine"
 	"github.com/chef/automate/components/authz-service/prng"
@@ -398,7 +397,7 @@ func TestCreatePolicy(t *testing.T) {
 				Effect:    api_v2.Statement_ALLOW,
 				Resources: []string{"cfgmgmt:delete", "cfgmgmt:list"},
 				Actions:   []string{"cfgmgmt:nodes:*"},
-				Projects:  []string{constants.UnassignedProjectID},
+				Projects:  []string{constants_v2.UnassignedProjectID},
 			}
 			req := api_v2.CreatePolicyReq{
 				Id:         "policy1",
@@ -412,7 +411,7 @@ func TestCreatePolicy(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 			assert.Equal(t, len(items)+1, store.ItemCount())
-			assert.ElementsMatch(t, []string{constants.UnassignedProjectID}, resp.Statements[0].Projects)
+			assert.ElementsMatch(t, []string{constants_v2.UnassignedProjectID}, resp.Statements[0].Projects)
 		}},
 
 		{"successfully creates policy with wildcard projects", func(t *testing.T) {
@@ -452,8 +451,8 @@ func TestCreatePolicy(t *testing.T) {
 			require.ElementsMatch(t, []string{"my-other-project"}, resp.Statements[2].Projects)
 
 			// key check: internal vs external representation
-			assert.ElementsMatch(t, []string{constants.AllProjectsID}, pol.Statements[1].Projects)
-			assert.ElementsMatch(t, []string{constants.AllProjectsExternalID}, resp.Statements[1].Projects)
+			assert.ElementsMatch(t, []string{constants_v2.AllProjectsID}, pol.Statements[1].Projects)
+			assert.ElementsMatch(t, []string{constants_v2.AllProjectsExternalID}, resp.Statements[1].Projects)
 		}},
 	}
 
@@ -634,7 +633,7 @@ func TestListPolicies(t *testing.T) {
 		{"returns mapped meta-project when present", func(t *testing.T) {
 			_, items := addSomePoliciesToStore(t, store, prng)
 			storedPol := genPolicy(t, "", prng)
-			storedPol.Statements[0].Projects = []string{constants.AllProjectsID}
+			storedPol.Statements[0].Projects = []string{constants_v2.AllProjectsID}
 			store.Add(storedPol.ID, &storedPol, cache.NoExpiration)
 
 			resp, err := cl.ListPolicies(ctx, &req)
@@ -643,7 +642,7 @@ func TestListPolicies(t *testing.T) {
 			require.Equal(t, len(items)+1, len(resp.Policies))
 			for _, pol := range resp.Policies {
 				if pol.Id == storedPol.ID {
-					assert.Equal(t, constants.AllProjectsExternalID, pol.Statements[0].Projects[0])
+					assert.Equal(t, constants_v2.AllProjectsExternalID, pol.Statements[0].Projects[0])
 				} else {
 					p := items[pol.Id]
 					assertPoliciesMatch(t, &p, pol)
@@ -778,7 +777,7 @@ func TestGetPolicy(t *testing.T) {
 		}},
 		{"returns mapped meta-project when present", func(t *testing.T) {
 			storedPol := genPolicy(t, "", prng)
-			storedPol.Statements[0].Projects = []string{constants.AllProjectsID}
+			storedPol.Statements[0].Projects = []string{constants_v2.AllProjectsID}
 			require.Zero(t, store.ItemCount())
 			store.Add(storedPol.ID, &storedPol, cache.NoExpiration)
 			req := api_v2.GetPolicyReq{
@@ -788,7 +787,7 @@ func TestGetPolicy(t *testing.T) {
 			pol, err := cl.GetPolicy(ctx, &req)
 			require.NoError(t, err)
 
-			assert.Equal(t, constants.AllProjectsExternalID, pol.Statements[0].Projects[0])
+			assert.Equal(t, constants_v2.AllProjectsExternalID, pol.Statements[0].Projects[0])
 		}},
 		{"fails with NotFound when ID doesn't match any policies", func(t *testing.T) {
 			addSomePoliciesToStore(t, store, prng)

--- a/components/authz-service/storage/v2/type.go
+++ b/components/authz-service/storage/v2/type.go
@@ -5,18 +5,16 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-)
 
-const (
-	UnassignedID = "(unassigned)"
+	constants "github.com/chef/automate/components/authz-service/constants/v2"
 )
 
 func ValidateProjects(projects []string) error {
 	for _, project := range projects {
-		if project == UnassignedID {
+		if project == constants.UnassignedProjectID {
 			return errors.Errorf("%q cannot explicitly be set. "+
 				"If you wish to create an object in %q, you should pass no projects on creation.",
-				UnassignedID, UnassignedID)
+				constants.UnassignedProjectID, constants.UnassignedProjectID)
 		}
 	}
 	return nil

--- a/components/teams-service/constants/constants.go
+++ b/components/teams-service/constants/constants.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	UnassignedProjectID = "(unassigned)"
+)

--- a/components/teams-service/server/v2/server_test.go
+++ b/components/teams-service/server/v2/server_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/chef/automate/lib/tls/test/helpers"
 	"github.com/chef/automate/lib/tracing"
 
+	"github.com/chef/automate/components/teams-service/constants"
 	"github.com/chef/automate/components/teams-service/service"
 	"github.com/chef/automate/components/teams-service/storage"
 	"github.com/chef/automate/components/teams-service/storage/postgres/datamigration"
@@ -220,7 +221,7 @@ func runAllServerTests(
 			})
 			require.NoError(t, err)
 
-			ctx = insertProjectsIntoNewContext([]string{"(unassigned)"})
+			ctx = insertProjectsIntoNewContext([]string{constants.UnassignedProjectID})
 			list, err := cl.GetTeams(ctx, &teams.GetTeamsReq{})
 			require.NoError(t, err)
 			require.NotNil(t, list)
@@ -472,7 +473,7 @@ func runAllServerTests(
 			require.NoError(t, err)
 			assert.Equal(t, 2+len(storage.NonDeletableTeams), len(teamListBefore.Teams))
 
-			ctx = insertProjectsIntoNewContext([]string{"(unassigned)"})
+			ctx = insertProjectsIntoNewContext([]string{constants.UnassignedProjectID})
 			resp, err2 := cl.DeleteTeam(ctx, &teams.DeleteTeamReq{Id: resp1.Team.Id})
 			require.NoError(t, err2)
 			require.NotNil(t, resp)
@@ -712,7 +713,7 @@ func runAllServerTests(
 				Name:     newName,
 				Projects: []string{"project2", "project3"},
 			}
-			updatedTeamResp, err := cl.UpdateTeam(insertProjectsIntoNewContext([]string{"(unassigned)"}), updateReq)
+			updatedTeamResp, err := cl.UpdateTeam(insertProjectsIntoNewContext([]string{constants.UnassignedProjectID}), updateReq)
 			require.NoError(t, err, "update team")
 			require.NotNil(t, resp)
 			assert.Equal(t, updateReq.Id, updatedTeamResp.Team.Id)
@@ -966,7 +967,7 @@ func runAllServerTests(
 					}
 
 					// act
-					resp2, err := cl.AddTeamMembers(insertProjectsIntoNewContext([]string{"(unassigned)"}), addReq)
+					resp2, err := cl.AddTeamMembers(insertProjectsIntoNewContext([]string{constants.UnassignedProjectID}), addReq)
 
 					// assert
 					require.NoError(t, err)
@@ -1200,7 +1201,7 @@ func runAllServerTests(
 					"user-2",
 				},
 			}
-			removeResp, err := cl.RemoveTeamMembers(insertProjectsIntoNewContext([]string{"(unassigned)"}), req)
+			removeResp, err := cl.RemoveTeamMembers(insertProjectsIntoNewContext([]string{constants.UnassignedProjectID}), req)
 			require.NoError(t, err)
 			assert.Equal(t, 1, len(removeResp.UserIds))
 
@@ -1366,7 +1367,7 @@ func runAllServerTests(
 				UserId: users[0],
 			}
 			fetchedData, err := cl.GetTeamsForMember(
-				insertProjectsIntoNewContext([]string{"project2", "(unassigned)"}), listReq)
+				insertProjectsIntoNewContext([]string{"project2", constants.UnassignedProjectID}), listReq)
 
 			require.NoError(t, err)
 			require.NotNil(t, fetchedData)
@@ -1487,7 +1488,7 @@ func runAllServerTests(
 			listReq := &teams.GetTeamsForMemberReq{
 				UserId: users[0],
 			}
-			fetchedData, err := cl.GetTeamsForMember(insertProjectsIntoNewContext([]string{"(unassigned)"}), listReq)
+			fetchedData, err := cl.GetTeamsForMember(insertProjectsIntoNewContext([]string{constants.UnassignedProjectID}), listReq)
 
 			require.NoError(t, err)
 			require.NotNil(t, fetchedData)
@@ -1722,7 +1723,7 @@ func runAllServerTests(
 			require.NoError(t, err)
 
 			resp, err := cl.GetTeamMembership(
-				insertProjectsIntoNewContext([]string{"(unassigned)"}),
+				insertProjectsIntoNewContext([]string{constants.UnassignedProjectID}),
 				&teams.GetTeamMembershipReq{
 					Id: initResp.Team.Id,
 				})

--- a/components/teams-service/storage/memstore/memstore.go
+++ b/components/teams-service/storage/memstore/memstore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/chef/automate/components/teams-service/constants"
 	"github.com/chef/automate/components/teams-service/storage"
 	"github.com/chef/automate/components/teams-service/storage/postgres"
 	"github.com/chef/automate/lib/logger"
@@ -357,7 +358,7 @@ func projectsIntersect(ctx context.Context, team storage.Team) bool {
 
 	teamProjects := team.Projects
 	if len(teamProjects) == 0 {
-		teamProjects = []string{"(unassigned)"}
+		teamProjects = []string{constants.UnassignedProjectID}
 	}
 
 	for _, projectFilter := range projectsFilter {


### PR DESCRIPTION
### :nut_and_bolt: Description

Purely cosmetic cleanup:
* Consolidated use of literal "(unassigned)" into exactly one use per service.
* Lots of indentation cleanup for readability in postgres tests for teams.
* Removed duplicate import in one file.

### :+1: Definition of Done

Everything still works.

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
