### PR TITLE
Migration node-state index to allow projects to be indexed

### DIFF
--- a/components/automate-deployment/pkg/backup/spec.go
+++ b/components/automate-deployment/pkg/backup/spec.go
@@ -295,7 +295,7 @@ func DefaultSpecs(chefServerEnabled bool, workflowEnabled bool) []Spec {
 			SyncEsIndices: []ElasticsearchOperation{
 				{
 					ServiceName:    "ingest-service",
-					MultiIndexSpec: "node-state-5,node-attribute,converge-history-*,actions-*",
+					MultiIndexSpec: "node-state-6,node-attribute,converge-history-*,actions-*",
 				},
 			},
 		},

--- a/components/automate-deployment/pkg/backup/spec_test.go
+++ b/components/automate-deployment/pkg/backup/spec_test.go
@@ -73,7 +73,7 @@ func TestDefaultSpecs(t *testing.T) {
 		spec := testSpecFor(t, "ingest-service", chefServerEnabled, workflowEnabled)
 		testRequireMetadata(t, spec)
 		testRequirePath(t, spec, "sync", "/hab/svc/ingest-service/data")
-		testRequireEs(t, spec, "sync", "ingest-service", "node-state-5,node-attribute,converge-history-*,actions-*")
+		testRequireEs(t, spec, "sync", "ingest-service", "node-state-6,node-attribute,converge-history-*,actions-*")
 	})
 	t.Run("license-control-service", func(t *testing.T) {
 		spec := testSpecFor(t, "license-control-service", chefServerEnabled, workflowEnabled)

--- a/components/config-mgmt-service/integration_test/nodes_test.go
+++ b/components/config-mgmt-service/integration_test/nodes_test.go
@@ -235,10 +235,1606 @@ func TestGetNodesRegexWithExactSameField(t *testing.T) {
 			},
 			expected: []string{"a2-dev", "a2-prod", "a1-prod", "a1-dev"},
 		},
+		{
+			description: "Case sensitive regex filters 1",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a2-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"name:a2-*"},
+			},
+			expected: []string{"a2-dev", "A2-Dev", "A2-prod", "a2-Prod"},
+		},
+		{
+			description: "Case sensitive regex filters 2",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a2-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"name:A2-*"},
+			},
+			expected: []string{"a2-dev", "A2-Dev", "A2-prod", "a2-Prod"},
+		},
 	}
 
 	for _, test := range cases {
 		t.Run(fmt.Sprintf("Regex with exact filter: %s", test.description), func(t *testing.T) {
+
+			// Adding required node data
+			for index := range test.nodes {
+				test.nodes[index].Exists = true
+				test.nodes[index].NodeInfo.EntityUuid = newUUID()
+			}
+
+			// Add node with project
+			suite.IngestNodes(test.nodes)
+			defer suite.DeleteAllDocuments()
+
+			// call GetNodes
+			res, err := cfgmgmt.GetNodes(context.Background(), &test.request)
+			assert.NoError(t, err)
+
+			names := getFieldValues(res, "name")
+
+			// Test what nodes are returned.
+			assert.ElementsMatch(t, test.expected, names)
+		})
+	}
+}
+
+func TestGetNodesWildcardCaseInsensitive(t *testing.T) {
+
+	cases := []struct {
+		description string
+		nodes       []iBackend.Node
+		request     request.Nodes
+		expected    []string
+	}{
+		// Node name
+		{
+			description: "Node name: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"name:a2-*"},
+			},
+			expected: []string{"a2-dev", "A2-Dev", "A2-prod", "a2-Prod"},
+		},
+		{
+			description: "Node name: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"name:A2-*"},
+			},
+			expected: []string{"a2-dev", "A2-Dev", "A2-prod", "a2-Prod"},
+		},
+
+		// organization
+		{
+			description: "Org: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:         "a",
+						OrganizationName: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:         "b",
+						OrganizationName: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:         "c",
+						OrganizationName: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:         "d",
+						OrganizationName: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:         "e",
+						OrganizationName: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"organization:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "Org: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:         "a",
+						OrganizationName: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:         "b",
+						OrganizationName: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:         "c",
+						OrganizationName: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:         "d",
+						OrganizationName: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:         "e",
+						OrganizationName: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"organization:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// environment
+		{
+			description: "environment: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "a",
+						Environment: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "b",
+						Environment: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "c",
+						Environment: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "d",
+						Environment: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "e",
+						Environment: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"environment:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "environment: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "a",
+						Environment: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "b",
+						Environment: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "c",
+						Environment: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "d",
+						Environment: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "e",
+						Environment: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"environment:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// platform
+		{
+			description: "Platform: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+						Platform: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+						Platform: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+						Platform: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+						Platform: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+						Platform: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"platform:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "platform: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+						Platform: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+						Platform: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+						Platform: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+						Platform: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+						Platform: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"platform:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// resource_names
+		{
+			description: "resource_names: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "a",
+						ResourceNames: []string{"a2-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "b",
+						ResourceNames: []string{"A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "c",
+						ResourceNames: []string{"A2-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "d",
+						ResourceNames: []string{"a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "e",
+						ResourceNames: []string{"a3-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"resource_names:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "resource_names: term lowercase with array values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "a",
+						ResourceNames: []string{"a2-dev", "a3-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "b",
+						ResourceNames: []string{"b2-prod", "A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "c",
+						ResourceNames: []string{"A2-prod", "A1-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "d",
+						ResourceNames: []string{"c-9", "a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "e",
+						ResourceNames: []string{"c-9", "a3-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"resource_names:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "resource_names: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "a",
+						ResourceNames: []string{"a2-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "b",
+						ResourceNames: []string{"A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "c",
+						ResourceNames: []string{"A2-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "d",
+						ResourceNames: []string{"a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:      "e",
+						ResourceNames: []string{"a3-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"resource_names:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// error_message
+		{
+			description: "error_message: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+					},
+					ErrorMessage: "a2-dev",
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+					},
+					ErrorMessage: "A2-Dev",
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+					},
+					ErrorMessage: "A2-prod",
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+					},
+					ErrorMessage: "a2-Prod",
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+					},
+					ErrorMessage: "a3-Prod",
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"error:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "error_message: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+					},
+					ErrorMessage: "a2-dev",
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+					},
+					ErrorMessage: "A2-Dev",
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+					},
+					ErrorMessage: "A2-prod",
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+					},
+					ErrorMessage: "a2-Prod",
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+					},
+					ErrorMessage: "a3-Prod",
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"error:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// recipes
+		{
+			description: "recipe: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+						Recipes:  []string{"a2-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+						Recipes:  []string{"A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+						Recipes:  []string{"A2-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+						Recipes:  []string{"a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+						Recipes:  []string{"a3-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"recipe:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "recipe: term lowercase with array values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+						Recipes:  []string{"a2-dev", "a3-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+						Recipes:  []string{"b2-prod", "A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+						Recipes:  []string{"A2-prod", "A1-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+						Recipes:  []string{"c-9", "a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+						Recipes:  []string{"c-9", "a4-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"recipe:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "recipe: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+						Recipes:  []string{"a2-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+						Recipes:  []string{"A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+						Recipes:  []string{"A2-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+						Recipes:  []string{"a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+						Recipes:  []string{"a3-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"recipe:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// chef_tags
+		{
+			description: "ChefTags: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+						ChefTags: []string{"a2-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+						ChefTags: []string{"A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+						ChefTags: []string{"A2-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+						ChefTags: []string{"a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+						ChefTags: []string{"a3-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"chef_tags:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "ChefTags: term lowercase with array values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+						ChefTags: []string{"a2-dev", "a3-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+						ChefTags: []string{"b2-prod", "A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+						ChefTags: []string{"A2-prod", "A1-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+						ChefTags: []string{"c-9", "a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+						ChefTags: []string{"c-9", "a4-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"chef_tags:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "ChefTags: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+						ChefTags: []string{"a2-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+						ChefTags: []string{"A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+						ChefTags: []string{"A2-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+						ChefTags: []string{"a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+						ChefTags: []string{"a3-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"chef_tags:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// cookbooks
+		{
+			description: "cookbooks: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "a",
+						Cookbooks: []string{"a2-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "b",
+						Cookbooks: []string{"A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "c",
+						Cookbooks: []string{"A2-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "d",
+						Cookbooks: []string{"a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "e",
+						Cookbooks: []string{"a3-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"cookbook:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "cookbooks: term lowercase with array values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "a",
+						Cookbooks: []string{"a2-dev", "a3-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "b",
+						Cookbooks: []string{"b2-prod", "A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "c",
+						Cookbooks: []string{"A2-prod", "A1-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "d",
+						Cookbooks: []string{"c-9", "a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "e",
+						Cookbooks: []string{"c-9", "a4-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"cookbook:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "cookbooks: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "a",
+						Cookbooks: []string{"a2-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "b",
+						Cookbooks: []string{"A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "c",
+						Cookbooks: []string{"A2-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "d",
+						Cookbooks: []string{"a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:  "e",
+						Cookbooks: []string{"a3-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"cookbook:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// attributes
+		{
+			description: "attribute: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+					},
+					Attributes: []string{"a2-dev"},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+					},
+					Attributes: []string{"A2-Dev"},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+					},
+					Attributes: []string{"A2-prod"},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+					},
+					Attributes: []string{"a2-Prod"},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+					},
+					Attributes: []string{"a3-Prod"},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"attribute:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "attribute: term lowercase with array values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+					},
+					Attributes: []string{"a2-dev", "a3-dev"},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+					},
+					Attributes: []string{"b2-prod", "A2-Dev"},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+					},
+					Attributes: []string{"A2-prod", "A1-prod"},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+					},
+					Attributes: []string{"c-9", "a2-Prod"},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+					},
+					Attributes: []string{"c-9", "a4-Prod"},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"attribute:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "attribute: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+					},
+					Attributes: []string{"a2-dev"},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+					},
+					Attributes: []string{"A2-Dev"},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+					},
+					Attributes: []string{"A2-prod"},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+					},
+					Attributes: []string{"a2-Prod"},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+					},
+					Attributes: []string{"a3-Prod"},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"attribute:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// chef_version
+		{
+			description: "chef_version: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "a",
+						ChefVersion: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "b",
+						ChefVersion: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "c",
+						ChefVersion: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "d",
+						ChefVersion: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "e",
+						ChefVersion: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"chef_version:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "chef_version: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "a",
+						ChefVersion: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "b",
+						ChefVersion: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "c",
+						ChefVersion: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "d",
+						ChefVersion: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "e",
+						ChefVersion: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"chef_version:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// roles
+		{
+			description: "roles: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+						Roles:    []string{"a2-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+						Roles:    []string{"A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+						Roles:    []string{"A2-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+						Roles:    []string{"a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+						Roles:    []string{"a3-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"role:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "roles: term lowercase with array values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+						Roles:    []string{"a2-dev", "a3-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+						Roles:    []string{"b2-prod", "A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+						Roles:    []string{"A2-prod", "A1-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+						Roles:    []string{"c-9", "a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+						Roles:    []string{"c-9", "a4-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"role:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "roles: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "a",
+						Roles:    []string{"a2-dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "b",
+						Roles:    []string{"A2-Dev"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "c",
+						Roles:    []string{"A2-prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "d",
+						Roles:    []string{"a2-Prod"},
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName: "e",
+						Roles:    []string{"a3-Prod"},
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"role:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// policy_group
+		{
+			description: "policy_group: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "a",
+						PolicyGroup: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "b",
+						PolicyGroup: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "c",
+						PolicyGroup: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "d",
+						PolicyGroup: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "e",
+						PolicyGroup: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"policy_group:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "policy_group: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "a",
+						PolicyGroup: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "b",
+						PolicyGroup: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "c",
+						PolicyGroup: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "d",
+						PolicyGroup: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:    "e",
+						PolicyGroup: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"policy_group:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// policy_name
+		{
+			description: "policy_name: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "a",
+						PolicyName: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "b",
+						PolicyName: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "c",
+						PolicyName: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "d",
+						PolicyName: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "e",
+						PolicyName: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"policy_name:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "policy_name: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "a",
+						PolicyName: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "b",
+						PolicyName: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "c",
+						PolicyName: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "d",
+						PolicyName: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "e",
+						PolicyName: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"policy_name:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// policy_revision
+		{
+			description: "policy_revision: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:       "a",
+						PolicyRevision: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:       "b",
+						PolicyRevision: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:       "c",
+						PolicyRevision: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:       "d",
+						PolicyRevision: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:       "e",
+						PolicyRevision: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"policy_revision:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "policy_revision: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:       "a",
+						PolicyRevision: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:       "b",
+						PolicyRevision: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:       "c",
+						PolicyRevision: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:       "d",
+						PolicyRevision: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:       "e",
+						PolicyRevision: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"policy_revision:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+
+		// source_fqdn
+		{
+			description: "source_fqdn: term lowercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "a",
+						SourceFqdn: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "b",
+						SourceFqdn: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "c",
+						SourceFqdn: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "d",
+						SourceFqdn: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "e",
+						SourceFqdn: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"source_fqdn:a2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			description: "source_fqdn: term uppercase with values with varying cases",
+			nodes: []iBackend.Node{
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "a",
+						SourceFqdn: "a2-dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "b",
+						SourceFqdn: "A2-Dev",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "c",
+						SourceFqdn: "A2-prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "d",
+						SourceFqdn: "a2-Prod",
+					},
+				},
+				{
+					NodeInfo: iBackend.NodeInfo{
+						NodeName:   "e",
+						SourceFqdn: "a3-Prod",
+					},
+				},
+			},
+			request: request.Nodes{
+				Filter: []string{"source_fqdn:A2-*"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(fmt.Sprintf("Wildcard case sensitive: %s", test.description), func(t *testing.T) {
 
 			// Adding required node data
 			for index := range test.nodes {

--- a/components/config-mgmt-service/integration_test/nodes_test.go
+++ b/components/config-mgmt-service/integration_test/nodes_test.go
@@ -235,64 +235,6 @@ func TestGetNodesRegexWithExactSameField(t *testing.T) {
 			},
 			expected: []string{"a2-dev", "a2-prod", "a1-prod", "a1-dev"},
 		},
-		{
-			description: "Case sensitive regex filters 1",
-			nodes: []iBackend.Node{
-				{
-					NodeInfo: iBackend.NodeInfo{
-						NodeName: "a2-dev",
-					},
-				},
-				{
-					NodeInfo: iBackend.NodeInfo{
-						NodeName: "A2-Dev",
-					},
-				},
-				{
-					NodeInfo: iBackend.NodeInfo{
-						NodeName: "A2-prod",
-					},
-				},
-				{
-					NodeInfo: iBackend.NodeInfo{
-						NodeName: "a2-Prod",
-					},
-				},
-			},
-			request: request.Nodes{
-				Filter: []string{"name:a2-*"},
-			},
-			expected: []string{"a2-dev", "A2-Dev", "A2-prod", "a2-Prod"},
-		},
-		{
-			description: "Case sensitive regex filters 2",
-			nodes: []iBackend.Node{
-				{
-					NodeInfo: iBackend.NodeInfo{
-						NodeName: "a2-dev",
-					},
-				},
-				{
-					NodeInfo: iBackend.NodeInfo{
-						NodeName: "A2-Dev",
-					},
-				},
-				{
-					NodeInfo: iBackend.NodeInfo{
-						NodeName: "A2-prod",
-					},
-				},
-				{
-					NodeInfo: iBackend.NodeInfo{
-						NodeName: "a2-Prod",
-					},
-				},
-			},
-			request: request.Nodes{
-				Filter: []string{"name:A2-*"},
-			},
-			expected: []string{"a2-dev", "A2-Dev", "A2-prod", "a2-Prod"},
-		},
 	}
 
 	for _, test := range cases {

--- a/components/config-mgmt-service/integration_test/suggestions_test.go
+++ b/components/config-mgmt-service/integration_test/suggestions_test.go
@@ -734,13 +734,13 @@ func TestSuggestionsWithTableDriven(t *testing.T) {
 		// Suggestions for Policy Group
 		{"should return all policy_group suggestions",
 			request.Suggestion{Type: "policy_group"},
-			[]string{"sports", "tv_series", "RPGs", "heros", "movies", "nintendo"}},
+			[]string{"sports", "tv_series", "rpgs", "heros", "movies", "nintendo"}},
 		{"should return zero policy_group suggestions",
 			request.Suggestion{Type: "policy_group", Text: "lol"},
 			[]string{}},
 		{"should return results when starting typing 'nintendo'",
 			request.Suggestion{Type: "policy_group", Text: "n"}, // less than 2 characters we return all results?
-			[]string{"sports", "tv_series", "RPGs", "heros", "movies", "nintendo"}},
+			[]string{"sports", "tv_series", "rpgs", "heros", "movies", "nintendo"}},
 		{"should return one policy_group suggestion 'nintendo'",
 			request.Suggestion{Type: "policy_group", Text: "ni"},
 			[]string{"nintendo"}},

--- a/components/ingest-service/backend/client.go
+++ b/components/ingest-service/backend/client.go
@@ -11,7 +11,7 @@ type Client interface {
 	// @param None
 	Initializing() bool
 	// @param (context, UTC time)
-	InitializeStore(context.Context)
+	InitializeStore(context.Context) error
 	// @param (context, UTC time, data)
 	InsertNode(context.Context, Node) error
 	// @param (context, UTC time, data)

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -241,53 +241,70 @@ func (es *Backend) createBulkUpdateRequestToIndexWithID(
 
 // InitializeStore runs the necessary initialization processes to make elasticsearch usable
 // in particular it creates the indexes and aliases for documents to be added
-func (es *Backend) InitializeStore(ctx context.Context) {
+func (es *Backend) InitializeStore(ctx context.Context) error {
 	if !es.initialized {
 		for _, esMap := range mappings.AllMappings {
 			if esMap.Timeseries {
-				es.createTemplate(ctx, esMap.Index, esMap.Mapping)
+				err := es.createTemplate(ctx, esMap.Index, esMap.Mapping)
+				if err != nil {
+					return err
+				}
 			} else {
-				es.createOrUpdateStore(ctx, esMap)
-				es.createStoreAliasIfNotExists(ctx, esMap.Alias, esMap.Index)
+				err := es.createOrUpdateStore(ctx, esMap)
+				if err != nil {
+					return err
+				}
+
+				err = es.createStoreAliasIfNotExists(ctx, esMap.Alias, esMap.Index)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
 	es.initialized = true
+
+	return nil
 }
 
-func (es *Backend) createStoreAliasIfNotExists(ctx context.Context, alias string, index string) {
+func (es *Backend) createStoreAliasIfNotExists(ctx context.Context, alias string, index string) error {
 	if len(alias) > 0 {
 		if !es.storeExists(ctx, alias) {
 			indexError := es.CreateAlias(ctx, alias, index)
 			if indexError != nil {
-				log.Errorf("Error creating alias %s with error: %s", alias, indexError.Error())
+				return errors.Errorf("Error creating alias %s with error: %s", alias, indexError.Error())
 			}
 		}
 	}
+
+	return nil
 }
 
-func (es *Backend) createTemplate(ctx context.Context, templateName string, mapping string) {
+func (es *Backend) createTemplate(ctx context.Context, templateName string, mapping string) error {
 	// We don't care if it already exists because it will update the template
 	_, err := es.client.IndexPutTemplate(templateName).BodyString(mapping).Do(ctx)
 	if err != nil {
-		log.Errorf("Error creating index %s with error: %s", templateName, err.Error())
+		return errors.Errorf("Error creating index %s with error: %s", templateName, err.Error())
 	}
+	return nil
 }
 
-func (es *Backend) createOrUpdateStore(ctx context.Context, esMap mappings.Mapping) {
+func (es *Backend) createOrUpdateStore(ctx context.Context, esMap mappings.Mapping) error {
 	indexName := esMap.Index
 	if !es.storeExists(ctx, indexName) {
 		indexError := es.createStore(ctx, indexName, esMap.Mapping)
 		if indexError != nil {
-			log.Errorf("Error creating index %s with error: %s", indexName, indexError.Error())
+			return errors.Errorf("Error creating index %s with error: %s", indexName, indexError.Error())
 		}
 	} else {
 		// Ensure we have the latest mapping registered.
 		indexError := es.updateMapping(ctx, esMap)
 		if indexError != nil {
-			log.Errorf("Error creating index %s with error: %s", indexName, indexError.Error())
+			return errors.Errorf("Error creating index %s with error: %s", indexName, indexError.Error())
 		}
 	}
+
+	return nil
 }
 
 func (es *Backend) CreateAlias(ctx context.Context, aliasName string, indexName string) error {

--- a/components/ingest-service/backend/elastic/mappings/node_state.go
+++ b/components/ingest-service/backend/elastic/mappings/node_state.go
@@ -42,6 +42,7 @@ var nodeProps = `
 	},
 	"node_name": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -54,7 +55,14 @@ var nodeProps = `
 		"null_value": false
 	},
 	"organization_name": {
-		"type": "keyword"
+		"type": "keyword",
+		"normalizer": "case_insensitive",
+		"fields": {
+			"engram" : {
+				"type": "text",
+				"analyzer": "autocomplete"
+			}
+		}
 	},
 	"run_list": {
 		"type": "keyword",
@@ -121,6 +129,7 @@ var nodeProps = `
 	},
 	"resource_names": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -130,6 +139,7 @@ var nodeProps = `
 	},
 	"error_message": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -139,6 +149,7 @@ var nodeProps = `
 	},
 	"recipes": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -148,6 +159,7 @@ var nodeProps = `
 	},
 	"chef_tags": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -157,6 +169,7 @@ var nodeProps = `
 	},
 	"cookbooks": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -166,6 +179,7 @@ var nodeProps = `
 	},
 	"attributes": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -175,6 +189,7 @@ var nodeProps = `
 	},
 	"platform": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -196,6 +211,7 @@ var nodeProps = `
 	},
 	"chef_version": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -208,6 +224,7 @@ var nodeProps = `
 	},
 	"environment": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -217,6 +234,7 @@ var nodeProps = `
 	},
 	"roles": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -262,10 +280,18 @@ var nodeProps = `
 		"type": "ip"
 	},
 	"source_fqdn": {
-		"type": "keyword"
+		"type": "keyword",
+		"normalizer": "case_insensitive",
+		"fields": {
+			"engram" : {
+				"type": "text",
+				"analyzer": "autocomplete"
+			}
+		}
 	},
 	"policy_group": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -275,6 +301,7 @@ var nodeProps = `
 	},
 	"policy_name": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -284,6 +311,7 @@ var nodeProps = `
 	},
 	"policy_revision": {
 		"type": "keyword",
+		"normalizer": "case_insensitive",
 		"fields": {
 			"engram" : {
 				"type": "text",
@@ -337,6 +365,13 @@ var NodeState = Mapping{
 				"refresh_interval": "5s"
 			},
 			 "analysis": {
+				"normalizer": {
+					"case_insensitive": {
+						"type": "custom",
+						"char_filter": [],
+						"filter": ["lowercase", "asciifolding"]
+					}
+				},
 				"analyzer": {
 					"autocomplete": {
 						"tokenizer": "autocomplete_tokenizer",

--- a/components/ingest-service/backend/elastic/mappings/node_state.go
+++ b/components/ingest-service/backend/elastic/mappings/node_state.go
@@ -323,7 +323,7 @@ var nodeProps = `
 
 // NodeState is the representation of our `node-state` Mapping
 var NodeState = Mapping{
-	Index:      "node-state-5",
+	Index:      "node-state-6",
 	Alias:      "node-state",
 	Type:       "node-state",
 	Timeseries: false,

--- a/components/ingest-service/grpc/grpc.go
+++ b/components/ingest-service/grpc/grpc.go
@@ -55,7 +55,7 @@ func Spawn(opts *serveropts.Opts) error {
 	log.WithFields(log.Fields{"uri": uri}).Info("Starting gRPC Server")
 	conn, err := net.Listen("tcp", uri)
 	if err != nil {
-		log.WithFields(log.Fields{"error": err}).Fatal("TCP listen failed")
+		log.WithError(err).Error("TCP listen failed")
 		return err
 	}
 
@@ -70,21 +70,21 @@ func Spawn(opts *serveropts.Opts) error {
 	// migration tasks.
 	migrationNeeded, err := migrationer.MigrationNeeded()
 	if err != nil {
-		log.WithFields(log.Fields{"error": err}).Fatal("Failed checking for migration")
+		log.WithError(err).Error("Failed checking for migration")
 		return err
 	}
 
 	if migrationNeeded {
 		err = migrationer.Start()
 		if err != nil {
-			log.WithFields(log.Fields{"error": err}).Fatal("Failed starting a migration")
+			log.WithError(err).Error("Failed starting a migration")
 			return err
 		}
 	} else {
 		migrationer.MarkUnneeded()
 		err = client.InitializeStore(context.Background())
 		if err != nil {
-			log.WithFields(log.Fields{"error": err}).Fatal("Failed initializing elasticsearch")
+			log.WithError(err).Error("Failed initializing elasticsearch")
 			return err
 		}
 	}
@@ -93,7 +93,7 @@ func Spawn(opts *serveropts.Opts) error {
 	authzConn, err := opts.ConnFactory.Dial("authz-service", opts.AuthzAddress)
 	if err != nil {
 		// This should never happen
-		log.WithFields(log.Fields{"error": err}).Fatal("Failed to create Authz connection")
+		log.WithError(err).Error("Failed to create Authz connection")
 		return err
 	}
 	defer authzConn.Close()
@@ -104,7 +104,7 @@ func Spawn(opts *serveropts.Opts) error {
 	eventConn, err := opts.ConnFactory.Dial("event-service", opts.EventAddress)
 	if err != nil {
 		// This should never happen
-		log.WithFields(log.Fields{"error": err}).Fatal("Failed to create Event connection")
+		log.WithError(err).Error("Failed to create Event connection")
 		return err
 	}
 	defer eventConn.Close()
@@ -115,7 +115,7 @@ func Spawn(opts *serveropts.Opts) error {
 	nodeMgrConn, err := opts.ConnFactory.Dial("nodemanager-service", opts.NodeManagerAddress)
 	if err != nil {
 		// This should never happen
-		log.WithFields(log.Fields{"error": err}).Fatal("Failed to create NodeManager connection")
+		log.WithError(err).Error("Failed to create NodeManager connection")
 		return err
 	}
 	defer nodeMgrConn.Close()
@@ -154,7 +154,7 @@ func Spawn(opts *serveropts.Opts) error {
 	esSidecarConn, err := opts.ConnFactory.Dial("es-sidecar-service", opts.EsSidecarAddress)
 	if err != nil {
 		// This should never happend
-		log.WithFields(log.Fields{"error": err}).Fatal("Failed to create ES Sidecar connection")
+		log.WithError(err).Error("Failed to create ES Sidecar connection")
 		return err
 	}
 	defer esSidecarConn.Close()

--- a/components/ingest-service/migration/a1_migration.go
+++ b/components/ingest-service/migration/a1_migration.go
@@ -19,7 +19,10 @@ func (ms *Status) migrateA1ToCurrent() error {
 	ms.calculateA1Tasks()
 
 	ms.update("Starting Stage 1")
-	ms.stage1()
+	err := ms.stage1()
+	if err != nil {
+		return err
+	}
 
 	ms.update("Starting Stage 2")
 	go ms.stage2()

--- a/components/ingest-service/migration/migration.go
+++ b/components/ingest-service/migration/migration.go
@@ -56,49 +56,68 @@ func New(client backend.Client) *Status {
 // the second stage is migration from 1 -> 2 does not know what state the first stage has left the data in.
 // For the migration framework we are always going to migrate from the current state to the current version.
 // This does cause a maintenance problem because for each new version the old migration stages need to be updated.
-func (ms *Status) Start() {
+func (ms *Status) Start() error {
 	exists, err := ms.hasA1ElasticsearchData()
 	if err != nil {
 		ms.updateErr(err.Error(), "Unable to detect migration status")
-		return
+		return err
 	}
 	if exists {
 		ms.update("Starting Automate 1.x migration")
-		ms.migrateA1ToCurrent()
-		return
+		err = ms.migrateA1ToCurrent()
+		if err != nil {
+			ms.updateErr(err.Error(), "Unable run 1.x to current migration")
+			return err
+		}
+		return nil
 	}
 
 	exists, err = ms.hasBerlinElasticsearchData()
 	if err != nil {
 		ms.updateErr(err.Error(), "Unable to detect migration status")
-		return
+		return err
 	}
 	if exists {
 		ms.update("Starting Berlin migration")
-		ms.migrateBerlinToCurrent()
-		return
+		err = ms.migrateBerlinToCurrent()
+		if err != nil {
+			ms.updateErr(err.Error(), "Unable run berlin to current migration")
+			return err
+		}
+		return nil
 	}
 
 	exists, err = ms.hasNodeState4Data()
 	if err != nil {
 		ms.updateErr(err.Error(), "Unable to detect migration status")
-		return
+		return err
 	}
 	if exists {
 		ms.update("Starting migration to latest node state index")
-		ms.migrateNodeStateToCurrent(a2NodeState4Index)
-		return
+		err = ms.migrateNodeStateToCurrent(a2NodeState4Index)
+		if err != nil {
+			ms.updateErr(err.Error(), "Unable run node-state 4 to current migration")
+			return err
+		}
+		return nil
 	}
 
 	exists, err = ms.hasNodeState5Data()
 	if err != nil {
 		ms.updateErr(err.Error(), "Unable to detect migration status")
-		return
+		return err
 	}
 	if exists {
 		ms.update("Starting migration to latest node state index")
-		ms.migrateNodeStateToCurrent(a2NodeState5Index)
+		err = ms.migrateNodeStateToCurrent(a2NodeState5Index)
+		if err != nil {
+			ms.updateErr(err.Error(), "Unable run node-state 4 to current migration")
+			return err
+		}
+		return nil
 	}
+
+	return nil
 }
 
 // MigrationNeeded Verify if a migration is needed

--- a/inspec/a2-upgrade-from-v1-integration/controls/elastic.rb
+++ b/inspec/a2-upgrade-from-v1-integration/controls/elastic.rb
@@ -32,9 +32,9 @@ control 'elastic-data-migration-1' do
 
     its('status') { should eq 200 }
 
-    it "returns JSON data about node-state-5" do
+    it "returns JSON data about node-state-6" do
       data = JSON.parse(subject.body)
-      expect(data).to have_key("node-state-5")
+      expect(data).to have_key("node-state-6")
     end
 
   end


### PR DESCRIPTION
### :nut_and_bolt: Description
This change performs a migration on the node-state index to allow the projects field to be indexed. 

When the projects field was added it had two properties ('index=false' and 'doc_values=false') unintentionally added that prevented it from being index or queriable. 
```
"projects": {
    "type": "keyword",
    "index": false,
    "doc_values": false
},
```

Later an update was made to remove those fields from the node-state mapping to make the 'projects' field look like below. 
```
"projects": {
        "type": "keyword"
},
```
When the ingest-service was updated with this change the below error was logged and the mapping was not update. The ingest-service started with no problems. 
```
Error creating index node-state-5 with error: elastic: Error 400 (Bad Request): Mapper for [projects] conflicts with existing mapping in other types:\n[mapper [projects] has different [index] values, mapper [projects] has different [doc_values] values] [type=illegal_argument_exception]"
```

A second change is to exit the ingest-service when an error like above happens. 


#### Merged in "Client Runs search bar with case insensitive wildcard filters" PR
PR https://github.com/chef/automate/pull/516 is merged into this PR because they both need migration of the node-state index. 
 
### :athletic_shoe: Demo Script / Repro Steps

#### Migration
1. To simulate the state of clients node-state mappings, change 'node-state-6' to 'node-state-5' here https://github.com/chef/automate/blob/master/components/ingest-service/backend/elastic/mappings/node_state.go#L326. 
1. Replace this line https://github.com/chef/automate/blob/master/components/ingest-service/backend/elastic/mappings/node_state.go#L65 with the below
```
    "type": "keyword",
    "index": false,
    "doc_values": false
```
1. `build components/ingest-service`
1. `start_all_services`
1. Ensure that the 'projects' field has the 'index' and 'doc_values' properties with this command  `curl $ELASTICSEARCH_URL/node-state/_mapping | jq . | less`
1. Watch the ingest-service logs ` sl | grep "ingest-service.default" &`
1. Revert all the changes to this file https://github.com/chef/automate/blob/master/components/ingest-service/backend/elastic/mappings/node_state.go
1. To simulate the update project and kick off the migration run `rebuild components/ingest-service`
1. Ensure no errors are in the logs then run `curl $ELASTICSEARCH_URL/node-state/_mapping | jq . | less` again to ensure that the 'projects' field look like below. 
```
"projects": {
        "type": "keyword"
},
```

#### Mapping update failure
1. Delete 'index' and 'doc_values' properties from the 'run_list' field from here https://github.com/chef/automate/blob/master/components/ingest-service/backend/elastic/mappings/node_state.go#L61
1. Watch the ingest-service logs with `sl | grep "ingest-service.default"&`
1. Apply the changes to the running service with `rebuild components/ingest-service/`
1. Ensure the ingest-service keeps failing to start with an error like the above one ("Error 400 (Bad Request)").
1. To fix the ingest-service remove the changes to this file https://github.com/chef/automate/blob/master/components/ingest-service/backend/elastic/mappings/node_state.go#L61 and `rebuild components/ingest-service/`


#### wildcard case insensitive filters
1. Update the node name https://github.com/chef/automate/blob/master/components/ingest-service/examples/converge-success-report.json#L2827 to "A2-prod"
1. Ingest the run `send_chef_run_example`
1. Update the node name again https://github.com/chef/automate/blob/master/components/ingest-service/examples/converge-success-report.json#L2827 to "a2-prod"
1. Ingest the run `send_chef_run_example`
1. Open the Client Runs page https://a2-dev.test/client-runs
1. Add a filter for `Node Name` value `a2-*`
1. Ensure both "A2-prod" and "a2-prod" are in the list
1. Remove all filters and add a filter for `Node Name` value `A2-*`
1. Again ensure both "A2-prod" and "a2-prod" are in the list

### :chains: Related Resources

https://github.com/chef/automate/issues/438 of the merged in PR here https://github.com/chef/automate/pull/516 
Copied off this PR: https://github.com/chef/a2/pull/4587

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
