### PR TITLE
[A2-839] Remove duplicates from IAM roles table in DB

### DIFF
--- a/components/authz-service/storage/postgres/datamigration/sql/06_v2_roles.up.sql
+++ b/components/authz-service/storage/postgres/datamigration/sql/06_v2_roles.up.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+UPDATE iam_roles
+    SET
+        actions = '{
+            secrets:*:get,
+            secrets:*:list,
+            infra:*:get,
+            infra:*:list,
+            compliance:*:get,
+            compliance:*:list,
+            system:*:get,
+            system:*:list,
+            event:*:get,
+            event:*:list,
+            ingest:*:get,
+            ingest:*:list,
+            iam:projects:list,
+            iam:projects:get
+        }'
+    WHERE
+        id = 'viewer';
+
+COMMIT;


### PR DESCRIPTION
### :nut_and_bolt: Description

In a recent migration we used the convenient add-to-array syntax of PSQL:
```
actions = actions || '{ secrets:*:get, secrets:*:list }'
```
Unfortunately, that resulted in duplicates of those entries.
![image](https://user-images.githubusercontent.com/6817500/57891089-f651f980-77ee-11e9-8224-fce71819e1bc.png)


This PR remove the duplicates by resetting the list.

### :+1: Definition of Done

Above actions only appear once in the DB.

### :athletic_shoe: Demo Script / Repro Steps

In the authz database:
```
SELECT * FROM iam_roles WHERE id = 'viewer';
```
From the command-line:
```
a2 -2 -o roles id viewer
```
or, in long-hand:
```
curl -sSkH "api-token: $TOK" "https://a2-dev.test/apis/iam/v2beta/roles" | \
jq -c '.roles[] | select (.id == "viewer")'
```

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
