### PR TITLE
added changes for node credentials page empty state

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.html
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.html
@@ -18,33 +18,35 @@
           </div>
         </app-authorized>
       </chef-toolbar>
-      <chef-table *ngIf="credentialsList.items.length > 0" class="credentials-list-table" (sort-toggled)="onSortToggled($event)">
-        <chef-thead>
-          <chef-tr>
-            <chef-th>
-              Name
-              <chef-sort-toggle sort="name" [order]="orderFor('name')"></chef-sort-toggle>
-            </chef-th>
-            <chef-th>
-              Type
-              <chef-sort-toggle sort="type" [order]="orderFor('type')"></chef-sort-toggle>
-            </chef-th>
-            <chef-th>
-              Last Modified
-              <chef-sort-toggle sort="last_modified" [order]="orderFor('last_modified')"></chef-sort-toggle>
-            </chef-th>
-            <chef-th></chef-th>
-          </chef-tr>
-        </chef-thead>
-
-        <chef-tbody>
-          <app-credentials-list-row
-            *ngFor="let credential of credentialsList.items"
-            [credential]="credential"
-            (deleteCredential)="deleteCredential.emit($event)">
-          </app-credentials-list-row>
-        </chef-tbody>
-      </chef-table>
+      <app-authorized [anyOf]="['/secrets/search' , 'post']">
+        <chef-table *ngIf="credentialsList.items.length > 0" class="credentials-list-table" (sort-toggled)="onSortToggled($event)">
+          <chef-thead>
+            <chef-tr>
+              <chef-th>
+                Name
+                <chef-sort-toggle sort="name" [order]="orderFor('name')"></chef-sort-toggle>
+              </chef-th>
+              <chef-th>
+                Type
+                <chef-sort-toggle sort="type" [order]="orderFor('type')"></chef-sort-toggle>
+              </chef-th>
+              <chef-th>
+                Last Modified
+                <chef-sort-toggle sort="last_modified" [order]="orderFor('last_modified')"></chef-sort-toggle>
+              </chef-th>
+              <chef-th></chef-th>
+            </chef-tr>
+          </chef-thead>
+  
+          <chef-tbody>
+            <app-credentials-list-row
+              *ngFor="let credential of credentialsList.items"
+              [credential]="credential"
+              (deleteCredential)="deleteCredential.emit($event)">
+            </app-credentials-list-row>
+          </chef-tbody>
+        </chef-table>
+      </app-authorized>
 
       <app-page-picker
         class="credentials-list-paging"

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.html
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.html
@@ -8,12 +8,17 @@
     <div class="credentials-list-body">
       <chef-toolbar>
         <app-authorized [anyOf]="['/secrets', 'post']">
-          <chef-button primary [routerLink]="['/settings/node-credentials/add']">
-            Add Credential
-          </chef-button>
+          <div *ngIf="credentialsList.items.length === 0" class="credentials-empty-state">
+            <p>Create the first credential to get started!</p>
+          </div>
+          <div [ngClass]="credentialsList.items.length === 0 ? 'credentials-empty-state' : ''">
+            <chef-button primary [routerLink]="['/settings/node-credentials/add']">
+              Add Credential
+            </chef-button>
+          </div>
         </app-authorized>
       </chef-toolbar>
-      <chef-table class="credentials-list-table" (sort-toggled)="onSortToggled($event)">
+      <chef-table *ngIf="credentialsList.items.length > 0" class="credentials-list-table" (sort-toggled)="onSortToggled($event)">
         <chef-thead>
           <chef-tr>
             <chef-th>

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.scss
@@ -10,6 +10,6 @@
   p {
     font-size: 18px;
     font-weight: 400;
-    margin-top: 35px;
+    margin-top: 70px;
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.scss
@@ -3,3 +3,13 @@
 .credentials-list-body {
   margin: $content-container-padding;
 }
+
+.credentials-empty-state {
+  text-align: center;
+
+   p {
+    font-size: 18px;
+    font-weight: 400;
+    margin-top: 35px;
+  }
+}

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.scss
@@ -7,7 +7,7 @@
 .credentials-empty-state {
   text-align: center;
 
-   p {
+  p {
     font-size: 18px;
     font-weight: 400;
     margin-top: 35px;


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description
Currently, when there are no credentials on the Node Credentials page we show an empty table, instead, we would like to follow the empty state pattern.
### :+1: Definition of Done
New changes screenshot
![node_credentials](https://user-images.githubusercontent.com/12297653/57716532-da3b4480-7696-11e9-97b3-9cac74c7d564.png)

### :chains: Related Resources
fixes https://github.com/chef/automate/issues/301