### PR TITLE
project filtering for stats profiles

### DIFF
--- a/components/compliance-service/api/stats/server/server.go
+++ b/components/compliance-service/api/stats/server/server.go
@@ -94,7 +94,11 @@ func (srv *Server) ReadProfiles(ctx context.Context, in *stats.Query) (*stats.Pr
 	if in.Size == 0 {
 		in.Size = 10000
 	}
-	formattedFilters := formatFilters(in.Filters)
+
+	formattedFilters, err := relaxting.FilterByProjects(ctx, formatFilters(in.Filters))
+	if err != nil {
+		return nil, utils.FormatErrorMsg(err, in.Id)
+	}
 
 	if in.Id != "" {
 		if in.Type == "" {
@@ -113,7 +117,7 @@ func (srv *Server) ReadProfiles(ctx context.Context, in *stats.Query) (*stats.Pr
 			if err != nil {
 				return nil, status.Error(codes.InvalidArgument, err.Error())
 			}
-			controlStats, err := srv.es.GetControlListStatsByProfileId(in.Id, int(from), int(perPage), formattedFilters, sort, order)
+			controlStats, err := srv.es.GetControlListStatsByProfileID(in.Id, int(from), int(perPage), formattedFilters, sort, order)
 			if err != nil {
 				err = utils.FormatErrorMsg(err, "")
 				return nil, err
@@ -177,11 +181,11 @@ func validateTrendData(in *stats.Query, filters map[string][]string) (err error)
 	return nil
 }
 
-func validatePaginationAndSorting(in *stats.Query) (from int32, per_page int32, sort string, asc bool, err error) {
+func validatePaginationAndSorting(in *stats.Query) (from int32, perPage int32, sort string, asc bool, err error) {
 	if in.PerPage == 0 {
 		in.PerPage = 1000
 	}
-	per_page = in.PerPage
+	perPage = in.PerPage
 
 	if in.Page == 0 {
 		in.Page = 1

--- a/components/compliance-service/integration_test/stats_server_read_profiles_test.go
+++ b/components/compliance-service/integration_test/stats_server_read_profiles_test.go
@@ -1,0 +1,459 @@
+package integration_test
+
+import (
+	"testing"
+
+	iam_v2 "github.com/chef/automate/api/interservice/authz/v2"
+	"github.com/chef/automate/components/compliance-service/ingest/events/compliance"
+
+	apiReporting "github.com/chef/automate/components/compliance-service/api/reporting"
+	reportingServer "github.com/chef/automate/components/compliance-service/api/reporting/server"
+	"github.com/chef/automate/components/compliance-service/api/stats"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authzConstants "github.com/chef/automate/components/authz-service/constants/v2"
+	statsServer "github.com/chef/automate/components/compliance-service/api/stats/server"
+	"github.com/chef/automate/components/compliance-service/reporting/relaxting"
+)
+
+var octoberTwentyFifthQuery = stats.Query{
+	Filters: []*stats.ListFilter{
+		{Type: "start_time", Values: []string{"2018-10-24T23:59:59Z"}},
+		{Type: "end_time", Values: []string{"2018-10-25T23:59:59Z"}},
+	},
+}
+
+func TestReadProfilesList(t *testing.T) {
+	statsServer := setupReadProfiles(t)
+	defer suite.DeleteAllDocuments()
+
+	successCases := []struct {
+		description         string
+		allowedProjects     []string
+		expectedProfileList []*stats.ProfileList
+	}{
+		{
+			description:     "Projects: user has access to all projects",
+			allowedProjects: []string{authzConstants.AllProjectsExternalID},
+
+			expectedProfileList: []*stats.ProfileList{{Name: "mylinux-success",
+				Id: "1de944869a847da87d3774feaacb41829935a2f46b558f7fc34b4da21586ae27", Passed: 5}},
+		},
+		{
+			description:     "Projects: user has access to one project with reports",
+			allowedProjects: []string{"project1"},
+
+			expectedProfileList: []*stats.ProfileList{{Name: "mylinux-success",
+				Id: "1de944869a847da87d3774feaacb41829935a2f46b558f7fc34b4da21586ae27", Passed: 2}},
+		},
+		{
+			description:     "Projects: user has access to some projects with reports",
+			allowedProjects: []string{"project1", "project2"},
+
+			expectedProfileList: []*stats.ProfileList{{Name: "mylinux-success",
+				Id: "1de944869a847da87d3774feaacb41829935a2f46b558f7fc34b4da21586ae27", Passed: 4}},
+		},
+		{
+			description:     "Projects: user has access to projects without reports",
+			allowedProjects: []string{"project4", "project5"},
+
+			expectedProfileList: []*stats.ProfileList{},
+		},
+		{
+			description:     "Projects: user has access to one project with reports and unassigned reports",
+			allowedProjects: []string{"project1", authzConstants.UnassignedProjectID},
+
+			expectedProfileList: []*stats.ProfileList{{Name: "mylinux-success",
+				Id: "1de944869a847da87d3774feaacb41829935a2f46b558f7fc34b4da21586ae27", Passed: 3}},
+		},
+		{
+			description:     "Projects: user has access to some projects with reports and unassigned reports",
+			allowedProjects: []string{"project1", "project2", authzConstants.UnassignedProjectID},
+
+			expectedProfileList: []*stats.ProfileList{{Name: "mylinux-success",
+				Id: "1de944869a847da87d3774feaacb41829935a2f46b558f7fc34b4da21586ae27", Passed: 5}},
+		},
+		{
+			description:     "Projects: user has access to projects without reports and unassigned reports",
+			allowedProjects: []string{"project4", "project5", authzConstants.UnassignedProjectID},
+
+			expectedProfileList: []*stats.ProfileList{{Name: "mylinux-success",
+				Id: "1de944869a847da87d3774feaacb41829935a2f46b558f7fc34b4da21586ae27", Passed: 1}},
+		},
+		{
+			description:     "Projects: user has access to unassigned reports",
+			allowedProjects: []string{authzConstants.UnassignedProjectID},
+
+			expectedProfileList: []*stats.ProfileList{{Name: "mylinux-success",
+				Id: "1de944869a847da87d3774feaacb41829935a2f46b558f7fc34b4da21586ae27", Passed: 1}},
+		},
+	}
+
+	for _, test := range successCases {
+		t.Run(test.description, func(t *testing.T) {
+			ctx := contextWithProjects(test.allowedProjects)
+
+			query := octoberTwentyFifthQuery
+
+			response, err := statsServer.ReadProfiles(ctx, &query)
+
+			assert.NoError(t, err)
+			require.NotNil(t, response)
+
+			assert.Equal(t, test.expectedProfileList, response.ProfileList,
+				"No ID passed in Profiles List")
+		})
+	}
+}
+
+func TestReadProfileSummary(t *testing.T) {
+	statsServer := setupReadProfiles(t)
+	defer suite.DeleteAllDocuments()
+
+	successCases := []struct {
+		description            string
+		allowedProjects        []string
+		expectedProfileSummary *stats.ProfileSummary
+	}{
+		{
+			description:     "Projects: user has access to all projects",
+			allowedProjects: []string{authzConstants.AllProjectsExternalID},
+
+			expectedProfileSummary: &stats.ProfileSummary{
+				Name:    "mylinux-success",
+				Version: "1.8.9",
+				Stats: &stats.ProfileSummaryStats{
+					Passed:      5,
+					Failed:      0,
+					Skipped:     0,
+					FailedNodes: 0,
+					TotalNodes:  5,
+				},
+			},
+		},
+		{
+			description:     "Projects: user has access to one project with reports",
+			allowedProjects: []string{"project1"},
+
+			expectedProfileSummary: &stats.ProfileSummary{
+				Name:    "mylinux-success",
+				Version: "1.8.9",
+				Stats: &stats.ProfileSummaryStats{
+					Passed:      2,
+					Failed:      0,
+					Skipped:     0,
+					FailedNodes: 0,
+					TotalNodes:  2,
+				},
+			},
+		},
+		{
+			description:     "Projects: user has access to some projects with reports",
+			allowedProjects: []string{"project1", "project2"},
+
+			expectedProfileSummary: &stats.ProfileSummary{
+				Name:    "mylinux-success",
+				Version: "1.8.9",
+				Stats: &stats.ProfileSummaryStats{
+					Passed:      4,
+					Failed:      0,
+					Skipped:     0,
+					FailedNodes: 0,
+					TotalNodes:  4,
+				},
+			},
+		},
+		{
+			description:     "Projects: user has access to projects without reports",
+			allowedProjects: []string{"project4", "project5"},
+
+			expectedProfileSummary: &stats.ProfileSummary{
+				Name:    "mylinux-success",
+				Version: "1.8.9",
+				Stats: &stats.ProfileSummaryStats{
+					Passed:      0,
+					Failed:      0,
+					Skipped:     0,
+					FailedNodes: 0,
+					TotalNodes:  0,
+				},
+			},
+		},
+		{
+			description:     "Projects: user has access to one project with reports and unassigned reports",
+			allowedProjects: []string{"project1", authzConstants.UnassignedProjectID},
+
+			expectedProfileSummary: &stats.ProfileSummary{
+				Name:    "mylinux-success",
+				Version: "1.8.9",
+				Stats: &stats.ProfileSummaryStats{
+					Passed:      3,
+					Failed:      0,
+					Skipped:     0,
+					FailedNodes: 0,
+					TotalNodes:  3,
+				},
+			},
+		},
+		{
+			description:     "Projects: user has access to some projects with reports and unassigned reports",
+			allowedProjects: []string{"project1", "project2", authzConstants.UnassignedProjectID},
+
+			expectedProfileSummary: &stats.ProfileSummary{
+				Name:    "mylinux-success",
+				Version: "1.8.9",
+				Stats: &stats.ProfileSummaryStats{
+					Passed:      5,
+					Failed:      0,
+					Skipped:     0,
+					FailedNodes: 0,
+					TotalNodes:  5,
+				},
+			},
+		},
+		{
+			description:     "Projects: user has access to projects without reports and unassigned reports",
+			allowedProjects: []string{"project4", "project5", authzConstants.UnassignedProjectID},
+
+			expectedProfileSummary: &stats.ProfileSummary{
+				Name:    "mylinux-success",
+				Version: "1.8.9",
+				Stats: &stats.ProfileSummaryStats{
+					Passed:      1,
+					Failed:      0,
+					Skipped:     0,
+					FailedNodes: 0,
+					TotalNodes:  1,
+				},
+			},
+		},
+		{
+			description:     "Projects: user has access to unassigned reports",
+			allowedProjects: []string{authzConstants.UnassignedProjectID},
+
+			expectedProfileSummary: &stats.ProfileSummary{
+				Name:    "mylinux-success",
+				Version: "1.8.9",
+				Stats: &stats.ProfileSummaryStats{
+					Passed:      1,
+					Failed:      0,
+					Skipped:     0,
+					FailedNodes: 0,
+					TotalNodes:  1,
+				},
+			},
+		},
+	}
+
+	for _, test := range successCases {
+		t.Run(test.description, func(t *testing.T) {
+			ctx := contextWithProjects(test.allowedProjects)
+
+			query := octoberTwentyFifthQuery
+
+			query.Type = "summary"
+			query.Id = "1de944869a847da87d3774feaacb41829935a2f46b558f7fc34b4da21586ae27"
+
+			response, err := statsServer.ReadProfiles(ctx, &query)
+
+			assert.NoError(t, err)
+			require.NotNil(t, response)
+
+			assert.Equal(t, test.expectedProfileSummary.Stats.Passed, response.ProfileSummary.Stats.Passed,
+				"No ID passed in Profiles List")
+
+			assert.Equal(t, test.expectedProfileSummary.Stats.Failed, response.ProfileSummary.Stats.Failed,
+				"No ID Failed in Profiles List")
+		})
+	}
+}
+
+func TestReadProfilesControlStats(t *testing.T) {
+	statsServer := setupReadProfiles(t)
+	defer suite.DeleteAllDocuments()
+
+	successCases := []struct {
+		description          string
+		allowedProjects      []string
+		expectedControlStats []*stats.ControlStats
+	}{
+		{
+			description:     "Projects: user has access to all projects",
+			allowedProjects: []string{authzConstants.AllProjectsExternalID},
+
+			expectedControlStats: []*stats.ControlStats{{
+				Control: "/etc/passwd must exist",
+				Title:   "Checking for /etc/passwd",
+				Passed:  5,
+				Failed:  0,
+				Skipped: 0,
+				Impact:  0.6,
+			}},
+		},
+		{
+			description:     "Projects: user has access to one project with reports",
+			allowedProjects: []string{"project1"},
+
+			expectedControlStats: []*stats.ControlStats{{
+				Control: "/etc/passwd must exist",
+				Title:   "Checking for /etc/passwd",
+				Passed:  2,
+				Failed:  0,
+				Skipped: 0,
+				Impact:  0.6,
+			}},
+		},
+		{
+			description:     "Projects: user has access to some projects with reports",
+			allowedProjects: []string{"project1", "project2"},
+
+			expectedControlStats: []*stats.ControlStats{{
+				Control: "/etc/passwd must exist",
+				Title:   "Checking for /etc/passwd",
+				Passed:  4,
+				Failed:  0,
+				Skipped: 0,
+				Impact:  0.6,
+			}},
+		},
+		{
+			description:          "Projects: user has access to projects without reports",
+			allowedProjects:      []string{"project4", "project5"},
+			expectedControlStats: []*stats.ControlStats{},
+		},
+		{
+			description:     "Projects: user has access to one project with reports and unassigned reports",
+			allowedProjects: []string{"project1", authzConstants.UnassignedProjectID},
+
+			expectedControlStats: []*stats.ControlStats{{
+				Control: "/etc/passwd must exist",
+				Title:   "Checking for /etc/passwd",
+				Passed:  3,
+				Failed:  0,
+				Skipped: 0,
+				Impact:  0.6,
+			}},
+		},
+		{
+			description:     "Projects: user has access to some projects with reports and unassigned reports",
+			allowedProjects: []string{"project1", "project2", authzConstants.UnassignedProjectID},
+
+			expectedControlStats: []*stats.ControlStats{{
+				Control: "/etc/passwd must exist",
+				Title:   "Checking for /etc/passwd",
+				Passed:  5,
+				Failed:  0,
+				Skipped: 0,
+				Impact:  0.6,
+			}},
+		},
+		{
+			description:     "Projects: user has access to projects without reports and unassigned reports",
+			allowedProjects: []string{"project4", "project5", authzConstants.UnassignedProjectID},
+
+			expectedControlStats: []*stats.ControlStats{{
+				Control: "/etc/passwd must exist",
+				Title:   "Checking for /etc/passwd",
+				Passed:  1,
+				Failed:  0,
+				Skipped: 0,
+				Impact:  0.6,
+			}},
+		},
+		{
+			description:     "Projects: user has access to unassigned reports",
+			allowedProjects: []string{authzConstants.UnassignedProjectID},
+
+			expectedControlStats: []*stats.ControlStats{{
+				Control: "/etc/passwd must exist",
+				Title:   "Checking for /etc/passwd",
+				Passed:  1,
+				Failed:  0,
+
+				Skipped: 0,
+				Impact:  0.6,
+			}},
+		},
+	}
+
+	for _, test := range successCases {
+		t.Run(test.description, func(t *testing.T) {
+			ctx := contextWithProjects(test.allowedProjects)
+
+			query := octoberTwentyFifthQuery
+
+			query.Type = "controls"
+			query.Id = "1de944869a847da87d3774feaacb41829935a2f46b558f7fc34b4da21586ae27"
+
+			response, err := statsServer.ReadProfiles(ctx, &query)
+
+			assert.NoError(t, err)
+			require.NotNil(t, response)
+
+			assert.Equal(t, test.expectedControlStats, response.ControlStats,
+				"No ID passed in Profiles List")
+		})
+	}
+}
+
+func setupReadProfiles(t *testing.T) *statsServer.Server {
+	reportFileName := "../ingest/examples/compliance-success-tiny-report.json"
+	everythingCtx := contextWithProjects([]string{authzConstants.AllProjectsExternalID})
+	statsServer := statsServer.New(&relaxting.ES2Backend{ESUrl: elasticsearchUrl})
+	reportingServer := reportingServer.New(&relaxting.ES2Backend{ESUrl: elasticsearchUrl})
+	n := 5
+	reportIds := make([]string, n)
+	for i := 0; i < n; i++ {
+		err := suite.ingestReport(reportFileName, func(r *compliance.Report) {
+			id := newUUID()
+
+			r.Environment = id
+			r.NodeName = id
+			r.NodeUuid = id
+			r.Platform.Name = id
+			r.Profiles[0].Controls = r.Profiles[0].Controls[:1]
+			r.Profiles = r.Profiles[:1]
+			r.Profiles[0].Title = id
+			r.Recipes = []string{id}
+			r.ReportUuid = id
+			r.Roles = []string{id}
+
+			reportIds[i] = id
+		})
+
+		require.NoError(t, err)
+	}
+	waitFor(func() bool {
+		response, _ := reportingServer.ListReports(everythingCtx, &apiReporting.Query{})
+
+		return response != nil && len(response.Reports) == n
+	})
+	reportsProjects := map[string][]string{
+		"project1": reportIds[1:3],
+		"project2": reportIds[2:5],
+		"project3": reportIds[3:],
+	}
+	projectRules := map[string]*iam_v2.ProjectRules{}
+	for k, v := range reportsProjects {
+		projectRules[k] = &iam_v2.ProjectRules{
+			Rules: []*iam_v2.ProjectRule{
+				{
+					Conditions: []*iam_v2.Condition{
+						{
+							Type:   iam_v2.ProjectRuleConditionTypes_ROLES,
+							Values: v,
+						},
+					},
+				},
+			},
+		}
+	}
+	// Send a project rules update event
+	esJobID, err := suite.ingesticESClient.UpdateReportProjectsTags(everythingCtx, projectRules)
+	assert.Nil(t, err)
+	suite.WaitForESJobToComplete(esJobID)
+	suite.RefreshComplianceReportIndex()
+	return statsServer
+}

--- a/components/compliance-service/integration_test/suite_test.go
+++ b/components/compliance-service/integration_test/suite_test.go
@@ -160,7 +160,6 @@ func (s *Suite) ingestReport(fileName string, f func(*compliance.Report)) error 
 
 func waitFor(f func() bool) {
 	period := time.Millisecond * 10
-
 	for {
 		if f() {
 			break

--- a/components/compliance-service/reporting/relaxting/profiles.go
+++ b/components/compliance-service/reporting/relaxting/profiles.go
@@ -329,7 +329,7 @@ func (backend ES2Backend) GetProfileSummaryByProfileId(profileId string, filters
 	}
 
 	// We are not filtering by ProfileID, we are passing it in as a uri resource.
-	//filtQuery := backend.getFiltersQuery(filters)
+	filtQuery := backend.getFiltersQuery(filters, false)
 
 	profileIDQuery := elastic.NewTermQuery("profiles.sha256", profileId)
 
@@ -337,6 +337,7 @@ func (backend ES2Backend) GetProfileSummaryByProfileId(profileId string, filters
 	reportIdsAndProfileIDQuery = reportIdsAndProfileIDQuery.Must(profileIDQuery)
 
 	profilesMinQuery := elastic.NewNestedQuery("profiles", reportIdsAndProfileIDQuery)
+	filtQuery = filtQuery.Must(profilesMinQuery)
 
 	passedFilterAgg := elastic.NewFilterAggregation().Filter(
 		elastic.NewTermQuery("profiles.controls.status", "passed"))
@@ -358,7 +359,7 @@ func (backend ES2Backend) GetProfileSummaryByProfileId(profileId string, filters
 	profilesAgg.SubAggregation("profiles_filter", profilesFilter)
 
 	searchSource := elastic.NewSearchSource().
-		Query(profilesMinQuery).
+		Query(filtQuery).
 		Aggregation("profiles", profilesAgg).
 		Size(0)
 

--- a/components/compliance-service/reporting/relaxting/stats.go
+++ b/components/compliance-service/reporting/relaxting/stats.go
@@ -50,6 +50,7 @@ func (backend ES2Backend) GetStatsSummary(filters map[string][]string) (*stats.R
 	return depth.getStatsSummaryResult(searchResult), nil
 }
 
+//GetStatsSummaryNodes - Gets summary stats, node centric, aggregate data for the given set of filters
 func (backend ES2Backend) GetStatsSummaryNodes(filters map[string][]string) (*stats.NodeSummary, error) {
 	myName := "GetStatsSummaryNodes"
 	depth, err := backend.NewDepth(filters, false, true)
@@ -88,6 +89,7 @@ func (backend ES2Backend) GetStatsSummaryNodes(filters map[string][]string) (*st
 	return depth.getStatsSummaryNodesResult(searchResult), nil
 }
 
+//GetStatsSummaryControls - Gets summary stats, control centric, aggregate data for the given set of filters
 func (backend ES2Backend) GetStatsSummaryControls(filters map[string][]string) (*stats.ControlsSummary, error) {
 	myName := "GetStatsSummaryControls"
 
@@ -127,6 +129,7 @@ func (backend ES2Backend) GetStatsSummaryControls(filters map[string][]string) (
 	return depth.getStatsSummaryControlsResult(searchResult), nil
 }
 
+//GetStatsFailures - Gets top failures, aggregate data for the given set of filters
 func (backend ES2Backend) GetStatsFailures(reportTypes []string, size int, filters map[string][]string) (*stats.Failures, error) {
 	myName := "GetStatsFailures"
 	var failures *stats.Failures
@@ -222,17 +225,17 @@ func (backend ES2Backend) GetProfileListWithAggregatedComplianceSummaries(
 	return depth.getProfileListWithAggregatedComplianceSummariesResults(searchResult, filters), nil
 }
 
-//GetControlListStatsByProfileId returns the control list for a given profile or profile and a child control
+//GetControlListStatsByProfileID returns the control list for a given profile or profile and a child control
 // the data retrieved from this appears at the bottom of the a2 page when you select a profile from list
-func (backend ES2Backend) GetControlListStatsByProfileId(profileId string, from int, size int,
+func (backend ES2Backend) GetControlListStatsByProfileID(profileID string, from int, size int,
 	filters map[string][]string, sortField string, sortAsc bool) ([]*stats.ControlStats, error) {
-	myName := "GetControlListStatsByProfileId"
+	myName := "GetControlListStatsByProfileID"
 
 	//deep filtering uses the filter contents to determine which Depth will be retrieved from the factory
-	// in the case of this func, we may not have the profileId in the filters. We will add it now if not,
+	// in the case of this func, we may not have the profileID in the filters. We will add it now if not,
 	// which will allow the abstract factory to do the right thing.
-	// There should only be one profileId in the filters and it must be identical to the profileId being passed in.
-	filters["profile_id"] = []string{profileId}
+	// There should only be one profileID in the filters and it must be identical to the profileID being passed in.
+	filters["profile_id"] = []string{profileID}
 
 	depth, err := backend.NewDepth(filters, false, true)
 	if err != nil {
@@ -267,5 +270,5 @@ func (backend ES2Backend) GetControlListStatsByProfileId(profileId string, from 
 
 	LogQueryPartMin(queryInfo.esIndex, searchResult.Aggregations, fmt.Sprintf("%s searchResult aggs", myName))
 
-	return depth.getControlListStatsByProfileIdResults(&backend, searchResult, profileId)
+	return depth.getControlListStatsByProfileIdResults(&backend, searchResult, profileID)
 }


### PR DESCRIPTION
Signed-off-by: Rick Marry <rmarry@chef.io>

### :nut_and_bolt: Description

Adding project filtering for the stats.proto ReadProfiles RPC.

### :chains: Related Resources

https://github.com/chef/automate/issues/67

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
