### PR TITLE
UI-578 Fix badge padding, add .badge Signed-Off-By: Tara Black <tblac…

### DIFF
--- a/components/chef-ui-library/src/atoms/chef-badge/chef-badge.scss
+++ b/components/chef-ui-library/src/atoms/chef-badge/chef-badge.scss
@@ -5,7 +5,7 @@
 // make it easier for folks to tweak the styles if needed
 // during implementation.
 chef-badge {
-  badge {
+  .badge {
     background: transparent;
     border: 0px solid transparent;
     color: inherit;

--- a/components/chef-ui-library/src/atoms/chef-badge/chef-badge.scss
+++ b/components/chef-ui-library/src/atoms/chef-badge/chef-badge.scss
@@ -19,7 +19,6 @@ chef-badge {
     font-family: inherit;
     height: inherit;
     line-height: inherit;
-    margin: 0;
     padding: 0 5px;
     pointer-events: inherit;
     text-decoration: inherit;
@@ -56,7 +55,9 @@ chef-badge {
   flex-wrap: nowrap;
   font-size: 10px;
   font-weight: 600;
-  margin: 5px;
+  letter-spacing: .2px;
+  line-height: 16px;
+  margin: 0px 5px;
   min-height: 15px;
   min-width: 15px;
   text-align: center;


### PR DESCRIPTION
…k@chef.io>

### :nut_and_bolt: Description
When using the badge component in the applications page to display empty data for application, environment and channel (https://github.com//pull/564), the padding size seems too small and not match the spec in the design spec.

<img width="1656" alt="Screen Shot 2019-06-12 at 7 07 35 PM" src="https://user-images.githubusercontent.com/4108100/59394488-6ba8df80-8d45-11e9-892e-8b34db9f1d36.png">

### :+1: Definition of Done
Badge padding like design
https://github.com/chef/automate/issues/262

### :chains: Related Resources
https://github.com/chef/automate/issues/578