### PR TITLE
Turn on code simplification checker in lint config.

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -23,6 +23,3 @@ disable = [
   "unparam",
   "lll",
 ]
-
-[linters-settings.gofmt]
-  simplify = false

--- a/components/applications-service/integration_test/service_groups_filters_test.go
+++ b/components/applications-service/integration_test/service_groups_filters_test.go
@@ -21,7 +21,7 @@ func TestServiceGroupsMultiServiceFilterStatusOk(t *testing.T) {
 		}
 		expected = &applications.ServiceGroups{
 			ServiceGroups: []*applications.ServiceGroup{
-				&applications.ServiceGroup{
+				{
 					Name:             "redis.default",
 					Release:          "core/redis/0.1.0/20190101121212",
 					Status:           applications.HealthStatus_OK,
@@ -52,7 +52,7 @@ func TestServiceGroupsMultiServiceFilterStatusCritical(t *testing.T) {
 		}
 		expected = &applications.ServiceGroups{
 			ServiceGroups: []*applications.ServiceGroup{
-				&applications.ServiceGroup{
+				{
 					Name:             "postgres.default",
 					Release:          "core/postgres/0.1.0/20190101121212",
 					Status:           applications.HealthStatus_CRITICAL,
@@ -85,7 +85,7 @@ func TestServiceGroupsMultiServiceFilterStatusWarning(t *testing.T) {
 		}
 		expected = &applications.ServiceGroups{
 			ServiceGroups: []*applications.ServiceGroup{
-				&applications.ServiceGroup{
+				{
 					Name:             "myapp.default",
 					Release:          "core/myapp/0.1.0/20190101121212",
 					Status:           applications.HealthStatus_WARNING,
@@ -117,7 +117,7 @@ func TestServiceGroupsMultiServiceFilterStatusUnknown(t *testing.T) {
 		}
 		expected = &applications.ServiceGroups{
 			ServiceGroups: []*applications.ServiceGroup{
-				&applications.ServiceGroup{
+				{
 					Name:             "test.default",
 					Release:          "core/test/0.1.0/20190101121212",
 					Status:           applications.HealthStatus_UNKNOWN,

--- a/components/applications-service/integration_test/service_groups_test.go
+++ b/components/applications-service/integration_test/service_groups_test.go
@@ -31,7 +31,7 @@ func TestGetServiceGroupsOneOk(t *testing.T) {
 		request  = new(applications.ServiceGroupsReq)
 		expected = &applications.ServiceGroups{
 			ServiceGroups: []*applications.ServiceGroup{
-				&applications.ServiceGroup{
+				{
 					Id:               "number",
 					Name:             "postgres.default",
 					Release:          "core/postgres/0.1.0/20190101121212",
@@ -64,7 +64,7 @@ func TestGetServiceGroupsOneCritical(t *testing.T) {
 		request  = new(applications.ServiceGroupsReq)
 		expected = &applications.ServiceGroups{
 			ServiceGroups: []*applications.ServiceGroup{
-				&applications.ServiceGroup{
+				{
 					Name:             "postgres.default",
 					Release:          "core/postgres/0.1.0/20190101121212",
 					Status:           applications.HealthStatus_CRITICAL,
@@ -96,7 +96,7 @@ func TestServiceGroupsMultiService(t *testing.T) {
 		request  = new(applications.ServiceGroupsReq)
 		expected = &applications.ServiceGroups{
 			ServiceGroups: []*applications.ServiceGroup{
-				&applications.ServiceGroup{
+				{
 					Name:             "myapp.default",
 					Release:          "core/myapp/0.1.0/20190101121212",
 					Status:           applications.HealthStatus_WARNING,
@@ -107,7 +107,7 @@ func TestServiceGroupsMultiService(t *testing.T) {
 						Warning: 1,
 					},
 				},
-				&applications.ServiceGroup{
+				{
 					Name:             "postgres.default",
 					Release:          "core/postgres/0.1.0/20190101121212",
 					Status:           applications.HealthStatus_CRITICAL,
@@ -119,7 +119,7 @@ func TestServiceGroupsMultiService(t *testing.T) {
 						Unknown:  1,
 					},
 				},
-				&applications.ServiceGroup{
+				{
 					Name:             "redis.default",
 					Release:          "core/redis/0.1.0/20190101121212",
 					Status:           applications.HealthStatus_OK,
@@ -129,7 +129,7 @@ func TestServiceGroupsMultiService(t *testing.T) {
 						Ok:    3,
 					},
 				},
-				&applications.ServiceGroup{
+				{
 					Name:             "test.default",
 					Release:          "core/test/0.1.0/20190101121212",
 					Status:           applications.HealthStatus_UNKNOWN,
@@ -158,7 +158,7 @@ func TestGetServiceGroupsOneWarning(t *testing.T) {
 		request  = new(applications.ServiceGroupsReq)
 		expected = &applications.ServiceGroups{
 			ServiceGroups: []*applications.ServiceGroup{
-				&applications.ServiceGroup{
+				{
 					Id:               "number",
 					Name:             "postgres.default",
 					Release:          "core/postgres/0.1.0/20190101121212",
@@ -191,7 +191,7 @@ func TestGetServiceGroupsOneUnknown(t *testing.T) {
 		request  = new(applications.ServiceGroupsReq)
 		expected = &applications.ServiceGroups{
 			ServiceGroups: []*applications.ServiceGroup{
-				&applications.ServiceGroup{
+				{
 					Id:               "number",
 					Name:             "postgres.default",
 					Release:          "core/postgres/0.1.0/20190101121212",
@@ -223,7 +223,7 @@ func TestGetServiceGroupsOneEach(t *testing.T) {
 		request  = new(applications.ServiceGroupsReq)
 		expected = &applications.ServiceGroups{
 			ServiceGroups: []*applications.ServiceGroup{
-				&applications.ServiceGroup{
+				{
 					Id:               "number",
 					Name:             "postgres.default",
 					Release:          "core/postgres/0.1.0/20190101121212",
@@ -491,7 +491,7 @@ func TestGetServiceGroupsMultiplePagesAndFilters(t *testing.T) {
 		}
 		expected = &applications.ServiceGroups{
 			ServiceGroups: []*applications.ServiceGroup{
-				&applications.ServiceGroup{
+				{
 					Name:                 "c.default",
 					Release:              "core/c/0.1.0/20190101121212",
 					Status:               applications.HealthStatus_OK,

--- a/components/applications-service/integration_test/services_by_sg_test.go
+++ b/components/applications-service/integration_test/services_by_sg_test.go
@@ -83,7 +83,7 @@ func TestGetServicesBySGSingleService(t *testing.T) {
 			expected = &applications.ServicesBySGRes{
 				Group: "postgres.default",
 				Services: []*applications.Service{
-					&applications.Service{
+					{
 						SupervisorId: "sup1234",
 						Group:        "postgres.default",
 						Release:      "core/postgres/0.1.0/20190101121212",
@@ -124,7 +124,7 @@ func TestGetServicesBySGWithPaginationParameter(t *testing.T) {
 			expected = &applications.ServicesBySGRes{
 				Group: "myapp.default",
 				Services: []*applications.Service{
-					&applications.Service{
+					{
 						SupervisorId: "sup1",
 						Group:        "myapp.default",
 						Release:      "core/myapp/0.1.0/20190101121212",
@@ -150,11 +150,11 @@ func TestGetServicesBySGMultiService(t *testing.T) {
 	defer suite.DeleteDataFromStorage()
 
 	expectedResponses := []*applications.ServicesBySGRes{
-		&applications.ServicesBySGRes{
+		{
 			Group:                "myapp.default",
 			ServicesHealthCounts: &applications.HealthCounts{Total: 3, Warning: 1, Ok: 2},
 			Services: []*applications.Service{
-				&applications.Service{
+				{
 					SupervisorId: "sup1",
 					Group:        "myapp.default",
 					Release:      "core/myapp/0.1.0/20190101121212",
@@ -162,7 +162,7 @@ func TestGetServicesBySGMultiService(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_WARNING,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup2",
 					Group:        "myapp.default",
 					Release:      "core/myapp/0.1.0/20190101121212",
@@ -170,7 +170,7 @@ func TestGetServicesBySGMultiService(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_OK,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup3",
 					Group:        "myapp.default",
 					Release:      "core/myapp/0.1.0/20190101121212",
@@ -180,11 +180,11 @@ func TestGetServicesBySGMultiService(t *testing.T) {
 				},
 			},
 		},
-		&applications.ServicesBySGRes{
+		{
 			Group:                "postgres.default",
 			ServicesHealthCounts: &applications.HealthCounts{Total: 3, Critical: 1, Ok: 1, Unknown: 1},
 			Services: []*applications.Service{
-				&applications.Service{
+				{
 					SupervisorId: "sup3",
 					Group:        "postgres.default",
 					Release:      "core/postgres/0.1.0/20190101121212",
@@ -192,7 +192,7 @@ func TestGetServicesBySGMultiService(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_CRITICAL,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup2",
 					Group:        "postgres.default",
 					Release:      "core/postgres/0.1.0/20190101121212",
@@ -200,7 +200,7 @@ func TestGetServicesBySGMultiService(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_UNKNOWN,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup1",
 					Group:        "postgres.default",
 					Release:      "core/postgres/0.1.0/20190101121212",
@@ -210,11 +210,11 @@ func TestGetServicesBySGMultiService(t *testing.T) {
 				},
 			},
 		},
-		&applications.ServicesBySGRes{
+		{
 			Group:                "redis.default",
 			ServicesHealthCounts: &applications.HealthCounts{Total: 3, Ok: 3},
 			Services: []*applications.Service{
-				&applications.Service{
+				{
 					SupervisorId: "sup1",
 					Group:        "redis.default",
 					Release:      "core/redis/0.1.0/20190101121212",
@@ -222,7 +222,7 @@ func TestGetServicesBySGMultiService(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_OK,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup2",
 					Group:        "redis.default",
 					Release:      "core/redis/0.1.0/20190101121212",
@@ -230,7 +230,7 @@ func TestGetServicesBySGMultiService(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_OK,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup3",
 					Group:        "redis.default",
 					Release:      "core/redis/0.1.0/20190101121212",
@@ -240,11 +240,11 @@ func TestGetServicesBySGMultiService(t *testing.T) {
 				},
 			},
 		},
-		&applications.ServicesBySGRes{
+		{
 			Group:                "test.default",
 			ServicesHealthCounts: &applications.HealthCounts{Total: 1, Unknown: 1},
 			Services: []*applications.Service{
-				&applications.Service{
+				{
 					SupervisorId: "sup4",
 					Group:        "test.default",
 					Release:      "core/test/0.1.0/20190101121212",
@@ -286,11 +286,11 @@ func TestGetServicesBySGMultiServiceWithHealthFilter(t *testing.T) {
 
 	var (
 		expectedOKResponses = []*applications.ServicesBySGRes{
-			&applications.ServicesBySGRes{
+			{
 				Group:                "myapp.default",
 				ServicesHealthCounts: &applications.HealthCounts{Total: 3, Warning: 1, Ok: 2},
 				Services: []*applications.Service{
-					&applications.Service{
+					{
 						SupervisorId: "sup2",
 						Group:        "myapp.default",
 						Release:      "core/myapp/0.1.0/20190101121212",
@@ -298,7 +298,7 @@ func TestGetServicesBySGMultiServiceWithHealthFilter(t *testing.T) {
 						HealthCheck:  applications.HealthStatus_OK,
 						Application:  a, Environment: e, Fqdn: "",
 					},
-					&applications.Service{
+					{
 						SupervisorId: "sup3",
 						Group:        "myapp.default",
 						Release:      "core/myapp/0.1.0/20190101121212",
@@ -308,11 +308,11 @@ func TestGetServicesBySGMultiServiceWithHealthFilter(t *testing.T) {
 					},
 				},
 			},
-			&applications.ServicesBySGRes{
+			{
 				Group:                "postgres.default",
 				ServicesHealthCounts: &applications.HealthCounts{Total: 3, Critical: 1, Ok: 1, Unknown: 1},
 				Services: []*applications.Service{
-					&applications.Service{
+					{
 						SupervisorId: "sup1",
 						Group:        "postgres.default",
 						Release:      "core/postgres/0.1.0/20190101121212",
@@ -322,25 +322,25 @@ func TestGetServicesBySGMultiServiceWithHealthFilter(t *testing.T) {
 					},
 				},
 			},
-			&applications.ServicesBySGRes{
+			{
 				Group:                "redis.default",
 				ServicesHealthCounts: &applications.HealthCounts{Total: 3, Ok: 3},
 				Services: []*applications.Service{
-					&applications.Service{
+					{
 						Group:       "redis.default",
 						Release:     "core/redis/0.1.0/20190101121212",
 						Status:      applications.ServiceStatus_RUNNING,
 						HealthCheck: applications.HealthStatus_OK,
 						Application: a, Environment: e, Fqdn: "",
 					},
-					&applications.Service{
+					{
 						Group:       "redis.default",
 						Release:     "core/redis/0.1.0/20190101121212",
 						Status:      applications.ServiceStatus_RUNNING,
 						HealthCheck: applications.HealthStatus_OK,
 						Application: a, Environment: e, Fqdn: "",
 					},
-					&applications.Service{
+					{
 						Group:       "redis.default",
 						Release:     "core/redis/0.1.0/20190101121212",
 						Status:      applications.ServiceStatus_RUNNING,
@@ -349,7 +349,7 @@ func TestGetServicesBySGMultiServiceWithHealthFilter(t *testing.T) {
 					},
 				},
 			},
-			&applications.ServicesBySGRes{
+			{
 				Group:                "test.default",
 				Services:             []*applications.Service{},
 				ServicesHealthCounts: &applications.HealthCounts{Total: 1, Unknown: 1},
@@ -357,16 +357,16 @@ func TestGetServicesBySGMultiServiceWithHealthFilter(t *testing.T) {
 		}
 
 		expectedCRITICALResponses = []*applications.ServicesBySGRes{
-			&applications.ServicesBySGRes{
+			{
 				Group:                "myapp.default",
 				Services:             []*applications.Service{},
 				ServicesHealthCounts: &applications.HealthCounts{Total: 3, Warning: 1, Ok: 2},
 			},
-			&applications.ServicesBySGRes{
+			{
 				Group:                "postgres.default",
 				ServicesHealthCounts: &applications.HealthCounts{Total: 3, Critical: 1, Ok: 1, Unknown: 1},
 				Services: []*applications.Service{
-					&applications.Service{
+					{
 						SupervisorId: "sup3",
 						Group:        "postgres.default",
 						Release:      "core/postgres/0.1.0/20190101121212",
@@ -376,12 +376,12 @@ func TestGetServicesBySGMultiServiceWithHealthFilter(t *testing.T) {
 					},
 				},
 			},
-			&applications.ServicesBySGRes{
+			{
 				Group:                "redis.default",
 				Services:             []*applications.Service{},
 				ServicesHealthCounts: &applications.HealthCounts{Total: 3, Ok: 3},
 			},
-			&applications.ServicesBySGRes{
+			{
 				Group:                "test.default",
 				Services:             []*applications.Service{},
 				ServicesHealthCounts: &applications.HealthCounts{Total: 1, Unknown: 1},
@@ -389,11 +389,11 @@ func TestGetServicesBySGMultiServiceWithHealthFilter(t *testing.T) {
 		}
 
 		expectedWARNINGResponses = []*applications.ServicesBySGRes{
-			&applications.ServicesBySGRes{
+			{
 				Group:                "myapp.default",
 				ServicesHealthCounts: &applications.HealthCounts{Total: 3, Warning: 1, Ok: 2},
 				Services: []*applications.Service{
-					&applications.Service{
+					{
 						SupervisorId: "sup1",
 						Group:        "myapp.default",
 						Release:      "core/myapp/0.1.0/20190101121212",
@@ -403,17 +403,17 @@ func TestGetServicesBySGMultiServiceWithHealthFilter(t *testing.T) {
 					},
 				},
 			},
-			&applications.ServicesBySGRes{
+			{
 				Group:                "postgres.default",
 				Services:             []*applications.Service{},
 				ServicesHealthCounts: &applications.HealthCounts{Total: 3, Critical: 1, Ok: 1, Unknown: 1},
 			},
-			&applications.ServicesBySGRes{
+			{
 				Group:                "redis.default",
 				Services:             []*applications.Service{},
 				ServicesHealthCounts: &applications.HealthCounts{Total: 3, Ok: 3},
 			},
-			&applications.ServicesBySGRes{
+			{
 				Group:                "test.default",
 				Services:             []*applications.Service{},
 				ServicesHealthCounts: &applications.HealthCounts{Total: 1, Unknown: 1},
@@ -421,16 +421,16 @@ func TestGetServicesBySGMultiServiceWithHealthFilter(t *testing.T) {
 		}
 
 		expectedUNKNOWNResponses = []*applications.ServicesBySGRes{
-			&applications.ServicesBySGRes{
+			{
 				Group:                "myapp.default",
 				Services:             []*applications.Service{},
 				ServicesHealthCounts: &applications.HealthCounts{Total: 3, Warning: 1, Ok: 2},
 			},
-			&applications.ServicesBySGRes{
+			{
 				Group:                "postgres.default",
 				ServicesHealthCounts: &applications.HealthCounts{Total: 3, Critical: 1, Ok: 1, Unknown: 1},
 				Services: []*applications.Service{
-					&applications.Service{
+					{
 						SupervisorId: "sup2",
 						Group:        "postgres.default",
 						Release:      "core/postgres/0.1.0/20190101121212",
@@ -440,16 +440,16 @@ func TestGetServicesBySGMultiServiceWithHealthFilter(t *testing.T) {
 					},
 				},
 			},
-			&applications.ServicesBySGRes{
+			{
 				Group:                "redis.default",
 				ServicesHealthCounts: &applications.HealthCounts{Total: 3, Ok: 3},
 				Services:             []*applications.Service{},
 			},
-			&applications.ServicesBySGRes{
+			{
 				Group:                "test.default",
 				ServicesHealthCounts: &applications.HealthCounts{Total: 1, Unknown: 1},
 				Services: []*applications.Service{
-					&applications.Service{
+					{
 						SupervisorId: "sup4",
 						Group:        "test.default",
 						Release:      "core/test/0.1.0/20190101121212",

--- a/components/applications-service/integration_test/services_test.go
+++ b/components/applications-service/integration_test/services_test.go
@@ -58,7 +58,7 @@ func TestGetServicesSingleService(t *testing.T) {
 			request  = &applications.ServicesReq{}
 			expected = &applications.ServicesRes{
 				Services: []*applications.Service{
-					&applications.Service{
+					{
 						SupervisorId: "sup1234",
 						Group:        "postgres.default",
 						Release:      "core/postgres/0.1.0/20190101121212",
@@ -87,7 +87,7 @@ func TestGetServicesMultiService(t *testing.T) {
 		// health status order.  ["CRITICAL", "UNKNOWN", "WARNING", "OK"]
 		expected = &applications.ServicesRes{
 			Services: []*applications.Service{
-				&applications.Service{
+				{
 					SupervisorId: "sup1",
 					Group:        "postgres.default",
 					Release:      "core/postgres/0.1.0/20190101121212",
@@ -95,7 +95,7 @@ func TestGetServicesMultiService(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_CRITICAL,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup2",
 					Group:        "test.default",
 					Release:      "core/test/0.1.0/20190101121212",
@@ -103,7 +103,7 @@ func TestGetServicesMultiService(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_UNKNOWN,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup3",
 					Group:        "test.default",
 					Release:      "core/test/0.1.0/20190101121212",
@@ -111,7 +111,7 @@ func TestGetServicesMultiService(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_UNKNOWN,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup1",
 					Group:        "myapp.default",
 					Release:      "core/myapp/0.1.0/20190101121212",
@@ -119,7 +119,7 @@ func TestGetServicesMultiService(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_WARNING,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup1",
 					Group:        "redis.default",
 					Release:      "core/redis/0.1.0/20190101121212",
@@ -127,7 +127,7 @@ func TestGetServicesMultiService(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_OK,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup4",
 					Group:        "test.default",
 					Release:      "core/test/0.1.0/20190101121212",
@@ -160,7 +160,7 @@ func TestGetServicesMultiServicaSortDESC(t *testing.T) {
 		// health status in descending order ["OK", "WARN", "UNKNOWN", "CRITICAL"]
 		expected = &applications.ServicesRes{
 			Services: []*applications.Service{
-				&applications.Service{
+				{
 					SupervisorId: "sup1",
 					Group:        "redis.default",
 					Release:      "core/redis/0.1.0/20190101121212",
@@ -168,7 +168,7 @@ func TestGetServicesMultiServicaSortDESC(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_OK,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup4",
 					Group:        "test.default",
 					Release:      "core/test/0.1.0/20190101121212",
@@ -176,7 +176,7 @@ func TestGetServicesMultiServicaSortDESC(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_OK,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup1",
 					Group:        "myapp.default",
 					Release:      "core/myapp/0.1.0/20190101121212",
@@ -184,7 +184,7 @@ func TestGetServicesMultiServicaSortDESC(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_WARNING,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup2",
 					Group:        "test.default",
 					Release:      "core/test/0.1.0/20190101121212",
@@ -192,7 +192,7 @@ func TestGetServicesMultiServicaSortDESC(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_UNKNOWN,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup3",
 					Group:        "test.default",
 					Release:      "core/test/0.1.0/20190101121212",
@@ -200,7 +200,7 @@ func TestGetServicesMultiServicaSortDESC(t *testing.T) {
 					HealthCheck:  applications.HealthStatus_UNKNOWN,
 					Application:  a, Environment: e, Fqdn: "",
 				},
-				&applications.Service{
+				{
 					SupervisorId: "sup1",
 					Group:        "postgres.default",
 					Release:      "core/postgres/0.1.0/20190101121212",
@@ -231,7 +231,7 @@ func TestGetServicesMultiServicaPagination(t *testing.T) {
 		}
 		expected = &applications.ServicesRes{
 			Services: []*applications.Service{
-				&applications.Service{
+				{
 					SupervisorId: "sup2",
 					Group:        "test.default",
 					Release:      "core/test/0.1.0/20190101121212",
@@ -290,7 +290,7 @@ func TestGetServicesMultiServicaPaginationAndSorting(t *testing.T) {
 		}
 		expected = &applications.ServicesRes{
 			Services: []*applications.Service{
-				&applications.Service{
+				{
 					SupervisorId: "sup1",
 					Group:        "redis.default",
 					Release:      "core/redis/0.1.0/20190101121212",
@@ -323,7 +323,7 @@ func TestGetServicesMultiServiceWithServiceGroupIDFilter(t *testing.T) {
 			}
 			expected = &applications.ServicesRes{
 				Services: []*applications.Service{
-					&applications.Service{
+					{
 						SupervisorId: "sup1",
 						Group:        "myapp.default",
 						Release:      "core/myapp/0.1.0/20190101121212",
@@ -355,7 +355,7 @@ func TestGetServicesMultiServiceWithHealthFilter(t *testing.T) {
 			}
 			expected = &applications.ServicesRes{
 				Services: []*applications.Service{
-					&applications.Service{
+					{
 						SupervisorId: "sup1",
 						Group:        "myapp.default",
 						Release:      "core/myapp/0.1.0/20190101121212",
@@ -391,7 +391,7 @@ func TestGetServicesMultiServiceWithHealthAndServiceGroupIdFilter(t *testing.T) 
 			}
 			expected = &applications.ServicesRes{
 				Services: []*applications.Service{
-					&applications.Service{
+					{
 						SupervisorId: "sup2",
 						Group:        "test.default",
 						Release:      "core/test/0.1.0/20190101121212",
@@ -399,7 +399,7 @@ func TestGetServicesMultiServiceWithHealthAndServiceGroupIdFilter(t *testing.T) 
 						HealthCheck:  applications.HealthStatus_UNKNOWN,
 						Application:  a, Environment: e, Fqdn: "",
 					},
-					&applications.Service{
+					{
 						SupervisorId: "sup3",
 						Group:        "test.default",
 						Release:      "core/test/0.1.0/20190101121212",

--- a/components/applications-service/pkg/generator/runner.go
+++ b/components/applications-service/pkg/generator/runner.go
@@ -193,7 +193,7 @@ func (s *SupSim) Run() {
 	s.PublishAll() // nolint: errcheck
 
 	ticker := time.NewTicker(time.Duration(s.Cfg.Tick) * time.Second)
-	for _ = range ticker.C {
+	for range ticker.C {
 		s.PublishAll() // nolint: errcheck
 	}
 }

--- a/components/applications-service/pkg/generator/runner_stats.go
+++ b/components/applications-service/pkg/generator/runner_stats.go
@@ -43,7 +43,7 @@ const statsPrintPerMinute = 2
 func (r *RunnerStatsKeeper) RunCollectAndPrintLoop() {
 	r.Report()
 	ticker := time.NewTicker(r.Interval())
-	for _ = range ticker.C {
+	for range ticker.C {
 		r.Report()
 		r.ResetCycleStats()
 	}

--- a/components/applications-service/pkg/params/filters_test.go
+++ b/components/applications-service/pkg/params/filters_test.go
@@ -28,7 +28,7 @@ func TestFormatFiltersMatrixOfFilters(t *testing.T) {
 			message: "with a single unique filter (1:1)",
 			filters: []string{"platform:centos"},
 			expected: map[string][]string{
-				"platform": []string{"centos"},
+				"platform": {"centos"},
 			},
 		},
 		{
@@ -39,7 +39,7 @@ func TestFormatFiltersMatrixOfFilters(t *testing.T) {
 				"platform:redhat",
 			},
 			expected: map[string][]string{
-				"platform": []string{"centos", "ubuntu", "redhat"},
+				"platform": {"centos", "ubuntu", "redhat"},
 			},
 		},
 		{
@@ -51,10 +51,10 @@ func TestFormatFiltersMatrixOfFilters(t *testing.T) {
 				"environment:prod",
 			},
 			expected: map[string][]string{
-				"status":       []string{"critical"},
-				"service_name": []string{"redis"},
-				"application":  []string{"cafe"},
-				"environment":  []string{"prod"},
+				"status":       {"critical"},
+				"service_name": {"redis"},
+				"application":  {"cafe"},
+				"environment":  {"prod"},
 			},
 		},
 		{
@@ -71,10 +71,10 @@ func TestFormatFiltersMatrixOfFilters(t *testing.T) {
 				"service_name:myapp",
 			},
 			expected: map[string][]string{
-				"status":       []string{"critical", "warning"},
-				"service_name": []string{"redis", "postgres", "myapp"},
-				"application":  []string{"cafe-us", "cafe-europe", "cafe-asia"},
-				"environment":  []string{"prod"},
+				"status":       {"critical", "warning"},
+				"service_name": {"redis", "postgres", "myapp"},
+				"application":  {"cafe-us", "cafe-europe", "cafe-asia"},
+				"environment":  {"prod"},
 			},
 		},
 	}

--- a/components/applications-service/pkg/server/server.go
+++ b/components/applications-service/pkg/server/server.go
@@ -149,7 +149,7 @@ func (app *ApplicationsServer) GetServicesBySG(
 		page, pageSize = params.GetPageParams(request.GetPagination())
 		sgStringID     = fmt.Sprint(request.GetServiceGroupId())
 		filters        = map[string][]string{
-			"service_group_id": []string{sgStringID},
+			"service_group_id": {sgStringID},
 		}
 	)
 

--- a/components/applications-service/pkg/storage/postgres/service_internal_test.go
+++ b/components/applications-service/pkg/storage/postgres/service_internal_test.go
@@ -26,7 +26,7 @@ func TestBuildWhereConstraintsFromFiltersMatrix(t *testing.T) {
 		{
 			message: "with service_group_id filter with single value returns built WHERE statement",
 			filters: map[string][]string{
-				"service_group_id": []string{"123"},
+				"service_group_id": {"123"},
 			},
 			expected:          "WHERE group_id = '123'",
 			shouldReturnError: false,
@@ -34,7 +34,7 @@ func TestBuildWhereConstraintsFromFiltersMatrix(t *testing.T) {
 		{
 			message: "with service_group_id filter with multiple values returns built WHERE statement",
 			filters: map[string][]string{
-				"service_group_id": []string{"123", "456"},
+				"service_group_id": {"123", "456"},
 			},
 			expected:          "WHERE group_id = '123' OR group_id = '456'",
 			shouldReturnError: false,
@@ -42,7 +42,7 @@ func TestBuildWhereConstraintsFromFiltersMatrix(t *testing.T) {
 		{
 			message: "with health filter with single value returns built WHERE statement",
 			filters: map[string][]string{
-				"health": []string{"UNKNOWN"},
+				"health": {"UNKNOWN"},
 			},
 			expected:          "WHERE health = 'UNKNOWN'",
 			shouldReturnError: false,
@@ -50,8 +50,8 @@ func TestBuildWhereConstraintsFromFiltersMatrix(t *testing.T) {
 		{
 			message: "with multiple valid filters and multiple values returns built WHERE statement",
 			filters: map[string][]string{
-				"service_group_id": []string{"123", "456"},
-				"health":           []string{"WARNING", "OK"},
+				"service_group_id": {"123", "456"},
+				"health":           {"WARNING", "OK"},
 			},
 			expected:          "WHERE group_id = '123' OR group_id = '456' AND health = 'WARNING' OR health = 'OK'",
 			shouldReturnError: false,
@@ -59,7 +59,7 @@ func TestBuildWhereConstraintsFromFiltersMatrix(t *testing.T) {
 		{
 			message: "valid filter with no value returns empty where constraints",
 			filters: map[string][]string{
-				"not-valid-filter": []string{},
+				"not-valid-filter": {},
 			},
 			expected:          noWhereConstraints,
 			shouldReturnError: false,
@@ -67,7 +67,7 @@ func TestBuildWhereConstraintsFromFiltersMatrix(t *testing.T) {
 		{
 			message: "invalid filter with no value returns empty where constraints",
 			filters: map[string][]string{
-				"not-valid-filter": []string{},
+				"not-valid-filter": {},
 			},
 			expected:          noWhereConstraints,
 			shouldReturnError: false,
@@ -75,7 +75,7 @@ func TestBuildWhereConstraintsFromFiltersMatrix(t *testing.T) {
 		{
 			message: "with invalid filters and a single value returns an error",
 			filters: map[string][]string{
-				"not-valid-filter": []string{"value"},
+				"not-valid-filter": {"value"},
 			},
 			expected:          noWhereConstraints,
 			shouldReturnError: true,
@@ -84,9 +84,9 @@ func TestBuildWhereConstraintsFromFiltersMatrix(t *testing.T) {
 		{
 			message: "with invalid filters with multiple values returns an error",
 			filters: map[string][]string{
-				"not-valid-filter": []string{"value"},
-				"not-awesome":      []string{"c", "o", "o", "l"},
-				"more":             []string{"not", "valid", "filters"},
+				"not-valid-filter": {"value"},
+				"not-awesome":      {"c", "o", "o", "l"},
+				"more":             {"not", "valid", "filters"},
 			},
 			expected:          noWhereConstraints,
 			shouldReturnError: true,
@@ -95,8 +95,8 @@ func TestBuildWhereConstraintsFromFiltersMatrix(t *testing.T) {
 		{
 			message: "with valid and invalid filters returns an error",
 			filters: map[string][]string{
-				"service_group_id": []string{"1234"},
-				"not-awesome":      []string{"c", "o", "o", "l"},
+				"service_group_id": {"1234"},
+				"not-awesome":      {"c", "o", "o", "l"},
 			},
 			expected:          noWhereConstraints,
 			shouldReturnError: true,

--- a/components/authz-service/engine/opa/opa_test.go
+++ b/components/authz-service/engine/opa/opa_test.go
@@ -118,7 +118,7 @@ func (tc *subjectsTestcase) name() string {
 
 func TestActionMatching(t *testing.T) {
 	tests := map[string][]testcase{
-		"positive": []testcase{
+		"positive": {
 			{"read", map[string]string{"match": "read"}, defaultCheck1},
 			{"read", map[string]string{"match": "*"}, defaultCheck1},
 			{"read", map[string]string{"match": "*", "nomatch": "foo"}, defaultCheck1},
@@ -126,7 +126,7 @@ func TestActionMatching(t *testing.T) {
 			{"read", map[string]string{"anothermatch": "*", "match": "read"}, defaultCheck2},
 			{"read", map[string]string{"nomatch": "write", "match": "read", "nomatch2": "execute"}, defaultCheck1},
 		},
-		"negative": []testcase{
+		"negative": {
 			{"read", map[string]string{}, noMatch},
 			{"read", map[string]string{"simple_different": "write"}, noMatch},
 			{"read", map[string]string{"simple_different": "write", "also_different": "execute"}, noMatch},
@@ -149,7 +149,7 @@ func TestActionMatching(t *testing.T) {
 
 func TestResourceMatching(t *testing.T) {
 	tests := map[string][]testcase{
-		"positive": []testcase{
+		"positive": {
 			// exact matching cases
 			{"compliance", map[string]string{"match": "compliance"}, defaultCheck1},
 			{"compliance:profiles:foobee", map[string]string{"match": "compliance:profiles:foobee"}, defaultCheck1},
@@ -175,7 +175,7 @@ func TestResourceMatching(t *testing.T) {
 				map[string]string{"nomatch": "cfgmgmt", "match": "compliance:profiles:*", "nomatch2": "auth"},
 				defaultCheck1},
 		},
-		"negative": []testcase{
+		"negative": {
 			// exact matching cases
 			{"compliance:scans", map[string]string{}, noMatch},
 			{"compliance:scans", map[string]string{"nomatch": "compliance:scans:123"}, noMatch},
@@ -219,7 +219,7 @@ func TestSubjectsMatching(t *testing.T) {
 		// keeping the input close to our actual formats makes the test cases
 		// more interesting. Also, we _could_ start to care about the format,
 		// and then it doesn't all have to be redone.
-		"positive": []subjectsTestcase{
+		"positive": {
 			// 1:1 matches
 			{[]string{"user:local:someid"}, map[string][]string{"match": {"user:local:someid"}}, defaultCheck1},
 			{[]string{"user:local:someid"},
@@ -309,7 +309,7 @@ func TestSubjectsMatching(t *testing.T) {
 			// token:*
 			{[]string{"token:5d29c419-cd6e-4f23-b57a-20c253dcaab1"}, map[string][]string{"match": {"token:*"}}, defaultCheck1},
 		},
-		"negative": []subjectsTestcase{
+		"negative": {
 			{[]string{"user:local:someid"}, map[string][]string{}, noMatch},
 			{[]string{"user:local:someid"}, map[string][]string{"nomatch": {"user:local:SOMEID"}}, noMatch},
 			{[]string{"user:local:someid"}, map[string][]string{"nomatch": {"user:local:someid "}}, noMatch},
@@ -353,7 +353,7 @@ func TestPolicyVariablesResourceMatching(t *testing.T) {
 		checks     []checkFunc
 	}
 	tests := map[string][]testcase{
-		"positive": []testcase{
+		"positive": {
 			{map[string]interface{}{
 				"subjects": []string{"user:local:alice"},
 				"resource": "auth:users:alice",
@@ -373,7 +373,7 @@ func TestPolicyVariablesResourceMatching(t *testing.T) {
 				"resource": "auth:users:alice",
 			}, map[string]string{"match": "auth:users:${a2:username}"}, defaultCheck1},
 		},
-		"negative": []testcase{
+		"negative": {
 			{map[string]interface{}{
 				"subjects": []string{"user:local:alice"},
 				"resource": "auth:users:bob",
@@ -424,7 +424,7 @@ type policy struct {
 
 func TestAuthorizedPairs(t *testing.T) {
 	tests := map[string]map[string]authorizedPairsTestcase{
-		"positive": map[string]authorizedPairsTestcase{
+		"positive": {
 			"one of two input pairs is allowed (single subjects input)": {
 				[]string{"user:local:someid"},
 				[]pair{
@@ -514,7 +514,7 @@ func TestAuthorizedPairs(t *testing.T) {
 					containsPair("cfgmgmt:nodes:101:runs:999", "read")),
 			},
 		},
-		"negative": map[string]authorizedPairsTestcase{
+		"negative": {
 			"no pair returned when no policies match their resources": {
 				[]string{"user:local:someid", "team:local:admins"},
 				[]pair{

--- a/components/authz-service/engine/opa/opa_v2_test.go
+++ b/components/authz-service/engine/opa/opa_v2_test.go
@@ -87,22 +87,22 @@ func TestAuthorizedWithStatements(t *testing.T) {
 }`
 
 	cases := map[string]map[string]interface{}{
-		"exact match": map[string]interface{}{
+		"exact match": {
 			"subjects": []string{"team:local:admins"},
 			"action":   "iam:teams:create",
 			"resource": "iam:teams",
 		},
-		"subject wildcard": map[string]interface{}{
+		"subject wildcard": {
 			"subjects": []string{"user:local:alice"},
 			"action":   "iam:teams:create",
 			"resource": "iam:teams",
 		},
-		"one of multiple actions": map[string]interface{}{
+		"one of multiple actions": {
 			"subjects": []string{"team:local:admins"},
 			"action":   "infra:nodes:delete",
 			"resource": "infra:nodes",
 		},
-		"one of multiple resources (wildcard)": map[string]interface{}{
+		"one of multiple resources (wildcard)": {
 			"subjects": []string{"team:local:admins"},
 			"action":   "compliance:profiles:create",
 			"resource": "compliance:profiles:yadda",
@@ -230,7 +230,7 @@ func TestAuthorizedProjects(t *testing.T) {
 }`
 
 	cases := map[string]map[string]interface{}{
-		"exact match": map[string]interface{}{
+		"exact match": {
 			"subjects": []string{"team:local:admins"},
 			"projects": []string{"p1", "p3", "p4"},
 			"action":   "iam:teams:create",
@@ -287,23 +287,23 @@ func TestIntrospectionV2(t *testing.T) {
 }`
 
 	cases := map[string]map[string]interface{}{
-		"exact match": map[string]interface{}{
+		"exact match": {
 			"subjects": []string{"team:local:admins"},
 			"pairs":    []map[string]string{{"action": "admin:create", "resource": "auth:teams"}},
 		},
-		"subject wildcard": map[string]interface{}{
+		"subject wildcard": {
 			"subjects": []string{"user:local:alice"},
 			"pairs":    []map[string]string{{"action": "admin:create", "resource": "auth:teams"}},
 		},
-		"one of multiple actions": map[string]interface{}{
+		"one of multiple actions": {
 			"subjects": []string{"team:local:admins"},
 			"pairs":    []map[string]string{{"action": "cfgmgmt:delete", "resource": "cfgmgmt:nodes"}},
 		},
-		"one of multiple resources (wildcard)": map[string]interface{}{
+		"one of multiple resources (wildcard)": {
 			"subjects": []string{"team:local:admins"},
 			"pairs":    []map[string]string{{"action": "compliance:upload", "resource": "compliance:profiles:yadda"}},
 		},
-		"multiple matches (all of the above)": map[string]interface{}{
+		"multiple matches (all of the above)": {
 			"subjects": []string{"team:local:admins"},
 			"pairs": []map[string]string{
 				{"action": "cfgmgmt:delete", "resource": "cfgmgmt:nodes"},

--- a/components/authz-service/engine/opa/policy.bindata.go
+++ b/components/authz-service/engine/opa/policy.bindata.go
@@ -339,13 +339,13 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"policy": &bintree{nil, map[string]*bintree{
-		"authz.rego":            &bintree{policyAuthzRego, map[string]*bintree{}},
-		"authz_v2.rego":         &bintree{policyAuthz_v2Rego, map[string]*bintree{}},
-		"common.rego":           &bintree{policyCommonRego, map[string]*bintree{}},
-		"introspection.rego":    &bintree{policyIntrospectionRego, map[string]*bintree{}},
-		"introspection_v2.rego": &bintree{policyIntrospection_v2Rego, map[string]*bintree{}},
-		"rule_mappings.rego":    &bintree{policyRule_mappingsRego, map[string]*bintree{}},
+	"policy": {nil, map[string]*bintree{
+		"authz.rego":            {policyAuthzRego, map[string]*bintree{}},
+		"authz_v2.rego":         {policyAuthz_v2Rego, map[string]*bintree{}},
+		"common.rego":           {policyCommonRego, map[string]*bintree{}},
+		"introspection.rego":    {policyIntrospectionRego, map[string]*bintree{}},
+		"introspection_v2.rego": {policyIntrospection_v2Rego, map[string]*bintree{}},
+		"rule_mappings.rego":    {policyRule_mappingsRego, map[string]*bintree{}},
 	}},
 }}
 

--- a/components/authz-service/server/v1/server_test.go
+++ b/components/authz-service/server/v1/server_test.go
@@ -226,10 +226,10 @@ func TestCreatePolicy(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			t.Run("successfully creates policy", func(t *testing.T) {
 				subjTests := map[string][]string{
-					"single subject":                  []string{"user:local:subject1"},
-					"multiple subjects":               []string{"user:local:subject1", "user:local:subject2", "user:local:subject3"},
-					"subject with long name":          []string{"user:local:long-long-long-long-long-long-long-long-long-name-here"},
-					"one-character long subject name": []string{"user:local:a"},
+					"single subject":                  {"user:local:subject1"},
+					"multiple subjects":               {"user:local:subject1", "user:local:subject2", "user:local:subject3"},
+					"subject with long name":          {"user:local:long-long-long-long-long-long-long-long-long-name-here"},
+					"one-character long subject name": {"user:local:a"},
 				}
 				for desc, tc := range subjTests {
 					t.Run("with valid action and "+desc, expectSuccess(cl, authz.CreatePolicyReq{
@@ -273,17 +273,17 @@ func TestCreatePolicy(t *testing.T) {
 
 			t.Run("returns InvalidArgument", func(t *testing.T) {
 				tests := map[string]authz.CreatePolicyReq{
-					"no subject submitted": authz.CreatePolicyReq{
+					"no subject submitted": {
 						Action:   "action",
 						Subjects: []string{},
 						Resource: "resource:1",
 					},
-					"no action submitted": authz.CreatePolicyReq{
+					"no action submitted": {
 						Action:   "",
 						Subjects: []string{"user:local:subject1", "user:local:subject2", "user:local:subject3"},
 						Resource: "resource:1",
 					},
-					"no resource submitted": authz.CreatePolicyReq{
+					"no resource submitted": {
 						Action:   "someaction",
 						Subjects: []string{"user:local:subject1", "user:local:subject2", "user:local:subject3"},
 						Resource: "",
@@ -439,8 +439,8 @@ func TestDeletePolicy(t *testing.T) {
 
 			t.Run("returns InvalidArgument", func(t *testing.T) {
 				tests := map[string]authz.DeletePolicyReq{
-					"no ID submitted":           authz.DeletePolicyReq{},
-					"submitted ID is no UUIDv4": authz.DeletePolicyReq{Id: "35bffbab-3a49-dd8a-94a1-9ea87ec5c3cc"},
+					"no ID submitted":           {},
+					"submitted ID is no UUIDv4": {Id: "35bffbab-3a49-dd8a-94a1-9ea87ec5c3cc"},
 				}
 				for desc, tc := range tests {
 					t.Run(desc, func(t *testing.T) {
@@ -467,12 +467,12 @@ func TestPurgeSubjectFromPolicies(t *testing.T) {
 			assertPolicyStoreLength(ctx, t, cl, len(testPolicies))
 
 			subjTests := map[string][][]string{
-				"single subject":                      [][]string{{"user:local:purge"}},
-				"multiple subjects (first)":           [][]string{{"user:local:purge", "user:local:subject2", "user:local:subject3"}},
-				"multiple subjects (last)":            [][]string{{"user:local:subject0", "user:local:purge"}},
-				"single subjects (multiple)":          [][]string{{"user:local:purge"}, {"user:local:purge"}},
-				"multiple subjects (first, multiple)": [][]string{{"user:local:purge"}, {"user:local:purge", "user:local:subject0"}},
-				"multiple subjects (last, multiple)":  [][]string{{"user:local:purge"}, {"user:local:subject0", "user:local:purge"}},
+				"single subject":                      {{"user:local:purge"}},
+				"multiple subjects (first)":           {{"user:local:purge", "user:local:subject2", "user:local:subject3"}},
+				"multiple subjects (last)":            {{"user:local:subject0", "user:local:purge"}},
+				"single subjects (multiple)":          {{"user:local:purge"}, {"user:local:purge"}},
+				"multiple subjects (first, multiple)": {{"user:local:purge"}, {"user:local:purge", "user:local:subject0"}},
+				"multiple subjects (last, multiple)":  {{"user:local:purge"}, {"user:local:subject0", "user:local:purge"}},
 			}
 			for desc, tc := range subjTests {
 				t.Run("with existing matching policy having "+desc, func(t *testing.T) {
@@ -639,9 +639,9 @@ func TestAuthzGRPCInteractionWithTestEngineStore(t *testing.T) {
 
 	t.Run("CreatePolicy updates the engine", func(t *testing.T) {
 		tests := map[string][]*authz.CreatePolicyReq{
-			"multiple policies": []*authz.CreatePolicyReq{req1, req2, req3},
-			"a single policy":   []*authz.CreatePolicyReq{req3},
-			"no policies":       []*authz.CreatePolicyReq{},
+			"multiple policies": {req1, req2, req3},
+			"a single policy":   {req3},
+			"no policies":       {},
 		}
 		for desc, testPolicies := range tests {
 			t.Run(desc, func(t *testing.T) {

--- a/components/authz-service/server/v2/migration_internal_test.go
+++ b/components/authz-service/server/v2/migration_internal_test.go
@@ -2294,43 +2294,43 @@ func TestV1PolicyMigration(t *testing.T) {
 
 func TestCheckForAdminTokenPolicyConfirmsNotAnAdminPolicy(t *testing.T) {
 	testCases := map[string]*storage_v1.Policy{
-		"policy with multiple subjects": &storage_v1.Policy{
+		"policy with multiple subjects": {
 			ID:       id(t),
 			Subjects: []string{"user:local:albertine", "team:local:admins"},
 			Action:   "update",
 			Resource: "telemetry:config",
 		},
-		"policy with two tokens as subjects": &storage_v1.Policy{
+		"policy with two tokens as subjects": {
 			ID:       id(t),
 			Subjects: []string{"token:282f41f1-e763-4094-9c59-c4eec1b71532", "token:282f41f1-e763-4094-9c59-c4eec1b71532"},
 			Action:   "*",
 			Resource: "*",
 		},
-		"policy with two subjects but only one token": &storage_v1.Policy{
+		"policy with two subjects but only one token": {
 			ID:       id(t),
 			Subjects: []string{"token:282f41f1-e763-4094-9c59-c4eec1b71532", "team:local:admins"},
 			Action:   "*",
 			Resource: "*",
 		},
-		"policy where action is not '*'": &storage_v1.Policy{
+		"policy where action is not '*'": {
 			ID:       id(t),
 			Subjects: []string{"token:282f41f1-e763-4094-9c59-c4eec1b71532"},
 			Action:   "update",
 			Resource: "*",
 		},
-		"policy where resource is not '*'": &storage_v1.Policy{
+		"policy where resource is not '*'": {
 			ID:       id(t),
 			Subjects: []string{"token:282f41f1-e763-4094-9c59-c4eec1b71532"},
 			Action:   "*",
 			Resource: "telemetry:config",
 		},
-		"policy where subject is not a token": &storage_v1.Policy{
+		"policy where subject is not a token": {
 			ID:       id(t),
 			Subjects: []string{"user:local:marie"},
 			Action:   "*",
 			Resource: "*",
 		},
-		"policy with empty subjects": &storage_v1.Policy{
+		"policy with empty subjects": {
 			ID:       id(t),
 			Subjects: []string{},
 			Action:   "*",

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -2492,7 +2492,7 @@ func TestAuthzGRPCInteractionWithTestEngineStore(t *testing.T) {
 		Name:    "singleStatementAllow",
 		Members: []string{},
 		Statements: []*api_v2.Statement{
-			&api_v2.Statement{
+			{
 				Effect:    api_v2.Statement_ALLOW,
 				Resources: []string{"some-resource", "some-other-resource"},
 				Actions:   []string{"infra:some:action", "infra:some:other"},
@@ -2505,19 +2505,19 @@ func TestAuthzGRPCInteractionWithTestEngineStore(t *testing.T) {
 		Name:    "multiStatementAllow",
 		Members: []string{},
 		Statements: []*api_v2.Statement{
-			&api_v2.Statement{
+			{
 				Effect:    api_v2.Statement_ALLOW,
 				Resources: []string{"someResource", "someOtherResource"},
 				Actions:   []string{"infra:some:action", "infra:some:other"},
 			},
-			&api_v2.Statement{
+			{
 				Effect:    api_v2.Statement_DENY,
 				Resources: []string{"someResource2", "someOtherResource"},
 				Actions:   []string{"infra:some:action"},
 				Role:      "",
 				Projects:  []string{},
 			},
-			&api_v2.Statement{
+			{
 				Effect:    api_v2.Statement_ALLOW,
 				Resources: []string{"someResource3"},
 				Actions:   []string{"infra:some:action"},
@@ -2533,8 +2533,8 @@ func TestAuthzGRPCInteractionWithTestEngineStore(t *testing.T) {
 
 	t.Run("CreatePolicy updates the engine", func(t *testing.T) {
 		tests := map[string][]*api_v2.CreatePolicyReq{
-			"add multiple policies": []*api_v2.CreatePolicyReq{singleStatementAllow, multiStatementAllow},
-			"add a single policy":   []*api_v2.CreatePolicyReq{multiStatementAllow},
+			"add multiple policies": {singleStatementAllow, multiStatementAllow},
+			"add a single policy":   {multiStatementAllow},
 		}
 		for desc, testPolicies := range tests {
 			t.Run(desc, func(t *testing.T) {
@@ -2577,7 +2577,7 @@ func TestAuthzGRPCInteractionWithTestEngineStore(t *testing.T) {
 			Name:    "updatedSingleStatementAllow",
 			Members: []string{},
 			Statements: []*api_v2.Statement{
-				&api_v2.Statement{
+				{
 					Effect:    api_v2.Statement_ALLOW,
 					Resources: []string{"update-some-resource", "updated-some-other-resource"},
 					Actions:   []string{"infra:some:updatedAction", "infra:some:updatedOther"},
@@ -2599,8 +2599,8 @@ func TestAuthzGRPCInteractionWithTestEngineStore(t *testing.T) {
 
 	t.Run("DeletePolicy updates the engine", func(t *testing.T) {
 		tests := map[string][]*api_v2.CreatePolicyReq{
-			"delete multiple policies": []*api_v2.CreatePolicyReq{singleStatementAllow, multiStatementAllow},
-			"delete a single policy":   []*api_v2.CreatePolicyReq{multiStatementAllow},
+			"delete multiple policies": {singleStatementAllow, multiStatementAllow},
+			"delete a single policy":   {multiStatementAllow},
 		}
 		for desc, testPolicies := range tests {
 			t.Run(desc, func(t *testing.T) {
@@ -3016,25 +3016,25 @@ func genPolicy(t *testing.T, id string, p *prng.Prng) storage.Policy {
 
 	statementCount := 1 + rand.Intn(maxStatements)
 	statements := make([]storage.Statement, statementCount)
-	for i, _ := range statements {
+	for i := range statements {
 
 		actionCount := 1 + rand.Intn(maxActions-1) // store will have [1, 5] actions
 		actions := make([]string, actionCount)
-		for i, _ := range actions {
+		for i := range actions {
 			actions[i] = fmt.Sprintf("%s:%s:%s-%d",
 				faker.Lorem().Word(), faker.Lorem().Word(), faker.Lorem().Word(), i)
 		}
 
 		resourceCount := rand.Intn(maxResources)
 		resources := make([]string, resourceCount)
-		for i, _ := range resources {
+		for i := range resources {
 			resources[i] = fmt.Sprintf("%s:%s:%s-%d",
 				faker.Lorem().Word(), faker.Lorem().Word(), faker.Lorem().Word(), i)
 		}
 
 		projectCount := 1 + rand.Intn(maxProjects)
 		projects := make([]string, projectCount)
-		for i, _ := range projects {
+		for i := range projects {
 			projects[i] = fmt.Sprintf("%s-%d",
 				faker.Lorem().Word(), i)
 		}

--- a/components/authz-service/server/v2/project_update_manager.go
+++ b/components/authz-service/server/v2/project_update_manager.go
@@ -273,7 +273,7 @@ func (manager *ProjectUpdateManager) startProjectUpdateForDomainResources(
 		Type:      &automate_event.EventType{Name: automate_event_type.ProjectRulesUpdate},
 		Data: &_struct.Struct{
 			Fields: map[string]*_struct.Value{
-				project_update_tags.ProjectUpdateIDTag: &_struct.Value{
+				project_update_tags.ProjectUpdateIDTag: {
 					Kind: &_struct.Value_StringValue{
 						StringValue: projectUpdateID,
 					},
@@ -297,7 +297,7 @@ func (manager *ProjectUpdateManager) cancelProjectUpdateForDomainResources() err
 		Type:      &automate_event.EventType{Name: automate_event_type.ProjectRulesCancelUpdate},
 		Data: &_struct.Struct{
 			Fields: map[string]*_struct.Value{
-				project_update_tags.ProjectUpdateIDTag: &_struct.Value{
+				project_update_tags.ProjectUpdateIDTag: {
 					Kind: &_struct.Value_StringValue{
 						StringValue: manager.projectUpdateID,
 					},
@@ -351,11 +351,11 @@ func (manager *ProjectUpdateManager) checkIfComplete() {
 
 func (manager *ProjectUpdateManager) resetDomainServicesData() {
 	manager.domainServices = []*domainService{
-		&domainService{
+		{
 			name:     event_ids.ComplianceInspecReportProducerID,
 			complete: false,
 		},
-		&domainService{
+		{
 			name:     event_ids.InfraClientRunsProducerID,
 			complete: false,
 		},

--- a/components/authz-service/server/v2/project_update_manager_test.go
+++ b/components/authz-service/server/v2/project_update_manager_test.go
@@ -337,7 +337,7 @@ func createFailureEventMsg(projectUpdateIDTag string, producer string) *automate
 		},
 		Data: &_struct.Struct{
 			Fields: map[string]*_struct.Value{
-				project_update_tags.ProjectUpdateIDTag: &_struct.Value{
+				project_update_tags.ProjectUpdateIDTag: {
 					Kind: &_struct.Value_StringValue{
 						StringValue: projectUpdateIDTag,
 					},
@@ -358,22 +358,22 @@ func createStatusEventMsg(projectUpdateIDTag string, estimatedTimeCompeleteInSec
 		},
 		Data: &_struct.Struct{
 			Fields: map[string]*_struct.Value{
-				"Completed": &_struct.Value{
+				"Completed": {
 					Kind: &_struct.Value_BoolValue{
 						BoolValue: completed,
 					},
 				},
-				"PercentageComplete": &_struct.Value{
+				"PercentageComplete": {
 					Kind: &_struct.Value_NumberValue{
 						NumberValue: percentageComplete,
 					},
 				},
-				"EstimatedTimeCompeleteInSec": &_struct.Value{
+				"EstimatedTimeCompeleteInSec": {
 					Kind: &_struct.Value_NumberValue{
 						NumberValue: estimatedTimeCompeleteInSec,
 					},
 				},
-				project_update_tags.ProjectUpdateIDTag: &_struct.Value{
+				project_update_tags.ProjectUpdateIDTag: {
 					Kind: &_struct.Value_StringValue{
 						StringValue: projectUpdateIDTag,
 					},

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -3719,13 +3719,13 @@ func TestListProjects(t *testing.T) {
 			ps, err := store.ListProjects(ctx)
 			require.NoError(t, err)
 			expectedProjects := []*storage.Project{
-				&storage.Project{
+				{
 					ID:       "foo",
 					Name:     "my foo project",
 					Type:     storage.ChefManaged,
 					Projects: []string{"foo"},
 				},
-				&storage.Project{
+				{
 					ID:       "bar",
 					Name:     "my bar project",
 					Type:     storage.Custom,
@@ -3746,13 +3746,13 @@ func TestListProjects(t *testing.T) {
 			ps, err := store.ListProjects(ctx)
 			require.NoError(t, err)
 			expectedProjects := []*storage.Project{
-				&storage.Project{
+				{
 					ID:       "foo",
 					Name:     "my foo project",
 					Type:     storage.ChefManaged,
 					Projects: []string{"foo"},
 				},
-				&storage.Project{
+				{
 					ID:       "bar",
 					Name:     "my bar project",
 					Type:     storage.Custom,
@@ -3771,13 +3771,13 @@ func TestListProjects(t *testing.T) {
 			ps, err := store.ListProjects(ctx)
 			require.NoError(t, err)
 			expectedProjects := []*storage.Project{
-				&storage.Project{
+				{
 					ID:       "foo",
 					Name:     "my foo project",
 					Type:     storage.ChefManaged,
 					Projects: []string{"foo"},
 				},
-				&storage.Project{
+				{
 					ID:       "bar",
 					Name:     "my bar project",
 					Type:     storage.Custom,
@@ -3798,13 +3798,13 @@ func TestListProjects(t *testing.T) {
 			ps, err := store.ListProjects(ctx)
 			require.NoError(t, err)
 			expectedProjects := []*storage.Project{
-				&storage.Project{
+				{
 					ID:       "foo",
 					Name:     "my foo project",
 					Type:     storage.ChefManaged,
 					Projects: []string{"foo"},
 				},
-				&storage.Project{
+				{
 					ID:       "bar",
 					Name:     "my bar project",
 					Type:     storage.Custom,
@@ -3826,19 +3826,19 @@ func TestListProjects(t *testing.T) {
 			ps, err := store.ListProjects(ctx)
 			require.NoError(t, err)
 			expectedProjects := []*storage.Project{
-				&storage.Project{
+				{
 					ID:       "foo",
 					Name:     "my foo project",
 					Type:     storage.ChefManaged,
 					Projects: []string{"foo"},
 				},
-				&storage.Project{
+				{
 					ID:       "bar",
 					Name:     "my bar project",
 					Type:     storage.Custom,
 					Projects: []string{"bar"},
 				},
-				&storage.Project{
+				{
 					ID:       "baz",
 					Name:     "my baz project",
 					Type:     storage.Custom,
@@ -3859,19 +3859,19 @@ func TestListProjects(t *testing.T) {
 			ps, err := store.ListProjects(ctx)
 			require.NoError(t, err)
 			expectedProjects := []*storage.Project{
-				&storage.Project{
+				{
 					ID:       "foo",
 					Name:     "my foo project",
 					Type:     storage.ChefManaged,
 					Projects: []string{"foo"},
 				},
-				&storage.Project{
+				{
 					ID:       "bar",
 					Name:     "my bar project",
 					Type:     storage.Custom,
 					Projects: []string{"bar"},
 				},
-				&storage.Project{
+				{
 					ID:       "baz",
 					Name:     "my baz project",
 					Type:     storage.Custom,

--- a/components/event-gateway/pkg/nats/server.go
+++ b/components/event-gateway/pkg/nats/server.go
@@ -90,7 +90,7 @@ func WithNATSGateway(c *config.EventGatewayConfig) NATSdConfigurator {
 			return errors.Wrapf(err, "generated invalid URL %q for event-service NATS service", internalURLstr)
 		}
 		nopts.Gateway.Gateways = []*natsd.RemoteGatewayOpts{
-			&natsd.RemoteGatewayOpts{Name: "event-service", TLSConfig: mTLSConfig, URLs: []*url.URL{internalNATSURL}},
+			{Name: "event-service", TLSConfig: mTLSConfig, URLs: []*url.URL{internalNATSURL}},
 		}
 		return nil
 	}

--- a/components/event-gateway/pkg/nats/tls_test.go
+++ b/components/event-gateway/pkg/nats/tls_test.go
@@ -31,11 +31,11 @@ func TestNATSWithSNI(t *testing.T) {
 		FrontendTLS: []certs.TLSConfig{
 			// Two certs with different CNs. Later in the test we connect to the
 			// server and use SNI to pick which cert we expect to get
-			certs.TLSConfig{
+			{
 				CertPath: "../../../../dev/certs/event-gateway-sni-one.crt",
 				KeyPath:  "../../../../dev/certs/event-gateway-sni-one.key",
 			},
-			certs.TLSConfig{
+			{
 				CertPath: "../../../../dev/certs/event-gateway-sni-two.crt",
 				KeyPath:  "../../../../dev/certs/event-gateway-sni-two.key",
 			},


### PR DESCRIPTION
Invokes the simplification provided by `gofmt -s` documented at https://golang.org/cmd/gofmt/#hdr-The_simplify_command