### PR TITLE
e2e: cypress all the envs

### DIFF
--- a/.expeditor/buildkite/cypress.sh
+++ b/.expeditor/buildkite/cypress.sh
@@ -7,6 +7,8 @@ cd /workdir/e2e
 instances_to_test=( \
     "a2-iamv2-local-fresh-install-${CHANNEL}.cd.chef.co" \
     "a2-iamv2-local-inplace-upgrade-${CHANNEL}.cd.chef.co" \
+    "a2-iamv2p1-local-fresh-install-${CHANNEL}.cd.chef.co" \
+    "a2-iamv2p1-local-inplace-upgrade-${CHANNEL}.cd.chef.co" \
     "a2-local-fresh-install-${CHANNEL}.cd.chef.co" \
     "a2-perf-test-single-local-inplace-upgrade-${CHANNEL}.cd.chef.co" \
 )

--- a/e2e/cypress/integration/02_global_filter.spec.js
+++ b/e2e/cypress/integration/02_global_filter.spec.js
@@ -1,7 +1,7 @@
 describe('global projects filter', () => {
-  const proj1  = "cypress-project-1"
-  const proj2  = "cypress-project-2"
-  const proj3  = "cypress-project-3"
+  const proj1 = { id: "cypress-project-1", name: "Cypress Project 1 " + Cypress.moment().format('MMDDYYhhmm') }
+  const proj2 = { id: "cypress-project-2", name: "Cypress Project 2 " + Cypress.moment().format('MMDDYYhhmm')}
+  const proj3 = { id: "cypress-project-3", name: "Cypress Project 3 " + Cypress.moment().format('MMDDYYhhmm') }
   // TODO uncomment with non-admin test
   // const pol_id = "cypress-policy"
   // const nonAdminUsername = "nonadmin"
@@ -29,7 +29,7 @@ describe('global projects filter', () => {
         if (version === 'v1') {
           cy.get('[data-cy=projects-filter-button]').click()
           
-          const allowedProjects = [proj1, proj2, proj3, '(unassigned)'];
+          const allowedProjects = [proj1.name, proj2.name, proj3.name, '(unassigned)'];
           // we don't check that projects in dropdown match *exactly* as
           // we can't control creation of other projects in the test env
           allowedProjects.forEach(project => {

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -132,14 +132,14 @@ Cypress.Commands.add("createPolicy", (id_token, id, username, projects) => {
     url: '/apis/iam/v2beta/policies',
     failOnStatusCode: false,
     body: {
-      id: id,
+      id,
       name: "non-admin policy",
       members: ["user:local:" + username],
       statements: [
         {
           effect: "ALLOW",
           actions: ["iam:teams:list", "iam:teams:get"],
-          projects: projects
+          projects
         }
       ]
     }
@@ -148,16 +148,15 @@ Cypress.Commands.add("createPolicy", (id_token, id, username, projects) => {
   })
 })
 
-Cypress.Commands.add("createProject", (id_token, id) => {
-  const name = "cypress project" + Cypress.moment().format('MMDDYYhhmm')
+Cypress.Commands.add("createProject", (id_token, { id, name }) => {
   cy.request({
     auth: { bearer: id_token },
     method: 'POST',
     url: '/apis/iam/v2beta/projects',
     failOnStatusCode: false,
     body: {
-      id: id,
-      name: name
+      id,
+      name
     }
   }).then((response) => {
     expect([200, 409]).to.include(response.status)


### PR DESCRIPTION
### Fix e2e project picker tests

These currently fail when run against an IAM v2.1 env. Looks like they hadn't been adapted when we've merged #546.

You can verify these by running

    env CYPRESS_BASE_URL=https://a2-iamv2p1-local-fresh-install-dev.cd.chef.co npm run cypress:open

in the chef vpn (sorry non-chef employees...), and selecting the global filter specs.

If you run them with

    CYPRESS_BASE_URL=https://a2-iamv2p1-local-inplace-upgrade-dev.cd.chef.co

you can watch them fail because of the issue fixes in #561.

###  e2e: include iamv2p1 environments

Note: this will fail if merged _after_ #561.