### PR TITLE
auth services: add rows.Err() checks

### DIFF
--- a/components/authn-service/Makefile
+++ b/components/authn-service/Makefile
@@ -50,12 +50,10 @@ mock:
 # seemingly mysterious ways. Since the overall test run still does not take too
 # long, this seems acceptable.
 test:
-	@go test -i $(packages)
 	@go test $(verbose) -p 1 $(packages) -cover
 
 test_with_db:
 	@docker ps | grep authn-postgres || (echo "Docker postgres not up. Run 'make setup_docker_pg' and try this command again."; exit 1)
-	go test -i $(packages)
 	@PG_URL="postgresql://postgres@127.0.0.1:5432/authn_test?sslmode=disable&timezone=UTC" go test -cover -count=1 -parallel=1 -p 1 $(packages)
 	@echo "Docker containers still up, run 'make kill_docker_pg' to bring them down or test again with make test_with_db."
 

--- a/components/authn-service/tokens/pg/adapter.go
+++ b/components/authn-service/tokens/pg/adapter.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 
 	"github.com/lib/pq"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	tokens "github.com/chef/automate/components/authn-service/tokens/types"
@@ -192,6 +193,9 @@ func (a *adapter) GetTokens(ctx context.Context) ([]*tokens.Token, error) {
 			return nil, err
 		}
 		ts = append(ts, &t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error retrieving result rows")
 	}
 	return ts, nil
 }

--- a/components/authz-service/storage/v1/postgres/postgres.go
+++ b/components/authz-service/storage/v1/postgres/postgres.go
@@ -128,7 +128,9 @@ func (p *pg) ListPolicies(ctx context.Context) ([]*storage.Policy, error) {
 
 		storagePolicies = append(storagePolicies, toStoragePolicy(pol))
 	}
-
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error retrieving result rows")
+	}
 	return storagePolicies, nil
 }
 
@@ -154,7 +156,9 @@ func (p *pg) ListPoliciesWithSubjects(ctx context.Context) ([]*storage.Policy, e
 
 		storagePolicies = append(storagePolicies, toStoragePolicy(pol))
 	}
-
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error retrieving result rows")
+	}
 	return storagePolicies, nil
 }
 
@@ -203,7 +207,9 @@ func (p *pg) PurgeSubjectFromPolicies(ctx context.Context, sub string) ([]uuid.U
 
 		polIDs = append(polIDs, id)
 	}
-
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error retrieving result rows")
+	}
 	return polIDs, nil
 }
 


### PR DESCRIPTION
Thanks to @stevendanna's attention to detail, this makes our auth services do what needs to be done when using `database/sql`'s [`(*Rows).Next`](https://golang.org/pkg/database/sql/#Rows.Next):

> Next prepares the next result row for reading with the Scan method. *It returns true on success, or false if there is no next result row **or an error happened while preparing it**.* Err should be consulted to distinguish between the two cases.