### PR TITLE
Add timestamp fields to database tables

### DIFF
--- a/components/applications-service/cmd/applications-publisher/main.go
+++ b/components/applications-service/cmd/applications-publisher/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/chef/automate/api/external/habitat"
 	"github.com/chef/automate/components/applications-service/pkg/nats"
 	"github.com/chef/automate/lib/tls/certs"
+	"github.com/golang/protobuf/ptypes"
 )
 
 var usageStr = `
@@ -85,7 +86,9 @@ func main() {
 		// applications-publisher binary to have multiple commands/sub-commands to send
 		// and do multiple things/messages
 		event = habitat.HealthCheckEvent{
-			EventMetadata:   &habitat.EventMetadata{},
+			EventMetadata: &habitat.EventMetadata{
+				OccurredAt: ptypes.TimestampNow(),
+			},
 			ServiceMetadata: &habitat.ServiceMetadata{},
 		}
 	)

--- a/components/applications-service/integration_test/global_test.go
+++ b/components/applications-service/integration_test/global_test.go
@@ -13,8 +13,10 @@ import (
 
 	"github.com/chef/automate/api/external/applications"
 	"github.com/chef/automate/api/external/habitat"
-	uuid "github.com/chef/automate/lib/uuid4"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
+
+	uuid "github.com/chef/automate/lib/uuid4"
 )
 
 var (
@@ -67,6 +69,7 @@ func DefaultHabitatEvent() *habitat.HealthCheckEvent {
 			Application: a,
 			Environment: e,
 			Site:        s,
+			OccurredAt:  ptypes.TimestampNow(),
 		},
 		ServiceMetadata: &habitat.ServiceMetadata{
 			UpdateConfig: &habitat.UpdateConfig{

--- a/components/applications-service/integration_test/storage_service_timestamp_test.go
+++ b/components/applications-service/integration_test/storage_service_timestamp_test.go
@@ -105,8 +105,8 @@ func TestStorageGetServiceFromUniqueFieldsExistUpdateLastEventOccurredAt(t *test
 		initialOccurredAtTimestamp = svc.LastEventOccurredAt
 	}
 
-	// Trigger an update but wait for a second before creating the new event
-	time.Sleep(1 * time.Second)
+	// Trigger an update but wait for half a second before creating the new event
+	time.Sleep(500 * time.Millisecond)
 	suite.IngestService(
 		NewHabitatEvent(
 			withSupervisorId("1q2w3e4r"),
@@ -120,10 +120,11 @@ func TestStorageGetServiceFromUniqueFieldsExistUpdateLastEventOccurredAt(t *test
 	if assert.True(t, exist) {
 		updatedOccurredAtTimestamp = svc.LastEventOccurredAt
 
-		// thea substraction from the initial and the updated timestamp should be greater than a second
+		// the updated timestamp must be after the initial one
 		assert.Truef(t, updatedOccurredAtTimestamp.After(initialOccurredAtTimestamp),
 			"last_event_occurred_at time was not updated after an update")
-		// update testify go package to use this
-		//assert.LessOrEqual(t, 1*time.Second, updatedOccurredAtTimestamp.Sub(initialOccurredAtTimestamp))
+		// TODO update testify go package to use this
+		// the substraction of the initial and the updated timestamp should be greater than a second
+		//assert.LessOrEqual(t, 500*time.Millisecond, updatedOccurredAtTimestamp.Sub(initialOccurredAtTimestamp))
 	}
 }

--- a/components/applications-service/integration_test/storage_service_timestamp_test.go
+++ b/components/applications-service/integration_test/storage_service_timestamp_test.go
@@ -18,6 +18,20 @@ func TestStorageGetServiceFromUniqueFieldsNotExist(t *testing.T) {
 	assert.Nil(t, svc)
 }
 
+func TestStorageGetServiceFromUniqueFieldsEmptyParameters(t *testing.T) {
+	svc, exist := suite.StorageClient.GetServiceFromUniqueFields("", "")
+	assert.False(t, exist)
+	assert.Nil(t, svc)
+
+	svc, exist = suite.StorageClient.GetServiceFromUniqueFields("foo", "")
+	assert.False(t, exist)
+	assert.Nil(t, svc)
+
+	svc, exist = suite.StorageClient.GetServiceFromUniqueFields("", "123")
+	assert.False(t, exist)
+	assert.Nil(t, svc)
+}
+
 func TestStorageGetServiceFromUniqueFieldsExist(t *testing.T) {
 	defer suite.DeleteDataFromStorage()
 
@@ -66,10 +80,11 @@ func TestStorageGetServiceFromUniqueFieldsExistUpdateLastEventOccurredAt(t *test
 		),
 	)
 	var (
-		svc, exist                 = suite.StorageClient.GetServiceFromUniqueFields("postgres", "1q2w3e4r")
 		initialOccurredAtTimestamp time.Time
 		updatedOccurredAtTimestamp time.Time
 	)
+
+	svc, exist := suite.StorageClient.GetServiceFromUniqueFields("postgres", "1q2w3e4r")
 	if assert.True(t, exist) {
 		initialOccurredAtTimestamp = svc.LastEventOccurredAt
 	}

--- a/components/applications-service/integration_test/storage_service_timestamp_test.go
+++ b/components/applications-service/integration_test/storage_service_timestamp_test.go
@@ -1,0 +1,86 @@
+//
+//  Author:: Salim Afiune <afiune@chef.io>
+//  Copyright:: Copyright 2019, Chef Software Inc.
+//
+
+package integration_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStorageGetServiceFromUniqueFieldsNotExist(t *testing.T) {
+	svc, exist := suite.StorageClient.GetServiceFromUniqueFields("foo", "123")
+	assert.False(t, exist)
+	assert.Nil(t, svc)
+}
+
+func TestStorageGetServiceFromUniqueFieldsExist(t *testing.T) {
+	defer suite.DeleteDataFromStorage()
+
+	suite.IngestService(
+		NewHabitatEvent(
+			withSupervisorId("1q2w3e4r"),
+			withServiceGroup("postgres.default"),
+			withPackageIdent("core/postgres/0.1.0/20190101121212"),
+			withStrategyAtOnce("stable"),
+			withApplication("cool-app"),
+			withEnvironment("development"),
+			withFqdn("app.example.com"),
+			withHealth("CRITICAL"),
+			withSite("us"),
+		),
+	)
+
+	svc, exist := suite.StorageClient.GetServiceFromUniqueFields("postgres", "1q2w3e4r")
+	if assert.True(t, exist) {
+		// TODO add the rest
+		assert.Equal(t, "postgres", svc.Name)
+		assert.Equal(t, "development", svc.Environment)
+	}
+}
+
+func TestStorageGetServiceFromUniqueFieldsExistUpdateLastEventOccurredAt(t *testing.T) {
+	defer suite.DeleteDataFromStorage()
+
+	suite.IngestService(
+		NewHabitatEvent(
+			withSupervisorId("1q2w3e4r"),
+			withServiceGroup("postgres.default"),
+			withPackageIdent("core/postgres/0.1.0/20190101121212"),
+		),
+	)
+	var (
+		svc, exist                 = suite.StorageClient.GetServiceFromUniqueFields("postgres", "1q2w3e4r")
+		initialOccurredAtTimestamp time.Time
+		updatedOccurredAtTimestamp time.Time
+	)
+	if assert.True(t, exist) {
+		initialOccurredAtTimestamp = svc.LastEventOccurredAt
+	}
+
+	// Trigger an update but wait for a second before creating the new event
+	time.Sleep(1 * time.Second)
+	suite.IngestService(
+		NewHabitatEvent(
+			withSupervisorId("1q2w3e4r"),
+			withServiceGroup("postgres.default"),
+			withPackageIdent("core/postgres/0.1.0/20190101121212"),
+			withHealth("CRITICAL"),
+		),
+	)
+
+	svc, exist = suite.StorageClient.GetServiceFromUniqueFields("postgres", "1q2w3e4r")
+	if assert.True(t, exist) {
+		updatedOccurredAtTimestamp = svc.LastEventOccurredAt
+
+		// thea substraction from the initial and the updated timestamp should be greater than a second
+		assert.Truef(t, updatedOccurredAtTimestamp.After(initialOccurredAtTimestamp),
+			"last_event_occurred_at time was not updated after an update")
+		// update testify go package to use this
+		//assert.LessOrEqual(t, 1*time.Second, updatedOccurredAtTimestamp.Sub(initialOccurredAtTimestamp))
+	}
+}

--- a/components/applications-service/integration_test/storage_service_timestamp_test.go
+++ b/components/applications-service/integration_test/storage_service_timestamp_test.go
@@ -37,9 +37,21 @@ func TestStorageGetServiceFromUniqueFieldsExist(t *testing.T) {
 
 	svc, exist := suite.StorageClient.GetServiceFromUniqueFields("postgres", "1q2w3e4r")
 	if assert.True(t, exist) {
-		// TODO add the rest
+		assert.NotEmpty(t, svc.ID)
+		assert.Equal(t, "1q2w3e4r", svc.SupMemberID)
+		assert.Equal(t, "core", svc.Origin)
 		assert.Equal(t, "postgres", svc.Name)
+		assert.Equal(t, "0.1.0", svc.Version)
+		assert.Equal(t, "20190101121212", svc.Release)
+		assert.Equal(t, "CRITICAL", svc.Health)
+		assert.Equal(t, "postgres.default", svc.Group)
+		assert.Equal(t, "app.example.com", svc.Fqdn)
+		assert.Equal(t, "cool-app", svc.Application)
 		assert.Equal(t, "development", svc.Environment)
+		assert.Equal(t, "stable", svc.Channel)
+		assert.Equal(t, "us", svc.Site)
+		assert.NotEmpty(t, svc.LastEventOccurredAt)
+		assert.True(t, svc.LastEventOccurredAt.Before(time.Now()))
 	}
 }
 

--- a/components/applications-service/integration_test/storage_service_timestamp_test.go
+++ b/components/applications-service/integration_test/storage_service_timestamp_test.go
@@ -19,15 +19,31 @@ func TestStorageGetServiceFromUniqueFieldsNotExist(t *testing.T) {
 }
 
 func TestStorageGetServiceFromUniqueFieldsEmptyParameters(t *testing.T) {
+	defer suite.DeleteDataFromStorage()
+
+	suite.IngestService(
+		NewHabitatEvent(
+			withSupervisorId("1q2w3e4r"),
+			withServiceGroup("postgres.default"),
+			withPackageIdent("core/postgres/0.1.0/20190101121212"),
+			withStrategyAtOnce("stable"),
+			withApplication("cool-app"),
+			withEnvironment("development"),
+			withFqdn("app.example.com"),
+			withHealth("CRITICAL"),
+			withSite("us"),
+		),
+	)
+
 	svc, exist := suite.StorageClient.GetServiceFromUniqueFields("", "")
 	assert.False(t, exist)
 	assert.Nil(t, svc)
 
-	svc, exist = suite.StorageClient.GetServiceFromUniqueFields("foo", "")
+	svc, exist = suite.StorageClient.GetServiceFromUniqueFields("postgres", "")
 	assert.False(t, exist)
 	assert.Nil(t, svc)
 
-	svc, exist = suite.StorageClient.GetServiceFromUniqueFields("", "123")
+	svc, exist = suite.StorageClient.GetServiceFromUniqueFields("", "1q2w3e4r")
 	assert.False(t, exist)
 	assert.Nil(t, svc)
 }

--- a/components/applications-service/pkg/storage/client.go
+++ b/components/applications-service/pkg/storage/client.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/chef/automate/api/external/habitat"
 )
@@ -9,6 +10,8 @@ import (
 type Client interface {
 	// @param (event)
 	IngestHealthCheckEvent(*habitat.HealthCheckEvent) error
+	// @param (name, memeber_id)
+	GetServiceFromUniqueFields(string, string) (*Service, bool)
 	// @param (sortField, sortAsc, page, pageSize, filters)
 	GetServices(string, bool, int32, int32, map[string][]string) ([]*Service, error)
 	// @param (sortField, sortAsc, page, pageSize, filters)
@@ -31,20 +34,21 @@ const (
 )
 
 type Service struct {
-	ID          int32  `db:"id"`
-	SupMemberID string `db:"sup_member_id"`
-	Origin      string
-	Name        string
-	Version     string
-	Release     string
-	Status      string
-	Health      string
-	Group       string
-	Fqdn        string
-	Application string
-	Environment string
-	Channel     string
-	Site        string
+	ID                  int32  `db:"id"`
+	SupMemberID         string `db:"sup_member_id"`
+	Origin              string
+	Name                string
+	Version             string
+	Release             string
+	Status              string
+	Health              string
+	Group               string
+	Fqdn                string
+	Application         string
+	Environment         string
+	Channel             string
+	Site                string
+	LastEventOccurredAt time.Time `db:"last_event_occurred_at"`
 }
 
 func (s *Service) FullReleaseString() string {

--- a/components/applications-service/pkg/storage/client.go
+++ b/components/applications-service/pkg/storage/client.go
@@ -10,7 +10,7 @@ import (
 type Client interface {
 	// @param (event)
 	IngestHealthCheckEvent(*habitat.HealthCheckEvent) error
-	// @param (name, memeber_id)
+	// @param (name, member_id)
 	GetServiceFromUniqueFields(string, string) (*Service, bool)
 	// @param (sortField, sortAsc, page, pageSize, filters)
 	GetServices(string, bool, int32, int32, map[string][]string) ([]*Service, error)

--- a/components/applications-service/pkg/storage/postgres/db.go
+++ b/components/applications-service/pkg/storage/postgres/db.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	gosql "database/sql"
+	"time"
 
 	"github.com/go-gorp/gorp"
 	_ "github.com/lib/pq"
@@ -88,38 +89,46 @@ func (db *Postgres) initDB() error {
 
 // service struct is the representation of the service table inside the db
 type service struct {
-	ID           int32  `db:"id"`
-	Origin       string `db:"origin"`
-	Name         string `db:"name"`
-	Version      string `db:"version"`
-	Release      string `db:"release"`
-	Status       string `db:"status"`
-	Health       string `db:"health"`
-	GroupID      int32  `db:"group_id"`
-	DeploymentID int32  `db:"deployment_id"`
-	SupID        int32  `db:"sup_id"`
-	Channel      string `db:"channel"`
-	FullPkgIdent string `db:"package_ident"`
+	ID           int32     `db:"id"`
+	Origin       string    `db:"origin"`
+	Name         string    `db:"name"`
+	Version      string    `db:"version"`
+	Release      string    `db:"release"`
+	Status       string    `db:"status"`
+	Health       string    `db:"health"`
+	GroupID      int32     `db:"group_id"`
+	DeploymentID int32     `db:"deployment_id"`
+	SupID        int32     `db:"sup_id"`
+	Channel      string    `db:"channel"`
+	FullPkgIdent string    `db:"package_ident"`
+	CreatedAt    time.Time `db:"-"`
+	UpdatedAt    time.Time `db:"-"`
 }
 
 // supervisor struct is the representation of the supervisor table inside the db
 type supervisor struct {
-	ID       int32  `db:"id"`
-	MemberID string `db:"member_id"`
-	Fqdn     string `db:"fqdn"`
-	Site     string `db:"site"`
+	ID        int32     `db:"id"`
+	MemberID  string    `db:"member_id"`
+	Fqdn      string    `db:"fqdn"`
+	Site      string    `db:"site"`
+	CreatedAt time.Time `db:"-"`
+	UpdatedAt time.Time `db:"-"`
 }
 
 // serviceGroup struct is the representation of the service_group table inside the db
 type serviceGroup struct {
-	ID           int32  `db:"id"`
-	Name         string `db:"name"`
-	DeploymentID int32  `db:"deployment_id"`
+	ID           int32     `db:"id"`
+	Name         string    `db:"name"`
+	DeploymentID int32     `db:"deployment_id"`
+	CreatedAt    time.Time `db:"-"`
+	UpdatedAt    time.Time `db:"-"`
 }
 
 // deployment struct is the representation of the deployment table inside the db
 type deployment struct {
-	ID          int32  `db:"id"`
-	AppName     string `db:"app_name"`
-	Environment string `db:"environment"`
+	ID          int32     `db:"id"`
+	AppName     string    `db:"app_name"`
+	Environment string    `db:"environment"`
+	CreatedAt   time.Time `db:"-"`
+	UpdatedAt   time.Time `db:"-"`
 }

--- a/components/applications-service/pkg/storage/postgres/db.go
+++ b/components/applications-service/pkg/storage/postgres/db.go
@@ -89,20 +89,21 @@ func (db *Postgres) initDB() error {
 
 // service struct is the representation of the service table inside the db
 type service struct {
-	ID           int32     `db:"id"`
-	Origin       string    `db:"origin"`
-	Name         string    `db:"name"`
-	Version      string    `db:"version"`
-	Release      string    `db:"release"`
-	Status       string    `db:"status"`
-	Health       string    `db:"health"`
-	GroupID      int32     `db:"group_id"`
-	DeploymentID int32     `db:"deployment_id"`
-	SupID        int32     `db:"sup_id"`
-	Channel      string    `db:"channel"`
-	FullPkgIdent string    `db:"package_ident"`
-	CreatedAt    time.Time `db:"-"`
-	UpdatedAt    time.Time `db:"-"`
+	ID                  int32     `db:"id"`
+	Origin              string    `db:"origin"`
+	Name                string    `db:"name"`
+	Version             string    `db:"version"`
+	Release             string    `db:"release"`
+	Status              string    `db:"status"`
+	Health              string    `db:"health"`
+	GroupID             int32     `db:"group_id"`
+	DeploymentID        int32     `db:"deployment_id"`
+	SupID               int32     `db:"sup_id"`
+	Channel             string    `db:"channel"`
+	FullPkgIdent        string    `db:"package_ident"`
+	LastEventOccurredAt time.Time `db:"last_event_occurred_at"`
+	CreatedAt           time.Time `db:"-"`
+	UpdatedAt           time.Time `db:"-"`
 }
 
 // supervisor struct is the representation of the supervisor table inside the db

--- a/components/applications-service/pkg/storage/postgres/schema/sql/04_timestamps.up.sql
+++ b/components/applications-service/pkg/storage/postgres/schema/sql/04_timestamps.up.sql
@@ -1,0 +1,39 @@
+-- Add created_at column to all tables in database
+ALTER TABLE deployment    ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE service_group ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE supervisor    ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE service       ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT NOW();
+
+-- Add updated_at column to all tables in database
+ALTER TABLE deployment    ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE service_group ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE supervisor    ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE service       ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT NOW();
+
+-- Add function to update timestamp of updated_at columns
+CREATE OR REPLACE FUNCTION update_timestamp_updated_at_column()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+-- Add triggers to all updated_at columns in database
+CREATE TRIGGER update_deployment_updated_at BEFORE UPDATE
+ON deployment FOR EACH ROW EXECUTE PROCEDURE
+update_timestamp_updated_at_column();
+
+CREATE TRIGGER update_service_group_updated_at BEFORE UPDATE
+ON service_group FOR EACH ROW EXECUTE PROCEDURE
+update_timestamp_updated_at_column();
+
+CREATE TRIGGER update_spervisor_updated_at BEFORE UPDATE
+ON supervisor FOR EACH ROW EXECUTE PROCEDURE
+update_timestamp_updated_at_column();
+
+CREATE TRIGGER update_service_updated_at BEFORE UPDATE
+ON service FOR EACH ROW EXECUTE PROCEDURE
+update_timestamp_updated_at_column();

--- a/components/applications-service/pkg/storage/postgres/schema/sql/04_timestamps.up.sql
+++ b/components/applications-service/pkg/storage/postgres/schema/sql/04_timestamps.up.sql
@@ -1,3 +1,7 @@
+-- Add last_event_occurred_at column to service table, this will be the timestamp of last
+-- event received from habitat, the actual timestamp is sent from the habitat supervisor
+ALTER TABLE service       ADD COLUMN last_event_occurred_at TIMESTAMP NOT NULL DEFAULT NOW();
+
 -- Add created_at column to all tables in database
 ALTER TABLE deployment    ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT NOW();
 ALTER TABLE service_group ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT NOW();

--- a/components/applications-service/pkg/storage/postgres/service.go
+++ b/components/applications-service/pkg/storage/postgres/service.go
@@ -11,7 +11,19 @@ import (
 
 const (
 	selectService = `
-SELECT * FROM service
+SELECT id
+  , origin
+  , name
+  , version
+  , release
+  , status
+  , health
+  , group_id
+  , deployment_id
+  , sup_id
+  , channel
+  , package_ident
+FROM service
 WHERE name = $1
   AND sup_id IN (
     SELECT id FROM supervisor

--- a/components/applications-service/pkg/storage/postgres/service_groups.go
+++ b/components/applications-service/pkg/storage/postgres/service_groups.go
@@ -295,13 +295,13 @@ func (db *Postgres) GetServiceGroupsHealthCounts() (*storage.HealthCounts, error
 
 // ServiceGroupExists returns the name of the service group if it exists
 func (db *Postgres) ServiceGroupExists(id string) (string, bool) {
-	var sg serviceGroup
-	err := db.SelectOne(&sg, "SELECT * FROM service_group WHERE id = $1", id)
+	var sgName string
+	err := db.SelectOne(&sgName, "SELECT name FROM service_group WHERE id = $1", id)
 	if err != nil {
 		return "", false
 	}
 
-	return sg.Name, true
+	return sgName, true
 }
 
 func queryFromStatusFilter(text string) (string, error) {

--- a/components/applications-service/pkg/storage/postgres/service_groups.go
+++ b/components/applications-service/pkg/storage/postgres/service_groups.go
@@ -295,6 +295,9 @@ func (db *Postgres) GetServiceGroupsHealthCounts() (*storage.HealthCounts, error
 
 // ServiceGroupExists returns the name of the service group if it exists
 func (db *Postgres) ServiceGroupExists(id string) (string, bool) {
+	if id == "" {
+		return "", false
+	}
 	var sgName string
 	err := db.SelectOne(&sgName, "SELECT name FROM service_group WHERE id = $1", id)
 	if err != nil {


### PR DESCRIPTION
### :nut_and_bolt: Description
We are adding timestamps to all our tables inside the applications-service.

### :+1: Definition of Done
Every table in the database has `created_at` and `updated_at` timestamps.

Additionally, we will start storing the timestamp of when habitat submitted
the event message. (new column in service table `last_event_occurred_at`)

### :athletic_shoe: Demo Script / Repro Steps
Build and start the applications-service and run the integration tests,
you can also login to the database and list the data.

### :chains: Related Resources
https://chefio.atlassian.net/browse/A2-892

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
