### PR TITLE
Link fixes to LDAP docs

### DIFF
--- a/components/automate-chef-io/content/docs/ldap.md
+++ b/components/automate-chef-io/content/docs/ldap.md
@@ -152,7 +152,7 @@ ldapsearch -H ldap://ldap-server:636/ \  # host
   '(&(objectClass=person)(memberof=CN=YourGroupToFilterOn,OU=Users,DC=YourDomain,DC=com))'
 ```
 
-See the [ldapsearch Queries]({{< relref "ldap.md#ldapsearch-queries" >}}) for more info on debugging
+See [Troubleshoot LDAP Search Queries]({{< relref "ldap.md#troubleshoot-ldap-search-queries" >}}) for more info on debugging
 your LDAP integration via `ldapsearch`.
 
 #### Login Bind
@@ -642,5 +642,4 @@ example in servers supporting _extensible match_, all group entries below
 `AGroups` and `BGroups` could be retrieved using a `group_query_filter` of
 `(|(ou:dn:=AGroups)(ou:dn:=BGroups))`.
 
-See [ldapwiki.com on "Extensible
-Match"](http://ldapwiki.com/wiki/ExtensibleMatch) for details.
+See [LDAP Wiki Extensible Match Search Filter](http://ldapwiki.com/wiki/ExtensibleMatch) for details.


### PR DESCRIPTION
Signed-off-by: susanev <susan.ra.evans@gmail.com>

### :nut_and_bolt: Description
A few link issues in the LDAP docs came up during usability studies at Chef Conf, this fixes them.

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
