### PR TITLE
[deployment] Persist the backup manifest on restore

### DIFF
--- a/components/automate-deployment/pkg/backup/runner.go
+++ b/components/automate-deployment/pkg/backup/runner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/chef/automate/components/automate-deployment/pkg/deployment"
 	"github.com/chef/automate/components/automate-deployment/pkg/events"
 	"github.com/chef/automate/components/automate-deployment/pkg/manifest"
+	"github.com/chef/automate/components/automate-deployment/pkg/persistence"
 	"github.com/chef/automate/components/automate-deployment/pkg/services"
 	"github.com/chef/automate/components/automate-deployment/pkg/target"
 	es "github.com/chef/automate/components/es-sidecar-service/pkg/elastic"
@@ -47,6 +48,9 @@ type Runner struct {
 	// Since we rely on a deployment lock for operations that change state
 	// we only need to track a single task and don't need another mutex.
 	runningTask *CancellableTask
+
+	// Used to save the backup manifest at the end of the restore
+	deploymentStore persistence.DeploymentStore
 
 	pgConnInfo      pg.ConnInfo
 	esSidecarInfo   ESSidecarConnInfo
@@ -146,6 +150,13 @@ func WithTarget(target target.Target) RunnerOpt {
 func WithReleaseManifest(releaseManifest manifest.ReleaseManifest) RunnerOpt {
 	return func(runner *Runner) {
 		runner.releaseManifest = releaseManifest
+	}
+}
+
+// WithDeploymentStore sets the deployment store for the runner
+func WithDeploymentStore(deploymentStore persistence.DeploymentStore) RunnerOpt {
+	return func(runner *Runner) {
+		runner.deploymentStore = deploymentStore
 	}
 }
 
@@ -544,6 +555,27 @@ func (r *Runner) startRestoreOperations(ctx context.Context) {
 
 	if err = r.restoreServices(desiredServices, restoreCtx, cancel); err != nil {
 		r.failf(err, "Failed to restore services")
+		return
+	}
+
+	m, ok := backupManifest.(*manifest.A2)
+	if !ok {
+		r.failf(errors.New("Unknown backup manifest type"), "Failed to persist manifest")
+		return
+	}
+
+	r.lockedDeployment.CurrentReleaseManifest = m
+	_, err = r.deploymentStore.UpdateDeployment(func(d *deployment.Deployment) error {
+		// TODO(jaym) This is not the right way to interact with deployment store. We should
+		//            modify the deployment it gives us with the updates we want and not
+		//            keep around a copy of it in memory. It turns out that doing that is
+		//            still too hard because there are objects that need to be initialized
+		//            one the deployment after deserialization.
+		*d = *r.lockedDeployment // nolint: govet
+		return nil
+	})
+	if err != nil {
+		r.failf(err, "Failed to persist deployment")
 		return
 	}
 

--- a/components/automate-deployment/pkg/server/server.go
+++ b/components/automate-deployment/pkg/server/server.go
@@ -2073,6 +2073,7 @@ func (s *server) reloadBackupRunner() error {
 		backup.WithConnFactory(s.connFactory),
 		backup.WithTarget(target),
 		backup.WithReleaseManifest(s.deployment.CurrentReleaseManifest),
+		backup.WithDeploymentStore(s.deploymentStore),
 	)
 
 	return nil


### PR DESCRIPTION
Previously, we were not persisting the manifest at the end of the
restore process. This meant that the first converge after an "upgrade
restore" would potentially result in a downgrade if the user had their
upgrade strategy set to none because the converge loop would use the
old manifest.

TODO:

- [ ] Needs a test somewhere

Signed-off-by: Steven Danna <steve@chef.io>