### PR TITLE
Give the bootstrap bunde its own file format

### DIFF
--- a/components/automate-cli/cmd/chef-automate/bootstrap.go
+++ b/components/automate-cli/cmd/chef-automate/bootstrap.go
@@ -30,7 +30,7 @@ func newBootstrapBundleCmd() *cobra.Command {
 	}
 
 	var createCmd = &cobra.Command{
-		Use: "create [/path/to/bundle.tar]",
+		Use: "create [/path/to/bundle.abb]",
 		Annotations: map[string]string{
 			NoCheckVersionAnnotation: NoCheckVersionAnnotation,
 			NoRequireRootAnnotation:  NoRequireRootAnnotation,
@@ -80,7 +80,7 @@ func runBootstrapBundleCreate(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return status.Annotate(err, status.FileAccessError)
 		}
-		outfile = filepath.Join(cwd, "bootstrap-bundle.tar")
+		outfile = filepath.Join(cwd, "bootstrap-bundle.abb")
 	}
 
 	if _, err := os.Stat(outfile); err == nil {


### PR DESCRIPTION
Slapped a header on the tar to give us the flexibility to
change it in the future if we need. The extension is
abb (Automate Bootstrap Bundle), similar to the airgap bundle.
