### PR TITLE
Adding project filter for GetEventTypeCounts

### DIFF
--- a/components/config-mgmt-service/grpcserver/event_feed.go
+++ b/components/config-mgmt-service/grpcserver/event_feed.go
@@ -124,6 +124,11 @@ func (s *CfgMgmtServer) GetEventTypeCounts(ctx context.Context,
 		return &response.EventCounts{}, errors.GrpcErrorFromErr(codes.InvalidArgument, err)
 	}
 
+	filters, err = filterByProjects(ctx, filters)
+	if err != nil {
+		return &response.EventCounts{}, errors.GrpcErrorFromErr(codes.Internal, err)
+	}
+
 	// Date Range
 	startTime, endTime, err := params.ValidateMillsecondDateRange(request.Start, request.End)
 	if err != nil {

--- a/components/config-mgmt-service/integration_test/event_counts_test.go
+++ b/components/config-mgmt-service/integration_test/event_counts_test.go
@@ -654,13 +654,7 @@ func TestEventTypeCountsProjectFilter(t *testing.T) {
 
 			// test response
 			assert.Equal(t, test.expected.Total, res.Total)
-
-			for _, expectedCount := range test.expected.Counts {
-				matchingResCount, err := findEventCountByName(expectedCount.Name, res.Counts)
-				assert.NoError(t, err)
-
-				assert.Equal(t, expectedCount.Count, matchingResCount.Count)
-			}
+			assert.ElementsMatch(t, test.expected.Counts, res.Counts)
 		})
 	}
 }

--- a/components/config-mgmt-service/integration_test/event_feed_test.go
+++ b/components/config-mgmt-service/integration_test/event_feed_test.go
@@ -488,7 +488,7 @@ func TestEventFeedProjectFilter(t *testing.T) {
 			expectedIDs: []string{},
 		},
 		{
-			description: "Two Actions with one project not matching any of several requested projects allowed",
+			description: "Two Actions with neither project not matching any of several requested projects allowed",
 			ctx:         contextWithProjects([]string{"project3", "project4", "project7", "project6"}),
 			actions: []iBackend.InternalChefAction{
 				{

--- a/components/config-mgmt-service/integration_test/event_feed_test.go
+++ b/components/config-mgmt-service/integration_test/event_feed_test.go
@@ -488,7 +488,7 @@ func TestEventFeedProjectFilter(t *testing.T) {
 			expectedIDs: []string{},
 		},
 		{
-			description: "Two Actions with neither project not matching any of several requested projects allowed",
+			description: "Two Actions with neither project matching any of several requested projects allowed",
 			ctx:         contextWithProjects([]string{"project3", "project4", "project7", "project6"}),
 			actions: []iBackend.InternalChefAction{
 				{


### PR DESCRIPTION
### :nut_and_bolt: Description

Adding project filtering for the event_feed.proto GetEventTypeCounts RPC.

### :chains: Related Resources

https://github.com/chef/automate/issues/69

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?