### PR TITLE
[deployment] Unpin automate-ha-backend packages.

### DIFF
--- a/integration/services/ha_backend/htpasswd
+++ b/integration/services/ha_backend/htpasswd
@@ -1,1 +1,0 @@
-admin:$apr1$T3TlJ99D$y2DMIZAMRBz63I44rb70G1

--- a/integration/services/ha_backend/init
+++ b/integration/services/ha_backend/init
@@ -2,14 +2,14 @@
 
 HA_BACKEND_DIR=$(dirname ${BASH_SOURCE[0]})
 HA_BACKEND_USER="admin"
-HA_BACKEND_PASSWORD="chefautomate"
+# changing to match the default in automate-ha-backend
+HA_BACKEND_PASSWORD="admin"
 
 ha_backend_container1=$(service_container_name "ha_backend_1")
 ha_backend_container2=$(service_container_name "ha_backend_2")
 
 ha_backend_private=$(service_config_path "ha_backend_private")
 ha_backend_config=$(service_config_path "ha_backend.toml")
-
 
 ha_backend_setup() {
     mkdir -p $ha_backend_private
@@ -26,6 +26,44 @@ ha_backend_setup() {
     local ha_backend_container2_ip=$(container_ip $ha_backend_container2)
     log_info "Launched $ha_backend_container2 with ip ${ha_backend_container2_ip}"
 
+    echo "Generating elasticsearch ssl keys"
+    # ganked from a2-ha-backend
+    certdir="$HA_BACKEND_DIR/certificates"
+    echo "CERTDIR IS $certdir"
+    mkdir -p $certdir
+
+    RANDFILE=$certdir/.rnd
+    #First, create a private key for the CA:
+    openssl genrsa -out $certdir/MyRootCA.key 2048
+
+    #Create the CA and enter the Organization details:
+    openssl req -x509 -new -key $certdir/MyRootCA.key -sha256 -out $certdir/MyRootCA.pem -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefrootca'
+
+    #the rsa keys
+    openssl genrsa -out $certdir/odfe-node-pkcs12.key 2048
+    openssl genrsa -out $certdir/odfe-admin-pkcs12.key 2048
+
+    #IMPORTANT: Convert these to PKCS#5 v1.5 to work correctly with the JDK.
+    openssl pkcs8 -v1 "PBE-SHA1-3DES" -in "$certdir/odfe-node-pkcs12.key" -topk8 -out "$certdir/odfe-node.key" -nocrypt
+    openssl pkcs8 -v1 "PBE-SHA1-3DES" -in "$certdir/odfe-admin-pkcs12.key" -topk8 -out "$certdir/odfe-admin.key" -nocrypt
+
+    #Create the CSR and enter the organization and server details for the node key
+    # Need to create a key per machine, this is where you specify the SAN.
+    # openssl req -new -key $certdir/odfe-node.key -out $certdir/odfe-node.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefnode'
+    openssl req -new -key $certdir/odfe-node.key -out $certdir/odfe-${ha_backend_container1}.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefnode' -extensions san -reqexts san -config <(echo '[req]'; echo 'distinguished_name=req'; echo '[san]'; echo "subjectAltName=IP:${ha_backend_container1_ip},DNS:${ha_backend_container1_ip}")
+    openssl req -new -key $certdir/odfe-node.key -out $certdir/odfe-${ha_backend_container2}.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefnode' -extensions san -reqexts san -config <(echo '[req]'; echo 'distinguished_name=req'; echo '[san]'; echo "subjectAltName=IP:${ha_backend_container2_ip},DNS:${ha_backend_container2_ip}")
+
+    #Create the CSR and enter the organization and server details for the admin key
+    openssl req -new -key $certdir/odfe-admin.key -out $certdir/odfe-admin.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefadmin'
+
+    #Use the CSR to generate the signed node Certificate:
+    # openssl x509 -req -in $certdir/odfe-node.csr -CA $certdir/MyRootCA.pem -CAkey $certdir/MyRootCA.key -CAcreateserial -out $certdir/odfe-node.pem -sha256
+    openssl x509 -req -in $certdir/odfe-${ha_backend_container1}.csr -CA $certdir/MyRootCA.pem -CAkey $certdir/MyRootCA.key -CAcreateserial -out $certdir/odfe-${ha_backend_container1}.pem -sha256
+    openssl x509 -req -in $certdir/odfe-${ha_backend_container2}.csr -CA $certdir/MyRootCA.pem -CAkey $certdir/MyRootCA.key -CAcreateserial -out $certdir/odfe-${ha_backend_container2}.pem -sha256
+
+    #Use the CSR to generate the signed admin Certificate:
+    openssl x509 -req -in $certdir/odfe-admin.csr -CA $certdir/MyRootCA.pem -CAkey $certdir/MyRootCA.key -CAcreateserial -out $certdir/odfe-admin.pem -sha256
+
     local openssl_cnf
     openssl_cnf="$(hab pkg path core/openssl)/ssl/openssl.cnf"
     if [ ! -f "$openssl_cnf" ]; then
@@ -33,18 +71,11 @@ ha_backend_setup() {
         return 1
     fi
 
-    hab pkg exec core/openssl openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
-        -keyout $ha_backend_private/nginx-selfsigned.pem \
-        -out $ha_backend_private/nginx-selfsigned.crt \
-        -reqexts SAN -extensions SAN -subj '/CN=elasticsearch' \
-        -config \
-        <(cat "$openssl_cnf" \
-        <(printf "\n[SAN]\nsubjectAltName=IP.1:${ha_backend_container1_ip},IP.2:${ha_backend_container2_ip}"))
-
-    cp $HA_BACKEND_DIR/htpasswd $ha_backend_private
-
     docker cp "$HA_BACKEND_DIR/setup.sh" "${ha_backend_container1}:/setup.sh"
     docker cp "$HA_BACKEND_DIR/setup.sh" "${ha_backend_container2}:/setup.sh"
+    docker cp "$certdir" "${ha_backend_container1}:/certificates"
+    docker cp "$certdir" "${ha_backend_container2}:/certificates"
+
 
     docker exec -t $ha_backend_container1 /setup.sh "$ha_backend_container1_ip"
     docker exec -t $ha_backend_container2 /setup.sh "$ha_backend_container2_ip"
@@ -70,21 +101,22 @@ ha_backend_setup() {
         return 1
     fi
 
-    # This config is for ES SSL & Basic Auth.
-    # We can use it again once ha backend adds back support
-    # nodes = ["https://${ha_backend_container1_ip}:9200", "https://${ha_backend_container2_ip}:9200"]
-    # [global.v1.external.elasticsearch.auth]
-    # scheme = "basic_auth"
-    # [global.v1.external.elasticsearch.auth.basic_auth]
-    # username = "${HA_BACKEND_USER}"
-    # password = "${HA_BACKEND_PASSWORD}"
-    # [global.v1.external.elasticsearch.ssl]
-    # server_name = "elasticsearch"
-    # root_cert = """$(cat $ha_backend_private/nginx-selfsigned.crt)"""
     cat <<DOC > $ha_backend_config
 [global.v1.external.elasticsearch]
 enable = true
-nodes = ["http://${ha_backend_container1_ip}:9200", "http://${ha_backend_container2_ip}:9200"]
+nodes = ["https://${ha_backend_container1_ip}:9200", "https://${ha_backend_container2_ip}:9200"]
+
+[global.v1.external.elasticsearch.auth]
+scheme = "basic_auth"
+
+[global.v1.external.elasticsearch.auth.basic_auth]
+username = "${HA_BACKEND_USER}"
+password = "${HA_BACKEND_PASSWORD}"
+
+[global.v1.external.elasticsearch.ssl]
+# defaults from automate-ha-backend
+server_name = "chefnode"
+root_cert = """$(cat ${certdir}/MyRootCA.pem)"""
 
 [global.v1.external.postgresql]
 enable = true
@@ -109,8 +141,8 @@ enable = true
 DOC
 
     sleep 45
-    curl -k "http://${ha_backend_container1_ip}:9200"
-    curl -k "http://${ha_backend_container2_ip}:9200"
+    curl -u admin:admin --cacert "${certdir}/MyRootCA.pem" --key "${certdir}/odfe-admin.key" --cert "${certdir}/odfe-admin.pem" --resolve "chefnode:9200:${ha_backend_container1_ip}" "https://chefnode:9200"
+    curl -u admin:admin --cacert "${certdir}/MyRootCA.pem" --key "${certdir}/odfe-admin.key" --cert "${certdir}/odfe-admin.pem" --resolve "chefnode:9200:${ha_backend_container2_ip}" "https://chefnode:9200"
 }
 
 ha_backend_dump_logs() {
@@ -131,3 +163,4 @@ ha_backend_teardown() {
     docker stop "$ha_backend_container1"
     docker stop "$ha_backend_container2"
 }
+

--- a/integration/services/ha_backend/init
+++ b/integration/services/ha_backend/init
@@ -27,9 +27,9 @@ ha_backend_setup() {
     log_info "Launched $ha_backend_container2 with ip ${ha_backend_container2_ip}"
 
     echo "Generating elasticsearch ssl keys"
-    # ganked from a2-ha-backend
+
+    # copy-pasta'd from a2-ha-backend
     certdir="$HA_BACKEND_DIR/certificates"
-    echo "CERTDIR IS $certdir"
     mkdir -p $certdir
 
     RANDFILE=$certdir/.rnd
@@ -48,16 +48,13 @@ ha_backend_setup() {
     openssl pkcs8 -v1 "PBE-SHA1-3DES" -in "$certdir/odfe-admin-pkcs12.key" -topk8 -out "$certdir/odfe-admin.key" -nocrypt
 
     #Create the CSR and enter the organization and server details for the node key
-    # Need to create a key per machine, this is where you specify the SAN.
-    # openssl req -new -key $certdir/odfe-node.key -out $certdir/odfe-node.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefnode'
     openssl req -new -key $certdir/odfe-node.key -out $certdir/odfe-${ha_backend_container1}.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefnode' -extensions san -reqexts san -config <(echo '[req]'; echo 'distinguished_name=req'; echo '[san]'; echo "subjectAltName=IP:${ha_backend_container1_ip},DNS:${ha_backend_container1_ip}")
     openssl req -new -key $certdir/odfe-node.key -out $certdir/odfe-${ha_backend_container2}.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefnode' -extensions san -reqexts san -config <(echo '[req]'; echo 'distinguished_name=req'; echo '[san]'; echo "subjectAltName=IP:${ha_backend_container2_ip},DNS:${ha_backend_container2_ip}")
 
     #Create the CSR and enter the organization and server details for the admin key
     openssl req -new -key $certdir/odfe-admin.key -out $certdir/odfe-admin.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefadmin'
 
-    #Use the CSR to generate the signed node Certificate:
-    # openssl x509 -req -in $certdir/odfe-node.csr -CA $certdir/MyRootCA.pem -CAkey $certdir/MyRootCA.key -CAcreateserial -out $certdir/odfe-node.pem -sha256
+    #Use the CSR to generate the signed node Certificates:
     openssl x509 -req -in $certdir/odfe-${ha_backend_container1}.csr -CA $certdir/MyRootCA.pem -CAkey $certdir/MyRootCA.key -CAcreateserial -out $certdir/odfe-${ha_backend_container1}.pem -sha256
     openssl x509 -req -in $certdir/odfe-${ha_backend_container2}.csr -CA $certdir/MyRootCA.pem -CAkey $certdir/MyRootCA.key -CAcreateserial -out $certdir/odfe-${ha_backend_container2}.pem -sha256
 
@@ -85,7 +82,8 @@ ha_backend_setup() {
     for try in {1..60}; do
         echo "Trying to create dbuser"
         errcode="0"
-        output="$(docker exec --env PGPASSWORD="thisisapassword" $ha_backend_container1 hab pkg exec core/postgresql11 psql \
+        output="$(docker exec --env PGPASSWORD="thisisapassword" --env HAB_LICENSE=accept-no-persist $ha_backend_container1 \
+	hab pkg exec core/postgresql11 psql \
             -h 127.0.0.1 -p 7432 -U admin -d postgres -c \
             "CREATE USER dbuser WITH PASSWORD 'thisisapassword'")" || errcode="$?"
         if [ "$errcode" -eq "0" ]; then

--- a/integration/services/ha_backend/setup.sh
+++ b/integration/services/ha_backend/setup.sh
@@ -10,7 +10,7 @@ vm.dirty_ratio=20
 vm.dirty_background_ratio=30
 vm.dirty_expire_centisecs=30000
 net.ipv4.ip_local_port_range=1024 65024 net.ipv4.tcp_max_syn_backlog=60000
-# net.ipv4.tcp_tw_reuse=1
+net.ipv4.tcp_tw_reuse=1
 net.core.somaxconn=1024
 EOF
 
@@ -33,6 +33,7 @@ Description=Habitat-Supervisor
 After=network-online.target
 
 [Service]
+Environment=HAB_LICENSE=accept-no-persist
 Type=simple
 ExecStartPre=-/bin/rm -f /hab/sup/default/LOCK
 ExecStart=/bin/hab sup run --peer-watch-file /services/ha_backend_peers
@@ -46,11 +47,11 @@ WantedBy=multi-user.target
 EOF
 chmod 664 /etc/systemd/system/hab-sup.service
 
-# Just needs to be more recent that 0.75 to get nested config support
+# Needs to be at least 0.75 to get nested config support
 # for automate-ha-backend
 echo "Installing latest hab"
-hab pkg install core/hab/0.79.1
-hab pkg binlink core/hab --force
+HAB_LICENSE="accept-no-persist" hab pkg install core/hab
+HAB_LICENSE="accept-no-persist" hab pkg binlink core/hab --force
 
 echo "Starting Habitat"
 systemctl daemon-reload
@@ -67,10 +68,10 @@ proxy_pkg_ident="chef/automate-backend-haproxy"
 ELASTICSEARCH_PKG_NAME="automate-backend-elasticsearch"
 elasticsearch_pkg_ident="chef/automate-backend-elasticsearch"
 
-hab pkg install --channel ${channel} "${elasticsearch_pkg_ident}"
-hab pkg install --channel ${channel} "${proxy_pkg_ident}"
-hab pkg install --channel ${channel} "${pgleaderchk_pkg_ident}"
-hab pkg install --channel ${channel} "${postgresql_pkg_ident}"
+HAB_LICENSE="accept-no-persist" hab pkg install --channel ${channel} "${elasticsearch_pkg_ident}"
+HAB_LICENSE="accept-no-persist" hab pkg install --channel ${channel} "${proxy_pkg_ident}"
+HAB_LICENSE="accept-no-persist" hab pkg install --channel ${channel} "${pgleaderchk_pkg_ident}"
+HAB_LICENSE="accept-no-persist" hab pkg install --channel ${channel} "${postgresql_pkg_ident}"
 
 echo "Copying certs into place"
 hostname=`hostname`
@@ -121,8 +122,8 @@ password = 'thisisapassword'
 EOF
 
 echo "Starting HA Backend Habitat services"
-hab svc load ${postgresql_pkg_ident} --topology leader --channel ${channel}
-hab svc load ${pgleaderchk_pkg_ident} --topology leader --bind database:"$PG_PKG_NAME".default --binding-mode=relaxed --channel ${channel}
-hab svc load ${proxy_pkg_ident} --topology leader --bind database:"$PG_PKG_NAME".default --bind pgleaderchk:"$PGLEADERCHK_PKG_NAME".default --binding-mode=relaxed --channel ${channel}
-hab svc load ${elasticsearch_pkg_ident} --topology leader --bind elasticsearch:"$ELASTICSEARCH_PKG_NAME".default --binding-mode=relaxed --channel ${channel}
+HAB_LICENSE="accept-no-persist" hab svc load ${postgresql_pkg_ident} --topology leader --channel ${channel}
+HAB_LICENSE="accept-no-persist" hab svc load ${pgleaderchk_pkg_ident} --topology leader --bind database:"$PG_PKG_NAME".default --binding-mode=relaxed --channel ${channel}
+HAB_LICENSE="accept-no-persist" hab svc load ${proxy_pkg_ident} --topology leader --bind database:"$PG_PKG_NAME".default --bind pgleaderchk:"$PGLEADERCHK_PKG_NAME".default --binding-mode=relaxed --channel ${channel}
+HAB_LICENSE="accept-no-persist" hab svc load ${elasticsearch_pkg_ident} --topology leader --bind elasticsearch:"$ELASTICSEARCH_PKG_NAME".default --binding-mode=relaxed --channel ${channel}
 

--- a/integration/services/ha_backend/setup.sh
+++ b/integration/services/ha_backend/setup.sh
@@ -10,7 +10,7 @@ vm.dirty_ratio=20
 vm.dirty_background_ratio=30
 vm.dirty_expire_centisecs=30000
 net.ipv4.ip_local_port_range=1024 65024 net.ipv4.tcp_max_syn_backlog=60000
-net.ipv4.tcp_tw_reuse=1
+# net.ipv4.tcp_tw_reuse=1
 net.core.somaxconn=1024
 EOF
 
@@ -46,6 +46,12 @@ WantedBy=multi-user.target
 EOF
 chmod 664 /etc/systemd/system/hab-sup.service
 
+# Just needs to be more recent that 0.75 to get nested config support
+# for automate-ha-backend
+echo "Installing latest hab"
+hab pkg install core/hab/0.79.1
+hab pkg binlink core/hab --force
+
 echo "Starting Habitat"
 systemctl daemon-reload
 systemctl enable hab-sup.service
@@ -54,20 +60,23 @@ systemctl start hab-sup.service
 echo "Installing HA Backend Habitat packages"
 channel="unstable"
 PG_PKG_NAME="automate-backend-postgresql"
-postgresql_pkg_ident="chef/$PG_PKG_NAME/0.1.80/20190424185119"
+postgresql_pkg_ident="chef/$PG_PKG_NAME"
 PGLEADERCHK_PKG_NAME="automate-backend-pgleaderchk"
-pgleaderchk_pkg_ident="chef/$PGLEADERCHK_PKG_NAME/0.1.80/20190424185119"
-proxy_pkg_ident="chef/automate-backend-haproxy/0.1.80/20190424185049"
+pgleaderchk_pkg_ident="chef/$PGLEADERCHK_PKG_NAME"
+proxy_pkg_ident="chef/automate-backend-haproxy"
 ELASTICSEARCH_PKG_NAME="automate-backend-elasticsearch"
-elasticsearch_pkg_ident="chef/automate-backend-elasticsearch/0.1.80/20190424185049"
-NGINX_PKG_NAME="automate-backend-nginx"
-nginx_pkg_ident="chef/$NGINX_PKG_NAME/0.1.80/20190424185119"
+elasticsearch_pkg_ident="chef/automate-backend-elasticsearch"
 
 hab pkg install --channel ${channel} "${elasticsearch_pkg_ident}"
 hab pkg install --channel ${channel} "${proxy_pkg_ident}"
 hab pkg install --channel ${channel} "${pgleaderchk_pkg_ident}"
 hab pkg install --channel ${channel} "${postgresql_pkg_ident}"
-hab pkg install --channel ${channel} "${nginx_pkg_ident}"
+
+echo "Copying certs into place"
+hostname=`hostname`
+
+# copy the certs to the correct names
+mv /certificates/odfe-$hostname.pem /certificates/odfe-node.pem
 
 echo "Configuring HA Backend Services"
 mkdir -p "/hab/user/${ELASTICSEARCH_PKG_NAME}/config/"
@@ -76,7 +85,7 @@ cat > "/hab/user/${ELASTICSEARCH_PKG_NAME}/config/user.toml" <<EOF
 es_java_opts = "-Xms1024m -Xmx1024m"
 
 [es_yaml.network]
-host = "_local_"
+host = "0.0.0.0"
 
 [es_yaml.transport]
 host = "_site_"
@@ -90,17 +99,20 @@ hosts = ["$(cat /services/ha_backend_peers | head -n 1)"]
 low = "95%"
 high = "98%"
 flood_stage = "99%"
-EOF
 
-mkdir -p "/hab/user/${NGINX_PKG_NAME}/config/"
-cat > "/hab/user/${NGINX_PKG_NAME}/config/user.toml" <<EOF
-listen_ip = "$1"
-system_fqdn = "elasticsearch"
-client_max_body_size = 250
-EOF
+[opendistro_ssl]
 
-cp /services/ha_backend_private/htpasswd /hab/user/"$NGINX_PKG_NAME"/config/.elasticsearch_htpasswd
-cp /services/ha_backend_private/nginx-selfsigned* /hab/user/"$NGINX_PKG_NAME"/config/
+# root pem cert that signed the two cert/key pairs below
+rootCA = """$(cat /certificates/MyRootCA.pem)"""
+
+# Certificate used for admin actions against https://9200
+admin_cert   = """$(cat /certificates/odfe-admin.pem)"""
+admin_key    = """$(cat /certificates/odfe-admin.key)"""
+
+# Certificate used for intracluster ssl on port 9300
+ssl_cert    = """$(cat /certificates/odfe-node.pem)"""
+ssl_key     = """$(cat /certificates/odfe-node.key)"""
+EOF
 
 mkdir -p "/hab/user/${PG_PKG_NAME}/config/"
 cat > "/hab/user/${PG_PKG_NAME}/config/user.toml" <<EOF
@@ -108,11 +120,9 @@ cat > "/hab/user/${PG_PKG_NAME}/config/user.toml" <<EOF
 password = 'thisisapassword'
 EOF
 
-
-
 echo "Starting HA Backend Habitat services"
 hab svc load ${postgresql_pkg_ident} --topology leader --channel ${channel}
 hab svc load ${pgleaderchk_pkg_ident} --topology leader --bind database:"$PG_PKG_NAME".default --binding-mode=relaxed --channel ${channel}
 hab svc load ${proxy_pkg_ident} --topology leader --bind database:"$PG_PKG_NAME".default --bind pgleaderchk:"$PGLEADERCHK_PKG_NAME".default --binding-mode=relaxed --channel ${channel}
-hab svc load ${elasticsearch_pkg_ident} --topology leader --bind elasticsearch:"$ELASTICSEARCH_PKG_NAME".default --binding-mode=relaxed --channel ${channel} 
-hab svc load ${nginx_pkg_ident} --channel ${channel}
+hab svc load ${elasticsearch_pkg_ident} --topology leader --bind elasticsearch:"$ELASTICSEARCH_PKG_NAME".default --binding-mode=relaxed --channel ${channel}
+


### PR DESCRIPTION
### :nut_and_bolt: Description
This at least gets us back to exercising the current automate-ha-backend packages.

For elasticsearch auth, we are no longer using nginx for elasticsearch auth, and we are generating certs for use with automate-backend-elasticsearch. Also, we are using a recent hab in the backend containers to get the nested config feature added in 0.75.

Signed-off-by: Yvonne Lam <yvonne@chef.io>

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
