### PR TITLE
[terraform] attempt to stabilize sysctl templates

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/files/a2-sysctl.conf
+++ b/terraform/test-environments/modules/chef_automate_install/files/a2-sysctl.conf
@@ -1,3 +1,0 @@
-# Kernel parameters required by A2 preflight check
-vm.max_map_count=262144
-vm.dirty_expire_centisecs=20000

--- a/terraform/test-environments/modules/chef_automate_install/main.tf
+++ b/terraform/test-environments/modules/chef_automate_install/main.tf
@@ -177,14 +177,19 @@ EOF
   }
 
   provisioner "file" {
-    source      = "${path.module}/files/a2-sysctl.conf"
-    destination = "/tmp/a2-sysctl.conf"
+    destination = "/tmp/60-chef-automate.conf"
+
+    content = <<EOF
+# Kernel parameters required by A2 preflight check
+vm.max_map_count=262144
+vm.dirty_expire_centisecs=20000
+EOF
   }
 
   provisioner "remote-exec" {
     inline = [
       "set -evx",
-      "sudo mv /tmp/a2-sysctl.conf /etc/sysctl.d/a2-sysctl.conf",
+      "sudo mv /tmp/60-chef-automate.conf /etc/sysctl.d/60-chef-automate.conf",
       "sudo --login sysctl --system",
     ]
   }


### PR DESCRIPTION
recently we've seen a fair share of failures from various fresh
install nodes in our test environments that aren't finding the
a2-sysctl.conf file in /tmp or even after applying them aren't
seeing the results in the system config when running the automate
preflight checks.

this change attempts to stabilize the writing of the chef automate
sysctl config by using the terraform file `content` feature rather
than loading the template from a local file. we've not seen similar
failures recently with the `content` feature, so this eliminates
one potential point of failure.

additionally, the file we write to /etc/sysctl.d has been renamed
from `a2-sysctl.conf` to `60-chef-automate.conf` to prevent any
ambiguity in the sorting or application of the sysctl config files.

Signed-off-by: Stephen Delano <stephen@chef.io>
