### PR TITLE
Proceed on update version conflict for compliance reports

### DIFF
--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -1,6 +1,7 @@
 package ingestic
 
 import (
+	"math/rand"
 	"time"
 
 	"fmt"
@@ -185,6 +186,9 @@ func (backend *ESClient) setDailyLatestToFalse(ctx context.Context, nodeId strin
 
 	retries := 3
 	err := errors.New("init")
+	sec := rand.Intn(60)
+	time.Sleep(time.Duration(sec) * time.Second)
+	logrus.Infof("Running NewUpdateByQueryService for node %s w/ report %s", nodeId, reportId)
 	for retries > 0 && err != nil {
 		_, err = elastic.NewUpdateByQueryService(backend.client).
 			Index(index).

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -1,7 +1,6 @@
 package ingestic
 
 import (
-	"math/rand"
 	"time"
 
 	"fmt"
@@ -184,20 +183,20 @@ func (backend *ESClient) setDailyLatestToFalse(ctx context.Context, nodeId strin
 
 	script := elastic.NewScript("ctx._source.daily_latest = false")
 
-	retries := 3
-	err := errors.New("init")
-	sec := rand.Intn(60)
-	time.Sleep(time.Duration(sec) * time.Second)
+	//retries := 3
+	//err := errors.New("init")
+	//sec := rand.Intn(60)
+	//time.Sleep(time.Duration(sec) * time.Second)
 	logrus.Infof("Running NewUpdateByQueryService for node %s w/ report %s", nodeId, reportId)
-	for retries > 0 && err != nil {
-		_, err = elastic.NewUpdateByQueryService(backend.client).
-			Index(index).
-			Query(boolQueryDailyLatestThisNodeNotThisReport).
-			Script(script).
-			Refresh("false").
-			Do(ctx)
-		retries -= 1
-	}
+	//for retries > 0 && err != nil {
+	_, err := elastic.NewUpdateByQueryService(backend.client).
+		Index(index).
+		Query(boolQueryDailyLatestThisNodeNotThisReport).
+		Script(script).
+		Refresh("true").
+		Do(ctx)
+	//	retries -= 1
+	//}
 
 	return err
 }

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -195,8 +195,11 @@ func (backend *ESClient) setDailyLatestToFalse(ctx context.Context, nodeId strin
 		Script(script).
 		Refresh("true").
 		Do(ctx)
-	//	retries -= 1
-	//}
+		//	retries -= 1
+		//}
+	if err != nil {
+		errors.Wrap(err, "daily_latest update failed")
+	}
 
 	return err
 }

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -188,6 +188,7 @@ func (backend *ESClient) setDailyLatestToFalse(ctx context.Context, nodeId strin
 		Query(boolQueryDailyLatestThisNodeNotThisReport).
 		Script(script).
 		Refresh("false").
+		ProceedOnVersionConflict().
 		Do(ctx)
 
 	return err

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -187,7 +187,7 @@ func (backend *ESClient) setDailyLatestToFalse(ctx context.Context, nodeId strin
 	//err := errors.New("init")
 	//sec := rand.Intn(60)
 	//time.Sleep(time.Duration(sec) * time.Second)
-	logrus.Infof("Running NewUpdateByQueryService for node %s w/ report %s", nodeId, reportId)
+	logrus.Infof("Running NewUpdateByQueryService for index %s node %s w/ report %s", index, nodeId, reportId)
 	//for retries > 0 && err != nil {
 	_, err := elastic.NewUpdateByQueryService(backend.client).
 		Index(index).
@@ -198,6 +198,7 @@ func (backend *ESClient) setDailyLatestToFalse(ctx context.Context, nodeId strin
 		//	retries -= 1
 		//}
 	if err != nil {
+		logrus.Errorf("!!!!!!!!!daily_latest update failed: %s", err.Error())
 		errors.Wrap(err, "daily_latest update failed")
 	}
 


### PR DESCRIPTION
I created two recurrent scan jobs with the same schedule. They targetted the same nodes. This caused ingestion on a number of scan jobs to conflict in ElasticSearch when doing the update in the `setDailyLatestToFalse` function.

```
Report processing error: rpc error: code = Internal desc = elastic: Error 409 (Conflict) elastic: Error 409 (Conflict)
```

![Screen Shot 2019-06-14 at 8 16 59 PM](https://user-images.githubusercontent.com/107378/59532718-74361d00-8ee1-11e9-838c-50c4dc87f1b0.png)


The report would be ingested, but because of the update failure, the scan job is failed and no link to see the results from the scan jobs page.

We have two options here:
1. Use ProceedOnVersionConflict to abort the update but not fail the request.
2. Implement a retry logic in go for the NewUpdateByQueryService call.

The PR implements `1.` and testing shows the scan jobs completing.