### PR TITLE
Run pg integration tests in automate lib

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -154,7 +154,7 @@ steps:
     command:
       - scripts/install_golang
       - cd lib
-      - make lint unit
+      - PG_USER="postgres" PATH=/usr/lib/postgresql/9.6/bin/:\$PATH make lint unit
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -219,7 +219,7 @@ steps:
     command:
       - scripts/install_golang
       - cd components/automate-deployment
-      - REAL_USERADD_TESTS=true PG_USER="postgres" PATH=/usr/lib/postgresql/9.6/bin/:\$PATH make ci
+      - REAL_USERADD_TESTS=true make ci
     timeout_in_minutes: 10
     retry:
       automatic:


### PR DESCRIPTION
These tests are not currently running on master:

    SKIP: TestDBInterface (0.00s)
        exporter_integration_test.go:61:
        Skipping exporter integration tests because pg_ctl was not
        found on path! To run these tests, you must have PostgreSQL
        installed

This has likely been the case since this library was extracted
from the deployment-service.

Signed-off-by: Steven Danna <steve@chef.io>