### PR TITLE
inspec: temporarily comment out flaky Rule API tests

### DIFF
--- a/inspec/a2-api-integration/controls/iam_v2.rb
+++ b/inspec/a2-api-integration/controls/iam_v2.rb
@@ -1020,17 +1020,19 @@ control 'iam-v2-1' do
         expect(resp.http_status.to_s).to match(/200|404/)
       end
 
-      it "GET /iam/v2beta/projects/:id/rules returns the rules for the project" do
-        resp = automate_api_request("/apis/iam/v2beta/projects/#{CUSTOM_PROJECT_ID}/rules")
-        expect(resp.http_status).to eq 200
-        expect(resp.parsed_response_body[:rules]).to match_array([CUSTOM_RULE_1, CUSTOM_RULE_2])
-      end
+      # TODO uncomment once ListRulesForProject has been refactored with staged rules
+      # it "GET /iam/v2beta/projects/:id/rules returns the rules for the project" do
+      #   resp = automate_api_request("/apis/iam/v2beta/projects/#{CUSTOM_PROJECT_ID}/rules")
+      #   expect(resp.http_status).to eq 200
+      #   expect(resp.parsed_response_body[:rules]).to match_array([CUSTOM_RULE_1, CUSTOM_RULE_2])
+      # end
 
-      it "GET /iam/v2beta/rules returns all the rules" do
-        resp = automate_api_request("/apis/iam/v2beta/rules")
-        expect(resp.http_status).to eq 200
-        expect(resp.parsed_response_body[:rules]).to match_array([CUSTOM_RULE_1, CUSTOM_RULE_2, CUSTOM_RULE_3])
-      end
+      # TODO uncomment once ListRules has been refactored with staged rules
+      # it "GET /iam/v2beta/rules returns all the rules" do
+      #   resp = automate_api_request("/apis/iam/v2beta/rules")
+      #   expect(resp.http_status).to eq 200
+      #   expect(resp.parsed_response_body[:rules]).to match_array([CUSTOM_RULE_1, CUSTOM_RULE_2, CUSTOM_RULE_3])
+      # end
 
       it "GET /iam/v2beta/rules/:id returns a specific rule" do
         resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}")
@@ -1038,42 +1040,44 @@ control 'iam-v2-1' do
         expect(resp.parsed_response_body[:rule]).to eq(CUSTOM_RULE_1)
       end
 
-      it "DELETE /iam/v2beta/rules/:id deletes the specific rule" do
-        resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}", http_method: 'DELETE')
-        expect(resp.http_status).to eq 200
-        expect(resp.parsed_response_body[:rule]).to eq(nil)
+      # TODO uncomment once DeleteRule has been refactored with staged rules
+      # it "DELETE /iam/v2beta/rules/:id deletes the specific rule" do
+      #   resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}", http_method: 'DELETE')
+      #   expect(resp.http_status).to eq 200
+      #   expect(resp.parsed_response_body[:rule]).to eq(nil)
 
-        resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}")
-        expect(resp.http_status).to eq 404
-      end
+      #   resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}")
+      #   expect(resp.http_status).to eq 404
+      # end
 
 
-      it "PUT /iam/v2beta/rules/:id updates the rule" do
-        updated_rule = {
-          id: CUSTOM_RULE_1[:id],
-          name: "updated display name",
-          project_id: CUSTOM_RULE_1[:project_id],
-          type: "NODE",
-          conditions: [
-            {
-              attribute: "CHEF_TAGS",
-              operator: "EQUALS",
-              values: ["new tag"]
-            }
-          ]
-        }
+      # TODO uncomment once ListRulesForProject has been refactored with staged rules
+      # it "PUT /iam/v2beta/rules/:id updates the rule" do
+      #   updated_rule = {
+      #     id: CUSTOM_RULE_1[:id],
+      #     name: "updated display name",
+      #     project_id: CUSTOM_RULE_1[:project_id],
+      #     type: "NODE",
+      #     conditions: [
+      #       {
+      #         attribute: "CHEF_TAGS",
+      #         operator: "EQUALS",
+      #         values: ["new tag"]
+      #       }
+      # #     ]
+      # #   }
 
-        resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}",
-          http_method: 'PUT',
-          request_body: updated_rule.to_json
-        )
-        expect(resp.http_status).to eq 200
-        expect(resp.parsed_response_body[:rule]).to eq(updated_rule)
+      #   resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}",
+      #     http_method: 'PUT',
+      #     request_body: updated_rule.to_json
+      #   )
+      #   expect(resp.http_status).to eq 200
+      #   expect(resp.parsed_response_body[:rule]).to eq(updated_rule)
 
-        resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}")
-        expect(resp.http_status).to eq 200
-        expect(resp.parsed_response_body[:rule]).to eq(updated_rule)
-      end
+      #   resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}")
+      #   expect(resp.http_status).to eq 200
+      #   expect(resp.parsed_response_body[:rule]).to eq(updated_rule)
+      # end
 
     end
   end


### PR DESCRIPTION
### :nut_and_bolt: Description

The Rules API is under 🚧 and some of its behavior is changing. Commenting out these tests until their new behavior is finalized

### :+1: Definition of Done

- [x] other Automate PRs are not blocked by flaky tests

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
