### PR TITLE
Add telemetry to count client-run based nodes and compliance stats

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.spec.ts
@@ -6,7 +6,11 @@ import { CookieModule } from 'ngx-cookie';
 import { ReportingNodesComponent } from './reporting-nodes.component';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
 import { StatsService, ReportQueryService, ReportDataService } from '../../shared/reporting';
+import { TelemetryService } from '../../../../services/telemetry/telemetry.service';
 
+class MockTelemetryService {
+  track() { }
+}
 describe('ReportingNodesComponent', () => {
   let fixture: ComponentFixture<ReportingNodesComponent>;
   let component: ReportingNodesComponent;
@@ -23,6 +27,7 @@ describe('ReportingNodesComponent', () => {
         ReportingNodesComponent
       ],
       providers: [
+        { provide: TelemetryService, useClass: MockTelemetryService },
         ChefSessionService,
         StatsService,
         ReportQueryService,

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
@@ -8,7 +8,11 @@ import * as moment from 'moment';
 import { ReportingOverviewComponent } from './reporting-overview.component';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
 import { StatsService, ReportQueryService, ReportDataService } from '../../shared/reporting';
+import { TelemetryService } from '../../../../services/telemetry/telemetry.service';
 
+class MockTelemetryService {
+  track() { }
+}
 describe('ReportingOverviewComponent', () => {
   let fixture: ComponentFixture<ReportingOverviewComponent>;
   let component: ReportingOverviewComponent;
@@ -26,6 +30,7 @@ describe('ReportingOverviewComponent', () => {
         ReportingOverviewComponent
       ],
       providers: [
+        { provide: TelemetryService, useClass: MockTelemetryService },
         ChefSessionService,
         StatsService,
         ReportQueryService,

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.spec.ts
@@ -7,6 +7,11 @@ import { ReportingProfilesComponent } from './reporting-profiles.component';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
 import { MockChefSessionService } from 'app/testing/mock-chef-session.service';
 import { StatsService, ReportQueryService, ReportDataService } from '../../shared/reporting';
+import { TelemetryService } from '../../../../services/telemetry/telemetry.service';
+
+class MockTelemetryService {
+  track() { }
+}
 
 describe('ReportingProfilesComponent', () => {
   let fixture: ComponentFixture<ReportingProfilesComponent>;
@@ -24,6 +29,7 @@ describe('ReportingProfilesComponent', () => {
         ReportingProfilesComponent
       ],
       providers: [
+        { provide: TelemetryService, useClass: MockTelemetryService },
         { provide: ChefSessionService, useClass: MockChefSessionService },
         StatsService,
         ReportQueryService,

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -15,7 +15,11 @@ import {
   ReportQueryService,
   ReportDataService
 } from '../shared/reporting';
+import { TelemetryService } from '../../../services/telemetry/telemetry.service';
 
+class MockTelemetryService {
+  track() { }
+}
 describe('ReportingComponent', () => {
   let fixture: ComponentFixture<ReportingComponent>,
     component: ReportingComponent,
@@ -36,6 +40,7 @@ describe('ReportingComponent', () => {
         ReportingComponent
       ],
       providers: [
+        { provide: TelemetryService, useClass: MockTelemetryService },
         ChefSessionService,
         StatsService,
         SuggestionsService,

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.spec.ts
@@ -18,7 +18,7 @@ describe('ReportDataService', () => {
       providers: [
         StatsService,
         ReportDataService,
-        { provide: TelemetryService, useClass: MockTelemetryService },
+        { provide: TelemetryService, useClass: MockTelemetryService }
       ],
       imports: [
         HttpClientTestingModule

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.spec.ts
@@ -3,6 +3,11 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of as observableOf } from 'rxjs';
 import { StatsService } from './stats.service';
 import { ReportDataService } from './report-data.service';
+import { TelemetryService } from '../../../../services/telemetry/telemetry.service';
+
+class MockTelemetryService {
+  track() { }
+}
 
 describe('ReportDataService', () => {
   let service: ReportDataService;
@@ -12,7 +17,8 @@ describe('ReportDataService', () => {
     TestBed.configureTestingModule({
       providers: [
         StatsService,
-        ReportDataService
+        ReportDataService,
+        { provide: TelemetryService, useClass: MockTelemetryService },
       ],
       imports: [
         HttpClientTestingModule

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
@@ -52,8 +52,8 @@ export class ReportDataService {
         // Data will give us nodes, platforms, profiles and environments
         // We will also report filters so that we know when these counts are constrained.
         if (data !== null) {
-          var summaryStats = data.stats
-          this.telemetryService.track("complianceCountsWithFilters", {summaryStats, filters})
+          const summaryStats = data.stats;
+          this.telemetryService.track('complianceCountsWithFilters', {summaryStats, filters});
         }
       });
   }

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { remove } from 'lodash';
 import { StatsService } from './stats.service';
+import { TelemetryService } from '../../../../services/telemetry/telemetry.service';
 
 interface ReportingSummary {
   stats: {
@@ -39,7 +40,8 @@ export class ReportDataService {
   };
 
   constructor(
-    private statsService: StatsService
+    private statsService: StatsService,
+    private telemetryService: TelemetryService
   ) {}
 
   getReportingSummary(filters) {
@@ -47,6 +49,12 @@ export class ReportDataService {
       .subscribe(data => {
         this.reportingSummaryEmpty = this.isAllZeros(data.stats);
         this.reportingSummary = data;
+        // Data will give us nodes, platforms, profiles and environments
+        // We will also report filters so that we know when these counts are constrained.
+        if (data !== null) {
+          var summaryStats = data.stats
+          this.telemetryService.track("complianceCountsWithFilters", {summaryStats, filters})
+        }
       });
   }
 

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -1,9 +1,14 @@
-import { map, takeUntil, finalize } from 'rxjs/operators';
+import {
+  map,
+  takeUntil,
+  finalize,
+  distinctUntilChanged,
+  distinctUntilKeyChanged
+} from 'rxjs/operators';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router, ParamMap } from '@angular/router';
 import { Subject, Observable, combineLatest } from 'rxjs';
-import { distinctUntilChanged, distinctUntilKeyChanged } from 'rxjs/operators';
 import { Chicklet, NodeCount, RollupState, SortDirection } from '../../types/types';
 import { Store, createSelector } from '@ngrx/store';
 import { NgrxStateAtom } from '../../ngrx.reducers';
@@ -324,7 +329,7 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
     )
     .pipe(takeUntil(this.isDestroyed))
     .subscribe(([nodeCounts, filterCount]) => {
-      if (filterCount === 0 && nodeCounts.total > 0){
+      if ( filterCount === 0 && nodeCounts.total > 0 ) {
         this.telemetryService.track('clientRunPureCount', nodeCounts);
       }
     });


### PR DESCRIPTION
We want to get a better idea of how many client-run and compliance nodes customers are hooking up to automate. This will help us to better understand if licenses are being fully utilized. 

client-run nodes are counted when no filters are applied. IAMv2.1 will
still apply filters but we can take the maximum reported.
compliance stats include filters since start and end time are often employed.
Signed-off-by: kmacgugan <kmacgugan@chef.io>

### :nut_and_bolt: Description

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps
Click on the client-runs tab. Look at the network traffic in the browser tools window and find the event with a payload reporting "clientRunPureCount".
Click on the compliance tab. Look at the network traffic in the browser tools window and find the event with a payload reporting "complianceCountsWithFilters"
### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
