### PR TITLE
Unlock staging area after hab builds are complete

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -132,6 +132,9 @@ subscriptions:
           post_commit: true
           only_if_modified:
             - components/chef-ui-library/*
+  # If a build in the habitat/build pipeline fails, unlock the staging area
+  - workload: buildkite_build_failed:{{agent_id}}:habitat/build:*
+    actions:
       - unlock_staging_area:post_merge:
           post_commit: true
           always_run: true
@@ -147,6 +150,9 @@ subscriptions:
           post_commit: true
       - bash:.expeditor/purge-cdn.sh:
           post_commit: true
+      - unlock_staging_area:post_merge:
+          post_commit: true
+          always_run: true
   # Update our compliance-profile pinnings when new profiles are released
   - workload: hab_package_published:unstable:chef/automate-compliance-profiles/*
     actions:


### PR DESCRIPTION
Improve the Expeditor logic to ensure that we're only building one set of packages at a time. 

### :nut_and_bolt: Description

* Unlock staging area if habitat build fails
* Unlock staging area after promotion if build succeeds

Signed-off-by: Tom Duffield <tom@chef.io>

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
