### PR TITLE
[A2-784] UI http interceptor

### DIFF
--- a/components/automate-gateway/gateway/middleware/auth_interceptor_internal_test.go
+++ b/components/automate-gateway/gateway/middleware/auth_interceptor_internal_test.go
@@ -79,6 +79,10 @@ func TestGetProjectsFromMetadata(t *testing.T) {
 		input    []string
 		expected []string
 	}{
+		"no projects": {
+			input:    []string{""},
+			expected: []string{""},
+		},
 		"a single project": {
 			input:    []string{"pikachu"},
 			expected: []string{"pikachu"},

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
@@ -1,17 +1,30 @@
+import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpClientAuthInterceptor } from './http-client-auth.interceptor';
-import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { StoreModule } from '@ngrx/store';
+
 import { ChefSessionService } from '../chef-session/chef-session.service';
+import {
+  ProjectsFilterState, ProjectsFilterOption
+} from '../projects-filter/projects-filter.reducer';
+import { HttpClientAuthInterceptor } from './http-client-auth.interceptor';
 
 describe('HttpClientAuthInterceptor', () => {
   let httpClient: HttpClient;
   let httpMock: HttpTestingController;
   let chefSession: ChefSessionService;
+  const projects = ['proj1', 'proj2', 'proj3'];
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [
+        HttpClientTestingModule,
+        StoreModule.forRoot({
+          projectsFilter: () => <ProjectsFilterState>{
+            options: projects.map(p => <ProjectsFilterOption>{ value: p })
+          }
+        })
+      ],
       providers: [
         ChefSessionService,
         {
@@ -36,6 +49,16 @@ describe('HttpClientAuthInterceptor', () => {
 
     expect(httpRequest.request.headers.get('Authorization'))
       .toEqual(`Bearer ${chefSession.id_token}`);
+  });
+
+  it('includes projects in all requests', done => {
+    httpClient.get('/endpoint').subscribe(done);
+
+    const httpRequest = httpMock.expectOne('/endpoint');
+    httpRequest.flush('response');
+
+    expect(httpRequest.request.headers.get('projects'))
+      .toEqual(projects.join(', '));
   });
 
   describe('when a 401 response is intercepted', () => {

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
@@ -13,56 +13,27 @@ describe('HttpClientAuthInterceptor', () => {
   let httpClient: HttpClient;
   let httpMock: HttpTestingController;
   let chefSession: ChefSessionService;
-  const projects = ['proj1', 'proj2', 'proj3'];
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        HttpClientTestingModule,
-        StoreModule.forRoot({
-          projectsFilter: () => <ProjectsFilterState>{
-            options: projects.map(p => <ProjectsFilterOption>{ value: p })
-          }
-        })
-      ],
-      providers: [
-        ChefSessionService,
-        {
-          provide: HTTP_INTERCEPTORS,
-          useClass: HttpClientAuthInterceptor,
-          multi: true
-        }
-      ]
+  describe('common functionality', () => {
+    beforeEach(() => {
+      configure();
+      httpClient = TestBed.get(HttpClient);
+      httpMock = TestBed.get(HttpTestingController);
+      chefSession = TestBed.get(ChefSessionService);
+      spyOnProperty(chefSession, 'id_token', 'get').and.returnValue('token');
     });
 
-    httpClient = TestBed.get(HttpClient);
-    httpMock = TestBed.get(HttpTestingController);
-    chefSession = TestBed.get(ChefSessionService);
-    spyOnProperty(chefSession, 'id_token', 'get').and.returnValue('token');
-  });
+    it('includes auth token in all requests', done => {
+      httpClient.get('/endpoint').subscribe(done);
 
-  it('includes auth token in all requests', done => {
-    httpClient.get('/endpoint').subscribe(done);
+      const httpRequest = httpMock.expectOne('/endpoint');
+      httpRequest.flush('response');
 
-    const httpRequest = httpMock.expectOne('/endpoint');
-    httpRequest.flush('response');
+      expect(httpRequest.request.headers.get('Authorization'))
+        .toEqual(`Bearer ${chefSession.id_token}`);
+    });
 
-    expect(httpRequest.request.headers.get('Authorization'))
-      .toEqual(`Bearer ${chefSession.id_token}`);
-  });
-
-  it('includes projects in all requests', done => {
-    httpClient.get('/endpoint').subscribe(done);
-
-    const httpRequest = httpMock.expectOne('/endpoint');
-    httpRequest.flush('response');
-
-    expect(httpRequest.request.headers.get('projects'))
-      .toEqual(projects.join(', '));
-  });
-
-  describe('when a 401 response is intercepted', () => {
-    it('logs out the session', done => {
+    it('when a 401 response is intercepted logs out the session', done => {
       spyOn(chefSession, 'logout');
       httpClient.get('/endpoint').subscribe(null, done);
 
@@ -72,4 +43,72 @@ describe('HttpClientAuthInterceptor', () => {
       expect(chefSession.logout).toHaveBeenCalled();
     });
   });
+
+  describe('project header', () => {
+
+    describe('with some projects', () => {
+      const projectsList = ['proj1', 'proj2', 'proj3'];
+
+      beforeEach(() => {
+        configure(projectsList.map(p => <ProjectsFilterOption>{ value: p }));
+        httpClient = TestBed.get(HttpClient);
+        httpMock = TestBed.get(HttpTestingController);
+        chefSession = TestBed.get(ChefSessionService);
+        spyOnProperty(chefSession, 'id_token', 'get').and.returnValue('token');
+      });
+
+      it('includes projects header in all requests', done => {
+        httpClient.get('/endpoint').subscribe(done);
+
+        const httpRequest = httpMock.expectOne('/endpoint');
+        httpRequest.flush('response');
+
+        expect(httpRequest.request.headers.keys()).toContain('projects');
+        expect(httpRequest.request.headers.get('projects')).toEqual(projectsList.join(', '));
+      });
+    });
+
+    describe('with no projects', () => {
+        const projectsList = [];
+
+      beforeEach(() => {
+        configure(projectsList.map(p => <ProjectsFilterOption>{ value: p }));
+        httpClient = TestBed.get(HttpClient);
+        httpMock = TestBed.get(HttpTestingController);
+        chefSession = TestBed.get(ChefSessionService);
+        spyOnProperty(chefSession, 'id_token', 'get').and.returnValue('token');
+      });
+
+      it('does not include projects header', done => {
+        httpClient.get('/endpoint').subscribe(done);
+
+        const httpRequest = httpMock.expectOne('/endpoint');
+        httpRequest.flush('response');
+
+        expect(httpRequest.request.headers.keys()).not.toContain('projects');
+      });
+    });
+  });
+
 });
+
+function configure(projects?: ProjectsFilterOption[]): void {
+  TestBed.configureTestingModule({
+    imports: [
+      HttpClientTestingModule,
+      StoreModule.forRoot({
+        projectsFilter: () => <ProjectsFilterState>{
+          options: projects || []
+        }
+      })
+    ],
+    providers: [
+      ChefSessionService,
+      {
+        provide: HTTP_INTERCEPTORS,
+        useClass: HttpClientAuthInterceptor,
+        multi: true
+      }
+    ]
+  });
+}

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
@@ -1,26 +1,46 @@
-import { throwError as observableThrowError,  Observable } from 'rxjs';
-
-import { catchError } from 'rxjs/operators';
-import { Injectable } from '@angular/core';
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { throwError as observableThrowError, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { get } from 'lodash/fp';
-import { ChefSessionService } from '../chef-session/chef-session.service';
+
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
+import * as selectors from 'app/services/projects-filter/projects-filter.selectors';
+import { ProjectsFilterOption } from '../projects-filter/projects-filter.reducer';
 
 @Injectable()
 export class HttpClientAuthInterceptor implements HttpInterceptor {
 
-  constructor(private chefSession: ChefSessionService) {}
+  private projects: string;
+
+  constructor(
+    private chefSession: ChefSessionService,
+    private store: Store<NgrxStateAtom>
+  ) {
+    this.store.select(selectors.options)
+      .subscribe((options: ProjectsFilterOption[]) => {
+        this.projects = options.map(p => p.value).join(', ') || 'proj1'; // TODO: empty string causes 403 errors ?!?
+      });
+  }
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next
       .handle(request.clone({
-        headers: request.headers.set('Authorization', `Bearer ${this.chefSession.id_token}`)
+        headers: request.headers
+          .set('Authorization', `Bearer ${this.chefSession.id_token}`)
+          .set('projects', this.getProjects())
       })).pipe(
-      catchError((response: HttpEvent<any>) => {
-        if (get('status', response) === 401) {
-          this.chefSession.logout();
-        }
-        return observableThrowError(response);
-      }));
+        catchError((response: HttpEvent<any>) => {
+          if (get('status', response) === 401) {
+            this.chefSession.logout();
+          }
+          return observableThrowError(response);
+        }));
+  }
+
+  private getProjects(): string {
+    return this.projects;
   }
 }

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
@@ -21,7 +21,7 @@ export class HttpClientAuthInterceptor implements HttpInterceptor {
   ) {
     this.store.select(selectors.options)
       .subscribe((options: ProjectsFilterOption[]) => {
-        this.projects = options.map(p => p.value).join(', ');
+        this.projects = options.filter(p => p.checked).map(p => p.value).join(', ');
       });
   }
 

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
+
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { ProjectsFilterOption } from './projects-filter.reducer';
 import * as selectors from './projects-filter.selectors';
@@ -9,17 +11,17 @@ const STORE_OPTIONS_KEY = 'projectsFilter.options';
 
 @Injectable()
 export class ProjectsFilterService {
-  options$ = this.store.select(selectors.options);
+  options$ = <Observable<ProjectsFilterOption[]>>this.store.select(selectors.options);
 
-  selectionLabel$ = this.store.select(selectors.selectionLabel);
+  selectionLabel$ = <Observable<string>>this.store.select(selectors.selectionLabel);
 
-  selectionCount$ = this.store.select(selectors.selectionCount);
+  selectionCount$ = <Observable<number>>this.store.select(selectors.selectionCount);
 
-  selectionCountVisible$ = this.store.select(selectors.selectionCountVisible);
+  selectionCountVisible$ = <Observable<boolean>>this.store.select(selectors.selectionCountVisible);
 
-  selectionCountActive$ = this.store.select(selectors.selectionCountActive);
+  selectionCountActive$ = <Observable<boolean>>this.store.select(selectors.selectionCountActive);
 
-  dropdownCaretVisible$ = this.store.select(selectors.dropdownCaretVisible);
+  dropdownCaretVisible$ = <Observable<boolean>>this.store.select(selectors.dropdownCaretVisible);
 
   constructor(private store: Store<NgrxStateAtom>) {}
 

--- a/lib/grpc/auth_context/auth_context.go
+++ b/lib/grpc/auth_context/auth_context.go
@@ -78,6 +78,18 @@ func NewOutgoingProjectsContext(ctx context.Context) context.Context {
 	return metadata.NewOutgoingContext(ctx, md)
 }
 
+// ContextWithoutProjects removes previously added projects from the GRPC metadata
+// for those system operations that must not be filtered by projects.
+func ContextWithoutProjects(ctx context.Context) context.Context {
+	// This will fail on service start context, so only remove projects if ok.
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		delete(md, "projects")
+		ctx = metadata.NewOutgoingContext(ctx, md)
+	}
+	return ctx
+}
+
 // FromContext returns the auth data previously associated with `ctx`,
 // or `nil` or "" if a piece of the information could not be found.
 func FromContext(ctx context.Context) *Properties {


### PR DESCRIPTION
### :nut_and_bolt: Description

This sends selected projects along with every API request from the UI.

### :+1: Definition of Done

Projects appear in the HTTP request headers

![image](https://user-images.githubusercontent.com/6817500/57469474-97631200-723b-11e9-9051-e0ee05920520.png)


### :athletic_shoe: Demo Script / Repro Steps

Select projects from the global projects filter then navigate somewhere in the UI (having self-refresh is in the browser is a separate card).

### :chains: Related Resources

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
