### PR TITLE
[A2-861] Expose skip policy migration option to end user

### DIFF
--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -37,7 +37,8 @@ without porting existing policies, use the `--skip-policy-migration` flag: `chef
 
 After you've logged in to Chef Automate, select the **Settings** tab in the top navigation bar, then select and locate the `Policies` section on the left hand panel.
 
-This lists all of your v2 policies:
+Here you can view all of your v2 policies. If you have upgraded without using the `--skip-policy-migration` flag, you will
+also see v1 policies. This includes the following:
 
 * New default (Chef-managed) policies: Administrator, Ingest, Editors, and Viewers.
 * Imported v1 default policies--now called *legacy policies*--in the new v2 policy format and marked with the `[Legacy]` prefix.
@@ -49,6 +50,8 @@ This lists all of your v2 policies:
 
 Now that you are up-and-running with v2 policies, as the first step we recommend that you reconstitute your v1 policies as v2 policies.
 Once that is done, then delete the old legacy v1 policies and you will have a clean, up-to-date system.
+
+Alternately, you can run `--skip-policy-migration` on upgrade to start without any policies at all. You will still need to create new v2 policies to preserve any IAM behavior from v1.
 
 The next few sections explain how to use Chef-managed policies and how to create custom policies.
 
@@ -228,6 +231,8 @@ Open the menu on any custom policy, located at the end of the policy row, and se
 A warning appears if members are still attached to the policy, because deleting that policy disrupts access for all of its members.
 However, you can still delete the policy.
 Repeat for each legacy policy.
+
+Alternately, you can run `--skip-policy-migration` on upgrade to start without any policies at all.
 
 ## Reverting to IAM v1
 

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -30,6 +30,9 @@ Creating default teams Editors and Viewers...
 Success: Enabled IAM v2
 ```
 
+Note: We recommend users do not migrate existing IAM v1 policies as they can interfere with expected behavior. To upgrade
+without porting existing policies, use the `--skip-policy-migration` flag: `chef-automate iam upgrade-to-v2 --skip-policy-migration`.
+
 ## View Policies
 
 After you've logged in to Chef Automate, select the **Settings** tab in the top navigation bar, then select and locate the `Policies` section on the left hand panel.

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -30,8 +30,7 @@ Creating default teams Editors and Viewers...
 Success: Enabled IAM v2
 ```
 
-Note: We recommend users do not migrate existing IAM v1 policies as they can interfere with expected behavior. To upgrade
-without porting existing policies, use the `--skip-policy-migration` flag: `chef-automate iam upgrade-to-v2 --skip-policy-migration`.
+Note: To upgrade without porting existing policies, use the `--skip-policy-migration` flag: `chef-automate iam upgrade-to-v2 --skip-policy-migration`.
 
 ## View Policies
 

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -36,8 +36,9 @@ Note: To upgrade without porting existing policies, use the `--skip-policy-migra
 
 After you've logged in to Chef Automate, select the **Settings** tab in the top navigation bar, then select and locate the `Policies` section on the left hand panel.
 
-Here you can view all of your v2 policies. If you have upgraded without using the `--skip-policy-migration` flag, you will
-also see v1 policies. This includes the following:
+In this section, you can view all of your v2 policies. If you have upgraded without using the `--skip-policy-migration` flag, you will also see v1 policies.
+
+This includes the following:
 
 * New default (Chef-managed) policies: Administrator, Ingest, Editors, and Viewers.
 * Imported v1 default policies--now called *legacy policies*--in the new v2 policy format and marked with the `[Legacy]` prefix.
@@ -230,8 +231,6 @@ Open the menu on any custom policy, located at the end of the policy row, and se
 A warning appears if members are still attached to the policy, because deleting that policy disrupts access for all of its members.
 However, you can still delete the policy.
 Repeat for each legacy policy.
-
-Alternately, you can run `--skip-policy-migration` on upgrade to start without any policies at all.
 
 ## Reverting to IAM v1
 

--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -19,8 +19,10 @@ IAM v2 is a beta release and its functionality is subject to change during this 
 This is an opt-in only feature during the beta period.
 Chef Automate users will not be automatically upgraded.
 
-We designed IAM v2 to leave your v1 policy data untouched during your upgrade to v2.
-If at any time you decide to opt back out of the beta and revert to v1, your original v1 policies will still be intact.
+We designed IAM v2 to leave your v1 policy data untouched during your upgrade to v2. We do, however, recommend that you do not
+migrate v1 policies upon upgrade as they can interfere with expected behavior; to that end, we have provided a
+`--skip-policy-migration` flag that may be used with the upgrade command.
+Whether or not you migrate your v1 policies, if at any time you decide to opt back out of the beta and revert to v1, your original v1 policies will still be intact.
 Reverting to v1, however, will remove any new v2 policies or roles created while using IAM v2.
 Note that this applies only to policies and roles in this beta period. Users, teams, and tokens are currently shared between v1 and v2, but these are slated for separation before the full v2 release.
 

--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -19,9 +19,9 @@ IAM v2 is a beta release and its functionality is subject to change during this 
 This is an opt-in only feature during the beta period.
 Chef Automate users will not be automatically upgraded.
 
-We designed IAM v2 to leave your v1 policy data untouched during your upgrade to v2. We do, however, recommend that you do not
-migrate v1 policies upon upgrade as they can interfere with expected behavior; to that end, we have provided a
-`--skip-policy-migration` flag that may be used with the upgrade command.
+We designed IAM v2 to leave your v1 policy data untouched during your upgrade to v2; however, you can choose to not port over v1 policies by using the provided 
+`--skip-policy-migration` flag with the upgrade command.
+
 Whether or not you migrate your v1 policies, if at any time you decide to opt back out of the beta and revert to v1, your original v1 policies will still be intact.
 Reverting to v1, however, will remove any new v2 policies or roles created while using IAM v2.
 Note that this applies only to policies and roles in this beta period. Users, teams, and tokens are currently shared between v1 and v2, but these are slated for separation before the full v2 release.

--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -102,7 +102,7 @@ Actions    | list of operations the role manages, e.g., read IAM users, get comp
 
 ### Members and Policies
 
-A **member**  called a _subject_ in v1) may be a user, a team, or a token.
+A **member**  (called a _subject_ in v1) may be a user, a team, or a token.
 Users and teams may be *local*, meaning they are defined within Chef Automate, or managed by an external identity provider, specifically LDAP or SAML.
 In this so far, v2 and v1 behave the same.
 

--- a/components/automate-cli/cmd/chef-automate/iam.go
+++ b/components/automate-cli/cmd/chef-automate/iam.go
@@ -105,13 +105,8 @@ func newIAMUpgradeToV2Cmd() *cobra.Command {
 		false,
 		"Upgrade to version 2.1 with beta project authorization.")
 
-	var err error
 	if !isDevMode() {
-		err = cmd.PersistentFlags().MarkHidden("beta2.1")
-		if err != nil {
-			fmt.Printf("failed configuring cobra: %s\n", err.Error())
-			panic("failed configuring cobra")
-		}
+		_ = cmd.PersistentFlags().MarkHidden("beta2.1")
 	}
 	return cmd
 }

--- a/components/automate-cli/cmd/chef-automate/iam.go
+++ b/components/automate-cli/cmd/chef-automate/iam.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"google.golang.org/grpc/codes"
 	grpc_status "google.golang.org/grpc/status"
 
@@ -106,9 +105,14 @@ func newIAMUpgradeToV2Cmd() *cobra.Command {
 		false,
 		"Upgrade to version 2.1 with beta project authorization.")
 
-	// all flags are hidden right now
-	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) { f.Hidden = !isDevMode() })
-
+	var err error
+	if !isDevMode() {
+		err = cmd.PersistentFlags().MarkHidden("beta2.1")
+		if err != nil {
+			fmt.Printf("failed configuring cobra: %s\n", err.Error())
+			panic("failed configuring cobra")
+		}
+	}
 	return cmd
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description

After exposing this flag to the end user, we also needed to update docs.

I have done this work in accord with the ticket, but I wonder if it would make more sense (at least, eventually) to make skipping policy migration the default behavior (as that is what we recommend) and provide a flag to automatically migrate. 🤷‍♀ 
