### PR TITLE
[deployment] Set HAB_LICENSE=accept-no-persist in a lot of places

### DIFF
--- a/components/automate-cli/cmd/chef-automate/dev.go
+++ b/components/automate-cli/cmd/chef-automate/dev.go
@@ -800,6 +800,7 @@ func runGRPCurl(cmd *cobra.Command, args []string) error {
 	cmdArgs = append(cmdArgs, grpcArgs...)
 
 	return command.Run("hab",
+		command.Envvar("HAB_LICENSE", "accept-no-persist"),
 		command.Args(cmdArgs...),
 		command.Stderr(os.Stderr),
 		command.Stdout(os.Stdout),

--- a/components/automate-cli/cmd/chef-automate/start_linux.go
+++ b/components/automate-cli/cmd/chef-automate/start_linux.go
@@ -5,8 +5,9 @@ import (
 	"os/exec"
 	"syscall"
 
-	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/spf13/cobra"
+
+	"github.com/chef/automate/components/automate-cli/pkg/status"
 )
 
 var startCommand = &cobra.Command{
@@ -32,7 +33,11 @@ func runStartCmd(cmd *cobra.Command, args []string) error {
 		}
 		startSupCmd := exec.Command("hab", "sup", "run")
 		startSupCmd.Env = os.Environ()
-		startSupCmd.Env = append(startSupCmd.Env, "DS_DEV=true", "CHEF_AUTOMATE_SKIP_SYSTEMD=true")
+		startSupCmd.Env = append(startSupCmd.Env,
+			"DS_DEV=true",
+			"CHEF_AUTOMATE_SKIP_SYSTEMD=true",
+			"HAB_LICENSE=accept-no-persist",
+		)
 		startSupCmd.Stdout = out
 		startSupCmd.Stderr = out
 		startSupCmd.SysProcAttr = &syscall.SysProcAttr{

--- a/components/automate-deployment/pkg/bootstrap/deployment_service_cmd.go
+++ b/components/automate-deployment/pkg/bootstrap/deployment_service_cmd.go
@@ -62,6 +62,7 @@ func (ds *DeploymentServiceCommand) DeployService(config *dc.ConfigRequest, m ma
 	return ds.CmdExecutor.Run("hab",
 		command.Args("pkg", "exec", habpkg.Ident(ds.dsPkg), "deployment-service",
 			"deploy-service", configFile, manifestFile),
+		command.Envvar("HAB_LICENSE", "accept-no-persist"),
 		command.Envvar("CHEF_AUTOMATE_LOG_LEVEL", logrus.GetLevel().String()),
 		command.Stdout(os.Stdout),
 		command.Stderr(os.Stderr))
@@ -83,6 +84,7 @@ func (ds *DeploymentServiceCommand) SetupSupervisor(config *dc.ConfigRequest, m 
 	return ds.CmdExecutor.Run("hab",
 		command.Args("pkg", "exec", habpkg.Ident(ds.dsPkg), "deployment-service",
 			"setup-supervisor", configFile, manifestFile),
+		command.Envvar("HAB_LICENSE", "accept-no-persist"),
 		command.Envvar("CHEF_AUTOMATE_LOG_LEVEL", logrus.GetLevel().String()),
 		command.Stdout(os.Stdout),
 		command.Stderr(os.Stderr))

--- a/components/automate-deployment/pkg/gatherlogs/command.go
+++ b/components/automate-deployment/pkg/gatherlogs/command.go
@@ -37,6 +37,7 @@ func (c *Command) execute() error {
 
 	err = command.Run(c.Cmd,
 		command.Args(c.Args...),
+		command.Envvar("HAB_LICENSE", "accept-no-persist"),
 		command.Stdout(out),
 		command.Stderr(out))
 	if err != nil {

--- a/components/automate-deployment/pkg/server/startup_helpers.go
+++ b/components/automate-deployment/pkg/server/startup_helpers.go
@@ -16,7 +16,10 @@ import (
 var logCmdTimeout = 5 * time.Second
 
 func habVersion() string {
-	output, err := command.Output("hab", command.Args("--version"), command.Timeout(logCmdTimeout))
+	output, err := command.Output("hab",
+		command.Args("--version"),
+		command.Envvar("HAB_LICENSE", "accept-no-persist"),
+		command.Timeout(logCmdTimeout))
 	if err != nil {
 		return fmt.Sprintf("unknown (hab --version failed with: %s)", output)
 	}
@@ -25,7 +28,10 @@ func habVersion() string {
 }
 
 func habSupVersion() string {
-	output, _ := command.Output("hab", command.Args("sup", "--version"), command.Timeout(logCmdTimeout))
+	output, _ := command.Output("hab",
+		command.Args("sup", "--version"),
+		command.Envvar("HAB_LICENSE", "accept-no-persist"),
+		command.Timeout(logCmdTimeout))
 	// hab sup --version returns non-zero even when it hasn't errored
 	// so for now we can just return the output I guess.
 	return strings.TrimSpace(output)

--- a/components/automate-deployment/pkg/target/hab_cmd.go
+++ b/components/automate-deployment/pkg/target/hab_cmd.go
@@ -10,6 +10,8 @@ var stdHabOptions = []command.Opt{
 	command.Envvar("HAB_NOCOLORING", "true"),
 	// Don't use progress bars in output
 	command.Envvar("HAB_NONINTERACTIVE", "true"),
+	// Don't prompt for license acceptance
+	command.Envvar("HAB_LICENSE", "accept-no-persist"),
 }
 
 // A HabCmd runs the `hab` command-line tool with a standard set of
@@ -38,6 +40,9 @@ type HabCmd interface {
 	// StopService stops an already-loaded service identified by
 	// the given habpkg.VersionedPackage.
 	StopService(habpkg.VersionedPackage) (string, error)
+
+	// Terminate supervisor, does not block
+	SupTerm() error
 }
 
 type LoadOption func([]string) []string
@@ -141,6 +146,12 @@ func (c *habCmd) StartService(svc habpkg.VersionedPackage) (string, error) {
 func (c *habCmd) StopService(svc habpkg.VersionedPackage) (string, error) {
 	args := command.Args("svc", "stop", habpkg.ShortIdent(svc))
 	return c.executor.CombinedOutput("hab", append(standardHabOptions(), args)...)
+}
+
+func (c *habCmd) SupTerm() error {
+	args := command.Args("sup", "term")
+	_, err := c.executor.Start("hab", append(standardHabOptions(), args)...)
+	return err
 }
 
 func standardHabOptions() []command.Opt {

--- a/components/automate-deployment/pkg/target/hab_cmd_test.go
+++ b/components/automate-deployment/pkg/target/hab_cmd_test.go
@@ -22,7 +22,7 @@ func TestInstallPackage(t *testing.T) {
 
 		mockExecutor.Expect("CombinedOutput", command.ExpectedCommand{
 			Cmd: "hab",
-			Env: []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Env: []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true", "HAB_LICENSE=accept-no-persist"},
 			Args: []string{
 				"pkg",
 				"install",
@@ -39,7 +39,7 @@ func TestInstallPackage(t *testing.T) {
 		installer := target.NewHabCmd(mockExecutor, true)
 		mockExecutor.Expect("CombinedOutput", command.ExpectedCommand{
 			Cmd: "hab",
-			Env: []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true", "HAB_FEAT_OFFLINE_INSTALL=true"},
+			Env: []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true", "HAB_LICENSE=accept-no-persist", "HAB_FEAT_OFFLINE_INSTALL=true"},
 			Args: []string{
 				"pkg",
 				"install",
@@ -58,7 +58,7 @@ func TestInstallPackage(t *testing.T) {
 		installer := target.NewHabCmd(mockExecutor, false)
 		mockExecutor.Expect("CombinedOutput", command.ExpectedCommand{
 			Cmd: "hab",
-			Env: []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Env: []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true", "HAB_LICENSE=accept-no-persist"},
 			Args: []string{
 				"pkg",
 				"install",
@@ -76,7 +76,7 @@ func TestInstallPackage(t *testing.T) {
 		installer := target.NewHabCmd(mockExecutor, false)
 		mockExecutor.Expect("CombinedOutput", command.ExpectedCommand{
 			Cmd: "hab",
-			Env: []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Env: []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true", "HAB_LICENSE=accept-no-persist"},
 			Args: []string{
 				"pkg",
 				"install",
@@ -102,7 +102,7 @@ func TestIsInstalled(t *testing.T) {
 
 		mockExecutor.Expect("Run", command.ExpectedCommand{
 			Cmd:  "hab",
-			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true", "HAB_LICENSE=accept-no-persist"},
 			Args: []string{"pkg", "path", pkgIdent},
 		}).Return(nil)
 
@@ -117,7 +117,7 @@ func TestIsInstalled(t *testing.T) {
 
 		mockExecutor.Expect("Run", command.ExpectedCommand{
 			Cmd:  "hab",
-			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true", "HAB_LICENSE=accept-no-persist"},
 			Args: []string{"pkg", "path", pkgIdent},
 		}).Return(nil)
 
@@ -133,7 +133,7 @@ func TestIsInstalled(t *testing.T) {
 
 		mockExecutor.Expect("Run", command.ExpectedCommand{
 			Cmd:  "hab",
-			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true", "HAB_LICENSE=accept-no-persist"},
 			Args: []string{"pkg", "path", pkgIdent},
 		}).Return(errors.New("no such package"))
 
@@ -155,7 +155,7 @@ func TestBinlinkPackage(t *testing.T) {
 
 		mockExecutor.Expect("CombinedOutput", command.ExpectedCommand{
 			Cmd:  "hab",
-			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true", "HAB_LICENSE=accept-no-persist"},
 			Args: []string{"pkg", "binlink", "--force", pkgIdent, "some_exe"},
 		}).Return("test command output", nil)
 
@@ -170,7 +170,7 @@ func TestBinlinkPackage(t *testing.T) {
 
 		mockExecutor.Expect("CombinedOutput", command.ExpectedCommand{
 			Cmd:  "hab",
-			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+			Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true", "HAB_LICENSE=accept-no-persist"},
 			Args: []string{"pkg", "binlink", "--force", pkgIdent, "some_exe"},
 		}).Return("test command output", errors.New("test command error"))
 

--- a/components/automate-deployment/pkg/target/local_target_test.go
+++ b/components/automate-deployment/pkg/target/local_target_test.go
@@ -96,7 +96,7 @@ type execMock struct {
 func expectHabCommand(cmd string, args ...string) command.ExpectedCommand {
 	return command.ExpectedCommand{
 		Cmd:  cmd,
-		Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true"},
+		Env:  []string{"HAB_NOCOLORING=true", "HAB_NONINTERACTIVE=true", "HAB_LICENSE=accept-no-persist"},
 		Args: args,
 	}
 }
@@ -424,7 +424,7 @@ func Test_installHabComponents(t *testing.T) {
 }
 
 func TestStop(t *testing.T) {
-	stopCmd := expectCommand("hab", "sup", "term")
+	stopCmd := expectHabCommand("hab", "sup", "term")
 	tests := []struct {
 		name    string
 		wantErr bool


### PR DESCRIPTION
This is a first pass at making sure we are calling hab with
HAB_LICENSE=no-accept-persist

Because `hab sup run` also requires a license check currently we also
need to set this in our systemd unit file. Since that is inherited by
all processes in our process tree, we are probably OK if we missed a
hab call or two, but I would rather not depend on that. Further, right
now we don't correctly restart our systemd unit file in all cases, so
this likely won't take effect unless chef/automate#90 is merged first.

Signed-off-by: Steven Danna <steve@chef.io>