### PR TITLE
use start_time as well as end_time when filtering reports for export

### DIFF
--- a/components/compliance-service/api/reporting/server/server.go
+++ b/components/compliance-service/api/reporting/server/server.go
@@ -163,7 +163,7 @@ func (srv *Server) Export(in *reporting.Query, stream reporting.ReportingService
 	}
 
 	// Step 1: Retrieving the latest report ID for each node based on the provided filters
-	esIndex, err := relaxting.GetEsIndex(formattedFilters, false, false)
+	esIndex, err := relaxting.GetEsIndex(formattedFilters, false, true)
 	if err != nil {
 		return status.Error(codes.Internal, fmt.Sprintf("Failed to determine how many reports exist: %s", err))
 	}

--- a/components/compliance-service/api/tests/export_test.go
+++ b/components/compliance-service/api/tests/export_test.go
@@ -42,6 +42,7 @@ func TestJSONExportWithEndTime(t *testing.T) {
 	query := rs.Query{
 		Type: "json",
 		Filters: []*rs.ListFilter{
+			{Type: "start_time", Values: []string{"2018-03-04T00:00:00Z"}},
 			{Type: "end_time", Values: []string{"2018-03-04T09:18:41Z"}},
 		},
 	}
@@ -91,6 +92,7 @@ func TestJSONExportWithProfileFilter(t *testing.T) {
 	profileFilterQuery := rs.Query{
 		Type: "json",
 		Filters: []*rs.ListFilter{
+			{Type: "start_time", Values: []string{"2018-03-04T00:00:00Z"}},
 			{Type: "end_time", Values: []string{"2018-03-04T09:18:41Z"}},
 			{Type: "profile_id", Values: []string{"09adcbb3b9b3233d5de63cd98a5ba3e155b3aaeb66b5abed379f5fb1ff143988"}},
 		},
@@ -141,6 +143,7 @@ func TestJSONExportWithTwoProfileFiltersReturnsError(t *testing.T) {
 	profileFilterQuery := rs.Query{
 		Type: "json",
 		Filters: []*rs.ListFilter{
+			{Type: "start_time", Values: []string{"2018-03-04T00:00:00Z"}},
 			{Type: "end_time", Values: []string{"2018-03-04T09:18:41Z"}},
 			{Type: "profile_id", Values: []string{"09adcbb3b9b3233d5de63cd98a5ba3e155b3aaeb66b5abed379f5fb1ff143988"}},
 			{Type: "profile_id", Values: []string{"41a02797bfea15592ba2748d55929d8d1f9da205816ef18d3bb2ebe4c5ce18a9"}},
@@ -158,6 +161,7 @@ func TestJSONExportWithTwoProfileFiltersReturnsError(t *testing.T) {
 	profileFilterQuery = rs.Query{
 		Type: "json",
 		Filters: []*rs.ListFilter{
+			{Type: "start_time", Values: []string{"2018-03-04T00:00:00Z"}},
 			{Type: "end_time", Values: []string{"2018-03-04T09:18:41Z"}},
 			{Type: "profile_name", Values: []string{"apache-baseline"}},
 			{Type: "profile_name", Values: []string{"fake-baseline"}},
@@ -175,6 +179,7 @@ func TestJSONExportWithTwoProfileFiltersReturnsError(t *testing.T) {
 	profileFilterQuery = rs.Query{
 		Type: "json",
 		Filters: []*rs.ListFilter{
+			{Type: "start_time", Values: []string{"2018-03-04T00:00:00Z"}},
 			{Type: "end_time", Values: []string{"2018-03-04T09:18:41Z"}},
 			{Type: "profile_id", Values: []string{"09adcbb3b9b3233d5de63cd98a5ba3e155b3aaeb66b5abed379f5fb1ff143988"}},
 			{Type: "profile_name", Values: []string{"fake-baseline"}},
@@ -203,6 +208,7 @@ func TestCSVExportWithEndTime(t *testing.T) {
 	profileFilterQuery := rs.Query{
 		Type: "csv",
 		Filters: []*rs.ListFilter{
+			{Type: "start_time", Values: []string{"2018-03-04T00:00:00Z"}},
 			{Type: "end_time", Values: []string{"2018-03-04T09:18:41Z"}},
 		},
 	}
@@ -246,6 +252,7 @@ func TestCSVExportWithEndTimeAndMissingFields(t *testing.T) {
 	profileFilterQuery := rs.Query{
 		Type: "csv",
 		Filters: []*rs.ListFilter{
+			{Type: "start_time", Values: []string{"2018-03-04T00:00:00Z"}},
 			{Type: "end_time", Values: []string{"2018-03-04T23:18:41Z"}},
 			{Type: "node_id", Values: []string{"a0ddd774-cbbb-49be-8730-49c92f3fc2a0"}},
 		},
@@ -290,6 +297,7 @@ func TestJSONExportWithControlFilter(t *testing.T) {
 	profileFilterQuery := rs.Query{
 		Type: "json",
 		Filters: []*rs.ListFilter{
+			{Type: "start_time", Values: []string{"2018-03-04T00:00:00Z"}},
 			{Type: "end_time", Values: []string{"2018-03-04T09:18:41Z"}},
 			{Type: "control", Values: []string{"nginx-02"}},
 			{Type: "profile_id", Values: []string{"09adcbb3b9b3233d5de63cd98a5ba3e155b3aaeb66b5abed379f5fb1ff143988"}},
@@ -344,6 +352,7 @@ func TestJSONExportWithTwoControlFiltersReturnsError(t *testing.T) {
 	profileFilterQuery := rs.Query{
 		Type: "json",
 		Filters: []*rs.ListFilter{
+			{Type: "start_time", Values: []string{"2018-03-04T00:00:00Z"}},
 			{Type: "end_time", Values: []string{"2018-03-04T09:18:41Z"}},
 			{Type: "control", Values: []string{"nginx-01"}},
 			{Type: "control", Values: []string{"nginx-02"}},


### PR DESCRIPTION
### :nut_and_bolt: Description
We need to consider start_time as well as end_time when performing export for compliance scans.

Currently, we ignore start_time and, instead, compute it as the [UTC] beginning of day for the same day as that of the end_time.  The rationale for this is that because all other apis for compliance reporting, use this approach to time span, so should export.  We have recently identified a real need to break the exports up into smaller time intervals, necessitating the use of start_time.

Once this PR merges, we will no longer compute start_time from end_time, we will use what is given.  From the UI perspective, nothing will change because now the UI will compute that start_time and send it to us.  The API users will benefit from this new flexibility.

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
