### PR TITLE
[releng] Fetch git tags in the pipeline

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -8,6 +8,9 @@ set -eu
 echo "Fetching origin/master"
 git fetch origin master
 
+# DEBUGGING FOR RELENG
+# Fetch the git tags to see if that addresses the weird smart build behavior for Habitat
+git fetch --tags --force
 
 # By default, Buildkite pulls down HEAD. If we're on a pull-request, pull down
 # the merged head: https://github.com/buildkite/agent/blob/master/bootstrap/bootstrap.go#L698


### PR DESCRIPTION


### :nut_and_bolt: Description
We're seeing some weird behavior in habitat builds where we are building
more packages than required. This might be because we're using outdated
tags. This is a debug commit to see if force fetching the tags addresses
the issue.

Signed-off-by: Tom Duffield <tom@chef.io>

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
