### PR TITLE
Ensure upgrade sets existing notifications rules critical_controls_only column to false

### DIFF
--- a/components/notifications-service/server/lib/data/migrations.ex
+++ b/components/notifications-service/server/lib/data/migrations.ex
@@ -55,7 +55,8 @@ defmodule Notifications.Data.Migrator.Migrations do
      %{description: "Add critical_controls_only to rules table",
        queries: [
         "ALTER TABLE rules ADD COLUMN critical_controls_only BOOLEAN;",
-        "ALTER TABLE rules ALTER COLUMN critical_controls_only SET DEFAULT FALSE;"]
+        "ALTER TABLE rules ALTER COLUMN critical_controls_only SET DEFAULT FALSE;",
+        "UPDATE rules SET critical_controls_only=FALSE;"]
      },
     ]
   end

--- a/components/notifications-service/server/lib/data/migrations.ex
+++ b/components/notifications-service/server/lib/data/migrations.ex
@@ -55,7 +55,10 @@ defmodule Notifications.Data.Migrator.Migrations do
      %{description: "Add critical_controls_only to rules table",
        queries: [
         "ALTER TABLE rules ADD COLUMN critical_controls_only BOOLEAN;",
-        "ALTER TABLE rules ALTER COLUMN critical_controls_only SET DEFAULT FALSE;",
+        "ALTER TABLE rules ALTER COLUMN critical_controls_only SET DEFAULT FALSE;"]
+     },
+     %{description: "UPDATE rules SET critical_controls_only=FALSE",
+       queries: [
         "UPDATE rules SET critical_controls_only=FALSE;"]
      },
     ]

--- a/components/notifications-service/server/lib/data/migrator.ex
+++ b/components/notifications-service/server/lib/data/migrator.ex
@@ -117,7 +117,10 @@ defmodule Notifications.Data.Migrator.DB do
   end
 
   def exec_migration_sql(conn, query) do
-    {:ok, _, _} = :epgsql.equery(conn, query, [])
-    :ok
+    Logger.info("migration query #{query}")
+    case :epgsql.equery(conn, query, []) do
+      {:ok, _, _} -> :ok
+      {:ok, _} -> :ok
+    end
   end
 end


### PR DESCRIPTION
Auto upgrade of test and dev environment on acceptance channel showed the follow error

`
May 29 00:00:07 ip-172-18-2-200 hab[2799]: notifications-service.default(O): 00:00:07.343 module=GRPC.Adapter.Cowboy.Handler [error] ** (Protobuf.InvalidError) Notifications.ServiceNowAlert#critical_controls_only is invalid!
May 29 00:00:07 ip-172-18-2-200 hab[2799]: notifications-service.default(O):     (protobuf) lib/protobuf/validator.ex:5: Protobuf.Validator.validate!/1
May 29 00:00:07 ip-172-18-2-200 hab[2799]: notifications-service.default(O):     (protobuf) lib/protobuf/encoder.ex:9: Protobuf.Encoder.encode/2
May 29 00:00:07 ip-172-18-2-200 hab[2799]: notifications-service.default(O):     (protobuf) lib/protobuf/encoder.ex:49: anonymous fn/4 in Protobuf.Encoder.encode_field/3
May 29 00:00:07 ip-172-18-2-200 hab[2799]: notifications-service.default(O):     (protobuf) lib/protobuf/encoder.ex:32: anonymous fn/6 in Protobuf.Encoder.encode/3
May 29 00:00:07 ip-172-18-2-200 hab[2799]: notifications-service.default(O):     (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
May 29 00:00:07 ip-172-18-2-200 hab[2799]: notifications-service.default(O):     (protobuf) lib/protobuf/encoder.ex:10: Protobuf.Encoder.encode/2
May 29 00:00:07 ip-172-18-2-200 hab[2799]: notifications-service.default(O):     (protobuf) lib/protobuf/encoder.ex:49: anonymous fn/4 in Protobuf.Encoder.encode_field/3
May 29 00:00:07 ip-172-18-2-200 hab[2799]: notifications-service.default(O):     (elixir) lib/enum.ex:1327: Enum."-map/2-lists^map/1-0-"/2
`

Investigation indicated that the default value of false on the column was not set on existing columns.

The migrator has been updated.

Signed-off-by: Martin Scott <mscott@chef.io>

### Testing

Reset the notifications_service database to migration level 6.
Created Slack, Webhook and ServiceNow notifications for CCRFailure, ComplianceFailure and Asset.
Deployed the updated notifications-service with migrations fix.
Migrations run and where verified in DB migrations table. Rules were verified in DB rules table.
Client runs and scans verified the existing functionality and the new functionality.


### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
