### PR TITLE
Include chef-server files in the support bundle

### DIFF
--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -452,6 +452,12 @@ func runGatherLogsLocalCmd(outfileOverride string, logLines uint64) error {
 	g.AddCopiesFromPath("config", "/hab/svc")
 	g.AddCopiesFromPath("logs", "/hab/svc")
 
+	// A2-chef-server-related files
+	g.AddCopiesFromPath("etc", "/hab/svc/automate-cs-bookshelf")
+	g.AddCopiesFromPath("etc", "/hab/svc/automate-cs-nginx")
+	g.AddCopiesFromPath("etc", "/hab/svc/automate-cs-oc-bifrost")
+	g.AddCopiesFromPath("etc", "/hab/svc/automate-cs-oc-erchef")
+
 	// local status
 	g.AddCommand("df_h", "df", "-h")
 	g.AddCommand("df_i", "df", "-i")

--- a/components/automate-deployment/pkg/server/gather-logs.go
+++ b/components/automate-deployment/pkg/server/gather-logs.go
@@ -95,6 +95,12 @@ func (s *server) GatherLogs(ctx context.Context, req *api.GatherLogsRequest,
 	g.AddCopiesFromPath("config", "/hab/svc")
 	g.AddCopiesFromPath("logs", "/hab/svc")
 
+	// A2-chef-server-related files
+	g.AddCopiesFromPath("etc", "/hab/svc/automate-cs-bookshelf")
+	g.AddCopiesFromPath("etc", "/hab/svc/automate-cs-nginx")
+	g.AddCopiesFromPath("etc", "/hab/svc/automate-cs-oc-bifrost")
+	g.AddCopiesFromPath("etc", "/hab/svc/automate-cs-oc-erchef")
+
 	// System info
 	g.AddCommand("df_h", "df", "-h")
 	g.AddCommand("df_i", "df", "-i")


### PR DESCRIPTION
### :nut_and_bolt: Description
Include chef-server's `etc` files in the support bundle.

We already collect the service logs and the config files.

#704 

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
