### PR TITLE
Rollback dequeue task on error

### DIFF
--- a/lib/workflow/postgres/postgres.go
+++ b/lib/workflow/postgres/postgres.go
@@ -558,6 +558,9 @@ func (pg *PostgresBackend) DequeueTask(ctx context.Context, taskName string) (*b
 
 	tid, task, err := pg.dequeueTask(tx, taskName)
 	if err != nil {
+		if rerr := tx.Rollback(); rerr != nil {
+			logrus.WithError(rerr).Error("Failed to rollback dequeue task")
+		}
 		cancel()
 		return nil, nil, err
 	}


### PR DESCRIPTION
Relying on cancel closes the underlying connection. If we
explicitly rollback first, we can use the connection.