### PR TITLE
[A2-808] OPA update for project rules

### DIFF
--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -2,7 +2,6 @@ package v2
 
 import (
 	"context"
-	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -670,12 +669,25 @@ func (s *policyServer) EngineUpdateInterceptor() grpc.UnaryServerInterceptor {
 			return resp, nil
 		}
 
-		// Note: the set of methods we _do not want to update_ our engine store
-		// is the smaller one. Also, updating too often is not as bad as
-		// updating too little.
-		if regexp.MustCompile(`^/chef.automate.domain.authz.v2.\w+/(Get|List|\w+Project$)`).
-			MatchString(info.FullMethod) {
-			return resp, nil
+		switch info.FullMethod {
+		// Important! Any new endpoint that requires refreshing the OPA cache must be added here.
+		case "/chef.automate.domain.authz.v2.Policies/ReplacePolicyMembers",
+			"/chef.automate.domain.authz.v2.Policies/CreatePolicy",
+			"/chef.automate.domain.authz.v2.Policies/DeletePolicy",
+			"/chef.automate.domain.authz.v2.Policies/UpdatePolicy",
+			"/chef.automate.domain.authz.v2.Policies/MigrateToV2",
+			"/chef.automate.domain.authz.v2.Policies/ResetToV1",
+			"/chef.automate.domain.authz.v2.Policies/CreateRole",
+			"/chef.automate.domain.authz.v2.Policies/DeleteRole",
+			"/chef.automate.domain.authz.v2.Policies/UpdateRole",
+			"/chef.automate.domain.authz.v2.Policies/RemovePolicyMembers",
+			"/chef.automate.domain.authz.v2.Policies/AddPolicyMembers",
+			"/chef.automate.domain.authz.v2.Policies/PurgeSubjectFromPolicies":
+			if err := s.updateEngineStore(ctx); err != nil {
+				return nil, status.Errorf(codes.Internal, "error updating engine store: %s", err.Error())
+			}
+		default:
+			// do nothing
 		}
 
 		s.log.Infof("Initiating store update for %s", info.FullMethod)

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -690,7 +690,7 @@ func (s *policyServer) EngineUpdateInterceptor() grpc.UnaryServerInterceptor {
 			// do nothing
 		}
 
-		s.log.Infof("Initiating store update for %s", info.FullMethod)
+		s.log.Debugf("Initiating store update for %s", info.FullMethod)
 		if err := s.updateEngineStore(ctx); err != nil {
 			return nil, status.Errorf(codes.Internal, "error updating engine store: %s", err.Error())
 		}

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -663,26 +664,23 @@ func (s *policyServer) EngineUpdateInterceptor() grpc.UnaryServerInterceptor {
 			return nil, err
 		}
 
-		// ignore anything not for this service
-		if !strings.HasPrefix(info.FullMethod, "/chef.automate.domain.authz.v2.Policies/") {
+		// ignore anything not related to the OPA store.
+		if !strings.HasPrefix(info.FullMethod, "/chef.automate.domain.authz.v2.Policies/") &&
+			!strings.HasPrefix(info.FullMethod, "/chef.automate.domain.authz.v2.Projects/") {
 			return resp, nil
 		}
 
 		// Note: the set of methods we _do not want to update_ our engine store
 		// is the smaller one. Also, updating too often is not as bad as
 		// updating too little.
-		switch info.FullMethod {
-		case "/chef.automate.domain.authz.v2.Policies/ListPolicies",
-			"/chef.automate.domain.authz.v2.Policies/ListRoles",
-			"/chef.automate.domain.authz.v2.Policies/GetPolicy",
-			"/chef.automate.domain.authz.v2.Policies/GetRole",
-			"/chef.automate.domain.authz.v2.Policies/ListPolicyMembers",
-			"/chef.automate.domain.authz.v2.Policies/GetPolicyVersion":
-			// do nothing
-		default:
-			if err := s.updateEngineStore(ctx); err != nil {
-				return nil, status.Errorf(codes.Internal, "error updating engine store: %s", err.Error())
-			}
+		if regexp.MustCompile(`^/chef.automate.domain.authz.v2.\w+/(Get|List|\w+Project$)`).
+			MatchString(info.FullMethod) {
+			return resp, nil
+		}
+
+		s.log.Infof("Initiating store update for %s", info.FullMethod)
+		if err := s.updateEngineStore(ctx); err != nil {
+			return nil, status.Errorf(codes.Internal, "error updating engine store: %s", err.Error())
 		}
 		return resp, nil
 	}

--- a/components/authz-service/server/v2/policy_refresher.go
+++ b/components/authz-service/server/v2/policy_refresher.go
@@ -117,7 +117,7 @@ func (refresher *policyRefresher) refresh(ctx context.Context, lastPolicyID stri
 		refresher.log.WithFields(logrus.Fields{
 			"lastPolicyID": lastPolicyID,
 			"curPolicyID":  curPolicyID,
-		}).Info("Refreshing engine store")
+		}).Debug("Refreshing engine store")
 
 		if err := refresher.updateEngineStore(ctx); err != nil {
 			refresher.log.WithError(err).Warn("Failed to refresh engine store")


### PR DESCRIPTION
### :nut_and_bolt: Description

Since project rules are stored in OPA alongside policies, we need to ensure that actions that update project rules will also trigger an OPA store update.
The mechanism for this is in place for policies and roles, and is (thanks to @jaym ) already wired for High Availability.
The few changes herein allow the as-yet-to-be-written API calls for project rule handling to tie in to the same mechanism.

### :+1: Definition of Done

Calls for project rules will be able to initiate OPA updates.

### :athletic_shoe: Demo Script / Repro Steps

1. Add some code into a project handler function (say CreateProject) in authz-service/storage/v2/postgres/postgres.go:
```
       err = p.notifyPolicyChange(ctx, tx)
       if err != nil {
               return nil, p.processError(err)
       }
```
You will see that code fragment used for policy and role actions already in place.

2. Adjust the gating regex in components/authz-service/server/v2/policy.go::L676 to allow "CreateProject"  for this demo. (So change the regex to this `^/chef.automate.domain.authz.v2.\w+/(Get|List|)`.

3. rebuild components/authz-service.

4. Invoke a curl command to create a project.

5. Observe the supervisor log--the last line is the proof of the pudding:
```
msg="Projects Authorized Query" action="iam:projects:create" projects="[]" resource="iam:projects" result="[*]" subject="[token:admin-1]"
msg="Accepted notification from postgres"
msg="Received policy change notification"
msg="Initiating store update for /chef.automate.domain.authz.v2.Projects/CreateProject"
```

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
