### PR TITLE
new changes for the notifications page empty state

### DIFF
--- a/components/automate-ui/src/app/pages/notifications/notifications.component.html
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.html
@@ -24,34 +24,36 @@
           </div>
         </app-authorized>
       </chef-toolbar>
-      <chef-table *ngIf="(rules$ | async)?.length > 0" id="notifications-list">
-        <chef-tr>
-          <chef-th class="sort" (click)="toggleSort('node_name')">
-            <div class="text-and-sort-icons">
-              <span>Notification Name</span>
-              <chef-icon aria-hidden="true" id="{{sortIcon('node_name')}}" class="sort-icon">arrow_drop_up</chef-icon>
-            </div>
-          </chef-th>
-          <chef-th>Alert Type</chef-th>
-          <chef-th aria-hidden="true"></chef-th>
-        </chef-tr>
-
-        <chef-tr tabindex="0" *ngFor="let rule of rules$ | async |
-          slice:(pageSize * (currentPage - 1)):(pageSize * (currentPage - 1)) + pageSize">
-          <chef-td class="{{rule.targetType}}">
-            <img src="assets/img/logo-{{rule.targetType}}.svg" alt="{{rule.targetType}} logo" />
-            <a [routerLink]="['/settings/notifications/form', rule.id]">{{ rule.name }}</a>
-          </chef-td>
-          <chef-td>
-            {{rule.AlertTypeLabels[rule.ruleType]}}
-          </chef-td>
-          <chef-td class="actions">
-            <chef-control-menu>
-              <chef-option (click)="deleteRule(rule)">Delete Notification</chef-option>
-            </chef-control-menu>
-          </chef-td>
-        </chef-tr>
-      </chef-table>
+      <app-authorized [anyOf]="['/notifications/rules', 'get']">
+        <chef-table *ngIf="(rules$ | async)?.length > 0" id="notifications-list">
+          <chef-tr>
+            <chef-th class="sort" (click)="toggleSort('node_name')">
+              <div class="text-and-sort-icons">
+                <span>Notification Name</span>
+                <chef-icon aria-hidden="true" id="{{sortIcon('node_name')}}" class="sort-icon">arrow_drop_up</chef-icon>
+              </div>
+            </chef-th>
+            <chef-th>Alert Type</chef-th>
+            <chef-th aria-hidden="true"></chef-th>
+          </chef-tr>
+  
+          <chef-tr tabindex="0" *ngFor="let rule of rules$ | async |
+            slice:(pageSize * (currentPage - 1)):(pageSize * (currentPage - 1)) + pageSize">
+            <chef-td class="{{rule.targetType}}">
+              <img src="assets/img/logo-{{rule.targetType}}.svg" alt="{{rule.targetType}} logo" />
+              <a [routerLink]="['/settings/notifications/form', rule.id]">{{ rule.name }}</a>
+            </chef-td>
+            <chef-td>
+              {{rule.AlertTypeLabels[rule.ruleType]}}
+            </chef-td>
+            <chef-td class="actions">
+              <chef-control-menu>
+                <chef-option (click)="deleteRule(rule)">Delete Notification</chef-option>
+              </chef-control-menu>
+            </chef-td>
+          </chef-tr>
+        </chef-table>
+      </app-authorized>
 
       <app-page-picker
         [total]="(rules$ | async)?.length"

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.html
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.html
@@ -16,10 +16,15 @@
 
       <chef-toolbar>
         <app-authorized [anyOf]="['/notifications/rules', 'post']">
-          <chef-button primary [routerLink]="['/settings/notifications/form']">Create Notification</chef-button>
+          <div *ngIf="(rules$ | async)?.length === 0" class="notifications-empty-state">
+            <p>Create the first notification to get started!</p>
+          </div>
+          <div [ngClass]="(rules$ | async)?.length === 0 ? 'notifications-empty-state' : ''">
+            <chef-button primary [routerLink]="['/settings/notifications/form']">Create Notification</chef-button>
+          </div>
         </app-authorized>
       </chef-toolbar>
-      <chef-table id="notifications-list">
+      <chef-table *ngIf="(rules$ | async)?.length > 0" id="notifications-list">
         <chef-tr>
           <chef-th class="sort" (click)="toggleSort('node_name')">
             <div class="text-and-sort-icons">

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.scss
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.scss
@@ -178,3 +178,13 @@ chef-icon#sort-asc {
     }
   }
 }
+
+.notifications-empty-state {
+  text-align: center;
+
+   p {
+    font-size: 18px;
+    font-weight: 400;
+    margin-top: 35px;
+  }
+}

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.scss
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.scss
@@ -182,7 +182,7 @@ chef-icon#sort-asc {
 .notifications-empty-state {
   text-align: center;
 
-   p {
+  p {
     font-size: 18px;
     font-weight: 400;
     margin-top: 35px;


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description
Currently, when there are no notifications on the Notifications page we show an empty table, instead, we would like to follow the empty state pattern.
### :+1: Definition of Done
New changes screenshot
![notifications_page](https://user-images.githubusercontent.com/12297653/57684099-be15b400-7652-11e9-95d2-bd21d99c6914.png)

### :chains: Related Resources
https://github.com/chef/automate/issues/302