### PR TITLE
Cover more ui cases with studio helper

### DIFF
--- a/.studio/applications-service
+++ b/.studio/applications-service
@@ -316,6 +316,32 @@ function applications_populate_database() {
       --origin custom --version "1.9.2" --release "20190115181111" --health 0\
       --sup-id "$(uuidgen)"
   done
+
+  # We have a custom visual treatment when application, environment, or channel
+  # are blank. Create one of each
+  applications_publish_supervisor_message --name "blank-app" --group "default"\
+    --origin custom --version "0.0.1" --release "20190115184890" --health 1\
+    --sup-id "$(uuidgen)" --site "default" --channel "stable" \
+    --application ""
+
+  applications_publish_supervisor_message --name "blank-env" --group "default"\
+    --origin custom --version "0.0.1" --release "20190115184890" --health 1\
+    --sup-id "$(uuidgen)" --site "default" --channel "stable" \
+    --environment ""
+
+  applications_publish_supervisor_message --name "blank-channel" --group "default"\
+    --origin custom --version "0.0.1" --release "20190115184890" --health 1\
+    --sup-id "$(uuidgen)" --site "default" --channel ""
+
+  ##
+  # Make enough service groups to force pagination. We need at least 26 groups
+  # to force pagination to happen. We also don't want to have to remember to
+  # update this part of the code if we modify the stuff above. So we just make
+  # 26 here and pagination will always happen.
+  for i in $(seq 26); do
+    applications_publish_supervisor_message --name "example$i" --group "acceptance"\
+      --origin custom --version "0.0.1" --health 0 --sup-id "$(uuidgen)"
+  done
 }
 
 function app_service_origin() {

--- a/.studio/applications-service
+++ b/.studio/applications-service
@@ -317,6 +317,22 @@ function applications_populate_database() {
       --sup-id "$(uuidgen)"
   done
 
+  ##
+  # Service groups with a larger set of health statuses. This excercises some
+  # filtering cases, such as whether a service group with 1 service in critical
+  # and 1 warning shows up when filtering for warning.
+  for health_code in $(seq 0 3); do
+    applications_publish_supervisor_message --name "pos-terminal" --group "us-east-1" \
+      --origin custom --version "2.3.4" --release "20190115181111" --health "$health_code" \
+      --sup-id "$(uuidgen)"
+  done
+
+  for health_code in 0 1 3 ; do
+    applications_publish_supervisor_message --name "pos-terminal" --group "us-east-2" \
+      --origin custom --version "2.3.4" --release "20190115181111" --health "$health_code" \
+      --sup-id "$(uuidgen)"
+  done
+
   # We have a custom visual treatment when application, environment, or channel
   # are blank. Create one of each
   applications_publish_supervisor_message --name "blank-app" --group "default"\

--- a/.studio/applications-service
+++ b/.studio/applications-service
@@ -105,7 +105,7 @@ function applications_benchmarks() {
     log_line "Generating HTML of the results at $(green $results_html)"
     benchstat -html $results_txt > $results_html
 
-    rename_benchmark_files
+    rename_benchmark_files "$@"
   )
 }
 
@@ -240,57 +240,57 @@ DOC
 function applications_populate_database() {
   install_if_missing core/util-linux uuidgen
 
-  for i in $(seq 1 12); do
+  for _ in $(seq 1 12); do
     applications_publish_supervisor_message --name nginx --group "kansas-prod"\
       --origin custom --version "1.0.1" --release "20190115184823" --health 2\
       --sup-id "$(uuidgen)" --site "testsite" --channel "stable"
   done
 
-  for i in $(seq 1 11); do
+  for _ in $(seq 1 11); do
     applications_publish_supervisor_message --name "billing-svc" --group "kansas-prod"\
       --origin custom --version "1.3.4" --release "20190115182382" --health 2\
       --sup-id "$(uuidgen)" --site "testsite" --channel "stable"
   done
 
   # 40 Critical
-  for i in $(seq 1 40); do
+  for _ in $(seq 1 40); do
     applications_publish_supervisor_message --name nginx --group dev\
       --origin custom --version "2.0.0" --release "20190115189976" --health 2\
       --sup-id "$(uuidgen)" --site "testsite" --channel "unstable"
   done
   # 10 OK
-  for i in $(seq 41 50); do
+  for _ in $(seq 41 50); do
     applications_publish_supervisor_message --name nginx --group dev\
       --origin custom --version "2.0.0" --release "20190115189976" --health 0\
       --sup-id "$(uuidgen)" --site "testsite" --channel "unstable"
   done
 
   # 40 Critical
-  for i in $(seq 1 40); do
+  for _ in $(seq 1 40); do
     applications_publish_supervisor_message --name redis --group default\
       --origin custom --version "1.0.1" --release "20190115189830" --health 2\
       --sup-id "$(uuidgen)" --site "default" --channel "stable"
   done
   # 10 OK
-  for i in $(seq 41 50); do
+  for _ in $(seq 41 50); do
     applications_publish_supervisor_message --name redis --group default\
       --origin custom --version "1.0.1" --release "20190115189830" --health 0\
       --sup-id "$(uuidgen)" --site "default" --channel "stable"
   done
 
   # Sample-app
-  for i in $(seq 1 3); do
+  for _ in $(seq 1 3); do
     applications_publish_supervisor_message --name "sample-app" --group "default"\
       --origin custom --version "0.0.1" --release "20190115184890" --health 0\
       --sup-id "$(uuidgen)" --site "default" --channel "stable"
   done
-  for i in $(seq 4 5); do
+  for _ in $(seq 4 5); do
     applications_publish_supervisor_message --name "sample-app" --group "default"\
       --origin custom --version "0.0.1" --release "20190115184890" --health 1\
       --sup-id "$(uuidgen)" --site "default" --channel "stable"
   done
 
-  for i in $(seq 1 4); do
+  for _ in $(seq 1 4); do
     applications_publish_supervisor_message --name "sample-app" --group "test"\
       --origin custom --version "0.0.1" --release "20190115184823" --health 0\
       --sup-id "$(uuidgen)" --site "testsite" --channel "stable"
@@ -304,14 +304,14 @@ function applications_populate_database() {
     --origin custom --version "0.0.1" --health 3 --sup-id "$(uuidgen)"
 
   # postgres.japan-prod
-  for i in $(seq 1 120); do
+  for _ in $(seq 1 120); do
     applications_publish_supervisor_message --name "postgres" --group "japan-prod"\
       --origin custom --version "2.3" --release "20190115184823" --health 0\
       --sup-id "$(uuidgen)"
   done
 
   # postgres.us-west1-prod (different supervisors than the postgres db above)
-  for i in $(seq 121 130); do
+  for _ in $(seq 121 130); do
     applications_publish_supervisor_message --name "postgres" --group "us-west1-prod"\
       --origin custom --version "1.9.2" --release "20190115181111" --health 0\
       --sup-id "$(uuidgen)"


### PR DESCRIPTION
### :nut_and_bolt: Description

Updates the `applications_populate_database` studio function to trigger a few more UI behaviors we have added since it was first written:
* Create enough service groups so that pagination happens
* Create service groups with no "application," this shows up with a special badge
* Create service groups with no "environment," this shows up with a special badge
* Create service groups with no "channel," this shows up with a special badge (on the right side detail panel)

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

1. `start_all_services` in the studio
2. `source .studiorc` to load the new studio helper code
3. `applications_populate_database`
4. Visit the UI at a2-dev.test, you should have more than 25 service groups and service groups that are missing application, environment, and channel (different service group for each case)

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?