### PR TITLE
Revert commented health bar https://github.com/chef/automate/pull/157

### DIFF
--- a/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
@@ -1,11 +1,11 @@
 import { RollupServiceStatus, SortDirection  } from '../../types/types';
 
 export interface HealthSummary {
-  total?: number;
-  ok?: number;
-  warning?: number;
-  critical?: number;
-  unknown?: number;
+  total: number;
+  ok: number;
+  warning: number;
+  critical: number;
+  unknown: number;
 }
 
 export interface Service {

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
@@ -1,11 +1,11 @@
 import { RollupServiceStatus, SortDirection  } from '../../types/types';
 
 export interface HealthSummary {
-  total: number;
-  ok: number;
-  warning: number;
-  critical: number;
-  unknown: number;
+  total?: number;
+  ok?: number;
+  warning?: number;
+  critical?: number;
+  unknown?: number;
 }
 
 export interface Service {

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
@@ -24,14 +24,26 @@ export interface ServiceGroupEntityState {
 
 export const ServiceGroupEntityInitialState: ServiceGroupEntityState = {
   serviceGroups: [],
-  serviceGroupHealthCounts: { },
+  serviceGroupHealthCounts: {
+    total: 0,
+    ok: 0,
+    warning: 0,
+    critical: 0,
+    unknown: 0
+  },
   status: EntityStatus.notLoaded,
   filters: { },
   servicesStatus: EntityStatus.notLoaded,
   errorResp: null,
   servicesFilters: { },
   servicesList: [],
-  servicesHealthSummary: { },
+  servicesHealthSummary: {
+    total: 0,
+    ok: 0,
+    warning: 0,
+    critical: 0,
+    unknown: 0
+  },
   selectedServiceGroupName: undefined
 };
 

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
@@ -31,7 +31,7 @@ export const ServiceGroupEntityInitialState: ServiceGroupEntityState = {
   errorResp: null,
   servicesFilters: { },
   servicesList: [],
-  servicesHealthSummary: undefined,
+  servicesHealthSummary: { },
   selectedServiceGroupName: undefined
 };
 

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
@@ -11,7 +11,7 @@ import {
 
 export interface ServiceGroupEntityState {
   serviceGroups: ServiceGroup[];
-  serviceGroupHealthCounts: HealthSummary[];
+  serviceGroupHealthCounts: HealthSummary;
   status: EntityStatus;
   filters: ServiceGroupFilters;
   servicesStatus: EntityStatus;
@@ -24,7 +24,7 @@ export interface ServiceGroupEntityState {
 
 export const ServiceGroupEntityInitialState: ServiceGroupEntityState = {
   serviceGroups: [],
-  serviceGroupHealthCounts: [],
+  serviceGroupHealthCounts: { },
   status: EntityStatus.notLoaded,
   filters: { },
   servicesStatus: EntityStatus.notLoaded,

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -8,7 +8,7 @@
       <chef-subheading>Services run by each Habitat Supervisor on a node.</chef-subheading>
     </chef-page-header>
     <div class="status-filter-bar">
-      <!-- <chef-status-filter-group lean>
+      <chef-status-filter-group lean>
         <chef-option class="filter general" value="general" (click)="updateServicesFilters('total')">
           <chef-icon class="filter-icon">group_work</chef-icon>
           <div class="filter-label">Total</div>
@@ -34,7 +34,7 @@
           <div class="filter-label">Unknown</div>
           <div class="filter-total">{{ (servicesHealthSummary$ | async).unknown }}</div>
         </chef-option>
-      </chef-status-filter-group> -->
+      </chef-status-filter-group>
     </div>
     <ul>
       <li class="service-item" *ngFor="let service of services$ | async">

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -9,7 +9,7 @@
     </chef-page-header>
     <div class="status-filter-bar">
       <chef-status-filter-group lean>
-        <chef-option class="filter general" value="general" (click)="updateServicesFilters('total')">
+        <chef-option class="filter general" value="general" (click)="updateServicesFilters('total')" selected>
           <chef-icon class="filter-icon">group_work</chef-icon>
           <div class="filter-label">Total</div>
           <div class="filter-total">{{ (servicesHealthSummary$ | async).total }}</div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -8,6 +8,7 @@ import {
   Service, ServicesFilters, HealthSummary
 } from '../../entities/service-groups/service-groups.model';
 import { UpdateSelectedSG } from '../../entities/service-groups/service-groups.actions';
+import { get } from 'lodash/fp';
 
 @Component({
   selector: 'app-services-sidebar',
@@ -41,8 +42,9 @@ export class ServicesSidebarComponent implements OnInit {
       (state) => state.servicesHealthSummary));
 
     this.currentPage = 1;
+
     this.servicesHealthSummary$.subscribe((healthSummary) => {
-      this.totalServices = healthSummary.total;
+      this.totalServices = get('total', healthSummary);
     });
   }
 

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -42,7 +42,9 @@ export class ServicesSidebarComponent implements OnInit {
 
     this.currentPage = 1;
 
-    this.servicesHealthSummary$.subscribe(healthSummary => this.totalServices = healthSummary.total);
+    this.servicesHealthSummary$.subscribe((healthSummary) => {
+      this.totalServices = healthSummary.total;
+    });
   }
 
   public closeServicesSidebar() {

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -42,8 +42,7 @@ export class ServicesSidebarComponent implements OnInit {
 
     this.currentPage = 1;
 
-    // this.servicesHealthSummary$.subscribe(healthSummary =>
-    // this.totalServices = healthSummary.total);
+    this.servicesHealthSummary$.subscribe(healthSummary => this.totalServices = healthSummary.total);
   }
 
   public closeServicesSidebar() {

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -41,7 +41,6 @@ export class ServicesSidebarComponent implements OnInit {
       (state) => state.servicesHealthSummary));
 
     this.currentPage = 1;
-
     this.servicesHealthSummary$.subscribe((healthSummary) => {
       this.totalServices = healthSummary.total;
     });

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -4,8 +4,8 @@
   <chef-subheading>Group of Habitat services running the same package and configuration.</chef-subheading>
 </chef-page-header>
 <div class="page-body">
-  <chef-status-filter-group>
-    <chef-option class="filter general" value="general" (click)="statusFilter('total')">
+  <chef-status-filter-group [value]="selectedStatus$ | async">
+    <chef-option class="filter general" value="general" (click)="statusFilter('total')" selected>
       <chef-icon class="filter-icon">group_work</chef-icon>
       <div class="filter-label">Total</div>
       <div class="filter-total">{{(HealthSummary$ | async)["total"]}}</div>

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -77,10 +77,12 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
 
     this.serviceGroupStatus$ = this.store.select(serviceGroupStatus);
     this.serviceGroups$ = this.store.select(allServiceGroups);
+
     this.HealthSummary$ = this.store.select(allServiceGroupHealth);
     this.HealthSummary$.subscribe((sgHealthSummary) => {
       this.totalServiceGroups = sgHealthSummary['total'];
     });
+
     this.selectedStatus$ = this.store.select(createSelector(serviceGroupState,
       (state) => state.filters.status));
 
@@ -100,7 +102,6 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
       (state) => state.filters.page));
 
     this.currentPage$.subscribe(currentPage => this.currentPage = currentPage);
-
   }
 
   ngOnDestroy() {

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -26,7 +26,7 @@ import { find, includes } from 'lodash/fp';
 export class ServiceGroupsComponent implements OnInit, OnDestroy {
   public serviceGroups$: Observable<ServiceGroup[]>;
   public serviceGroupStatus$: Observable<EntityStatus>;
-  public HealthSummary$: Observable<HealthSummary[]>;
+  public HealthSummary$: Observable<HealthSummary>;
 
   // The selected service-group id that will be sent to the services-sidebar
   public selectedServiceGroupId: number;

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -34,32 +34,36 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   // Weather or not the the services sidebar is visible
   public servicesSidebarVisible = false;
 
+  // The current page the user is visualizing
+  public currentPage = 1;
+
+  // The number of service groups to display per page
+  public pageSize = 25;
+
+  // Total number of service groups
+  public totalServiceGroups = 0;
+
   // The collection of allowable status
   private allowedStatus = ['ok', 'critical', 'warning', 'unknown'];
 
   // The currently selected health status filter
-  selectedStatus$: Observable<string>;
+  public selectedStatus$: Observable<string>;
 
   // Has this component been destroyed
   private isDestroyed: Subject<boolean> = new Subject();
 
-  selectedFieldDirection$: Observable<SortDirection>;
-  selectedSortField$: Observable<string>;
-  currentPage$: Observable<number>;
+  private selectedFieldDirection$: Observable<SortDirection>;
+  private selectedSortField$: Observable<string>;
+  private currentPage$: Observable<number>;
 
-  currentFieldDirection: SortDirection;
-  currentSortField: string;
+  private currentFieldDirection: SortDirection;
+  private currentSortField: string;
 
-  defaultFieldDirection: FieldDirection = {
+  private defaultFieldDirection: FieldDirection = {
     name: 'ASC',
     percent_ok: 'ASC'
   };
 
-  currentPage = 1;
-  // The number of service groups to display per page
-  pageSize = 25;
-  // TODO: Wire this up with real data
-  totalServiceGroups = 50;
   // The collection of allowable sort directions
   private allowedSortDirections = ['asc', 'desc', 'ASC', 'DESC'];
 


### PR DESCRIPTION
The health filter bar was commented out with the PR https://github.com/chef/automate/pull/157, this work is to uncomment it and have the bar visible again.

It also fixed the problem found in the above PR where the Redux state was not well initialized.

EXTRA: Fixed more little nitpicks from the codebase. Also used the selected status variable to make it persistent on reload.

Signed-off-by: Salim Afiune <afiune@chef.io>