### PR TITLE
UI-272 Mini Donut Charts EAS Table Signed-off-by: Tara Black <ttblack…

### DIFF
--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -56,10 +56,29 @@
         (click)="openServicesSidebar(serviceGroup.id)"
         *ngFor="let serviceGroup of serviceGroups$ | async">
         <chef-td class="{{serviceGroup.status}} health">
+          <div class="chart-container">
+            <chef-radial-chart>
+              <span slot="innerText">
+                <span class="percent">
+                  <span class="value">{{ serviceGroup.health_percentage }}</span>%
+                </span>
+              </span>
+            
+              <chef-data-point value="{{ serviceGroup.services_health_counts.critical }}" class="critical">
+                {{ serviceGroup.services_health_counts.critical }} Critical
+              </chef-data-point>
+              <chef-data-point value="{{ serviceGroup.services_health_counts.warning }}" class="warning">
+                {{ serviceGroup.services_health_counts.warning }} Warning
+              </chef-data-point>
+              <chef-data-point value="{{ serviceGroup.services_health_counts.ok }}" class="ok">
+                {{ serviceGroup.services_health_counts.ok }} Ok
+              </chef-data-point>
+              <chef-data-point value="{{ serviceGroup.services_health_counts.unknown }}" class="unknown">
+                {{ serviceGroup.services_health_counts.unknown }} Unknown
+              </chef-data-point>
+            </chef-radial-chart>
+          </div>
           <chef-icon class="{{serviceGroup.status}}">{{ serviceGroup.status | serviceStatusIcon }}</chef-icon>
-          <chef-pill class="{{serviceGroup.status}}">
-            <div class="skinny-pill">{{ serviceGroup.health_percentage }}%</div>
-          </chef-pill>
         </chef-td>
         <chef-td class="services">
           {{ serviceGroup.services_health_counts.ok }} of {{ serviceGroup.services_health_counts.total }} OK

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
@@ -64,6 +64,9 @@ chef-td {
   chef-icon {
     font-size: 18px;
     margin-right: 8px;
+    position: absolute;
+    left: 90px;
+    top: 25px;
 
     &.OK {
       color: $chef-success;
@@ -226,3 +229,47 @@ chef-tr.sg-row {
     }
   }
 }
+
+.chart-container {
+  display: flex;
+  width: 70px;
+}
+
+chef-radial-chart {
+  width: 70px;
+  height: 70px;
+
+  .percent {
+    font-size: 10px;
+    font-weight: bolder;
+
+    .value {
+      font-size: 16px;
+    }
+  }
+
+  ::ng-deep .critical {
+    color: $chef-critical;
+    fill: $chef-critical;
+    stroke: $chef-critical;
+  }
+
+  ::ng-deep .warning {
+    color: $chef-warning;
+    fill: $chef-warning;
+    stroke: $chef-warning;
+  }
+
+  ::ng-deep .ok {
+    color: $chef-ok;
+    fill: $chef-ok;
+    stroke: $chef-ok;
+  }
+
+  ::ng-deep .unknown {
+    color: $chef-unknown;
+    fill: $chef-unknown;
+    stroke: $chef-unknown;
+  }
+}
+

--- a/components/automate-ui/src/styles/_colors.scss
+++ b/components/automate-ui/src/styles/_colors.scss
@@ -22,7 +22,10 @@ $mystic: #E6EBEE;
 $haze: #F3F6F8;
 $white: #FFFFFF;
 $black: #000000;
-
+// charts
+$atomic-tangerine: #FF9654;
+$blue-de-france: #3DA5FF;
+$gray: #B7BCBC;
 
 // ------------------------------------------------------------------------------------- //
 // gradients

--- a/components/automate-ui/src/styles/_variables.scss
+++ b/components/automate-ui/src/styles/_variables.scss
@@ -9,6 +9,7 @@ $chef-primary-bright: $royal-blue;
 $chef-primary-light: $malibu;
 //secondary
 $chef-critical: $pink;
+$chef-warning: $atomic-tangerine;
 $chef-major: $violet;
 $chef-minor: $indigo;
 $chef-success: $science-blue;
@@ -20,6 +21,9 @@ $chef-lightest-grey: $haze;
 $chef-white: $white;
 $chef-black: $black;
 $transparent-white: rgba(255, 255, 255, 0.85);
+//chart
+$chef-ok: $blue-de-france;
+$chef-unknown: $gray;
 
 // logos
 $default-logo: url('/assets/img/logos/AutomateLogo-default.svg');


### PR DESCRIPTION
…@chef.io>

### :nut_and_bolt: Description
Add a mini donut chart to each table row to visualize the service instance health status in the group.

<img width="1199" alt="Screen Shot 2019-05-20 at 5 57 19 PM" src="https://user-images.githubusercontent.com/4108100/58056984-d7be6c00-7b28-11e9-8402-61ab8e23170e.png">

### :+1: Definition of Done
Reuse the existing chef-radial-chart with only one circle
Make the size to match with what’s shown in the mockup, 48 * 48px area for each mini donut.
Depending on the effort it takes, the donut chart can be either interactive or non-interactive.
Colors: chef-critical for `critical` services count, #FF9654 (new color to be added to the palette) for `warning` services count; #3DA5FF (new color to be added to the palette) for `OK` services count; #B7BCBC (new color to be added to the palette) for `unknown` services count.
Link to the extended color palette, related cards: https://github.com/chef/automate/issues/309, https://github.com/chef/automate/issues/275

### :chains: Related Resources
https://chefio.atlassian.net/browse/A2-792
https://chef.invisionapp.com/share/PZQMKLHYC8B#/348323823_Slice_1-1

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ x] Code actually executed?
- [x ] Vetting performed (unit tests, lint, etc.)?
