### PR TITLE
cypress: wait for introspect 'some' before moving on

### DIFF
--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -15,9 +15,9 @@ Cypress.Commands.add("restoreStorage", () => {
     localStorage.setItem(key, LOCAL_STORAGE_MEMORY[key]);
   });
   Object.keys(SESSION_MEMORY).forEach(key => {
-	  sessionStorage.setItem(key, SESSION_MEMORY[key]);
+    sessionStorage.setItem(key, SESSION_MEMORY[key]);
   });
-  
+
   cy.server()
   // mock refresh token call in case it fails
   let user = JSON.parse(localStorage.getItem('chef-automate-user'))
@@ -41,6 +41,8 @@ Cypress.Commands.add("login", (url, username) => {
   cy.visit(url)
   cy.get('button').contains('Log in with Username').click().then(() => {
     cy.url().should('include', '/dex/auth/')
+    cy.server()
+    cy.route('POST', '/api/v0/auth/introspect_some').as('getAuth')
 
     // login
     cy.get('#login')
@@ -51,10 +53,12 @@ Cypress.Commands.add("login", (url, username) => {
 
     cy.get('[type=submit]').click().then(() => {
       expect(localStorage.getItem('chef-automate-user')).to.contain(username)
-    
+
       // close welcome modal if present
       cy.get('app-welcome-modal').invoke('hide')
       cy.saveStorage()
+
+      cy.wait('@getAuth')
     })
   })
 })


### PR DESCRIPTION
See if this helps the compliance cypress test to stop timing out. 

* https://buildkite.com/chef/chef-automate-master-deploy-dev/builds/216#b0f7117e-f8aa-4140-a902-4c29123523df
* https://buildkite.com/chef/chef-automate-master-deploy-dev/builds/217#22785621-f911-4b87-87b5-2a9ddc74ebbb
