### PR TITLE
UI-262 Add badge stencil component Signed-Off By: Tara Black <tblack…

### DIFF
--- a/components/chef-ui-library/src/atoms/chef-badge/chef-badge.e2e.tsx
+++ b/components/chef-ui-library/src/atoms/chef-badge/chef-badge.e2e.tsx
@@ -7,10 +7,7 @@ describe('chef-badge', () => {
   beforeEach(async () => {
     page = await newE2EPage();
     await page.setContent(`
-      <chef-badge>
-        <chef-icon>check</chef-icon>
-        <span>Badge Text</span>
-      </chef-badge>
+      <chef-badge>Badge Text</chef-badge>
     `);
     element = await page.find('chef-badge');
   });
@@ -19,72 +16,57 @@ describe('chef-badge', () => {
     expect(element).toHaveClass('hydrated');
   });
 
-  it('displays slotted content', async () => {
-    expect(await element.find('chef-icon')).toBeTruthy();
-  });
-
-  describe('when `type` prop is not set', () => {
-    it('defaults `type` attr to `badge`', async () => {
-      expect(element.getAttribute('type')).toEqual('badge');
+  describe('when `no-data` prop is not set', () => {
+    it('defaults `no-data` attr to `false`', async () => {
+      expect(element.getAttribute('noData')).toBeNull();
     });
   });
 
-  describe('when `type` prop is set', () => {
-    it('sets `type` attr to prop val', async () => {
-      element.setProperty('type', 'reset');
-      await page.waitForChanges();
-
-      expect(element.getAttribute('type')).toEqual('reset');
-    });
-  });
-
-  describe('when `disabled` property is false', () => {
+  describe('when `no-data` property is true', () => {
     beforeEach(async () => {
-      element.setProperty('disabled', false);
+      element.setProperty('noData', true);
       await page.waitForChanges();
     });
 
-    it('does not have an `aria-disabled` attribute', async () => {
-      expect(element.hasAttribute('aria-disabled')).toEqual(false);
+    it('has an `no-data` attribute', async () => {
+      expect(element.getAttribute('noData')).toBeNull();
     });
   });
 
-  describe('when `disabled` property is true', () => {
+  describe('when `id` property is set', () => {
     beforeEach(async () => {
-      element.setProperty('disabled', true);
+      element.setProperty('id', 'myId');
       await page.waitForChanges();
     });
 
-    it('has an `aria-disabled` attribute', async () => {
-      expect(element.hasAttribute('aria-disabled')).toEqual(true);
+    it('has an `id` attribute', async () => {
+      expect(element.getAttribute('id')).toEqual('myId');
     });
   });
 
-  describe('when clicked', () => {
+  describe('when `id` property is not set', () => {
+
+    it('will not have a `id` attribute', async () => {
+      expect(element.getAttribute('id')).toBeNull();
+    });
+  });
+
+  describe('when `tooltip` property is set', () => {
     beforeEach(async () => {
-      await page.$eval('chef-badge', el => {
-        el.addEventListener('click', () => el.innerHTML = 'clicked');
-      });
+      element.setProperty('id', 'myId');
+      element.setProperty('tooltip', 'Tooltip');
       await page.waitForChanges();
     });
 
-    it('triggers click handlers', async () => {
-      await element.click();
-      await page.waitForChanges();
-      expect(element).toEqualText('clicked');
+    it('has an `tooltip` attribute', async () => {
+      expect(element.getAttribute('tooltip')).toEqual('Tooltip');
     });
+  });
 
-    describe('and when disabled', () => {
-      beforeEach(async () => {
-        element.setProperty('disabled', true);
-        await page.waitForChanges();
-      });
+  describe('when `tooltip` property is not set', () => {
 
-      it('does not trigger click handlers', async () => {
-        await element.click();
-        await page.waitForChanges();
-        expect(element).not.toEqualText('clicked');
-      });
+    it('will not have a `tooltip` attribute', async () => {
+      expect(element.getAttribute('tooltip')).toBeNull();
     });
   });
 });

--- a/components/chef-ui-library/src/atoms/chef-badge/chef-badge.e2e.tsx
+++ b/components/chef-ui-library/src/atoms/chef-badge/chef-badge.e2e.tsx
@@ -1,0 +1,90 @@
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
+
+describe('chef-badge', () => {
+  let page: E2EPage;
+  let element: E2EElement;
+
+  beforeEach(async () => {
+    page = await newE2EPage();
+    await page.setContent(`
+      <chef-badge>
+        <chef-icon>check</chef-icon>
+        <span>Badge Text</span>
+      </chef-badge>
+    `);
+    element = await page.find('chef-badge');
+  });
+
+  it('renders', async () => {
+    expect(element).toHaveClass('hydrated');
+  });
+
+  it('displays slotted content', async () => {
+    expect(await element.find('chef-icon')).toBeTruthy();
+  });
+
+  describe('when `type` prop is not set', () => {
+    it('defaults `type` attr to `badge`', async () => {
+      expect(element.getAttribute('type')).toEqual('badge');
+    });
+  });
+
+  describe('when `type` prop is set', () => {
+    it('sets `type` attr to prop val', async () => {
+      element.setProperty('type', 'reset');
+      await page.waitForChanges();
+
+      expect(element.getAttribute('type')).toEqual('reset');
+    });
+  });
+
+  describe('when `disabled` property is false', () => {
+    beforeEach(async () => {
+      element.setProperty('disabled', false);
+      await page.waitForChanges();
+    });
+
+    it('does not have an `aria-disabled` attribute', async () => {
+      expect(element.hasAttribute('aria-disabled')).toEqual(false);
+    });
+  });
+
+  describe('when `disabled` property is true', () => {
+    beforeEach(async () => {
+      element.setProperty('disabled', true);
+      await page.waitForChanges();
+    });
+
+    it('has an `aria-disabled` attribute', async () => {
+      expect(element.hasAttribute('aria-disabled')).toEqual(true);
+    });
+  });
+
+  describe('when clicked', () => {
+    beforeEach(async () => {
+      await page.$eval('chef-badge', el => {
+        el.addEventListener('click', () => el.innerHTML = 'clicked');
+      });
+      await page.waitForChanges();
+    });
+
+    it('triggers click handlers', async () => {
+      await element.click();
+      await page.waitForChanges();
+      expect(element).toEqualText('clicked');
+    });
+
+    describe('and when disabled', () => {
+      beforeEach(async () => {
+        element.setProperty('disabled', true);
+        await page.waitForChanges();
+      });
+
+      it('does not trigger click handlers', async () => {
+        await element.click();
+        await page.waitForChanges();
+        expect(element).not.toEqualText('clicked');
+      });
+    });
+  });
+});

--- a/components/chef-ui-library/src/atoms/chef-badge/chef-badge.scss
+++ b/components/chef-ui-library/src/atoms/chef-badge/chef-badge.scss
@@ -1,0 +1,98 @@
+@import '../../global/variables.css';
+
+// Reset styles for the inner badge.
+// Most styling should be done on the parent. This should
+// make it easier for folks to tweak the styles if needed
+// during implementation.
+chef-badge {
+  badge {
+    background: transparent;
+    border: 0px solid transparent;
+    color: inherit;
+    cursor: inherit;
+    display: inherit;
+    align-items: inherit;
+    justify-content: inherit;
+    flex-direction: inherit;
+    flex-wrap: inherit;
+    font-size: inherit;
+    font-family: inherit;
+    height: inherit;
+    line-height: inherit;
+    margin: 0;
+    padding: 0 5px;
+    pointer-events: inherit;
+    text-decoration: inherit;
+    text-transform: uppercase;
+    width: inherit;
+    min-width: inherit;
+    max-width: inherit;
+    height: inherit;
+    min-height: inherit;
+    max-height: inherit;
+  }
+
+  &[tooltip] {
+    cursor: pointer;
+  }
+}
+
+chef-badge {
+  #{--background-color}: var(--chef-lightest-grey);
+  #{--border-color}: var(--chef-grey);
+  #{--color}: var(--chef-primary-dark);
+}
+
+chef-badge {
+  background-color: var(--background-color);
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--border-color);
+  border-radius: 2px;
+  color: var(--color);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: nowrap;
+  font-size: 10px;
+  font-weight: 600;
+  margin: 5px;
+  min-height: 15px;
+  min-width: 15px;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: top;
+
+  chef-tooltip {
+    font-size: 13px;
+    padding: 1.5em;
+  }
+
+  &[no-data] {
+    border-style: dashed;
+  }
+}
+
+chef-badge[primary] {
+  #{--background-color}: var(--chef-badge-primary-background);
+  #{--border-color}: var(--chef-badge-primary-border);
+  #{--color}: var(--chef-badge-primary-color);
+}
+
+chef-badge[critical] {
+  #{--background-color}: var(--chef-badge-critical-background);
+  #{--border-color}: var(--chef-badge-critical-border);
+  #{--color}: var(--chef-badge-critical-color);
+}
+
+chef-badge[warning] {
+  #{--background-color}: var(--chef-badge-warning-background);
+  #{--border-color}: var(--chef-badge-warning-border);
+  #{--color}: var(--chef-badge-warning-color);
+}
+
+chef-badge[success] {
+  #{--background-color}: var(--chef-badge-success-background);
+  #{--border-color}: var(--chef-badge-success-border);
+  #{--color}: var(--chef-badge-success-color);
+}

--- a/components/chef-ui-library/src/atoms/chef-badge/chef-badge.tsx
+++ b/components/chef-ui-library/src/atoms/chef-badge/chef-badge.tsx
@@ -5,8 +5,11 @@ import {
 
 /**
  * @description
- * `<chef-badge>` is used to Badges are generally used to provide context or emphasis on a characteristic of another object in the interface, e.g., the channel name for a Habitat package. They are generally actionless. But when there are more descriptions needed to help explain the context, a hover state with tooltip can be added.
- *  
+ * `<chef-badge>` is used to Badges are generally used to provide context or emphasis on a
+ * characteristic of another object in the interface, e.g., the channel name for a Habitat
+ * package. They are generally actionless. But when there are more descriptions needed to
+ * help explain the context, a hover state with tooltip can be added.
+ *
  * Semantic colors can be applied to indicate: general, primary, critical, warning, and success.
  *
  * @example
@@ -15,9 +18,9 @@ import {
  * <chef-badge critical>critical</chef-badge>
  * <chef-badge warning>warning</chef-badge>
  * <chef-badge success>success</chef-badge>
- * 
+ *
  * <chef-separator></chef-separator>
- * 
+ *
  * <chef-badge no-data>general</chef-badge>
  * <chef-badge no-data primary>primary</chef-badge>
  * <chef-badge no-data critical>critical</chef-badge>
@@ -30,9 +33,9 @@ import {
  * <chef-badge critical id="critical-tooltip" tooltip="Tooltip">critical</chef-badge>
  * <chef-badge warning id="warning-tooltip" tooltip="Tooltip">warning</chef-badge>
  * <chef-badge success id="success-tooltip" tooltip="Tooltip">success</chef-badge>
- * 
+ *
  * <chef-separator></chef-separator>
- * 
+ *
  * <chef-badge no-data id="general-2-tooltip" tooltip="Tooltip">general</chef-badge>
  * <chef-badge no-data primary id="primary-2-tooltip" tooltip="Tooltip">primary</chef-badge>
  * <chef-badge no-data critical id="critical-2-tooltip" tooltip="Tooltip">critical</chef-badge>
@@ -61,24 +64,13 @@ export class ChefBadge {
   @Prop({ reflectToAttr: true }) tooltip: string;
 
   render() {
-    if (this.tooltip && this.id) {
-      return (
-        <div>
-          <chef-tooltip for={this.id}>{this.tooltip}</chef-tooltip>
-          <badge
-            id={this.id}
-            no-data={this.noData}>
-            <slot />
-          </badge>
-        </div>
-      );
-    } else {
-      return (
-        <badge
-          no-data={this.noData}>
-          <slot />
-        </badge>
-      );
-    }
+    const tooltip = this.tooltip ? <chef-tooltip for={this.id}>{this.tooltip}</chef-tooltip> : null;
+    const badge = (
+      <div class="badge" id={this.id} no-data={this.noData}>
+        <slot />
+      </div>
+    );
+
+    return [badge, tooltip];
   }
 }

--- a/components/chef-ui-library/src/atoms/chef-badge/chef-badge.tsx
+++ b/components/chef-ui-library/src/atoms/chef-badge/chef-badge.tsx
@@ -1,0 +1,84 @@
+import {
+  Component,
+  Prop
+} from '@stencil/core';
+
+/**
+ * @description
+ * `<chef-badge>` is used to Badges are generally used to provide context or emphasis on a characteristic of another object in the interface, e.g., the channel name for a Habitat package. They are generally actionless. But when there are more descriptions needed to help explain the context, a hover state with tooltip can be added.
+ *  
+ * Semantic colors can be applied to indicate: general, primary, critical, warning, and success.
+ *
+ * @example
+ * <chef-badge>general</chef-badge>
+ * <chef-badge primary>primary</chef-badge>
+ * <chef-badge critical>critical</chef-badge>
+ * <chef-badge warning>warning</chef-badge>
+ * <chef-badge success>success</chef-badge>
+ * 
+ * <chef-separator></chef-separator>
+ * 
+ * <chef-badge no-data>general</chef-badge>
+ * <chef-badge no-data primary>primary</chef-badge>
+ * <chef-badge no-data critical>critical</chef-badge>
+ * <chef-badge no-data warning>warning</chef-badge>
+ * <chef-badge no-data success>success</chef-badge>
+ *
+ * @example
+ * <chef-badge id="general-tooltip" tooltip="Tooltip">general</chef-badge>
+ * <chef-badge primary id="primary-tooltip" tooltip="Tooltip">primary</chef-badge>
+ * <chef-badge critical id="critical-tooltip" tooltip="Tooltip">critical</chef-badge>
+ * <chef-badge warning id="warning-tooltip" tooltip="Tooltip">warning</chef-badge>
+ * <chef-badge success id="success-tooltip" tooltip="Tooltip">success</chef-badge>
+ * 
+ * <chef-separator></chef-separator>
+ * 
+ * <chef-badge no-data id="general-2-tooltip" tooltip="Tooltip">general</chef-badge>
+ * <chef-badge no-data primary id="primary-2-tooltip" tooltip="Tooltip">primary</chef-badge>
+ * <chef-badge no-data critical id="critical-2-tooltip" tooltip="Tooltip">critical</chef-badge>
+ * <chef-badge no-data warning id="warning-2-tooltip" tooltip="Tooltip">warning</chef-badge>
+ * <chef-badge no-data success id="success-2-tooltip" tooltip="Tooltip">success</chef-badge>
+ */
+@Component({
+  tag: 'chef-badge',
+  styleUrl: 'chef-badge.scss'
+})
+export class ChefBadge {
+
+  /**
+   * Indicate badge has no data
+   */
+  @Prop({ reflectToAttr: true }) noData = false;
+
+  /**
+   * The ID of the element to attach the tooltip
+   */
+  @Prop({ reflectToAttr: true }) id: string;
+
+  /**
+   * Text to be displayed within tooltips
+   */
+  @Prop({ reflectToAttr: true }) tooltip: string;
+
+  render() {
+    if (this.tooltip && this.id) {
+      return (
+        <div>
+          <chef-tooltip for={this.id}>{this.tooltip}</chef-tooltip>
+          <badge
+            id={this.id}
+            no-data={this.noData}>
+            <slot />
+          </badge>
+        </div>
+      );
+    } else {
+      return (
+        <badge
+          no-data={this.noData}>
+          <slot />
+        </badge>
+      );
+    }
+  }
+}

--- a/components/chef-ui-library/src/global/variables.css
+++ b/components/chef-ui-library/src/global/variables.css
@@ -26,6 +26,20 @@
   --atomic-tangerine: #FF9654;
   --blue-de-france: #3DA5FF;
   --gray: #B7BCBC;
+  --blue: #174AF0;
+  --lavender-blue: #BDCBFB;
+  --lavender: #DEE5FD;
+  --maroon: #BA1E6A;
+  --lavender-pink: #F387D4;
+  --piggy-pink: #F9DBEA;
+  --mahogany: #B74500;
+  --deep-peach: #FFCAAA;
+  --antique-white: #FFE5D4;
+  --dark-cerulean: #00417A;
+  --medium-teal-blue: #005BAB;
+  --columbia-blue: #9ED2FF;
+  --glitter: #CFE8FF;
+
 
   /* ** THESE SEMANTIC COLOR VARIABLES ARE FREE TO BE USED WITHIN AUTOMATE ** */
   /* primary */
@@ -58,5 +72,21 @@
   --chef-modal-bg-color: rgba(34, 36, 53, 0.4);
     /* based on chef-gray 0.65 opacity. */
   --chef-loading-bg-color: rgba(224, 228, 230, 0.65);
-}
 
+  /* ADDING COLORS TO BE USED IN BADGES */
+  --chef-badge-primary-background: var(--lavender);
+  --chef-badge-primary-border: var(--lavender-blue);
+  --chef-badge-primary-color: var(--blue);
+
+  --chef-badge-critical-background: var(--piggy-pink);
+  --chef-badge-critical-border: var(--lavender-pink);
+  --chef-badge-critical-color: var(--maroon);
+
+  --chef-badge-warning-background: var(--antique-white);
+  --chef-badge-warning-border: var(--deep-peach);
+  --chef-badge-warning-color: var(--mahogany);
+
+  --chef-badge-success-background: var(--glitter);
+  --chef-badge-success-border: var(--columbia-blue);
+  --chef-badge-success-color: var(--medium-teal-blue);
+}


### PR DESCRIPTION
…@chef.io>

### :nut_and_bolt: Description
Badges are generally used to provide context or emphasis on a characteristic of another object in the interface, e.g., the channel name for a Habitat package. They are generally action-less. But when there are more descriptions needed to help explain the context, a hover state with tooltip can be added.
Semantic colors can be applied to indicate: general, primary, critical, warning, and success.
![image](https://user-images.githubusercontent.com/4108100/58668358-3ee4d900-82fe-11e9-961d-00d3008cdb58.png)

One use case for badges is to represent empty data in tables and cards. This variation includes a style change for the background outline.
Semantic colors can be applied to indicate: general, primary, critical, and warning.
![image](https://user-images.githubusercontent.com/4108100/58668366-460be700-82fe-11e9-910f-d468b9cb43c7.png)

### :+1: Definition of Done
Include all types of badges in the Stencil component library. Developers can choose which type of badge to display and whether it has a hover state with tooltips.
Document the usage in Chef UI library - Atom and update the site: https://ui-library.cd.chef.co/atoms

### :chains: Related Resources
https://github.com/chef/automate/issues/262
