### PR TITLE
[deployment] Send TaskComplete to event stream during restore

### DIFF
--- a/components/automate-deployment/pkg/backup/runner.go
+++ b/components/automate-deployment/pkg/backup/runner.go
@@ -469,6 +469,9 @@ func (r *Runner) startRestoreOperations(ctx context.Context) {
 		// and that any listeners on the event stream will get the task complete
 		// signal.
 		r.unlockDeployment()
+		if r.eventSender != nil {
+			r.eventSender.TaskComplete()
+		}
 		close(r.errChan)
 		close(r.eventTerm)
 		r.clearRunningTask()


### PR DESCRIPTION
Without the TaskComplete() message the DeployStatus grpc request never
finishes server-side. This can lead to the service failing to stop
when sent a TERM.

Signed-off-by: Steven Danna <steve@chef.io>