### PR TITLE
added changes to remove compliance label icons

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
@@ -18,25 +18,25 @@
           <chef-table>
             <chef-tr>
               <chef-th>
-                <chef-icon>local_offer</chef-icon> Version
+                Version
               </chef-th>
               <chef-td>{{ profile.version }}</chef-td>
             </chef-tr>
             <chef-tr>
               <chef-th>
-                <chef-icon>person</chef-icon> Maintainer
+                Maintainer
               </chef-th>
               <chef-td>{{ profile.maintainer }}</chef-td>
             </chef-tr>
             <chef-tr>
               <chef-th>
-                <chef-icon>account_balance</chef-icon> License
+                License
               </chef-th>
               <chef-td>{{ profile.license }}</chef-td>
             </chef-tr>
             <chef-tr>
               <chef-th>
-                <chef-icon>storage</chef-icon> Platform
+                Platform
               </chef-th>
               <chef-td>{{ displaySupports(profile.supports) }}</chef-td>
             </chef-tr>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
@@ -60,20 +60,20 @@
           <chef-table>
             <chef-tr>
               <chef-th>
-                <chef-icon>computer</chef-icon> Nodes
+                Nodes
               </chef-th>
               <chef-td>{{ reportData.reportingSummary.stats.nodes | number }}</chef-td>
             </chef-tr>
             <chef-tr>
               <chef-th id="report-date-label">
-                <chef-icon>date_range</chef-icon> Report Date
+                Report Date
                 <chef-tooltip for="report-date-label">Latest information available for everything at this date.</chef-tooltip>
               </chef-th>
               <chef-td>{{ reportQuery.endDate | date: 'longDate' }}</chef-td>
             </chef-tr>
             <chef-tr>
               <chef-th>
-                <chef-icon>equalizer</chef-icon> Status
+                Status
               </chef-th>
               <chef-td>{{ reportData.reportingSummary.status | titlecase }}</chef-td>
             </chef-tr>
@@ -81,7 +81,7 @@
           <chef-table>
             <chef-tr>
               <chef-th>
-                <chef-icon>storage</chef-icon> Platform
+                Platform
               </chef-th>
               <chef-td>
                 {{ reportData.reportingSummary.stats.platforms | number }}
@@ -90,7 +90,7 @@
             </chef-tr>
             <chef-tr>
               <chef-th>
-                <chef-icon>public</chef-icon> Environment
+                Environment
               </chef-th>
               <chef-td>
                 {{ reportData.reportingSummary.stats.environments | number }}
@@ -99,7 +99,7 @@
             </chef-tr>
             <chef-tr>
               <chef-th>
-                <chef-icon>description</chef-icon> Profiles
+                Profiles
               </chef-th>
               <chef-td>
                 {{ reportData.reportingSummary.stats.profiles | number }}

--- a/components/automate-ui/src/app/pages/profile-details/profile-details.component.html
+++ b/components/automate-ui/src/app/pages/profile-details/profile-details.component.html
@@ -64,32 +64,32 @@
           <chef-table>
             <chef-tr>
               <chef-th>
-                <chef-icon>equalizer</chef-icon> Status
+                Status
               </chef-th>
               <chef-td *ngIf="isAvailable">Available</chef-td>
               <chef-td *ngIf="isInstalled">Installed</chef-td>
             </chef-tr>
             <chef-tr>
               <chef-th>
-                <chef-icon>local_offer</chef-icon> Version
+                Version
               </chef-th>
               <chef-td>{{ profile.version }}</chef-td>
             </chef-tr>
             <chef-tr>
               <chef-th>
-                <chef-icon>person</chef-icon> Maintainer
+                Maintainer
               </chef-th>
               <chef-td>{{ profile.maintainer }}</chef-td>
             </chef-tr>
             <chef-tr>
               <chef-th>
-                <chef-icon>account_balance</chef-icon> License
+                License
               </chef-th>
               <chef-td>{{ profile.license }}</chef-td>
             </chef-tr>
             <chef-tr>
               <chef-th>
-                <chef-icon>storage</chef-icon> Platform
+                Platform
               </chef-th>
               <chef-td>{{ displaySupports(profile.supports) }}</chef-td>
             </chef-tr>


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description
Based on feedback from @jonong1972 here: #254 (comment)
I have removed the icons that are in front of the labels.
### :+1: Definition of Done
1. Asset Store > Profiles / Available > SELECT A PROFILE. You will see the icons in the header in front of the labels.
![1022](https://user-images.githubusercontent.com/12297653/57620524-a2ed6a80-75a6-11e9-90e9-8b03f4265462.png)
2. Compliance > Profiles > SELECT A PROFILE
![1022-1](https://user-images.githubusercontent.com/12297653/57620542-b13b8680-75a6-11e9-8528-345eca418d29.png)
3. Compliance > EXPAND Report Metadata section
![1022-2](https://user-images.githubusercontent.com/12297653/57620558-be587580-75a6-11e9-9acb-facedae74f10.png)

### :chains: Related Resources
https://github.com/chef/automate/issues/307