### PR TITLE
[.bldr.toml] Fix typos in bldr config

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -815,14 +815,14 @@ paths = [
 ]
 
 [automate-workflow-server]
-plan_path = "automate-workflow-server"
+plan_path = "components/automate-workflow-server"
 paths = [
   "components/automate-workflow-ctl/*",
   "components/automate-workflow-server/*"
 ]
 
 [automate-ui]
-plan_path = ": components/automate-ui"
+plan_path = "components/automate-ui"
 paths = [
   "components/automate-ui/*",
   "components/chef-ui-library/*"


### PR DESCRIPTION
The part of the bldr.toml with these typos is not auto-generated.
They probably snuck in during the conversion from the .expeditor.yml.

Signed-off-by: Steven Danna <steve@chef.io>