### PR TITLE
fixed issue for the client run page search bar shows empty suggestion

### DIFF
--- a/components/automate-ui/src/app/page-components/client-runs-search-bar/client-runs-search-bar.component.ts
+++ b/components/automate-ui/src/app/page-components/client-runs-search-bar/client-runs-search-bar.component.ts
@@ -70,7 +70,11 @@ export class ClientRunsSearchBarComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.filterValues) {
-      this.suggestions = List<string>(changes.filterValues.currentValue);
+      if (changes.filterValues.currentValue.length > 0 && changes.filterValues.currentValue[0] !== undefined){
+        this.suggestions = List<string>(changes.filterValues.currentValue);
+      } else {
+        this.suggestions = List<string>();
+      }
       this.isLoadingSuggestions = false;
     }
 

--- a/components/automate-ui/src/app/page-components/client-runs-search-bar/client-runs-search-bar.component.ts
+++ b/components/automate-ui/src/app/page-components/client-runs-search-bar/client-runs-search-bar.component.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 import { Subject, Observable, of as observableOf } from 'rxjs';
 import { List } from 'immutable';
-import { clamp } from 'lodash';
+import { clamp, compact } from 'lodash';
 import { Chicklet } from '../../types/types';
 import {
   debounceTime, switchMap, distinctUntilChanged
@@ -70,17 +70,18 @@ export class ClientRunsSearchBarComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.filterValues) {
-      if (changes.filterValues.currentValue.length > 0 && changes.filterValues.currentValue[0] !== undefined){
-        this.suggestions = List<string>(changes.filterValues.currentValue);
-      } else {
-        this.suggestions = List<string>();
-      }
+      const listValues = this.handleFiltersValues(changes.filterValues.currentValue);
+      this.suggestions = List<string>(listValues);
       this.isLoadingSuggestions = false;
     }
 
     if (changes.filterTypes) {
       this.visibleCategories = List<Chicklet>(changes.filterTypes.currentValue);
     }
+  }
+
+  handleFiltersValues(currentValues) {
+    return compact(currentValues);
   }
 
   handleFiltersClick() {

--- a/components/automate-ui/src/app/page-components/client-runs-search-bar/client-runs-search-bar.component.ts
+++ b/components/automate-ui/src/app/page-components/client-runs-search-bar/client-runs-search-bar.component.ts
@@ -70,18 +70,13 @@ export class ClientRunsSearchBarComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.filterValues) {
-      const listValues = this.handleFiltersValues(changes.filterValues.currentValue);
-      this.suggestions = List<string>(listValues);
+      this.suggestions = List<string>(compact(changes.filterValues.currentValue));
       this.isLoadingSuggestions = false;
     }
 
     if (changes.filterTypes) {
       this.visibleCategories = List<Chicklet>(changes.filterTypes.currentValue);
     }
-  }
-
-  handleFiltersValues(currentValues) {
-    return compact(currentValues);
   }
 
   handleFiltersClick() {


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description
Fixed issue for the client_run page search bar shows empty suggestion if the user selects the policy group filter and policy name filter.

### :athletic_shoe: Demo Script / Repro Steps
https://files.slack.com/files-pri/T03GRS9QS-FHCMEHV5J/download/policy_group_undefined_filter_bug.mov
### :chains: Related Resources
https://github.com/chef/a2/issues/5420