### PR TITLE
add license acceptance to kitchen yml used for testing

### DIFF
--- a/components/compliance-service/smokin/.kitchen.yml
+++ b/components/compliance-service/smokin/.kitchen.yml
@@ -19,6 +19,7 @@ provisioner:
     data_collector.token: <%= ENV['COLLECTOR_TOKEN'] %>
     ssl_verify_mode: :verify_none
     verify_api_cert: false
+    chef_license: accept
 
 
 platforms:


### PR DESCRIPTION
### :nut_and_bolt: Description
quick tiny change. need this to be able to run our kitchen yml for test purposes
