### PR TITLE
Benchmarks for Applications Service

### DIFF
--- a/.studio/applications-service
+++ b/.studio/applications-service
@@ -74,7 +74,7 @@ function applications_integration() {
   check_if_deployinate_started || return 1
 
   # Go based integration tests
-  A2_SVC_NAME="applications-service" A2_SVC_PATH="/hab/svc/applications-service" go_test "github.com/chef/automate/components/applications-service/integration_test" -v
+  A2_SVC_NAME="applications-service" A2_SVC_PATH="/hab/svc/applications-service" go_test "github.com/chef/automate/components/applications-service/integration_test" -v -bench=.
 }
 
 document "applications_publish_raw_message" <<DOC

--- a/components/applications-service/integration_test/ingestion_benchmark_test.go
+++ b/components/applications-service/integration_test/ingestion_benchmark_test.go
@@ -1,0 +1,76 @@
+//
+//  Author:: Salim Afiune <afiune@chef.io>
+//  Copyright:: Copyright 2019, Chef Software Inc.
+//
+
+package integration_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	uuid "github.com/chef/automate/lib/uuid4"
+)
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RandString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
+
+func BenchmarkIngestionNewServices(b *testing.B) {
+	var criticality = []string{"ok", "critical", "warning", "unknown"}
+
+	defer suite.DeleteDataFromStorage()
+
+	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		var (
+			uuid, _ = uuid.NewV4()
+			svcName = RandString(10)
+			health  = criticality[rand.Intn(4)]
+		)
+
+		event := NewHabitatEvent(
+			withSupervisorId(uuid.String()),
+			withPackageIdent(fmt.Sprintf("core/%s/0.1.0/20190101121212", svcName)),
+			withServiceGroup(fmt.Sprintf("%s.default", svcName)),
+			withStrategyAtOnce("stable"),
+			withApplication("cool-app"),
+			withEnvironment("development"),
+			withFqdn(fmt.Sprintf("%s.example.com", svcName)),
+			withHealth(health),
+			withSite("us"),
+		)
+
+		b.StartTimer()
+		suite.IngestService(event)
+	}
+}
+
+func BenchmarkIngestionUpdateServices(b *testing.B) {
+	b.StopTimer()
+	defer suite.DeleteDataFromStorage()
+	event := NewHabitatEvent(
+		withSupervisorId("1234"),
+		withPackageIdent("core/app/0.1.0/20190101121212"),
+		withServiceGroup("app.default"),
+		withStrategyAtOnce("stable"),
+		withApplication("cool-app"),
+		withEnvironment("development"),
+		withFqdn("app.example.com"),
+		withHealth("CRITICAL"),
+		withSite("us"),
+	)
+	suite.IngestService(event)
+
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		suite.IngestService(event)
+	}
+}

--- a/components/applications-service/integration_test/ingestion_benchmark_test.go
+++ b/components/applications-service/integration_test/ingestion_benchmark_test.go
@@ -6,47 +6,15 @@
 package integration_test
 
 import (
-	"fmt"
-	"math/rand"
 	"testing"
-
-	uuid "github.com/chef/automate/lib/uuid4"
 )
 
-const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
-func RandString(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = letterBytes[rand.Intn(len(letterBytes))]
-	}
-	return string(b)
-}
-
 func BenchmarkIngestionNewServices(b *testing.B) {
-	var criticality = []string{"ok", "critical", "warning", "unknown"}
-
 	defer suite.DeleteDataFromStorage()
 
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()
-		var (
-			uuid, _ = uuid.NewV4()
-			svcName = RandString(10)
-			health  = criticality[rand.Intn(4)]
-		)
-
-		event := NewHabitatEvent(
-			withSupervisorId(uuid.String()),
-			withPackageIdent(fmt.Sprintf("core/%s/0.1.0/20190101121212", svcName)),
-			withServiceGroup(fmt.Sprintf("%s.default", svcName)),
-			withStrategyAtOnce("stable"),
-			withApplication("cool-app"),
-			withEnvironment("development"),
-			withFqdn(fmt.Sprintf("%s.example.com", svcName)),
-			withHealth(health),
-			withSite("us"),
-		)
+		event := NewHabitatEventRandomized()
 
 		b.StartTimer()
 		suite.IngestService(event)

--- a/components/applications-service/integration_test/service_groups_benchmark_test.go
+++ b/components/applications-service/integration_test/service_groups_benchmark_test.go
@@ -1,0 +1,84 @@
+//
+//  Author:: Salim Afiune <afiune@chef.io>
+//  Copyright:: Copyright 2019, Chef Software Inc.
+//
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/chef/automate/api/external/applications"
+	"github.com/chef/automate/api/external/habitat"
+)
+
+var (
+	sgRes *applications.ServiceGroups
+	sgErr error
+)
+
+func BenchmarkGetServiceGroups(b *testing.B) {
+	defer suite.DeleteDataFromStorage()
+
+	var (
+		ctx            = context.Background()
+		request        = new(applications.ServiceGroupsReq)
+		iterations     = 20
+		incremental    = 50
+		maxGroups      = incremental * iterations
+		nServiceGroups = 0
+	)
+
+	for i := 0; i <= iterations; i++ {
+		suite.IngestServices(habNServiceGroups(nServiceGroups))
+
+		b.Run(fmt.Sprintf("max_%d_with_%d_groups", maxGroups, nServiceGroups), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				sgRes, sgErr = suite.ApplicationsServer.GetServiceGroups(ctx, request)
+			}
+		})
+
+		nServiceGroups = nServiceGroups + incremental
+	}
+}
+
+func BenchmarkGetServiceGroupsHeavyLoad(b *testing.B) {
+	defer suite.DeleteDataFromStorage()
+
+	var (
+		ctx            = context.Background()
+		request        = new(applications.ServiceGroupsReq)
+		iterations     = 5
+		incremental    = 1000
+		maxGroups      = incremental * iterations
+		nServiceGroups = 0
+	)
+
+	for i := 0; i <= iterations; i++ {
+		suite.IngestServices(habNServiceGroups(nServiceGroups))
+
+		b.Run(fmt.Sprintf("max_%d_with_%d_groups", maxGroups, nServiceGroups), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				sgRes, sgErr = suite.ApplicationsServer.GetServiceGroups(ctx, request)
+			}
+		})
+
+		nServiceGroups = nServiceGroups + incremental
+	}
+}
+
+func habNServiceGroups(total int) []*habitat.HealthCheckEvent {
+	eventArray := make([]*habitat.HealthCheckEvent, total)
+
+	for n := 0; n < total; n++ {
+		eventArray[n] = NewHabitatEvent(
+			withSupervisorId(fmt.Sprintf("s-%d", n)),
+			withServiceGroup(fmt.Sprintf("app-%d.default", n)),
+			withPackageIdent(fmt.Sprintf("core/app-%d/0.1.0/20190101121212", n)),
+		)
+	}
+
+	return eventArray
+}

--- a/components/applications-service/integration_test/service_groups_benchmark_test.go
+++ b/components/applications-service/integration_test/service_groups_benchmark_test.go
@@ -25,8 +25,8 @@ func BenchmarkGetServiceGroups(b *testing.B) {
 	var (
 		ctx            = context.Background()
 		request        = new(applications.ServiceGroupsReq)
-		iterations     = 20
-		incremental    = 50
+		iterations     = 10
+		incremental    = 100
 		maxGroups      = incremental * iterations
 		nServiceGroups = 0
 	)

--- a/components/applications-service/integration_test/services_benchmark_test.go
+++ b/components/applications-service/integration_test/services_benchmark_test.go
@@ -25,8 +25,8 @@ func BenchmarkGetServices(b *testing.B) {
 	var (
 		ctx         = context.Background()
 		request     = new(applications.ServicesReq)
-		iterations  = 20
-		incremental = 50
+		iterations  = 10
+		incremental = 100
 		maxServices = incremental * iterations
 		nServices   = 0
 	)

--- a/components/applications-service/integration_test/services_benchmark_test.go
+++ b/components/applications-service/integration_test/services_benchmark_test.go
@@ -1,0 +1,84 @@
+//
+//  Author:: Salim Afiune <afiune@chef.io>
+//  Copyright:: Copyright 2019, Chef Software Inc.
+//
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/chef/automate/api/external/applications"
+	"github.com/chef/automate/api/external/habitat"
+)
+
+var (
+	sRes *applications.ServicesRes
+	sErr error
+)
+
+func BenchmarkGetServices(b *testing.B) {
+	defer suite.DeleteDataFromStorage()
+
+	var (
+		ctx         = context.Background()
+		request     = new(applications.ServicesReq)
+		iterations  = 20
+		incremental = 50
+		maxServices = incremental * iterations
+		nServices   = 0
+	)
+
+	for i := 0; i <= iterations; i++ {
+		suite.IngestServices(habNServices(nServices))
+
+		b.Run(fmt.Sprintf("max_%d_with_%d_services", maxServices, nServices), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				sRes, sErr = suite.ApplicationsServer.GetServices(ctx, request)
+			}
+		})
+
+		nServices = nServices + incremental
+	}
+}
+
+func BenchmarkGetServicesHeavyLoad(b *testing.B) {
+	defer suite.DeleteDataFromStorage()
+
+	var (
+		ctx         = context.Background()
+		request     = new(applications.ServicesReq)
+		iterations  = 5
+		incremental = 1000
+		maxServices = incremental * iterations
+		nServices   = 0
+	)
+
+	for i := 0; i <= iterations; i++ {
+		suite.IngestServices(habNServices(nServices))
+
+		b.Run(fmt.Sprintf("max_%d_with_%d_services", maxServices, nServices), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				sRes, sErr = suite.ApplicationsServer.GetServices(ctx, request)
+			}
+		})
+
+		nServices = nServices + incremental
+	}
+}
+
+func habNServices(total int) []*habitat.HealthCheckEvent {
+	eventArray := make([]*habitat.HealthCheckEvent, total)
+
+	for n := 0; n < total; n++ {
+		eventArray[n] = NewHabitatEvent(
+			withSupervisorId(fmt.Sprintf("s-%d", n)),
+			withServiceGroup("app.default"),
+			withPackageIdent("core/app/0.1.0/20190101121212"),
+		)
+	}
+
+	return eventArray
+}


### PR DESCRIPTION
### :nut_and_bolt: Description
Currently, in the EAS Team, we are struggling a little bit to make decisions
in the backend, that is inside the `applications-service`.

We don't have a way to know the implications of adding or modifying code
and therefore, as engineers, we make lots of theories and deductions of
what "it could happen" based on assumptions.

An example is the following PR that is adding some extra complexity in
the query side of the micro-service. https://github.com/chef/automate/pull/490

This work is the first iteration to introduce benchmarks in our integration
tests to measure two main GRPC functions that we expose to consumers
(endpoints and the UI). These measurements will be recorded in our pipeline
so that we can understand how the system progress or degrades on code
changes.

### :+1: Definition of Done
After this change is merged, we will start recording times based on
Go Benchmarks for the GRPC functions:

- `GetServiceGroups` - Lists all service-groups in the system.
- `GetServices` - Lists all services in the system.

### :athletic_shoe: Demo Script / Repro Steps

- Start the studio
- Start the applications service: (you don't have to build the applications-service) 
```
[1][default:/src:0]# start_deployment_service;
[2][default:/src:0]# chef-automate dev deploy-some --with-deps "chef/applications-service"
```
- Run the integration tests. `applications_integration`

Here is the [(link)](https://buildkite.com/chef/chef-automate-master-verify-private/builds/1725#04637108-dcfb-4052-817e-1f8953d9f206) of the BuildKite Job that ran them

Output Gist: https://gist.github.com/afiune/f298f71788294d698e134dd82ad4b39c#file-pr-495-md

### :chains: Related Resources
N/A

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
