### PR TITLE
[A2-771] follow-up ProjectsAuthorized fix

### DIFF
--- a/components/authz-service/constants/v2/constants.go
+++ b/components/authz-service/constants/v2/constants.go
@@ -33,10 +33,12 @@ const (
 
 // IAM v2 well-known role IDs
 const (
-	OwnerRoleID  = "owner"
-	EditorRoleID = "editor"
-	ViewerRoleID = "viewer"
-	IngestRoleID = "ingest"
+	OwnerRoleID            = "owner"
+	EditorRoleID           = "editor"
+	ViewerRoleID           = "viewer"
+	IngestRoleID           = "ingest"
+	ProjectAdminRoleID     = "project-admin"
+	IAMMembersViewerRoleID = "iam-members-viewer"
 )
 
 // IAM v2 well-known project IDs

--- a/components/authz-service/engine/conformance/conformance_v2_test.go
+++ b/components/authz-service/engine/conformance/conformance_v2_test.go
@@ -83,7 +83,7 @@ func TestV2IsAuthorized(t *testing.T) {
 func TestV2ProjectsAuthorized(t *testing.T) {
 	ctx, engines := setup(t)
 	sub, act, res := "user:local:admin", "iam:users:create", "iam:users"
-	proj1, proj2, proj3, proj4, unassigned := "proj-1", "proj-2", "proj-3", "proj-4", "(unassigned)"
+	proj1, proj2, proj3, proj4, unassigned := "proj-1", "proj-2", "proj-3", "proj-4", constants.UnassignedProjectID
 	allProjects := []string{proj1, proj2, proj3, proj4, unassigned}
 
 	// We're always passing the same arguments to ProjectsAuthorized(). This allows for
@@ -359,7 +359,6 @@ func TestV2ProjectsAuthorized(t *testing.T) {
 			})
 
 			t.Run("policy that allows all projects returns all when all projects requested", func(t *testing.T) {
-				proj3, proj4, unassigned := "proj-3", "proj-4", "(unassigned)"
 				pol := map[string]interface{}{
 					"members": engine.Subject(sub),
 					"statements": map[string]interface{}{

--- a/components/authz-service/server/v2/authz.go
+++ b/components/authz-service/server/v2/authz.go
@@ -90,9 +90,10 @@ func (s *authzServer) ProjectsAuthorized(
 
 	requestedProjects := req.ProjectsFilter
 
+	allProjectsRequested := len(req.ProjectsFilter) == 0
 	var allProjects []string
 	var err error
-	if len(req.ProjectsFilter) == 0 {
+	if allProjectsRequested {
 		allProjects, err = s.getAllProjects(ctx)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
@@ -109,7 +110,10 @@ func (s *authzServer) ProjectsAuthorized(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	authorizedProjects = handleAllProjectsResponse(engineResp, allProjects)
+	authorizedProjects = engineResp
+	if allProjectsRequested {
+		authorizedProjects = handleAllProjectsResponse(engineResp, allProjects)
+	}
 
 	s.logProjectQuery(req, authorizedProjects)
 	return &api.ProjectsAuthorizedResp{

--- a/components/authz-service/server/v2/authz_test.go
+++ b/components/authz-service/server/v2/authz_test.go
@@ -66,18 +66,17 @@ func TestV2p1ProjectsAuthorized(t *testing.T) {
 				[]string{},    // no projects
 				[]string(nil), // well, almost verbatim
 			},
-			"when engine response is ALL projects and another project, returns external ALL projects": {
-				[]string{constants.AllProjectsID, "p3"},
-				[]string{constants.AllProjectsExternalID},
-			},
-			"when engine response is ALL projects, returns external ALL projects": {
-				[]string{constants.AllProjectsID},
+			"when engine response is list of all projects + unassigned, returns external ALL projects": {
+				[]string{"p1", "p2", "p3", "(unassigned)"},
 				[]string{constants.AllProjectsExternalID},
 			},
 		}
 		for name, tc := range cases {
 			t.Run(name, func(t *testing.T) {
 				eng.projects = tc.allowedProjects
+				addProjectToStore(t, ts.projectCache, "p1", "Numero 1", storage.Custom)
+				addProjectToStore(t, ts.projectCache, "p2", "Numero 2", storage.Custom)
+				addProjectToStore(t, ts.projectCache, "p3", "Numero 3", storage.Custom)
 				resp, err := ts.authz.ProjectsAuthorized(ctx, &api_v2.ProjectsAuthorizedReq{
 					Subjects:       []string{"user:local:admin"},
 					Resource:       "some:thing",
@@ -166,7 +165,6 @@ func TestFilterAuthorizedProjects(t *testing.T) {
 		ctx, ts := setupV2AuthTests(t, &eng)
 		addProjectToStore(t, ts.projectCache, "project-1", "Numero 1", storage.Custom)
 		addProjectToStore(t, ts.projectCache, "project-2", "Numero 2", storage.Custom)
-		ts.projectCache.Add("project-1", "project-2", 0)
 		allProjects := []string{"project-1", "project-2", "(unassigned)"}
 
 		resp, err := ts.authz.FilterAuthorizedProjects(ctx,

--- a/components/authz-service/server/v2/system.go
+++ b/components/authz-service/server/v2/system.go
@@ -185,7 +185,6 @@ func SystemPolicies() []*storage.Policy {
 				},
 				Projects: []string{constants.AllProjectsID},
 			},
-			// TODO can't delete admin team from admin policy
 		},
 	}
 

--- a/components/authz-service/server/v2/system.go
+++ b/components/authz-service/server/v2/system.go
@@ -171,6 +171,8 @@ func SystemPolicies() []*storage.Policy {
 					"iam:roles:" + constants.EditorRoleID,
 					"iam:roles:" + constants.ViewerRoleID,
 					"iam:roles:" + constants.IngestRoleID,
+					"iam:roles:" + constants.ProjectAdminRoleID,
+					"iam:roles:" + constants.IAMMembersViewerRoleID,
 				},
 				Projects: []string{constants.AllProjectsID},
 			},

--- a/inspec/a2-iam-v2-integration/controls/base.rb
+++ b/inspec/a2-iam-v2-integration/controls/base.rb
@@ -81,7 +81,9 @@ EOF
     "owner",
     "editor",
     "viewer",
-    "ingest"
+    "ingest",
+    "project-admin",
+    "iam-members-viewer"
   ]
 
   NON_ADMIN_USERNAME_V2 = 'inspec_test_non_admin_with_iam_v2'

--- a/inspec/a2-iam-v2p1-only-integration/controls/role_projects.rb
+++ b/inspec/a2-iam-v2p1-only-integration/controls/role_projects.rb
@@ -13,6 +13,15 @@ control 'iam-v2-projects-1' do
   CUSTOM_ROLE_ID_1 = "inspec-custom-role-1-#{TIMESTAMP}"
   CUSTOM_ROLE_ID_2 = "inspec-custom-role-2-#{TIMESTAMP}"
   CUSTOM_ROLE_ID_3 = "inspec-custom-role-3-#{TIMESTAMP}"
+    
+  DEFAULT_ROLE_IDS = [
+    "owner",
+    "editor",
+    "viewer",
+    "ingest",
+    "project-admin",
+    "iam-members-viewer"
+  ]
 
   CUSTOM_ROLE_1 = {
           id: CUSTOM_ROLE_ID_1,
@@ -36,7 +45,7 @@ control 'iam-v2-projects-1' do
           type: "CUSTOM"
   }
 
-  Roles = [ CUSTOM_ROLE_1, CUSTOM_ROLE_2, CUSTOM_ROLE_3 ]
+  CUSTOM_ROLES = [ CUSTOM_ROLE_1, CUSTOM_ROLE_2, CUSTOM_ROLE_3 ]
 
   CUSTOM_PROJECT_1 = {
           id: CUSTOM_PROJECT_ID_1,
@@ -60,7 +69,7 @@ control 'iam-v2-projects-1' do
         expect(resp.http_status).to eq 200
       end
  
-      Roles.each do|role|
+      CUSTOM_ROLES.each do|role|
         resp = automate_api_request("/apis/iam/v2beta/roles",
           http_method: 'POST',
           request_body: role.to_json
@@ -70,7 +79,7 @@ control 'iam-v2-projects-1' do
     end
 
     after(:all) do
-      Roles.each do|role|
+      CUSTOM_ROLES.each do|role|
         resp = automate_api_request("/apis/iam/v2beta/roles/#{role[:id]}", http_method: 'delete')
         expect(resp.http_status).to eq 200
       end
@@ -140,8 +149,10 @@ control 'iam-v2-projects-1' do
         "/apis/iam/v2beta/roles"
         )
       expect(resp.http_status).to eq 200
-      # expect(resp.parsed_response_body[:roles].map{|r| r[:id] }).to match_array(["a","b"])
-      expect(resp.parsed_response_body[:roles].length).to be > 3
+      expected_roles = CUSTOM_ROLES.map { |r| r[:id] } + DEFAULT_ROLE_IDS
+      expected_roles.each do |role| 
+        expect(resp.parsed_response_body[:roles].map{|r| r[:id] }).to include(role)
+      end
     end
   end
 
@@ -159,7 +170,7 @@ control 'iam-v2-projects-1' do
         expect(resp.http_status).to eq 200
       end
  
-      Roles.each do|role|
+      CUSTOM_ROLES.each do|role|
         resp = automate_api_request("/apis/iam/v2beta/roles",
           http_method: 'POST',
           request_body: role.to_json
@@ -205,7 +216,7 @@ control 'iam-v2-projects-1' do
       expect(resp.http_status).to eq 200
       resp = automate_api_request("/apis/iam/v2beta/roles/#{POLICY_ROLE_ID}", http_method: 'delete')
       expect(resp.http_status).to eq 200
-      Roles.each do|role|
+      CUSTOM_ROLES.each do|role|
         if role[:id] != CUSTOM_ROLE_ID_1
           resp = automate_api_request("/apis/iam/v2beta/roles/#{role[:id]}", http_method: 'delete')
           expect(resp.http_status).to eq 200


### PR DESCRIPTION
### :nut_and_bolt: Description
follow-up to https://github.com/chef/automate/pull/135 

### :+1: Definition of Done
- [x] when all projects are allowed and the request contains no project headers, authz-service passes on `*` to the domain services

### :athletic_shoe: Demo Script / Repro Steps
```
[16][default:/src:0]# chef-automate iam upgrade-to-v2 --beta2.1

Enabling IAM v2.1
Migrating v1 policies...
Creating default teams Editors and Viewers...

Migrating existing teams...

Success: Enabled IAM v2.1

[22][default:/src:0]# curl -H "api-token: $TOK"  -d '{"id": "p1", "name": "project 1"}' https://localhost/apis/iam/v2beta/projects --insecure | jq
{
  "project": {
    "name": "project 1",
    "id": "p1",
    "type": "CUSTOM",
    "projects": [
      "p1"
    ]
  }
}

[18][default:/src:0]# curl -H "api-token: $TOK"  -d '{"id": "team1", "name": "team 1", "projects": ["p1"]}' https://localhost/apis/iam/v2beta/teams --insecure | jq
{
  "team": {
    "id": "team1",
    "name": "team 1",
    "projects": [
      "p1"
    ]
  }
}

[23][default:/src:0]# curl -H "api-token: $TOK"  https://localhost/apis/iam/v2beta/teams --insecure | jq
{
  "teams": [
    {
      "id": "admins",
      "name": "Members of the admins team, by default, have access to all parts of the API.",
      "projects": []
    },
    {
      "id": "editors",
      "name": "Editors",
      "projects": []
    },
    {
      "id": "viewers",
      "name": "Viewers",
      "projects": []
    },
    {
      "id": "team1",
      "name": "team 1",
      "projects": [
        "p1"
      ]
    }
  ]
}

[26][default:/src:0]# sl
--> Tailing the Habitat Supervisor's output (use 'Ctrl+c' to stop)
...
[2019-04-30T20:33:48+00:00] authz-service.default(O): time="2019-04-30T20:33:48Z" level=info msg="Projects Authorized Query" action="iam:teams:list" projects="[]" resource="iam:teams" result="[*]" subject="[token:e0a18396-7960-4a12-a185-3ef02f6df5f3]"
```
(punch line is `result=[*]` in the log)

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
