### PR TITLE
Use binlink-dir in a1 migration nightly tests

### DIFF
--- a/components/automate-deployment/a1-migration/create_artifact.sh
+++ b/components/automate-deployment/a1-migration/create_artifact.sh
@@ -26,7 +26,7 @@ function install_from_results_or_depot() {
     fi
   fi
 
-  HAB_LICENSE=accept-no-persist hab pkg install -b /bin "chef/$1" --channel "$channel"
+  HAB_LICENSE=accept-no-persist hab pkg install --binlink-dir /bin "chef/$1" --channel "$channel"
 }
 
 if find /a1-migration/hab_keys/ -name devchef*sig.key | grep -c devchef

--- a/components/automate-deployment/a1-migration/run_upgrade_from_a1.sh
+++ b/components/automate-deployment/a1-migration/run_upgrade_from_a1.sh
@@ -25,7 +25,7 @@ function install_from_results_or_depot() {
     fi
   fi
 
-  HAB_LICENSE=accept-no-persist hab pkg install -b /bin "chef/$package" --channel "$channel"
+  HAB_LICENSE=accept-no-persist hab pkg install --binlink-dir /bin "chef/$package" --channel "$channel"
 }
 
 install_from_results_or_depot automate-cli dev "$HARTIFACT_DIR"


### PR DESCRIPTION
We install the latest habitat in that test. These changes should fix up
compatibility issues habitat-sh/habitat#6597, which reverts the behavior
of `hab pkg install -b` to what it used to be. For future compatibility,
I've used the `--binlink-dir` flag, which seems to be the new way of
doing things