### PR TITLE
[A2-763] Hide "Access Management" on sidebar

### DIFF
--- a/components/automate-ui/src/app/components/admin-sidebar/admin-sidebar.component.html
+++ b/components/automate-ui/src/app/components/admin-sidebar/admin-sidebar.component.html
@@ -26,7 +26,7 @@
       <chef-sidebar-entry route="/settings/tokens" icon="vpn_key">API Tokens</chef-sidebar-entry>
     </app-authorized>
 
-    <div *ngIf="(iamMajorVersion$ | async) === 'v2'">
+    <div *ngIf="(iamMajorVersion$ | async) !== 'v1'">
       <div class="group" *ngIf="policies.visible || roles.visible || projects.visible && (iamMinorVersion$ | async) === 'v1'">Access Management</div>
       <app-authorized #policies [allOf]="['/iam/v2beta/policies', 'get']">
         <chef-sidebar-entry route="/settings/policies" icon="security">Policies</chef-sidebar-entry>

--- a/components/automate-ui/src/app/components/admin-sidebar/admin-sidebar.component.html
+++ b/components/automate-ui/src/app/components/admin-sidebar/admin-sidebar.component.html
@@ -27,7 +27,7 @@
     </app-authorized>
 
     <div *ngIf="(iamMajorVersion$ | async) !== 'v1'">
-      <div class="group" *ngIf="policies.visible || roles.visible || projects.visible && (iamMinorVersion$ | async) === 'v1'">Access Management</div>
+      <div class="group" *ngIf="policies.visible || roles.visible || (projects.visible && (iamMinorVersion$ | async) === 'v1')">Access Management</div>
       <app-authorized #policies [allOf]="['/iam/v2beta/policies', 'get']">
         <chef-sidebar-entry route="/settings/policies" icon="security">Policies</chef-sidebar-entry>
       </app-authorized>

--- a/components/automate-ui/src/app/components/admin-sidebar/admin-sidebar.component.html
+++ b/components/automate-ui/src/app/components/admin-sidebar/admin-sidebar.component.html
@@ -26,8 +26,8 @@
       <chef-sidebar-entry route="/settings/tokens" icon="vpn_key">API Tokens</chef-sidebar-entry>
     </app-authorized>
 
-    <div *ngIf="(iamMajorVersion$ | async) !== 'v1'">
-      <div class="group" *ngIf="policies.visible || roles.visible || projects.visible">Access Management</div>
+    <div *ngIf="(iamMajorVersion$ | async) === 'v2'">
+      <div class="group" *ngIf="policies.visible || roles.visible || projects.visible && (iamMinorVersion$ | async) === 'v1'">Access Management</div>
       <app-authorized #policies [allOf]="['/iam/v2beta/policies', 'get']">
         <chef-sidebar-entry route="/settings/policies" icon="security">Policies</chef-sidebar-entry>
       </app-authorized>


### PR DESCRIPTION
### :nut_and_bolt: Description

Previously, if logged in as an "Editor" on 2.0, we were seeing the "Access Management" title in the sidebar without any subcategories.

With this change, an Editor does not see the title on 2.0. However, on 2.1, the editor can see both the title and "Projects" underneath. 

On 2.0:
<img width="1059" alt="Screen Shot 2019-05-17 at 1 58 55 PM" src="https://user-images.githubusercontent.com/24259050/57955956-290df780-78ac-11e9-9405-99f9ec13a5f3.png">

On 2.1:
<img width="1060" alt="Screen Shot 2019-05-17 at 1 58 29 PM" src="https://user-images.githubusercontent.com/24259050/57955916-0aa7fc00-78ac-11e9-883f-35f479caaf22.png">


