### PR TITLE
Adding project filters for GetNodesCounts

### DIFF
--- a/components/config-mgmt-service/grpcserver/cfg_mgmt.go
+++ b/components/config-mgmt-service/grpcserver/cfg_mgmt.go
@@ -97,6 +97,11 @@ func (s *CfgMgmtServer) GetNodesCounts(ctx context.Context, request *request.Nod
 		return nodesCounts, errors.GrpcErrorFromErr(codes.InvalidArgument, err)
 	}
 
+	filters, err = filterByProjects(ctx, filters)
+	if err != nil {
+		return nodesCounts, errors.GrpcErrorFromErr(codes.Internal, err)
+	}
+
 	state, err := s.client.GetNodesCounts(filters)
 	if err != nil {
 		return nodesCounts, errors.GrpcErrorFromErr(codes.Internal, err)


### PR DESCRIPTION
### :nut_and_bolt: Description

Adding project filtering for the cfgmgmt.proto GetNodesCounts RPC.

### :chains: Related Resources

https://github.com/chef/automate/issues/68

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?