### PR TITLE
remove node state link from client run page

### DIFF
--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
@@ -4,7 +4,6 @@
 </div>
 
 <app-server-org-filter-sidebar>
-  <!-- <chef-sidebar-entry route="/client-runs" icon="storage">Node State</chef-sidebar-entry> -->
   <a *ngIf="isWorkflowEnabled$ | async" href="/workflow">
     <chef-icon class="sidebar-icon" aria-hidden="true">local_shipping</chef-icon>
     Workflow

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
@@ -4,7 +4,7 @@
 </div>
 
 <app-server-org-filter-sidebar>
-  <chef-sidebar-entry route="/client-runs" icon="storage">Node State</chef-sidebar-entry>
+  <!-- <chef-sidebar-entry route="/client-runs" icon="storage">Node State</chef-sidebar-entry> -->
   <a *ngIf="isWorkflowEnabled$ | async" href="/workflow">
     <chef-icon class="sidebar-icon" aria-hidden="true">local_shipping</chef-icon>
     Workflow


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description
During usability studies at ChefConf 2019 participants repeatedly clicked on the Node State link on the Client Runs page expecting something to happen. This task removes that link if we add more items to the left-nav of that page in the future we can add it back.

After talking with @jonong1972 this task is only removing the link from the _Client Runs_ landing page, it will still be visible on node detail pages, we can revisit that in the future if necessary.

### :+1: Definition of Done
![client_runs_page](https://user-images.githubusercontent.com/12297653/58170634-8beafe80-7cb1-11e9-9d76-d98fd622b577.png)

### :chains: Related Resources
https://github.com/chef/automate/issues/397