### PR TITLE
added UI changes for API tokens page empty state

### DIFF
--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
@@ -29,16 +29,16 @@
     <div class="page-body">
       <chef-toolbar>
         <app-authorized [anyOf]="[['/iam/v2beta/tokens', 'post'], ['/auth/tokens', 'post']]">
-          <div *ngIf="(sortedApiTokens$ | async)?.length === 0" class="token-empty-state">
+          <div *ngIf="(apiTokenCount$ | async) === 0" class="token-empty-state">
             <p>Create the first token to get started!</p>
           </div>
-          <div [ngClass]="(sortedApiTokens$ | async)?.length === 0 ? 'token-empty-state' : ''">
+          <div [ngClass]="(apiTokenCount$ | async) === 0 ? 'token-empty-state' : ''">
             <chef-button id="create-button" primary (click)="openCreateModal()">Create Token</chef-button>
           </div>
         </app-authorized>
       </chef-toolbar>
       <app-authorized [anyOf]="[['/iam/v2beta/tokens', 'get'], ['/auth/tokens', 'get']]">
-        <chef-table *ngIf="(sortedApiTokens$ | async)?.length > 0">
+        <chef-table *ngIf="(apiTokenCount$ | async) > 0">
           <chef-thead>
             <chef-tr>
               <chef-th>Name</chef-th>

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
@@ -29,13 +29,19 @@
     <div class="page-body">
       <chef-toolbar>
         <app-authorized [anyOf]="[['/iam/v2beta/tokens', 'post'], ['/auth/tokens', 'post']]">
-          <chef-button id="create-button" primary (click)="openCreateModal()">Create Token</chef-button>
+          <div *ngIf="(sortedApiTokens$ | async)?.length === 0" class="token-empty-state">
+            <p>Create the first token to get started!</p>
+            <chef-button id="create-button" primary (click)="openCreateModal()">Create Token</chef-button>
+          </div>
+          <div *ngIf="(sortedApiTokens$ | async)?.length > 0">
+            <chef-button id="create-button" primary (click)="openCreateModal()">Create Token</chef-button>
+          </div>
         </app-authorized>
       </chef-toolbar>
       <app-authorized [anyOf]="[['/iam/v2beta/tokens', 'get'], ['/auth/tokens', 'get']]">
         <chef-table>
           <chef-thead>
-            <chef-tr>
+            <chef-tr *ngIf="(sortedApiTokens$ | async)?.length > 0">
               <chef-th>Name</chef-th>
               <chef-th>Created date</chef-th>
               <chef-th>Status</chef-th>

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
@@ -31,17 +31,16 @@
         <app-authorized [anyOf]="[['/iam/v2beta/tokens', 'post'], ['/auth/tokens', 'post']]">
           <div *ngIf="(sortedApiTokens$ | async)?.length === 0" class="token-empty-state">
             <p>Create the first token to get started!</p>
-            <chef-button id="create-button" primary (click)="openCreateModal()">Create Token</chef-button>
           </div>
-          <div *ngIf="(sortedApiTokens$ | async)?.length > 0">
+          <div [ngClass]="(sortedApiTokens$ | async)?.length === 0 ? 'token-empty-state' : ''">
             <chef-button id="create-button" primary (click)="openCreateModal()">Create Token</chef-button>
           </div>
         </app-authorized>
       </chef-toolbar>
       <app-authorized [anyOf]="[['/iam/v2beta/tokens', 'get'], ['/auth/tokens', 'get']]">
-        <chef-table>
+        <chef-table *ngIf="(sortedApiTokens$ | async)?.length > 0">
           <chef-thead>
-            <chef-tr *ngIf="(sortedApiTokens$ | async)?.length > 0">
+            <chef-tr>
               <chef-th>Name</chef-th>
               <chef-th>Created date</chef-th>
               <chef-th>Status</chef-th>

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.scss
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.scss
@@ -8,10 +8,10 @@ chef-table {
 
 .token-empty-state {
   text-align: center;
-  margin-top: 30px;
 
   p {
     font-size: 18px;
     font-weight: 400;
+    margin-top: 35px;
   }
 }

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.scss
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.scss
@@ -9,6 +9,7 @@ chef-table {
 .token-empty-state {
   text-align: center;
   margin-top: 30px;
+
   p {
     font-size: 18px;
     font-weight: 400;

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.scss
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.scss
@@ -5,3 +5,12 @@ chef-table {
     justify-content: flex-end;
   }
 }
+
+.token-empty-state {
+  text-align: center;
+  margin-top: 30px;
+  p {
+    font-size: 18px;
+    font-weight: 400;
+  }
+}


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description
Currently, when there are no api tokens on the API Tokens page we show an empty table, instead, we would like to follow the empty state pattern.

### :athletic_shoe: Demo Script / Repro Steps
Existing UI
![reproduce_303](https://user-images.githubusercontent.com/12297653/57527854-53acfd00-734e-11e9-84f5-7aeb96116266.png)

New changes
![fixed_303](https://user-images.githubusercontent.com/12297653/57527899-717a6200-734e-11e9-936f-c73b5e7c9ee2.png)

### :chains: Related Resources
https://github.com/chef/automate/issues/303
