### PR TITLE
Increase CI ES heap size to 2gb

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/main.tf
+++ b/terraform/test-environments/modules/chef_automate_install/main.tf
@@ -295,7 +295,7 @@ XoB1V6vwQXRubclyH8Ei2+1j
   [elasticsearch.v1]
     [elasticsearch.v1.sys]
       [elasticsearch.v1.sys.runtime]
-        heapsize = "${var.enable_cloudwatch_metrics == "true" ? "16g" : "1g"}"
+        heapsize = "${var.enable_cloudwatch_metrics == "true" ? "16g" : "2g"}"
 TOML
   }
 


### PR DESCRIPTION
We currently have 8GB of ram on our terraform-managed CI machines.
Let's bump the ES heap size to 1/4th of that. 1gb isn't really an
appropriate default for long-lived installations.

Signed-off-by: Steven Danna <steve@chef.io>