### PR TITLE
Trigger replication notification of authz policies

### DIFF
--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -78,7 +78,10 @@ func NewPoliciesServer(
 	pl storage_v1.PoliciesLister,
 	vChan chan api.Version) (PolicyServer, error) {
 
-	policyRefresher := NewPolicyRefresher(ctx, l, s, e)
+	policyRefresher, err := NewPolicyRefresher(ctx, l, s, e)
+	if err != nil {
+		return nil, errors.Wrap(err, "start policy refresher")
+	}
 
 	srv := &policyServer{
 		log:             l,

--- a/components/authz-service/storage/v2/memstore/memstore.go
+++ b/components/authz-service/storage/v2/memstore/memstore.go
@@ -9,8 +9,8 @@ import (
 
 	v2_constants "github.com/chef/automate/components/authz-service/constants/v2"
 	storage_errors "github.com/chef/automate/components/authz-service/storage"
-	"github.com/chef/automate/components/authz-service/storage/v2"
 	storage "github.com/chef/automate/components/authz-service/storage/v2"
+	v2 "github.com/chef/automate/components/authz-service/storage/v2"
 )
 
 type State struct {

--- a/components/authz-service/storage/v2/memstore/policy_change_notifier.go
+++ b/components/authz-service/storage/v2/memstore/policy_change_notifier.go
@@ -3,7 +3,7 @@ package memstore
 import (
 	"sync"
 
-	"github.com/chef/automate/components/authz-service/storage/v2"
+	v2 "github.com/chef/automate/components/authz-service/storage/v2"
 )
 
 type policyChangeNotifierManager struct {

--- a/components/authz-service/storage/v2/memstore/policy_change_notifier.go
+++ b/components/authz-service/storage/v2/memstore/policy_change_notifier.go
@@ -1,0 +1,54 @@
+package memstore
+
+import (
+	"sync"
+
+	"github.com/chef/automate/components/authz-service/storage/v2"
+)
+
+type policyChangeNotifierManager struct {
+	lock     sync.Mutex
+	channels []*policyChangeNotifier
+}
+
+type policyChangeNotifier struct {
+	manager *policyChangeNotifierManager
+	c       chan v2.PolicyChangeNotification
+}
+
+func newPolicyChangeNotifierManager() *policyChangeNotifierManager {
+	return &policyChangeNotifierManager{}
+}
+
+func (manager *policyChangeNotifierManager) notifyChange() {
+	manager.lock.Lock()
+	defer manager.lock.Unlock()
+
+	for _, c := range manager.channels {
+		select {
+		case c.c <- v2.PolicyChangeNotification{}:
+		default:
+		}
+	}
+}
+
+func (manager *policyChangeNotifierManager) register() *policyChangeNotifier {
+	manager.lock.Lock()
+	defer manager.lock.Unlock()
+
+	c := &policyChangeNotifier{
+		c:       make(chan v2.PolicyChangeNotification, 1),
+		manager: manager,
+	}
+	manager.channels = append(manager.channels, c)
+	return c
+}
+
+func (*policyChangeNotifier) Close() error {
+	// This is test code, don't need to worry about cleanin stuff up
+	return nil
+}
+
+func (p *policyChangeNotifier) C() <-chan v2.PolicyChangeNotification {
+	return p.c
+}

--- a/components/authz-service/storage/v2/postgres/policy_change_notifier.go
+++ b/components/authz-service/storage/v2/postgres/policy_change_notifier.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/chef/automate/components/authz-service/storage/v2"
+	v2 "github.com/chef/automate/components/authz-service/storage/v2"
 	"github.com/lib/pq"
 	"github.com/sirupsen/logrus"
 )

--- a/components/authz-service/storage/v2/postgres/policy_change_notifier.go
+++ b/components/authz-service/storage/v2/postgres/policy_change_notifier.go
@@ -1,0 +1,77 @@
+package postgres
+
+import (
+	"context"
+	"time"
+
+	"github.com/chef/automate/components/authz-service/storage/v2"
+	"github.com/lib/pq"
+	"github.com/sirupsen/logrus"
+)
+
+type policyChangeNotifier struct {
+	conninfo             string
+	minReconnectInterval time.Duration
+	maxReconnectInterval time.Duration
+	pingInterval         time.Duration
+	notificationChan     chan v2.PolicyChangeNotification
+	shutdown             func()
+}
+
+func newPolicyChangeNotifier(ctx context.Context, conninfo string) (v2.PolicyChangeNotifier, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	p := &policyChangeNotifier{
+		conninfo:             conninfo,
+		minReconnectInterval: 10 * time.Second,
+		maxReconnectInterval: time.Minute,
+		pingInterval:         10 * time.Second,
+		notificationChan:     make(chan v2.PolicyChangeNotification, 1),
+		shutdown:             cancel,
+	}
+	listener := pq.NewListener(p.conninfo, p.minReconnectInterval, p.maxReconnectInterval, nil)
+	err := listener.Listen("policychange")
+	if err != nil {
+		return nil, err
+	}
+
+	go p.run(ctx, listener)
+	return p, nil
+}
+
+func (p *policyChangeNotifier) C() <-chan v2.PolicyChangeNotification {
+	return p.notificationChan
+}
+
+func (p *policyChangeNotifier) Close() error {
+	p.shutdown()
+	return nil
+}
+
+func (p *policyChangeNotifier) run(ctx context.Context, listener *pq.Listener) {
+
+RUNLOOP:
+	for {
+		select {
+		case <-ctx.Done():
+			break RUNLOOP
+		case n := <-listener.Notify:
+			if n == nil {
+				continue
+			}
+			select {
+			case p.notificationChan <- v2.PolicyChangeNotification{}:
+				logrus.Info("Accepted notification from postgres")
+			default:
+				logrus.Debug("Notification listener mailbox full")
+			}
+		case <-time.After(p.pingInterval):
+			err := listener.Ping()
+			if err != nil {
+				logrus.WithError(err).Warn("Notification listener failed to ping database")
+			}
+		}
+	}
+	if err := listener.Close(); err != nil {
+		logrus.WithError(err).Warn("Failed to close notification listener")
+	}
+}

--- a/components/authz-service/storage/v2/storage.go
+++ b/components/authz-service/storage/v2/storage.go
@@ -24,6 +24,13 @@ type Storage interface {
 	MigrationStatusProvider
 }
 
+type PolicyChangeNotification struct{}
+
+type PolicyChangeNotifier interface {
+	C() <-chan PolicyChangeNotification
+	Close() error
+}
+
 type policyStorage interface {
 	ReplacePolicyMembers(context.Context, string, []Member) ([]Member, error)
 	RemovePolicyMembers(context.Context, string, []Member) ([]Member, error)
@@ -41,6 +48,7 @@ type policyStorage interface {
 	PurgeSubjectFromPolicies(ctx context.Context, subject string) ([]string, error)
 
 	GetPolicyChangeID(context.Context) (string, error)
+	GetPolicyChangeNotifier(context.Context) (PolicyChangeNotifier, error)
 }
 
 type roleStorage interface {


### PR DESCRIPTION
This PR uses postgres' LISTEN/NOTIFY feature to notify all authz nodes
of changes to the policies. This makes the replication start almost
instantaneously, for sure faster that the 10 second anti entropy timer
we have right now.