### PR TITLE
Add app and env to service-group table

### DIFF
--- a/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
@@ -28,6 +28,8 @@ export interface ServiceGroup {
   status: string;
   health_percentage: boolean;
   services_health_counts: HealthSummary;
+  applications: string;
+  environment: string;
 }
 
 export interface ServiceGroupFilters {
@@ -58,4 +60,6 @@ export interface ServiceGroupsPayload {
 export interface FieldDirection {
   name: SortDirection;
   percent_ok: SortDirection;
+  environment: SortDirection;
+  app_name: SortDirection;
 }

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -35,7 +35,7 @@
     <chef-thead>
         <chef-tr>
           <chef-th class="health sort" (click)="onToggleSort('percent_ok')">
-            Health<i class="sort-icon {{sortIcon('percent_ok')}}"></i>
+            Health <i class="sort-icon {{sortIcon('percent_ok')}}"></i>
           </chef-th>
           <chef-th class="services">
             Services
@@ -45,6 +45,12 @@
           </chef-th>
           <chef-th class="release">
             Release
+          </chef-th>
+          <chef-th class="env sort" (click)="onToggleSort('environment')">
+            Env <i class="sort-icon {{sortIcon('environment')}}"></i>
+          </chef-th>
+          <chef-th class="app sort" (click)="onToggleSort('app_name')">
+            App <i class="sort-icon {{sortIcon('app_name')}}"></i>
           </chef-th>
         </chef-tr>
     </chef-thead>
@@ -72,6 +78,12 @@
         </chef-td>
         <chef-td class="release">
           {{ serviceGroup.release }}
+        </chef-td>
+        <chef-td class="env">
+          {{ serviceGroup.environment }}
+        </chef-td>
+        <chef-td class="app">
+          {{ serviceGroup.application }}
         </chef-td>
       </chef-tr>
     </chef-tbody>

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
@@ -42,7 +42,18 @@ chef-td {
 
   &.release {
     min-width: 160px;
-    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &.env {
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &.app {
+    max-width: 160px;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -60,7 +60,9 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   private currentSortField: string;
   private defaultFieldDirection: FieldDirection = {
     name: 'ASC',
-    percent_ok: 'ASC'
+    percent_ok: 'ASC',
+    environment: 'ASC',
+    app_name: 'ASC'
   };
 
   constructor(


### PR DESCRIPTION
### :nut_and_bolt: Description

- Add app and env columns to the table
- Resize existing columns to fit the new columns
- Sort on app and env

### :+1: Definition of Done
We can visualize the application and environment names of a group of services in the UI. Also, we should be able to sort on them.

### :athletic_shoe: Demo Script / Repro Steps
_(this process depends on how you do UI development)_ 

- Build the Automate UI
- Start all services. `start_all_services`
- Populate the database. `applications_populate_database`
- Go to the Applications Tab and Test.

#### Sortable Columns
![app-env-sort](https://user-images.githubusercontent.com/5712253/58536494-099e9500-81f1-11e9-9308-6bdf0949f6a2.gif)

#### Expanded View
<img width="1904" alt="Screen Shot 2019-05-29 at 9 08 03 AM" src="https://user-images.githubusercontent.com/5712253/58536630-6bf79580-81f1-11e9-9cfe-8e3f3afdb2b5.png">

#### Mid-Size View
<img width="1758" alt="Screen Shot 2019-05-29 at 9 08 16 AM" src="https://user-images.githubusercontent.com/5712253/58536634-6ef28600-81f1-11e9-91f1-3af62d33881a.png">

#### Contracted View
<img width="1453" alt="Screen Shot 2019-05-29 at 9 08 57 AM" src="https://user-images.githubusercontent.com/5712253/58536639-72860d00-81f1-11e9-9ea3-fc6fa49a332b.png">

### :chains: Related Resources
Closes Sub-Task: https://chefio.atlassian.net/browse/A2-829
Finishes Epic: https://chefio.atlassian.net/browse/A2-791

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
