### PR TITLE
Fix unit test bug in applications-service

### DIFF
--- a/components/applications-service/pkg/storage/postgres/service_internal_test.go
+++ b/components/applications-service/pkg/storage/postgres/service_internal_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -115,7 +116,11 @@ func TestBuildWhereConstraintsFromFiltersMatrix(t *testing.T) {
 				assert.Nil(t, err)
 			}
 
-			assert.Equal(t, test.expected, actual)
+			assert.ElementsMatch(t, clauses(test.expected), clauses(actual))
 		})
 	}
+}
+
+func clauses(predicate string) []string {
+	return regexp.MustCompile("WHERE | AND ").Split(predicate, -1)
 }


### PR DESCRIPTION
### :nut_and_bolt: Description

The unit test in question (TestBuildWhereConstraintsFromFiltersMatrix) was, as @phiggins divined, implicitly depending on the order of a hash which of course means it will fail... unless it happens to succeed. This removes that fun element of non-determinism.

### :+1: Definition of Done

Test always passes.

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
