### PR TITLE
Action ingestion project tagging

### DIFF
--- a/components/ingest-service/backend/chef_action.go
+++ b/components/ingest-service/backend/chef_action.go
@@ -24,4 +24,5 @@ type InternalChefAction struct {
 	ServiceHostname  string    `json:"service_hostname,omitempty"`
 	UserAgent        string    `json:"user_agent,omitempty"`
 	Data             string    `json:"data,omitempty"`
+	Projects         []string  `json:"projects"`
 }

--- a/components/ingest-service/backend/elastic/mappings/actions.go
+++ b/components/ingest-service/backend/elastic/mappings/actions.go
@@ -77,6 +77,9 @@ var Actions = Mapping{
 					"recorded_at": {
 						"type": "date",
 						"format": "strict_date_optional_time||epoch_millis"
+					},
+					"projects": {
+						"type": "keyword"
 					}
 				}
 			}

--- a/components/ingest-service/pipeline/processor/action_project_tagger.go
+++ b/components/ingest-service/pipeline/processor/action_project_tagger.go
@@ -1,0 +1,98 @@
+package processor
+
+import (
+	chef "github.com/chef/automate/api/external/ingest/request"
+	iam_v2 "github.com/chef/automate/api/interservice/authz/v2"
+	"github.com/chef/automate/components/ingest-service/pipeline/message"
+	"github.com/chef/automate/lib/stringutils"
+	log "github.com/sirupsen/logrus"
+)
+
+// BuildActionProjectTagger - Build a project tagger for Chef Actions
+func BuildActionProjectTagger(authzClient iam_v2.ProjectsClient) message.ChefActionPipe {
+	return func(in <-chan message.ChefAction) <-chan message.ChefAction {
+		return actionBundleProjectTagger(in, authzClient)
+	}
+}
+
+// This processor is bundling all the messages that are currently in the 'in' channel. The bundling
+// of messages decreases the number of times the authz-service is called for project rules. The way
+// it works is when a message comes in, we make a call to the authz-service for the rules. We use
+// these rules for all the messages that are currently in the queue. The 'bundleSize' is the number
+// of messages that can use the current project rules from authz.
+func actionBundleProjectTagger(in <-chan message.ChefAction,
+	authzClient iam_v2.ProjectsClient) <-chan message.ChefAction {
+	out := make(chan message.ChefAction, 100)
+	go func() {
+		bundleSize := 0
+		var projectRulesCollection map[string]*iam_v2.ProjectRules
+		for msg := range in {
+			if bundleSize <= 0 {
+				bundleSize = len(in)
+				log.WithFields(log.Fields{
+					"message_id": msg.ID,
+					"bundleSize": bundleSize,
+				}).Debug("BundleProjectTagging - Update Project rules")
+				projectRulesCollection = getProjectRulesFromAuthz(msg.Ctx, authzClient)
+			} else {
+				// Skip
+				bundleSize--
+			}
+
+			msg.InternalChefAction.Projects = findMatchingProjectsForAction(msg.Action, projectRulesCollection)
+
+			out <- msg
+		}
+		close(out)
+	}()
+
+	return out
+}
+
+func findMatchingProjectsForAction(action *chef.Action, projects map[string]*iam_v2.ProjectRules) []string {
+	matchingProjects := make([]string, 0)
+
+	for projectName, project := range projects {
+		if actionMatchesRules(action, project.Rules) {
+			matchingProjects = append(matchingProjects, projectName)
+		}
+	}
+
+	return matchingProjects
+}
+
+// Only one rule has to be true for the project to match (ORed together).
+func actionMatchesRules(action *chef.Action, rules []*iam_v2.ProjectRule) bool {
+	for _, rule := range rules {
+		if rule.Type == iam_v2.ProjectRuleTypes_EVENT && actionMatchesAllConditions(action, rule.Conditions) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// All the conditions must be true for a rule to be true (ANDed together).
+// If there are no conditions then the rule is false
+func actionMatchesAllConditions(action *chef.Action, conditions []*iam_v2.Condition) bool {
+	if len(conditions) == 0 {
+		return false
+	}
+
+	for _, condition := range conditions {
+		switch condition.Type {
+		case iam_v2.ProjectRuleConditionTypes_CHEF_SERVERS:
+			if !stringutils.SliceContains(condition.Values, action.RemoteHostname) {
+				return false
+			}
+		case iam_v2.ProjectRuleConditionTypes_CHEF_ORGS:
+			if !stringutils.SliceContains(condition.Values, action.OrganizationName) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+
+	return true
+}

--- a/components/ingest-service/pipeline/processor/action_project_tagger_test.go
+++ b/components/ingest-service/pipeline/processor/action_project_tagger_test.go
@@ -1,0 +1,416 @@
+package processor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	chef "github.com/chef/automate/api/external/ingest/request"
+	iam_v2 "github.com/chef/automate/api/interservice/authz/v2"
+	"github.com/chef/automate/components/ingest-service/pipeline/message"
+)
+
+// All the conditions must be true for a rule to be true (ANDed together).
+// Only one rule has to be true for the project to match (ORed together).
+// If there are no rules the project does not match
+// If the rule does not have any conditions it does not match any resources.
+func TestActionProjectRulesMatching(t *testing.T) {
+	cases := []struct {
+		description string
+		action      *chef.Action
+		rules       []*iam_v2.ProjectRule
+		matching    bool
+	}{
+		{
+			description: "A project with no rules does not match any resources",
+			matching:    false,
+			action:      &chef.Action{},
+			rules:       []*iam_v2.ProjectRule{},
+		},
+		{
+			description: "A project with one rule that does not have any conditions does not match any resources",
+			matching:    false,
+			action:      &chef.Action{},
+			rules: []*iam_v2.ProjectRule{
+				{
+					Type: iam_v2.ProjectRuleTypes_EVENT,
+				},
+			},
+		},
+		{
+			description: "Single rule single condition matching incorrect rule type",
+			matching:    false,
+			action: &chef.Action{
+				RemoteHostname:   "chef-server.org",
+				OrganizationName: "org1",
+			},
+			rules: []*iam_v2.ProjectRule{
+				{
+					Type: iam_v2.ProjectRuleTypes_EVENT,
+					Conditions: []*iam_v2.Condition{
+						{
+							Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ENVIRONMENTS,
+							Values: []string{"production"},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "A rule of type ProjectRuleTypes_NODE does not match any actions",
+			matching:    false,
+			action: &chef.Action{
+				RemoteHostname:   "chef-server.org",
+				OrganizationName: "org_1",
+			},
+			rules: []*iam_v2.ProjectRule{
+				{
+					Type: iam_v2.ProjectRuleTypes_NODE,
+					Conditions: []*iam_v2.Condition{
+						{
+							Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+							Values: []string{"org_1"},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Two rules of type NODE and EVENT should match",
+			matching:    true,
+			action: &chef.Action{
+				RemoteHostname:   "chef-server.org",
+				OrganizationName: "org_1",
+			},
+			rules: []*iam_v2.ProjectRule{
+				{
+					Type: iam_v2.ProjectRuleTypes_NODE,
+					Conditions: []*iam_v2.Condition{
+						{
+							Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+							Values: []string{"org_1"},
+						},
+					},
+				},
+				{
+					Type: iam_v2.ProjectRuleTypes_EVENT,
+					Conditions: []*iam_v2.Condition{
+						{
+							Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+							Values: []string{"org_1"},
+						},
+					},
+				},
+			},
+		},
+
+		// Orgs
+		{
+			description: "Org: Single rule matching",
+			matching:    true,
+			action: &chef.Action{
+				RemoteHostname:   "chef-server.org",
+				OrganizationName: "org_1",
+			},
+			rules: []*iam_v2.ProjectRule{
+				{
+					Type: iam_v2.ProjectRuleTypes_EVENT,
+					Conditions: []*iam_v2.Condition{
+						{
+							Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+							Values: []string{"org_1"},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Org: Single rule differing case non-matching",
+			matching:    false,
+			action: &chef.Action{
+				RemoteHostname:   "chef-server.org",
+				OrganizationName: "Org_1",
+			},
+			rules: []*iam_v2.ProjectRule{
+				{
+					Type: iam_v2.ProjectRuleTypes_EVENT,
+					Conditions: []*iam_v2.Condition{
+						{
+							Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+							Values: []string{"org_1"},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Org: Single rule non-matching",
+			matching:    false,
+			action: &chef.Action{
+				RemoteHostname:   "chef-server.org",
+				OrganizationName: "org_1",
+			},
+			rules: []*iam_v2.ProjectRule{
+				{
+					Type: iam_v2.ProjectRuleTypes_NODE,
+					Conditions: []*iam_v2.Condition{
+						{
+							Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+							Values: []string{"org_2"},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Org: two on same field rule matching",
+			matching:    true,
+			action: &chef.Action{
+				RemoteHostname:   "chef-server.org",
+				OrganizationName: "org_1",
+			},
+			rules: []*iam_v2.ProjectRule{
+				{
+					Type: iam_v2.ProjectRuleTypes_EVENT,
+					Conditions: []*iam_v2.Condition{
+						{
+							Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+							Values: []string{"org_1", "org_2"},
+						},
+					},
+				},
+			},
+		},
+
+		// Chef Server
+		{
+			description: "Chef Server: Single rule matching",
+			matching:    true,
+			action: &chef.Action{
+				RemoteHostname:   "chef_server_1",
+				OrganizationName: "org_1",
+			},
+			rules: []*iam_v2.ProjectRule{
+				{
+					Type: iam_v2.ProjectRuleTypes_EVENT,
+					Conditions: []*iam_v2.Condition{
+						{
+							Type:   iam_v2.ProjectRuleConditionTypes_CHEF_SERVERS,
+							Values: []string{"chef_server_1"},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Chef Server: Single rule differing case non-matching",
+			matching:    false,
+			action: &chef.Action{
+				RemoteHostname:   "Chef_server_1",
+				OrganizationName: "org_1",
+			},
+			rules: []*iam_v2.ProjectRule{
+				{
+					Type: iam_v2.ProjectRuleTypes_EVENT,
+					Conditions: []*iam_v2.Condition{
+						{
+							Type:   iam_v2.ProjectRuleConditionTypes_CHEF_SERVERS,
+							Values: []string{"chef_server_1"},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Chef Server: Single rule non-matching",
+			matching:    false,
+			action: &chef.Action{
+				RemoteHostname:   "chef_server_2",
+				OrganizationName: "org_1",
+			},
+			rules: []*iam_v2.ProjectRule{
+				{
+					Type: iam_v2.ProjectRuleTypes_EVENT,
+					Conditions: []*iam_v2.Condition{
+						{
+							Type:   iam_v2.ProjectRuleConditionTypes_CHEF_SERVERS,
+							Values: []string{"chef_server_1"},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Chef Server: two condition values on the same field one matching",
+			matching:    true,
+			action: &chef.Action{
+				RemoteHostname:   "chef_server_1",
+				OrganizationName: "org_1",
+			},
+			rules: []*iam_v2.ProjectRule{
+				{
+					Type: iam_v2.ProjectRuleTypes_EVENT,
+					Conditions: []*iam_v2.Condition{
+						{
+							Type:   iam_v2.ProjectRuleConditionTypes_CHEF_SERVERS,
+							Values: []string{"chef_server_1", "chef_server_2"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Run all the cases!
+	for _, test := range cases {
+		t.Run(fmt.Sprintf("action match: %s", test.description),
+			func(t *testing.T) {
+				projectMatch := actionMatchesRules(test.action, test.rules)
+
+				assert.Equal(t, test.matching, projectMatch, test.description)
+			})
+	}
+}
+
+func TestActionBundlerSingleMessage(t *testing.T) {
+	inbox := make(chan message.ChefAction, 100)
+	listProjectRulesCount := 0
+	authzClient := iam_v2.NewMockProjectsClient(gomock.NewController(t))
+	authzClient.EXPECT().ListProjectRules(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx interface{}, in interface{}) (*iam_v2.ProjectCollectionRulesResp, error) {
+			listProjectRulesCount++
+			return &iam_v2.ProjectCollectionRulesResp{}, nil
+		})
+	errc := make(chan error)
+
+	inbox <- message.NewChefAction(context.Background(), &chef.Action{}, errc)
+	close(inbox)
+	out := actionBundleProjectTagger(inbox, authzClient)
+
+	<-out
+
+	assert.Equal(t, 1, listProjectRulesCount)
+}
+
+// When 5 messages are in the inbox the ListProjectRules function is only called once.
+func TestActionBundler5Messages(t *testing.T) {
+	inbox := make(chan message.ChefAction, 100)
+	listProjectRulesCount := 0
+	authzClient := iam_v2.NewMockProjectsClient(gomock.NewController(t))
+	authzClient.EXPECT().ListProjectRules(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx interface{}, in interface{}) (*iam_v2.ProjectCollectionRulesResp, error) {
+			listProjectRulesCount++
+			return &iam_v2.ProjectCollectionRulesResp{}, nil
+		})
+	errc := make(chan error)
+
+	inbox <- message.NewChefAction(context.Background(), &chef.Action{}, errc)
+	inbox <- message.NewChefAction(context.Background(), &chef.Action{}, errc)
+	inbox <- message.NewChefAction(context.Background(), &chef.Action{}, errc)
+	inbox <- message.NewChefAction(context.Background(), &chef.Action{}, errc)
+	inbox <- message.NewChefAction(context.Background(), &chef.Action{}, errc)
+	close(inbox)
+
+	out := actionBundleProjectTagger(inbox, authzClient)
+
+	<-out
+	<-out
+	<-out
+	<-out
+	<-out
+
+	assert.Equal(t, 1, listProjectRulesCount)
+}
+
+// A simple run through of the bundle project tagger processor.
+// Two messages are sent through with only one matching a project.
+func TestActionBundlerMatchProjectRule(t *testing.T) {
+	inbox := make(chan message.ChefAction, 100)
+	testProjectName := "Test"
+	orgName := "org_1"
+	projectRules := map[string]*iam_v2.ProjectRules{}
+	projectRules[testProjectName] = &iam_v2.ProjectRules{
+		Rules: []*iam_v2.ProjectRule{
+			{
+				Type: iam_v2.ProjectRuleTypes_EVENT,
+				Conditions: []*iam_v2.Condition{
+					{
+						Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+						Values: []string{orgName},
+					},
+				},
+			},
+		},
+	}
+	authzClient := iam_v2.NewMockProjectsClient(gomock.NewController(t))
+	authzClient.EXPECT().ListProjectRules(gomock.Any(), gomock.Any()).Return(
+		&iam_v2.ProjectCollectionRulesResp{ProjectRules: projectRules}, nil)
+	errc := make(chan error)
+
+	action1 := message.NewChefAction(context.Background(), &chef.Action{
+		OrganizationName: orgName,
+	}, errc)
+
+	action2 := message.NewChefAction(context.Background(), &chef.Action{
+		OrganizationName: "no_match",
+	}, errc)
+
+	inbox <- action1
+	inbox <- action2
+	close(inbox)
+
+	out := BuildActionProjectTagger(authzClient)(inbox)
+
+	processMsg1 := <-out
+	assert.Equal(t, []string{testProjectName}, processMsg1.InternalChefAction.Projects)
+
+	processMsg2 := <-out
+	assert.Equal(t, []string{}, processMsg2.InternalChefAction.Projects)
+}
+
+func TestActionBundlerMatchProjectRuleNodeRuleType(t *testing.T) {
+	inbox := make(chan message.ChefAction, 100)
+	testProjectName := "Test"
+	orgName := "org_1"
+	projectRules := map[string]*iam_v2.ProjectRules{}
+	projectRules[testProjectName] = &iam_v2.ProjectRules{
+		Rules: []*iam_v2.ProjectRule{
+			{
+				Type: iam_v2.ProjectRuleTypes_NODE,
+				Conditions: []*iam_v2.Condition{
+					{
+						Type:   iam_v2.ProjectRuleConditionTypes_CHEF_ORGS,
+						Values: []string{orgName},
+					},
+				},
+			},
+		},
+	}
+	authzClient := iam_v2.NewMockProjectsClient(gomock.NewController(t))
+	authzClient.EXPECT().ListProjectRules(gomock.Any(), gomock.Any()).Return(
+		&iam_v2.ProjectCollectionRulesResp{ProjectRules: projectRules}, nil)
+	errc := make(chan error)
+
+	action1 := message.NewChefAction(context.Background(), &chef.Action{
+		OrganizationName: orgName,
+	}, errc)
+
+	action2 := message.NewChefAction(context.Background(), &chef.Action{
+		OrganizationName: "no_match",
+	}, errc)
+
+	inbox <- action1
+	inbox <- action2
+	close(inbox)
+
+	out := BuildActionProjectTagger(authzClient)(inbox)
+
+	processMsg1 := <-out
+	assert.Equal(t, []string{}, processMsg1.InternalChefAction.Projects)
+
+	processMsg2 := <-out
+	assert.Equal(t, []string{}, processMsg2.InternalChefAction.Projects)
+}

--- a/components/ingest-service/pipeline/processor/action_project_tagger_test.go
+++ b/components/ingest-service/pipeline/processor/action_project_tagger_test.go
@@ -298,13 +298,9 @@ func TestActionBundlerSingleMessage(t *testing.T) {
 // When 5 messages are in the inbox the ListProjectRules function is only called once.
 func TestActionBundler5Messages(t *testing.T) {
 	inbox := make(chan message.ChefAction, 100)
-	listProjectRulesCount := 0
 	authzClient := iam_v2.NewMockProjectsClient(gomock.NewController(t))
-	authzClient.EXPECT().ListProjectRules(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx interface{}, in interface{}) (*iam_v2.ProjectCollectionRulesResp, error) {
-			listProjectRulesCount++
-			return &iam_v2.ProjectCollectionRulesResp{}, nil
-		})
+	authzClient.EXPECT().ListProjectRules(gomock.Any(), gomock.Any()).Times(1).Return(
+		&iam_v2.ProjectCollectionRulesResp{}, nil)
 	errc := make(chan error)
 
 	inbox <- message.NewChefAction(context.Background(), &chef.Action{}, errc)
@@ -321,8 +317,6 @@ func TestActionBundler5Messages(t *testing.T) {
 	<-out
 	<-out
 	<-out
-
-	assert.Equal(t, 1, listProjectRulesCount)
 }
 
 // A simple run through of the bundle project tagger processor.

--- a/components/ingest-service/server/chef.go
+++ b/components/ingest-service/server/chef.go
@@ -30,7 +30,7 @@ type ChefIngestServer struct {
 func NewChefIngestServer(client backend.Client, authzClient iam_v2.ProjectsClient) *ChefIngestServer {
 	return &ChefIngestServer{
 		chefRunPipeline:    pipeline.NewChefRunPipeline(client, authzClient),
-		chefActionPipeline: pipeline.NewChefActionPipeline(client),
+		chefActionPipeline: pipeline.NewChefActionPipeline(client, authzClient),
 		client:             client,
 		authzClient:        authzClient,
 	}


### PR DESCRIPTION
### :nut_and_bolt: Description

Adds RBAC project tagging to the Chef Action ingestion.

### :athletic_shoe: Demo Script / Repro Steps

1. `build components/ingest-service`
1. `start_all_services`
1. `send_chef_action_example`
1. `curl $ELASTICSEARCH_URL/actions-*/_search | jq . | less`
1. Ensure 'some project name' is in the project array

### :chains: Related Resources

issue - https://github.com/chef/automate/issues/62
similar PR but for CCRs - https://github.com/chef/a2/pull/5236

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
