### PR TITLE
Add chmod to atomic file writer

### DIFF
--- a/components/automate-deployment/pkg/bootstrap/bundle_creator.go
+++ b/components/automate-deployment/pkg/bootstrap/bundle_creator.go
@@ -41,13 +41,9 @@ func (b *BundleCreator) writeFile(tarReader *tar.Reader, hdr *tar.Header) error 
 		tarReader,
 		fileutils.WithAtomicWriteFileMode(hdr.FileInfo().Mode()),
 		fileutils.WithAtomicWriteChown(hdr.Uid, hdr.Gid),
+		fileutils.WithAtomicWriteChmod(hdr.FileInfo().Mode()),
 	)
 	if err != nil {
-		return err
-	}
-	// atomic write respects the umask, so we do this one non atomic thing
-	// to get the right mode
-	if err := os.Chmod(absPath, hdr.FileInfo().Mode()); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
The file creation mode is affected by umask, which is undesirable
in some cases.
