### PR TITLE
Load Test Fixes

### DIFF
--- a/components/applications-service/cmd/applications-load-gen/commands/describe.go
+++ b/components/applications-service/cmd/applications-load-gen/commands/describe.go
@@ -41,6 +41,8 @@ func runDescribeCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	fmt.Print(supGroups.RollupStats())
+
 	for _, supGroup := range supGroups {
 		fmt.Print(supGroup.PrettyStr())
 	}

--- a/components/applications-service/dev/applications-load-gen/2019-04-results.md
+++ b/components/applications-service/dev/applications-load-gen/2019-04-results.md
@@ -1,0 +1,78 @@
+EAS/Applications Performance Test April 2019
+============================================
+
+Results
+-------
+
+One modification was made to the application service ingestion code to allow for multi-threaded processing of incoming messages. A few modifications were necessary to enable the load generator to successfully create thousands of connections to the event-gateway's NATS instance. With these modifications in place, the system was capable of handling approximately 650 messages per second at a steady state. Higher loads of up to 800 messages per second were applied; in these cases the messages were accepted and buffered by the nats-streaming system.
+
+Discussion
+----------
+
+* A message rate of 600 messages per second corresponds to 18,000 services with a 30s healthcheck interval.
+* To reserve some headroom, we recommend no more than 15,000 services if using an equivalent configuration.
+* Actual performance may depend greatly on disk IO performance, so could be lower on systems with less performant hardware.
+* Engineers at Chef Software have observed significant operational issues when buffers grow large; as a result of this work, the maximum number of outstanding messages has been set to 100,000. This provides the following behaviors:
+  * At a processing rate of 500 messages/s, the backlog can be cleared in less than 5 minutes if load is removed at the front-end.
+  * If the system has 100 messages/s of headroom, the backlog can be cleared in less than 25 minutes.
+
+
+System Configuration
+--------------------
+
+Testing was performed in AWS EC2, Oregon region.
+
+Existing documentation for Chef Automate v1 recommends a system with 4(v)CPUs and 16GiB of RAM as a minimum for a production system. Some performance testing work I had previously done suggested 264GiB as a reasonable size for the root EBS volume. The Instance was configured as follows:
+
+* OS: Amazon Linux 2
+* Instance Type: m5.xlarge
+  * vCPU: 4
+  * RAM: 16 GiB
+* Root EBS Volume:
+  * 264 GiB
+  * 792 IOPS (default for a volume this size)
+* Only port 22 was exposed via security group; other ports accessed via tunneling
+
+OS Setup
+--------
+
+Package installation:
+
+```
+yum update -y
+yum install curl tmux git htop -y
+```
+
+Update sysctl settings for Chef Automate:
+
+```
+vim /etc/sysctl.conf
+## add this:
+# vm.max_map_count=262144
+# vm.dirty_expire_centisecs=20000
+## Then run this:
+sysctl -f /etc/sysctl.conf
+```
+
+Automate was installed according to the instructions, with the following modifications:
+* `channel`: `"dev"` -- to get the latest builds
+* `es heapsize`: `"8g"` -- EAS doesn't use Es, but this would be typical for this system configuration
+* Set `override-origin` and `hartifacts` dir -- to side-load dev packages with fixes
+
+After initial deployment of Chef Automate, the following additional configuration was done:
+* apply the license key used by Chef developers
+* `chef-automate applications enable` -- Enable applications features on the backend.
+* `chef-automate dev enable-prometheus` -- enables metrics collection from Automate
+
+With this configuration, it's useful to give the following options to ssh:
+* `-L 10109:localhost:10109` -- access Automate's prometheus via http://localhost:10109
+* `-L 443:localhost:443` -- access Automate's UI. This requires `ssh` to be root on the client side, so you may need to pass `-i /path/to/my/id_rsa` as well.
+
+ULIMIT: Even when running as root, the system limits the number of open files allowed by default. In order to create the number of client connections required to simulate larger loads, it is necessary to increase this limit:
+`ulimit -n 102400`.
+
+Load Test Configuration
+-----------------------
+
+Configuration was based on the `noms.toml` configuration from the `dev/applications-load-gen` directory. This configuration creates two supervisor configurations with three services each. The total count of simulated supervisors was set to different values throughout the test to explore the system's capability to handle various amounts of load. One particularly valuable observation was to compare the message rate as measured by the load generator to that reported by the applications service. This helped to detect when nats-streaming began to buffer messages.
+

--- a/components/applications-service/pkg/generator/config.go
+++ b/components/applications-service/pkg/generator/config.go
@@ -31,7 +31,7 @@ func (l *LoadProfileCfg) BuildRunner() (*LoadGenRunner, error) {
 	return &LoadGenRunner{SupervisorGroups: groups}, nil
 }
 
-func (l *LoadProfileCfg) BuildSupervisorGroups() ([]*SupervisorGroup, error) {
+func (l *LoadProfileCfg) BuildSupervisorGroups() (SupervisorGroupCollection, error) {
 	groups := []*SupervisorGroup{}
 
 	for _, supCfg := range l.GeneratorCfg.Supervisors {
@@ -53,7 +53,7 @@ func (l *LoadProfileCfg) BuildSupervisorGroups() ([]*SupervisorGroup, error) {
 
 		groups = append(groups, &group)
 	}
-	return groups, nil
+	return SupervisorGroupCollection(groups), nil
 }
 
 // [templates]

--- a/components/applications-service/pkg/generator/runner.go
+++ b/components/applications-service/pkg/generator/runner.go
@@ -151,14 +151,6 @@ func (s *SupervisorGroup) NewSup(n int32, cfg *RunnerConfig, stats *RunnerStatsK
 		Stats:             stats,
 	}
 	return sup, nil
-
-	// err = sup.Run()
-	// if err != nil {
-	// 	fmt.Printf("Supervisor failed to run: %s\n", err)
-	// 	return err
-	// }
-
-	// return nil
 }
 
 type SupSim struct {

--- a/components/applications-service/pkg/generator/runner.go
+++ b/components/applications-service/pkg/generator/runner.go
@@ -185,7 +185,7 @@ func (s *SupSim) Connect() error {
 	return s.nc.Connect()
 }
 
-func (s *SupSim) Run() error {
+func (s *SupSim) Run() {
 	s.Stats.SupStarted()
 	defer s.Stats.SupDied()
 	defer s.nc.Close()
@@ -204,7 +204,6 @@ func (s *SupSim) Run() error {
 	for _ = range ticker.C {
 		s.PublishAll() // nolint: errcheck
 	}
-	return nil
 }
 
 func (s *SupSim) PublishAll() error {

--- a/components/applications-service/pkg/nats/nats.go
+++ b/components/applications-service/pkg/nats/nats.go
@@ -133,7 +133,7 @@ func (nc *NatsClient) Connect() error {
 		}).Error("Unable to connect to server")
 
 		baseSleep := int64(uint32(1) << tries)
-		randomization := rand.Int63n(int64(baseSleep))
+		randomization := rand.Int63n(baseSleep)
 		totalSleep := baseSleep + randomization
 		time.Sleep(time.Duration(totalSleep) * time.Second)
 

--- a/components/applications-service/pkg/nats/nats.go
+++ b/components/applications-service/pkg/nats/nats.go
@@ -3,6 +3,7 @@ package nats
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"math/rand"
 	"time"
 
 	"github.com/chef/automate/api/external/applications"
@@ -51,7 +52,7 @@ func NewExternalClient(url, cluster, client, durable, subject string) *NatsClien
 		durableID:         durable,
 		subject:           subject,
 		HabServiceEventCh: make(chan *applications.HabService), // buffered channel?
-		retries:           10,
+		retries:           5,
 	}
 }
 
@@ -64,7 +65,7 @@ func New(url, cluster, client, durable, subject string, tlsConfig certs.TLSConfi
 		durableID:         durable,
 		subject:           subject,
 		HabServiceEventCh: make(chan *applications.HabService), // buffered channel?
-		retries:           10,
+		retries:           5,
 		TLSConfig:         tlsConfig,
 	}
 }
@@ -97,7 +98,7 @@ func (nc *NatsClient) Connect() error {
 	var (
 		conn  stan.Conn
 		err   error
-		tries = 0
+		tries = uint64(0)
 	)
 
 	tlsConf, err := nc.natsTLSConfig()
@@ -116,7 +117,7 @@ func (nc *NatsClient) Connect() error {
 		"mtls_enabled": mTLSEnabled,
 	}).Info("Connecting to NATS Server")
 
-	for tries < nc.retries {
+	for tries < uint64(nc.retries) {
 		conn, err = nc.tryConnect(tlsConf)
 		if err == nil {
 			nc.conn = conn
@@ -131,7 +132,10 @@ func (nc *NatsClient) Connect() error {
 			"max_retries": nc.retries,
 		}).Error("Unable to connect to server")
 
-		time.Sleep(5 * time.Second)
+		baseSleep := int64(uint32(1) << tries)
+		randomization := rand.Int63n(int64(baseSleep))
+		totalSleep := baseSleep + randomization
+		time.Sleep(time.Duration(totalSleep) * time.Second)
 
 		tries++
 	}

--- a/components/applications-service/pkg/server/ingest.go
+++ b/components/applications-service/pkg/server/ingest.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/chef/automate/api/external/applications"
+	"github.com/chef/automate/components/applications-service/pkg/config"
+	"github.com/chef/automate/components/applications-service/pkg/nats"
+	"github.com/chef/automate/components/applications-service/pkg/storage/postgres"
+)
+
+const numWorkers = 50
+
+type Ingester struct {
+	Cfg              *config.Applications
+	DBClient         *postgres.Postgres
+	natsClient       *nats.NatsClient
+	workerInputQueue chan<- *applications.HabService
+	workerTaskQueue  <-chan *applications.HabService
+}
+
+func NewIngester(c *config.Applications, db *postgres.Postgres) *Ingester {
+
+	q := make(chan *applications.HabService)
+
+	return &Ingester{
+		Cfg:              c,
+		DBClient:         db,
+		workerInputQueue: q,
+		workerTaskQueue:  q,
+	}
+
+}
+
+// Connect initiates the connection to the NATS server. It's separate from
+// Run() so connection errors can be handled easily while still running the
+// ingester in a goroutine.
+func (i *Ingester) Connect() error {
+	url := "nats://%s:%d"
+
+	natsClient := nats.NewDefaults(
+		fmt.Sprintf(url, i.Cfg.Events.Host, i.Cfg.Events.Port),
+		i.Cfg.Events.ClusterID,
+		*i.Cfg.TLSConfig,
+	)
+
+	// Trigger NATS Subscription
+	err := natsClient.ConnectAndSubscribe()
+	if err != nil {
+		return errors.Wrapf(err, "could not connect to nats-streaming")
+	}
+	i.natsClient = natsClient
+	return nil
+}
+
+func (i *Ingester) Run() {
+	for n := 0; n <= numWorkers; n++ {
+		go i.runWorkerLoop()
+	}
+	// Receive digested messages from the event channel and
+	// send them to the datastore for processing
+	// TODO @afiune Move this logic into an ingestion pipeline
+	for {
+		select {
+		case event := <-i.natsClient.HabServiceEventCh:
+			i.workerInputQueue <- event
+		}
+	}
+}
+
+func (i *Ingester) runWorkerLoop() {
+	for {
+		select {
+		case event := <-i.workerTaskQueue:
+			err := i.DBClient.IngestHabEvent(event)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"error": err.Error(),
+				}).Error("Unable to ingest habitat event")
+			}
+		}
+	}
+}

--- a/components/applications-service/pkg/storage/postgres/db.go
+++ b/components/applications-service/pkg/storage/postgres/db.go
@@ -11,19 +11,19 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// postgres is a wrapping struct that will hold the database mapping object
+// Postgres is a wrapping struct that will hold the database mapping object
 // from the underlying db/sql implementation (gorp) plus our service config
 // specifically for storage.
 //
 // Additionally this struct implements our storage.Client interface
-type postgres struct {
+type Postgres struct {
 	*gorp.DbMap
 	*config.Postgres
 }
 
-// New creates a new postgres client
-func New(dbConf *config.Postgres) (*postgres, error) {
-	pg := &postgres{Postgres: dbConf}
+// New creates a new Postgres client
+func New(dbConf *config.Postgres) (*Postgres, error) {
+	pg := &Postgres{Postgres: dbConf}
 
 	log.WithFields(log.Fields{
 		"uri": pg.URI,
@@ -42,12 +42,12 @@ func New(dbConf *config.Postgres) (*postgres, error) {
 }
 
 // ping will verify if the database mapped with gorp is available
-func (db *postgres) ping() error {
+func (db *Postgres) ping() error {
 	return db.Db.Ping()
 }
 
 // connect opens a connection to the database
-func (db *postgres) connect() error {
+func (db *Postgres) connect() error {
 	dbMap, err := gosql.Open("postgres", db.URI)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to open database with uri: %s", db.URI)
@@ -66,7 +66,7 @@ func (db *postgres) connect() error {
 }
 
 // initDB initializes the database
-func (db *postgres) initDB() error {
+func (db *Postgres) initDB() error {
 	// Create the schema
 	// @afiune Can we rename this library?
 	if err := migrator.Migrate(db.URI, db.SchemaPath); err != nil {

--- a/components/applications-service/pkg/storage/postgres/hab_event.go
+++ b/components/applications-service/pkg/storage/postgres/hab_event.go
@@ -45,7 +45,7 @@ var (
 )
 
 // IngestHabEvents process habitat events and store them into the database
-func (db *postgres) IngestHabEvent(event *applications.HabService) error {
+func (db *Postgres) IngestHabEvent(event *applications.HabService) error {
 	opsInFlight.Inc()
 	defer opsInFlight.Dec()
 	processingStart := time.Now()
@@ -66,7 +66,7 @@ func (db *postgres) IngestHabEvent(event *applications.HabService) error {
 }
 
 // IngestHabEvents process habitat events and store them into the database
-func (db *postgres) IngestHabEventWithoutMetrics(event *applications.HabService) error {
+func (db *Postgres) IngestHabEventWithoutMetrics(event *applications.HabService) error {
 	log.WithFields(log.Fields{
 		"storage": "postgres",
 		"message": event,
@@ -98,7 +98,7 @@ func (db *postgres) IngestHabEventWithoutMetrics(event *applications.HabService)
 // insertNewService assumes the service to be inserted doesn't exist already,
 // this function is wrapped with a transaction func since it could do multiple things
 // like insert a supervisor, service_group, deployment and the service itself.
-func (db *postgres) insertNewService(event *applications.HabService) error {
+func (db *Postgres) insertNewService(event *applications.HabService) error {
 
 	return dblib.Transaction(db.DbMap, func(tx *gorp.Transaction) error {
 
@@ -194,7 +194,7 @@ WHERE app_name = $1
   AND environment = $2
 `
 
-func (db *postgres) getDeploymentID(app, env string) (int32, bool) {
+func (db *Postgres) getDeploymentID(app, env string) (int32, bool) {
 	var id int32
 	err := db.SelectOne(&id, selectDeploymentID, app, env)
 	if err != nil {
@@ -209,7 +209,7 @@ SELECT id FROM supervisor
 WHERE member_id = $1
 `
 
-func (db *postgres) getSupervisorID(member string) (int32, bool) {
+func (db *Postgres) getSupervisorID(member string) (int32, bool) {
 	var sid int32
 	err := db.SelectOne(&sid, selectSupervisorID, member)
 	if err != nil {
@@ -224,7 +224,7 @@ SELECT id FROM service_group
 WHERE name = $1
 `
 
-func (db *postgres) getServiceGroupID(name string) (int32, bool) {
+func (db *Postgres) getServiceGroupID(name string) (int32, bool) {
 	var gid int32
 	err := db.SelectOne(&gid, selectServiceGroupID, name)
 	if err != nil {

--- a/components/applications-service/pkg/storage/postgres/service.go
+++ b/components/applications-service/pkg/storage/postgres/service.go
@@ -58,7 +58,7 @@ FROM service AS s
 // GetServicesHealthCounts retrieves the health counts from all services in the database.
 // This function accepts a set of filters that can be applied to the SQL query to get the
 // health counts of a subset of the services in the database
-func (db *postgres) GetServicesHealthCounts(filters map[string][]string) (*storage.HealthCounts, error) {
+func (db *Postgres) GetServicesHealthCounts(filters map[string][]string) (*storage.HealthCounts, error) {
 	var (
 		sHealthCounts         storage.HealthCounts
 		WhereConstraints, err = buildWhereConstraintsFromFilters(filters)
@@ -79,7 +79,7 @@ func (db *postgres) GetServicesHealthCounts(filters map[string][]string) (*stora
 }
 
 // GetServices returns a list of services
-func (db *postgres) GetServices(
+func (db *Postgres) GetServices(
 	sortField string, sortAsc bool,
 	page int32, pageSize int32,
 	filters map[string][]string,
@@ -115,7 +115,7 @@ func (db *postgres) GetServices(
 }
 
 // getServiceFromUniqueFields retreives a service from the db without the need of an id
-func (db *postgres) getServiceFromUniqueFields(origin, name, member string) (*service, bool) {
+func (db *Postgres) getServiceFromUniqueFields(origin, name, member string) (*service, bool) {
 	var svc service
 	err := db.SelectOne(&svc, selectService, origin, name, member)
 	if err != nil {

--- a/components/applications-service/pkg/storage/postgres/service_groups.go
+++ b/components/applications-service/pkg/storage/postgres/service_groups.go
@@ -125,7 +125,7 @@ func (sgh *serviceGroupHealth) OverallHealth() string {
 }
 
 // getServiceFromUniqueFields retrieve a service from the db without the need of an id
-func (db *postgres) GetServiceGroups(
+func (db *Postgres) GetServiceGroups(
 	sortField string, sortAsc bool,
 	page int32, pageSize int32,
 	filters map[string][]string) ([]*storage.ServiceGroupDisplay, error) {
@@ -209,7 +209,7 @@ func (sgh *serviceGroupHealth) ReleaseString() string {
 }
 
 // GetServiceGroupsHealthCounts retrieves the health counts from all service groups in the database
-func (db *postgres) GetServiceGroupsHealthCounts() (*storage.HealthCounts, error) {
+func (db *Postgres) GetServiceGroupsHealthCounts() (*storage.HealthCounts, error) {
 	var sgHealthCounts storage.HealthCounts
 	err := db.SelectOne(&sgHealthCounts, selectServiceGroupsHealthCounts)
 	if err != nil {
@@ -220,7 +220,7 @@ func (db *postgres) GetServiceGroupsHealthCounts() (*storage.HealthCounts, error
 }
 
 // ServiceGroupExists returns the name of the service group if it exists
-func (db *postgres) ServiceGroupExists(id string) (string, bool) {
+func (db *Postgres) ServiceGroupExists(id string) (string, bool) {
 	var sg serviceGroup
 	err := db.SelectOne(&sg, "SELECT * FROM service_group WHERE id = $1", id)
 	if err != nil {

--- a/components/applications-service/pkg/storage/postgres/testing_functions.go
+++ b/components/applications-service/pkg/storage/postgres/testing_functions.go
@@ -2,7 +2,7 @@ package postgres
 
 // EmptyStorage deletes all the data from the database
 // @afiune This function is only used by our Integration Test framework
-func (db *postgres) EmptyStorage() error {
+func (db *Postgres) EmptyStorage() error {
 	_, err := db.Exec("DELETE FROM deployment")
 	if err != nil {
 		return err

--- a/components/automate-prometheus/habitat/config/prometheus.yml
+++ b/components/automate-prometheus/habitat/config/prometheus.yml
@@ -2,7 +2,7 @@
 #
 # my global config
 global:
-  scrape_interval:     1m # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
   evaluation_interval: 1m # Evaluate rules every 15 seconds. The default is every 1 minute.
   # scrape_timeout is set to the global default (10s).
 


### PR DESCRIPTION
### :nut_and_bolt: Description

This patch contains a handful of small-ish items I fixed/changed in the process of load testing the ingestion system:
* Set lower limits on NATS streaming message storage. We've had operational problems with unlimited queues in the past; NATS is not unlimited by default, but the limits are too large for our current performance characteristics. I opted to not do anything too fancy but left a lengthy code comment explaining.
* first step changing ingestion code to a pipeline. We use one goroutine to read messages from NATS and pass them via a go channel to a set of worker goroutines. Since go uses m:n threading we can just spawn a fairly large fixed number of workers.
* Add some rollup stats when describing a load generator configuration so you have a better idea what the generated load will be.
* Make the load generator initiate connections to the event gateway in a more sequential fashion; it takes a few minutes to setup thousands of connections.
* randomized exponential backoff when connecting to event gateway fails; this is faster for a single retry and slower but more likely to eventually succeed when lots of retries are needed.

### :+1: Definition of Done

This is a bit open-ended but the PR addresses all the issues I found during the performance test.

### :athletic_shoe: Demo Script / Repro Steps

See the documentation of the results and process of the test for more about how to run your own load test.

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?