### PR TITLE
add filtering for last scan and last run data on nodes endpoint

### DIFF
--- a/components/nodemanager-service/pgdb/filtering.go
+++ b/components/nodemanager-service/pgdb/filtering.go
@@ -120,6 +120,10 @@ func acceptedJSONFilterFields(field string) bool {
 		return true
 	case "last_scan ->> 'Status'":
 		return true
+	case "last_run ->> 'PenultimateStatus'":
+		return true
+	case "last_scan ->> 'PenultimateStatus'":
+		return true
 	default:
 		return false
 	}

--- a/components/nodemanager-service/pgdb/filtering.go
+++ b/components/nodemanager-service/pgdb/filtering.go
@@ -91,8 +91,10 @@ func buildWhereFilter(mergeableFilters []*common.Filter, tableAbbrev string, fil
 
 // Builds an IN where condition like: j.parent_id IN ('e57605ed-bb8a-49b8-606c-af0e2b31b139')
 func whereFieldIn(field string, arr []string, tableAbbrev string) (condition string, err error) {
-	if !utils.IsSqlSafe(field) {
-		return "", &utils.InvalidError{Msg: fmt.Sprintf("Unsupported character found in field: %s", field)}
+	if !acceptedJSONFilterFields(field) {
+		if !utils.IsSqlSafe(field) {
+			return "", &utils.InvalidError{Msg: fmt.Sprintf("Unsupported character found in field: %s", field)}
+		}
 	}
 	condition += fmt.Sprintf("%s.%s IN (", tableAbbrev, field)
 	if len(arr) > 0 {
@@ -113,6 +115,10 @@ func acceptedJSONFilterFields(field string) bool {
 	case "last_run ->> 'EndTime'":
 		return true
 	case "last_scan ->> 'EndTime'":
+		return true
+	case "last_run ->> 'Status'":
+		return true
+	case "last_scan ->> 'Status'":
 		return true
 	default:
 		return false

--- a/components/nodemanager-service/pgdb/nodes.go
+++ b/components/nodemanager-service/pgdb/nodes.go
@@ -595,8 +595,8 @@ var nodesFilterField = map[string]string{
 	"status":                "status", // reachable, unreachable, unknown
 	"last_run_timerange":    "last_run ->> 'EndTime'",
 	"last_scan_timerange":   "last_scan ->> 'EndTime'",
-	// run data status
-	// scan data status
+	"last_run_status":       "last_run ->> 'Status'",
+	"last_scan_status":      "last_scan ->> 'Status'",
 	// run data penultimate status
 	// scan data penultimate status
 }

--- a/components/nodemanager-service/pgdb/nodes.go
+++ b/components/nodemanager-service/pgdb/nodes.go
@@ -593,6 +593,12 @@ var nodesFilterField = map[string]string{
 	"state":                 "source_state", // running, stopped, terminated
 	"statechange_timerange": "statechange_timestamp",
 	"status":                "status", // reachable, unreachable, unknown
+	// last check in range (run data end time) - last_run_end_time
+	// last scan time range (scan data end time) - last_scan_end_time
+	// run data status
+	// scan data status
+	// run data penultimate status
+	// scan data penultimate status
 }
 
 func validateNodeFilters(filters []*common.Filter) error {

--- a/components/nodemanager-service/pgdb/nodes.go
+++ b/components/nodemanager-service/pgdb/nodes.go
@@ -580,25 +580,25 @@ func handleNodeTagFilters(filters []*common.Filter) []*common.Filter {
 }
 
 var nodesFilterField = map[string]string{
-	"account_id":            "source_account_id", // azure: uuid, aws: 10 digit #
-	"last_contact":          "last_contact",
-	"manager_id":            "manager_id",
-	"manager_type":          "manager", // aws-ec2, aws-api, azure-api, automate
-	"name":                  "name",
-	"platform_name":         "platform",
-	"platform_release":      "platform_version",
-	"project":               "project",
-	"region":                "source_region",
-	"source_id":             "source_id",
-	"state":                 "source_state", // running, stopped, terminated
-	"statechange_timerange": "statechange_timestamp",
-	"status":                "status", // reachable, unreachable, unknown
-	"last_run_timerange":    "last_run ->> 'EndTime'",
-	"last_scan_timerange":   "last_scan ->> 'EndTime'",
-	"last_run_status":       "last_run ->> 'Status'",
-	"last_scan_status":      "last_scan ->> 'Status'",
-	// run data penultimate status
-	// scan data penultimate status
+	"account_id":                   "source_account_id", // azure: uuid, aws: 10 digit #
+	"last_contact":                 "last_contact",
+	"manager_id":                   "manager_id",
+	"manager_type":                 "manager", // aws-ec2, aws-api, azure-api, automate
+	"name":                         "name",
+	"platform_name":                "platform",
+	"platform_release":             "platform_version",
+	"project":                      "project",
+	"region":                       "source_region",
+	"source_id":                    "source_id",
+	"state":                        "source_state", // running, stopped, terminated
+	"statechange_timerange":        "statechange_timestamp",
+	"status":                       "status", // reachable, unreachable, unknown
+	"last_run_timerange":           "last_run ->> 'EndTime'",
+	"last_scan_timerange":          "last_scan ->> 'EndTime'",
+	"last_run_status":              "last_run ->> 'Status'",
+	"last_scan_status":             "last_scan ->> 'Status'",
+	"last_run_penultimate_status":  "last_run ->> 'PenultimateStatus'",
+	"last_scan_penultimate_status": "last_scan ->> 'PenultimateStatus'",
 }
 
 func validateNodeFilters(filters []*common.Filter) error {

--- a/components/nodemanager-service/pgdb/nodes.go
+++ b/components/nodemanager-service/pgdb/nodes.go
@@ -593,8 +593,8 @@ var nodesFilterField = map[string]string{
 	"state":                 "source_state", // running, stopped, terminated
 	"statechange_timerange": "statechange_timestamp",
 	"status":                "status", // reachable, unreachable, unknown
-	// last check in range (run data end time) - last_run_end_time
-	// last scan time range (scan data end time) - last_scan_end_time
+	"last_run_timerange":    "last_run ->> 'EndTime'",
+	"last_scan_timerange":   "last_scan ->> 'EndTime'",
 	// run data status
 	// scan data status
 	// run data penultimate status

--- a/components/nodemanager-service/pgdb/nodes_integration_test.go
+++ b/components/nodemanager-service/pgdb/nodes_integration_test.go
@@ -35,15 +35,12 @@ func TestRunNodesIntegrationSuite(t *testing.T) {
 func (suite *NodesIntegrationSuite) TestGetNodesCanFilterByManagerIDAndReturnsAllManagerIDs() {
 	mgr1 := manager.NodeManager{Name: "mgr1", Type: "aws-ec2"}
 	mgrID1, err := suite.Database.AddNodeManager(&mgr1, "11111111")
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	// TODO: Is there another easy way to add a second node manager besides changing the type?
 	mgr2 := manager.NodeManager{Name: "mgr2", Type: "aws-api"}
 	mgrID2, err := suite.Database.AddNodeManager(&mgr2, "22222222")
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	// Host set here is Name after roundtripping to the DB with AddManagerNodesToDB/GetNodes
 	node1 := manager.ManagerNode{Id: "i-1111111", Region: "us-west-2", Host: "Node1"}
@@ -63,9 +60,8 @@ func (suite *NodesIntegrationSuite) TestGetNodesCanFilterByManagerIDAndReturnsAl
 	}
 	// Get the nodes in the DB that belong to the first manager, ordered by their name.
 	newNodes, count, err := suite.Database.GetNodes("name", nodes.Query_ASC, 1, 100, []*common.Filter{filter})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(2, len(newNodes))
 	suite.Equal(&pgdb.TotalCount{Total: 2, Unreachable: 0, Reachable: 0, Unknown: 2}, count)
 
@@ -79,9 +75,7 @@ func (suite *NodesIntegrationSuite) TestGetNodesCanFilterByManagerIDAndReturnsAl
 func (suite *NodesIntegrationSuite) TestGetNodesCanFilterByEmptyManagerIDList() {
 	mgr1 := manager.NodeManager{Name: "mgr1", Type: "aws-ec2"}
 	mgrID1, err := suite.Database.AddNodeManager(&mgr1, "11111111")
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	// Host set here is Name after roundtripping to the DB with AddManagerNodesToDB/GetNodes
 	node1 := manager.ManagerNode{Id: "i-1111111", Region: "us-west-2", Host: "Node1"}
@@ -90,9 +84,7 @@ func (suite *NodesIntegrationSuite) TestGetNodesCanFilterByEmptyManagerIDList() 
 	suite.Equal(1, len(nodeIds))
 
 	node2Id, err := suite.Database.AddNode(&nodes.Node{Name: "Node2", Manager: "automate", Tags: []*common.Kv{}, TargetConfig: &nodes.TargetConfig{}})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	filter := &common.Filter{
 		Key:    "manager_id",
@@ -100,9 +92,8 @@ func (suite *NodesIntegrationSuite) TestGetNodesCanFilterByEmptyManagerIDList() 
 	}
 	// Get the nodes in the DB that belong to the first manager, ordered by their name.
 	newNodes, count, err := suite.Database.GetNodes("name", nodes.Query_ASC, 1, 100, []*common.Filter{filter})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(1, len(newNodes))
 	suite.Equal(&pgdb.TotalCount{Total: 1, Unreachable: 0, Reachable: 0, Unknown: 2}, count)
 
@@ -113,17 +104,13 @@ func (suite *NodesIntegrationSuite) TestGetNodesCanFilterByEmptyManagerIDList() 
 
 func (suite *NodesIntegrationSuite) TestGetNodesCanFilterByNameWithWildcard() {
 	node1Id, err := suite.Database.AddNode(&nodes.Node{Name: "Taco Node", Manager: "automate", Tags: []*common.Kv{}, TargetConfig: &nodes.TargetConfig{}})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	node2Id, err := suite.Database.AddNode(&nodes.Node{Name: "Tostada Node", Manager: "automate", Tags: []*common.Kv{}, TargetConfig: &nodes.TargetConfig{}})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	_, err = suite.Database.AddNode(&nodes.Node{Name: "Nacho Node", Manager: "automate", Tags: []*common.Kv{}, TargetConfig: &nodes.TargetConfig{}})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	filter := &common.Filter{
 		Key:    "name",
@@ -134,9 +121,8 @@ func (suite *NodesIntegrationSuite) TestGetNodesCanFilterByNameWithWildcard() {
 		Values: []string{"Tostada"},
 	}
 	fetchedNodes, count, err := suite.Database.GetNodes("name", nodes.Query_ASC, 1, 100, []*common.Filter{filter, filter2})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(2, len(fetchedNodes))
 	suite.Equal(&pgdb.TotalCount{Total: 2, Unreachable: 0, Reachable: 0, Unknown: 3}, count)
 
@@ -148,17 +134,13 @@ func (suite *NodesIntegrationSuite) TestGetNodesCanFilterByNameWithWildcard() {
 
 func (suite *NodesIntegrationSuite) TestGetNodesCanExcludeByNameWithWildcard() {
 	_, err := suite.Database.AddNode(&nodes.Node{Name: "Taco Node", Manager: "automate", Tags: []*common.Kv{}, TargetConfig: &nodes.TargetConfig{}})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	_, err = suite.Database.AddNode(&nodes.Node{Name: "Tostada Node", Manager: "automate", Tags: []*common.Kv{}, TargetConfig: &nodes.TargetConfig{}})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	node3Id, err := suite.Database.AddNode(&nodes.Node{Name: "Nacho Node", Manager: "automate", Tags: []*common.Kv{}, TargetConfig: &nodes.TargetConfig{}})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	filter := &common.Filter{
 		Key:     "name",
@@ -171,9 +153,8 @@ func (suite *NodesIntegrationSuite) TestGetNodesCanExcludeByNameWithWildcard() {
 		Exclude: true,
 	}
 	fetchedNodes, count, err := suite.Database.GetNodes("name", nodes.Query_ASC, 1, 100, []*common.Filter{filter, filter2})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(1, len(fetchedNodes))
 	suite.Equal(&pgdb.TotalCount{Total: 1, Unreachable: 0, Reachable: 0, Unknown: 3}, count)
 
@@ -199,22 +180,18 @@ func (suite *NodesIntegrationSuite) TestGetNodesReturnsErrorWithConflictingInclu
 
 func (suite *NodesIntegrationSuite) TestGetNodesCanFilterByTags() {
 	node1Id, err := suite.Database.AddNode(&nodes.Node{Name: "Taco Node", Manager: "automate", Tags: []*common.Kv{{Key: "tacos", Value: "yes"}}, TargetConfig: &nodes.TargetConfig{}})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	_, err = suite.Database.AddNode(&nodes.Node{Name: "Nacho Node", Manager: "automate", Tags: []*common.Kv{{Key: "nachos", Value: "yes"}}, TargetConfig: &nodes.TargetConfig{}})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	filter := &common.Filter{
 		Key:    "tacos",
 		Values: []string{"yes"},
 	}
 	fetchedNodes, count, err := suite.Database.GetNodes("name", nodes.Query_ASC, 1, 100, []*common.Filter{filter})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(1, len(fetchedNodes))
 	suite.Equal(&pgdb.TotalCount{Total: 1, Unreachable: 0, Reachable: 0, Unknown: 2}, count)
 
@@ -388,17 +365,14 @@ func (suite *NodesIntegrationSuite) TestFilterByLastCheckInRange() {
 		},
 	}
 	err := suite.Database.ProcessIncomingNode(node)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	timeRangeMax := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
 	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
 		{Key: "last_run_timerange", Values: []string{"2019-03-05T00:00:00Z", timeRangeMax}},
 	})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(1, len(listNodes))
 	suite.Equal(nowTime, listNodes[0].GetRunData().GetEndTime())
 }
@@ -422,17 +396,14 @@ func (suite *NodesIntegrationSuite) TestFilterByLastScanTimeRange() {
 		},
 	}
 	err := suite.Database.ProcessIncomingNode(node)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	timeRangeMax := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
 	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
 		{Key: "last_scan_timerange", Values: []string{"2019-03-05T00:00:00Z", timeRangeMax}},
 	})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(1, len(listNodes))
 	suite.Equal(nowTime, listNodes[0].GetScanData().GetEndTime())
 }
@@ -456,16 +427,13 @@ func (suite *NodesIntegrationSuite) TestFilterByRunDataStatus() {
 		},
 	}
 	err := suite.Database.ProcessIncomingNode(node)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
 		{Key: "last_run_status", Values: []string{"FAILED"}},
 	})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(1, len(listNodes))
 	suite.Equal(nodes.LastContactData_FAILED, listNodes[0].GetRunData().GetStatus())
 }
@@ -489,16 +457,13 @@ func (suite *NodesIntegrationSuite) TestFilterByScanDataStatus() {
 		},
 	}
 	err := suite.Database.ProcessIncomingNode(node)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
 		{Key: "last_scan_status", Values: []string{"FAILED"}},
 	})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(1, len(listNodes))
 	suite.Equal(nodes.LastContactData_FAILED, listNodes[0].GetScanData().GetStatus())
 }
@@ -522,21 +487,17 @@ func (suite *NodesIntegrationSuite) TestFilterByRunDataPenultStatus() {
 		},
 	}
 	err := suite.Database.ProcessIncomingNode(node)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	node.RunData.Status = nodes.LastContactData_PASSED
 	err = suite.Database.ProcessIncomingNode(node)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
 		{Key: "last_run_penultimate_status", Values: []string{"FAILED"}},
 	})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(1, len(listNodes))
 	suite.Equal(nodes.LastContactData_FAILED, listNodes[0].GetRunData().GetPenultimateStatus())
 	suite.Equal(nodes.LastContactData_PASSED, listNodes[0].GetRunData().GetStatus())
@@ -545,9 +506,8 @@ func (suite *NodesIntegrationSuite) TestFilterByRunDataPenultStatus() {
 		{Key: "last_run_penultimate_status", Values: []string{"FAILED"}},
 		{Key: "last_run_status", Values: []string{"PASSED"}},
 	})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(1, len(listNodes))
 
 }
@@ -571,22 +531,17 @@ func (suite *NodesIntegrationSuite) TestFilterByScanDataPenultStatus() {
 		},
 	}
 	err := suite.Database.ProcessIncomingNode(node)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	node.ScanData.Status = nodes.LastContactData_SKIPPED
 	err = suite.Database.ProcessIncomingNode(node)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
 		{Key: "last_scan_penultimate_status", Values: []string{"FAILED"}},
 	})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(1, len(listNodes))
 	suite.Equal(nodes.LastContactData_FAILED, listNodes[0].GetScanData().GetPenultimateStatus())
 	suite.Equal(nodes.LastContactData_SKIPPED, listNodes[0].GetScanData().GetStatus())
@@ -595,9 +550,8 @@ func (suite *NodesIntegrationSuite) TestFilterByScanDataPenultStatus() {
 		{Key: "last_scan_penultimate_status", Values: []string{"FAILED"}},
 		{Key: "last_scan_status", Values: []string{"SKIPPED"}},
 	})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(1, len(listNodes))
 }
 
@@ -620,9 +574,7 @@ func (suite *NodesIntegrationSuite) TestFilterByScanDataAndRunDataStatus() {
 		},
 	}
 	err := suite.Database.ProcessIncomingNode(node)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	node = &manager.NodeMetadata{
 		Uuid:            "1223-4254-2424-1322",
@@ -641,17 +593,14 @@ func (suite *NodesIntegrationSuite) TestFilterByScanDataAndRunDataStatus() {
 		},
 	}
 	err = suite.Database.ProcessIncomingNode(node)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
 
 	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
 		{Key: "last_scan_status", Values: []string{"FAILED"}},
 		{Key: "last_run_status", Values: []string{"PASSED"}},
 	})
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	suite.Require().NoError(err)
+
 	suite.Equal(1, len(listNodes))
 	suite.Equal(nodes.LastContactData_FAILED, listNodes[0].GetScanData().GetStatus())
 	suite.Equal(nodes.LastContactData_PASSED, listNodes[0].GetRunData().GetStatus())

--- a/components/nodemanager-service/pgdb/nodes_integration_test.go
+++ b/components/nodemanager-service/pgdb/nodes_integration_test.go
@@ -366,3 +366,27 @@ func (suite *NodesIntegrationSuite) TestProjectsAreRoundtrippedThroughNodeLifecy
 	suite.Require().NoError(err)
 	suite.Equal([]string{"Mexican Restaurant Menu", "Best Soups"}, controlNode.Projects)
 }
+
+func (suite *NodesIntegrationSuite) TestFilterByLastCheckInRange() {
+
+}
+
+func (suite *NodesIntegrationSuite) TestFilterByLastScanTimeRange() {
+
+}
+
+func (suite *NodesIntegrationSuite) TestFilterByRunDataStatus() {
+
+}
+
+func (suite *NodesIntegrationSuite) TestFilterByScanDataStatus() {
+
+}
+
+func (suite *NodesIntegrationSuite) TestFilterByRunDataPenultStatus() {
+
+}
+
+func (suite *NodesIntegrationSuite) TestFilterByScanDataPenultStatus() {
+
+}

--- a/components/nodemanager-service/pgdb/nodes_integration_test.go
+++ b/components/nodemanager-service/pgdb/nodes_integration_test.go
@@ -346,25 +346,27 @@ func (suite *NodesIntegrationSuite) TestProjectsAreRoundtrippedThroughNodeLifecy
 	suite.Equal([]string{"Mexican Restaurant Menu", "Best Soups"}, controlNode.Projects)
 }
 
+var nowTime = ptypes.TimestampNow()
+var baseNodeData = manager.NodeMetadata{
+	Uuid:            "1223-4254-2424-1322",
+	Name:            "my really cool client run node",
+	PlatformName:    "debian",
+	PlatformRelease: "8.6",
+	LastContact:     nowTime,
+	SourceId:        "",
+	SourceRegion:    "",
+	SourceAccountId: "",
+	JobUuid:         "12343-232324-1231242",
+}
+
 func (suite *NodesIntegrationSuite) TestFilterByLastCheckInRange() {
-	nowTime := ptypes.TimestampNow()
-	node := &manager.NodeMetadata{
-		Uuid:            "1223-4254-2424-1322",
-		Name:            "my really cool client run node",
-		PlatformName:    "debian",
-		PlatformRelease: "8.6",
-		LastContact:     nowTime,
-		SourceId:        "",
-		SourceRegion:    "",
-		SourceAccountId: "",
-		JobUuid:         "12343-232324-1231242",
-		RunData: &nodes.LastContactData{
-			Id:      "1003-9254-2004-1322",
-			EndTime: nowTime,
-			Status:  nodes.LastContactData_PASSED,
-		},
+	node := baseNodeData
+	node.RunData = &nodes.LastContactData{
+		Id:      "1003-9254-2004-1322",
+		EndTime: nowTime,
+		Status:  nodes.LastContactData_PASSED,
 	}
-	err := suite.Database.ProcessIncomingNode(node)
+	err := suite.Database.ProcessIncomingNode(&node)
 	suite.Require().NoError(err)
 
 	timeRangeMax := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
@@ -378,24 +380,13 @@ func (suite *NodesIntegrationSuite) TestFilterByLastCheckInRange() {
 }
 
 func (suite *NodesIntegrationSuite) TestFilterByLastScanTimeRange() {
-	nowTime := ptypes.TimestampNow()
-	node := &manager.NodeMetadata{
-		Uuid:            "1223-4254-2424-1322",
-		Name:            "my really cool client run node",
-		PlatformName:    "debian",
-		PlatformRelease: "8.6",
-		LastContact:     nowTime,
-		SourceId:        "",
-		SourceRegion:    "",
-		SourceAccountId: "",
-		JobUuid:         "12343-232324-1231242",
-		ScanData: &nodes.LastContactData{
-			Id:      "1003-9254-2004-1322",
-			EndTime: nowTime,
-			Status:  nodes.LastContactData_PASSED,
-		},
+	node := baseNodeData
+	node.ScanData = &nodes.LastContactData{
+		Id:      "1003-9254-2004-1322",
+		EndTime: nowTime,
+		Status:  nodes.LastContactData_PASSED,
 	}
-	err := suite.Database.ProcessIncomingNode(node)
+	err := suite.Database.ProcessIncomingNode(&node)
 	suite.Require().NoError(err)
 
 	timeRangeMax := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
@@ -409,24 +400,13 @@ func (suite *NodesIntegrationSuite) TestFilterByLastScanTimeRange() {
 }
 
 func (suite *NodesIntegrationSuite) TestFilterByRunDataStatus() {
-	nowTime := ptypes.TimestampNow()
-	node := &manager.NodeMetadata{
-		Uuid:            "1223-4254-2424-1322",
-		Name:            "my really cool client run node",
-		PlatformName:    "debian",
-		PlatformRelease: "8.6",
-		LastContact:     nowTime,
-		SourceId:        "",
-		SourceRegion:    "",
-		SourceAccountId: "",
-		JobUuid:         "12343-232324-1231242",
-		RunData: &nodes.LastContactData{
-			Id:      "1003-9254-2004-1322",
-			EndTime: nowTime,
-			Status:  nodes.LastContactData_FAILED,
-		},
+	node := baseNodeData
+	node.RunData = &nodes.LastContactData{
+		Id:      "1003-9254-2004-1322",
+		EndTime: nowTime,
+		Status:  nodes.LastContactData_FAILED,
 	}
-	err := suite.Database.ProcessIncomingNode(node)
+	err := suite.Database.ProcessIncomingNode(&node)
 	suite.Require().NoError(err)
 
 	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
@@ -439,24 +419,13 @@ func (suite *NodesIntegrationSuite) TestFilterByRunDataStatus() {
 }
 
 func (suite *NodesIntegrationSuite) TestFilterByScanDataStatus() {
-	nowTime := ptypes.TimestampNow()
-	node := &manager.NodeMetadata{
-		Uuid:            "1223-4254-2424-1322",
-		Name:            "my really cool client run node",
-		PlatformName:    "debian",
-		PlatformRelease: "8.6",
-		LastContact:     nowTime,
-		SourceId:        "",
-		SourceRegion:    "",
-		SourceAccountId: "",
-		JobUuid:         "12343-232324-1231242",
-		ScanData: &nodes.LastContactData{
-			Id:      "1003-9254-2004-1322",
-			EndTime: nowTime,
-			Status:  nodes.LastContactData_FAILED,
-		},
+	node := baseNodeData
+	node.ScanData = &nodes.LastContactData{
+		Id:      "1003-9254-2004-1322",
+		EndTime: nowTime,
+		Status:  nodes.LastContactData_FAILED,
 	}
-	err := suite.Database.ProcessIncomingNode(node)
+	err := suite.Database.ProcessIncomingNode(&node)
 	suite.Require().NoError(err)
 
 	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
@@ -469,28 +438,17 @@ func (suite *NodesIntegrationSuite) TestFilterByScanDataStatus() {
 }
 
 func (suite *NodesIntegrationSuite) TestFilterByRunDataPenultStatus() {
-	nowTime := ptypes.TimestampNow()
-	node := &manager.NodeMetadata{
-		Uuid:            "1223-4254-2424-1322",
-		Name:            "my really cool client run node",
-		PlatformName:    "debian",
-		PlatformRelease: "8.6",
-		LastContact:     nowTime,
-		SourceId:        "",
-		SourceRegion:    "",
-		SourceAccountId: "",
-		JobUuid:         "12343-232324-1231242",
-		RunData: &nodes.LastContactData{
-			Id:      "1003-9254-2004-1322",
-			EndTime: nowTime,
-			Status:  nodes.LastContactData_FAILED,
-		},
+	node := baseNodeData
+	node.RunData = &nodes.LastContactData{
+		Id:      "1003-9254-2004-1322",
+		EndTime: nowTime,
+		Status:  nodes.LastContactData_FAILED,
 	}
-	err := suite.Database.ProcessIncomingNode(node)
+	err := suite.Database.ProcessIncomingNode(&node)
 	suite.Require().NoError(err)
 
 	node.RunData.Status = nodes.LastContactData_PASSED
-	err = suite.Database.ProcessIncomingNode(node)
+	err = suite.Database.ProcessIncomingNode(&node)
 	suite.Require().NoError(err)
 
 	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
@@ -513,28 +471,17 @@ func (suite *NodesIntegrationSuite) TestFilterByRunDataPenultStatus() {
 }
 
 func (suite *NodesIntegrationSuite) TestFilterByScanDataPenultStatus() {
-	nowTime := ptypes.TimestampNow()
-	node := &manager.NodeMetadata{
-		Uuid:            "1223-4254-2424-1322",
-		Name:            "my really cool client run node",
-		PlatformName:    "debian",
-		PlatformRelease: "8.6",
-		LastContact:     nowTime,
-		SourceId:        "",
-		SourceRegion:    "",
-		SourceAccountId: "",
-		JobUuid:         "12343-232324-1231242",
-		ScanData: &nodes.LastContactData{
-			Id:      "1003-9254-2004-1322",
-			EndTime: nowTime,
-			Status:  nodes.LastContactData_FAILED,
-		},
+	node := baseNodeData
+	node.ScanData = &nodes.LastContactData{
+		Id:      "1003-9254-2004-1322",
+		EndTime: nowTime,
+		Status:  nodes.LastContactData_FAILED,
 	}
-	err := suite.Database.ProcessIncomingNode(node)
+	err := suite.Database.ProcessIncomingNode(&node)
 	suite.Require().NoError(err)
 
 	node.ScanData.Status = nodes.LastContactData_SKIPPED
-	err = suite.Database.ProcessIncomingNode(node)
+	err = suite.Database.ProcessIncomingNode(&node)
 	suite.Require().NoError(err)
 
 	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
@@ -556,43 +503,22 @@ func (suite *NodesIntegrationSuite) TestFilterByScanDataPenultStatus() {
 }
 
 func (suite *NodesIntegrationSuite) TestFilterByScanDataAndRunDataStatus() {
-	nowTime := ptypes.TimestampNow()
-	node := &manager.NodeMetadata{
-		Uuid:            "1223-4254-2424-1322",
-		Name:            "my really cool client run node",
-		PlatformName:    "debian",
-		PlatformRelease: "8.6",
-		LastContact:     nowTime,
-		SourceId:        "",
-		SourceRegion:    "",
-		SourceAccountId: "",
-		JobUuid:         "12343-232324-1231242",
-		ScanData: &nodes.LastContactData{
-			Id:      "1003-9254-2004-1322",
-			EndTime: nowTime,
-			Status:  nodes.LastContactData_FAILED,
-		},
+	node := baseNodeData
+	node.ScanData = &nodes.LastContactData{
+		Id:      "1003-9254-2004-1322",
+		EndTime: nowTime,
+		Status:  nodes.LastContactData_FAILED,
 	}
-	err := suite.Database.ProcessIncomingNode(node)
+	err := suite.Database.ProcessIncomingNode(&node)
 	suite.Require().NoError(err)
 
-	node = &manager.NodeMetadata{
-		Uuid:            "1223-4254-2424-1322",
-		Name:            "my really cool client run node",
-		PlatformName:    "debian",
-		PlatformRelease: "8.6",
-		LastContact:     nowTime,
-		SourceId:        "",
-		SourceRegion:    "",
-		SourceAccountId: "",
-		JobUuid:         "12343-232324-1231242",
-		RunData: &nodes.LastContactData{
-			Id:      "1003-9254-2004-1322",
-			EndTime: nowTime,
-			Status:  nodes.LastContactData_PASSED,
-		},
+	node2 := baseNodeData
+	node2.RunData = &nodes.LastContactData{
+		Id:      "0803-97654-2098-1322",
+		EndTime: nowTime,
+		Status:  nodes.LastContactData_PASSED,
 	}
-	err = suite.Database.ProcessIncomingNode(node)
+	err = suite.Database.ProcessIncomingNode(&node2)
 	suite.Require().NoError(err)
 
 	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{

--- a/components/nodemanager-service/pgdb/nodes_integration_test.go
+++ b/components/nodemanager-service/pgdb/nodes_integration_test.go
@@ -600,3 +600,59 @@ func (suite *NodesIntegrationSuite) TestFilterByScanDataPenultStatus() {
 	}
 	suite.Equal(1, len(listNodes))
 }
+
+func (suite *NodesIntegrationSuite) TestFilterByScanDataAndRunDataStatus() {
+	nowTime := ptypes.TimestampNow()
+	node := &manager.NodeMetadata{
+		Uuid:            "1223-4254-2424-1322",
+		Name:            "my really cool client run node",
+		PlatformName:    "debian",
+		PlatformRelease: "8.6",
+		LastContact:     nowTime,
+		SourceId:        "",
+		SourceRegion:    "",
+		SourceAccountId: "",
+		JobUuid:         "12343-232324-1231242",
+		ScanData: &nodes.LastContactData{
+			Id:      "1003-9254-2004-1322",
+			EndTime: nowTime,
+			Status:  nodes.LastContactData_FAILED,
+		},
+	}
+	err := suite.Database.ProcessIncomingNode(node)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	node = &manager.NodeMetadata{
+		Uuid:            "1223-4254-2424-1322",
+		Name:            "my really cool client run node",
+		PlatformName:    "debian",
+		PlatformRelease: "8.6",
+		LastContact:     nowTime,
+		SourceId:        "",
+		SourceRegion:    "",
+		SourceAccountId: "",
+		JobUuid:         "12343-232324-1231242",
+		RunData: &nodes.LastContactData{
+			Id:      "1003-9254-2004-1322",
+			EndTime: nowTime,
+			Status:  nodes.LastContactData_PASSED,
+		},
+	}
+	err = suite.Database.ProcessIncomingNode(node)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
+		{Key: "last_scan_status", Values: []string{"FAILED"}},
+		{Key: "last_run_status", Values: []string{"PASSED"}},
+	})
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+	suite.Equal(1, len(listNodes))
+	suite.Equal(nodes.LastContactData_FAILED, listNodes[0].GetScanData().GetStatus())
+	suite.Equal(nodes.LastContactData_PASSED, listNodes[0].GetRunData().GetStatus())
+}

--- a/components/nodemanager-service/pgdb/nodes_integration_test.go
+++ b/components/nodemanager-service/pgdb/nodes_integration_test.go
@@ -438,11 +438,69 @@ func (suite *NodesIntegrationSuite) TestFilterByLastScanTimeRange() {
 }
 
 func (suite *NodesIntegrationSuite) TestFilterByRunDataStatus() {
+	nowTime := ptypes.TimestampNow()
+	node := &manager.NodeMetadata{
+		Uuid:            "1223-4254-2424-1322",
+		Name:            "my really cool client run node",
+		PlatformName:    "debian",
+		PlatformRelease: "8.6",
+		LastContact:     nowTime,
+		SourceId:        "",
+		SourceRegion:    "",
+		SourceAccountId: "",
+		JobUuid:         "12343-232324-1231242",
+		RunData: &nodes.LastContactData{
+			Id:      "1003-9254-2004-1322",
+			EndTime: nowTime,
+			Status:  nodes.LastContactData_FAILED,
+		},
+	}
+	err := suite.Database.ProcessIncomingNode(node)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
 
+	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
+		{Key: "last_run_status", Values: []string{"FAILED"}},
+	})
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+	suite.Equal(1, len(listNodes))
+	suite.Equal(nodes.LastContactData_FAILED, listNodes[0].GetRunData().GetStatus())
 }
 
 func (suite *NodesIntegrationSuite) TestFilterByScanDataStatus() {
+	nowTime := ptypes.TimestampNow()
+	node := &manager.NodeMetadata{
+		Uuid:            "1223-4254-2424-1322",
+		Name:            "my really cool client run node",
+		PlatformName:    "debian",
+		PlatformRelease: "8.6",
+		LastContact:     nowTime,
+		SourceId:        "",
+		SourceRegion:    "",
+		SourceAccountId: "",
+		JobUuid:         "12343-232324-1231242",
+		ScanData: &nodes.LastContactData{
+			Id:      "1003-9254-2004-1322",
+			EndTime: nowTime,
+			Status:  nodes.LastContactData_FAILED,
+		},
+	}
+	err := suite.Database.ProcessIncomingNode(node)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
 
+	listNodes, _, err := suite.Database.GetNodes("", nodes.Query_ASC, 1, 100, []*common.Filter{
+		{Key: "last_scan_status", Values: []string{"FAILED"}},
+	})
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+	suite.Equal(1, len(listNodes))
+	suite.Equal(nodes.LastContactData_FAILED, listNodes[0].GetScanData().GetStatus())
 }
 
 func (suite *NodesIntegrationSuite) TestFilterByRunDataPenultStatus() {


### PR DESCRIPTION
### :nut_and_bolt: Description
This work adds support for filtering by:
 - last run and last scan end time ranges
 - last run and last scan status
 - last run and last scan penultimate status

### :+1: Definition of Done
able to filter by above defined criteria on the `api/v0/nodes` endpoint
https://github.com/chef/automate/issues/192