### PR TITLE
add a test for filtering by profile status

### DIFF
--- a/components/compliance-service/api/tests/08_search_profiles_spec.rb
+++ b/components/compliance-service/api/tests/08_search_profiles_spec.rb
@@ -180,6 +180,30 @@ describe File.basename(__FILE__) do
     }.to_json
     assert_equal(expected_data, actual_data.to_json)
 
+    # Filter by status
+    actual_data = GRPC reporting, :list_profiles, Reporting::Query.new(
+        filters: [
+            Reporting::ListFilter.new(type: "end_time", values: ["2018-03-04T#{END_OF_DAY}"]),
+            Reporting::ListFilter.new(type: 'status', values: ['passed'])
+        ],
+        page: 1, per_page: 2)
+    expected_data = {
+        "profiles" => [
+            {
+                "name" => "nginx-baseline",
+                "title" => "DevSec Nginx Baseline",
+                "id" => "09adcbb3b9b3233d5de63cd98a5ba3e155b3aaeb66b5abed379f5fb1ff143988",
+                "version" => "2.1.0",
+                "status" => "passed"
+            }
+        ],
+        "counts" => {
+            "total" => 1,
+            "passed" => 1
+        }
+    }.to_json
+    assert_equal(expected_data, actual_data.to_json)
+
     # Get profiles used by node with node_id
     actual_data = GRPC reporting, :list_profiles, Reporting::Query.new(filters: [
         Reporting::ListFilter.new(type: 'node_id', values: ['9b9f4e51-b049-4b10-9555-10578916e149']),

--- a/components/compliance-service/api/tests/08_search_profiles_spec.rb
+++ b/components/compliance-service/api/tests/08_search_profiles_spec.rb
@@ -184,25 +184,32 @@ describe File.basename(__FILE__) do
     actual_data = GRPC reporting, :list_profiles, Reporting::Query.new(
         filters: [
             Reporting::ListFilter.new(type: "end_time", values: ["2018-03-04T#{END_OF_DAY}"]),
-            Reporting::ListFilter.new(type: 'status', values: ['passed'])
+            Reporting::ListFilter.new(type: 'status', values: ['skipped'])
         ],
         page: 1, per_page: 2)
     expected_data = {
         "profiles" => [
             {
-                "name" => "nginx-baseline",
-                "title" => "DevSec Nginx Baseline",
-                "id" => "09adcbb3b9b3233d5de63cd98a5ba3e155b3aaeb66b5abed379f5fb1ff143988",
-                "version" => "2.1.0",
-                "status" => "passed"
+                "name" => "fake-baseline",
+                "title" => "A fake one",
+                "id" => "41a02797bfea15592ba2748d55929d8d1f9da205816ef18d3bb2ebe4c5ce18a9",
+                "version" => "2.0.1",
+                "status" => "skipped"
+            },
+            {
+                "name" => "apache-baseline",
+                "title" => "DevSec Apache Baseline",
+                "id" => "41a02784bfea15592ba2748d55927d8d1f9da205816ef18d3bb2ebe4c5ce18a9",
+                "version" => "2.0.1",
+                "status" => "skipped"
             }
         ],
         "counts" => {
-            "total" => 1,
-            "passed" => 1
+            "total" => 2,
+            "skipped" => 2
         }
-    }.to_json
-    assert_equal(expected_data, actual_data.to_json)
+    }
+    assert_equal_json_content(expected_data, actual_data)
 
     # Get profiles used by node with node_id
     actual_data = GRPC reporting, :list_profiles, Reporting::Query.new(filters: [


### PR DESCRIPTION
### :nut_and_bolt: Description
I wasn't clear on whether or not status filtering on compliance reporting profiles is supported or not, so i added a test. And it is!! 🎉 
Figured we should commit the test, so we know for sure that it's supported

### :+1: Definition of Done
test for filtering by status on compliance reporting profiles

### Related Resources
https://github.com/chef/automate/issues/443