### PR TITLE
[A2-786] Correct project intersection query for roles

### DIFF
--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -815,7 +815,7 @@ func checkIfRoleIntersectsProjectsFilter(ctx context.Context, q Querier,
 				FILTER (WHERE rp.project_id IS NOT NULL), '{(unassigned)}') && $2 AS intersection
 			FROM iam_roles AS r
 			LEFT OUTER JOIN iam_role_projects AS rp ON rp.role_id=r.db_id
-			WHERE r.id = $1 GROUP BY rp.project_id;`,
+			WHERE r.id = $1;`,
 		id, pq.Array(projectsFilter))
 
 	var result bool


### PR DESCRIPTION
### :nut_and_bolt: Description

The new integration tests in role_projects.rb ( A2-747 In Development ) showed three failing tests:
![image](https://user-images.githubusercontent.com/6817500/56858769-e607d680-6934-11e9-93ff-4ecb1a0e9e4f.png)

The TL;DR is that there is a role containing 2 projects, one that is allowed and one that is denied. The call is authorized correctly: `ProjectsAuthorized` returns the allowed project. The call then proceeds to the authz service to perform a get, update, or delete. There, it invokes a piece of inline SQL to determine if the given role has a project that matches the allowed project that was requested. The SQL was incorrectly saying "no" when it should have said "yes".

This turned out to be a non-deterministic artifact which is why it may have escaped notice until now. In fact, I reproduced the scenario from the `GetRole` integration test on the command line, i.e. running curl instead of running the integration test. The database was set up with the necessary entities in an identical fashion. Really. Truly. Identical. And yet, on the command line the curl returned the correct result.

So the next question was _why was this non-deterministic?_
It turns out that with the set of data I selected, the bit of SQL that checked the project filtering returned _multiple_ rows. (It was never supposed to do that; it should always return a single row.)
Each of those multiple rows was a boolean. But because it returned multiple rows, and the Go code that evaluated the result simply _took the first row_, the output order matters! In the integration test, it was set up in such a way that it outputted `false, true` for the two rows while my command-line curl outputted `true, false`. That is why the integration test failed and the curl succeeded.

And the final question was _why was the query outputting multiple rows?_
Take a look at the code change and you will be surprised. To get a single result instead of multiple it was necessary to _delete the GROUP BY_. 😮 Don't believe me? Try this:
```
-- just using some static data
WITH elements AS (
    SELECT 'p1' AS item UNION
    SELECT 'p2' UNION
    SELECT 'p2' UNION
    SELECT 'p3'
)
-- but this reproduces the query from our production code:
SELECT COALESCE(array_agg(item) FILTER (WHERE item IS NOT NULL),'{foo}') && '{p1, p2}' as result
FROM elements
GROUP BY item;

 result 
--------
 f
 t
 t
(3 rows)
```
The above 3 rows resulted because of the `GROUP BY`. Now here is the same code except the `GROUP BY` is omitted:
```
WITH elements AS (
    SELECT 'p1' AS item UNION
    SELECT 'p2' UNION
    SELECT 'p2' UNION
    SELECT 'p3'
)
SELECT COALESCE(array_agg(item) FILTER (WHERE item IS NOT NULL),'{foo}') && '{p1, p2}' as result
FROM elements;                                                                                                                                                                                             

 result 
--------
 t
(1 row)
```

### :+1: Definition of Done

![image](https://user-images.githubusercontent.com/6817500/56858886-bd80dc00-6936-11e9-9a98-74001455816c.png)

### :athletic_shoe: Demo Script / Repro Steps

Setup for this requires including two other branches in the build and creating assorted auth objects in the DB which is done by the integration test.

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
