### PR TITLE
use test framework to spin up a2 cluster

### DIFF
--- a/integration/run_test
+++ b/integration/run_test
@@ -75,6 +75,11 @@ if [ ${#test_external_services[@]} -ne 0 ]; then
     done
 fi
 
+if [ ! -z "$EXTERNAL_ONLY" ]; then
+    echo "Started external services... exiting"
+    exit 0
+fi
+
 echo "${docker_run_args[*]}"
 
 docker run "${docker_run_args[@]}" chefes/a2-integration:latest

--- a/integration/services/automate_cluster/a2_setup.sh
+++ b/integration/services/automate_cluster/a2_setup.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -e /services/ha_backend.toml ]; then
+    echo "automate cluster depends on ha backend cluster"
+    exit 1
+fi
+
+echo "Doing sysctl stuff"
+cat > /etc/sysctl.d/00-chef.conf <<EOF
+vm.swappiness=10
+vm.max_map_count=262144
+vm.dirty_ratio=20
+vm.dirty_background_ratio=30
+vm.dirty_expire_centisecs=30000
+net.ipv4.ip_local_port_range=1024 65024 net.ipv4.tcp_max_syn_backlog=60000
+net.ipv4.tcp_tw_reuse=1
+net.core.somaxconn=1024
+EOF
+
+sysctl -p /etc/sysctl.d/00-chef.conf
+
+cat > /etc/security/limits.d/20-nproc.conf<<EOF
+*   soft  nproc     65536
+*   hard  nproc     65536
+*   soft  nofile    1048576
+*   hard  nofile    1048576
+EOF
+
+if [ -z "$HAB_ORIGIN" ]; then
+    HAB_ORIGIN="chef"
+fi
+
+HARTIFACTS_PATH="$PWD/results"
+A2_CONFIG_PATH="/services/automate_cluster_private/config.toml"
+
+if [ ! -e "$A2_CONFIG_PATH" ]; then
+    echo "Rendering config"
+    /services/automate_cluster_private/chef-automate init-config \
+        --channel dev \
+        --file "$A2_CONFIG_PATH" \
+        --upgrade-strategy "at-once"
+
+    cat /services/ha_backend.toml >> $A2_CONFIG_PATH
+fi
+
+
+echo "Starting automate container"
+/services/automate_cluster_private/chef-automate deploy $A2_CONFIG_PATH \
+        --hartifacts "$HARTIFACTS_PATH" \
+        --override-origin "$HAB_ORIGIN" \
+        --admin-password chefautomate \
+        --accept-terms-and-mlsa

--- a/integration/services/automate_cluster/init
+++ b/integration/services/automate_cluster/init
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+AUTOMATE_CLUSTER_DIR=$(dirname ${BASH_SOURCE[0]})
+
+automate_cluster_container1=$(service_container_name "automate_cluster_1")
+automate_cluster_container2=$(service_container_name "automate_cluster_2")
+automate_cluster_container_nginx=$(service_container_name "automate_cluster_nginx")
+
+automate_cluster_private=$(service_config_path "automate_cluster_private")
+
+automate_cluster_setup() {
+    echo "Automate cluster directory: $automate_cluster_private"
+
+    mkdir -p $automate_cluster_private
+
+    curl https://packages.chef.io/files/dev/automate/latest/chef-automate_linux_amd64.zip | gunzip - > \
+        "$automate_cluster_private/chef-automate" && chmod +x "$automate_cluster_private/chef-automate"
+
+    docker_run $automate_cluster_container1
+    local automate_cluster_container1_ip=$(container_ip $automate_cluster_container1)
+    log_info "Launched $automate_cluster_container1 with ip ${automate_cluster_container1_ip}"
+
+    docker_run $automate_cluster_container2
+    local automate_cluster_container2_ip=$(container_ip $automate_cluster_container2)
+    log_info "Launched $automate_cluster_container2 with ip ${automate_cluster_container2_ip}"
+
+    #hab pkg exec core/openssl openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
+        #-keyout $automate_cluster_private/nginx-selfsigned.pem \
+        #-out $automate_cluster_private/nginx-selfsigned.crt \
+        #-reqexts SAN -extensions SAN -subj '/CN=elasticsearch' \
+        #-config \
+        #<(cat "$openssl_cnf" \
+        #<(printf "\n[SAN]\nsubjectAltName=IP.1:${automate_cluster_container1_ip},IP.2:${automate_cluster_container2_ip}"))
+
+    docker cp "$AUTOMATE_CLUSTER_DIR/a2_setup.sh" "${automate_cluster_container1}:/a2_setup.sh"
+    docker cp "$AUTOMATE_CLUSTER_DIR/a2_setup.sh" "${automate_cluster_container2}:/a2_setup.sh"
+    #docker cp "$AUTOMATE_CLUSTER_DIR/nginx_setup.sh" "${automate_cluster_container_nginx}:/nginx_setup.sh"
+
+    docker exec -t $automate_cluster_container1 /a2_setup.sh "$automate_cluster_container1_ip"
+    docker exec -t $automate_cluster_container2 /a2_setup.sh "$automate_cluster_container2_ip"
+    #docker exec -t $automate_cluster_container_nginx /nginx_setup.sh "$automate_cluster_container_nginx_ip"
+}
+
+automate_cluster_dump_logs() {
+    :
+}
+
+automate_cluster_teardown() {
+    docker stop "$automate_cluster_container1"
+    docker stop "$automate_cluster_container2"
+    docker stop "$automate_cluster_container_nginx"
+}

--- a/integration/tests/multi_node.sh
+++ b/integration/tests/multi_node.sh
@@ -1,0 +1,20 @@
+test_name="multi_node"
+test_external_services=(ha_backend automate_cluster)
+#test_backup_restore=true
+
+do_deploy() {
+    :
+    #chef-automate deploy config.toml \
+        #--hartifacts "$test_hartifacts_path" \
+        #--override-origin "$HAB_ORIGIN" \
+        #--manifest-dir "$test_manifest_path" \
+        #--enable-chef-server \
+        #--admin-password chefautomate \
+        #--accept-terms-and-mlsa
+}
+
+do_create_config() {
+    :
+    #do_create_config_default
+    #cat /services/ha_backend.toml >> $test_config_path
+}


### PR DESCRIPTION
Currently, run's 2 A2 nodes and 2 HA backend nodes

```
EXTERNAL_ONLY=1 HAB_ORIGIN=jaym ./integration/run_test ./integration/tests/multi_node.sh
```

Still todo is a load balancer


