### PR TITLE
[CI] Set HAB_LICENSE=accept-no-persist in nightly A1 tests

### DIFF
--- a/components/automate-deployment/a1-migration/install.rb
+++ b/components/automate-deployment/a1-migration/install.rb
@@ -69,12 +69,17 @@ remote_file hab_zip_path do
 end
 
 execute "tar --strip=1 -xvf #{hab_zip_path} -C #{Chef::Config[:file_cache_path]}"
-execute "#{Chef::Config[:file_cache_path]}/hab pkg install core/hab"
-execute "#{Chef::Config[:file_cache_path]}/hab pkg binlink core/hab hab"
+
+execute "#{Chef::Config[:file_cache_path]}/hab pkg install core/hab" do
+  environment({"HAB_LICENSE" => "accept-no-persist"})
+end
+
+execute "#{Chef::Config[:file_cache_path]}/hab pkg binlink core/hab hab" do
+  environment({"HAB_LICENSE" => "accept-no-persist"})
+end
 
 group 'hab'
 
 user 'hab' do
   group 'hab'
 end
-

--- a/components/automate-deployment/basic-a1/install.rb
+++ b/components/automate-deployment/basic-a1/install.rb
@@ -63,12 +63,17 @@ remote_file hab_zip_path do
 end
 
 execute "tar --strip=1 -xvf #{hab_zip_path} -C #{Chef::Config[:file_cache_path]}"
-execute "#{Chef::Config[:file_cache_path]}/hab pkg install core/hab"
-execute "#{Chef::Config[:file_cache_path]}/hab pkg binlink core/hab hab"
+
+execute "#{Chef::Config[:file_cache_path]}/hab pkg install core/hab" do
+    environment({"HAB_LICENSE" => "accept-no-persist"})
+end
+
+execute "#{Chef::Config[:file_cache_path]}/hab pkg binlink core/hab hab" do
+    environment({"HAB_LICENSE" => "accept-no-persist"})
+end
 
 group 'hab'
 
 user 'hab' do
   group 'hab'
 end
-


### PR DESCRIPTION
The most recent habitat now requires license acceptance.

See also: https://github.com/chef/automate/pull/207

Signed-off-by: Steven Danna <steve@chef.io>