### PR TITLE
[A2-813] Apply Staged Project Rules API

### DIFF
--- a/components/authz-service/engine/opa/opa.go
+++ b/components/authz-service/engine/opa/opa.go
@@ -225,6 +225,11 @@ func (s *State) DumpDataV2p1(ctx context.Context) error {
 	return dumpData(ctx, s.v2p1Store, s.log)
 }
 
+func (s *State) DumpDataRules(ctx context.Context) error {
+	s.log.Infof("data: %#v", s.ruleStore.Items())
+	return nil
+}
+
 func dumpData(ctx context.Context, store storage.Store, l logger.Logger) error {
 	txn, err := store.NewTransaction(ctx)
 	if err != nil {
@@ -234,6 +239,7 @@ func dumpData(ctx context.Context, store storage.Store, l logger.Logger) error {
 	if err != nil {
 		return err
 	}
+
 	l.Infof("data: %#v", data)
 	return store.Commit(ctx, txn)
 }

--- a/components/authz-service/server/server.go
+++ b/components/authz-service/server/server.go
@@ -71,7 +71,9 @@ func NewGRPCServer(ctx context.Context,
 		return nil, errors.Wrap(err, "could not initialize v1 server")
 	}
 
-	v2PolServer, err := v2.NewPostgresPolicyServer(ctx, l, e, migrationsConfig,
+	// TODO (tc) Refactor how singletons are shared between GRPC servers. Should we also
+	// be sharing a single v2 store / pg instance?
+	v2PolServer, policyRefresher, err := v2.NewPostgresPolicyServer(ctx, l, e, migrationsConfig,
 		dataMigrationsConfig, v1Server.Storage(), vChan)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not initialize v2 policy server")
@@ -88,7 +90,7 @@ func NewGRPCServer(ctx context.Context,
 	}
 
 	v2ProjectsServer, err := v2.NewPostgresProjectsServer(ctx, l, migrationsConfig,
-		dataMigrationsConfig, e, eventServiceClient, configManager)
+		dataMigrationsConfig, e, eventServiceClient, configManager, policyRefresher)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not initialize v2 projects server")
 	}

--- a/components/authz-service/server/v2/policy_refresher.go
+++ b/components/authz-service/server/v2/policy_refresher.go
@@ -306,7 +306,7 @@ func NewMockPolicyRefresher() PolicyRefresher {
 	return &mockPolicyRefresher{}
 }
 
-func (refresher *mockPolicyRefresher) Refresh(context.Context) error {
+func (*mockPolicyRefresher) Refresh(context.Context) error {
 	return nil
 }
 

--- a/components/authz-service/server/v2/policy_refresher.go
+++ b/components/authz-service/server/v2/policy_refresher.go
@@ -299,17 +299,3 @@ func (refresher *policyRefresher) getRuleMap(ctx context.Context) (map[string][]
 func pretty(vsn api.Version) string {
 	return fmt.Sprintf("IAM v%d.%d", int32(vsn.Major), int32(vsn.Minor))
 }
-
-type mockPolicyRefresher struct{}
-
-func NewMockPolicyRefresher() PolicyRefresher {
-	return &mockPolicyRefresher{}
-}
-
-func (*mockPolicyRefresher) Refresh(context.Context) error {
-	return nil
-}
-
-func (refresher *mockPolicyRefresher) RefreshAsync() error {
-	return nil
-}

--- a/components/authz-service/server/v2/policy_refresher.go
+++ b/components/authz-service/server/v2/policy_refresher.go
@@ -299,3 +299,17 @@ func (refresher *policyRefresher) getRuleMap(ctx context.Context) (map[string][]
 func pretty(vsn api.Version) string {
 	return fmt.Sprintf("IAM v%d.%d", int32(vsn.Major), int32(vsn.Minor))
 }
+
+type mockPolicyRefresher struct{}
+
+func NewMockPolicyRefresher() PolicyRefresher {
+	return &mockPolicyRefresher{}
+}
+
+func (refresher *mockPolicyRefresher) Refresh(context.Context) error {
+	return nil
+}
+
+func (refresher *mockPolicyRefresher) RefreshAsync() error {
+	return nil
+}

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -2984,7 +2984,7 @@ func setupV2WithMigrationState(t *testing.T,
 	configMgr, err := config.NewManager("/tmp/.authz-delete-me")
 	require.NoError(t, err)
 	projectsSrv, err := v2.NewProjectsServer(ctx, l, mem_v2,
-		rulesRetriever, eventServiceClient, configMgr, v2.NewMockPolicyRefresher())
+		rulesRetriever, eventServiceClient, configMgr, testhelpers.NewMockPolicyRefresher())
 	require.NoError(t, err)
 
 	vSwitch := v2.NewSwitch(vChan)

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -2977,14 +2977,14 @@ func setupV2WithMigrationState(t *testing.T,
 		require.NoError(t, migration(mem_v2)) // this is IAM v2
 	}
 
-	polV2, err := v2.NewPoliciesServer(ctx, l, mem_v2, writer, pl, vChan)
+	polV2, _, err := v2.NewPoliciesServer(ctx, l, mem_v2, writer, pl, vChan)
 	require.NoError(t, err)
 
 	eventServiceClient := &testhelpers.MockEventServiceClient{}
 	configMgr, err := config.NewManager("/tmp/.authz-delete-me")
 	require.NoError(t, err)
 	projectsSrv, err := v2.NewProjectsServer(ctx, l, mem_v2,
-		rulesRetriever, eventServiceClient, configMgr)
+		rulesRetriever, eventServiceClient, configMgr, v2.NewMockPolicyRefresher())
 	require.NoError(t, err)
 
 	vSwitch := v2.NewSwitch(vChan)

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -2925,14 +2925,15 @@ func assertRolesMatch(t *testing.T, storageRole storage.Role, apiRole api_v2.Rol
 }
 
 type testSetup struct {
-	policy       api_v2.PoliciesClient
-	authz        api_v2.AuthorizationClient
-	projects     api_v2.ProjectsClient
-	policyCache  *cache.Cache
-	roleCache    *cache.Cache
-	projectCache *cache.Cache
-	status       storage.MigrationStatusProvider
-	switcher     *v2.VersionSwitch
+	policy         api_v2.PoliciesClient
+	authz          api_v2.AuthorizationClient
+	projects       api_v2.ProjectsClient
+	policyCache    *cache.Cache
+	roleCache      *cache.Cache
+	projectCache   *cache.Cache
+	status         storage.MigrationStatusProvider
+	switcher       *v2.VersionSwitch
+	rulesRetriever engine.ProjectRulesRetriever
 }
 
 func setupV2WithWriter(t *testing.T,
@@ -3017,14 +3018,15 @@ func setupV2WithMigrationState(t *testing.T,
 	}
 
 	return testSetup{
-		policy:       api_v2.NewPoliciesClient(conn),
-		authz:        api_v2.NewAuthorizationClient(conn),
-		projects:     api_v2.NewProjectsClient(conn),
-		policyCache:  mem_v2.PoliciesCache(),
-		roleCache:    mem_v2.RolesCache(),
-		projectCache: mem_v2.ProjectsCache(),
-		status:       mem_v2,
-		switcher:     vSwitch,
+		policy:         api_v2.NewPoliciesClient(conn),
+		authz:          api_v2.NewAuthorizationClient(conn),
+		projects:       api_v2.NewProjectsClient(conn),
+		policyCache:    mem_v2.PoliciesCache(),
+		roleCache:      mem_v2.RolesCache(),
+		projectCache:   mem_v2.ProjectsCache(),
+		status:         mem_v2,
+		switcher:       vSwitch,
+		rulesRetriever: rulesRetriever,
 	}
 }
 

--- a/components/authz-service/server/v2/project.go
+++ b/components/authz-service/server/v2/project.go
@@ -181,7 +181,7 @@ func (s *ProjectState) ApplyRulesStart(
 			"cannot apply rules: apply already in progress")
 	default:
 		return nil, status.Error(codes.Internal,
-			"failed to parse apply state")
+			"failed to parse state of rule apply")
 	}
 
 	err := s.store.ApplyStagedRules(ctx)
@@ -196,16 +196,16 @@ func (s *ProjectState) ApplyRulesStart(
 	// We will be refactoring with workflow to make this safer soon.
 	err = s.policyRefresher.Refresh(ctx)
 	if err != nil {
-		s.log.Warnf("error refreshing policy cache: %s", err.Error())
+		s.log.Warnf("error refreshing policy cache. the rules were updated but the apply was not started, please try again.")
 		return nil, status.Errorf(codes.Internal,
-			"error refreshing policy cache. the rules were updated but the apply was not started, please try again.")
+			"error refreshing policy cache: %s", err.Error())
 	}
 
 	err = s.ProjectUpdateManager.Start()
 	if err != nil {
-		s.log.Warnf("error starting project update: %s", err.Error())
+		s.log.Warnf("error starting project update. the rules and cache were updated but the apply was not started, please try again.")
 		return nil, status.Errorf(codes.Internal,
-			"error starting project update. the rules and cache were updated but the apply was not started, please try again.")
+			"error starting project update: %s", err.Error())
 	}
 
 	return &api.ApplyRulesStartResp{}, nil

--- a/components/authz-service/server/v2/project.go
+++ b/components/authz-service/server/v2/project.go
@@ -186,6 +186,7 @@ func (s *state) ApplyRulesStart(
 
 	err := s.store.ApplyStagedRules(ctx)
 	if err != nil {
+		s.log.Warnf("error applying staged projects: %s", err.Error())
 		return nil, status.Errorf(codes.Internal,
 			"error applying staged projects: %s", err.Error())
 	}
@@ -195,14 +196,16 @@ func (s *state) ApplyRulesStart(
 	// We will be refactoring with workflow to make this safer soon.
 	err = s.policyRefresher.Refresh(ctx)
 	if err != nil {
+		s.log.Warnf("error refreshing policy cache: %s", err.Error())
 		return nil, status.Errorf(codes.Internal,
-			"error refreshing policy cache: %s\nthe rules were updated but the apply was not started, please try again", err.Error())
+			"error refreshing policy cache. the rules were updated but the apply was not started, please try again.")
 	}
 
 	err = s.projectUpdateManager.Start()
 	if err != nil {
+		s.log.Warnf("error starting project update: %s", err.Error())
 		return nil, status.Errorf(codes.Internal,
-			"error starting project update: %s\nthe rules and cache were updated but the apply was not started, please try again", err.Error())
+			"error starting project update. the rules and cache were updated but the apply was not started, please try again.")
 	}
 
 	return &api.ApplyRulesStartResp{}, nil

--- a/components/authz-service/server/v2/project_test.go
+++ b/components/authz-service/server/v2/project_test.go
@@ -458,7 +458,7 @@ func setupProjectsAndRules(t *testing.T) (api.ProjectsClient, *cache.Cache, *cac
 	configMgr, err := config.NewManager(configFile)
 	require.NoError(t, err)
 	projectsSrv, err := v2.NewProjectsServer(ctx, l, mem_v2, &testhelpers.TestProjectRulesRetriever{},
-		eventServiceClient, configMgr, v2.NewMockPolicyRefresher())
+		eventServiceClient, configMgr, testhelpers.NewMockPolicyRefresher())
 	require.NoError(t, err)
 
 	serviceCerts := helpers.LoadDevCerts(t, "authz-service")

--- a/components/authz-service/server/v2/project_test.go
+++ b/components/authz-service/server/v2/project_test.go
@@ -458,7 +458,7 @@ func setupProjectsAndRules(t *testing.T) (api.ProjectsClient, *cache.Cache, *cac
 	configMgr, err := config.NewManager(configFile)
 	require.NoError(t, err)
 	projectsSrv, err := v2.NewProjectsServer(ctx, l, mem_v2, &testhelpers.TestProjectRulesRetriever{},
-		eventServiceClient, configMgr)
+		eventServiceClient, configMgr, v2.NewMockPolicyRefresher())
 	require.NoError(t, err)
 
 	serviceCerts := helpers.LoadDevCerts(t, "authz-service")

--- a/components/authz-service/server/v2/rules_property_test.go
+++ b/components/authz-service/server/v2/rules_property_test.go
@@ -22,7 +22,8 @@ const (
 )
 
 func TestCreateRuleProperties(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	testFW := testhelpers.NewTestFramework(t, ctx)
 	cl := testFW.Projects
 	testDB := testFW.TestDB

--- a/components/authz-service/server/v2/rules_property_test.go
+++ b/components/authz-service/server/v2/rules_property_test.go
@@ -23,7 +23,10 @@ const (
 
 func TestCreateRuleProperties(t *testing.T) {
 	ctx := context.Background()
-	cl, testDB, _, _, seed := testhelpers.SetupProjectsAndRulesWithDB(t)
+	testFW := testhelpers.NewTestFramework(t, ctx)
+	cl := testFW.Projects
+	testDB := testFW.TestDB
+	seed := testFW.Seed
 
 	graphicRange := rangetable.Merge(unicode.GraphicRanges...)
 
@@ -161,4 +164,5 @@ func TestCreateRuleProperties(t *testing.T) {
 		}),
 	))
 	properties.TestingRun(t)
+	testFW.Shutdown(t, ctx)
 }

--- a/components/authz-service/server/v2/system_integration_test.go
+++ b/components/authz-service/server/v2/system_integration_test.go
@@ -2,25 +2,25 @@ package v2_test
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/chef/automate/lib/logger"
-
 	api_v2 "github.com/chef/automate/api/interservice/authz/v2"
-	"github.com/chef/automate/components/authz-service/engine/opa"
+	"github.com/chef/automate/components/authz-service/testhelpers"
 )
 
 // In these tests, we assert that our default policies are in place, and do
 // their job as expected. For this, we setup a v2 server using a proper OPA
 // engine instance, and run a few queries.
 
-func TestSystemPolicies(t *testing.T) {
+func TestIntegrationSystemPolicies(t *testing.T) {
 	ctx := context.Background()
 	ts := setupWithOPAV2(t)
-	cl := ts.authz
+	cl := ts.Authz
 
 	isAuthorized := func(subject, action, resource string) func(*testing.T) {
 		return func(t *testing.T) {
@@ -50,46 +50,175 @@ func TestSystemPolicies(t *testing.T) {
 
 	for desc, test := range cases {
 		t.Run(desc, test)
+		ts.TestDB.Flush(t)
 	}
+
+	ts.Shutdown(t, ctx)
 }
 
-func TestFilterAuthorizedProjectsWithSystemPolicies(t *testing.T) {
+func TestIntegrationFilterAuthorizedProjectsWithSystemPolicies(t *testing.T) {
 	ctx := context.Background()
 	ts := setupWithOPAV2p1(t)
 
-	t.Run("user should only get projects they have non-system level access to", func(t *testing.T) {
-		_, err := ts.projects.CreateProject(ctx, &api_v2.CreateProjectReq{
-			Id:   "project-1",
-			Name: "name1",
-		})
-		require.NoError(t, err)
-
-		statement := api_v2.Statement{
-			Effect:    api_v2.Statement_ALLOW,
-			Resources: []string{"infra:nodes:*"},
-			Actions:   []string{"infra:nodes:get", "infra:nodes:list"},
-			Projects:  []string{"project-1"},
-		}
-		req := api_v2.CreatePolicyReq{
-			Id:         "policy1",
-			Name:       "my favorite policy",
-			Members:    []string{"user:local:alice"},
-			Statements: []*api_v2.Statement{&statement},
-		}
-		_, err = ts.policy.CreatePolicy(ctx, &req)
-		require.NoError(t, err)
-
-		resp, err := ts.authz.FilterAuthorizedProjects(ctx,
-			&api_v2.FilterAuthorizedProjectsReq{
-				Subjects: []string{"user:local:alice"},
+	cases := []struct {
+		desc string
+		f    func(*testing.T)
+	}{
+		{"user should only get projects they have non-system level access to", func(t *testing.T) {
+			_, err := ts.Projects.CreateProject(ctx, &api_v2.CreateProjectReq{
+				Id:   "project-1",
+				Name: "name1",
 			})
-		require.NoError(t, err)
+			require.NoError(t, err)
 
-		assert.ElementsMatch(t, []string{"project-1"}, resp.Projects)
+			statement := api_v2.Statement{
+				Effect:    api_v2.Statement_ALLOW,
+				Resources: []string{"infra:nodes:*"},
+				Actions:   []string{"infra:nodes:get", "infra:nodes:list"},
+				Projects:  []string{"project-1"},
+			}
+			req := api_v2.CreatePolicyReq{
+				Id:         "policy1",
+				Name:       "my favorite policy",
+				Members:    []string{"user:local:alice"},
+				Statements: []*api_v2.Statement{&statement},
+			}
+			_, err = ts.Policy.CreatePolicy(ctx, &req)
+			require.NoError(t, err)
+
+			// force sync refresh
+			err = ts.PolicyRefresher.Refresh(ctx)
+			require.NoError(t, err)
+
+			resp, err := ts.Authz.FilterAuthorizedProjects(ctx,
+				&api_v2.FilterAuthorizedProjectsReq{
+					Subjects: []string{"user:local:alice"},
+				})
+			require.NoError(t, err)
+
+			fmt.Println(resp.Projects)
+			assert.ElementsMatch(t, []string{"project-1"}, resp.Projects)
+		}},
+	}
+
+	rand.Shuffle(len(cases), func(i, j int) {
+		cases[i], cases[j] = cases[j], cases[i]
 	})
+
+	for _, test := range cases {
+		t.Run(test.desc, test.f)
+		ts.Flush(t, ctx)
+	}
+
+	ts.Shutdown(t, ctx)
 }
 
-func TestListRulesForAllProjects(t *testing.T) {
+// func TestIntegrationApplyRulesStart(t *testing.T) {
+// 	ctx := context.Background()
+// 	ts := setupWithOPAV2p1(t)
+
+// 	values1, values2, values3 := []string{"opscode", "chef"}, []string{"chef"}, []string{"other", "org"}
+// 	type1 := api_v2.ProjectRuleTypes_NODE
+// 	conditions1 := []*api_v2.Condition{
+// 		{
+// 			Attribute: api_v2.ProjectRuleConditionAttributes_CHEF_ORGS,
+// 			Values:    values1,
+// 			Operator:  api_v2.ProjectRuleConditionOperators_MEMBER_OF,
+// 		},
+// 	}
+// 	type2 := api_v2.ProjectRuleTypes_EVENT
+// 	conditions2 := []*api_v2.Condition{
+// 		{
+// 			Attribute: api_v2.ProjectRuleConditionAttributes_CHEF_ORGS,
+// 			Values:    values2,
+// 			Operator:  api_v2.ProjectRuleConditionOperators_EQUALS,
+// 		},
+// 	}
+// 	conditions3 := []*api_v2.Condition{
+// 		{
+// 			Attribute: api_v2.ProjectRuleConditionAttributes_CHEF_ORGS,
+// 			Values:    values3,
+// 			Operator:  api_v2.ProjectRuleConditionOperators_MEMBER_OF,
+// 		},
+// 	}
+
+// 	cases := []struct {
+// 		desc string
+// 		f    func(*testing.T)
+// 	}{
+// 		{"if no rules rules exist, returns nothing is put in the cache", func(t *testing.T) {
+// 			resp, err := ts.Projects.ApplyRulesStart(ctx, &api_v2.ApplyRulesStartReq{})
+// 			assert.Equal(t, &api_v2.ApplyRulesStartResp{}, resp)
+// 			assert.NoError(t, err)
+// 			rules, err := ts.Engine.ListProjectMappings(ctx)
+// 			assert.NoError(t, err)
+// 			assert.Equal(t, 0, len(rules))
+// 		}},
+// 		{"if staged rules rules exist, returns them in the cache", func(t *testing.T) {
+// 			id1, id2, id3 := "rule-number-1", "rule-number-2", "rule-number-3"
+// 			pid1, pid2 := "foo-project", "bar-project"
+// 			name := "you don't talk about fight club"
+
+// 			_, err := ts.Projects.CreateProject(ctx, &api_v2.CreateProjectReq{
+// 				Id:   pid1,
+// 				Name: name,
+// 			})
+// 			require.NoError(t, err)
+
+// 			_, err = ts.Projects.CreateProject(ctx, &api_v2.CreateProjectReq{
+// 				Id:   pid2,
+// 				Name: name,
+// 			})
+// 			require.NoError(t, err)
+
+// 			_, err = ts.Projects.CreateRule(ctx, &api_v2.CreateRuleReq{
+// 				Id:         id1,
+// 				Name:       name,
+// 				Type:       type1,
+// 				ProjectId:  pid1,
+// 				Conditions: conditions1,
+// 			})
+// 			require.NoError(t, err)
+// 			_, err = ts.Projects.CreateRule(ctx, &api_v2.CreateRuleReq{
+// 				Id:         id2,
+// 				Name:       name,
+// 				Type:       type2,
+// 				ProjectId:  pid1,
+// 				Conditions: conditions2,
+// 			})
+// 			require.NoError(t, err)
+// 			_, err = ts.Projects.CreateRule(ctx, &api_v2.CreateRuleReq{
+// 				Id:         id3,
+// 				Name:       name,
+// 				Type:       type2,
+// 				ProjectId:  pid2,
+// 				Conditions: conditions3,
+// 			})
+// 			require.NoError(t, err)
+
+// 			resp, err := ts.Projects.ApplyRulesStart(ctx, &api_v2.ApplyRulesStartReq{})
+// 			assert.Equal(t, &api_v2.ApplyRulesStartResp{}, resp)
+// 			assert.NoError(t, err)
+// 			rules, err := ts.Engine.ListProjectMappings(ctx)
+// 			assert.NoError(t, err)
+// 			assert.Equal(t, 3, len(rules))
+// 		}},
+// 	}
+
+// 	rand.Shuffle(len(cases), func(i, j int) {
+// 		cases[i], cases[j] = cases[j], cases[i]
+// 	})
+
+// 	for _, test := range cases {
+// 		t.Run(test.desc, test.f)
+// 		ts.Flush(t, ctx)
+// 	}
+
+// ts.Shutdown(t, ctx)
+
+// }
+
+func TestIntegrationListRulesForAllProjects(t *testing.T) {
 	ctx := context.Background()
 	ts := setupWithOPAV2p1(t)
 
@@ -118,91 +247,131 @@ func TestListRulesForAllProjects(t *testing.T) {
 		},
 	}
 
-	t.Run("if no rules exist, returns empty list", func(t *testing.T) {
-		list, err := ts.projects.ListRules(ctx, &api_v2.ListRulesReq{})
-		require.Empty(t, list.Rules)
-		require.NoError(t, err)
+	cases := []struct {
+		desc string
+		f    func(*testing.T)
+	}{
+		{"if no rules exist, returns empty list", func(t *testing.T) {
+			list, err := ts.Projects.ListRules(ctx, &api_v2.ListRulesReq{})
+			require.Empty(t, list.Rules)
+			require.NoError(t, err)
 
-		resp, err := ts.projects.ListRulesForAllProjects(ctx, &api_v2.ListRulesForAllProjectsReq{})
-		require.NoError(t, err)
-		assert.Equal(t, &api_v2.ListRulesForAllProjectsResp{}, resp)
+			resp, err := ts.Projects.ListRulesForAllProjects(ctx, &api_v2.ListRulesForAllProjectsReq{})
+			require.NoError(t, err)
+			assert.Equal(t, &api_v2.ListRulesForAllProjectsResp{}, resp)
+		}},
+		{"if multiple rules exist, returns complete rule map after projects applied", func(t *testing.T) {
+			id1, id2, id3 := "rule-number-1", "rule-number-2", "rule-number-3"
+			pid1, pid2 := "foo-project", "bar-project"
+			name := "you don't talk about fight club"
+
+			_, err := ts.Projects.CreateProject(ctx, &api_v2.CreateProjectReq{
+				Id:   pid1,
+				Name: name,
+			})
+			require.NoError(t, err)
+
+			_, err = ts.Projects.CreateProject(ctx, &api_v2.CreateProjectReq{
+				Id:   pid2,
+				Name: name,
+			})
+			require.NoError(t, err)
+
+			createResp1, err := ts.Projects.CreateRule(ctx, &api_v2.CreateRuleReq{
+				Id:         id1,
+				Name:       name,
+				Type:       type1,
+				ProjectId:  pid1,
+				Conditions: conditions1,
+			})
+			require.NoError(t, err)
+			createResp2, err := ts.Projects.CreateRule(ctx, &api_v2.CreateRuleReq{
+				Id:         id2,
+				Name:       name,
+				Type:       type2,
+				ProjectId:  pid1,
+				Conditions: conditions2,
+			})
+			require.NoError(t, err)
+			createResp3, err := ts.Projects.CreateRule(ctx, &api_v2.CreateRuleReq{
+				Id:         id3,
+				Name:       name,
+				Type:       type2,
+				ProjectId:  pid2,
+				Conditions: conditions3,
+			})
+			require.NoError(t, err)
+
+			expectedRules1 := []*api_v2.ProjectRule{createResp1.Rule, createResp2.Rule}
+			expectedRules2 := []*api_v2.ProjectRule{createResp3.Rule}
+
+			// Before rule apply
+			list, err := ts.Projects.ListRules(ctx, &api_v2.ListRulesReq{})
+			require.Equal(t, 0, len(list.Rules))
+			require.NoError(t, err)
+			beforeResp, err := ts.Projects.ListRulesForAllProjects(ctx, &api_v2.ListRulesForAllProjectsReq{})
+			require.NoError(t, err)
+			require.Equal(t, 0, len(beforeResp.ProjectRules))
+
+			// After rule apply
+			_, err = ts.Projects.ApplyRulesStart(ctx, &api_v2.ApplyRulesStartReq{})
+			assert.NoError(t, err)
+
+			// Force the OPA cache up to date
+			err = ts.PolicyRefresher.Refresh(ctx)
+
+			resp, err := ts.Projects.ListRulesForAllProjects(ctx, &api_v2.ListRulesForAllProjectsReq{})
+			fmt.Println("asdf")
+			fmt.Println(resp.ProjectRules)
+			fmt.Println("expected")
+			fmt.Println(expectedRules1)
+			fmt.Println(expectedRules2)
+
+			require.NoError(t, err)
+			actualPid1Rules, ok := resp.ProjectRules[pid1]
+			require.True(t, ok)
+			actualPid2Rules, ok := resp.ProjectRules[pid2]
+			require.True(t, ok)
+			assert.ElementsMatch(t, expectedRules1, actualPid1Rules.Rules)
+			assert.ElementsMatch(t, expectedRules2, actualPid2Rules.Rules)
+		}},
+	}
+
+	rand.Shuffle(len(cases), func(i, j int) {
+		cases[i], cases[j] = cases[j], cases[i]
 	})
 
-	t.Run("if multiple rules exist, returns complete rule map", func(t *testing.T) {
-		id1, id2, id3 := "rule-number-1", "rule-number-2", "rule-number-3"
-		pid1, pid2 := "foo-project", "bar-project"
-		name := "you don't talk about fight club"
-		createResp1, err := ts.projects.CreateRule(ctx, &api_v2.CreateRuleReq{
-			Id:         id1,
-			Name:       name,
-			Type:       type1,
-			ProjectId:  pid1,
-			Conditions: conditions1,
-		})
-		require.NoError(t, err)
-		createResp2, err := ts.projects.CreateRule(ctx, &api_v2.CreateRuleReq{
-			Id:         id2,
-			Name:       name,
-			Type:       type2,
-			ProjectId:  pid1,
-			Conditions: conditions2,
-		})
-		require.NoError(t, err)
-		createResp3, err := ts.projects.CreateRule(ctx, &api_v2.CreateRuleReq{
-			Id:         id3,
-			Name:       name,
-			Type:       type2,
-			ProjectId:  pid2,
-			Conditions: conditions3,
-		})
-		require.NoError(t, err)
+	for _, test := range cases {
+		t.Run(test.desc, test.f)
+		ts.Flush(t, ctx)
+	}
 
-		expectedRules1 := []*api_v2.ProjectRule{createResp1.Rule, createResp2.Rule}
-		expectedRules2 := []*api_v2.ProjectRule{createResp3.Rule}
-
-		list, err := ts.projects.ListRules(ctx, &api_v2.ListRulesReq{})
-		require.Equal(t, 3, len(list.Rules))
-		require.NoError(t, err)
-
-		resp, err := ts.projects.ListRulesForAllProjects(ctx, &api_v2.ListRulesForAllProjectsReq{})
-		require.NoError(t, err)
-		actualPid1Rules, ok := resp.ProjectRules[pid1]
-		require.True(t, ok)
-		actualPid2Rules, ok := resp.ProjectRules[pid2]
-		require.True(t, ok)
-		assert.ElementsMatch(t, expectedRules1, actualPid1Rules.Rules)
-		assert.ElementsMatch(t, expectedRules2, actualPid2Rules.Rules)
-	})
+	ts.Shutdown(t, ctx)
 }
 
-func setupWithOPAV2(t *testing.T) testSetup {
+func setupWithOPAV2(t *testing.T) *testhelpers.TestFramework {
 	return setupWithOPAV2pX(t, false)
 }
 
-func setupWithOPAV2p1(t *testing.T) testSetup {
+func setupWithOPAV2p1(t *testing.T) *testhelpers.TestFramework {
 	return setupWithOPAV2pX(t, true)
 }
 
-func setupWithOPAV2pX(t *testing.T, twoPointOne bool) testSetup {
+func setupWithOPAV2pX(t *testing.T, twoPointOne bool) *testhelpers.TestFramework {
 	t.Helper()
 	ctx := context.Background()
 
-	l, err := logger.NewLogger("text", "debug")
-	require.NoError(t, err, "init logger for storage+engine")
-
-	o, err := opa.New(ctx, l)
-	require.NoError(t, err, "init OPA")
-
-	vChan := make(chan api_v2.Version, 1)
-	emptyV1List := v1Lister{}
-	ts := setupV2WithMigrationState(t, o, o, &emptyV1List, o, vChan, nil)
+	tf := testhelpers.NewTestFramework(t, ctx)
 	var flag api_v2.Flag
 	if twoPointOne {
 		flag = api_v2.Flag_VERSION_2_1
 	} else {
 		flag = api_v2.Flag_VERSION_2_0
 	}
-	_, err = ts.policy.MigrateToV2(ctx, &api_v2.MigrateToV2Req{Flag: flag})
+	_, err := tf.Policy.MigrateToV2(ctx, &api_v2.MigrateToV2Req{
+		Flag:           flag,
+		SkipV1Policies: true,
+	})
 	require.NoError(t, err)
-	return ts
+	return tf
 }

--- a/components/authz-service/server/v2/system_integration_test.go
+++ b/components/authz-service/server/v2/system_integration_test.go
@@ -5,12 +5,16 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	api_v2 "github.com/chef/automate/api/interservice/authz/v2"
+	"github.com/chef/automate/components/authz-service/config"
 	"github.com/chef/automate/components/authz-service/testhelpers"
+	project_update_tags "github.com/chef/automate/lib/authz"
+	event_ids "github.com/chef/automate/lib/event"
 )
 
 // In these tests, we assert that our default policies are in place, and do
@@ -18,8 +22,10 @@ import (
 // engine instance, and run a few queries.
 
 func TestIntegrationSystemPolicies(t *testing.T) {
-	ctx := context.Background()
-	ts := setupWithOPAV2(t)
+	// TODO (tc): Do we need to set up a new TestFramework instance per test?
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ts := setupWithOPAV2p1(t)
 	cl := ts.Authz
 
 	isAuthorized := func(subject, action, resource string) func(*testing.T) {
@@ -57,14 +63,15 @@ func TestIntegrationSystemPolicies(t *testing.T) {
 }
 
 func TestIntegrationFilterAuthorizedProjectsWithSystemPolicies(t *testing.T) {
-	ctx := context.Background()
-	ts := setupWithOPAV2p1(t)
-
 	cases := []struct {
 		desc string
 		f    func(*testing.T)
 	}{
 		{"user should only get projects they have non-system level access to", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ts := setupWithOPAV2p1(t)
+
 			_, err := ts.Projects.CreateProject(ctx, &api_v2.CreateProjectReq{
 				Id:   "project-1",
 				Name: "name1",
@@ -96,8 +103,9 @@ func TestIntegrationFilterAuthorizedProjectsWithSystemPolicies(t *testing.T) {
 				})
 			require.NoError(t, err)
 
-			fmt.Println(resp.Projects)
 			assert.ElementsMatch(t, []string{"project-1"}, resp.Projects)
+
+			ts.Shutdown(t, ctx)
 		}},
 	}
 
@@ -107,121 +115,10 @@ func TestIntegrationFilterAuthorizedProjectsWithSystemPolicies(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.desc, test.f)
-		ts.Flush(t, ctx)
 	}
-
-	ts.Shutdown(t, ctx)
 }
 
-// func TestIntegrationApplyRulesStart(t *testing.T) {
-// 	ctx := context.Background()
-// 	ts := setupWithOPAV2p1(t)
-
-// 	values1, values2, values3 := []string{"opscode", "chef"}, []string{"chef"}, []string{"other", "org"}
-// 	type1 := api_v2.ProjectRuleTypes_NODE
-// 	conditions1 := []*api_v2.Condition{
-// 		{
-// 			Attribute: api_v2.ProjectRuleConditionAttributes_CHEF_ORGS,
-// 			Values:    values1,
-// 			Operator:  api_v2.ProjectRuleConditionOperators_MEMBER_OF,
-// 		},
-// 	}
-// 	type2 := api_v2.ProjectRuleTypes_EVENT
-// 	conditions2 := []*api_v2.Condition{
-// 		{
-// 			Attribute: api_v2.ProjectRuleConditionAttributes_CHEF_ORGS,
-// 			Values:    values2,
-// 			Operator:  api_v2.ProjectRuleConditionOperators_EQUALS,
-// 		},
-// 	}
-// 	conditions3 := []*api_v2.Condition{
-// 		{
-// 			Attribute: api_v2.ProjectRuleConditionAttributes_CHEF_ORGS,
-// 			Values:    values3,
-// 			Operator:  api_v2.ProjectRuleConditionOperators_MEMBER_OF,
-// 		},
-// 	}
-
-// 	cases := []struct {
-// 		desc string
-// 		f    func(*testing.T)
-// 	}{
-// 		{"if no rules rules exist, returns nothing is put in the cache", func(t *testing.T) {
-// 			resp, err := ts.Projects.ApplyRulesStart(ctx, &api_v2.ApplyRulesStartReq{})
-// 			assert.Equal(t, &api_v2.ApplyRulesStartResp{}, resp)
-// 			assert.NoError(t, err)
-// 			rules, err := ts.Engine.ListProjectMappings(ctx)
-// 			assert.NoError(t, err)
-// 			assert.Equal(t, 0, len(rules))
-// 		}},
-// 		{"if staged rules rules exist, returns them in the cache", func(t *testing.T) {
-// 			id1, id2, id3 := "rule-number-1", "rule-number-2", "rule-number-3"
-// 			pid1, pid2 := "foo-project", "bar-project"
-// 			name := "you don't talk about fight club"
-
-// 			_, err := ts.Projects.CreateProject(ctx, &api_v2.CreateProjectReq{
-// 				Id:   pid1,
-// 				Name: name,
-// 			})
-// 			require.NoError(t, err)
-
-// 			_, err = ts.Projects.CreateProject(ctx, &api_v2.CreateProjectReq{
-// 				Id:   pid2,
-// 				Name: name,
-// 			})
-// 			require.NoError(t, err)
-
-// 			_, err = ts.Projects.CreateRule(ctx, &api_v2.CreateRuleReq{
-// 				Id:         id1,
-// 				Name:       name,
-// 				Type:       type1,
-// 				ProjectId:  pid1,
-// 				Conditions: conditions1,
-// 			})
-// 			require.NoError(t, err)
-// 			_, err = ts.Projects.CreateRule(ctx, &api_v2.CreateRuleReq{
-// 				Id:         id2,
-// 				Name:       name,
-// 				Type:       type2,
-// 				ProjectId:  pid1,
-// 				Conditions: conditions2,
-// 			})
-// 			require.NoError(t, err)
-// 			_, err = ts.Projects.CreateRule(ctx, &api_v2.CreateRuleReq{
-// 				Id:         id3,
-// 				Name:       name,
-// 				Type:       type2,
-// 				ProjectId:  pid2,
-// 				Conditions: conditions3,
-// 			})
-// 			require.NoError(t, err)
-
-// 			resp, err := ts.Projects.ApplyRulesStart(ctx, &api_v2.ApplyRulesStartReq{})
-// 			assert.Equal(t, &api_v2.ApplyRulesStartResp{}, resp)
-// 			assert.NoError(t, err)
-// 			rules, err := ts.Engine.ListProjectMappings(ctx)
-// 			assert.NoError(t, err)
-// 			assert.Equal(t, 3, len(rules))
-// 		}},
-// 	}
-
-// 	rand.Shuffle(len(cases), func(i, j int) {
-// 		cases[i], cases[j] = cases[j], cases[i]
-// 	})
-
-// 	for _, test := range cases {
-// 		t.Run(test.desc, test.f)
-// 		ts.Flush(t, ctx)
-// 	}
-
-// ts.Shutdown(t, ctx)
-
-// }
-
-func TestIntegrationListRulesForAllProjects(t *testing.T) {
-	ctx := context.Background()
-	ts := setupWithOPAV2p1(t)
-
+func TestIntegrationRuleApplyAndList(t *testing.T) {
 	values1, values2, values3 := []string{"opscode", "chef"}, []string{"chef"}, []string{"other", "org"}
 	type1 := api_v2.ProjectRuleTypes_NODE
 	conditions1 := []*api_v2.Condition{
@@ -251,16 +148,25 @@ func TestIntegrationListRulesForAllProjects(t *testing.T) {
 		desc string
 		f    func(*testing.T)
 	}{
-		{"if no rules exist, returns empty list", func(t *testing.T) {
-			list, err := ts.Projects.ListRules(ctx, &api_v2.ListRulesReq{})
-			require.Empty(t, list.Rules)
-			require.NoError(t, err)
+		{"if no rules rules exist, returns nothing is put in the cache", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ts := setupWithOPAV2p1(t)
 
-			resp, err := ts.Projects.ListRulesForAllProjects(ctx, &api_v2.ListRulesForAllProjectsReq{})
-			require.NoError(t, err)
-			assert.Equal(t, &api_v2.ListRulesForAllProjectsResp{}, resp)
+			resp, err := ts.Projects.ApplyRulesStart(ctx, &api_v2.ApplyRulesStartReq{})
+			assert.Equal(t, &api_v2.ApplyRulesStartResp{}, resp)
+			assert.NoError(t, err)
+			rules, err := ts.Engine.ListProjectMappings(ctx)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(rules))
+
+			ts.Shutdown(t, ctx)
 		}},
-		{"if multiple rules exist, returns complete rule map after projects applied", func(t *testing.T) {
+		{"if no rules exist, insert some, apply them, then return the complete rule map", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ts := setupWithOPAV2p1(t)
+
 			id1, id2, id3 := "rule-number-1", "rule-number-2", "rule-number-3"
 			pid1, pid2 := "foo-project", "bar-project"
 			name := "you don't talk about fight club"
@@ -302,6 +208,9 @@ func TestIntegrationListRulesForAllProjects(t *testing.T) {
 			})
 			require.NoError(t, err)
 
+			createResp1.Rule.Status = "applied"
+			createResp2.Rule.Status = "applied"
+			createResp3.Rule.Status = "applied"
 			expectedRules1 := []*api_v2.ProjectRule{createResp1.Rule, createResp2.Rule}
 			expectedRules2 := []*api_v2.ProjectRule{createResp3.Rule}
 
@@ -317,23 +226,165 @@ func TestIntegrationListRulesForAllProjects(t *testing.T) {
 			_, err = ts.Projects.ApplyRulesStart(ctx, &api_v2.ApplyRulesStartReq{})
 			assert.NoError(t, err)
 
-			// Force the OPA cache up to date
-			err = ts.PolicyRefresher.Refresh(ctx)
-
 			resp, err := ts.Projects.ListRulesForAllProjects(ctx, &api_v2.ListRulesForAllProjectsReq{})
-			fmt.Println("asdf")
-			fmt.Println(resp.ProjectRules)
-			fmt.Println("expected")
-			fmt.Println(expectedRules1)
-			fmt.Println(expectedRules2)
-
 			require.NoError(t, err)
 			actualPid1Rules, ok := resp.ProjectRules[pid1]
 			require.True(t, ok)
 			actualPid2Rules, ok := resp.ProjectRules[pid2]
 			require.True(t, ok)
-			assert.ElementsMatch(t, expectedRules1, actualPid1Rules.Rules)
-			assert.ElementsMatch(t, expectedRules2, actualPid2Rules.Rules)
+			rulesEqual(t, expectedRules1, actualPid1Rules.Rules)
+			rulesEqual(t, expectedRules2, actualPid2Rules.Rules)
+
+			ts.Shutdown(t, ctx)
+		}},
+		{"when some rules exist, update and modify them, re-apply and list the updated rules from the cache", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ts := setupWithOPAV2p1(t)
+
+			id1, id2, id3 := "rule-number-1", "rule-number-2", "rule-number-3"
+			pid1, pid2 := "foo-project", "bar-project"
+			name := "you don't talk about fight club"
+
+			_, err := ts.Projects.CreateProject(ctx, &api_v2.CreateProjectReq{
+				Id:   pid1,
+				Name: name,
+			})
+			require.NoError(t, err)
+
+			_, err = ts.Projects.CreateProject(ctx, &api_v2.CreateProjectReq{
+				Id:   pid2,
+				Name: name,
+			})
+			require.NoError(t, err)
+
+			createResp1, err := ts.Projects.CreateRule(ctx, &api_v2.CreateRuleReq{
+				Id:         id1,
+				Name:       name,
+				Type:       type1,
+				ProjectId:  pid1,
+				Conditions: conditions1,
+			})
+			require.NoError(t, err)
+			createResp2, err := ts.Projects.CreateRule(ctx, &api_v2.CreateRuleReq{
+				Id:         id2,
+				Name:       name,
+				Type:       type1,
+				ProjectId:  pid1,
+				Conditions: conditions2,
+			})
+			require.NoError(t, err)
+			createResp3, err := ts.Projects.CreateRule(ctx, &api_v2.CreateRuleReq{
+				Id:         id3,
+				Name:       name,
+				Type:       type2,
+				ProjectId:  pid2,
+				Conditions: conditions3,
+			})
+			require.NoError(t, err)
+
+			// Apply rules
+			_, err = ts.Projects.ApplyRulesStart(ctx, &api_v2.ApplyRulesStartReq{})
+			assert.NoError(t, err)
+
+			testhelpers.WaitForWithTimeout(t, func() bool {
+				return config.RunningState == ts.ProjectUpdateManager.State()
+			}, time.Second*3, "State did not switch to Running")
+
+			createResp1.Rule.Status = "applied"
+			createResp2.Rule.Status = "applied"
+			createResp3.Rule.Status = "applied"
+			expectedRules1 := []*api_v2.ProjectRule{createResp1.Rule, createResp2.Rule}
+			expectedRules2 := []*api_v2.ProjectRule{createResp3.Rule}
+
+			resp, err := ts.Projects.ListRulesForAllProjects(ctx, &api_v2.ListRulesForAllProjectsReq{})
+			require.NoError(t, err)
+			actualPid1Rules, ok := resp.ProjectRules[pid1]
+			require.True(t, ok)
+			actualPid2Rules, ok := resp.ProjectRules[pid2]
+			require.True(t, ok)
+			rulesEqual(t, expectedRules1, actualPid1Rules.Rules)
+			rulesEqual(t, expectedRules2, actualPid2Rules.Rules)
+
+			// Manually trigger completed state and wait for it to be true
+			eventData := ts.LatestEvent.Data
+			projectUpdateIDTag := eventData.Fields[project_update_tags.ProjectUpdateIDTag].GetStringValue()
+
+			infraStatusEvent := testhelpers.CreateStatusEventMsg(projectUpdateIDTag,
+				0.0,  // EstimatedTimeCompleteInSec
+				1.0,  // percentageComplete
+				true, // completed
+				event_ids.InfraClientRunsProducerID)
+			err = ts.ProjectUpdateManager.ProcessStatusEvent(infraStatusEvent)
+			assert.NoError(t, err)
+
+			eventData = ts.LatestEvent.Data
+			projectUpdateIDTag = eventData.Fields[project_update_tags.ProjectUpdateIDTag].GetStringValue()
+
+			complianceStatusEvent := testhelpers.CreateStatusEventMsg(projectUpdateIDTag,
+				0.0,  // EstimatedTimeCompleteInSec
+				1.0,  // percentageComplete
+				true, // completed
+				event_ids.ComplianceInspecReportProducerID)
+			err = ts.ProjectUpdateManager.ProcessStatusEvent(complianceStatusEvent)
+			assert.NoError(t, err)
+
+			testhelpers.WaitForWithTimeout(t, func() bool {
+				return config.NotRunningState == ts.ProjectUpdateManager.State()
+			}, time.Second*3, "State did not switch to Running")
+
+			// Update and delete rules
+			_, err = ts.Projects.DeleteRule(ctx, &api_v2.DeleteRuleReq{Id: id1})
+			require.NoError(t, err)
+
+			newConditions := []*api_v2.Condition{
+				{
+					Attribute: api_v2.ProjectRuleConditionAttributes_CHEF_TAGS,
+					Values:    []string{"test_tag1", "test_tag2"},
+					Operator:  api_v2.ProjectRuleConditionOperators_MEMBER_OF,
+				},
+				{
+					Attribute: api_v2.ProjectRuleConditionAttributes_CHEF_ORGS,
+					Values:    []string{"test_org"},
+					Operator:  api_v2.ProjectRuleConditionOperators_EQUALS,
+				},
+			}
+
+			_, err = ts.Projects.UpdateRule(ctx, &api_v2.UpdateRuleReq{
+				Id:         createResp2.Rule.Id,
+				ProjectId:  createResp2.Rule.ProjectId,
+				Name:       "this has been updated",
+				Type:       createResp2.Rule.Type,
+				Conditions: newConditions,
+			})
+			require.NoError(t, err)
+
+			// Re-apply and check cache
+			_, err = ts.Projects.ApplyRulesStart(ctx, &api_v2.ApplyRulesStartReq{})
+			assert.NoError(t, err)
+
+			expectedAfterApplyRules1 := []*api_v2.ProjectRule{
+				&api_v2.ProjectRule{
+					Id:         createResp2.Rule.Id,
+					ProjectId:  createResp2.Rule.ProjectId,
+					Name:       "this has been updated",
+					Type:       createResp2.Rule.Type,
+					Conditions: newConditions,
+					Status:     "applied",
+				},
+			}
+			eexpectedAfterApplyRules2 := []*api_v2.ProjectRule{createResp3.Rule}
+
+			resp2, err := ts.Projects.ListRulesForAllProjects(ctx, &api_v2.ListRulesForAllProjectsReq{})
+			require.NoError(t, err)
+			actualAfterApplyPid1Rules, ok := resp2.ProjectRules[pid1]
+			require.True(t, ok)
+			actualAfterApplyPid2Rules, ok := resp2.ProjectRules[pid2]
+			require.True(t, ok)
+			rulesEqual(t, expectedAfterApplyRules1, actualAfterApplyPid1Rules.Rules)
+			rulesEqual(t, eexpectedAfterApplyRules2, actualAfterApplyPid2Rules.Rules)
+
+			ts.Shutdown(t, ctx)
 		}},
 	}
 
@@ -343,10 +394,39 @@ func TestIntegrationListRulesForAllProjects(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.desc, test.f)
-		ts.Flush(t, ctx)
+	}
+}
+
+func rulesEqual(t *testing.T, expected, actual []*api_v2.ProjectRule) {
+	t.Helper()
+	if len(expected) != len(actual) {
+		t.FailNow()
+		fmt.Printf("expected len %d != actual len %d", len(expected), len(actual))
 	}
 
-	ts.Shutdown(t, ctx)
+	for i, expectedRule := range expected {
+		actualRule := actual[i]
+		assert.Equal(t, expectedRule.Id, actualRule.Id)
+		assert.Equal(t, expectedRule.ProjectId, actualRule.ProjectId)
+		assert.Equal(t, expectedRule.Type, actualRule.Type)
+		assert.Equal(t, expectedRule.Deleted, actualRule.Deleted)
+		assert.Equal(t, expectedRule.Status, actualRule.Status)
+
+		expectedConditions := expectedRule.Conditions
+		actualConditions := actualRule.Conditions
+
+		if len(expectedConditions) != len(actualConditions) {
+			t.FailNow()
+			fmt.Printf("expected len %d != actual len %d", len(expectedConditions), len(actualConditions))
+		}
+
+		for i, expectedCondition := range expectedConditions {
+			actualCondition := actualConditions[i]
+			assert.Equal(t, expectedCondition.Attribute, actualCondition.Attribute)
+			assert.Equal(t, expectedCondition.Values, actualCondition.Values)
+			assert.Equal(t, expectedCondition.Operator, actualCondition.Operator)
+		}
+	}
 }
 
 func setupWithOPAV2(t *testing.T) *testhelpers.TestFramework {

--- a/components/authz-service/storage/v2/memstore/memstore.go
+++ b/components/authz-service/storage/v2/memstore/memstore.go
@@ -339,7 +339,7 @@ func (s *State) DeleteRule(ctx context.Context, id string) error {
 	return nil
 }
 
-func (s *State) ApplyStagedRules(ctx context.Context) error {
+func (*State) ApplyStagedRules(context.Context) error {
 	// TODO
 	return nil
 }

--- a/components/authz-service/storage/v2/memstore/memstore.go
+++ b/components/authz-service/storage/v2/memstore/memstore.go
@@ -339,6 +339,11 @@ func (s *State) DeleteRule(ctx context.Context, id string) error {
 	return nil
 }
 
+func (s *State) ApplyStagedRules(ctx context.Context) error {
+	// TODO
+	return nil
+}
+
 func (s *State) CreateProject(_ context.Context, project *storage.Project) (*storage.Project, error) {
 	if project.Type == storage.Custom {
 		items := s.projects.Items()

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -1297,7 +1297,7 @@ func (p *pg) ApplyStagedRules(ctx context.Context) error {
 			SELECT a.id FROM iam_project_rules AS a
 			LEFT OUTER JOIN iam_staged_project_rules AS s
 			ON s.id=a.id
-			WHERE s.deleted=true);`)
+			WHERE s.deleted)`)
 	if err != nil {
 		return p.processError(err)
 	}

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -974,11 +974,6 @@ func (p *pg) CreateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 		}
 	}
 
-	err = p.notifyPolicyChange(ctx, tx)
-	if err != nil {
-		return nil, p.processError(err)
-	}
-
 	err = tx.Commit()
 	if err != nil {
 		return nil, storage_errors.NewErrTxCommit(err)
@@ -1297,6 +1292,11 @@ func (p *pg) ApplyStagedRules(ctx context.Context) error {
 	}
 
 	_, err = tx.ExecContext(ctx, `DELETE FROM iam_staged_project_rules;`)
+	if err != nil {
+		return p.processError(err)
+	}
+
+	err = p.notifyPolicyChange(ctx, tx)
 	if err != nil {
 		return p.processError(err)
 	}

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -1273,6 +1273,9 @@ func (p *pg) ApplyStagedRules(ctx context.Context) error {
 		}
 		ids[id] = dbID
 	}
+	if err := rows.Err(); err != nil {
+		return errors.Wrap(err, "error retrieving result rows")
+	}
 
 	for id, dbID := range ids {
 		_, err = tx.ExecContext(ctx,

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -1251,14 +1251,14 @@ func (p *pg) ApplyStagedRules(ctx context.Context) error {
 				ON CONFLICT (id) DO UPDATE
 				SET name=excluded.name, type=excluded.type
 				RETURNING id, db_id;`)
+	if err != nil {
+		return p.processError(err)
+	}
 	defer func() {
 		if err := rows.Close(); err != nil {
 			p.logger.Warnf("failed to close db rows: %s", err.Error())
 		}
 	}()
-	if err != nil {
-		return p.processError(err)
-	}
 
 	// For every staged rule updated, we need to update conditions.
 	ids := make(map[string]string)

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -3310,6 +3310,7 @@ func TestCreateRule(t *testing.T) {
 			require.NoError(t, err)
 			rule, err := storage.NewRule("new-id-1", "project-not-found", "name", storage.Node, []storage.Condition{condition1})
 			require.NoError(t, err)
+
 			resp, err := store.CreateRule(ctx, &rule)
 			assert.Nil(t, resp)
 			assert.Equal(t, storage_errors.ErrForeignKey, err)
@@ -3318,12 +3319,9 @@ func TestCreateRule(t *testing.T) {
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
-			condition1, err := storage.NewCondition(storage.Node, []string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule, err := storage.NewRule("new-id-1", projID, "name", storage.Node, []storage.Condition{condition1})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule)
-			resp, err := store.CreateRule(ctx, &rule)
+			rule := insertAppliedRuleWithMultipleConditions(t, db, "copy", projID, storage.Node)
+
+			resp, err := store.CreateRule(ctx, rule)
 			assert.Nil(t, resp)
 			assert.Equal(t, storage_errors.ErrConflict, err)
 		},
@@ -3331,12 +3329,9 @@ func TestCreateRule(t *testing.T) {
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
-			condition1, err := storage.NewCondition(storage.Node, []string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule, err := storage.NewRule("new-id-1", projID, "name", storage.Node, []storage.Condition{condition1})
-			insertStagedRule(t, db, &rule, false)
-			require.NoError(t, err)
-			resp, err := store.CreateRule(ctx, &rule)
+			rule := insertStagedRuleWithMultipleConditions(t, db, "copy", projID, storage.Node, false)
+
+			resp, err := store.CreateRule(ctx, rule)
 			assert.Nil(t, resp)
 			assert.Equal(t, storage_errors.ErrConflict, err)
 		},
@@ -3470,7 +3465,7 @@ func TestListRules(t *testing.T) {
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
-			insertStagedRuleWithMultipleConditions(t, db, projID, storage.Node, false)
+			insertStagedRuleWithMultipleConditions(t, db, "staged-rule", projID, storage.Node, false)
 			resp, err := store.ListRules(ctx)
 			assert.NoError(t, err)
 			assert.Nil(t, resp)
@@ -3482,21 +3477,12 @@ func TestListRules(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
-
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			rule2, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule2)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			rule1 := insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, ruleType)
+			rule2 := insertAppliedRuleWithMultipleConditions(t, db, "rule-2", projID, ruleType)
 
 			resp, err := store.ListRules(ctx)
 			assert.NoError(t, err)
-			assert.ElementsMatch(t, []*storage.Rule{rule1, &rule2}, resp)
+			assert.ElementsMatch(t, []*storage.Rule{rule1, rule2}, resp)
 		},
 		"when staged and applied rules exist with no project filter, returns applied rules": func(t *testing.T) {
 			ctx := context.Background()
@@ -3505,23 +3491,13 @@ func TestListRules(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
-
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			rule2, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertStagedRule(t, db, &rule2, false)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
-			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+			rule1 := insertAppliedRuleWithMultipleConditions(t, db, "rule1", projID, ruleType)
+			insertStagedRuleWithMultipleConditions(t, db, "rule2", projID, ruleType, false)
 
 			resp, err := store.ListRules(ctx)
 			assert.NoError(t, err)
 			require.NotZero(t, len(resp))
-			assert.Equal(t, rule1, resp[0])
+			assert.ElementsMatch(t, []*storage.Rule{rule1}, resp)
 		},
 		"when multiple rules exist with a project filter, returns filtered list": func(t *testing.T) {
 			ctx := context.Background()
@@ -3533,22 +3509,14 @@ func TestListRules(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", projID2})
 
 			ruleType := storage.Node
-			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
+			insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, ruleType)
 
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule2)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			rule2 := insertAppliedRuleWithMultipleConditions(t, db, "rule-2", projID2, ruleType)
 
 			resp, err := store.ListRules(ctx)
 			assert.NoError(t, err)
 			require.NotZero(t, len(resp))
-			assert.Equal(t, &rule2, resp[0])
+			assert.ElementsMatch(t, []*storage.Rule{rule2}, resp)
 		},
 	}
 
@@ -3577,31 +3545,15 @@ func TestListStagedAndAppliedRules(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			rule2, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule2)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			rule1 := insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, ruleType)
+			rule2 := insertAppliedRuleWithMultipleConditions(t, db, "rule-2", projID, ruleType)
 
-			rule3 := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
-			condition8, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-4"}, storage.ChefServer, storage.MemberOf)
-			rule4, err := storage.NewRule("new-id-4", projID, "name4", ruleType,
-				[]storage.Condition{condition8})
-			require.NoError(t, err)
-			insertStagedRule(t, db, &rule4, false)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule3.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule4.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+			rule3 := insertStagedRuleWithMultipleConditions(t, db, "rule-3", projID, ruleType, false)
+			rule4 := insertStagedRuleWithMultipleConditions(t, db, "rule-4", projID, ruleType, false)
 
 			resp, err := store.ListStagedAndAppliedRules(ctx)
 			require.NoError(t, err)
-			assert.ElementsMatch(t, []*storage.Rule{rule1, &rule2, rule3, &rule4}, resp)
+			assert.ElementsMatch(t, []*storage.Rule{rule1, rule2, rule3, rule4}, resp)
 		},
 		"when multiple staged and applied rules exist with a project filter, returns filtered list": func(t *testing.T) {
 			ctx := context.Background()
@@ -3613,32 +3565,16 @@ func TestListStagedAndAppliedRules(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", projID2})
 
 			ruleType := storage.Node
-			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule2)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			insertAppliedRuleWithMultipleConditions(t, db, "applied-rule", projID, ruleType)
+			rule2 := insertAppliedRuleWithMultipleConditions(t, db, "applied-rule2", projID2, ruleType)
 
-			rule3 := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
-			condition8, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-4"}, storage.ChefServer, storage.MemberOf)
-			rule4, err := storage.NewRule("new-id-4", projID2, "name4", ruleType,
-				[]storage.Condition{condition8})
-			require.NoError(t, err)
-			insertStagedRule(t, db, &rule4, false)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule3.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule4.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+			insertStagedRuleWithMultipleConditions(t, db, "staged-rule", projID, ruleType, false)
+			rule4 := insertStagedRuleWithMultipleConditions(t, db, "staged-rule4", projID2, ruleType, false)
 
 			resp, err := store.ListStagedAndAppliedRules(ctx)
 			assert.NoError(t, err)
 			require.NotZero(t, len(resp))
-			assert.ElementsMatch(t, []*storage.Rule{&rule2, &rule4}, resp)
+			assert.ElementsMatch(t, []*storage.Rule{rule2, rule4}, resp)
 		},
 	}
 
@@ -3682,7 +3618,7 @@ func TestListRulesForProject(t *testing.T) {
 			projID2 := "project-2"
 			insertTestProject(t, db, projID2, "pika p", storage.Custom)
 
-			insertAppliedRuleWithMultipleConditions(t, db, projID2, storage.Node)
+			insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID2, storage.Node)
 
 			resp, err := store.ListRulesForProject(ctx, projID)
 			assert.NoError(t, err)
@@ -3699,28 +3635,14 @@ func TestListRulesForProject(t *testing.T) {
 			insertTestProject(t, db, projID2, "pika p", storage.Custom)
 
 			ruleType := storage.Node
-			insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
-
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule2)
-
-			condition5, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-3", "chef-server-4"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule3, err := storage.NewRule("new-id-3", projID2, "name3", ruleType,
-				[]storage.Condition{condition5})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule3)
+			insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, ruleType)
+			rule2 := insertAppliedRuleWithMultipleConditions(t, db, "rule-2", projID2, ruleType)
+			rule3 := insertAppliedRuleWithMultipleConditions(t, db, "rule-3", projID2, ruleType)
 
 			resp, err := store.ListRulesForProject(ctx, projID2)
 			assert.NoError(t, err)
 			assert.Equal(t, 2, len(resp))
-			assert.ElementsMatch(t, []*storage.Rule{&rule2, &rule3}, resp)
+			assert.ElementsMatch(t, []*storage.Rule{rule2, rule3}, resp)
 		}},
 		{"when the requested project is in the filter, returns the rules for the project", func(t *testing.T) {
 			ctx := context.Background()
@@ -3732,28 +3654,14 @@ func TestListRulesForProject(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", projID2})
 
 			ruleType := storage.Node
-			insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
-
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule2)
-
-			condition5, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-3", "chef-server-4"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule3, err := storage.NewRule("new-id-3", projID2, "name3", ruleType,
-				[]storage.Condition{condition5})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule3)
+			insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, ruleType)
+			rule2 := insertAppliedRuleWithMultipleConditions(t, db, "rule-2", projID2, ruleType)
+			rule3 := insertAppliedRuleWithMultipleConditions(t, db, "rule-3", projID2, ruleType)
 
 			resp, err := store.ListRulesForProject(ctx, projID2)
 			assert.NoError(t, err)
 			assert.Equal(t, 2, len(resp))
-			assert.ElementsMatch(t, []*storage.Rule{&rule2, &rule3}, resp)
+			assert.ElementsMatch(t, []*storage.Rule{rule2, rule3}, resp)
 		}},
 		{"when the requested project is not in the filter, returns an empty list", func(t *testing.T) {
 			ctx := context.Background()
@@ -3765,26 +3673,10 @@ func TestListRulesForProject(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", "project-4"})
 
 			ruleType := storage.Node
-			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
+			insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, ruleType)
 
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule2)
-
-			condition5, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-3", "chef-server-4"}, storage.ChefServer, storage.MemberOf)
-			rule3, err := storage.NewRule("new-id-3", projID2, "name3", ruleType,
-				[]storage.Condition{condition5})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule3)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule3.ID))
-			assertCount(t, 5, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			insertAppliedRuleWithMultipleConditions(t, db, "rule-2", projID2, ruleType)
+			insertAppliedRuleWithMultipleConditions(t, db, "rule-3", projID2, ruleType)
 
 			resp, err := store.ListRulesForProject(ctx, projID2)
 			assert.NoError(t, err)
@@ -3835,7 +3727,7 @@ func TestListRulesForProject(t *testing.T) {
 			require.NoError(t, err)
 			insertStagedRule(t, db, &updatedRule, false)
 
-			appliedRule := insertAppliedRuleWithMultipleConditions(t, db, projID, condition.Type)
+			appliedRule := insertAppliedRuleWithMultipleConditions(t, db, "applied", projID, condition.Type)
 
 			resp, err := store.ListRulesForProject(ctx, projID)
 			assert.NoError(t, err)
@@ -3846,52 +3738,28 @@ func TestListRulesForProject(t *testing.T) {
 			projID := "foo-project"
 			insertTestProject(t, db, projID, "first project", storage.Custom)
 
-			condition1, err := storage.NewCondition(storage.Node,
-				[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule1, err := storage.NewRule("bar-rule", projID, "bar rule", condition1.Type, []storage.Condition{condition1})
-			assert.NoError(t, err)
-			insertAppliedRule(t, db, &rule1)
-
-			condition2, err := storage.NewCondition(storage.Node,
-				[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule2, err := storage.NewRule("foo-rule", projID, "coo foo rule", condition2.Type, []storage.Condition{condition2})
-			assert.NoError(t, err)
-			insertAppliedRule(t, db, &rule2)
-
-			insertDeletedStagedRule(t, db, &rule2)
+			rule1 := insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, storage.Node)
+			rule2 := insertAppliedRuleWithMultipleConditions(t, db, "rule-2", projID, storage.Event)
+			insertDeletedStagedRule(t, db, rule2)
 
 			resp, err := store.ListRulesForProject(ctx, projID)
 			assert.NoError(t, err)
-			assert.ElementsMatch(t, []*storage.Rule{&rule1}, resp)
+			assert.ElementsMatch(t, []*storage.Rule{rule1}, resp)
 		}},
 		{"when multiple projects exist, returns only the requested project's rules", func(t *testing.T) {
 			ctx := context.Background()
 			projID1 := "foo-project"
 			insertTestProject(t, db, projID1, "first project", storage.Custom)
-
-			condition1, err := storage.NewCondition(storage.Node,
-				[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule1, err := storage.NewRule("foo-rule", projID1, "coo foo rule", condition1.Type, []storage.Condition{condition1})
-			assert.NoError(t, err)
-			insertAppliedRule(t, db, &rule1)
+			rule1 := insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID1, storage.Event)
 
 			projID2 := "bar-project"
 			insertTestProject(t, db, projID2, "second project", storage.Custom)
-
-			condition2, err := storage.NewCondition(storage.Node,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.Equals)
-			require.NoError(t, err)
-			rule2, err := storage.NewRule("bar-rule", projID2, "coo foo rule", condition2.Type, []storage.Condition{condition2})
-			assert.NoError(t, err)
-			insertAppliedRule(t, db, &rule2)
+			rule2 := insertAppliedRuleWithMultipleConditions(t, db, "rule-2", projID2, storage.Node)
 
 			resp, err := store.ListRulesForProject(ctx, projID1)
 			assert.NoError(t, err)
-			assert.ElementsMatch(t, []*storage.Rule{&rule1}, resp)
-			assert.NotContains(t, resp, &rule2)
+			assert.ElementsMatch(t, []*storage.Rule{rule1}, resp)
+			assert.NotContains(t, resp, rule2)
 		}},
 	}
 
@@ -3937,9 +3805,6 @@ func TestUpdateRule(t *testing.T) {
 				[]storage.Condition{condition1})
 			require.NoError(t, err)
 			insertAppliedRule(t, db, &ruleOriginal)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1 AND name=$2 AND type=$3 AND project_id=$4`,
-				ruleOriginal.ID, ruleOriginal.Name, ruleOriginal.Type.String(), ruleOriginal.ProjectID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
 			projID2 := "project-2"
 			insertTestProject(t, db, projID2, "pika p", storage.Custom)
@@ -3989,12 +3854,13 @@ func TestUpdateRule(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			rule := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
+			rule := insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"new-chef-server"}, storage.ChefServer, storage.MemberOf)
+			require.NoError(t, err)
 			conditions := []storage.Condition{condition4}
-			ruleUpdated, err := storage.NewRule("new-id-1", projID, "name", ruleType, append(conditions, rule.Conditions...))
+			ruleUpdated, err := storage.NewRule(rule.ID, projID, "name", ruleType, append(conditions, rule.Conditions...))
 			require.NoError(t, err)
 			ruleUpdated.Status = Applied
 			resp, err := store.UpdateRule(ctx, &ruleUpdated)
@@ -4026,6 +3892,7 @@ func TestUpdateRule(t *testing.T) {
 
 			condition4, err := storage.NewCondition(rule.Type,
 				[]string{"new-chef-server"}, storage.ChefServer, storage.MemberOf)
+			require.NoError(t, err)
 			ruleUpdated, err := storage.NewRule("new-id-1", projID, "updated", rule.Type,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
@@ -4044,12 +3911,11 @@ func TestUpdateRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"not-a-match", "some-other-project"})
 
 			ruleType := storage.Node
-			ruleOriginal := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1 AND name=$2 AND type=$3 AND project_id=$4`,
-				ruleOriginal.ID, ruleOriginal.Name, ruleOriginal.Type.String(), ruleOriginal.ProjectID))
+			ruleOriginal := insertAppliedRuleWithMultipleConditions(t, db, "rule-original", projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"new-chef-server"}, storage.ChefServer, storage.MemberOf)
+			require.NoError(t, err)
 			conditions := []storage.Condition{condition4}
 			ruleUpdated, err := storage.NewRule(ruleOriginal.ID, projID, "name", ruleType, append(conditions, ruleOriginal.Conditions...))
 			require.NoError(t, err)
@@ -4066,12 +3932,13 @@ func TestUpdateRule(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			ruleOriginal := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleOriginal := insertAppliedRuleWithMultipleConditions(t, db, "rule-original", projID, ruleType)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1 AND name=$2 AND type=$3 AND project_id=$4`,
 				ruleOriginal.ID, ruleOriginal.Name, ruleOriginal.Type.String(), ruleOriginal.ProjectID))
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"new-chef-server"}, storage.ChefServer, storage.MemberOf)
+			require.NoError(t, err)
 			conditions := []storage.Condition{condition4}
 			updatedRule, err := storage.NewRule(ruleOriginal.ID, projID, "new name", ruleType, append(conditions, ruleOriginal.Conditions...))
 			require.NoError(t, err)
@@ -4128,7 +3995,9 @@ func TestUpdateRule(t *testing.T) {
 
 			newCondition, err := storage.NewCondition(storage.Event,
 				[]string{"new-chef-server-2"}, storage.ChefServer, storage.Equals)
+			require.NoError(t, err)
 			updatedRule, err := storage.NewRule(originalRule.ID, originalRule.ProjectID, "foo bar", originalRule.Type, append(conditions, newCondition))
+			require.NoError(t, err)
 
 			resp, err := store.UpdateRule(ctx, &updatedRule)
 			require.NoError(t, err)
@@ -4192,16 +4061,7 @@ func TestGetStagedOrAppliedRule(t *testing.T) {
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
-			ruleType := storage.Node
-			condition1, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType, []storage.Condition{condition1})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule)
-
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, storage.Node)
 
 			resp, err := store.GetStagedOrAppliedRule(ctx, "not-found")
 			assert.Nil(t, resp)
@@ -4209,23 +4069,11 @@ func TestGetStagedOrAppliedRule(t *testing.T) {
 		},
 		"when multiple rules exists with no project filter, return correct rule": func(t *testing.T) {
 			ctx := context.Background()
-
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
-			ruleType := storage.Node
-			ruleToGet := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
-
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			otherRule, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &otherRule)
-
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToGet.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, otherRule.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			ruleToGet := insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, storage.Node)
+			insertAppliedRuleWithMultipleConditions(t, db, "other-rule", projID, storage.Event)
 
 			resp, err := store.GetStagedOrAppliedRule(ctx, ruleToGet.ID)
 			assert.NoError(t, err)
@@ -4240,16 +4088,8 @@ func TestGetStagedOrAppliedRule(t *testing.T) {
 			insertTestProject(t, db, projID2, "pika p", storage.Custom)
 			ctx = insertProjectsIntoContext(ctx, []string{projID, projID2, "some-other-project"})
 
-			ruleType := storage.Node
-			ruleToGet := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, ruleToGet.ID))
-
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule2)
+			ruleToGet := insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, storage.Node)
+			insertAppliedRuleWithMultipleConditions(t, db, "other-project-rule", projID2, storage.Event)
 
 			resp, err := store.GetStagedOrAppliedRule(ctx, ruleToGet.ID)
 			assert.NoError(t, err)
@@ -4264,15 +4104,8 @@ func TestGetStagedOrAppliedRule(t *testing.T) {
 			insertTestProject(t, db, projID2, "pika p", storage.Custom)
 			ctx = insertProjectsIntoContext(ctx, []string{projID2, "some-other-project"})
 
-			ruleType := storage.Node
-			ruleToGet := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
-
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			rule2, err := storage.NewRule("new-id-2", projID2, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule2)
+			ruleToGet := insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, storage.Event)
+			insertAppliedRuleWithMultipleConditions(t, db, "other-rule", projID2, storage.Node)
 
 			resp, err := store.GetStagedOrAppliedRule(ctx, ruleToGet.ID)
 			assert.Nil(t, resp)
@@ -4373,62 +4206,39 @@ func TestDeleteRule(t *testing.T) {
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
-			ruleType := storage.Node
-			condition1, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType, []storage.Condition{condition1})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule)
+			rule := insertAppliedRuleWithMultipleConditions(t, db, "some-rule", projID, storage.Event)
 
-			err = store.DeleteRule(ctx, "not-found")
+			err := store.DeleteRule(ctx, "not-found")
 			assert.Equal(t, storage_errors.ErrNotFound, err)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 		},
 		"when an applied and staged rule exists but the wrong id requested, returns NotFoundErr": func(t *testing.T) {
 			ctx := context.Background()
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
-			ruleType := storage.Node
-			condition1, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType, []storage.Condition{condition1})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &rule)
-			insertStagedRule(t, db, &rule, false)
+			rule := insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, storage.Event)
+			insertStagedRuleWithMultipleConditions(t, db, rule.ID, rule.ProjectID, rule.Type, false)
 
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
-
-			err = store.DeleteRule(ctx, "not-found")
+			err := store.DeleteRule(ctx, "not-found")
 			assert.Equal(t, storage_errors.ErrNotFound, err)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
 		"when only staged rule exists but the wrong id requested, returns NotFoundErr": func(t *testing.T) {
 			ctx := context.Background()
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
-			ruleType := storage.Node
-			condition1, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
-			require.NoError(t, err)
-			rule, err := storage.NewRule("new-id-1", projID, "name", ruleType, []storage.Condition{condition1})
-			require.NoError(t, err)
-			insertStagedRule(t, db, &rule, false)
+			rule := insertStagedRuleWithMultipleConditions(t, db, "staged", projID, storage.Event, false)
 
-			err = store.DeleteRule(ctx, "not-found")
+			err := store.DeleteRule(ctx, "not-found")
 			assert.Equal(t, storage_errors.ErrNotFound, err)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
 		"when multiple staged rules exist with no project filter, delete rule and associated conditions": func(t *testing.T) {
 			ctx := context.Background()
@@ -4437,27 +4247,15 @@ func TestDeleteRule(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, "delete-me", projID, ruleType, false)
+			ruleToSave := insertStagedRuleWithMultipleConditions(t, db, "save-me", projID, ruleType, false)
 
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-
-			insertStagedRule(t, db, &ruleToSave, false)
-
-			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_project_rules`))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
-
-			err = store.DeleteRule(ctx, ruleToDelete.ID)
+			err := store.DeleteRule(ctx, ruleToDelete.ID)
 			assert.NoError(t, err)
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules`))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
 		"when multiple staged rules exist with a matching project filter and no applied rules, delete rule and associated conditions": func(t *testing.T) {
 			ctx := context.Background()
@@ -4467,24 +4265,14 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{projID, "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, "delete-me", projID, ruleType, false)
+			insertStagedRuleWithMultipleConditions(t, db, "save-me", projID, ruleType, false)
 
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertStagedRule(t, db, &ruleToSave, false)
-
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
-
-			err = store.DeleteRule(ctx, ruleToDelete.ID)
+			err := store.DeleteRule(ctx, ruleToDelete.ID)
 			assert.NoError(t, err)
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules`))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
 		"when multiple staged rules exists with a non-matching project filter, do not delete anything": func(t *testing.T) {
 			ctx := context.Background()
@@ -4494,24 +4282,14 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, "delete-me", projID, ruleType, false)
+			ruleToSave := insertStagedRuleWithMultipleConditions(t, db, "save-me", projID, ruleType, false)
 
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-
-			insertStagedRule(t, db, &ruleToSave, false)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
-
-			err = store.DeleteRule(ctx, ruleToDelete.ID)
+			err := store.DeleteRule(ctx, ruleToDelete.ID)
 			assert.Equal(t, storage_errors.ErrNotFound, err)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+			assertCount(t, 6, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
 		"when multiple staged and applied rules exist with a non-matching project filter, do not delete anything": func(t *testing.T) {
 			ctx := context.Background()
@@ -4521,11 +4299,12 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
-			insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, "delete-me", projID, ruleType, false)
+			insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
+			require.NoError(t, err)
 			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition4})
 			require.NoError(t, err)
@@ -4546,22 +4325,14 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{projID, "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
-			insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToDelete := insertAppliedRuleWithMultipleConditions(t, db, "delete-me", projID, ruleType)
+			ruleToSave := insertStagedRuleWithMultipleConditions(t, db, "save-me", projID, ruleType, false)
 
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertStagedRule(t, db, &ruleToSave, false)
-			insertAppliedRule(t, db, &ruleToSave)
-
-			err = store.DeleteRule(ctx, ruleToDelete.ID)
+			err := store.DeleteRule(ctx, ruleToDelete.ID)
 			assert.NoError(t, err)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=true`, ruleToDelete.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=false`, ruleToSave.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions WHERE rule_db_id=(SELECT r.db_id FROM iam_staged_project_rules r WHERE r.id=$1)`, ruleToDelete.ID))
 		},
 		"when multiple applied rules exist with a matching project filter, mark for delete": func(t *testing.T) {
 			ctx := context.Background()
@@ -4571,16 +4342,10 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{projID, "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToDelete := insertAppliedRuleWithMultipleConditions(t, db, "delete-me", projID, ruleType)
+			ruleToSave := insertAppliedRuleWithMultipleConditions(t, db, "save-me", projID, ruleType)
 
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &ruleToSave)
-
-			err = store.DeleteRule(ctx, ruleToDelete.ID)
+			err := store.DeleteRule(ctx, ruleToDelete.ID)
 			assert.NoError(t, err)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=true`, ruleToDelete.ID))
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=false`, ruleToSave.ID))
@@ -4594,16 +4359,10 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"wrong-project", "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToDelete := insertAppliedRuleWithMultipleConditions(t, db, "delete-me", projID, ruleType)
+			ruleToSave := insertAppliedRuleWithMultipleConditions(t, db, "save-me", projID, ruleType)
 
-			condition4, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
-			ruleToSave, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
-				[]storage.Condition{condition4})
-			require.NoError(t, err)
-			insertAppliedRule(t, db, &ruleToSave)
-
-			err = store.DeleteRule(ctx, ruleToDelete.ID)
+			err := store.DeleteRule(ctx, ruleToDelete.ID)
 			assert.Equal(t, storage_errors.ErrNotFound, err)
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToDelete.ID))
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, ruleToSave.ID))
@@ -4631,29 +4390,25 @@ func TestApplyStagedRules(t *testing.T) {
 		{"when there are no staged rules, applied rules are unchanged", func(t *testing.T) {
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
-			rule := insertAppliedRuleWithMultipleConditions(t, db, projID, storage.Node)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules
-				WHERE id=$1 AND project_id=$2 AND name=$3 AND type=$4`, rule.ID, rule.ProjectID, rule.Name, rule.Type.String()))
+			rule := insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID, storage.Node)
 
 			err := store.ApplyStagedRules(ctx)
 			assert.NoError(t, err)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules
 				WHERE id=$1 AND project_id=$2 AND name=$3 AND type=$4`, rule.ID, rule.ProjectID, rule.Name, rule.Type.String()))
 		}},
-		{"when there are n staged rules marked for update but no applied rules, it creates n staged rules", func(t *testing.T) {
+		{"when there are n staged rules marked for update but no applied rules, it creates n applied rules", func(t *testing.T) {
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 			ruleType := storage.Node
-			rule1 := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
+			rule1 := insertStagedRuleWithMultipleConditions(t, db, "rule-1", projID, ruleType, false)
 			condition, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
+			require.NoError(t, err)
 			rule2, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition})
 			require.NoError(t, err)
 			insertStagedRule(t, db, &rule2, false)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule1.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 
 			err = store.ApplyStagedRules(ctx)
 			assert.NoError(t, err)
@@ -4661,37 +4416,20 @@ func TestApplyStagedRules(t *testing.T) {
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions WHERE rule_db_id=(SELECT r.db_id FROM iam_project_rules r WHERE r.id=$1)`, rule1.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions WHERE rule_db_id=(SELECT r.db_id FROM iam_project_rules r WHERE r.id=$1)`, rule2.ID))
 		}},
 		{"when all staged rules are marked for delete, there are no applied rules or conditions remaining", func(t *testing.T) {
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 			ruleType := storage.Node
-			insertAppliedRuleWithMultipleConditions(t, db, projID, storage.Node)
-			rule1 := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, true)
+			ruleToDelete1 := insertAppliedRuleWithMultipleConditions(t, db, "delete-me-1", projID, storage.Node)
+			insertStagedRuleWithMultipleConditions(t, db, ruleToDelete1.ID, projID, ruleType, true)
 
-			condition1, err := storage.NewCondition(ruleType,
-				[]string{"chef-server-2"}, storage.ChefServer, storage.Equals)
-			require.NoError(t, err)
-			rule2, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
-				[]storage.Condition{condition1})
-			require.NoError(t, err)
-			rule2.Deleted = true
-			insertStagedRule(t, db, &rule2, true)
+			ruleToDelete2 := insertAppliedRuleWithMultipleConditions(t, db, "delete-me-2", projID, storage.Node)
+			insertStagedRuleWithMultipleConditions(t, db, ruleToDelete2.ID, projID, ruleType, true)
 
-			condition2, err := storage.NewCondition(ruleType,
-				[]string{"tag1", "tag2"}, storage.ChefTag, storage.MemberOf)
-			require.NoError(t, err)
-			rule2.Conditions = []storage.Condition{condition1, condition2}
-			insertAppliedRule(t, db, &rule2)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule1.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 5, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
-
-			err = store.ApplyStagedRules(ctx)
+			err := store.ApplyStagedRules(ctx)
 			assert.NoError(t, err)
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules`))
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
@@ -4700,10 +4438,12 @@ func TestApplyStagedRules(t *testing.T) {
 		}},
 		{"when there are staged rules for update and delete that are a subset of applied rules, update or delete relevant rules", func(t *testing.T) {
 			projID := "project-1"
+			id1 := "project-1-rule"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
+			
 			ruleType := storage.Node
-			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, storage.Node)
-			insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, true)
+			rule1 := insertAppliedRuleWithMultipleConditions(t, db, id1, projID, storage.Node)
+			insertStagedRuleWithMultipleConditions(t, db, id1, projID, ruleType, true)
 
 			condition1, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.Equals)
@@ -4737,17 +4477,6 @@ func TestApplyStagedRules(t *testing.T) {
 			require.NoError(t, err)
 			insertAppliedRule(t, db, &rule3)
 
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule1.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 2, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules`))
-			assertCount(t, 5, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
-
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule3.ID))
-			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_project_rules`))
-			assertCount(t, 7, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
-
 			err = store.ApplyStagedRules(ctx)
 			assert.NoError(t, err)
 
@@ -4769,8 +4498,9 @@ func TestApplyStagedRules(t *testing.T) {
 					rule3.ID, rule3.Name, rule3.ProjectID, rule3.Type.String(),
 				),
 			)
-			assertCount(t, 2, db.QueryRow(`SELECT count(*) FROM iam_project_rules`))
-			assertCount(t, 5, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+			assertCount(t, 2, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions WHERE rule_db_id=(SELECT r.db_id FROM iam_project_rules r WHERE r.id=$1)`, rule2.ID))
+			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions WHERE rule_db_id=(SELECT r.db_id FROM iam_project_rules r WHERE r.id=$1)`, rule3.ID))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions WHERE rule_db_id=(SELECT r.db_id FROM iam_project_rules r WHERE r.id=$1)`, rule1.ID))
 		}},
 	}
 
@@ -7142,23 +6872,22 @@ func insertDeletedStagedRule(t *testing.T, db *testhelpers.TestDB, rule *storage
 	insertStagedRule(t, db, rule, true)
 }
 
-func insertAppliedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB, projID string, ruleType storage.RuleType) *storage.Rule {
+func insertAppliedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB, id, projID string, ruleType storage.RuleType) *storage.Rule {
 	t.Helper()
-	rule := createRuleObjectWithMultipleConditions(t, projID, ruleType, Applied, false)
+	rule := createRuleObjectWithMultipleConditions(t, id, projID, ruleType, Applied, false)
 	insertAppliedRule(t, db, rule)
 	return rule
 }
 
-func insertStagedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB, projID string, ruleType storage.RuleType, deleted bool) *storage.Rule {
+func insertStagedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB, id, projID string, ruleType storage.RuleType, deleted bool) *storage.Rule {
 	t.Helper()
-	rule := createRuleObjectWithMultipleConditions(t, projID, ruleType, Staged, deleted)
+	rule := createRuleObjectWithMultipleConditions(t, id, projID, ruleType, Staged, deleted)
 	insertStagedRule(t, db, rule, deleted)
 	return rule
 }
 
-func createRuleObjectWithMultipleConditions(t *testing.T, projID string, ruleType storage.RuleType, status string, deleted bool) *storage.Rule {
+func createRuleObjectWithMultipleConditions(t *testing.T, id, projID string, ruleType storage.RuleType, status string, deleted bool) *storage.Rule {
 	t.Helper()
-	id := "new-id-1"
 	condition1, err := storage.NewCondition(ruleType,
 		[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
 	require.NoError(t, err)

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -3750,7 +3750,7 @@ func TestListRulesForProject(t *testing.T) {
 			ctx := context.Background()
 			projID1 := "foo-project"
 			insertTestProject(t, db, projID1, "first project", storage.Custom)
-			rule1 := insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID1, storage.Event)
+			rule1 := insertAppliedRuleWithMultipleConditions(t, db, "rule-1", projID1, storage.Node)
 
 			projID2 := "bar-project"
 			insertTestProject(t, db, projID2, "second project", storage.Custom)
@@ -4440,7 +4440,7 @@ func TestApplyStagedRules(t *testing.T) {
 			projID := "project-1"
 			id1 := "project-1-rule"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
-			
+
 			ruleType := storage.Node
 			rule1 := insertAppliedRuleWithMultipleConditions(t, db, id1, projID, storage.Node)
 			insertStagedRuleWithMultipleConditions(t, db, id1, projID, ruleType, true)
@@ -6875,18 +6875,18 @@ func insertDeletedStagedRule(t *testing.T, db *testhelpers.TestDB, rule *storage
 func insertAppliedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB, id, projID string, ruleType storage.RuleType) *storage.Rule {
 	t.Helper()
 	rule := createRuleObjectWithMultipleConditions(t, id, projID, ruleType, Applied, false)
-	insertAppliedRule(t, db, rule)
-	return rule
+	insertAppliedRule(t, db, &rule)
+	return &rule
 }
 
 func insertStagedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB, id, projID string, ruleType storage.RuleType, deleted bool) *storage.Rule {
 	t.Helper()
 	rule := createRuleObjectWithMultipleConditions(t, id, projID, ruleType, Staged, deleted)
-	insertStagedRule(t, db, rule, deleted)
-	return rule
+	insertStagedRule(t, db, &rule, deleted)
+	return &rule
 }
 
-func createRuleObjectWithMultipleConditions(t *testing.T, id, projID string, ruleType storage.RuleType, status string, deleted bool) *storage.Rule {
+func createRuleObjectWithMultipleConditions(t *testing.T, id, projID string, ruleType storage.RuleType, status string, deleted bool) storage.Rule {
 	t.Helper()
 	condition1, err := storage.NewCondition(ruleType,
 		[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
@@ -6901,7 +6901,7 @@ func createRuleObjectWithMultipleConditions(t *testing.T, id, projID string, rul
 		[]storage.Condition{condition1, condition2, condition3})
 	require.NoError(t, err)
 	rule.Status = status
-	return &rule
+	return rule
 }
 
 func insertProjectsIntoContext(ctx context.Context, projects []string) context.Context {

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -23,7 +23,10 @@ import (
 	uuid "github.com/chef/automate/lib/uuid4"
 )
 
-const applied = "applied"
+const (
+	Applied = "applied"
+	Staged  = "staged"
+)
 
 // Note: to set up PG locally for running these tests,
 // run the following from your command line from the components/authz-service folder:
@@ -3467,7 +3470,7 @@ func TestListRules(t *testing.T) {
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
-			insertStagedRuleWithMultipleConditions(t, db, projID, storage.Node)
+			insertStagedRuleWithMultipleConditions(t, db, projID, storage.Node, false)
 			resp, err := store.ListRules(ctx)
 			assert.NoError(t, err)
 			assert.Nil(t, resp)
@@ -3585,7 +3588,7 @@ func TestListStagedAndAppliedRules(t *testing.T) {
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
-			rule3 := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType)
+			rule3 := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
 			condition8, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-4"}, storage.ChefServer, storage.MemberOf)
 			rule4, err := storage.NewRule("new-id-4", projID, "name4", ruleType,
@@ -3621,7 +3624,7 @@ func TestListStagedAndAppliedRules(t *testing.T) {
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
-			rule3 := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType)
+			rule3 := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
 			condition8, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-4"}, storage.ChefServer, storage.MemberOf)
 			rule4, err := storage.NewRule("new-id-4", projID2, "name4", ruleType,
@@ -3993,7 +3996,7 @@ func TestUpdateRule(t *testing.T) {
 			conditions := []storage.Condition{condition4}
 			ruleUpdated, err := storage.NewRule("new-id-1", projID, "name", ruleType, append(conditions, rule.Conditions...))
 			require.NoError(t, err)
-			ruleUpdated.Status = applied
+			ruleUpdated.Status = Applied
 			resp, err := store.UpdateRule(ctx, &ruleUpdated)
 			assert.NoError(t, err)
 			assert.Equal(t, &ruleUpdated, resp)
@@ -4317,7 +4320,7 @@ func TestGetStagedOrAppliedRule(t *testing.T) {
 				Type:       rule.Type,
 				Conditions: rule.Conditions,
 				Deleted:    false,
-				Status:     applied,
+				Status:     Applied,
 			}
 			assert.Equal(t, &expectedRule, resp)
 		},
@@ -4434,7 +4437,7 @@ func TestDeleteRule(t *testing.T) {
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 
 			ruleType := storage.Node
-			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
@@ -4464,7 +4467,7 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{projID, "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
@@ -4491,7 +4494,7 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
@@ -4518,7 +4521,7 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
 			insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
@@ -4543,7 +4546,7 @@ func TestDeleteRule(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{projID, "project-2"})
 
 			ruleType := storage.Node
-			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType)
+			ruleToDelete := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
 			insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
@@ -4641,13 +4644,13 @@ func TestApplyStagedRules(t *testing.T) {
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
 			ruleType := storage.Node
-			rule1 := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType)
+			rule1 := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, false)
 			condition, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
 			rule2, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
 				[]storage.Condition{condition})
 			require.NoError(t, err)
-			insertStagedRule(t, db, rule2)
+			insertStagedRule(t, db, &rule2, false)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule1.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
@@ -4659,6 +4662,115 @@ func TestApplyStagedRules(t *testing.T) {
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
 			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+		}},
+		{"when all staged rules are marked for delete, there are no applied rules or conditions remaining", func(t *testing.T) {
+			projID := "project-1"
+			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
+			ruleType := storage.Node
+			insertAppliedRuleWithMultipleConditions(t, db, projID, storage.Node)
+			rule1 := insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, true)
+
+			condition1, err := storage.NewCondition(ruleType,
+				[]string{"chef-server-2"}, storage.ChefServer, storage.Equals)
+			require.NoError(t, err)
+			rule2, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
+				[]storage.Condition{condition1})
+			require.NoError(t, err)
+			rule2.Deleted = true
+			insertStagedRule(t, db, &rule2, true)
+
+			condition2, err := storage.NewCondition(ruleType,
+				[]string{"tag1", "tag2"}, storage.ChefTag, storage.MemberOf)
+			require.NoError(t, err)
+			rule2.Conditions = []storage.Condition{condition1, condition2}
+			insertAppliedRule(t, db, &rule2)
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule1.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule2.ID))
+			assertCount(t, 4, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
+			assertCount(t, 5, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+
+			err = store.ApplyStagedRules(ctx)
+			assert.NoError(t, err)
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules`))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_project_rules`))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+		}},
+		{"when there are staged rules for update and delete that are a subset of applied rules, update or delete relevant rules", func(t *testing.T) {
+			projID := "project-1"
+			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
+			ruleType := storage.Node
+			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, storage.Node)
+			insertStagedRuleWithMultipleConditions(t, db, projID, ruleType, true)
+
+			condition1, err := storage.NewCondition(ruleType,
+				[]string{"chef-server-2"}, storage.ChefServer, storage.Equals)
+			require.NoError(t, err)
+			rule2, err := storage.NewRule("new-id-2", projID, "name2", ruleType,
+				[]storage.Condition{condition1})
+			require.NoError(t, err)
+			insertAppliedRule(t, db, &rule2)
+
+			condition2, err := storage.NewCondition(ruleType,
+				[]string{"tag1", "tag2"}, storage.ChefTag, storage.MemberOf)
+			require.NoError(t, err)
+			rule2.Conditions = []storage.Condition{condition1, condition2}
+			rule2UpdatedName := "this name has been updated"
+			rule2UpdatedType := storage.Event
+			rule2.Name = rule2UpdatedName
+			rule2.Type = rule2UpdatedType
+			insertStagedRule(t, db, &rule2, false)
+
+			condition3, err := storage.NewCondition(ruleType,
+				[]string{"role1"}, storage.ChefRole, storage.Equals)
+			require.NoError(t, err)
+			condition4, err := storage.NewCondition(ruleType,
+				[]string{"Event"}, storage.Environment, storage.Equals)
+			require.NoError(t, err)
+			condition5, err := storage.NewCondition(ruleType,
+				[]string{"org1", "org2"}, storage.Organization, storage.MemberOf)
+			require.NoError(t, err)
+			rule3, err := storage.NewRule("new-id-3", projID, "name3", ruleType,
+				[]storage.Condition{condition3, condition4, condition5})
+			require.NoError(t, err)
+			insertAppliedRule(t, db, &rule3)
+
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule1.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1`, rule2.ID))
+			assertCount(t, 2, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules`))
+			assertCount(t, 5, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule3.ID))
+			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_project_rules`))
+			assertCount(t, 7, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
+
+			err = store.ApplyStagedRules(ctx)
+			assert.NoError(t, err)
+
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules`))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+
+			assertEmpty(t,
+				db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1 AND name=$2 AND project_id=$3 AND type=$4`,
+					rule1.ID, rule1.Name, rule1.ProjectID, rule1.Type.String(),
+				),
+			)
+			assertCount(t, 1,
+				db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1 AND name=$2 AND project_id=$3 AND type=$4`,
+					rule2.ID, rule2UpdatedName, rule2.ProjectID, rule2UpdatedType.String(),
+				),
+			)
+			assertCount(t, 1,
+				db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1 AND name=$2 AND project_id=$3 AND type=$4`,
+					rule3.ID, rule3.Name, rule3.ProjectID, rule3.Type.String(),
+				),
+			)
+			assertCount(t, 2, db.QueryRow(`SELECT count(*) FROM iam_project_rules`))
+			assertCount(t, 5, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 		}},
 	}
 
@@ -6997,7 +7109,7 @@ func insertAppliedRule(t *testing.T, db *testhelpers.TestDB, rule *storage.Rule)
 	assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1 AND name=$2 AND type=$3 AND project_id=$4`,
 		rule.ID, rule.Name, rule.Type.String(), rule.ProjectID))
 	assertCount(t, len(rule.Conditions), db.QueryRow(`SELECT count(*) FROM iam_rule_conditions WHERE rule_db_id=(SELECT r.db_id FROM iam_project_rules r WHERE r.id=$1)`, rule.ID))
-	rule.Status = applied
+	rule.Status = Applied
 }
 
 func insertStagedRule(t *testing.T, db *testhelpers.TestDB, rule *storage.Rule, deleted bool) {
@@ -7027,16 +7139,19 @@ func insertDeletedStagedRule(t *testing.T, db *testhelpers.TestDB, rule *storage
 
 func insertAppliedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB, projID string, ruleType storage.RuleType) *storage.Rule {
 	t.Helper()
-	return insertRuleWithMultipleConditionsIntoTable(t, db, projID, ruleType, "iam_project_rules", "iam_rule_conditions", applied)
+	rule := createRuleObjectWithMultipleConditions(t, projID, ruleType, Applied, false)
+	insertAppliedRule(t, db, rule)
+	return rule
 }
 
-func insertStagedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB, projID string, ruleType storage.RuleType) *storage.Rule {
+func insertStagedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB, projID string, ruleType storage.RuleType, deleted bool) *storage.Rule {
 	t.Helper()
-	return insertRuleWithMultipleConditionsIntoTable(t, db, projID, ruleType, "iam_staged_project_rules", "iam_staged_rule_conditions", "staged")
+	rule := createRuleObjectWithMultipleConditions(t, projID, ruleType, Staged, deleted)
+	insertStagedRule(t, db, rule, deleted)
+	return rule
 }
 
-func insertRuleWithMultipleConditionsIntoTable(t *testing.T, db *testhelpers.TestDB, projID string, ruleType storage.RuleType,
-	ruleTable, conditionTable, status string) *storage.Rule {
+func createRuleObjectWithMultipleConditions(t *testing.T, projID string, ruleType storage.RuleType, status string, deleted bool) *storage.Rule {
 	t.Helper()
 	id := "new-id-1"
 	condition1, err := storage.NewCondition(ruleType,
@@ -7051,15 +7166,6 @@ func insertRuleWithMultipleConditionsIntoTable(t *testing.T, db *testhelpers.Tes
 	rule, err := storage.NewRule(id, projID, "name", ruleType,
 		[]storage.Condition{condition1, condition2, condition3})
 	require.NoError(t, err)
-
-	stmt := fmt.Sprintf("INSERT INTO %s (id, project_id, name, type) VALUES ($1, $2, $3, $4) RETURNING db_id", ruleTable)
-	var dbID string
-	require.NoError(t, db.QueryRow(stmt, rule.ID, projID, rule.Name, ruleType.String()).Scan(&dbID))
-	for _, c := range rule.Conditions {
-		stmt = fmt.Sprintf("INSERT INTO %s (rule_db_id, value, attribute, operator) VALUES ($1, $2, $3, $4)", conditionTable)
-		_, err = db.Exec(stmt, dbID, pq.Array(c.Value), c.Attribute.String(), c.Operator.String())
-		require.NoError(t, err)
-	}
 	rule.Status = status
 	return &rule
 }

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -6730,6 +6730,9 @@ func TestMigrationStatusProvider(t *testing.T) {
 	defer store.Close()
 	ctx := context.Background()
 
+	_, err := db.Exec(`DELETE FROM migration_status; INSERT INTO migration_status(state) VALUES ('init')`)
+	require.NoError(t, err)
+
 	cases := map[string]func(*testing.T){
 		"when nothing was ever stored, returns pristine": func(t *testing.T) {
 			ms, err := store.MigrationStatus(ctx)
@@ -6837,6 +6840,8 @@ func TestMigrationStatusProvider(t *testing.T) {
 	for name, test := range cases {
 		t.Run(name, test)
 		db.Flush(t)
+		_, err := db.Exec(`DELETE FROM migration_status; INSERT INTO migration_status(state) VALUES ('init')`)
+		require.NoError(t, err)
 	}
 }
 

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -44,7 +44,7 @@ const (
 // make kill_docker_pg
 
 func TestGetPolicy(t *testing.T) {
-	store, db, prngSeed := testhelpers.SetupTestDB(t)
+	store, db, prngSeed, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -363,7 +363,7 @@ func TestGetPolicy(t *testing.T) {
 }
 
 func TestListPolicyMembers(t *testing.T) {
-	store, db, prngSeed := testhelpers.SetupTestDB(t)
+	store, db, prngSeed, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 	ctx := context.Background()
@@ -499,7 +499,7 @@ func TestListPolicyMembers(t *testing.T) {
 }
 
 func TestListPolicies(t *testing.T) {
-	store, db, prngSeed := testhelpers.SetupTestDB(t)
+	store, db, prngSeed, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -954,7 +954,7 @@ func TestListPolicies(t *testing.T) {
 }
 
 func TestDeletePolicy(t *testing.T) {
-	store, db, prngSeed := testhelpers.SetupTestDB(t)
+	store, db, prngSeed, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -1182,7 +1182,7 @@ func TestDeletePolicy(t *testing.T) {
 }
 
 func TestCreatePolicy(t *testing.T) {
-	store, db, prngSeed := testhelpers.SetupTestDB(t)
+	store, db, prngSeed, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 	ctx := context.Background()
@@ -1732,7 +1732,7 @@ func TestCreatePolicy(t *testing.T) {
 }
 
 func TestReplacePolicyMembers(t *testing.T) {
-	store, db, prngSeed := testhelpers.SetupTestDB(t)
+	store, db, prngSeed, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -2006,7 +2006,7 @@ func TestReplacePolicyMembers(t *testing.T) {
 }
 
 func TestRemovePolicyMembers(t *testing.T) {
-	store, db, prngSeed := testhelpers.SetupTestDB(t)
+	store, db, prngSeed, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -2253,7 +2253,7 @@ func TestRemovePolicyMembers(t *testing.T) {
 }
 
 func TestAddPolicyMembers(t *testing.T) {
-	store, db, prngSeed := testhelpers.SetupTestDB(t)
+	store, db, prngSeed, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -2594,7 +2594,7 @@ func TestAddPolicyMembers(t *testing.T) {
 }
 
 func TestUpdatePolicy(t *testing.T) {
-	store, db, prngSeed := testhelpers.SetupTestDB(t)
+	store, db, prngSeed, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -3299,7 +3299,7 @@ func TestUpdatePolicy(t *testing.T) {
 }
 
 func TestCreateRule(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 	ctx := context.Background()
@@ -3454,7 +3454,7 @@ func TestCreateRule(t *testing.T) {
 }
 
 func TestListRules(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -3558,7 +3558,7 @@ func TestListRules(t *testing.T) {
 	}
 }
 func TestListStagedAndAppliedRules(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -3649,7 +3649,7 @@ func TestListStagedAndAppliedRules(t *testing.T) {
 }
 
 func TestListRulesForProject(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -3906,7 +3906,7 @@ func TestListRulesForProject(t *testing.T) {
 }
 
 func TestUpdateRule(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -4176,7 +4176,7 @@ func TestUpdateRule(t *testing.T) {
 }
 
 func TestGetStagedOrAppliedRule(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -4358,7 +4358,7 @@ func TestGetStagedOrAppliedRule(t *testing.T) {
 }
 
 func TestDeleteRule(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -4618,7 +4618,7 @@ func TestDeleteRule(t *testing.T) {
 }
 
 func TestApplyStagedRules(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 	// No project filter concerns in these tests so safe to re-use context.
@@ -4785,7 +4785,7 @@ func TestApplyStagedRules(t *testing.T) {
 }
 
 func TestCreateProject(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 	ctx := context.Background()
@@ -4899,7 +4899,7 @@ func TestCreateProject(t *testing.T) {
 }
 
 func TestUpdateProject(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -4992,7 +4992,7 @@ func TestUpdateProject(t *testing.T) {
 }
 
 func TestGetProject(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -5074,7 +5074,7 @@ func TestGetProject(t *testing.T) {
 }
 
 func TestDeleteProject(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -5174,7 +5174,7 @@ func TestDeleteProject(t *testing.T) {
 }
 
 func TestListProjects(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -5370,7 +5370,7 @@ func TestListProjects(t *testing.T) {
 }
 
 func TestCreateRole(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 	ctx := context.Background()
@@ -5505,7 +5505,7 @@ func TestCreateRole(t *testing.T) {
 }
 
 func TestListRoles(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -5842,7 +5842,7 @@ func TestListRoles(t *testing.T) {
 }
 
 func TestGetRole(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -6064,7 +6064,7 @@ func TestGetRole(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
-	store, db, prngSeed := testhelpers.SetupTestDB(t)
+	store, db, prngSeed, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 	ctx := context.Background()
@@ -6111,7 +6111,7 @@ func TestReset(t *testing.T) {
 }
 
 func TestDeleteRole(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -6343,7 +6343,7 @@ func TestDeleteRole(t *testing.T) {
 }
 
 func TestUpdateRole(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 	nonexistingRole := storage.Role{
@@ -6725,7 +6725,7 @@ func TestUpdateRole(t *testing.T) {
 }
 
 func TestMigrationStatusProvider(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 	ctx := context.Background()
@@ -6841,7 +6841,7 @@ func TestMigrationStatusProvider(t *testing.T) {
 }
 
 func TestPurgeSubjectFromPolicies(t *testing.T) {
-	store, db, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 	ctx := context.Background()

--- a/components/authz-service/storage/v2/storage.go
+++ b/components/authz-service/storage/v2/storage.go
@@ -76,6 +76,7 @@ type ruleStorage interface {
 	ListStagedAndAppliedRules(context.Context) ([]*Rule, error)
 	DeleteRule(context.Context, string) error
 	ListRulesForProject(context.Context, string) ([]*Rule, error)
+	ApplyStagedRules(context.Context) error
 }
 
 type MigrationStatusProvider interface {

--- a/components/authz-service/testhelpers/testhelpers.go
+++ b/components/authz-service/testhelpers/testhelpers.go
@@ -56,7 +56,7 @@ func SetupProjectsAndRulesWithDB(t *testing.T) (api.ProjectsClient, *TestDB, sto
 	l, err := logger.NewLogger("text", "error")
 	require.NoError(t, err, "init logger for storage")
 	projectsSrv, err := server.NewProjectsServer(ctx, l, pg, &TestProjectRulesRetriever{},
-		eventServiceClient, configMgr, server.NewMockPolicyRefresher())
+		eventServiceClient, configMgr, NewMockPolicyRefresher())
 	require.NoError(t, err)
 
 	serviceCerts := helpers.LoadDevCerts(t, "authz-service")
@@ -210,4 +210,18 @@ type TestProjectRulesRetriever struct{}
 func (t *TestProjectRulesRetriever) ListProjectMappings(
 	context.Context) (map[string][]storage.Rule, error) {
 	return make(map[string][]storage.Rule, 0), nil
+}
+
+type mockPolicyRefresher struct{}
+
+func NewMockPolicyRefresher() server.PolicyRefresher {
+	return &mockPolicyRefresher{}
+}
+
+func (*mockPolicyRefresher) Refresh(context.Context) error {
+	return nil
+}
+
+func (refresher *mockPolicyRefresher) RefreshAsync() error {
+	return nil
 }

--- a/components/authz-service/testhelpers/testhelpers.go
+++ b/components/authz-service/testhelpers/testhelpers.go
@@ -56,7 +56,7 @@ func SetupProjectsAndRulesWithDB(t *testing.T) (api.ProjectsClient, *TestDB, sto
 	l, err := logger.NewLogger("text", "error")
 	require.NoError(t, err, "init logger for storage")
 	projectsSrv, err := server.NewProjectsServer(ctx, l, pg, &TestProjectRulesRetriever{},
-		eventServiceClient, configMgr)
+		eventServiceClient, configMgr, server.NewMockPolicyRefresher())
 	require.NoError(t, err)
 
 	serviceCerts := helpers.LoadDevCerts(t, "authz-service")

--- a/lib/config/config_mgmt.go
+++ b/lib/config/config_mgmt.go
@@ -3,9 +3,10 @@ package config
 import (
 	"bytes"
 
-	"github.com/chef/automate/lib/io/fileutils"
 	toml "github.com/pelletier/go-toml"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/chef/automate/lib/io/fileutils"
 )
 
 // Manager - configuration manager for the service


### PR DESCRIPTION
### :nut_and_bolt: Description

Update `POST /apis/iam/v2beta/apply-rules` to apply all staged project rules and then trigger a `Refresh` of the OPA cache before kicking of the reindex.

Please see the commit titled `[SHAME]` for context around how the `PolicyRefresher` singleton is being routed around.

### :athletic_shoe: Demo Script / Repro Steps

##### Build and generate

```
start_all_services
rebuild components/authz-service
chef-automate iam upgrade-to-v2 --beta2.1
export TOK=`chef-automate iam token create my-token --admin`
chef_load_nodes 100
```

##### Make projects and stage initial rules

```
# curl -kH "api-token: $TOK" -XPOST -d "$(jq -n '{ id: "project1", name: "my project 1" }')" https://localhost/apis/iam/v2beta/projects
# curl -kH "api-token: $TOK" -XPOST -d "$(jq -n '{ id: "project2", name: "my project 2" }')" https://localhost/apis/iam/v2beta/projects
# curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/rules -d "$(jq -n '{ id: "rule1", name: "my foo rule", type: "NODE", project_id: "project1", conditions: [{ operator: "EQUALS", attribute: "CHEF_ORGS", values: ["The Misfits"]}]}')" | jq .
# curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/rules -d "$(jq -n '{ id: "rule2", name: "my foo rule", type: "NODE", project_id: "project2", conditions: [{ operator: "MEMBER_OF", attribute: "CHEF_ORGS", values: ["Guardians of the Galaxy", "The Avengers"]}]}')" | jq .
```

Everything is still in unassigned because rules are staged only:

```
# curl -H "projects: (unassigned)" -sH "api-token: $TOK" https://localhost/api/v0/cfgmgmt/nodes?pagination.size=1000 --insecure | jq . | grep "The Misfits" | wc -l
3
# curl -H "projects: (unassigned)" -sH "api-token: $TOK" https://localhost/api/v0/cfgmgmt/nodes?pagination.size=1000 --insecure | jq . | grep "The Avengers" | wc -l
6
```

Can see things staged:

```
chef_authz_service=# select * from iam_project_rules;
 db_id | id | project_id | name | type
-------+----+------------+------+------
(0 rows)

chef_authz_service=# select * from iam_staged_project_rules;
 db_id |  id   | project_id |    name     | type | deleted
-------+-------+------------+-------------+------+---------
     2 | rule1 | project1   | my foo rule | node | f
     3 | rule2 | project2   | my foo rule | node | f
(2 rows)
```

##### Apply Initial Rules

```
# curl -kH "api-token: $TOK" -XPOST https://localhost/apis/iam/v2beta/apply-rules
```

It should be fast since we only have 100 nodes.

Can see everything moved from staged into applied:

```
chef_authz_service=# select * from iam_project_rules;
 db_id |  id   | project_id |    name     | type
-------+-------+------------+-------------+------
     1 | rule1 | project1   | my foo rule | node
     2 | rule2 | project2   | my foo rule | node
(2 rows)

chef_authz_service=# select * from iam_staged_project_rules;
 db_id | id | project_id | name | type | deleted
-------+----+------------+------+------+---------
(0 rows)
```

And can now curl nodes that have rules with projects:

```
# curl -H "projects: project1" -sH "api-token: $TOK" https://localhost/api/v0/cfgmgmt/nodes?pagination.size=1000 --insecure | jq . | grep "The Misfits" | wc -l
3
curl -H "projects: project2" -sH "api-token: $TOK" https://localhost/api/v0/cfgmgmt/nodes?pagination.size=1000 --insecure | jq . | grep "The Avengers" | wc -l
6
```

##### Update and Delete projects

Now delete rule1 and update rule2:

```
# curl -kH "api-token: $TOK" -XDELETE https://localhost/apis/iam/v2beta/rules/rule1
TODO
```

Can see the changes are staged in the DB:

```
chef_authz_service=# select * from iam_staged_project_rules;
 db_id |  id   | project_id |    name     | type | deleted
-------+-------+------------+-------------+------+---------
     1 | rule1 | project1   | my foo rule | node | t
(1 row)

chef_authz_service=# select * from iam_project_rules;
 db_id |  id   | project_id |    name     | type
-------+-------+------------+-------------+------
     1 | rule1 | project1   | my foo rule | node
     2 | rule2 | project2   | my foo rule | node
(2 rows)
```

And not live:

```
# curl -H "projects: project1" -sH "api-token: $TOK" https://localhost/api/v0/cfgmgmt/nodes?pagination.size=1000 --insecure | jq . | grep "The Misfits" | wc -l
3
TODO
```

Re-apply the rules:

```
# curl -kH "api-token: $TOK" -XPOST https://localhost/apis/iam/v2beta/apply-rules
```

See the updated results:

```
# curl -H "projects: project1" -sH "api-token: $TOK" https://localhost/api/v0/cfgmgmt/nodes?pagination.size=1000 --insecure | jq . | grep "The Misfits" | wc -l
0
# curl -H "projects: (unassigned)" -sH "api-token: $TOK" https://localhost/api/v0/cfgmgmt/nodes?pagination.size=1000 --insecure | jq . | grep "The Misfits" | wc -l
3
TODO
```

### :chains: Related Resources

https://github.com/chef/automate/pull/651

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
