### PR TITLE
Switching ingest migrations to work async

### DIFF
--- a/components/ingest-service/backend/client.go
+++ b/components/ingest-service/backend/client.go
@@ -83,5 +83,7 @@ type Client interface {
 	ReindexInsightstoActions(context.Context, string, string) error
 	RefreshIndex(context.Context, string) error
 	GetNodeCount(context.Context, string) (int64, error)
-	ReindexNodeStateToLatest(context.Context, string) error
+	// @parm (context, previousIndex)
+	// @return (taskID, error)
+	ReindexNodeStateToLatest(context.Context, string) (string, error)
 }

--- a/components/ingest-service/backend/client.go
+++ b/components/ingest-service/backend/client.go
@@ -83,7 +83,7 @@ type Client interface {
 	ReindexInsightstoActions(context.Context, string, string) error
 	RefreshIndex(context.Context, string) error
 	GetNodeCount(context.Context, string) (int64, error)
-	// @parm (context, previousIndex)
+	// @param (context, previousIndex)
 	// @return (taskID, error)
 	ReindexNodeStateToLatest(context.Context, string) (string, error)
 }

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -324,11 +324,11 @@ func (es *Backend) updateMapping(ctx context.Context, esMap mappings.Mapping) er
 	return err
 }
 
-func (es *Backend) ReindexNodeStateToLatest(ctx context.Context, previousIndex string) error {
+func (es *Backend) ReindexNodeStateToLatest(ctx context.Context, previousIndex string) (string, error) {
 	src := elastic.NewReindexSource().Index(previousIndex)
 	dst := elastic.NewReindexDestination().Index(mappings.NodeState.Index)
-	_, err := es.client.Reindex().Source(src).Destination(dst).Do(ctx)
-	return err
+	startTaskResult, err := es.client.Reindex().Source(src).Destination(dst).DoAsync(ctx)
+	return startTaskResult.TaskId, err
 }
 
 func (es *Backend) storeExists(ctx context.Context, indexName string) bool {


### PR DESCRIPTION
The migration of the node-state index is timing out on the a2-local-inplace-upgrade-dev.cd.chef.co 
 server. This could be timing out because the migration is leaving the connection open while the reindex happens. This PR is performing the reindex async. 

Below is the error seen on the a2-local-inplace-upgrade-dev.cd.chef.co  server:
`Jun 07 19:25:12 a2-local-inplace-upgrade-dev.cd.chef.co hab[6080]: ingest-service.default(O): time="2019-06-07T19:25:12Z" level=fatal msg="Unable to reindex node-state to latest" error="elastic: Error 504 (Gateway Timeout)" type=migration`

This code has been tested locally, but I can not get the migration to take as long as it does on the `a2-local-inplace-upgrade-dev.cd.chef.co` server. 