### PR TITLE
Reimport root certificate when restarting Elasticsearch

### DIFF
--- a/components/automate-elasticsearch/habitat/config/init_ca
+++ b/components/automate-elasticsearch/habitat/config/init_ca
@@ -2,7 +2,10 @@
 
 exec 2>&1
 
-if ! [[ -f {{pkg.svc_var_path}}/ca.jks ]]; then
+# importcert won't replace an already existing certificate,
+# so we delete and recreate the store on startup
+rm -f "{{pkg.svc_var_path}}/ca.jks" 
+
 {{pkgPathFor "core/jre8"}}/bin/keytool -importcert \
 	-trustcacerts \
 	-file {{pkg.svc_config_path}}/root_ca.crt \
@@ -10,6 +13,5 @@ if ! [[ -f {{pkg.svc_var_path}}/ca.jks ]]; then
 	-keystore {{pkg.svc_var_path}}/ca.jks \
 	-storepass "changeit" \
 	-noprompt
-fi
 
 chown hab:hab {{pkg.svc_var_path}}/ca.jks


### PR DESCRIPTION
ES uses the root cert to talk to the backup gateway. If the root
certificate for the services is regenerated, ES was not reimporting it
and backups were failing. This fixes that.

Fixes #568


I didn't try to delete and import the cert because my bash isn't great and delete returns an error if the alias does not exist and you try to delete it meaning you have to handle errors and because it's java all error codes are probably just `1`