### PR TITLE
[FIX-PIPELINE] Disable Angular Analytics

### DIFF
--- a/components/automate-ui/habitat/plan.sh
+++ b/components/automate-ui/habitat/plan.sh
@@ -38,6 +38,9 @@ do_unpack() {
 }
 
 do_build() {
+  # Disabling Usage Analytics
+  export NG_CLI_ANALYTICS=false
+
   for dir in $CACHE_PATH/chef-ui-library $CACHE_PATH/automate-ui; do
     pushd $dir
       echo "Building $dir"
@@ -61,6 +64,7 @@ do_build() {
       for b in node_modules/.bin/*; do
         fix_interpreter "$(readlink -f -n "$b")" core/coreutils bin/env
       done
+
       # Compile the Angular application
       npm run build:prod
 


### PR DESCRIPTION
### :nut_and_bolt: Description
Currently master is broken to build Automate UI components.

When trying to build we are getting the following message:
```
> @angular/cli@8.0.0 postinstall /hab/cache/src/automate-ui-2.0.0/chef-ui-library/node_modules/@angular/cli
> node ./bin/postinstall/script.js

? Would you like to share anonymous usage data with the Angular Team at Google under
Google’s Privacy Policy at https://policies.google.com/privacy? (Y/N) 
```

Look at this PR: https://github.com/chef/automate/pull/435

### :+1: Definition of Done
We can build UI components in master.

### :athletic_shoe: Demo Script / Repro Steps
Start the studio and build a UI package.

### :chains: Related Resources
N/A

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
