### PR TITLE
Removing angular prompt

### DIFF
--- a/components/automate-ui/habitat/plan.sh
+++ b/components/automate-ui/habitat/plan.sh
@@ -38,6 +38,7 @@ do_unpack() {
 }
 
 do_build() {
+  NG_FORCE_TTY='FALSE'
   for dir in $CACHE_PATH/chef-ui-library $CACHE_PATH/automate-ui; do
     pushd $dir
       echo "Building $dir"


### PR DESCRIPTION
The automate-ui component does not build without user interaction any more. I am seeing the below promt when running `build component/automate-ui`
```> @angular/cli@8.0.0 postinstall /hab/cache/src/automate-ui-2.0.0/chef-ui-library/node_modules/@angular/cli
> node ./bin/postinstall/script.js

? Would you like to share anonymous usage data with the Angular Team at Google under
Google's Privacy Policy at https://policies.google.com/privacy? For more details and
how to change this setting, see http://angular.io/analytics. (y/N)
```

This change will remove the prompt

Found this solution from looking here https://github.com/angular/angular-cli/blob/master/packages/angular/cli/models/analytics.ts#L363