### PR TITLE
[A2-814] ListRulesForProject returns latest rule updates

### DIFF
--- a/components/authz-service/storage/postgres/migration/sql/51_change_project_rules_query.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/51_change_project_rules_query.up.sql
@@ -1,0 +1,54 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION
+  query_rules_for_project(_project_id TEXT, _project_filter TEXT[])
+  RETURNS setof json AS $$
+
+  -- fetch staged rules
+   SELECT json_build_object(
+    'id', r.id,
+    'project_id', r.project_id,
+    'name', r.name,
+    'type', r.type,
+    'status', 'staged',
+    'conditions', json_agg(
+      json_build_object(
+        'value', rc.value,
+        'operator', rc.operator,
+        'attribute', rc.attribute
+      )
+    )
+  ) AS rule
+  FROM iam_staged_project_rules AS r
+  INNER JOIN iam_staged_rule_conditions AS rc ON rc.rule_db_id=r.db_id
+  WHERE projects_match_for_rule(project_id, _project_filter) AND r.deleted=false
+  GROUP BY r.id, r.project_id, r.name, r.type
+
+  UNION ALL
+
+  -- fetch applied rules
+  SELECT json_build_object(
+    'id', r.id,
+    'project_id', r.project_id,
+    'name', r.name,
+    'type', r.type,
+    'status', 'applied',
+    'conditions', json_agg(
+      json_build_object(
+        'value', rc.value,
+        'operator', rc.operator,
+        'attribute', rc.attribute
+      )
+    )
+  ) AS rule
+  FROM iam_project_rules AS r
+  INNER JOIN iam_rule_conditions AS rc
+  ON rc.rule_db_id=r.db_id
+  WHERE _project_id=project_id AND projects_match_for_rule(project_id, _project_filter)
+    -- return applied rule only if no staged changes exist
+    AND NOT EXISTS (SELECT 1 FROM iam_staged_project_rules WHERE id=r.id)
+  GROUP BY r.id, r.project_id, r.name, r.type;
+
+ $$ LANGUAGE sql;
+
+ COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/51_change_project_rules_query.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/51_change_project_rules_query.up.sql
@@ -22,7 +22,7 @@ CREATE OR REPLACE FUNCTION
   FROM iam_staged_project_rules AS r
   INNER JOIN iam_staged_rule_conditions AS rc 
   ON rc.rule_db_id=r.db_id
-  WHERE _project_id=r.project_id AND projects_match_for_rule(project_id, _project_filter) AND r.deleted=false
+  WHERE _project_id=r.project_id AND projects_match_for_rule(r.project_id, _project_filter) AND r.deleted=false
   GROUP BY r.id, r.project_id, r.name, r.type
 
   UNION ALL
@@ -45,7 +45,7 @@ CREATE OR REPLACE FUNCTION
   FROM iam_project_rules AS r
   INNER JOIN iam_rule_conditions AS rc
   ON rc.rule_db_id=r.db_id
-  WHERE _project_id=r.project_id AND projects_match_for_rule(project_id, _project_filter)
+  WHERE _project_id=r.project_id AND projects_match_for_rule(r.project_id, _project_filter)
     -- return applied rule only if no staged changes exist
     AND NOT EXISTS (SELECT 1 FROM iam_staged_project_rules WHERE id=r.id)
   GROUP BY r.id, r.project_id, r.name, r.type;

--- a/components/authz-service/storage/postgres/migration/sql/51_change_project_rules_query.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/51_change_project_rules_query.up.sql
@@ -20,8 +20,9 @@ CREATE OR REPLACE FUNCTION
     )
   ) AS rule
   FROM iam_staged_project_rules AS r
-  INNER JOIN iam_staged_rule_conditions AS rc ON rc.rule_db_id=r.db_id
-  WHERE _project_id=project_id AND projects_match_for_rule(project_id, _project_filter) AND r.deleted=false
+  INNER JOIN iam_staged_rule_conditions AS rc 
+  ON rc.rule_db_id=r.db_id
+  WHERE _project_id=r.project_id AND projects_match_for_rule(project_id, _project_filter) AND r.deleted=false
   GROUP BY r.id, r.project_id, r.name, r.type
 
   UNION ALL
@@ -44,7 +45,7 @@ CREATE OR REPLACE FUNCTION
   FROM iam_project_rules AS r
   INNER JOIN iam_rule_conditions AS rc
   ON rc.rule_db_id=r.db_id
-  WHERE _project_id=project_id AND projects_match_for_rule(project_id, _project_filter)
+  WHERE _project_id=r.project_id AND projects_match_for_rule(project_id, _project_filter)
     -- return applied rule only if no staged changes exist
     AND NOT EXISTS (SELECT 1 FROM iam_staged_project_rules WHERE id=r.id)
   GROUP BY r.id, r.project_id, r.name, r.type;

--- a/components/authz-service/storage/postgres/migration/sql/51_change_project_rules_query.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/51_change_project_rules_query.up.sql
@@ -21,7 +21,7 @@ CREATE OR REPLACE FUNCTION
   ) AS rule
   FROM iam_staged_project_rules AS r
   INNER JOIN iam_staged_rule_conditions AS rc ON rc.rule_db_id=r.db_id
-  WHERE projects_match_for_rule(project_id, _project_filter) AND r.deleted=false
+  WHERE _project_id=project_id AND projects_match_for_rule(project_id, _project_filter) AND r.deleted=false
   GROUP BY r.id, r.project_id, r.name, r.type
 
   UNION ALL

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -50,3 +50,4 @@
 - [`48_remove_deleted_staged_conditions_column.up.sql`](48_remove_deleted_staged_conditions_column.up.sql)
 - [`49_update_rule_triggers.up.sql`](49_update_rule_triggers.up.sql)
 - [`50_add_status_field_to_rules.up.sql`](50_add_status_field_to_rules.up.sql)
+- [`51_change_project_rules_query.up.sql`](51_change_project_rules_query.up.sql)

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -3661,7 +3661,7 @@ func TestListRulesForProject(t *testing.T) {
 			assert.Nil(t, resp)
 			assert.Zero(t, len(resp))
 		}},
-		{"when no rules, returns an empty list", func(t *testing.T) {
+		{"when no rules exist, returns an empty list", func(t *testing.T) {
 			ctx := context.Background()
 			projID := "project-1"
 			insertTestProject(t, db, projID, "let's go jigglypuff - topsecret", storage.Custom)
@@ -3686,7 +3686,7 @@ func TestListRulesForProject(t *testing.T) {
 			assert.Nil(t, resp)
 			assert.Zero(t, len(resp))
 		}},
-		{"when multiple rules exist with no project filter, returns the most up-to-date rules for the project", func(t *testing.T) {
+		{"when multiple applied rules exist with no project filter, returns rules for the project", func(t *testing.T) {
 			ctx := context.Background()
 
 			projID := "project-1"
@@ -3719,7 +3719,7 @@ func TestListRulesForProject(t *testing.T) {
 			assert.Equal(t, 2, len(resp))
 			assert.ElementsMatch(t, []*storage.Rule{&rule2, &rule3}, resp)
 		}},
-		{"when the project is in the filter, returns the rules for the project", func(t *testing.T) {
+		{"when the requested project is in the filter, returns the rules for the project", func(t *testing.T) {
 			ctx := context.Background()
 
 			projID := "project-1"
@@ -3729,7 +3729,7 @@ func TestListRulesForProject(t *testing.T) {
 			ctx = insertProjectsIntoContext(ctx, []string{"project-3", projID2})
 
 			ruleType := storage.Node
-			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
+			insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
@@ -3746,17 +3746,13 @@ func TestListRulesForProject(t *testing.T) {
 				[]storage.Condition{condition5})
 			require.NoError(t, err)
 			insertAppliedRule(t, db, &rule3)
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule3.ID))
-			assertCount(t, 5, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
 			resp, err := store.ListRulesForProject(ctx, projID2)
 			assert.NoError(t, err)
 			assert.Equal(t, 2, len(resp))
 			assert.ElementsMatch(t, []*storage.Rule{&rule2, &rule3}, resp)
 		}},
-		{"when the project is not in the filter, returns an empty list", func(t *testing.T) {
+		{"when the requested project is not in the filter, returns an empty list", func(t *testing.T) {
 			ctx := context.Background()
 
 			projID := "project-1"
@@ -3791,7 +3787,7 @@ func TestListRulesForProject(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Zero(t, len(resp))
 		}},
-		{"when there are staged changes for the project's rules, returns the latest changes to the rules", func(t *testing.T) {
+		{"when there are only staged changes for the project's rules, returns the staged versions of the rules", func(t *testing.T) {
 			ctx := context.Background()
 			projID := "project-1"
 			insertTestProject(t, db, projID, "first project", storage.Custom)
@@ -3815,7 +3811,7 @@ func TestListRulesForProject(t *testing.T) {
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, []*storage.Rule{&updatedRule}, resp)
 		}},
-		{"when there are staged changes for some of the project's rules, returns mix of staged and applied rules", func(t *testing.T) {
+		{"when there are staged changes for some of the project's rules, returns those staged versions and rules that have no staged changes", func(t *testing.T) {
 			ctx := context.Background()
 			projID := "project-1"
 			insertTestProject(t, db, projID, "first project", storage.Custom)
@@ -3842,26 +3838,32 @@ func TestListRulesForProject(t *testing.T) {
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, []*storage.Rule{&updatedRule, appliedRule}, resp)
 		}},
-		{"when a project's rule has been marked for deletion, it will not be returned", func(t *testing.T) {
+		{"when a project has two applied rules and one is staged for deletion, returns only the non-deleted one", func(t *testing.T) {
 			ctx := context.Background()
 			projID := "foo-project"
 			insertTestProject(t, db, projID, "first project", storage.Custom)
 
-			condition, err := storage.NewCondition(storage.Node,
+			condition1, err := storage.NewCondition(storage.Node,
 				[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
 			require.NoError(t, err)
-			rule, err := storage.NewRule("foo-rule", projID, "coo foo rule", condition.Type, []storage.Condition{condition})
+			rule1, err := storage.NewRule("bar-rule", projID, "bar rule", condition1.Type, []storage.Condition{condition1})
 			assert.NoError(t, err)
-			insertAppliedRule(t, db, &rule)
+			insertAppliedRule(t, db, &rule1)
 
-			// mark for deletion
-			insertStagedRule(t, db, &rule, true)
+			condition2, err := storage.NewCondition(storage.Node,
+				[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
+			require.NoError(t, err)
+			rule2, err := storage.NewRule("foo-rule", projID, "coo foo rule", condition2.Type, []storage.Condition{condition2})
+			assert.NoError(t, err)
+			insertAppliedRule(t, db, &rule2)
+
+			insertDeletedStagedRule(t, db, &rule2)
 
 			resp, err := store.ListRulesForProject(ctx, projID)
 			assert.NoError(t, err)
-			assert.ElementsMatch(t, []*storage.Rule{}, resp)
+			assert.ElementsMatch(t, []*storage.Rule{&rule1}, resp)
 		}},
-		{"when multiple projects exist, only the requested project's rules are returned", func(t *testing.T) {
+		{"when multiple projects exist, returns only the requested project's rules", func(t *testing.T) {
 			ctx := context.Background()
 			projID1 := "foo-project"
 			insertTestProject(t, db, projID1, "first project", storage.Custom)
@@ -4147,7 +4149,7 @@ func TestUpdateRule(t *testing.T) {
 			require.NoError(t, err)
 			insertAppliedRule(t, db, &originalRule)
 			deletedUpdatedRule, err := storage.NewRule(originalRule.ID, originalRule.ProjectID, "foo bar", originalRule.Type, conditions)
-			insertStagedRule(t, db, &deletedUpdatedRule, true)
+			insertDeletedStagedRule(t, db, &deletedUpdatedRule)
 
 			newCondition, err := storage.NewCondition(storage.Event,
 				[]string{"new-chef-server-2"}, storage.ChefServer, storage.Equals)
@@ -6958,6 +6960,11 @@ func insertStagedRule(t *testing.T, db *testhelpers.TestDB, rule *storage.Rule, 
 	assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND name=$2 AND type=$3 AND project_id=$4`,
 		rule.ID, rule.Name, rule.Type.String(), rule.ProjectID))
 	assertCount(t, len(rule.Conditions), db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions WHERE rule_db_id=(SELECT r.db_id FROM iam_staged_project_rules r WHERE r.id=$1)`, rule.ID))
+}
+
+func insertDeletedStagedRule(t *testing.T, db *testhelpers.TestDB, rule *storage.Rule) {
+	t.Helper()
+	insertStagedRule(t, db, rule, true)
 }
 
 func insertAppliedRuleWithMultipleConditions(t *testing.T, db *testhelpers.TestDB, projID string, ruleType storage.RuleType) *storage.Rule {

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -3696,7 +3696,7 @@ func TestListRulesForProject(t *testing.T) {
 			insertTestProject(t, db, projID2, "pika p", storage.Custom)
 
 			ruleType := storage.Node
-			rule1 := insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
+			insertAppliedRuleWithMultipleConditions(t, db, projID, ruleType)
 
 			condition4, err := storage.NewCondition(ruleType,
 				[]string{"chef-server-2"}, storage.ChefServer, storage.MemberOf)
@@ -3713,11 +3713,6 @@ func TestListRulesForProject(t *testing.T) {
 				[]storage.Condition{condition5})
 			require.NoError(t, err)
 			insertAppliedRule(t, db, &rule3)
-
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule1.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule2.ID))
-			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_project_rules WHERE id=$1`, rule3.ID))
-			assertCount(t, 5, db.QueryRow(`SELECT count(*) FROM iam_rule_conditions`))
 
 			resp, err := store.ListRulesForProject(ctx, projID2)
 			assert.NoError(t, err)
@@ -3800,7 +3795,7 @@ func TestListRulesForProject(t *testing.T) {
 			ctx := context.Background()
 			projID := "project-1"
 			insertTestProject(t, db, projID, "first project", storage.Custom)
-			
+
 			condition, err := storage.NewCondition(storage.Node,
 				[]string{"chef-server-1"}, storage.ChefServer, storage.MemberOf)
 			require.NoError(t, err)

--- a/inspec/a2-api-integration/controls/iam_v2.rb
+++ b/inspec/a2-api-integration/controls/iam_v2.rb
@@ -1088,7 +1088,7 @@ EOF
         expect(resp.parsed_response_body[:rule]).to eq(CUSTOM_RULE_1)
       end
 
-      it "GET /iam/v2beta/projects/:id/rules returns the most up-to-date rules for the project" do
+      it "GET /iam/v2beta/projects/:id/rules returns any staged rules and applied rules with no staged changes for the project" do
         updated_rule = {
           id: CUSTOM_RULE_2[:id],
           name: "updated display name",

--- a/inspec/a2-api-integration/controls/iam_v2.rb
+++ b/inspec/a2-api-integration/controls/iam_v2.rb
@@ -1074,12 +1074,11 @@ EOF
         expect(resp.http_status.to_s).to match(/200|404/)
       end
 
-      # TODO uncomment once ListRulesForProject has been refactored with staged rules
-      # it "GET /iam/v2beta/projects/:id/rules returns the rules for the project" do
-      #   resp = automate_api_request("/apis/iam/v2beta/projects/#{CUSTOM_PROJECT_ID}/rules")
-      #   expect(resp.http_status).to eq 200
-      #   expect(resp.parsed_response_body[:rules]).to match_array([CUSTOM_RULE_1, CUSTOM_RULE_2])
-      # end
+      it "GET /iam/v2beta/projects/:id/rules returns the most up-to-date rules for the project" do
+        resp = automate_api_request("/apis/iam/v2beta/projects/#{CUSTOM_PROJECT_ID}/rules")
+        expect(resp.http_status).to eq 200
+        expect(resp.parsed_response_body[:rules]).to match_array([CUSTOM_RULE_1, CUSTOM_RULE_2])
+      end
 
       # TODO uncomment once ListRules has been refactored with staged rules
       # it "GET /iam/v2beta/rules returns all the rules" do


### PR DESCRIPTION
### :nut_and_bolt: Description

Any user viewing a project's rules should be able to see the latest staged changes to a project. This PR refactors ListRulesForProject to check both the `applied` and `staged` rule tables and ensure that only the most up-to-date version of the rule is returned in the list.

This also means any applied rule that has been staged for deletion will not be returned in this list.

### :athletic_shoe: Demo Script / Repro Steps

db setup
```
# first project with one rule is updated

insert into iam_projects (id, name, type, projects) values ('foo-project', 'Foo Project', 'custom', ARRAY['foo-project']);

insert into iam_project_rules (id, project_id, name, type) values ('foo-rule', 'foo-project', 'foorule', 'node');

insert into iam_rule_conditions (rule_db_id, attribute, value, operator) values ((SELECT db_id from iam_project_rules where id='foo-rule'), 'chef-server', ARRAY['foo'], 'equals');

insert into iam_staged_project_rules (id, project_id, name, type, deleted) values ('foo-rule', 'foo-project', 'updated foorule', 'node', false);

insert into iam_staged_rule_conditions (rule_db_id, attribute, value, operator) values ((SELECT db_id from iam_staged_project_rules where id='foo-rule'), 'chef-server', ARRAY['new foo'], 'equals');


# second project with one rule that has not been changed

insert into iam_projects (id, name, type, projects) values ('bar-project', 'Bar Project', 'custom', ARRAY['bar-project']);

insert into iam_project_rules (id, project_id, name, type) values ('bar-rule', 'bar-project', 'barrule', 'node');

insert into iam_rule_conditions (rule_db_id, attribute, value, operator) values ((SELECT db_id from iam_project_rules where id='bar-rule'), 'chef-server', ARRAY['bar'], 'equals');
```

curl
```
export TOK=`chef-automate iam token create TEST --admin`
curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/projects/foo-project/rules | jq
{
  "rules": [
    {
      "id": "foo-rule",
      "project_id": "foo-project",
      "name": "updated foorule",
      "type": "NODE",
      "conditions": [
        {
          "attribute": "CHEF_SERVERS",
          "values": [
            "new foo"
          ],
          "operator": "EQUALS"
        }
      ]
    }
  ]
}

curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/projects/bar-project/rules | jq
{
  "rules": [
    {
      "id": "bar-rule",
      "project_id": "bar-project",
      "name": "barrule",
      "type": "NODE",
      "conditions": [
        {
          "attribute": "CHEF_SERVERS",
          "values": [
            "bar"
          ],
          "operator": "EQUALS"
        }
      ]
    }
  ]
}
```
note the `applied` version of the rule is not returned.

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
