### PR TITLE
Fix a few issues with the policy membership UI

### DIFF
--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -56,7 +56,7 @@
             <chef-tr>
               <chef-th class="checkbox-row"></chef-th>
               <chef-th>
-                Name
+                ID
               </chef-th>
               <chef-th>
                 Type

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -101,7 +101,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
                   this.policy = <Policy>Object.assign({}, policy);
 
                   teams.forEach((team: Team) => {
-                    const member = stringToMember(`team:local:${team.name}`);
+                    const member = stringToMember(`team:local:${team.id}`);
                     this.memberURLs[member.name] = ['/settings', 'teams', team.id];
                     // We'll refresh the sorted map for the chef-table below.
                     this.addAvailableMember(member, false);

--- a/components/automate-ui/src/app/pages/policy/details/policy-details.component.html
+++ b/components/automate-ui/src/app/pages/policy/details/policy-details.component.html
@@ -40,23 +40,25 @@
         <div *ngIf="(members$ | async)?.length === 0" id="getting-started">Add the first members to get started!</div>
         <chef-toolbar>
           <chef-button primary
-            [routerLink]="['/settings', 'policies', policy.id, 'add-members']">Add Members</chef-button>
+            [routerLink]="['/settings', 'policies', policy?.id, 'add-members']">Add Members</chef-button>
         </chef-toolbar>
         <chef-table *ngIf="(members$ | async)?.length > 0">
           <chef-thead>
             <chef-tr>
-              <chef-th>Name</chef-th>
+              <chef-th>ID</chef-th>
               <chef-th>Type</chef-th>
               <chef-th></chef-th>
             </chef-tr>
           </chef-thead>
           <chef-tbody>
             <chef-tr *ngFor="let member of members$ | async">
-              <!-- TODO (tc) we should link to local users and teams once we switch those APIs to named IDs.
-              can't now since we don't have the GUIDs for them unless we queried them by name for each
-              row somehow. -->
               <chef-td>
-                {{ member.displayName }}
+                <a *ngIf="memberURLs.hasOwnProperty(member.name)" [routerLink]="memberURLs[member.name]" target="_blank">
+                  {{ member.displayName }}
+                </a>
+                <ng-container *ngIf="!memberURLs.hasOwnProperty(member.name)">
+                  {{ member.displayName }}
+                </ng-container>
               </chef-td>
               <chef-td>
                 {{ member.displayType }}

--- a/components/automate-ui/src/app/pages/policy/details/policy-details.component.html
+++ b/components/automate-ui/src/app/pages/policy/details/policy-details.component.html
@@ -53,7 +53,7 @@
           <chef-tbody>
             <chef-tr *ngFor="let member of members$ | async">
               <chef-td>
-                <a *ngIf="memberURLs.hasOwnProperty(member.name)" [routerLink]="memberURLs[member.name]" target="_blank">
+                <a *ngIf="memberURLs.hasOwnProperty(member.name)" [routerLink]="memberURLs[member.name]">
                   {{ member.displayName }}
                 </a>
                 <ng-container *ngIf="!memberURLs.hasOwnProperty(member.name)">


### PR DESCRIPTION
### :nut_and_bolt: Description

* Fixed policy member add UI issue where it was incorrectly using local team names instead of IDs to add members to policy. This was resulting in being able to add "Viewers" to the viewers policy already containing the local team "viewers".
* Fixed policy membership table in policy details view to have the correct table column header of ID instead of Name.
* Fixed issue where you could get a console error if policy isn't loaded on time.
* Fixed TODO where we were populating links for local users and teams in policy details membership table.

Working links to local teams and users:

<img width="1258" alt="Screen Shot 2019-05-21 at 1 24 32 PM" src="https://user-images.githubusercontent.com/1899715/58128567-cf1f7180-7bcc-11e9-9165-082d1feebc36.png">

Capital V "Viewers" no longer showing up and properly showing local team IDs instead of Names:

<img width="1256" alt="Screen Shot 2019-05-21 at 1 24 57 PM" src="https://user-images.githubusercontent.com/1899715/58128571-d0e93500-7bcc-11e9-9ad4-c36f94b749d2.png">

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
