### PR TITLE
Default sorting by percent_ok for service-groups table

### DIFF
--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.spec.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.spec.ts
@@ -157,7 +157,7 @@ describe('ServiceGroupsComponent', () => {
       expect(component.store.dispatch).toHaveBeenCalledWith(
         new UpdateServiceGroupFilters({filters: {
           status: undefined,
-          sortField: 'name',
+          sortField: 'percent_ok',
           sortDirection: 'ASC',
           page: 1,
           pageSize: 25
@@ -173,7 +173,7 @@ describe('ServiceGroupsComponent', () => {
       expect(component.store.dispatch).toHaveBeenCalledWith(
         new UpdateServiceGroupFilters({filters: {
           status: undefined,
-          sortField: 'name',
+          sortField: 'percent_ok',
           sortDirection: 'ASC',
           page: 1,
           pageSize: 25
@@ -188,7 +188,7 @@ describe('ServiceGroupsComponent', () => {
       expect(component.store.dispatch).toHaveBeenCalledWith(
         new UpdateServiceGroupFilters({filters: {
           status: 'ok',
-          sortField: 'name',
+          sortField: 'percent_ok',
           sortDirection: 'ASC',
           page: 1,
           pageSize: 25
@@ -203,7 +203,7 @@ describe('ServiceGroupsComponent', () => {
       expect(component.store.dispatch).toHaveBeenCalledWith(
         new UpdateServiceGroupFilters({filters: {
           status: undefined,
-          sortField: 'name',
+          sortField: 'percent_ok',
           sortDirection: 'ASC',
           page: 1,
           pageSize: 25
@@ -218,7 +218,7 @@ describe('ServiceGroupsComponent', () => {
       expect(component.store.dispatch).toHaveBeenCalledWith(
         new UpdateServiceGroupFilters({filters: {
           status: undefined,
-          sortField: 'name',
+          sortField: 'percent_ok',
           sortDirection: 'ASC',
           page: 1,
           pageSize: 25

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -52,13 +52,15 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   // The collection of allowable sort directions
   private allowedSortDirections = ['asc', 'desc', 'ASC', 'DESC'];
 
+  // Sorft field by default
+  readonly defaultSortField = 'percent_ok';
+
   private selectedFieldDirection$: Observable<SortDirection>;
   private selectedSortField$: Observable<string>;
   private healthSummary$: Observable<HealthSummary>;
   private currentPage$: Observable<number>;
   private currentFieldDirection: SortDirection;
   private currentSortField: string;
-  private defaultSortField = 'percent_ok';
   private defaultFieldDirection: FieldDirection = {
     name: 'ASC',
     percent_ok: 'ASC',

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -58,6 +58,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   private currentPage$: Observable<number>;
   private currentFieldDirection: SortDirection;
   private currentSortField: string;
+  private defaultSortField = 'percent_ok';
   private defaultFieldDirection: FieldDirection = {
     name: 'ASC',
     percent_ok: 'ASC',
@@ -294,7 +295,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
     if ( sortField !== undefined && this.defaultFieldDirection.hasOwnProperty(sortField.text) ) {
       return sortField.text;
     }
-    return 'name';
+    return this.defaultSortField;
   }
 
   private getSortDirection(allUrlParameters: Chicklet[]): 'ASC' | 'DESC' {


### PR DESCRIPTION
### :nut_and_bolt: Description
Set the default sorting field to `percent_ok` for the service-group table.

### :+1: Definition of Done
1) By default, sort by Group Health OK percentage number: from smallest to largest. (0-100) Within the same percentage number sort by level of criticality. When the sorting order is toggled, within the same percentage number, still sort by level of criticality. The level of criticality must always be Critical, Unknown and Warning in that order.

2) Switch the primary sorting criteria with the secondary. That is by default, sort by Level of criticality: The order is Critical, Unknown, Warning and Ok. Within the same level of criticality sort by “group health Ok percentage number”. The group health OK percentage number must always be ordered from 0-100.

### :athletic_shoe: Demo Script / Repro Steps

- Start all services and build the UI. 
- Populate the applications database. 
- Then navigate to the Applications Tab.

### :chains: Related Resources
https://chefio.atlassian.net/browse/A2-840

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
