### PR TITLE
[A2-879] Refactor DeleteRule to work with staged rules

### DIFF
--- a/components/authz-service/storage/postgres/migration/sql/48_remove_deleted_staged_conditions_column.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/48_remove_deleted_staged_conditions_column.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE iam_staged_rule_conditions DROP COLUMN deleted CASCADE;
+
+COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -47,3 +47,4 @@
 - [`45_query_rules_for_project.up.sql`](45_query_rules_for_project.up.sql)
 - [`46_add_application_policies.up.sql`](46_add_application_policies.up.sql)
 - [`47_staged_rules_tables.up.sql`](47_staged_rules_tables.up.sql)
+- [`48_remove_deleted_staged_conditions_column.up.sql`](48_remove_deleted_staged_conditions_column.up.sql)

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -19,6 +19,11 @@ import (
 	"github.com/chef/automate/lib/logger"
 )
 
+const (
+	pgApplied = "applied"
+	pgStaged  = "staged"
+)
+
 type pg struct {
 	db          *sql.DB
 	logger      logger.Logger
@@ -802,11 +807,9 @@ func (p *pg) DeleteRole(ctx context.Context, id string) error {
 		return p.processError(err)
 	}
 
-	count, err := res.RowsAffected()
+	err = p.singleRowResultOrNotFoundErr(res)
 	if err != nil {
-		return p.processError(err)
-	} else if count != 1 {
-		return storage_errors.ErrNotFound
+		return err
 	}
 
 	err = p.notifyPolicyChange(ctx, tx)
@@ -963,19 +966,17 @@ func (p *pg) CreateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 		return nil, p.processError(err)
 	}
 
-	row := tx.QueryRowContext(ctx,
-		`SELECT query_rule_table_associations($1);`, rule.ID)
-
-	var associations []string
-	if err := row.Scan(pq.Array(&associations)); err != nil {
+	assocMap, err := p.getMapOfRuleAssociations(ctx, tx, rule.ID)
+	if err != nil {
 		return nil, p.processError(err)
 	}
+
 	// If any associations return, then the rule already exists in current, staged, or both tables
-	if len(associations) > 0 {
+	if len(assocMap) > 0 {
 		return nil, storage_errors.ErrConflict
 	}
 
-	row = tx.QueryRowContext(ctx,
+	row := tx.QueryRowContext(ctx,
 		`INSERT INTO iam_staged_project_rules (id, project_id, name, type, deleted) VALUES ($1, $2, $3, $4, $5) RETURNING db_id;`,
 		rule.ID, rule.ProjectID, rule.Name, rule.Type.String(), false)
 	var ruleDbID string
@@ -985,8 +986,8 @@ func (p *pg) CreateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 
 	for _, condition := range rule.Conditions {
 		_, err := tx.ExecContext(ctx,
-			`INSERT INTO iam_staged_rule_conditions (rule_db_id, value, attribute, operator, deleted) VALUES ($1, $2, $3, $4, $5);`,
-			ruleDbID, pq.Array(condition.Value), condition.Attribute.String(), condition.Operator.String(), false,
+			`INSERT INTO iam_staged_rule_conditions (rule_db_id, value, attribute, operator) VALUES ($1, $2, $3, $4);`,
+			ruleDbID, pq.Array(condition.Value), condition.Attribute.String(), condition.Operator.String(),
 		)
 		if err != nil {
 			return nil, p.processError(err)
@@ -1078,19 +1079,72 @@ func (p *pg) DeleteRule(ctx context.Context, id string) error {
 		return p.processError(err)
 	}
 
-	res, err := tx.ExecContext(ctx,
-		`DELETE FROM iam_project_rules WHERE id=$1 AND projects_match_for_rule(project_id, $2);`,
-		id, pq.Array(projectsFilter),
-	)
+	assocMap, err := p.getMapOfRuleAssociations(ctx, tx, id)
 	if err != nil {
 		return p.processError(err)
 	}
 
-	count, err := res.RowsAffected()
-	if err != nil {
-		return p.processError(err)
-	} else if count == 0 {
+	_, ruleStaged := assocMap[pgStaged]
+	_, ruleApplied := assocMap[pgApplied]
+
+	if !ruleStaged && !ruleApplied {
 		return storage_errors.ErrNotFound
+	}
+
+	if ruleApplied {
+		if ruleStaged {
+			res, err := tx.ExecContext(ctx,
+				`UPDATE iam_staged_project_rules
+					SET deleted=true
+					WHERE id=$1 AND projects_match_for_rule(project_id, $2);`,
+				id, pq.Array(projectsFilter),
+			)
+			if err != nil {
+				return p.processError(err)
+			}
+			err = p.singleRowResultOrNotFoundErr(res)
+			if err != nil {
+				return err
+			}
+		} else {
+			// check if filtered by project filter
+			res, err := tx.ExecContext(ctx,
+				`SELECT db_id FROM iam_project_rules
+					WHERE id=$1 AND projects_match_for_rule(project_id, $2);`,
+				id, pq.Array(projectsFilter),
+			)
+			if err != nil {
+				return p.processError(err)
+			}
+			err = p.singleRowResultOrNotFoundErr(res)
+			if err != nil {
+				return err
+			}
+
+			_, err = tx.ExecContext(ctx,
+				`INSERT INTO iam_staged_project_rules
+					SELECT s.db_id, s.id, s.project_id, s.name, s.type, 'true'
+					FROM iam_project_rules AS s
+					WHERE s.id=$1 AND projects_match_for_rule(s.project_id, $2);`,
+				id, pq.Array(projectsFilter),
+			)
+			if err != nil {
+				return p.processError(err)
+			}
+		}
+	} else if ruleStaged { // if only staged and not applied
+		res, err := tx.ExecContext(ctx,
+			`DELETE FROM iam_staged_project_rules
+				WHERE id=$1 AND projects_match_for_rule(project_id, $2);`,
+			id, pq.Array(projectsFilter),
+		)
+		if err != nil {
+			return p.processError(err)
+		}
+		err = p.singleRowResultOrNotFoundErr(res)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = tx.Commit()
@@ -1279,11 +1333,9 @@ func (p *pg) UpdateProject(ctx context.Context, project *v2.Project) (*v2.Projec
 		return nil, p.processError(err)
 	}
 
-	count, err := res.RowsAffected()
+	err = p.singleRowResultOrNotFoundErr(res)
 	if err != nil {
-		return nil, p.processError(err)
-	} else if count != 1 {
-		return nil, storage_errors.ErrNotFound
+		return nil, err
 	}
 
 	// Currently, we don't change anything from what is passed in.
@@ -1323,11 +1375,9 @@ func (p *pg) DeleteProject(ctx context.Context, id string) error {
 		return p.processError(err)
 	}
 
-	count, err := res.RowsAffected()
+	err = p.singleRowResultOrNotFoundErr(res)
 	if err != nil {
-		return p.processError(err)
-	} else if count != 1 {
-		return storage_errors.ErrNotFound
+		return err
 	}
 
 	return nil
@@ -1397,6 +1447,31 @@ func (p *pg) Close() error {
 
 func (p *pg) Pristine(ctx context.Context) error {
 	return p.recordMigrationStatus(ctx, enumPristine)
+}
+
+func (p *pg) singleRowResultOrNotFoundErr(result sql.Result) error {
+	count, err := result.RowsAffected()
+	if err != nil {
+		return p.processError(err)
+	}
+	if count != 1 {
+		return storage_errors.ErrNotFound
+	}
+	return nil
+}
+
+func (p *pg) getMapOfRuleAssociations(ctx context.Context, q Querier, id string) (map[string]bool, error) {
+	assocRow := q.QueryRowContext(ctx, `SELECT query_rule_table_associations($1);`, id)
+	var associations []string
+	if err := assocRow.Scan(pq.Array(&associations)); err != nil {
+		return nil, err
+	}
+
+	set := make(map[string]bool, len(associations))
+	for _, s := range associations {
+		set[s] = true
+	}
+	return set, nil
 }
 
 func (p *pg) recordMigrationStatusAndNotifyPG(ctx context.Context, ms string) error {

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -4100,10 +4100,11 @@ func TestDeleteRule(t *testing.T) {
 			err = store.DeleteRule(ctx, ruleToDelete.ID)
 			assert.NoError(t, err)
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules`))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
-		"when multiple staged rules exists with a matching project filter, delete rule and associated conditions": func(t *testing.T) {
+		"when multiple staged rules exists with a matching project filter and no applied rules, delete rule and associated conditions": func(t *testing.T) {
 			ctx := context.Background()
 
 			projID := "project-1"

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -4008,7 +4008,7 @@ func TestDeleteRule(t *testing.T) {
 			err := store.DeleteRule(ctx, "not-found")
 			assert.Equal(t, storage_errors.ErrNotFound, err)
 		},
-		"when the wrong id requested, returns NotFoundErr": func(t *testing.T) {
+		"when an applied rule exists but the wrong id requested, returns NotFoundErr": func(t *testing.T) {
 			ctx := context.Background()
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
@@ -4029,33 +4029,193 @@ func TestDeleteRule(t *testing.T) {
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 		},
-		"when multiple rules exists with no project filter, delete rule and associated conditions": func(t *testing.T) {
+		"when an applied and staged rule exists but the wrong id requested, returns NotFoundErr": func(t *testing.T) {
+			ctx := context.Background()
+			projID := "project-1"
+			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
+
+			ruleType := storage.Node
+			condition1, err := storage.NewCondition(ruleType,
+				[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
+			require.NoError(t, err)
+			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType, []storage.Condition{condition1})
+			require.NoError(t, err)
+			insertAppliedRule(t, db, rule)
+			insertStagedRule(t, db, rule)
+
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+
+			err = store.DeleteRule(ctx, "not-found")
+			assert.Equal(t, storage_errors.ErrNotFound, err)
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+		},
+		"when only staged rule exists but the wrong id requested, returns NotFoundErr": func(t *testing.T) {
+			ctx := context.Background()
+			projID := "project-1"
+			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
+
+			ruleType := storage.Node
+			condition1, err := storage.NewCondition(ruleType,
+				[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
+			require.NoError(t, err)
+			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType, []storage.Condition{condition1})
+			require.NoError(t, err)
+			insertStagedRule(t, db, rule)
+
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+
+			err = store.DeleteRule(ctx, "not-found")
+			assert.Equal(t, storage_errors.ErrNotFound, err)
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+		},
+		"when multiple staged rules exists with no project filter, delete rule and associated conditions": func(t *testing.T) {
 			ctx := context.Background()
 
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			ruleToDelete := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertAppliedRule(t, db, ruleToSave)
+			insertStagedRule(t, db, ruleToSave)
 
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToDelete.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToSave.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_project_rules`))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
+			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 
 			err = store.DeleteRule(ctx, ruleToDelete.ID)
 			assert.NoError(t, err)
-			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToDelete.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules`))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules`))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
-		"when multiple rules exists with a matching project filter, delete rule and associated conditions": func(t *testing.T) {
+		"when multiple staged rules exists with a matching project filter, delete rule and associated conditions": func(t *testing.T) {
+			ctx := context.Background()
+
+			projID := "project-1"
+			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
+			ctx = insertProjectsIntoContext(ctx, []string{projID, "project-2"})
+
+			ruleType := storage.Node
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType)
+
+			condition4, err := storage.NewCondition(ruleType,
+				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
+			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
+				[]storage.Condition{condition4})
+			require.NoError(t, err)
+			insertStagedRule(t, db, ruleToSave)
+
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
+			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+
+			err = store.DeleteRule(ctx, ruleToDelete.ID)
+			assert.NoError(t, err)
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules`))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+		},
+		"when multiple staged rules exists with a non-matching project filter, do not delete anything": func(t *testing.T) {
+			ctx := context.Background()
+
+			projID := "project-1"
+			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
+			ctx = insertProjectsIntoContext(ctx, []string{"project-3", "project-2"})
+
+			ruleType := storage.Node
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType)
+
+			condition4, err := storage.NewCondition(ruleType,
+				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
+			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
+				[]storage.Condition{condition4})
+			require.NoError(t, err)
+			insertStagedRule(t, db, ruleToSave)
+
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
+			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+
+			err = store.DeleteRule(ctx, ruleToDelete.ID)
+			assert.Equal(t, storage_errors.ErrNotFound, err)
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
+			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+		},
+		"when multiple staged and applied rules exist with a non-matching project filter, do not delete anything": func(t *testing.T) {
+			ctx := context.Background()
+
+			projID := "project-1"
+			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
+			ctx = insertProjectsIntoContext(ctx, []string{"project-3", "project-2"})
+
+			ruleType := storage.Node
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType)
+			insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
+
+			condition4, err := storage.NewCondition(ruleType,
+				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
+			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
+				[]storage.Condition{condition4})
+			require.NoError(t, err)
+			insertStagedRule(t, db, ruleToSave)
+			insertAppliedRule(t, db, ruleToSave)
+
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=false`, ruleToDelete.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=false`, ruleToSave.ID))
+			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+
+			err = store.DeleteRule(ctx, ruleToDelete.ID)
+			assert.Equal(t, storage_errors.ErrNotFound, err)
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=false`, ruleToDelete.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=false`, ruleToSave.ID))
+			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+		},
+		"when multiple staged and applied rules exist with a matching project filter, mark for delete": func(t *testing.T) {
+			ctx := context.Background()
+
+			projID := "project-1"
+			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
+			ctx = insertProjectsIntoContext(ctx, []string{projID, "project-2"})
+
+			ruleType := storage.Node
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType)
+			insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
+
+			condition4, err := storage.NewCondition(ruleType,
+				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
+			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
+				[]storage.Condition{condition4})
+			require.NoError(t, err)
+			insertStagedRule(t, db, ruleToSave)
+			insertAppliedRule(t, db, ruleToSave)
+
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=false`, ruleToDelete.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=false`, ruleToSave.ID))
+			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+
+			err = store.DeleteRule(ctx, ruleToDelete.ID)
+			assert.NoError(t, err)
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=true`, ruleToDelete.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=false`, ruleToSave.ID))
+			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+		},
+		"when multiple applied rules exist with a matching project filter, mark for delete": func(t *testing.T) {
 			ctx := context.Background()
 
 			projID := "project-1"
@@ -4072,22 +4232,22 @@ func TestDeleteRule(t *testing.T) {
 			require.NoError(t, err)
 			insertAppliedRule(t, db, ruleToSave)
 
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToDelete.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToSave.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 
 			err = store.DeleteRule(ctx, ruleToDelete.ID)
 			assert.NoError(t, err)
-			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToDelete.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules`))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=true`, ruleToDelete.ID))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=false`, ruleToSave.ID))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
-		"when multiple rules exists with a non-matching project filter, do not delete anything": func(t *testing.T) {
+		"when multiple applied rules exist with a non-matching project filter, do nothing and return NotFoundErr": func(t *testing.T) {
 			ctx := context.Background()
 
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
-			ctx = insertProjectsIntoContext(ctx, []string{"project-3", "project-2"})
+			ctx = insertProjectsIntoContext(ctx, []string{"wrong-project", "project-2"})
 
 			ruleType := storage.Node
 			ruleToDelete := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
@@ -4099,15 +4259,15 @@ func TestDeleteRule(t *testing.T) {
 			require.NoError(t, err)
 			insertAppliedRule(t, db, ruleToSave)
 
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToDelete.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToSave.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 
 			err = store.DeleteRule(ctx, ruleToDelete.ID)
 			assert.Equal(t, storage_errors.ErrNotFound, err)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToDelete.ID))
-			assertCount(t, 2, db.QueryRow(`SELECT count(*) FROM iam_project_rules`))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
 	}
 
@@ -6449,8 +6609,8 @@ func insertStagedRule(t *testing.T, db *testhelpers.TestDB, rule storage.Rule) {
 	require.NoError(t, row.Scan(&dbID))
 	for _, c := range rule.Conditions {
 		_, err := db.Exec(`
-			INSERT INTO iam_staged_rule_conditions (rule_db_id, value, attribute, operator, deleted) VALUES ($1, $2, $3, $4, $5);`,
-			dbID, pq.Array(c.Value), c.Attribute.String(), c.Operator.String(), false)
+			INSERT INTO iam_staged_rule_conditions (rule_db_id, value, attribute, operator) VALUES ($1, $2, $3, $4);`,
+			dbID, pq.Array(c.Value), c.Attribute.String(), c.Operator.String())
 		require.NoError(t, err)
 	}
 }
@@ -6470,18 +6630,26 @@ func insertAppliedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestD
 		[]storage.Condition{condition1, condition2, condition3})
 	require.NoError(t, err)
 
-	row := db.QueryRow(`
-		INSERT INTO iam_project_rules (id, project_id, name, type) VALUES ($1, $2, $3, $4) RETURNING db_id;`,
-		rule.ID, projID, rule.Name, ruleType.String())
-	var dbID string
-	err = row.Scan(&dbID)
+	insertAppliedRule(t, db, rule)
+	return &rule
+}
+
+func insertStagedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB, projID string, ruleType storage.RuleType) *storage.Rule {
+	t.Helper()
+	condition1, err := storage.NewCondition(ruleType,
+		[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
 	require.NoError(t, err)
-	for _, c := range rule.Conditions {
-		_, err = db.Exec(`
-			INSERT INTO iam_rule_conditions (rule_db_id, value, attribute, operator) VALUES ($1, $2, $3, $4);`,
-			dbID, pq.Array(c.Value), c.Attribute.String(), c.Operator.String())
-		require.NoError(t, err)
-	}
+	condition2, err := storage.NewCondition(ruleType,
+		[]string{"org1", "org2", "org3"}, storage.Organization, storage.MemberOf)
+	require.NoError(t, err)
+	condition3, err := storage.NewCondition(ruleType,
+		[]string{"chef-server-2"}, storage.ChefServer, storage.Equals)
+	require.NoError(t, err)
+	rule, err := storage.NewRule("new-id-1", projID, "name", ruleType,
+		[]storage.Condition{condition1, condition2, condition3})
+	require.NoError(t, err)
+
+	insertStagedRule(t, db, rule)
 	return &rule
 }
 


### PR DESCRIPTION
Signed-off-by: Tyler Cloke <tylercloke@gmail.com>

### :nut_and_bolt: Description

Update DeleteRule to work in the staged world. Deleted the staged condition `deleted` column since it was not necessary.

##### Applied but not staged

```
[9][default:/src:0]# chef-automate dev psql chef_authz_service
psql (9.6.11)
SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
Type "help" for help.

chef_authz_service=# select * from iam_project_rules;
 db_id |  id  | project_id |   name    | type
-------+------+------------+-----------+------
     2 | test | prod       | test name | node
(1 row)

chef_authz_service=# select * from iam_staged_project_rules;
 db_id |  id  | project_id |   name    | type | deleted
-------+------+------------+-----------+------+---------
     2 | test | prod       | test name | node | t
(1 row)
```

##### Applied and staged copies

```
chef_authz_service=# update iam_staged_project_rules set deleted=false;
UPDATE 1
chef_authz_service=# select * from iam_staged_project_rules;
 db_id |  id  | project_id |   name    | type | deleted
-------+------+------------+-----------+------+---------
     2 | test | prod       | test name | node | f
(1 row)

chef_authz_service=# \q
[10][default:/src:0]# curl -kH "api-token: $TOK" -XDELETE https://localhost/apis/iam/v2beta/rules/test
[11][default:/src:0]# chef-automate dev psql chef_authz_service
psql (9.6.11)
SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
Type "help" for help.

chef_authz_service=# select * from iam_staged_project_rules;
 db_id |  id  | project_id |   name    | type | deleted
-------+------+------------+-----------+------+---------
     2 | test | prod       | test name | node | t
(1 row)
```

##### Staged only

```
chef_authz_service=# select * from iam_staged_project_rules
chef_authz_service-# ;
 db_id |     id     | project_id |      name       | type | deleted
-------+------------+------------+-----------------+------+---------
     1 | new-staged | prod       | new staged rule | node | f
(1 rows)
curl -kH "api-token: $TOK" -XDELETE https://localhost/apis/iam/v2beta/rules/new-staged
chef_authz_service=# select * from iam_staged_project_rules;
 db_id | id | project_id | name | type | deleted
-------+----+------------+------+------+---------
(0 rows)
```

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
