### PR TITLE
modify automate cli and ui user menu to include major automate version

### DIFF
--- a/components/automate-cli/cmd/chef-automate/version.go
+++ b/components/automate-cli/cmd/chef-automate/version.go
@@ -34,6 +34,7 @@ type versionResult struct {
 var verbose bool
 
 func runVersionCmd(cmd *cobra.Command, args []string) error {
+	writer.Printf("Version: %s\n", "2")
 	printClientVersion()
 	return printServerVersion()
 }
@@ -43,11 +44,10 @@ func printClientVersion() {
 	if verbose {
 		writer.Println("CLI")
 		writer.Println("===")
-		writer.Printf("Version: %s\n", version.BuildTime)
-		writer.Printf("Build time: %s\n", version.BuildTime)
+		writer.Printf("CLI Build: %s\n", version.BuildTime)
 		writer.Printf("Git SHA: %s\n", version.GitSHA)
 	} else {
-		writer.Printf("CLI version: %s\n", version.BuildTime)
+		writer.Printf("CLI Build: %s\n", version.BuildTime)
 	}
 }
 
@@ -81,8 +81,7 @@ func printServerVersion() error {
 		writer.Println("======")
 		// TODO: (yzl) When we know what we want to display for Version, update it to be something other
 		// than the timestamp.
-		writer.Printf("Version: %s\n", response.BuildTimestamp)
-		writer.Printf("Build time: %s\n", response.BuildTimestamp)
+		writer.Printf("Server Build: %s\n", response.BuildTimestamp)
 		writer.Printf("Git SHA: %s\n", response.BuildSha)
 		err := printUpgradeStatus()
 		if err != nil {
@@ -90,7 +89,7 @@ func printServerVersion() error {
 		}
 	} else {
 		// get a server version
-		writer.Printf("Server version: %s\n", response.BuildTimestamp)
+		writer.Printf("Server Build: %s\n", response.BuildTimestamp)
 	}
 	status.GlobalResult = versionResult{
 		ClientVersion:   version.BuildTime,

--- a/components/automate-ui/e2e/app.e2e-spec.ts
+++ b/components/automate-ui/e2e/app.e2e-spec.ts
@@ -131,8 +131,8 @@ describe('Main Navigation', () => {
 describe('User Dropdown', () => {
 
   it('displays the version text', () => {
-    const expectedVersion = '20180416135645';
-    const body = `{"build_timestamp":"${expectedVersion}"}`;
+    const expectedBuild = '20180416135645';
+    const body = `{"build_timestamp":"${expectedBuild}"}`;
 
     fakeServer().get('/api/v0/version').many().reply(200, body);
 
@@ -142,7 +142,9 @@ describe('User Dropdown', () => {
     element(by.css('app-profile')).click();
 
     const versionLink = $('.version');
-    expect(versionLink.getText()).toBe(`Version: ${expectedVersion}`);
+    expect(versionLink.getText()).toBe('Version: 2');
+    const buildLink = $('.build');
+    expect(buildLink.getText()).toBe(`Build: ${expectedBuild}`);
   });
 
   it('shows the welcome modal when "About Chef Automate" clicked', () => {

--- a/components/automate-ui/src/app/page-components/profile/profile.component.html
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.html
@@ -27,8 +27,9 @@
         </li>
       </app-authorized>
       <li class="dropdown-list-item">
-        <span class="version">Version: {{ buildVersion }}</span>
-        <ul class="dropdown-sub-list">
+        <span class="version">Version: 2</span>
+        <span class="build">Build: {{ buildVersion }}</span>
+		<ul class="dropdown-sub-list">
           <li>
             <button (click)="showWelcomeModal()"
               (keydown.arrowup)="handleArrowUp($event)"

--- a/components/automate-ui/src/app/page-components/profile/profile.component.html
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.html
@@ -29,7 +29,7 @@
       <li class="dropdown-list-item">
         <span class="version">Version: 2</span>
         <span class="build">Build: {{ buildVersion }}</span>
-		<ul class="dropdown-sub-list">
+        <ul class="dropdown-sub-list">
           <li>
             <button (click)="showWelcomeModal()"
               (keydown.arrowup)="handleArrowUp($event)"

--- a/components/automate-ui/src/app/page-components/profile/profile.component.scss
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.scss
@@ -98,3 +98,8 @@ a, button:not(.dropdown-toggle) {
   right: 16px;
   top: 8px;
 }
+
+.version:after {
+  content: '\A';
+  white-space: pre;
+}

--- a/components/automate-ui/src/app/page-components/profile/profile.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.spec.ts
@@ -19,7 +19,7 @@ class MockMetadataService {
 }
 
 class MockTelemetryService {
-  track(_event?: string, _properties?: any): void {}
+  track(_event?: string, _properties?: any): void { }
 }
 
 describe('ProfileComponent', () => {
@@ -45,7 +45,7 @@ describe('ProfileComponent', () => {
         { provide: MetadataService, useClass: MockMetadataService },
         { provide: ChefSessionService, useClass: MockChefSessionService }
       ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     });
 
     localStorage.setItem('welcome-modal-seen', 'true');
@@ -84,7 +84,7 @@ describe('ProfileComponent', () => {
 
       expect(metadataService.getBuildVersion).toHaveBeenCalled();
       expect(telemetryService.track).toHaveBeenCalledWith('automateVersion',
-        { automateVersion: `${expectedVersion}`});
+        { automateVersion: `${expectedVersion}` });
       expect(component.buildVersion).toEqual(expectedVersion);
     });
   });
@@ -102,10 +102,10 @@ describe('ProfileComponent', () => {
   });
 
   describe('displayName', () => {
-      it('returns first and last', () => {
-        expect(component.displayName).toEqual(chefSessionService.fullname);
-        expect(component.displayName).toEqual('Test Mock');
-      });
+    it('returns first and last', () => {
+      expect(component.displayName).toEqual(chefSessionService.fullname);
+      expect(component.displayName).toEqual('Test Mock');
+    });
   });
 
   describe('email', () => {
@@ -115,7 +115,7 @@ describe('ProfileComponent', () => {
     });
   });
 
-   describe('username', () => {
+  describe('username', () => {
     it('returns the username for the session user', () => {
       expect(component.userName).toEqual(chefSessionService.username);
       expect(component.userName).toEqual('testmock');
@@ -164,8 +164,8 @@ describe('ProfileComponent', () => {
       component.dropdownVisible = true;
       fixture.detectChanges();
 
-      const expected = `Version: ${version}`;
-      const actual = element.nativeElement.querySelector('.version').innerText;
+      const expected = `Build: ${version}`;
+      const actual = element.nativeElement.querySelector('.build').innerText;
       expect(actual).toEqual(expected);
     });
   });

--- a/inspec/a2-deploy-integration/controls/base.rb
+++ b/inspec/a2-deploy-integration/controls/base.rb
@@ -9,7 +9,7 @@ end
 # chef-automate version: prints the version
 #
 describe command("chef-automate version") do
-  its('stdout') { should match /CLI version: \d{14}\nServer version: \d{14}\n/ }
+  its('stdout') { should match /Version: 2\nCLI Build: \d{14}\nServer Build: \d{14}\n/ }
   its('stderr') { should eq '' }
   its('exit_status') { should eq 0 }
 end


### PR DESCRIPTION
### :nut_and_bolt: Description
As noted in https://github.com/chef/automate/issues/432, we have made the decision to include the "major" Automate version (2) where the build number is listed for the Automate product.

This change makes those modifications for the user menu in the Automate ui and the automate cli.
<img width="359" alt="automate-cli version" src="https://user-images.githubusercontent.com/10341541/58961189-dfefeb80-8765-11e9-9f64-350f339a99cf.png">
<img width="254" alt="Screen Shot 2019-06-05 at 07 40 54" src="https://user-images.githubusercontent.com/10341541/58961190-dfefeb80-8765-11e9-8c22-7eb476b2e2a9.png">

### :+1: Definition of Done
Version: 2 is displayed above build number for the user menu and cli

### :athletic_shoe: Demo Script / Repro Steps
rebuild ui & cli
chef-automate version
check user menu in ui

