### PR TITLE
[A2-798] split partial result update calls for v2 and v2.1

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -235,8 +235,7 @@ steps:
         hab studio run "source scripts/verify_studio_init &&
           start_deployment_service &&
           chef-automate dev deployinate &&
-          chef-automate iam upgrade-to-v2 &&
-          remove_legacy_v1_policies &&
+          chef-automate iam upgrade-to-v2 --skip-policy-migration &&
           gateway_integration"
     timeout_in_minutes: 20
     retry:

--- a/components/authz-service/engine/conformance/conformance_test.go
+++ b/components/authz-service/engine/conformance/conformance_test.go
@@ -674,7 +674,7 @@ func setupV1(t testing.TB) (context.Context, map[string]engine.Engine) {
 func setupV2(t testing.TB) (context.Context, map[string]engine.Engine) {
 	ctx, engines := setup(t)
 	if o, ok := engines["opa"]; ok {
-		o.V2SetPolicies(ctx, map[string]interface{}{}, map[string]interface{}{})
+		o.V2SetPolicies(ctx, map[string]interface{}{}, map[string]interface{}{}, map[string][]interface{}{})
 	}
 	return ctx, engines
 }

--- a/components/authz-service/engine/conformance/conformance_test.go
+++ b/components/authz-service/engine/conformance/conformance_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestIsAuthorized(t *testing.T) {
-	ctx, engines := setup(t)
+	ctx, engines := setupV1(t)
 	sub, act, res := "user:local:admin", "read", "auth:users:admin"
 
 	// We're always passing the same arguments to IsAuthorized(). This allows for
@@ -210,7 +210,7 @@ func TestIsAuthorized(t *testing.T) {
 }
 
 func TestHierarchicalResourcePolicies(t *testing.T) {
-	ctx, engines := setup(t)
+	ctx, engines := setupV1(t)
 	sub, act, res := "user:local:someid", "read", "compliance:scans:123"
 	args := func() (context.Context, engine.Subjects, engine.Action, engine.Resource) {
 		return ctx, engine.Subject(sub), engine.Action(act), engine.Resource(res)
@@ -308,7 +308,7 @@ func TestHierarchicalResourcePolicies(t *testing.T) {
 }
 
 func TestWildcardActionPolicies(t *testing.T) {
-	ctx, engines := setup(t)
+	ctx, engines := setupV1(t)
 	sub, act, res := "user:local:someid", "read", "nodes:property"
 	args := func() (context.Context, engine.Subjects, engine.Action, engine.Resource) {
 		return ctx, engine.Subject(sub), engine.Action(act), engine.Resource(res)
@@ -397,7 +397,7 @@ func TestWildcardActionPolicies(t *testing.T) {
 }
 
 func TestWildcardSubjectsPolicies(t *testing.T) {
-	ctx, engines := setup(t)
+	ctx, engines := setupV1(t)
 	sub, act, res := "user:local:someid", "read", "nodes:property"
 	args := func() (context.Context, engine.Subjects, engine.Action, engine.Resource) {
 		return ctx, engine.Subject(sub), engine.Action(act), engine.Resource(res)
@@ -489,7 +489,7 @@ func TestWildcardSubjectsPolicies(t *testing.T) {
 }
 
 func TestFilterAuthorizedPairs(t *testing.T) {
-	ctx, engines := setup(t)
+	ctx, engines := setupV1(t)
 	sub, act0, res0, act1, res1 := "user:local:someid", "read", "nodes:someid", "delete", "compliance:profiles"
 	pair0 := engine.Pair{Resource: engine.Resource(res0), Action: engine.Action(act0)}
 	pair1 := engine.Pair{Resource: engine.Resource(res1), Action: engine.Action(act1)}
@@ -661,6 +661,30 @@ func BenchmarkFilterAuthorizedPairs(b *testing.B) {
 			filterResult = r
 		})
 	}
+}
+
+func setupV1(t testing.TB) (context.Context, map[string]engine.Engine) {
+	ctx, engines := setup(t)
+	if o, ok := engines["opa"]; ok {
+		o.SetPolicies(ctx, map[string]interface{}{})
+	}
+	return ctx, engines
+}
+
+func setupV2(t testing.TB) (context.Context, map[string]engine.Engine) {
+	ctx, engines := setup(t)
+	if o, ok := engines["opa"]; ok {
+		o.V2SetPolicies(ctx, map[string]interface{}{}, map[string]interface{}{})
+	}
+	return ctx, engines
+}
+
+func setupV2p1(t testing.TB) (context.Context, map[string]engine.Engine) {
+	ctx, engines := setup(t)
+	if o, ok := engines["opa"]; ok {
+		o.V2p1SetPolicies(ctx, map[string]interface{}{}, map[string]interface{}{}, map[string][]interface{}{})
+	}
+	return ctx, engines
 }
 
 func setup(t testing.TB) (context.Context, map[string]engine.Engine) {

--- a/components/authz-service/engine/conformance/conformance_v2_test.go
+++ b/components/authz-service/engine/conformance/conformance_v2_test.go
@@ -713,10 +713,10 @@ func setPoliciesV2pX(t testing.TB, twoPointOne bool, e engine.Engine, policiesAn
 		roleMap[role["id"].(string)] = role
 	}
 	if twoPointOne {
-		err := e.V2p1SetPolicies(ctx, policyMap, roleMap, make(map[string][]interface{}))
+		err := e.V2p1SetPolicies(ctx, policyMap, roleMap, map[string][]interface{}{})
 		require.NoError(t, err, "set policies(v2.1)")
 	} else {
-		err := e.V2SetPolicies(ctx, policyMap, roleMap)
+		err := e.V2SetPolicies(ctx, policyMap, roleMap, map[string][]interface{}{})
 		require.NoError(t, err, "set policies(v2)")
 	}
 }

--- a/components/authz-service/engine/conformance/conformance_v2_test.go
+++ b/components/authz-service/engine/conformance/conformance_v2_test.go
@@ -80,7 +80,7 @@ func TestV2IsAuthorized(t *testing.T) {
 	}
 }
 
-func TestV2ProjectsAuthorized(t *testing.T) {
+func TestV2p1ProjectsAuthorized(t *testing.T) {
 	ctx, engines := setup(t)
 	sub, act, res := "user:local:admin", "iam:users:create", "iam:users"
 	proj1, proj2, proj3, proj4, unassigned := "proj-1", "proj-2", "proj-3", "proj-4", constants.UnassignedProjectID
@@ -112,7 +112,7 @@ func TestV2ProjectsAuthorized(t *testing.T) {
 						},
 					},
 				}
-				setPoliciesV2(t, e, pol)
+				setPoliciesV2p1(t, e, pol)
 				actual, err := e.V2ProjectsAuthorized(args([]string{proj1, proj2}))
 				require.NoError(t, err)
 				assert.Equal(t, []string{proj1}, actual)
@@ -134,7 +134,7 @@ func TestV2ProjectsAuthorized(t *testing.T) {
 					"id":      "handyman",
 					"actions": []string{act},
 				}
-				setPoliciesV2(t, e, pol, role)
+				setPoliciesV2p1(t, e, pol, role)
 				actual, err := e.V2ProjectsAuthorized(args([]string{proj1, proj2}))
 				require.NoError(t, err)
 				assert.ElementsMatch(t, []string{proj1, proj2}, actual)
@@ -156,7 +156,7 @@ func TestV2ProjectsAuthorized(t *testing.T) {
 					"id":      "handyman",
 					"actions": []string{act},
 				}
-				setPoliciesV2(t, e, pol, role)
+				setPoliciesV2p1(t, e, pol, role)
 				actual, err := e.V2ProjectsAuthorized(args([]string{proj1, proj2}))
 				require.NoError(t, err)
 				assert.Equal(t, []string{}, actual)
@@ -178,7 +178,7 @@ func TestV2ProjectsAuthorized(t *testing.T) {
 					"id":      "handyman",
 					"actions": []string{act},
 				}
-				setPoliciesV2(t, e, pol, role)
+				setPoliciesV2p1(t, e, pol, role)
 				actual, err := e.V2ProjectsAuthorized(args(allProjects))
 				require.NoError(t, err)
 				assert.Equal(t, []string{proj1}, actual)
@@ -201,7 +201,7 @@ func TestV2ProjectsAuthorized(t *testing.T) {
 					"id":      "handyman",
 					"actions": []string{act},
 				}
-				setPoliciesV2(t, e, pol, role)
+				setPoliciesV2p1(t, e, pol, role)
 				actual, err := e.V2ProjectsAuthorized(args([]string{"*"}))
 				require.NoError(t, err)
 				assert.Equal(t, []string{}, actual)
@@ -219,7 +219,7 @@ func TestV2ProjectsAuthorized(t *testing.T) {
 						},
 					},
 				}
-				setPoliciesV2(t, e, pol)
+				setPoliciesV2p1(t, e, pol)
 				actual, err := e.V2ProjectsAuthorized(args([]string{proj1, proj2}))
 				require.NoError(t, err)
 				assert.Equal(t, []string{}, actual)
@@ -237,7 +237,7 @@ func TestV2ProjectsAuthorized(t *testing.T) {
 						},
 					},
 				}
-				setPoliciesV2(t, e, pol)
+				setPoliciesV2p1(t, e, pol)
 				actual, err := e.V2ProjectsAuthorized(args([]string{proj1, proj2}))
 				require.NoError(t, err)
 				assert.ElementsMatch(t, []string{}, actual)
@@ -261,7 +261,7 @@ func TestV2ProjectsAuthorized(t *testing.T) {
 						},
 					},
 				}
-				setPoliciesV2(t, e, pol)
+				setPoliciesV2p1(t, e, pol)
 				actual, err := e.V2ProjectsAuthorized(args([]string{proj1, proj2}))
 				require.NoError(t, err)
 				assert.ElementsMatch(t, []string{proj2}, actual)
@@ -285,7 +285,7 @@ func TestV2ProjectsAuthorized(t *testing.T) {
 						},
 					},
 				}
-				setPoliciesV2(t, e, pol)
+				setPoliciesV2p1(t, e, pol)
 				actual, err := e.V2ProjectsAuthorized(args([]string{proj1, proj2}))
 				require.NoError(t, err)
 				assert.ElementsMatch(t, []string{}, actual)
@@ -309,7 +309,7 @@ func TestV2ProjectsAuthorized(t *testing.T) {
 						},
 					},
 				}
-				setPoliciesV2(t, e, pol)
+				setPoliciesV2p1(t, e, pol)
 				actual, err := e.V2ProjectsAuthorized(args(allProjects))
 				require.NoError(t, err)
 				assert.ElementsMatch(t, []string{}, actual)
@@ -333,7 +333,7 @@ func TestV2ProjectsAuthorized(t *testing.T) {
 						},
 					},
 				}
-				setPoliciesV2(t, e, pol)
+				setPoliciesV2p1(t, e, pol)
 				// in the server, we fetch the list of all projects when the projects filter is empty
 				actual, err := e.V2ProjectsAuthorized(args(allProjects))
 				require.NoError(t, err)
@@ -352,7 +352,7 @@ func TestV2ProjectsAuthorized(t *testing.T) {
 						},
 					},
 				}
-				setPoliciesV2(t, e, pol)
+				setPoliciesV2p1(t, e, pol)
 				actual, err := e.V2ProjectsAuthorized(args([]string{proj1, proj2}))
 				require.NoError(t, err)
 				assert.ElementsMatch(t, []string{proj1, proj2}, actual)
@@ -560,7 +560,7 @@ func TestV2FilterAuthorizedProjects(t *testing.T) {
 						},
 					},
 				}
-				setPoliciesV2(t, e, policy0, policy1)
+				setPoliciesV2p1(t, e, policy0, policy1)
 				expectedProjects := []string{proj0, proj1, proj2}
 
 				filtered, err := e.V2FilterAuthorizedProjects(args())
@@ -592,7 +592,7 @@ func TestV2FilterAuthorizedProjects(t *testing.T) {
 						},
 					},
 				}
-				setPoliciesV2(t, e, policy0, policy1)
+				setPoliciesV2p1(t, e, policy0, policy1)
 				expectedProjects := []string{proj0, proj1}
 
 				filtered, err := e.V2FilterAuthorizedProjects(args())
@@ -624,7 +624,7 @@ func TestV2FilterAuthorizedProjects(t *testing.T) {
 						},
 					},
 				}
-				setPoliciesV2(t, e, policy0, policy1)
+				setPoliciesV2p1(t, e, policy0, policy1)
 				expectedProjects := []string{proj0, proj1}
 
 				filtered, err := e.V2FilterAuthorizedProjects(args())
@@ -667,7 +667,7 @@ func TestV2FilterAuthorizedProjects(t *testing.T) {
 						},
 					},
 				}
-				setPoliciesV2(t, e, policy0, policy1)
+				setPoliciesV2p1(t, e, policy0, policy1)
 				expectedProjects := []string{proj0, proj1, proj2}
 
 				filtered, err := e.V2FilterAuthorizedProjects(args())
@@ -679,6 +679,14 @@ func TestV2FilterAuthorizedProjects(t *testing.T) {
 }
 
 func setPoliciesV2(t testing.TB, e engine.Engine, policiesAndRoles ...interface{}) {
+	setPoliciesV2pX(t, false, e, policiesAndRoles...)
+}
+
+func setPoliciesV2p1(t testing.TB, e engine.Engine, policiesAndRoles ...interface{}) {
+	setPoliciesV2pX(t, true, e, policiesAndRoles...)
+}
+
+func setPoliciesV2pX(t testing.TB, twoPointOne bool, e engine.Engine, policiesAndRoles ...interface{}) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -704,6 +712,11 @@ func setPoliciesV2(t testing.TB, e engine.Engine, policiesAndRoles ...interface{
 	for _, role := range roles {
 		roleMap[role["id"].(string)] = role
 	}
-	err := e.V2SetPolicies(ctx, policyMap, roleMap, make(map[string][]interface{}))
+	var err error
+	if twoPointOne {
+		err = e.V2p1SetPolicies(ctx, policyMap, roleMap, make(map[string][]interface{}))
+	} else {
+		err = e.V2SetPolicies(ctx, policyMap, roleMap, make(map[string][]interface{}))
+	}
 	require.NoError(t, err, "set policies(v2)")
 }

--- a/components/authz-service/engine/conformance/conformance_v2_test.go
+++ b/components/authz-service/engine/conformance/conformance_v2_test.go
@@ -22,7 +22,7 @@ import (
  ************ ************ ************ ************ ************ ************/
 
 func TestV2IsAuthorized(t *testing.T) {
-	ctx, engines := setup(t)
+	ctx, engines := setupV2(t)
 	sub, act, res := "user:local:admin", "iam:users:create", "iam:users"
 
 	// We're always passing the same arguments to IsAuthorized(). This allows for
@@ -81,7 +81,7 @@ func TestV2IsAuthorized(t *testing.T) {
 }
 
 func TestV2p1ProjectsAuthorized(t *testing.T) {
-	ctx, engines := setup(t)
+	ctx, engines := setupV2p1(t)
 	sub, act, res := "user:local:admin", "iam:users:create", "iam:users"
 	proj1, proj2, proj3, proj4, unassigned := "proj-1", "proj-2", "proj-3", "proj-4", constants.UnassignedProjectID
 	allProjects := []string{proj1, proj2, proj3, proj4, unassigned}
@@ -370,7 +370,7 @@ func TestV2p1ProjectsAuthorized(t *testing.T) {
 						},
 					},
 				}
-				setPoliciesV2(t, e, pol)
+				setPoliciesV2p1(t, e, pol)
 				// in the server, we fetch the list of all projects when the projects filter is empty
 				actual, err := e.V2ProjectsAuthorized(args(allProjects))
 				require.NoError(t, err)
@@ -381,7 +381,7 @@ func TestV2p1ProjectsAuthorized(t *testing.T) {
 }
 
 func TestV2FilterAuthorizedPairs(t *testing.T) {
-	ctx, engines := setup(t)
+	ctx, engines := setupV2(t)
 	sub, act0, res0, act1, res1 := "user:local:someid", "iam:users:create",
 		"nodes:someid", "compliance:profiles:delete", "compliance:profiles"
 	pair0 := engine.Pair{Resource: engine.Resource(res0), Action: engine.Action(act0)}
@@ -493,7 +493,7 @@ func TestV2FilterAuthorizedPairs(t *testing.T) {
 }
 
 func TestV2FilterAuthorizedProjects(t *testing.T) {
-	ctx, engines := setup(t)
+	ctx, engines := setupV2p1(t)
 	sub := "user:local:someid"
 	act0, res0 := "iam:users:create", "nodes:someid"
 	act1, res1 := "compliance:profiles:delete", "compliance:profiles"
@@ -712,11 +712,11 @@ func setPoliciesV2pX(t testing.TB, twoPointOne bool, e engine.Engine, policiesAn
 	for _, role := range roles {
 		roleMap[role["id"].(string)] = role
 	}
-	var err error
 	if twoPointOne {
-		err = e.V2p1SetPolicies(ctx, policyMap, roleMap, make(map[string][]interface{}))
+		err := e.V2p1SetPolicies(ctx, policyMap, roleMap, make(map[string][]interface{}))
+		require.NoError(t, err, "set policies(v2.1)")
 	} else {
-		err = e.V2SetPolicies(ctx, policyMap, roleMap, make(map[string][]interface{}))
+		err := e.V2SetPolicies(ctx, policyMap, roleMap)
+		require.NoError(t, err, "set policies(v2)")
 	}
-	require.NoError(t, err, "set policies(v2)")
 }

--- a/components/authz-service/engine/engine.go
+++ b/components/authz-service/engine/engine.go
@@ -72,7 +72,7 @@ type Writer interface {
 }
 
 type V2Writer interface {
-	V2SetPolicies(context.Context, map[string]interface{}, map[string]interface{}, map[string][]interface{}) error
+	V2SetPolicies(context.Context, map[string]interface{}, map[string]interface{}) error
 }
 
 type V2p1Writer interface {

--- a/components/authz-service/engine/engine.go
+++ b/components/authz-service/engine/engine.go
@@ -72,7 +72,7 @@ type Writer interface {
 }
 
 type V2Writer interface {
-	V2SetPolicies(context.Context, map[string]interface{}, map[string]interface{}) error
+	V2SetPolicies(context.Context, map[string]interface{}, map[string]interface{}, map[string][]interface{}) error
 }
 
 type V2p1Writer interface {

--- a/components/authz-service/engine/engine.go
+++ b/components/authz-service/engine/engine.go
@@ -18,9 +18,13 @@ type Engine interface {
 	// service needs V2Authorizer, the policy section cares about V2Writer), so we
 	// collect them here instead of introducing a V2Engine interface.
 	V2Authorizer
-	V2Writer
-
+	V2pXWriter
 	ProjectRulesRetriever
+}
+
+type V2pXWriter interface {
+	V2Writer
+	V2p1Writer
 }
 
 // V1Engine is the interface representing the IAM v1 backing engine methods:
@@ -69,6 +73,10 @@ type Writer interface {
 
 type V2Writer interface {
 	V2SetPolicies(context.Context, map[string]interface{}, map[string]interface{}, map[string][]interface{}) error
+}
+
+type V2p1Writer interface {
+	V2p1SetPolicies(context.Context, map[string]interface{}, map[string]interface{}, map[string][]interface{}) error
 }
 
 type ProjectRulesRetriever interface {

--- a/components/authz-service/engine/opa/opa.go
+++ b/components/authz-service/engine/opa/opa.go
@@ -631,12 +631,10 @@ func (s *State) SetPolicies(ctx context.Context, policies map[string]interface{}
 // and resets the partial evaluation cache for v2
 func (s *State) V2SetPolicies(
 	ctx context.Context, policyMap map[string]interface{},
-	roleMap map[string]interface{}, ruleMap map[string][]interface{}) error {
-	// TODO: v2 doesn't care about rules
+	roleMap map[string]interface{}) error {
 	s.v2Store = inmem.NewFromObject(map[string]interface{}{
 		"policies": policyMap,
 		"roles":    roleMap,
-		"rules":    ruleMap,
 	})
 
 	return s.initPartialResultV2(ctx)

--- a/components/authz-service/engine/opa/opa.go
+++ b/components/authz-service/engine/opa/opa.go
@@ -166,8 +166,6 @@ func (s *State) initPartialResult(ctx context.Context) error {
 		return errors.Wrap(err, "partial eval")
 	}
 	s.partialAuth = pr
-	s.v2PartialAuth = rego.PartialResult{}
-	s.v2PartialProjects = rego.PartialResult{}
 	return nil
 }
 
@@ -189,8 +187,6 @@ func (s *State) initPartialResultV2(ctx context.Context) error {
 		return errors.Wrap(err, "partial eval (authorized)")
 	}
 	s.v2PartialAuth = v2Partial
-	s.partialAuth = rego.PartialResult{}
-	s.v2PartialProjects = rego.PartialResult{}
 	return nil
 }
 
@@ -211,8 +207,11 @@ func (s *State) initPartialResultV2p1(ctx context.Context) error {
 		return errors.Wrap(err, "partial eval (authorized_project)")
 	}
 	s.v2PartialProjects = v2PartialProjects
-	s.partialAuth = rego.PartialResult{}
-	s.v2PartialAuth = rego.PartialResult{}
+
+	s.log.Info("Ran partial update v2.1")
+	if err := s.DumpDataV2p1(ctx); err != nil {
+		s.log.Warnf("error dumping v2.1 data: %v", err)
+	}
 	return nil
 }
 

--- a/components/authz-service/engine/opa/opa.go
+++ b/components/authz-service/engine/opa/opa.go
@@ -436,7 +436,7 @@ func (s *State) RulesForProject(
 
 // ListProjectMappings returns a map of all the rules for each projectID.
 func (s *State) ListProjectMappings(ctx context.Context) (map[string][]engine.Rule, error) {
-	rs, err := s.evalQuery(ctx, s.queries[listProjectMapQuery], map[string]interface{}{}, s.v2p1Store)
+	rs, err := s.evalQuery(ctx, s.queries[listProjectMapQuery], map[string]interface{}{}, s.v2Store)
 	if err != nil {
 		return nil, &ErrEvaluation{e: err}
 	}

--- a/components/authz-service/engine/opa/opa.go
+++ b/components/authz-service/engine/opa/opa.go
@@ -207,11 +207,6 @@ func (s *State) initPartialResultV2p1(ctx context.Context) error {
 		return errors.Wrap(err, "partial eval (authorized_project)")
 	}
 	s.v2PartialProjects = v2PartialProjects
-
-	s.log.Info("Ran partial update v2.1")
-	if err := s.DumpDataV2p1(ctx); err != nil {
-		s.log.Warnf("error dumping v2.1 data: %v", err)
-	}
 	return nil
 }
 

--- a/components/authz-service/engine/opa/opa.go
+++ b/components/authz-service/engine/opa/opa.go
@@ -448,7 +448,7 @@ func (s *State) RulesForProject(
 
 // ListProjectMappings returns a map of all the rules for each projectID.
 func (s *State) ListProjectMappings(ctx context.Context) (map[string][]engine.Rule, error) {
-	rs, err := s.evalQuery(ctx, s.queries[listProjectMapQuery], map[string]interface{}{}, s.v2Store)
+	rs, err := s.evalQuery(ctx, s.queries[listProjectMapQuery], map[string]interface{}{}, s.v2p1Store)
 	if err != nil {
 		return nil, &ErrEvaluation{e: err}
 	}

--- a/components/authz-service/engine/opa/opa.go
+++ b/components/authz-service/engine/opa/opa.go
@@ -221,6 +221,10 @@ func (s *State) initPartialResultV2p1(ctx context.Context) error {
 	}
 	s.v2PartialProjects = v2PartialProjects
 
+	s.log.Info("Ran partial update v2.1")
+	if err := s.DumpDataV2p1(ctx); err != nil {
+		s.log.Warnf("error dumping v2.1 data: %v", err)
+	}
 	return nil
 }
 
@@ -249,12 +253,16 @@ func dumpData(ctx context.Context, store storage.Store, l logger.Logger) error {
 	if err != nil {
 		return err
 	}
-	l.Debugf("data: %#v", data)
+	l.Infof("data: %#v", data)
 	return store.Commit(ctx, txn)
 }
 
 func (s *State) DumpDataV2(ctx context.Context) error {
 	return dumpData(ctx, s.v2Store, s.log)
+}
+
+func (s *State) DumpDataV2p1(ctx context.Context) error {
+	return dumpData(ctx, s.v2p1Store, s.log)
 }
 
 // IsAuthorized evaluates whether a given [subject, resource, action] tuple

--- a/components/authz-service/engine/opa/opa.go
+++ b/components/authz-service/engine/opa/opa.go
@@ -228,17 +228,24 @@ func (s *State) newCompiler() (*ast.Compiler, error) {
 // DumpData is a bit fast-and-loose when it comes to error checking; it's not meant
 // to be used in production
 func (s *State) DumpData(ctx context.Context) error {
-	txn, err := s.store.NewTransaction(ctx)
+	return dumpData(ctx, s.store, s.log)
+}
+
+func dumpData(ctx context.Context, store storage.Store, l logger.Logger) error {
+	txn, err := store.NewTransaction(ctx)
 	if err != nil {
 		return err
 	}
-	data, err := s.store.Read(ctx, txn, storage.Path([]string{}))
+	data, err := store.Read(ctx, txn, storage.Path([]string{}))
 	if err != nil {
 		return err
 	}
-	// used to check activity in OPA store
-	s.log.Debugf("data retrieved from OPA store: %#v", data)
-	return s.store.Commit(ctx, txn)
+	l.Debugf("data: %#v", data)
+	return store.Commit(ctx, txn)
+}
+
+func (s *State) DumpDataV2(ctx context.Context) error {
+	return dumpData(ctx, s.v2Store, s.log)
 }
 
 // IsAuthorized evaluates whether a given [subject, resource, action] tuple

--- a/components/authz-service/engine/opa/opa.go
+++ b/components/authz-service/engine/opa/opa.go
@@ -631,10 +631,12 @@ func (s *State) SetPolicies(ctx context.Context, policies map[string]interface{}
 // and resets the partial evaluation cache for v2
 func (s *State) V2SetPolicies(
 	ctx context.Context, policyMap map[string]interface{},
-	roleMap map[string]interface{}) error {
+	roleMap map[string]interface{}, ruleMap map[string][]interface{}) error {
+	// TODO: v2 doesn't care about rules
 	s.v2Store = inmem.NewFromObject(map[string]interface{}{
 		"policies": policyMap,
 		"roles":    roleMap,
+		"rules":    ruleMap,
 	})
 
 	return s.initPartialResultV2(ctx)

--- a/components/authz-service/engine/opa/opa.go
+++ b/components/authz-service/engine/opa/opa.go
@@ -420,7 +420,7 @@ func (s *State) V2FilterAuthorizedProjects(
 		"subjects": subjects,
 	}
 
-	rs, err := s.evalQuery(ctx, s.queries[filteredProjectsV2Query], opaInput, s.v2Store)
+	rs, err := s.evalQuery(ctx, s.queries[filteredProjectsV2Query], opaInput, s.v2p1Store)
 	if err != nil {
 		return nil, &ErrEvaluation{e: err}
 	}
@@ -439,7 +439,7 @@ func (s *State) RulesForProject(
 		"project_id": projectID,
 	}
 
-	rs, err := s.evalQuery(ctx, s.queries[rulesForProjectQuery], opaInput, s.v2Store)
+	rs, err := s.evalQuery(ctx, s.queries[rulesForProjectQuery], opaInput, s.v2p1Store)
 	if err != nil {
 		return nil, &ErrEvaluation{e: err}
 	}
@@ -644,6 +644,7 @@ func (s *State) SetPolicies(ctx context.Context, policies map[string]interface{}
 func (s *State) V2SetPolicies(
 	ctx context.Context, policyMap map[string]interface{},
 	roleMap map[string]interface{}, ruleMap map[string][]interface{}) error {
+	// TODO: v2 doesn't care about rules
 	s.v2Store = inmem.NewFromObject(map[string]interface{}{
 		"policies": policyMap,
 		"roles":    roleMap,

--- a/components/authz-service/engine/opa/opa.go
+++ b/components/authz-service/engine/opa/opa.go
@@ -166,6 +166,8 @@ func (s *State) initPartialResult(ctx context.Context) error {
 		return errors.Wrap(err, "partial eval")
 	}
 	s.partialAuth = pr
+	s.v2PartialAuth = rego.PartialResult{}
+	s.v2PartialProjects = rego.PartialResult{}
 	return nil
 }
 
@@ -187,6 +189,8 @@ func (s *State) initPartialResultV2(ctx context.Context) error {
 		return errors.Wrap(err, "partial eval (authorized)")
 	}
 	s.v2PartialAuth = v2Partial
+	s.partialAuth = rego.PartialResult{}
+	s.v2PartialProjects = rego.PartialResult{}
 	return nil
 }
 
@@ -207,11 +211,8 @@ func (s *State) initPartialResultV2p1(ctx context.Context) error {
 		return errors.Wrap(err, "partial eval (authorized_project)")
 	}
 	s.v2PartialProjects = v2PartialProjects
-
-	s.log.Info("Ran partial update v2.1")
-	if err := s.DumpDataV2p1(ctx); err != nil {
-		s.log.Warnf("error dumping v2.1 data: %v", err)
-	}
+	s.partialAuth = rego.PartialResult{}
+	s.v2PartialAuth = rego.PartialResult{}
 	return nil
 }
 

--- a/components/authz-service/engine/opa/opa.go
+++ b/components/authz-service/engine/opa/opa.go
@@ -107,19 +107,6 @@ func New(ctx context.Context, l logger.Logger, opts ...OptFunc) (*State, error) 
 	if err := s.initModules(); err != nil {
 		return nil, errors.Wrap(err, "init OPA modules")
 	}
-
-	if err := s.initPartialResult(ctx); err != nil {
-		return nil, errors.Wrap(err, "init OPA partial result state")
-	}
-
-	if err := s.initPartialResultV2(ctx); err != nil {
-		return nil, errors.Wrap(err, "init OPA partial result state (v2)")
-	}
-
-	if err := s.initPartialResultV2p1(ctx); err != nil {
-		return nil, errors.Wrap(err, "init OPA partial result state (v2.1)")
-	}
-
 	return &s, nil
 }
 

--- a/components/authz-service/engine/opa/opa_internal_test.go
+++ b/components/authz-service/engine/opa/opa_internal_test.go
@@ -316,11 +316,11 @@ func BenchmarkInitPartialResultV2(b *testing.B) {
 
 	for d := 0; d < 5; d++ {
 		b.Run(fmt.Sprintf("default policies, run %d times", d), func(b *testing.B) {
-			for n := 0; n < b.N; n++ {
-				s, err := New(ctx, l)
-				require.NoError(b, err, "init state")
-				s.v2Store = store
+			s, err := New(ctx, l)
+			require.NoError(b, err, "init state")
+			s.v2Store = store
 
+			for n := 0; n < b.N; n++ {
 				for e := 0; e <= d; e++ {
 					r = s.initPartialResultV2(ctx)
 					if r != nil {

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -116,15 +116,15 @@ func NewPoliciesServer(
 	}
 	srv.setVersion(v)
 
-	if err := srv.updateEngineStore(ctx); err != nil {
-		return nil, errors.Wrap(err, "initialize engine storage")
-	}
-
 	if v.Major == api.Version_V2 {
 		err = srv.store.ApplyV2DataMigrations(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "error migrating v2 data")
 		}
+	}
+
+	if err := srv.updateEngineStore(ctx); err != nil {
+		return nil, errors.Wrap(err, "initialize engine storage")
 	}
 
 	return srv, nil

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -117,14 +117,13 @@ func NewPoliciesServer(
 	srv.setVersion(v)
 
 	if v.Major == api.Version_V2 {
-		err = srv.store.ApplyV2DataMigrations(ctx)
-		if err != nil {
+		if err := srv.store.ApplyV2DataMigrations(ctx); err != nil {
 			return nil, errors.Wrap(err, "error migrating v2 data")
 		}
 	}
 
 	if err := srv.updateEngineStore(ctx); err != nil {
-		return nil, errors.Wrap(err, "initialize engine storage")
+		return nil, errors.Wrapf(err, "initialize engine storage (%v)", v)
 	}
 
 	return srv, nil

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -122,6 +122,7 @@ func NewPoliciesServer(
 		}
 	}
 
+	// now that the data is all set, attempt to feed it into OPA:
 	if err := srv.updateEngineStore(ctx); err != nil {
 		return nil, errors.Wrapf(err, "initialize engine storage (%v)", v)
 	}

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -100,10 +100,6 @@ func NewPoliciesServer(
 		l.Warn("cleaned up in-progress migration status")
 	}
 
-	if err := srv.updateEngineStore(ctx); err != nil {
-		return nil, errors.Wrap(err, "initialize engine storage")
-	}
-
 	// check migration status
 	ms, err := srv.store.MigrationStatus(ctx)
 	if err != nil {
@@ -119,6 +115,10 @@ func NewPoliciesServer(
 		v = api.Version{Major: api.Version_V1, Minor: api.Version_V0}
 	}
 	srv.setVersion(v)
+
+	if err := srv.updateEngineStore(ctx); err != nil {
+		return nil, errors.Wrap(err, "initialize engine storage")
+	}
 
 	if v.Major == api.Version_V2 {
 		err = srv.store.ApplyV2DataMigrations(ctx)

--- a/components/authz-service/server/v2/policy_refresher.go
+++ b/components/authz-service/server/v2/policy_refresher.go
@@ -187,8 +187,8 @@ func (refresher *policyRefresher) updateEngineStore(ctx context.Context, vsn api
 	switch {
 	case vsn.Minor == api.Version_V1: // v2.1
 		return refresher.engine.V2p1SetPolicies(ctx, policyMap, roleMap, ruleMap)
-	default: // v2
-		return refresher.engine.V2SetPolicies(ctx, policyMap, roleMap)
+	default: // v2.0
+		return refresher.engine.V2SetPolicies(ctx, policyMap, roleMap, ruleMap)
 	}
 }
 

--- a/components/authz-service/server/v2/policy_refresher.go
+++ b/components/authz-service/server/v2/policy_refresher.go
@@ -184,7 +184,7 @@ func (refresher *policyRefresher) updateEngineStore(ctx context.Context, vsn api
 	case vsn.Major == api.Version_V2 && vsn.Minor == api.Version_V1: // v2.1
 		return refresher.engine.V2p1SetPolicies(ctx, policyMap, roleMap, ruleMap)
 	default: // v2.0
-		return refresher.engine.V2SetPolicies(ctx, policyMap, roleMap, ruleMap)
+		return refresher.engine.V2SetPolicies(ctx, policyMap, roleMap)
 	}
 }
 

--- a/components/authz-service/server/v2/policy_refresher.go
+++ b/components/authz-service/server/v2/policy_refresher.go
@@ -185,10 +185,10 @@ func (refresher *policyRefresher) updateEngineStore(ctx context.Context, vsn api
 	}
 
 	switch {
-	case vsn.Minor == api.Version_V1: // v2
-		return refresher.engine.V2SetPolicies(ctx, policyMap, roleMap)
-	default: // v2.1
+	case vsn.Minor == api.Version_V1: // v2.1
 		return refresher.engine.V2p1SetPolicies(ctx, policyMap, roleMap, ruleMap)
+	default: // v2
+		return refresher.engine.V2SetPolicies(ctx, policyMap, roleMap)
 	}
 }
 

--- a/components/authz-service/server/v2/policy_refresher.go
+++ b/components/authz-service/server/v2/policy_refresher.go
@@ -185,8 +185,20 @@ func (refresher *policyRefresher) updateEngineStore(ctx context.Context, vsn api
 	default: // v2.0 OR v1.0
 		return refresher.engine.V2SetPolicies(ctx, policyMap, roleMap, ruleMap)
 	}
-	// Note 2019/06/04 (sr): v1?! Yes, IAM v1. Our POC code depends on this query to be
-	// answered regardless of whether IAM is v1, v2 or v2.1.
+	// Note 2019/06/04 (sr): v1?! Yes, IAM v1. Our POC code depends on this query
+	// to be answered regardless of whether IAM is v1, v2 or v2.1.
+	//
+	// Note 2019/06/05 (sr): this doesn't yet support upgrading from v2 to v2.1 in
+	// a multi-node scenario -- since this would happen with nodes A and B:
+	//
+	// A: receive an upgrade-to-v2 --beta2.1 request, migrate stuff in the
+	//    database, set the internal state's version field to v2.1, update the v2.1
+	//    store
+	// B: receives an update-store-notification, has the internal state still set
+	//    to v2, will update the v2 store -- not v2.1
+	//
+	// A potential solution is to include the version in the notification bounced
+	// through the database. I'll look into that in a follow-up PR.
 }
 
 func (refresher *policyRefresher) getPolicyMap(ctx context.Context) (map[string]interface{}, error) {

--- a/components/authz-service/server/v2/policy_refresher.go
+++ b/components/authz-service/server/v2/policy_refresher.go
@@ -163,11 +163,6 @@ func (refresher *policyRefresher) RefreshAsync() error {
 
 // updates OPA engine store with policy
 func (refresher *policyRefresher) updateEngineStore(ctx context.Context, vsn api.Version) error {
-	if vsn.Major != api.Version_V2 {
-		// do nothing, IAM v1 isn't made multi-node-aware for now
-		return nil
-	}
-
 	// Engine updates need unfiltered access to all data.
 	ctx = auth_context.ContextWithoutProjects(ctx)
 
@@ -187,9 +182,11 @@ func (refresher *policyRefresher) updateEngineStore(ctx context.Context, vsn api
 	switch {
 	case vsn.Minor == api.Version_V1: // v2.1
 		return refresher.engine.V2p1SetPolicies(ctx, policyMap, roleMap, ruleMap)
-	default: // v2.0
+	default: // v2.0 OR v1.0
 		return refresher.engine.V2SetPolicies(ctx, policyMap, roleMap, ruleMap)
 	}
+	// Note 2019/06/04 (sr): v1?! Yes, IAM v1. Our POC code depends on this query to be
+	// answered regardless of whether IAM is v1, v2 or v2.1.
 }
 
 func (refresher *policyRefresher) getPolicyMap(ctx context.Context) (map[string]interface{}, error) {

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -3228,8 +3228,8 @@ type testEngine struct {
 
 func (te *testEngine) V2SetPolicies(
 	ctx context.Context, policies map[string]interface{},
-	roles map[string]interface{}) error {
-	return te.V2p1SetPolicies(ctx, policies, roles, map[string][]interface{}{})
+	roles map[string]interface{}, rules map[string][]interface{}) error {
+	return te.V2p1SetPolicies(ctx, policies, roles, rules)
 }
 
 func (te *testEngine) V2p1SetPolicies(

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -2261,6 +2261,7 @@ func TestMigrateToV2(t *testing.T) {
 			assert.Zero(t, roleStore.ItemCount())
 		},
 		"when migration recorded as failed, it is run": func(t *testing.T) {
+			require.NoError(t, status.InProgress(ctx))
 			require.NoError(t, status.Failure(ctx))
 
 			_, err := cl.MigrateToV2(ctx, &api_v2.MigrateToV2Req{})
@@ -2399,6 +2400,7 @@ func TestGetPolicyVersion(t *testing.T) {
 			assert.Equal(t, expectedV2p1, resp.Version)
 		},
 		"reports failed migration as v1": func(t *testing.T) {
+			require.NoError(t, status.InProgress(ctx))
 			require.NoError(t, status.Failure(ctx))
 			resp, err := cl.GetPolicyVersion(ctx, &api_v2.GetPolicyVersionReq{})
 			require.NoError(t, err)
@@ -2465,6 +2467,7 @@ func TestResetToV1(t *testing.T) {
 			assert.Equal(t, storage.Pristine, ms)
 		},
 		"migration status failure, resets to pristine": func(t *testing.T) {
+			require.NoError(t, status.InProgress(ctx))
 			require.NoError(t, status.Failure(ctx))
 
 			_, err := cl.ResetToV1(ctx, &api_v2.ResetToV1Req{})
@@ -2934,7 +2937,8 @@ type testSetup struct {
 
 func setupV2WithWriter(t *testing.T,
 	writer engine.V2pXWriter) testSetup {
-	return setupV2(t, nil, writer, nil, make(chan api_v2.Version, 1))
+	return setupV2WithMigrationState(t, nil, writer, nil, make(chan api_v2.Version, 1),
+		func(s storage.MigrationStatusProvider) error { return s.Success(context.Background()) }) // IAM v2
 }
 
 func setupV2(t *testing.T,
@@ -2942,6 +2946,16 @@ func setupV2(t *testing.T,
 	writer engine.V2pXWriter,
 	pl storage_v1.PoliciesLister,
 	vChan chan api_v2.Version) testSetup {
+	return setupV2WithMigrationState(t, authorizer, writer, pl, vChan, nil)
+}
+
+func setupV2WithMigrationState(t *testing.T,
+	authorizer engine.V2Authorizer,
+	writer engine.V2pXWriter,
+	pl storage_v1.PoliciesLister,
+	vChan chan api_v2.Version,
+	migration func(storage.MigrationStatusProvider) error) testSetup {
+
 	t.Helper()
 	ctx := context.Background()
 
@@ -2953,7 +2967,10 @@ func setupV2(t *testing.T,
 	}
 
 	mem_v2 := memstore_v2.New()
-	require.NoError(t, mem_v2.Success(ctx)) // this is IAM v2
+	if migration != nil {
+		require.NoError(t, migration(mem_v2)) // this is IAM v2
+	}
+
 	polV2, err := v2.NewPoliciesServer(ctx, l, mem_v2, writer, pl, vChan)
 	require.NoError(t, err)
 

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/chef/automate/lib/tls/test/helpers"
 )
 
-var dummyWriter engine.V2Writer = nil
+var dummyWriter engine.V2pXWriter = nil
 
 func TestCreatePolicy(t *testing.T) {
 	ctx := context.Background()
@@ -2933,13 +2933,13 @@ type testSetup struct {
 }
 
 func setupV2WithWriter(t *testing.T,
-	writer engine.V2Writer) testSetup {
+	writer engine.V2pXWriter) testSetup {
 	return setupV2(t, nil, writer, nil, nil)
 }
 
 func setupV2(t *testing.T,
 	authorizer engine.V2Authorizer,
-	writer engine.V2Writer,
+	writer engine.V2pXWriter,
 	pl storage_v1.PoliciesLister,
 	vChan chan api_v2.Version) testSetup {
 	t.Helper()
@@ -3216,6 +3216,12 @@ func (te *testEngine) V2SetPolicies(
 	te.roleMap = roles
 	te.ruleMap = rules
 	return nil
+}
+
+func (te *testEngine) V2p1SetPolicies(
+	ctx context.Context, policies map[string]interface{},
+	roles map[string]interface{}, rules map[string][]interface{}) error {
+	return te.V2SetPolicies(ctx, policies, roles, rules)
 }
 
 func id(t *testing.T, p *prng.Prng) string {

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -2934,7 +2934,7 @@ type testSetup struct {
 
 func setupV2WithWriter(t *testing.T,
 	writer engine.V2pXWriter) testSetup {
-	return setupV2(t, nil, writer, nil, nil)
+	return setupV2(t, nil, writer, nil, make(chan api_v2.Version, 1))
 }
 
 func setupV2(t *testing.T,
@@ -2953,6 +2953,7 @@ func setupV2(t *testing.T,
 	}
 
 	mem_v2 := memstore_v2.New()
+	require.NoError(t, mem_v2.Success(ctx)) // this is IAM v2
 	polV2, err := v2.NewPoliciesServer(ctx, l, mem_v2, writer, pl, vChan)
 	require.NoError(t, err)
 

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -2938,7 +2938,9 @@ type testSetup struct {
 func setupV2WithWriter(t *testing.T,
 	writer engine.V2pXWriter) testSetup {
 	return setupV2WithMigrationState(t, nil, writer, nil, make(chan api_v2.Version, 1),
-		func(s storage.MigrationStatusProvider) error { return s.Success(context.Background()) }) // IAM v2
+		// if the MigrationStatus is set to "Success", that means we've migrated
+		// successfully to IAM v2 ("SuccessBeta1" is v2.1).
+		func(s storage.MigrationStatusProvider) error { return s.Success(context.Background()) })
 }
 
 func setupV2(t *testing.T,
@@ -3229,6 +3231,8 @@ type testEngine struct {
 func (te *testEngine) V2SetPolicies(
 	ctx context.Context, policies map[string]interface{},
 	roles map[string]interface{}, rules map[string][]interface{}) error {
+	// these only set the structs {policy,rule,role}Map, nothing specific to v2 and
+	// v2.1 yet
 	return te.V2p1SetPolicies(ctx, policies, roles, rules)
 }
 

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -3209,19 +3209,19 @@ type testEngine struct {
 }
 
 func (te *testEngine) V2SetPolicies(
-	_ context.Context, policies map[string]interface{},
+	ctx context.Context, policies map[string]interface{},
+	roles map[string]interface{}) error {
+	return te.V2p1SetPolicies(ctx, policies, roles, map[string][]interface{}{})
+}
+
+func (te *testEngine) V2p1SetPolicies(
+	ctx context.Context, policies map[string]interface{},
 	roles map[string]interface{}, rules map[string][]interface{}) error {
 	te.policyMap = policies
 	// TODO: use these
 	te.roleMap = roles
 	te.ruleMap = rules
 	return nil
-}
-
-func (te *testEngine) V2p1SetPolicies(
-	ctx context.Context, policies map[string]interface{},
-	roles map[string]interface{}, rules map[string][]interface{}) error {
-	return te.V2SetPolicies(ctx, policies, roles, rules)
 }
 
 func id(t *testing.T, p *prng.Prng) string {

--- a/components/authz-service/storage/v2/memstore/memstore.go
+++ b/components/authz-service/storage/v2/memstore/memstore.go
@@ -498,6 +498,7 @@ func (s *State) InProgress(context.Context) error {
 func (s *State) Failure(context.Context) error {
 	if s.ms == storage.InProgress {
 		s.ms = storage.Failed
+		return nil
 	}
 	return errors.New("cannot transition to failure")
 }

--- a/components/authz-service/storage/v2/memstore/memstore.go
+++ b/components/authz-service/storage/v2/memstore/memstore.go
@@ -496,8 +496,10 @@ func (s *State) InProgress(context.Context) error {
 }
 
 func (s *State) Failure(context.Context) error {
-	s.ms = storage.Failed
-	return nil
+	if s.ms == storage.InProgress {
+		s.ms = storage.Failed
+	}
+	return errors.New("cannot transition to failure")
 }
 
 func (s *State) MigrationStatus(context.Context) (storage.MigrationStatus, error) {

--- a/components/authz-service/storage/v2/postgres/policy_change_notifier.go
+++ b/components/authz-service/storage/v2/postgres/policy_change_notifier.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"time"
 
-	v2 "github.com/chef/automate/components/authz-service/storage/v2"
 	"github.com/lib/pq"
 	"github.com/sirupsen/logrus"
+
+	v2 "github.com/chef/automate/components/authz-service/storage/v2"
 )
 
 type policyChangeNotifier struct {

--- a/integration/tests/upgrade_reset_iam_v2.sh
+++ b/integration/tests/upgrade_reset_iam_v2.sh
@@ -33,41 +33,28 @@ hab_curl() {
 do_test_deploy() {
     local output
 
-    log_info "checking 'chef-automate iam version'"
-    output=$(chef-automate iam version)
-    if ! grep -q "IAM v1" <<< "$output"; then
-        log_error "expected \"IAM v1\", got output:"
-        log_error "$output"
-        return 1
-    fi
+    expect_iam_version "IAM v1.0" || return 1
 
     local token
     log_info "checking 'chef-automate admin-token'"
-    token=$(chef-automate admin-token)
+    token="$(chef-automate admin-token)"
     if grep -q "Error" <<< "$token"; then
         log_error "expected token, got error:"
         log_error "$token"
         return 1
     fi
 
-    log_info "Upgrading to IAM v2"
-    chef-automate iam upgrade-to-v2 || return 1
-
-    log_info "Checking IAM version"
-    output=$(chef-automate iam version)
-    if ! grep -q "IAM v2" <<< "$output"; then
-        log_error "expected \"IAM v2\", got output:"
-        log_error "$output"
-        return 1
-    fi
-    log_info "On $output"
+    log_info "v1 -> v2"
+    expect_iam_upgrade_output "Success: Enabled IAM v2" \
+        "$(chef-automate iam upgrade-to-v2)" || return 1
+    expect_iam_version "IAM v2.0" || return 1
 
     # Check that the number of policies stored is exactly equal to the number
     # of default policies
     log_info "Verifying V2 policies"
     local policies
 
-    policies=$(curl -s -k -H "api-token: $token" https://localhost/apis/iam/v2beta/policies)
+    policies="$(curl -s -k -H "api-token: $token" https://localhost/apis/iam/v2beta/policies)"
     if ! jq -e '.policies | length == 13' <<< "$policies" >/dev/null; then
         log_error "Found the wrong number of policies, expected 13 policies, got response:"
         log_error "$policies"
@@ -76,49 +63,60 @@ do_test_deploy() {
 
     log_info "Verifying 3 teams exist (admins, operators, viewers)"
     local teams
-    teams=$(curl -s -k -H "api-token: $token" https://localhost/api/v0/auth/teams)
+    teams="$(curl -s -k -H "api-token: $token" https://localhost/api/v0/auth/teams)"
     if ! jq -e '.teams | length == 3' <<< "$teams" >/dev/null; then
         log_error "Found the wrong number of teams, expected 3 teams, got response:"
         log_error "$teams"
         return 1
     fi
 
-    log_info "Upgrading to IAM v2 successful"
+    log_info "v2 -> v2 (expect failure)"
+    expect_iam_upgrade_output "You have already upgraded to IAM v2." \
+        "$(chef-automate iam upgrade-to-v2 2>&1)" || return 1
 
-    log_info "Attempting to upgrade to IAM v2 a second time (expect failure)"
-    output="$(chef-automate iam upgrade-to-v2 2>&1)" # capture stderr
-    local expected_output="You have already upgraded to IAM v2."
-    if ! grep -q "$expected_output" <<< "$output"; then
+    log_info "v2 -> v2.1"
+    expect_iam_upgrade_output "Success: Enabled IAM v2.1" \
+        "$(chef-automate iam upgrade-to-v2 --beta2.1)" || return 1
+    expect_iam_version "IAM v2.1" || return 1
+
+    log_info "v2.1 -> v1"
+    chef-automate iam reset-to-v1 || return 1
+    expect_iam_version "IAM v1.0" || return 1
+
+    log_info "v1 -> v2.1"
+    expect_iam_upgrade_output "Success: Enabled IAM v2.1" \
+        "$(chef-automate iam upgrade-to-v2 --beta2.1)" || return 1
+
+    log_info "v2.1 -> v2"
+    expect_iam_upgrade_output "Success: Enabled IAM v2" \
+        "$(chef-automate iam upgrade-to-v2)" || return 1
+    expect_iam_version "IAM v2.0" || return 1
+
+    log_info "v2 -> v1"
+    chef-automate iam reset-to-v1 || return 1
+    expect_iam_version "IAM v1.0" || return 1
+
+    do_test_deploy_default
+}
+
+expect_iam_upgrade_output() {
+    local expected_output="${1}"
+    local actual_output="${2}"
+    if ! grep -q "$expected_output" <<< "$actual_output"; then
         log_error "unexpected output:"
         log_error "expected (substring): ${expected_output}"
-        log_error "actual output: ${output}"
+        log_error "actual output: ${actual_output}"
         return 1
     fi
+}
 
-    log_info "Reset to IAM v1"
-    chef-automate iam reset-to-v1 || return 1
-
-    log_info "Upgrading to IAM v2 (again, successful)"
-    output=$(chef-automate iam upgrade-to-v2)
-    local expected_output="Success: Enabled IAM v2"
-    if ! grep -q "$expected_output" <<< "$output"; then
-        log_error "unexpected output:"
-        log_error "expected (substring): ${expected_output}"
-        log_error "actual output: ${output}"
-        return 1
-    fi
-
-    log_info "Reset to IAM v1 (again)"
-    chef-automate iam reset-to-v1 || return 1
-
-    output=$(chef-automate iam version)
-    if ! grep -q "IAM v1" <<< "$output"; then
-        log_error "expected \"IAM v1\", got output:"
+expect_iam_version() {
+    local expected="${1}"
+    log_info "checking 'chef-automate iam version'"
+    output="$(chef-automate iam version)"
+    if ! grep -q "$expected" <<< "$output"; then
+        log_error "expected \"${expected}\", got output:"
         log_error "$output"
         return 1
     fi
-
-    log_info "Reset to IAM v1 successful"
-
-    do_test_deploy_default
 }


### PR DESCRIPTION
### :nut_and_bolt: Description

`authz-service` uses OPA's partial eval feature to save time when authorizing requests by "pre-calculating" everything it can figure out without knowing the (variable) input data. However, that process itself takes time, any change to the relevant data (policies, roles, projects) requires a rebuild of that entire state.

When introducing IAM v2.1, we've taken a bit of a shortcut, and have rebuilt both the v2 and the v2.1 queries' partial eval state. This PR is about fixing that.

The need to fix it arises from the rebuild time, which is dependent on the data it's built with, increasing when the data increases (linearly? haven't checked) -- and it's become noticable, and annoying.

#### ℹ️ Notes

- This PR also expands the current upgrade-to-v2-and-reset-to-v1 tests by going some extra loops through v2.1 as well, see [`integration/tests/upgrade_reset_iam_v2.sh`](https://github.com/chef/automate/pull/467/files#diff-c2011348cfa003a68d46851e7d3216c7)
- If you look at the commits, you'll find that I had to revert some of the cleanups I thought necessary. The need here was `ingest-service`, it seems to query the v2.1-related projects-rules stuff on ingest, regardless of whether A2 is using IAM v1, v2 or v2.1.

### :+1: Definition of Done

When using IAM v2.1, only the v2.1 partial eval result is rebuilt on updated data, and when using v2, only the v2 state is.

### :athletic_shoe: Demo Script / Repro Steps

- `rebuild components/authz-service`
- upgrade to IAM v2.1 (`chef-automate iam upgrade-to-v2 --beta2.1`)
- create two projects and 30 policies, measuring the time it takes:
  - projects foo and bar: `curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/projects -d "$(jq -n '{ id: "foo", name: "my foo project" }')"` and `curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/projects -d "$(jq -n '{ id: "bar", name: "my bar project" }')"`
```
[118][default:/src:0]# time for i in $(seq 1 30); do curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/policies -d "$(sed "s/ID/$i/" pol.json)"; done
real    0m5.211s
user    0m0.252s
sys     0m0.060s
```
this is with `pol.json` containing
```
{
  "name": "testpolicy",
  "id": "testpolicy-id-ID",
  "members": [
    "team:local:viewers"
  ],
  "statements": [
    {
      "effect": "ALLOW",
      "actions": [],
      "role": "viewer",
      "projects": [
        "*"
      ]
    }
  ],
  "projects": [ "foo", "bar" ]
}
```
- delete those policies, 
```
[119][default:/src:2]# chef-automate dev psql chef_authz_service -- -c "delete from iam_policies where id ilike 'testpolicy-id-%'"
DELETE 30
```
- downgrade to v2, redo timing the 30 inserts:
```
[121][default:/src:130]# chef-automate iam upgrade-to-v2

Upgrading to IAM v2
Migrating v1 policies...
Creating default teams Editors and Viewers...
Skipped: Editors team already exists
Skipped: Viewers team already exists

Migrating existing teams...

Success: Enabled IAM v2
[122][default:/src:0]# time for i in $(seq 1 30); do curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/policies -d "$(sed "s/ID/$i/" _dump/pol.json)"; done
[output omitted]
real    8m41.688s
user    0m0.300s
sys     0m0.112s
```

⚠️ This is odd, isn't it? So, this doesn't solve the issue for IAM v2 customers; but it does promise us a bright and fast future in IAM v2.1. **Now I don't really understand (yet) why v2.1 is so much faster to rebuild**, but at least we don't drag v2 around 😅. Also, not updating v2.1 when updating v2 takes _some_ of the work away; combined with not updating the engine store twice, this hopefully helps a little.

### :chains: Related Resources

- [A2-798](https://chefio.atlassian.net/browse/A2-798) 👈 this is about the perceivable delay 🐛 this hopes to improve.

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
