### PR TITLE
Add ability to complete workflow instance with a result

### DIFF
--- a/lib/workflow/backend/backend.go
+++ b/lib/workflow/backend/backend.go
@@ -19,8 +19,9 @@ type Driver interface {
 
 	GetScheduledWorkflowParameters(ctx context.Context, instanceName string, workflowName string) ([]byte, error)
 	GetScheduledWorkflowRecurrence(ctx context.Context, instanceName string, workflowName string) (string, error)
-
 	ListWorkflowSchedules(ctx context.Context) ([]*Schedule, error)
+
+	GetWorkflowInstanceByName(ctx context.Context, instanceName string, workflowName string) (*WorkflowInstance, error)
 
 	Init() error
 	Close() error
@@ -31,6 +32,7 @@ type WorkflowInstanceStatus string
 const (
 	WorkflowInstanceStatusRunning   WorkflowInstanceStatus = "running"
 	WorkflowInstanceStatusAbandoned WorkflowInstanceStatus = "abandoned"
+	WorkflowInstanceStatusCompleted WorkflowInstanceStatus = "completed"
 )
 
 type WorkflowInstance struct {
@@ -39,6 +41,9 @@ type WorkflowInstance struct {
 	Status       WorkflowInstanceStatus
 	Parameters   []byte
 	Payload      []byte
+
+	IsRunning bool
+	Result    []byte
 }
 
 type WorkflowEventType string
@@ -97,7 +102,7 @@ type WorkflowCompleter interface {
 
 	Continue(payload []byte) error
 	Abandon() error
-	Done() error
+	Done(result []byte) error
 	Close() error
 }
 

--- a/lib/workflow/integration/counting_workflow_test.go
+++ b/lib/workflow/integration/counting_workflow_test.go
@@ -64,7 +64,7 @@ func (suite *WorkflowTestSuite) TestCountToNWorkflow() {
 							instance10Count = currentCount
 						}
 						wgWorkflow.Done()
-						return w.Complete()
+						return w.Complete(workflow.WithResult(currentCount))
 					}
 					return w.Continue(currentCount)
 				},
@@ -84,6 +84,13 @@ func (suite *WorkflowTestSuite) TestCountToNWorkflow() {
 	// Otherwise, Stop cancels the context, which prevents any transactions
 	// from commiting.
 	time.Sleep(20 * time.Millisecond)
+
+	w100, err := m.GetWorkflowInstanceByName(context.Background(), instance100Name, workflowName)
+	suite.Require().NoError(err)
+	var total int
+	suite.NoError(w100.GetResult(&total))
+	suite.Equal(100, total)
+
 	err = m.Stop()
 	suite.NoError(err)
 }

--- a/lib/workflow/postgres/postgres.go
+++ b/lib/workflow/postgres/postgres.go
@@ -437,7 +437,7 @@ func (pg *PostgresBackend) GetWorkflowInstanceByName(ctx context.Context, instan
 	if err != nil {
 		if err == sql.ErrNoRows {
 			row := tx.QueryRowContext(ctx,
-				"SELECT parameters, result FROM workflow_results WHERE workflow_name = $1 AND instance_name = $2 ORDER BY end_at DESC",
+				"SELECT parameters, result FROM workflow_results WHERE workflow_name = $1 AND instance_name = $2 ORDER BY id DESC",
 				workflowName, instanceName,
 			)
 			err := row.Scan(

--- a/lib/workflow/postgres/postgres.go
+++ b/lib/workflow/postgres/postgres.go
@@ -25,7 +25,7 @@ const (
 
 	enqueueWorkflowQuery  = `SELECT enqueue_workflow($1, $2, $3)`
 	dequeueWorkflowQuery  = `SELECT * FROM dequeue_workflow(VARIADIC $1)`
-	completeWorkflowQuery = `SELECT complete_workflow($1)`
+	completeWorkflowQuery = `SELECT complete_workflow($1, $2)`
 	continueWorkflowQuery = `SELECT continue_workflow($1, $2, $3, $4, $5)`
 	abandonWorkflowQuery  = `SELECT abandon_workflow($1, $2, $3)`
 
@@ -412,6 +412,56 @@ VALUES ($1, $2, $3, $4, $5, $6)`,
 	return wrapErr(tx.Commit(), "failed to commit workflow schedule update")
 }
 
+func (pg *PostgresBackend) GetWorkflowInstanceByName(ctx context.Context, instanceName string, workflowName string) (*backend.WorkflowInstance, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	tx, err := pg.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	row := tx.QueryRowContext(ctx,
+		"SELECT status, parameters, payload FROM workflow_instances WHERE workflow_name = $1 AND instance_name = $2",
+		workflowName, instanceName,
+	)
+	workflowInstance := backend.WorkflowInstance{
+		WorkflowName: workflowName,
+		InstanceName: instanceName,
+	}
+	err = row.Scan(
+		&workflowInstance.Status,
+		&workflowInstance.Parameters,
+		&workflowInstance.Payload,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			row := tx.QueryRowContext(ctx,
+				"SELECT parameters, result FROM workflow_results WHERE workflow_name = $1 AND instance_name = $2 ORDER BY end_at DESC",
+				workflowName, instanceName,
+			)
+			err := row.Scan(
+				&workflowInstance.Parameters,
+				&workflowInstance.Result,
+			)
+			if err != nil {
+				if err == sql.ErrNoRows {
+					return nil, workflow.ErrWorkflowInstanceNotFound
+				}
+				return nil, err
+			}
+			workflowInstance.Status = backend.WorkflowInstanceStatusCompleted
+		} else {
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return &workflowInstance, nil
+}
+
 func (pg *PostgresBackend) EnqueueWorkflow(ctx context.Context, w *backend.WorkflowInstance) error {
 	wrapErr := func(err error, msg string) error {
 		return errors.Wrap(err, msg)
@@ -622,11 +672,11 @@ func (taskc *PostgresTaskCompleter) Succeed(results []byte) error {
 	})
 }
 
-func (workc *PostgresWorkflowCompleter) Done() error {
+func (workc *PostgresWorkflowCompleter) Done(result []byte) error {
 	ctx := workc.ctx
 	defer workc.cancel()
 
-	_, err := workc.tx.ExecContext(ctx, completeWorkflowQuery, workc.wid)
+	_, err := workc.tx.ExecContext(ctx, completeWorkflowQuery, workc.wid, result)
 	if err != nil {
 		return errors.Wrapf(err, "failed to mark workflow %d as complete", workc.wid)
 	}


### PR DESCRIPTION
The nomenclature here needs some discussion. Perhaps payload/result is the wrong thing and we could just call it state. Then you wouldn't need to check if you're running or not to determine if you should grab the payload or the result.