### PR TITLE
Clean up data before test

### DIFF
--- a/e2e/cypress/integration/02_global_filter.spec.js
+++ b/e2e/cypress/integration/02_global_filter.spec.js
@@ -9,31 +9,14 @@ describe('global projects filter', () => {
   before(() => {
     cy.adminLogin('/').then(() => {
       let admin = JSON.parse(localStorage.getItem('chef-automate-user'))
-
+      cy.cleanupProjects(admin.id_token)
       cy.createProject(admin.id_token, proj1)
       cy.createProject(admin.id_token, proj2)
       cy.createProject(admin.id_token, proj3)
-      // TODO uncomment with non-admin test
+      // TODO uncomment with non-admin test/ move up project creation
       // cy.createUser(admin.id_token, nonAdminUsername)
       // cy.createPolicy(admin.id_token, pol_id, nonAdminUsername, [proj1, proj2])
       cy.logout()
-    })
-  })
-
-  after(() => {
-    cy.adminLogin('/').then(() => {
-      let admin = JSON.parse(localStorage.getItem('chef-automate-user'))
-      cy.cleanupProjects(admin.id_token)
-      // TODO uncomment with non-admin test
-      // cy.cleanupUsers(admin.id_token)
-      // cy.request({
-      //   auth: { bearer: admin.id_token },
-      //   method: 'DELETE',
-      //   url: `/apis/iam/v2beta/policies/${pol_id}`,
-      //   failOnStatusCode: false
-      // }).then((response) => {
-      //   expect([200, 404]).to.include(response.status)
-      // })
     })
   })
 

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -97,14 +97,12 @@ Cypress.Commands.add("cleanupProjects", (id_token) => {
     failOnStatusCode: false
   }).then((resp) => {
     for (let project of resp.body.projects) {
-      if (project.id.startsWith('cypress')) {
-        cy.request({
-          auth: { bearer: id_token },
-          method: 'DELETE',
-          url: `/apis/iam/v2beta/projects/${project.id}`,
-          failOnStatusCode: false
-        })
-      }
+      cy.request({
+        auth: { bearer: id_token },
+        method: 'DELETE',
+        url: `/apis/iam/v2beta/projects/${project.id}`,
+        failOnStatusCode: false
+      })
     }
   })
 })


### PR DESCRIPTION
### :nut_and_bolt: Description

This test was hitting our precondition that only 6 projects exist-- when we attempted to create data for this test, it collided with 4 existing projects on the `inplace` box.

I don't see those projects being created programmatically in our code, so I'm assuming someone did it manually? 

JIC, we're now blowing away existing projects before running the test. This should be less troublesome when we remove the precondition. 