### PR TITLE
Add proper IAMv2p1 machines to deployment farm

### DIFF
--- a/terraform/test-environments/scenarios/single_local_iamv2_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2_fresh_install.tf
@@ -53,5 +53,5 @@ module "single_local_iamv2_fresh_install_deploy" {
   # Automate Install
   channel         = "${var.channel}"
   deployment_type = "local"
-  iam_version     = "v2.1"
+  iam_version     = "v2"
 }

--- a/terraform/test-environments/scenarios/single_local_iamv2p1_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2p1_fresh_install.tf
@@ -1,0 +1,57 @@
+#
+# A simple local install of A2 with IAMv2p1 using the chef-automate CLI. It is rebuilt everytime we run `terraform apply`.
+#
+
+module "single_local_iamv2p1_fresh_install" {
+  source = "git@github.com:chef/es-terraform.git//modules/cd_instance_v2"
+
+  # DNS components ( a2-iamv2p1-local-fresh-install-{{channel}}.cd.chef.co )
+  subdomain        = "a2-iamv2p1-local-fresh-install"
+  subdomain_suffix = "-${var.dns_suffix}"
+
+  # Metadata
+  meta_title       = "Single Local (Fresh Install) with IAMv2p1"
+  meta_description = "A2 stack with IAMv2p1 (using SAML) deployed locally as Habitat packages on a single host using the chef-automate CLI."
+  meta_type        = "habitat"
+
+  # AWS Instance Configuration
+  vpc            = "${var.environment}"
+  platform       = "ubuntu-16.04"
+  key_name       = "cd-infrastructure"
+  instance_type  = "m5.large"
+  root_volume_gb = "50"
+  always_rebuild = "true"
+
+  # Required AWS Tags
+  tag_dept        = "CoreEng"
+  tag_contact     = "${var.aws_tag_contact}"
+  tag_application = "a2"
+
+  additional_tags = {
+    X-Package-Type     = "habitat"
+    X-Install-Utility  = "chef-automate-cli"
+    X-Install-Strategy = "fresh-install"
+    X-Topology         = "single"
+    X-Deployment-Type  = "local"
+    X-Channel          = "${var.channel}"
+  }
+}
+
+module "single_local_iamv2p1_fresh_install_deploy" {
+  source = "../modules/chef_automate_install"
+
+  instance_id   = "${module.single_local_iamv2p1_fresh_install.instance_id}"
+  instance_fqdn = "${module.single_local_iamv2p1_fresh_install.fqdn}"
+  ssh_username  = "${module.single_local_iamv2p1_fresh_install.ssh_username}"
+
+  journald_system_max_use = "${var.channel == "acceptance" ? "20G" : "6G"}"
+
+  # Chef Baseline
+  enable_monitoring = "false"
+  chef_environment  = "${var.chef_environment}"
+
+  # Automate Install
+  channel         = "${var.channel}"
+  deployment_type = "local"
+  iam_version     = "v2.1"
+}

--- a/terraform/test-environments/scenarios/single_local_iamv2p1_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2p1_inplace_upgrade.tf
@@ -18,7 +18,7 @@ module "single_local_iamv2p1_inplace_upgrade" {
   vpc            = "${var.environment}"
   platform       = "ubuntu-16.04"
   key_name       = "cd-infrastructure"
-  instance_type  = "m4.large"
+  instance_type  = "m5.large"
   root_volume_gb = "200"
 
   # Required AWS Tags

--- a/terraform/test-environments/scenarios/single_local_iamv2p1_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2p1_inplace_upgrade.tf
@@ -1,0 +1,57 @@
+#
+# A simple local install of A2 with IAMv2 using the chef-automate CLI. It currently uses a pseudo-inplace upgrade.
+#
+
+module "single_local_iamv2p1_inplace_upgrade" {
+  source = "git@github.com:chef/es-terraform.git//modules/cd_instance_v2"
+
+  # DNS components ( a2-iamv2p1-local-inplace-upgrade-{{channel}}.cd.chef.co )
+  subdomain        = "a2-iamv2p1-local-inplace-upgrade"
+  subdomain_suffix = "-${var.dns_suffix}"
+
+  # Metadata
+  meta_title       = "Single Local (Inplace Upgrade) with IAMv2p1"
+  meta_description = "A2 stack with IAMv2p1 (using SAML) deployed locally as Habitat packages on a single host using the chef-automate CLI."
+  meta_type        = "habitat"
+
+  # AWS Instance Configuration
+  vpc            = "${var.environment}"
+  platform       = "ubuntu-16.04"
+  key_name       = "cd-infrastructure"
+  instance_type  = "m4.large"
+  root_volume_gb = "200"
+
+  # Required AWS Tags
+  tag_dept        = "CoreEng"
+  tag_contact     = "${var.aws_tag_contact}"
+  tag_application = "a2"
+
+  additional_tags = {
+    X-Package-Type     = "habitat"
+    X-Install-Utility  = "chef-automate-cli"
+    X-Install-Strategy = "inplace-upgrade"
+    X-Topology         = "single"
+    X-Deployment-Type  = "local"
+    X-Channel          = "${var.channel}"
+  }
+}
+
+module "single_local_iamv2p1_inplace_upgrade_deploy" {
+  source = "../modules/chef_automate_install"
+
+  instance_id   = "${module.single_local_iamv2p1_inplace_upgrade.instance_id}"
+  instance_fqdn = "${module.single_local_iamv2p1_inplace_upgrade.fqdn}"
+  ssh_username  = "${module.single_local_iamv2p1_inplace_upgrade.ssh_username}"
+
+  journald_system_max_use = "${var.channel == "acceptance" ? "20G" : "6G"}"
+
+  # Chef Baseline
+  enable_monitoring = "true"
+  chef_environment  = "${var.chef_environment}"
+
+  # Automate Install
+  channel         = "${var.channel}"
+  deployment_type = "local"
+  upgrade         = "true"
+  iam_version     = "v2.1"
+}


### PR DESCRIPTION
### :nut_and_bolt: Description

Previously I had repurposed the IAM v2 "fresh install" machine in the deployment farm to 2.1 (leaving the "inplace upgrade" at v2). But that "conservation of resources" led to more confusion than savings, so this PR reverts the change on the IAM v2 "fresh install" machine _and_ creates first-class siblings for v2.1, both fresh install and inplace upgrade.

### :+1: Definition of Done

New v2p1 machines are provisioned on each of the dev and acceptance dashboards.

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
