### PR TITLE
compliance reporting nodes: filter by inspec version (backend)

### DIFF
--- a/components/compliance-service/api/tests/02_nodes_spec.rb
+++ b/components/compliance-service/api/tests/02_nodes_spec.rb
@@ -392,6 +392,54 @@ describe File.basename(__FILE__) do
     }.to_json
     assert_equal(expected_nodes, actual_nodes.to_json)
 
+    # Test filters by inspec version
+    actual_nodes = GRPC reporting, :list_nodes, Reporting::Query.new(filters: [
+        Reporting::ListFilter.new(type: 'inspec_version', values: ['3.1.0']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z'])
+    ])
+    expected_nodes = {
+        "nodes" => [
+            {
+                "id" => "9b9f4e51-b049-4b10-9555-10578916e149",
+                "name" => "centos-beta",
+                "platform" => {
+                    "name" => "centos",
+                    "release" => "5.11"
+                },
+                "environment" => "DevSec Prod beta",
+                "latestReport" => {
+                    "id" => "bb93e1b2-36d6-439e-ac70-cccccccccc04",
+                    "endTime" => {
+                        "seconds" => 1520155121
+                    },
+                    "status" => "passed",
+                    "controls" => {
+                        "total" => 18,
+                        "passed" => {
+                            "total" => 3
+                        },
+                        "skipped" => {
+                            "total" => 15
+                        },
+                        "failed" => {}
+                    }
+                },
+                "tags" => [],
+                "profiles" => []
+            }
+        ],
+        "total" => 1
+    }.to_json
+    assert_equal(expected_nodes, actual_nodes.to_json)
+
+    # Test filters by inspec version
+    actual_nodes = GRPC reporting, :list_nodes, Reporting::Query.new(filters: [
+        Reporting::ListFilter.new(type: 'inspec_version', values: ['3.1.3']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z'])
+    ])
+    assert_equal(actual_nodes.total, 4)
+
+
     # Test filters by env and status
     actual_nodes = GRPC reporting, :list_nodes, Reporting::Query.new(filters: [
         Reporting::ListFilter.new(type: 'environment', values: ['DevSec Prod beta']),

--- a/components/compliance-service/generator/dump/audit_reports/2018-03-04_centos(3)-beta-nginx(p)-apache(s)-fake(s)-passed.json
+++ b/components/compliance-service/generator/dump/audit_reports/2018-03-04_centos(3)-beta-nginx(p)-apache(s)-fake(s)-passed.json
@@ -8,7 +8,7 @@
   "roles": ["base_linux", "apache_linux", "nginx-hardening-prod", "dot.role"],
   "recipes": ["apache_extras", "apache_extras::harden", "java::default", "nagios::fix"],
   "end_time": "2018-03-04T09:18:41Z",
-  "version": "3.1.3",
+  "version": "3.1.0",
   "platform": {
     "name": "centos",
     "release": "5.11"

--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -655,6 +655,11 @@ func (backend ES2Backend) getFiltersQuery(filters map[string][]string, latestOnl
 		boolQuery = boolQuery.Must(termQuery)
 	}
 
+	if len(filters["inspec_version"]) > 0 {
+		termQuery := elastic.NewTermsQuery("version", stringArrayToInterfaceArray(filters["inspec_version"])...)
+		boolQuery = boolQuery.Must(termQuery)
+	}
+
 	if len(filters["job_id"]) > 0 {
 		termQuery := elastic.NewTermsQuery("job_uuid", stringArrayToInterfaceArray(filters["job_id"])...)
 		boolQuery = boolQuery.Must(termQuery)


### PR DESCRIPTION
### :nut_and_bolt: Description
Adds support for filtering compliance reporting nodes by inspec version 🎉 
_note: this does not include the ui changes needed to make this searchable from ui searchbar_

### :+1: Definition of Done
can filter compliance nodes by inspec version

### :athletic_shoe: Demo Script / Repro Steps
rebuild compliance
send some inspec reports in with different inspec versions
use the api to filter by "inspec_version"

### :chains: Related Resources
https://github.com/chef/automate/issues/431

