### PR TITLE
[A2-878] Update Rule Refactor

### DIFF
--- a/components/authz-service/server/v2/project.go
+++ b/components/authz-service/server/v2/project.go
@@ -355,7 +355,7 @@ func (s *state) UpdateRule(ctx context.Context, req *api.UpdateRuleReq) (*api.Up
 				"cannot change project_id for existing rule with ID %q ", req.Id)
 		}
 		return nil, status.Errorf(codes.Internal,
-			"error creating rule with ID %q: %s", req.Id, err.Error())
+			"error updating rule with ID %q: %s", req.Id, err.Error())
 	}
 
 	apiRule, err := fromStorageRule(resp)
@@ -376,7 +376,7 @@ func (s *state) GetRule(ctx context.Context, req *api.GetRuleReq) (*api.GetRuleR
 			"error retrieving rule with ID %q: %s", req.Id, err.Error())
 	}
 	if resp.Deleted {
-		return nil, status.Errorf(codes.NotFound, "could not find rule with ID %q", req.Id)
+		return nil, status.Errorf(codes.NotFound, "rule with ID %q marked for deletion", req.Id)
 	}
 
 	apiRule, err := fromStorageRule(resp)

--- a/components/authz-service/storage/errors.go
+++ b/components/authz-service/storage/errors.go
@@ -36,6 +36,10 @@ var (
 	// ErrMarkedForDeletion indicates an update was attempted on a rule that
 	// is staged for deletion (cannot be "un-deleted")
 	ErrMarkedForDeletion = errors.New("rule marked for deletion")
+
+	// ErrChangeTypeForRule indicates that an update operation attempted to change
+	// the type for a rule, which is not allowed.
+	ErrChangeTypeForRule = errors.New("cannot change rule type")
 )
 
 // ErrTxCommit occurs when the database attempts to commit a transaction and

--- a/components/authz-service/storage/errors.go
+++ b/components/authz-service/storage/errors.go
@@ -32,6 +32,10 @@ var (
 	// ErrChangeProjectForRule indicates that an update operation attempted to change
 	// the project for a rule, which is not allowed.
 	ErrChangeProjectForRule = errors.New("cannot change rule project")
+
+	// ErrMarkedForDeletion indicates an update was attempted on a rule that
+	// is staged for deletion (cannot be "un-deleted")
+	ErrMarkedForDeletion = errors.New("rule marked for deletion")
 )
 
 // ErrTxCommit occurs when the database attempts to commit a transaction and

--- a/components/authz-service/storage/errors.go
+++ b/components/authz-service/storage/errors.go
@@ -31,7 +31,7 @@ var (
 
 	// ErrChangeProjectForRule indicates that an update operation attempted to change
 	// the project for a rule, which is not allowed.
-	ErrChangeProjectForRule = errors.New("cannot change rule")
+	ErrChangeProjectForRule = errors.New("cannot change rule project")
 )
 
 // ErrTxCommit occurs when the database attempts to commit a transaction and

--- a/components/authz-service/storage/postgres/migration/sql/49_update_rule_triggers.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/49_update_rule_triggers.up.sql
@@ -35,18 +35,6 @@ BEGIN
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION fn_project_id_check() RETURNS TRIGGER AS $$
-BEGIN 
-    RAISE EXCEPTION 'cannot change project_id: % -> %', OLD.project_id, NEW.project_id USING
-        ERRCODE='PRJID';
-END$$ LANGUAGE plpgsql;
-
--- cannot update project id
-CREATE TRIGGER verify_project_id BEFORE UPDATE OF project_id ON iam_staged_project_rules
-FOR EACH ROW
-WHEN (OLD.project_id != NEW.project_id)
-EXECUTE PROCEDURE fn_project_id_check();
-
 CREATE OR REPLACE FUNCTION fn_deleted_rule_check() RETURNS TRIGGER AS $$
 BEGIN 
     RAISE EXCEPTION 'rule with id % has been deleted', NEW.id USING

--- a/components/authz-service/storage/postgres/migration/sql/49_update_rule_triggers.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/49_update_rule_triggers.up.sql
@@ -1,0 +1,56 @@
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION update_rule(in_rule_id text, in_project_id text, in_name text, in_type text, in_deleted boolean)
+RETURNS TEXT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  rule_id TEXT;
+BEGIN
+    IF (EXISTS (SELECT id FROM iam_project_rules WHERE id=in_rule_id)) THEN -- cannot 'update' a non-existed applied rule
+            INSERT INTO iam_staged_project_rules as ispr (id, project_id, name, type, deleted)
+            VALUES (in_rule_id, in_project_id, in_name, in_type, false)
+            ON CONFLICT (id) -- applied rule has already been updated, so update the staged version of it
+                DO UPDATE
+                        SET
+                        id = in_rule_id,
+                        project_id = in_project_id,
+                        name          = in_name,
+                        type   = in_type,
+                        deleted    = in_deleted
+            WHERE ispr.id = in_rule_id
+        RETURNING ispr.id INTO rule_id;
+        RETURN rule_id;
+    -- TODO: add conditions
+    ELSE
+        RAISE EXCEPTION 'noooooot found %', in_rule_id USING -- do we need this? maybe we can just return null or something?
+        ERRCODE='NOAPPLIEDRULE';
+    END IF;
+            RETURN rule_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fn_project_id_check() RETURNS TRIGGER AS $$
+BEGIN 
+    RAISE EXCEPTION 'cannot change project_id: % -> %', OLD.project_id, NEW.project_id USING
+        ERRCODE='PROJID';
+END$$ LANGUAGE plpgsql;
+
+-- cannot update project it
+CREATE TRIGGER verify_project_id BEFORE UPDATE OF project_id ON iam_staged_project_rules
+FOR EACH ROW
+WHEN (OLD.project_id != NEW.project_id) 
+EXECUTE PROCEDURE fn_project_id_check();
+
+CREATE OR REPLACE FUNCTION fn_deleted_rule_check() RETURNS TRIGGER AS $$
+BEGIN 
+    RAISE EXCEPTION 'rule with id % has been deleted', NEW.id USING
+        ERRCODE='RULEDELETED'; 
+END$$ LANGUAGE plpgsql;
+
+-- cannot update a rule that is staged for deletion 
+CREATE TRIGGER verify_not_deleted BEFORE UPDATE ON iam_staged_project_rules
+FOR EACH ROW
+WHEN (OLD.deleted = true)
+EXECUTE PROCEDURE fn_deleted_rule_check();

--- a/components/authz-service/storage/postgres/migration/sql/49_update_rule_triggers.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/49_update_rule_triggers.up.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-CREATE OR REPLACE FUNCTION update_rule(_in_rule_id text, _in_project_id text, _in_name text, _in_type text, _in_deleted boolean, projects_filter TEXT[])
+CREATE OR REPLACE FUNCTION update_rule(_in_rule_id text, _in_project_id text, _in_name text, _in_type text, projects_filter TEXT[])
 RETURNS TEXT
 LANGUAGE plpgsql
 AS $$
@@ -27,8 +27,7 @@ BEGIN
                 id          = _in_rule_id,
                 project_id  = _in_project_id,
                 name        = _in_name,
-                type        = _in_type,
-                deleted     = _in_deleted
+                type        = _in_type
             WHERE ispr.id = _in_rule_id AND projects_match_for_rule(ispr.project_id, projects_filter)
         RETURNING ispr.db_id INTO rule_db_id;
     RETURN rule_db_id;

--- a/components/authz-service/storage/postgres/migration/sql/49_update_rule_triggers.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/49_update_rule_triggers.up.sql
@@ -1,37 +1,34 @@
-
 BEGIN;
 
-CREATE OR REPLACE FUNCTION update_rule(in_rule_id text, in_project_id text, in_name text, in_type text, in_deleted boolean, projects_filter TEXT[])
+CREATE OR REPLACE FUNCTION update_rule(_in_rule_id text, _in_project_id text, _in_name text, _in_type text, _in_deleted boolean, projects_filter TEXT[])
 RETURNS TEXT
 LANGUAGE plpgsql
 AS $$
 DECLARE
   rule_db_id INTEGER;
 BEGIN
-    IF (NOT EXISTS (SELECT id FROM iam_project_rules ipr WHERE id=in_rule_id AND projects_match_for_rule(ipr.project_id, projects_filter))) AND
-        (NOT EXISTS (SELECT id FROM iam_staged_project_rules ipr WHERE id=in_rule_id AND projects_match_for_rule(ipr.project_id, projects_filter))) THEN
-            RAISE EXCEPTION 'not found %', in_rule_id USING
-            ERRCODE='case_not_found'; -- do we need this more specific? can we just return 20000?
-    ELSIF (NOT EXISTS (SELECT id, project_id FROM iam_project_rules ipr WHERE id=in_rule_id AND project_id=in_project_id)) AND
-        (NOT EXISTS (SELECT id, project_id FROM iam_staged_project_rules ipr WHERE id=in_rule_id AND project_id=in_project_id)) THEN
-            RAISE EXCEPTION 'incoming project does not match rule project %', in_rule_id USING -- do we need this? maybe we can just return null or something?
-            ERRCODE='PRJTR';
+    IF (NOT EXISTS (SELECT id FROM iam_project_rules WHERE id=_in_rule_id AND projects_match_for_rule(project_id, projects_filter))) AND
+        (NOT EXISTS (SELECT id FROM iam_staged_project_rules WHERE id=_in_rule_id AND projects_match_for_rule(project_id, projects_filter))) THEN
+            RAISE EXCEPTION 'not found %', _in_rule_id
+            USING ERRCODE='case_not_found';
+    ELSIF (NOT EXISTS (SELECT id, project_id FROM iam_project_rules WHERE id=_in_rule_id AND project_id=_in_project_id)) AND
+        (NOT EXISTS (SELECT id, project_id FROM iam_staged_project_rules WHERE id=_in_rule_id AND project_id=_in_project_id)) THEN
+            RAISE EXCEPTION 'incoming project does not match rule project %', _in_rule_id
+            USING ERRCODE='PRJTR';
     ELSE
         INSERT INTO iam_staged_project_rules as ispr (id, project_id, name, type, deleted)
-        VALUES (in_rule_id, in_project_id, in_name, in_type, false)
-        ON CONFLICT (id) -- applied rule has already been updated, so update the staged version of it
-            DO UPDATE
-                    SET
-                    id = in_rule_id,
-                    project_id = in_project_id,
-                    name          = in_name,
-                    type   = in_type,
-                    deleted    = in_deleted
-        WHERE ispr.id = in_rule_id AND projects_match_for_rule(ispr.project_id, projects_filter)
+        VALUES (_in_rule_id, _in_project_id, _in_name, _in_type, false)
+        ON CONFLICT (id) DO-- applied rule has already been updated, so update the staged version of it
+            UPDATE SET
+                id          = _in_rule_id,
+                project_id  = _in_project_id,
+                name        = _in_name,
+                type        = _in_type,
+                deleted     = _in_deleted
+            WHERE ispr.id = _in_rule_id AND projects_match_for_rule(ispr.project_id, projects_filter)
         RETURNING ispr.db_id INTO rule_db_id;
     RETURN rule_db_id;
     END IF;
-    RETURN rule_db_id;
 END;
 $$;
 

--- a/components/authz-service/storage/postgres/migration/sql/49_update_rule_triggers.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/49_update_rule_triggers.up.sql
@@ -15,6 +15,10 @@ BEGIN
         (NOT EXISTS (SELECT id, project_id FROM iam_staged_project_rules WHERE id=_in_rule_id AND project_id=_in_project_id)) THEN
             RAISE EXCEPTION 'incoming project does not match rule project %', _in_rule_id
             USING ERRCODE='PRJTR';
+    ELSIF (NOT EXISTS (SELECT id, type FROM iam_project_rules WHERE id=_in_rule_id AND type=_in_type)) AND
+        (NOT EXISTS (SELECT id, type FROM iam_staged_project_rules WHERE id=_in_rule_id AND type=_in_type)) THEN
+            RAISE EXCEPTION 'incoming type does not match rule type %', _in_rule_id
+            USING ERRCODE='RLTYP';
     ELSE
         INSERT INTO iam_staged_project_rules as ispr (id, project_id, name, type, deleted)
         VALUES (_in_rule_id, _in_project_id, _in_name, _in_type, false)

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -48,3 +48,5 @@
 - [`46_add_application_policies.up.sql`](46_add_application_policies.up.sql)
 - [`47_staged_rules_tables.up.sql`](47_staged_rules_tables.up.sql)
 - [`48_remove_deleted_staged_conditions_column.up.sql`](48_remove_deleted_staged_conditions_column.up.sql)
+- [`49_update_rule_triggers.up.sql`](49_update_rule_triggers.up.sql)
+

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -49,4 +49,3 @@
 - [`47_staged_rules_tables.up.sql`](47_staged_rules_tables.up.sql)
 - [`48_remove_deleted_staged_conditions_column.up.sql`](48_remove_deleted_staged_conditions_column.up.sql)
 - [`49_update_rule_triggers.up.sql`](49_update_rule_triggers.up.sql)
-

--- a/components/authz-service/storage/postgres/postgres.go
+++ b/components/authz-service/storage/postgres/postgres.go
@@ -83,6 +83,8 @@ func parsePQError(err *pq.Error) error {
 		return storage.ErrChangeProjectForRule
 	case "RDLTD": // Custom code: attempt to update a rule that is staged for deletion
 		return storage.ErrMarkedForDeletion
+	case "RLTYP": // Custom code: attempt to update a rule's type that is immutable
+		return storage.ErrChangeTypeForRule
 	}
 
 	return storage.ErrDatabase

--- a/components/authz-service/storage/postgres/postgres.go
+++ b/components/authz-service/storage/postgres/postgres.go
@@ -81,6 +81,8 @@ func parsePQError(err *pq.Error) error {
 		return storage.ErrNotFound
 	case "PRJTR": // custom code for when a user tries to change a rule's project
 		return storage.ErrChangeProjectForRule
+	case "RDLTD": // object is staged for deletion and cannot be updated
+		return storage.ErrMarkedForDeletion
 	}
 
 	return storage.ErrDatabase

--- a/components/authz-service/storage/postgres/postgres.go
+++ b/components/authz-service/storage/postgres/postgres.go
@@ -71,17 +71,17 @@ func ProcessError(err error) error {
 // parsePQError is able to parse pq specific errors into storage interface errors.
 func parsePQError(err *pq.Error) error {
 	switch err.Code {
-	case "DRPPC": // Our custom error code for non-deletable policies defined in migration 02.
+	case "DRPPC": // Custom code: attempt to delete a non-deletable policy defined in migration 02
 		return storage.ErrCannotDelete
 	case "23505": // Unique violation
 		return storage.ErrConflict
 	case "23503": // Foreign key violation
 		return storage.ErrForeignKey
-	case "20000": // not found
+	case "20000": // Not found
 		return storage.ErrNotFound
-	case "PRJTR": // custom code for when a user tries to change a rule's project
+	case "PRJTR": // Custom code: attempt to change a rule's projects that are immutable
 		return storage.ErrChangeProjectForRule
-	case "RDLTD": // object is staged for deletion and cannot be updated
+	case "RDLTD": // Custom code: attempt to update a rule that is staged for deletion
 		return storage.ErrMarkedForDeletion
 	}
 

--- a/components/authz-service/storage/postgres/postgres.go
+++ b/components/authz-service/storage/postgres/postgres.go
@@ -77,6 +77,10 @@ func parsePQError(err *pq.Error) error {
 		return storage.ErrConflict
 	case "23503": // Foreign key violation
 		return storage.ErrForeignKey
+	case "20000": // not found
+		return storage.ErrNotFound
+	case "PRJTR": // custom code for when a user tries to change a rule's project
+		return storage.ErrChangeProjectForRule
 	}
 
 	return storage.ErrDatabase

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -1034,6 +1034,12 @@ func (p *pg) UpdateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 		return nil, p.processError(err)
 	}
 
+	// Delete the existing conditions. Don't need to worry about not found case since a rule must have conditions.
+	_, err = tx.ExecContext(ctx, `DELETE FROM iam_staged_rule_conditions WHERE rule_db_id=$1;`, ruleDbID)
+	if err != nil {
+		return nil, p.processError(err)
+	}
+
 	for _, condition := range rule.Conditions {
 		_, err := tx.ExecContext(ctx,
 			`INSERT INTO iam_staged_rule_conditions (rule_db_id, value, attribute, operator) VALUES ($1, $2, $3, $4);`,

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -1024,8 +1024,8 @@ func (p *pg) UpdateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 	}
 
 	row := tx.QueryRowContext(ctx,
-		`SELECT update_rule($1, $2, $3, $4, $5, $6)`,
-		rule.ID, rule.ProjectID, rule.Name, rule.Type.String(), false, pq.Array(projectsFilter))
+		`SELECT update_rule($1, $2, $3, $4, $5)`,
+		rule.ID, rule.ProjectID, rule.Name, rule.Type.String(), pq.Array(projectsFilter))
 	var ruleDbID int
 	if err := row.Scan(&ruleDbID); err != nil {
 		if err == sql.ErrNoRows {

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -1039,12 +1039,6 @@ func (p *pg) UpdateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 		return nil, p.processError(err)
 	}
 
-	// Delete the existing conditions. Don't need to worry about not found case since a rule must have conditions.
-	_, err = tx.ExecContext(ctx, `DELETE FROM iam_staged_rule_conditions WHERE rule_db_id=$1;`, ruleDbID)
-	if err != nil {
-		return nil, p.processError(err)
-	}
-
 	for _, condition := range rule.Conditions {
 		_, err := tx.ExecContext(ctx,
 			`INSERT INTO iam_staged_rule_conditions (rule_db_id, value, attribute, operator) VALUES ($1, $2, $3, $4);`,

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
 
@@ -1030,12 +1029,8 @@ func (p *pg) UpdateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 	var ruleDbID int
 	if err := row.Scan(&ruleDbID); err != nil {
 		if err == sql.ErrNoRows {
-			// TODO for testing only
-			spew.Printf("HEY! no rows error here %#v\n\n", err)
 			return nil, storage_errors.ErrNotFound
 		}
-		// TODO for testing only
-		spew.Printf("HEY! other error here %#v\n\n", err)
 		return nil, p.processError(err)
 	}
 
@@ -1051,7 +1046,6 @@ func (p *pg) UpdateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 
 	err = tx.Commit()
 	if err != nil {
-		spew.Printf("HEY! tx error here %#v\n\n", err)
 		return nil, storage_errors.NewErrTxCommit(err)
 	}
 

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -1034,7 +1034,7 @@ func (p *pg) UpdateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 		return nil, p.processError(err)
 	}
 
-	// Delete the existing conditions. Don't need to worry about not found case since a rule must have conditions.
+	// Delete the existing conditions. Don't need to worry about "not found" case since a rule must have conditions.
 	_, err = tx.ExecContext(ctx, `DELETE FROM iam_staged_rule_conditions WHERE rule_db_id=$1;`, ruleDbID)
 	if err != nil {
 		return nil, p.processError(err)

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -4137,7 +4137,7 @@ func TestDeleteRule(t *testing.T) {
 			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType, []storage.Condition{condition1})
 			require.NoError(t, err)
 			insertAppliedRule(t, db, rule)
-			insertStagedRule(t, db, rule)
+			insertStagedRule(t, db, rule, false)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule.ID))
@@ -4162,7 +4162,7 @@ func TestDeleteRule(t *testing.T) {
 			require.NoError(t, err)
 			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType, []storage.Condition{condition1})
 			require.NoError(t, err)
-			insertStagedRule(t, db, rule)
+			insertStagedRule(t, db, rule, false)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
@@ -4172,7 +4172,7 @@ func TestDeleteRule(t *testing.T) {
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
-		"when multiple staged rules exists with no project filter, delete rule and associated conditions": func(t *testing.T) {
+		"when multiple staged rules exist with no project filter, delete rule and associated conditions": func(t *testing.T) {
 			ctx := context.Background()
 
 			projID := "project-1"
@@ -4186,7 +4186,7 @@ func TestDeleteRule(t *testing.T) {
 			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertStagedRule(t, db, ruleToSave)
+			insertStagedRule(t, db, ruleToSave, false)
 
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_project_rules`))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
@@ -4200,7 +4200,7 @@ func TestDeleteRule(t *testing.T) {
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules`))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
-		"when multiple staged rules exists with a matching project filter and no applied rules, delete rule and associated conditions": func(t *testing.T) {
+		"when multiple staged rules exist with a matching project filter and no applied rules, delete rule and associated conditions": func(t *testing.T) {
 			ctx := context.Background()
 
 			projID := "project-1"
@@ -4215,7 +4215,7 @@ func TestDeleteRule(t *testing.T) {
 			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertStagedRule(t, db, ruleToSave)
+			insertStagedRule(t, db, ruleToSave, false)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
@@ -4242,7 +4242,7 @@ func TestDeleteRule(t *testing.T) {
 			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertStagedRule(t, db, ruleToSave)
+			insertStagedRule(t, db, ruleToSave, false)
 
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
@@ -4270,7 +4270,7 @@ func TestDeleteRule(t *testing.T) {
 			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertStagedRule(t, db, ruleToSave)
+			insertStagedRule(t, db, ruleToSave, false)
 			insertAppliedRule(t, db, ruleToSave)
 
 			err = store.DeleteRule(ctx, ruleToDelete.ID)
@@ -4295,7 +4295,7 @@ func TestDeleteRule(t *testing.T) {
 			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
-			insertStagedRule(t, db, ruleToSave)
+			insertStagedRule(t, db, ruleToSave, false)
 			insertAppliedRule(t, db, ruleToSave)
 
 			err = store.DeleteRule(ctx, ruleToDelete.ID)
@@ -6738,7 +6738,7 @@ func insertStagedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB
 		[]storage.Condition{condition1, condition2, condition3})
 	require.NoError(t, err)
 
-	insertStagedRule(t, db, rule)
+	insertStagedRule(t, db, rule, false)
 
 	assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule.ID))
 	assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions WHERE rule_db_id=(SELECT r.db_id FROM iam_staged_project_rules r WHERE r.id=$1)`, rule.ID))

--- a/inspec/a2-api-integration/controls/iam_v2.rb
+++ b/inspec/a2-api-integration/controls/iam_v2.rb
@@ -1094,44 +1094,41 @@ EOF
         expect(resp.parsed_response_body[:rule]).to eq(CUSTOM_RULE_1)
       end
 
-      # TODO uncomment once DeleteRule has been refactored with staged rules
-      # it "DELETE /iam/v2beta/rules/:id deletes the specific rule" do
-      #   resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}", http_method: 'DELETE')
-      #   expect(resp.http_status).to eq 200
-      #   expect(resp.parsed_response_body[:rule]).to eq(nil)
+      it "DELETE /iam/v2beta/rules/:id deletes the specific rule" do
+        resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}", http_method: 'DELETE')
+        expect(resp.http_status).to eq 200
+        expect(resp.parsed_response_body[:rule]).to eq(nil)
 
-      #   resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}")
-      #   expect(resp.http_status).to eq 404
-      # end
+        resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}")
+        expect(resp.http_status).to eq 404
+      end
 
+      it "PUT /iam/v2beta/rules/:id updates the rule" do
+        updated_rule = {
+          id: CUSTOM_RULE_1[:id],
+          name: "updated display name",
+          project_id: CUSTOM_RULE_1[:project_id],
+          type: "NODE",
+          conditions: [
+            {
+              attribute: "CHEF_TAGS",
+              operator: "EQUALS",
+              values: ["new tag"]
+            }
+           ]
+         }
 
-      # TODO uncomment once ListRulesForProject has been refactored with staged rules
-      # it "PUT /iam/v2beta/rules/:id updates the rule" do
-      #   updated_rule = {
-      #     id: CUSTOM_RULE_1[:id],
-      #     name: "updated display name",
-      #     project_id: CUSTOM_RULE_1[:project_id],
-      #     type: "NODE",
-      #     conditions: [
-      #       {
-      #         attribute: "CHEF_TAGS",
-      #         operator: "EQUALS",
-      #         values: ["new tag"]
-      #       }
-      # #     ]
-      # #   }
+        resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}",
+          http_method: 'PUT',
+          request_body: updated_rule.to_json
+        )
+        expect(resp.http_status).to eq 200
+        expect(resp.parsed_response_body[:rule]).to eq(updated_rule)
 
-      #   resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}",
-      #     http_method: 'PUT',
-      #     request_body: updated_rule.to_json
-      #   )
-      #   expect(resp.http_status).to eq 200
-      #   expect(resp.parsed_response_body[:rule]).to eq(updated_rule)
-
-      #   resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}")
-      #   expect(resp.http_status).to eq 200
-      #   expect(resp.parsed_response_body[:rule]).to eq(updated_rule)
-      # end
+        resp = automate_api_request("/apis/iam/v2beta/rules/#{CUSTOM_RULE_1[:id]}")
+        expect(resp.http_status).to eq 200
+        expect(resp.parsed_response_body[:rule]).to eq(updated_rule)
+      end
 
     end
   end


### PR DESCRIPTION
### :nut_and_bolt: Description

Previously, the UpdateRule API directly updated the rules. Since any rule update takes time to completely apply to ingested resources, we're refactoring the rules API so that all changes to rules are stored in a `staged` rules table (preserving the rules in their current state in the `applied` table). Only when the user calls ApplyRules will the updated rules in the staging table be applied to the `applied` rules table.

### :+1: Definition of Done

UpdateRule now:

1) Creates a new "staged rule" for existing "applied" rule
2) Updates existing "staged rule" if already created
3) Does not update staged rules marked for deletion

TODO: what should memstore implementation look like?

### :athletic_shoe: Demo Script / Repro Steps
#### Setup
```
build components/authz-service
start_all_services
export TOK=`chef-automate iam token create TEST --admin`
```
#### Creates a new "staged rule" for existing "applied" rule

1. insert an "applied" rule into DB (if we use curl, it will just go to staged)
```
chef-automate dev psql chef_authz_service

insert into iam_projects (id, name, type, projects) values ('foo-project', 'Foo Project', 'custom', ARRAY['foo-project']);

insert into iam_project_rules (id, project_id, name, type) values ('foo-rule', 'foo-project', 'foorule', 'node');

\q
```
2. update rule via curl
```
curl -kH "api-token: $TOK" -X PUT https://localhost/apis/iam/v2beta/rules/foo-rule -d "$(jq -n '{ id: "foo-rule", name: "my updated foo rule", type: "NODE", project_id: "foo-project", conditions: [{ attribute: "CHEF_SERVERS", operator: "MEMBER_OF", values: ["prod", "staging"]}]}')" | jq .

# returns rule with updated name and conditions
```
3. get updated rule via curl (always returns most updated version of the rule, aka whatever is staged)
```
curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/rules/foo-rule | jq .

# returns rule with updated name and conditions
```

#### Updates existing "staged rule" if already created
1. curl create new rule
```
curl -kH "api-token: $TOK" -X POST https://localhost/apis/iam/v2beta/rules -d "$(jq -n '{ id: "bar-rule", name: "my bar rule", type: "EVENT", project_id: "foo-project", conditions: [{ attribute: "CHEF_ORGS", operator: "EQUALS", values: ["dev"]}]}')" | jq .
```
2. update rule via curl
```
curl -kH "api-token: $TOK" -X PUT https://localhost/apis/iam/v2beta/rules/bar-rule -d "$(jq -n '{ id: "bar-rule", name: "my updated bar rule", type: "EVENT", project_id: "foo-project", conditions: [{ attribute: "CHEF_ORGS", operator: "EQUALS", values: ["dev"]}, { attribute: "CHEF_SERVERS", operator: "EQUALS", values: ["prod"]}]}')" | jq .

# returns rule with updated name and conditions
```
3. get updated rule via curl 
```
curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/rules/bar-rule | jq .

# returns rule with updated name and conditions
```

#### Does not update staged rules marked for deletion
1. delete applied rule via curl (marks staged rule as deleted)
```
curl -kH "api-token: $TOK" -X DELETE https://localhost/apis/iam/v2beta/rules/foo-rule | jq .
```
2. update rule via curl
```
curl -kH "api-token: $TOK" -X PUT https://localhost/apis/iam/v2beta/rules/foo-rule -d "$(jq -n '{ id: "foo-rule", name: "my updated foo rule", type: "NODE", project_id: "foo-project", conditions: [{ attribute: "CHEF_SERVERS", operator: "MEMBER_OF", values: ["prod", "staging"]}]}')" | jq .

{
  "error": "error creating rule with ID \"foo-rule\": rule marked for deletion",
  "message": "error creating rule with ID \"foo-rule\": rule marked for deletion",
  "code": 13,
  "details": []
}
```

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
