### PR TITLE
[readme] change SLA to RTM per OSS Practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ For more information see:
 
 **Project State**: [Active](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md#active)
 
-**Issues Response SLA**: 5 business days
+**Issues Response Time Maximum**: 5 business days
 
-**Pull Request Response SLA**: 5 business days
+**Pull Request Response Time Maximum**: 5 business days
 
 ## Components
 


### PR DESCRIPTION
the Chef OSS Practices documentation refers to response time with the
term Response Time Maximum (RTM) instead of Service Level Agreement.
this change reflects that language.

link: https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md#what-is-the-response-time-maximum