### PR TITLE
[A2-882] authz-service: fix v1 to v2 policy migration issues with applications

### DIFF
--- a/components/authz-service/README.md
+++ b/components/authz-service/README.md
@@ -615,6 +615,20 @@ For others, it will be necessary to add and remove policies
 to lock the system down so that known users are authorized to access
 specific resources.
 
+#### Adding New Default Policies
+
+To add a new default policy, the following is needed:
+
+1. A new IAM v1 policy: these are defined in [migrations](storage/postgres/migration/sql/),
+   and the [v1 constants package](constants/v1/constants.go#L3-L4).
+2. A new IAM v2 (system) policy: they are defined in [server/v2/system](server/v2/system.go#L31).
+3. A new IAM v2 default policy (which can be deleted by users), or any additions
+   to default roles, are done in [datamigrations](storage/postgres/datamigration/sql/).
+3. Migration logic: When upgrading from IAM v1 to v2 (v2.1), v1 policies are
+   converted. The conversion logic needs to be made aware of the new v1 policies, and
+   how (and if) they are to be migrated (if they haven't been deleted). The procedure for
+   converting legacy policies is defined in [server/v2/migration](server/v2/migration.go).
+
 ### Policy API
 
 Documentation of the complete Policy API are available [here](TBD).

--- a/components/authz-service/server/v2/migration.go
+++ b/components/authz-service/server/v2/migration.go
@@ -506,6 +506,8 @@ func convertV1Resource(resource string) ([]string, error) {
 		return combineTermsIntoResourceSlice(terms), nil
 	case "*":
 		return []string{"*"}, nil
+	case "service_groups":
+		return []string{"applications:serviceGroups"}, nil
 	default:
 		return nil, fmt.Errorf("did not recognize base v1 resource term: %s", terms[0])
 	}

--- a/components/authz-service/server/v2/migration.go
+++ b/components/authz-service/server/v2/migration.go
@@ -507,8 +507,6 @@ func convertV1Resource(resource string) ([]string, error) {
 	case "*":
 		return []string{"*"}, nil
 	default:
-		// TODO: should we just warn the logs in this case and not crash the whole migration on the off
-		// chance that the user created a policy where they mistyped a resource name?
 		return nil, fmt.Errorf("did not recognize base v1 resource term: %s", terms[0])
 	}
 }

--- a/components/authz-service/server/v2/migration.go
+++ b/components/authz-service/server/v2/migration.go
@@ -126,6 +126,7 @@ var v1PoliciesToSkip = map[string]struct{}{
 	constants_v1.OcErchefIngestEventsPolicyID:           {},
 	constants_v1.CSNginxComplianceProfilesPolicyID:      {},
 	constants_v1.CSNginxComplianceDataCollectorPolicyID: {},
+	constants_v1.ApplicationsServiceGroupsPolicyID:      {},
 }
 
 var v1CfgmgmtPolicies = map[string]struct{}{

--- a/components/authz-service/server/v2/migration_internal_test.go
+++ b/components/authz-service/server/v2/migration_internal_test.go
@@ -2239,6 +2239,21 @@ func TestV1PolicyMigration(t *testing.T) {
 				}),
 			),
 		},
+		"service_groups,list": {
+			storage_v1.Policy{
+				ID:       polID,
+				Subjects: []string{"user:local:albertine", "team:local:admins"},
+				Action:   "list",
+				Resource: "service_groups",
+			},
+			checks(
+				hasStatements(storage_v2.Statement{
+					Effect:    storage_v2.Allow,
+					Resources: []string{"applications:serviceGroups"},
+					Actions:   []string{"*:list"},
+				}),
+			),
+		},
 		"v1 default compliance token upload profile policy": {
 			wellknown(t, constants_v1.ComplianceTokenUploadProfilesPolicyID),
 			checks(hasID(constants_v2.ComplianceTokenPolicyID)),

--- a/components/authz-service/server/v2/migration_internal_test.go
+++ b/components/authz-service/server/v2/migration_internal_test.go
@@ -2279,6 +2279,10 @@ func TestV1PolicyMigration(t *testing.T) {
 			wellknown(t, constants_v1.CSNginxComplianceDataCollectorPolicyID),
 			checks(isSkipped()),
 		},
+		"v1 default application policy": {
+			wellknown(t, constants_v1.ApplicationsServiceGroupsPolicyID),
+			checks(isSkipped()),
+		},
 	}
 
 	for desc, test := range cases {


### PR DESCRIPTION
### :nut_and_bolt: Description

- [X] skip the v1 default policy for `service_groups`: it's implemented by additions to the `viewer` and `editor` roles in v2 (v2.1)
- [X] add an integration test to ensure we don't introduce "unknown well-known" (🤦‍♂) v1 policies again
- [x] add the required mapping logic to have customers' v1 policies for `service_groups` properly migrated
- [X] add some docs indicating how to properly add new default policies to A2

### :+1: Definition of Done

- Three ✅ above.

### :athletic_shoe: Demo Script / Repro Steps

- `rebuild components/authz-service`
- `chef-automate iam reset-to-v1`
- `export TOK=$(chef-automate admin-token)`
- create a custom `service_groups` v1 policy:
   ```
   curl -kH "api-token: $TOK" https://localhost/api/v0/auth/policies -d '{"action":"*","subjects" ["user:*"],"resource":"service_groups","effect":"allow"}'
   ```
- upgrade to v2:
```
# chef-automate iam upgrade-to-v2

Upgrading to IAM v2
Migrating v1 policies...
Creating default teams Editors and Viewers...
Skipped: Editors team already exists
Skipped: Viewers team already exists

Migrating existing teams...

Success: Enabled IAM v2
```
☝️ notice that there's none of these errors anymore:
```
Skipped policies:
  convert v1 policy "aee14d59-da0b-4974-ba6d-1a018b024874"
  unknown "well-known" policy

  convert v1 policy "9afdf13e-74ab-4797-8a31-32ece05938b4"
  could not derive v2 resource: did not recognize base v1 resource term: service_groups
```

### :chains: Related Resources

- [A2-882](https://chefio.atlassian.net/browse/A2-882)
- #462 

### :white_check_mark: Checklist

- [X] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [X] Code actually executed?
- [X] Vetting performed (unit tests, lint, etc.)?
