### PR TITLE
Use the single ElasticSearch Connection object instead of one per request

### DIFF
--- a/components/compliance-service/reporting/relaxting/util.go
+++ b/components/compliance-service/reporting/relaxting/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/chef/automate/lib/grpc/auth_context"
@@ -28,6 +29,9 @@ type ReportingTransport struct {
 	ChefDeliveryUser  string
 	ChefDeliveryToken string
 }
+
+var once sync.Once
+var esClient *elastic.Client
 
 var err error
 
@@ -58,13 +62,15 @@ func (backend *ES2Backend) getHttpClient() *http.Client {
 }
 
 func (backend *ES2Backend) ES2Client() (*elastic.Client, error) {
-	//logrus.Debugf("Creating ES client...")
-	return elastic.NewClient(
-		elastic.SetHttpClient(backend.getHttpClient()),
-		elastic.SetURL(backend.ESUrl),
-		elastic.SetSniff(false),
-		//elastic.SetTraceLog(logrus.New()), // logging from the elastic library. We could enable this when the log level is debug
-	)
+	//this is now a singleton as per best practice as outlined in the comment section of the elastic.NewClient
+	once.Do(func() {
+		esClient, err = elastic.NewClient(
+			elastic.SetHttpClient(backend.getHttpClient()),
+			elastic.SetURL(backend.ESUrl),
+			elastic.SetSniff(false),
+		)
+	})
+	return esClient, err
 }
 
 // Removes element with index i from array arr


### PR DESCRIPTION
For compliance, we were using one and sometimes many ElasticSearch connection per request.  This PR changes that to one ES connection per compliance-service instance.  This will result in far fewer sockets being managed which will, in turn, eliminate the "could not get elastic connection" errors were seeing.

Signed-off-by: Rick Marry <rmarry@chef.io>

### :nut_and_bolt: Description

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
