### PR TITLE
Adding error searching to client runs

### DIFF
--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.spec.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.spec.ts
@@ -57,7 +57,8 @@ describe('ClientRunsComponent', () => {
     it('ensure types are included', () => {
       const expected = [
         'attribute', 'cookbook', 'chef_tags', 'chef_version', 'environment', 'name', 'platform',
-        'policy_group', 'policy_name', 'policy_revision', 'recipe', 'role', 'resource_name'];
+        'policy_group', 'policy_name', 'policy_revision', 'recipe', 'role', 'resource_name',
+        'error'];
 
       const types = component.categoryTypes.map(type => type.type);
 

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -70,6 +70,10 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
       text: 'Environment'
     },
     {
+      type: 'error',
+      text: 'Error'
+    },
+    {
       type: 'name',
       text: 'Node Name'
     },


### PR DESCRIPTION
### :nut_and_bolt: Description

Adding back the error message searching/filtering to the Client Runs page. 

This feature was removed with this PR https://github.com/chef/automate/pull/474 because an Elasticsearch migration had to be performed to fix an existing problem. 

https://github.com/chef/automate/pull/415 is the original PR that added this feature. 

### :athletic_shoe: Demo Script / Repro Steps

Use the repro steps from this PR https://github.com/chef/automate/pull/415

### :chains: Related Resources

Original PR - https://github.com/chef/automate/pull/415
PR that removed the feature - https://github.com/chef/automate/pull/474

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
