### PR TITLE
automate-load-balancer += http2

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -109,6 +109,26 @@ steps:
   # or take a long time.
   - wait
 
+  - label: "[integration] automate-load-balancer"
+    command:
+      - . scripts/verify_setup
+      - |
+        hab studio run "source scripts/verify_studio_init &&
+          start_deployment_service &&
+          chef-automate dev deploy-some chef/automate-load-balancer --with-deps &&
+          automate_load_balancer_integration"
+    timeout_in_minutes: 20
+    retry:
+      automatic:
+        limit: 1
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - HAB_STUDIO_SUP=false
+            - HAB_NONINTERACTIVE=true
+
   - label: "[integration] applications-service"
     command:
       - . scripts/verify_setup

--- a/.studio/automate-load-balancer
+++ b/.studio/automate-load-balancer
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+document "automate_load_balancer_integration" <<DOC
+  Runs some integration tests for automate-load-balancer
+DOC
+automate_load_balancer_integration() {
+  local target=${1:-"https://127.0.0.1"}
+  local output
+
+  install_if_missing core/curl curl
+  if ! output=$(curl --http2 -vk "$target" 2>&1); then
+    echo "non-zero exit code from curl: ${output}"
+    return 1
+  fi
+  if ! grep -q "ALPN, server accepted to use h2" <<< "${output}"; then
+    echo "server did NOT accept to use HTTP/2"
+    return 1
+  fi
+}
+

--- a/components/automate-load-balancer/habitat/config/nginx.conf
+++ b/components/automate-load-balancer/habitat/config/nginx.conf
@@ -102,9 +102,9 @@ http {
   {{#each cfg.frontend_tls as |tls| ~}}
   server {
     {{#if ../cfg.ngx.http.ipv6_supported ~}}
-    listen [::]:{{ ../cfg.service.https_port }} ssl ipv6only=off;
+    listen [::]:{{ ../cfg.service.https_port }} ssl http2 ipv6only=off;
     {{else ~}}
-    listen {{ ../cfg.service.https_port }} ssl;
+    listen {{ ../cfg.service.https_port }} http2 ssl;
     {{/if ~}}
     server_name {{tls.server_name}};
 


### PR DESCRIPTION
In @msorens' performance investigations, he observed that some latency is introduced by the fact that a browser only open _n_ TCP connections to one origin (_n=6_ for Chrome, it seems). This is unfortunate, but since HTTP2 solves that, by pipelining multiple requests in a single connection, it seemed worthwhile to give that a try.

And indeed, it seems that the specific delay ("stalled" in the dev tools' details view) goes down significantly when using HTTP2.

So, let's do this 😉 

Note that for the problem at hand here, internal connections don't matter as much -- so this only enables HTTP2 at the edge.

✅ Added a simple test, which outputs nothing on success. But glancing at `sup.log`, we find
```
automate-load-balancer.default [25/Jun/2019:12:47:02 +0000]  "GET / HTTP/2.0" 200 "0.002" 2016 "-" "curl/7.63.0" "172.17.0.2:10161" "200" "0.000" 27
```
So, it's doing its thing ✔️ 