### PR TITLE
Switch on assetRules rather than rules

### DIFF
--- a/components/data-feed-service/service/data-feed-service.go
+++ b/components/data-feed-service/service/data-feed-service.go
@@ -105,7 +105,7 @@ func Start(dataFeedConfig *config.DataFeedConfig) {
 					log.Debugf("Rule Name %v", assetRules[rule].Name)
 					log.Debugf("Rule Event %v", assetRules[rule].Event)
 					log.Debugf("Rule Action %v", assetRules[rule].Action)
-					switch action := rules[rule].Action.(type) {
+					switch action := assetRules[rule].Action.(type) {
 					case *notifications.Rule_ServiceNowAlert:
 						log.Debugf("Service now alert URL  %v", action.ServiceNowAlert.Url)
 						log.Debugf("Service now alert secret  %v", action.ServiceNowAlert.SecretId)


### PR DESCRIPTION
Signed-off-by: Martin Scott <mscott@chef.io>

### :nut_and_bolt: Description
The code is switching on an element from the wrong array. This doesn't appear to cause any issue but needs changed for correctness. I noticed this in development when adding functionality for compliance reports, in which it did cause an issue with the URL.

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps
Can't be reproduced on master.

### :chains: Related Resources

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
