### PR TITLE
Reconfigure EAS dashboard to make sidebar static

### DIFF
--- a/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
@@ -39,7 +39,7 @@ export interface ServiceGroupFilters {
 }
 
 export interface ServicesFilters {
-  service_group_id?: number;
+  service_group_id?: string;
   health: string;
   page: number;
   pageSize?: number;

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -1,4 +1,4 @@
-<chef-side-panel id="services-panel" class="services-panel" tabindex="0" visible>
+<div id="services-panel" class="services-panel">
   <chef-page-header>
     <chef-heading>
       <chef-icon>grain</chef-icon>
@@ -68,4 +68,4 @@
   <div class="services-panel-body no-services" *ngIf="!serviceGroupId">
     Add service groups to see more service details
   </div>
-</chef-side-panel>
+</div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -1,12 +1,14 @@
-<chef-click-outside omit="sg-row" (clickOutside)="closeServicesSidebar()">
-  <chef-side-panel id="services-panel" class="services-panel" tabindex="0" [visible]="visible">
-    <chef-page-header>
-      <chef-heading>
-        <chef-icon>grain</chef-icon>
-        Services in {{ serviceGroupName$ | async }}
-      </chef-heading>
-      <chef-subheading>Services run by each Habitat Supervisor on a node.</chef-subheading>
-    </chef-page-header>
+<chef-side-panel id="services-panel" class="services-panel" tabindex="0" visible>
+  <chef-page-header>
+    <chef-heading>
+      <chef-icon>grain</chef-icon>
+      Services in
+      <span *ngIf="serviceGroupId">{{ serviceGroupName$ | async }}</span>
+      <span *ngIf="!serviceGroupId">Group</span>
+    </chef-heading>
+    <chef-subheading>Services run by each Habitat Supervisor on a node.</chef-subheading>
+  </chef-page-header>
+  <div class="services-panel-body" *ngIf="serviceGroupId">
     <div class="status-filter-bar">
       <chef-status-filter-group [value]="selectedHealth" lean>
         <chef-option class="filter general" value="total" (click)="updateHealthFilter('total')" selected>
@@ -62,5 +64,8 @@
       [page]="currentPage"
       (pageChanged)="updatePageNumber($event)">
     </app-page-picker>
-  </chef-side-panel>
-</chef-click-outside>
+  </div>
+  <div class="services-panel-body no-services" *ngIf="!serviceGroupId">
+    Add service groups to see more service details
+  </div>
+</chef-side-panel>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -26,7 +26,7 @@
           <div class="filter-label">Warning</div>
           <div class="filter-total">{{ servicesHealthSummary.warning }}</div>
         </chef-option>
-        <chef-option class="filter success" value='success' (click)="updateHealthFilter('ok')">
+        <chef-option class="filter success" value='ok' (click)="updateHealthFilter('ok')">
           <chef-icon class="filter-icon">check_circle</chef-icon>
           <div class="filter-label">OK</div>
           <div class="filter-total">{{ servicesHealthSummary.ok }}</div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -10,7 +10,6 @@ ul {
   border-left: 1px solid $chef-grey;
   box-shadow: none;
   transition: none;
-  outline: none;
 }
 
 app-page-picker {

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -6,7 +6,11 @@ ul {
 }
 
 .services-panel {
-  background-color: #FFFFFF;
+  background-color: $chef-white;
+  border-left: 1px solid $chef-grey;
+  box-shadow: none;
+  transition: none;
+  outline: none;
 }
 
 app-page-picker {

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -1,15 +1,20 @@
 @import "~styles/variables";
 @import "~styles/mixins";
 
-ul {
-  margin-top: 5px;
+:host {
+  display: block;
+  position: fixed;
+  width: 450px;
+  top: 70px;
+  right: 0;
+  bottom: 0;
+  background: $chef-white;
+  border-left: 1px solid $chef-grey;
+  overflow: auto;
 }
 
-.services-panel {
-  background-color: $chef-white;
-  border-left: 1px solid $chef-grey;
-  box-shadow: none;
-  transition: none;
+ul {
+  margin-top: 5px;
 }
 
 app-page-picker {

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnDestroy, OnInit, Input } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Observable, Subject } from 'rxjs';
@@ -20,7 +20,6 @@ import { includes, getOr } from 'lodash/fp';
 export class ServicesSidebarComponent implements OnInit, OnDestroy {
   @Input() serviceGroupId: number;
   @Input() visible: boolean;
-  @Output() closeServicesSidebarEvent: EventEmitter<any> = new EventEmitter();
 
   public services$: Observable<Service[]>;
   public serviceGroupName$: Observable<string>;
@@ -66,10 +65,6 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
-  }
-
-  public closeServicesSidebar() {
-    this.closeServicesSidebarEvent.emit(null);
   }
 
   public updateHealthFilter(health: string): void {

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -18,7 +18,7 @@ import { includes, getOr } from 'lodash/fp';
 })
 
 export class ServicesSidebarComponent implements OnInit, OnDestroy {
-  @Input() serviceGroupId: number;
+  @Input() serviceGroupId: string;
   @Input() visible: boolean;
 
   public services$: Observable<Service[]>;

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit, Input } from '@angular/core';
+import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Observable, Subject } from 'rxjs';
@@ -8,7 +9,6 @@ import { createSelector } from '@ngrx/store';
 import {
   Service, ServicesFilters, HealthSummary
 } from '../../entities/service-groups/service-groups.model';
-import { UpdateSelectedSG } from '../../entities/service-groups/service-groups.actions';
 import { includes, getOr } from 'lodash/fp';
 
 @Component({
@@ -37,7 +37,10 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   // Has this component been destroyed
   private isDestroyed: Subject<boolean> = new Subject();
 
-  constructor(private store: Store<NgrxStateAtom>) { }
+  constructor(
+    private store: Store<NgrxStateAtom>,
+    private router: Router
+  ) { }
 
   ngOnInit() {
     this.services$ = this.store.select(createSelector(serviceGroupState,
@@ -101,12 +104,10 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   }
 
   private updateServicesFilters(): void {
-    const servicesFilters: ServicesFilters = {
-      service_group_id: this.serviceGroupId,
-      health: this.selectedHealth,
-      page: this.currentPage,
-      pageSize: this.pageSize
+    const queryParams = {
+      'sgStatus': this.selectedHealth,
+      'sgPage': this.currentPage
     };
-    this.store.dispatch(new UpdateSelectedSG(servicesFilters));
+    this.router.navigate([], { queryParams, queryParamsHandling: 'merge' });
   }
 }

--- a/components/automate-ui/src/app/pages/applications/applications.component.scss
+++ b/components/automate-ui/src/app/pages/applications/applications.component.scss
@@ -1,5 +1,9 @@
+@import "~styles/variables";
+
 main {
-  background: white;
+  background: $chef-white;
+  height: calc(100vh - 70px);
+  overflow: auto;
 }
 
 chef-subheading {

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -54,7 +54,7 @@
         tabindex="0"
         class="{{serviceGroup.status}} sg-row"
         [ngClass]="{'selected': (selectedServiceGroupId === serviceGroup.id)}"
-        (click)="openServicesSidebar(serviceGroup.id)"
+        (click)="onServiceGroupClick(serviceGroup.id)"
         *ngFor="let serviceGroup of serviceGroups$ | async">
         <chef-td class="{{serviceGroup.status}} health">
           <chef-icon class="{{serviceGroup.status}}">{{ serviceGroup.status | serviceStatusIcon }}</chef-icon>

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -54,7 +54,9 @@
         tabindex="0"
         class="{{serviceGroup.status}} sg-row"
         [ngClass]="{'selected': (selectedServiceGroupId === serviceGroup.id)}"
-        (click)="onServiceGroupClick(serviceGroup.id)"
+        (click)="onServiceGroupSelect($event, serviceGroup.id)"
+        (keydown.space)="onServiceGroupSelect($event, serviceGroup.id)"
+        (keydown.enter)="onServiceGroupSelect($event, serviceGroup.id)"
         *ngFor="let serviceGroup of serviceGroups$ | async">
         <chef-td class="{{serviceGroup.status}} health">
           <chef-icon class="{{serviceGroup.status}}">{{ serviceGroup.status | serviceStatusIcon }}</chef-icon>
@@ -89,6 +91,7 @@
   </div>
 </div>
 <app-services-sidebar
+  tabindex="0"
   [serviceGroupId]="selectedServiceGroupId"
   class="services-sidebar-container">
 </app-services-sidebar>

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -20,7 +20,7 @@
       <div class="filter-label">Warning</div>
       <div class="filter-total">{{ sgHealthSummary["warning"] }}</div>
     </chef-option>
-    <chef-option class="filter success" value='success' (click)="statusFilter('ok')">
+    <chef-option class="filter success" value='ok' (click)="statusFilter('ok')">
       <chef-icon class="filter-icon">check_circle</chef-icon>
       <div class="filter-label">OK</div>
       <div class="filter-total">{{ sgHealthSummary["ok"] }}</div>

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -90,7 +90,5 @@
 </div>
 <app-services-sidebar
   [serviceGroupId]="selectedServiceGroupId"
-  [visible]="servicesSidebarVisible"
-  class="services-sidebar-container"
-  (closeServicesSidebarEvent)="closeServicesSidebar()">
+  class="services-sidebar-container">
 </app-services-sidebar>

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -53,6 +53,7 @@
       <chef-tr
         tabindex="0"
         class="{{serviceGroup.status}} sg-row"
+        [ngClass]="{'selected': (selectedServiceGroupId === serviceGroup.id)}"
         (click)="openServicesSidebar(serviceGroup.id)"
         *ngFor="let serviceGroup of serviceGroups$ | async">
         <chef-td class="{{serviceGroup.status}} health">

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -87,10 +87,10 @@
       <chef-button primary>Learn More</chef-button>
     </div>
   </div>
-  <app-services-sidebar
-    [serviceGroupId]="selectedServiceGroupId"
-    [visible]="servicesSidebarVisible"
-    class="services-sidebar-container"
-    (closeServicesSidebarEvent)="closeServicesSidebar()">
-  </app-services-sidebar>
 </div>
+<app-services-sidebar
+  [serviceGroupId]="selectedServiceGroupId"
+  [visible]="servicesSidebarVisible"
+  class="services-sidebar-container"
+  (closeServicesSidebarEvent)="closeServicesSidebar()">
+</app-services-sidebar>

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
@@ -3,6 +3,11 @@
 
 .page-body {
   padding-top: 0;
+  margin-right: 450px;
+}
+
+chef-page-header {
+  margin-right: 450px;
 }
 
 // Table list styles

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
@@ -120,41 +120,67 @@ chef-td {
 }
 
 chef-tr.sg-row {
-  &>chef-td:first-child:before {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    width: 2px;
-    transition: width 0.2s;
-    background: $chef-success;
-    border-top-left-radius: $global-radius;
-    border-bottom-left-radius: $global-radius;
+  > chef-td:first-child {
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      width: 2px;
+      transition: width 0.2s;
+      background: $chef-success;
+      border-top-left-radius: $global-radius;
+      border-bottom-left-radius: $global-radius;
+    }
+
+    &.OK::before {
+      background: $chef-success;
+    }
+
+    &.WARNING::before {
+      background: $chef-primary;
+    }
+
+    &.UNKNOWN::before {
+      background: $chef-dark-grey;
+    }
+
+    &.CRITICAL::before {
+      background: $chef-critical;
+    }
+
+    &.DEPLOYING::before {
+      background: $chef-dark-grey;
+    }
   }
 
-  &:hover>chef-td:first-child:before {
-    width: 7px;
+  &:hover,
+  &.selected {
+    > chef-td:first-child::before {
+      width: 7px;
+    }
   }
 
-  &>chef-td.OK:first-child:before {
-    background: $chef-success;
-  }
+  &.selected {
+    position: relative;
 
-  &>chef-td.WARNING:first-child:before {
-    background: $chef-primary;
-  }
+    &::after {
+      display: block;
+      position: absolute;
+      right: -12px;
+      top: 50%;
+      transform: rotate(45deg);
+      border: 4px solid transparent;
+      border-right: 4px solid $chef-primary-bright;
+      border-top: 4px solid $chef-primary-bright;
+      margin-top: -4px;
+      content: '';
+    }
 
-  &>chef-td.UNKNOWN:first-child:before {
-    background: $chef-dark-grey;
-  }
-
-  &>chef-td.CRITICAL:first-child:before {
-    background: $chef-critical;
-  }
-
-  &>chef-td.DEPLOYING:first-child:before {
-    background: $chef-dark-grey;
+    > chef-td {
+      background: #F2F8FD;
+    }
   }
 }
 

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -179,7 +179,9 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
     this.router.navigate([], {queryParams});
   }
 
-  public onServiceGroupClick(id: string) {
+  public onServiceGroupSelect(event: Event, id: string) {
+    event.preventDefault();
+
     const queryParams = { ...this.route.snapshot.queryParams };
     queryParams['sgId'] = id;
     delete queryParams['sgPage'];
@@ -190,7 +192,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   public updateServicesSidebar(servicesFilters: ServicesFilters) {
     this.selectedServiceGroupId = servicesFilters.service_group_id;
     this.store.dispatch(new UpdateSelectedSG(servicesFilters));
-    document.getElementById('services-panel').focus();
+    document.querySelector<HTMLElement>('app-services-sidebar').focus();
   }
 
   private getSelectedStatus(allParameters: Chicklet[]): RollupServiceStatus {

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -82,11 +82,12 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
     this.serviceGroups$ = this.store.select(allServiceGroups);
 
     this.healthSummary$ = this.store.select(allServiceGroupHealth);
-    this.healthSummary$.subscribe(sgHealthSummary => this.sgHealthSummary = sgHealthSummary);
+    this.healthSummary$.pipe(takeUntil(this.isDestroyed))
+      .subscribe(sgHealthSummary => this.sgHealthSummary = sgHealthSummary);
 
     this.selectedStatus$ = this.store.select(createSelector(serviceGroupState,
       (state) => state.filters.status));
-    this.selectedStatus$.subscribe((status) => {
+    this.selectedStatus$.pipe(takeUntil(this.isDestroyed)).subscribe((status) => {
       // This code enables the pagination of service groups correctly, when the user selects
       // a Health Filter, we adjust the total number of service groups
       if ( includes(status, this.allowedStatus) ) {
@@ -99,19 +100,20 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
     this.selectedFieldDirection$ = this.store.select(createSelector(serviceGroupState,
       (state) => state.filters.sortDirection));
 
-    this.selectedFieldDirection$.subscribe(currentFieldDirection =>
-      this.currentFieldDirection = currentFieldDirection);
+    this.selectedFieldDirection$.pipe(takeUntil(this.isDestroyed))
+      .subscribe(currentFieldDirection => this.currentFieldDirection = currentFieldDirection);
 
     this.selectedSortField$ = this.store.select(createSelector(serviceGroupState,
       (state) => state.filters.sortField));
 
-    this.selectedSortField$.subscribe(currentSortField =>
+    this.selectedSortField$.pipe(takeUntil(this.isDestroyed)).subscribe(currentSortField =>
       this.currentSortField = currentSortField);
 
     this.currentPage$ = this.store.select(createSelector(serviceGroupState,
       (state) => state.filters.page));
 
-    this.currentPage$.subscribe(currentPage => this.currentPage = currentPage);
+    this.currentPage$.pipe(takeUntil(this.isDestroyed))
+      .subscribe(currentPage => this.currentPage = currentPage);
   }
 
   ngOnDestroy() {

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -31,9 +31,6 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   // The selected service-group id that will be sent to the services-sidebar
   public selectedServiceGroupId: number;
 
-  // Weather or not the the services sidebar is visible
-  public servicesSidebarVisible = false;
-
   // The current page the user is visualizing
   public currentPage = 1;
 
@@ -157,15 +154,8 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
       health: 'total'
     };
     this.selectedServiceGroupId = id;
-    this.servicesSidebarVisible = true;
     this.store.dispatch(new UpdateSelectedSG(servicesFilters));
     document.getElementById('services-panel').focus();
-  }
-
-  public closeServicesSidebar() {
-    if (this.servicesSidebarVisible) {
-      this.servicesSidebarVisible = false;
-    }
   }
 
   private getSelectedStatus(allParameters: Chicklet[]): RollupServiceStatus {

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -29,7 +29,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   public sgHealthSummary: HealthSummary;
 
   // The selected service-group id that will be sent to the services-sidebar
-  public selectedServiceGroupId: number;
+  public selectedServiceGroupId: string;
 
   // The current page the user is visualizing
   public currentPage = 1;


### PR DESCRIPTION
### :nut_and_bolt: Description

Reconfigures the *Applications* view to keep the sidebar permanently visible and to serialize its state to the URL.

![](https://user-images.githubusercontent.com/479121/57870931-6481c680-77c5-11e9-8a25-3e7eef6165a1.gif)

### :+1: Definition of Done

- The right hand side bar is persistent. it is visible when you load the apps tab and cannot be hidden
- when I first load the applications tab, the first row on the left side table is selected and the right sidebar is populated with the right data for that row
- persist the state of which row on the left is selected in the URL
- persist the state of which filters are active on the right sidebar in the URL
- persist the state of the pages on the right sidebar in the URL
- when I select a new row on the left table, it resets the state of the sidebar things

### :athletic_shoe: Demo Script / Repro Steps

- Nav to *Applications* view
- See sidebar remain permanently visible
- See sidebar filter/paging state serialized to URL query params

### :chains: Related Resources

https://github.com/chef/automate/issues/185

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
