### PR TITLE
do not run detect job if node has ssm backend

### DIFF
--- a/components/compliance-service/inspec-agent/resolver/resolver.go
+++ b/components/compliance-service/inspec-agent/resolver/resolver.go
@@ -466,6 +466,10 @@ func (r *Resolver) handleManagerNodes(ctx context.Context, m *manager.NodeManage
 							backend = inspec.BackendAZWindows
 						}
 					}
+					if ssmJob == true && job.Type == "detect" {
+						logrus.Warnf("action not supported: cannot run a detect job on ssm node %s", node.Name)
+						continue
+					}
 				}
 				baseJob = types.InspecBaseJob{
 					JobID:    job.Id,
@@ -582,6 +586,10 @@ func (r *Resolver) resolveStaticJob(ctx context.Context, job *jobs.Job) ([]*type
 		resolvedTC, err := convertNodeTcToInspecTc(node.TargetConfig)
 		if err != nil {
 			logrus.Errorf("Could not resolve target config for node %s, due to: %s", id, err.Error())
+			continue
+		}
+		if resolvedTC.Backend == "ssm" && job.Type == "detect" {
+			logrus.Warnf("action not supported: cannot run a detect job on ssm node %s", node.Name)
 			continue
 		}
 		agentJob := r.resolveStaticJobInfo(job, node, resolvedTC, id)

--- a/components/compliance-service/inspec-agent/resolver/resolver.go
+++ b/components/compliance-service/inspec-agent/resolver/resolver.go
@@ -447,10 +447,11 @@ func (r *Resolver) handleManagerNodes(ctx context.Context, m *manager.NodeManage
 				if len(nodeName) == 0 {
 					nodeName = node.Host
 				}
-				ssmJob, skip := false, false
+				ssmJob := false
 				// if the user has specified ssh/winrm secrets to be associated with the node
 				// then let's prioritize that -- otherwise try ssm
 				if len(credsArr) == 0 {
+					var skip bool
 					skip, ssmJob = handleSSMNodes(node, job, &backend)
 					if skip {
 						logrus.Warnf("action not supported: cannot run a detect job on ssm node %s", node.Name)


### PR DESCRIPTION
### :nut_and_bolt: Description
We do not currently support detect jobs on ssm nodes.  This is functionality we would like to one day support, but it will require a bit more work.  
In one case we were erroneously allowing detect ssm jobs to go through, marking them as "reachable" without ever having tried to reach them, leading to a confusing experience for the user.
In another case we were (again) erroneously allowing detect ssm jobs to go through, but not detecting that the node was ssm, and trying to run a detect on the job, resulting in a cryptic error of type `train ssm plugin missing`.
So this work ensures we skip nodes if they meet two criteria:
- job type is detect
- node backend is ssm

### :+1: Definition of Done
ssm nodes skip detect jobs

### :athletic_shoe: Demo Script / Repro Steps
build compliance
add aws-ec2 integration (credentialless)
expect to _not_ see nodes be reachable. expect to _not_ see status update when rerun button is clicked.
run ssm job; expect it to work as usual

