### PR TITLE
Add `chef-progress-bar` component

### DIFF
--- a/components/chef-ui-library/src/atoms/chef-progress-bar/chef-progress-bar.e2e.tsx
+++ b/components/chef-ui-library/src/atoms/chef-progress-bar/chef-progress-bar.e2e.tsx
@@ -1,0 +1,83 @@
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
+
+describe('chef-progress-bar', () => {
+  let page: E2EPage;
+  let element: E2EElement;
+
+  beforeEach(async () => {
+    page = await newE2EPage();
+    await page.setContent(`
+      <chef-progress-bar></chef-progress-bar>
+    `);
+    element = await page.find('chef-progress-bar');
+  });
+
+  it('renders', async () => {
+    expect(element).toHaveClass('hydrated');
+  });
+
+  it('sets `role` attribute to `progressbar`', async () => {
+    expect(element.getAttribute('role')).toEqual('progressbar');
+  });
+
+  it('sets `aria-valuenow` attribute', async () => {
+    expect(element.getAttribute('aria-valuenow')).toEqual('0');
+  });
+
+  it('sets `aria-valuemin` attribute', async () => {
+    expect(element.getAttribute('aria-valuemin')).toEqual('0');
+  });
+
+  it('sets `aria-valuemax` attribute', async () => {
+    expect(element.getAttribute('aria-valuemax')).toEqual('100');
+  });
+
+  it('displays a progress bar based on value, valueMin, and valueMax', async () => {
+    element.setProperty('value', 0.5);
+    element.setProperty('valueMin', 0);
+    element.setProperty('valueMax', 1);
+    await page.waitForChanges();
+
+    const progressBars = element.querySelector('.progress-bars');
+    const valueBar = progressBars.querySelector('.value');
+    expect(valueBar.getAttribute('style')).toContain('width: 50%');
+  });
+
+  describe('when prefixText or suffixText is set', () => {
+    beforeEach(async () => {
+      element.setProperty('prefixText', 'Uploading files');
+      element.setProperty('suffixText', '10% completed');
+      await page.waitForChanges();
+    });
+
+    it('sets `aria-valuetext` attribute', async () => {
+      expect(element.getAttribute('aria-valuetext')).toEqual('Uploading files 10% completed');
+    });
+
+    it('displays progress text', async () => {
+      const progressText = element.querySelector('.progress-text');
+      const prefixText = progressText.querySelector('.prefix');
+      const suffixText = progressText.querySelector('.suffix');
+      expect(progressText).not.toBeNull();
+      expect(prefixText.textContent).toContain('Uploading files');
+      expect(suffixText.textContent).toContain('10% completed');
+    });
+  });
+
+  describe('when prefixText and suffixText is not set', () => {
+    beforeEach(async () => {
+      element.setProperty('prefixText', '');
+      element.setProperty('suffixText', '');
+      await page.waitForChanges();
+    });
+
+    it('does not set `aria-valuetext` attribute', () => {
+      expect(element.hasAttribute('aria-valuetext')).toEqual(false);
+    });
+
+    it('does not display progress text', () => {
+      const progressText = element.querySelector('.progress-text');
+      expect(progressText).toBeNull();
+    });
+  });
+});

--- a/components/chef-ui-library/src/atoms/chef-progress-bar/chef-progress-bar.scss
+++ b/components/chef-ui-library/src/atoms/chef-progress-bar/chef-progress-bar.scss
@@ -1,0 +1,33 @@
+chef-progress-bar {
+  display: block;
+  margin: 1em 0;
+
+  .progress-text {
+    display: flex;
+    justify-content: space-between;
+    font-size: 13px;
+    margin-bottom: 6px;
+  }
+
+  .progress-bars {
+    position: relative;
+    height: 6px;
+
+    .bar {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      height: 100%;
+      border-radius: var(--chef-border-radius);
+
+      &.value {
+        background: #9CB2F9;
+      }
+
+      &.total {
+        background: #DEE5FD;
+        width: 100%;
+      }
+    }
+  }
+}

--- a/components/chef-ui-library/src/atoms/chef-progress-bar/chef-progress-bar.tsx
+++ b/components/chef-ui-library/src/atoms/chef-progress-bar/chef-progress-bar.tsx
@@ -1,0 +1,120 @@
+import { Component, Prop } from '@stencil/core';
+
+/**
+ * @description
+ * The `<chef-progress-bar>` atom is used to display progress status information.
+ *
+ * @example
+ * <chef-progress-bar value="10"></chef-progress-bar>
+ * <chef-progress-bar value="50"></chef-progress-bar>
+ * <chef-progress-bar value="90"></chef-progress-bar>
+ *
+ * @example
+ * <chef-progress-bar value="0.1" value-min="0" value-max="1"></chef-progress-bar>
+ * <chef-progress-bar value="0.5" value-min="0" value-max="1"></chef-progress-bar>
+ * <chef-progress-bar value="0.9" value-min="0" value-max="1"></chef-progress-bar>
+ *
+ * @example
+ * <chef-progress-bar value="10" prefix-text="10%"></chef-progress-bar>
+ * <chef-progress-bar value="50" prefix-text="50%"></chef-progress-bar>
+ * <chef-progress-bar value="90" prefix-text="90%"></chef-progress-bar>
+ *
+ * @example
+ * <chef-progress-bar value="10" suffix-text="10%"></chef-progress-bar>
+ * <chef-progress-bar value="50" suffix-text="50%"></chef-progress-bar>
+ * <chef-progress-bar value="90" suffix-text="90%"></chef-progress-bar>
+ *
+ * @example
+ * <chef-progress-bar value="10" prefix-text="10% Complete" suffix-text="90% Remaining"></chef-progress-bar>
+ * <chef-progress-bar value="50" prefix-text="50% Complete" suffix-text="50% Remaining"></chef-progress-bar>
+ * <chef-progress-bar value="90" prefix-text="90% Complete" suffix-text="10% Remaining"></chef-progress-bar>
+ *
+ * @example
+ * <chef-progress-bar value="10" prefix-text="10% complete" suffix-text="01:00:00 until finished"></chef-progress-bar>
+ * <chef-progress-bar value="50" prefix-text="50% complete" suffix-text="00:30:00 until finished"></chef-progress-bar>
+ * <chef-progress-bar value="90" prefix-text="90% complete" suffix-text="00:01:00 until finished"></chef-progress-bar>
+ *
+ * @example
+ * <chef-progress-bar value="0" value-max="150" prefix-text="Upload starting" suffix-text="0 of 150 uploaded"></chef-progress-bar>
+ * <chef-progress-bar value="75" value-max="150" prefix-text="Upload in progress" suffix-text="75 of 150 uploaded"></chef-progress-bar>
+ * <chef-progress-bar value="150" value-max="150"  prefix-text="Upload completed" suffix-text="150 of 150 uploaded"></chef-progress-bar>
+ */
+@Component({
+  tag: 'chef-progress-bar',
+  styleUrl: 'chef-progress-bar.scss'
+})
+export class ChefProgressBar {
+  /**
+   * The current progress value.
+   */
+  @Prop() value = 0;
+
+  /**
+   * The minimum progress value.
+   */
+  @Prop() valueMin = 0;
+
+  /**
+   * The maximum progress value.
+   */
+  @Prop() valueMax = 100;
+
+  /**
+   * Optional text to display at the start of the progress bar.
+   */
+  @Prop() prefixText = '';
+
+  /**
+   * Optional text to display at the end of the progress bar.
+   */
+  @Prop() suffixText = '';
+
+  get hasProgressText(): boolean {
+    return this.prefixText.length > 0 || this.suffixText.length > 0;
+  }
+
+  get ariaValueText(): string {
+    return this.hasProgressText ? [this.prefixText, this.suffixText].join(' ').trim() : null;
+  }
+
+  get ariaValueNow(): string {
+    return `${this.value}`;
+  }
+
+  get ariaValueMin(): string {
+    return `${this.valueMin}`;
+  }
+
+  get ariaValueMax(): string {
+    return `${this.valueMax}`;
+  }
+
+  hostData() {
+    return {
+      'role': 'progressbar',
+      'aria-valuenow': this.ariaValueNow,
+      'aria-valuemin': this.ariaValueMin,
+      'aria-valuemax': this.ariaValueMax,
+      'aria-valuetext': this.ariaValueText
+    };
+  }
+
+  render() {
+    const progressText = this.hasProgressText ? (
+      <div class="progress-text" aria-hidden>
+        <div class="prefix">{ this.prefixText }</div>
+        <div class="suffix">{ this.suffixText }</div>
+      </div>
+    ) : null;
+
+    const valueStyle = { width: `${(this.value / (this.valueMax - this.valueMin)) * 100}%` };
+    const progressBars = (
+      <div class="progress-bars" aria-hidden>
+        <div class="bar total"></div>
+        <div class="bar value" style={valueStyle}></div>
+      </div>
+    );
+
+    return [progressText, progressBars];
+  }
+}


### PR DESCRIPTION
### :nut_and_bolt: Description

Adds a progress-bar component to the ui-library. This commit was pulled from this WIP branch that utilizes this progress-bar: https://github.com/chef/automate/pull/511

![](https://user-images.githubusercontent.com/479121/58976701-56501600-8785-11e9-9e29-d8af18b38423.png)

### :chains: Related Resources

https://github.com/chef/automate/pull/511

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
