### PR TITLE
Project filter GetRuns

### DIFF
--- a/components/config-mgmt-service/backend/client.go
+++ b/components/config-mgmt-service/backend/client.go
@@ -17,8 +17,8 @@ import (
 // use in the future. Think about it as a set of contracts that the API
 // requires to fulfill the requests
 type Client interface {
-	// @params (nodeid)
-	GetNode(string) (Node, error)
+	// @params (nodeid, filters)
+	NodeExists(nodeID string, projectFilters map[string][]string) (bool, error)
 	// @params (page, perPage, sortField, ascending, filters)
 	GetNodes(int, int, string, bool, map[string][]string) ([]Node, error)
 	// @params (filters)

--- a/components/config-mgmt-service/backend/elastic/nodes.go
+++ b/components/config-mgmt-service/backend/elastic/nodes.go
@@ -24,13 +24,10 @@ func init() {
 	}
 }
 
-// GetNode Returns a single Node
-func (es Backend) GetNode(id string) (backend.Node, error) {
-	var node backend.Node
-	filters := map[string][]string{
-		"exists":      []string{"true"},
-		"entity_uuid": []string{id},
-	}
+// NodeExists - Does a node with entity_uuid == 'nodeID' exists
+func (es Backend) NodeExists(nodeID string, filters map[string][]string) (bool, error) {
+	filters["exists"] = []string{"true"}
+	filters["entity_uuid"] = []string{nodeID}
 	filtersQuery := newBoolQueryFromFilters(filters)
 
 	searchResult, err := es.client.Search().
@@ -38,24 +35,14 @@ func (es Backend) GetNode(id string) (backend.Node, error) {
 		Index(IndexNodeState).
 		Do(context.Background())
 	if err != nil {
-		return node, err
+		return false, err
 	}
 
-	if searchResult.Hits.TotalHits > 0 {
-		// We will expect a single hit to come back from the ES query
-		// and then unmarshal the Source into a backend.Node
-		hit := searchResult.Hits.Hits[0]
-		err = json.Unmarshal(*hit.Source, &node)
-		if err != nil {
-			log.WithFields(log.Fields{
-				"object": hit.Source,
-			}).WithError(err).Debug("Unable to unmarshal the node object")
-		}
-	} else {
-		err = errors.New(errors.NodeNotFound, "Invalid ID")
+	if searchResult.Hits.TotalHits == 0 {
+		return false, nil
 	}
 
-	return node, err
+	return true, err
 }
 
 // GetInventoryNodes - Collect inventory nodes from elasticsearch. This function allows
@@ -253,7 +240,7 @@ func (es Backend) GetNodesCounts(filters map[string][]string) (backend.NodesCoun
 
 	searchTerm := "status"
 
-	statusNodesBuckets, err := es.getAggregationBucket(boolQuery, "node-state", searchTerm)
+	statusNodesBuckets, err := es.getAggregationBucket(boolQuery, IndexNodeState, searchTerm)
 	if err != nil {
 		return ns, err
 	}

--- a/components/config-mgmt-service/backend/elastic/nodes.go
+++ b/components/config-mgmt-service/backend/elastic/nodes.go
@@ -38,11 +38,7 @@ func (es Backend) NodeExists(nodeID string, filters map[string][]string) (bool, 
 		return false, err
 	}
 
-	if searchResult.Hits.TotalHits == 0 {
-		return false, nil
-	}
-
-	return true, err
+	return searchResult.Hits.TotalHits > 0, nil
 }
 
 // GetInventoryNodes - Collect inventory nodes from elasticsearch. This function allows

--- a/components/config-mgmt-service/backend/mock/mock.go
+++ b/components/config-mgmt-service/backend/mock/mock.go
@@ -33,11 +33,8 @@ func New() Backend {
 // In order to be a proper backend you have to implement all the contracts that
 // the Client interface has setup, this will ensure that the endpoints we have
 // defined will always be able to get the data from any backend we configure
-func (m Backend) GetNode(id string) (backend.Node, error) {
-	n := new(backend.Node)
-	n.EntityUuid = id
-	n.NodeName = "mock"
-	return *n, nil
+func (m Backend) NodeExists(id string, filters map[string][]string) (bool, error) {
+	return false, nil
 }
 
 func (m Backend) GetNodesCounts(filters map[string][]string) (backend.NodesCounts, error) {
@@ -91,11 +88,11 @@ func (m Backend) GetListForField(searchTerm string) ([]string, error) {
 
 func (m Backend) GetSuggestions(term string, text string) ([]backend.Suggestion, error) {
 	suggestions := []backend.Suggestion{
-		backend.Suggestion{
+		{
 			Text:  "Node 1",
 			Score: 4.4892697,
 		},
-		backend.Suggestion{
+		{
 			Text:  "ubuntu",
 			Score: 3.9768348,
 		},
@@ -107,11 +104,11 @@ func (m Backend) GetPolicyCookbooks(revisionID string) (backend.PolicyCookbooks,
 	return backend.PolicyCookbooks{
 		PolicyName: "infra_base",
 		CookbookLocks: []backend.PolicyCookbookLock{
-			backend.PolicyCookbookLock{
+			{
 				CookbookName: "apt",
 				PolicyID:     "any",
 			},
-			backend.PolicyCookbookLock{
+			{
 				CookbookName: "cookbook",
 				PolicyID:     "paula_smith",
 			},

--- a/components/config-mgmt-service/backend/mock/mock_test.go
+++ b/components/config-mgmt-service/backend/mock/mock_test.go
@@ -24,7 +24,7 @@ func TestNew(t *testing.T) {
 	subject.New()
 }
 
-func TestGetNode(t *testing.T) {
+func TestNodeExists(t *testing.T) {
 	expected := "999"
 	exists, err := subject.New().NodeExists(expected, map[string][]string{})
 	assert.Nil(t, err)

--- a/components/config-mgmt-service/backend/mock/mock_test.go
+++ b/components/config-mgmt-service/backend/mock/mock_test.go
@@ -26,9 +26,9 @@ func TestNew(t *testing.T) {
 
 func TestGetNode(t *testing.T) {
 	expected := "999"
-	node, err := subject.New().GetNode(expected)
+	exists, err := subject.New().NodeExists(expected, map[string][]string{})
 	assert.Nil(t, err)
-	assert.Equal(t, node.EntityUuid, expected)
+	assert.False(t, exists)
 }
 
 func TestGetNodesCounts(t *testing.T) {

--- a/components/config-mgmt-service/integration_test/runs_test.go
+++ b/components/config-mgmt-service/integration_test/runs_test.go
@@ -41,21 +41,21 @@ func TestRunsReturnErrorWithWrongParameters(t *testing.T) {
 	)
 
 	cases := []request.Runs{
-		request.Runs{NodeId: "fake", Filter: []string{"platform=centos"}},
-		request.Runs{NodeId: "fake", Filter: []string{"wrong"}},
-		request.Runs{NodeId: "fake", Filter: []string{":success"}},
-		request.Runs{NodeId: "fake", Filter: []string{"platform:"}},
-		request.Runs{NodeId: "fake", Filter: []string{"platform:foo:bar"}},
-		request.Runs{NodeId: "fake", Start: "2000-00-00"},
-		request.Runs{NodeId: "fake", Start: "00-00-00"},
-		request.Runs{NodeId: "fake", Start: "18-10-10"},
-		request.Runs{NodeId: "fake", Start: "20-01-01"},
-		request.Runs{NodeId: "fake", Start: "17:01:01"},
-		request.Runs{NodeId: "fake", End: "01-01-1800"},
-		request.Runs{NodeId: "fake", End: "3000-12"},
-		request.Runs{NodeId: "fake", End: "2019"},
-		request.Runs{NodeId: "fake", End: "1888:01:01"},
-		request.Runs{NodeId: "fake", End: "2027/01/01"},
+		{NodeId: "fake", Filter: []string{"platform=centos"}},
+		{NodeId: "fake", Filter: []string{"wrong"}},
+		{NodeId: "fake", Filter: []string{":success"}},
+		{NodeId: "fake", Filter: []string{"platform:"}},
+		{NodeId: "fake", Filter: []string{"platform:foo:bar"}},
+		{NodeId: "fake", Start: "2000-00-00"},
+		{NodeId: "fake", Start: "00-00-00"},
+		{NodeId: "fake", Start: "18-10-10"},
+		{NodeId: "fake", Start: "20-01-01"},
+		{NodeId: "fake", Start: "17:01:01"},
+		{NodeId: "fake", End: "01-01-1800"},
+		{NodeId: "fake", End: "3000-12"},
+		{NodeId: "fake", End: "2019"},
+		{NodeId: "fake", End: "1888:01:01"},
+		{NodeId: "fake", End: "2027/01/01"},
 	}
 
 	for _, test := range cases {
@@ -74,7 +74,7 @@ func TestRunsWithANodeNotFoundReturnsError(t *testing.T) {
 
 	expected := new(gp.ListValue)
 	res, err := cfgmgmt.GetRuns(ctx, &req)
-	grpctest.AssertCode(t, codes.NotFound, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, res)
 }
 func TestRunsWithFilterReturnsListWithOneNode(t *testing.T) {
@@ -83,7 +83,15 @@ func TestRunsWithFilterReturnsListWithOneNode(t *testing.T) {
 		runs   = twoRunsArray(nodeID)
 		req    = request.Runs{NodeId: nodeID}
 		ctx    = context.Background()
+		node   = iBackend.Node{
+			Exists: true,
+			NodeInfo: iBackend.NodeInfo{
+				EntityUuid: nodeID,
+			},
+		}
 	)
+
+	suite.IngestNodes([]iBackend.Node{node})
 	suite.IngestRuns(runs)
 	defer suite.DeleteAllDocuments()
 
@@ -120,8 +128,15 @@ func TestRunsWithPagination(t *testing.T) {
 		runs   = twoRunsArray(nodeID)
 		req    = request.Runs{NodeId: nodeID}
 		ctx    = context.Background()
+		node   = iBackend.Node{
+			Exists: true,
+			NodeInfo: iBackend.NodeInfo{
+				EntityUuid: nodeID,
+			},
+		}
 	)
 
+	suite.IngestNodes([]iBackend.Node{node})
 	suite.IngestRuns(runs)
 	defer suite.DeleteAllDocuments()
 
@@ -173,7 +188,7 @@ func TestRunsWithTableDriven(t *testing.T) {
 		}
 		nodeArray = func(id string) []iBackend.Node {
 			return []iBackend.Node{
-				iBackend.Node{
+				{
 					NodeInfo: iBackend.NodeInfo{EntityUuid: id},
 					Exists:   true},
 			}

--- a/components/ingest-service/integration_test/suite_test.go
+++ b/components/ingest-service/integration_test/suite_test.go
@@ -8,6 +8,7 @@ package integration_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -103,7 +104,22 @@ func (s *Suite) GlobalTeardown() {
 
 // GetNode retrives a Chef Node
 func (s *Suite) GetNode(id string) (cfgBackend.Node, error) {
-	return s.cfgmgmt.GetNode(id)
+	filterMap := make(map[string][]string, 0)
+	filterMap["entity_uuid"] = []string{id}
+	nodes, err := s.cfgmgmt.GetNodes(1, 1, "node_name", true, filterMap)
+	if err != nil {
+		return cfgBackend.Node{}, err
+	}
+
+	if len(nodes) > 1 {
+		return cfgBackend.Node{}, errors.New("More than one node returned")
+	}
+
+	if len(nodes) == 0 {
+		return cfgBackend.Node{}, errors.New("type=NodeNotFound")
+	}
+
+	return nodes[0], nil
 }
 
 // GetNodes retrives X Chef Nodes


### PR DESCRIPTION
### :nut_and_bolt: Description

Add project filtering for the cfgmgmt.proto GetRuns RPC.

This PR does change the behavior of the GetRuns RPC in that before if the node from the passed in NodeID an error with "Invalid ID" was returned. Now, no error is returned and an empty run list is returned. 

### :chains: Related Resources

https://github.com/chef/automate/issues/68

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
