### PR TITLE
[license usage] add timestamp to scanned nodes

### DIFF
--- a/components/automate-cli/pkg/diagnostics/integration/compliance_report_scan_nodes.go
+++ b/components/automate-cli/pkg/diagnostics/integration/compliance_report_scan_nodes.go
@@ -188,7 +188,7 @@ func CreateComplianceReportScanNodesDiagnostic() diagnostics.Diagnostic {
 					assert.NotEqual(tstCtx, "", node.ID)
 					assert.NotEqual(tstCtx, "", node.Name)
 					assert.NotEqual(tstCtx, "", node.ScanJobID)
-
+					//assert.NotEqual(tstCtx, "", node.LastSeen)
 				}
 
 				if !containsEntity {

--- a/components/automate-deployment/pkg/server/node_inventory.go
+++ b/components/automate-deployment/pkg/server/node_inventory.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
-	google_protobuf1 "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
+	tslib "github.com/chef/automate/lib/grpc/timestamp"
 	configReq "github.com/chef/automate/api/interservice/cfgmgmt/request"
 	"github.com/chef/automate/api/interservice/cfgmgmt/service"
 	api "github.com/chef/automate/api/interservice/deployment"
@@ -62,7 +62,7 @@ func (s *server) NodeInventory(ctx context.Context,
 				PlatformFamily:  node.PlatformFamily,
 				Platform:        node.Platform,
 				PlatformVersion: node.PlatformVersion,
-				Checkin:         toTimeString(node.Checkin),
+				Checkin:         tslib.TimestampString(node.Checkin),
 				ClientVersion:   node.ClientVersion,
 				Ec2InstanceId:   node.Ec2InstanceId,
 				Ec2InstanceType: node.Ec2InstanceType,
@@ -96,17 +96,6 @@ func (s *server) NodeInventory(ctx context.Context,
 	return &api.NodeInventoryResponse{
 		Nodes: nodeCollection,
 	}, nil
-}
-
-func toTimeString(timestamp *google_protobuf1.Timestamp) string {
-	if timestamp == nil {
-		return ""
-	}
-	t, err := ptypes.Timestamp(timestamp)
-	if err != nil {
-		return ""
-	}
-	return t.Format(time.RFC3339)
 }
 
 func (s *server) getComplianceNodes(ctx context.Context, hourAgo time.Time) ([]*reporting.Node, error) {
@@ -164,7 +153,7 @@ func includeIfNotAlreadyInList(configMgmtNodes map[string]*api.InventoryNode, co
 				Status:          "active",
 				Platform:        node.GetPlatform().GetName(),
 				PlatformVersion: node.GetPlatform().GetRelease(),
-				Checkin:         toTimeString(node.GetLatestReport().GetEndTime()),
+				Checkin:         tslib.TimestampString(node.GetLatestReport().GetEndTime()),
 			}
 			nodeCollection = append(nodeCollection, n)
 		}

--- a/components/automate-deployment/pkg/server/node_inventory.go
+++ b/components/automate-deployment/pkg/server/node_inventory.go
@@ -8,11 +8,11 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
-	tslib "github.com/chef/automate/lib/grpc/timestamp"
 	configReq "github.com/chef/automate/api/interservice/cfgmgmt/request"
 	"github.com/chef/automate/api/interservice/cfgmgmt/service"
 	api "github.com/chef/automate/api/interservice/deployment"
 	"github.com/chef/automate/components/compliance-service/api/reporting"
+	tslib "github.com/chef/automate/lib/grpc/timestamp"
 )
 
 func (s *server) NodeInventory(ctx context.Context,

--- a/components/automate-deployment/pkg/server/usage.go
+++ b/components/automate-deployment/pkg/server/usage.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
+	tspb "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
@@ -12,6 +12,7 @@ import (
 	"github.com/chef/automate/api/interservice/cfgmgmt/response"
 	"github.com/chef/automate/api/interservice/cfgmgmt/service"
 	api "github.com/chef/automate/api/interservice/deployment"
+	tslib "github.com/chef/automate/lib/grpc/timestamp"
 )
 
 func (s *server) Usage(ctx context.Context,
@@ -32,7 +33,7 @@ func (s *server) Usage(ctx context.Context,
 	}, nil
 }
 
-func (s *server) getConfigMgmtNodes(ctx context.Context, startTime *timestamp.Timestamp) ([]*api.NodeUsage, error) {
+func (s *server) getConfigMgmtNodes(ctx context.Context, startTime *tspb.Timestamp) ([]*api.NodeUsage, error) {
 	var nodeCollection []*api.NodeUsage
 
 	configMgmtAddr := s.AddressForService("config-mgmt-service")
@@ -96,8 +97,8 @@ type nodeUsageMetadata struct {
 }
 
 func populateUsageNode(node *response.InventoryNode) (*api.NodeUsage, error) {
-	lastSeen := toTimeString(node.Checkin)
-	lastCcrReceived := toTimeString(node.LastCcrReceived)
+	lastSeen := tslib.TimestampString(node.Checkin)
+	lastCcrReceived := tslib.TimestampString(node.LastCcrReceived)
 	checkinType := ""
 	if lastSeen == lastCcrReceived {
 		checkinType = "chef-client"

--- a/lib/grpc/timestamp/timestamp.go
+++ b/lib/grpc/timestamp/timestamp.go
@@ -7,22 +7,11 @@ import (
 	tspb "github.com/golang/protobuf/ptypes/timestamp"
 )
 
-const (
-	// Seconds field of the earliest valid Timestamp.
-	// This is time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC).Unix().
-	minValidSeconds = -62135596800
-
-	// Seconds field just after the latest valid Timestamp.
-	// This is time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC).Unix().
-	maxValidSeconds = 253402300800
-)
-
 // TimestampString: return a string representation of the ptype timestamp
-
 // this is inspired by the ptypes.TimestampString() function that
 // encodes errors into the string when receiving a nil or mis-typed
 // timestamp.  it also returns the string in RFC3339 format instead of
-// RFC3339nano format in order to keep compatiblity w/ the current
+// RFC3339nano format in order to keep compatibility w/ the current
 // behavior
 func TimestampString(ts *tspb.Timestamp) string {
 	t, err := ptypes.Timestamp(ts)

--- a/lib/grpc/timestamp/timestamp.go
+++ b/lib/grpc/timestamp/timestamp.go
@@ -1,0 +1,33 @@
+package timestamp
+
+import (
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	tspb "github.com/golang/protobuf/ptypes/timestamp"
+)
+
+const (
+	// Seconds field of the earliest valid Timestamp.
+	// This is time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC).Unix().
+	minValidSeconds = -62135596800
+
+	// Seconds field just after the latest valid Timestamp.
+	// This is time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC).Unix().
+	maxValidSeconds = 253402300800
+)
+
+// TimestampString: return a string representation of the ptype timestamp
+
+// this is inspired by the ptypes.TimestampString() function that
+// encodes errors into the string when receiving a nil or mis-typed
+// timestamp.  it also returns the string in RFC3339 format instead of
+// RFC3339nano format in order to keep compatiblity w/ the current
+// behavior
+func TimestampString(ts *tspb.Timestamp) string {
+	t, err := ptypes.Timestamp(ts)
+	if err != nil {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}

--- a/lib/grpc/timestamp/timestamp_test.go
+++ b/lib/grpc/timestamp/timestamp_test.go
@@ -1,0 +1,28 @@
+package timestamp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	tspb "github.com/golang/protobuf/ptypes/timestamp"
+)
+
+func TestTimestampString(t *testing.T) {
+	for _, test := range []struct {
+		ts       *tspb.Timestamp
+		expected string
+	}{
+		// very basic test
+		{&tspb.Timestamp{Seconds: 0, Nanos: 0}, "1970-01-01T00:00:00Z"},
+		// make sure we dont add nanos to the output
+		{&tspb.Timestamp{Seconds: 0, Nanos: 9}, "1970-01-01T00:00:00Z"},
+		// test nil
+		{nil, ""},
+		// test invalid (negative time, extra time)
+		{&tspb.Timestamp{Seconds: minValidSeconds - 1, Nanos: 0}, ""},
+		{&tspb.Timestamp{Seconds: maxValidSeconds + 1, Nanos: 0}, ""},
+	} {
+		assert.Equal(t, test.expected, TimestampString(test.ts))
+	}
+}
+

--- a/lib/grpc/timestamp/timestamp_test.go
+++ b/lib/grpc/timestamp/timestamp_test.go
@@ -7,6 +7,16 @@ import (
 	tspb "github.com/golang/protobuf/ptypes/timestamp"
 )
 
+const (
+	// Seconds field of the earliest valid Timestamp.
+	// This is time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC).Unix().
+	minValidSeconds = -62135596800
+
+	// Seconds field just after the latest valid Timestamp.
+	// This is time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC).Unix().
+	maxValidSeconds = 253402300800
+)
+
 func TestTimestampString(t *testing.T) {
 	for _, test := range []struct {
 		ts       *tspb.Timestamp


### PR DESCRIPTION
this change adds timestamp strings to scanned nodes in the
`chef-automate license usage` command. the output (taken below from
test data) now looks like the following:

```
"scanned_nodes": [
  {
    "id": "cd03cf26-7ab3-4b14-87f4-9ef54bbac1c8",
    "name": "integration-diagnostic-20190427004524",
    "scan_job_id": "7f7a8772-3180-4dc3-9af6-95a463e78388",
    "last_seen": "2019-04-27T00:45:26Z"
  }
]
```

the key naming `last_seen` was chosed to keep consistency with the
timestamp used in the chef runs section of the output and uses the
same timestamp fomatting for consistency

Signed-off-by: Stephen Delano <stephen@chef.io>

### :nut_and_bolt: Description

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
