### PR TITLE
[CI] Accept inspec license during terraform install

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
+++ b/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
@@ -70,7 +70,7 @@ wait_for_upgrade() {
 }
 
 hardened_security_inspec_scan() {
-    /opt/chef/embedded/bin/inspec exec /tmp/a2-hardened-security || exit_status=$?
+    CHEF_LICENSE="accept-no-persist" /opt/chef/embedded/bin/inspec exec /tmp/a2-hardened-security || exit_status=$?
     if [[ $exit_status -ne 0 && $exit_status -ne 101 ]]; then
         exit $exit_status
     fi


### PR DESCRIPTION
This is untested, but this environment variable is what we use in
other locations to accept the inspec license.

Signed-off-by: Steven Danna <steve@chef.io>