### PR TITLE
[A2-855] projects filter UI cleanup

### DIFF
--- a/components/automate-ui/src/app/entities/projects/project.model.ts
+++ b/components/automate-ui/src/app/entities/projects/project.model.ts
@@ -9,7 +9,6 @@ export interface Project {
 export class ProjectConstants {
   static readonly UNASSIGNED_PROJECT_ID = '(unassigned)';
   static readonly UNASSIGNED_PROJECT_LABEL = 'Unassigned resources';
-  static readonly ALL_RESOURCES_LABEL = 'All resources';
   static readonly ALL_PROJECTS_LABEL = 'All projects';
   static readonly MULTIPLE_PROJECTS_LABEL = 'Multiple projects';
 }

--- a/components/automate-ui/src/app/entities/projects/project.model.ts
+++ b/components/automate-ui/src/app/entities/projects/project.model.ts
@@ -8,7 +8,7 @@ export interface Project {
 
 export class ProjectConstants {
   static readonly UNASSIGNED_PROJECT_ID = '(unassigned)';
-  static readonly UNASSIGNED_PROJECT_LABEL = 'Unassigned resources';
+  static readonly UNASSIGNED_PROJECT_LABEL = '(unassigned)';
   static readonly ALL_PROJECTS_LABEL = 'All projects';
   static readonly MULTIPLE_PROJECTS_LABEL = 'Multiple projects';
 }

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -22,6 +22,7 @@
 
   &:disabled {
     color: $chef-primary-dark;
+    cursor: default; // no pointer when there's only one element
   }
 
   // seems to be needed only for Safari

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -1,6 +1,9 @@
 import { Component, EventEmitter, OnChanges, Input, Output } from '@angular/core';
 import { cloneDeep } from 'lodash/fp';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
+import { ProjectConstants } from 'app/entities/projects/project.model';
+
+const { ALL_PROJECTS_LABEL } = ProjectConstants;
 
 @Component({
   selector: 'app-projects-filter-dropdown',
@@ -10,7 +13,7 @@ import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filt
 export class ProjectsFilterDropdownComponent implements OnChanges {
   @Input() options: ProjectsFilterOption[] = [];
 
-  @Input() selectionLabel = 'All Resources';
+  @Input() selectionLabel = ALL_PROJECTS_LABEL;
 
   @Input() selectionCount = 0;
 

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
@@ -253,7 +253,7 @@ describe('projectsFilterReducer', () => {
         genUnassignedProject()
       );
 
-      it('displays "Unassigned resources"', () => {
+      it('displays "(unassigned)"', () => {
         const { selectionLabel } = projectsFilterReducer(initialState, action);
         expect(selectionLabel).toEqual(UNASSIGNED_PROJECT_LABEL);
       });
@@ -321,7 +321,7 @@ describe('projectsFilterReducer', () => {
           genProject('zz-proj')
         );
 
-        it('displays "Unassigned resources"', () => {
+        it('displays "(unassigned)"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
           expect(selectionLabel).toEqual(UNASSIGNED_PROJECT_LABEL);
         });
@@ -421,7 +421,7 @@ describe('projectsFilterReducer', () => {
           genProject('b-proj')
         );
 
-        it('displays "Unassigned resources"', () => {
+        it('displays "(unassigned)"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
           expect(selectionLabel).toEqual(UNASSIGNED_PROJECT_LABEL);
         });

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
@@ -14,7 +14,6 @@ import { LoadOptions, LoadOptionsSuccess } from './projects-filter.actions';
 const {
   UNASSIGNED_PROJECT_ID,
   UNASSIGNED_PROJECT_LABEL,
-  ALL_RESOURCES_LABEL,
   ALL_PROJECTS_LABEL,
   MULTIPLE_PROJECTS_LABEL
 } = ProjectConstants;
@@ -278,9 +277,9 @@ describe('projectsFilterReducer', () => {
           genProject('zz-proj')
         );
 
-        it('displays "All resources"', () => {
+        it('displays "All projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
-          expect(selectionLabel).toEqual(ALL_RESOURCES_LABEL);
+          expect(selectionLabel).toEqual(ALL_PROJECTS_LABEL);
         });
 
         it('displays no count badge', () => {
@@ -343,9 +342,9 @@ describe('projectsFilterReducer', () => {
           genProject('zz-proj', true)
         );
 
-        it('displays "All resources"', () => {
+        it('displays "All projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
-          expect(selectionLabel).toEqual(ALL_RESOURCES_LABEL);
+          expect(selectionLabel).toEqual(ALL_PROJECTS_LABEL);
         });
         it('displays no count badge', () => {
           const { selectionCountVisible } = projectsFilterReducer(initialState, action);
@@ -372,9 +371,9 @@ describe('projectsFilterReducer', () => {
           genProject('b-proj')
         );
 
-        it('displays "All resources"', () => {
+        it('displays "All projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
-          expect(selectionLabel).toEqual(ALL_RESOURCES_LABEL);
+          expect(selectionLabel).toEqual(ALL_PROJECTS_LABEL);
         });
 
         it('displays no count badge', () => {
@@ -551,9 +550,9 @@ describe('projectsFilterReducer', () => {
           genProject('b-proj', true)
         );
 
-        it('displays "All resources"', () => {
+        it('displays "All projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
-          expect(selectionLabel).toEqual(ALL_RESOURCES_LABEL);
+          expect(selectionLabel).toEqual(ALL_PROJECTS_LABEL);
         });
         it('displays no count badge', () => {
           const { selectionCountVisible } = projectsFilterReducer(initialState, action);

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -9,7 +9,6 @@ import {
 
 const {
   UNASSIGNED_PROJECT_ID,
-  ALL_RESOURCES_LABEL,
   ALL_PROJECTS_LABEL,
   MULTIPLE_PROJECTS_LABEL
 } = ProjectConstants;
@@ -38,7 +37,7 @@ export interface ProjectsFilterState {
 export const projectsFilterInitialState: ProjectsFilterState = {
   options: [],
   optionsLoadingStatus: EntityStatus.notLoaded,
-  selectionLabel: ALL_RESOURCES_LABEL,
+  selectionLabel: ALL_PROJECTS_LABEL,
   selectionCount: 0,
   selectionCountVisible: false,
   selectionCountActive: false,
@@ -107,11 +106,11 @@ function selectionLabel(options: ProjectsFilterOption[]): string {
   }
 
   if (hasAllProjectsChecked && hasUnassignedChecked) {
-    return ALL_RESOURCES_LABEL;
+    return ALL_PROJECTS_LABEL;
   }
 
   if (hasNoProjectsChecked && hasUnassigned && !hasUnassignedChecked) {
-    return ALL_RESOURCES_LABEL;
+    return ALL_PROJECTS_LABEL;
   }
 
   if (hasOneChecked || hasOneProjectChecked) {


### PR DESCRIPTION
### :nut_and_bolt: Description

Small fry that came up in ChefConf user testing. Please see the individual commit messages.

That said, I'm no UI expert, please review with that in mind 😄 

### :athletic_shoe: Demo Script / Repro Steps

- deployinate, use `automate-ui-devproxy` or `automate-ui`, use `grpcurl` to trigger different backend conditions:
- create a project:
```
[34][default:/src:0]# chef-automate dev grpcurl authz-service -- -d '{"id": "foo", "name": "foo"}'  chef.automate.domain.authz.v2.Projects/CreateProject
{
  "project": {
    "name": "foo",
    "id": "foo",
    "type": "CUSTOM",
    "projects": [
      "foo"
    ]
  }
}
```
- delete it:
```
[33][default:/src:0]# chef-automate dev grpcurl authz-service -- -d '{"id": "foo"}'  chef.automate.domain.authz.v2.Projects/DeleteProject
{

}
```

### :chains: Related Resources

- [A2-855](https://chefio.atlassian.net/browse/A2-855)

### :white_check_mark: Checklist

- [X] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [X] Code actually executed?
- [X] Vetting performed (unit tests, lint, etc.)?
