### PR TITLE
enabling SSL for PostgreSQL in ha_backend integration tests

### DIFF
--- a/integration/services/ha_backend/init
+++ b/integration/services/ha_backend/init
@@ -39,24 +39,27 @@ ha_backend_setup() {
     #Create the CA and enter the Organization details:
     openssl req -x509 -new -key $certdir/MyRootCA.key -sha256 -out $certdir/MyRootCA.pem -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefrootca'
 
-    #the rsa keys
+    #the rsa keys for odfe and postgresql
     openssl genrsa -out $certdir/odfe-node-pkcs12.key 2048
     openssl genrsa -out $certdir/odfe-admin-pkcs12.key 2048
+    openssl genrsa -out $certdir/postgresql.key 2048
 
     #IMPORTANT: Convert these to PKCS#5 v1.5 to work correctly with the JDK.
     openssl pkcs8 -v1 "PBE-SHA1-3DES" -in "$certdir/odfe-node-pkcs12.key" -topk8 -out "$certdir/odfe-node.key" -nocrypt
     openssl pkcs8 -v1 "PBE-SHA1-3DES" -in "$certdir/odfe-admin-pkcs12.key" -topk8 -out "$certdir/odfe-admin.key" -nocrypt
 
-    #Create the CSR and enter the organization and server details for the node key
+    #Create the CSR and enter the organization and server details for the odfe and postgresql keys
     openssl req -new -key $certdir/odfe-node.key -out $certdir/odfe-${ha_backend_container1}.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefnode' -extensions san -reqexts san -config <(echo '[req]'; echo 'distinguished_name=req'; echo '[san]'; echo "subjectAltName=IP:${ha_backend_container1_ip},DNS:${ha_backend_container1_ip}")
     openssl req -new -key $certdir/odfe-node.key -out $certdir/odfe-${ha_backend_container2}.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefnode' -extensions san -reqexts san -config <(echo '[req]'; echo 'distinguished_name=req'; echo '[san]'; echo "subjectAltName=IP:${ha_backend_container2_ip},DNS:${ha_backend_container2_ip}")
+    openssl req -new -key $certdir/postgresql.key -out $certdir/postgresql.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefpostgresql' -extensions san -reqexts san -config <(echo '[req]'; echo 'distinguished_name=req'; echo '[san]'; echo "subjectAltName=IP:${ha_backend_container1_ip},IP:${ha_backend_container2_ip},DNS:${ha_backend_container1_ip},DNS:${ha_backend_container2_ip}")
 
     #Create the CSR and enter the organization and server details for the admin key
     openssl req -new -key $certdir/odfe-admin.key -out $certdir/odfe-admin.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefadmin'
 
-    #Use the CSR to generate the signed node Certificates:
+    #Use the CSR to generate the signed odfe and postgresql Certificates:
     openssl x509 -req -in $certdir/odfe-${ha_backend_container1}.csr -CA $certdir/MyRootCA.pem -CAkey $certdir/MyRootCA.key -CAcreateserial -out $certdir/odfe-${ha_backend_container1}.pem -sha256
     openssl x509 -req -in $certdir/odfe-${ha_backend_container2}.csr -CA $certdir/MyRootCA.pem -CAkey $certdir/MyRootCA.key -CAcreateserial -out $certdir/odfe-${ha_backend_container2}.pem -sha256
+    openssl x509 -req -in $certdir/postgresql.csr -CA $certdir/MyRootCA.pem -CAkey $certdir/MyRootCA.key -CAcreateserial -out $certdir/postgresql.pem -sha256
 
     #Use the CSR to generate the signed admin Certificate:
     openssl x509 -req -in $certdir/odfe-admin.csr -CA $certdir/MyRootCA.pem -CAkey $certdir/MyRootCA.key -CAcreateserial -out $certdir/odfe-admin.pem -sha256
@@ -121,8 +124,8 @@ enable = true
 nodes = ["${ha_backend_container1_ip}:7432", "${ha_backend_container2_ip}:7432"]
 
 [global.v1.external.postgresql.ssl]
-mode = "disable"
-enable = false
+enable = true
+root_cert = """$(cat ${certdir}/MyRootCA.pem)"""
 
 [global.v1.external.postgresql.auth]
 scheme = "password"
@@ -138,6 +141,7 @@ password = "thisisapassword"
 enable = true
 DOC
 
+    echo "Validating odfe connectivity"
     sleep 45
     curl -u admin:admin --cacert "${certdir}/MyRootCA.pem" --key "${certdir}/odfe-admin.key" --cert "${certdir}/odfe-admin.pem" --resolve "chefnode:9200:${ha_backend_container1_ip}" "https://chefnode:9200"
     curl -u admin:admin --cacert "${certdir}/MyRootCA.pem" --key "${certdir}/odfe-admin.key" --cert "${certdir}/odfe-admin.pem" --resolve "chefnode:9200:${ha_backend_container2_ip}" "https://chefnode:9200"
@@ -161,4 +165,3 @@ ha_backend_teardown() {
     docker stop "$ha_backend_container1"
     docker stop "$ha_backend_container2"
 }
-

--- a/integration/services/ha_backend/setup.sh
+++ b/integration/services/ha_backend/setup.sh
@@ -119,6 +119,10 @@ mkdir -p "/hab/user/${PG_PKG_NAME}/config/"
 cat > "/hab/user/${PG_PKG_NAME}/config/user.toml" <<EOF
 [superuser]
 password = 'thisisapassword'
+[ssl]
+enable = true
+ssl_cert    = """$(cat /certificates/postgresql.pem)"""
+ssl_key     = """$(cat /certificates/postgresql.key)"""
 EOF
 
 echo "Starting HA Backend Habitat services"
@@ -126,4 +130,3 @@ HAB_LICENSE="accept-no-persist" hab svc load ${postgresql_pkg_ident} --topology 
 HAB_LICENSE="accept-no-persist" hab svc load ${pgleaderchk_pkg_ident} --topology leader --bind database:"$PG_PKG_NAME".default --binding-mode=relaxed --channel ${channel}
 HAB_LICENSE="accept-no-persist" hab svc load ${proxy_pkg_ident} --topology leader --bind database:"$PG_PKG_NAME".default --bind pgleaderchk:"$PGLEADERCHK_PKG_NAME".default --binding-mode=relaxed --channel ${channel}
 HAB_LICENSE="accept-no-persist" hab svc load ${elasticsearch_pkg_ident} --topology leader --bind elasticsearch:"$ELASTICSEARCH_PKG_NAME".default --binding-mode=relaxed --channel ${channel}
-


### PR DESCRIPTION
Signed-off-by: Jeremy J. Miller <jm@chef.io>

### :nut_and_bolt: Description
This enables SSL mode for PostgreSQL in `ha_data_services` integration tests.
It is in preparation for when this PR lands:
https://github.com/chef/a2-ha-backend/pull/146

The work here has been validated by running:
`HAB_ORIGIN=jeremymv2 ./integration/run_test ./integration/tests/ha_data_services.sh` with custom pkg_idents for the following:

```
postgresql_pkg_ident="jeremymv2/automate-backend-postgresql/0.1.99/20190515201044"
pgleaderchk_pkg_ident="jeremymv2/automate-backend-pgleaderchk/0.1.99/20190515200841"
```

The above `postgresql_pkg_ident` and `pgleaderchk_pkg_ident` pkg_idents were built and validated in https://github.com/chef/a2-ha-backend/pull/146. When that PR merges, the ha_backend integration tests here will pick up the latest versions of those.

When both this PR and https://github.com/chef/a2-ha-backend/pull/146 are approved we can remove the `DO-NOT-MERGE` labels from each and merge the backend one first followed shortly after by this one.

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
