### PR TITLE
Adding project filtering to GetEventStringBuckets

### DIFF
--- a/components/config-mgmt-service/grpcserver/event_feed.go
+++ b/components/config-mgmt-service/grpcserver/event_feed.go
@@ -173,6 +173,11 @@ func (s *CfgMgmtServer) GetEventStringBuckets(ctx context.Context, request *requ
 		return &response.EventStrings{}, errors.GrpcErrorFromErr(codes.InvalidArgument, err)
 	}
 
+	filters, err = filterByProjects(ctx, filters)
+	if err != nil {
+		return &response.EventStrings{}, errors.GrpcErrorFromErr(codes.Internal, err)
+	}
+
 	// Create the three strings
 	for i, task := range tasksMap {
 		eventString, err := s.client.GetEventString(


### PR DESCRIPTION
### :nut_and_bolt: Description

Adding project filtering for the event_feed.proto GetEventStringBuckets RPC.

### :chains: Related Resources

https://github.com/chef/automate/issues/69

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?