### PR TITLE
UI-456 EOF compliance/profiles bug Signed-Off-By: Tara Black <tblack@…

### DIFF
--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -224,12 +224,12 @@ const routes: Routes = [
     },
     {
       path: 'profiles',
-      redirectTo: '/compliance/profiles',
+      redirectTo: '/compliance/profile',
       pathMatch: 'full'
     },
     {
       path: 'profiles/profile-details',
-      redirectTo: '/compliance/profiles/profile-details',
+      redirectTo: '/compliance/profile/profile-details',
       pathMatch: 'full'
     },
     {

--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -224,12 +224,12 @@ const routes: Routes = [
     },
     {
       path: 'profiles',
-      redirectTo: '/compliance/profile',
+      redirectTo: '/compliance/compliance-profiles',
       pathMatch: 'full'
     },
     {
       path: 'profiles/profile-details',
-      redirectTo: '/compliance/profile/profile-details',
+      redirectTo: '/compliance/compliance-profiles/profile-details',
       pathMatch: 'full'
     },
     {

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.html
@@ -3,7 +3,7 @@
 <div class="container">
   <main>
     <chef-breadcrumbs>
-      <chef-breadcrumb [link]="['/compliance/profiles']">Profiles</chef-breadcrumb>
+      <chef-breadcrumb [link]="['/compliance/profile']">Profiles</chef-breadcrumb>
       {{ profile?.title }}
     </chef-breadcrumbs>
 

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.html
@@ -3,7 +3,7 @@
 <div class="container">
   <main>
     <chef-breadcrumbs>
-      <chef-breadcrumb [link]="['/compliance/profile']">Profiles</chef-breadcrumb>
+      <chef-breadcrumb [link]="['/compliance/compliance-profiles']">Profiles</chef-breadcrumb>
       {{ profile?.title }}
     </chef-breadcrumbs>
 

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
@@ -127,7 +127,7 @@
             <chef-tr *ngFor="let profile of filteredProfiles">
               <chef-td>
                 <a
-                  [routerLink]="['/compliance/profile/profile-details']"
+                  [routerLink]="['/compliance/compliance-profiles/profile-details']"
                   [queryParams]="{name: profile.name, version: profile.version, owner: user}">
                   {{ profile.title }}
                 </a>
@@ -166,7 +166,7 @@
             <chef-tr *ngFor="let profile of profileUpdatesAvailable">
               <chef-td>
                 <a
-                  [routerLink]="['/compliance/profile/profile-details']"
+                  [routerLink]="['/compliance/compliance-profiles/profile-details']"
                   [queryParams]="{name: profile.name, version: profile.version}">
                   {{ profile.title }}
                 </a>
@@ -196,7 +196,7 @@
             <chef-tr *ngFor="let profile of filteredAvailableProfiles">
               <chef-td>
                 <a
-                  [routerLink]="['/compliance/profile/profile-details']"
+                  [routerLink]="['/compliance/compliance-profiles/profile-details']"
                   [queryParams]="{name: profile.name, version: profile.version}">
                   {{ profile.title }}
                 </a>

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
@@ -127,7 +127,7 @@
             <chef-tr *ngFor="let profile of filteredProfiles">
               <chef-td>
                 <a
-                  [routerLink]="['/compliance/profiles/profile-details']"
+                  [routerLink]="['/compliance/profile/profile-details']"
                   [queryParams]="{name: profile.name, version: profile.version, owner: user}">
                   {{ profile.title }}
                 </a>
@@ -166,7 +166,7 @@
             <chef-tr *ngFor="let profile of profileUpdatesAvailable">
               <chef-td>
                 <a
-                  [routerLink]="['/compliance/profiles/profile-details']"
+                  [routerLink]="['/compliance/profile/profile-details']"
                   [queryParams]="{name: profile.name, version: profile.version}">
                   {{ profile.title }}
                 </a>
@@ -196,7 +196,7 @@
             <chef-tr *ngFor="let profile of filteredAvailableProfiles">
               <chef-td>
                 <a
-                  [routerLink]="['/compliance/profiles/profile-details']"
+                  [routerLink]="['/compliance/profile/profile-details']"
                   [queryParams]="{name: profile.name, version: profile.version}">
                   {{ profile.title }}
                 </a>

--- a/components/automate-ui/src/app/pages/+compliance/+profile/profile.routing.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/profile.routing.ts
@@ -6,16 +6,11 @@ import { ProfileOverviewComponent } from './+profile-overview/profile-overview.c
 const routes: Routes = [
   {
     path: '',
-    children: [
-        {
-        path: '',
-        component: ProfileOverviewComponent
-        },
-        {
-        path: 'profile-details',
-        component: ProfileDetailsComponent
-        }
-    ]
+    component: ProfileOverviewComponent
+  },
+  {
+    path: 'profile-details',
+    component: ProfileDetailsComponent
   }
 ];
 

--- a/components/automate-ui/src/app/pages/+compliance/compliance-reporting-sidebar/compliance-reporting-sidebar.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/compliance-reporting-sidebar/compliance-reporting-sidebar.component.html
@@ -10,7 +10,7 @@
       <chef-sidebar-entry route="/compliance/scan-jobs" icon="wifi_tethering">Scan Jobs</chef-sidebar-entry>
     </app-authorized>
     <app-authorized #profiles [allOf]="[['/compliance/profiles/search', 'post']]">
-      <chef-sidebar-entry route="/compliance/profile" icon="library_books">Profiles</chef-sidebar-entry>
+      <chef-sidebar-entry route="/compliance/compliance-profiles" icon="library_books">Profiles</chef-sidebar-entry>
     </app-authorized>
   </div>
 </chef-sidebar>

--- a/components/automate-ui/src/app/pages/+compliance/compliance-reporting-sidebar/compliance-reporting-sidebar.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/compliance-reporting-sidebar/compliance-reporting-sidebar.component.html
@@ -10,7 +10,7 @@
       <chef-sidebar-entry route="/compliance/scan-jobs" icon="wifi_tethering">Scan Jobs</chef-sidebar-entry>
     </app-authorized>
     <app-authorized #profiles [allOf]="[['/compliance/profiles/search', 'post']]">
-      <chef-sidebar-entry route="/compliance/profiles" icon="library_books">Profiles</chef-sidebar-entry>
+      <chef-sidebar-entry route="/compliance/profile" icon="library_books">Profiles</chef-sidebar-entry>
     </app-authorized>
   </div>
 </chef-sidebar>

--- a/components/automate-ui/src/app/pages/+compliance/compliance.routing.ts
+++ b/components/automate-ui/src/app/pages/+compliance/compliance.routing.ts
@@ -32,7 +32,7 @@ const routes: Routes = [
         loadChildren: './+scanner/scanner.module#ScannerModule'
       },
       {
-        path: 'profiles',
+        path: 'profile',
         loadChildren: './+profile/profile.module#ProfileModule'
       }
     ]

--- a/components/automate-ui/src/app/pages/+compliance/compliance.routing.ts
+++ b/components/automate-ui/src/app/pages/+compliance/compliance.routing.ts
@@ -32,7 +32,7 @@ const routes: Routes = [
         loadChildren: './+scanner/scanner.module#ScannerModule'
       },
       {
-        path: 'profile',
+        path: 'compliance-profiles',
         loadChildren: './+profile/profile.module#ProfileModule'
       }
     ]

--- a/components/automate-ui/src/app/pages/compliance-landing/compliance-landing.component.ts
+++ b/components/automate-ui/src/app/pages/compliance-landing/compliance-landing.component.ts
@@ -24,7 +24,7 @@ export class ComplianceLandingComponent {
     },
     {
       allOfCheck: [['/compliance/profiles/search', 'post', '']],
-      route: '/compliance/profile'
+      route: '/compliance/compliance-profiles'
     }
   ];
 

--- a/components/automate-ui/src/app/pages/compliance-landing/compliance-landing.component.ts
+++ b/components/automate-ui/src/app/pages/compliance-landing/compliance-landing.component.ts
@@ -24,7 +24,7 @@ export class ComplianceLandingComponent {
     },
     {
       allOfCheck: [['/compliance/profiles/search', 'post', '']],
-      route: '/compliance/profiles'
+      route: '/compliance/profile'
     }
   ];
 


### PR DESCRIPTION
…chef.io>

### :nut_and_bolt: Description
in acceptance (not current)
navigating directly to compliance/profiles
or refreshing that page once you're there results in a EOF

### :+1: Definition of Done
change route to compliance/compliance-profiles
this will need to be updated throughout the docs as well
https://automate.chef.io/docs/asset-store/#using-the-asset-store
https://automate.chef.io/docs/asset-store/#about-the-profile-identifier
https://automate.chef.io/docs/asset-store/#api-calls

### :chains: Related Resources
https://github.com/chef/automate/issues/456
