### PR TITLE
Remove color definition from breadcrumb links

### DIFF
--- a/components/automate-ui/src/app/components/breadcrumb/breadcrumb.component.scss
+++ b/components/automate-ui/src/app/components/breadcrumb/breadcrumb.component.scss
@@ -2,7 +2,6 @@
 
 .breadcrumb {
   display: inline-block;
-  color: $chef-primary-bright;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description
Removes the link color from the breadcrumb links so they inherit the proper `<a>` tag styles.

![breadcrumb-color](https://user-images.githubusercontent.com/7217000/57402383-1436b300-718c-11e9-8a2d-765033917932.gif)

### :athletic_shoe: Demo Script / Repro Steps
Start up the UI and hover on any of the breadcrumb links to make sure they have a hover color.

### :chains: Related Resources
https://github.com/chef/automate/issues/151

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
