### PR TITLE
Fix compliance status inconsistency for skipped node

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
@@ -60,8 +60,8 @@
         <chef-td>{{ node.environment }}</chef-td>
         <chef-td>{{ formatTime(node.latest_report.end_time) }}</chef-td>
         <chef-td>
-          <span class="controls-status" [ngClass]="statusControls(node.latest_report.controls)">
-            {{ statusControlsSeverity(node.latest_report.controls) | uppercase }}
+          <span class="controls-status" [ngClass]="node.latest_report.status">
+            {{ statusControlsSeverity(node.latest_report.controls, node.latest_report.status) | uppercase }}
           </span>
         </chef-td>
         <chef-td>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.ts
@@ -198,20 +198,7 @@ export class ReportingNodesComponent implements OnInit, OnDestroy {
     }
   }
 
-  statusControls(controls) {
-    const failed = controls.failed.total;
-    const skipped = controls.skipped.total;
-    const passed = controls.passed.total;
-    switch (true) {
-      case (failed > 0): return 'failed';
-      case (passed > 0 || skipped === 0): return 'passed';
-      case (passed === 0 && skipped > 0): return 'skipped';
-      default: return '';
-    }
-  }
-
-  statusControlsSeverity(controls) {
-    const status = this.statusControls(controls);
+  statusControlsSeverity(controls, status) {
     switch (status) {
       case ('failed'): return `${controls.failed.total} Failed`;
       case ('passed'): return 'Passed';

--- a/components/compliance-service/api/tests/04_stats_spec.rb
+++ b/components/compliance-service/api/tests/04_stats_spec.rb
@@ -550,6 +550,16 @@ if !ENV['NO_STATS_TESTS']
       }
       assert_equal_json_content(expected_data, actual_data)
 
+      # Compliance Summary without filters for a node skipped due to unsupported os
+      actual_data = GRPC stats, :read_summary, Stats::Query.new(type: "nodes", filters: [
+        Stats::ListFilter.new(type: 'end_time', values: ['2018-03-07T23:59:59Z'])
+      ])
+      expected_data = {
+        "nodeSummary" => {
+          "skipped" => 1
+        }
+      }
+      assert_equal_json_content(expected_data, actual_data)
 
       # Compliance Summary Nodes with filters
       actual_data = GRPC stats, :read_summary, Stats::Query.new(

--- a/components/compliance-service/api/tests/05_stats_summary_spec.rb
+++ b/components/compliance-service/api/tests/05_stats_summary_spec.rb
@@ -329,15 +329,15 @@ if !ENV['NO_STATS_SUMMARY_TESTS']
       Stats::ListFilter.new(type: 'control', values: ['nginx-01'])
       ])
       expected_data = {
-          "reportSummary" => {
+        "reportSummary" => {
           "status" => "failed",
           "stats" => {
-              "nodes" => 4,
-          "platforms" => 2,
-          "environments" => 2,
-          "profiles" => 1
-      }
-      }
+            "nodes" => 4,
+            "platforms" => 2,
+            "environments" => 2,
+            "profiles" => 1
+          }
+        }
       }.to_json
       assert_equal(expected_data, actual_data.to_json)
 
@@ -349,15 +349,15 @@ if !ENV['NO_STATS_SUMMARY_TESTS']
           Stats::ListFilter.new(type: "platform", values: ["centos"])
       ])
       expected_data = {
-          "reportSummary" => {
+        "reportSummary" => {
           "status" => "passed",   #look at this business! yes! for this control, we have a status of passed! notice the test above, we had 4 nodes with a status of failed
           "stats" => {
-              "nodes" => 1,
-          "platforms" => 1,
-          "environments" => 1,
-          "profiles" => 1
-      }
-      }
+            "nodes" => 1,
+            "platforms" => 1,
+            "environments" => 1,
+            "profiles" => 1
+          }
+        }
       }.to_json
 
       assert_equal(expected_data, actual_data.to_json)

--- a/components/compliance-service/generator/report/samples/o10-full.json
+++ b/components/compliance-service/generator/report/samples/o10-full.json
@@ -1,0 +1,33 @@
+{
+  "platform": {
+    "name": "mac_os_x",
+    "release": "17.7.0"
+  },
+  "profiles": [
+    {
+      "name": "mywindows",
+      "version": "0.1.3",
+      "sha256": "a41afaeb1d0ac15b9078d7ea139e741b6b27c1706c39ab0b09f3983f43c5940e",
+      "title": "My Demo Windows Profile",
+      "maintainer": "Demo, Inc.",
+      "summary": "Verify that Windows nodes are configured securely",
+      "license": "Proprietary, All rights reserved",
+      "copyright": "Demo, Inc.",
+      "copyright_email": "support@example.com",
+      "supports": [
+        {
+          "platform-family": "windows"
+        }
+      ],
+      "attributes": [],
+      "groups": [],
+      "controls": [],
+      "status": "skipped",
+      "skip_message": "Skipping profile: 'mywindows' on unsupported platform: 'mac_os_x/17.7.0'."
+    }
+  ],
+  "statistics": {
+    "duration": 0.021608
+  },
+  "version": "3.9.0"
+}

--- a/components/compliance-service/reporting/relaxting/stats_report_level.go
+++ b/components/compliance-service/reporting/relaxting/stats_report_level.go
@@ -338,19 +338,13 @@ func (depth *ReportDepth) getStatsSummaryResult(aggRoot *elastic.SearchResult) *
 
 func (depth *ReportDepth) getStatsSummaryNodesAggs() map[string]elastic.Aggregation {
 	aggCompliant := elastic.NewFilterAggregation().
-		Filter(elastic.NewBoolQuery().
-			Must(elastic.NewTermQuery("controls_sums.failed.total", 0)).
-			Should(elastic.NewTermQuery("controls_sums.skipped.total", 0),
-				elastic.NewRangeQuery("controls_sums.passed.total").Gt(0)))
+		Filter(elastic.NewTermQuery("status", "passed"))
 
 	aggSkipped := elastic.NewFilterAggregation().
-		Filter(elastic.NewBoolQuery().
-			Must(elastic.NewTermQuery("controls_sums.failed.total", 0)).
-			Must(elastic.NewTermQuery("controls_sums.passed.total", 0)).
-			Must(elastic.NewRangeQuery("controls_sums.skipped.total").Gt(0)))
+		Filter(elastic.NewTermQuery("status", "skipped"))
 
 	aggNoncompliant := elastic.NewFilterAggregation().
-		Filter(elastic.NewRangeQuery("controls_sums.failed.total").Gt(0))
+		Filter(elastic.NewTermQuery("status", "failed"))
 
 	aggHighRisk := elastic.NewFilterAggregation().
 		Filter(elastic.NewRangeQuery("controls_sums.failed.critical").Gt(0))


### PR DESCRIPTION
Fixes https://github.com/chef/automate/issues/165

Required a backend change for the `Summary > Node Status` section and UI change for the `Nodes > Control Failures` column value.