### PR TITLE
UI-508 Client Run Design Updates Signed-Off-By: Tara Black <tblack@ch…

### DIFF
--- a/components/automate-ui/src/app/page-components/client-runs-search-bar/client-runs-search-bar.component.ts
+++ b/components/automate-ui/src/app/page-components/client-runs-search-bar/client-runs-search-bar.component.ts
@@ -271,7 +271,7 @@ export class ClientRunsSearchBarComponent implements OnChanges {
           return `Enter ${normal_type} name`;
       }
     } else {
-      return 'Enter name';
+      return 'Filter by...';
     }
   }
 

--- a/components/automate-ui/src/app/page-components/converge-radial-graph/converge-radial-graph.component.html
+++ b/components/automate-ui/src/app/page-components/converge-radial-graph/converge-radial-graph.component.html
@@ -7,7 +7,7 @@ after the async onInit function runs -->
 </chef-alert>
 <div class="chart-container"  *ngIf="count !== undefined">
   <div class="label">
-    <div class="display3">Chef Client Run Status</div>
+    <h2 class="display3">Chef Client Run Status</h2>
 
     <div class="chart-legend">
       <div class="display5">

--- a/components/automate-ui/src/app/page-components/converge-radial-graph/converge-radial-graph.component.scss
+++ b/components/automate-ui/src/app/page-components/converge-radial-graph/converge-radial-graph.component.scss
@@ -4,7 +4,7 @@
   display: flex;
   justify-content: space-between;
   background-color: $chef-white;
-  padding: 20px 0 20px 20px;
+  padding: 0 20px;
   width: 50%;
   border-radius: $global-radius;
   box-shadow: 0 0 16px 0 $chef-light-grey;
@@ -12,8 +12,12 @@
   .label {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: space-evenly;
     color: inherit;
+  }
+
+  h2 {
+    font-weight: 400;
   }
 
   .chart-legend {

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
@@ -20,9 +20,10 @@
     Failed to retrieve data.
   </chef-notification>
   <main>
-    <h1 class="visually-hidden">Node Converge State Page</h1>
     <div class="node-list-container">
       <chef-page-header>
+        <chef-heading>Client Runs</chef-heading>
+        <chef-subheading>Nodes connected to Chef Automate by way of chef-client.</chef-subheading>
 
         <app-client-runs-search-bar
           [numberOfFilters]="numberOfSearchBarFilters$ | async"

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.scss
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.scss
@@ -23,7 +23,10 @@
 
 chef-page-header {
   position: relative;
-  padding-bottom: 35px;
+
+  chef-subheading {
+    padding-bottom: 32px;
+  }
 }
 
 app-client-runs-search-bar {


### PR DESCRIPTION
…ef.io>

<img width="1665" alt="Screen Shot 2019-06-17 at 4 59 08 PM" src="https://user-images.githubusercontent.com/4108100/59639574-44755800-9121-11e9-8192-ad8593271cc7.png">

### :nut_and_bolt: Description
A few design clean-up tasks on the client runs page.

### :+1: Definition of Done
General
Change search box placeholder text from Enter name to Filter by...
Remove the visually-hidden ‌h1 on the page
Remove the padding-bottom: 35px; from the bottom of the chef-page-header

Header Updates
Add a chef-heading of Client Runs
Add a chef-subheading of Nodes connected to Chef Automate by way of chef-client.
Add 32 pixels of space between the subheading and search.

Status Chart Updates
Semantically, change Chef Client Run Status to use an ‌h2
Change the style of Chef Client Run Status to have a weight of 400
Change the chart content to use justify-content: space-evenly instead of justify-content: space-between
Remove the top/bottom 20px padding on the chart container

### :chains: Related Resources
https://github.com/chef/automate/issues/508