### PR TITLE
cypress: ensure we click next only after selecting a profile

### DIFF
--- a/components/automate-ui/src/app/page-components/job-profiles-form/job-profiles-form.component.html
+++ b/components/automate-ui/src/app/page-components/job-profiles-form/job-profiles-form.component.html
@@ -3,9 +3,7 @@
   <chef-table>
     <chef-tr>
       <chef-th>
-        <input
-          type="checkbox"
-          formControlName="allSelected"
+        <input type="checkbox" formControlName="allSelected" data-cy="select-all-profiles"
           [indeterminate]="form.controls['someSelected'].value" />
         Profile Name
       </chef-th>
@@ -17,9 +15,8 @@
       </chef-th>
     </chef-tr>
     <chef-tbody formArrayName="profiles">
-      <chef-tr
-      *ngFor="let profileGroup of form.controls['profiles']['controls']; let pIndex = index;"
-      [formGroup]="profileGroup">
+      <chef-tr *ngFor="let profileGroup of form.controls['profiles']['controls']; let pIndex = index;"
+        [formGroup]="profileGroup">
         <chef-td>
           <input type="checkbox" formControlName="include" />
           {{profileGroup.value.title}}

--- a/e2e/cypress/integration/compliance/01_ssh_scan_job.spec.js
+++ b/e2e/cypress/integration/compliance/01_ssh_scan_job.spec.js
@@ -146,30 +146,31 @@ describe('create a manual node ssh scan job and cleanup after', () => {
       // click next
       cy.contains('Next').click().then(() => {
         // select profiles
-        cy.get('chef-job-profiles-form input[type="checkbox"]').check()
-        // click next
-        cy.contains('Next').click().then(() => {
+        cy.get('chef-job-profiles-form input[type="checkbox"]').check().then(() => {
+          // click next
+          cy.contains('Next').click().then(() => {
 
-          // give the scan job a name
-          cy.get('form input[formcontrolname="name"]').type('a ' + jobName)
+            // give the scan job a name
+            cy.get('form input[formcontrolname="name"]').type('a ' + jobName)
 
-          // expand the recurrence schedule and schedule job to repeat every 1 day
-          cy.get('chef-job-schedule-form input[type="checkbox"]').check()
-          cy.get('.schedule-body input[type="checkbox"]').check()
-          cy.get('fieldset[formgroupname="repeat"]').get('select').last().select('Days')
+            // expand the recurrence schedule and schedule job to repeat every 1 day
+            cy.get('chef-job-schedule-form input[type="checkbox"]').check()
+            cy.get('.schedule-body input[type="checkbox"]').check()
+            cy.get('fieldset[formgroupname="repeat"]').get('select').last().select('Days')
 
-          // click save
-          cy.contains('Save').click().then(() => {
-            cy.url().should('include', '/compliance/scanner/jobs')
+            // click save
+            cy.contains('Save').click().then(() => {
+              cy.url().should('include', '/compliance/scanner/jobs')
 
-            // assert table has scan job
-            cy.contains(jobName).should('exist')
+              // assert table has scan job
+              cy.contains(jobName).should('exist')
 
-            // click into the scan job to view runs page
-            cy.contains(jobName)
-              .click().then(() => {
-                cy.url().should('include', '/scans')
-              })
+              // click into the scan job to view runs page
+              cy.contains(jobName)
+                .click().then(() => {
+                  cy.url().should('include', '/scans')
+                })
+            })
           })
         })
       })
@@ -266,7 +267,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     cy.wait('@deleteScanJob')
 
     // ensure that the job is deleted
-    cy.url().should('include','/compliance/scanner/jobs')
+    cy.url().should('include', '/compliance/scanner/jobs')
     cy.get('chef-tbody').should(($b) => {
       expect($b).not.to.contain(jobName)
     })

--- a/e2e/cypress/integration/compliance/01_ssh_scan_job.spec.js
+++ b/e2e/cypress/integration/compliance/01_ssh_scan_job.spec.js
@@ -146,7 +146,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
       // click next
       cy.contains('Next').click().then(() => {
         // select profiles
-        cy.get('chef-job-profiles-form input[type="checkbox"]').check().then(() => {
+        cy.get('chef-job-profiles-form').find('[data-cy=select-all-profiles]').check().then(() => {
           // click next
           cy.contains('Next').click().then(() => {
 


### PR DESCRIPTION
### :nut_and_bolt: Description
It's hard to know if this will help much at all. 

i basically just added a `then(() => {` after the profile selection to ensure we don't try to click next until we've done that, since i found when viewing the failure videos that we were failing to select a profile and the unable to select next after

tests passed when run 4x consecutively against iamv2-inplace-upgrade -- it certainly won't hurt, so it's worth a try.

### :+1: Definition of Done
cypress tests are little less flaky
