### PR TITLE
Elasticsearch actions project update

### DIFF
--- a/components/ingest-service/backend/chef_action.go
+++ b/components/ingest-service/backend/chef_action.go
@@ -24,4 +24,5 @@ type InternalChefAction struct {
 	ServiceHostname  string    `json:"service_hostname,omitempty"`
 	UserAgent        string    `json:"user_agent,omitempty"`
 	Data             string    `json:"data,omitempty"`
+	Projects         []string  `json:"projects"`
 }

--- a/components/ingest-service/backend/client.go
+++ b/components/ingest-service/backend/client.go
@@ -69,6 +69,8 @@ type Client interface {
 	SendBulkRequest(context.Context, []elastic.BulkableRequest) error
 	// @param (context, projectRules)
 	UpdateNodeProjectTags(context.Context, map[string]*iam_v2.ProjectRules) (string, error)
+	// @param (context, projectRules)
+	UpdateActionProjectTags(context.Context, map[string]*iam_v2.ProjectRules) (string, error)
 	// @param (context, jobID)
 	JobStatus(context.Context, string) (JobStatus, error)
 	// @param (context, jobID)

--- a/components/ingest-service/backend/elastic/actions.go
+++ b/components/ingest-service/backend/elastic/actions.go
@@ -7,7 +7,9 @@ package elastic
 
 import (
 	"context"
+	"fmt"
 
+	iam_v2 "github.com/chef/automate/api/interservice/authz/v2"
 	"github.com/chef/automate/components/ingest-service/backend"
 	"github.com/chef/automate/components/ingest-service/backend/elastic/mappings"
 	"github.com/olivere/elastic"
@@ -26,4 +28,62 @@ func (es *Backend) CreateBulkActionRequest(action backend.InternalChefAction) el
 	mapping := mappings.Actions
 	time := action.RecordedAt
 	return es.createBulkUpdateRequestToTimeseriesIndex(mapping, time, action)
+}
+
+func (es *Backend) UpdateActionProjectTags(ctx context.Context,
+	projectTaggingRules map[string]*iam_v2.ProjectRules) (string, error) {
+	script := `
+		ArrayList matchingProjects = new ArrayList();
+		for (def project : params.projects) {
+			for (def rule : project.rules) {
+				def match = rule.conditions.length != 0;
+				for (def condition : rule.conditions) {
+					if (condition.chefServers.length > 0) {
+						def found = false;
+						for (def chefServer : condition.chefServers){
+							if (ctx._source.remote_hostname == chefServer ) {
+								found = true;
+								break;
+							}
+						}
+						if ( !found ) {
+							match = false;
+							break;
+						}
+					}
+					if (condition.organizations.length > 0) {
+						def found = false;
+						for (def organization : condition.organizations){
+							if (ctx._source.organization_name == organization ) {
+								found = true;
+								break;
+							}
+						}
+						if ( !found ) {
+							match = false;
+							break;
+						}
+					}
+				}
+				if ( match ) {
+					matchingProjects.add(project.name);
+					break;
+				}
+			}
+		}
+
+		ctx._source.projects = matchingProjects.toArray();
+	`
+
+	index := fmt.Sprintf("%s-%s", mappings.Actions.Index, "*")
+
+	startTaskResult, err := elastic.NewUpdateByQueryService(es.client).
+		Index(index).
+		Type(mappings.Actions.Type).
+		Script(elastic.NewScript(script).Params(convertProjectTaggingRulesToEsParams(projectTaggingRules))).
+		WaitForCompletion(false).
+		ProceedOnVersionConflict().
+		DoAsync(ctx)
+
+	return startTaskResult.TaskId, err
 }

--- a/components/ingest-service/backend/elastic/mappings/actions.go
+++ b/components/ingest-service/backend/elastic/mappings/actions.go
@@ -77,6 +77,9 @@ var Actions = Mapping{
 					"recorded_at": {
 						"type": "date",
 						"format": "strict_date_optional_time||epoch_millis"
+					},
+					"projects": {
+						"type": "keyword"
 					}
 				}
 			}

--- a/components/ingest-service/integration_test/project_update_actions_test.go
+++ b/components/ingest-service/integration_test/project_update_actions_test.go
@@ -1,0 +1,342 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	iam_v2 "github.com/chef/automate/api/interservice/authz/v2"
+	iBackend "github.com/chef/automate/components/ingest-service/backend"
+	"github.com/chef/automate/components/ingest-service/backend/elastic/mappings"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectUpdateActionsPainlessElasticsearchScript(t *testing.T) {
+	var (
+		ctx = context.Background()
+	)
+
+	cases := []struct {
+		description string
+		action      iBackend.InternalChefAction
+		projects    map[string]*iam_v2.ProjectRules
+		projectIDs  []string
+	}{
+		// Orgs
+		{
+			description: "Org: Single rule matching update",
+			action: iBackend.InternalChefAction{
+				OrganizationName: "org1",
+				Projects:         []string{"old_tag"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project9": &iam_v2.ProjectRules{
+					Rules: []*iam_v2.ProjectRule{
+						&iam_v2.ProjectRule{
+							Conditions: []*iam_v2.Condition{
+								&iam_v2.Condition{
+									Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+									Values: []string{"org1"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{"project9"},
+		},
+		{
+			description: "Org: no matching actions",
+			action: iBackend.InternalChefAction{
+				OrganizationName: "org1",
+				Projects:         []string{"old_tag"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project9": &iam_v2.ProjectRules{
+					Rules: []*iam_v2.ProjectRule{
+						&iam_v2.ProjectRule{
+							Conditions: []*iam_v2.Condition{
+								&iam_v2.Condition{
+									Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+									Values: []string{"org2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{},
+		},
+		{
+			description: "Org: project rules match current action project tags",
+			action: iBackend.InternalChefAction{
+				OrganizationName: "org1",
+				Projects:         []string{"old_tag"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"old_tag": &iam_v2.ProjectRules{
+					Rules: []*iam_v2.ProjectRule{
+						&iam_v2.ProjectRule{
+							Conditions: []*iam_v2.Condition{
+								&iam_v2.Condition{
+									Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+									Values: []string{"org1"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{"old_tag"},
+		},
+
+		// chefServers
+		{
+			description: "chefServers: Single rule matching",
+			action: iBackend.InternalChefAction{
+				RemoteHostname: "chef-server.org",
+				Projects:       []string{"old_tag"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project9": &iam_v2.ProjectRules{
+					Rules: []*iam_v2.ProjectRule{
+						&iam_v2.ProjectRule{
+							Conditions: []*iam_v2.Condition{
+								&iam_v2.Condition{
+									Type:   iam_v2.ProjectRuleConditionTypes_CHEF_SERVERS,
+									Values: []string{"chef-server.org"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{"project9"},
+		},
+		{
+			description: "chefServers: Single rule not matching",
+			action: iBackend.InternalChefAction{
+				RemoteHostname: "chef-server2.org",
+				Projects:       []string{"old_tag"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project9": &iam_v2.ProjectRules{
+					Rules: []*iam_v2.ProjectRule{
+						&iam_v2.ProjectRule{
+							Conditions: []*iam_v2.Condition{
+								&iam_v2.Condition{
+									Type:   iam_v2.ProjectRuleConditionTypes_CHEF_SERVERS,
+									Values: []string{"chef-server.org"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{},
+		},
+		{
+			description: "chefServers: Single rule differing case not matching",
+			action: iBackend.InternalChefAction{
+				RemoteHostname: "Chef-server.org",
+				Projects:       []string{"old_tag"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project9": &iam_v2.ProjectRules{
+					Rules: []*iam_v2.ProjectRule{
+						&iam_v2.ProjectRule{
+							Conditions: []*iam_v2.Condition{
+								&iam_v2.Condition{
+									Type:   iam_v2.ProjectRuleConditionTypes_CHEF_SERVERS,
+									Values: []string{"chef-server.org"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{},
+		},
+		{
+			description: "chefServers: Single rule with two values on a condition",
+			action: iBackend.InternalChefAction{
+				RemoteHostname: "chef-server.org",
+				Projects:       []string{"old_tag"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project9": &iam_v2.ProjectRules{
+					Rules: []*iam_v2.ProjectRule{
+						&iam_v2.ProjectRule{
+							Conditions: []*iam_v2.Condition{
+								&iam_v2.Condition{
+									Type:   iam_v2.ProjectRuleConditionTypes_CHEF_SERVERS,
+									Values: []string{"chef-server.org", "chef-server2.org"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{"project9"},
+		},
+		{
+			description: "chefServers: two rules both matching on different fields",
+			action: iBackend.InternalChefAction{
+				RemoteHostname:   "chef-server.org",
+				OrganizationName: "org1",
+				Projects:         []string{"old_tag"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project9": &iam_v2.ProjectRules{
+					Rules: []*iam_v2.ProjectRule{
+						&iam_v2.ProjectRule{
+							Conditions: []*iam_v2.Condition{
+								&iam_v2.Condition{
+									Type:   iam_v2.ProjectRuleConditionTypes_CHEF_SERVERS,
+									Values: []string{"chef-server.org"},
+								},
+							},
+						},
+						&iam_v2.ProjectRule{
+							Conditions: []*iam_v2.Condition{
+								&iam_v2.Condition{
+									Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+									Values: []string{"org1"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{"project9"},
+		},
+		{
+			description: "chefServers: two rules with only one matching",
+			action: iBackend.InternalChefAction{
+				RemoteHostname:   "chef-server.org",
+				OrganizationName: "org1",
+				Projects:         []string{"old_tag"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project9": &iam_v2.ProjectRules{
+					Rules: []*iam_v2.ProjectRule{
+						&iam_v2.ProjectRule{
+							Conditions: []*iam_v2.Condition{
+								&iam_v2.Condition{
+									Type:   iam_v2.ProjectRuleConditionTypes_CHEF_SERVERS,
+									Values: []string{"chef-server2.org"},
+								},
+							},
+						},
+						&iam_v2.ProjectRule{
+							Conditions: []*iam_v2.Condition{
+								&iam_v2.Condition{
+									Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+									Values: []string{"org1"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{"project9"},
+		},
+		{
+			description: "chefServers: one rule two conditions with only one matching",
+			action: iBackend.InternalChefAction{
+				RemoteHostname:   "chef-server.org",
+				OrganizationName: "org1",
+				Projects:         []string{"old_tag"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project9": &iam_v2.ProjectRules{
+					Rules: []*iam_v2.ProjectRule{
+						&iam_v2.ProjectRule{
+							Conditions: []*iam_v2.Condition{
+								&iam_v2.Condition{
+									Type:   iam_v2.ProjectRuleConditionTypes_CHEF_SERVERS,
+									Values: []string{"chef-server2.org"},
+								},
+								&iam_v2.Condition{
+									Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+									Values: []string{"org1"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{},
+		},
+
+		// General
+		{
+			description: "project rules does not have any rules",
+			action: iBackend.InternalChefAction{
+				RemoteHostname:   "chef-server.org",
+				OrganizationName: "org1",
+				Projects:         []string{"old_tag"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"old_tag": &iam_v2.ProjectRules{
+					Rules: []*iam_v2.ProjectRule{},
+				},
+			},
+			projectIDs: []string{},
+		},
+		{
+			description: "project rule does not have any conditions",
+			action: iBackend.InternalChefAction{
+				RemoteHostname:   "chef-server.org",
+				OrganizationName: "org1",
+				Projects:         []string{"old_tag"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"old_tag": &iam_v2.ProjectRules{
+					Rules: []*iam_v2.ProjectRule{
+						&iam_v2.ProjectRule{
+							Conditions: []*iam_v2.Condition{},
+						},
+					},
+				},
+			},
+			projectIDs: []string{},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(fmt.Sprintf("action match: %s", test.description),
+			func(t *testing.T) {
+				test.action.RecordedAt = time.Now()
+				suite.IngestActions([]iBackend.InternalChefAction{test.action})
+				// Send a project rules update event
+				esJobID, err := suite.ingest.UpdateActionProjectTags(ctx, test.projects)
+				assert.Nil(t, err)
+
+				jobStatus, err := suite.ingest.JobStatus(ctx, esJobID)
+				assert.Nil(t, err)
+				for !jobStatus.Completed {
+					time.Sleep(time.Millisecond * 5)
+					jobStatus, err = suite.ingest.JobStatus(ctx, esJobID)
+					assert.Nil(t, err)
+					if err != nil {
+						assert.FailNow(t, "testing job complete")
+					}
+				}
+
+				suite.RefreshIndices(fmt.Sprintf("%s-%s", mappings.Actions.Index, "*"))
+
+				// assert the node's project IDs
+				actualActions, err := suite.GeActions(100)
+				assert.Nil(t, err)
+				assert.Equal(t, 1, len(actualActions), "wrong number of actions retrieved")
+
+				actualAction := actualActions[0]
+
+				assert.ElementsMatch(t, test.projectIDs, actualAction.Projects)
+
+				suite.DeleteAllDocuments()
+			})
+	}
+}

--- a/components/ingest-service/integration_test/suite_test.go
+++ b/components/ingest-service/integration_test/suite_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+var actionIndexes = fmt.Sprintf("%s-%s", mappings.Actions.Index, "*")
+
 // TODO @afiune most of this file is very similar to the suite_test.go living
 // inside config-mgmt-service, we could have a single suite file for both (or more)
 
@@ -170,7 +172,7 @@ func (s *Suite) IngestActions(actions []iBackend.InternalChefAction) {
 	}
 
 	// Refresh Indices
-	s.RefreshIndices(mappings.Actions.Index + "-*")
+	s.RefreshIndices(actionIndexes)
 }
 
 // RefreshIndices will refresh the provided ES Index or list of Indices

--- a/components/ingest-service/integration_test/suite_test.go
+++ b/components/ingest-service/integration_test/suite_test.go
@@ -110,6 +110,15 @@ func (s *Suite) GetNodes(x int) ([]cfgBackend.Node, error) {
 	return s.cfgmgmt.GetNodes(1, x, "node_name", true, filterMap)
 }
 
+// GetActions retrives X Chef Actions
+func (s *Suite) GeActions(x int) ([]cfgBackend.Action, error) {
+	filterMap := make(map[string][]string, 0)
+	actions, _, err := s.cfgmgmt.GetActions(filterMap,
+		time.Time{}, time.Now().Add(time.Hour*24*365), x, time.Time{}, "", true)
+
+	return actions, err
+}
+
 // GetNonExistingNodes retrives X Chef Nodes that doesn't actually exist :thinking:
 //
 // We need this custom function since we need a way to verify the nodes we update and
@@ -151,6 +160,17 @@ func (s *Suite) IngestNodes(nodes []iBackend.Node) {
 
 	// Refresh Indices
 	s.RefreshIndices(mappings.NodeState.Index)
+}
+
+// IngestActions ingests a number of actions then refreshe the all the action indexes
+func (s *Suite) IngestActions(actions []iBackend.InternalChefAction) {
+	// Insert actions
+	for _, action := range actions {
+		s.ingest.InsertAction(context.Background(), action)
+	}
+
+	// Refresh Indices
+	s.RefreshIndices(mappings.Actions.Index + "-*")
 }
 
 // RefreshIndices will refresh the provided ES Index or list of Indices


### PR DESCRIPTION
### :nut_and_bolt: Description

Adding a Chef Actions project tag updater function. This function takes the authz rule set and creates a painless script that is pushed to elasticsearch. This script walks through each Chef Action and updates their projects based on the rules. 

### :athletic_shoe: Demo Script / Repro Steps

No demo until Chef actions can be ingested with projects. 

### :chains: Related Resources

https://github.com/chef/automate/issues/62

This PR is the same work for updating nodes - https://github.com/chef/a2/pull/5301

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
