### PR TITLE
[release notes] add upgrade impact warning

### DIFF
--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -18,6 +18,10 @@ pushd ./automate.wiki
 
   # Reset "Current Release Notes" wiki page
   cat >./Current-Release-Notes.md <<EOH
+## Upgrade Impact
+
+If you are upgrading from a version prior to 20190410001346, please read our [Important Compliance Outage Announcement](https://discourse.chef.io/t/important-compliance-outage-information-on-automate-2-april-15th-upgrade/14909).
+
 ## New Features
 -
 


### PR DESCRIPTION
until a date to be decided further in the future, the release notes
should contain a warning and link to our post on the upgrade impact
related to deep filtering index changes. before we forget to add them
I've put them into the automatic release note template that gets
reset on every promotion

Signed-off-by: Stephen Delano <stephen@chef.io>

### :nut_and_bolt: Description

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?