### PR TITLE
Adds missing feature flag to enable EAS Dashboard

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/main.tf
+++ b/terraform/test-environments/modules/chef_automate_install/main.tf
@@ -209,6 +209,7 @@ EOF
   [gateway.v1.sys]
     [gateway.v1.sys.service]
       trial_license_url = "https://licensing-${var.channel}.chef.io/create-trial"
+      enable_apps_feature = ${var.enable_eas_dashboard}
 
 [event_gateway.v1]
   [event_gateway.v1.sys]


### PR DESCRIPTION
This is the missing feature flag: https://github.com/chef/automate/blob/master/api/config/gateway/config_request.proto#L38

I tested this time the change manually on the server to verify it works and after running the installation module from terraform it worked just fine, you can even visualize data in the Applications Tabs:

<img width="1443" alt="Screen Shot 2019-05-01 at 9 37 29 PM" src="https://user-images.githubusercontent.com/5712253/57054320-7b6ad980-6c59-11e9-8e01-c188831aa039.png">

Signed-off-by: Salim Afiune <afiune@chef.io>
