### PR TITLE
automate-ui: cleanup statusText usage

### DIFF
--- a/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
@@ -13,11 +13,11 @@ import { ApplyStatus } from 'app/entities/license/license.reducer';
 import { LicenseStatus } from 'app/entities/license/license.model';
 import { LicenseApplyComponent } from './license-apply.component';
 
-function genErrorResp(statusCode: number, msg: string): any /* HttpErrorResponse */ {
+function genErrorResp(status: number, msg: string): any /* HttpErrorResponse */ {
   // not a full-fledged HttpErrorResponse but enough for our needs
   return {
-    status: statusCode,
-    statusText: 'Bad Request',
+    status,
+    statusText: 'Bad Request', // Note: always "OK" when using HTTP2
     url: 'https://a2-dev.test/api/v0/license/apply',
     ok: false,
     name: 'HttpErrorResponse',

--- a/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
@@ -24,11 +24,11 @@ class MockSessionStorageService {
   public putBoolean(): void {}
 }
 
-function genErrorResp(statusCode: number, msg: string): any /* HttpErrorResponse */ {
+function genErrorResp(status: number, msg: string): any /* HttpErrorResponse */ {
   // not a full-fledged HttpErrorResponse but enough for our needs
   return {
-    status: statusCode,
-    statusText: 'Bad Request',
+    status,
+    statusText: 'Bad Request', // Note: always "OK" when using HTTP2
     url: 'https://a2-dev.test/api/v0/license/apply',
     ok: false,
     name: 'HttpErrorResponse',

--- a/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
+++ b/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
@@ -79,6 +79,8 @@ export class ChefSessionService implements CanActivate {
       } else {
         // TODO 2017/12/15 (sr): is there anything we could do that's better than
         // this?
+        // NOTE 2019/06/27 (sr): this defaults to OK when using HTTP2; not worth
+        // messing with, though, this all needs to be redone.
         console.log(`Session refresh failed: ${xhr.statusText}`);
       }
     }

--- a/components/automate-ui/src/app/services/config/config.service.spec.ts
+++ b/components/automate-ui/src/app/services/config/config.service.spec.ts
@@ -47,7 +47,9 @@ describe('ConfigService', () => {
 
       expect(req.request.method).toEqual('GET');
 
-      req.flush(errorMsg, { status: 404, statusText: 'Not Found' });
+      // Note 2019/06/27 (sr): When using HTTP/2, statusText will always be "OK"
+      // so our logic shouldn't depend on it.
+      req.flush(errorMsg, { status: 404, statusText: 'OK' });
     });
   });
 });

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
@@ -39,7 +39,9 @@ describe('HttpClientAuthInterceptor', () => {
       httpClient.get('/endpoint').subscribe(null, done);
 
       const httpRequest = httpMock.expectOne('/endpoint');
-      httpRequest.flush('response', { status: 401, statusText: 'Not Authorized' });
+      // Note 2019/06/27 (sr): When using HTTP/2, statusText will always be "OK"
+      // so our logic shouldn't depend on it.
+      httpRequest.flush('response', { status: 401, statusText: 'OK' });
 
       expect(chefSession.logout).toHaveBeenCalled();
     });

--- a/components/automate-ui/src/app/services/telemetry/telemetry.service.ts
+++ b/components/automate-ui/src/app/services/telemetry/telemetry.service.ts
@@ -1,6 +1,6 @@
 import { map, filter } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { Router, NavigationEnd } from '@angular/router';
 import { ReplaySubject, Observable, Subject } from 'rxjs';
 import * as Sniffr from 'sniffr';
@@ -176,8 +176,8 @@ export class TelemetryService {
            });
 
         },
-        error => {
-          console.log(`Error retrieving Segment API key: ${error.status}/${error.statusText}`);
+        ({ status, error: { message } }: HttpErrorResponse) => {
+          console.log(`Error retrieving Segment API key: ${status}/${message}`);
         });
   }
 
@@ -258,8 +258,8 @@ export class TelemetryService {
          _response => {
            // WooHoo! we successfully submitted our telemetry event to the pipeline!
          },
-         error => {
-           console.log(`Error emitting telemetry event: ${error.status} - ${error.statusText}`);
+         ({ status, error: { message } }: HttpErrorResponse) => {
+           console.log(`Error emitting telemetry event: ${status} - ${message}`);
          }
        );
   }


### PR DESCRIPTION
- removed from test specs where it didn't matter
- replaced with error.message where it did matter
- placed a comment on it where I didn't want to change anything

What is this? HTTP/2 doesn't send a "status text". Status text is the last segment after

    HTTP/x.y <CODE> <REASON>
 
in the server response, so, where with HTTP/1.1 we see

    HTTP/1.1 401 Unauthorized

with HTTP/2, we see

    HTTP/2 401

The corresponding [RFC7540 paragraph][1] is

> HTTP/2 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line.

[1]: https://greenbytes.de/tech/webdav/rfc7540.html#rfc.section.8.1.2.4.p.2
