### PR TITLE
automate-gateway: cleanup GRPC/HTTP multiplexing cruft

### DIFF
--- a/components/automate-gateway/integration/license_usage_nodes_test.go
+++ b/components/automate-gateway/integration/license_usage_nodes_test.go
@@ -22,7 +22,7 @@ import (
 const (
 	complianceEndpoint = "127.0.0.1:10121"
 	secretsEndpoint    = "127.0.0.1:10131"
-	gatewayEndpoint    = "127.0.0.1:2000"
+	gatewayEndpoint    = "127.0.0.1:2001"
 	nodesEndpoint      = "127.0.0.1:10120"
 )
 

--- a/components/automate-gateway/integration/nodes_test.go
+++ b/components/automate-gateway/integration/nodes_test.go
@@ -23,7 +23,7 @@ var host = os.Getenv("AUTOMATE_ACCEPTANCE_TARGET_HOST")
 func TestGatewayNodesClient(t *testing.T) {
 	complianceEndpoint := "127.0.0.1:10121"
 	secretsEndpoint := "127.0.0.1:10131"
-	gatewayEndpoint := "127.0.0.1:2000"
+	gatewayEndpoint := "127.0.0.1:2001"
 	nodesEndpoint := "127.0.0.1:10120"
 	ctx := context.Background()
 	connFactory := helpers.SecureConnFactoryHabWithDeploymentServiceCerts()


### PR DESCRIPTION
### :nut_and_bolt: Description

This was carried over from some ancient grpc-gateway example code[1]; and
we're not exposing the GRPC API that way right now.

Using (*grpc.Server).ServeHTTP has some issues:

1. it's known to be slow, very slow[2]
2. it's seems to be not working with go-grpc >= 1.19 [3]

Furthermore, we're exposing the proper GRPC server (the native go-grpc
one) on a different port. If decide to (finally!) expose our GRPC API,
that's the thing we should expose.

So, since we don't need this multiplexing business, we shouldn't keep
the code around. This is the cleanup.

[1]: https://github.com/philips/grpc-gateway-example/
[2]: https://github.com/grpc/grpc-go/issues/586
[3]: https://github.com/soheilhy/cmux/issues/64#issuecomment-491999193

