### PR TITLE
[A2-779] Projects filter refinement

### DIFF
--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -6,7 +6,7 @@ import { orderBy } from 'lodash/fp';
 
 import { Project, ProjectConstants } from 'app/entities/projects/project.model';
 
-const UNASSIGNED_PROJECT_ID = ProjectConstants.UNASSIGNED_PROJECT_ID;
+const { UNASSIGNED_PROJECT_ID } = ProjectConstants;
 
 @Component({
   selector: 'app-projects-dropdown',

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -4,9 +4,9 @@ import {
 
 import { orderBy } from 'lodash/fp';
 
-import { Project } from 'app/entities/projects/project.model';
+import { Project, ProjectConstants } from 'app/entities/projects/project.model';
 
-const UNASSIGNED_LABEL = '(unassigned)';
+const UNASSIGNED_PROJECT_ID = ProjectConstants.UNASSIGNED_PROJECT_ID;
 
 @Component({
   selector: 'app-projects-dropdown',
@@ -31,7 +31,7 @@ export class ProjectsDropdownComponent implements OnInit {
 
   active = false;
   showError = false;
-  label = UNASSIGNED_LABEL;
+  label = UNASSIGNED_PROJECT_ID;
 
   // Map of projects currently selected
   selectedProjects = {};
@@ -109,7 +109,7 @@ export class ProjectsDropdownComponent implements OnInit {
         break;
       }
       case 0: {
-        this.label = UNASSIGNED_LABEL;
+        this.label = UNASSIGNED_PROJECT_ID;
         break;
       }
       default: {

--- a/components/automate-ui/src/app/entities/projects/project.model.ts
+++ b/components/automate-ui/src/app/entities/projects/project.model.ts
@@ -5,3 +5,11 @@ export interface Project {
   name: string;
   type: IAMType;
 }
+
+export class ProjectConstants {
+  static readonly UNASSIGNED_PROJECT_ID = '(unassigned)';
+  static readonly UNASSIGNED_PROJECT_LABEL = 'Unassigned resources';
+  static readonly ALL_RESOURCES_LABEL = 'All resources';
+  static readonly ALL_PROJECTS_LABEL = 'All projects';
+  static readonly MULTIPLE_PROJECTS_LABEL = 'Multiple projects';
+}

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -8,7 +8,7 @@
     [ngClass]="{'active': selectionCountActive }">
     {{ selectionCount }}
   </span>
-  <chef-icon *ngIf="this.editableOptions.length > 1" aria-hidden>keyboard_arrow_down</chef-icon>
+  <chef-icon *ngIf="dropdownCaretVisible" aria-hidden>keyboard_arrow_down</chef-icon>
 </button>
 <chef-dropdown class="dropdown" *ngIf="dropdownActive" (keydown.esc)="handleEscape()">
   <chef-click-outside class="dropdown-body" omit="dropdown-label" (clickOutside)="handleEscape()">

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -8,7 +8,7 @@
     [ngClass]="{'active': selectionCountActive }">
     {{ selectionCount }}
   </span>
-  <chef-icon aria-hidden>keyboard_arrow_down</chef-icon>
+  <chef-icon *ngIf="this.editableOptions.length > 1" aria-hidden>keyboard_arrow_down</chef-icon>
 </button>
 <chef-dropdown class="dropdown" *ngIf="dropdownActive" (keydown.esc)="handleEscape()">
   <chef-click-outside class="dropdown-body" omit="dropdown-label" (clickOutside)="handleEscape()">

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -1,7 +1,7 @@
 <button class="dropdown-label"
   aria-label="Projects filter"
   [attr.title]="selectionLabel"
-  [attr.tabindex]="dropdownCaretVisible? 0 : -1"
+  [disabled]="!dropdownCaretVisible"
   (click)="handleLabelClick()">
   <span class="selection-label">{{ selectionLabel }}</span>
   <span class="selection-count"

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -1,6 +1,7 @@
 <button class="dropdown-label"
   aria-label="Projects filter"
   [attr.title]="selectionLabel"
+  [attr.tabindex]="dropdownCaretVisible? 0 : -1"
   (click)="handleLabelClick()">
   <span class="selection-label">{{ selectionLabel }}</span>
   <span class="selection-count"

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -20,6 +20,11 @@
   background: transparent;
   font-weight: 600;
 
+  // seems to be needed only for Safari
+  &:active {
+    color: $chef-primary-dark;
+  }
+
   > chef-icon {
     font-size: 16px;
     color: $chef-primary-dark;

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -20,6 +20,10 @@
   background: transparent;
   font-weight: 600;
 
+  &:disabled {
+    color: $chef-primary-dark;
+  }
+
   // seems to be needed only for Safari
   &:active {
     color: $chef-primary-dark;

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -32,6 +32,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    line-height: normal; // solves descender clipping due to overflow: hidden
   }
 
   .selection-count {

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -18,6 +18,8 @@ export class ProjectsFilterDropdownComponent implements OnChanges {
 
   @Input() selectionCountActive = false;
 
+  @Input() dropdownCaretVisible = false;
+
   @Output() onSelection = new EventEmitter<ProjectsFilterOption[]>();
 
   editableOptions: ProjectsFilterOption[] = [];

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -31,17 +31,16 @@ describe('ProjectsFilterDropdownComponent', () => {
       component.selectionCountVisible = true;
       component.selectionCountActive = true;
       fixture.detectChanges();
-
-      label = fixture.nativeElement.querySelector('.dropdown-label');
-      count = fixture.nativeElement.querySelector('.selection-count');
     });
 
     it('displays label text', () => {
+      label = fixture.nativeElement.querySelector('.dropdown-label');
       expect(label).not.toBeNull();
       expect(label.textContent.trim()).toContain(component.selectionLabel);
     });
 
     it('has an "aria-label"', () => {
+      label = fixture.nativeElement.querySelector('.dropdown-label');
       expect(label.getAttribute('aria-label')).toEqual('Projects filter');
     });
 
@@ -49,10 +48,10 @@ describe('ProjectsFilterDropdownComponent', () => {
       beforeEach(() => {
         component.selectionCountVisible = false;
         fixture.detectChanges();
-        count = fixture.nativeElement.querySelector('.selection-count');
       });
 
       it('the selection count is hidden', () => {
+        count = fixture.nativeElement.querySelector('.selection-count');
         expect(count).toBeNull();
       });
     });
@@ -64,6 +63,7 @@ describe('ProjectsFilterDropdownComponent', () => {
       });
 
       it('the selection count is visible', () => {
+        count = fixture.nativeElement.querySelector('.selection-count');
         expect(count).not.toBeNull();
         expect(count.textContent.trim()).toEqual(component.selectionCount.toString());
       });
@@ -76,6 +76,7 @@ describe('ProjectsFilterDropdownComponent', () => {
       });
 
       it('the selection count does not have an "active" className', () => {
+        count = fixture.nativeElement.querySelector('.selection-count');
         expect(count.classList.contains('active')).toEqual(false);
       });
     });
@@ -87,6 +88,7 @@ describe('ProjectsFilterDropdownComponent', () => {
       });
 
       it('the selection count has an "active" className', () => {
+        count = fixture.nativeElement.querySelector('.selection-count');
         expect(count.classList.contains('active')).toEqual(true);
       });
     });
@@ -180,12 +182,26 @@ describe('ProjectsFilterDropdownComponent', () => {
 
   describe('resetOptions()', () => {
     beforeEach(() => {
+      component.options = [
+        {
+          value: 'project-1',
+          label: 'Project 1',
+          checked: false
+        },
+        {
+          value: 'project-2',
+          label: 'Project 2',
+          checked: true
+        }
+      ];
       component.editableOptions = [];
       component.optionsEdited = true;
+
       component.resetOptions();
     });
 
     it('resets any previous selection changes by copying the provided options', () => {
+      expect(component.editableOptions).not.toEqual([]);
       expect(component.editableOptions).not.toBe(component.options);
       expect(component.editableOptions).toEqual(component.options);
     });

--- a/components/automate-ui/src/app/page-components/projects-filter/projects-filter.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter/projects-filter.component.html
@@ -4,5 +4,6 @@
   [selectionCount]="projectsFilter.selectionCount$ | async"
   [selectionCountVisible]="projectsFilter.selectionCountVisible$ | async"
   [selectionCountActive]="projectsFilter.selectionCountActive$ | async"
+  [dropdownCaretVisible]="projectsFilter.dropdownCaretVisible$ | async"
   (onSelection)="projectsFilter.saveOptions($event)">
 </app-projects-filter-dropdown>

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.actions.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.actions.ts
@@ -1,6 +1,6 @@
 import { Action } from '@ngrx/store';
 import { HttpErrorResponse } from '@angular/common/http';
-import { ProjectsFilterOption } from './projects-filter.reducer';
+import { ProjectsFilterOption, ProjectsFilterOptionTuple } from './projects-filter.reducer';
 
 export enum ProjectsFilterActionTypes {
   LOAD_OPTIONS         = 'PROJECTS_FILTER::LOAD_OPTIONS',
@@ -15,7 +15,7 @@ export class LoadOptions implements Action {
 
 export class LoadOptionsSuccess implements Action {
   readonly type = ProjectsFilterActionTypes.LOAD_OPTIONS_SUCCESS;
-  constructor(public payload: ProjectsFilterOption[]) { }
+  constructor(public payload: ProjectsFilterOptionTuple) { }
 }
 
 export class LoadOptionsFailure implements Action {

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
@@ -3,7 +3,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { of as observableOf } from 'rxjs';
 import { switchMap, catchError, map, tap } from 'rxjs/operators';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { ProjectsFilterOption } from './projects-filter.reducer';
+import { ProjectsFilterOption, ProjectsFilterOptionTuple } from './projects-filter.reducer';
 import { ProjectsFilterService } from './projects-filter.service';
 import {
   ProjectsFilterActionTypes,
@@ -27,11 +27,10 @@ export class ProjectsFilterEffects {
       return this.projectsFilter.fetchOptions().pipe(
         map((fetched: ProjectsFilterOption[]) => {
           const restored = this.projectsFilter.restoreOptions() || [];
-          const loaded = fetched.map(fetchedOpt => {
-            const restoredOpt = restored.filter(opt => opt.value === fetchedOpt.value)[0];
-            return restoredOpt ? { ...fetchedOpt, checked: restoredOpt.checked } : fetchedOpt;
+          return new LoadOptionsSuccess(<ProjectsFilterOptionTuple>{
+            fetched: fetched,
+            restored: restored
           });
-          return new LoadOptionsSuccess(loaded);
         }),
         catchError((error: HttpErrorResponse) => observableOf(new LoadOptionsFailure(error))));
     }));

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
@@ -89,8 +89,9 @@ describe('projectsFilterReducer', () => {
         expect(selectionCountVisible).toBe(false);
       });
 
-      // TODO
       it('does not display caret to open dropdown', () => {
+        const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+        expect(dropdownCaretVisible).toBe(false);
       });
     });
 
@@ -110,14 +111,13 @@ describe('projectsFilterReducer', () => {
         expect(selectionCountVisible).toBe(false);
       });
 
-      // TODO
       it('does not display caret to open dropdown', () => {
+        const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+        expect(dropdownCaretVisible).toBe(false);
       });
     });
 
     describe('with exactly one project plus unassigned allowed', () => {
-
-      // TODO: Also check that every case displays the caret to open dropdown
 
       describe('when nothing is selected', () => {
         const payload: ProjectsFilterOption[] = [
@@ -134,6 +134,11 @@ describe('projectsFilterReducer', () => {
         it('displays no count badge', () => {
           const { selectionCountVisible } = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(false);
+        });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
         });
       });
 
@@ -153,6 +158,11 @@ describe('projectsFilterReducer', () => {
           const { selectionCountVisible } = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(false);
         });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
+        });
       });
 
       describe('when only unassigned is selected', () => {
@@ -170,6 +180,11 @@ describe('projectsFilterReducer', () => {
           const { selectionCountVisible } = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(false);
         });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
+        });
       });
 
       describe('selecting project and selecting unassigned', () => {
@@ -186,6 +201,11 @@ describe('projectsFilterReducer', () => {
         it('displays no count badge', () => {
           const { selectionCountVisible } = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(false);
+        });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
         });
       });
     });
@@ -213,6 +233,11 @@ describe('projectsFilterReducer', () => {
           const { selectionCountVisible } = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(false);
         });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
+        });
       });
 
       describe('when single project is selected', () => {
@@ -234,6 +259,11 @@ describe('projectsFilterReducer', () => {
           const { selectionCountVisible } = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(false);
         });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
+        });
       });
 
       describe('when only unassigned is selected', () => {
@@ -254,6 +284,11 @@ describe('projectsFilterReducer', () => {
           const { selectionCountVisible } = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(false);
         });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
+        });
       });
 
       describe('selecting single project and selecting unassigned', () => {
@@ -273,6 +308,11 @@ describe('projectsFilterReducer', () => {
         it('displays no count badge', () => {
           const { selectionCountVisible } = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(false);
+        });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
         });
       });
 
@@ -297,6 +337,11 @@ describe('projectsFilterReducer', () => {
           expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
           expect(selectionCount).toEqual(payload.filter(p => p.checked).length);
         });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
+        });
       });
 
       describe('selecting multiple but not all projects and selecting unassigned', () => {
@@ -319,6 +364,11 @@ describe('projectsFilterReducer', () => {
           expect(selectionCountVisible).toBe(true);
           expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
           expect(selectionCount).toEqual(payload.filter(p => p.checked).length - 1);
+        });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
         });
       });
 
@@ -343,6 +393,11 @@ describe('projectsFilterReducer', () => {
           expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
           expect(selectionCount).toEqual(payload.filter(p => p.checked).length);
         });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
+        });
       });
 
       describe('selecting all projects and selecting unassigned', () => {
@@ -362,6 +417,11 @@ describe('projectsFilterReducer', () => {
         it('displays no count badge', () => {
           const { selectionCountVisible } = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(false);
+        });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
         });
       });
     });
@@ -391,6 +451,11 @@ describe('projectsFilterReducer', () => {
           expect(selectionCountActive).toBe(BADGE_GREY_STATE);
           expect(selectionCount).toEqual(payload.length);
         });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
+        });
       });
 
       describe('when single project is selected', () => {
@@ -410,6 +475,11 @@ describe('projectsFilterReducer', () => {
         it('displays no count badge', () => {
           const { selectionCountVisible } = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(false);
+        });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
         });
       });
 
@@ -433,6 +503,11 @@ describe('projectsFilterReducer', () => {
           expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
           expect(selectionCount).toEqual(payload.filter(p => p.checked).length);
         });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
+        });
       });
 
       describe('selecting all projects', () => {
@@ -454,6 +529,11 @@ describe('projectsFilterReducer', () => {
           expect(selectionCountVisible).toBe(true);
           expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
           expect(selectionCount).toEqual(payload.filter(p => p.checked).length);
+        });
+
+        it('displays caret to open dropdown', () => {
+          const { dropdownCaretVisible } = projectsFilterReducer(initialState, action);
+          expect(dropdownCaretVisible).toBe(true);
         });
       });
     });

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
@@ -9,7 +9,14 @@ import {
 } from './projects-filter.reducer';
 import { LoadOptions, LoadOptionsSuccess } from './projects-filter.actions';
 
+// TODO Get these from reducer.ts
 const UNASSIGNED_PROJECT = '(unassigned)';
+const UNASSIGNED_PROJECT_LABEL = 'Unassigned resources';
+const ALL_RESOURCES_LABEL = 'All resources';
+const ALL_PROJECTS_LABEL = 'All projects';
+const MULTIPLE_PROJECTS_LABEL = 'Multiple projects';
+const BADGE_GREY_STATE = false;
+const BADGE_BLUE_STATE = true;
 
 describe('projectsFilterReducer', () => {
   const initialState: ProjectsFilterState = projectsFilterInitialState;
@@ -30,7 +37,9 @@ describe('projectsFilterReducer', () => {
         genProject('p1', false)
       ];
       const action = new LoadOptionsSuccess(payload);
+
       const { optionsLoadingStatus } = projectsFilterReducer(initialState, action);
+
       expect(optionsLoadingStatus).toEqual(EntityStatus.loadingSuccess);
     });
 
@@ -42,65 +51,142 @@ describe('projectsFilterReducer', () => {
         genProject('a-proj', false)
       ];
       const action = new LoadOptionsSuccess(payload);
+
       const { options } = projectsFilterReducer(initialState, action);
+
       expect(map('label', options)).toEqual(['a-proj', 'b-proj', 'c-proj', 'd-proj']);
     });
 
     it('with unassigned, sorts projects except unassigned at bottom when storing them', () => {
       const payload: ProjectsFilterOption[] = [
         genProject('d-proj', false),
-        <ProjectsFilterOption>{
-          label: 'Unassigned resources',
-          checked: true,
-          value: UNASSIGNED_PROJECT
-        },
+        genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
         genProject('b-proj', false),
         genProject('zz-proj', false),
         genProject('a-proj', false)
       ];
       const action = new LoadOptionsSuccess(payload);
+
       const { options } = projectsFilterReducer(initialState, action);
+
       expect(map('value', options))
         .toEqual(['a-proj', 'b-proj', 'd-proj', 'zz-proj', UNASSIGNED_PROJECT]);
     });
 
     describe('with exactly one allowed project', () => {
+      const payload: ProjectsFilterOption[] = [
+        genProject('zz-proj', false)
+      ];
+      const action = new LoadOptionsSuccess(payload);
 
       it('displays project name', () => {
+        const { selectionLabel } = projectsFilterReducer(initialState, action);
+        expect(selectionLabel).toEqual('zz-proj');
       });
 
+      it('displays no count badge', () => {
+        const { selectionCountVisible } = projectsFilterReducer(initialState, action);
+        expect(selectionCountVisible).toBe(false);
+      });
+
+      // TODO
       it('does not display caret to open dropdown', () => {
       });
     });
 
     describe('with only unassigned resources allowed', () => {
+      const payload: ProjectsFilterOption[] = [
+        genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT)
+      ];
+      const action = new LoadOptionsSuccess(payload);
 
       it('displays "Unassigned resources"', () => {
+        const { selectionLabel } = projectsFilterReducer(initialState, action);
+        expect(selectionLabel).toEqual(UNASSIGNED_PROJECT_LABEL);
       });
 
+      it('displays no count badge', () => {
+        const { selectionCountVisible } = projectsFilterReducer(initialState, action);
+        expect(selectionCountVisible).toBe(false);
+      });
+
+      // TODO
       it('does not display caret to open dropdown', () => {
       });
     });
 
     describe('with exactly one project plus unassigned allowed', () => {
 
-      // Also check that every case displays the caret to open dropdown
+      // TODO: Also check that every case displays the caret to open dropdown
 
-      it('when nothing is selected displays "All resources"', () => {
+      describe('when nothing is selected', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT),
+          genProject('zz-proj', false)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays "All resources"', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual(ALL_RESOURCES_LABEL);
+        });
+
+        it('displays no count badge', () => {
+          const { selectionCountVisible } = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(false);
+        });
       });
-      it('when nothing is selected displays no count badge', () => {
+
+      describe('when project is selected', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT),
+          genProject('zz-proj', true)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays that project', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual('zz-proj');
+        });
+
+        it('displays no count badge', () => {
+          const { selectionCountVisible } = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(false);
+        });
       });
-      it('when project selected displays that project', () => {
+
+      describe('when only unassigned is selected', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
+          genProject('zz-proj', false)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays "Unassigned resources"', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual(UNASSIGNED_PROJECT_LABEL);
+        });
+        it('displays no count badge', () => {
+          const { selectionCountVisible } = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(false);
+        });
       });
-      it('when project selected displays no count badge', () => {
-      });
-      it('when only unassigned selected displays "Unassigned resources"', () => {
-      });
-      it('when only unassigned selected displays no count badge', () => {
-      });
-      it('selecting project and selecting unassigned displays "All resources"', () => {
-      });
-      it('selecting project and selecting unassigned displays no count badge', () => {
+
+      describe('selecting project and selecting unassigned', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
+          genProject('zz-proj', true)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays "All resources"', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual(ALL_RESOURCES_LABEL);
+        });
+        it('displays no count badge', () => {
+          const { selectionCountVisible } = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(false);
+        });
       });
     });
 
@@ -108,70 +194,269 @@ describe('projectsFilterReducer', () => {
 
       // Also check that every case displays the caret to open dropdown
 
-      it('when nothing is selected displays "All resources"', () => {
-      });
-      it('when nothing is selected displays no count badge', () => {
-      });
-      it('when single project selected displays that project', () => {
-      });
-      it('when single project selected displays no count badge', () => {
-      });
-      it('when only unassigned selected displays "Unassigned resources"', () => {
-      });
-      it('when only unassigned selected displays no count badge', () => {
-      });
-      it('when single project plus unassigned selected displays that project', () => {
-      });
-      it('when single project plus unassigned selected displays no count badge', () => {
-      });
-      it('selecting multiple but not all projects and not selecting unassigned'
-        + ' displays "Multiple projects"', () => {
+      describe('when nothing is selected', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject('zz-proj', false),
+          genProject('c-proj', false),
+          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT),
+          genProject('b-proj', false),
+          genProject('c-proj', false)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays "All resources"', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual(ALL_RESOURCES_LABEL);
         });
-      it('selecting multiple but not all projects and not selecting unassigned'
-        + ' displays blue count badge', () => {
+
+        it('displays no count badge', () => {
+          const { selectionCountVisible } = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(false);
         });
-      it('selecting multiple but not all projects and selecting unassigned'
-        + ' displays "Multiple projects"', () => {
+      });
+
+      describe('when single project is selected', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject('zz-proj', false),
+          genProject('c-proj', false),
+          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT),
+          genProject('b-proj', true),
+          genProject('c-proj', false)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays that project', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual('b-proj');
         });
-      it('selecting multiple but not all projects and selecting unassigned'
-        + ' displays blue count badge excluding unassigned', () => {
+
+        it('displays no count badge', () => {
+          const { selectionCountVisible } = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(false);
         });
-      it('selecting all projects and not selecting unassigned'
-        + ' displays "All projects"', () => {
+      });
+
+      describe('when only unassigned is selected', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject('zz-proj', false),
+          genProject('c-proj', false),
+          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
+          genProject('b-proj', false),
+          genProject('c-proj', false)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays "Unassigned resources"', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual(UNASSIGNED_PROJECT_LABEL);
         });
-      it('selecting all projects and not selecting unassigned'
-        + ' displays blue count badge', () => {
+        it('displays no count badge', () => {
+          const { selectionCountVisible } = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(false);
         });
-      it('selecting all projects and selecting unassigned'
-        + ' displays "All resources"', () => {
+      });
+
+      describe('selecting single project and selecting unassigned', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject('zz-proj', true),
+          genProject('c-proj', false),
+          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
+          genProject('b-proj', false),
+          genProject('c-proj', false)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays selected project', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual('zz-proj');
         });
-      it('selecting all projects and selecting unassigned'
-        + ' displays no count badge', () => {
+        it('displays no count badge', () => {
+          const { selectionCountVisible } = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(false);
         });
+      });
+
+      describe('selecting multiple but not all projects and not selecting unassigned', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject('zz-proj', true),
+          genProject('c-proj', true),
+          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT),
+          genProject('b-proj', true),
+          genProject('c-proj', false)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays "Multiple projects"', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual(MULTIPLE_PROJECTS_LABEL);
+        });
+        it('displays blue count badge with count of checked projects', () => {
+          const { selectionCount, selectionCountActive, selectionCountVisible }
+            = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(true);
+          expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
+          expect(selectionCount).toEqual(payload.filter(p => p.checked).length);
+        });
+      });
+
+      describe('selecting multiple but not all projects and selecting unassigned', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject('zz-proj', true),
+          genProject('c-proj', true),
+          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
+          genProject('b-proj', true),
+          genProject('c-proj', false)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays "Multiple projects"', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual(MULTIPLE_PROJECTS_LABEL);
+        });
+        it('displays blue count badge excluding unassigned in count', () => {
+          const { selectionCount, selectionCountActive, selectionCountVisible }
+            = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(true);
+          expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
+          expect(selectionCount).toEqual(payload.filter(p => p.checked).length - 1);
+        });
+      });
+
+      describe('selecting all projects and not selecting unassigned', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject('zz-proj', true),
+          genProject('c-proj', true),
+          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT),
+          genProject('b-proj', true),
+          genProject('c-proj', true)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays "All projects"', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual(ALL_PROJECTS_LABEL);
+        });
+        it('displays blue count badge with count of checked projects', () => {
+          const { selectionCount, selectionCountActive, selectionCountVisible }
+            = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(true);
+          expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
+          expect(selectionCount).toEqual(payload.filter(p => p.checked).length);
+        });
+      });
+
+      describe('selecting all projects and selecting unassigned', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject('zz-proj', true),
+          genProject('c-proj', true),
+          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
+          genProject('b-proj', true),
+          genProject('c-proj', true)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays "All resources"', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual(ALL_RESOURCES_LABEL);
+        });
+        it('displays no count badge', () => {
+          const { selectionCountVisible } = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(false);
+        });
+      });
     });
 
     describe('with at least 2 projects allowed but not unassigned', () => {
 
       // Also check that every case displays the caret to open dropdown
 
-      it('when nothing is selected displays "All projects"', () => {
+      describe('when nothing is selected', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject('zz-proj', false),
+          genProject('c-proj', false),
+          genProject('b-proj', false),
+          genProject('c-proj', false)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays "All projects"', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual(ALL_PROJECTS_LABEL);
+        });
+
+        it('displays grey count badge with count of ALL projects', () => {
+          const { selectionCount, selectionCountActive, selectionCountVisible }
+            = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(true);
+          expect(selectionCountActive).toBe(BADGE_GREY_STATE);
+          expect(selectionCount).toEqual(payload.length);
+        });
       });
-      it('when nothing is selected displays grey count badge', () => {
+
+      describe('when single project is selected', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject('zz-proj', false),
+          genProject('c-proj', false),
+          genProject('b-proj', true),
+          genProject('c-proj', false)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays that project', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual('b-proj');
+        });
+
+        it('displays no count badge', () => {
+          const { selectionCountVisible } = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(false);
+        });
       });
-      it('when single project selected displays that project', () => {
+
+      describe('selecting multiple but not all projects', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject('zz-proj', true),
+          genProject('c-proj', true),
+          genProject('b-proj', true),
+          genProject('c-proj', false)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays "Multiple projects"', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual(MULTIPLE_PROJECTS_LABEL);
+        });
+        it('displays blue count badge with count of checked projects', () => {
+          const { selectionCount, selectionCountActive, selectionCountVisible }
+            = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(true);
+          expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
+          expect(selectionCount).toEqual(payload.filter(p => p.checked).length);
+        });
       });
-      it('when single project selected displays no count badge', () => {
-      });
-      it('selecting multiple but not all projects displays "Multiple projects"', () => {
-      });
-      it('selecting multiple but not all projects displays blue count badge', () => {
-      });
-      it('selecting all projects displays "All projects"', () => {
-      });
-      it('selecting all projects displays blue count badge', () => {
+
+      describe('selecting all projects', () => {
+        const payload: ProjectsFilterOption[] = [
+          genProject('zz-proj', true),
+          genProject('c-proj', true),
+          genProject('b-proj', true),
+          genProject('c-proj', true)
+        ];
+        const action = new LoadOptionsSuccess(payload);
+
+        it('displays "All projects"', () => {
+          const { selectionLabel } = projectsFilterReducer(initialState, action);
+          expect(selectionLabel).toEqual(ALL_PROJECTS_LABEL);
+        });
+        it('displays blue count badge with count of checked projects', () => {
+          const { selectionCount, selectionCountActive, selectionCountVisible }
+            = projectsFilterReducer(initialState, action);
+          expect(selectionCountVisible).toBe(true);
+          expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
+          expect(selectionCount).toEqual(payload.filter(p => p.checked).length);
+        });
       });
     });
-
   });
 
   function genProject(label: string, checked: boolean, value?: string): ProjectsFilterOption {

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
@@ -1,0 +1,184 @@
+import { map } from 'lodash/fp';
+
+import { EntityStatus } from 'app/entities/entities';
+import {
+  ProjectsFilterState,
+  projectsFilterInitialState,
+  projectsFilterReducer,
+  ProjectsFilterOption
+} from './projects-filter.reducer';
+import { LoadOptions, LoadOptionsSuccess } from './projects-filter.actions';
+
+const UNASSIGNED_PROJECT = '(unassigned)';
+
+describe('projectsFilterReducer', () => {
+  const initialState: ProjectsFilterState = projectsFilterInitialState;
+
+  describe('LOAD_OPTIONS', () => {
+    const action = new LoadOptions();
+
+    it('sets status to loading', () => {
+      const { optionsLoadingStatus } = projectsFilterReducer(initialState, action);
+      expect(optionsLoadingStatus).toEqual(EntityStatus.loading);
+    });
+  });
+
+  describe('LOAD_OPTIONS_SUCCESS', () => {
+
+    it('sets status to success', () => {
+      const payload: ProjectsFilterOption[] = [
+        genProject('p1', false)
+      ];
+      const action = new LoadOptionsSuccess(payload);
+      const { optionsLoadingStatus } = projectsFilterReducer(initialState, action);
+      expect(optionsLoadingStatus).toEqual(EntityStatus.loadingSuccess);
+    });
+
+    it('without unassigned, sorts projects when storing them', () => {
+      const payload: ProjectsFilterOption[] = [
+        genProject('d-proj', false),
+        genProject('b-proj', false),
+        genProject('c-proj', false),
+        genProject('a-proj', false)
+      ];
+      const action = new LoadOptionsSuccess(payload);
+      const { options } = projectsFilterReducer(initialState, action);
+      expect(map('label', options)).toEqual(['a-proj', 'b-proj', 'c-proj', 'd-proj']);
+    });
+
+    it('with unassigned, sorts projects except unassigned at bottom when storing them', () => {
+      const payload: ProjectsFilterOption[] = [
+        genProject('d-proj', false),
+        <ProjectsFilterOption>{
+          label: 'Unassigned resources',
+          checked: true,
+          value: UNASSIGNED_PROJECT
+        },
+        genProject('b-proj', false),
+        genProject('zz-proj', false),
+        genProject('a-proj', false)
+      ];
+      const action = new LoadOptionsSuccess(payload);
+      const { options } = projectsFilterReducer(initialState, action);
+      expect(map('value', options))
+        .toEqual(['a-proj', 'b-proj', 'd-proj', 'zz-proj', UNASSIGNED_PROJECT]);
+    });
+
+    describe('with exactly one allowed project', () => {
+
+      it('displays project name', () => {
+      });
+
+      it('does not display caret to open dropdown', () => {
+      });
+    });
+
+    describe('with only unassigned resources allowed', () => {
+
+      it('displays "Unassigned resources"', () => {
+      });
+
+      it('does not display caret to open dropdown', () => {
+      });
+    });
+
+    describe('with exactly one project plus unassigned allowed', () => {
+
+      // Also check that every case displays the caret to open dropdown
+
+      it('when nothing is selected displays "All resources"', () => {
+      });
+      it('when nothing is selected displays no count badge', () => {
+      });
+      it('when project selected displays that project', () => {
+      });
+      it('when project selected displays no count badge', () => {
+      });
+      it('when only unassigned selected displays "Unassigned resources"', () => {
+      });
+      it('when only unassigned selected displays no count badge', () => {
+      });
+      it('selecting project and selecting unassigned displays "All resources"', () => {
+      });
+      it('selecting project and selecting unassigned displays no count badge', () => {
+      });
+    });
+
+    describe('with multiple projects plus unassigned allowed', () => {
+
+      // Also check that every case displays the caret to open dropdown
+
+      it('when nothing is selected displays "All resources"', () => {
+      });
+      it('when nothing is selected displays no count badge', () => {
+      });
+      it('when single project selected displays that project', () => {
+      });
+      it('when single project selected displays no count badge', () => {
+      });
+      it('when only unassigned selected displays "Unassigned resources"', () => {
+      });
+      it('when only unassigned selected displays no count badge', () => {
+      });
+      it('when single project plus unassigned selected displays that project', () => {
+      });
+      it('when single project plus unassigned selected displays no count badge', () => {
+      });
+      it('selecting multiple but not all projects and not selecting unassigned'
+        + ' displays "Multiple projects"', () => {
+        });
+      it('selecting multiple but not all projects and not selecting unassigned'
+        + ' displays blue count badge', () => {
+        });
+      it('selecting multiple but not all projects and selecting unassigned'
+        + ' displays "Multiple projects"', () => {
+        });
+      it('selecting multiple but not all projects and selecting unassigned'
+        + ' displays blue count badge excluding unassigned', () => {
+        });
+      it('selecting all projects and not selecting unassigned'
+        + ' displays "All projects"', () => {
+        });
+      it('selecting all projects and not selecting unassigned'
+        + ' displays blue count badge', () => {
+        });
+      it('selecting all projects and selecting unassigned'
+        + ' displays "All resources"', () => {
+        });
+      it('selecting all projects and selecting unassigned'
+        + ' displays no count badge', () => {
+        });
+    });
+
+    describe('with at least 2 projects allowed but not unassigned', () => {
+
+      // Also check that every case displays the caret to open dropdown
+
+      it('when nothing is selected displays "All projects"', () => {
+      });
+      it('when nothing is selected displays grey count badge', () => {
+      });
+      it('when single project selected displays that project', () => {
+      });
+      it('when single project selected displays no count badge', () => {
+      });
+      it('selecting multiple but not all projects displays "Multiple projects"', () => {
+      });
+      it('selecting multiple but not all projects displays blue count badge', () => {
+      });
+      it('selecting all projects displays "All projects"', () => {
+      });
+      it('selecting all projects displays blue count badge', () => {
+      });
+    });
+
+  });
+
+  function genProject(label: string, checked: boolean, value?: string): ProjectsFilterOption {
+    return <ProjectsFilterOption>{
+      label: label,
+      checked: checked,
+      value: value ? value : label
+    };
+  }
+});

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
@@ -1,6 +1,7 @@
 import { map } from 'lodash/fp';
 
 import { EntityStatus } from 'app/entities/entities';
+import { ProjectConstants } from 'app/entities/projects/project.model';
 import {
   ProjectsFilterState,
   projectsFilterInitialState,
@@ -9,12 +10,11 @@ import {
 } from './projects-filter.reducer';
 import { LoadOptions, LoadOptionsSuccess } from './projects-filter.actions';
 
-// TODO Get these from reducer.ts
-const UNASSIGNED_PROJECT = '(unassigned)';
-const UNASSIGNED_PROJECT_LABEL = 'Unassigned resources';
-const ALL_RESOURCES_LABEL = 'All resources';
-const ALL_PROJECTS_LABEL = 'All projects';
-const MULTIPLE_PROJECTS_LABEL = 'Multiple projects';
+const UNASSIGNED_PROJECT_ID = ProjectConstants.UNASSIGNED_PROJECT_ID;
+const UNASSIGNED_PROJECT_LABEL = ProjectConstants.UNASSIGNED_PROJECT_LABEL;
+const ALL_RESOURCES_LABEL = ProjectConstants.ALL_RESOURCES_LABEL;
+const ALL_PROJECTS_LABEL = ProjectConstants.ALL_PROJECTS_LABEL;
+const MULTIPLE_PROJECTS_LABEL = ProjectConstants.MULTIPLE_PROJECTS_LABEL;
 const BADGE_GREY_STATE = false;
 const BADGE_BLUE_STATE = true;
 
@@ -60,7 +60,7 @@ describe('projectsFilterReducer', () => {
     it('with unassigned, sorts projects except unassigned at bottom when storing them', () => {
       const payload: ProjectsFilterOption[] = [
         genProject('d-proj', false),
-        genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
+        genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT_ID),
         genProject('b-proj', false),
         genProject('zz-proj', false),
         genProject('a-proj', false)
@@ -70,7 +70,7 @@ describe('projectsFilterReducer', () => {
       const { options } = projectsFilterReducer(initialState, action);
 
       expect(map('value', options))
-        .toEqual(['a-proj', 'b-proj', 'd-proj', 'zz-proj', UNASSIGNED_PROJECT]);
+        .toEqual(['a-proj', 'b-proj', 'd-proj', 'zz-proj', UNASSIGNED_PROJECT_ID]);
     });
 
     describe('with exactly one allowed project', () => {
@@ -97,7 +97,7 @@ describe('projectsFilterReducer', () => {
 
     describe('with only unassigned resources allowed', () => {
       const payload: ProjectsFilterOption[] = [
-        genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT)
+        genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT_ID)
       ];
       const action = new LoadOptionsSuccess(payload);
 
@@ -121,7 +121,7 @@ describe('projectsFilterReducer', () => {
 
       describe('when nothing is selected', () => {
         const payload: ProjectsFilterOption[] = [
-          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT),
+          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT_ID),
           genProject('zz-proj', false)
         ];
         const action = new LoadOptionsSuccess(payload);
@@ -144,7 +144,7 @@ describe('projectsFilterReducer', () => {
 
       describe('when project is selected', () => {
         const payload: ProjectsFilterOption[] = [
-          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT),
+          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT_ID),
           genProject('zz-proj', true)
         ];
         const action = new LoadOptionsSuccess(payload);
@@ -167,7 +167,7 @@ describe('projectsFilterReducer', () => {
 
       describe('when only unassigned is selected', () => {
         const payload: ProjectsFilterOption[] = [
-          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
+          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT_ID),
           genProject('zz-proj', false)
         ];
         const action = new LoadOptionsSuccess(payload);
@@ -189,7 +189,7 @@ describe('projectsFilterReducer', () => {
 
       describe('selecting project and selecting unassigned', () => {
         const payload: ProjectsFilterOption[] = [
-          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
+          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT_ID),
           genProject('zz-proj', true)
         ];
         const action = new LoadOptionsSuccess(payload);
@@ -218,7 +218,7 @@ describe('projectsFilterReducer', () => {
         const payload: ProjectsFilterOption[] = [
           genProject('zz-proj', false),
           genProject('c-proj', false),
-          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT),
+          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT_ID),
           genProject('b-proj', false),
           genProject('c-proj', false)
         ];
@@ -244,7 +244,7 @@ describe('projectsFilterReducer', () => {
         const payload: ProjectsFilterOption[] = [
           genProject('zz-proj', false),
           genProject('c-proj', false),
-          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT),
+          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT_ID),
           genProject('b-proj', true),
           genProject('c-proj', false)
         ];
@@ -270,7 +270,7 @@ describe('projectsFilterReducer', () => {
         const payload: ProjectsFilterOption[] = [
           genProject('zz-proj', false),
           genProject('c-proj', false),
-          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
+          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT_ID),
           genProject('b-proj', false),
           genProject('c-proj', false)
         ];
@@ -295,7 +295,7 @@ describe('projectsFilterReducer', () => {
         const payload: ProjectsFilterOption[] = [
           genProject('zz-proj', true),
           genProject('c-proj', false),
-          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
+          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT_ID),
           genProject('b-proj', false),
           genProject('c-proj', false)
         ];
@@ -320,7 +320,7 @@ describe('projectsFilterReducer', () => {
         const payload: ProjectsFilterOption[] = [
           genProject('zz-proj', true),
           genProject('c-proj', true),
-          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT),
+          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT_ID),
           genProject('b-proj', true),
           genProject('c-proj', false)
         ];
@@ -348,7 +348,7 @@ describe('projectsFilterReducer', () => {
         const payload: ProjectsFilterOption[] = [
           genProject('zz-proj', true),
           genProject('c-proj', true),
-          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
+          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT_ID),
           genProject('b-proj', true),
           genProject('c-proj', false)
         ];
@@ -376,7 +376,7 @@ describe('projectsFilterReducer', () => {
         const payload: ProjectsFilterOption[] = [
           genProject('zz-proj', true),
           genProject('c-proj', true),
-          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT),
+          genProject(UNASSIGNED_PROJECT_LABEL, false, UNASSIGNED_PROJECT_ID),
           genProject('b-proj', true),
           genProject('c-proj', true)
         ];
@@ -404,7 +404,7 @@ describe('projectsFilterReducer', () => {
         const payload: ProjectsFilterOption[] = [
           genProject('zz-proj', true),
           genProject('c-proj', true),
-          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT),
+          genProject(UNASSIGNED_PROJECT_LABEL, true, UNASSIGNED_PROJECT_ID),
           genProject('b-proj', true),
           genProject('c-proj', true)
         ];

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
@@ -142,13 +142,17 @@ describe('projectsFilterReducer', () => {
       });
 
       it('returns all fetched values when no restored values', () => {
-        const action = genAction(
-          genProject('zz-proj'),
-          genProject('c-proj', true),
-          genUnassignedProject(),
-          genProject('a-proj', true),
-          genProject('b-proj')
-        );
+        const action = new LoadOptionsSuccess(
+          <ProjectsFilterOptionTuple>{
+            fetched: [
+              genProject('zz-proj'),
+              genProject('c-proj', true),
+              genUnassignedProject(),
+              genProject('a-proj', true),
+              genProject('b-proj')
+            ],
+            restored: {}
+          });
 
         const { options } = projectsFilterReducer(initialState, action);
 
@@ -160,7 +164,6 @@ describe('projectsFilterReducer', () => {
           action.payload.fetched[2]
         ]);
       });
-
 
       it('includes all fetched options even if not in restored', () => {
         const action = new LoadOptionsSuccess(
@@ -476,7 +479,7 @@ describe('projectsFilterReducer', () => {
             = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(true);
           expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
-          expect(selectionCount).toEqual(action.payload.fetched.filter(p => p.checked).length);
+          expect(selectionCount).toEqual(action.payload.restored.filter(p => p.checked).length);
         });
 
         it('displays caret to open dropdown', () => {
@@ -503,7 +506,7 @@ describe('projectsFilterReducer', () => {
             = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(true);
           expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
-          expect(selectionCount).toEqual(action.payload.fetched.filter(p => p.checked).length - 1);
+          expect(selectionCount).toEqual(action.payload.restored.filter(p => p.checked).length - 1);
         });
 
         it('displays caret to open dropdown', () => {
@@ -530,7 +533,7 @@ describe('projectsFilterReducer', () => {
             = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(true);
           expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
-          expect(selectionCount).toEqual(action.payload.fetched.filter(p => p.checked).length);
+          expect(selectionCount).toEqual(action.payload.restored.filter(p => p.checked).length);
         });
 
         it('displays caret to open dropdown', () => {
@@ -586,7 +589,7 @@ describe('projectsFilterReducer', () => {
             = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(true);
           expect(selectionCountActive).toBe(BADGE_GREY_STATE);
-          expect(selectionCount).toEqual(action.payload.fetched.length);
+          expect(selectionCount).toEqual(action.payload.restored.length);
         });
 
         it('displays caret to open dropdown', () => {
@@ -636,7 +639,7 @@ describe('projectsFilterReducer', () => {
             = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(true);
           expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
-          expect(selectionCount).toEqual(action.payload.fetched.filter(p => p.checked).length);
+          expect(selectionCount).toEqual(action.payload.restored.filter(p => p.checked).length);
         });
 
         it('displays caret to open dropdown', () => {
@@ -662,7 +665,7 @@ describe('projectsFilterReducer', () => {
             = projectsFilterReducer(initialState, action);
           expect(selectionCountVisible).toBe(true);
           expect(selectionCountActive).toBe(BADGE_BLUE_STATE);
-          expect(selectionCount).toEqual(action.payload.fetched.filter(p => p.checked).length);
+          expect(selectionCount).toEqual(action.payload.restored.filter(p => p.checked).length);
         });
 
         it('displays caret to open dropdown', () => {
@@ -686,6 +689,17 @@ describe('projectsFilterReducer', () => {
   }
 
   function genAction(...projects: ProjectsFilterOption[]): LoadOptionsSuccess {
+    // If any checked projects supplied, use that more correctly as the restored list;
+    // the fetched list should really have no notion of checked or not.
+    // Then generate the fetched list as the same thing with checked false for all projects.
+    if (projects.filter(p => p.checked === true)) {
+      return new LoadOptionsSuccess(
+        <ProjectsFilterOptionTuple>{
+          fetched: projects.map(p => Object.assign({}, p, { checked: false })),
+          restored: projects
+        });
+    }
+    // Otherwise, we don't care about the restored list.
     return new LoadOptionsSuccess(
       <ProjectsFilterOptionTuple>{ fetched: projects, restored: {} });
   }

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
@@ -10,11 +10,14 @@ import {
 } from './projects-filter.reducer';
 import { LoadOptions, LoadOptionsSuccess } from './projects-filter.actions';
 
-const UNASSIGNED_PROJECT_ID = ProjectConstants.UNASSIGNED_PROJECT_ID;
-const UNASSIGNED_PROJECT_LABEL = ProjectConstants.UNASSIGNED_PROJECT_LABEL;
-const ALL_RESOURCES_LABEL = ProjectConstants.ALL_RESOURCES_LABEL;
-const ALL_PROJECTS_LABEL = ProjectConstants.ALL_PROJECTS_LABEL;
-const MULTIPLE_PROJECTS_LABEL = ProjectConstants.MULTIPLE_PROJECTS_LABEL;
+const {
+  UNASSIGNED_PROJECT_ID,
+  UNASSIGNED_PROJECT_LABEL,
+  ALL_RESOURCES_LABEL,
+  ALL_PROJECTS_LABEL,
+  MULTIPLE_PROJECTS_LABEL
+} = ProjectConstants;
+
 const BADGE_GREY_STATE = false;
 const BADGE_BLUE_STATE = true;
 

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -18,6 +18,7 @@ export interface ProjectsFilterState {
   selectionCount: number;
   selectionCountVisible: boolean;
   selectionCountActive: boolean;
+  dropdownCaretVisible: boolean;
 }
 
 export const projectsFilterInitialState: ProjectsFilterState = {
@@ -26,7 +27,8 @@ export const projectsFilterInitialState: ProjectsFilterState = {
   selectionLabel: 'All resources',
   selectionCount: 0,
   selectionCountVisible: false,
-  selectionCountActive: false
+  selectionCountActive: false,
+  dropdownCaretVisible: false
 };
 
 export function projectsFilterReducer(
@@ -57,7 +59,8 @@ export function projectsFilterReducer(
         set('selectionLabel', selectionLabel(action.payload)),
         set('selectionCount', selectionCount(action.payload)),
         set('selectionCountVisible', selectionCountVisible(action.payload)),
-        set('selectionCountActive', selectionCountActive(action.payload))
+        set('selectionCountActive', selectionCountActive(action.payload)),
+        set('dropdownCaretVisible', dropdownCaretVisible(action.payload))
       )(state) as ProjectsFilterState;
     }
 
@@ -71,7 +74,8 @@ export function projectsFilterReducer(
         set('selectionLabel', selectionLabel(action.payload)),
         set('selectionCount', selectionCount(action.payload)),
         set('selectionCountVisible', selectionCountVisible(action.payload)),
-        set('selectionCountActive', selectionCountActive(action.payload))
+        set('selectionCountActive', selectionCountActive(action.payload)),
+        set('dropdownCaretVisible', dropdownCaretVisible(action.payload))
       )(state) as ProjectsFilterState;
     }
   }
@@ -146,4 +150,9 @@ function selectionCountVisible(options: ProjectsFilterOption[]): boolean {
 function selectionCountActive(options: ProjectsFilterOption[]): boolean {
   const checkedOptions = options.filter(o => o.checked);
   return checkedOptions.length > 0;
+}
+
+function dropdownCaretVisible(options: ProjectsFilterOption[]): boolean {
+  const hasOnlyOneOption = options.length === 1;
+  return !hasOnlyOneOption;
 }

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -1,4 +1,4 @@
-import { set, pipe } from 'lodash/fp';
+import { set, pipe, find } from 'lodash/fp';
 import { LoadingStatus } from 'app/types/types';
 import {
   ProjectsFilterActions,
@@ -40,8 +40,19 @@ export function projectsFilterReducer(
     }
 
     case ProjectsFilterActionTypes.LOAD_OPTIONS_SUCCESS: {
+      const sortedOptions = action.payload.filter(o => o.value !== UNASSIGNED_PROJECT).sort(
+          (a, b) => {
+            const opts = { numeric: true, sensitivity: 'base' };
+            return a.label.localeCompare(b.label, undefined, opts)
+              || a.label.localeCompare(b.label, undefined, { numeric: true });
+          }
+        );
+      const unassignedProject = find(['value', UNASSIGNED_PROJECT], action.payload);
+      if (unassignedProject) {
+        sortedOptions.push(unassignedProject)
+      }
       return pipe(
-        set('options', action.payload),
+        set('options', sortedOptions),
         set('optionsLoadingStatus', LoadingStatus.loadingSuccess),
         set('selectionLabel', selectionLabel(action.payload)),
         set('selectionCount', selectionCount(action.payload)),

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -69,21 +69,17 @@ export function projectsFilterReducer(
 }
 
 function selectionLabel(options: ProjectsFilterOption[]): string {
+  const UNASSIGNED_PROJECT = '(unassigned)';
   const checkedOptions = options.filter(o => o.checked);
-  const projectOptions = options.filter(o => o.value !== 'unassigned-resources');
+  const projectOptions = options.filter(o => o.value !== UNASSIGNED_PROJECT);
   const checkedProjects = projectOptions.filter(o => o.checked);
-  const hasOnlyProjects = projectOptions.length === options.length;
-  const hasNoneChecked = checkedOptions.length === 0;
-  const hasAllChecked = checkedOptions.length === options.length;
   const hasOneOption = options.length === 1;
   const hasOneChecked = checkedOptions.length === 1;
   const hasOneProjectChecked = checkedProjects.length === 1;
   const hasSomeProjectsChecked = checkedProjects.length > 1;
-  const hasOnlySomeProjectsChecked = hasSomeProjectsChecked && !hasAllChecked;
   const hasAllProjectsChecked = checkedProjects.length === projectOptions.length;
-  const hasOnlyAllProjectsChecked = hasOnlyProjects ?
-    hasAllProjectsChecked || hasNoneChecked :
-    hasAllProjectsChecked && !hasAllChecked;
+  const hasUnassignedChecked =
+    options.filter(o => o.value === UNASSIGNED_PROJECT && o.checked).length === 1;
 
   if (hasOneOption) {
     return options[0].label;
@@ -97,12 +93,12 @@ function selectionLabel(options: ProjectsFilterOption[]): string {
     return checkedProjects[0].label;
   }
 
-  if (hasOnlySomeProjectsChecked) {
-    return 'Multiple projects';
+  if (hasAllProjectsChecked && !hasUnassignedChecked) {
+    return 'All projects';
   }
 
-  if (hasOnlyAllProjectsChecked) {
-    return 'All projects';
+  if (hasSomeProjectsChecked && !hasUnassignedChecked) {
+    return 'Multiple projects';
   }
 
   return 'All resources';

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -95,32 +95,31 @@ function selectionLabel(options: ProjectsFilterOption[]): string {
   const hasNoProjectsChecked = checkedProjects.length === 0;
   const hasAllProjectsChecked = checkedProjects.length === projectOptions.length;
   const hasSomeProjectsChecked = checkedProjects.length > 1 && !hasAllProjectsChecked;
+  const hasUnassigned = options.filter(o => o.value === UNASSIGNED_PROJECT).length === 1;
   const hasUnassignedChecked =
     options.filter(o => o.value === UNASSIGNED_PROJECT && o.checked).length === 1;
-  const unassignedAvailable = options.filter(o => o.value === UNASSIGNED_PROJECT).length === 1;
 
   if (hasOneOption) {
     return options[0].label;
   }
 
-  if (hasOneChecked) {
+  if (hasAllProjectsChecked && hasUnassignedChecked) {
+    return 'All resources';
+  }
+
+  if (hasNoProjectsChecked && hasUnassigned && !hasUnassignedChecked) {
+    return 'All resources';
+  }
+
+  if (hasOneChecked || hasOneProjectChecked) {
     return checkedOptions[0].label;
-  }
-
-  if (hasOneProjectChecked) {
-    return checkedProjects[0].label;
-  }
-
-  if ((hasAllProjectsChecked && (!hasUnassignedChecked || !unassignedAvailable))
-    || (hasNoProjectsChecked && !unassignedAvailable)) {
-      return 'All projects';
   }
 
   if (hasSomeProjectsChecked) {
     return 'Multiple projects';
   }
 
-  return 'All resources';
+  return 'All projects';
 }
 
 function selectionCount(options: ProjectsFilterOption[]): number {

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -1,5 +1,5 @@
 import { set, pipe, find } from 'lodash/fp';
-import { LoadingStatus } from 'app/types/types';
+import { EntityStatus } from 'app/entities/entities';
 import {
   ProjectsFilterActions,
   ProjectsFilterActionTypes
@@ -13,7 +13,7 @@ export interface ProjectsFilterOption {
 
 export interface ProjectsFilterState {
   options: ProjectsFilterOption[];
-  optionsLoadingStatus: LoadingStatus;
+  optionsLoadingStatus: EntityStatus;
   selectionLabel: string;
   selectionCount: number;
   selectionCountVisible: boolean;
@@ -22,7 +22,7 @@ export interface ProjectsFilterState {
 
 export const projectsFilterInitialState: ProjectsFilterState = {
   options: [],
-  optionsLoadingStatus: LoadingStatus.notLoaded,
+  optionsLoadingStatus: EntityStatus.notLoaded,
   selectionLabel: 'All resources',
   selectionCount: 0,
   selectionCountVisible: false,
@@ -36,7 +36,7 @@ export function projectsFilterReducer(
   switch (action.type) {
 
     case ProjectsFilterActionTypes.LOAD_OPTIONS: {
-      return set('optionsLoadingStatus', LoadingStatus.loading, state);
+      return set('optionsLoadingStatus', EntityStatus.loading, state);
     }
 
     case ProjectsFilterActionTypes.LOAD_OPTIONS_SUCCESS: {
@@ -49,11 +49,11 @@ export function projectsFilterReducer(
         );
       const unassignedProject = find(['value', UNASSIGNED_PROJECT], action.payload);
       if (unassignedProject) {
-        sortedOptions.push(unassignedProject)
+        sortedOptions.push(unassignedProject);
       }
       return pipe(
         set('options', sortedOptions),
-        set('optionsLoadingStatus', LoadingStatus.loadingSuccess),
+        set('optionsLoadingStatus', EntityStatus.loadingSuccess),
         set('selectionLabel', selectionLabel(action.payload)),
         set('selectionCount', selectionCount(action.payload)),
         set('selectionCountVisible', selectionCountVisible(action.payload)),
@@ -62,7 +62,7 @@ export function projectsFilterReducer(
     }
 
     case ProjectsFilterActionTypes.LOAD_OPTIONS_FAILURE: {
-      return set('optionsLoadingStatus', LoadingStatus.loadingFailure, state);
+      return set('optionsLoadingStatus', EntityStatus.loadingFailure, state);
     }
 
     case ProjectsFilterActionTypes.SAVE_OPTIONS: {
@@ -108,7 +108,7 @@ function selectionLabel(options: ProjectsFilterOption[]): string {
   }
 
   if ((hasAllProjectsChecked && (!hasUnassignedChecked || !unassignedAvailable))
-    || (hasNoProjectsChecked && !unassignedAvailable)){
+    || (hasNoProjectsChecked && !unassignedAvailable)) {
       return 'All projects';
   }
 

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -7,10 +7,12 @@ import {
   ProjectsFilterActionTypes
 } from './projects-filter.actions';
 
-const UNASSIGNED_PROJECT_ID = ProjectConstants.UNASSIGNED_PROJECT_ID;
-const ALL_RESOURCES_LABEL = ProjectConstants.ALL_RESOURCES_LABEL;
-const ALL_PROJECTS_LABEL = ProjectConstants.ALL_PROJECTS_LABEL;
-const MULTIPLE_PROJECTS_LABEL = ProjectConstants.MULTIPLE_PROJECTS_LABEL;
+const {
+  UNASSIGNED_PROJECT_ID,
+  ALL_RESOURCES_LABEL,
+  ALL_PROJECTS_LABEL,
+  MULTIPLE_PROJECTS_LABEL
+} = ProjectConstants;
 
 export interface ProjectsFilterOption {
   label: string;

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -56,8 +56,8 @@ export function projectsFilterReducer(
     }
 
     case ProjectsFilterActionTypes.LOAD_OPTIONS_SUCCESS: {
-      const merged = mergeOptions(action.payload.fetched, action.payload.restored);
-      const sortedOptions = sortOptions(merged);
+      const mergedOptions = mergeOptions(action.payload.fetched, action.payload.restored);
+      const sortedOptions = sortOptions(mergedOptions);
       return pipe(
         set('options', sortedOptions),
         set('optionsLoadingStatus', EntityStatus.loadingSuccess),

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -76,10 +76,12 @@ function selectionLabel(options: ProjectsFilterOption[]): string {
   const hasOneOption = options.length === 1;
   const hasOneChecked = checkedOptions.length === 1;
   const hasOneProjectChecked = checkedProjects.length === 1;
-  const hasSomeProjectsChecked = checkedProjects.length > 1;
+  const hasNoProjectsChecked = checkedProjects.length === 0;
   const hasAllProjectsChecked = checkedProjects.length === projectOptions.length;
+  const hasSomeProjectsChecked = checkedProjects.length > 1 && !hasAllProjectsChecked;
   const hasUnassignedChecked =
     options.filter(o => o.value === UNASSIGNED_PROJECT && o.checked).length === 1;
+  const unassignedAvailable = options.filter(o => o.value === UNASSIGNED_PROJECT).length === 1;
 
   if (hasOneOption) {
     return options[0].label;
@@ -93,11 +95,12 @@ function selectionLabel(options: ProjectsFilterOption[]): string {
     return checkedProjects[0].label;
   }
 
-  if (hasAllProjectsChecked && !hasUnassignedChecked) {
-    return 'All projects';
+  if ((hasAllProjectsChecked && (!hasUnassignedChecked || !unassignedAvailable))
+    || (hasNoProjectsChecked && !unassignedAvailable)){
+      return 'All projects';
   }
 
-  if (hasSomeProjectsChecked && !hasUnassignedChecked) {
+  if (hasSomeProjectsChecked) {
     return 'Multiple projects';
   }
 

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -1,9 +1,16 @@
 import { set, pipe, find } from 'lodash/fp';
+
 import { EntityStatus } from 'app/entities/entities';
+import { ProjectConstants } from 'app/entities/projects/project.model';
 import {
   ProjectsFilterActions,
   ProjectsFilterActionTypes
 } from './projects-filter.actions';
+
+const UNASSIGNED_PROJECT_ID = ProjectConstants.UNASSIGNED_PROJECT_ID;
+const ALL_RESOURCES_LABEL = ProjectConstants.ALL_RESOURCES_LABEL;
+const ALL_PROJECTS_LABEL = ProjectConstants.ALL_PROJECTS_LABEL;
+const MULTIPLE_PROJECTS_LABEL = ProjectConstants.MULTIPLE_PROJECTS_LABEL;
 
 export interface ProjectsFilterOption {
   label: string;
@@ -24,7 +31,7 @@ export interface ProjectsFilterState {
 export const projectsFilterInitialState: ProjectsFilterState = {
   options: [],
   optionsLoadingStatus: EntityStatus.notLoaded,
-  selectionLabel: 'All resources',
+  selectionLabel: ALL_RESOURCES_LABEL,
   selectionCount: 0,
   selectionCountVisible: false,
   selectionCountActive: false,
@@ -42,14 +49,15 @@ export function projectsFilterReducer(
     }
 
     case ProjectsFilterActionTypes.LOAD_OPTIONS_SUCCESS: {
-      const sortedOptions = action.payload.filter(o => o.value !== UNASSIGNED_PROJECT).sort(
-          (a, b) => {
-            const opts = { numeric: true, sensitivity: 'base' };
-            return a.label.localeCompare(b.label, undefined, opts)
-              || a.label.localeCompare(b.label, undefined, { numeric: true });
-          }
+      const sortedOptions = action.payload
+        .filter(o => o.value !== UNASSIGNED_PROJECT_ID)
+        .sort((a, b) => {
+          const opts = { numeric: true, sensitivity: 'base' };
+          return a.label.localeCompare(b.label, undefined, opts)
+            || a.label.localeCompare(b.label, undefined, { numeric: true });
+        }
         );
-      const unassignedProject = find(['value', UNASSIGNED_PROJECT], action.payload);
+      const unassignedProject = find(['value', UNASSIGNED_PROJECT_ID], action.payload);
       if (unassignedProject) {
         sortedOptions.push(unassignedProject);
       }
@@ -83,11 +91,9 @@ export function projectsFilterReducer(
   return state;
 }
 
-const UNASSIGNED_PROJECT = '(unassigned)';
-
 function selectionLabel(options: ProjectsFilterOption[]): string {
   const checkedOptions = options.filter(o => o.checked);
-  const projectOptions = options.filter(o => o.value !== UNASSIGNED_PROJECT);
+  const projectOptions = options.filter(o => o.value !== UNASSIGNED_PROJECT_ID);
   const checkedProjects = projectOptions.filter(o => o.checked);
   const hasOneOption = options.length === 1;
   const hasOneChecked = checkedOptions.length === 1;
@@ -95,20 +101,20 @@ function selectionLabel(options: ProjectsFilterOption[]): string {
   const hasNoProjectsChecked = checkedProjects.length === 0;
   const hasAllProjectsChecked = checkedProjects.length === projectOptions.length;
   const hasSomeProjectsChecked = checkedProjects.length > 1 && !hasAllProjectsChecked;
-  const hasUnassigned = options.filter(o => o.value === UNASSIGNED_PROJECT).length === 1;
+  const hasUnassigned = options.filter(o => o.value === UNASSIGNED_PROJECT_ID).length === 1;
   const hasUnassignedChecked =
-    options.filter(o => o.value === UNASSIGNED_PROJECT && o.checked).length === 1;
+    options.filter(o => o.value === UNASSIGNED_PROJECT_ID && o.checked).length === 1;
 
   if (hasOneOption) {
     return options[0].label;
   }
 
   if (hasAllProjectsChecked && hasUnassignedChecked) {
-    return 'All resources';
+    return ALL_RESOURCES_LABEL;
   }
 
   if (hasNoProjectsChecked && hasUnassigned && !hasUnassignedChecked) {
-    return 'All resources';
+    return ALL_RESOURCES_LABEL;
   }
 
   if (hasOneChecked || hasOneProjectChecked) {
@@ -116,14 +122,14 @@ function selectionLabel(options: ProjectsFilterOption[]): string {
   }
 
   if (hasSomeProjectsChecked) {
-    return 'Multiple projects';
+    return MULTIPLE_PROJECTS_LABEL;
   }
 
-  return 'All projects';
+  return ALL_PROJECTS_LABEL;
 }
 
 function selectionCount(options: ProjectsFilterOption[]): number {
-  const checkedProjects = options.filter(o => o.checked && o.value !== UNASSIGNED_PROJECT);
+  const checkedProjects = options.filter(o => o.checked && o.value !== UNASSIGNED_PROJECT_ID);
   return checkedProjects.length > 0 ? checkedProjects.length : options.length;
 }
 
@@ -134,7 +140,7 @@ function selectionCountVisible(options: ProjectsFilterOption[]): boolean {
   }
 
   const checkedOptions = options.filter(o => o.checked);
-  const projectOptions = options.filter(o => o.value !== UNASSIGNED_PROJECT);
+  const projectOptions = options.filter(o => o.value !== UNASSIGNED_PROJECT_ID);
   const checkedProjects = projectOptions.filter(o => o.checked);
   const hasOnlyProjects = projectOptions.length === options.length;
   const hasNoneChecked = checkedOptions.length === 0;

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -68,8 +68,9 @@ export function projectsFilterReducer(
   return state;
 }
 
+const UNASSIGNED_PROJECT = '(unassigned)';
+
 function selectionLabel(options: ProjectsFilterOption[]): string {
-  const UNASSIGNED_PROJECT = '(unassigned)';
   const checkedOptions = options.filter(o => o.checked);
   const projectOptions = options.filter(o => o.value !== UNASSIGNED_PROJECT);
   const checkedProjects = projectOptions.filter(o => o.checked);
@@ -108,7 +109,7 @@ function selectionLabel(options: ProjectsFilterOption[]): string {
 }
 
 function selectionCount(options: ProjectsFilterOption[]): number {
-  const checkedProjects = options.filter(o => o.checked && o.value !== 'unassigned-resources');
+  const checkedProjects = options.filter(o => o.checked && o.value !== UNASSIGNED_PROJECT);
   return checkedProjects.length > 0 ? checkedProjects.length : options.length;
 }
 
@@ -119,7 +120,7 @@ function selectionCountVisible(options: ProjectsFilterOption[]): boolean {
   }
 
   const checkedOptions = options.filter(o => o.checked);
-  const projectOptions = options.filter(o => o.value !== 'unassigned-resources');
+  const projectOptions = options.filter(o => o.value !== UNASSIGNED_PROJECT);
   const checkedProjects = projectOptions.filter(o => o.checked);
   const hasOnlyProjects = projectOptions.length === options.length;
   const hasNoneChecked = checkedOptions.length === 0;

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.selectors.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.selectors.ts
@@ -16,3 +16,6 @@ export const selectionCountVisible = createSelector(projectsFilterState,
 
 export const selectionCountActive = createSelector(projectsFilterState,
   state => state.selectionCountActive);
+
+export const dropdownCaretVisible = createSelector(projectsFilterState,
+  state => state.dropdownCaretVisible);

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -56,7 +56,7 @@ export class ProjectsFilterService {
       },
       {
         value: ProjectConstants.UNASSIGNED_PROJECT_ID,
-        label: 'Unassigned Resources',
+        label: ProjectConstants.UNASSIGNED_PROJECT_LABEL,
         checked: false
       },
       {

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -52,8 +52,13 @@ export class ProjectsFilterService {
         checked: false
       },
       {
-        value: 'project-5',
-        label: 'Project 5',
+        value: '(unassigned)',
+        label: 'Unassigned Resources',
+        checked: false
+      },
+      {
+        value: 'ze end of the alpha project',
+        label: 'ZETA PROJ',
         checked: false
       },
       {
@@ -64,11 +69,6 @@ export class ProjectsFilterService {
       {
         value: 'super-project',
         label: 'Super Duper Project',
-        checked: false
-      },
-      {
-        value: '(unassigned)',
-        label: 'Unassigned Resources',
         checked: false
       }
     ]);

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -20,6 +20,8 @@ export class ProjectsFilterService {
 
   selectionCountActive$ = this.store.select(selectors.selectionCountActive);
 
+  dropdownCaretVisible$ = this.store.select(selectors.dropdownCaretVisible);
+
   constructor(private store: Store<NgrxStateAtom>) {}
 
   loadOptions() {

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Observable, of as observableOf } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { ProjectConstants } from 'app/entities/projects/project.model';
 import { ProjectsFilterOption } from './projects-filter.reducer';
 import * as selectors from './projects-filter.selectors';
 import { LoadOptions, SaveOptions } from './projects-filter.actions';
@@ -54,7 +55,7 @@ export class ProjectsFilterService {
         checked: false
       },
       {
-        value: '(unassigned)',
+        value: ProjectConstants.UNASSIGNED_PROJECT_ID,
         label: 'Unassigned Resources',
         checked: false
       },

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -67,7 +67,7 @@ export class ProjectsFilterService {
         checked: false
       },
       {
-        value: 'unassigned-resources',
+        value: '(unassigned)',
         label: 'Unassigned Resources',
         checked: false
       }

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Feature } from 'app/services/feature-flags/types';
 
+import { GetIamVersion } from 'app/entities/policies/policy.actions';
 import { notificationState } from 'app/entities/notifications/notification.selectors';
 import { routeURL } from './route.selectors';
 import { Notification } from 'app/entities/notifications/notification.model';
@@ -61,6 +62,7 @@ export class UIComponent implements OnInit {
     this.store.select(routeURL).subscribe((url: string) => {
       this.renderNavbar = url.split('/').pop() !== 'add-members';
     });
+    this.store.dispatch(new GetIamVersion());
   }
 
   onTriggerApplyLicense(reason: LicenseApplyReason): void {


### PR DESCRIPTION
### :nut_and_bolt: Description

This PR implements remaining bits of the global projects filter.
Essentially the first thing I did was back up the reducer with a comprehensive set of unit tests. 
But I did that using what I call "Extreme TDD": write all the test names first to convert  requirements to code: 
![image](https://user-images.githubusercontent.com/6817500/57140364-734f8e80-6d6c-11e9-9b14-b7495034d1f2.png)

See the full list here:
https://github.com/chef/automate/blob/046fa3f5af0f1a28420aa482423c46f2687217f9/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts#L67

Once those requirements were confirmed, I then fleshed out all the tests.
This allowed me to easily determine what was left to do; the list below shows the failing tests, indicating that the component was not successfully doing what the test purports.
![image](https://user-images.githubusercontent.com/6817500/57140401-8a8e7c00-6d6c-11e9-9484-4b103e150fdd.png)


What made the creation of a comprehensive set of unit tests a very straightforward task was @scottopherson 's wonderfully clean code, wherein the visual components were utterly simple and  the complexity was kept in the reducer. That is the ideal design for testability because the reducer is, by definition, a pure function, and pure functions are the most one could desire for unit testing. I only needed to add one missing facet to the interface (`dropdownCaretVisible`) to be able to test the dropdown label content, the display of the dropdown caret, the count of projects in the badge adjacent to the label, the presence of the badge, and even the color of the badge.

Besides telling me what was left to be done, the set of unit tests made it fast to iterate over changes. I no longer had to manually try out multiple scenarios in the browser with every change. I just made some edits, and with the magic of the Wallaby continuous test runner, I had instant feedback as to whether the unit tests were getting better or worse.

This was amazingly useful in the reducer (projects-filter.reducer.ts):  if you take a look at the `selectionLabel` function it is essentially a codified Karnaugh map. I could thus swap things around and try different logic as I was worked toward a minimization of terms there.

BTW, see PR - #172 for video of how the visual component operates.

### :+1: Definition of Done

All unit tests pass--see chart below.
Also included in this PR:

1. Fixed the descenders being clipped in the dropdown label (thanks for pointing that out @susanev !).
2. Made the global project filter appear on all pages, not just settings pages. (Technically, it would appear on all pages before, but only _after_ you first visited the Settings page.)
3. Poll every 5 minutes to re-evaluate the IAM version so that, should the IAM version change, the global projects filter (and everything else depending on IAM version) will re-sync automatically without requiring any browser refresh.
4. Cleanup the use of the magic string `(unassigned)` in the ui project so that--like authz, teams, and authn before it--the string is only defined once in the project.

![image](https://user-images.githubusercontent.com/6817500/57112160-b588b980-6cf3-11e9-909b-af2139565cda.png)

### :athletic_shoe: Demo Script / Repro Steps

1. start_all_services
2. Build your UI component locally via the method of your choice. Ultimately the last step should be `make serve` so that if you make any edits as mentioned below, they will be automatically picked up.
3. Load the app in the browser.

The global projects filter will be present on every page.
It remembers its last value even after refreshing the browser (thanks, @scottopherson !)
The list of projects you find there are hard-coded, static data.
To test out the various scenarios in the requirements, just edit the list at the bottom of projects-filter.service.ts. Reload your browser once the ui rebuilds and then check the filter.

### :chains: Related Resources

PR - #172 

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
