### PR TITLE
Remove health status filter grey outlines on hover

### DIFF
--- a/components/chef-ui-library/src/molecules/chef-status-filter-group/chef-status-filter-group.scss
+++ b/components/chef-ui-library/src/molecules/chef-status-filter-group/chef-status-filter-group.scss
@@ -107,6 +107,7 @@ chef-status-filter-group {
     }
 
     &:hover {
+      box-shadow: 0px 0px 0px 0px;
 
       &.general {
         background: #F3F6F8;

--- a/components/chef-ui-library/src/molecules/chef-status-filter-group/chef-status-filter-group.tsx
+++ b/components/chef-ui-library/src/molecules/chef-status-filter-group/chef-status-filter-group.tsx
@@ -9,7 +9,7 @@ import find from 'lodash/fp/find';
 
 /**
  * @description
- * A toggle button. Uses the chef-option atom to define it's different states.
+ * A group of status filters. Uses the chef-option atom to render the status filters.
  *
  * @example
  * <chef-status-filter-group id="filters-example">


### PR DESCRIPTION
### :nut_and_bolt: Description
A very quick change to remove the grey outline of the health status filter on hover.

### :+1: Definition of Done
Hover state style update: Remove the grey outlines for the background container for the five filters (total, critical, warning, OK and unknown) above the table and in the sidebar.

![image](https://user-images.githubusercontent.com/5712253/59201629-25178180-8b9b-11e9-9922-3f9b5ef41ccf.png)
![image](https://user-images.githubusercontent.com/5712253/59201634-29439f00-8b9b-11e9-990c-49d9f8b1788e.png)

### :athletic_shoe: Demo Script / Repro Steps
Build and start the chef-ui-library.
Then, navigate to http://localhost:3334/molecules/chef-status-filter-group

### :chains: Related Resources
Jira: https://chefio.atlassian.net/browse/A2-842
Closes https://github.com/chef/automate/issues/472

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
