### PR TITLE
[BugFix] Load pagination controls on component initialization

### DIFF
--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -4,7 +4,7 @@
   <chef-subheading>Group of Habitat services running the same package and configuration.</chef-subheading>
 </chef-page-header>
 <div class="page-body">
-  <chef-status-filter-group [value]="selectedStatus$ | async">
+  <chef-status-filter-group [value]="selectedStatus">
     <chef-option class="filter general" value="total" (click)="statusFilter('total')" selected>
       <chef-icon class="filter-icon">group_work</chef-icon>
       <div class="filter-label">Total</div>

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.spec.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.spec.ts
@@ -112,6 +112,28 @@ describe('ServiceGroupsComponent', () => {
   });
 
   describe('onToggleSort', () => {
+    describe('with defaults', () => {
+      it('should return "name" as sorting field', () => {
+        expect(component.defaultSortField ).toEqual('percent_ok');
+        expect(component.currentSortField ).toEqual('percent_ok');
+        expect(component.currentFieldDirection).toEqual('ASC');
+      });
+
+      it('should change sort direction on already selected sorting field', () => {
+        spyOn(component.router, 'navigate');
+        component.onToggleSort('percent_ok');
+        expect(component.router.navigate).toHaveBeenCalledWith(
+          [], {queryParams: { sortField: ['percent_ok'], sortDirection: ['DESC'] }});
+      });
+    });
+
+    it('when set to an allowed value', () => {
+      spyOn(component.router, 'navigate');
+      component.onToggleSort('environment');
+      expect(component.router.navigate).toHaveBeenCalledWith(
+        [], {queryParams: { sortField: ['environment'], sortDirection: ['ASC'] }});
+    });
+
     it('when set to an allowed value', () => {
       spyOn(component.router, 'navigate');
       component.onToggleSort('name');
@@ -121,9 +143,9 @@ describe('ServiceGroupsComponent', () => {
 
     it('when set to an allowed value', () => {
       spyOn(component.router, 'navigate');
-      component.onToggleSort('percent_ok');
+      component.onToggleSort('app_name');
       expect(component.router.navigate).toHaveBeenCalledWith(
-        [], {queryParams: { sortField: ['percent_ok'], sortDirection: ['ASC'] }});
+        [], {queryParams: { sortField: ['app_name'], sortDirection: ['ASC'] }});
     });
   });
 

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.spec.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.spec.ts
@@ -63,9 +63,7 @@ describe('ServiceGroupsComponent', () => {
 
       describe('and OK status filter update', () => {
         beforeEach(() => {
-          this.ngrxStore.dispatch(new UpdateServiceGroupFilters({filters: {
-            status: 'ok',
-          }}));
+          this.ngrxStore.dispatch(new UpdateServiceGroupFilters({filters: {status: 'ok'}}));
         });
 
         it('should update the total number of service groups and selected status', fakeAsync(() => {


### PR DESCRIPTION
### :nut_and_bolt: Description
If you navigate to `/applications` and have 26+ service groups, you don't see the pagination controls. If you change the status filters, then the pagination controls will appear.

**EXTRA:** Found out that we didn't write tests for the new default sorting field `percent_ok`, so I added them here.

### :+1: Definition of Done
Pagination controls should work on the first load of the Applications Tab page.

### :athletic_shoe: Demo Script / Repro Steps

1) Run automate-ui unit tests!
2) Build and start the automate-ui and all automate services.
3) Ingest a few services messages by using the studio helper:
```
[3][default:/src:0]# for i in a b c d e f g h i j k l m n o p q r s t u v w x y z; do
applications_publish_supervisor_message --sup-id $(uuidgen) --name $i
done
```

The UI should show the paginator at the end of the page like this:
![image](https://user-images.githubusercontent.com/5712253/59674270-3ed04e80-91c3-11e9-8873-d8dc03d0f4e1.png)


### :chains: Related Resources
Jira: https://chefio.atlassian.net/browse/A2-883
Closes https://github.com/chef/automate/issues/620

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
