### PR TITLE
compliance export: set start time to beg of day of end time

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -173,12 +173,28 @@ export class StatsService {
 
   downloadReport(format: string, filters: any[]): Observable<string> {
     const url = `${CC_API_URL}/reporting/export`;
-    const body = { type: format,
-                   filters: this.formatFilters(filters) };
 
+    filters = this.formatFilters(filters)
+
+    // for export, we want to send the start_time as the beg of day of end time
+    // so we find the endtime in the filters, and then set start time to beg of that day
+    const filtersCopy = [];
+    let endtime = filters.find(function (filt) {
+      return filt["type"] == "end_time"
+    })
+    filters.forEach(function (filt) {
+      if (filt["type"] == "start_time") {
+        let val = moment(endtime["values"][0]).startOf('day')
+        filt["values"] = [val.format('YYYY-MM-DDTHH:mm:ssZ')]
+      }
+      filtersCopy.push(filt)
+    })
+
+    const body = { type: format,
+                   filters: filtersCopy};
+                   
     return this.httpClient.post(url, body, {responseType: 'text'});
   }
-
 
   getSingleReport(reportID: string, filters: any[]): Observable<any> {
     const url = `${CC_API_URL}/reporting/reports/id/${reportID}`;

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -173,27 +173,20 @@ export class StatsService {
 
   downloadReport(format: string, filters: any[]): Observable<string> {
     const url = `${CC_API_URL}/reporting/export`;
-
-    filters = this.formatFilters(filters);
-
     // for export, we want to send the start_time as the beg of day of end time
     // so we find the endtime in the filters, and then set start time to beg of that day
-    const filtersCopy = [];
-    const endtime = filters.find(function (filt) {
-      return filt['type'] === 'end_time';
-    });
-    filters.forEach(function (filt) {
-      if (filt['type'] === 'start_time') {
-        const val = moment(endtime['values'][0]).startOf('day');
-        filt['values'] = [val.format('YYYY-MM-DDTHH:mm:ssZ')];
+    const endtime = filters.find(filter => filter['end_time']);
+    const filtersCopy = filters.map(filter => {
+      if (filter['start_time']) {
+        filter['start_time'] = moment(endtime).startOf('day');
       }
-      filtersCopy.push(filt);
+      return filter;
     });
 
-    const body = { type: format,
-                   filters: filtersCopy};
+    const body = { type: format, filters: this.formatFilters(filtersCopy)};
     return this.httpClient.post(url, body, {responseType: 'text'});
   }
+
 
   getSingleReport(reportID: string, filters: any[]): Observable<any> {
     const url = `${CC_API_URL}/reporting/reports/id/${reportID}`;

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -174,25 +174,24 @@ export class StatsService {
   downloadReport(format: string, filters: any[]): Observable<string> {
     const url = `${CC_API_URL}/reporting/export`;
 
-    filters = this.formatFilters(filters)
+    filters = this.formatFilters(filters);
 
     // for export, we want to send the start_time as the beg of day of end time
     // so we find the endtime in the filters, and then set start time to beg of that day
     const filtersCopy = [];
-    let endtime = filters.find(function (filt) {
-      return filt["type"] == "end_time"
-    })
+    const endtime = filters.find(function (filt) {
+      return filt['type'] === 'end_time';
+    });
     filters.forEach(function (filt) {
-      if (filt["type"] == "start_time") {
-        let val = moment(endtime["values"][0]).startOf('day')
-        filt["values"] = [val.format('YYYY-MM-DDTHH:mm:ssZ')]
+      if (filt['type'] === 'start_time') {
+        const val = moment(endtime['values'][0]).startOf('day');
+        filt['values'] = [val.format('YYYY-MM-DDTHH:mm:ssZ')];
       }
-      filtersCopy.push(filt)
-    })
+      filtersCopy.push(filt);
+    });
 
     const body = { type: format,
                    filters: filtersCopy};
-                   
     return this.httpClient.post(url, body, {responseType: 'text'});
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description
on the backend side of things, we are ignoring the start time for the
export endpoint, and simulating the behaviour here, where we say
start time is beg of day of end time. we would like to change this to
respect the provided start time for api users, so we need to adjust the
ui to send start time as beg of day of end time (instead of beg of day
from 10 days ago) so that we can maintain the behaviour of the ui export.

fixes https://github.com/chef/automate/issues/532

### :+1: Definition of Done
start time on export endpoint is beg of day of end time

### :athletic_shoe: Demo Script / Repro Steps
send some compliance scans in (chef_load_compliance_scans -N5)
rebuild ui
open dev tools
export json/csv
check headers

<img width="1031" alt="Screen Shot 2019-06-20 at 07 08 18" src="https://user-images.githubusercontent.com/10341541/59852155-81ad3600-932b-11e9-8d85-ca8b176fe5f0.png">

**this is not quite correct yet. it should have that Z at the end of the start time...help?**
^^ nevermind! got help from @scottopherson and all good now!