### PR TITLE
session-service: allow for multiple relay states

### DIFF
--- a/components/session-service/Makefile
+++ b/components/session-service/Makefile
@@ -29,8 +29,7 @@ start: build
 	./bin/session-service examples/config.yml
 
 test:
-	@go test -v -i $(packages)
-	@go test -v $(packages) -cover
+	@go test -v -count=1 $(packages) -cover
 
 # this command lists all the changes since master, and looks for modifications
 # to the migration files -- if there's any of (M)odify, (R)ename, or (D)elete,

--- a/components/session-service/server/server.go
+++ b/components/session-service/server/server.go
@@ -262,6 +262,13 @@ func (s *Server) callbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// remove used relay_state
+	if err := sess.Remove(w, relayStateKey+"_"+state); err != nil { // nolint: vetshadow
+		s.log.Debugf("failed to remove relay state: %v", err)
+		http.Error(w, errors.Wrap(err, "failed to remove relay state").Error(), http.StatusInternalServerError)
+		return
+	}
+
 	if token.RefreshToken != "" {
 		err = sess.PutString(w, "refresh_token", token.RefreshToken)
 		if err != nil {

--- a/components/session-service/server/server.go
+++ b/components/session-service/server/server.go
@@ -208,24 +208,30 @@ func (s *Server) callbackHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sess := s.mgr.Load(r)
-	relayState, err := sess.GetString(relayStateKey)
-	if err != nil {
-		s.log.Debugf("bad session data (relay state): %v", err)
-		http.Error(w, "bad session data (relay state)", http.StatusBadRequest)
-		return
-	}
-	s.log.Debugf("retrieved relay state %q", relayState)
 	code := r.FormValue("code")
 	if code == "" {
 		s.log.Debugf("no code in request: %q", r.Form)
 		http.Error(w, fmt.Sprintf("no code in request: %q", r.Form), http.StatusBadRequest)
 		return
 	}
-	if state := r.FormValue("state"); state != relayState {
-		s.log.Debugf("expected state %q got %q", relayState, state)
-		http.Error(w, fmt.Sprintf("expected state %q got %q", relayState, state), http.StatusBadRequest)
+	state := r.FormValue("state")
+	if state == "" {
+		s.log.Debugf("no state in request: %q", r.Form)
+		http.Error(w, fmt.Sprintf("no state in request: %q", r.Form), http.StatusBadRequest)
 		return
 	}
+	knownRelayState, err := sess.GetBool(relayStateKey + "_" + state)
+	if err != nil {
+		s.log.Debugf("bad session data (relay state): %v", err)
+		http.Error(w, "bad session data (relay state)", http.StatusBadRequest)
+		return
+	}
+	if !knownRelayState {
+		s.log.Debugf("unknown relay state: %q", state)
+		http.Error(w, fmt.Sprintf("unknown relay state in request: %q", state), http.StatusBadRequest)
+		return
+	}
+	s.log.Debugf("relay state %q known", state)
 
 	token, err := s.client.Exchange(r.Context(), code)
 	if err != nil {
@@ -568,7 +574,7 @@ func (s *Server) newHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// bind relay state to session
-	if err := sess.PutString(w, relayStateKey, relayState); err != nil {
+	if err := sess.PutBool(w, relayStateKey+"_"+relayState, true); err != nil {
 		s.log.Errorf("couldn't put relay state into session: %s", err)
 		httpError(w, http.StatusInternalServerError)
 		return


### PR DESCRIPTION
### :nut_and_bolt: Description

Before, the following could happen:

- tab A: get logged out, sent to dex -- relay state 1
- tab B: get logged out, sent to dex -- relay state 2, overwrites relay
  state 1
- login in tab A, be sent back to session-service
- relay state 2 != 1, error out

Now, we don't bind a single relay state to the session (which would be
overwritten when a second logout occours), but multiple relay states.
To achieve this, we don't store a string key in the session (with key
"relay_state"), but multiple booleans, with key
"relay_state_<RELAY_STATE>". Since we only need to check whether a state
we get back from dex matches a known relay state, and never need to
retrieve all relay states, that works.

ℹ️Use `chef-automate dev psql chef_session_service -- -c 'delete from sessions'` to kill your session for debugging.
ℹ️To look at the backend's session data (associated with a browser cookie), use
```
$ chef-automate dev psql chef_session_service -- -t -c "select token, encode(data, 'escape') from sessions"
 Bh-N_Ixh1UHk70E5v0eHmIU4xIZHSgfmt-odOcCV2CA | {"data":{"refresh_token":"ChlsNGY2YzY2bHF4b2Jheng2cGd6dmxyaXA1Ehl0c2picm92cmRxZGNpeDZxN3VsZmx6b28y"},"deadline":1560609668293293832}
```

☑️ This approach would potentially accumulate client and relay states in the session object. It's been taken care of -- please see the individual commits.
☑️ The PR also addresses potentially existing `client_state`s -- allowing for multiple tabs to each go back to where they came from (see demo steps)

⚠️ This is not the long-awaited, multiple-tabs-and-a-great-login/logout-UX refactoring! It's *more bandaid*, but nothing blocking us the path later.

### :+1: Definition of Done

- open two new A2 tabs
- login in tab A, login in tab B
- no error in either one
- repeat the same with B and A reversed; no error either

### :athletic_shoe: Demo Script / Repro Steps

- disable SAML: `chef-automate config show > all.toml`, remove the `[dex]` block, `chef-automate config set all.toml`
- `rebuild components/session-service`
- login and open four tabs: https://a2-dev.test/event-feed, https://a2-dev.test/client-runs, https://a2-dev.test/compliance/reports/overview, and https://a2-dev.test/settings/notifications
- kill all sessions:
   ```
   [8][default:/src:0]# chef-automate dev psql chef_session_service -- -c 'delete from sessions'
   DELETE 1
   ```
- get some coffee, talk to someone or just stare at the wall for at most 3 minutes
- notice that all tabs are showing a login screen; login **in each of them** in some order that doesn't matter
- when they've all gone to login, you can see 4 pairs of relay_state + client_state in the session data:
```
 [60][default:/src:130]# env PAGER=cat chef-automate dev psql chef_session_service -- -t -c "select token, encode(data, 'escape') from sessions"
 tsnZV_9t4qeQxRkON0_mvvz-YfM-A9NHzRegzyoPn68 | {"data":{"client_state_9xtqQgFCLBccrg==":"/event-feed","client_state__BwydK9lWZI26A==":"/settings/notifications","client_state_ba4H6domQlJCeQ==":"/client-runs","client_state_mfEQLXE3f2y5ZQ==":"/compliance/reports/overview","relay_state_9xtqQgFCLBccrg==":true,"relay_state__BwydK9lWZI26A==":true,"relay_state_ba4H6domQlJCeQ==":true,"relay_state_mfEQLXE3f2y5ZQ==":true},"deadline":1560609862251170983}
```
- notice that you're sent back to the pages you had been on

(⚠️ If you kill the session record after a tab has already gone to login, this one won't be able to login again -- but that's an artifact of the demo setup)

### :chains: Related Resources

- [A2-775](https://chefio.atlassian.net/browse/A2-775)

### :white_check_mark: Checklist

- [X] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [X] Code actually executed?
- [X] Vetting performed (unit tests, lint, etc.)?
