### PR TITLE
Case Insensitive wildcard searching

### DIFF
--- a/components/compliance-service/integration_test/reporting_server_list_nodes_test.go
+++ b/components/compliance-service/integration_test/reporting_server_list_nodes_test.go
@@ -361,7 +361,7 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 			expectedIds: []string{"3", "2"},
 		},
 		{
-			description: "chef_server: case insensitive wildcard 1",
+			description: "chef server: case insensitive wildcard 1",
 			reports: []*relaxting.ESInSpecReport{
 				{
 					NodeID:     "1",

--- a/components/compliance-service/integration_test/reporting_server_list_nodes_test.go
+++ b/components/compliance-service/integration_test/reporting_server_list_nodes_test.go
@@ -307,7 +307,6 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 		query       reporting.Query
 		expectedIds []string
 	}{
-
 		// chef server
 		{
 			description: "chef server: '*' wildcard",
@@ -360,6 +359,58 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 				},
 			},
 			expectedIds: []string{"3", "2"},
+		},
+		{
+			description: "chef_server: case insensitive wildcard 1",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:     "1",
+					SourceFQDN: "A2-prod",
+				},
+				{
+					NodeID:     "2",
+					SourceFQDN: "a2-Dev",
+				},
+				{
+					NodeID:     "3",
+					SourceFQDN: "A1-dev",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "chef_server",
+						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "chef_server: case insensitive wildcard 2",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:     "1",
+					SourceFQDN: "A2-prod",
+				},
+				{
+					NodeID:     "2",
+					SourceFQDN: "a2-Dev",
+				},
+				{
+					NodeID:     "3",
+					SourceFQDN: "A1-dev",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "chef_server",
+						Values: []string{"A2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
 		},
 
 		// chef tags
@@ -415,6 +466,58 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 			},
 			expectedIds: []string{"3", "2"},
 		},
+		{
+			description: "chef_tags: case insensitive wildcard 1",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:   "1",
+					ChefTags: []string{"A2-prod"},
+				},
+				{
+					NodeID:   "2",
+					ChefTags: []string{"a2-Dev"},
+				},
+				{
+					NodeID:   "3",
+					ChefTags: []string{"A1-dev"},
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "chef_tags",
+						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "chef_tags: case insensitive wildcard 2",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:   "1",
+					ChefTags: []string{"A2-prod"},
+				},
+				{
+					NodeID:   "2",
+					ChefTags: []string{"a2-Dev"},
+				},
+				{
+					NodeID:   "3",
+					ChefTags: []string{"A1-dev"},
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "chef_tags",
+						Values: []string{"A2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
 
 		// environment
 		{
@@ -468,6 +571,58 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 				},
 			},
 			expectedIds: []string{"3", "2"},
+		},
+		{
+			description: "environment: case insensitive wildcard 1",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:      "1",
+					Environment: "A2-prod",
+				},
+				{
+					NodeID:      "2",
+					Environment: "a2-Dev",
+				},
+				{
+					NodeID:      "3",
+					Environment: "A1-dev",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "environment",
+						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "environment: case insensitive wildcard 2",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:      "1",
+					Environment: "A2-prod",
+				},
+				{
+					NodeID:      "2",
+					Environment: "a2-Dev",
+				},
+				{
+					NodeID:      "3",
+					Environment: "A1-dev",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "environment",
+						Values: []string{"A2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
 		},
 
 		// node
@@ -523,6 +678,58 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 			},
 			expectedIds: []string{"3", "2"},
 		},
+		{
+			description: "node: case insensitive wildcard 1",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:   "1",
+					NodeName: "A2-prod",
+				},
+				{
+					NodeID:   "2",
+					NodeName: "a2-Dev",
+				},
+				{
+					NodeID:   "3",
+					NodeName: "A1-dev",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "node_name",
+						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "node: case insensitive wildcard 2",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:   "1",
+					NodeName: "A2-prod",
+				},
+				{
+					NodeID:   "2",
+					NodeName: "a2-Dev",
+				},
+				{
+					NodeID:   "3",
+					NodeName: "A1-dev",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "node_name",
+						Values: []string{"A2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
 
 		// organization
 		{
@@ -576,6 +783,58 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 				},
 			},
 			expectedIds: []string{"3", "2"},
+		},
+		{
+			description: "organization: case insensitive wildcard 1",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:           "1",
+					OrganizationName: "A2-prod",
+				},
+				{
+					NodeID:           "2",
+					OrganizationName: "a2-Dev",
+				},
+				{
+					NodeID:           "3",
+					OrganizationName: "A1-dev",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "organization",
+						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "organization: case insensitive wildcard 2",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:           "1",
+					OrganizationName: "A2-prod",
+				},
+				{
+					NodeID:           "2",
+					OrganizationName: "a2-Dev",
+				},
+				{
+					NodeID:           "3",
+					OrganizationName: "A1-dev",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "organization",
+						Values: []string{"A2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
 		},
 
 		// platform
@@ -667,6 +926,94 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 			},
 			expectedIds: []string{"3", "2"},
 		},
+		{
+			description: "platform: case insensitive wildcard 1",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID: "1",
+					Platform: struct {
+						Name    string `json:"name"`
+						Release string `json:"release"`
+						Full    string `json:"full"`
+					}{
+						Name: "A2-prod",
+					},
+				},
+				{
+					NodeID: "2",
+					Platform: struct {
+						Name    string `json:"name"`
+						Release string `json:"release"`
+						Full    string `json:"full"`
+					}{
+						Name: "a2-Dev",
+					},
+				},
+				{
+					NodeID: "3",
+					Platform: struct {
+						Name    string `json:"name"`
+						Release string `json:"release"`
+						Full    string `json:"full"`
+					}{
+						Name: "A1-dev",
+					},
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "platform",
+						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "platform: case insensitive wildcard 2",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID: "1",
+					Platform: struct {
+						Name    string `json:"name"`
+						Release string `json:"release"`
+						Full    string `json:"full"`
+					}{
+						Name: "A2-prod",
+					},
+				},
+				{
+					NodeID: "2",
+					Platform: struct {
+						Name    string `json:"name"`
+						Release string `json:"release"`
+						Full    string `json:"full"`
+					}{
+						Name: "a2-Dev",
+					},
+				},
+				{
+					NodeID: "3",
+					Platform: struct {
+						Name    string `json:"name"`
+						Release string `json:"release"`
+						Full    string `json:"full"`
+					}{
+						Name: "A1-dev",
+					},
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "platform",
+						Values: []string{"A2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
 
 		// Policy group
 		{
@@ -720,6 +1067,58 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 				},
 			},
 			expectedIds: []string{"3", "2"},
+		},
+		{
+			description: "policy_group: case insensitive wildcard 1",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:      "1",
+					PolicyGroup: "A2-prod",
+				},
+				{
+					NodeID:      "2",
+					PolicyGroup: "a2-Dev",
+				},
+				{
+					NodeID:      "3",
+					PolicyGroup: "A1-dev",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "policy_group",
+						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "policy_group: case insensitive wildcard 2",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:      "1",
+					PolicyGroup: "A2-prod",
+				},
+				{
+					NodeID:      "2",
+					PolicyGroup: "a2-Dev",
+				},
+				{
+					NodeID:      "3",
+					PolicyGroup: "A1-dev",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "policy_group",
+						Values: []string{"A2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
 		},
 
 		// Policy Name
@@ -775,6 +1174,58 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 			},
 			expectedIds: []string{"3", "2"},
 		},
+		{
+			description: "policy_name: case insensitive wildcard 1",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:     "1",
+					PolicyName: "A2-prod",
+				},
+				{
+					NodeID:     "2",
+					PolicyName: "a2-Dev",
+				},
+				{
+					NodeID:     "3",
+					PolicyName: "A1-dev",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "policy_name",
+						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "policy_name: case insensitive wildcard 2",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:     "1",
+					PolicyName: "A2-prod",
+				},
+				{
+					NodeID:     "2",
+					PolicyName: "a2-Dev",
+				},
+				{
+					NodeID:     "3",
+					PolicyName: "A1-dev",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "policy_name",
+						Values: []string{"A2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
 
 		// Recipe
 		{
@@ -828,6 +1279,58 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 				},
 			},
 			expectedIds: []string{"3", "2"},
+		},
+		{
+			description: "recipe: case insensitive wildcard 1",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:  "1",
+					Recipes: []string{"A2-prod"},
+				},
+				{
+					NodeID:  "2",
+					Recipes: []string{"a2-Dev"},
+				},
+				{
+					NodeID:  "3",
+					Recipes: []string{"A1-dev"},
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "recipe",
+						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "recipe: case insensitive wildcard 2",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:  "1",
+					Recipes: []string{"A2-prod"},
+				},
+				{
+					NodeID:  "2",
+					Recipes: []string{"a2-Dev"},
+				},
+				{
+					NodeID:  "3",
+					Recipes: []string{"A1-dev"},
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "recipe",
+						Values: []string{"A2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
 		},
 
 		// Roles
@@ -883,6 +1386,58 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 			},
 			expectedIds: []string{"3", "2"},
 		},
+		{
+			description: "role: case insensitive wildcard 1",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID: "1",
+					Roles:  []string{"A2-prod"},
+				},
+				{
+					NodeID: "2",
+					Roles:  []string{"a2-Dev"},
+				},
+				{
+					NodeID: "3",
+					Roles:  []string{"A1-dev"},
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "role",
+						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "role: case insensitive wildcard 2",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID: "1",
+					Roles:  []string{"A2-prod"},
+				},
+				{
+					NodeID: "2",
+					Roles:  []string{"a2-Dev"},
+				},
+				{
+					NodeID: "3",
+					Roles:  []string{"A1-dev"},
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "role",
+						Values: []string{"A2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
 
 		// Profile
 		{
@@ -918,6 +1473,82 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 					{
 						Type:   "profile_name",
 						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "Profile: case insensitive wildcard 1",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID: "1",
+					Profiles: []relaxting.ESInSpecReportProfile{
+						{
+							Title: "A2-prod",
+						},
+					},
+				},
+				{
+					NodeID: "2",
+					Profiles: []relaxting.ESInSpecReportProfile{
+						{
+							Title: "A2-dev",
+						},
+					},
+				},
+				{
+					NodeID: "3",
+					Profiles: []relaxting.ESInSpecReportProfile{
+						{
+							Title: "a1-dev",
+						},
+					},
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "profile_name",
+						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "Profile: case insensitive wildcard 2",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID: "1",
+					Profiles: []relaxting.ESInSpecReportProfile{
+						{
+							Title: "A2-prod",
+						},
+					},
+				},
+				{
+					NodeID: "2",
+					Profiles: []relaxting.ESInSpecReportProfile{
+						{
+							Title: "a2-dev",
+						},
+					},
+				},
+				{
+					NodeID: "3",
+					Profiles: []relaxting.ESInSpecReportProfile{
+						{
+							Title: "a1-dev",
+						},
+					},
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "profile_name",
+						Values: []string{"A2-*"},
 					},
 				},
 			},
@@ -970,6 +1601,106 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 					{
 						Type:   "control_name",
 						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "control: case insensitive wildcard 1",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID: "1",
+					Profiles: []relaxting.ESInSpecReportProfile{
+						{
+							Controls: []relaxting.ESInSpecReportControl{
+								{
+									Title: "A2-prod",
+								},
+							},
+						},
+					},
+				},
+				{
+					NodeID: "2",
+					Profiles: []relaxting.ESInSpecReportProfile{
+						{
+							Controls: []relaxting.ESInSpecReportControl{
+								{
+									Title: "A2-dev",
+								},
+							},
+						},
+					},
+				},
+				{
+					NodeID: "3",
+					Profiles: []relaxting.ESInSpecReportProfile{
+						{
+							Controls: []relaxting.ESInSpecReportControl{
+								{
+									Title: "a1-dev",
+								},
+							},
+						},
+					},
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "control_name",
+						Values: []string{"a2-*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "control: case insensitive wildcard 2",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID: "1",
+					Profiles: []relaxting.ESInSpecReportProfile{
+						{
+							Controls: []relaxting.ESInSpecReportControl{
+								{
+									Title: "a2-prod",
+								},
+							},
+						},
+					},
+				},
+				{
+					NodeID: "2",
+					Profiles: []relaxting.ESInSpecReportProfile{
+						{
+							Controls: []relaxting.ESInSpecReportControl{
+								{
+									Title: "A2-dev",
+								},
+							},
+						},
+					},
+				},
+				{
+					NodeID: "3",
+					Profiles: []relaxting.ESInSpecReportProfile{
+						{
+							Controls: []relaxting.ESInSpecReportControl{
+								{
+									Title: "a1-dev",
+								},
+							},
+						},
+					},
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "control_name",
+						Values: []string{"A2-*"},
 					},
 				},
 			},

--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -584,13 +584,13 @@ func (backend ES2Backend) getFiltersQuery(filters map[string][]string, latestOnl
 	}
 
 	if len(filters["control_name"]) > 0 {
-		termQuery := backend.newNestedTermQueryFromFilter("profiles.controls.title", "profiles.controls",
+		termQuery := backend.newNestedTermQueryFromFilter("profiles.controls.title.lower", "profiles.controls",
 			filters["control_name"])
 		boolQuery = boolQuery.Must(termQuery)
 	}
 
 	if len(filters["profile_name"]) > 0 {
-		termQuery := backend.newNestedTermQueryFromFilter("profiles.title", "profiles", filters["profile_name"])
+		termQuery := backend.newNestedTermQueryFromFilter("profiles.title.lower", "profiles", filters["profile_name"])
 		boolQuery = boolQuery.Must(termQuery)
 	}
 
@@ -661,22 +661,23 @@ func (backend ES2Backend) getFiltersQuery(filters map[string][]string, latestOnl
 }
 
 func (backend ES2Backend) getESFieldName(filterType string) string {
+	ESFieldName := filterType
 	switch filterType {
 	case "organization":
-		return "organization_name"
+		ESFieldName = "organization_name"
 	case "chef_server":
-		return "source_fqdn"
+		ESFieldName = "source_fqdn"
 	case "platform":
-		return "platform.name"
+		ESFieldName = "platform.name"
 	case "role":
-		return "roles"
+		ESFieldName = "roles"
 	case "recipe":
-		return "recipes"
+		ESFieldName = "recipes"
 	case "inspec_version":
-		return "version"
-	default:
-		return filterType
+		ESFieldName = "version"
 	}
+
+	return ESFieldName + ".lower"
 }
 
 func (backend ES2Backend) newTermQueryFromFilter(ESField string,

--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -663,21 +663,31 @@ func (backend ES2Backend) getFiltersQuery(filters map[string][]string, latestOnl
 func (backend ES2Backend) getESFieldName(filterType string) string {
 	ESFieldName := filterType
 	switch filterType {
-	case "organization":
-		ESFieldName = "organization_name"
 	case "chef_server":
-		ESFieldName = "source_fqdn"
-	case "platform":
-		ESFieldName = "platform.name"
-	case "role":
-		ESFieldName = "roles"
-	case "recipe":
-		ESFieldName = "recipes"
+		ESFieldName = "source_fqdn.lower"
 	case "inspec_version":
-		ESFieldName = "version"
+		ESFieldName = "version.lower"
+	case "organization":
+		ESFieldName = "organization_name.lower"
+	case "platform":
+		ESFieldName = "platform.name.lower"
+	case "recipe":
+		ESFieldName = "recipes.lower"
+	case "role":
+		ESFieldName = "roles.lower"
+	case "environment":
+		ESFieldName = "environment.lower"
+	case "chef_tags":
+		ESFieldName = "chef_tags.lower"
+	case "policy_group":
+		ESFieldName = "policy_group.lower"
+	case "policy_name":
+		ESFieldName = "policy_name.lower"
+	case "node_name":
+		ESFieldName = "node_name.lower"
 	}
 
-	return ESFieldName + ".lower"
+	return ESFieldName
 }
 
 func (backend ES2Backend) newTermQueryFromFilter(ESField string,


### PR DESCRIPTION
### :nut_and_bolt: Description

Adding case insensitive wildcard searching/filtering when using the compliance reporting search bar.

### :athletic_shoe: Demo Script / Repro Steps

1. `build components/compliance-service && start_all_services`
1. Ingest a few InSpec reports with different nodes. Vary the data for all the searchable fields SourceFQDN, ChefTags, Environment, NodeName, OrganizationName, Platform, PolicyGroup, PolicyName, Recipes, Roles, Profiles Titles, and Controls titles. Use the `send_inspec_example` and the `components/compliance-service/ingest/examples/compliance-success-tiny-report.json` file to create the nodes. Create upper and lower case values. 
1. Open the UI https://a2-dev.test/compliance/reports/overview
1. Test each of the search bar types with the '?' and '*' characters.  

### :chains: Related Resources

https://github.com/chef/automate/issues/325

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
