### PR TITLE
cleanup tmp file from running authz service tests

### DIFF
--- a/components/authz-service/config/config_mgmt.go
+++ b/components/authz-service/config/config_mgmt.go
@@ -5,10 +5,12 @@ import (
 	"os"
 	"time"
 
+	toml "github.com/pelletier/go-toml"
+	// TODO: should use the service's logger
+	log "github.com/sirupsen/logrus"
+
 	base_config "github.com/chef/automate/lib/config"
 	event_ids "github.com/chef/automate/lib/event"
-	toml "github.com/pelletier/go-toml"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -53,7 +55,7 @@ func NewManager(configFile string) (*Manager, error) {
 
 	// Testing Updating
 	baseManager := base_config.NewManager(configFile, storedConfig)
-	err = baseManager.UpdateConfig(func(config interface{}) (interface{}, error) {
+	err = baseManager.UpdateConfig(func(interface{}) (interface{}, error) {
 		return storedConfig, nil
 	})
 	if err != nil {
@@ -62,7 +64,7 @@ func NewManager(configFile string) (*Manager, error) {
 
 	return &Manager{
 		baseConfigManager: baseManager,
-	}, err
+	}, nil
 }
 
 // Close - to close out the channel for this object.
@@ -75,8 +77,7 @@ func (manager *Manager) Close() {
 func (manager *Manager) GetProjectUpdateStage() ProjectUpdateStage {
 	aggregateConfig, ok := manager.baseConfigManager.Config.(aggregateConfig)
 	if !ok {
-		log.Error("baseConfigManager.Config is not of type 'aggregateConfig'")
-		os.Exit(1)
+		panic("baseConfigManager.Config is not of type 'aggregateConfig'")
 	}
 	return aggregateConfig.ProjectUpdateStage
 }

--- a/components/authz-service/config/config_mgmt_test.go
+++ b/components/authz-service/config/config_mgmt_test.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/chef/automate/components/authz-service/config"
 	event_ids "github.com/chef/automate/lib/event"
-	"github.com/stretchr/testify/assert"
 )
 
 const cFile = "/tmp/.authz-service-test-delete-me.toml"
@@ -42,7 +43,7 @@ func TestManagerConfigProjectUpdateConfig(t *testing.T) {
   `)
 	err := ioutil.WriteFile(cFile, data, 0644)
 	defer os.Remove(cFile)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// New config should load the file
 	configMgr, err := config.NewManager(cFile)

--- a/components/authz-service/config/config_mgmt_test.go
+++ b/components/authz-service/config/config_mgmt_test.go
@@ -65,6 +65,7 @@ func TestManagerConfigProjectUpdateConfig(t *testing.T) {
 func TestManagerBadFile(t *testing.T) {
 	_, err := config.NewManager("")
 	assert.Error(t, err)
+	assert.NoError(t, os.Remove(".tmp.."), "cleanup tmp file")
 }
 
 func TestManagerConfigProjectUpdateConfigDefault(t *testing.T) {


### PR DESCRIPTION
Has this ever happened to you after running the tests of authz-service`?
```
$ git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

        components/authz-service/config/.tmp..

nothing added to commit but untracked files present (use "git add" to track)
```
With this PR, it shouldn't happen again 😃 