### PR TITLE
Specify creds for the a1 data package used by nightly migration tests

### DIFF
--- a/components/automate-deployment/a1-migration/README.md
+++ b/components/automate-deployment/a1-migration/README.md
@@ -108,7 +108,13 @@ If you wish to publish artifacts to the depot, you must first:
    `#releng-support` slack channel)
 
 Now create a hab data artifact: `make a1-migration-create-artifact`
-Optionally upload it: `make a1-migration-upload-artifact`
+Optionally upload: `make a1-migration-upload-artifact`
+
+If you rebuild the data artifact used in the nightly a1-migration test, you will need to
+update `A1_BUILDER_PASSWORD` and `AUTOMATE_API_DEFAULT_PASSWORD` in `automate/scripts/nightly_migration.sh`
+with the credentials generated during `make a1-migration-up` when you built the data artifact. The generated creds are in
+`automate/components/automate-deployment/a1-migration/keys/enterprise-test-admin-login-creds`.
+
 
 ```
 NOTE: If you have troubles with docker make sure you increase the resources available

--- a/components/automate-deployment/a1-migration/load-artifact
+++ b/components/automate-deployment/a1-migration/load-artifact
@@ -9,7 +9,7 @@ chef-server-ctl stop
 ## code path
 ## see https://chefio.atlassian.net/wiki/spaces/ENG/pages/455147533/Migrating+A1+Elasticsearch+data
 ## and https://drive.google.com/open?id=1dtdt8kRXywDAE9G03WX7a3mWQoAWsYY1
-DATA_PACKAGE_RELEASE="20190524202433"
+DATA_PACKAGE_RELEASE="20190530183952"
 HAB_LICENSE=accept-no-persist hab pkg install "devchef/a1-migration-data-full/0.0.1/$DATA_PACKAGE_RELEASE" --channel unstable
 
 echo "waiting for migration data to sync..."

--- a/scripts/nightly_migration.sh
+++ b/scripts/nightly_migration.sh
@@ -40,5 +40,5 @@ make a1-migration-up
 sleep 20 # TODO: Do we really need this sleep?
 make a1-migration-load-sample-data
 HARTIFACT_DIR="/a2/results" make a1-migration-migrate
-# Password for a1-migration-data-full/0.0.1/20181210102316
-A1_BUILDER_PASSWORD='N4pYOUDm0AFo0XbCje0ipbphmzQf4NrWK2c=' AUTOMATE_API_DEFAULT_PASSWORD='hDMfTHlHasxieSrk3HhSFaur9L+Oe4D0wzQ=' make a1-migration-test
+# Password for a1-migration-data-full/0.0.1/20190530183952
+A1_BUILDER_PASSWORD='KfK1LU/nGzk6J8BmnD+G3GwPn9+TqD5VGwQ=' AUTOMATE_API_DEFAULT_PASSWORD='WThqQgjnI6vAhi3TEVoM7GntWBI1HvJMREQ=' make a1-migration-test


### PR DESCRIPTION
### :nut_and_bolt: Description
The creds used to test a1 -> a2 migrations in the nightly need to match those generated when the a1 data package was built.

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
