### PR TITLE
Enables habitat client permissions on required messaging channels

### DIFF
--- a/components/event-gateway/integration_test/suite_test.go
+++ b/components/event-gateway/integration_test/suite_test.go
@@ -70,7 +70,7 @@ func TestMain(m *testing.M) {
 	// Global Setup hook: initialize anything required for the test
 	// run, e.g., initializing ES indices, inserting test data, etc.
 	if err := suite.GlobalSetup(); err != nil {
-		fmt.Println("Test failed global setup. exiting.")
+		fmt.Printf("Test failed global setup with err %v. Exiting.", err)
 		os.Exit(1)
 	}
 

--- a/components/event-gateway/pkg/nats/authenticator.go
+++ b/components/event-gateway/pkg/nats/authenticator.go
@@ -150,6 +150,7 @@ func habNatsUser() *natsd.User {
 			Publish: &natsd.SubjectPermission{
 				Allow: []string{
 					"_INBOX.>",
+					"_HB.>",
 					"_STAN.discover.event-service",
 					"_STAN.discover.event-service.*",
 					"_STAN.pub.*.habitat",
@@ -160,6 +161,9 @@ func habNatsUser() *natsd.User {
 				Allow: []string{
 					"_INBOX.>",
 					"_STAN.acks.>",
+					"_HB.>",
+					"_STAN.discover.event-service.*",
+					">",
 				},
 			},
 		},


### PR DESCRIPTION
Signed-off-by: gpeers <gpeers@chef.io>

### :nut_and_bolt: Description

This PR furthers the EAS observability initiative by providing the permissions which allow the Habitat client to publish and subscribe to Automate messaging channels.

### :+1: Definition of Done

- Habitat can exchange heartbeat messages with Automate's streaming server, NATS
- Habitat can publish messages regarding Supervisor events to Automate
- Habitat can receive replies and acknowledgements from Automate

### :athletic_shoe: Demo Script / Repro Steps

There are two ways to test this functionality: one is by exercising the related Automate integration tests in Habitat Studio, and the other is by running the Habitat Supervisor against Automate.

To exercise the Studio integration tests:
Grab the branch and open Studio
Build the `event-gateway` component
Start all services
The services should be on IAMv1; if they're not, run `chef-automate iam reset-to-v1`
Check your config using `chef-automate config show`. You should see something like

```[applications]
  [applications.v1]
    [applications.v1.sys]
      [applications.v1.sys.service]
        enable_nats_feature = true

[event_service]
  [event_service.v1]
    [event_service.v1.sys]
      [event_service.v1.sys.service]
        enable_nats_feature = true
      [event_service.v1.sys.log]

[event_gateway]
  [event_gateway.v1]
    [event_gateway.v1.sys]
      [event_gateway.v1.sys.service]
        enable_nats_feature = true
        disable_frontend_tls = false
      [event_gateway.v1.sys.log]

```
Notice that `enable_nats_feature = true` for applications, event-service, and event-gateway, and `disable_frontend_tls = false`
In Studio, run `event_gateway_integration`; the tests should pass

In order to run the Habitat Supervisor against Automate, you'll need running instances of messaging-enabled Habitat (currently on a feature branch) and Automate. Automate must be on IAMv2, and frontend TLS must be disabled. You'll need an admin token from Automate so Habitat can establish a connection to the Automate streaming server, NATS. You'll invoke the Supervisor with a command something like:

```
sudo -E RUST_LOG=habitat_sup::event=trace,ratsio=trace RUST_BACKTRACE=1 HAB_FEAT_EVENT_STREAM=1
HAB_LAUNCH_BINARY=<your-path>/habitat/target/debug/hab-launch 
HAB_SUP_BINARY=<your-path>/habitat/target/debug/hab-sup 
<your-path>/habitat/target/debug/hab sup run --event-stream-application <your-app> 
--event-stream-environment <your-env> --event-stream-token <your-token> 
--event-stream-url <your-automate-host-ip>:<your-nats-port>
```

These are high-level instructions as this feature is still in development. If you need help, reach out. :)

### :chains: Related Resources

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
