### PR TITLE
Be specific when using instance name

### DIFF
--- a/lib/workflow/backend/backend.go
+++ b/lib/workflow/backend/backend.go
@@ -11,14 +11,14 @@ type Driver interface {
 
 	DequeueTask(ctx context.Context, taskName string) (*Task, TaskCompleter, error)
 
-	CreateWorkflowSchedule(ctx context.Context, scheduleName string, workflowName string, parameters []byte, enabled bool, recurrence string, nextRunAt time.Time) error
+	CreateWorkflowSchedule(ctx context.Context, instanceName string, workflowName string, parameters []byte, enabled bool, recurrence string, nextRunAt time.Time) error
 	GetDueRecurringWorkflow(ctx context.Context) (*Schedule, RecurringWorkflowCompleter, error)
 	GetNextScheduledWorkflow(ctx context.Context) (*Schedule, error)
 	UpdateWorkflowScheduleByID(ctx context.Context, id int64, opts WorkflowScheduleUpdateOpts) error
-	UpdateWorkflowScheduleByName(ctx context.Context, scheduleName string, workflowName string, opts WorkflowScheduleUpdateOpts) error
+	UpdateWorkflowScheduleByName(ctx context.Context, instanceName string, workflowName string, opts WorkflowScheduleUpdateOpts) error
 
-	GetScheduledWorkflowParameters(ctx context.Context, scheduleName string, workflowName string) ([]byte, error)
-	GetScheduledWorkflowRecurrence(ctx context.Context, scheduleName string, workflowName string) (string, error)
+	GetScheduledWorkflowParameters(ctx context.Context, instanceName string, workflowName string) ([]byte, error)
+	GetScheduledWorkflowRecurrence(ctx context.Context, instanceName string, workflowName string) (string, error)
 
 	ListWorkflowSchedules(ctx context.Context) ([]*Schedule, error)
 
@@ -112,7 +112,7 @@ type Schedule struct {
 	// need the ID to create unique workflow names.
 	ID             int64
 	Enabled        bool
-	Name           string
+	InstanceName   string
 	WorkflowName   string
 	Parameters     []byte
 	Recurrence     string

--- a/lib/workflow/integration/schedule_test.go
+++ b/lib/workflow/integration/schedule_test.go
@@ -70,7 +70,7 @@ func (suite *WorkflowTestSuite) TestSimpleScheduleWorkflow() {
 	found := false
 	schedules, err := m.ListWorkflowSchedules(context.Background())
 	for _, s := range schedules {
-		if s.WorkflowName == workflowName && s.Name == instanceName {
+		if s.WorkflowName == workflowName && s.InstanceName == instanceName {
 			found = true
 		}
 	}
@@ -174,7 +174,7 @@ func (suite *WorkflowTestSuite) TestExpiringSchedule() {
 	found := false
 	schedules, err := m.ListWorkflowSchedules(context.Background())
 	for _, s := range schedules {
-		if s.WorkflowName == workflowName && s.Name == instanceName {
+		if s.WorkflowName == workflowName && s.InstanceName == instanceName {
 			suite.Assert().True(s.Enabled)
 			found = true
 		}
@@ -188,7 +188,7 @@ func (suite *WorkflowTestSuite) TestExpiringSchedule() {
 	found = false
 	schedules, err = m.ListWorkflowSchedules(context.Background())
 	for _, s := range schedules {
-		if s.WorkflowName == workflowName && s.Name == instanceName {
+		if s.WorkflowName == workflowName && s.InstanceName == instanceName {
 			suite.Assert().False(s.Enabled,
 				"expected scheduled workflow to be disabled because it expired")
 			found = true

--- a/lib/workflow/postgres/sql_schema.go
+++ b/lib/workflow/postgres/sql_schema.go
@@ -15,7 +15,7 @@ BEGIN;
 CREATE TABLE recurring_workflow_schedules (
     id BIGSERIAL PRIMARY KEY,
 
-    name TEXT NOT NULL,
+    instance_name TEXT NOT NULL,
     workflow_name TEXT NOT NULL,
     parameters BYTEA,
     recurrence TEXT,
@@ -25,7 +25,7 @@ CREATE TABLE recurring_workflow_schedules (
     last_enqueued_at TIMESTAMPTZ,
     next_run_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
-    CONSTRAINT say_my_name UNIQUE(name, workflow_name)
+    CONSTRAINT say_my_name UNIQUE(instance_name, workflow_name)
 );
 
 CREATE OR REPLACE FUNCTION update_recurring_workflow_parameters(
@@ -69,7 +69,7 @@ CREATE TYPE workflow_instance_status AS ENUM('running', 'abandoned');
 
 CREATE TABLE workflow_instances (
     id BIGSERIAL PRIMARY KEY,
-    name TEXT NOT NULL,
+    instance_name TEXT NOT NULL,
     workflow_name TEXT NOT NULL,
     parameters BYTEA,
     payload BYTEA,
@@ -79,12 +79,12 @@ CREATE TABLE workflow_instances (
     completed_tasks INTEGER NOT NULL DEFAULT 0,
     status workflow_instance_status NOT NULL DEFAULT 'running',
 
-    CONSTRAINT say_my_name1 UNIQUE(name, workflow_name)
+    CONSTRAINT say_my_name1 UNIQUE(instance_name, workflow_name)
 );
 
 CREATE TABLE workflow_results (
     id BIGSERIAL PRIMARY KEY,
-    name TEXT NOT NULL,
+    instance_name TEXT NOT NULL,
     workflow_name TEXT NOT NULL,
     parameters BYTEA,
     start_at TIMESTAMPTZ NOT NULL,
@@ -140,14 +140,14 @@ CREATE TABLE workflow_events (
 
 -- Workflow Functions
 CREATE OR REPLACE FUNCTION enqueue_workflow(
-    name TEXT,
+    instance_name TEXT,
     workflow_name TEXT,
     parameters BYTEA)
 RETURNS INTEGER
 AS $$
     WITH winst AS (
-        INSERT INTO workflow_instances(name, workflow_name, parameters)
-            VALUES(name, workflow_name, parameters)
+        INSERT INTO workflow_instances(instance_name, workflow_name, parameters)
+            VALUES(instance_name, workflow_name, parameters)
             ON CONFLICT DO NOTHING
             RETURNING id
         )
@@ -165,7 +165,7 @@ AS $$
     WITH nextwinst AS (
         SELECT
             a.id id,
-            a.name instance_name,
+            a.instance_name instance_name,
             a.workflow_name workflow_name,
             a.status status,
             a.parameters parameters,
@@ -194,7 +194,6 @@ RETURNS VOID
 AS $$
     INSERT INTO workflow_events(event_type, workflow_instance_id)
         VALUES('cancel', workflow_instance_id);
-    -- TODO: notify
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION abandon_workflow(_workflow_instance_id BIGINT, eid BIGINT, _completed_tasks INTEGER)
@@ -229,11 +228,11 @@ LANGUAGE SQL
 AS $$
     WITH 
     done_workflows AS (
-        SELECT id, name, workflow_name, parameters, start_at 
+        SELECT id, instance_name, workflow_name, parameters, start_at 
         FROM workflow_instances where id = wid
     )
-    INSERT INTO workflow_results(name, workflow_name, parameters, start_at)
-        (SELECT name, workflow_name, parameters, start_at FROM done_workflows);
+    INSERT INTO workflow_results(instance_name, workflow_name, parameters, start_at)
+        (SELECT instance_name, workflow_name, parameters, start_at FROM done_workflows);
     
     DELETE FROM tasks WHERE workflow_instance_id = wid;
     DELETE FROM tasks_results WHERE workflow_instance_id = wid;

--- a/lib/workflow/recurring_workflow_scheduler.go
+++ b/lib/workflow/recurring_workflow_scheduler.go
@@ -87,7 +87,7 @@ func (w *workflowScheduler) scheduleWorkflow(ctx context.Context) (time.Duration
 		logrus.Warnf("Recurring workflow %fs past due. (expected at %s)", time.Since(s.NextDueAt).Seconds(), s.NextDueAt)
 	}
 
-	workflowInstanceName := s.Name
+	workflowInstanceName := s.InstanceName
 
 	// TODO(ssd) 2019-05-13: We might need two different
 	// rule types here to suppor the different use cases.
@@ -112,7 +112,7 @@ func (w *workflowScheduler) scheduleWorkflow(ctx context.Context) (time.Duration
 		if err == ErrWorkflowInstanceExists {
 			logrus.Warnf(
 				"Recurring workflow %q still running, consider increasing recurrence interval",
-				s.Name)
+				s.InstanceName)
 			// TODO(jaym): what do we want to do here? i think we're going to keep trying
 			//             until we succeed here? Maybe we want to skip this interval?
 			return maxWakeupInterval, nil

--- a/lib/workflow/workflow.go
+++ b/lib/workflow/workflow.go
@@ -361,7 +361,7 @@ func (m *WorkflowManager) Stop() error {
 // rule provided. The first run will happen during when the recurrence is first
 // due from Now.
 func (m *WorkflowManager) CreateWorkflowSchedule(
-	scheduleName string,
+	instanceName string,
 	workflowName string,
 	parameters interface{},
 	enabled bool,
@@ -375,7 +375,7 @@ func (m *WorkflowManager) CreateWorkflowSchedule(
 	if err != nil {
 		return err
 	}
-	return m.backend.CreateWorkflowSchedule(context.TODO(), scheduleName, workflowName,
+	return m.backend.CreateWorkflowSchedule(context.TODO(), instanceName, workflowName,
 		jsonData, enabled, recurRule.String(), nextRunAt)
 }
 
@@ -415,9 +415,9 @@ func UpdateRecurrence(recurRule *rrule.RRule) WorkflowScheduleUpdateOpts {
 }
 
 // UpdateWorkflowScheduleByName updates the scheduled workflow identified by
-// (scheduleName, workflowName).
+// (instanceName, workflowName).
 func (m *WorkflowManager) UpdateWorkflowScheduleByName(ctx context.Context,
-	scheduleName string, workflowName string, opts ...WorkflowScheduleUpdateOpts) error {
+	instanceName string, workflowName string, opts ...WorkflowScheduleUpdateOpts) error {
 
 	o := backend.WorkflowScheduleUpdateOpts{}
 	for _, opt := range opts {
@@ -426,7 +426,7 @@ func (m *WorkflowManager) UpdateWorkflowScheduleByName(ctx context.Context,
 			return err
 		}
 	}
-	return m.backend.UpdateWorkflowScheduleByName(ctx, scheduleName, workflowName, o)
+	return m.backend.UpdateWorkflowScheduleByName(ctx, instanceName, workflowName, o)
 }
 
 // ListWorkflowSchedules list all the scheduled workflows.
@@ -443,9 +443,9 @@ func (m *WorkflowManager) ListWorkflowSchedules(ctx context.Context) ([]*Schedul
 }
 
 // GetScheduledWorkflowParameters returns the parameters that the scheduled workflow
-// identified by (scheduleName, workflowName) will be started with.
-func (m *WorkflowManager) GetScheduledWorkflowParameters(ctx context.Context, scheduleName string, workflowName string, out interface{}) error {
-	data, err := m.backend.GetScheduledWorkflowParameters(ctx, scheduleName, workflowName)
+// identified by (instanceName, workflowName) will be started with.
+func (m *WorkflowManager) GetScheduledWorkflowParameters(ctx context.Context, instanceName string, workflowName string, out interface{}) error {
+	data, err := m.backend.GetScheduledWorkflowParameters(ctx, instanceName, workflowName)
 	if err != nil {
 		return errors.Wrap(err, "could not retrieve parameters for workflow")
 	}
@@ -458,9 +458,9 @@ func (m *WorkflowManager) GetScheduledWorkflowParameters(ctx context.Context, sc
 }
 
 // GetScheduledWorkflowRecurrence returns the recurrence rule for the scheduled workflow
-// identified by (scheduleName, workflowName)
-func (m *WorkflowManager) GetScheduledWorkflowRecurrence(ctx context.Context, scheduleName string, workflowName string) (*rrule.RRule, error) {
-	ruleStr, err := m.backend.GetScheduledWorkflowRecurrence(ctx, scheduleName, workflowName)
+// identified by (instanceName, workflowName)
+func (m *WorkflowManager) GetScheduledWorkflowRecurrence(ctx context.Context, instanceName string, workflowName string) (*rrule.RRule, error) {
+	ruleStr, err := m.backend.GetScheduledWorkflowRecurrence(ctx, instanceName, workflowName)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not retrieve parameters for workflow")
 	}

--- a/tools/workflow-scaffold/main.go
+++ b/tools/workflow-scaffold/main.go
@@ -359,7 +359,7 @@ func runScheduleTest(_ *cobra.Command, args []string) error {
 	}
 
 	workflowManager.UpdateWorkflowScheduleByName(context.Background(),
-		schedules[0].Name, schedules[0].WorkflowName, workflow.UpdateParameters("youwin"))
+		schedules[0].InstanceName, schedules[0].WorkflowName, workflow.UpdateParameters("youwin"))
 
 	workflowManager.Start(context.Background())
 
@@ -370,7 +370,7 @@ func runScheduleTest(_ *cobra.Command, args []string) error {
 		}
 		for _, s := range schedules {
 			logrus.WithFields(logrus.Fields{
-				"name":          s.Name,
+				"name":          s.InstanceName,
 				"workflow_name": s.WorkflowName,
 				"enabled":       s.Enabled,
 				"next_due_at":   s.NextDueAt,


### PR DESCRIPTION
In a lot of places, we use name, which is ambiguous. This
changes those cases to specifically call out that it is
an instance name. schedule name has also been changed to
instance name as those are the same.