### PR TITLE
azure integration: include names in tag search

### DIFF
--- a/components/nodemanager-service/managers/azure/azure.go
+++ b/components/nodemanager-service/managers/azure/azure.go
@@ -678,7 +678,7 @@ func (creds *Creds) QueryField(ctx context.Context, filters []*common.Filter, fi
 		if err != nil {
 			return nil, errors.Wrap(err, "QueryField unable to list locations")
 		}
-	case "names":
+	case "names", "tags:name":
 		vmsResult, err := creds.QueryVMs(ctx, []*common.Filter{})
 		if err != nil {
 			return nil, errors.Wrap(err, "QueryField unable to query vms")
@@ -696,6 +696,7 @@ func (creds *Creds) QueryField(ctx context.Context, filters []*common.Filter, fi
 		for k := range tags {
 			resultArray = append(resultArray, k)
 		}
+		resultArray = append(resultArray, "name")
 	case "subscriptions":
 		for _, sub := range subs {
 			resultArray = append(resultArray, fmt.Sprintf("%s:%s", sub.Name, sub.Id))

--- a/components/nodemanager-service/tests/azure_vm_nodes_integration_test.go
+++ b/components/nodemanager-service/tests/azure_vm_nodes_integration_test.go
@@ -111,9 +111,17 @@ func TestAzureVMSearchNodeFields(t *testing.T) {
 	fields, err = mgrClient.SearchNodeFields(ctx, &query)
 	require.NoError(t, err)
 	require.NotEqual(t, 0, len(fields.GetFields()))
+	t.Logf("fields found are %v", fields)
+	require.Equal(t, mgrtesthelpers.Contains(fields.GetFields(), "name"), true)
 
 	t.Log("search node fields for list of values for tags:Test")
 	query.Field = "tags:Test"
+	fields, err = mgrClient.SearchNodeFields(ctx, &query)
+	require.NoError(t, err)
+	require.NotEqual(t, 0, len(fields.GetFields()))
+
+	t.Log("search node fields for list of values for names")
+	query.Field = "tags:name"
 	fields, err = mgrClient.SearchNodeFields(ctx, &query)
 	require.NoError(t, err)
 	require.NotEqual(t, 0, len(fields.GetFields()))


### PR DESCRIPTION
### :nut_and_bolt: Description
This is a small improvement to improve the experience of filtering nodes when using the Azure vm integration.
In AWS, name is considered a tag, whereas in Azure name is considered a separate field. Given that we only provide search via tags and regions when creating a scan job, this means users using the AWS-ec2 integration were able to search by name while users using the Azure-vm integration were not.   Including the name in the tag search will allow users of the Azure-vm integration to filter nodes by name when creating a scan job, getting us closer to parity between the two integrations.

### :+1: Definition of Done
Name shows up as an available tag when using the Azure-vm integration. Available names are listed as tag values. Nodes are filtered by the name selected.

### :athletic_shoe: Demo Script / Repro Steps
rebuild nodemanager-service
add an Azure integration
look for name in the tags, and filter by a name
expect to see the nodes filtered by that name

