### PR TITLE
fix some failing tests that occurred after we started supporting inspec ver filtering

### DIFF
--- a/components/compliance-service/api/tests/03_deep_reports_spec.rb
+++ b/components/compliance-service/api/tests/03_deep_reports_spec.rb
@@ -663,7 +663,7 @@ describe File.basename(__FILE__) do
     assert_equal(Reporting::Report, res.class)
 
     puts res['version']
-    assert_equal('3.1.3', res['version'])
+    assert_equal('3.1.0', res['version'])
     assert_equal('bb93e1b2-36d6-439e-ac70-cccccccccc04', res['id'])
     assert_equal('9b9f4e51-b049-4b10-9555-10578916e149', res['node_id'])
     assert_equal('centos-beta', res['node_name'])
@@ -711,7 +711,7 @@ describe File.basename(__FILE__) do
     assert_equal(Reporting::Report, res.class)
 
     puts res['version']
-    assert_equal('3.1.3', res['version'])
+    assert_equal('3.1.0', res['version'])
     assert_equal('bb93e1b2-36d6-439e-ac70-cccccccccc04', res['id'])
     assert_equal('9b9f4e51-b049-4b10-9555-10578916e149', res['node_id'])
     assert_equal('centos-beta', res['node_name'])
@@ -759,7 +759,7 @@ describe File.basename(__FILE__) do
     assert_equal(Reporting::Report, res.class)
 
     puts res['version']
-    assert_equal('3.1.3', res['version'])
+    assert_equal('3.1.0', res['version'])
     assert_equal('bb93e1b2-36d6-439e-ac70-cccccccccc04', res['id'])
     assert_equal('9b9f4e51-b049-4b10-9555-10578916e149', res['node_id'])
     assert_equal('centos-beta', res['node_name'])

--- a/components/compliance-service/api/tests/03_reports_spec.rb
+++ b/components/compliance-service/api/tests/03_reports_spec.rb
@@ -626,7 +626,7 @@ describe File.basename(__FILE__) do
     assert_equal(Reporting::Report, res.class)
 
     puts res['version']
-    assert_equal('3.1.3', res['version'])
+    assert_equal('3.1.0', res['version'])
     assert_equal('bb93e1b2-36d6-439e-ac70-cccccccccc04', res['id'])
     assert_equal('9b9f4e51-b049-4b10-9555-10578916e149', res['node_id'])
     assert_equal('centos-beta', res['node_name'])

--- a/components/compliance-service/api/tests/08_deep_search_profiles_spec.rb
+++ b/components/compliance-service/api/tests/08_deep_search_profiles_spec.rb
@@ -44,6 +44,7 @@ describe File.basename(__FILE__) do
                         },
                         "status" => "passed",
                         "controls" => {
+                            "total" => 1,
                             "passed" => {
                                 "total" => 1
                             },
@@ -69,6 +70,7 @@ describe File.basename(__FILE__) do
                         },
                         "status" => "failed",
                         "controls" => {
+                            "total" => 1,
                             "passed" => {},
                             "skipped" => {},
                             "failed" => {
@@ -95,6 +97,7 @@ describe File.basename(__FILE__) do
                         },
                         "status" => "failed",
                         "controls" => {
+                            "total" => 1,
                             "passed" => {},
                             "skipped" => {},
                             "failed" => {
@@ -121,6 +124,7 @@ describe File.basename(__FILE__) do
                         },
                         "status" => "failed",
                         "controls" => {
+                            "total" => 1,
                             "passed" => {},
                             "skipped" => {},
                             "failed" => {


### PR DESCRIPTION
When we changed our inspec version in one of our test json files, in order to test inspec version filtering, we broke a few tests.  This pr gets them back in line.


### :nut_and_bolt: Description

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
