### PR TITLE
[A2-787] authz-service and teams-service db cleanup

### DIFF
--- a/components/authz-service/storage/postgres/migration/sql/41_query_roles_with_projects_match.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/41_query_roles_with_projects_match.up.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION
+  query_roles(_projects_filter TEXT[])
+  RETURNS setof json AS $$
+
+  WITH t AS (
+    SELECT
+      r.id,
+      r.name,
+      r.type,
+      r.actions,
+      (SELECT array_agg(rp.project_id) FILTER (WHERE rp.project_id IS NOT NULL)) AS projects
+    FROM iam_roles AS r
+    LEFT OUTER JOIN iam_role_projects AS rp ON rp.role_id = r.db_id
+    GROUP BY r.id, r.name, r.type, r.actions
+  )
+  SELECT
+    json_build_object(
+      'id', t.id,
+      'name', t.name,
+      'type', t.type,
+      'actions', t.actions,
+      'projects', COALESCE(t.projects, '{}')
+    ) AS role FROM t
+  WHERE projects_match(t.projects::TEXT[],  _projects_filter);
+
+$$ LANGUAGE sql;
+
+COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/42_remove_leftover_functions.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/42_remove_leftover_functions.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- These are leftover, deprecated functions, whose signatures have changed.
+
+DROP FUNCTION IF EXISTS query_projects();
+
+DROP FUNCTION IF EXISTS query_project(TEXT);
+
+DROP FUNCTION IF EXISTS query_policies();
+
+DROP FUNCTION IF EXISTS query_policy(TEXT);
+
+COMMIT;

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -5194,7 +5194,7 @@ func TestPurgeSubjectFromPolicies(t *testing.T) {
 func assertProjectsMatch(t *testing.T, db *testDB, project storage.Project) {
 	t.Helper()
 	dbProject := storage.Project{}
-	err := db.QueryRow(`SELECT query_project($1);`, project.ID).Scan(&dbProject)
+	err := db.QueryRow(`SELECT query_project($1, '{}');`, project.ID).Scan(&dbProject)
 	require.NoError(t, err)
 	assert.Equal(t, project, dbProject)
 }

--- a/components/teams-service/storage/postgres/postgres.go
+++ b/components/teams-service/storage/postgres/postgres.go
@@ -76,10 +76,12 @@ func (p *postgres) UpgradeToV2(ctx context.Context) error {
 	return nil
 }
 
+// StoreTeam saves a team to the DB. This is used by IAM v1 ONLY!
 func (p *postgres) StoreTeam(ctx context.Context, name string, description string) (storage.Team, error) {
 	return p.StoreTeamWithProjects(ctx, name, description, []string{})
 }
 
+// StoreTeam saves a team to the DB.
 func (p *postgres) StoreTeamWithProjects(ctx context.Context,
 	name string, description string, projects []string) (storage.Team, error) {
 
@@ -101,8 +103,7 @@ func (p *postgres) StoreTeamWithProjects(ctx context.Context,
 	return team, nil
 }
 
-// GetTeam fetches a database team by id and its users, returning a storage team
-// with users
+// GetTeam fetches a team by id. This is used by IAM v1 ONLY!
 func (p *postgres) GetTeam(ctx context.Context, teamID uuid.UUID) (storage.Team, error) {
 	return p.getTeam(ctx, p.db, teamID)
 }
@@ -120,6 +121,7 @@ func (p *postgres) getTeam(ctx context.Context, q querier, teamID uuid.UUID) (st
 	return t, nil
 }
 
+// DeleteTeam deletes a team from the DB. This is used by IAM v1 ONLY!
 func (p *postgres) DeleteTeam(ctx context.Context, teamID uuid.UUID) (storage.Team, error) {
 	var t storage.Team
 	err := p.db.QueryRowContext(ctx,
@@ -133,6 +135,7 @@ func (p *postgres) DeleteTeam(ctx context.Context, teamID uuid.UUID) (storage.Te
 	return t, nil
 }
 
+// DeleteTeam deletes a team from the DB.
 func (p *postgres) DeleteTeamByName(ctx context.Context, teamName string) (storage.Team, error) {
 	projectsFilter, err := ProjectsListFromContext(ctx)
 	if err != nil {
@@ -153,7 +156,7 @@ func (p *postgres) DeleteTeamByName(ctx context.Context, teamName string) (stora
 	return t, nil
 }
 
-// EditTeam does a full update on a database team.
+// EditTeam does a full update on a database team. This is used by IAM v1 ONLY!
 func (p *postgres) EditTeam(ctx context.Context, team storage.Team) (storage.Team, error) {
 	var t storage.Team
 	// ensure we do not pass null projects to db
@@ -202,7 +205,7 @@ func (p *postgres) EditTeamByName(ctx context.Context,
 	return t, nil
 }
 
-// GetTeams fetches teams from the database, returning an array of storage teams.
+// GetTeams fetches teams from the DB as an array.
 func (p *postgres) GetTeams(ctx context.Context) ([]storage.Team, error) {
 	projectsFilter, err := ProjectsListFromContext(ctx)
 	if err != nil {
@@ -284,7 +287,7 @@ func (p *postgres) RemoveUsers(ctx context.Context, teamID uuid.UUID, userIDs []
 	return team, nil
 }
 
-// GetTeamByName returns the team by name
+// GetTeamByName fetches a team by name.
 func (p *postgres) GetTeamByName(ctx context.Context, teamName string) (storage.Team, error) {
 	projectsFilter, err := ProjectsListFromContext(ctx)
 	if err != nil {


### PR DESCRIPTION
### :nut_and_bolt: Description

While performing an audit of our code to examine how project filtering is handled amongst all the auth entities, I noticed a few things that needed clean-up.

1. Swapping in `projects_match` in `query_roles` in lieu of the duplicate, inline code.

2. Removing deprecated functions that were still present due to signature changes due to two issues: (a) `create or replace` only replaces if the function signature matches; otherwise it is just `create`. 
(b) the `drop function` command also requires matching signatures; otherwise it fails silently.

3. DB functions in teams-service are a hodgepodge of v1 and v2 code. It is important to delineate which are v1 only so the casual reader does not get alarmed that project-handling is absent from those.

Examine the individual commits for the details.

### :+1: Definition of Done

Code is a bit cleaner than before.

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
