### PR TITLE
take group info from profile when parsing

### DIFF
--- a/components/compliance-service/reporting/relaxting/profiles.go
+++ b/components/compliance-service/reporting/relaxting/profiles.go
@@ -88,10 +88,10 @@ func (esprofile *ESInspecProfile) parseInspecProfile(profile inspec.Profile) err
 	esprofile.Sha256 = profile.Sha256
 	// no need for Status and SkipMessage here as it's not static metadata of the profile
 	var groups []inspec.Group
-	for _, group := range groups {
+	for _, group := range profile.Groups {
 		eGroup := inspec.Group{
-			ID:       group.ID,
-			Title:    group.Title,
+			ID:       group.Id,
+			Title:    &group.Title,
 			Controls: group.Controls,
 		}
 		groups = append(groups, eGroup)


### PR DESCRIPTION
Signed-off-by: Rick Marry <rmarry@chef.io>

### :nut_and_bolt: Description
When posting a profile to be ingested, we need to take the group information from the profile itself. 
