### PR TITLE
Temporarily disable smart builds until bldr_channel issues are addressed

### DIFF
--- a/.expeditor/build.habitat.yml
+++ b/.expeditor/build.habitat.yml
@@ -1,6 +1,7 @@
 ---
 origin: chef
-smart_build: true
+# Disabling smart build until multi-bldr channel issues can be addressed
+smart_build: false
 studio_secrets:
   GITHUB_TOKEN:
     account: github/chef-ci


### PR DESCRIPTION


### :nut_and_bolt: Description

By default, habitat looks in HAB_BLDR_CHANNEL and then stable when
attempting to find package dependencies. What we need to be able to do
is specify a list of channels (i.e. bldr-*,dev,stable).

Signed-off-by: Tom Duffield <tom@chef.io>

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
