### PR TITLE
Set HAB_LICENSE in various CI scripts

### DIFF
--- a/scripts/install_golang
+++ b/scripts/install_golang
@@ -3,6 +3,7 @@ set -euo pipefail
 
 export HAB_NONINTERACTIVE=true
 export HAB_NOCOLORING=true
+export HAB_LICENSE="accept-no-persist"
 
 desired_golang_version() {
     local top_level

--- a/scripts/install_grpcurl
+++ b/scripts/install_grpcurl
@@ -3,6 +3,7 @@ set -euo pipefail
 
 export HAB_NONINTERACTIVE=true
 export HAB_NOCOLORING=true
+export HAB_LICENSE="accept-no-persist"
 
 install_grpcurl() {
   hab pkg install core/grpcurl -b -f

--- a/scripts/install_inspec
+++ b/scripts/install_inspec
@@ -3,6 +3,7 @@ set -euo pipefail
 
 export HAB_NONINTERACTIVE=true
 export HAB_NOCOLORING=true
+export HAB_LICENSE="accept-no-persist"
 
 desired_inspec_version() {
     local top_level


### PR DESCRIPTION
These scripts are used by the compliance tests to install the correct
versions of dependencies. The hab licensing changes require us to
accept the license.

Signed-off-by: Steven Danna <steve@chef.io>