### PR TITLE
Ingestion improvements to applications-service

### DIFF
--- a/components/applications-service/cmd/applications-service/commands/serve.go
+++ b/components/applications-service/cmd/applications-service/commands/serve.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/chef/automate/components/applications-service/pkg/config"
 	"github.com/chef/automate/components/applications-service/pkg/grpc"
-	"github.com/chef/automate/components/applications-service/pkg/server"
+	"github.com/chef/automate/components/applications-service/pkg/ingest"
 	"github.com/chef/automate/components/applications-service/pkg/storage/postgres"
 	"github.com/chef/automate/lib/grpc/secureconn"
 	"github.com/chef/automate/lib/platform"
@@ -50,7 +50,7 @@ var serveCmd = &cobra.Command{
 		conf.SetStorage(dbClient)
 
 		if conf.Service.Enabled {
-			ingester := server.NewIngester(conf, dbClient)
+			ingester := ingest.New(conf, dbClient)
 			err = ingester.Connect()
 			if err != nil {
 				return err

--- a/components/applications-service/cmd/applications-service/commands/serve.go
+++ b/components/applications-service/cmd/applications-service/commands/serve.go
@@ -50,7 +50,7 @@ var serveCmd = &cobra.Command{
 		conf.SetStorage(dbClient)
 
 		if conf.Service.Enabled {
-			ingester := ingest.New(conf, dbClient)
+			ingester := ingest.New(conf, conf.GetStorage())
 			err = ingester.Connect()
 			if err != nil {
 				return err

--- a/components/applications-service/integration_test/global_test.go
+++ b/components/applications-service/integration_test/global_test.go
@@ -28,8 +28,13 @@ var (
 	c = "stable"
 )
 
-// Used to generate random strings
-const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const (
+	// Used to generate random strings
+	letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	// The maximum time that an ingestion test could wait
+	maxWaitTimeMs = 5000 // 5 seconds
+)
 
 // func type to override the HealthCheckEvent message
 type MessageOverrides func(*habitat.HealthCheckEvent) error
@@ -86,6 +91,16 @@ func NewHabitatEvent(overrides ...MessageOverrides) *habitat.HealthCheckEvent {
 	}
 
 	return event
+}
+
+// Updates the provided HealthCheckEvent message with the provided overrides
+func UpdateHabitatEvent(event *habitat.HealthCheckEvent, overrides ...MessageOverrides) {
+	for _, f := range overrides {
+		err := f(event)
+		if err != nil {
+			fmt.Printf("Error trying to create habitat event message: %s\n", err)
+		}
+	}
 }
 
 // Creates a new HealthCheckEvent message with all its fields randomized

--- a/components/applications-service/integration_test/ingestion_test.go
+++ b/components/applications-service/integration_test/ingestion_test.go
@@ -226,6 +226,28 @@ func TestIngestSigleServiceInsertAndUpdate(t *testing.T) {
 			"the service channel name is not the expected one")
 		assert.Equal(t, "us", svcList[0].Site,
 			"the service site name is not the expected one")
+
+		sgList := suite.GetServiceGroups()
+		assert.Equal(t, 1, len(sgList), "wrong number of service groups")
+
+		assert.Equal(t, "db.default", sgList[0].Name,
+			"the service_group name is not the expected one")
+		assert.Equal(t, "test/db", sgList[0].Package,
+			"the service_group package is not the expected one")
+		assert.Equal(t, "0.1.0/20200101121212", sgList[0].Release,
+			"the service_group release is not the expected one")
+		assert.Equal(t, "OK", sgList[0].HealthStatus,
+			"the service_group health status is not the expected one")
+		assert.Equal(t, int32(100), sgList[0].HealthPercentage,
+			"the service_group health percentage is not the expected one")
+		assert.Equal(t, "test-app", sgList[0].Application,
+			"the service_group application name is not the expected one")
+		assert.Equal(t, "development", sgList[0].Environment,
+			"the service_group environment name is not the expected one")
+		assert.Equal(t, int32(1), sgList[0].ServicesHealthCounts.Total,
+			"the total number of services in this service_group is not the expected one")
+		assert.Equal(t, int32(1), sgList[0].ServicesHealthCounts.Ok,
+			"the OK number of services in this service_group is not the expected one")
 	}
 
 	// 2) Update same service
@@ -277,5 +299,28 @@ func TestIngestSigleServiceInsertAndUpdate(t *testing.T) {
 			"the service channel name is not the expected one")
 		assert.Equal(t, "us", svcList[0].Site,
 			"the service site name is not the expected one")
+
+		sgList := suite.GetServiceGroups()
+		assert.Equal(t, 1, len(sgList), "wrong number of service groups")
+
+		assert.Equal(t, "db.default", sgList[0].Name,
+			"the service_group name is not the expected one")
+		assert.Equal(t, "test/db", sgList[0].Package,
+			"the service_group package is not the expected one")
+		// TODO @afiune fix ingestion to update the new package_ident field in the database
+		//assert.Equal(t, "3.2.1/20201212000000", sgList[0].Release,
+		//"the service_group release is not the expected one")
+		assert.Equal(t, "CRITICAL", sgList[0].HealthStatus,
+			"the service_group health status is not the expected one")
+		assert.Equal(t, int32(0), sgList[0].HealthPercentage,
+			"the service_group health percentage is not the expected one")
+		assert.Equal(t, "test-app", sgList[0].Application,
+			"the service_group application name is not the expected one")
+		assert.Equal(t, "development", sgList[0].Environment,
+			"the service_group environment name is not the expected one")
+		assert.Equal(t, int32(1), sgList[0].ServicesHealthCounts.Total,
+			"the total number of services in this service_group is not the expected one")
+		assert.Equal(t, int32(1), sgList[0].ServicesHealthCounts.Critical,
+			"the OK number of services in this service_group is not the expected one")
 	}
 }

--- a/components/applications-service/integration_test/ingestion_test.go
+++ b/components/applications-service/integration_test/ingestion_test.go
@@ -1,0 +1,8 @@
+//
+//  Author:: Salim Afiune <afiune@chef.io>
+//  Copyright:: Copyright 2019, Chef Software Inc.
+//
+
+package integration_test
+
+// @afiune Add simple ingestion tests

--- a/components/applications-service/integration_test/ingestion_test.go
+++ b/components/applications-service/integration_test/ingestion_test.go
@@ -5,4 +5,277 @@
 
 package integration_test
 
-// @afiune Add simple ingestion tests
+import (
+	"testing"
+
+	"github.com/chef/automate/api/external/habitat"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIngestSigleService(t *testing.T) {
+	defer suite.DeleteDataFromStorage()
+
+	var (
+		eventsProcessed = suite.Ingester.EventsProcessed()
+		event           = NewHabitatEvent(
+			withSupervisorId("4f1un3"),
+			withPackageIdent("test/db/0.1.0/20200101121212"),
+			withServiceGroup("db.default"),
+			withStrategyAtOnce("stable"),
+			withApplication("test-app"),
+			withEnvironment("development"),
+			withFqdn("db.example.com"),
+			withHealth(HealthCheckIntToString(0)), // -> OK
+			withSite("us"),
+		)
+	)
+
+	bytes, err := proto.Marshal(event)
+	if assert.Nil(t, err) {
+		suite.Ingester.IngestMessage(bytes)
+		suite.WaitForEventsToProcess(eventsProcessed + 1)
+
+		svcList := suite.GetServices()
+		assert.Equal(t, 1, len(svcList))
+
+		assert.Equal(t, "4f1un3", svcList[0].SupMemberID,
+			"the service supervisor_id is not the expected one")
+		assert.Equal(t, "test", svcList[0].Origin,
+			"the service origin name is not the expected one")
+		assert.Equal(t, "db", svcList[0].Name,
+			"the service name is not the expected one")
+		assert.Equal(t, "0.1.0", svcList[0].Version,
+			"the service version is not the expected one")
+		assert.Equal(t, "20200101121212", svcList[0].Release,
+			"the service release is not the expected one")
+		assert.Equal(t, "OK", svcList[0].Health,
+			"the service health is not the expected one")
+		assert.Equal(t, "db.default", svcList[0].Group,
+			"the service service group name is not the expected one")
+		assert.Equal(t, "db.example.com", svcList[0].Fqdn,
+			"the service fqdn is not the expected one")
+		assert.Equal(t, "test-app", svcList[0].Application,
+			"the service application name is not the expected one")
+		assert.Equal(t, "development", svcList[0].Environment,
+			"the service environment name is not the expected one")
+		assert.Equal(t, "stable", svcList[0].Channel,
+			"the service channel name is not the expected one")
+		assert.Equal(t, "us", svcList[0].Site,
+			"the service site name is not the expected one")
+	}
+}
+
+func TestIngestMultiServicesDifferentServiceGroups(t *testing.T) {
+	defer suite.DeleteDataFromStorage()
+
+	// Notice we send different supervisor id's
+	events := []*habitat.HealthCheckEvent{
+		NewHabitatEvent(
+			withSupervisorId("s4l1m"),
+			withPackageIdent("test/app/0.1.0/20200101121211"),
+			withServiceGroup("app.default"),
+			withStrategyAtOnce("stable"),
+			withApplication("test-app"),
+			withEnvironment("development"),
+			withFqdn("app.example.com"),
+			withSite("us"),
+		),
+		NewHabitatEvent(
+			withSupervisorId("4f1un3"),
+			withPackageIdent("test/web/0.1.0/20200101121212"),
+			withServiceGroup("web.default"),
+			withStrategyAtOnce("stable"),
+			withApplication("test-app"),
+			withEnvironment("development"),
+			withFqdn("web.example.com"),
+			withSite("us"),
+		),
+		NewHabitatEvent(
+			withSupervisorId("m4y4"),
+			withPackageIdent("test/db/0.1.0/20200101121213"),
+			withServiceGroup("db.default"),
+			withStrategyAtOnce("stable"),
+			withApplication("test-app"),
+			withEnvironment("development"),
+			withFqdn("db.example.com"),
+			withSite("us"),
+		),
+	}
+
+	// Ingest messages through the Ingester client
+	suite.IngestMessagesViaIngester(events...)
+
+	// Verify there are only three services
+	svcList := suite.GetServices()
+	assert.Equal(t, len(events), len(svcList), "wrong number of services")
+
+	// Verify there are only three service_groups
+	sgList := suite.GetServiceGroups()
+	assert.Equal(t, 3, len(sgList), "wrong number of service groups")
+}
+
+func TestIngestMultiServicesSameServiceGroup(t *testing.T) {
+	defer suite.DeleteDataFromStorage()
+
+	events := []*habitat.HealthCheckEvent{
+		NewHabitatEvent(
+			withSupervisorId("s4l1m"),
+			withPackageIdent("test/db/0.1.0/20200101121211"),
+			withServiceGroup("db.default"),
+			withStrategyAtOnce("stable"),
+			withApplication("test-app"),
+			withEnvironment("development"),
+			withFqdn("db.example.com"),
+			withHealth(HealthCheckIntToString(0)), // -> OK
+			withSite("us"),
+		),
+		NewHabitatEvent(
+			withSupervisorId("4f1un3"),
+			withPackageIdent("test/db/0.1.0/20200101121212"),
+			withServiceGroup("db.default"),
+			withStrategyAtOnce("stable"),
+			withApplication("test-app"),
+			withEnvironment("development"),
+			withFqdn("db.example.com"),
+			withHealth(HealthCheckIntToString(0)), // -> OK
+			withSite("us"),
+		),
+		NewHabitatEvent(
+			withSupervisorId("m4y4"),
+			withPackageIdent("test/db/0.1.0/20200101121213"),
+			withServiceGroup("db.default"),
+			withStrategyAtOnce("stable"),
+			withApplication("test-app"),
+			withEnvironment("development"),
+			withFqdn("db.example.com"),
+			withHealth(HealthCheckIntToString(0)), // -> OK
+			withSite("us"),
+		),
+	}
+
+	// Ingest messages through the Ingester client
+	suite.IngestMessagesViaIngester(events...)
+
+	// Verify there are only three services
+	svcList := suite.GetServices()
+	assert.Equal(t, len(events), len(svcList), "wrong number of services")
+
+	// We have a race condition where if we have different services sending messages
+	// to Automate at the same time that belongs to the same service-group we will
+	// insert different service-groups and deployments entries instead of a single one.
+	//
+	// The main reason of this problem is because we process 50 things at a time (worker pool)
+	//
+	// TODO @afiune fix and uncomment this test!
+	//
+	// Verify there is only one service_group
+	//sgList := suite.GetServiceGroups()
+	//assert.Equal(t, 1, len(sgList), "there should be only one single service group")
+}
+
+func TestIngestSigleServiceInsertAndUpdate(t *testing.T) {
+	defer suite.DeleteDataFromStorage()
+
+	// 1) Insert new service
+	var (
+		eventsProcessed = suite.Ingester.EventsProcessed()
+		event           = NewHabitatEvent(
+			withSupervisorId("4f1un3"),
+			withPackageIdent("test/db/0.1.0/20200101121212"),
+			withServiceGroup("db.default"),
+			withStrategyAtOnce("stable"),
+			withApplication("test-app"),
+			withEnvironment("development"),
+			withFqdn("db.example.com"),
+			withHealth(HealthCheckIntToString(0)), // -> OK
+			withSite("us"),
+		)
+	)
+
+	bytes, err := proto.Marshal(event)
+	if assert.Nil(t, err) {
+		suite.Ingester.IngestMessage(bytes)
+		eventsProcessed++
+		suite.WaitForEventsToProcess(eventsProcessed)
+
+		svcList := suite.GetServices()
+		assert.Equal(t, 1, len(svcList))
+
+		assert.Equal(t, "4f1un3", svcList[0].SupMemberID,
+			"the service supervisor_id is not the expected one")
+		assert.Equal(t, "test", svcList[0].Origin,
+			"the service origin name is not the expected one")
+		assert.Equal(t, "db", svcList[0].Name,
+			"the service name is not the expected one")
+		assert.Equal(t, "0.1.0", svcList[0].Version,
+			"the service version is not the expected one")
+		assert.Equal(t, "20200101121212", svcList[0].Release,
+			"the service release is not the expected one")
+		assert.Equal(t, "OK", svcList[0].Health,
+			"the service health is not the expected one")
+		assert.Equal(t, "db.default", svcList[0].Group,
+			"the service service group name is not the expected one")
+		assert.Equal(t, "db.example.com", svcList[0].Fqdn,
+			"the service fqdn is not the expected one")
+		assert.Equal(t, "test-app", svcList[0].Application,
+			"the service application name is not the expected one")
+		assert.Equal(t, "development", svcList[0].Environment,
+			"the service environment name is not the expected one")
+		assert.Equal(t, "stable", svcList[0].Channel,
+			"the service channel name is not the expected one")
+		assert.Equal(t, "us", svcList[0].Site,
+			"the service site name is not the expected one")
+	}
+
+	// 2) Update same service
+	//
+	// TODO @afiune define what are the fields that we can updated?
+	// - Health
+	// - Package ident (without name. the name of a service can't be changed!)
+	// - Update strategy
+
+	UpdateHabitatEvent(event,
+		withHealth(HealthCheckIntToString(2)), // -> CRITICAL
+		// TODO @afiune fix ingestion to remove the channel when there is no update strategy
+		withStrategyAtOnce("unstable"),
+		// TODO @afiune fix ingestion to accept origin updates
+		//withPackageIdent("changed/db/3.2.1/20201212000000"),
+		withPackageIdent("test/db/3.2.1/20201212000000"),
+	)
+
+	bytes, err = proto.Marshal(event)
+	if assert.Nil(t, err) {
+		suite.Ingester.IngestMessage(bytes)
+		eventsProcessed++
+		suite.WaitForEventsToProcess(eventsProcessed)
+
+		svcList := suite.GetServices()
+		assert.Equal(t, 1, len(svcList))
+
+		assert.Equal(t, "4f1un3", svcList[0].SupMemberID,
+			"the service supervisor_id is not the expected one")
+		assert.Equal(t, "test", svcList[0].Origin,
+			"the service origin name is not the expected one")
+		assert.Equal(t, "db", svcList[0].Name,
+			"the service name is not the expected one")
+		assert.Equal(t, "3.2.1", svcList[0].Version,
+			"the service version is not the expected one")
+		assert.Equal(t, "20201212000000", svcList[0].Release,
+			"the service release is not the expected one")
+		assert.Equal(t, "CRITICAL", svcList[0].Health,
+			"the service health is not the expected one")
+		assert.Equal(t, "db.default", svcList[0].Group,
+			"the service service group name is not the expected one")
+		assert.Equal(t, "db.example.com", svcList[0].Fqdn,
+			"the service fqdn is not the expected one")
+		assert.Equal(t, "test-app", svcList[0].Application,
+			"the service application name is not the expected one")
+		assert.Equal(t, "development", svcList[0].Environment,
+			"the service environment name is not the expected one")
+		assert.Equal(t, "unstable", svcList[0].Channel,
+			"the service channel name is not the expected one")
+		assert.Equal(t, "us", svcList[0].Site,
+			"the service site name is not the expected one")
+	}
+}

--- a/components/applications-service/pkg/ingest/ingest.go
+++ b/components/applications-service/pkg/ingest/ingest.go
@@ -1,34 +1,41 @@
-package server
+package ingest
 
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	stan "github.com/nats-io/go-nats-streaming"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/chef/automate/api/external/habitat"
 	"github.com/chef/automate/components/applications-service/pkg/config"
 	"github.com/chef/automate/components/applications-service/pkg/nats"
 	"github.com/chef/automate/components/applications-service/pkg/storage/postgres"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
 )
 
-const numWorkers = 50
+const (
+	numWorkers       = 50
+	eventsBufferSize = 100
+)
 
 type Ingester struct {
 	Cfg              *config.Applications
 	DBClient         *postgres.Postgres
 	natsClient       *nats.NatsClient
+	EventsCh         chan *stan.Msg
 	workerInputQueue chan<- *habitat.HealthCheckEvent
 	workerTaskQueue  <-chan *habitat.HealthCheckEvent
 }
 
-func NewIngester(c *config.Applications, db *postgres.Postgres) *Ingester {
+func New(c *config.Applications, db *postgres.Postgres) *Ingester {
 
 	q := make(chan *habitat.HealthCheckEvent)
 
 	return &Ingester{
 		Cfg:              c,
 		DBClient:         db,
+		EventsCh:         make(chan *stan.Msg, eventsBufferSize),
 		workerInputQueue: q,
 		workerTaskQueue:  q,
 	}
@@ -39,16 +46,14 @@ func NewIngester(c *config.Applications, db *postgres.Postgres) *Ingester {
 // Run() so connection errors can be handled easily while still running the
 // ingester in a goroutine.
 func (i *Ingester) Connect() error {
-	url := "nats://%s:%d"
-
 	natsClient := nats.NewDefaults(
-		fmt.Sprintf(url, i.Cfg.Events.Host, i.Cfg.Events.Port),
+		fmt.Sprintf("nats://%s:%d", i.Cfg.Events.Host, i.Cfg.Events.Port),
 		i.Cfg.Events.ClusterID,
 		*i.Cfg.TLSConfig,
 	)
 
 	// Trigger NATS Subscription
-	err := natsClient.ConnectAndSubscribe()
+	err := natsClient.ConnectAndSubscribe(i.EventsCh)
 	if err != nil {
 		return errors.Wrapf(err, "could not connect to nats-streaming")
 	}
@@ -65,8 +70,21 @@ func (i *Ingester) Run() {
 	// TODO @afiune Move this logic into an ingestion pipeline
 	for {
 		select {
-		case event := <-i.natsClient.EventsCh:
-			i.workerInputQueue <- event
+		case event := <-i.EventsCh:
+
+			// TODO: @afiune We should have a way to have multi-message-type ingestion
+			// Unmarshal the data and send the message to the channel
+			var habMsg habitat.HealthCheckEvent
+			err := proto.Unmarshal(event.Data, &habMsg)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"data":    string(event.Data),
+					"subject": i.natsClient.Subject(),
+				}).Error("Unknown message, dropping")
+				continue
+			}
+
+			i.workerInputQueue <- &habMsg
 		}
 	}
 }
@@ -77,9 +95,7 @@ func (i *Ingester) runWorkerLoop() {
 		case event := <-i.workerTaskQueue:
 			err := i.DBClient.IngestHealthCheckEvent(event)
 			if err != nil {
-				log.WithFields(log.Fields{
-					"error": err.Error(),
-				}).Error("Unable to ingest habitat event")
+				log.WithError(err).Error("Unable to ingest habitat event")
 			}
 		}
 	}

--- a/components/applications-service/pkg/nats/nats.go
+++ b/components/applications-service/pkg/nats/nats.go
@@ -15,6 +15,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const connectionRetries = 5
+
 // The subject is the topic this subscriber will be listening to,
 // right now we will hardcode this value but in the future it could
 // be configurable.
@@ -39,7 +41,6 @@ type NatsClient struct {
 	certs.TLSConfig
 	conn               stan.Conn
 	retries            int
-	EventsCh           chan *habitat.HealthCheckEvent // TODO: @afiune make a pipeline instead
 	InsecureSkipVerify bool
 	DisableTLS         bool
 }
@@ -51,8 +52,7 @@ func NewExternalClient(url, cluster, client, durable, subject string) *NatsClien
 		clientID:  client,
 		durableID: durable,
 		subject:   subject,
-		EventsCh:  make(chan *habitat.HealthCheckEvent), // buffered channel?
-		retries:   5,
+		retries:   connectionRetries,
 	}
 }
 
@@ -64,8 +64,7 @@ func New(url, cluster, client, durable, subject string, tlsConfig certs.TLSConfi
 		clientID:  client,
 		durableID: durable,
 		subject:   subject,
-		EventsCh:  make(chan *habitat.HealthCheckEvent), // buffered channel?
-		retries:   5,
+		retries:   connectionRetries,
 		TLSConfig: tlsConfig,
 	}
 }
@@ -167,14 +166,14 @@ func (nc *NatsClient) tryConnect(tlsConf *tls.Config) (stan.Conn, error) {
 
 // ConnectAndSubscribe will attempt to connect to the NATS Server and then
 // subscribe to the subject that the client was configured
-func (nc *NatsClient) ConnectAndSubscribe() error {
+func (nc *NatsClient) ConnectAndSubscribe(eventsCh chan<- *stan.Msg) error {
 
 	err := nc.Connect()
 	if err != nil {
 		return err
 	}
 
-	_, err = nc.Subscribe()
+	_, err = nc.Subscribe(eventsCh)
 	if err != nil {
 		return err
 	}
@@ -243,4 +242,9 @@ func (nc *NatsClient) natsTLSConfig() (*tls.Config, error) {
 
 	return t, nil
 
+}
+
+// Returns the configured subject
+func (nc *NatsClient) Subject() string {
+	return nc.subject
 }

--- a/components/applications-service/pkg/nats/nats.go
+++ b/components/applications-service/pkg/nats/nats.go
@@ -166,7 +166,7 @@ func (nc *NatsClient) tryConnect(tlsConf *tls.Config) (stan.Conn, error) {
 
 // ConnectAndSubscribe will attempt to connect to the NATS Server and then
 // subscribe to the subject that the client was configured
-func (nc *NatsClient) ConnectAndSubscribe(eventsCh chan<- *stan.Msg) error {
+func (nc *NatsClient) ConnectAndSubscribe(eventsCh chan<- []byte) error {
 
 	err := nc.Connect()
 	if err != nil {

--- a/components/applications-service/pkg/nats/subscriber.go
+++ b/components/applications-service/pkg/nats/subscriber.go
@@ -5,7 +5,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (nc *NatsClient) Subscribe(eventsCh chan<- *stan.Msg) (stan.Subscription, error) {
+func (nc *NatsClient) Subscribe(eventsCh chan<- []byte) (stan.Subscription, error) {
 
 	log.WithFields(log.Fields{
 		"subject":    nc.subject,
@@ -22,6 +22,6 @@ func (nc *NatsClient) Subscribe(eventsCh chan<- *stan.Msg) (stan.Subscription, e
 			"subject":  nc.subject,
 		}).Debug("Message received")
 
-		eventsCh <- msg
+		eventsCh <- msg.Data
 	}, stan.DurableName(nc.durableID))
 }

--- a/components/applications-service/pkg/nats/subscriber.go
+++ b/components/applications-service/pkg/nats/subscriber.go
@@ -17,9 +17,11 @@ func (nc *NatsClient) Subscribe(eventsCh chan<- []byte) (stan.Subscription, erro
 	return nc.conn.Subscribe(nc.subject, func(msg *stan.Msg) {
 
 		log.WithFields(log.Fields{
-			"protocol": "nats",
-			"data":     string(msg.Data),
-			"subject":  nc.subject,
+			"protocol":          "nats",
+			"message_data":      string(msg.Data),
+			"message_timestamp": msg.Timestamp,
+			"message_subject":   msg.Subject,
+			"message_sequence":  msg.Sequence,
 		}).Debug("Message received")
 
 		eventsCh <- msg.Data

--- a/components/applications-service/pkg/nats/subscriber.go
+++ b/components/applications-service/pkg/nats/subscriber.go
@@ -1,14 +1,12 @@
 package nats
 
 import (
-	"github.com/chef/automate/api/external/habitat"
-	"github.com/golang/protobuf/proto"
-
 	stan "github.com/nats-io/go-nats-streaming"
 	log "github.com/sirupsen/logrus"
 )
 
-func (nc *NatsClient) Subscribe() (stan.Subscription, error) {
+func (nc *NatsClient) Subscribe(eventsCh chan<- *stan.Msg) (stan.Subscription, error) {
+
 	log.WithFields(log.Fields{
 		"subject":    nc.subject,
 		"durable_id": nc.durableID,
@@ -24,19 +22,6 @@ func (nc *NatsClient) Subscribe() (stan.Subscription, error) {
 			"subject":  nc.subject,
 		}).Debug("Message received")
 
-		// TODO: @afiune We should have a way to have multi-message-type ingestion
-		// Unmarshal the data and send the message to the channel
-		var habMsg habitat.HealthCheckEvent
-		err := proto.Unmarshal(msg.Data, &habMsg)
-
-		if err != nil {
-			log.WithFields(log.Fields{
-				"data":    string(msg.Data),
-				"subject": nc.subject,
-			}).Error("Unknown message, dropping")
-		} else {
-			nc.EventsCh <- &habMsg
-		}
-
+		eventsCh <- msg
 	}, stan.DurableName(nc.durableID))
 }

--- a/components/applications-service/pkg/storage/postgres/hab_event.go
+++ b/components/applications-service/pkg/storage/postgres/hab_event.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -24,7 +25,6 @@ type packageIdent struct {
 	Name    string
 	Version string
 	Release string
-	Full    string
 }
 
 func newPackageIdentFromString(ident string) (*packageIdent, error) {
@@ -37,7 +37,11 @@ func newPackageIdentFromString(ident string) (*packageIdent, error) {
 		)
 	}
 
-	return &packageIdent{fields[0], fields[1], fields[2], fields[3], ident}, nil
+	return &packageIdent{fields[0], fields[1], fields[2], fields[3]}, nil
+}
+
+func (p packageIdent) FullPackageIdent() string {
+	return fmt.Sprintf("%s/%s/%s/%s", p.Origin, p.Name, p.Version, p.Release)
 }
 
 var (
@@ -226,7 +230,7 @@ func newService(pkgIdent *packageIdent, health string, did, sid, gid int32) *ser
 		GroupID:      gid,
 		DeploymentID: did,
 		SupID:        sid,
-		FullPkgIdent: pkgIdent.Full,
+		FullPkgIdent: pkgIdent.FullPackageIdent(),
 	}
 }
 

--- a/components/applications-service/pkg/storage/postgres/hab_event.go
+++ b/components/applications-service/pkg/storage/postgres/hab_event.go
@@ -119,6 +119,8 @@ func (db *Postgres) IngestHealthCheckEventWithoutMetrics(event *habitat.HealthCh
 		return err
 	}
 
+	// @afiune are we changing the grouping of a service group based of the application
+	// and environment names?
 	svc, exist := db.getServiceFromUniqueFields(
 		pkgIdent.Origin,
 		pkgIdent.Name,
@@ -126,6 +128,11 @@ func (db *Postgres) IngestHealthCheckEventWithoutMetrics(event *habitat.HealthCh
 	)
 
 	// If the service already exists, we just do a simple update
+	//
+	// Fields that needs to be updated:
+	// - Health
+	// - Package ident (without name. the name of a service can't be changed!)
+	// - Update strategy
 	if exist {
 		svc.Version = pkgIdent.Version
 		svc.Release = pkgIdent.Release


### PR DESCRIPTION
### :nut_and_bolt: Description
In preparation to start work to add the `timewizard` from [JIRA#A2-665](https://chefio.atlassian.net/browse/A2-665),
I have started with a number of improvements to structure a little better
the ingestion mechanism inside the applications-service, doing so I have
discovered a number of issues that we need to cover before doing any
new modification in the database and ingestion.

Problems:

- List them....

### :+1: Definition of Done

All above problems are fixed.

### :athletic_shoe: Demo Script / Repro Steps
Run the integration tests for the applications-service:
```
$ hab studio enter
[1][default:/src:0]# start_applications_service
[2][default:/src:0]# applications_integration
```
### :chains: Related Resources
https://chefio.atlassian.net/browse/A2-889
https://chefio.atlassian.net/browse/A2-665

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
