### PR TITLE
ensure we get the actual value for end time when calculating start of day for start_time

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
@@ -400,4 +400,16 @@ describe('StatsService', () => {
       req.flush(text);
     });
   });
+
+  describe('setStartTimeToBegDayEndTime()', () => {
+    it('sets start time to beg of day of end time date', () => {
+      expect(service.setStartTimeToBegDayEndTime([
+        { 'end_time': moment('2017-11-15T23:59:59Z').utcOffset(0) },
+        { 'start_time': moment().format('YYYY-MM-DDTHH:mm:ssZ') }
+      ])).toEqual([
+        { 'end_time': moment('2017-11-15T23:59:59Z').utcOffset(0) },
+        { 'start_time': moment('2017-11-15T23:59:59Z').utcOffset(0).startOf('day') }
+      ]);
+    });
+  });
 });

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -178,7 +178,7 @@ export class StatsService {
     const endtime = filters.find(filter => filter['end_time']);
     const filtersCopy = filters.map(filter => {
       if (filter['start_time']) {
-        filter['start_time'] = moment(endtime).startOf('day');
+        filter['start_time'] = moment(endtime['end_time']).startOf('day');
       }
       return filter;
     });

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -175,6 +175,13 @@ export class StatsService {
     const url = `${CC_API_URL}/reporting/export`;
     // for export, we want to send the start_time as the beg of day of end time
     // so we find the endtime in the filters, and then set start time to beg of that day
+    const filtersCopy = this.setStartTimeToBegDayEndTime(filters);
+
+    const body = { type: format, filters: this.formatFilters(filtersCopy) };
+    return this.httpClient.post(url, body, { responseType: 'text' });
+  }
+
+  setStartTimeToBegDayEndTime(filters) {
     const endtime = filters.find(filter => filter['end_time']);
     const filtersCopy = filters.map(filter => {
       if (filter['start_time']) {
@@ -182,11 +189,8 @@ export class StatsService {
       }
       return filter;
     });
-
-    const body = { type: format, filters: this.formatFilters(filtersCopy)};
-    return this.httpClient.post(url, body, {responseType: 'text'});
+    return filtersCopy;
   }
-
 
   getSingleReport(reportID: string, filters: any[]): Observable<any> {
     const url = `${CC_API_URL}/reporting/reports/id/${reportID}`;


### PR DESCRIPTION
### :nut_and_bolt: Description
As noted in https://github.com/chef/automate/pull/639#issuecomment-504463446, a recent change we made was setting the start time on export to beginning of today, instead of beginning of day of end time.
I discovered we were getting the end time object, but not the value, and so moment was just setting start time to the beginning of today's date.
This change ensures that we're getting the actual value.

<img width="702" alt="Screen Shot 2019-06-21 at 12 59 44" src="https://user-images.githubusercontent.com/10341541/59945576-44c56a00-9425-11e9-9b4f-ee2b73590b99.png">
<img width="637" alt="Screen Shot 2019-06-21 at 12 59 53" src="https://user-images.githubusercontent.com/10341541/59945577-44c56a00-9425-11e9-9fde-078b136cc0d2.png">


### :+1: Definition of Done
start time is set to beg of day of whatever value is the end time

