### PR TITLE
[A2-248] Add global projects-filter components

### DIFF
--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -51,6 +51,7 @@ import {
   NodeNoRunsDetailsResolverService
 } from './services/node-details/node-noruns-details-resolver.service';
 import { NodeRunsService } from './services/node-details/node-runs.service';
+import { ProjectsFilterService } from './services/projects-filter/projects-filter.service';
 import { RulesService } from './services/rules/rules.service';
 import { RunHistoryStore } from './services/run-history-store/run-history.store';
 import { SessionStorageService } from './services/storage/sessionstorage.service';
@@ -146,6 +147,12 @@ import {
 import { NodeRollupComponent } from './page-components/node-rollup/node-rollup.component';
 import { NotificationFormComponent } from './pages/notification-form/notification-form.component';
 import { NotificationsComponent } from './pages/notifications/notifications.component';
+import {
+  ProjectsFilterComponent
+} from './page-components/projects-filter/projects-filter.component';
+import {
+  ProjectsFilterDropdownComponent
+} from './page-components/projects-filter-dropdown/projects-filter-dropdown.component';
 import { ProfileComponent } from './page-components/profile/profile.component';
 import { ProfileDetailsComponent } from './pages/profile-details/profile-details.component';
 import {
@@ -228,6 +235,8 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     NodeRollupComponent,
     NotificationFormComponent,
     NotificationsComponent,
+    ProjectsFilterComponent,
+    ProjectsFilterDropdownComponent,
     ProfileComponent,
     ProfileDetailsComponent,
     ProfileSidebarComponent,
@@ -310,6 +319,7 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     PolicyRequests,
     ProfileRequests,
     ProjectRequests,
+    ProjectsFilterService,
     RoleRequests,
     { provide: RouterStateSerializer, useClass: RouterSerializer },
     RulesService,

--- a/components/automate-ui/src/app/ngrx.effects.ts
+++ b/components/automate-ui/src/app/ngrx.effects.ts
@@ -15,6 +15,7 @@ import { ManagerEffects } from './entities/managers/manager.effects';
 import { PolicyEffects } from './entities/policies/policy.effects';
 import { ProfileEffects } from './entities/profiles/profile.effects';
 import { ProjectEffects } from './entities/projects/project.effects';
+import { ProjectsFilterEffects } from './services/projects-filter/projects-filter.effects';
 import { RoleEffects } from './entities/roles/role.effects';
 import { ServiceGroupsEffects } from './entities/service-groups/service-groups.effects';
 import { ScannerEffects } from './pages/+compliance/+scanner/state/scanner.effects';
@@ -38,6 +39,7 @@ import { UserPermEffects } from './entities/userperms/userperms.effects';
       PolicyEffects,
       ProfileEffects,
       ProjectEffects,
+      ProjectsFilterEffects,
       RoleEffects,
       ServiceGroupsEffects,
       ScannerEffects,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -5,6 +5,7 @@ import * as credentials from './pages/+compliance/+credentials/credentials.state
 import * as scanner from './pages/+compliance/+scanner/state/scanner.state';
 import * as eventFeed from './services/event-feed/event-feed.reducer';
 import * as sidebar from './services/sidebar/sidebar.reducer';
+import * as projectsFilter from './services/projects-filter/projects-filter.reducer';
 
 import {
   ApiTokenEntityState,
@@ -65,6 +66,7 @@ export interface NgrxStateAtom {
   router: RouterReducerState;
   scanner: scanner.ScannerState;
   sidebar: sidebar.SidebarState;
+  projectsFilter: projectsFilter.ProjectsFilterState;
 
   // UI State
   integrations_add: IntegrationsAddState;
@@ -154,6 +156,7 @@ export const ngrxReducers = {
   scanner: scanner.scannerReducer,
   router: routerReducer,
   event_feed: eventFeed.eventFeedReducer,
+  projectsFilter: projectsFilter.projectsFilterReducer,
   sidebar: sidebar.sidebarReducer,
 
   // UI State

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -35,6 +35,7 @@
       </div>
     </div>
     <div class="right-nav" role="menubar">
+      <app-projects-filter></app-projects-filter>
       <app-profile></app-profile>
     </div>
   </nav>

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -35,7 +35,9 @@
       </div>
     </div>
     <div class="right-nav" role="menubar">
-      <app-projects-filter></app-projects-filter>
+      <app-projects-filter
+        *ngIf="(iamMajorVersion$ | async) === 'v2' && (iamMinorVersion$ | async) === 'v1'">
+      </app-projects-filter>
       <app-profile></app-profile>
     </div>
   </nav>

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.spec.ts
@@ -16,6 +16,7 @@ describe('NavbarComponent', () => {
       declarations: [
         NavbarComponent,
         MockComponent({ selector: 'app-profile' }),
+        MockComponent({ selector: 'app-projects-filter' }),
         MockComponent({ selector: 'chef-icon' }),
         MockComponent({ selector: 'chef-tooltip' }),
         MockComponent({ selector: 'app-authorized',
@@ -57,7 +58,14 @@ describe('NavbarComponent', () => {
     });
   });
 
-  it('should display the profile dropdown', () => {
+  it('displays the projects filter', () => {
+    element = fixture.nativeElement;
+    fixture.detectChanges();
+
+    expect(element.querySelector('app-projects-filter')).not.toBeNull();
+  });
+
+  it('displays the profile dropdown', () => {
     element = fixture.nativeElement;
     fixture.detectChanges();
 

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.spec.ts
@@ -1,17 +1,30 @@
 import { RouterTestingModule } from '@angular/router/testing';
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StoreModule } from '@ngrx/store';
+import { of as observableOf } from 'rxjs';
 import { NavbarComponent } from './navbar.component';
 import { MockComponent } from 'ng2-mock-component';
 import { using } from 'app/testing/spec-helpers';
-import { FeatureFlagsService } from '../../../app/services/feature-flags/feature-flags.service';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+import {
+  PolicyEntityInitialState,
+  policyEntityReducer
+} from 'app/entities/policies/policy.reducer';
 
 describe('NavbarComponent', () => {
-  let fixture, element;
+  let component: NavbarComponent;
+  let element: HTMLElement;
+  let fixture: ComponentFixture<NavbarComponent>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule
+        RouterTestingModule,
+        StoreModule.forRoot({
+          policies: policyEntityReducer
+        }, {
+          initialState: { policies: PolicyEntityInitialState }
+        })
       ],
       declarations: [
         NavbarComponent,
@@ -29,13 +42,13 @@ describe('NavbarComponent', () => {
     });
 
     fixture = TestBed.createComponent(NavbarComponent);
-    element = fixture.debugElement;
+    fixture.detectChanges();
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
   });
 
   it('displays the logo navigation link', () => {
-    const logo = element.nativeElement.querySelector('.logo');
-    fixture.detectChanges();
-
+    const logo = element.querySelector('.logo');
     expect(logo).not.toBeNull();
     expect(logo.getAttribute('href')).toBe('/');
   });
@@ -49,26 +62,25 @@ describe('NavbarComponent', () => {
     ['Settings',    '/settings',             6]
   ], function (label: string, path: string, position: number) {
     it(`displays the ${label} navigation link`, () => {
-      const link = element.nativeElement
-        .querySelector(`.navigation-menu > *:nth-child(${position}) a`);
-      fixture.detectChanges();
-
-      expect(link.innerText).toBe(label);
+      const link = element.querySelector(`.navigation-menu > *:nth-child(${position}) a`);
+      expect(link.textContent).toBe(label);
       expect(link.getAttribute('href')).toBe(path);
     });
   });
 
-  it('displays the projects filter', () => {
-    element = fixture.nativeElement;
-    fixture.detectChanges();
-
-    expect(element.querySelector('app-projects-filter')).not.toBeNull();
+  it('displays the profile dropdown', () => {
+    expect(element.querySelector('app-profile')).not.toBeNull();
   });
 
-  it('displays the profile dropdown', () => {
-    element = fixture.nativeElement;
-    fixture.detectChanges();
+  describe('when IAM v2.1 is enabled', () => {
+    beforeEach(() => {
+      component.iamMajorVersion$ = observableOf('v2');
+      component.iamMinorVersion$ = observableOf('v1');
+      fixture.detectChanges();
+    });
 
-    expect(element.querySelector('app-profile')).not.toBeNull();
+    it('displays the projects filter', () => {
+      expect(element.querySelector('app-projects-filter')).not.toBeNull();
+    });
   });
 });

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.ts
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.ts
@@ -1,5 +1,9 @@
 import { Component, isDevMode, OnInit } from '@angular/core';
-import { FeatureFlagsService } from '../../../app/services/feature-flags/feature-flags.service';
+import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+import { iamMinorVersion, iamMajorVersion } from 'app/entities/policies/policy.selectors';
 
 @Component({
   selector: 'app-navbar',
@@ -10,8 +14,13 @@ import { FeatureFlagsService } from '../../../app/services/feature-flags/feature
 export class NavbarComponent implements OnInit {
   public applicationsFeatureFlagOn: boolean;
 
+  public iamMajorVersion$: Observable<string>;
+
+  public iamMinorVersion$: Observable<string>;
+
   constructor(
-    private featureFlagsService: FeatureFlagsService
+    private featureFlagsService: FeatureFlagsService,
+    private store: Store<NgrxStateAtom>
   ) {}
 
   isDevMode() {
@@ -20,5 +29,7 @@ export class NavbarComponent implements OnInit {
 
   ngOnInit() {
     this.applicationsFeatureFlagOn = this.featureFlagsService.getFeatureStatus('applications');
+    this.iamMajorVersion$ = this.store.select(iamMajorVersion);
+    this.iamMinorVersion$ = this.store.select(iamMinorVersion);
   }
 }

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -1,0 +1,27 @@
+<button class="dropdown-label"
+  aria-label="Projects filter"
+  [attr.title]="selectionLabel"
+  (click)="handleLabelClick($event)">
+  <span class="selection-label">{{ selectionLabel }}</span>
+  <span class="selection-count"
+    *ngIf="selectionCountVisible"
+    [ngClass]="{'active': selectionCountActive }">
+    {{ selectionCount }}
+  </span>
+  <chef-icon aria-hidden>keyboard_arrow_down</chef-icon>
+</button>
+<chef-dropdown class="dropdown" *ngIf="dropdownActive" (keydown.esc)="handleEscape()">
+  <chef-click-outside class="dropdown-body" omit="dropdown-label" (clickOutside)="handleEscape()">
+    <span class="optgroup-label">Projects</span>
+    <chef-checkbox
+      *ngFor="let option of editableOptions; index as i"
+      [attr.title]="option.label"
+      [checked]="option.checked"
+      (change)="handleOptionChange($event, i)"
+      (keydown.arrowup)="handleArrowUp($event)"
+      (keydown.arrowdown)="handleArrowDown($event)">{{ option.label }}</chef-checkbox>
+    <div class="dropdown-footer">
+      <chef-button primary [attr.disabled]="!optionsEdited" (click)="handleApplyClick($event)">Apply Changes</chef-button>
+    </div>
+  </chef-click-outside>
+</chef-dropdown>

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -28,7 +28,7 @@
 
   .selection-label {
     display: inline-block;
-    max-width: 150px;
+    max-width: 180px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -1,0 +1,116 @@
+@import "~styles/variables";
+@import "~styles/mixins";
+
+:host {
+  display: block;
+  position: relative;
+  padding-left: 35px;
+}
+
+.dropdown-label {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  position: relative;
+  z-index: 2;
+  padding: 10px 0;
+  margin-left: auto;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  font-weight: 600;
+
+  > chef-icon {
+    font-size: 16px;
+    color: $chef-primary-dark;
+    margin-left: 8px;
+  }
+
+  .selection-label {
+    display: inline-block;
+    max-width: 150px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .selection-count {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    font-size: 14px;
+    line-height: 20px;
+    text-align: center;
+    border-radius: 50%;
+    margin-left: 10px;
+    background: $chef-grey;
+
+    &.active {
+      background: $chef-primary-bright;
+      color: $chef-white;
+    }
+  }
+}
+
+.dropdown {
+  display: block;
+  position: absolute;
+  right: -10px;
+  max-width: 250px;
+  border: 1px solid $chef-grey;
+  font-size: 14px;
+  z-index: 3;
+
+  &::before {
+    display: block;
+    position: absolute;
+    top: -6px;
+    right: 12px;
+    width: 10px;
+    height: 10px;
+    background: $chef-white;
+    transform: rotate(45deg);
+    border-left: 1px solid $chef-grey;
+    border-top: 1px solid $chef-grey;
+    content: '';
+  }
+
+  .dropdown-body {
+    display: block;
+
+    > span {
+      display: block;
+      color: $chef-dark-grey;
+      text-transform: uppercase;
+      font-size: 11px;
+      padding: 9px 18px 0;
+    }
+
+    chef-checkbox {
+      display: flex;
+      padding: 9px 18px;
+      align-items: start;
+      font-weight: 600;
+
+      &:first-child {
+        padding-top: 18px;
+      }
+
+      &:last-child {
+        padding-bottom: 18px;
+      }
+
+      ::ng-deep .label-wrap {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+  }
+
+  .dropdown-footer {
+    display: flex;
+    justify-content: center;
+    padding: 0 8px 8px 8px;
+  }
+}

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -1,0 +1,80 @@
+import { Component, EventEmitter, OnChanges, Input, Output } from '@angular/core';
+import { cloneDeep } from 'lodash/fp';
+import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
+
+@Component({
+  selector: 'app-projects-filter-dropdown',
+  templateUrl: './projects-filter-dropdown.component.html',
+  styleUrls: [ './projects-filter-dropdown.component.scss' ]
+})
+export class ProjectsFilterDropdownComponent implements OnChanges {
+  @Input() options: ProjectsFilterOption[] = [];
+
+  @Input() selectionLabel = 'All Resources';
+
+  @Input() selectionCount = 0;
+
+  @Input() selectionCountVisible = false;
+
+  @Input() selectionCountActive = false;
+
+  @Output() onSelection = new EventEmitter<ProjectsFilterOption[]>();
+
+  editableOptions: ProjectsFilterOption[] = [];
+
+  optionsEdited = false;
+
+  dropdownActive = false;
+
+  ngOnChanges(changes) {
+    if (changes.options) {
+      this.resetOptions();
+    }
+  }
+
+  resetOptions() {
+    this.editableOptions = cloneDeep(this.options);
+    this.optionsEdited = false;
+  }
+
+  handleLabelClick() {
+    if (this.editableOptions.length > 1) {
+      this.dropdownActive = !this.dropdownActive;
+      this.resetOptions();
+    }
+  }
+
+  handleEscape() {
+    this.dropdownActive = false;
+    this.resetOptions();
+  }
+
+  handleOptionChange(event, index) {
+    this.editableOptions[index].checked = event.detail;
+    this.optionsEdited = true;
+  }
+
+  handleApplyClick() {
+    this.dropdownActive = false;
+    this.optionsEdited = false;
+    this.onSelection.emit(this.editableOptions);
+  }
+
+  handleArrowUp(event) {
+    event.preventDefault();
+
+    const element = event.target.previousElementSibling;
+    if (element) {
+      element.focus();
+    }
+  }
+
+  handleArrowDown(event) {
+    event.preventDefault();
+
+    const element = event.target.nextElementSibling;
+    if (element) {
+      element.focus();
+    }
+  }
+}

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -1,0 +1,350 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ProjectsFilterDropdownComponent } from './projects-filter-dropdown.component';
+
+describe('ProjectsFilterDropdownComponent', () => {
+  let component: ProjectsFilterDropdownComponent;
+  let fixture: ComponentFixture<ProjectsFilterDropdownComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+      declarations: [
+        ProjectsFilterDropdownComponent
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProjectsFilterDropdownComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('dropdown label', () => {
+    let label, count;
+
+    beforeEach(() => {
+      component.selectionLabel = 'Multiple projects';
+      component.selectionCount = 3;
+      component.selectionCountVisible = true;
+      component.selectionCountActive = true;
+      fixture.detectChanges();
+
+      label = fixture.nativeElement.querySelector('.dropdown-label');
+      count = fixture.nativeElement.querySelector('.selection-count');
+    });
+
+    it('displays label text', () => {
+      expect(label).not.toBeNull();
+      expect(label.textContent.trim()).toContain(component.selectionLabel);
+    });
+
+    it('has an "aria-label"', () => {
+      expect(label.getAttribute('aria-label')).toEqual('Projects filter');
+    });
+
+    describe('when .selectionCountVisible is false', () => {
+      beforeEach(() => {
+        component.selectionCountVisible = false;
+        fixture.detectChanges();
+        count = fixture.nativeElement.querySelector('.selection-count');
+      });
+
+      it('the selection count is hidden', () => {
+        expect(count).toBeNull();
+      });
+    });
+
+    describe('when .selectionCountVisible is true', () => {
+      beforeEach(() => {
+        component.selectionCountVisible = true;
+        fixture.detectChanges();
+      });
+
+      it('the selection count is visible', () => {
+        expect(count).not.toBeNull();
+        expect(count.textContent.trim()).toEqual(component.selectionCount.toString());
+      });
+    });
+
+    describe('when .selectionCountActive is false', () => {
+      beforeEach(() => {
+        component.selectionCountActive = false;
+        fixture.detectChanges();
+      });
+
+      it('the selection count does not have an "active" className', () => {
+        expect(count.classList.contains('active')).toEqual(false);
+      });
+    });
+
+    describe('when .selectionCountActive is true', () => {
+      beforeEach(() => {
+        component.selectionCountActive = true;
+        fixture.detectChanges();
+      });
+
+      it('the selection count has an "active" className', () => {
+        expect(count.classList.contains('active')).toEqual(true);
+      });
+    });
+  });
+
+  describe('dropdown', () => {
+    beforeEach(() => {
+      component.dropdownActive = true;
+      component.editableOptions = [
+        {
+          value: 'project-1',
+          label: 'Project 1',
+          checked: false
+        },
+        {
+          value: 'project-2',
+          label: 'Project 2',
+          checked: true
+        }
+      ];
+      fixture.detectChanges();
+    });
+
+    it('displays a list of checkbox options', () => {
+      const options = Array.from(fixture.nativeElement.querySelectorAll('chef-checkbox'));
+      expect(options.length).toEqual(2);
+      options.forEach((option: HTMLInputElement, index: number) => {
+        const { label, checked } = component.editableOptions[index];
+        expect(option.textContent).toEqual(label);
+        expect(option.checked).toEqual(checked);
+      });
+    });
+
+    it('displays an "Apply Changes" button', () => {
+      const button = fixture.nativeElement.querySelector('chef-button');
+      expect(button).not.toBeNull();
+      expect(button.textContent).toEqual('Apply Changes');
+      expect(button.hasAttribute('disabled')).toEqual(true);
+    });
+
+    describe('when .dropdownActive is false', () => {
+      beforeEach(() => {
+        component.dropdownActive = false;
+        fixture.detectChanges();
+      });
+
+      it('the dropdown is hidden', () => {
+        const dropdown = fixture.nativeElement.querySelector('.dropdown');
+        expect(dropdown).toBeNull();
+      });
+    });
+
+    describe('when .dropdownActive is true', () => {
+      beforeEach(() => {
+        component.dropdownActive = true;
+        fixture.detectChanges();
+      });
+
+      it('the dropdown is visible', () => {
+        const dropdown = fixture.nativeElement.querySelector('.dropdown');
+        expect(dropdown).not.toBeNull();
+      });
+    });
+
+    describe('when .optionsEdited is false', () => {
+      beforeEach(() => {
+        component.dropdownActive = true;
+        component.optionsEdited = false;
+        fixture.detectChanges();
+      });
+
+      it('the "Apply" button is disabled', () => {
+        const button = fixture.nativeElement.querySelector('chef-button');
+        expect(button.getAttribute('disabled')).toEqual('true');
+      });
+    });
+
+    describe('when .optionsEdited is true', () => {
+      beforeEach(() => {
+        component.dropdownActive = true;
+        component.optionsEdited = true;
+        fixture.detectChanges();
+      });
+
+      it('the "Apply" button is enabled', () => {
+        const button = fixture.nativeElement.querySelector('chef-button');
+        expect(button.getAttribute('disabled')).toEqual('false');
+      });
+    });
+  });
+
+  describe('resetOptions()', () => {
+    beforeEach(() => {
+      component.editableOptions = [];
+      component.optionsEdited = true;
+      component.resetOptions();
+    });
+
+    it('resets any previous selection changes by copying the provided options', () => {
+      expect(component.editableOptions).not.toBe(component.options);
+      expect(component.editableOptions).toEqual(component.options);
+    });
+
+    it('marks the list of options as unedited', () => {
+      expect(component.optionsEdited).toEqual(false);
+    });
+  });
+
+  describe('handleLabelClick()', () => {
+    describe('when more than one option is available', () => {
+      beforeEach(() => {
+        component.editableOptions = [
+          {
+            value: 'project-1',
+            label: 'Project 1',
+            checked: false
+          },
+          {
+            value: 'project-2',
+            label: 'Project 2',
+            checked: false
+          }
+        ];
+        component.dropdownActive = false;
+        spyOn(component, 'resetOptions');
+
+        component.handleLabelClick();
+      });
+
+      it('toggles dropdown visibility', () => {
+        expect(component.dropdownActive).toEqual(true);
+      });
+
+      it('resets any previous selection changes', () => {
+        expect(component.resetOptions).toHaveBeenCalled();
+      });
+    });
+
+    describe('when only one option is available', () => {
+      beforeEach(() => {
+        component.editableOptions = [
+          {
+            value: 'project-1',
+            label: 'Project 1',
+            checked: false
+          }
+        ];
+        component.dropdownActive = false;
+        spyOn(component, 'resetOptions');
+
+        component.handleLabelClick();
+      });
+
+      it('does nothing', () => {
+        expect(component.dropdownActive).toEqual(false);
+        expect(component.resetOptions).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('handleEscape()', () => {
+    beforeEach(() => {
+      spyOn(component, 'resetOptions');
+      component.dropdownActive = true;
+      component.handleEscape();
+    });
+
+    it('hides the dropdown', () => {
+      expect(component.dropdownActive).toEqual(false);
+    });
+
+    it('resets any previous selection changes', () => {
+      expect(component.resetOptions).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleOptionChange()', () => {
+    beforeEach(() => {
+      component.editableOptions = [
+        {
+          value: 'project-1',
+          label: 'Project 1',
+          checked: false
+        }
+      ];
+      component.optionsEdited = false;
+      component.handleOptionChange({ detail: true }, 0);
+    });
+
+    it('updates the value of `checked` to the emitted value', () => {
+      expect(component.editableOptions[0].checked).toEqual(true);
+    });
+
+    it('marks the list of options as edited', () => {
+      expect(component.optionsEdited).toEqual(true);
+    });
+  });
+
+  describe('handleApplyClick()', () => {
+    beforeEach(() => {
+      spyOn(component.onSelection, 'emit');
+      component.dropdownActive = true;
+      component.optionsEdited = true;
+      component.handleApplyClick();
+    });
+
+    it('hides the dropdown', () => {
+      expect(component.dropdownActive).toEqual(false);
+    });
+
+    it('disables the "Apply Changes" button', () => {
+      expect(component.optionsEdited).toEqual(false);
+    });
+
+    it('emits "onSelection" event with list of updated options', () => {
+      expect(component.onSelection.emit).toHaveBeenCalledWith(component.editableOptions);
+    });
+  });
+
+  describe('handleArrowUp()', () => {
+    let event, previousElementSibling;
+
+    beforeEach(() => {
+      previousElementSibling = { focus: jasmine.createSpy('focus') };
+      event = {
+        preventDefault: jasmine.createSpy('preventDefault'),
+        target: { previousElementSibling }
+      };
+      component.handleArrowUp(event);
+    });
+
+    it('prevents the default event behavior', () => {
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it('focuses the previous element sibling', () => {
+      expect(previousElementSibling.focus).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleArrowDown()', () => {
+    let event, nextElementSibling;
+
+    beforeEach(() => {
+      nextElementSibling = { focus: jasmine.createSpy('focus') };
+      event = {
+        preventDefault: jasmine.createSpy('preventDefault'),
+        target: { nextElementSibling }
+      };
+      component.handleArrowDown(event);
+    });
+
+    it('prevents the default event behavior', () => {
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it('focuses the next element sibling', () => {
+      expect(nextElementSibling.focus).toHaveBeenCalled();
+    });
+  });
+});

--- a/components/automate-ui/src/app/page-components/projects-filter/projects-filter.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter/projects-filter.component.html
@@ -1,0 +1,8 @@
+<app-projects-filter-dropdown
+  [options]="projectsFilter.options$ | async"
+  [selectionLabel]="projectsFilter.selectionLabel$ | async"
+  [selectionCount]="projectsFilter.selectionCount$ | async"
+  [selectionCountVisible]="projectsFilter.selectionCountVisible$ | async"
+  [selectionCountActive]="projectsFilter.selectionCountActive$ | async"
+  (onSelection)="projectsFilter.saveOptions($event)">
+</app-projects-filter-dropdown>

--- a/components/automate-ui/src/app/page-components/projects-filter/projects-filter.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter/projects-filter.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/components/automate-ui/src/app/page-components/projects-filter/projects-filter.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter/projects-filter.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { ProjectsFilterService } from 'app/services/projects-filter/projects-filter.service';
+
+@Component({
+  selector: 'app-projects-filter',
+  templateUrl: './projects-filter.component.html',
+  styleUrls: [ './projects-filter.component.scss' ]
+})
+export class ProjectsFilterComponent {
+  constructor(private projectsFilter: ProjectsFilterService) {
+    this.projectsFilter.loadOptions();
+  }
+}

--- a/components/automate-ui/src/app/page-components/projects-filter/projects-filter.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter/projects-filter.spec.ts
@@ -1,0 +1,43 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { StoreModule } from '@ngrx/store';
+import {
+  projectsFilterInitialState,
+  projectsFilterReducer
+} from 'app/services/projects-filter/projects-filter.reducer';
+import { ProjectsFilterService } from 'app/services/projects-filter/projects-filter.service';
+import { ProjectsFilterComponent } from './projects-filter.component';
+
+describe('ProjectsFilterComponent', () => {
+  let fixture: ComponentFixture<ProjectsFilterComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+      declarations: [
+        ProjectsFilterComponent
+      ],
+      providers: [
+        ProjectsFilterService
+      ],
+      imports: [
+        StoreModule.forRoot({
+          projectsFilter: projectsFilterReducer
+        }, {
+          initialState: { projectsFilter: projectsFilterInitialState }
+        })
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProjectsFilterComponent);
+    fixture.detectChanges();
+  });
+
+  it('displays a projects filter dropdown', () => {
+    const projectsFilter = fixture.nativeElement.querySelector('app-projects-filter-dropdown');
+    expect(projectsFilter).not.toBeNull();
+  });
+});

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.actions.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.actions.ts
@@ -1,0 +1,35 @@
+import { Action } from '@ngrx/store';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ProjectsFilterOption } from './projects-filter.reducer';
+
+export enum ProjectsFilterActionTypes {
+  LOAD_OPTIONS         = 'PROJECTS_FILTER::LOAD_OPTIONS',
+  LOAD_OPTIONS_SUCCESS = 'PROJECTS_FILTER::LOAD_OPTIONS::SUCCESS',
+  LOAD_OPTIONS_FAILURE = 'PROJECTS_FILTER::LOAD_OPTIONS::FAILURE',
+  SAVE_OPTIONS =         'PROJECTS_FILTER::SAVE_OPTIONS'
+}
+
+export class LoadOptions implements Action {
+  readonly type = ProjectsFilterActionTypes.LOAD_OPTIONS;
+}
+
+export class LoadOptionsSuccess implements Action {
+  readonly type = ProjectsFilterActionTypes.LOAD_OPTIONS_SUCCESS;
+  constructor(public payload: ProjectsFilterOption[]) { }
+}
+
+export class LoadOptionsFailure implements Action {
+  readonly type = ProjectsFilterActionTypes.LOAD_OPTIONS_FAILURE;
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export class SaveOptions implements Action {
+  readonly type = ProjectsFilterActionTypes.SAVE_OPTIONS;
+  constructor(public payload: ProjectsFilterOption[]) { }
+}
+
+export type ProjectsFilterActions =
+  | LoadOptions
+  | LoadOptionsSuccess
+  | LoadOptionsFailure
+  | SaveOptions;

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of as observableOf } from 'rxjs';
+import { switchMap, catchError, map, tap } from 'rxjs/operators';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { ProjectsFilterOption } from './projects-filter.reducer';
+import { ProjectsFilterService } from './projects-filter.service';
+import {
+  ProjectsFilterActionTypes,
+  LoadOptions,
+  LoadOptionsSuccess,
+  LoadOptionsFailure,
+  SaveOptions
+} from './projects-filter.actions';
+
+@Injectable()
+export class ProjectsFilterEffects {
+  constructor(
+    private actions$: Actions,
+    private projectsFilter: ProjectsFilterService
+  ) { }
+
+  @Effect()
+  loadOptions$ = this.actions$.pipe(
+    ofType<LoadOptions>(ProjectsFilterActionTypes.LOAD_OPTIONS),
+    switchMap(() => {
+      return this.projectsFilter.fetchOptions().pipe(
+        map((fetched: ProjectsFilterOption[]) => {
+          const restored = this.projectsFilter.restoreOptions() || [];
+          const loaded = fetched.map(fetchedOpt => {
+            const restoredOpt = restored.filter(opt => opt.value === fetchedOpt.value)[0];
+            return restoredOpt ? { ...fetchedOpt, checked: restoredOpt.checked } : fetchedOpt;
+          });
+          return new LoadOptionsSuccess(loaded);
+        }),
+        catchError((error: HttpErrorResponse) => observableOf(new LoadOptionsFailure(error))));
+    }));
+
+  @Effect({ dispatch: false })
+  saveOptions$ = this.actions$.pipe(
+    ofType<SaveOptions>(ProjectsFilterActionTypes.SAVE_OPTIONS),
+    tap(({ payload }) => this.projectsFilter.storeOptions(payload))
+  );
+}

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -1,0 +1,110 @@
+import { set, pipe } from 'lodash/fp';
+import { LoadingStatus } from 'app/types/types';
+import {
+  ProjectsFilterActions,
+  ProjectsFilterActionTypes
+} from './projects-filter.actions';
+
+export interface ProjectsFilterOption {
+  label: string;
+  value: string;
+  checked: boolean;
+}
+
+export interface ProjectsFilterState {
+  options: ProjectsFilterOption[];
+  optionsLoadingStatus: LoadingStatus;
+  selectionLabel: string;
+  selectionCount: number;
+  selectionCountVisible: boolean;
+  selectionCountActive: boolean;
+}
+
+export const projectsFilterInitialState: ProjectsFilterState = {
+  options: [],
+  optionsLoadingStatus: LoadingStatus.notLoaded,
+  selectionLabel: 'All resources',
+  selectionCount: 0,
+  selectionCountVisible: false,
+  selectionCountActive: false
+};
+
+export function projectsFilterReducer(
+  state: ProjectsFilterState = projectsFilterInitialState,
+  action: ProjectsFilterActions): ProjectsFilterState {
+
+  switch (action.type) {
+
+    case ProjectsFilterActionTypes.LOAD_OPTIONS: {
+      return set('optionsLoadingStatus', LoadingStatus.loading, state);
+    }
+
+    case ProjectsFilterActionTypes.LOAD_OPTIONS_SUCCESS: {
+      return pipe(
+        set('options', action.payload),
+        set('optionsLoadingStatus', LoadingStatus.loadingSuccess),
+        set('selectionLabel', selectionLabel(action.payload)),
+        set('selectionCount', selectionCount(action.payload)),
+        set('selectionCountVisible', selectionCountVisible(action.payload)),
+        set('selectionCountActive', selectionCountActive(action.payload))
+      )(state) as ProjectsFilterState;
+    }
+
+    case ProjectsFilterActionTypes.LOAD_OPTIONS_FAILURE: {
+      return set('optionsLoadingStatus', LoadingStatus.loadingFailure, state);
+    }
+
+    case ProjectsFilterActionTypes.SAVE_OPTIONS: {
+      return pipe(
+        set('options', action.payload),
+        set('selectionLabel', selectionLabel(action.payload)),
+        set('selectionCount', selectionCount(action.payload)),
+        set('selectionCountVisible', selectionCountVisible(action.payload)),
+        set('selectionCountActive', selectionCountActive(action.payload))
+      )(state) as ProjectsFilterState;
+    }
+  }
+
+  return state;
+}
+
+function selectionLabel(options: ProjectsFilterOption[]): string {
+  const checked = options.filter(o => o.checked);
+
+  if (options.length === 1) {
+    return options[0].label;
+  }
+
+  if (checked.length === 1) {
+    return checked[0].label;
+  }
+
+  if (checked.length === options.length) {
+    return 'All projects';
+  }
+
+  if (checked.length > 1) {
+    return 'Multiple projects';
+  }
+
+  return 'All resources';
+}
+
+function selectionCount(options: ProjectsFilterOption[]): number {
+  const checked = options.filter(o => o.checked);
+  return checked.length > 0 ? checked.length : options.length;
+}
+
+function selectionCountVisible(options: ProjectsFilterOption[]): boolean {
+  const checked = options.filter(o => o.checked);
+  const hasMultipleOptions = options.length > 1;
+  const hasNoneSelected = checked.length === 0;
+  const hasMultipleSelected = checked.length > 1 && checked.length < options.length;
+  const hasLessThanAllSelected = checked.length < options.length;
+  return hasMultipleOptions && (hasNoneSelected || (hasMultipleSelected && hasLessThanAllSelected));
+}
+
+function selectionCountActive(options: ProjectsFilterOption[]): boolean {
+  const checked = options.filter(o => o.checked);
+  return checked.length > 0;
+}

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -69,42 +69,70 @@ export function projectsFilterReducer(
 }
 
 function selectionLabel(options: ProjectsFilterOption[]): string {
-  const checked = options.filter(o => o.checked);
+  const checkedOptions = options.filter(o => o.checked);
+  const projectOptions = options.filter(o => o.value !== 'unassigned-resources');
+  const checkedProjects = projectOptions.filter(o => o.checked);
+  const hasOnlyProjects = projectOptions.length === options.length;
+  const hasNoneChecked = checkedOptions.length === 0;
+  const hasAllChecked = checkedOptions.length === options.length;
+  const hasOneOption = options.length === 1;
+  const hasOneChecked = checkedOptions.length === 1;
+  const hasOneProjectChecked = checkedProjects.length === 1;
+  const hasSomeProjectsChecked = checkedProjects.length > 1;
+  const hasOnlySomeProjectsChecked = hasSomeProjectsChecked && !hasAllChecked;
+  const hasAllProjectsChecked = checkedProjects.length === projectOptions.length;
+  const hasOnlyAllProjectsChecked = hasOnlyProjects ?
+    hasAllProjectsChecked || hasNoneChecked :
+    hasAllProjectsChecked && !hasAllChecked;
 
-  if (options.length === 1) {
+  if (hasOneOption) {
     return options[0].label;
   }
 
-  if (checked.length === 1) {
-    return checked[0].label;
+  if (hasOneChecked) {
+    return checkedOptions[0].label;
   }
 
-  if (checked.length === options.length) {
-    return 'All projects';
+  if (hasOneProjectChecked) {
+    return checkedProjects[0].label;
   }
 
-  if (checked.length > 1) {
+  if (hasOnlySomeProjectsChecked) {
     return 'Multiple projects';
+  }
+
+  if (hasOnlyAllProjectsChecked) {
+    return 'All projects';
   }
 
   return 'All resources';
 }
 
 function selectionCount(options: ProjectsFilterOption[]): number {
-  const checked = options.filter(o => o.checked);
-  return checked.length > 0 ? checked.length : options.length;
+  const checkedProjects = options.filter(o => o.checked && o.value !== 'unassigned-resources');
+  return checkedProjects.length > 0 ? checkedProjects.length : options.length;
 }
 
 function selectionCountVisible(options: ProjectsFilterOption[]): boolean {
-  const checked = options.filter(o => o.checked);
-  const hasMultipleOptions = options.length > 1;
-  const hasNoneSelected = checked.length === 0;
-  const hasMultipleSelected = checked.length > 1 && checked.length < options.length;
-  const hasLessThanAllSelected = checked.length < options.length;
-  return hasMultipleOptions && (hasNoneSelected || (hasMultipleSelected && hasLessThanAllSelected));
+  const hasOnlyOneOption = options.length === 1;
+  if (hasOnlyOneOption) {
+    return false;
+  }
+
+  const checkedOptions = options.filter(o => o.checked);
+  const projectOptions = options.filter(o => o.value !== 'unassigned-resources');
+  const checkedProjects = projectOptions.filter(o => o.checked);
+  const hasOnlyProjects = projectOptions.length === options.length;
+  const hasNoneChecked = checkedOptions.length === 0;
+  const hasAllChecked = checkedOptions.length === options.length;
+  const hasSomeProjectsChecked = checkedProjects.length > 1;
+
+  return hasOnlyProjects ?
+    hasSomeProjectsChecked || hasNoneChecked :
+    hasSomeProjectsChecked && !hasAllChecked;
 }
 
 function selectionCountActive(options: ProjectsFilterOption[]): boolean {
-  const checked = options.filter(o => o.checked);
-  return checked.length > 0;
+  const checkedOptions = options.filter(o => o.checked);
+  return checkedOptions.length > 0;
 }

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.selectors.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.selectors.ts
@@ -1,0 +1,18 @@
+import { createSelector } from '@ngrx/store';
+
+export const projectsFilterState = state => state.projectsFilter;
+
+export const options = createSelector(projectsFilterState, state => state.options);
+
+export const optionsLoadingStatus = createSelector(projectsFilterState,
+  state => state.optionsLoadingStatus);
+
+export const selectionLabel = createSelector(projectsFilterState, state => state.selectionLabel);
+
+export const selectionCount = createSelector(projectsFilterState, state => state.selectionCount);
+
+export const selectionCountVisible = createSelector(projectsFilterState,
+  state => state.selectionCountVisible);
+
+export const selectionCountActive = createSelector(projectsFilterState,
+  state => state.selectionCountActive);

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -65,12 +65,12 @@ export class ProjectsFilterService {
         value: 'super-project',
         label: 'Super Duper Project',
         checked: false
+      },
+      {
+        value: 'unassigned-resources',
+        label: 'Unassigned Resources',
+        checked: false
       }
-      // {
-      //   value: 'unassigned-resources',
-      //   label: 'Unassigned Resources',
-      //   checked: false
-      // }
     ]);
   }
 }

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@angular/core';
+import { Observable, of as observableOf } from 'rxjs';
+import { Store } from '@ngrx/store';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { ProjectsFilterOption } from './projects-filter.reducer';
+import * as selectors from './projects-filter.selectors';
+import { LoadOptions, SaveOptions } from './projects-filter.actions';
+
+const STORE_OPTIONS_KEY = 'projectsFilter.options';
+
+@Injectable()
+export class ProjectsFilterService {
+  options$ = this.store.select(selectors.options);
+
+  selectionLabel$ = this.store.select(selectors.selectionLabel);
+
+  selectionCount$ = this.store.select(selectors.selectionCount);
+
+  selectionCountVisible$ = this.store.select(selectors.selectionCountVisible);
+
+  selectionCountActive$ = this.store.select(selectors.selectionCountActive);
+
+  constructor(private store: Store<NgrxStateAtom>) {}
+
+  loadOptions() {
+    this.store.dispatch(new LoadOptions());
+  }
+
+  saveOptions(options: ProjectsFilterOption[]) {
+    this.store.dispatch(new SaveOptions(options));
+  }
+
+  storeOptions(options: ProjectsFilterOption[]) {
+    localStorage.setItem(STORE_OPTIONS_KEY, JSON.stringify(options));
+  }
+
+  restoreOptions(): ProjectsFilterOption[] {
+    return JSON.parse(localStorage.getItem(STORE_OPTIONS_KEY));
+  }
+
+  fetchOptions(): Observable<ProjectsFilterOption[]> {
+    // Request some options available to the user.
+    return observableOf([
+      {
+        value: 'project-2',
+        label: 'Project 2',
+        checked: false
+      },
+      {
+        value: 'project-4',
+        label: 'Project 4',
+        checked: false
+      },
+      {
+        value: 'project-5',
+        label: 'Project 5',
+        checked: false
+      },
+      {
+        value: 'project-that-has-a-really-long-name',
+        label: 'Project that has a really long name',
+        checked: false
+      },
+      {
+        value: 'super-project',
+        label: 'Super Duper Project',
+        checked: false
+      }
+      // {
+      //   value: 'unassigned-resources',
+      //   label: 'Unassigned Resources',
+      //   checked: false
+      // }
+    ]);
+  }
+}


### PR DESCRIPTION
### :nut_and_bolt: Description

Adds some UI components for the global projects filter and wires them up to static placeholder data.

![](https://user-images.githubusercontent.com/479121/56723623-904de700-6706-11e9-93a4-5171829fbf09.gif)

### :chains: Related Resources
https://chefio.atlassian.net/browse/A2-248

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
