### PR TITLE
cloud integrations: if no name is defined for node when adding, use id

### DIFF
--- a/components/nodemanager-service/pgdb/node-managers-cloud.go
+++ b/components/nodemanager-service/pgdb/node-managers-cloud.go
@@ -324,6 +324,9 @@ func (db *DB) UpdateOrInsertInstanceSourceStateInDb(instance InstanceState, mgrI
 		id, err = db.SelectStr(sqlUpdateInstanceSourceStateAndStatus, instance.ID, instance.Region, sourceAcctID, instanceState, "unreachable", nowTime, connectionErr)
 	case "RUNNING":
 		id, err = db.SelectStr(sqlUpsertInstanceSourceState, uuid, name, instance.ID, instanceState, instance.Region, sourceAcctID, tcByte, nowTime, mgrType)
+	default:
+		logrus.Errorf("unknown instance state reported %s", instanceState)
+		return false, nil
 	}
 	if err != nil {
 		return false, errors.Wrapf(err, "UpdateInstanceSourceState unable to update instance %s %s", instance.ID, name)

--- a/components/nodemanager-service/pgdb/node_managers_cloud_integration_test.go
+++ b/components/nodemanager-service/pgdb/node_managers_cloud_integration_test.go
@@ -53,7 +53,7 @@ func (suite *NodeManagersAndNodesDBSuite) TestUpdateOrInsertInstanceSourceStateI
 	if err != nil {
 		suite.FailNow(err.Error())
 	}
-	suite.Equal(1, len(stoppedNodes))
+	suite.Equal(0, len(stoppedNodes))
 
 	// instance state: running
 	runningInstanceState := pgdb.InstanceState{ID: "i-079356", State: "running", Region: "eu-west-1"}


### PR DESCRIPTION
### :nut_and_bolt: Description
I noticed some nodes were getting added in with no name. 
When we query the Azure node state we get the name of the instance, but when we query aws node state we do not.  So this logic just ensures that if we are adding a node b/c it is new to us, and it does not have a name defined, we use the id as the name, so there's some way to identify the node

### :+1: Definition of Done
nodes discovered via aws instance check have the id as their name

