### PR TITLE
automate-ui-150 Initial dev of multi-select delete

### DIFF
--- a/components/automate-ui/e2e/integrations.e2e-spec.ts
+++ b/components/automate-ui/e2e/integrations.e2e-spec.ts
@@ -385,7 +385,7 @@ describe('Integrations', () => {
     it('displays a list of nodes belonging to the nodemanager', () => {
       const list = $('#manager-nodes-list');
       const nameColumn = list.$$('chef-tbody chef-tr').map(row => {
-        return row.$('chef-td:first-child').getText();
+        return row.$('chef-td:nth-child(2)').getText();
       });
 
       expect(list.isDisplayed()).toEqual(true);

--- a/components/automate-ui/src/app/entities/managers/manager.actions.ts
+++ b/components/automate-ui/src/app/entities/managers/manager.actions.ts
@@ -10,6 +10,9 @@ export enum ManagerActionTypes {
   GET_NODES             = 'MANAGER::GET_NODES',
   GET_NODES_SUCCESS     = 'MANAGER::GET_NODES::SUCCESS',
   GET_NODES_FAILURE     = 'MANAGER::GET_NODES::FAILURE',
+  DELETE_NODES          = 'MANAGER::NODES::DELETE',
+  DELETE_NODES_SUCCESS  = 'MANAGER::NODES::DELETE::SUCCESS',
+  DELETE_NODES_FAILURE  = 'MANAGER::NODES::DELETE::FAILURE',
   SEARCH_NODES          = 'MANAGER::SEARCH_NODES',
   SEARCH_NODES_SUCCESS  = 'MANAGER::SEARCH_NODES::SUCCESS',
   SEARCH_NODES_FAILURE  = 'MANAGER::SEARCH_NODES::FAILURE',
@@ -85,6 +88,23 @@ export class ManagerGetNodesSuccess implements Action {
 export class ManagerGetNodesFailure implements Action {
   readonly type = ManagerActionTypes.GET_NODES_FAILURE;
   constructor(public payload: HttpErrorResponse) {}
+}
+
+export class ManagerDeleteNodes implements Action {
+  readonly type = ManagerActionTypes.DELETE_NODES;
+  constructor(public payload: { ids: string[] }) {}
+}
+
+export class ManagerDeleteNodesSuccess implements Action {
+  readonly type = ManagerActionTypes.DELETE_NODES_SUCCESS;
+
+  constructor( ) {}
+}
+
+export class ManagerDeleteNodesFailure implements Action {
+  readonly type = ManagerActionTypes.DELETE_NODES_FAILURE;
+
+  constructor(public payload: HttpErrorResponse) { }
 }
 
 export interface ManagerSearchNodesPayload {
@@ -273,6 +293,9 @@ export type ManagerActions =
   | ManagerGetNodes
   | ManagerGetNodesSuccess
   | ManagerGetNodesFailure
+  | ManagerDeleteNodes
+  | ManagerDeleteNodesSuccess
+  | ManagerDeleteNodesFailure
   | ManagerSearchNodes
   | ManagerSearchNodesSuccess
   | ManagerAllNodes

--- a/components/automate-ui/src/app/entities/managers/manager.effects.ts
+++ b/components/automate-ui/src/app/entities/managers/manager.effects.ts
@@ -51,7 +51,9 @@ import {
 import { CreateNotification } from '../notifications/notification.actions';
 import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from '../../ngrx.reducers';
-import { IntegrationsDetailState } from '../../pages/integrations/detail/integrations-detail.reducer';
+import {
+  IntegrationsDetailState
+} from '../../pages/integrations/detail/integrations-detail.reducer';
 import { Type } from '../notifications/notification.model';
 import { ROUTER_NAVIGATION, RouterNavigationAction } from '@ngrx/router-store';
 

--- a/components/automate-ui/src/app/entities/managers/manager.effects.ts
+++ b/components/automate-ui/src/app/entities/managers/manager.effects.ts
@@ -1,4 +1,4 @@
-import { catchError, withLatestFrom, switchMap, mergeMap, map, filter } from 'rxjs/operators';
+import { catchError, withLatestFrom, mergeMap, map, filter } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs';

--- a/components/automate-ui/src/app/entities/managers/manager.reducer.ts
+++ b/components/automate-ui/src/app/entities/managers/manager.reducer.ts
@@ -65,6 +65,14 @@ export function managerEntityReducer(state: ManagerEntityState = ManagerEntityIn
         set(`nodesByManager.${managerId}.loading`, false, state));
     }
 
+    case ManagerActionTypes.DELETE_NODES: {
+      return set('status', EntityStatus.loading, state);
+    }
+
+    case ManagerActionTypes.DELETE_NODES_SUCCESS: {
+      return set('status', EntityStatus.loadingSuccess, state);
+    }
+
     case ManagerActionTypes.SEARCH_NODES: {
       const {managerId} = action.payload;
       return set(`nodesByManager.${managerId}.loading`, true, state);

--- a/components/automate-ui/src/app/entities/managers/manager.requests.ts
+++ b/components/automate-ui/src/app/entities/managers/manager.requests.ts
@@ -57,6 +57,12 @@ export class ManagerRequests {
       return this.http.post(url, body);
   }
 
+  public deleteNodes(nodeIds: string[]): Observable<boolean> {
+    const url = `${env.nodes_url}/delete/ids`;
+    const body = { ids: nodeIds };
+    return this.http.post<any>(url, body);
+  }
+
   public searchFields(payload: ManagerSearchFieldsPayload):
     Observable<ManagerSearchFieldsResponse> {
       const url = `${env.nodemgrs_url}/id/${payload.managerId}/search-fields`;

--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.html
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.html
@@ -34,9 +34,17 @@
     </chef-page-header>
 
     <div class="page-body">
+      <chef-button primary caution 
+        [disabled]="!hasSelectedNodes()" 
+        (click)="deleteNodes()">
+        Remove Nodes
+      </chef-button>
       <chef-table id="manager-nodes-list">
         <chef-thead>
           <chef-tr>
+            <chef-th>
+              <chef-checkbox (click)="selectAllNodes($event, managerDetail.managerNodes)"></chef-checkbox>
+            </chef-th>
             <chef-th>Name</chef-th>
             <chef-th>Platform</chef-th>
             <chef-th>Status</chef-th>
@@ -44,6 +52,10 @@
         </chef-thead>
         <chef-tbody>
           <chef-tr *ngFor="let node of managerDetail.managerNodes">
+            <chef-td>
+                <chef-checkbox *ngIf="isNodeSelected(node.id)" checked (click)="unselectNode(node.id)"></chef-checkbox>
+                <chef-checkbox *ngIf="!isNodeSelected(node.id)" (click)="selectNode(node.id)"></chef-checkbox>
+            </chef-td>
             <chef-td>{{ node.name }}</chef-td>
             <chef-td>{{ node.platform }}</chef-td>
             <chef-td>{{ node.status }}</chef-td>

--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.html
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.html
@@ -34,11 +34,13 @@
     </chef-page-header>
 
     <div class="page-body">
-      <chef-button primary caution 
-        [disabled]="!hasSelectedNodes()" 
-        (click)="deleteNodes()">
-        Remove Nodes
-      </chef-button>
+      <chef-toolbar>
+        <chef-button primary caution 
+          [disabled]="!hasSelectedNodes()" 
+          (click)="deleteNodes()">
+          Remove Nodes
+        </chef-button>
+      </chef-toolbar>
       <chef-table id="manager-nodes-list">
         <chef-thead>
           <chef-tr>

--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.scss
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.scss
@@ -17,3 +17,12 @@ chef-page-header {
     }
   }
 }
+
+.page-body {
+  chef-table#manager-nodes-list {
+    chef-th:first-child,
+    chef-td:first-child {
+      flex-grow: 0.05;
+    }
+  }
+}

--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.ts
@@ -47,7 +47,7 @@ export class IntegrationsDetailComponent {
     if (event.currentTarget['checked']) {
       this.selectedNodes = [];
     } else {
-      nodes.forEach((node)=> {
+      nodes.forEach((node) => {
         this.selectedNodes.push(node.id);
       });
     }

--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.ts
@@ -6,6 +6,8 @@ import { Observable } from 'rxjs';
 import { NgrxStateAtom } from '../../../ngrx.reducers';
 import { IntegrationsDetailState } from './integrations-detail.reducer';
 import { integrationsDetail } from './integrations-detail.selectors';
+import { includes, without } from 'lodash';
+import { DeleteNodes } from 'app/entities/client-runs/client-runs.actions';
 
 @Component({
   selector: 'app-integrations-detail',
@@ -15,6 +17,7 @@ import { integrationsDetail } from './integrations-detail.selectors';
 export class IntegrationsDetailComponent {
 
   managerDetail$: Observable<IntegrationsDetailState>;
+  selectedNodes: string[] = [];
 
   constructor(
     private router: Router,
@@ -25,5 +28,35 @@ export class IntegrationsDetailComponent {
 
   onPageChanged(page) {
     this.router.navigate([], { queryParams: { page }, queryParamsHandling: 'merge' });
+  }
+
+  deleteNodes() {
+    this.store.dispatch(new DeleteNodes({ nodeIdsToDelete: this.selectedNodes }));
+  }
+
+  selectNode(id: string) {
+    this.selectedNodes.push(id);
+  }
+
+  unselectNode(id: string) {
+    this.selectedNodes = without(this.selectedNodes, id);
+  }
+
+  selectAllNodes(event: Event, nodes: any[]) {
+    if (event.currentTarget['checked']) {
+      this.selectedNodes = [];
+    } else {
+      nodes.forEach((node)=> {
+        this.selectedNodes.push(node.id);
+      });
+    }
+  }
+
+  isNodeSelected(id: string) {
+    return includes(this.selectedNodes, id);
+  }
+
+  hasSelectedNodes() {
+    return this.selectedNodes.length > 0;
   }
 }

--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.ts
@@ -7,7 +7,7 @@ import { NgrxStateAtom } from '../../../ngrx.reducers';
 import { IntegrationsDetailState } from './integrations-detail.reducer';
 import { integrationsDetail } from './integrations-detail.selectors';
 import { includes, without } from 'lodash';
-import { DeleteNodes } from 'app/entities/client-runs/client-runs.actions';
+import { ManagerDeleteNodes } from 'app/entities/managers/manager.actions';
 
 @Component({
   selector: 'app-integrations-detail',
@@ -31,7 +31,8 @@ export class IntegrationsDetailComponent {
   }
 
   deleteNodes() {
-    this.store.dispatch(new DeleteNodes({ nodeIdsToDelete: this.selectedNodes }));
+    this.store.dispatch(new ManagerDeleteNodes({ ids: this.selectedNodes }));
+    this.selectedNodes = [];
   }
 
   selectNode(id: string) {


### PR DESCRIPTION
### :nut_and_bolt: Description
The Automate nodemanager details page designs include a multi-select delete option.
the endpoint for the multi-select delete is: a2-url/api/v0/nodes/delete/ids, which takes a POST msg of form ["123..", "456.."]

### :+1: Definition of Done
Automate nodemanager details page has multi-select delete for nodes.

Signed-off-by: ?
