### PR TITLE
Use upgrade_strategy none for airgap backup test

### DIFF
--- a/integration/tests/airgap_backup.sh
+++ b/integration/tests/airgap_backup.sh
@@ -15,6 +15,7 @@ do_deploy() {
         --airgap-bundle bundle.aib \
         --admin-password chefautomate \
         --accept-terms-and-mlsa \
+        --upgrade-strategy none \
         --debug
 }
 
@@ -25,4 +26,5 @@ do_restore() {
         --override-origin "$HAB_ORIGIN" \
         --debug \
         "${test_backup_id}"
+    chef-automate upgrade status
 }


### PR DESCRIPTION
There's currently a bug with this that should be fixed in #203.
Restoring does not use the correct manifest after restore and
deployment-service gets confused.
