### PR TITLE
 Allow workflows to indicate failure 

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -3,3 +3,6 @@ include ../Makefile.common_go
 
 unit:
 	go test -v ./...
+
+integration:
+	go test -tags integration ./...

--- a/lib/workflow/backend/backend.go
+++ b/lib/workflow/backend/backend.go
@@ -43,6 +43,7 @@ type WorkflowInstance struct {
 	Payload      []byte
 
 	IsRunning bool
+	Err       error
 	Result    []byte
 }
 
@@ -102,6 +103,7 @@ type WorkflowCompleter interface {
 
 	Continue(payload []byte) error
 	Abandon() error
+	Fail(err error) error
 	Done(result []byte) error
 	Close() error
 }

--- a/lib/workflow/integration/workflow_error_test.go
+++ b/lib/workflow/integration/workflow_error_test.go
@@ -1,0 +1,47 @@
+// +build integration
+
+package integration_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/chef/automate/lib/workflow"
+)
+
+// TestWorkflowFail tests that a call to w.Fail ends the workflow
+// with an error that can be recovered.
+func (suite *WorkflowTestSuite) TestWorkflowFail() {
+	workflowName := randName("failing")
+	instanceName := randName("instance")
+
+	doneChan := make(chan struct{})
+	m := suite.newManager(
+		WithWorkflowExecutor(
+			workflowName,
+			&workflowExecutorWrapper{
+				onStart: func(w workflow.WorkflowInstance, ev workflow.StartEvent) workflow.Decision {
+					close(doneChan)
+					return w.Fail(errors.New("expected test error"))
+				},
+				onTaskComplete: func(w workflow.WorkflowInstance, ev workflow.TaskCompleteEvent) workflow.Decision {
+					return w.Complete()
+				},
+			},
+		),
+	)
+	defer m.Stop()
+	err := m.EnqueueWorkflow(context.Background(), workflowName, instanceName, nil)
+	suite.Require().NoError(err, "Failed to enqueue workflow")
+	<-doneChan
+	time.Sleep(20 * time.Millisecond)
+	w, err := m.GetWorkflowInstanceByName(context.Background(), instanceName, workflowName)
+	suite.NoError(err)
+	suite.Error(w.Err())
+	suite.False(w.IsRunning())
+	suite.Equal(w.Err().Error(), "expected test error")
+	err = m.Stop()
+	suite.NoError(err)
+}

--- a/lib/workflow/workflow.go
+++ b/lib/workflow/workflow.go
@@ -155,6 +155,11 @@ type WorkflowInstance interface {
 	// this workflow instance is processed by a WorkflowExecutor next.
 	Continue(payload interface{}) Decision
 
+	// Fail returns a decision to end the execution of the
+	// workflow because of an error that occurred when processing
+	// the workflow event.
+	Fail(error) Decision
+
 	// InstanceName returns the workflow instance name
 	InstanceName() string
 
@@ -236,6 +241,13 @@ func (w *workflowInstanceImpl) Continue(payload interface{}) Decision {
 	}
 }
 
+func (w *workflowInstanceImpl) Fail(err error) Decision {
+	return Decision{
+		failed: true,
+		err:    err,
+	}
+}
+
 type ImmutableWorkflowInstance interface {
 	// GetPayload unmarshals the payload of the workflow instance into the
 	// value pointed at by obj. This payload is any state the user wishes
@@ -249,6 +261,8 @@ type ImmutableWorkflowInstance interface {
 	IsRunning() bool
 
 	GetResult(obj interface{}) error
+
+	Err() error
 }
 
 type immutableWorkflowInstanceImpl struct {
@@ -279,6 +293,10 @@ func (w *immutableWorkflowInstanceImpl) GetResult(obj interface{}) error {
 	return nil
 }
 
+func (w *immutableWorkflowInstanceImpl) Err() error {
+	return w.instance.Err
+}
+
 func (w *immutableWorkflowInstanceImpl) IsRunning() bool {
 	return w.instance.Status != backend.WorkflowInstanceStatusCompleted
 }
@@ -289,8 +307,10 @@ func (w *immutableWorkflowInstanceImpl) IsRunning() bool {
 type Decision struct {
 	complete   bool
 	continuing bool
+	failed     bool
 	payload    interface{}
 	result     interface{}
+	err        error
 	tasks      []backend.Task
 }
 
@@ -735,32 +755,43 @@ func (m *WorkflowManager) processWorkflow(ctx context.Context, workflowNames []s
 		panic("WTF")
 	}
 	s.End("user")
-
-	if decision.complete {
-		s.Begin("complete")
+	logctx := logrus.WithFields(logrus.Fields{
+		"enqueued_tasks":  wevt.EnqueuedTaskCount,
+		"completed_tasks": wevt.CompletedTaskCount,
+	})
+	if decision.failed {
+		s.Begin("failed")
 		if wevt.CompletedTaskCount != wevt.EnqueuedTaskCount {
-			logrus.WithFields(logrus.Fields{
-				"enqueued":  wevt.EnqueuedTaskCount,
-				"completed": wevt.CompletedTaskCount,
-			}).Info("Abandoning workflow")
+			logctx.Info("Abandoning workflow because it has pending tasks")
 			if err := completer.Abandon(); err != nil {
-				logrus.WithError(err).Error("failed to abandon workflow")
+				logctx.WithError(err).Error("failed to abandon workflow")
 			}
 		} else {
-			logrus.WithFields(logrus.Fields{
-				"enqueued":  wevt.EnqueuedTaskCount,
-				"completed": wevt.CompletedTaskCount,
-			}).Info("Completing workflow")
-
+			logctx.Info("Ending workflow because of an error")
+			err = completer.Fail(decision.err)
+			if err != nil {
+				logctx.WithError(err).Error("failed to complete workflow")
+			}
+		}
+		s.End("failed")
+	} else if decision.complete {
+		s.Begin("complete")
+		if wevt.CompletedTaskCount != wevt.EnqueuedTaskCount {
+			logctx.Info("Abandoning workflow because it has pending tasks")
+			if err := completer.Abandon(); err != nil {
+				logctx.WithError(err).Error("failed to abandon workflow")
+			}
+		} else {
+			logctx.Info("Completing workflow")
 			jsonResult, err := jsonify(decision.result)
 			if err != nil {
-				logrus.WithError(err).Error("failed to jsonify workflow result")
+				logctx.WithError(err).Error("failed to jsonify workflow result")
 				jsonResult = nil
 			}
 
 			err = completer.Done(jsonResult)
 			if err != nil {
-				logrus.WithError(err).Error("failed to complete workflow")
+				logctx.WithError(err).Error("failed to complete workflow")
 			}
 		}
 		s.End("complete")

--- a/lib/workflow/workflow.go
+++ b/lib/workflow/workflow.go
@@ -762,12 +762,13 @@ func (m *WorkflowManager) processWorkflow(ctx context.Context, workflowNames []s
 	if decision.failed {
 		s.Begin("failed")
 		if wevt.CompletedTaskCount != wevt.EnqueuedTaskCount {
-			logctx.Info("Abandoning workflow because it has pending tasks")
+			logctx.WithError(decision.err).Info(
+				"Abandoning workflow because it returned an error and has pending tasks")
 			if err := completer.Abandon(); err != nil {
 				logctx.WithError(err).Error("failed to abandon workflow")
 			}
 		} else {
-			logctx.Info("Ending workflow because of an error")
+			logctx.WithError(decision.err).Info("Ending workflow because of an error")
 			err = completer.Fail(decision.err)
 			if err != nil {
 				logctx.WithError(err).Error("failed to complete workflow")


### PR DESCRIPTION
### :nut_and_bolt: Description

This allows you do to:

```
return w.Fail(err)
```

inside a workflow executor callback, which is useful because 
of all the error checking that has to happen around the serialization
and deserialization of the payload and task results.

While here, I cleaned up some SQL that was using various in_val tables
that I don't think are necessary.

Signed-off-by: Steven Danna <steve@chef.io>