### PR TITLE
Fix all paginators from the Applications Tab

### DIFF
--- a/components/applications-service/integration_test/global_test.go
+++ b/components/applications-service/integration_test/global_test.go
@@ -6,10 +6,12 @@
 package integration_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/chef/automate/api/external/applications"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -75,4 +77,74 @@ func TestMain(m *testing.M) {
 
 	// call with result of m.Run()
 	os.Exit(exitCode)
+}
+
+// assertServiceGroupsEqual verifies that the two provided ServiceGroup Array are equal
+func assertServiceGroupsEqual(t *testing.T, expected, actual *applications.ServiceGroups) {
+
+	// If the actual service-groups array is nil,
+	// then the expected one should also be nil
+	if actual == nil {
+		assert.Nil(t, expected)
+		return
+	}
+	// If both arrays of service groups are not equal, return an error
+	if assert.Equal(t, len(expected.ServiceGroups), len(actual.ServiceGroups),
+		fmt.Sprintf("The service-groups doesn't have the same length. (expected:%d) (actual:%d)",
+			len(expected.ServiceGroups), len(actual.ServiceGroups))) {
+
+		for i := range expected.ServiceGroups {
+			assert.Equal(t,
+				expected.ServiceGroups[i].Name,
+				actual.ServiceGroups[i].Name,
+				"The service_group name is not the expected one")
+			assert.Equal(t,
+				expected.ServiceGroups[i].Release,
+				actual.ServiceGroups[i].Release,
+				"The service_group release is not the expected one")
+			assert.Equal(t,
+				expected.ServiceGroups[i].HealthPercentage,
+				actual.ServiceGroups[i].HealthPercentage,
+				"The service_group health percentage is not the expected one")
+			assert.Equal(t,
+				expected.ServiceGroups[i].Status,
+				actual.ServiceGroups[i].Status,
+				"The service_group status is not the expected one")
+			assert.Equal(t,
+				expected.ServiceGroups[i].ServicesHealthCounts,
+				actual.ServiceGroups[i].ServicesHealthCounts,
+				"The services health counts from the service_group is not the expected one")
+		}
+	}
+}
+
+// Returns a matrix of services equal to the following overall Service Group Health Status:
+// {
+//   "total": 4,
+//   "ok": 1,
+//   "warning": 1,
+//   "critical": 1,
+//   "unknown": 1
+// }
+// TODO @afiune add more apps & envs
+func habServicesMatrix() []*applications.HabService {
+	return []*applications.HabService{
+		// service_group 1 <-> With a Health Status = 'OK'
+		NewHabServiceMsg("sup1", a, e, "default", "core", "redis", "0.1.0", "20190101121212", "OK"),
+		NewHabServiceMsg("sup2", a, e, "default", "core", "redis", "0.1.0", "20190101121212", "OK"),
+		NewHabServiceMsg("sup3", a, e, "default", "core", "redis", "0.1.0", "20190101121212", "OK"),
+
+		// service_group 2 <-> With a Health Status = 'WARNING'
+		NewHabServiceMsg("sup1", a, e, "default", "core", "myapp", "0.1.0", "20190101121212", "WARNING"),
+		NewHabServiceMsg("sup2", a, e, "default", "core", "myapp", "0.1.0", "20190101121212", "OK"),
+		NewHabServiceMsg("sup3", a, e, "default", "core", "myapp", "0.1.0", "20190101121212", "OK"),
+
+		// service_group 3 <-> With a Health Status = 'CRITICAL'
+		NewHabServiceMsg("sup1", a, e, "default", "core", "postgres", "0.1.0", "20190101121212", "OK"),
+		NewHabServiceMsg("sup2", a, e, "default", "core", "postgres", "0.1.0", "20190101121212", "UNKNOWN"),
+		NewHabServiceMsg("sup3", a, e, "default", "core", "postgres", "0.1.0", "20190101121212", "CRITICAL"),
+
+		// service_group 4 <-> With a Health Status = 'UNKNOWN'
+		NewHabServiceMsg("sup4", a, e, "default", "core", "test", "0.1.0", "20190101121212", "UNKNOWN"),
+	}
 }

--- a/components/applications-service/integration_test/service_groups_filters_test.go
+++ b/components/applications-service/integration_test/service_groups_filters_test.go
@@ -146,8 +146,8 @@ func TestServiceGroupsFilterStatusWrongParameter(t *testing.T) {
 		request = &applications.ServiceGroupsReq{
 			Filter: []string{"status:not-valid-status"},
 		}
-		expected    = new(applications.ServiceGroups)
-		expectedErr = "invalid status filter 'not-valid-status'"
+		expected    *applications.ServiceGroups = nil
+		expectedErr                             = "invalid status filter 'not-valid-status'"
 	)
 
 	response, err := suite.ApplicationsServer.GetServiceGroups(ctx, request)
@@ -165,8 +165,8 @@ func TestServiceGroupsFilterWrongType(t *testing.T) {
 		request = &applications.ServiceGroupsReq{
 			Filter: []string{"foo:bar"},
 		}
-		expected    = new(applications.ServiceGroups)
-		expectedErr = "invalid filter. (foo:[bar])"
+		expected    *applications.ServiceGroups = nil
+		expectedErr                             = "invalid filter. (foo:[bar])"
 	)
 
 	response, err := suite.ApplicationsServer.GetServiceGroups(ctx, request)

--- a/components/applications-service/integration_test/service_groups_health_counts_test.go
+++ b/components/applications-service/integration_test/service_groups_health_counts_test.go
@@ -205,34 +205,3 @@ func TestServiceGroupsHealthCountsOnServiceUpdateAllCritical(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, response, expectedAfterUpdate)
 }
-
-// Returns a matrix of services equal to the following overall Service Group Health Status:
-// {
-//   "total": 4,
-//   "ok": 1,
-//   "warning": 1,
-//   "critical": 1,
-//   "unknown": 1
-// }
-// TODO @afiune add more apps & envs
-func habServicesMatrix() []*applications.HabService {
-	return []*applications.HabService{
-		// service_group 1 <-> With a Health Status = 'OK'
-		NewHabServiceMsg("sup1", a, e, "default", "core", "redis", "0.1.0", "20190101121212", "OK"),
-		NewHabServiceMsg("sup2", a, e, "default", "core", "redis", "0.1.0", "20190101121212", "OK"),
-		NewHabServiceMsg("sup3", a, e, "default", "core", "redis", "0.1.0", "20190101121212", "OK"),
-
-		// service_group 2 <-> With a Health Status = 'WARNING'
-		NewHabServiceMsg("sup1", a, e, "default", "core", "myapp", "0.1.0", "20190101121212", "WARNING"),
-		NewHabServiceMsg("sup2", a, e, "default", "core", "myapp", "0.1.0", "20190101121212", "OK"),
-		NewHabServiceMsg("sup3", a, e, "default", "core", "myapp", "0.1.0", "20190101121212", "OK"),
-
-		// service_group 3 <-> With a Health Status = 'CRITICAL'
-		NewHabServiceMsg("sup1", a, e, "default", "core", "postgres", "0.1.0", "20190101121212", "OK"),
-		NewHabServiceMsg("sup2", a, e, "default", "core", "postgres", "0.1.0", "20190101121212", "UNKNOWN"),
-		NewHabServiceMsg("sup3", a, e, "default", "core", "postgres", "0.1.0", "20190101121212", "CRITICAL"),
-
-		// service_group 4 <-> With a Health Status = 'UNKNOWN'
-		NewHabServiceMsg("sup4", a, e, "default", "core", "test", "0.1.0", "20190101121212", "UNKNOWN"),
-	}
-}

--- a/components/applications-service/integration_test/service_groups_test.go
+++ b/components/applications-service/integration_test/service_groups_test.go
@@ -25,7 +25,7 @@ func TestServiceGroupsBasic(t *testing.T) {
 	assert.Equal(t, expected, response)
 }
 
-func TestServiceGroupsHealthOneOk(t *testing.T) {
+func TestGetServiceGroupsOneOk(t *testing.T) {
 	var (
 		ctx      = context.Background()
 		request  = new(applications.ServiceGroupsReq)
@@ -58,7 +58,7 @@ func TestServiceGroupsHealthOneOk(t *testing.T) {
 	assertServiceGroupsEqual(t, expected, response)
 }
 
-func TestServiceGroupsHealthOneCritical(t *testing.T) {
+func TestGetServiceGroupsOneCritical(t *testing.T) {
 	var (
 		ctx      = context.Background()
 		request  = new(applications.ServiceGroupsReq)
@@ -152,7 +152,7 @@ func TestServiceGroupsMultiService(t *testing.T) {
 	assertServiceGroupsEqual(t, expected, response)
 }
 
-func TestServiceGroupsHealthOneWarning(t *testing.T) {
+func TestGetServiceGroupsOneWarning(t *testing.T) {
 	var (
 		ctx      = context.Background()
 		request  = new(applications.ServiceGroupsReq)
@@ -185,7 +185,7 @@ func TestServiceGroupsHealthOneWarning(t *testing.T) {
 	assertServiceGroupsEqual(t, expected, response)
 }
 
-func TestServiceGroupsHealthOneUnknown(t *testing.T) {
+func TestGetServiceGroupsOneUnknown(t *testing.T) {
 	var (
 		ctx      = context.Background()
 		request  = new(applications.ServiceGroupsReq)
@@ -217,7 +217,7 @@ func TestServiceGroupsHealthOneUnknown(t *testing.T) {
 	assert.Nil(t, err)
 	assertServiceGroupsEqual(t, expected, response)
 }
-func TestServiceGroupsHealthOneEach(t *testing.T) {
+func TestGetServiceGroupsOneEach(t *testing.T) {
 	var (
 		ctx      = context.Background()
 		request  = new(applications.ServiceGroupsReq)
@@ -259,7 +259,7 @@ func TestServiceGroupsHealthOneEach(t *testing.T) {
 	assertServiceGroupsEqual(t, expected, response)
 }
 
-func TestServiceGroupsHealthSortedDesc(t *testing.T) {
+func TestGetServiceGroupsSortedDesc(t *testing.T) {
 	var (
 		ctx     = context.Background()
 		request = &applications.ServiceGroupsReq{
@@ -291,7 +291,7 @@ func TestServiceGroupsHealthSortedDesc(t *testing.T) {
 	assert.Equal(t, "a.default", response.ServiceGroups[3].Name)
 }
 
-func TestServiceGroupsHealthSortedAsc(t *testing.T) {
+func TestGetServiceGroupsSortedAsc(t *testing.T) {
 	var (
 		ctx     = context.Background()
 		request = &applications.ServiceGroupsReq{
@@ -323,7 +323,7 @@ func TestServiceGroupsHealthSortedAsc(t *testing.T) {
 	assert.Equal(t, "d.default", response.ServiceGroups[3].Name)
 }
 
-func TestServiceGroupsHealthSortedPercent(t *testing.T) {
+func TestGetServiceGroupsSortedPercent(t *testing.T) {
 	var (
 		ctx     = context.Background()
 		request = &applications.ServiceGroupsReq{
@@ -354,7 +354,7 @@ func TestServiceGroupsHealthSortedPercent(t *testing.T) {
 	assert.Equal(t, int32(0), response.ServiceGroups[2].HealthPercentage)
 }
 
-func TestServiceGroupsHealthSortedPercentAsc(t *testing.T) {
+func TestGetServiceGroupsSortedPercentAsc(t *testing.T) {
 	var (
 		ctx     = context.Background()
 		request = &applications.ServiceGroupsReq{

--- a/components/applications-service/pkg/params/pagination_test.go
+++ b/components/applications-service/pkg/params/pagination_test.go
@@ -77,10 +77,26 @@ func TestPaginationMatrix(t *testing.T) {
 		},
 		{
 			pagination: &query.Pagination{
+				Page: -1,
+				Size: 2,
+			},
+			expectedPage: 1,
+			expectedSize: 2,
+		},
+		{
+			pagination: &query.Pagination{
 				Page: 0,
 				Size: 0,
 			},
 			expectedPage: 1,
+			expectedSize: 25,
+		},
+		{
+			pagination: &query.Pagination{
+				Page: 9,
+				Size: -10,
+			},
+			expectedPage: 9,
 			expectedSize: 25,
 		},
 	}

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
@@ -38,8 +38,8 @@ export interface ServiceGroupFilters {
 
 export interface ServicesFilters {
   service_group_id?: number;
-  health?: string;
-  page?: number;
+  health: string;
+  page: number;
   pageSize?: number;
 }
 

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
@@ -35,7 +35,10 @@ export const ServiceGroupEntityInitialState: ServiceGroupEntityState = {
   filters: { },
   servicesStatus: EntityStatus.notLoaded,
   errorResp: null,
-  servicesFilters: { },
+  servicesFilters: {
+    page: 1,
+    health: 'total'
+  },
   servicesList: [],
   servicesHealthSummary: {
     total: 0,

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -8,31 +8,31 @@
       <chef-subheading>Services run by each Habitat Supervisor on a node.</chef-subheading>
     </chef-page-header>
     <div class="status-filter-bar">
-      <chef-status-filter-group lean>
-        <chef-option class="filter general" value="general" (click)="updateServicesFilters('total')" selected>
+      <chef-status-filter-group [value]="selectedHealth" lean>
+        <chef-option class="filter general" value="total" (click)="updateHealthFilter('total')" selected>
           <chef-icon class="filter-icon">group_work</chef-icon>
           <div class="filter-label">Total</div>
-          <div class="filter-total">{{ (servicesHealthSummary$ | async).total }}</div>
+          <div class="filter-total">{{ servicesHealthSummary.total }}</div>
         </chef-option>
-        <chef-option class="filter critical" value='critical' (click)="updateServicesFilters('critical')">
+        <chef-option class="filter critical" value='critical' (click)="updateHealthFilter('critical')">
           <chef-icon class="filter-icon">warning</chef-icon>
           <div class="filter-label">Critical</div>
-          <div class="filter-total">{{ (servicesHealthSummary$ | async).critical }}</div>
+          <div class="filter-total">{{ servicesHealthSummary.critical }}</div>
         </chef-option>
-        <chef-option class="filter warning" value='warning' (click)="updateServicesFilters('warning')">
+        <chef-option class="filter warning" value='warning' (click)="updateHealthFilter('warning')">
           <chef-icon class="filter-icon">error</chef-icon>
           <div class="filter-label">Warning</div>
-          <div class="filter-total">{{ (servicesHealthSummary$ | async).warning }}</div>
+          <div class="filter-total">{{ servicesHealthSummary.warning }}</div>
         </chef-option>
-        <chef-option class="filter success" value='success' (click)="updateServicesFilters('ok')">
+        <chef-option class="filter success" value='success' (click)="updateHealthFilter('ok')">
           <chef-icon class="filter-icon">check_circle</chef-icon>
           <div class="filter-label">OK</div>
-          <div class="filter-total">{{ (servicesHealthSummary$ | async).ok }}</div>
+          <div class="filter-total">{{ servicesHealthSummary.ok }}</div>
         </chef-option>
-        <chef-option class="filter unknown" value='unknown' (click)="updateServicesFilters('unknown')">
+        <chef-option class="filter unknown" value='unknown' (click)="updateHealthFilter('unknown')">
           <chef-icon class="filter-icon">help</chef-icon>
           <div class="filter-label">Unknown</div>
-          <div class="filter-total">{{ (servicesHealthSummary$ | async).unknown }}</div>
+          <div class="filter-total">{{ servicesHealthSummary.unknown }}</div>
         </chef-option>
       </chef-status-filter-group>
     </div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -10,9 +10,8 @@ ul {
 }
 
 app-page-picker {
-  margin-left: auto;
-  margin-right: auto;
-  width: 225px;
+  padding-left: 35px;
+  padding-bottom: 35px;
 }
 
 .service-item {

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -8,7 +8,7 @@ import {
   Service, ServicesFilters, HealthSummary
 } from '../../entities/service-groups/service-groups.model';
 import { UpdateSelectedSG } from '../../entities/service-groups/service-groups.actions';
-import { get } from 'lodash/fp';
+import { includes, getOr } from 'lodash/fp';
 
 @Component({
   selector: 'app-services-sidebar',
@@ -21,13 +21,18 @@ export class ServicesSidebarComponent implements OnInit {
   @Input() visible: boolean;
   @Output() closeServicesSidebarEvent: EventEmitter<any> = new EventEmitter();
 
-  public selectedHealth: string;
   public services$: Observable<Service[]>;
   public serviceGroupName$: Observable<string>;
+  public selectedHealth = 'total';
   public currentPage = 1;
   public pageSize = 25;
   public totalServices = 0;
-  public servicesHealthSummary$: Observable<HealthSummary>;
+  public servicesHealthSummary: HealthSummary;
+
+  // The collection of allowable status
+  private allowedStatus = ['ok', 'critical', 'warning', 'unknown'];
+  private svcHealthSummary$: Observable<HealthSummary>;
+  private currentServicesFilters$: Observable<ServicesFilters>;
 
   constructor(private store: Store<NgrxStateAtom>) { }
 
@@ -38,13 +43,19 @@ export class ServicesSidebarComponent implements OnInit {
     this.serviceGroupName$ = this.store.select(createSelector(serviceGroupState,
       (state) => state.selectedServiceGroupName));
 
-    this.servicesHealthSummary$ = this.store.select(createSelector(serviceGroupState,
+    this.svcHealthSummary$ = this.store.select(createSelector(serviceGroupState,
       (state) => state.servicesHealthSummary));
+    this.svcHealthSummary$.subscribe((servicesHealthSummary) => {
+      this.servicesHealthSummary = servicesHealthSummary;
+      this.totalServices = getOr(0, this.selectedHealth, this.servicesHealthSummary);
+    });
 
-    this.currentPage = 1;
-
-    this.servicesHealthSummary$.subscribe((healthSummary) => {
-      this.totalServices = get('total', healthSummary);
+    this.currentServicesFilters$ = this.store.select(createSelector(serviceGroupState,
+      (state) => state.servicesFilters));
+    this.currentServicesFilters$.subscribe((servicesFilters) => {
+      this.selectedHealth = getOr('total', 'health', servicesFilters);
+      this.currentPage    = getOr(1, 'page', servicesFilters);
+      this.totalServices  = getOr(0, this.selectedHealth, this.servicesHealthSummary);
     });
   }
 
@@ -52,20 +63,20 @@ export class ServicesSidebarComponent implements OnInit {
     this.closeServicesSidebarEvent.emit(null);
   }
 
-  public updateServicesFilters(health: string): void {
-    this.selectedHealth = health;
-    const servicesFilters: ServicesFilters = {
-      service_group_id: this.serviceGroupId,
-      health: health,
-      page: this.currentPage,
-      pageSize: this.pageSize
-    };
-    this.store.dispatch(new UpdateSelectedSG(servicesFilters));
+  public updateHealthFilter(health: string): void {
+    if ( includes(health, this.allowedStatus) ) {
+      this.selectedHealth = health;
+    } else {
+      this.selectedHealth = 'total';
+    }
+
+    this.currentPage = 1;
+    this.updateServicesFilters();
   }
 
-  updatePageNumber(pageNumber: number) {
+  public updatePageNumber(pageNumber: number) {
     this.currentPage = pageNumber;
-    this.updateServicesFilters(this.selectedHealth);
+    this.updateServicesFilters();
   }
 
   // healthCheckStatus returns the formated health_check status from the provided service
@@ -83,5 +94,15 @@ export class ServicesSidebarComponent implements OnInit {
       default:
         return service.health_check;
     }
+  }
+
+  private updateServicesFilters(): void {
+    const servicesFilters: ServicesFilters = {
+      service_group_id: this.serviceGroupId,
+      health: this.selectedHealth,
+      page: this.currentPage,
+      pageSize: this.pageSize
+    };
+    this.store.dispatch(new UpdateSelectedSG(servicesFilters));
   }
 }

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -8,27 +8,27 @@
     <chef-option class="filter general" value="general" (click)="statusFilter('total')" selected>
       <chef-icon class="filter-icon">group_work</chef-icon>
       <div class="filter-label">Total</div>
-      <div class="filter-total">{{(HealthSummary$ | async)["total"]}}</div>
+      <div class="filter-total">{{ sgHealthSummary["total"] }}</div>
     </chef-option>
     <chef-option class="filter critical" value='critical' (click)="statusFilter('critical')">
       <chef-icon class="filter-icon">warning</chef-icon>
       <div class="filter-label">Critical</div>
-      <div class="filter-total">{{(HealthSummary$ | async)["critical"]}}</div>
+      <div class="filter-total">{{ sgHealthSummary["critical"] }}</div>
     </chef-option>
     <chef-option class="filter warning" value='warning' (click)="statusFilter('warning')">
       <chef-icon class="filter-icon">error</chef-icon>
       <div class="filter-label">Warning</div>
-      <div class="filter-total">{{(HealthSummary$ | async)["warning"]}}</div>
+      <div class="filter-total">{{ sgHealthSummary["warning"] }}</div>
     </chef-option>
     <chef-option class="filter success" value='success' (click)="statusFilter('ok')">
       <chef-icon class="filter-icon">check_circle</chef-icon>
       <div class="filter-label">OK</div>
-      <div class="filter-total">{{(HealthSummary$ | async)["ok"]}}</div>
+      <div class="filter-total">{{ sgHealthSummary["ok"] }}</div>
     </chef-option>
     <chef-option class="filter unknown" value='unknown' (click)="statusFilter('unknown')">
       <chef-icon class="filter-icon">help</chef-icon>
       <div class="filter-label">Unknown</div>
-      <div class="filter-total">{{(HealthSummary$ | async)["unknown"]}}</div>
+      <div class="filter-total">{{ sgHealthSummary["unknown"] }}</div>
     </chef-option>
   </chef-status-filter-group>
   <chef-table class="service-group-list" *ngIf="(serviceGroupStatus$ | async) == 'loadingSuccess'">

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -5,7 +5,7 @@
 </chef-page-header>
 <div class="page-body">
   <chef-status-filter-group [value]="selectedStatus$ | async">
-    <chef-option class="filter general" value="general" (click)="statusFilter('total')" selected>
+    <chef-option class="filter general" value="total" (click)="statusFilter('total')" selected>
       <chef-icon class="filter-icon">group_work</chef-icon>
       <div class="filter-label">Total</div>
       <div class="filter-total">{{ sgHealthSummary["total"] }}</div>

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.spec.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.spec.ts
@@ -209,5 +209,20 @@ describe('ServiceGroupsComponent', () => {
           pageSize: 25
         }}));
     }));
+
+    it('when a user navigates to a negative page use the default page number', fakeAsync(() => {
+      spyOn(component.store, 'dispatch');
+
+      component.updateAllFilters([{type: 'page', text: '-2'}]);
+
+      expect(component.store.dispatch).toHaveBeenCalledWith(
+        new UpdateServiceGroupFilters({filters: {
+          status: undefined,
+          sortField: 'name',
+          sortDirection: 'ASC',
+          page: 1,
+          pageSize: 25
+        }}));
+    }));
   });
 });

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -220,6 +220,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
     }
     return 'sort';
   }
+
   private getSelectedPageNumber(allUrlParameters: Chicklet[]): number {
     const pageChicklet = find((chicklet) => {
       return chicklet.type === 'page';

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -26,7 +26,7 @@ import { find, includes } from 'lodash/fp';
 export class ServiceGroupsComponent implements OnInit, OnDestroy {
   public serviceGroups$: Observable<ServiceGroup[]>;
   public serviceGroupStatus$: Observable<EntityStatus>;
-  public HealthSummary$: Observable<HealthSummary>;
+  public sgHealthSummary: HealthSummary;
 
   // The selected service-group id that will be sent to the services-sidebar
   public selectedServiceGroupId: number;
@@ -43,29 +43,28 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   // Total number of service groups
   public totalServiceGroups = 0;
 
-  // The collection of allowable status
-  private allowedStatus = ['ok', 'critical', 'warning', 'unknown'];
-
   // The currently selected health status filter
   public selectedStatus$: Observable<string>;
+
+  // The collection of allowable status
+  private allowedStatus = ['ok', 'critical', 'warning', 'unknown'];
 
   // Has this component been destroyed
   private isDestroyed: Subject<boolean> = new Subject();
 
+  // The collection of allowable sort directions
+  private allowedSortDirections = ['asc', 'desc', 'ASC', 'DESC'];
+
   private selectedFieldDirection$: Observable<SortDirection>;
   private selectedSortField$: Observable<string>;
+  private healthSummary$: Observable<HealthSummary>;
   private currentPage$: Observable<number>;
-
   private currentFieldDirection: SortDirection;
   private currentSortField: string;
-
   private defaultFieldDirection: FieldDirection = {
     name: 'ASC',
     percent_ok: 'ASC'
   };
-
-  // The collection of allowable sort directions
-  private allowedSortDirections = ['asc', 'desc', 'ASC', 'DESC'];
 
   constructor(
     private route: ActivatedRoute,
@@ -82,13 +81,20 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
     this.serviceGroupStatus$ = this.store.select(serviceGroupStatus);
     this.serviceGroups$ = this.store.select(allServiceGroups);
 
-    this.HealthSummary$ = this.store.select(allServiceGroupHealth);
-    this.HealthSummary$.subscribe((sgHealthSummary) => {
-      this.totalServiceGroups = sgHealthSummary['total'];
-    });
+    this.healthSummary$ = this.store.select(allServiceGroupHealth);
+    this.healthSummary$.subscribe(sgHealthSummary => this.sgHealthSummary = sgHealthSummary);
 
     this.selectedStatus$ = this.store.select(createSelector(serviceGroupState,
       (state) => state.filters.status));
+    this.selectedStatus$.subscribe((status) => {
+      // This code enables the pagination of service groups correctly, when the user selects
+      // a Health Filter, we adjust the total number of service groups
+      if ( includes(status, this.allowedStatus) ) {
+          this.totalServiceGroups = this.sgHealthSummary[status];
+      } else {
+          this.totalServiceGroups = this.sgHealthSummary['total'];
+      }
+    });
 
     this.selectedFieldDirection$ = this.store.select(createSelector(serviceGroupState,
       (state) => state.filters.sortDirection));

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -15,7 +15,7 @@ import {
 import {
   serviceGroupStatus, allServiceGroups, serviceGroupState, allServiceGroupHealth
 } from '../../entities/service-groups/service-groups.selector';
-import { find, includes } from 'lodash/fp';
+import { find, includes, get } from 'lodash/fp';
 
 @Component({
   selector: 'app-service-groups',
@@ -90,9 +90,9 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
       // This code enables the pagination of service groups correctly, when the user selects
       // a Health Filter, we adjust the total number of service groups
       if ( includes(status, this.allowedStatus) ) {
-          this.totalServiceGroups = this.sgHealthSummary[status];
+          this.totalServiceGroups = get(status, this.sgHealthSummary);
       } else {
-          this.totalServiceGroups = this.sgHealthSummary['total'];
+          this.totalServiceGroups = get('total', this.sgHealthSummary);
       }
     });
 
@@ -151,6 +151,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   public openServicesSidebar(id: number) {
     const servicesFilters: ServicesFilters = {
       service_group_id: id,
+      page: 1,
       health: 'total'
     };
     this.selectedServiceGroupId = id;


### PR DESCRIPTION
### :nut_and_bolt: Description
We had a number of issues with our paginators, this change is fixing them all so that the UI and Backend work as expected.

### :+1: Definition of Done
You can use all Paginators in the Applications Tab. That includes when using the health filters! 🎉 

### :athletic_shoe: Demo Script / Repro Steps
Start the studio and build the applications-service. Then build and start the automate-ui in your preferred way. Finally, start all services.
```
$ hab studio enter
[1][default:/src:0]# export DEVPROXY_URL=localhost
[2][default:/src:0]# build components/automate-ui-devproxy
[3][default:/src:0]# build components/applications-service 
[4][default:/src:0]# start_automate_ui_background
[5][default:/src:0]# start_all_services
```

Populate the database (by running the helper method `applications_populate_database`) and navigate in your browser to https://a2-dev.test/applications and use all paginators! 😸 

### :chains: Related Resources
https://chefio.atlassian.net/browse/A2-769

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?