### PR TITLE
Design fixes for event feed

### DIFF
--- a/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.scss
+++ b/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.scss
@@ -3,6 +3,10 @@
 
 .event-feed-guitar-strings {
   background-color: $chef-white;
+  margin-bottom: 35px;
+  min-width: 540px;
+  border: 1px solid $chef-grey;
+  border-top: none;
 }
 
 .delete {

--- a/components/automate-ui/src/app/page-components/event-feed-select/event-feed-select.component.scss
+++ b/components/automate-ui/src/app/page-components/event-feed-select/event-feed-select.component.scss
@@ -4,6 +4,10 @@
   margin: 10px;
   line-height: 1;
   box-shadow: 0 0 20px rgba($gray-light, .20);
+
+  ::ng-deep .selected-value {
+    padding-top: 17px;
+  }
 }
 
 .event-type-name {

--- a/components/automate-ui/src/app/page-components/event-feed-select/event-feed-select.component.scss
+++ b/components/automate-ui/src/app/page-components/event-feed-select/event-feed-select.component.scss
@@ -8,7 +8,6 @@
 
 .event-type-name {
   font-size: 12px;
-  margin-bottom: 2px;
   font-weight: bold;
 }
 
@@ -16,6 +15,7 @@
   display: none;
   color: inherit;
   font-size: 9px;
+  margin-top: 2px;
 }
 
 chef-option .event-type-count {

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.html
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.html
@@ -1,6 +1,6 @@
 <ul class="event-feed-table">
   <caption class="visually-hidden">Event Feed Table</caption>
-  <li *ngFor="let event of events; index as i" tabindex="0" class="event-row">
+  <li *ngFor="let event of events; index as i" class="event-row">
     <div class="event-date-time">
       <div class="event-time">{{event.startTime | date:'h:mm a' }}</div>
       <div class="event-day">{{event.startTime | date:'EEEE' }},</div>

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.scss
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.scss
@@ -67,15 +67,15 @@
 .event-type {
   display: inline-block;
   vertical-align: middle;
-  width: 125px;
-  font-size: .675em;
+  width: 150px;
+  font-size: 12px;
   font-weight: bold;
 }
 
 .event-description {
   display: inline-block;
   vertical-align: middle;
-  font-size: .675em;
+  font-size: 12px;
   line-height: 12pt;
   max-width: calc(100% - 185px);
 

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.scss
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.scss
@@ -69,7 +69,7 @@
   vertical-align: middle;
   width: 150px;
   font-size: 12px;
-  font-weight: bold;
+  font-weight: 400;
 }
 
 .event-description {

--- a/components/chef-ui-library/src/molecules/chef-select/chef-select.scss
+++ b/components/chef-ui-library/src/molecules/chef-select/chef-select.scss
@@ -4,6 +4,7 @@ chef-select {
   border-color: chef-hsl(var(--chef-grey));
   display: inline-block;
   background-color: chef-hsl(var(--chef-white));
+  cursor: pointer;
 
   .selected-value {
     display: block;


### PR DESCRIPTION
### :nut_and_bolt: Description
![event-feed](https://user-images.githubusercontent.com/7217000/57662205-36bd3780-75a3-11e9-98b1-70221a6882a8.gif)

Some minor design tweaks to the event feed. Above screenshot shows the added border to the guitar strings graph, centered select menu title, and focus order (which skips the rows in the event feed table). 

### :chains: Related Resources
https://chefio.atlassian.net/browse/UI-162

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
