### PR TITLE
Trigger replication notification of authz policies

### DIFF
--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -78,7 +78,10 @@ func NewPoliciesServer(
 	pl storage_v1.PoliciesLister,
 	vChan chan api.Version) (PolicyServer, error) {
 
-	policyRefresher := NewPolicyRefresher(ctx, l, s, e)
+	policyRefresher, err := NewPolicyRefresher(ctx, l, s, e)
+	if err != nil {
+		return nil, errors.Wrap(err, "start policy refresher")
+	}
 
 	srv := &policyServer{
 		log:             l,

--- a/components/authz-service/storage/v2/memstore/memstore.go
+++ b/components/authz-service/storage/v2/memstore/memstore.go
@@ -10,10 +10,12 @@ import (
 	v2_constants "github.com/chef/automate/components/authz-service/constants/v2"
 	storage_errors "github.com/chef/automate/components/authz-service/storage"
 	storage "github.com/chef/automate/components/authz-service/storage/v2"
+	v2 "github.com/chef/automate/components/authz-service/storage/v2"
 )
 
 type State struct {
 	policyChangeID int64 // DO NOT MOVE, must be 64-bit aligned for atomic increment
+	changeManager  *policyChangeNotifierManager
 	policies       *cache.Cache
 	roles          *cache.Cache
 	projects       *cache.Cache
@@ -28,12 +30,14 @@ func New() *State {
 		roles:          cache.New(cache.NoExpiration, -1),
 		projects:       cache.New(cache.NoExpiration, -1),
 		policyChangeID: 0,
+		changeManager:  newPolicyChangeNotifierManager(),
 	}
 	return s
 }
 
 func (s *State) bumpPolicyVersion() {
 	atomic.AddInt64(&s.policyChangeID, int64(1))
+	s.changeManager.notifyChange()
 }
 
 func (s *State) CreatePolicy(_ context.Context, inputPol *storage.Policy) (*storage.Policy, error) {
@@ -229,6 +233,11 @@ func (s *State) DeletePolicy(ctx context.Context, policyID string) error {
 
 func (s *State) GetPolicyChangeID(_ context.Context) (string, error) {
 	return string(atomic.LoadInt64(&s.policyChangeID)), nil
+}
+
+func (s *State) GetPolicyChangeNotifier(ctx context.Context) (v2.PolicyChangeNotifier, error) {
+	notifier := s.changeManager.register()
+	return notifier, nil
 }
 
 func (s *State) CreateProject(_ context.Context, project *storage.Project) (*storage.Project, error) {

--- a/components/authz-service/storage/v2/memstore/policy_change_notifier.go
+++ b/components/authz-service/storage/v2/memstore/policy_change_notifier.go
@@ -1,0 +1,54 @@
+package memstore
+
+import (
+	"sync"
+
+	v2 "github.com/chef/automate/components/authz-service/storage/v2"
+)
+
+type policyChangeNotifierManager struct {
+	lock     sync.Mutex
+	channels []*policyChangeNotifier
+}
+
+type policyChangeNotifier struct {
+	manager *policyChangeNotifierManager
+	c       chan v2.PolicyChangeNotification
+}
+
+func newPolicyChangeNotifierManager() *policyChangeNotifierManager {
+	return &policyChangeNotifierManager{}
+}
+
+func (manager *policyChangeNotifierManager) notifyChange() {
+	manager.lock.Lock()
+	defer manager.lock.Unlock()
+
+	for _, c := range manager.channels {
+		select {
+		case c.c <- v2.PolicyChangeNotification{}:
+		default:
+		}
+	}
+}
+
+func (manager *policyChangeNotifierManager) register() *policyChangeNotifier {
+	manager.lock.Lock()
+	defer manager.lock.Unlock()
+
+	c := &policyChangeNotifier{
+		c:       make(chan v2.PolicyChangeNotification, 1),
+		manager: manager,
+	}
+	manager.channels = append(manager.channels, c)
+	return c
+}
+
+func (*policyChangeNotifier) Close() error {
+	// This is test code, don't need to worry about cleanin stuff up
+	return nil
+}
+
+func (p *policyChangeNotifier) C() <-chan v2.PolicyChangeNotification {
+	return p.c
+}

--- a/components/authz-service/storage/v2/postgres/policy_change_notifier.go
+++ b/components/authz-service/storage/v2/postgres/policy_change_notifier.go
@@ -1,0 +1,77 @@
+package postgres
+
+import (
+	"context"
+	"time"
+
+	v2 "github.com/chef/automate/components/authz-service/storage/v2"
+	"github.com/lib/pq"
+	"github.com/sirupsen/logrus"
+)
+
+type policyChangeNotifier struct {
+	conninfo             string
+	minReconnectInterval time.Duration
+	maxReconnectInterval time.Duration
+	pingInterval         time.Duration
+	notificationChan     chan v2.PolicyChangeNotification
+	shutdown             func()
+}
+
+func newPolicyChangeNotifier(ctx context.Context, conninfo string) (v2.PolicyChangeNotifier, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	p := &policyChangeNotifier{
+		conninfo:             conninfo,
+		minReconnectInterval: 10 * time.Second,
+		maxReconnectInterval: time.Minute,
+		pingInterval:         10 * time.Second,
+		notificationChan:     make(chan v2.PolicyChangeNotification, 1),
+		shutdown:             cancel,
+	}
+	listener := pq.NewListener(p.conninfo, p.minReconnectInterval, p.maxReconnectInterval, nil)
+	err := listener.Listen("policychange")
+	if err != nil {
+		return nil, err
+	}
+
+	go p.run(ctx, listener)
+	return p, nil
+}
+
+func (p *policyChangeNotifier) C() <-chan v2.PolicyChangeNotification {
+	return p.notificationChan
+}
+
+func (p *policyChangeNotifier) Close() error {
+	p.shutdown()
+	return nil
+}
+
+func (p *policyChangeNotifier) run(ctx context.Context, listener *pq.Listener) {
+
+RUNLOOP:
+	for {
+		select {
+		case <-ctx.Done():
+			break RUNLOOP
+		case n := <-listener.Notify:
+			if n == nil {
+				continue
+			}
+			select {
+			case p.notificationChan <- v2.PolicyChangeNotification{}:
+				logrus.Info("Accepted notification from postgres")
+			default:
+				logrus.Debug("Notification listener mailbox full")
+			}
+		case <-time.After(p.pingInterval):
+			err := listener.Ping()
+			if err != nil {
+				logrus.WithError(err).Warn("Notification listener failed to ping database")
+			}
+		}
+	}
+	if err := listener.Close(); err != nil {
+		logrus.WithError(err).Warn("Failed to close notification listener")
+	}
+}

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -23,7 +23,7 @@ type pg struct {
 	db          *sql.DB
 	logger      logger.Logger
 	dataMigConf datamigration.Config
-	connInfo    string
+	conninfo    string
 }
 
 // New instantiates the postgres storage backend.
@@ -37,7 +37,7 @@ func New(ctx context.Context, l logger.Logger, migConf migration.Config,
 		return nil, err
 	}
 
-	return &pg{db: db, logger: l, dataMigConf: dataMigConf, connInfo: migConf.PGURL.String()}, nil
+	return &pg{db: db, logger: l, dataMigConf: dataMigConf, conninfo: migConf.PGURL.String()}, nil
 }
 
 type Querier interface {
@@ -322,7 +322,7 @@ func (p *pg) GetPolicyChangeID(ctx context.Context) (string, error) {
 }
 
 func (p *pg) GetPolicyChangeNotifier(ctx context.Context) (v2.PolicyChangeNotifier, error) {
-	return newPolicyChangeNotifier(ctx, p.connInfo)
+	return newPolicyChangeNotifier(ctx, p.conninfo)
 }
 
 // insertPolicyWithQuerier inserts a new custom policy. It does not return the

--- a/components/authz-service/storage/v2/storage.go
+++ b/components/authz-service/storage/v2/storage.go
@@ -24,6 +24,13 @@ type Storage interface {
 	MigrationStatusProvider
 }
 
+type PolicyChangeNotification struct{}
+
+type PolicyChangeNotifier interface {
+	C() <-chan PolicyChangeNotification
+	Close() error
+}
+
 type policyStorage interface {
 	ReplacePolicyMembers(context.Context, string, []Member) ([]Member, error)
 	RemovePolicyMembers(context.Context, string, []Member) ([]Member, error)
@@ -41,6 +48,7 @@ type policyStorage interface {
 	PurgeSubjectFromPolicies(ctx context.Context, subject string) ([]string, error)
 
 	GetPolicyChangeID(context.Context) (string, error)
+	GetPolicyChangeNotifier(context.Context) (PolicyChangeNotifier, error)
 }
 
 type roleStorage interface {


### PR DESCRIPTION
This PR uses postgres' LISTEN/NOTIFY feature to notify all authz nodes
to of changes to the policies. This makes the replication start almost
instantaneously, for sure faster that the 10 second anti entropy timer
we have right now.
