### PR TITLE
[promotion] automate weekly promotion announcement

### DIFF
--- a/.expeditor/announce-acceptance.sh
+++ b/.expeditor/announce-acceptance.sh
@@ -3,10 +3,12 @@
 current=$(curl https://packages.chef.io/manifests/current/automate/latest.json 2>/dev/null | jq -r '.git_sha');
 acceptance=$(curl https://packages.chef.io/manifests/acceptance/automate/latest.json 2>/dev/null | jq -r '.git_sha');
 
-cat <<EOF
+read -r -d '' message <<EOF
 @here :success: A2 has been promoted from \`dev\` to \`acceptance\` :success:
 
 The list of changes can be found here: https://github.com/chef/automate/compare/${current}...${acceptance}
 
 Please take your time to fill out the release notes by *EOD WEDNESDAY*: https://github.com/chef/automate/wiki/Current-Release-Notes
 EOF
+
+post_slack_message "a2-team" "$message"

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -840,6 +840,12 @@ promote:
           - value_one: "{{target_channel}}"
             operator: equals
             value_two: current
+    - bash:.expeditor/announce-acceptance.sh:
+        post_commit: true
+        only_if_conditions:
+          - value_one: "{{target_channel}}"
+            operator: equals
+            value_two: acceptance
     - trigger_pipeline:deploy/acceptance:
         only_if_conditions:
           - value_one: "{{target_channel}}"


### PR DESCRIPTION
The PR automates the weekly internal promotion announcement such that it doesn't need to be run from a local laptop and pasted to Slack.

Signed-off-by: Stephen Delano <stephen@chef.io>

### :nut_and_bolt: Description

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?