### PR TITLE
UI-72 (UI-138) add link to create new node from automate nodemanager details …

### DIFF
--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.html
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.html
@@ -37,12 +37,12 @@
       <chef-toolbar>
         <chef-button primary
           routerLink="/compliance/scanner/nodes/add">
-          Add nodes
+          Add Nodes
         </chef-button>
         <chef-button primary caution 
           [disabled]="!hasSelectedNodes()" 
           (click)="deleteNodes()">
-          Remove nodes
+          Remove Nodes
         </chef-button>
       </chef-toolbar>
       <chef-table id="manager-nodes-list">

--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.html
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.html
@@ -35,10 +35,14 @@
 
     <div class="page-body">
       <chef-toolbar>
+        <chef-button primary
+          routerLink="/compliance/scanner/nodes/add">
+          Add nodes
+        </chef-button>
         <chef-button primary caution 
           [disabled]="!hasSelectedNodes()" 
           (click)="deleteNodes()">
-          Remove Nodes
+          Remove nodes
         </chef-button>
       </chef-toolbar>
       <chef-table id="manager-nodes-list">


### PR DESCRIPTION
…page Signed-off-by: Tara Black <tblack@chef.io>

### :nut_and_bolt: Description

original issue: #72

In order to make it easier for our users to navigate to adding nodes to the Automate nodemanager, give them a way to get there by adding a link to the "add nodes" page from the Automate nodemanager details screen.

url for automate details page: a2-url/settings/node-integrations/e69dc612-7e67-43f2-9b19-256afd385820

url for add nodes page: a2-url/compliance/scanner/nodes/add

### :+1: Definition of Done

Automate nodemanager details page has a link (as shown above) to the add nodes page.

### :chains: Related Resources

https://github.com/chef/automate/issues/72

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [x ] Vetting performed (unit tests, lint, etc.)?
