### PR TITLE
 Add scan time on Scan Results node lists

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
@@ -115,6 +115,7 @@
                 <p class="node-name">
                   <strong>{{ node.name }}</strong>
                 </p>
+                <p>{{formatDaysAgo(node.latest_report.end_time)}}</p>
               </div>
               <chef-button secondary (click)="onNodeSelected(node)">
                 <chef-icon>add</chef-icon>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.spec.ts
@@ -64,7 +64,7 @@ describe('ReportingProfileComponent', () => {
           {type: { name: 'profile_id' }, value: { text: '123'} },
           {type: { name: 'control_id' }, value: { text: '321'} }
         ],
-        { perPage: 1000, page: 1, sort: 'latest_report.end_time', order: 'DESC' });
+        { perPage: 1000, page: 1, sort: 'latest_report.end_time', order: 'desc' });
     });
   });
 });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.spec.ts
@@ -64,7 +64,7 @@ describe('ReportingProfileComponent', () => {
           {type: { name: 'profile_id' }, value: { text: '123'} },
           {type: { name: 'control_id' }, value: { text: '321'} }
         ],
-        { perPage: 1000, page: 1 });
+        { perPage: 1000, page: 1, sort: 'latest_report.end_time', order: 'DESC' });
     });
   });
 });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
@@ -130,7 +130,10 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
     const profileFilter = {type: { name: 'profile_id' } , value: { text: params.profileId}};
     const controlFilter = {type: { name: 'control_id' } , value: { text: params.controlId}};
     filters = [profileFilter, controlFilter].concat(filters);
-    return this.statsService.getNodes(filters, paginationOverride).pipe(
+    params = paginationOverride;
+    params['sort'] = 'latest_report.end_time';
+    params['order'] = 'desc';
+    return this.statsService.getNodes(filters, params).pipe(
       map(data => {
         return data.items.map(node => {
           node.status = node.latest_report.status;

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
@@ -10,6 +10,7 @@ import { StatsService } from '../../shared/reporting/stats.service';
 import { ReportQueryService } from '../../shared/reporting/report-query.service';
 import { ScanResultsService } from '../../shared/reporting/scan-results.service';
 import { paginationOverride } from '../shared';
+import * as moment from 'moment';
 
 @Component({
   selector: 'app-reporting-profile',
@@ -204,5 +205,9 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
+  }
+
+  formatDaysAgo(timestamp) {
+    return moment(timestamp).fromNow();
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
@@ -24,7 +24,7 @@
         <chef-td class="title-cell">
           <chef-icon class="status-icon" [ngClass]="profile.status">
             {{ statusIcon(profile.status) }}
-          </chef-icon> 
+          </chef-icon>
           <a [routerLink]="['/compliance/reporting/profiles', profile.id]">{{ profile.title }}</a>
         </chef-td>
         <chef-td class="version-cell">{{ profile.version }}</chef-td>
@@ -82,6 +82,7 @@
                   <p class="node-name">
                     <strong>{{ node.name }}</strong>
                   </p>
+                  <p>{{formatDaysAgo(node.latest_report.end_time)}}</p>
                 </div>
                 <chef-button secondary (click)="getControls(node)">
                   <chef-icon>chevron_right</chef-icon>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.ts
@@ -6,6 +6,7 @@ import { Filter } from '../types';
 import { paginationOverride } from '../shared';
 import { StatsService, ReportQueryService, ReportDataService } from '../../shared/reporting';
 import { ChefSessionService } from '../../../../services/chef-session/chef-session.service';
+import * as moment from 'moment';
 
 @Component({
   selector: 'app-reporting-profiles',
@@ -207,4 +208,7 @@ export class ReportingProfilesComponent implements OnInit, OnDestroy {
     this.openControls[control.id].pane = pane;
   }
 
+  formatDaysAgo(timestamp) {
+    return moment(timestamp).fromNow();
+  }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.ts
@@ -114,7 +114,8 @@ export class ReportingProfilesComponent implements OnInit, OnDestroy {
       type: { name: 'profile_id' },
       value: { text: profile.id }
     };
-
+    listParams['sort'] = 'latest_report.end_time';
+    listParams['order'] = 'desc';
     this.statsService.getNodes(filters, listParams).pipe(
       takeUntil(this.isDestroyed))
       .subscribe(data => {


### PR DESCRIPTION
Fixes https://github.com/chef/automate/issues/149

On top of adding the scan time under the node name, this PR also changes the `latest_report.end_time` sort order from  ASC(default) to DESC to put the recently scanned nodes at the top of the list.

Result:
![Screen Shot 2019-04-24 at 11 09 50 AM](https://user-images.githubusercontent.com/107378/56691952-fc195b00-66d8-11e9-9e0d-7ca30369bbdc.png)