### PR TITLE
notes for adding data in automate for compliance, scan jobs, node integrations

### DIFF
--- a/components/compliance-service/docs/adding_test_data.md
+++ b/components/compliance-service/docs/adding_test_data.md
@@ -6,10 +6,11 @@ from hab studio:
 
 # Adding nodes to populate the nodes and scan jobs pages
 
-_note: this should be run on your local system, not from within the studio_
-
 ensure you have `jq` installed
+the token is retrieved by running `get_admin_token` from within the studio
+if you've never run the get_secrets script, or haven't in a while, run `CHEF_USERNAME=username scripts/get_secrets` from the studio
 
+_note: this should be run on your local system, not from within the studio_
 `source dev/secrets-env.sh`
 `A2_URL='https://a2-dev.test' A2_TOKEN='token_val' components/compliance-service/scripts/create-pg-data.sh`
 

--- a/components/compliance-service/docs/adding_test_data.md
+++ b/components/compliance-service/docs/adding_test_data.md
@@ -1,0 +1,59 @@
+# Adding nodes to populate the compliance reporting page
+
+from hab studio: 
+
+`chef_load_compliance_scans -N20` 
+
+# Adding nodes to populate the nodes and scan jobs pages
+
+_note: this should be run on your local system, not from within the studio_
+
+ensure you have `jq` installed
+
+`source dev/secrets-env.sh`
+`A2_URL='https://a2-dev.test' A2_TOKEN='token_val' components/compliance-service/scripts/create-pg-data.sh`
+
+# Adding profiles
+
+this should be done by downloading profiles from the "Available" tab under the "Asset Store"
+
+# Adding cloud integrations
+
+AWS:
+ - use the `okta_aws` functionality to get your temporary aws credentials (see details here)[https://chefio.atlassian.net/wiki/spaces/ENG/pages/94259373/SOP-001+-+Gaining+access+to+okta+AWS+accounts+via+the+AWS+API#SOP-001-GainingaccesstooktaAWSaccountsviatheAWSAPI-Step1:Installokta_aws]
+
+ - use the api to add integrations using these credentials:
+ ```
+ curl -s --insecure -H "api-token: $token_value" https://a2-dev.test/api/v0/nodemanagers -d '{
+    "name": "my aws api integration with session token",
+    "type": "aws-api",
+    "instance_credentials": [],
+    "credential_data": [
+            {"key": "AWS_ACCESS_KEY_ID", "value": "value" },
+            {"key": "AWS_SECRET_ACCESS_KEY", "value": "value" },
+            {"key": "AWS_SESSION_TOKEN", "value": "value" }
+   ]
+}'
+```
+_Note: to add an ec2 integration for aws, change type from "aws-api" to "aws-ec2"_
+
+Azure:
+- turn on the integration by typing 'beta' into your browser and enabling it
+- search for 'Compliance Azure Creds' in LastPass
+- use these credentials to create your Azure integrations
+
+GCP:
+- turn on the integration by typing 'beta' into your browser and enabling it
+- search for 'GCP creds (compliance)' in LastPass
+- use these credentials to create your GCP integration
+
+# Deleting data
+
+to delete the postgres data:
+
+`A2_URL='https://a2-dev.test' A2_TOKEN='token_val' components/compliance-service/scripts/delete-pg-data.sh`
+
+
+to delete the elasticsearch data:
+
+`curl -s http://localhost:10141/_cat/indices/comp*?h=i | while read compliance_index; do curl -X DELETE http://localhost:10141/$compliance_index; done`

--- a/components/compliance-service/scripts/create-pg-data.sh
+++ b/components/compliance-service/scripts/create-pg-data.sh
@@ -10,9 +10,12 @@
 
 url=${A2_URL}
 token=${A2_TOKEN}
-node_count=10
-job_count=2
+node_count=12
+job_count=3
+docker_machine=`docker ps | awk 'FNR == 2 {print $1}'`
 
+echo "target docker machine: " $docker_machine
+echo "target acceptance host: " $AUTOMATE_ACCEPTANCE_TARGET_HOST
 echo "running data generation script for pg data against ${url} with ${token}"
 
 # create the ssh secrets
@@ -33,8 +36,8 @@ ssh_secret_ec2=$(curl -s --insecure -H "api-token: $token" $url/api/v0/secrets -
   "name": "my ssh secret",
   "type": "ssh",
   "data": [
-    { "key": "username", "value": "$AUTOMATE_ACCEPTANCE_TARGET_USERNAME" },
-    { "key": "password", "value": "$AUTOMATE_ACCEPTANCE_TARGET_PASSWORD" }
+    { "key": "username", "value": "'${AUTOMATE_ACCEPTANCE_TARGET_USERNAME}'" },
+    { "key": "password", "value": "'${AUTOMATE_ACCEPTANCE_TARGET_PASSWORD}'" }
   ]
 }'  | jq '.id')
 
@@ -42,7 +45,7 @@ echo $ssh_secret_ec2
 
 
 # add nodes
-for i in $(seq 1 $((node_count/2))); do
+for i in $(seq 1 $((node_count/3))); do
   echo "creating node" $i
   vagrant_node_id=$( curl -s --insecure -H "api-token: $token" $url/api/v0/nodes -d '{
     "name": "my-vagrant-node",
@@ -55,19 +58,35 @@ for i in $(seq 1 $((node_count/2))); do
       },
       "tags": [
         { "key":"test-node", "value":"is amazing" },
-        { "key":"compliance-service", "value":"rockin like whoa" },
-        { "key": "_no_auto_detect", "value": "true"}
+        { "key":"compliance-service", "value":"rockin like whoa" }
       ]
   }' | jq '.id'); echo $vagrant_node_id; done
 
-for i in $(seq 1 $((node_count/2))); do
+ for i in $(seq 1 $((node_count/3))); do
+  echo "creating node" $i
+  docker_node_id=$( curl -s --insecure -H "api-token: $token" $url/api/v0/nodes -d '{
+    "name": "my-docker-node",
+    "manager":"automate",
+      "target_config": {
+        "backend":"docker",
+        "host":"'${docker_machine}'",
+        "secrets":[],
+        "port": 22
+      },
+      "tags": [
+        { "key":"test-node", "value":"is amazing" },
+        { "key":"compliance-service", "value":"rockin like whoa" }
+      ]
+  }' | jq '.id'); echo $docker_node_id; done 
+
+for i in $(seq 1 $((node_count/3))); do
   echo "creating node" $i
   ec2_node_id=$( curl -s --insecure -H "api-token: $token" $url/api/v0/nodes -d '{
     "name": "my-ssh-node",
     "manager":"automate",
       "target_config": {
         "backend":"ssh",
-        "host":"$AUTOMATE_ACCEPTANCE_TARGET_HOST",
+        "host":"'${AUTOMATE_ACCEPTANCE_TARGET_HOST}'",
         "secrets":['${ssh_secret_ec2}'],
         "port": 22
       },
@@ -88,7 +107,7 @@ for i in $(seq 1 ${job_count}); do
       "name": "my job",
       "tags": [],
       "type": "exec",
-      "nodes": ['${vagrant_node_id}', '${ec2_node_id}'],
+      "nodes": ['${vagrant_node_id}', '${ec2_node_id}', '${docker_node_id}'],
       "profiles": ["https://github.com/dev-sec/linux-baseline/archive/master.tar.gz", "https://github.com/dev-sec/ssh-baseline/archive/master.tar.gz"],
       "retries": 1,
       "node_selectors": []

--- a/components/compliance-service/scripts/create-pg-data.sh
+++ b/components/compliance-service/scripts/create-pg-data.sh
@@ -107,7 +107,7 @@ for i in $(seq 1 ${job_count}); do
       "name": "my job",
       "tags": [],
       "type": "exec",
-      "nodes": ['${vagrant_node_id}', '${ec2_node_id}', '${docker_node_id}'],
+      "nodes": ['${ec2_node_id}'],
       "profiles": ["https://github.com/dev-sec/linux-baseline/archive/master.tar.gz", "https://github.com/dev-sec/ssh-baseline/archive/master.tar.gz"],
       "retries": 1,
       "node_selectors": []


### PR DESCRIPTION
### :nut_and_bolt: Description

Just adding some notes on how to add data in Automate for compliance reporting, scan jobs, and node integrations.
I've also added a docker test target in the create-pg-data script. I'm not convinced this will actually work from the dev environment, since we're in a vagrant box or docker box and reaching out to a local docker machine isn't realllly possible, but maybe it works for the docker dev env as it is testing itself?anyways, I'm leaving it there for now as having an unreachable node is also good for dummy data.  

This also makes me wonder why we don't allow users to add docker containers for scanning in Automate? I'll look into this more..

### :+1: Definition of Done
Notes on how to add data in dev environment.

