### PR TITLE
[release notes] update messaging w/ docs tweaks

### DIFF
--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -20,7 +20,7 @@ pushd ./automate.wiki
   cat >./Current-Release-Notes.md <<EOH
 ## Upgrade Impact
 
-If you are upgrading from a version prior to 20190410001346, please read our [Important Compliance Outage Announcement](https://discourse.chef.io/t/important-compliance-outage-information-on-automate-2-april-15th-upgrade/14909).
+ICYMI: If you are upgrading from a version prior to 20190410001346, please read our [Important Compliance Outage Announcement](https://discourse.chef.io/t/important-compliance-outage-information-on-automate-2-april-15th-upgrade/14909).
 
 ## New Features
 -


### PR DESCRIPTION
this change updates the messaging for the weekly release notes to
include the changes applied by the docs team to the most recent
release. this will prevent us from needing to make additional changes
each week

Signed-off-by: Stephen Delano <stephen@chef.io>
