### PR TITLE
[A2-811] Table to stage rule changes

### DIFF
--- a/components/authz-service/server/v2/project.go
+++ b/components/authz-service/server/v2/project.go
@@ -367,7 +367,7 @@ func (s *state) UpdateRule(ctx context.Context, req *api.UpdateRuleReq) (*api.Up
 }
 
 func (s *state) GetRule(ctx context.Context, req *api.GetRuleReq) (*api.GetRuleResp, error) {
-	resp, err := s.store.GetStagedOrCurrentRule(ctx, req.Id)
+	resp, err := s.store.GetStagedOrAppliedRule(ctx, req.Id)
 	if err != nil {
 		if err == storage_errors.ErrNotFound {
 			return nil, status.Errorf(codes.NotFound, "could not find rule with ID %q", req.Id)

--- a/components/authz-service/server/v2/project.go
+++ b/components/authz-service/server/v2/project.go
@@ -379,7 +379,6 @@ func (s *state) GetRule(ctx context.Context, req *api.GetRuleReq) (*api.GetRuleR
 		return nil, status.Errorf(codes.NotFound, "could not find rule with ID %q", req.Id)
 	}
 
-
 	apiRule, err := fromStorageRule(resp)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal,

--- a/components/authz-service/server/v2/project.go
+++ b/components/authz-service/server/v2/project.go
@@ -367,7 +367,7 @@ func (s *state) UpdateRule(ctx context.Context, req *api.UpdateRuleReq) (*api.Up
 }
 
 func (s *state) GetRule(ctx context.Context, req *api.GetRuleReq) (*api.GetRuleResp, error) {
-	resp, err := s.store.GetRule(ctx, req.Id)
+	resp, err := s.store.GetStagedOrCurrentRule(ctx, req.Id)
 	if err != nil {
 		if err == storage_errors.ErrNotFound {
 			return nil, status.Errorf(codes.NotFound, "could not find rule with ID %q", req.Id)
@@ -375,6 +375,10 @@ func (s *state) GetRule(ctx context.Context, req *api.GetRuleReq) (*api.GetRuleR
 		return nil, status.Errorf(codes.Internal,
 			"error retrieving rule with ID %q: %s", req.Id, err.Error())
 	}
+	if resp.Deleted {
+		return nil, status.Errorf(codes.NotFound, "could not find rule with ID %q", req.Id)
+	}
+
 
 	apiRule, err := fromStorageRule(resp)
 	if err != nil {

--- a/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+CREATE TYPE staged_rule_state
+  AS ENUM (
+    'new',
+    'deleted',
+    'updated'
+    );
+
+CREATE TABLE iam_staged_project_rules (
+  db_id SERIAL PRIMARY KEY,
+  id TEXT NOT NULL UNIQUE,
+  project_id TEXT REFERENCES iam_projects,
+  name TEXT NOT NULL,
+  type TEXT NOT NULL,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  state (pending)
+);
+
+CREATE TABLE iam_staged_rule_conditions (
+  db_id SERIAL PRIMARY KEY,
+  rule_db_id INTEGER REFERENCES iam_staged_project_rules ON DELETE CASCADE,
+  value TEXT[] NOT NULL,
+  attribute TEXT NOT NULL,
+  operator TEXT NOT NULL,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  state staged_rule_state NOT NULL
+);
+
+COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
@@ -43,13 +43,13 @@ CREATE OR REPLACE FUNCTION
 $$ LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION
-  query_staged_rule_table(_rule_db_id TEXT)
+  query_staged_rule_table(_id TEXT)
   RETURNS TEXT[] AS $$
 
   SELECT ARRAY(
-    SELECT 'current' as TableName from iam_project_rules c where c.id=_rule_db_id
+    SELECT 'current' as TableName from iam_project_rules c where c.id=_id
     UNION
-    SELECT 'staged' as TableName from iam_staged_project_rules a where a.id=_rule_db_id
+    SELECT 'staged' as TableName from iam_staged_project_rules a where a.id=_id
     );
 
 $$ LANGUAGE sql;

--- a/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
@@ -1,25 +1,12 @@
 BEGIN;
 
-CREATE TABLE iam_staged_projects (
-  db_id SERIAL,
-  id TEXT PRIMARY KEY,
-  name TEXT NOT NULL,
-  type iam_policy_type NOT NULL DEFAULT 'custom',
-  projects TEXT[],
-  deleted BOOLEAN,
-  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-);
-
 CREATE TABLE iam_staged_project_rules (
   db_id SERIAL PRIMARY KEY,
   id TEXT NOT NULL UNIQUE,
-  project_id TEXT REFERENCES iam_staged_projects ON DELETE CASCADE,
+  project_id TEXT REFERENCES iam_projects ON DELETE CASCADE,
   name TEXT NOT NULL,
   type TEXT NOT NULL,
-  deleted BOOLEAN,
-  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  deleted BOOLEAN
 );
 
 CREATE TABLE iam_staged_rule_conditions (
@@ -28,21 +15,8 @@ CREATE TABLE iam_staged_rule_conditions (
   value TEXT[] NOT NULL,
   attribute TEXT NOT NULL,
   operator TEXT NOT NULL,
-  deleted BOOLEAN,
-  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+  deleted BOOLEAN
 );
-
-CREATE OR REPLACE FUNCTION
-  projects_match_for_staged_rule(_project_id TEXT, _projects_filter TEXT[])
-  RETURNS BOOLEAN AS $$
-    BEGIN
-      RETURN (
-        array_length(_projects_filter, 1) IS NULL
-        OR _project_id = ANY (_projects_filter)
-      );
-    END
-$$ LANGUAGE PLPGSQL;
 
 CREATE OR REPLACE FUNCTION
   query_staged_rule(_rule_db_id TEXT, _project_filter TEXT[])
@@ -54,17 +28,15 @@ CREATE OR REPLACE FUNCTION
       r.project_id,
       r.name,
       r.type,
-      r.deleted,
-      r.updated_at,
-      r.created_at
+      r.deleted
       -- A rule can't exist without conditions so we don't need to worry
       -- about null case here.
       json_agg(rc) AS conditions
     FROM iam_staged_project_rules AS r
     LEFT OUTER JOIN iam_staged_rule_conditions
     AS rc ON rc.rule_db_id=r.db_id
-    WHERE id=_rule_db_id AND projects_match_for_staged_rule(project_id, _project_filter)
-    GROUP BY r.id, r.project_id, r.name, r.type, r.deleted, r.updated_at, r.created_at
+    WHERE id=_rule_db_id AND projects_match_for_rule(project_id, _project_filter)
+    GROUP BY r.id, r.project_id, r.name, r.type, r.deleted
   )
   SELECT row_to_json(t) AS rule FROM t;
 
@@ -77,17 +49,6 @@ CREATE OR REPLACE FUNCTION
     UNION
     SELECT 'staged' as TableName from iam_staged_project_rules a where a.id=_rule_db_id
     );
-
-$$ LANGUAGE sql;
-
-CREATE OR REPLACE FUNCTION
-  query_staged_project(_project_id TEXT, _projects_filter TEXT[])
-  RETURNS json AS $$
-
-  WITH t AS
-    (SELECT p.id, p.name, p.type, p.projects p.deleted FROM iam_staged_projects p
-      WHERE p.id = _project_id AND (array_length(_projects_filter, 1) IS NULL OR p.projects && _projects_filter))
-  SELECT row_to_json(t) AS role FROM t;
 
 $$ LANGUAGE sql;
 

--- a/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
@@ -1,12 +1,5 @@
 BEGIN;
 
-CREATE TYPE staged_rule_state
-  AS ENUM (
-    'new',
-    'deleted',
-    'updated'
-    );
-
 CREATE TABLE iam_staged_project_rules (
   db_id SERIAL PRIMARY KEY,
   id TEXT NOT NULL UNIQUE,
@@ -15,7 +8,7 @@ CREATE TABLE iam_staged_project_rules (
   type TEXT NOT NULL,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  state staged_rule_state NOT NULL
+  deleted BOOLEAN
 );
 
 CREATE TABLE iam_staged_rule_conditions (

--- a/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
@@ -6,7 +6,7 @@ CREATE TABLE iam_staged_project_rules (
   project_id TEXT REFERENCES iam_projects ON DELETE CASCADE,
   name TEXT NOT NULL,
   type TEXT NOT NULL,
-  deleted BOOLEAN
+  deleted BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE iam_staged_rule_conditions (
@@ -15,7 +15,7 @@ CREATE TABLE iam_staged_rule_conditions (
   value TEXT[] NOT NULL,
   attribute TEXT NOT NULL,
   operator TEXT NOT NULL,
-  deleted BOOLEAN
+  deleted BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 CREATE OR REPLACE FUNCTION

--- a/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
@@ -1,14 +1,24 @@
 BEGIN;
 
+CREATE TABLE iam_staged_projects (
+  db_id SERIAL,
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  deleted BOOLEAN,
+  type iam_policy_type NOT NULL DEFAULT 'custom',
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+);
+
 CREATE TABLE iam_staged_project_rules (
   db_id SERIAL PRIMARY KEY,
   id TEXT NOT NULL UNIQUE,
-  project_id TEXT REFERENCES iam_projects,
+  project_id TEXT REFERENCES iam_staged_projects ON DELETE CASCADE,
   name TEXT NOT NULL,
   type TEXT NOT NULL,
+  deleted BOOLEAN,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  deleted BOOLEAN
 );
 
 CREATE TABLE iam_staged_rule_conditions (

--- a/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
@@ -28,7 +28,7 @@ CREATE OR REPLACE FUNCTION
       r.project_id,
       r.name,
       r.type,
-      r.deleted
+      r.deleted,
       -- A rule can't exist without conditions so we don't need to worry
       -- about null case here.
       json_agg(rc) AS conditions
@@ -39,6 +39,8 @@ CREATE OR REPLACE FUNCTION
     GROUP BY r.id, r.project_id, r.name, r.type, r.deleted
   )
   SELECT row_to_json(t) AS rule FROM t;
+
+$$ LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION
   query_staged_rule_table(_rule_db_id TEXT)

--- a/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
@@ -43,7 +43,7 @@ CREATE OR REPLACE FUNCTION
 $$ LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION
-  query_staged_rule_table(_id TEXT)
+  query_rule_table_associations(_id TEXT)
   RETURNS TEXT[] AS $$
 
   SELECT ARRAY(

--- a/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/47_staged_rules_tables.up.sql
@@ -66,9 +66,9 @@ CREATE OR REPLACE FUNCTION
   RETURNS TEXT[] AS $$
 
   SELECT ARRAY(
-    SELECT 'current' as TableName from iam_project_rules c where c.id=_id
+    SELECT 'applied' as TableName from iam_project_rules a where a.id=_id
     UNION
-    SELECT 'staged' as TableName from iam_staged_project_rules a where a.id=_id
+    SELECT 'staged' as TableName from iam_staged_project_rules s where s.id=_id
     );
 
 $$ LANGUAGE sql;

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -46,3 +46,4 @@
 - [`44_policy_rules.up.sql`](44_policy_rules.up.sql)
 - [`45_query_rules_for_project.up.sql`](45_query_rules_for_project.up.sql)
 - [`46_add_application_policies.up.sql`](46_add_application_policies.up.sql)
+- [`47_staged_rules_tables.up.sql`](47_staged_rules_tables.up.sql)

--- a/components/authz-service/storage/v2/memstore/memstore.go
+++ b/components/authz-service/storage/v2/memstore/memstore.go
@@ -271,7 +271,7 @@ func (s *State) UpdateRule(_ context.Context, rule *storage.Rule) (*storage.Rule
 	return rule, nil
 }
 
-func (s *State) GetRule(_ context.Context, id string) (*storage.Rule, error) {
+func (s *State) GetStagedOrCurrentRule(_ context.Context, id string) (*storage.Rule, error) {
 	item, exists := s.rules.Get(id)
 	if !exists {
 		return nil, storage_errors.ErrNotFound
@@ -314,7 +314,7 @@ func (s *State) ListRulesForProject(_ context.Context, projectID string) ([]*sto
 }
 
 func (s *State) DeleteRule(ctx context.Context, id string) error {
-	_, err := s.GetRule(ctx, id)
+	_, err := s.GetStagedOrCurrentRule(ctx, id)
 
 	if err != nil {
 		return err

--- a/components/authz-service/storage/v2/memstore/memstore.go
+++ b/components/authz-service/storage/v2/memstore/memstore.go
@@ -271,7 +271,7 @@ func (s *State) UpdateRule(_ context.Context, rule *storage.Rule) (*storage.Rule
 	return rule, nil
 }
 
-func (s *State) GetStagedOrCurrentRule(_ context.Context, id string) (*storage.Rule, error) {
+func (s *State) GetStagedOrAppliedRule(_ context.Context, id string) (*storage.Rule, error) {
 	item, exists := s.rules.Get(id)
 	if !exists {
 		return nil, storage_errors.ErrNotFound
@@ -314,7 +314,7 @@ func (s *State) ListRulesForProject(_ context.Context, projectID string) ([]*sto
 }
 
 func (s *State) DeleteRule(ctx context.Context, id string) error {
-	_, err := s.GetStagedOrCurrentRule(ctx, id)
+	_, err := s.GetStagedOrAppliedRule(ctx, id)
 
 	if err != nil {
 		return err

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -964,7 +964,7 @@ func (p *pg) CreateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 	}
 	
 	row:= tx.QueryRowContext(ctx,
-		`SELECT query_staged_rule_table($1);`, rule.ID)
+		`SELECT query_rule_table_associations($1);`, rule.ID)
 	if err != nil {
 		return nil, p.processError(err)
 	}

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -1103,7 +1103,7 @@ func (p *pg) DeleteRule(ctx context.Context, id string) error {
 	return nil
 }
 
-func (p *pg) GetStagedOrCurrentRule(ctx context.Context, id string) (*v2.Rule, error) {
+func (p *pg) GetStagedOrAppliedRule(ctx context.Context, id string) (*v2.Rule, error) {
 	projectsFilter, err := projectsListFromContext(ctx)
 	if err != nil {
 		return nil, p.processError(err)

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -1103,7 +1103,7 @@ func (p *pg) DeleteRule(ctx context.Context, id string) error {
 	return nil
 }
 
-func (p *pg) GetRule(ctx context.Context, id string) (*v2.Rule, error) {
+func (p *pg) GetStagedOrCurrentRule(ctx context.Context, id string) (*v2.Rule, error) {
 	projectsFilter, err := projectsListFromContext(ctx)
 	if err != nil {
 		return nil, p.processError(err)
@@ -1118,7 +1118,7 @@ func (p *pg) GetRule(ctx context.Context, id string) (*v2.Rule, error) {
 	}
 
 	var rule v2.Rule
-	row := tx.QueryRowContext(ctx, `SELECT query_rule from query_rule($1, $2);`,
+	row := tx.QueryRowContext(ctx, `SELECT query_staged_rule($1, $2);`,
 		id, pq.Array(projectsFilter),
 	)
 	err = row.Scan(&rule)

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -962,12 +962,10 @@ func (p *pg) CreateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 	if err != nil {
 		return nil, p.processError(err)
 	}
-	
-	row:= tx.QueryRowContext(ctx,
+
+	row := tx.QueryRowContext(ctx,
 		`SELECT query_rule_table_associations($1);`, rule.ID)
-	if err != nil {
-		return nil, p.processError(err)
-	}
+
 	var associations []string
 	if err := row.Scan(pq.Array(&associations)); err != nil {
 		return nil, p.processError(err)

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -3309,7 +3309,7 @@ func TestCreateRule(t *testing.T) {
 			assert.Nil(t, resp)
 			assert.Error(t, storage_errors.ErrForeignKey, err)
 		},
-		"when rule exists in the current rules table, return Err": func(t *testing.T) {
+		"when rule exists in the applied rules table, return Err": func(t *testing.T) {
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
@@ -3317,7 +3317,7 @@ func TestCreateRule(t *testing.T) {
 			require.NoError(t, err)
 			rule, err := storage.NewRule("new-id-1", projID, "name", storage.Node, []storage.Condition{condition1})
 			require.NoError(t, err)
-			insertRule(t, db, rule)
+			insertAppliedRule(t, db, rule)
 			resp, err := store.CreateRule(ctx, &rule)
 			assert.Nil(t, resp)
 			assert.Error(t, storage_errors.ErrConflict, err)
@@ -3468,14 +3468,14 @@ func TestListRules(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			rule1 := insertRuleWithMultipleConditions(t, db, projID, ruleType)
+			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			rule2, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertRule(t, db, rule2)
+			insertAppliedRule(t, db, rule2)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
@@ -3494,14 +3494,14 @@ func TestListRules(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", projID2})
 
 			ruleType := storage.Node
-			rule1 := insertRuleWithMultipleConditions(t, db, projID, ruleType)
+			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertRule(t, db, rule2)
+			insertAppliedRule(t, db, rule2)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
@@ -3552,7 +3552,7 @@ func TestListRulesForProject(t *testing.T) {
 			projID2 := "project-2"
 			insertTestProject(t, db, projID2, "pika p", storage.Custom)
 
-			insertRuleWithMultipleConditions(t, db, projID2, storage.Node)
+			insertAppliedRuleWithMultipleConditions(t, db, projID2, storage.Node)
 
 			resp, err := store.ListRulesForProject(ctx, projID)
 			assert.NoError(t, err)
@@ -3569,21 +3569,21 @@ func TestListRulesForProject(t *testing.T) {
 			insertTestProject(t, db, projID2, "pika p", storage.Custom)
 
 			ruleType := storage.Node
-			rule1 := insertRuleWithMultipleConditions(t, db, projID, ruleType)
+			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertRule(t, db, rule2)
+			insertAppliedRule(t, db, rule2)
 
 			condition5, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-3", "chef-server-4"}, storage.ChefServer, storage.MemberOf)
 			rule3, err := storage.NewRule("new-id-3", projID2, "name3", ruleType,
 				[]storage.Condition{condition5})
 			require.NoError(t, err)
-			insertRule(t, db, rule3)
+			insertAppliedRule(t, db, rule3)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
@@ -3605,21 +3605,21 @@ func TestListRulesForProject(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", projID2})
 
 			ruleType := storage.Node
-			rule1 := insertRuleWithMultipleConditions(t, db, projID, ruleType)
+			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertRule(t, db, rule2)
+			insertAppliedRule(t, db, rule2)
 
 			condition5, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-3", "chef-server-4"}, storage.ChefServer, storage.MemberOf)
 			rule3, err := storage.NewRule("new-id-3", projID2, "name3", ruleType,
 				[]storage.Condition{condition5})
 			require.NoError(t, err)
-			insertRule(t, db, rule3)
+			insertAppliedRule(t, db, rule3)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule3.ID))
@@ -3640,21 +3640,21 @@ func TestListRulesForProject(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", "project-4"})
 
 			ruleType := storage.Node
-			rule1 := insertRuleWithMultipleConditions(t, db, projID, ruleType)
+			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertRule(t, db, rule2)
+			insertAppliedRule(t, db, rule2)
 
 			condition5, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-3", "chef-server-4"}, storage.ChefServer, storage.MemberOf)
 			rule3, err := storage.NewRule("new-id-3", projID2, "name3", ruleType,
 				[]storage.Condition{condition5})
 			require.NoError(t, err)
-			insertRule(t, db, rule3)
+			insertAppliedRule(t, db, rule3)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule3.ID))
@@ -3707,7 +3707,7 @@ func TestUpdateRule(t *testing.T) {
 			ruleOriginal, err := storage.NewRule("new-id-1", "project-1", "name", ruleType,
 				[]storage.Condition{condition1})
 			require.NoError(t, err)
-			insertRule(t, db, ruleOriginal)
+			insertAppliedRule(t, db, ruleOriginal)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1 AND name=$2 AND type=$3 AND project_id=$4`,
 				ruleOriginal.ID, ruleOriginal.Name, ruleOriginal.Type.String(), ruleOriginal.ProjectID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
@@ -3729,7 +3729,7 @@ func TestUpdateRule(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			rule := insertRuleWithMultipleConditions(t, db, projID, ruleType)
+			rule := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
 			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
@@ -3764,7 +3764,7 @@ func TestUpdateRule(t *testing.T) {
 			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType,
 				[]storage.Condition{condition1, condition2, condition3})
 			require.NoError(t, err)
-			insertRule(t, db, rule)
+			insertAppliedRule(t, db, rule)
 			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
 			newRuleType := storage.Event
@@ -3787,7 +3787,7 @@ func TestUpdateRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"not-a-match", "some-other-project"})
 
 			ruleType := storage.Node
-			ruleOriginal := insertRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleOriginal := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1 AND name=$2 AND type=$3 AND project_id=$4`,
 				ruleOriginal.ID, ruleOriginal.Name, ruleOriginal.Type.String(), ruleOriginal.ProjectID))
 
@@ -3809,19 +3809,19 @@ func TestUpdateRule(t *testing.T) {
 	}
 }
 
-func TestGetRule(t *testing.T) {
+func TestGetStagedOrAppliedRule(t *testing.T) {
 	store, db, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
 	cases := map[string]func(*testing.T){
-		"when no rules exist, returns NotFoundErr": func(t *testing.T) {
+		"when no rules exist in either staged or applied, returns NotFoundErr": func(t *testing.T) {
 			ctx := context.Background()
-			resp, err := store.GetRule(ctx, "not-found")
+			resp, err := store.GetStagedOrAppliedRule(ctx, "not-found")
 			assert.Nil(t, resp)
 			assert.Equal(t, storage_errors.ErrNotFound, err)
 		},
-		"when the wrong id requested, returns NotFoundErr": func(t *testing.T) {
+		"when the rule doesn't exist in applied or staged, returns NotFoundErr": func(t *testing.T) {
 			ctx := context.Background()
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
@@ -3832,12 +3832,12 @@ func TestGetRule(t *testing.T) {
 			require.NoError(t, err)
 			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType, []storage.Condition{condition1})
 			require.NoError(t, err)
-			insertRule(t, db, rule)
+			insertAppliedRule(t, db, rule)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
-			resp, err := store.GetRule(ctx, "not-found")
+			resp, err := store.GetStagedOrAppliedRule(ctx, "not-found")
 			assert.Nil(t, resp)
 			assert.Equal(t, storage_errors.ErrNotFound, err)
 		},
@@ -3848,20 +3848,20 @@ func TestGetRule(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			ruleToGet := insertRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToGet := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			otherRule, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertRule(t, db, otherRule)
+			insertAppliedRule(t, db, otherRule)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToGet.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, otherRule.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
-			resp, err := store.GetRule(ctx, ruleToGet.ID)
+			resp, err := store.GetStagedOrAppliedRule(ctx, ruleToGet.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, ruleToGet, resp)
 		},
@@ -3875,7 +3875,7 @@ func TestGetRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{projID, projID2, "some-other-project"})
 
 			ruleType := storage.Node
-			ruleToGet := insertRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToGet := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToGet.ID))
 
 			condition4, err := storage.NewCondition(ruleType,
@@ -3883,12 +3883,12 @@ func TestGetRule(t *testing.T) {
 			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertRule(t, db, rule2)
+			insertAppliedRule(t, db, rule2)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
-			resp, err := store.GetRule(ctx, ruleToGet.ID)
+			resp, err := store.GetStagedOrAppliedRule(ctx, ruleToGet.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, ruleToGet, resp)
 		},
@@ -3902,22 +3902,92 @@ func TestGetRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{projID2, "some-other-project"})
 
 			ruleType := storage.Node
-			ruleToGet := insertRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToGet := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertRule(t, db, rule2)
+			insertAppliedRule(t, db, rule2)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToGet.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
-			resp, err := store.GetRule(ctx, ruleToGet.ID)
+			resp, err := store.GetStagedOrAppliedRule(ctx, ruleToGet.ID)
 			assert.Nil(t, resp)
 			assert.Equal(t, storage_errors.ErrNotFound, err)
+		},
+		"when the rule exists only in the staged table, returns the staged rule": func(t *testing.T) {
+			ctx := context.Background()
+			projID := "project-1"
+			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
+
+			condition1, err := storage.NewCondition(storage.Node, []string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
+			require.NoError(t, err)
+			rule, err := storage.NewRule("new-id-1", projID, "name", storage.Node, []storage.Condition{condition1})
+			insertStagedRule(t, db, rule)
+			require.NoError(t, err)
+			resp, err := store.GetStagedOrAppliedRule(ctx, rule.ID)
+			assert.NotNil(t, resp)
+			expectedRule := storage.Rule{
+				ID: rule.ID,
+				ProjectID: rule.ProjectID,
+				Name: rule.Name,
+				Type: rule.Type,
+				Conditions: rule.Conditions,
+				Deleted: false,
+			}
+			assert.Equal(t, &expectedRule, resp)
+		},
+		"when the rule exists only in the applied table, returns the applied rule": func(t *testing.T) {
+			ctx := context.Background()
+			projID := "project-1"
+			insertTestProject(t, db, projID, "my new project", storage.Custom)
+
+			condition1, err := storage.NewCondition(storage.Node, []string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
+			require.NoError(t, err)
+			rule, err := storage.NewRule("new-id-1", projID, "name", storage.Node, []storage.Condition{condition1})
+			insertAppliedRule(t, db, rule)
+			require.NoError(t, err)
+			resp, err := store.GetStagedOrAppliedRule(ctx, rule.ID)
+			assert.NotNil(t, resp)
+			expectedRule := storage.Rule{
+				ID: rule.ID,
+				ProjectID: rule.ProjectID,
+				Name: rule.Name,
+				Type: rule.Type,
+				Conditions: rule.Conditions,
+				Deleted: false,
+			}
+			assert.Equal(t, &expectedRule, resp)
+		},
+		"when the rule exists in the staged and applied tables, returns the staged rule": func(t *testing.T) {
+			ctx := context.Background()
+			projID := "project-1"
+			insertTestProject(t, db, projID, "my new project", storage.Custom)
+
+			condition1, err := storage.NewCondition(storage.Node, []string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
+			require.NoError(t, err)
+			rule, err := storage.NewRule("new-id-1", projID, "applied name", storage.Node, []storage.Condition{condition1})
+			insertAppliedRule(t, db, rule)
+			require.NoError(t, err)
+
+			stagedRule, err := storage.NewRule(rule.ID, rule.ProjectID, "update: staged name", rule.Type, rule.Conditions)
+			insertStagedRule(t, db, stagedRule)
+			require.NoError(t, err)
+			resp, err := store.GetStagedOrAppliedRule(ctx, rule.ID)
+			assert.NotNil(t, resp)
+			expectedRule := storage.Rule{
+				ID: stagedRule.ID,
+				ProjectID: stagedRule.ProjectID,
+				Name: stagedRule.Name,
+				Type: stagedRule.Type,
+				Conditions: stagedRule.Conditions,
+				Deleted: false,
+			}
+			assert.Equal(t, &expectedRule, resp)
 		},
 	}
 
@@ -3949,7 +4019,7 @@ func TestDeleteRule(t *testing.T) {
 			require.NoError(t, err)
 			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType, []storage.Condition{condition1})
 			require.NoError(t, err)
-			insertRule(t, db, rule)
+			insertAppliedRule(t, db, rule)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
@@ -3966,14 +4036,14 @@ func TestDeleteRule(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			ruleToDelete := insertRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToDelete := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertRule(t, db, ruleToSave)
+			insertAppliedRule(t, db, ruleToSave)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToDelete.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToSave.ID))
@@ -3993,14 +4063,14 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{projID, "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := insertRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToDelete := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertRule(t, db, ruleToSave)
+			insertAppliedRule(t, db, ruleToSave)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToDelete.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToSave.ID))
@@ -4020,14 +4090,14 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := insertRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToDelete := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertRule(t, db, ruleToSave)
+			insertAppliedRule(t, db, ruleToSave)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToDelete.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToSave.ID))
@@ -6357,7 +6427,7 @@ func insertStatementProject(t *testing.T, db *testhelpers.TestDB, statementID uu
 	require.NoError(t, err)
 }
 
-func insertRule(t *testing.T, db *testhelpers.TestDB, rule storage.Rule) {
+func insertAppliedRule(t *testing.T, db *testhelpers.TestDB, rule storage.Rule) {
 	t.Helper()
 	row := db.QueryRow(`
 		INSERT INTO iam_project_rules (id, project_id, name, type) VALUES ($1, $2, $3, $4) RETURNING db_id;`,
@@ -6389,7 +6459,7 @@ func insertStagedRule(t *testing.T, db *testhelpers.TestDB, rule storage.Rule) {
 	}
 }
 
-func insertRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB, projID string, ruleType storage.RuleType) *storage.Rule {
+func insertAppliedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB, projID string, ruleType storage.RuleType) *storage.Rule {
 	t.Helper()
 	condition1, err := storage.NewCondition(ruleType,
 		[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -3428,7 +3428,8 @@ func TestCreateRule(t *testing.T) {
 			condition3, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2", "chef-server-3"}, storage.ChefServer, storage.MemberOf)
 			require.NoError(t, err)
-			rule, err := storage.NewRule("new-id-1", "project-1", "name", ruleType,
+			ruleID := "new-id-1"
+			rule, err := storage.NewRule(ruleID, "project-1", "name", ruleType,
 				[]storage.Condition{condition1, condition2, condition3})
 			require.NoError(t, err)
 			resp, err := store.CreateRule(ctx, &rule)
@@ -3436,7 +3437,8 @@ func TestCreateRule(t *testing.T) {
 			require.Equal(t, &rule, resp)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND type=$2 AND project_id=$3 AND name=$4 AND deleted=$5`,
 				rule.ID, rule.Type.String(), rule.ProjectID, rule.Name, false))
-			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions WHERE rule_db_id=(SELECT r.db_id FROM iam_staged_project_rules r WHERE r.id=$1)`,
+				ruleID))
 		},
 	}
 

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -3445,15 +3445,14 @@ func TestListRules(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			rule1 := createRuleWithMultipleConditions(t, store, projID, ruleType)
+			rule1 := insertRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			rule2, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &rule2)
-			require.NoError(t, err)
+			insertRule(t, db, rule2)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
@@ -3472,15 +3471,14 @@ func TestListRules(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", projID2})
 
 			ruleType := storage.Node
-			rule1 := createRuleWithMultipleConditions(t, store, projID, ruleType)
+			rule1 := insertRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &rule2)
-			require.NoError(t, err)
+			insertRule(t, db, rule2)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
@@ -3531,7 +3529,7 @@ func TestListRulesForProject(t *testing.T) {
 			projID2 := "project-2"
 			insertTestProject(t, db, projID2, "pika p", storage.Custom)
 
-			createRuleWithMultipleConditions(t, store, projID2, storage.Node)
+			insertRuleWithMultipleConditions(t, db, projID2, storage.Node)
 
 			resp, err := store.ListRulesForProject(ctx, projID)
 			assert.NoError(t, err)
@@ -3548,23 +3546,22 @@ func TestListRulesForProject(t *testing.T) {
 			insertTestProject(t, db, projID2, "pika p", storage.Custom)
 
 			ruleType := storage.Node
-			rule1 := createRuleWithMultipleConditions(t, store, projID, ruleType)
+			rule1 := insertRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &rule2)
-			require.NoError(t, err)
+			insertRule(t, db, rule2)
 
 			condition5, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-3", "chef-server-4"}, storage.ChefServer, storage.MemberOf)
 			rule3, err := storage.NewRule("new-id-3", projID2, "name3", ruleType,
 				[]storage.Condition{condition5})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &rule3)
-			require.NoError(t, err)
+			insertRule(t, db, rule3)
+
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule3.ID))
@@ -3585,23 +3582,21 @@ func TestListRulesForProject(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", projID2})
 
 			ruleType := storage.Node
-			rule1 := createRuleWithMultipleConditions(t, store, projID, ruleType)
+			rule1 := insertRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &rule2)
-			require.NoError(t, err)
+			insertRule(t, db, rule2)
 
 			condition5, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-3", "chef-server-4"}, storage.ChefServer, storage.MemberOf)
 			rule3, err := storage.NewRule("new-id-3", projID2, "name3", ruleType,
 				[]storage.Condition{condition5})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &rule3)
-			require.NoError(t, err)
+			insertRule(t, db, rule3)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule3.ID))
@@ -3622,23 +3617,21 @@ func TestListRulesForProject(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", "project-4"})
 
 			ruleType := storage.Node
-			rule1 := createRuleWithMultipleConditions(t, store, projID, ruleType)
+			rule1 := insertRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &rule2)
-			require.NoError(t, err)
+			insertRule(t, db, rule2)
 
 			condition5, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-3", "chef-server-4"}, storage.ChefServer, storage.MemberOf)
 			rule3, err := storage.NewRule("new-id-3", projID2, "name3", ruleType,
 				[]storage.Condition{condition5})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &rule3)
-			require.NoError(t, err)
+			insertRule(t, db, rule3)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule3.ID))
@@ -3691,8 +3684,7 @@ func TestUpdateRule(t *testing.T) {
 			ruleOriginal, err := storage.NewRule("new-id-1", "project-1", "name", ruleType,
 				[]storage.Condition{condition1})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &ruleOriginal)
-			require.NoError(t, err)
+			insertRule(t, db, ruleOriginal)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1 AND name=$2 AND type=$3 AND project_id=$4`,
 				ruleOriginal.ID, ruleOriginal.Name, ruleOriginal.Type.String(), ruleOriginal.ProjectID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
@@ -3714,7 +3706,7 @@ func TestUpdateRule(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			rule := createRuleWithMultipleConditions(t, store, projID, ruleType)
+			rule := insertRuleWithMultipleConditions(t, db, projID, ruleType)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
 			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
@@ -3749,8 +3741,7 @@ func TestUpdateRule(t *testing.T) {
 			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType,
 				[]storage.Condition{condition1, condition2, condition3})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &rule)
-			require.NoError(t, err)
+			insertRule(t, db, rule)
 			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
 			newRuleType := storage.Event
@@ -3773,7 +3764,7 @@ func TestUpdateRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"not-a-match", "some-other-project"})
 
 			ruleType := storage.Node
-			ruleOriginal := createRuleWithMultipleConditions(t, store, projID, ruleType)
+			ruleOriginal := insertRuleWithMultipleConditions(t, db, projID, ruleType)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1 AND name=$2 AND type=$3 AND project_id=$4`,
 				ruleOriginal.ID, ruleOriginal.Name, ruleOriginal.Type.String(), ruleOriginal.ProjectID))
 
@@ -3818,8 +3809,8 @@ func TestGetRule(t *testing.T) {
 			require.NoError(t, err)
 			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType, []storage.Condition{condition1})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &rule)
-			require.NoError(t, err)
+			insertRule(t, db, rule)
+
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
@@ -3834,15 +3825,15 @@ func TestGetRule(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			ruleToGet := createRuleWithMultipleConditions(t, store, projID, ruleType)
+			ruleToGet := insertRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			otherRule, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &otherRule)
-			require.NoError(t, err)
+			insertRule(t, db, otherRule)
+
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToGet.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, otherRule.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
@@ -3861,7 +3852,7 @@ func TestGetRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{projID, projID2, "some-other-project"})
 
 			ruleType := storage.Node
-			ruleToGet := createRuleWithMultipleConditions(t, store, projID, ruleType)
+			ruleToGet := insertRuleWithMultipleConditions(t, db, projID, ruleType)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToGet.ID))
 
 			condition4, err := storage.NewCondition(ruleType,
@@ -3869,8 +3860,8 @@ func TestGetRule(t *testing.T) {
 			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &rule2)
-			require.NoError(t, err)
+			insertRule(t, db, rule2)
+
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
@@ -3888,15 +3879,15 @@ func TestGetRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{projID2, "some-other-project"})
 
 			ruleType := storage.Node
-			ruleToGet := createRuleWithMultipleConditions(t, store, projID, ruleType)
+			ruleToGet := insertRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &rule2)
-			require.NoError(t, err)
+			insertRule(t, db, rule2)
+
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToGet.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
@@ -3935,8 +3926,8 @@ func TestDeleteRule(t *testing.T) {
 			require.NoError(t, err)
 			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType, []storage.Condition{condition1})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &rule)
-			require.NoError(t, err)
+			insertRule(t, db, rule)
+
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
@@ -3952,15 +3943,14 @@ func TestDeleteRule(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			ruleToDelete := createRuleWithMultipleConditions(t, store, projID, ruleType)
+			ruleToDelete := insertRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &ruleToSave)
-			require.NoError(t, err)
+			insertRule(t, db, ruleToSave)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToDelete.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToSave.ID))
@@ -3980,15 +3970,14 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{projID, "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := createRuleWithMultipleConditions(t, store, projID, ruleType)
+			ruleToDelete := insertRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &ruleToSave)
-			require.NoError(t, err)
+			insertRule(t, db, ruleToSave)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToDelete.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToSave.ID))
@@ -4008,15 +3997,14 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := createRuleWithMultipleConditions(t, store, projID, ruleType)
+			ruleToDelete := insertRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			_, err = store.CreateRule(ctx, &ruleToSave)
-			require.NoError(t, err)
+			insertRule(t, db, ruleToSave)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToDelete.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToSave.ID))
@@ -6165,27 +6153,7 @@ func TestPurgeSubjectFromPolicies(t *testing.T) {
 	}
 }
 
-func createRuleWithMultipleConditions(t *testing.T, store storage.Storage, projID string, ruleType storage.RuleType) *storage.Rule {
-	t.Helper()
-	ctx := context.Background()
-	condition1, err := storage.NewCondition(ruleType,
-		[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
-	require.NoError(t, err)
-	condition2, err := storage.NewCondition(ruleType,
-		[]string{"org1", "org2", "org3"}, storage.Organization, storage.MemberOf)
-	require.NoError(t, err)
-	condition3, err := storage.NewCondition(ruleType,
-		[]string{"chef-server-2"}, storage.ChefServer, storage.Equals)
-	require.NoError(t, err)
-	req, err := storage.NewRule("new-id-1", projID, "name", ruleType,
-		[]storage.Condition{condition1, condition2, condition3})
-	require.NoError(t, err)
-	resp, err := store.CreateRule(ctx, &req)
-	require.NoError(t, err)
-	return resp
-}
-
-func assertProjectsMatch(t *testing.T, db *testhelpers.TestDB, project storage.Project) {
+func assertProjectsMatch(t *testing.T, db *testDB, project storage.Project) {
 	t.Helper()
 	dbProject := storage.Project{}
 	err := db.QueryRow(`SELECT query_project($1, '{}');`, project.ID).Scan(&dbProject)
@@ -6364,6 +6332,136 @@ func insertStatementProject(t *testing.T, db *testhelpers.TestDB, statementID uu
 			INSERT INTO iam_statement_projects (statement_id, project_id) VALUES ($1, $2);`,
 		statementID, projectId)
 	require.NoError(t, err)
+}
+
+func insertRule(t *testing.T, db *testDB, rule storage.Rule) {
+	t.Helper()
+	row := db.QueryRow(`
+		INSERT INTO iam_project_rules (id, project_id, name, type) VALUES ($1, $2, $3, $4) RETURNING db_id;`,
+		rule.ID, rule.ProjectID, rule.Name, rule.Type)
+	var dbID string
+	err := row.Scan(&dbID)
+	require.NoError(t, err)
+	for _, c := range rule.Conditions {
+		_, err = db.Exec(`
+			INSERT INTO iam_rule_conditions (rule_db_id, value, attribute, operator) VALUES ($1, $2, $3, $4);`,
+			dbID, pq.Array(c.Value), c.Attribute, c.Operator)
+		require.NoError(t, err)
+	}
+}
+
+func insertRuleWithMultipleConditions(t *testing.T, db *testDB, projID string, ruleType storage.RuleType) *storage.Rule {
+	t.Helper()
+	condition1, err := storage.NewCondition(ruleType,
+		[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
+	require.NoError(t, err)
+	condition2, err := storage.NewCondition(ruleType,
+		[]string{"org1", "org2", "org3"}, storage.Organization, storage.MemberOf)
+	require.NoError(t, err)
+	condition3, err := storage.NewCondition(ruleType,
+		[]string{"chef-server-2"}, storage.ChefServer, storage.Equals)
+	require.NoError(t, err)
+	rule, err := storage.NewRule("new-id-1", projID, "name", ruleType,
+		[]storage.Condition{condition1, condition2, condition3})
+	require.NoError(t, err)
+
+	row := db.QueryRow(`
+		INSERT INTO iam_project_rules (id, project_id, name, type) VALUES ($1, $2, $3, $4) RETURNING db_id;`,
+		rule.ID, projID, rule.Name, ruleType)
+	var dbID string
+	err = row.Scan(&dbID)
+	require.NoError(t, err)
+	for _, c := range rule.Conditions {
+		_, err = db.Exec(`
+			INSERT INTO iam_rule_conditions (rule_db_id, value, attribute, operator) VALUES ($1, $2, $3, $4);`,
+			dbID, pq.Array(c.Value), c.Attribute, c.Operator)
+		require.NoError(t, err)
+	}
+	return &rule
+}
+
+func setup(t *testing.T) (storage.Storage, *testDB, *prng.Prng) {
+	t.Helper()
+
+	ctx := context.Background()
+	l, err := logger.NewLogger("text", "error")
+	require.NoError(t, err, "init logger for postgres storage")
+
+	migrationConfig, err := migrationConfigIfPGTestsToBeRun(l, "../../postgres/migration/sql")
+	if err != nil {
+		t.Fatalf("couldn't initialize pg config for tests: %s", err.Error())
+	}
+
+	dataMigrationConfig, err := migrationConfigIfPGTestsToBeRun(l, "../../postgres/datamigration/sql")
+	if err != nil {
+		t.Fatalf("couldn't initialize pg config for tests: %s", err.Error())
+	}
+
+	if migrationConfig == nil && dataMigrationConfig == nil {
+		t.Skipf("start pg container and set PG_URL to run")
+	}
+
+	// reset database the hard way -- we do this to ensure that our comparison
+	// between database content and hardcoded storage default policies actually
+	// compares the migrated policies with the hardcoded ones (and NOT the
+	// hardcoded policies with the hardcoded policies).
+	db := openDB(t)
+	_, err = db.ExecContext(ctx, resetDatabaseStatement)
+	require.NoError(t, err, "error resetting database")
+	_, err = db.Exec(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`)
+	require.NoError(t, err, "error creating extension")
+
+	backend, err := postgres.New(ctx, l, *migrationConfig, datamigration.Config(*dataMigrationConfig))
+	require.NoError(t, err)
+	return backend, &testDB{DB: db}, prng.Seed(t)
+}
+
+// migrationConfigIfPGTestsToBeRun either returns the pg migration config
+// if PG_URL is set or we are in CI, otherwise it returns nil, indicating
+// postgres based tests shouldn't be run.
+func migrationConfigIfPGTestsToBeRun(l logger.Logger, migrationPath string) (*migration.Config, error) {
+	customPGURL, pgURLPassed := os.LookupEnv("PG_URL")
+	ciMode := os.Getenv("CI") == "true"
+
+	// If in CI mode, use the default
+	if ciMode {
+		pgURL, err := url.Parse("postgres://postgres@127.0.0.1:5432/authz_test?sslmode=disable")
+		if err != nil {
+			return nil, err
+		}
+		return &migration.Config{
+			Path:   migrationPath,
+			Logger: l,
+			PGURL:  pgURL,
+		}, nil
+	}
+
+	// If PG_URL wasn't passed (and we aren't in CI)
+	// we shouldn't run the postgres tests, return nil.
+	if !pgURLPassed {
+		return nil, nil
+	}
+
+	pgURL, err := url.Parse(customPGURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &migration.Config{
+		Path:   migrationPath,
+		Logger: l,
+		PGURL:  pgURL,
+	}, nil
+}
+
+func openDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("postgres", "postgres://postgres:postgres@127.0.0.1:5432/authz_test?sslmode=disable")
+	require.NoError(t, err, "error opening db")
+	err = db.Ping()
+	require.NoError(t, err, "error pinging db")
+
+	return db
 }
 
 func insertProjectsIntoContext(ctx context.Context, projects []string) context.Context {

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -3390,9 +3390,6 @@ func TestCreateRule(t *testing.T) {
 				[]storage.Condition{condition1, condition2, condition3})
 			require.Error(t, err)
 		},
-		// TODO
-		// case: cannot create rule if it already exists in current rules
-		// case: cannot create rule if it already exists in staged rules
 		"create node rule with multiple conditions": func(t *testing.T) {
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
@@ -3434,7 +3431,6 @@ func TestCreateRule(t *testing.T) {
 			rule, err := storage.NewRule("new-id-1", "project-1", "name", ruleType,
 				[]storage.Condition{condition1, condition2, condition3})
 			require.NoError(t, err)
-				assertCount(t, 0, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules`))
 			resp, err := store.CreateRule(ctx, &rule)
 			require.NoError(t, err)
 			require.Equal(t, &rule, resp)

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -3364,6 +3364,9 @@ func TestCreateRule(t *testing.T) {
 				[]storage.Condition{condition1, condition2, condition3})
 			require.Error(t, err)
 		},
+		// TODO
+		// case: cannot create rule if it already exists in current rules
+		// case: cannot create rule if it already exists in staged rules
 		"create node rule with multiple conditions": func(t *testing.T) {
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
@@ -3385,9 +3388,9 @@ func TestCreateRule(t *testing.T) {
 			resp, err := store.CreateRule(ctx, &rule)
 			require.NoError(t, err)
 			require.Equal(t, &rule, resp)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1 AND type=$2 AND project_id=$3 AND name=$4`,
-				rule.ID, rule.Type.String(), rule.ProjectID, rule.Name))
-			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND type=$2 AND project_id=$3 AND name=$4 AND state=$5`,
+				rule.ID, rule.Type.String(), rule.ProjectID, rule.Name, "new"))
+			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
 		"create event rule with multiple conditions": func(t *testing.T) {
 			projID := "project-1"
@@ -3410,9 +3413,9 @@ func TestCreateRule(t *testing.T) {
 			resp, err := store.CreateRule(ctx, &rule)
 			require.NoError(t, err)
 			require.Equal(t, &rule, resp)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1 AND type=$2 AND project_id=$3 AND name=$4`,
-				rule.ID, rule.Type.String(), rule.ProjectID, rule.Name))
-			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND type=$2 AND project_id=$3 AND name=$4 AND state=$5`,
+				rule.ID, rule.Type.String(), rule.ProjectID, rule.Name, "new"))
+			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
 	}
 

--- a/components/authz-service/storage/v2/rule.go
+++ b/components/authz-service/storage/v2/rule.go
@@ -15,6 +15,7 @@ type Rule struct {
 	Name       string      `json:"name"`
 	Type       RuleType    `json:"type"`
 	Conditions []Condition `json:"conditions"`
+	Deleted	   bool        `json:"deleted"`
 }
 
 // Scan implements pq Scan interface for a Rule reference
@@ -46,6 +47,7 @@ func NewRule(id string, projectID string, name string,
 		Name:       name,
 		Type:       ruleType,
 		Conditions: conditions,
+		Deleted:    false,
 	}, nil
 }
 

--- a/components/authz-service/storage/v2/rule.go
+++ b/components/authz-service/storage/v2/rule.go
@@ -15,7 +15,7 @@ type Rule struct {
 	Name       string      `json:"name"`
 	Type       RuleType    `json:"type"`
 	Conditions []Condition `json:"conditions"`
-	Deleted	   bool        `json:"deleted"`
+	Deleted    bool        `json:"deleted"`
 }
 
 // Scan implements pq Scan interface for a Rule reference

--- a/components/authz-service/storage/v2/storage.go
+++ b/components/authz-service/storage/v2/storage.go
@@ -70,7 +70,7 @@ type projectStorage interface {
 
 type ruleStorage interface {
 	CreateRule(context.Context, *Rule) (*Rule, error)
-	GetStagedOrCurrentRule(context.Context, string) (*Rule, error)
+	GetStagedOrAppliedRule(context.Context, string) (*Rule, error)
 	UpdateRule(context.Context, *Rule) (*Rule, error)
 	ListRules(context.Context) ([]*Rule, error)
 	DeleteRule(context.Context, string) error

--- a/components/authz-service/storage/v2/storage.go
+++ b/components/authz-service/storage/v2/storage.go
@@ -70,7 +70,7 @@ type projectStorage interface {
 
 type ruleStorage interface {
 	CreateRule(context.Context, *Rule) (*Rule, error)
-	GetRule(context.Context, string) (*Rule, error)
+	GetStagedOrCurrentRule(context.Context, string) (*Rule, error)
 	UpdateRule(context.Context, *Rule) (*Rule, error)
 	ListRules(context.Context) ([]*Rule, error)
 	DeleteRule(context.Context, string) error


### PR DESCRIPTION
### :nut_and_bolt: Description

Before kicking off a long-running re-indexing of tagged resources, users need to be able to stage changes.  This table is the starting point (along with the function `CreateRule` and `GetStagedOrAppliedRule` for POC). 

NOTE:

Technically, we don't want to trigger a reindex if only the name of a rule/project has changed. We've included it anyway to reduce complexity on this first go, but we will eventually want to handle those differently.

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
