### PR TITLE
[A2-858] Add telemetry to EAS apps UI

### DIFF
--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -67,7 +67,7 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
       this.selectedHealth = getOr('total', 'health', servicesFilters);
       this.currentPage    = getOr(1, 'page', servicesFilters);
       this.totalServices  = getOr(0, this.selectedHealth, this.servicesHealthSummary);
-      this.telemetryService.track('applicationServiceCount', {
+      this.telemetryService.track('applicationsServiceCount', {
          serviceGroupId: this.serviceGroupId,
          totalServices: this.totalServices,
          statusFilter: this.selectedHealth
@@ -88,7 +88,7 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
     }
 
     this.currentPage = 1;
-    this.telemetryService.track('applicationStatusFilter',
+    this.telemetryService.track('applicationsStatusFilter',
      { entity: 'service', statusFilter: this.selectedHealth});
     this.updateServicesFilters();
   }
@@ -96,7 +96,7 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   public updatePageNumber(pageNumber: number) {
     this.currentPage = pageNumber;
     const totalPages = Math.ceil(this.totalServices / this.pageSize) || 1;
-    this.telemetryService.track('applicationPageChange',
+    this.telemetryService.track('applicationsPageChange',
      { entity: 'service', pageNumber: pageNumber, totalPages: totalPages});
     this.updateServicesFilters();
   }

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -12,6 +12,7 @@ import {
   Service, ServicesFilters, HealthSummary
 } from '../../entities/service-groups/service-groups.model';
 import { includes, getOr } from 'lodash/fp';
+import { TelemetryService } from 'app/services/telemetry/telemetry.service';
 
 @Component({
   selector: 'app-services-sidebar',
@@ -42,7 +43,8 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
 
   constructor(
     private store: Store<NgrxStateAtom>,
-    private router: Router
+    private router: Router,
+    private telemetryService: TelemetryService
   ) { }
 
   ngOnInit() {
@@ -65,6 +67,11 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
       this.selectedHealth = getOr('total', 'health', servicesFilters);
       this.currentPage    = getOr(1, 'page', servicesFilters);
       this.totalServices  = getOr(0, this.selectedHealth, this.servicesHealthSummary);
+      this.telemetryService.track('applicationServiceCount', {
+         serviceGroupId: this.serviceGroupId,
+         totalServices: this.totalServices,
+         statusFilter: this.selectedHealth
+      });
     });
   }
 
@@ -81,11 +88,16 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
     }
 
     this.currentPage = 1;
+    this.telemetryService.track('applicationStatusFilter',
+     { entity: 'service', statusFilter: this.selectedHealth});
     this.updateServicesFilters();
   }
 
   public updatePageNumber(pageNumber: number) {
     this.currentPage = pageNumber;
+    const totalPages = Math.ceil(this.totalServices / this.pageSize) || 1;
+    this.telemetryService.track('applicationPageChange',
+     { entity: 'service', pageNumber: pageNumber, totalPages: totalPages});
     this.updateServicesFilters();
   }
 

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.spec.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.spec.ts
@@ -10,7 +10,13 @@ import {
   UpdateServiceGroupFilters,
   GetServiceGroupsCountsSuccess
 } from 'app/entities/service-groups/service-groups.actions';
+import { TelemetryService } from 'app/services/telemetry/telemetry.service';
 
+class MockTelemetryService {
+  track(_event?: string, _properties?: any): void {
+
+  }
+}
 
 describe('ServiceGroupsComponent', () => {
   let fixture, component;
@@ -22,7 +28,7 @@ describe('ServiceGroupsComponent', () => {
         ServiceStatusIconPipe,
         ServiceGroupsComponent
       ],
-      providers: [],
+      providers: [  { provide: TelemetryService, useClass: MockTelemetryService }],
       imports: [
         StoreModule.forRoot({
           serviceGroups: serviceGroupEntityReducer

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -128,7 +128,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
           this.selectedStatus = 'total';
           this.totalServiceGroups = get('total', this.sgHealthSummary);
       }
-      this.telemetryService.track('applicationServiceGroupCount', {
+      this.telemetryService.track('applicationsServiceGroupCount', {
         totalServiceGroups: this.totalServiceGroups,
         statusFilter: status
       });
@@ -207,7 +207,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
     const queryParams = {...this.route.snapshot.queryParams};
     if ( includes(status, this.allowedStatus) ) {
       queryParams['status'] = [status];
-      this.telemetryService.track('applicationStatusFilter',
+      this.telemetryService.track('applicationsStatusFilter',
         { entity: 'serviceGroup', statusFilter: status});
     } else {
       delete queryParams['status'];
@@ -263,7 +263,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   onPageChange(pageNumber: number) {
     const queryParams = { ...this.route.snapshot.queryParams, page: pageNumber };
     const totalPages = Math.ceil(this.totalServiceGroups / this.pageSize) || 1;
-    this.telemetryService.track('applicationPageChange',
+    this.telemetryService.track('applicationsPageChange',
      { entity: 'serviceGroup', pageNumber: pageNumber, totalPages: totalPages});
     if (pageNumber <= 1) {
       delete queryParams['page'];
@@ -287,7 +287,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
 
   onUpdateSort(event): void {
     const {field, fieldDirection} = event;
-    this.telemetryService.track('applicationSort',
+    this.telemetryService.track('applicationsSort',
       { field: field, fieldDirection: fieldDirection});
     if (this.defaultFieldDirection.hasOwnProperty(field) &&
       this.allowedSortDirections.includes(fieldDirection) ) {

--- a/components/automate-ui/src/app/services/telemetry/telemetry.service.ts
+++ b/components/automate-ui/src/app/services/telemetry/telemetry.service.ts
@@ -44,6 +44,8 @@ export class TelemetryService {
   private maxNodes;
   private instanceId;
   private buildVersion;
+  private previousUrl: string;
+  private currentUrl: string;
 
   constructor(private httpClient: HttpClient,
     private configService: ConfigService,
@@ -55,7 +57,9 @@ export class TelemetryService {
     // browsing of the user.
     router.events.subscribe((event) => {
       if (event instanceof NavigationEnd) {
-        this.page(event.url);
+        this.previousUrl = this.currentUrl;
+        this.currentUrl = event.url;
+        this.page(this.currentUrl, {previousUrl: this.previousUrl});
       }
     });
 


### PR DESCRIPTION
Added track calls for total service groups and service
Added track calls for status filter, pagination for service groups and service
Added track calls for sorting service group table
For status filter and pagination the track call names are shared and an entity
attribute is added so we can see information about both in the same table

Signed-off-by: kmacgugan <kmacgugan@chef.io>

### :nut_and_bolt: Description

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps
Start the UI 
Open up the debug tools and look at the network traffic. 
When you click on sort you should see an event for applicationSort.
When you click on a status filter you should see an event for applicationStatusFilter
Every time the page loads you should see an event for applicationServiceCount
Clicking on a service group to change the services sidebar you should see an event for applicationServiceCount
Pagination clicks will produce applicationPageChange events
You should also be able to see all of these events in https://metabase-acceptance.chef.co/
### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
