### PR TITLE
Adding a retry to the cypress tests

### DIFF
--- a/.expeditor/deploy.pipeline.yml
+++ b/.expeditor/deploy.pipeline.yml
@@ -28,6 +28,9 @@ steps:
 
   - label: ":cypress:"
     command: .expeditor/buildkite/cypress.sh
+    retry:
+      automatic:
+        limit: 1
     concurrency: 1
     concurrency_group: chef-automate-master/deploy/$CHANNEL
     timeout_in_minutes: 30


### PR DESCRIPTION
Adding a retry to the cypress tests. We are seeing some compliance tests are randomly failing from timeouts. The guess is that they might be timing out because the servers they are testing on are restarting their services. 

* https://buildkite.com/chef/chef-automate-master-deploy-dev/builds/216#b0f7117e-f8aa-4140-a902-4c29123523df
* https://buildkite.com/chef/chef-automate-master-deploy-dev/builds/217#_
