### PR TITLE
ci: don't build the merge ref, try to rebase ourselves

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -12,14 +12,8 @@ git fetch origin master
 # Fetch the git tags to see if that addresses the weird smart build behavior for Habitat
 git fetch --tags --force
 
-# By default, Buildkite pulls down HEAD. If we're on a pull-request, pull down
-# the merged head: https://github.com/buildkite/agent/blob/master/bootstrap/bootstrap.go#L698
-if [[ "$BUILDKITE_PULL_REQUEST" != "false" ]]; then
-  echo "Switching to refspec 'refs/pull/$BUILDKITE_PULL_REQUEST/merge'"
-  git fetch origin +refs/pull/$BUILDKITE_PULL_REQUEST/merge
-  git checkout -qf FETCH_HEAD
-fi
-
 # Count retries as BK annotations; don't make all jobs explode if the script
 # is removed.
 [[ -x "scripts/count_retries" ]] && scripts/count_retries
+
+git diff-tree -s --pretty=%B HEAD | buildkite-agent annotate --context built-commit --style info

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -15,10 +15,16 @@ git fetch --tags --force
 # rebase onto current master to ensure this PR is closer to what happens when it's merged
 git config user.email "you@example.com" # these are needed for the rebase attempt
 git config user.name "Your Name"
-if ! git rebase origin/master; then
+master=$(git show-ref -s --abbrev origin/master)
+pr_head=$(git show-ref -s --abbrev HEAD)
+github="https://github.com/chef/automate/commit/"
+if output=$(git rebase origin/master); then
+  buildkite-agent annotate --style success --context rebase-pr-branch \
+    "Rebased onto master ([${master}](${github}${master}))."
+else
   git rebase --abort
   buildkite-agent annotate --style warning --context rebase-pr-branch \
-    "Couldn't rebase onto origin/master ($(git show-ref -s origin/master)), building PR HEAD $(git show-ref -s HEAD)"
+    "Couldn't rebase onto master ([${master}](${github}${master})), building PR HEAD ([${pr_head}](${github}${pr_head}))."
 fi
 
 # Count retries as BK annotations; don't make all jobs explode if the script

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -19,11 +19,11 @@ master=$(git show-ref -s --abbrev origin/master)
 pr_head=$(git show-ref -s --abbrev HEAD)
 github="https://github.com/chef/automate/commit/"
 if output=$(git rebase origin/master); then
-  buildkite-agent annotate --style success --context rebase-pr-branch \
+  buildkite-agent annotate --style success --context rebase-pr-branch-${master} \
     "Rebased onto master ([${master}](${github}${master}))."
 else
   git rebase --abort
-  buildkite-agent annotate --style warning --context rebase-pr-branch \
+  buildkite-agent annotate --style warning --context rebase-pr-branch-${master} \
     "Couldn't rebase onto master ([${master}](${github}${master})), building PR HEAD ([${pr_head}](${github}${pr_head}))."
 fi
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -12,8 +12,15 @@ git fetch origin master
 # Fetch the git tags to see if that addresses the weird smart build behavior for Habitat
 git fetch --tags --force
 
+# rebase onto current master to ensure this PR is closer to what happens when it's merged
+git config user.email "you@example.com" # these are needed for the rebase attempt
+git config user.name "Your Name"
+if ! git rebase origin/master; then
+  git rebase --abort
+  buildkite-agent annotate --style warning --context rebase-pr-branch \
+    "Couldn't rebase onto origin/master ($(git show-ref -s origin/master)), building PR HEAD $(git show-ref -s HEAD)"
+fi
+
 # Count retries as BK annotations; don't make all jobs explode if the script
 # is removed.
 [[ -x "scripts/count_retries" ]] && scripts/count_retries
-
-git diff-tree -s --pretty=%B HEAD | buildkite-agent annotate --context built-commit --style info


### PR DESCRIPTION
This has proven to be buggy, and misleading. When force-pushing a PR
branch, the merge head doesn't get updated reliably, and the CI run thus
builds the wrong thing, old code.

Additionally, the BK UI will claim it was building the correct commit,
which confuses even more.

~This adds an info message with the commit being built, for extra
visibility.~ Now, we're attempting to non-interactively rebase onto what's `origin/master` at _build time_; and warn if it fails. If it fails, we'll run the build job with the PR's HEAD.

If everything's fine rebasing, it'll show
![image](https://user-images.githubusercontent.com/870638/59429749-b3c91000-8de0-11e9-8eab-1d934dc55e1a.png)

If not, you'll see
![image](https://user-images.githubusercontent.com/870638/59429865-ff7bb980-8de0-11e9-8147-e6eb2171ac44.png)

*however*, your build will still be executed ([see this for a test run where the rebase fails](https://buildkite.com/chef/chef-automate-master-verify-private/builds/2054))