### PR TITLE
Fix bug where css variable nesting was broken

### DIFF
--- a/components/chef-ui-library/src/atoms/chef-input/chef-input.scss
+++ b/components/chef-ui-library/src/atoms/chef-input/chef-input.scss
@@ -8,7 +8,7 @@ chef-input {
   display: inline-block;
 
   &.focused {
-    border-color: var(--focus-border-color), var(--default-focus-border);
+    border-color: var(--focus-border-color, var(--default-focus-border));
   }
 
   input {

--- a/components/chef-ui-library/src/atoms/chef-loading-spinner/chef-loading-spinner.scss
+++ b/components/chef-ui-library/src/atoms/chef-loading-spinner/chef-loading-spinner.scss
@@ -31,6 +31,6 @@ chef-loading-spinner[fixed] {
   left: 0;
   right: 0;
   bottom: 0;
-  background: chef-hsla(var(--chef-grey), 0.65);
+  background: var(--chef-loading-bg-color);
   z-index: 200;
 }

--- a/components/chef-ui-library/src/atoms/chef-tooltip/chef-tooltip.scss
+++ b/components/chef-ui-library/src/atoms/chef-tooltip/chef-tooltip.scss
@@ -28,7 +28,7 @@ chef-tooltip {
   }
 
   &.top {
-    transform: translate(-50%), calc(-100% - 0.75em);
+    transform: translate(-50%, calc(-100% - 0.75em));
 
     &::after {
       left: 50%;

--- a/components/chef-ui-library/src/global/variables.css
+++ b/components/chef-ui-library/src/global/variables.css
@@ -52,6 +52,11 @@
 
   /* misc */
   --chef-border-radius: 4px;
-  --chef-box-shadow: 0 0 12px 0 var(--chef-dark-grey);
+  --chef-box-shadow: 0 0 12px 0 rgba(110, 119, 119, 0.2);
+
+  /* based on chef-primary-dark 0.4 opacity. */
+  --chef-modal-bg-color: rgba(34, 36, 53, 0.4);
+    /* based on chef-gray 0.65 opacity. */
+  --chef-loading-bg-color: rgba(224, 228, 230, 0.65);
 }
 

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.scss
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.scss
@@ -12,7 +12,7 @@ chef-modal {
     z-index: 1000;
     width: 100%;
     height: 100%;
-    background-color: chef-hsla(var(--chef-primary-dark), 0.4);
+    background-color: var(--chef-modal-bg-color);
   }
 
   .modal {
@@ -27,7 +27,7 @@ chef-modal {
     padding: 30px;
 
     #{--default-modal-width}: 700px;
-    width: var(--modal-width), var(--default-modal-width);
+    width: var(--modal-width, var(--default-modal-width));
 
     .close {
       position: absolute;
@@ -38,7 +38,7 @@ chef-modal {
 
     [slot=title] {
       #{--default-title-size}: 24px;
-      font-size: var(--title-size), var(--default-title-size);
+      font-size: var(--title-size, var(--default-title-size));
     }
   }
 }

--- a/components/chef-ui-library/src/molecules/chef-status-filter-group/chef-status-filter-group.scss
+++ b/components/chef-ui-library/src/molecules/chef-status-filter-group/chef-status-filter-group.scss
@@ -1,5 +1,5 @@
 chef-status-filter-group {
-  --active-color: var(--toggle-active-color), var(--chef-primary-bright);
+  --active-color: var(--toggle-active-color, var(--chef-primary-bright));
   display: flex;
 
   .filter {

--- a/components/chef-ui-library/src/molecules/chef-toggle/chef-toggle.scss
+++ b/components/chef-ui-library/src/molecules/chef-toggle/chef-toggle.scss
@@ -2,8 +2,8 @@ chef-toggle {
   #{--default-active-color}: var(--chef-white);
   #{--default-active-background-color}: var(--chef-primary-bright);
 
-  #{--active-color}: var(--toggle-active-color), var(--default-active-color);
-  #{--active-background-color}: var(--toggle-active-background-color), var(--default-active-background-color);
+  #{--active-color}: var(--toggle-active-color, var(--default-active-color));
+  #{--active-background-color}: var(--toggle-active-background-color, var(--default-active-background-color));
 
   display: inline-flex;
   background-color: var(--chef-white);


### PR DESCRIPTION
### :nut_and_bolt: Description

This commit https://github.com/chef/automate/commit/58632b31856c8fb1dca13f1b323b197cb0dc3d2a#diff-c206cc432a36a0164b93bff1503dc802L30 accidentally changed css variable nesting incorrectly in a few spots from this:

`var(--non-default, var(--default));`

To this improper format:

`var(--non-default), var(--default);`

I've fixed it in all the places I found in that commit.

![Screen Shot 2019-05-17 at 3 21 50 PM](https://user-images.githubusercontent.com/1899715/57959353-3a5d0100-78b8-11e9-9fd0-f6ed32ec8a99.png)

![Screen Shot 2019-05-17 at 3 26 47 PM](https://user-images.githubusercontent.com/1899715/57959354-4052e200-78b8-11e9-881c-2471b3e00dd9.png)

![Screen Shot 2019-05-17 at 3 35 07 PM](https://user-images.githubusercontent.com/1899715/57959591-6af16a80-78b9-11e9-95ad-971a78a15424.png)

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
