### PR TITLE
Adding InSpec version to Compliance page search bar

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -65,7 +65,7 @@ describe('ReportingComponent', () => {
 
       const expected = [
         'chef_server', 'chef_tags', 'control', 'environment', 'node', 'organization', 'platform',
-        'policy_group', 'policy_name', 'profile', 'recipe', 'role'];
+        'policy_group', 'policy_name', 'profile', 'recipe', 'role', 'inspec_version'];
 
       expect(expected.sort()).toEqual(availableFilterTypesNames.sort());
     });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -57,6 +57,12 @@ export class ReportingComponent implements OnInit, OnDestroy {
       'placeholder': 'Name'
     },
     {
+      'name': 'inspec_version',
+      'title': 'InSpec Version',
+      'description': '',
+      'placeholder': 'InSpec Version'
+    },
+    {
       'name': 'node',
       'title': 'Node',
       'description':

--- a/components/compliance-service/api/tests/07_suggestions_w_filters_spec.rb
+++ b/components/compliance-service/api/tests/07_suggestions_w_filters_spec.rb
@@ -46,12 +46,12 @@ describe File.basename(__FILE__) do
       "Assign one global unicast IPv6 addresses to each interface--sysctl-28--",
       "Disable Core Dumps--sysctl-31--",
       "Disable log martians--sysctl-17--",
-      "Disable TRACE-methods--apache-09--",
       "Disable Source Routing--sysctl-13--",
+      "Disable TRACE-methods--apache-09--",
       "Disable IPv6 if it is not needed--sysctl-18--",
       "Disable learning Hop limit from router advertisement--sysctl-24--",
       "Disable the system`s acceptance of router advertisement--sysctl-25--",
-      "Disable insecure HTTP-methods--apache-10--" ]
+      "Disable loading kernel modules--sysctl-29--" ]
     assert_suggestions_text_id_version(expected, actual_data)
 
 
@@ -199,8 +199,8 @@ describe File.basename(__FILE__) do
     assert_suggestions_text_id_version( [
       "redhat(2)-alpha-nginx(f)-apache(s)-failed--9b9f4e51-b049-4b10-9555-10578916e111--",
       "windows(1)-zeta-apache(s)-skipped--a0ddd774-cbbb-49be-8730-49c92f3fc2a0--",
-      "RedHat(2)-beta-nginx(f)-apache(s)-failed--9b9f4e51-b049-4b10-9555-10578916e222--",
-      "redhat(2)-alpha-nginx(f)-apache(f)-failed--9b9f4e51-b049-4b10-9555-10578916e112--"
+      "redhat(2)-alpha-nginx(f)-apache(f)-failed--9b9f4e51-b049-4b10-9555-10578916e112--",
+      "RedHat(2)-beta-nginx(f)-apache(s)-failed--9b9f4e51-b049-4b10-9555-10578916e222--"
     ], actual_data )
 
       # suggest nodes with invalid filters

--- a/components/compliance-service/api/tests/07_suggestions_w_filters_spec.rb
+++ b/components/compliance-service/api/tests/07_suggestions_w_filters_spec.rb
@@ -46,12 +46,12 @@ describe File.basename(__FILE__) do
       "Assign one global unicast IPv6 addresses to each interface--sysctl-28--",
       "Disable Core Dumps--sysctl-31--",
       "Disable log martians--sysctl-17--",
-      "Disable Source Routing--sysctl-13--",
       "Disable TRACE-methods--apache-09--",
+      "Disable Source Routing--sysctl-13--",
       "Disable IPv6 if it is not needed--sysctl-18--",
       "Disable learning Hop limit from router advertisement--sysctl-24--",
       "Disable the system`s acceptance of router advertisement--sysctl-25--",
-      "Disable loading kernel modules--sysctl-29--" ]
+      "Disable insecure HTTP-methods--apache-10--" ]
     assert_suggestions_text_id_version(expected, actual_data)
 
 
@@ -199,8 +199,8 @@ describe File.basename(__FILE__) do
     assert_suggestions_text_id_version( [
       "redhat(2)-alpha-nginx(f)-apache(s)-failed--9b9f4e51-b049-4b10-9555-10578916e111--",
       "windows(1)-zeta-apache(s)-skipped--a0ddd774-cbbb-49be-8730-49c92f3fc2a0--",
-      "redhat(2)-alpha-nginx(f)-apache(f)-failed--9b9f4e51-b049-4b10-9555-10578916e112--",
-      "RedHat(2)-beta-nginx(f)-apache(s)-failed--9b9f4e51-b049-4b10-9555-10578916e222--"
+      "RedHat(2)-beta-nginx(f)-apache(s)-failed--9b9f4e51-b049-4b10-9555-10578916e222--",
+      "redhat(2)-alpha-nginx(f)-apache(f)-failed--9b9f4e51-b049-4b10-9555-10578916e112--"
     ], actual_data )
 
       # suggest nodes with invalid filters

--- a/components/compliance-service/api/tests/07_suggestions_w_filters_spec.rb
+++ b/components/compliance-service/api/tests/07_suggestions_w_filters_spec.rb
@@ -174,6 +174,16 @@ describe File.basename(__FILE__) do
     )
     assert_suggestions_text(["nagios::fix", "apache_extras", "apache_extras::harden"], actual_data)
 
+    # suggest inspec version
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+      type: 'inspec_version',
+      text: '3.1',
+      filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2016-02-02T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2019-03-04T23:59:59Z'])
+      ]
+    )
+    assert_suggestions_text(["3.1.0", "3.1.3"], actual_data)
 
     # suggest nodes with valid filters
     actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(

--- a/components/compliance-service/ingest/ingestic/mappings/comp-profiles.go
+++ b/components/compliance-service/ingest/ingestic/mappings/comp-profiles.go
@@ -28,8 +28,7 @@ var ComplianceProfiles = Mapping{
           "max_gram": 20,
           "token_chars": [
             "letter",
-            "digit",
-            "punctuation"
+            "digit"
           ]
         }
       },

--- a/components/compliance-service/ingest/ingestic/mappings/comp-profiles.go
+++ b/components/compliance-service/ingest/ingestic/mappings/comp-profiles.go
@@ -28,7 +28,8 @@ var ComplianceProfiles = Mapping{
           "max_gram": 20,
           "token_chars": [
             "letter",
-            "digit"
+            "digit",
+            "punctuation"
           ]
         }
       },

--- a/components/compliance-service/ingest/ingestic/mappings/comp-rep-date.go
+++ b/components/compliance-service/ingest/ingestic/mappings/comp-rep-date.go
@@ -24,7 +24,8 @@ var ComplianceRepDate = Mapping{
           "min_gram": 2,
           "token_chars": [
             "letter",
-            "digit"
+            "digit",
+            "punctuation"
           ],
           "type": "edge_ngram"
         }

--- a/components/compliance-service/ingest/ingestic/mappings/comp-rep-date.go
+++ b/components/compliance-service/ingest/ingestic/mappings/comp-rep-date.go
@@ -16,10 +16,25 @@ var ComplianceRepDate = Mapping{
             "lowercase"
           ],
           "tokenizer": "autocomplete_tokenizer"
+        },
+        "autocomplete_version_numbers": {
+          "filter": [
+            "lowercase"
+          ],
+          "tokenizer": "autocomplete_version_number_tokenizer"
         }
       },
       "tokenizer": {
         "autocomplete_tokenizer": {
+          "max_gram": 20,
+          "min_gram": 2,
+          "token_chars": [
+            "letter",
+            "digit"
+          ],
+          "type": "edge_ngram"
+        },
+        "autocomplete_version_number_tokenizer": {
           "max_gram": 20,
           "min_gram": 2,
           "token_chars": [
@@ -344,7 +359,7 @@ var ComplianceRepDate = Mapping{
           "fields": {
             "engram": {
               "type": "text",
-              "analyzer": "autocomplete"
+              "analyzer": "autocomplete_version_numbers"
             },
             "lower": {
               "normalizer": "case_insensitive",

--- a/components/compliance-service/ingest/ingestic/mappings/comp-sum-date.go
+++ b/components/compliance-service/ingest/ingestic/mappings/comp-sum-date.go
@@ -24,7 +24,8 @@ var ComplianceSumDate = Mapping{
           "min_gram": 2,
           "token_chars": [
             "letter",
-            "digit"
+            "digit",
+            "punctuation"
           ],
           "type": "edge_ngram"
         }

--- a/components/compliance-service/ingest/ingestic/mappings/comp-sum-date.go
+++ b/components/compliance-service/ingest/ingestic/mappings/comp-sum-date.go
@@ -16,10 +16,25 @@ var ComplianceSumDate = Mapping{
             "lowercase"
           ],
           "tokenizer": "autocomplete_tokenizer"
+        },
+        "autocomplete_version_numbers": {
+          "filter": [
+            "lowercase"
+          ],
+          "tokenizer": "autocomplete_version_number_tokenizer"
         }
       },
       "tokenizer": {
         "autocomplete_tokenizer": {
+          "max_gram": 20,
+          "min_gram": 2,
+          "token_chars": [
+            "letter",
+            "digit"
+          ],
+          "type": "edge_ngram"
+        },
+        "autocomplete_version_number_tokenizer": {
           "max_gram": 20,
           "min_gram": 2,
           "token_chars": [
@@ -281,7 +296,7 @@ var ComplianceSumDate = Mapping{
           "fields": {
             "engram": {
               "type": "text",
-              "analyzer": "autocomplete"
+              "analyzer": "autocomplete_version_numbers"
             },
             "lower": {
               "normalizer": "case_insensitive",

--- a/components/compliance-service/integration_test/reporting_server_list_nodes_test.go
+++ b/components/compliance-service/integration_test/reporting_server_list_nodes_test.go
@@ -116,6 +116,52 @@ func TestListNodesFiltering(t *testing.T) {
 			expectedIds: []string{},
 		},
 
+		// inspec_version
+		{
+			description: "Filter out one of the nodes by chef servers",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:        "1",
+					InSpecVersion: "3.1.0",
+				},
+				{
+					NodeID:        "2",
+					InSpecVersion: "3.1.3",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "inspec_version",
+						Values: []string{"3.1.0"},
+					},
+				},
+			},
+			expectedIds: []string{"1"},
+		},
+		{
+			description: "Filter out all of the nodes by chef servers",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:        "1",
+					InSpecVersion: "3.1.0",
+				},
+				{
+					NodeID:        "2",
+					InSpecVersion: "3.1.3",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "inspec_version",
+						Values: []string{"3.1.4"},
+					},
+				},
+			},
+			expectedIds: []string{},
+		},
+
 		// chef tags
 		{
 			description: "Filter out one of the nodes with chef tags",
@@ -307,6 +353,61 @@ func TestListNodesWildcardFiltering(t *testing.T) {
 		query       reporting.Query
 		expectedIds []string
 	}{
+
+		// inspec_version
+		{
+			description: "inspec_version: '*' wildcard",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:        "1",
+					InSpecVersion: "3.1.0",
+				},
+				{
+					NodeID:        "2",
+					InSpecVersion: "3.1.3",
+				},
+				{
+					NodeID:        "3",
+					InSpecVersion: "4.1.3",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "inspec_version",
+						Values: []string{"3.*"},
+					},
+				},
+			},
+			expectedIds: []string{"1", "2"},
+		},
+		{
+			description: "inspec_version: '?' wildcard",
+			reports: []*relaxting.ESInSpecReport{
+				{
+					NodeID:        "1",
+					InSpecVersion: "3.1.0",
+				},
+				{
+					NodeID:        "2",
+					InSpecVersion: "3.1.3",
+				},
+				{
+					NodeID:        "3",
+					InSpecVersion: "4.1.3",
+				},
+			},
+			query: reporting.Query{
+				Filters: []*reporting.ListFilter{
+					{
+						Type:   "inspec_version",
+						Values: []string{"?.1.3"},
+					},
+				},
+			},
+			expectedIds: []string{"3", "2"},
+		},
+
 		// chef server
 		{
 			description: "chef server: '*' wildcard",

--- a/components/compliance-service/integration_test/reporting_server_list_suggestions_test.go
+++ b/components/compliance-service/integration_test/reporting_server_list_suggestions_test.go
@@ -95,6 +95,74 @@ func TestReportingListSuggestionsFiltering(t *testing.T) {
 			expectedTerms: []string{},
 		},
 
+		// inspec_version
+		{
+			description: "Only two versions are returned",
+			summaries: []*relaxting.ESInSpecSummary{
+				{
+					NodeID:        "1",
+					InSpecVersion: "3.1.0",
+				},
+				{
+					NodeID:        "2",
+					InSpecVersion: "3.1.1",
+				},
+				{
+					NodeID:        "3",
+					InSpecVersion: "4.1.0",
+				},
+			},
+			request: reporting.SuggestionRequest{
+				Type: "inspec_version",
+				Text: "3.1",
+			},
+			expectedTerms: []string{"3.1.0", "3.1.1"},
+		},
+		{
+			description: "All inspec_version are returned",
+			summaries: []*relaxting.ESInSpecSummary{
+				{
+					NodeID:        "1",
+					InSpecVersion: "3.1.0",
+				},
+				{
+					NodeID:        "2",
+					InSpecVersion: "3.1.1",
+				},
+				{
+					NodeID:        "3",
+					InSpecVersion: "4.1.0",
+				},
+			},
+			request: reporting.SuggestionRequest{
+				Type: "inspec_version",
+				Text: "",
+			},
+			expectedTerms: []string{"3.1.0", "3.1.1", "4.1.0"},
+		},
+		{
+			description: "No inspec_version are returned",
+			summaries: []*relaxting.ESInSpecSummary{
+				{
+					NodeID:        "1",
+					InSpecVersion: "3.1.0",
+				},
+				{
+					NodeID:        "2",
+					InSpecVersion: "3.1.1",
+				},
+				{
+					NodeID:        "3",
+					InSpecVersion: "4.1.0",
+				},
+			},
+			request: reporting.SuggestionRequest{
+				Type: "inspec_version",
+				Text: "1.0",
+			},
+			expectedTerms: []string{},
+		},
+
 		// chef_server
 		{
 			description: "Only two chef servers are returned",

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -26,18 +26,19 @@ func (backend ES2Backend) GetSuggestions(typeParam string, filters map[string][]
 	}
 
 	var SUGGESTIONS_TYPES = map[string]string{
-		"environment":  "environment",
-		"platform":     "platform.name",
-		"node":         "node_name",
-		"role":         "roles",
-		"recipe":       "recipes",
-		"profile":      "profiles.title",
-		"control":      "profiles.controls.title",
-		"organization": "organization_name",
-		"chef_server":  "source_fqdn",
-		"chef_tags":    "chef_tags",
-		"policy_group": "policy_group",
-		"policy_name":  "policy_name",
+		"environment":    "environment",
+		"platform":       "platform.name",
+		"node":           "node_name",
+		"role":           "roles",
+		"recipe":         "recipes",
+		"profile":        "profiles.title",
+		"control":        "profiles.controls.title",
+		"organization":   "organization_name",
+		"chef_server":    "source_fqdn",
+		"chef_tags":      "chef_tags",
+		"policy_group":   "policy_group",
+		"policy_name":    "policy_name",
+		"inspec_version": "version",
 	}
 
 	target, ok := SUGGESTIONS_TYPES[typeParam]


### PR DESCRIPTION
![Screen Shot 2019-06-21 at 4 09 48 PM](https://user-images.githubusercontent.com/1679247/59955438-02a92200-943f-11e9-90e2-87a316fe0d59.png)

### :nut_and_bolt: Description

Adding the InSpec version to the Compliance page search bar. During testing this addition we noticed that for suggestions '.' characters are treated differently. The problem was that the Elasticsearch tokenizer was not including the '.' in the tokens. To fix the problem we have to add the "punctuation" term to the "autocomplete_tokenizer". 

### :notebook: Notes
* Without a migration of the existing indexes only the reports ingested after this change will have InSpec Version numbers show up in the search bar suggestions. 

### :athletic_shoe: Demo Script / Repro Steps

1. `build components/compliance-service && build components/automate-ui && start_all_services`
1. `send_inspec_example`
1. Change the "version" field on this file components/compliance-service/ingest/examples/compliance-success-tiny-report.json
1. Then ingest a report with `send_inspec_example`
1. Do this for two more reports then go to https://a2-dev.test/compliance/reports/overview
1. In the search bar, select the "InSpec Version" and type "3." ensure all the versions that start with "3." are in the suggestions. 
1. Select a version from the suggestions and ensure that only the nodes with that version are listed. 

### :chains: Related Resources

https://github.com/chef/automate/issues/431

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
