### PR TITLE
[A2-798] fix v2.1 upgrade issue for multi-node settings

### DIFF
--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -31,7 +31,6 @@ type policyServer struct {
 	engine          engine.V2pXWriter
 	v1              storage_v1.PoliciesLister
 	vChan           chan api.Version
-	version         api.Version
 	policyRefresher PolicyRefresher
 }
 
@@ -710,7 +709,7 @@ func (s *policyServer) EngineUpdateInterceptor() grpc.UnaryServerInterceptor {
 }
 
 func (s *policyServer) updateEngineStore(ctx context.Context) error {
-	return s.policyRefresher.Refresh(ctx, s.version)
+	return s.policyRefresher.Refresh(ctx)
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -893,9 +892,10 @@ func (s *policyServer) logPolicies(policies []*storage.Policy) {
 	s.log.WithFields(kv).Info("Policy definition")
 }
 
-func (s *policyServer) setVersion(v api.Version) {
+// setVersionForInterceptorSwitch informs the interceptor piece of this server
+// to deny v1 requests if set to v2/v2.1 and vice-versa.
+func (s *policyServer) setVersionForInterceptorSwitch(v api.Version) {
 	if s.vChan != nil {
 		s.vChan <- v
-		s.version = v
 	}
 }

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -113,7 +113,7 @@ func NewPoliciesServer(
 	default:
 		v = api.Version{Major: api.Version_V1, Minor: api.Version_V0}
 	}
-	srv.setVersion(v)
+	srv.setVersionForInterceptorSwitch(v)
 
 	if v.Major == api.Version_V2 {
 		if err := srv.store.ApplyV2DataMigrations(ctx); err != nil {
@@ -600,7 +600,7 @@ func (s *policyServer) MigrateToV2(ctx context.Context,
 		return nil, status.Errorf(codes.Internal, "record migration status: %s", err.Error())
 	}
 
-	s.setVersion(v)
+	s.setVersionForInterceptorSwitch(v)
 	return &api.MigrateToV2Resp{Reports: reports}, nil
 }
 
@@ -622,7 +622,7 @@ func (s *policyServer) handleMinorUpgrade(ctx context.Context, ms storage.Migrat
 	}
 
 	if upgraded {
-		s.setVersion(version)
+		s.setVersionForInterceptorSwitch(version)
 	}
 	return upgraded, nil
 }
@@ -649,7 +649,7 @@ func (s *policyServer) ResetToV1(ctx context.Context,
 	if err := s.store.Reset(ctx); err != nil {
 		return nil, status.Errorf(codes.Internal, "reset database state: %s", err.Error())
 	}
-	s.setVersion(api.Version{Major: api.Version_V1, Minor: api.Version_V0})
+	s.setVersionForInterceptorSwitch(api.Version{Major: api.Version_V1, Minor: api.Version_V0})
 	return &api.ResetToV1Resp{}, nil
 }
 

--- a/components/authz-service/server/v2/policy_refresher.go
+++ b/components/authz-service/server/v2/policy_refresher.go
@@ -157,6 +157,12 @@ func (refresher *policyRefresher) updateEngineStore(ctx context.Context) error {
 	// Engine updates need unfiltered access to all data.
 	ctx = auth_context.ContextWithoutProjects(ctx)
 
+	// Retrieve the IAM version from the database: some other node could have
+	// done a migration (v2 <-> v2.1) and this one wouldn't know. However, on
+	// success, it's written to the database, and we can thus retrieve it from
+	// there. Also, these version changes are registered as "policy changes",
+	// so even if no v2[.1] policy has actually changed, we'll update the correct
+	// store (v2 or v2.1) here.
 	vsn, err := refresher.getIAMVersion(ctx)
 	if err != nil {
 		refresher.log.WithError(err).Warn("Failed to retrieve IAM version")

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -2855,8 +2855,7 @@ func TestVersionChannel(t *testing.T) {
 		ts.projectCache.Flush()
 
 		// reset to v1
-		ts.switcher.Version = api_v2.Version{Major: api_v2.Version_V1, Minor: api_v2.Version_V0}
-		require.Equal(iamV1, ts.switcher.Version)
+		ts.switcher.Version = iamV1
 
 		t.Run(test.desc, test.f)
 	}

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -52,16 +52,14 @@ type Querier interface {
 
 // CreatePolicy stores a new policy and its statements in postgres and returns the final policy.
 func (p *pg) CreatePolicy(ctx context.Context, pol *v2.Policy) (*v2.Policy, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// Note(sr): we're using BeginTx with the context that'll be cancelled in a
-	// `defer` when the function ends. This should rollback transactions that
-	// haven't been committed -- what would happen when any of the following
-	// `err != nil` cases return early.
-	// However, I haven't played with this extensively, so there's a bit of a
-	// chance that this understanding is just plain wrong.
-
+	// Note(sr): we're using BeginTx with the context that'll be cancelled when
+	// GRPC is done with the method call.
+	// This should rollback transactions that haven't been committed -- what would
+	// happen when any of the following `err != nil` cases return early.
+	//
+	// See https://gist.github.com/srenatus/ce12b31ea517f16c024e4f8736fa5f2b for
+	// a toy experiment asserting that the context actually is cancelled when the
+	// GRPC method is done.
 	tx, err := p.db.BeginTx(ctx, nil /* use driver default */)
 	if err != nil {
 		return nil, p.processError(err)
@@ -98,8 +96,6 @@ func (p *pg) CreatePolicy(ctx context.Context, pol *v2.Policy) (*v2.Policy, erro
 
 func (p *pg) PurgeSubjectFromPolicies(ctx context.Context, sub string) ([]string, error) {
 	var polIDs []string
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 	tx, err := p.db.BeginTx(ctx, nil /* use driver default */)
 	if err != nil {
 		return nil, p.processError(err)
@@ -175,9 +171,6 @@ func (p *pg) GetPolicy(ctx context.Context, id string) (*v2.Policy, error) {
 }
 
 func (p *pg) DeletePolicy(ctx context.Context, id string) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tx, err := p.db.BeginTx(ctx, nil /* use driver default */)
 	if err != nil {
 		return p.processError(err)
@@ -211,9 +204,6 @@ func (p *pg) DeletePolicy(ctx context.Context, id string) error {
 }
 
 func (p *pg) UpdatePolicy(ctx context.Context, pol *v2.Policy) (*v2.Policy, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tx, err := p.db.BeginTx(ctx, nil /* use driver default */)
 	if err != nil {
 		return nil, p.processError(err)
@@ -431,9 +421,6 @@ func (p *pg) queryPolicy(ctx context.Context, id string, q Querier) (*v2.Policy,
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 func (p *pg) ListPolicyMembers(ctx context.Context, id string) ([]v2.Member, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tx, err := p.db.BeginTx(ctx, nil /* use driver default */)
 	if err != nil {
 		return nil, p.processError(err)
@@ -460,9 +447,6 @@ func (p *pg) ListPolicyMembers(ctx context.Context, id string) ([]v2.Member, err
 }
 
 func (p *pg) AddPolicyMembers(ctx context.Context, id string, members []v2.Member) ([]v2.Member, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tx, err := p.db.BeginTx(ctx, nil /* use driver default */)
 	if err != nil {
 		return nil, p.processError(err)
@@ -506,9 +490,6 @@ func (p *pg) AddPolicyMembers(ctx context.Context, id string, members []v2.Membe
 }
 
 func (p *pg) ReplacePolicyMembers(ctx context.Context, policyID string, members []v2.Member) ([]v2.Member, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tx, err := p.db.BeginTx(ctx, nil /* use driver default */)
 	if err != nil {
 		return nil, p.processError(err)
@@ -555,10 +536,6 @@ func (p *pg) ReplacePolicyMembers(ctx context.Context, policyID string, members 
 // list of members to remove and return the list of remaining users.
 func (p *pg) RemovePolicyMembers(ctx context.Context,
 	policyID string, members []v2.Member) ([]v2.Member, error) {
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tx, err := p.db.BeginTx(ctx, nil /* use driver default */)
 	if err != nil {
 		return nil, p.processError(err)
@@ -682,9 +659,6 @@ func (p *pg) getPolicyMembersWithQuerier(ctx context.Context, id string, q Queri
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 func (p *pg) CreateRole(ctx context.Context, role *v2.Role) (*v2.Role, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tx, err := p.db.BeginTx(ctx, nil /* use driver default */)
 	if err != nil {
 		return nil, p.processError(err)
@@ -739,9 +713,6 @@ func (p *pg) ListRoles(ctx context.Context) ([]*v2.Role, error) {
 }
 
 func (p *pg) GetRole(ctx context.Context, id string) (*v2.Role, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	projectsFilter, err := projectsListFromContext(ctx)
 	if err != nil {
 		return nil, p.processError(err)
@@ -776,9 +747,6 @@ func (p *pg) GetRole(ctx context.Context, id string) (*v2.Role, error) {
 }
 
 func (p *pg) DeleteRole(ctx context.Context, id string) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	projectsFilter, err := projectsListFromContext(ctx)
 	if err != nil {
 		return p.processError(err)
@@ -823,9 +791,6 @@ func (p *pg) DeleteRole(ctx context.Context, id string) error {
 }
 
 func (p *pg) UpdateRole(ctx context.Context, role *v2.Role) (*v2.Role, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	projectsFilter, err := projectsListFromContext(ctx)
 	if err != nil {
 		return nil, p.processError(err)
@@ -955,9 +920,6 @@ func (p *pg) insertRoleWithQuerier(ctx context.Context, role *v2.Role, q Querier
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 func (p *pg) CreateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, p.processError(err)
@@ -995,10 +957,6 @@ func (p *pg) UpdateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 	if err != nil {
 		return nil, p.processError(err)
 	}
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, p.processError(err)
@@ -1052,10 +1010,6 @@ func (p *pg) DeleteRule(ctx context.Context, id string) error {
 	if err != nil {
 		return p.processError(err)
 	}
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return p.processError(err)
@@ -1089,10 +1043,6 @@ func (p *pg) GetRule(ctx context.Context, id string) (*v2.Rule, error) {
 	if err != nil {
 		return nil, p.processError(err)
 	}
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, p.processError(err)
@@ -1123,10 +1073,6 @@ func (p *pg) ListRules(ctx context.Context) ([]*v2.Rule, error) {
 	if err != nil {
 		return nil, p.processError(err)
 	}
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, p.processError(err)
@@ -1162,9 +1108,6 @@ func (p *pg) ListRules(ctx context.Context) ([]*v2.Rule, error) {
 }
 
 func (p *pg) ListRulesForProject(ctx context.Context, projectID string) ([]*v2.Rule, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	projectsFilter, err := projectsListFromContext(ctx)
 	if err != nil {
 		return nil, p.processError(err)
@@ -1210,9 +1153,6 @@ func (p *pg) ListRulesForProject(ctx context.Context, projectID string) ([]*v2.R
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 func (p *pg) CreateProject(ctx context.Context, project *v2.Project) (*v2.Project, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, p.processError(err)
@@ -1244,9 +1184,6 @@ func (p *pg) CreateProject(ctx context.Context, project *v2.Project) (*v2.Projec
 }
 
 func (p *pg) UpdateProject(ctx context.Context, project *v2.Project) (*v2.Project, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	projectsFilter, err := projectsListFromContext(ctx)
 	if err != nil {
 		return nil, p.processError(err)

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -1383,6 +1383,9 @@ func (p *pg) Pristine(ctx context.Context) error {
 }
 
 func (p *pg) recordMigrationStatusAndNotifyPG(ctx context.Context, ms string) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	tx, err := p.db.BeginTx(ctx, nil /* use driver default */)
 	if err != nil {
 		return p.processError(err)


### PR DESCRIPTION
### :nut_and_bolt: Description

Since there's two different stores for these now, it matters in a
multi-node setting which version the server is operating under. Since
the version is derived from the migration status, which in turn is
stored in the database, we make a change to that a "policy change
event": any instance that is connected to the database, but hasn't been
the one processing the migration GRPC call, will be informed that it
needs to update its store.

Figuring out which store to update is done by querying the database for
its migration status; it no longer is retrieved from local state of the
server instance.

Note: this does not notify other nodes in unhappy paths, since a failure
to migrate v1 policies should prohibit a switch to v2 (or v2.1).

### :+1: Definition of Done

Stuff still works single-node. -- This is a _best effort_ fix for getting switches between v2 and v2.1 in multi-node settings work, I don't believe we have any proper testing in place for this (_I don't even know how to spin it up!_)... 😅 

### :athletic_shoe: Demo Script / Repro Steps

NA

### :chains: Related Resources

- #467 for splitting the store updates in v2 vs v2.1

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
