### PR TITLE
Update Automate UI to use users V2 model and V2 APIs when beta enabled

### DIFF
--- a/components/automate-ui/e2e/admin.e2e-spec.ts
+++ b/components/automate-ui/e2e/admin.e2e-spec.ts
@@ -3,9 +3,18 @@ import { fakeServer } from './helpers/fake_server';
 import { DatetimePipe } from '../src/app/pipes/datetime.pipe';
 
 describe('Admin pages', () => {
-
   describe('User Management', () => {
     beforeEach(() => {
+      fakeServer()
+        .get('/apis/iam/v2beta/policy_version')
+        .many()
+        .reply(200, JSON.stringify({
+          'version': {
+            'major': 'V1',
+            'minor': 'V0'
+          }
+        }));
+
       fakeServer()
         .post('/api/v0/auth/introspect_some', JSON.stringify(
           {

--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -99,7 +99,7 @@ const routes: Routes = [
           component: UserManagementComponent
         },
         {
-          path: 'users/:username',
+          path: 'users/:id',
           component: UserDetailsComponent
         },
         {
@@ -175,7 +175,7 @@ const routes: Routes = [
       ]
     },
     {
-      path: 'user-details/:username',
+      path: 'user-details/:id',
       component: UserDetailsComponent,
       resolve: { isNonAdmin: UserDetailsNonAdminResolve }
     },

--- a/components/automate-ui/src/app/entities/users/user.actions.ts
+++ b/components/automate-ui/src/app/entities/users/user.actions.ts
@@ -11,9 +11,9 @@ export enum UserActionTypes {
   GET_ALL                 = 'USER::GET_ALL',
   GET_ALL_SUCCESS         = 'USER::GET_ALL::SUCCESS',
   GET_ALL_FAILURE         = 'USER::GET_ALL::FAILURE',
-  GET_BY_USERNAME         = 'USER::GET_BY_USERNAME',
-  GET_BY_USERNAME_SUCCESS = 'USER::GET_BY_USERNAME::SUCCESS',
-  GET_BY_USERNAME_FAILURE = 'USER::GET_BY_USERNAME::FAILURE',
+  GET                     = 'USER::GET',
+  GET_SUCCESS             = 'USER::GET::SUCCESS',
+  GET_FAILURE             = 'USER::GET::FAILURE',
   UPDATE                  = 'USER::UPDATE',
   UPDATE_SUCCESS          = 'USER::UPDATE::SUCCESS',
   UPDATE_FAILURE          = 'USER::UPDATE::FAILURE',
@@ -42,19 +42,18 @@ export class GetUsersFailure implements Action {
   constructor(public payload: HttpErrorResponse) { }
 }
 
-// TODO rename
-export class GetUserByUsername implements Action {
-  readonly type = UserActionTypes.GET_BY_USERNAME;
+export class GetUser implements Action {
+  readonly type = UserActionTypes.GET;
   constructor(public payload: {id: string}) { }
 }
 
-export class GetUserByUsernameSuccess implements Action {
-  readonly type = UserActionTypes.GET_BY_USERNAME_SUCCESS;
+export class GetUserSuccess implements Action {
+  readonly type = UserActionTypes.GET_SUCCESS;
   constructor(public payload: User) { }
 }
 
-export class GetUserByUsernameFailure implements Action {
-  readonly type = UserActionTypes.GET_BY_USERNAME_FAILURE;
+export class GetUserFailure implements Action {
+  readonly type = UserActionTypes.GET_FAILURE;
   constructor(public payload: HttpErrorResponse) { }
 }
 
@@ -128,9 +127,9 @@ export type UserActions =
   | GetUsers
   | GetUsersSuccess
   | GetUsersFailure
-  | GetUserByUsername
-  | GetUserByUsernameSuccess
-  | GetUserByUsernameFailure
+  | GetUser
+  | GetUserSuccess
+  | GetUserFailure
   | UpdateUser
   | UpdateUserSuccess
   | UpdateUserFailure

--- a/components/automate-ui/src/app/entities/users/user.actions.ts
+++ b/components/automate-ui/src/app/entities/users/user.actions.ts
@@ -42,9 +42,10 @@ export class GetUsersFailure implements Action {
   constructor(public payload: HttpErrorResponse) { }
 }
 
+// TODO rename
 export class GetUserByUsername implements Action {
   readonly type = UserActionTypes.GET_BY_USERNAME;
-  constructor(public payload: {username: string}) { }
+  constructor(public payload: {id: string}) { }
 }
 
 export class GetUserByUsernameSuccess implements Action {
@@ -98,8 +99,8 @@ export class DeleteUserFailure implements Action {
 }
 
 export interface CreateUserPayload {
+  id: string;
   name: string;
-  username: string;
   password: string;
 }
 

--- a/components/automate-ui/src/app/entities/users/user.effects.ts
+++ b/components/automate-ui/src/app/entities/users/user.effects.ts
@@ -1,10 +1,14 @@
-import { catchError, mergeMap, map } from 'rxjs/operators';
+import { catchError, mergeMap, map, filter } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
+import { Store } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { of } from 'rxjs';
+import { of, combineLatest } from 'rxjs';
+import { identity } from 'lodash/fp';
 
+import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { CreateNotification } from '../notifications/notification.actions';
+import { iamMajorVersion } from 'app/entities/policies/policy.selectors';
 import { Type } from '../notifications/notification.model';
 import {
   CreateUser,
@@ -35,17 +39,20 @@ import { SelfUser } from './userself.model';
 export class UserEffects {
   constructor(
     private actions$: Actions,
-    private requests: UserRequests
+    private requests: UserRequests,
+    private store$: Store<NgrxStateAtom>
   ) { }
 
   // 7/6/18: TODO in follow-up PR: fetch teams for all users - bd
   @Effect()
-  getUsers$ = this.actions$.pipe(
-    ofType(UserActionTypes.GET_ALL),
-    mergeMap((_action: GetUsers) =>
-      this.requests.getUsers().pipe(
-        map((resp: GetUsersSuccessPayload) => new GetUsersSuccess(resp)),
-        catchError((error: HttpErrorResponse) => of(new GetUsersFailure(error))))));
+  getUsers$ = combineLatest(
+    this.actions$.pipe(ofType<GetUsers>(UserActionTypes.GET_ALL)),
+    this.store$.select(iamMajorVersion).pipe(filter(identity)))
+    .pipe(
+      mergeMap(([_action, version]) =>
+        this.requests.getUsers(version).pipe(
+          map((resp: GetUsersSuccessPayload) => new GetUsersSuccess(resp)),
+          catchError((error: HttpErrorResponse) => of(new GetUsersFailure(error))))));
 
   @Effect()
   getUsersFailure$ = this.actions$.pipe(
@@ -58,13 +65,16 @@ export class UserEffects {
       });
     }));
 
+  // TODO rename
   @Effect()
-  getUserByUsername$ = this.actions$.pipe(
-    ofType(UserActionTypes.GET_BY_USERNAME),
-    mergeMap(({ payload: { username }}: GetUserByUsername) =>
-      this.requests.getUserByUsername(username).pipe(
-        map((resp: User) => new GetUserByUsernameSuccess(resp)),
-        catchError((error: HttpErrorResponse) => of(new GetUserByUsernameFailure(error))))));
+  getUserByUsername$ = combineLatest(
+    this.actions$.pipe(ofType<GetUserByUsername>(UserActionTypes.GET_BY_USERNAME)),
+    this.store$.select(iamMajorVersion).pipe(filter(identity)))
+    .pipe(
+      mergeMap(([action, version]) =>
+        this.requests.getUser(action.payload.id, version).pipe(
+          map((resp: User) => new GetUserByUsernameSuccess(resp)),
+          catchError((error: HttpErrorResponse) => of(new GetUserByUsernameFailure(error))))));
 
   @Effect()
   getUserByUsernameFailure$ = this.actions$.pipe(
@@ -78,10 +88,12 @@ export class UserEffects {
     }));
 
   @Effect()
-  updateUser$ = this.actions$.pipe(
-    ofType(UserActionTypes.UPDATE),
-    mergeMap(({ payload }: UpdateUser) =>
-      this.requests.updateUser(payload).pipe(
+  updateUser$ = combineLatest(
+    this.actions$.pipe(ofType<UpdateUser>(UserActionTypes.UPDATE)),
+    this.store$.select(iamMajorVersion).pipe(filter(identity)))
+    .pipe(
+      mergeMap(([action, version]) =>
+      this.requests.updateUser(action.payload, version).pipe(
         map((resp: User) => new UpdateUserSuccess(resp)),
         catchError((error: HttpErrorResponse) => of(new UpdateUserFailure(error))))));
 
@@ -105,10 +117,12 @@ export class UserEffects {
     }));
 
   @Effect()
-  updateSelf$ = this.actions$.pipe(
-    ofType(UserActionTypes.UPDATE_SELF),
-    mergeMap(({ payload }: UpdateSelf) =>
-      this.requests.updateSelf(payload).pipe(
+  updateSelf$ = combineLatest(
+    this.actions$.pipe(ofType<UpdateSelf>(UserActionTypes.UPDATE_SELF)),
+    this.store$.select(iamMajorVersion).pipe(filter(identity)))
+    .pipe(
+      mergeMap(([action, version]) =>
+      this.requests.updateSelf(action.payload, version).pipe(
         map((resp: SelfUser) => new UpdateSelfSuccess(resp)),
         catchError((error: HttpErrorResponse) => of(new UpdateUserFailure(error))))));
 
@@ -120,12 +134,13 @@ export class UserEffects {
       message: 'Successfully updated your details'
     })));
 
-
   @Effect()
-  deleteUser$ = this.actions$.pipe(
-    ofType(UserActionTypes.DELETE),
-    mergeMap(({ payload }: DeleteUser) =>
-      this.requests.deleteUser(payload).pipe(
+  deleteUser$ = combineLatest(
+    this.actions$.pipe(ofType<DeleteUser>(UserActionTypes.DELETE)),
+    this.store$.select(iamMajorVersion).pipe(filter(identity)))
+    .pipe(
+      mergeMap(([action, version]) =>
+      this.requests.deleteUser(action.payload, version).pipe(
         map((user: User) => new DeleteUserSuccess(user)),
         catchError((error: HttpErrorResponse) => of(new DeleteUserFailure(error))))));
 
@@ -146,14 +161,15 @@ export class UserEffects {
         type: Type.error,
         message: `Could not delete user: ${msg || error}`
       });
-    }
-    ));
+    }));
 
   @Effect()
-  createUser$ = this.actions$.pipe(
-    ofType(UserActionTypes.CREATE),
-    mergeMap((action: CreateUser) =>
-      this.requests.createUser(action.payload).pipe(
+  createUser$ = combineLatest(
+    this.actions$.pipe(ofType<CreateUser>(UserActionTypes.CREATE)),
+    this.store$.select(iamMajorVersion).pipe(filter(identity)))
+    .pipe(
+      mergeMap(([action, version]) =>
+      this.requests.createUser(action.payload, version).pipe(
         map((resp: User) => new CreateUserSuccess(resp)),
         catchError((error) => of(new CreateUserFailure(error))))));
 

--- a/components/automate-ui/src/app/entities/users/user.effects.ts
+++ b/components/automate-ui/src/app/entities/users/user.effects.ts
@@ -1,10 +1,9 @@
-import { catchError, mergeMap, map, filter } from 'rxjs/operators';
+import { catchError, mergeMap, map } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Store } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of, combineLatest } from 'rxjs';
-import { identity } from 'lodash/fp';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { CreateNotification } from '../notifications/notification.actions';
@@ -47,7 +46,7 @@ export class UserEffects {
   @Effect()
   getUsers$ = combineLatest(
     this.actions$.pipe(ofType<GetUsers>(UserActionTypes.GET_ALL)),
-    this.store$.select(iamMajorVersion).pipe(filter(identity)))
+    this.store$.select(iamMajorVersion))
     .pipe(
       mergeMap(([_action, version]) =>
         this.requests.getUsers(version).pipe(
@@ -69,7 +68,7 @@ export class UserEffects {
   @Effect()
   getUser$ = combineLatest(
     this.actions$.pipe(ofType<GetUser>(UserActionTypes.GET)),
-    this.store$.select(iamMajorVersion).pipe(filter(identity)))
+    this.store$.select(iamMajorVersion))
     .pipe(
       mergeMap(([action, version]) =>
         this.requests.getUser(action.payload.id, version).pipe(
@@ -90,7 +89,7 @@ export class UserEffects {
   @Effect()
   updateUser$ = combineLatest(
     this.actions$.pipe(ofType<UpdateUser>(UserActionTypes.UPDATE)),
-    this.store$.select(iamMajorVersion).pipe(filter(identity)))
+    this.store$.select(iamMajorVersion))
     .pipe(
       mergeMap(([action, version]) =>
       this.requests.updateUser(action.payload, version).pipe(
@@ -119,7 +118,7 @@ export class UserEffects {
   @Effect()
   updateSelf$ = combineLatest(
     this.actions$.pipe(ofType<UpdateSelf>(UserActionTypes.UPDATE_SELF)),
-    this.store$.select(iamMajorVersion).pipe(filter(identity)))
+    this.store$.select(iamMajorVersion))
     .pipe(
       mergeMap(([action, version]) =>
       this.requests.updateSelf(action.payload, version).pipe(
@@ -137,7 +136,7 @@ export class UserEffects {
   @Effect()
   deleteUser$ = combineLatest(
     this.actions$.pipe(ofType<DeleteUser>(UserActionTypes.DELETE)),
-    this.store$.select(iamMajorVersion).pipe(filter(identity)))
+    this.store$.select(iamMajorVersion))
     .pipe(
       mergeMap(([action, version]) =>
       this.requests.deleteUser(action.payload, version).pipe(
@@ -166,7 +165,7 @@ export class UserEffects {
   @Effect()
   createUser$ = combineLatest(
     this.actions$.pipe(ofType<CreateUser>(UserActionTypes.CREATE)),
-    this.store$.select(iamMajorVersion).pipe(filter(identity)))
+    this.store$.select(iamMajorVersion))
     .pipe(
       mergeMap(([action, version]) =>
       this.requests.createUser(action.payload, version).pipe(

--- a/components/automate-ui/src/app/entities/users/user.effects.ts
+++ b/components/automate-ui/src/app/entities/users/user.effects.ts
@@ -21,9 +21,9 @@ import {
   GetUsersSuccess,
   GetUsersSuccessPayload,
   GetUsersFailure,
-  GetUserByUsername,
-  GetUserByUsernameSuccess,
-  GetUserByUsernameFailure,
+  GetUser,
+  GetUserSuccess,
+  GetUserFailure,
   UpdateUser,
   UpdateUserSuccess,
   UpdateUserFailure,
@@ -67,19 +67,19 @@ export class UserEffects {
 
   // TODO rename
   @Effect()
-  getUserByUsername$ = combineLatest(
-    this.actions$.pipe(ofType<GetUserByUsername>(UserActionTypes.GET_BY_USERNAME)),
+  getUser$ = combineLatest(
+    this.actions$.pipe(ofType<GetUser>(UserActionTypes.GET)),
     this.store$.select(iamMajorVersion).pipe(filter(identity)))
     .pipe(
       mergeMap(([action, version]) =>
         this.requests.getUser(action.payload.id, version).pipe(
-          map((resp: User) => new GetUserByUsernameSuccess(resp)),
-          catchError((error: HttpErrorResponse) => of(new GetUserByUsernameFailure(error))))));
+          map((resp: User) => new GetUserSuccess(resp)),
+          catchError((error: HttpErrorResponse) => of(new GetUserFailure(error))))));
 
   @Effect()
-  getUserByUsernameFailure$ = this.actions$.pipe(
-    ofType(UserActionTypes.GET_BY_USERNAME_FAILURE),
-    map(({ payload: { error } }: GetUserByUsernameFailure) => {
+  getUserFailure$ = this.actions$.pipe(
+    ofType(UserActionTypes.GET),
+    map(({ payload: { error } }: GetUserFailure) => {
       const msg = error.error;
       return new CreateNotification({
         type: Type.error,

--- a/components/automate-ui/src/app/entities/users/user.model.ts
+++ b/components/automate-ui/src/app/entities/users/user.model.ts
@@ -2,7 +2,6 @@ export interface User {
   id: string;
   name: string;
   membership_id: string;
-  projects: Array<string>;
   password?: string; // only used for updating, never returned by the API
 }
 
@@ -21,7 +20,7 @@ export function userHashToArray(userHash: HashMapOfUsers): User[] {
 export function userArrayToHash(userArray: User[]): HashMapOfUsers {
   const userHash: HashMapOfUsers = {};
   userArray.forEach((user: User) => {
-    userHash[user.id] = user;
+    userHash[user.membership_id] = user;
   });
   return userHash;
 }

--- a/components/automate-ui/src/app/entities/users/user.model.ts
+++ b/components/automate-ui/src/app/entities/users/user.model.ts
@@ -1,7 +1,8 @@
 export interface User {
   id: string;
   name: string;
-  username: string;
+  membership_id: string;
+  projects: Array<string>;
   password?: string; // only used for updating, never returned by the API
 }
 

--- a/components/automate-ui/src/app/entities/users/user.reducer.spec.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.spec.ts
@@ -34,14 +34,12 @@ describe('userStatusEntityReducer', () => {
   const user: User = {
     id: 'test',
     name: 'test user',
-    membership_id: 'a953c5bb-82a5-41be-b7dd-a5de1ea53ada',
-    projects: []
+    membership_id: 'a953c5bb-82a5-41be-b7dd-a5de1ea53ada'
   };
   const user2: User = {
     id: 'test2',
     name: 'test user2',
-    membership_id: 'b953c5bb-82a5-41be-b7dd-a5de1ea53ada',
-    projects: []
+    membership_id: 'b953c5bb-82a5-41be-b7dd-a5de1ea53ada'
   };
   const users: GetUsersSuccessPayload = {
     users: [ user, user2 ]
@@ -111,7 +109,7 @@ describe('userStatusEntityReducer', () => {
       });
     });
 
-    describe('GET_BY_USERNAME', () => {
+    describe('GET', () => {
       const payload = { id: 'test' };
       const action = new GetUser(payload);
 

--- a/components/automate-ui/src/app/entities/users/user.reducer.spec.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.spec.ts
@@ -16,12 +16,12 @@ import {
   GetUsersFailure,
   GetUsersSuccess,
   GetUsersSuccessPayload,
-  GetUserByUsernameSuccess,
-  GetUserByUsername,
+  GetUserSuccess,
+  GetUser,
   UpdateUser,
   UpdateUserSuccess,
   DeleteUserSuccess,
-  GetUserByUsernameFailure,
+  GetUserFailure,
   UpdateUserFailure,
   DeleteUser,
   DeleteUserFailure
@@ -32,14 +32,16 @@ describe('userStatusEntityReducer', () => {
   const initialState: UserEntityState = UserEntityInitialState;
   const httpErrorResponse = new HttpErrorResponse({ status: 400 });
   const user: User = {
-    id: 'a953c5bb-82a5-41be-b7dd-a5de1ea53ada',
-    username: 'test',
-    name: 'test user'
+    id: 'test',
+    name: 'test user',
+    membership_id: 'a953c5bb-82a5-41be-b7dd-a5de1ea53ada',
+    projects: []
   };
   const user2: User = {
-    id: 'b953c5bb-82a5-41be-b7dd-a5de1ea53ada',
-    username: 'test2',
-    name: 'test user2'
+    id: 'test2',
+    name: 'test user2',
+    membership_id: 'b953c5bb-82a5-41be-b7dd-a5de1ea53ada',
+    projects: []
   };
   const users: GetUsersSuccessPayload = {
     users: [ user, user2 ]
@@ -77,8 +79,8 @@ describe('userStatusEntityReducer', () => {
 
     describe('CREATE', () => {
       const payload: CreateUserPayload = {
+        id: 'test',
         name: 'test user',
-        username: 'test',
         password: 'testing123!'
       };
       const action = new CreateUser(payload);
@@ -110,8 +112,8 @@ describe('userStatusEntityReducer', () => {
     });
 
     describe('GET_BY_USERNAME', () => {
-      const payload = { username: 'test' };
-      const action = new GetUserByUsername(payload);
+      const payload = { id: 'test' };
+      const action = new GetUser(payload);
 
       it('sets status to loading', () => {
         const { status } = userEntityReducer(initialState, action);
@@ -119,9 +121,9 @@ describe('userStatusEntityReducer', () => {
       });
     });
 
-    describe('GET_BY_USERNAME_SUCCESS', () => {
+    describe('GET_SUCCESS', () => {
       const payload = user;
-      const action = new GetUserByUsernameSuccess(payload);
+      const action = new GetUserSuccess(payload);
 
       it('sets status to loadingSuccess', () => {
         const prevState = { ...initialState, state: EntityStatus.loading };
@@ -131,14 +133,14 @@ describe('userStatusEntityReducer', () => {
 
       it('loads the one user into the users state', () => {
         const { entities } = userEntityReducer(initialState, action);
-        expect(Object.keys(entities)).toEqual(['a953c5bb-82a5-41be-b7dd-a5de1ea53ada']);
-        expect(entities['a953c5bb-82a5-41be-b7dd-a5de1ea53ada']).toEqual(user);
+        expect(Object.keys(entities)).toEqual([user.id]);
+        expect(entities[user.id]).toEqual(user);
       });
     });
 
-    describe('GET_BY_USERNAME_FAILURE', () => {
+    describe('GET_FAILURE', () => {
       const payload = httpErrorResponse;
-      const action = new GetUserByUsernameFailure(payload);
+      const action = new GetUserFailure(payload);
 
       it('sets status to loadingSuccess', () => {
         const prevState = { ...initialState, state: EntityStatus.loading };

--- a/components/automate-ui/src/app/entities/users/user.reducer.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.ts
@@ -32,14 +32,14 @@ export function userEntityReducer(state: UserEntityState = UserEntityInitialStat
     case UserActionTypes.GET_ALL_FAILURE:
       return set('status', EntityStatus.loadingFailure, state);
 
-    case UserActionTypes.GET_BY_USERNAME:
+    case UserActionTypes.GET:
       return set('status', EntityStatus.loading, state);
 
-    case UserActionTypes.GET_BY_USERNAME_SUCCESS:
+    case UserActionTypes.GET_SUCCESS:
       return set('status', EntityStatus.loadingSuccess,
         userEntityAdapter.addOne(action.payload, state));
 
-    case UserActionTypes.GET_BY_USERNAME_FAILURE:
+    case UserActionTypes.GET_FAILURE:
       return set('status', EntityStatus.loadingFailure, state);
 
     case UserActionTypes.UPDATE:

--- a/components/automate-ui/src/app/entities/users/user.requests.ts
+++ b/components/automate-ui/src/app/entities/users/user.requests.ts
@@ -5,6 +5,7 @@ import { HttpClient } from '@angular/common/http';
 import { mapKeys, snakeCase } from 'lodash/fp';
 
 import { environment as env } from 'environments/environment';
+import { IAMMajorVersion } from 'app/entities/policies/policy.model';
 import { CreateUserPayload } from './user.actions';
 import { User } from './user.model';
 import { SelfUser } from './userself.model';
@@ -13,35 +14,159 @@ export interface UsersResponse {
   users: User[];
 }
 
+export interface UsersResponseV1 {
+  users: UserV1[];
+}
+
+interface UserResponse {
+  user: User;
+}
+
+interface CreateUserPayloadV1 {
+  username: string;
+  name: string;
+  password: string;
+}
+
+interface UserV1 {
+  id: string;
+  name: string;
+  username: string;
+  password?: string; // only used for updating, never returned by the API
+}
+
+function convertUserV1ToUser(user: UserV1): User {
+  return {
+    id: user.username,
+    name: user.name,
+    membership_id: user.id,
+    projects: [] // TODO add real projects
+  };
+}
+
+function convertUserToUserV1(user: User): UserV1 {
+  return {
+    username: user.id,
+    name: user.name,
+    id: user.membership_id,
+    password: user.password
+  };
+}
+
+function convertCreateUserPayloadToV1(userPayload: CreateUserPayload): CreateUserPayloadV1 {
+  return {
+    username: userPayload.id,
+    name: userPayload.name,
+    password: userPayload.password
+  };
+}
+
 @Injectable()
 export class UserRequests {
 
   constructor(private http: HttpClient) { }
 
-  public getUsers(): Observable<UsersResponse> {
-    return this.http.get<UsersResponse>(`${env.auth_url}/users`);
+  public getUsers(version: IAMMajorVersion = 'v1'):
+    Observable<UsersResponse> {
+    switch (version) {
+      case 'v2': {
+        return this.http.get<UsersResponse>(`${env.auth_v2_url}/users`);
+      }
+      default: {
+        return this.http.get(`${env.auth_url}/users`).pipe(map((usersResponse: UsersResponseV1) => {
+          const list: Array<User> = [];
+          usersResponse.users.forEach((user: UserV1) => list.push(convertUserV1ToUser(user)));
+            return <UsersResponse>{
+              users: list
+            };
+        }));
+      }
+    }
   }
 
-  public getUserByUsername(username: string): Observable<User> {
-    return this.http.get<User>(`${env.auth_url}/users/${username}`);
+  public getUser(id: string,
+    version: IAMMajorVersion = 'v1'): Observable<User> {
+
+    switch (version) {
+      case 'v2': {
+        return this.http.get<UserResponse>(`${env.auth_v2_url}/users/${id}`)
+          .pipe(map(userResponse => userResponse.user));
+      }
+      default: {
+        return this.http.get<UserV1>(`${env.auth_url}/users/${id}`)
+          .pipe(map(userV1 => convertUserV1ToUser(userV1)));
+      }
+    }
   }
 
-  public createUser(userData: CreateUserPayload): Observable<User> {
-    return this.http.post<User>(`${env.auth_url}/users`, mapKeys(snakeCase, userData));
+  public createUser(userData: CreateUserPayload,
+    version: IAMMajorVersion = 'v1'): Observable<User> {
+
+    switch (version) {
+      case 'v2': {
+        return this.http.post<UserResponse>(`${env.auth_v2_url}/users`,
+          mapKeys(snakeCase, userData))
+            .pipe(map(userResponse => userResponse.user));
+      }
+      default: {
+        return this.http.post<UserV1>(`${env.auth_url}/users`,
+          mapKeys(snakeCase, convertCreateUserPayloadToV1(userData)))
+            .pipe(map(userV1 => convertUserV1ToUser(userV1)));
+      }
+    }
   }
 
-  public updateUser(userData: User): Observable<User> {
-    return this.http.put<User>(`${env.auth_url}/users/${userData.username}`,
-      mapKeys(snakeCase, userData));
+  public updateUser(userData: User,
+    version: IAMMajorVersion = 'v1'): Observable<User> {
+
+    switch (version) {
+      case 'v2': {
+        return this.http.put<UserResponse>(`${env.auth_v2_url}/users/${userData.id}`,
+          mapKeys(snakeCase, userData))
+            .pipe(map(userResponse => userResponse.user));
+      }
+      default: {
+        return this.http.put<UserV1>(`${env.auth_url}/users/${userData.id}`,
+          mapKeys(snakeCase, convertUserToUserV1(userData)))
+            .pipe(map(userV1 => convertUserV1ToUser(userV1)));
+      }
+    }
   }
 
-  public updateSelf(userData: SelfUser): Observable<User> {
-    return this.http.put<User>(`${env.users_url}/${userData.username}`,
-      mapKeys(snakeCase, userData));
+  public updateSelf(userData: SelfUser, version: IAMMajorVersion = 'v1'): Observable<User> {
+      switch (version) {
+        case 'v2': {
+          return this.http.put<UserResponse>(`${env.auth_v2_url}/self/${userData.id}`,
+            mapKeys(snakeCase, userData))
+              .pipe(map(userResponse => userResponse.user));
+        }
+        default: {
+          const updateSelfV1Payload = {
+            username: userData.id,
+            name: userData.name,
+            id: userData.membership_id,
+            password: userData.password,
+            previous_password: userData.previous_password
+          };
+          return this.http.put<UserV1>(`${env.users_url}/${userData.id}`,
+            mapKeys(snakeCase, updateSelfV1Payload))
+              .pipe(map(userV1 => convertUserV1ToUser(userV1)));
+        }
+      }
   }
 
-  public deleteUser(user: User): Observable<User> {
-    return this.http.delete<User>(`${env.auth_url}/users/${user.username}`).pipe(
-      map(() => user)); // bounce it back, so it can be used
+  public deleteUser(user: User,
+    version: IAMMajorVersion = 'v1'): Observable<User> {
+
+    switch (version) {
+      case 'v2': {
+        return this.http.delete<UserResponse>(`${env.auth_v2_url}/users/${user.id}`).pipe(
+          map(() => user)); // bounce it back, so it can be used
+      }
+      default: {
+        return this.http.delete<UserV1>(`${env.auth_url}/users/${user.id}`).pipe(
+          map(() => user)); // bounce it back, so it can be used
+      }
+    }
   }
 }

--- a/components/automate-ui/src/app/entities/users/user.requests.ts
+++ b/components/automate-ui/src/app/entities/users/user.requests.ts
@@ -74,11 +74,9 @@ export class UserRequests {
       }
       default: {
         return this.http.get(`${env.auth_url}/users`).pipe(map((usersResponse: UsersResponseV1) => {
-          const list: Array<User> = [];
-          usersResponse.users.forEach((user: UserV1) => list.push(convertUserV1ToUser(user)));
-            return <UsersResponse>{
-              users: list
-            };
+          return <UsersResponse>{
+            users: usersResponse.users.map((user: UserV1) => convertUserV1ToUser(user))
+          };
         }));
       }
     }

--- a/components/automate-ui/src/app/entities/users/user.requests.ts
+++ b/components/automate-ui/src/app/entities/users/user.requests.ts
@@ -39,8 +39,7 @@ function convertUserV1ToUser(user: UserV1): User {
   return {
     id: user.username,
     name: user.name,
-    membership_id: user.id,
-    projects: [] // TODO add real projects
+    membership_id: user.id
   };
 }
 

--- a/components/automate-ui/src/app/entities/users/user.selectors.ts
+++ b/components/automate-ui/src/app/entities/users/user.selectors.ts
@@ -24,5 +24,5 @@ export const updateStatus = createSelector(
 export const userFromRoute = createSelector(
   userEntities,
   routeParams,
-  (state, {username}) => find({username}, state)
+  (state, {id}) => find({id}, state)
 );

--- a/components/automate-ui/src/app/entities/users/userself.model.ts
+++ b/components/automate-ui/src/app/entities/users/userself.model.ts
@@ -1,7 +1,7 @@
 export interface SelfUser {
   id: string;
   name: string;
-  username: string;
+  membership_id: string;
   password?: string; // only used for updating, never returned by the API
   previous_password?: string; // only used for updating, never returned by the API
 }

--- a/components/automate-ui/src/app/page-components/user-table/user-table.component.html
+++ b/components/automate-ui/src/app/page-components/user-table/user-table.component.html
@@ -19,10 +19,10 @@
     <chef-tbody>
       <chef-tr *ngFor="let user of users$ | async">
         <chef-td class="name-column">
-          <a [routerLink]="['/settings', 'users', user.username]">{{ user.name }}</a>
+          <a [routerLink]="['/settings', 'users', user.id]">{{ user.name }}</a>
         </chef-td>
         <chef-td class="username-column">
-          {{ user.username }}
+          {{ user.id }}
         </chef-td>
         <chef-td class="garbage-column">
           <!-- TODO (tc) We do not yet have a way of checking permissions on a specific object.

--- a/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.html
+++ b/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.html
@@ -26,7 +26,7 @@
             <a [routerLink]="userLink(user)">{{ user.name }}</a>
           </chef-td>
           <chef-td>
-            {{ user.username }}
+            {{ user.id }}
           </chef-td>
         </chef-tr>
       </ng-container>

--- a/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UserTeamMembershipTableComponent } from './user-team-membership-table.component';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
-import { User, userHashToArray } from 'app/entities/users/user.model';
+import { User, userHashToArray, userArrayToHash } from 'app/entities/users/user.model';
 import { StoreModule } from '@ngrx/store';
 import { userEntityReducer } from 'app/entities/users/user.reducer';
 import * as faker from 'faker';
@@ -114,15 +114,14 @@ describe('UserTeamMembershipTableComponent', () => {
 
     describe('when usersToFilter is not empty', () => {
       const kuzkoID = faker.random.uuid();
+      const kuzko = <User>{
+        membership_id: kuzkoID,
+        name: 'Brock Samson',
+        id: 'kuzko'
+      };
 
       beforeEach(() => {
-        component.mapOfUsersToFilter = {};
-        component.mapOfUsersToFilter[userAlreadyInList.membership_id] = userAlreadyInList;
-        component.mapOfUsersToFilter[kuzkoID] = {
-          membership_id: kuzkoID,
-          name: 'Brock Samson',
-          id: 'kuzko'
-        };
+        component.mapOfUsersToFilter = userArrayToHash([userAlreadyInList, kuzko]);
       });
 
       describe('when user is in the list to filter', () => {

--- a/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.spec.ts
@@ -11,9 +11,10 @@ describe('UserTeamMembershipTableComponent', () => {
   let component: UserTeamMembershipTableComponent;
   let fixture: ComponentFixture<UserTeamMembershipTableComponent>;
   const userAlreadyInList = <User>{
-    id: faker.random.uuid(),
+    membership_id: faker.random.uuid(),
     name: 'Hank Venture',
-    username: 'enrico_matasa'
+    id: 'enrico_matasa',
+    projects: []
   };
 
   beforeEach(() => {
@@ -45,9 +46,10 @@ describe('UserTeamMembershipTableComponent', () => {
 
   describe('addOrRemoveUser', () => {
     const testUserToAddOrRemove = <User>{
-      id: 'c39d5157-4198-478b-b75c-c2a77ac0ffa8',
+      membership_id: 'c39d5157-4198-478b-b75c-c2a77ac0ffa8',
       name: 'Dean Venture',
-      username: 'deanie'
+      id: 'deanie',
+      projects: []
     };
 
     describe('when usersToAdd is empty', () => {
@@ -66,9 +68,10 @@ describe('UserTeamMembershipTableComponent', () => {
         component.usersToAdd = {
           'enrico_matasa': userAlreadyInList,
           'kuzko': {
-            id: 'c39d5157-4198-478b-b75c-c2a77ac0ffa8',
+            membership_id: 'c39d5157-4198-478b-b75c-c2a77ac0ffa8',
             name: 'Brock Samson',
-            username: 'kuzko'
+            id: 'kuzko',
+            projects: []
           }
         };
       });
@@ -88,7 +91,7 @@ describe('UserTeamMembershipTableComponent', () => {
           expect(userHashToArray(component.usersToAdd).length).toBe(2);
           component.addOrRemoveUser(false, userAlreadyInList);
           expect(userHashToArray(component.usersToAdd).length).toBe(1);
-          expect(Object.keys(component.usersToAdd)).not.toContain(testUserToAddOrRemove.username);
+          expect(Object.keys(component.usersToAdd)).not.toContain(testUserToAddOrRemove.id);
         });
       });
     });
@@ -96,9 +99,10 @@ describe('UserTeamMembershipTableComponent', () => {
 
   describe('userNotFiltered', () => {
     const testUserToFilter = <User>{
-      id: faker.random.uuid(),
+      membership_id: faker.random.uuid(),
       name: 'Dean Venture',
-      username: 'deanie'
+      id: 'deanie',
+      projects: []
     };
 
     describe('when usersToFilter is empty', () => {
@@ -117,11 +121,12 @@ describe('UserTeamMembershipTableComponent', () => {
 
       beforeEach(() => {
         component.mapOfUsersToFilter = {};
-        component.mapOfUsersToFilter[userAlreadyInList.id] = userAlreadyInList;
+        component.mapOfUsersToFilter[userAlreadyInList.membership_id] = userAlreadyInList;
         component.mapOfUsersToFilter[kuzkoID] = {
-          id: kuzkoID,
+          membership_id: kuzkoID,
           name: 'Brock Samson',
-          username: 'kuzko'
+          id: 'kuzko',
+          projects: []
         };
       });
 
@@ -136,9 +141,10 @@ describe('UserTeamMembershipTableComponent', () => {
         let otherUser: User;
         beforeEach(() => {
           otherUser = {
-            id: '119d5157-4198-478b-b75c-c2a77ac0ff11',
+            membership_id: '119d5157-4198-478b-b75c-c2a77ac0ff11',
             name: 'Montag the Dog',
-            username: 'taggerbot9000'
+            id: 'taggerbot9000',
+            projects: []
           };
         });
 
@@ -155,9 +161,10 @@ describe('UserTeamMembershipTableComponent', () => {
     let users: User[];
     const kuzkoID = faker.random.uuid();
     const kuzko = {
-      id: kuzkoID,
+      membership_id: kuzkoID,
       name: 'Brock Samson',
-      username: 'kuzko'
+      id: 'kuzko',
+      projects: []
     };
 
     describe('when both mapOfUsersToFilter and input users are empty', () => {
@@ -175,7 +182,7 @@ describe('UserTeamMembershipTableComponent', () => {
     describe('when both mapOfUsersToFilter and input match exactly', () => {
       beforeEach(() => {
         component.mapOfUsersToFilter = {};
-        component.mapOfUsersToFilter[userAlreadyInList.id] = userAlreadyInList;
+        component.mapOfUsersToFilter[userAlreadyInList.membership_id] = userAlreadyInList;
         component.mapOfUsersToFilter[kuzkoID] = kuzko;
         users = [userAlreadyInList, kuzko];
       });
@@ -201,14 +208,15 @@ describe('UserTeamMembershipTableComponent', () => {
     describe('when mapOfUsersToFilter is not a superset of input', () => {
       beforeEach(() => {
         const otherUser = {
-          id: faker.random.uuid(),
+          membership_id: faker.random.uuid(),
           name: 'Montag the Dog',
-          username: 'taggerbot9000'
+          id: 'taggerbot9000',
+          projects: []
         };
 
         component.mapOfUsersToFilter = {};
-        component.mapOfUsersToFilter[userAlreadyInList.id] = userAlreadyInList;
-        component.mapOfUsersToFilter[kuzko.id] = kuzko;
+        component.mapOfUsersToFilter[userAlreadyInList.membership_id] = userAlreadyInList;
+        component.mapOfUsersToFilter[kuzko.membership_id] = kuzko;
         users = [userAlreadyInList, kuzko, otherUser];
       });
 

--- a/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.spec.ts
@@ -13,8 +13,7 @@ describe('UserTeamMembershipTableComponent', () => {
   const userAlreadyInList = <User>{
     membership_id: faker.random.uuid(),
     name: 'Hank Venture',
-    id: 'enrico_matasa',
-    projects: []
+    id: 'enrico_matasa'
   };
 
   beforeEach(() => {
@@ -48,8 +47,7 @@ describe('UserTeamMembershipTableComponent', () => {
     const testUserToAddOrRemove = <User>{
       membership_id: 'c39d5157-4198-478b-b75c-c2a77ac0ffa8',
       name: 'Dean Venture',
-      id: 'deanie',
-      projects: []
+      id: 'deanie'
     };
 
     describe('when usersToAdd is empty', () => {
@@ -70,8 +68,7 @@ describe('UserTeamMembershipTableComponent', () => {
           'kuzko': {
             membership_id: 'c39d5157-4198-478b-b75c-c2a77ac0ffa8',
             name: 'Brock Samson',
-            id: 'kuzko',
-            projects: []
+            id: 'kuzko'
           }
         };
       });
@@ -101,8 +98,7 @@ describe('UserTeamMembershipTableComponent', () => {
     const testUserToFilter = <User>{
       membership_id: faker.random.uuid(),
       name: 'Dean Venture',
-      id: 'deanie',
-      projects: []
+      id: 'deanie'
     };
 
     describe('when usersToFilter is empty', () => {
@@ -125,8 +121,7 @@ describe('UserTeamMembershipTableComponent', () => {
         component.mapOfUsersToFilter[kuzkoID] = {
           membership_id: kuzkoID,
           name: 'Brock Samson',
-          id: 'kuzko',
-          projects: []
+          id: 'kuzko'
         };
       });
 
@@ -143,8 +138,7 @@ describe('UserTeamMembershipTableComponent', () => {
           otherUser = {
             membership_id: '119d5157-4198-478b-b75c-c2a77ac0ff11',
             name: 'Montag the Dog',
-            id: 'taggerbot9000',
-            projects: []
+            id: 'taggerbot9000'
           };
         });
 
@@ -163,8 +157,7 @@ describe('UserTeamMembershipTableComponent', () => {
     const kuzko = {
       membership_id: kuzkoID,
       name: 'Brock Samson',
-      id: 'kuzko',
-      projects: []
+      id: 'kuzko'
     };
 
     describe('when both mapOfUsersToFilter and input users are empty', () => {
@@ -210,8 +203,7 @@ describe('UserTeamMembershipTableComponent', () => {
         const otherUser = {
           membership_id: faker.random.uuid(),
           name: 'Montag the Dog',
-          id: 'taggerbot9000',
-          projects: []
+          id: 'taggerbot9000'
         };
 
         component.mapOfUsersToFilter = {};

--- a/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.ts
+++ b/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.ts
@@ -39,7 +39,7 @@ export class UserTeamMembershipTableComponent implements OnInit, OnDestroy {
         (a, b) => {
           // See https://stackoverflow.com/a/38641281 for these options
           const opts = { numeric: true, sensitivity: 'base' };
-          // sort by name then by username
+          // sort by name then by id
           return a.name.localeCompare(b.name, undefined, opts) ||
             a.name.localeCompare(b.name, undefined, { numeric: true}) ||
             a.id.localeCompare(b.id, undefined, opts);

--- a/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.ts
+++ b/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.ts
@@ -80,7 +80,7 @@ export class UserTeamMembershipTableComponent implements OnInit, OnDestroy {
   }
 
   public userNotFiltered(user: User): boolean {
-    return !(user.id in this.mapOfUsersToFilter);
+    return !(user.membership_id in this.mapOfUsersToFilter);
   }
 
   public usersNotFiltered(): User[] {

--- a/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.ts
+++ b/components/automate-ui/src/app/page-components/user-team-membership-table/user-team-membership-table.component.ts
@@ -42,7 +42,7 @@ export class UserTeamMembershipTableComponent implements OnInit, OnDestroy {
           // sort by name then by username
           return a.name.localeCompare(b.name, undefined, opts) ||
             a.name.localeCompare(b.name, undefined, { numeric: true}) ||
-            a.username.localeCompare(b.username, undefined, opts);
+            a.id.localeCompare(b.id, undefined, opts);
         }
       )),
       takeUntil(this.isDestroyed))
@@ -65,9 +65,9 @@ export class UserTeamMembershipTableComponent implements OnInit, OnDestroy {
 
   addOrRemoveUser(checked: boolean, user: User): void {
     if (checked) {
-      this.usersToAdd[user.username] = user;
+      this.usersToAdd[user.id] = user;
     } else {
-      delete this.usersToAdd[user.username];
+      delete this.usersToAdd[user.id];
     }
   }
 
@@ -100,7 +100,7 @@ export class UserTeamMembershipTableComponent implements OnInit, OnDestroy {
   }
 
   public userLink(user: User): string {
-    return `/settings/users/${user.username}`;
+    return `/settings/users/${user.id}`;
   }
 
   public subscribeToUsersToFilter(): void {

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -108,8 +108,8 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
                   });
 
                   users.forEach((user: User) => {
-                    const member = stringToMember(`user:local:${user.username}`);
-                    this.memberURLs[member.name] = ['/settings', 'users', user.username];
+                    const member = stringToMember(`user:local:${user.id}`);
+                    this.memberURLs[member.name] = ['/settings', 'users', user.id];
                     // We'll refresh the sorted map for the chef-table below.
                     this.addAvailableMember(member, false);
                   });

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
@@ -96,8 +96,8 @@ describe('TeamDetailsComponent', () => {
     it('intermixes capitals and lowercase with lowercase first', () => {
       store.dispatch(new GetTeamUsersSuccess({ user_ids: ['user-id-1', 'user-id-2'] }));
       store.dispatch(new GetUsersSuccess({ users: [
-        { id: 'user-id-1', name: 'Alice', username: 'alice' },
-        { id: 'user-id-2', name: 'alice', username: 'alice' }
+        { membership_id: 'user-id-1', name: 'Alice', id: 'alice1', projects: [] },
+        { membership_id: 'user-id-2', name: 'alice', id: 'alice2', projects: [] }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(2);
@@ -111,9 +111,9 @@ describe('TeamDetailsComponent', () => {
         user_ids: ['user-id-1', 'user-id-20', 'user-id-2']
       }));
       store.dispatch(new GetUsersSuccess({ users: [
-        { id: 'user-id-1', name: 'alice in wonderland', username: 'same' },
-        { id: 'user-id-20', name: 'alice', username: 'same' },
-        { id: 'user-id-2', name: 'Alice', username: 'same' }
+        { membership_id: 'user-id-1', name: 'alice in wonderland', id: 'alice1', projects: [] },
+        { membership_id: 'user-id-20', name: 'alice', id: 'alice2', projects: [] },
+        { membership_id: 'user-id-2', name: 'Alice', id: 'alice3', projects: [] }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(3);
@@ -127,19 +127,19 @@ describe('TeamDetailsComponent', () => {
       store.dispatch(new GetTeamUsersSuccess({
         user_ids: ['user-id-22', 'user-id-1', 'user-id-20', 'user-id-2'] }));
       store.dispatch(new GetUsersSuccess({ users: [
-       { id: 'user-id-22', name: 'Bob', username: 'builder2001' },
-       { id: 'user-id-2', name: 'Bob', username: 'builder2000' },
-       { id: 'user-id-1', name: 'Alice in Wonderland', username: 'alice' },
-       { id: 'user-id-20', name: 'alice', username: 'the-other-alice' }
+       { membership_id: 'user-id-22', name: 'Bob', id: 'builder2001', projects: [] },
+       { membership_id: 'user-id-2', name: 'Bob', id: 'builder2000', projects: [] },
+       { membership_id: 'user-id-1', name: 'Alice in Wonderland', id: 'alice', projects: [] },
+       { membership_id: 'user-id-20', name: 'alice', id: 'the-other-alice', projects: [] }
      ]}));
      component.sortedUsers$.subscribe(users => {
        expect(users.length).toBe(4);
        expect(users[0]).toEqual(jasmine.objectContaining({ name: 'alice' }));
        expect(users[1]).toEqual(jasmine.objectContaining({ name: 'Alice in Wonderland' }));
        expect(users[2]).toEqual(
-         jasmine.objectContaining({ name: 'Bob', username: 'builder2000' }));
+         jasmine.objectContaining({ name: 'Bob', id: 'builder2000' }));
        expect(users[3]).toEqual(
-         jasmine.objectContaining({ name: 'Bob', username: 'builder2001' }));
+         jasmine.objectContaining({ name: 'Bob', id: 'builder2001' }));
      });
     });
 
@@ -147,11 +147,11 @@ describe('TeamDetailsComponent', () => {
       store.dispatch(new GetTeamUsersSuccess({
         user_ids: ['user-id-1', 'user-id-2', 'user-id-3', 'user-id-4', 'user-id-5'] }));
       store.dispatch(new GetUsersSuccess({ users: [
-        { id: 'user-id-1', name: 'Alice01', username: 'alice' },
-        { id: 'user-id-2', name: 'Alice300', username: 'alice' },
-        { id: 'user-id-3', name: 'Alice3', username: 'alice' },
-        { id: 'user-id-4', name: 'Alice-2', username: 'alice' },
-        { id: 'user-id-5', name: 'alice', username: 'alice' }
+        { membership_id: 'user-id-1', name: 'Alice01', id: 'alice1', projects: [] },
+        { membership_id: 'user-id-2', name: 'Alice300', id: 'alice2', projects: [] },
+        { membership_id: 'user-id-3', name: 'Alice3', id: 'alice3', projects: [] },
+        { membership_id: 'user-id-4', name: 'Alice-2', id: 'alice4', projects: [] },
+        { membership_id: 'user-id-5', name: 'alice', id: 'alice5', projects: [] }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(5);
@@ -167,19 +167,19 @@ describe('TeamDetailsComponent', () => {
       store.dispatch(new GetTeamUsersSuccess({
         user_ids: ['user-id-1', 'user-id-2', 'user-id-3', 'user-id-4', 'user-id-5'] }));
       store.dispatch(new GetUsersSuccess({ users: [
-        { id: 'user-id-1', name: 'Alice', username: 'Alice01' },
-        { id: 'user-id-2', name: 'Alice', username: 'Alice300' },
-        { id: 'user-id-3', name: 'Alice', username: 'Alice3' },
-        { id: 'user-id-4', name: 'Alice', username: 'Alice-2' },
-        { id: 'user-id-5', name: 'Alice', username: 'alice' }
+        { membership_id: 'user-id-1', name: 'Alice', id: 'Alice01', projects: [] },
+        { membership_id: 'user-id-2', name: 'Alice', id: 'Alice300', projects: [] },
+        { membership_id: 'user-id-3', name: 'Alice', id: 'Alice3', projects: [] },
+        { membership_id: 'user-id-4', name: 'Alice', id: 'Alice-2', projects: [] },
+        { membership_id: 'user-id-5', name: 'Alice', id: 'alice', projects: [] }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(5);
-        expect(users[0]).toEqual(jasmine.objectContaining({ username: 'alice' }));
-        expect(users[1]).toEqual(jasmine.objectContaining({ username: 'Alice-2' }));
-        expect(users[2]).toEqual(jasmine.objectContaining({ username: 'Alice01' }));
-        expect(users[3]).toEqual(jasmine.objectContaining({ username: 'Alice3' }));
-        expect(users[4]).toEqual(jasmine.objectContaining({ username: 'Alice300' }));
+        expect(users[0]).toEqual(jasmine.objectContaining({ id: 'alice' }));
+        expect(users[1]).toEqual(jasmine.objectContaining({ id: 'Alice-2' }));
+        expect(users[2]).toEqual(jasmine.objectContaining({ id: 'Alice01' }));
+        expect(users[3]).toEqual(jasmine.objectContaining({ id: 'Alice3' }));
+        expect(users[4]).toEqual(jasmine.objectContaining({ id: 'Alice300' }));
       });
     });
   });

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
@@ -96,8 +96,8 @@ describe('TeamDetailsComponent', () => {
     it('intermixes capitals and lowercase with lowercase first', () => {
       store.dispatch(new GetTeamUsersSuccess({ user_ids: ['user-id-1', 'user-id-2'] }));
       store.dispatch(new GetUsersSuccess({ users: [
-        { membership_id: 'user-id-1', name: 'Alice', id: 'alice1', projects: [] },
-        { membership_id: 'user-id-2', name: 'alice', id: 'alice2', projects: [] }
+        { membership_id: 'user-id-1', name: 'Alice', id: 'alice1' },
+        { membership_id: 'user-id-2', name: 'alice', id: 'alice2' }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(2);
@@ -111,9 +111,9 @@ describe('TeamDetailsComponent', () => {
         user_ids: ['user-id-1', 'user-id-20', 'user-id-2']
       }));
       store.dispatch(new GetUsersSuccess({ users: [
-        { membership_id: 'user-id-1', name: 'alice in wonderland', id: 'alice1', projects: [] },
-        { membership_id: 'user-id-20', name: 'alice', id: 'alice2', projects: [] },
-        { membership_id: 'user-id-2', name: 'Alice', id: 'alice3', projects: [] }
+        { membership_id: 'user-id-1', name: 'alice in wonderland', id: 'alice1' },
+        { membership_id: 'user-id-20', name: 'alice', id: 'alice2' },
+        { membership_id: 'user-id-2', name: 'Alice', id: 'alice3' }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(3);
@@ -127,10 +127,10 @@ describe('TeamDetailsComponent', () => {
       store.dispatch(new GetTeamUsersSuccess({
         user_ids: ['user-id-22', 'user-id-1', 'user-id-20', 'user-id-2'] }));
       store.dispatch(new GetUsersSuccess({ users: [
-       { membership_id: 'user-id-22', name: 'Bob', id: 'builder2001', projects: [] },
-       { membership_id: 'user-id-2', name: 'Bob', id: 'builder2000', projects: [] },
-       { membership_id: 'user-id-1', name: 'Alice in Wonderland', id: 'alice', projects: [] },
-       { membership_id: 'user-id-20', name: 'alice', id: 'the-other-alice', projects: [] }
+       { membership_id: 'user-id-22', name: 'Bob', id: 'builder2001' },
+       { membership_id: 'user-id-2', name: 'Bob', id: 'builder2000' },
+       { membership_id: 'user-id-1', name: 'Alice in Wonderland', id: 'alice' },
+       { membership_id: 'user-id-20', name: 'alice', id: 'the-other-alice' }
      ]}));
      component.sortedUsers$.subscribe(users => {
        expect(users.length).toBe(4);
@@ -147,11 +147,11 @@ describe('TeamDetailsComponent', () => {
       store.dispatch(new GetTeamUsersSuccess({
         user_ids: ['user-id-1', 'user-id-2', 'user-id-3', 'user-id-4', 'user-id-5'] }));
       store.dispatch(new GetUsersSuccess({ users: [
-        { membership_id: 'user-id-1', name: 'Alice01', id: 'alice1', projects: [] },
-        { membership_id: 'user-id-2', name: 'Alice300', id: 'alice2', projects: [] },
-        { membership_id: 'user-id-3', name: 'Alice3', id: 'alice3', projects: [] },
-        { membership_id: 'user-id-4', name: 'Alice-2', id: 'alice4', projects: [] },
-        { membership_id: 'user-id-5', name: 'alice', id: 'alice5', projects: [] }
+        { membership_id: 'user-id-1', name: 'Alice01', id: 'alice1' },
+        { membership_id: 'user-id-2', name: 'Alice300', id: 'alice2' },
+        { membership_id: 'user-id-3', name: 'Alice3', id: 'alice3' },
+        { membership_id: 'user-id-4', name: 'Alice-2', id: 'alice4' },
+        { membership_id: 'user-id-5', name: 'alice', id: 'alice5' }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(5);
@@ -167,11 +167,11 @@ describe('TeamDetailsComponent', () => {
       store.dispatch(new GetTeamUsersSuccess({
         user_ids: ['user-id-1', 'user-id-2', 'user-id-3', 'user-id-4', 'user-id-5'] }));
       store.dispatch(new GetUsersSuccess({ users: [
-        { membership_id: 'user-id-1', name: 'Alice', id: 'Alice01', projects: [] },
-        { membership_id: 'user-id-2', name: 'Alice', id: 'Alice300', projects: [] },
-        { membership_id: 'user-id-3', name: 'Alice', id: 'Alice3', projects: [] },
-        { membership_id: 'user-id-4', name: 'Alice', id: 'Alice-2', projects: [] },
-        { membership_id: 'user-id-5', name: 'Alice', id: 'alice', projects: [] }
+        { membership_id: 'user-id-1', name: 'Alice', id: 'Alice01' },
+        { membership_id: 'user-id-2', name: 'Alice', id: 'Alice300' },
+        { membership_id: 'user-id-3', name: 'Alice', id: 'Alice3' },
+        { membership_id: 'user-id-4', name: 'Alice', id: 'Alice-2' },
+        { membership_id: 'user-id-5', name: 'Alice', id: 'alice' }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(5);

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -105,11 +105,11 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
           (a, b) => {
             // See https://stackoverflow.com/a/38641281 for these options
             const opts = { numeric: true, sensitivity: 'base' };
-            // sort by name then by username
+            // sort by name then by id
             return a.name.localeCompare(b.name, undefined, opts) ||
               a.name.localeCompare(b.name, undefined, { numeric: true }) ||
               a.id.localeCompare(b.id, undefined, opts);
-          })),
+            })),
         takeUntil(this.isDestroyed)
       );
 

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -97,7 +97,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
           }
           // Map UUID membership to user records and remove any entries that don't
           // map to user records.
-          return at(tUsers, keyBy('id', users))
+          return at(tUsers, keyBy('membership_id', users))
             .filter(userRecord => userRecord !== undefined);
         }),
         map((users: User[]) => users.sort(
@@ -107,8 +107,9 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
             // sort by name then by username
             return a.name.localeCompare(b.name, undefined, opts) ||
               a.name.localeCompare(b.name, undefined, { numeric: true }) ||
-              a.username.localeCompare(b.username, undefined, opts);
-          }))
+              a.id.localeCompare(b.id, undefined, opts);
+          })),
+        takeUntil(this.isDestroyed)
       );
 
     // If, however, the user browses directly to /settings/teams/ID, the store
@@ -155,7 +156,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   addUsers(users: HashMapOfUsers): void {
     this.toggleUserMembershipView();
 
-    const userIDs = Object.values(users).map((user: User) => user.id);
+    const userIDs = Object.values(users).map((user: User) => user.membership_id);
 
     this.store.dispatch(new AddTeamUsers(<TeamUserMgmtPayload>{
       id: this.teamId,
@@ -166,7 +167,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   removeUser(user: User): void {
     this.store.dispatch(new RemoveTeamUsers(<TeamUserMgmtPayload>{
       id: this.teamId,
-      user_ids: [user.id]
+      user_ids: [user.membership_id]
     }));
   }
 

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.html
@@ -2,7 +2,7 @@
 <app-profile-sidebar *ngIf="!isAdminView"> </app-profile-sidebar>
 
 <div class="container">
-  <main *ngIf="isAdminView || user?.username">
+  <main *ngIf="isAdminView || user?.id">
     <app-delete-object-modal
       [visible]="modalVisible"
       objectNoun="user"
@@ -33,7 +33,7 @@
             </form>
           </ng-container>
           <div class="container-big-header inline-container">
-            <span class="text"> {{ user?.username }}</span>
+            <span class="text"> {{ user?.id }}</span>
           </div>
         </div>
         <div class="button-column">

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.spec.ts
@@ -33,8 +33,7 @@ describe('UserDetailsComponent', () => {
   const user: User = {
     name: 'Alice Schmidt',
     id: 'alice',
-    membership_id: '6e98f609-586d-4816-a6de-e841e659b11d',
-    projects: []
+    membership_id: '6e98f609-586d-4816-a6de-e841e659b11d'
   };
 
   const initialState = {

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.spec.ts
@@ -15,8 +15,8 @@ import {
 } from 'app/entities/users/user.reducer';
 import { User } from 'app/entities/users/user.model';
 import {
-  GetUserByUsername,
-  GetUserByUsernameSuccess,
+  GetUser,
+  GetUserSuccess,
   DeleteUser,
   DeleteUserSuccess
 } from 'app/entities/users/user.actions';
@@ -32,15 +32,16 @@ describe('UserDetailsComponent', () => {
 
   const user: User = {
     name: 'Alice Schmidt',
-    username: 'alice',
-    id: '6e98f609-586d-4816-a6de-e841e659b11d'
+    id: 'alice',
+    membership_id: '6e98f609-586d-4816-a6de-e841e659b11d',
+    projects: []
   };
 
   const initialState = {
     router: {
       state: {
         url: '/settings/users/alice',
-        params: { username: 'alice' },
+        params: { id: 'alice' },
         queryParams: {},
         fragment: ''
       },
@@ -104,7 +105,7 @@ describe('UserDetailsComponent', () => {
       // Note: this is the happy end of a "fetch user data" exchange with the
       // backend -- so, for setting the stage for testing, it is exactly what
       // we need
-      store.dispatch(new GetUserByUsernameSuccess(user));
+      store.dispatch(new GetUserSuccess(user));
     });
 
     it('exists', () => {
@@ -117,7 +118,7 @@ describe('UserDetailsComponent', () => {
 
     it('dispatches an action to get its user data', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
-        new GetUserByUsername({ username: user.username}));
+        new GetUser({ id: user.id }));
     });
   });
 
@@ -134,13 +135,13 @@ describe('UserDetailsComponent', () => {
 
     it('dispatches an action to get its user data', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
-        new GetUserByUsername({ username: user.username}));
+        new GetUser({ id: user.id }));
     });
   });
 
   describe('when deleting the user', () => {
     beforeEach(() => {
-      store.dispatch(new GetUserByUsernameSuccess(user));
+      store.dispatch(new GetUserSuccess(user));
       component.deleteUser();
     });
 

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.ts
@@ -82,8 +82,8 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
       store.select(userStatus))
       .pipe(
         map(([state, status]) => {
-          const username = this.user.username;
-          return status === EntityStatus.loadingSuccess && !find({ username }, state);
+          const id = this.user.id;
+          return status === EntityStatus.loadingSuccess && !find({ id }, state);
         }));
 
     this.subscriptions = [
@@ -95,10 +95,10 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
       // Note: if the user browses directly to /settings/users/USERNAME, the state
       // will not contain any user data -- so we need to fetch it.
       store.select(routeParams).pipe(
-        pluck('username'),
+        pluck('id'),
         filter(identity))
-        .subscribe((username: string) => {
-          store.dispatch(new GetUserByUsername({username}));
+        .subscribe((id: string) => {
+          store.dispatch(new GetUserByUsername({id}));
         }),
 
       // if the user is gone, go back to list
@@ -163,7 +163,13 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
   private updatePasswordForSelf(): void {
     const password = this.passwordForm.get('newPassword').value;
     const previous_password = this.passwordForm.get('oldPassword').value;
-    this.store.dispatch(new UpdateSelf({ ...this.user, password, previous_password }));
+    this.store.dispatch(new UpdateSelf({
+      id: this.user.id,
+      name: this.user.name,
+      membership_id: this.user.membership_id,
+      password: password,
+      previous_password: previous_password
+    }));
   }
 
   public updateFullName(): void {
@@ -171,7 +177,11 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
     this.store.dispatch(
       this.isAdminView ?
         new UpdateUser({ ...this.user, name })
-        : new UpdateSelf({ ...this.user, name }));
+        : new UpdateSelf({
+          id: this.user.id,
+          name: name,
+          membership_id: this.user.membership_id
+        }));
   }
 
   public openDeleteConfirmationModal(): void {

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.ts
@@ -12,7 +12,7 @@ import { routeParams } from 'app/route.selectors';
 import { EntityStatus } from 'app/entities/entities';
 import {
   DeleteUser,
-  GetUserByUsername,
+  GetUser,
   UpdateUser,
   UpdateSelf
  } from 'app/entities/users/user.actions';
@@ -98,7 +98,7 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
         pluck('id'),
         filter(identity))
         .subscribe((id: string) => {
-          store.dispatch(new GetUserByUsername({id}));
+          store.dispatch(new GetUser({id}));
         }),
 
       // if the user is gone, go back to list

--- a/components/automate-ui/src/app/pages/user-management/user-management.component.spec.ts
+++ b/components/automate-ui/src/app/pages/user-management/user-management.component.spec.ts
@@ -91,10 +91,10 @@ describe('UserManagementComponent', () => {
 
     it('intermixes capitals and lowercase with lowercase first', () => {
       store.dispatch(new GetUsersSuccess({ users: [
-        { id: 'uuid-1', name: 'Alice', username: 'alice' },
-        { id: 'uuid-2', name: 'alice', username: 'alice' },
-        { id: 'uuid-3', name: 'bob', username: 'builder2000' },
-        { id: 'uuid-4', name: 'Bob', username: 'builder2000' }
+        { membership_id: 'uuid-1', name: 'Alice', id: 'alice2', projects: [] },
+        { membership_id: 'uuid-2', name: 'alice', id: 'alice1', projects: [] },
+        { membership_id: 'uuid-3', name: 'bob', id: 'builder2001', projects: [] },
+        { membership_id: 'uuid-4', name: 'Bob', id: 'builder2000', projects: [] }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(4);
@@ -107,9 +107,9 @@ describe('UserManagementComponent', () => {
 
     it('sorts by whole string before case', () => {
       store.dispatch(new GetUsersSuccess({ users: [
-        { id: 'uuid-1', name: 'alice in wonderland', username: 'same' },
-        { id: 'uuid-20', name: 'alice', username: 'same' },
-        { id: 'uuid-2', name: 'Alice', username: 'same' }
+        { membership_id: 'uuid-1', name: 'alice in wonderland', id: 'alice1', projects: [] },
+        { membership_id: 'uuid-20', name: 'alice', id: 'alice2', projects: [] },
+        { membership_id: 'uuid-2', name: 'Alice', id: 'alice3', projects: [] }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(3);
@@ -121,29 +121,29 @@ describe('UserManagementComponent', () => {
 
     it('sorts by name then by username', () => {
       store.dispatch(new GetUsersSuccess({ users: [
-       { id: 'uuid-22', name: 'Bob', username: 'builder2001' },
-       { id: 'uuid-2', name: 'Bob', username: 'builder2000' },
-       { id: 'uuid-1', name: 'Alice in Wonderland', username: 'alice' },
-       { id: 'uuid-20', name: 'alice', username: 'the-other-alice' }
+       { membership_id: 'uuid-22', name: 'Bob', id: 'builder2001', projects: []  },
+       { membership_id: 'uuid-2', name: 'Bob', id: 'builder2000', projects: []  },
+       { membership_id: 'uuid-1', name: 'Alice in Wonderland', id: 'alice', projects: []  },
+       { membership_id: 'uuid-20', name: 'alice', id: 'the-other-alice', projects: []  }
      ]}));
      component.sortedUsers$.subscribe(users => {
        expect(users.length).toBe(4);
        expect(users[0]).toEqual(jasmine.objectContaining({ name: 'alice' }));
        expect(users[1]).toEqual(jasmine.objectContaining({ name: 'Alice in Wonderland' }));
        expect(users[2]).toEqual(
-         jasmine.objectContaining({ name: 'Bob', username: 'builder2000' }));
+         jasmine.objectContaining({ name: 'Bob', id: 'builder2000' }));
        expect(users[3]).toEqual(
-         jasmine.objectContaining({ name: 'Bob', username: 'builder2001' }));
+         jasmine.objectContaining({ name: 'Bob', id: 'builder2001' }));
      });
     });
 
     it('uses natural ordering in name', () => {
       store.dispatch(new GetUsersSuccess({ users: [
-        { id: 'uuid-1', name: 'Alice01', username: 'alice' },
-        { id: 'uuid-2', name: 'Alice300', username: 'alice' },
-        { id: 'uuid-3', name: 'Alice3', username: 'alice' },
-        { id: 'uuid-4', name: 'Alice-2', username: 'alice' },
-        { id: 'uuid-5', name: 'alice', username: 'alice' }
+        { membership_id: 'uuid-1', name: 'Alice01', id: 'alice1', projects: [] },
+        { membership_id: 'uuid-2', name: 'Alice300', id: 'alice2', projects: [] },
+        { membership_id: 'uuid-3', name: 'Alice3', id: 'alice3', projects: [] },
+        { membership_id: 'uuid-4', name: 'Alice-2', id: 'alice4', projects: [] },
+        { membership_id: 'uuid-5', name: 'alice', id: 'alice5', projects: [] }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(5);
@@ -157,19 +157,19 @@ describe('UserManagementComponent', () => {
 
     it('uses natural ordering in username', () => {
       store.dispatch(new GetUsersSuccess({ users: [
-        { id: 'uuid-1', name: 'Alice', username: 'Alice01' },
-        { id: 'uuid-2', name: 'Alice', username: 'Alice300' },
-        { id: 'uuid-3', name: 'Alice', username: 'Alice3' },
-        { id: 'uuid-4', name: 'Alice', username: 'Alice-2' },
-        { id: 'uuid-5', name: 'Alice', username: 'alice' }
+        { membership_id: 'uuid-1', name: 'Alice', id: 'Alice01', projects: [] },
+        { membership_id: 'uuid-2', name: 'Alice', id: 'Alice300', projects: [] },
+        { membership_id: 'uuid-3', name: 'Alice', id: 'Alice3', projects: [] },
+        { membership_id: 'uuid-4', name: 'Alice', id: 'Alice-2', projects: [] },
+        { membership_id: 'uuid-5', name: 'Alice', id: 'alice', projects: [] }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(5);
-        expect(users[0]).toEqual(jasmine.objectContaining({ username: 'alice' }));
-        expect(users[1]).toEqual(jasmine.objectContaining({ username: 'Alice-2' }));
-        expect(users[2]).toEqual(jasmine.objectContaining({ username: 'Alice01' }));
-        expect(users[3]).toEqual(jasmine.objectContaining({ username: 'Alice3' }));
-        expect(users[4]).toEqual(jasmine.objectContaining({ username: 'Alice300' }));
+        expect(users[0]).toEqual(jasmine.objectContaining({ id: 'alice' }));
+        expect(users[1]).toEqual(jasmine.objectContaining({ id: 'Alice-2' }));
+        expect(users[2]).toEqual(jasmine.objectContaining({ id: 'Alice01' }));
+        expect(users[3]).toEqual(jasmine.objectContaining({ id: 'Alice3' }));
+        expect(users[4]).toEqual(jasmine.objectContaining({ id: 'Alice300' }));
       });
     });
 

--- a/components/automate-ui/src/app/pages/user-management/user-management.component.spec.ts
+++ b/components/automate-ui/src/app/pages/user-management/user-management.component.spec.ts
@@ -91,10 +91,10 @@ describe('UserManagementComponent', () => {
 
     it('intermixes capitals and lowercase with lowercase first', () => {
       store.dispatch(new GetUsersSuccess({ users: [
-        { membership_id: 'uuid-1', name: 'Alice', id: 'alice2', projects: [] },
-        { membership_id: 'uuid-2', name: 'alice', id: 'alice1', projects: [] },
-        { membership_id: 'uuid-3', name: 'bob', id: 'builder2001', projects: [] },
-        { membership_id: 'uuid-4', name: 'Bob', id: 'builder2000', projects: [] }
+        { membership_id: 'uuid-1', name: 'Alice', id: 'alice2' },
+        { membership_id: 'uuid-2', name: 'alice', id: 'alice1' },
+        { membership_id: 'uuid-3', name: 'bob', id: 'builder2001' },
+        { membership_id: 'uuid-4', name: 'Bob', id: 'builder2000' }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(4);
@@ -107,9 +107,9 @@ describe('UserManagementComponent', () => {
 
     it('sorts by whole string before case', () => {
       store.dispatch(new GetUsersSuccess({ users: [
-        { membership_id: 'uuid-1', name: 'alice in wonderland', id: 'alice1', projects: [] },
-        { membership_id: 'uuid-20', name: 'alice', id: 'alice2', projects: [] },
-        { membership_id: 'uuid-2', name: 'Alice', id: 'alice3', projects: [] }
+        { membership_id: 'uuid-1', name: 'alice in wonderland', id: 'alice1' },
+        { membership_id: 'uuid-20', name: 'alice', id: 'alice2' },
+        { membership_id: 'uuid-2', name: 'Alice', id: 'alice3' }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(3);
@@ -121,10 +121,10 @@ describe('UserManagementComponent', () => {
 
     it('sorts by name then by username', () => {
       store.dispatch(new GetUsersSuccess({ users: [
-       { membership_id: 'uuid-22', name: 'Bob', id: 'builder2001', projects: []  },
-       { membership_id: 'uuid-2', name: 'Bob', id: 'builder2000', projects: []  },
-       { membership_id: 'uuid-1', name: 'Alice in Wonderland', id: 'alice', projects: []  },
-       { membership_id: 'uuid-20', name: 'alice', id: 'the-other-alice', projects: []  }
+       { membership_id: 'uuid-22', name: 'Bob', id: 'builder2001'  },
+       { membership_id: 'uuid-2', name: 'Bob', id: 'builder2000'  },
+       { membership_id: 'uuid-1', name: 'Alice in Wonderland', id: 'alice'  },
+       { membership_id: 'uuid-20', name: 'alice', id: 'the-other-alice'  }
      ]}));
      component.sortedUsers$.subscribe(users => {
        expect(users.length).toBe(4);
@@ -139,11 +139,11 @@ describe('UserManagementComponent', () => {
 
     it('uses natural ordering in name', () => {
       store.dispatch(new GetUsersSuccess({ users: [
-        { membership_id: 'uuid-1', name: 'Alice01', id: 'alice1', projects: [] },
-        { membership_id: 'uuid-2', name: 'Alice300', id: 'alice2', projects: [] },
-        { membership_id: 'uuid-3', name: 'Alice3', id: 'alice3', projects: [] },
-        { membership_id: 'uuid-4', name: 'Alice-2', id: 'alice4', projects: [] },
-        { membership_id: 'uuid-5', name: 'alice', id: 'alice5', projects: [] }
+        { membership_id: 'uuid-1', name: 'Alice01', id: 'alice1' },
+        { membership_id: 'uuid-2', name: 'Alice300', id: 'alice2' },
+        { membership_id: 'uuid-3', name: 'Alice3', id: 'alice3' },
+        { membership_id: 'uuid-4', name: 'Alice-2', id: 'alice4' },
+        { membership_id: 'uuid-5', name: 'alice', id: 'alice5' }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(5);
@@ -157,11 +157,11 @@ describe('UserManagementComponent', () => {
 
     it('uses natural ordering in username', () => {
       store.dispatch(new GetUsersSuccess({ users: [
-        { membership_id: 'uuid-1', name: 'Alice', id: 'Alice01', projects: [] },
-        { membership_id: 'uuid-2', name: 'Alice', id: 'Alice300', projects: [] },
-        { membership_id: 'uuid-3', name: 'Alice', id: 'Alice3', projects: [] },
-        { membership_id: 'uuid-4', name: 'Alice', id: 'Alice-2', projects: [] },
-        { membership_id: 'uuid-5', name: 'Alice', id: 'alice', projects: [] }
+        { membership_id: 'uuid-1', name: 'Alice', id: 'Alice01' },
+        { membership_id: 'uuid-2', name: 'Alice', id: 'Alice300' },
+        { membership_id: 'uuid-3', name: 'Alice', id: 'Alice3' },
+        { membership_id: 'uuid-4', name: 'Alice', id: 'Alice-2' },
+        { membership_id: 'uuid-5', name: 'Alice', id: 'alice' }
       ]}));
       component.sortedUsers$.subscribe(users => {
         expect(users.length).toBe(5);

--- a/components/automate-ui/src/app/pages/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/pages/user-management/user-management.component.ts
@@ -72,7 +72,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
           // sort by name then by username
           return a.name.localeCompare(b.name, undefined, opts) ||
             a.name.localeCompare(b.name, undefined, { numeric: true}) ||
-            a.username.localeCompare(b.username, undefined, opts);
+            a.id.localeCompare(b.id, undefined, opts);
         }
       )));
 
@@ -124,7 +124,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
 
     const userCreateReq = <CreateUserPayload>{
       name: formValues.fullname,
-      username: formValues.username,
+      id: formValues.username,
       password: formValues.password
     };
 


### PR DESCRIPTION
### :nut_and_bolt: Description

Replaces all of the UI's internal model of user with the V2 version and keeps all logic around the V1 vs V2 model encapsulated in `user.requests.ts`. Also updates NGRX store to query the V2 endpoints when the IAM V2 is enabled.

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
