### PR TITLE
Adding error message to csv export

### DIFF
--- a/components/config-mgmt-service/grpcserver/node_export.go
+++ b/components/config-mgmt-service/grpcserver/node_export.go
@@ -58,8 +58,8 @@ type displayNode struct {
 	SourceFqdn         string                  `csv:"Source FQDN" json:"source_fqdn"`
 	IpAddress          string                  `csv:"IP Address" json:"ip_address"`
 	Deprecations       []backend.Deprecation   `csv:"-" json:"deprecations"`
-	Error              backend.ChefError       `csv:"-" json:"error"`
 	ExpandedRunList    backend.ExpandedRunList `csv:"-" json:"expanded_run_list"`
+	ErrorMessage       string                  `csv:"Error Message" json:"error_message"`
 }
 
 // === missing fields ===
@@ -264,8 +264,8 @@ func nodeToDisplayNode(node backend.Node) displayNode {
 		PolicyGroup:        node.PolicyGroup,
 		PolicyRevision:     node.PolicyRevision,
 		SourceFqdn:         node.SourceFqdn,
-		Error:              backend.ChefError(node.Error),
 		ExpandedRunList:    backend.ExpandedRunList(node.ExpandedRunList),
 		Deprecations:       deprecations,
+		ErrorMessage:       node.ErrorMessage,
 	}
 }


### PR DESCRIPTION
### :nut_and_bolt: Description

Adding the error message to the CSV and JSON client runs export. An error message will be included in the export if the node is in a failed state

### :athletic_shoe: Demo Script / Repro Steps
1. `build components/config-mgmt-service && start_all_services`
1. `send_chef_run_failure_example`
1. Open https://a2-dev.test/client-runs
1. Export the node list as CSV
1. Ensure there is a column labeled 'Error Message' with a message for the exported node
1. Export the node list as JSON
1. Ensure there is a field 'error_message' with a message. 

### :chains: Related Resources

https://github.com/chef/automate/issues/447

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
