### PR TITLE
make json well-formed for compliance export

### DIFF
--- a/components/compliance-service/api/reporting/server/server.go
+++ b/components/compliance-service/api/reporting/server/server.go
@@ -201,12 +201,18 @@ func getExportHandler(format string, stream reporting.ReportingService_ExportSer
 }
 
 func jsonExport(stream reporting.ReportingService_ExportServer) exportHandler {
+	initialRun := true
 	return func(data *reporting.Report) error {
 		raw, err := json.Marshal(data)
 		if err != nil {
 			return fmt.Errorf("Failed to marshal JSON export data: %+v", err)
 		}
 
+		if initialRun {
+			initialRun = false
+		} else {
+			raw = append([]byte(","), raw...)
+		}
 		reader := bytes.NewReader(raw)
 		buf := make([]byte, streamBufferSize)
 

--- a/components/compliance-service/api/tests/export_test.go
+++ b/components/compliance-service/api/tests/export_test.go
@@ -49,6 +49,10 @@ func TestJSONExportWithEndTime(t *testing.T) {
 	require.NoError(t, err)
 
 	data := make([]byte, 0)
+	//the gateway wraps the response in [] because it's a json array
+	//since we are not using the gateway in this test, we need to do that wrapping
+	//here's the '[' (open wrapper)
+	data = append([]byte("["), data...)
 	for {
 		tdata, err := stream.Recv()
 		if err != nil && err == io.EOF {
@@ -59,11 +63,14 @@ func TestJSONExportWithEndTime(t *testing.T) {
 		require.NoError(t, err)
 		data = append(data, tdata.GetContent()...)
 	}
+	//and here's the ']' (close wrapper)
+	data = append(data, []byte("]")...)
 
-	var report rs.Report
-	err = json.Unmarshal(data, &report)
+	var reports []rs.Report
+	err = json.Unmarshal(data, &reports)
 	require.NoError(t, err)
 
+	report := reports[0]
 	assert.Equal(t, 3, len(report.GetProfiles()))
 	assert.Equal(t, "bb93e1b2-36d6-439e-ac70-cccccccccc04", report.GetId())
 	assert.Equal(t, "10.3.4.5", report.Ipaddress)
@@ -93,6 +100,10 @@ func TestJSONExportWithProfileFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	data := make([]byte, 0)
+	//the gateway wraps the response in [] because it's a json array
+	//since we are not using the gateway in this test, we need to do that wrapping
+	//here's the '[' (open wrapper)
+	data = append([]byte("["), data...)
 	for {
 		tdata, err := stream.Recv()
 		if err != nil && err == io.EOF {
@@ -103,11 +114,14 @@ func TestJSONExportWithProfileFilter(t *testing.T) {
 		require.NoError(t, err)
 		data = append(data, tdata.GetContent()...)
 	}
+	//and here's the ']' (close wrapper)
+	data = append(data, []byte("]")...)
 
-	var report rs.Report
-	err = json.Unmarshal(data, &report)
+	var reports []rs.Report
+	err = json.Unmarshal(data, &reports)
 	require.NoError(t, err)
 
+	report := reports[0]
 	assert.Equal(t, 1, len(report.GetProfiles()))
 	assert.Equal(t, "09adcbb3b9b3233d5de63cd98a5ba3e155b3aaeb66b5abed379f5fb1ff143988", report.GetProfiles()[0].GetSha256())
 	assert.Equal(t, "bb93e1b2-36d6-439e-ac70-cccccccccc04", report.GetId())
@@ -286,6 +300,10 @@ func TestJSONExportWithControlFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	data := make([]byte, 0)
+	//the gateway wraps the response in [] because it's a json array
+	//since we are not using the gateway in this test, we need to do that wrapping
+	//here's the '[' (open wrapper)
+	data = append([]byte("["), data...)
 	for {
 		tdata, err := stream.Recv()
 		if err != nil && err == io.EOF {
@@ -296,11 +314,14 @@ func TestJSONExportWithControlFilter(t *testing.T) {
 		require.NoError(t, err)
 		data = append(data, tdata.GetContent()...)
 	}
+	//and here's the ']' (close wrapper)
+	data = append(data, []byte("]")...)
 
-	var report rs.Report
-	err = json.Unmarshal(data, &report)
+	var reports []rs.Report
+	err = json.Unmarshal(data, &reports)
 	require.NoError(t, err)
 
+	report := reports[0]
 	assert.Equal(t, "bb93e1b2-36d6-439e-ac70-cccccccccc04", report.GetId())
 	assert.Equal(t, 1, len(report.GetProfiles()))
 	assert.Equal(t, "09adcbb3b9b3233d5de63cd98a5ba3e155b3aaeb66b5abed379f5fb1ff143988", report.GetProfiles()[0].GetSha256())


### PR DESCRIPTION
Signed-off-by: Rick Marry <rmarry@chef.io>

### :nut_and_bolt: Description
As users of the compliance json export endpoint, we need to have properly formed json returned in the response of the request.  

Currently, the response is designed to be made up of a json array of json objects.  The problem is that this array is not surrounded by open/close square braces, and the objects within it are not comma separated; both of which are required in order for a json array to be considered well-formed.

This PR addresses both shortcomings and as a result, the compliance json export is now well-formed.

### :+1: Definition of Done
The json that comes back is well formed.

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
