### PR TITLE
authz-service/{datamigrations,migrations}: add Makefile for timestamp versions

### DIFF
--- a/components/authz-service/storage/postgres/datamigration/sql/Makefile
+++ b/components/authz-service/storage/postgres/datamigration/sql/Makefile
@@ -1,0 +1,1 @@
+../../migration/sql/Makefile

--- a/components/authz-service/storage/postgres/migration/sql/Makefile
+++ b/components/authz-service/storage/postgres/migration/sql/Makefile
@@ -1,0 +1,5 @@
+name:=TODO
+new: filename=$(shell echo "$$(date -u '+%Y%m%d%H%M%S')_$(name).up.sql")
+new:
+	@touch $(filename)
+	@echo "=> $(filename)"


### PR DESCRIPTION
This is @phiggins idea -- it's _very_ unlikely that two PRs ever touch
the same migration again.

To create a new one, use `make new`. You can also pass a name:

    $ cd components/authz-service/storage/postgres/migration/sql/
    $ make new
    => 20190607130445_TODO.up.sql
    $ make new name=do_foo_things
    => 20190607130452_do_foo_things.up.sql

Of course, it's possible that the migrations of two different PRs do not
commute (i.e., A;B is different from B;A), but that situation has always
been a problem.

The library we use ends up [calling `sort.Sort` on the versions](https://github.com/mattes/migrate/blob/4768a648fbd9e04389a73a21139d14a4ccb1a61a/source/migration.go#L73), casted to integers. So, this is fine.