### PR TITLE
Fix nightly migration tests

### DIFF
--- a/components/automate-deployment/a1-migration/a1-migration-data-full/hooks/install
+++ b/components/automate-deployment/a1-migration/a1-migration-data-full/hooks/install
@@ -31,6 +31,3 @@ touch /etc/delivery/.a1-migration-data-ready
 
 echo "A1 configuration and data loaded"
 
-# Run forever
-set +x
-while :; do sleep 1; done

--- a/components/automate-deployment/a1-migration/a1-migration-data-full/plan.sh
+++ b/components/automate-deployment/a1-migration/a1-migration-data-full/plan.sh
@@ -17,6 +17,9 @@ pkg_build_deps=(
 )
 pkg_svc_user=root
 pkg_svc_group=root
+# Workaround to ensure install hook runs as root:
+# https://github.com/habitat-sh/habitat/issues/6341
+pkg_svc_run="return 0"
 
 do_build() {
   return 0

--- a/components/automate-deployment/a1-migration/load-artifact
+++ b/components/automate-deployment/a1-migration/load-artifact
@@ -5,23 +5,12 @@ set -ex
 automate-ctl stop
 chef-server-ctl stop
 
-## mitigate intermittent "Unable to spawn Supervisor, Text file busy (os error 26)" error
-(HAB_LICENSE=accept-no-persist hab sup run || sleep 5; HAB_LICENSE=accept-no-persist hab sup run || sleep 5; HAB_LICENSE=accept-no-persist hab sup run) &
-
-set +x
-until HAB_LICENSE=accept-no-persist hab svc status &> /dev/null; do
-  sleep 1
-done
-set -x
-
 ## This package contains data with es2 indices in it so we test the reindex
 ## code path
 ## see https://chefio.atlassian.net/wiki/spaces/ENG/pages/455147533/Migrating+A1+Elasticsearch+data
 ## and https://drive.google.com/open?id=1dtdt8kRXywDAE9G03WX7a3mWQoAWsYY1
-DATA_PACKAGE_RELEASE="20181210102316"
-# hab pkg install /a1-migration/results/devchef-a1-migration-data-full-0.0.1-${DATA_PACKAGE_RELEASE}-x86_64-linux.hart
+DATA_PACKAGE_RELEASE="20190524202433"
 HAB_LICENSE=accept-no-persist hab pkg install "devchef/a1-migration-data-full/0.0.1/$DATA_PACKAGE_RELEASE" --channel unstable
-HAB_LICENSE=accept-no-persist hab svc load "devchef/a1-migration-data-full/0.0.1/$DATA_PACKAGE_RELEASE" &
 
 echo "waiting for migration data to sync..."
 
@@ -32,17 +21,6 @@ until [[ -f /etc/delivery/.a1-migration-data-ready ]]; do
 done
 
 echo "done!"
-
-# kill off the data package, lest it be resurrected and break things at a bad time
-HAB_LICENSE=accept-no-persist hab svc unload devchef/a1-migration-data-full
-
-# Kill off our background job and the hab-launcher as well. This
-# appears necessary as of hab-launcher 8282/hab 0.62.1
-kill %1
-kill "$(cat /hab/sup/default/LOCK)"
-
-# Wait for the supervisor tree to die and any open file handles to free up.
-sleep 5
 
 # In case our a1 artifact has an old license in it
 [[ ! -d /var/opt/delivery/license ]] && mkdir -p /var/opt/delivery/license


### PR DESCRIPTION
### :nut_and_bolt: Description
The nightly migration tests fail when habitat 0.81 is used to load the a1 data package, due to a workaround we had in place for an intermittent problem starting a habitat supervisor to load the data package so that the run hook could copy the a1 data to the proper locations. We no longer need the workaround because we can use a habitat install hook to put the a1 data in the desired locations.

TODO
- [x] Upload new a1 data package to devchef origin. (The test will fail until otherwise.)

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
