### PR TITLE
UI-463 Add config gap to donut chart component Signed-Off-By: Tara Bl…

### DIFF
--- a/components/chef-ui-library/src/charts/chef-radial-chart/chef-radial-chart.tsx
+++ b/components/chef-ui-library/src/charts/chef-radial-chart/chef-radial-chart.tsx
@@ -66,7 +66,7 @@ let UID = 0;
  *     color: var(--chef-unknown);
  *   }
  * </style>
- * <chef-radial-chart style="width: 220px; height: 220px;">
+ * <chef-radial-chart gap-size=".05" style="width: 220px; height: 220px;">
  *   <span slot="innerText">Text for the center of the chart</span>
  *
  *   <chef-data-point value="4" class="failed">4 Failed</chef-data-point>
@@ -87,6 +87,11 @@ export class ChefRadialChart {
   @Prop() id: string;
 
   /**
+   * The width of the gap to apply between chart segments.
+   */
+  @Prop({ reflectToAttr: true }) gapSize = .03;
+
+  /**
    * Optionally hide tooltips. They are shown by default.
    */
   @Prop() tooltips = true;
@@ -105,7 +110,9 @@ export class ChefRadialChart {
 
   @Method() updateDataPoints() {
     const dataPoints = Array.from(this.el.querySelectorAll('chef-data-point'));
-    this.dataPoints = groupBy((d) => d.secondary ? 'secondary' : 'primary', dataPoints);
+    const dataPointsWithValues = [];
+    dataPoints.forEach((d) => (Number(d.value) > 0) ? dataPointsWithValues.push(d) : null);
+    this.dataPoints = groupBy((d) => d.secondary ? 'secondary' : 'primary', dataPointsWithValues);
   }
 
   componentWillLoad() {
@@ -113,7 +120,7 @@ export class ChefRadialChart {
   }
 
   render() {
-    const pieChart = pie().sort(null).value((d) => d.value);
+    const pieChart = pie().sort(null).value((d) => d.value).padAngle(this.gapSize);
     const { primary, secondary } = this.dataPoints;
     const hasSecondaryPoints = this.dataPoints.secondary !== undefined;
     const primarySegments = zip(pieChart(primary), primary);

--- a/components/chef-ui-library/src/charts/chef-radial-chart/chef-radial-chart.tsx
+++ b/components/chef-ui-library/src/charts/chef-radial-chart/chef-radial-chart.tsx
@@ -66,11 +66,11 @@ let UID = 0;
  *     color: var(--chef-unknown);
  *   }
  * </style>
- * <chef-radial-chart gap-size=".05" style="width: 220px; height: 220px;">
+ * <chef-radial-chart gap-size="5" style="width: 220px; height: 220px;">
  *   <span slot="innerText">Text for the center of the chart</span>
  *
- *   <chef-data-point value="4" class="failed">4 Failed</chef-data-point>
- *   <chef-data-point value="3" class="warning">3 Warning</chef-data-point>
+ *   <chef-data-point value="" class="failed">4 Failed</chef-data-point>
+ *   <chef-data-point value="" class="warning">3 Warning</chef-data-point>
  *   <chef-data-point value="2" class="success">2 Successful</chef-data-point>
  *   <chef-data-point value="1" class="skipped">1 Skipped</chef-data-point>
  * </chef-radial-chart>
@@ -87,9 +87,9 @@ export class ChefRadialChart {
   @Prop() id: string;
 
   /**
-   * The width of the gap to apply between chart segments.
+   * The width of the gap (in degrees) to apply between chart segments.
    */
-  @Prop({ reflectToAttr: true }) gapSize = .03;
+  @Prop({ reflectToAttr: true }) gapSize = 2;
 
   /**
    * Optionally hide tooltips. They are shown by default.
@@ -120,7 +120,7 @@ export class ChefRadialChart {
   }
 
   render() {
-    const pieChart = pie().sort(null).value((d) => d.value).padAngle(this.gapSize);
+    const pieChart = pie().sort(null).value((d) => d.value).padAngle(this.gapSize * Math.PI / 180);
     const { primary, secondary } = this.dataPoints;
     const hasSecondaryPoints = this.dataPoints.secondary !== undefined;
     const primarySegments = zip(pieChart(primary), primary);


### PR DESCRIPTION
…ack <tblack@chef.io>

<img width="507" alt="Screen Shot 2019-06-19 at 7 19 56 PM" src="https://user-images.githubusercontent.com/4108100/59809672-44af5800-92c7-11e9-82e3-86d1718647e7.png">

### :nut_and_bolt: Description
When there is multiple statuses represented by different status colors are presented in a donut chart, it becomes harder for the user to tell them apart intuitively. Adding a gap between the connecting edge can improve its readability.

### :+1: Definition of Done
Update the existing donut chart component in the UI library:

When there is only one color in the donut chart, remove the current gray line on the highest point of the circle.

The size of the gap should be configurable depending on the overall size of the chart (provided by the designer in the instance)

Apply the change on the Service Groups page with the gap size = 1px.

### Replication Steps
Type the word, feat, on your keyboard // Turn on EAS Applications
run cmds:
[hab studio]: applications_populate_database
[hab studio]: make update-ui-lib
Service groups is under applications

### :chains: Related Resources
https://github.com/chef/automate/issues/463
