### PR TITLE
automate-gateway: add ?pretty parameter to every grpc-gateway method

### DIFF
--- a/components/automate-chef-io/content/docs/api-tokens.md
+++ b/components/automate-chef-io/content/docs/api-tokens.md
@@ -125,5 +125,5 @@ compliance resource.
 
    ```bash
    export TOK=<your_admin_api_token>
-   curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["token:95aef20b-0a4e-4698-bd69-ce2cf44c2e35"], "action":"read", "resource":"compliance:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies | jq
+   curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["token:95aef20b-0a4e-4698-bd69-ce2cf44c2e35"], "action":"read", "resource":"compliance:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies?pretty
    ```

--- a/components/automate-chef-io/content/docs/authorization-overview.md
+++ b/components/automate-chef-io/content/docs/authorization-overview.md
@@ -71,14 +71,14 @@ but for most instances, restricting at the uppermost namespace will suffice.
 A command to create a policy has this form:
 
 ```bash
-curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["subject1", "subject2"], "action":"whatever_action", "resource":"whatever_resource"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies | jq
+curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["subject1", "subject2"], "action":"whatever_action", "resource":"whatever_resource"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies?pretty
 ```
 
 Here is a concrete example, granting `read` permission for the user `user@example.com`
 and for the members of `team:ldap:ops` on resource `cfgmgmt:nodes:*`:
 
 ```bash
-curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["user:local:user@example.com"], "action":"read", "resource":"cfgmgmt:nodes:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies | jq
+curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["user:local:user@example.com"], "action":"read", "resource":"cfgmgmt:nodes:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies?pretty
 ```
 
 ### Action
@@ -356,7 +356,7 @@ Before exercising any of the commands in the remainder of this document:
 Use the following `curl` command to list all existing policies:
 
 ```bash
-curl -s -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/policies | jq
+curl -s -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/policies?pretty
 ```
 
 ### List Specific Existing Policies
@@ -392,7 +392,7 @@ This may be a policy that gives permissions directly to a user, but more likely 
 1. Use the ID of the policy to delete it (replace the `{id}` placeholder with the actual ID):
 
     ```bash
-    curl -s -X DELETE -H "api-token: $TOK" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/policies/{id} | jq
+    curl -s -X DELETE -H "api-token: $TOK" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/policies/{id}?pretty
     ```
 
 ## Common Use Cases
@@ -420,7 +420,7 @@ access to all resources with the command below.
 and it grants full access to all of Chef Automate's resources.
 
 ```bash
-curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["user:ldap:example_user@example.com"], "action":"*", "resource":"*"}' https:/{{< example_fqdn "automate" >}}/api/v0/auth/policies | jq
+curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["user:ldap:example_user@example.com"], "action":"*", "resource":"*"}' https:/{{< example_fqdn "automate" >}}/api/v0/auth/policies?pretty
 ```
 
 *NOTE*: Use [chef-automate iam admin-access restore]({{< relref "cli-chef-automate.md" >}}) if you wish to restore the factory default administrator access settings after modifying the `admins` team or `Local Administrator` .
@@ -470,7 +470,7 @@ To remove that access, delete policies permitting all users to access `cfgmgmt` 
 1. Delete those policies using their IDs, one at a time (replace the `{id}` placeholder with the actual ID):
 
     ```bash
-    curl -s -X DELETE -H "api-token: $TOK" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/policies/{id} | jq
+    curl -s -X DELETE -H "api-token: $TOK" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/policies/{id}?pretty
     ```
 
    Now only users with admin-level permissions have access to anything related
@@ -488,7 +488,7 @@ here's how you would give that permission to a specific user or team:
 1. Create a new policy permitting the specified teams/users to access Configuration Management:
 
     ```bash
-    curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["team:saml:ops"], "action":"*", "resource":"cfgmgmt:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies | jq
+    curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["team:saml:ops"], "action":"*", "resource":"cfgmgmt:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies?pretty
     ```
 
    Now only members of the `ops` team may access Configuration Management data and functionality.
@@ -509,15 +509,15 @@ In this situation, you'll want to delete the default policies for both Configura
 1. Delete each of those policies using their IDs (replace the `{id}` placeholder with the actual ID):
 
     ```bash
-    curl -s -X DELETE -H "api-token: $TOK" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/policies/{id} | jq
+    curl -s -X DELETE -H "api-token: $TOK" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/policies/{id}?pretty
     ```
 
 1. Create policies permitting the specified teams/users to access `cfgmgmt` and `compliance` as necessary:
 
     ```bash
-    curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["team:ldap:ops"], "action":"*", "resource":"cfgmgmt:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies | jq
+    curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["team:ldap:ops"], "action":"*", "resource":"cfgmgmt:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies?pretty
 
-    curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["team:ldap:sec"], "action":"*", "resource":"compliance:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies | jq
+    curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["team:ldap:sec"], "action":"*", "resource":"compliance:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies?pretty
     ```
 
 In this example, only members of the `ops` LDAP team can access Configuration Management data
@@ -540,5 +540,5 @@ and functionality, while members of the `sec` LDAP team can access Compliance da
 1. Create policies to permit that client to read `compliance:*`
 
     ```bash
-    curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["token:95aef20b-0a4e-4698-bd69-ce2cf44c2e35"], "action":"read", "resource":"compliance:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies | jq
+    curl -s -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"subjects":["token:95aef20b-0a4e-4698-bd69-ce2cf44c2e35"], "action":"read", "resource":"compliance:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies?pretty
     ```

--- a/components/automate-chef-io/content/docs/configuration.md
+++ b/components/automate-chef-io/content/docs/configuration.md
@@ -86,7 +86,7 @@ and copy the User ID, then use:
 ```bash
 export TOK=`chef-automate admin-token`
 
-curl -X PUT -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"name":"Local Administrator", "id": "<admin user ID>", "password":"<password>"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/users/admin | jq
+curl -X PUT -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"name":"Local Administrator", "id": "<admin user ID>", "password":"<password>"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/users/admin?pretty
 ```
 
 #### Load Balancer Certificate and Private Key

--- a/components/automate-chef-io/content/docs/iam-v2-api-reference.md
+++ b/components/automate-chef-io/content/docs/iam-v2-api-reference.md
@@ -33,7 +33,7 @@ See the [IAM v2 User's Guide]({{< relref "iam-v2-guide.md" >}}) for more informa
 ### Listing Policies
 
 ```bash
-curl -s -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies | jq
+curl -s -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies?pretty
 ```
 
 The output includes both `Chef-managed` and `custom` policies.
@@ -51,7 +51,7 @@ Find the `id` field for the policy of interest--for example, the ID from the def
 Plug that in to the URL as shown:
 
 ```bash
-curl -s -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/administrator-access | jq
+curl -s -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/administrator-access?pretty
 ```
 
 In the browser: Navigate to the *Policies* page under the **Settings**  tab, and then select an individual policy to open its details.
@@ -88,7 +88,7 @@ You can see the actions contained in the `editor` role in the [Roles section]({{
 Assuming you stored the above JSON in the file "policy.json", pass it to `curl` to create the policy:
 
 ```bash
-curl -s -H "api-token: $TOK" -d @policy.json https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies | jq
+curl -s -H "api-token: $TOK" -d @policy.json https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies?pretty
 ```
 
 ### Updating a Policy
@@ -129,13 +129,13 @@ As an example, to update the example policy to keep the first policy statement a
 To update your policy, replace the last component of the path in the command with the ID of the target policy.
 
 ```bash
-curl -s -H "api-token: $TOK" -d @policy.json -X PUT https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id} | jq
+curl -s -H "api-token: $TOK" -d @policy.json -X PUT https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}?pretty
 ```
 
 You can also make the change specifying the data inline:
 
 ```bash
-curl -s -H "api-token: $TOK" -d '{"name":"Test Policy", "id":"test-policy", "members":["team:local:alpha","team:ldap:beta"], "statements": [{"actions": [ "iam:users:list"], "effect": "ALLOW"}]}' -X PUT https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id} | jq
+curl -s -H "api-token: $TOK" -d '{"name":"Test Policy", "id":"test-policy", "members":["team:local:alpha","team:ldap:beta"], "statements": [{"actions": [ "iam:users:list"], "effect": "ALLOW"}]}' -X PUT https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}?pretty
 ```
 
 ### Policy Membership
@@ -153,7 +153,7 @@ From the command line, specifying a complete list of members is often simpler th
 This command *replaces* the policy's membership.
 
 ```bash
-curl -s -H "api-token: $TOK" -X PUT -d '{"members":["team:local:admins","token:admin-token"]}' https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}/members | jq
+curl -s -H "api-token: $TOK" -X PUT -d '{"members":["team:local:admins","token:admin-token"]}' https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}/members?pretty
 ```
 
 #### Adding Members to Policies
@@ -163,7 +163,7 @@ The `members` property must be an array argument, even if supplying only one mem
 Note that both the HTTP method (PUT above and POST here) and the URL are different than the command used for [setting policy membership]({{< relref "iam-v2-api-reference.md#setting-policy-membership" >}}).
 
 ```bash
-curl -s -H "api-token: $TOK" -X POST -d '{"members":["team:local:editors"]}' https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}/members:add | jq
+curl -s -H "api-token: $TOK" -X POST -d '{"members":["team:local:editors"]}' https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}/members:add?pretty
 ```
 
 In the browser: Navigate to the *Policies* page under the **Settings** tab. and select an individual policy to open its detail view.
@@ -179,7 +179,7 @@ This example removes the `team:local:admins` team from the policy.
 Note that the `members` property must be an array argument, even if only supplying one member.
 
 ```bash
-curl -s -H "api-token: $TOK" -X POST -d '{"members":["team:local:admins"]}' https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}/members:remove | jq
+curl -s -H "api-token: $TOK" -X POST -d '{"members":["team:local:admins"]}' https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}/members:remove?pretty
 ```
 
 In the browser: Navigate to the *Policies* page under the **Settings** tab., and then select an individual policy to open its detail view.
@@ -194,7 +194,7 @@ See [Listing Policies]({{< relref "iam-v2-api-reference.md#listing-policies" >}}
 Use the policy ID as the final path component to delete a policy:
 
 ```bash
-curl -s -H "api-token: $TOK" -X DELETE https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id} | jq
+curl -s -H "api-token: $TOK" -X DELETE https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}?pretty
 ```
 
 In the browser: Navigate to the *Policies* page under the **Settings** tab., and then find the policy you wish to delete.
@@ -216,7 +216,7 @@ Ingest      | ingest      | `infra:ingest:*`, `compliance:profiles:get`, `compli
 ### Listing Roles
 
 ```bash
-curl -s -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles | jq
+curl -s -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles?pretty
 ```
 
 The output details each role name, role type, and actions it contains.
@@ -231,7 +231,7 @@ This may be obtained by first fetching the list of all roles; see [Listing Roles
 Use the role ID as the final path component to fetch a role:
 
 ```bash
-curl -s -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles/editor | jq
+curl -s -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles/editor?pretty
 ```
 
 In the browser: Navigate to the *Roles* page under the **Settings** tab, and then select an individual role to open its detail view.
@@ -242,7 +242,7 @@ In the IAM v2 beta, custom roles must be created on the command line.
 Use the following `curl` command to create a role combining some editor actions with some administrator actions:
 
 ```bash
-curl -s -H "api-token: $TOK" -d '{"name": "Test Role", "id": "test-role-1", "actions": ["infra:*", "compliance:*", "teams:*", "users:*"] }' https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles | jq
+curl -s -H "api-token: $TOK" -d '{"name": "Test Role", "id": "test-role-1", "actions": ["infra:*", "compliance:*", "teams:*", "users:*"] }' https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles?pretty
 ```
 
 ### Updating a Role
@@ -251,7 +251,7 @@ In the IAM v2 beta, custom roles must be updated on the command line.
 Use the following command to update the previously created role to remove the action `infra:*`:
 
 ```bash
-curl -s -H "api-token: $TOK" -d '{"name": "Test Role", "actions": ["compliance:*", "teams:*", "users:*"] }' -X PUT https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles/test-role-1 | jq
+curl -s -H "api-token: $TOK" -d '{"name": "Test Role", "actions": ["compliance:*", "teams:*", "users:*"] }' -X PUT https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles/test-role-1?pretty
 ```
 
 It is important to note that for the `actions` property in the JSON you must specify the complete list of actions.
@@ -264,7 +264,7 @@ Use the following command to delete the previously created role.
 Use the role ID as the final path component to delete a role:
 
 ```bash
-curl -s -H "api-token: $TOK" -X DELETE https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles/test-role-1 | jq
+curl -s -H "api-token: $TOK" -X DELETE https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles/test-role-1?pretty
 ```
 
 ## Tokens
@@ -277,7 +277,7 @@ To specify tokens in a [member expression]({{< relref "iam-v2-overview.md#member
 List all tokens with this command:
 
 ```bash
-curl -s -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/tokens | jq
+curl -s -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/tokens?pretty
 ```
 
 ## Restoring Admin Access

--- a/components/automate-chef-io/content/docs/teams.md
+++ b/components/automate-chef-io/content/docs/teams.md
@@ -56,7 +56,7 @@ Now, you can [create a new policy]({{< ref "authorization-overview.md#common-use
 To create a Chef Automate team, you'll need to provide a name and description. Team names must be unique.
 
 ```bash
-curl -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"name":"Team Name", "description":"My Chef Team"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/teams | jq
+curl -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"name":"Team Name", "description":"My Chef Team"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/teams?pretty
 ```
 
 ### Fetching Teams
@@ -64,13 +64,13 @@ curl -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"name":"Team 
 You can fetch a team by its ID:
 
 ```bash
-curl -H  "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/teams/{id} | jq
+curl -H  "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/teams/{id}?pretty
 ```
 
 You can also fetch all teams, collectively:
 
 ```bash
-curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/teams | jq
+curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/teams?pretty
 ```
 
 ### Updating Teams
@@ -78,7 +78,7 @@ curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/te
 To update a team, you must supply its name and description:
 
 ```bash
-curl -X PUT -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"name":"An Updated Team Name", "description": "An updated description"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/teams/{ID} | jq
+curl -X PUT -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"name":"An Updated Team Name", "description": "An updated description"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/teams/{ID}?pretty
 ```
 
 ### Deleting Teams
@@ -96,7 +96,7 @@ curl -X DELETE -H "api-token: $TOK" -H "Content-Type: application/json" https://
 To view a user's teams, you will need the user's ID:
 
 ```bash
-curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/users/{user_ID}/teams | jq
+curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/users/{user_ID}/teams?pretty
 ```
 
 ### Viewing a Team's Users
@@ -104,7 +104,7 @@ curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/us
 To view a team's users, you will need the team's ID. This returns JSON that contains an array of user IDs associated with the team:
 
 ```bash
-curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/teams/{team_ID}/users | jq
+curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/teams/{team_ID}/users?pretty
 ```
 
 ### Adding Users to a Team
@@ -112,7 +112,7 @@ curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/te
 To add users to a team, you will need both the team ID and the IDs of the users you will add:
 
 ```bash
-curl -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"user_ids":["userID", "secondUserID"]}' https://{{< example_fqdn "automate" >}}/api/v0/auth/teams/{team_ID}/users | jq
+curl -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"user_ids":["userID", "secondUserID"]}' https://{{< example_fqdn "automate" >}}/api/v0/auth/teams/{team_ID}/users?pretty
 ```
 
 ### Removing Users from a Team
@@ -158,17 +158,17 @@ You may also complete this operation from the command line.
     Fetch all users (with IDs):
 
     ```bash
-    curl -H "api-token: $TOK" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/users | jq
+    curl -H "api-token: $TOK" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/users?pretty
     ```
 
 1. Add the user(s) to the `admins` team:
 
     ```bash
-    curl -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"user_ids":["userID", "secondUserID]}' https://{{< example_fqdn "automate" >}}/api/v0/auth/teams/$ID/users | jq
+    curl -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"user_ids":["userID", "secondUserID]}' https://{{< example_fqdn "automate" >}}/api/v0/auth/teams/$ID/users?pretty
     ```
 
 1. Verify that the user is a member of the team by listing all members of the `admins` team:
 
     ```bash
-    curl -H "api-token: $TOK" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/teams/$ID/users | jq
+    curl -H "api-token: $TOK" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/teams/$ID/users?pretty
     ```

--- a/components/automate-chef-io/content/docs/users.md
+++ b/components/automate-chef-io/content/docs/users.md
@@ -52,7 +52,7 @@ To create a Chef Automate user, you'll need a name, username, and password.
 The username must be unique.
 
 ```bash
-curl -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"name":"Your Name", "username":"username001rulez", "password":"password"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/users | jq
+curl -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"name":"Your Name", "username":"username001rulez", "password":"password"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/users?pretty
 ```
 
 #### Fetching Users
@@ -61,19 +61,19 @@ You can fetch a single user by username. Keep in mind that certain characters
 in a username (such as a space) may need to be escaped in the URL.
 
 ```bash
-curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/users/username001rulez | jq
+curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/users/username001rulez?pretty
 ```
 
 More generally, here is the format showing a `{username}` placeholder:
 
 ```bash
-curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/users/{username} | jq
+curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/users/{username}?pretty
 ```
 
 You can also fetch a list of all users by omitting the final username segment of the URL:
 
 ```bash
-curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/users | jq
+curl -H "api-token: $TOK" https://{{< example_fqdn "automate" >}}/api/v0/auth/users?pretty
 ```
 
 #### Updating Users
@@ -84,14 +84,14 @@ Then, also in the payload, you must specify the full name--_even if you do not w
 Finally, include the password in the payload, but only if you do want to change it.
 
 ```bash
-curl -X PUT -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"name":"Revised Full Name", "id": "userID", "password": "another_pwd"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/users/{username} | jq
+curl -X PUT -H "api-token: $TOK" -H "Content-Type: application/json" -d '{"name":"Revised Full Name", "id": "userID", "password": "another_pwd"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/users/{username}?pretty
 ```
 
 A non-admin user is also able to change their own password through the UI.
 For completeness, here is the API call to perform the same action.
 
 ```bash
-curl -X PUT -H "api-token: $TOK" -H "Content-Type: application/json" -XPUT -d'{"id":"userID","name":"Revised Full Name","username":"username001rulez","password":"another_pwd","previous_password":"password"}' https://{{< example_fqdn "automate" >}}/api/v0/users/{username} | jq
+curl -X PUT -H "api-token: $TOK" -H "Content-Type: application/json" -XPUT -d'{"id":"userID","name":"Revised Full Name","username":"username001rulez","password":"another_pwd","previous_password":"password"}' https://{{< example_fqdn "automate" >}}/api/v0/users/{username}?pretty
 ```
 
 ### Deleting Users
@@ -99,7 +99,7 @@ curl -X PUT -H "api-token: $TOK" -H "Content-Type: application/json" -XPUT -d'{"
 To delete a user, supply the `username`:
 
 ```bash
-curl -X DELETE -H "api-token: $TOK" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/users/{username} | jq
+curl -X DELETE -H "api-token: $TOK" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/users/{username}?pretty
 ```
 
 ### User Self-Maintenance

--- a/components/automate-gateway/gateway/services.go
+++ b/components/automate-gateway/gateway/services.go
@@ -321,6 +321,7 @@ func versionedRESTMux(grpcURI string, dopts []grpc.DialOption, toggles gwRouteFe
 func muxFromRegisterMap(grpcURI string, dopts []grpc.DialOption, localEndpoints map[string]registerFunc) (*runtime.ServeMux, error) {
 	opts := []runtime.ServeMuxOption{
 		runtime.WithIncomingHeaderMatcher(headerMatcher),
+		runtime.WithMarshalerOption("application/json+pretty", &runtime.JSONPb{OrigName: true, EmitDefaults: true, Indent: "  "}),
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{OrigName: true, EmitDefaults: true}),
 		runtime.WithMetadata(middleware.CertificatePasser),
 	}


### PR DESCRIPTION
Now, if you query, for example, either one of

    https://a2-dev.test/apis/iam/v2beta/policies?pretty
    https://a2-dev.test/apis/iam/v2beta/policies?pretty=1
    https://a2-dev.test/apis/iam/v2beta/policies?pretty=true
    https://a2-dev.test/apis/iam/v2beta/policies?pretty=please

you'll get a pretty-printed JSON response. 
Any handcrafted handlers are _not_ getting this, only the handlers we get from grpc-gateway.

### TODOs
- [x] update docs where we pipe our output into `jq .`
- [x] add integration test