### PR TITLE
Add projects to permission-based routing of Settings tab

### DIFF
--- a/components/automate-ui/src/app/components/admin-sidebar/admin-sidebar.component.spec.ts
+++ b/components/automate-ui/src/app/components/admin-sidebar/admin-sidebar.component.spec.ts
@@ -63,6 +63,7 @@ describe('AdminSidebarComponent', () => {
   describe('IAM v2', () => {
     beforeEach(() => {
       component.iamMajorVersion$ = observableOf('v2');
+      component.iamMinorVersion$ = observableOf('v1');
     });
 
     it('shows all links consistent with settings-landing', () => {

--- a/components/automate-ui/src/app/pages/settings-landing/settings-landing.component.ts
+++ b/components/automate-ui/src/app/pages/settings-landing/settings-landing.component.ts
@@ -21,9 +21,8 @@ export class SettingsLandingComponent {
       route: '/settings/tokens'
     },
     { allOfCheck: [['/iam/v2beta/policies', 'get', '']], route: '/settings/policies' },
-    { allOfCheck: [['/iam/v2beta/roles', 'get', '']], route: '/settings/roles' }
-    // TODO: include when feature flag turned off:
-    // { allOfCheck: [['/iam/v2beta/projects', 'get', '']], route: '/settings/projects' }
+    { allOfCheck: [['/iam/v2beta/roles', 'get', '']], route: '/settings/roles' },
+    { allOfCheck: [['/iam/v2beta/projects', 'get', '']], route: '/settings/projects' }
   ];
 
 }


### PR DESCRIPTION
### :nut_and_bolt: Description

Takes care of a "TODO" in SettingsLanding component necessary to making routing fully correct once projects are enabled (with IAM v2.1).

When a user selects the Settings tab, the SettingsLanding component is responsible for taking the user to the first page he/she has permission to visit. The set of possible pages is defined by the admin sidebar, where the order of appearance determines the order of possible landing.
The first couple entries in the admin sidebar are Notifications and Node Integrations. Thus, if the user does not have permission for Notifications, it will be passed over. If the user does have permission for Node Integrations, that page will be visited.
Projects, as it happens, is the very last item in the list, so this change really only covers the case of a user having no permissions for anything in the admin sidebar except projects.

Notice: technically, the SettingsLanding component is not quite correct. Projects only exists in v2.1 but if it gets there (meaning no permissions for anything else) then projects will still be checked _even in v2.0_. Of course, there is only the remotest possibility that there would be a policy giving permission for it in v2.0, so I judge that it does not do a version check to be acceptable. (Also, I started a spike to see about adding version-awareness to SettingsLanding and it got too convoluted to be worth it--https://github.com/chef/automate/compare/ms/settings-landing-spike?expand=1). Furthermore, we have not been distinguishing v1 from v2 in SettingsLanding component for some time, and it has not caused any consternation.

### :+1: Definition of Done

Projects page will be landed on upon selecting `Settings` tab if the user has no permissions for any other pages in the admin sidebar.

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
