### PR TITLE
Downgrade hab to 0.69

### DIFF
--- a/.expeditor/create-manifest.rb
+++ b/.expeditor/create-manifest.rb
@@ -57,9 +57,9 @@ def get_latest(channel, origin, name)
   # IF YOU UPDATE THESE PINS YOU MUST ALSO UPDATE THE core/hab PIN IN components/automate-deployment/habitat/plan.sh
   #
   pinned_hab_components = {
-    "hab"          => { "origin" => "core", "name" => "hab",          "version" => "0.79.1", "release" => "20190410220617"},
-    "hab-sup"      => { "origin" => "core", "name" => "hab-sup",      "version" => "0.79.1", "release" => "20190410223329"},
-    "hab-launcher" => { "origin" => "core", "name" => "hab-launcher", "version" => "10180",   "release" => "20190409144132"}
+    "hab"          => { "origin" => "core", "name" => "hab",          "version" => "0.69.0", "release" => "20181127182011"},
+    "hab-sup"      => { "origin" => "core", "name" => "hab-sup",      "version" => "0.69.0", "release" => "20181127183841"},
+    "hab-launcher" => { "origin" => "core", "name" => "hab-launcher", "version" => "9106",   "release" => "20181126205526"}
   }
 
   if pinned_databases.keys.include?(name)

--- a/.studiorc
+++ b/.studiorc
@@ -10,7 +10,7 @@ scaffolding_go_import_path="${scaffolding_go_base_path}/${scaffolding_go_repo_na
 
 export HAB_ORIGIN=${HAB_ORIGIN:-chef}
 # Bring ci-studio-common to life
-RECOMMENDED_HAB_VERSION="0.79.1"
+RECOMMENDED_HAB_VERSION="0.77.0"
 # shellcheck disable=1090
 if [ -d "${CI_STUDIO_COMMON:-}" ]; then
   echo "CI_STUDIO_COMMON override in effect; using $CI_STUDIO_COMMON, not chef/ci-studio-common habitat package"

--- a/components/automate-deployment/habitat/plan.sh
+++ b/components/automate-deployment/habitat/plan.sh
@@ -12,7 +12,7 @@ pkg_deps=(
   # runtime by Habitat.
   #
   # IF YOU UPDATE THIS PIN YOU MUST ALSO UPDATE .expeditor/create-manifest.rb
-  core/hab/0.79.1/20190410220617
+  core/hab/0.69.0/20181127182011
   core/net-tools
   core/procps-ng
   core/util-linux

--- a/components/automate-deployment/pkg/converge/compiler.go
+++ b/components/automate-deployment/pkg/converge/compiler.go
@@ -807,7 +807,8 @@ func (phase *SupervisorUpgradePhase) updateHapSupSymlink(_ *eventWriter, target 
 	}
 
 	desiredPkg := phase.desiredSupState.SupPkg()
-	if err != nil || !habpkg.GreaterOrEqual(&currentPkg, &desiredPkg) {
+
+	if err != nil || currentPkg != desiredPkg {
 		if err := target.SymlinkHabSup(desiredPkg); err != nil {
 			return errors.Wrap(err, "failed to create hab-sup symlink")
 		}

--- a/components/automate-deployment/pkg/target/local_target.go
+++ b/components/automate-deployment/pkg/target/local_target.go
@@ -676,7 +676,7 @@ func (t *LocalTarget) HabSupRestartRequired(desiredPkg habpkg.HabPkg) (bool, err
 		return false, errors.Wrap(err, "determining running hab-sup version")
 	}
 
-	restartRequired := !habpkg.GreaterOrEqual(&runningHabVersion, &desiredPkg)
+	restartRequired := runningHabVersion != desiredPkg
 	logrus.WithFields(logrus.Fields{
 		"restart_required": restartRequired,
 		"desired_version":  habpkg.VersionString(&desiredPkg),


### PR DESCRIPTION
We hit https://github.com/habitat-sh/habitat/issues/6252 again in our pipeline. This time, we were able to get a stacktrace, but we still don't understand where it's coming from or why it's happening