### PR TITLE
Re-sync introspection logging with code operation

### DIFF
--- a/components/automate-gateway/handler/authz.go
+++ b/components/automate-gateway/handler/authz.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
@@ -250,14 +251,30 @@ func (a *AuthzServer) IntrospectAllProjects(
 }
 
 func logResult(log *logrus.Entry, endpointMap map[string]*gwAuthzRes.MethodsAllowed) {
-	if len(endpointMap) == 0 {
-		log.Debug("Allowed paths: NONE")
-		return
-	}
 	paths := make([]string, len(endpointMap))
 	i := 0
-	for k := range endpointMap {
-		paths[i] = k
+	for k, v := range endpointMap {
+		methods := []string{}
+		if v.Get == true {
+			methods = append(methods, "Get")
+		}
+		if v.Put == true {
+			methods = append(methods, "Put")
+		}
+		if v.Post == true {
+			methods = append(methods, "Post")
+		}
+		if v.Delete == true {
+			methods = append(methods, "Delete")
+		}
+		if v.Patch == true {
+			methods = append(methods, "Patch")
+		}
+		if len(methods) > 0 {
+			paths[i] = fmt.Sprintf("%s[%s]", k, strings.Join(methods, ","))
+		} else {
+			paths[i] = fmt.Sprintf("%s[NONE]", k)
+		}
 		i++
 	}
 	log.Debugf("Allowed paths: " + strings.Join(paths, ", "))

--- a/components/automate-gateway/handler/authz.go
+++ b/components/automate-gateway/handler/authz.go
@@ -255,19 +255,19 @@ func logResult(log *logrus.Entry, endpointMap map[string]*gwAuthzRes.MethodsAllo
 	i := 0
 	for k, v := range endpointMap {
 		methods := []string{}
-		if v.Get == true {
+		if v.Get {
 			methods = append(methods, "Get")
 		}
-		if v.Put == true {
+		if v.Put {
 			methods = append(methods, "Put")
 		}
-		if v.Post == true {
+		if v.Post {
 			methods = append(methods, "Post")
 		}
-		if v.Delete == true {
+		if v.Delete {
 			methods = append(methods, "Delete")
 		}
-		if v.Patch == true {
+		if v.Patch {
 			methods = append(methods, "Patch")
 		}
 		if len(methods) > 0 {


### PR DESCRIPTION
### :nut_and_bolt: Description

Introspection changed some time back,
to return results for every endpoint,
even if all methods were false.

### :+1: Definition of Done

Supervisor log accurately reflects introspection results.

### :athletic_shoe: Demo Script / Repro Steps

1. rebuild components/automate-gateway
2. Enable debug logging in gateway:
```
 chef-automate debug set-log-level automate-gateway debug
```
3. Run `sl | grep Allowed` in hab studio to monitor the log.
4. Navigate around in the browser and observe log lines like these:
```
level=debug msg="Allowed paths: /iam/v2beta/policies[NONE]" ...
level=debug msg="Allowed paths: /retention/nodes/status[Get]" ...
level=debug msg="Allowed paths: /auth/users[Get,Post]" ...
```

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
