### PR TITLE
[A2-783] Wire up  the projects filter "Apply Changes" button

### DIFF
--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -297,6 +297,10 @@ const routes: Routes = [
     pathMatch: 'prefix',
     redirectTo: 'settings/node-credentials'
   },
+  { // ued by projects-filter.service.ts
+    path: 'reload',
+    children: []
+  },
   // END Deprecated routes.
   { // everything unknown goes to client runs
     path: '**',

--- a/components/automate-ui/src/app/page-components/projects-filter/projects-filter.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter/projects-filter.component.spec.ts
@@ -1,6 +1,8 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { StoreModule } from '@ngrx/store';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
 import {
   projectsFilterInitialState,
   projectsFilterReducer
@@ -21,6 +23,7 @@ describe('ProjectsFilterComponent', () => {
         ProjectsFilterService
       ],
       imports: [
+        RouterTestingModule,
         StoreModule.forRoot({
           projectsFilter: projectsFilterReducer
         }, {

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
@@ -23,7 +24,7 @@ export class ProjectsFilterService {
 
   dropdownCaretVisible$ = <Observable<boolean>>this.store.select(selectors.dropdownCaretVisible);
 
-  constructor(private store: Store<NgrxStateAtom>) {}
+  constructor(private store: Store<NgrxStateAtom>, private router: Router) { }
 
   loadOptions() {
     this.store.dispatch(new LoadOptions());
@@ -35,6 +36,18 @@ export class ProjectsFilterService {
 
   storeOptions(options: ProjectsFilterOption[]) {
     localStorage.setItem(STORE_OPTIONS_KEY, JSON.stringify(options));
+
+    // To get back to where we are
+    const currentUrl = location.pathname + location.search;
+
+    // This is a dummy URL but it must exist in the routing module.
+    const reloadUrl = '/reload';
+
+    // The router only routes if the route changes.
+    // This first switches to somewhere-that-is-not-here
+    // then back to here, so the router will do its thing.
+    this.router.navigateByUrl(reloadUrl, { skipLocationChange: true })
+      .then(() => this.router.navigateByUrl(currentUrl, { skipLocationChange: true }));
   }
 
   restoreOptions(): ProjectsFilterOption[] {


### PR DESCRIPTION
### :nut_and_bolt: Description

Before this change, the project filter would only take effect when you navigate to a different page within Automate. Now, when you change the filter, the current page will refresh itself to reflect the new set of projects, too.

Here I have project p2 selected, and nodes in that project display:
![image](https://user-images.githubusercontent.com/6817500/57560305-a7ade680-733a-11e9-9fc5-01bdd9c80f06.png)

When I switch to project p4, which has no nodes, the list becomes empty:
![image](https://user-images.githubusercontent.com/6817500/57560325-be543d80-733a-11e9-9080-fdaa7681734c.png)


### :+1: Definition of Done

Filters work throughout Automate.

### :athletic_shoe: Demo Script / Repro Steps

Rebuild automate-ui.
Create some projects and assign them to some entities.
Exercise the global project filter on the appropriate page by selecting new projects and observe the list filtering change (almost) immediately when "Apply Changes" is selected.

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
