### PR TITLE
Fixing flaky UI e2e test

### DIFF
--- a/components/automate-ui/e2e/event-feed-page.e2e-spec.ts
+++ b/components/automate-ui/e2e/event-feed-page.e2e-spec.ts
@@ -9,9 +9,18 @@ describe('Event Feed: Guitar String Graph Interaction', () => {
 
   it('should have a working dropdown filter', () => {
     const select = element(by.css('app-event-feed-select chef-select'));
-    select.click();
 
-    expect(select.getAttribute('class')).toContain('active');
+    // Click the event feed dropdown filter and wait until the filter turns 'active'
+    select.click().then(() => {
+      return new Promise(function(resolve) {
+        browser.wait(() => {
+          return select.getAttribute('class').then((values: string) => {
+            return values.indexOf('active') > 0;
+          });
+        // resolve the promise when the 'active' attribute is found or after one second
+        }, 1000).then( () => resolve());
+      });
+    });
   });
 
   xit('Event Feed page is accessible', (done) => {


### PR DESCRIPTION

![active](https://user-images.githubusercontent.com/1679247/57733964-9d9b2900-7655-11e9-9344-842cbac22e1c.gif)

Fixing a flaky UI e2e test. When selecting the event feed dropdown filter the 'active' attribute should be added. The problem was that the test was checking before that 'active' attribute was added. So, the fix here is to wait until after the click and then check for the 'active' attribute for about a second. The other option was to add a sleep statement and sleeps cause other problems. 

I found a solution thanks to this website https://www.captechconsulting.com/blogs/keep-your-promises-making-the-jump-from-selenium-to-protractor