### PR TITLE
nodes: filtering by multiple tags

### DIFF
--- a/components/compliance-service/api/tests/30_jobs_docker_spec.rb
+++ b/components/compliance-service/api/tests/30_jobs_docker_spec.rb
@@ -664,7 +664,7 @@ describe File.basename(__FILE__) do
       Common::Filter.new(key: "environment", values: ["trou"]),
       Common::Filter.new(key: "group", values: ["mak", "do"])
     ])
-    assert_equal(1, filtered_nodes_by_tags.total)
+    assert_equal(2, filtered_nodes_by_tags.total)
   end
 
   it "does not include deleted jobs in job list" do

--- a/components/nodemanager-service/pgdb/filtering.go
+++ b/components/nodemanager-service/pgdb/filtering.go
@@ -38,16 +38,20 @@ func mergeFilters(mergeableFilters []*common.Filter) ([]common.Filter, error) {
 	return filters, nil
 }
 
-func handleTagFilters(filter common.Filter) (string, error) {
-	tagKeyFilter := strings.TrimPrefix(filter.Key, "tags:")
-	newTagCondition, err := wherePatternMatchTags(tagKeyFilter, filter.Values, "t")
-	if err != nil {
-		return "", errors.Wrap(err, "buildWhereFilter error")
+func handleTagFilters(tagFilters []common.Filter) (string, error) {
+	var tagConditions []string
+	for _, filter := range tagFilters {
+		tagKeyFilter := strings.TrimPrefix(filter.Key, "tags:")
+		newTagCondition, err := wherePatternMatchTags(tagKeyFilter, filter.Values, "t")
+		if err != nil {
+			return "", errors.Wrap(err, "buildWhereFilter error")
+		}
+		if filter.Exclude {
+			newTagCondition = fmt.Sprintf("NOT (%s)", newTagCondition)
+		}
+		tagConditions = append(tagConditions, newTagCondition)
 	}
-	if filter.Exclude {
-		newTagCondition = fmt.Sprintf("NOT (%s)", newTagCondition)
-	}
-	return newTagCondition, nil
+	return strings.Join(tagConditions, " OR "), nil
 }
 
 // Takes a filter map (should be validated for content) and table abbreviation and returns a wherefilter
@@ -62,16 +66,12 @@ func buildWhereFilter(mergeableFilters []*common.Filter, tableAbbrev string, fil
 	}
 
 	var conditions []string
-	var oRConditionsForTags []string
+	var tagFilters []common.Filter
 	for _, filter := range filters {
 		var newCondition string
 		var err error
 		if strings.HasPrefix(filter.Key, "tags:") {
-			newTagCondition, err := handleTagFilters(filter)
-			if err != nil {
-				return "", errors.Wrap(err, "buildWhereFilter error build tag filters")
-			}
-			oRConditionsForTags = append(oRConditionsForTags, newTagCondition)
+			tagFilters = append(tagFilters, filter)
 			continue
 		} else {
 			switch filterField[filter.Key] {
@@ -101,15 +101,15 @@ func buildWhereFilter(mergeableFilters []*common.Filter, tableAbbrev string, fil
 		conditions = append(conditions, newCondition)
 	}
 
-	if len(oRConditionsForTags) == 0 {
-		whereFilter = fmt.Sprintf("WHERE (%s)", strings.Join(conditions, " AND "))
-	} else {
-		if len(conditions) > 0 {
-			whereFilter = fmt.Sprintf("WHERE (%s AND %s)", strings.Join(conditions, " AND "), strings.Join(oRConditionsForTags, " OR "))
-		} else {
-			whereFilter = fmt.Sprintf("WHERE (%s)", strings.Join(oRConditionsForTags, " OR "))
+	if len(tagFilters) > 0 {
+		tagCondition, err := handleTagFilters(tagFilters)
+		if err != nil {
+			return "", errors.Wrap(err, "buildWhereFilter error building tags")
 		}
+		conditions = append(conditions, tagCondition)
 	}
+
+	whereFilter = fmt.Sprintf("WHERE (%s)", strings.Join(conditions, " AND "))
 	logrus.Debugf("buildWhereFilter, whereFilter=%s", whereFilter)
 	return whereFilter, nil
 }


### PR DESCRIPTION
### :nut_and_bolt: Description
fixes https://github.com/chef/automate/issues/370

When creating a scan job, and filtering by tag values for the Automate node manager, we are currently unable to filter by multiple tags.

### :+1: Definition of Done
Able to filter nodes by multiple tags (Automate nodemanager)

### :athletic_shoe: Demo Script / Repro Steps
rebuild nodemanager
create some nodes with different tags
create a scan job filtering by those tags
