### PR TITLE
Removing Error search bar type

### DIFF
--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.spec.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.spec.ts
@@ -57,8 +57,7 @@ describe('ClientRunsComponent', () => {
     it('ensure types are included', () => {
       const expected = [
         'attribute', 'cookbook', 'chef_tags', 'chef_version', 'environment', 'name', 'platform',
-        'policy_group', 'policy_name', 'policy_revision', 'recipe', 'role', 'resource_name',
-        'error'];
+        'policy_group', 'policy_name', 'policy_revision', 'recipe', 'role', 'resource_name'];
 
       const types = component.categoryTypes.map(type => type.type);
 

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -70,10 +70,6 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
       text: 'Environment'
     },
     {
-      type: 'error',
-      text: 'Error'
-    },
-    {
       type: 'name',
       text: 'Node Name'
     },


### PR DESCRIPTION

![Screen Shot 2019-05-31 at 3 57 54 PM](https://user-images.githubusercontent.com/1679247/58738974-e32d5500-83bc-11e9-9535-3c8e045ee60d.png)


### :nut_and_bolt: Description

Removing the 'Error' search bar type for client runs. 

This is being removed because of a problem with updating the elasticsearch 'node-state' mapping. 

### :chains: Related Resources

https://github.com/chef/automate/pull/415

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
