### PR TITLE
Add neglected version-adjustment for OPA call

### DIFF
--- a/components/authz-service/engine/conformance/conformance_v2_test.go
+++ b/components/authz-service/engine/conformance/conformance_v2_test.go
@@ -387,8 +387,8 @@ func TestV2FilterAuthorizedPairs(t *testing.T) {
 		"nodes:someid", "compliance:profiles:delete", "compliance:profiles"
 	pair0 := engine.Pair{Resource: engine.Resource(res0), Action: engine.Action(act0)}
 	pair1 := engine.Pair{Resource: engine.Resource(res1), Action: engine.Action(act1)}
-	args := func() (context.Context, engine.Subjects, []engine.Pair) {
-		return ctx, engine.Subject(sub), []engine.Pair{pair0, pair1}
+	args := func() (context.Context, engine.Subjects, []engine.Pair, bool) {
+		return ctx, engine.Subject(sub), []engine.Pair{pair0, pair1}, false
 	}
 
 	for desc, e := range engines {

--- a/components/authz-service/engine/engine.go
+++ b/components/authz-service/engine/engine.go
@@ -61,7 +61,7 @@ type V2Authorizer interface {
 
 	// FilterAuthorizedProjects returns a sublist of the passed-in pairs
 	// allowed by the subjects.
-	V2FilterAuthorizedPairs(context.Context, Subjects, []Pair) ([]Pair, error)
+	V2FilterAuthorizedPairs(context.Context, Subjects, []Pair, bool) ([]Pair, error)
 
 	// V2FilterAuthorizedProjects returns a list of allowed projects
 	// for the given subjects

--- a/components/authz-service/server/v2/authz.go
+++ b/components/authz-service/server/v2/authz.go
@@ -62,8 +62,7 @@ func (s *authzServer) ProjectsAuthorized(
 	var authorizedProjects []string
 	// we check the version set in the channel on policy server
 	// in order to determine whether or not projects should factor in the authorization decision
-	version := s.vSwitch.Version
-	if !isBeta2p1(version) {
+	if !s.isBeta2p1() {
 		authorized, err := s.engine.V2IsAuthorized(ctx,
 			engine.Subjects(req.Subjects),
 			engine.Action(req.Action),
@@ -127,7 +126,8 @@ func (s *authzServer) FilterAuthorizedPairs(
 	req *api.FilterAuthorizedPairsReq) (*api.FilterAuthorizedPairsResp, error) {
 	resp, err := s.engine.V2FilterAuthorizedPairs(ctx,
 		engine.Subjects(req.Subjects),
-		toEnginePairs(req.Pairs))
+		toEnginePairs(req.Pairs),
+		s.isBeta2p1())
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -170,7 +170,8 @@ func (s *authzServer) FilterAuthorizedProjects(
 	}, nil
 }
 
-func isBeta2p1(version api.Version) bool {
+func (s *authzServer) isBeta2p1() bool {
+	version := s.vSwitch.Version
 	return version.Major == api.Version_V2 && version.Minor == api.Version_V1
 }
 

--- a/components/authz-service/server/v2/authz_test.go
+++ b/components/authz-service/server/v2/authz_test.go
@@ -258,7 +258,8 @@ func (e *responderEngine) V2ProjectsAuthorized(
 func (e *responderEngine) V2FilterAuthorizedPairs(
 	context.Context,
 	engine.Subjects,
-	[]engine.Pair) ([]engine.Pair, error) {
+	[]engine.Pair,
+	bool) ([]engine.Pair, error) {
 	return e.pairs, nil
 }
 

--- a/inspec/a2-iam-v2p1-only-integration/controls/introspection.rb
+++ b/inspec/a2-iam-v2p1-only-integration/controls/introspection.rb
@@ -1,0 +1,81 @@
+# encoding: utf-8
+# copyright: 2019, Chef Software, Inc.
+# license: All rights reserved
+
+title 'IAM v2.1 migration API authz introspection integration tests'
+
+control 'introspection-iam-v2.1-1' do
+  title 'authz introspection with IAM v2.1'
+  desc 'these checks ensure that authz introspection works
+    after having switched to IAM v2.1'
+
+  describe 'introspect all' do
+    it 'returns what we expect' do
+      resp = automate_api_request('/api/v0/auth/introspect')
+      expect(resp.http_status).to eq 200
+    end
+  end
+
+  describe 'introspect some' do
+    it 'returns what we expect' do
+      resp = automate_api_request('/api/v0/auth/introspect_some',
+                                  http_method: 'POST',
+                                  request_body:  {
+                                    paths: [
+                                      '/compliance/reporting/stats/summary',
+                                      '/compliance/reporting/stats/failures',
+                                      '/compliance/reporting/stats/trend',
+                                    ]
+                                  }.to_json)
+      expect(resp.http_status).to eq 200
+      expect(resp.parsed_response_body[:endpoints]).to eq(
+        {
+          '/compliance/reporting/stats/failures': {
+            'get': false,
+            'put': false,
+            'post': true,
+            'delete': false,
+            'patch': false
+          },
+          '/compliance/reporting/stats/summary': {
+            'get': false,
+            'put': false,
+            'post': true,
+            'delete': false,
+            'patch': false
+          },
+          '/compliance/reporting/stats/trend': {
+            'get': false,
+            'put': false,
+            'post': true,
+            'delete': false,
+            'patch': false
+          },
+        }
+      )
+    end
+  end
+
+  describe 'introspect some with parameters' do
+    it 'returns what we expect' do
+      resp = automate_api_request('/api/v0/auth/introspect',
+                                  http_method: 'POST',
+                                  request_body:  {
+                                    path: '/auth/policies/foo',
+                                    parameters: [ 'foo' ],
+                                  }.to_json)
+      expect(resp.http_status).to eq 200
+      expect(resp.parsed_response_body[:endpoints]).to eq(
+        {
+          '/auth/policies/foo': {
+            'get': false,
+            'put': false,
+            'post': false,
+            'delete': true,
+            'patch': false
+          },
+        }
+      )
+    end
+  end
+end

--- a/integration/tests/iam_v2.sh
+++ b/integration/tests/iam_v2.sh
@@ -41,6 +41,12 @@ do_test_deploy() {
     log_info "run chef-automate iam upgrade-to-v2"
     chef-automate iam upgrade-to-v2 || return 1
 
+    # ensure service startup works with IAM v2:
+    # - kill authz-service to force startup,
+    # - wait for service status to be healthy again
+    log_info "restarting authz-service, waiting 5s for it to come up again"
+    pkill -f authz-service && sleep 5 && chef-automate status -w || return 1
+
     log_info "run chef-automate iam token INSPEC_UPGRADE_IAM_V2_3_ADMIN_TOKEN --admin"
     local admin_token
     admin_token=$(chef-automate iam token create INSPEC_UPGRADE_IAM_V2_3_ADMIN_TOKEN --admin)

--- a/integration/tests/iam_v2_only.sh
+++ b/integration/tests/iam_v2_only.sh
@@ -41,6 +41,13 @@ do_deploy() {
 do_test_deploy() {
     log_info "run chef-automate iam upgrade-to-v2"
     chef-automate iam upgrade-to-v2 || return 1
+
+    # ensure service startup works with IAM v2:
+    # - kill authz-service to force startup,
+    # - wait for service status to be healthy again
+    log_info "restarting authz-service, waiting 5s for it to come up again"
+    pkill -f authz-service && sleep 5 && chef-automate status -w || return 1
+
     log_info "creating test users with automate-cli"
     chef-automate dev create-iam-dev-users || return 1
     do_test_deploy_default

--- a/integration/tests/iam_v2p1_only.sh
+++ b/integration/tests/iam_v2p1_only.sh
@@ -42,6 +42,12 @@ do_test_deploy() {
     log_info "run chef-automate iam upgrade-to-v2 --beta2.1 --skip-policy-migration"
     chef-automate iam upgrade-to-v2 --beta2.1 --skip-policy-migration || return 1
 
+    # ensure service startup works with IAM v2.1:
+    # - kill authz-service to force startup,
+    # - wait for service status to be healthy again
+    log_info "restarting authz-service, waiting 5s for it to come up again"
+    pkill -f authz-service && sleep 5 && chef-automate status -w || return 1
+
     verify_legacy_policies_not_migrated
 
     do_test_deploy_default


### PR DESCRIPTION
### :nut_and_bolt: Description

Amongst the ad-hoc OPA queries that were all assigned to specific stores in opa.go,
there was one that was assigned to v2 when it is actually used both by v2 and v2.1.
Added the mechanism to provide the version so it can appropriately version-adjust on the OPA call.

### :+1: Definition of Done

We no longer see the **absence** of the header bar:
![image](https://user-images.githubusercontent.com/6817500/59230558-acacc280-8b92-11e9-9d74-3c2fd896632b.png)

### :athletic_shoe: Demo Script / Repro Steps

This is the set of steps that manifested the issue:
1. Start fresh hab studio and start the world.
2. Upgrade to 2.1: `chef-automate iam upgrade-to-v2 --beta2.1`
3. Login as admin and observe that all tabs are present across the top nav bar.
4. Restart authz-service: `pkill authz-service`
5. Refresh browser. 

Before the fix, all introspection calls now return "deny" so the top nav bar was essentially absent.
Now it is correctly populated.

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
