### PR TITLE
break the summary tests into separate tests for nodes, reports and controls

### DIFF
--- a/components/compliance-service/integration_test/stats_server_read_trend_test.go
+++ b/components/compliance-service/integration_test/stats_server_read_trend_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"fmt"
 	"testing"
 
 	iam_v2 "github.com/chef/automate/api/interservice/authz/v2"
@@ -154,26 +155,26 @@ func TestReadTrend(t *testing.T) {
 			{Type: "end_time", Values: []string{"2018-10-25T23:59:59Z"}},
 		},
 	}
-	for _, test := range successCases {
-		t.Run(test.description, func(t *testing.T) {
-			ctx := contextWithProjects(test.allowedProjects)
 
-			octoberTwentyFifthQuery.Type = "nodes"
-			response, err := statsServer.ReadTrend(ctx, octoberTwentyFifthQuery)
+	trendTypes := []string{
+		"nodes",
+		"controls",
+	}
 
-			assert.NoError(t, err)
-			require.NotNil(t, response)
+	for _, trendType := range trendTypes {
+		octoberTwentyFifthQuery.Type = trendType
+		for _, test := range successCases {
+			t.Run(test.description, func(t *testing.T) {
+				ctx := contextWithProjects(test.allowedProjects)
 
-			assert.Equal(t, test.expectedPassedCnt, response.Trends[0].Passed, "Nodes Passed count")
+				response, err := statsServer.ReadTrend(ctx, octoberTwentyFifthQuery)
 
-			octoberTwentyFifthQuery.Type = "controls"
-			response, err = statsServer.ReadTrend(ctx, octoberTwentyFifthQuery)
+				assert.NoError(t, err)
+				require.NotNil(t, response)
 
-			assert.NoError(t, err)
-			require.NotNil(t, response)
-
-			//controls trends
-			assert.Equal(t, test.expectedPassedCnt, response.Trends[0].Passed, "Controls Passed count")
-		})
+				assert.Equal(t, test.expectedPassedCnt, response.Trends[0].Passed,
+					fmt.Sprintf("%s - Passed count", trendType))
+			})
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Rick Marry <rmarry@chef.io>

### :nut_and_bolt: Description
In order to improve test readability and, in case of test failures, to more easily see failure origin, the stats summary tests are being separated into three distinct sections:
1 - reports
2 - nodes
3 - controls

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
