### PR TITLE
ci: don't wrap emoji jobnames in backticks

### DIFF
--- a/scripts/count_retries
+++ b/scripts/count_retries
@@ -2,20 +2,15 @@
 
 set -xe
 
+# if this is not a retry, don't bother
+[[ "$BUILDKITE_RETRY_COUNT" -eq 0 ]] && exit 0
+
 url="${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}"
+# if jobname is, say, :inspec:, don't wrap it in backticks
+message="$(awk -v l="$BUILDKITE_LABEL" -v n="$BUILDKITE_RETRY_COUNT"\
+  'BEGIN{ printf "%s retried %s\n", (l ~ /^:.*:$/) ? l : "`" l "`", (n == 1) ? "once" :  n " times" }' /dev/null )"
 
 if command -v buildkite-agent
 then
-    if [ "$BUILDKITE_RETRY_COUNT" -eq 1 ]
-    then
-        cat << EOF | buildkite-agent annotate --style "warning" --context "job-retries-$BUILDKITE_LABEL"
-[\`$BUILDKITE_LABEL\` retried once]($url)
-EOF
-    fi
-    if [ "$BUILDKITE_RETRY_COUNT" -gt 1 ]
-    then
-        cat << EOF | buildkite-agent annotate --style "warning" --context "job-retries-$BUILDKITE_LABEL"
-[\`$BUILDKITE_LABEL\` retried $BUILDKITE_RETRY_COUNT times]($url)
-EOF
-    fi
+    buildkite-agent annotate --style "warning" --context "job-retries-$BUILDKITE_LABEL" <<<"[$message]($url)"
 fi


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/870638/59350147-aac23b00-8d1b-11e9-98a8-4e1fa26e3f8c.png)

We just cannot let this happen. Also freeing two `cat`s in the process.