### PR TITLE
[A2-292] Property-based tests for rules

### DIFF
--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -21,7 +21,6 @@ import (
 	uuid "github.com/chef/automate/lib/uuid4"
 
 	api_v2 "github.com/chef/automate/api/interservice/authz/v2"
-	"github.com/chef/automate/components/authz-service/config"
 	constants_v1 "github.com/chef/automate/components/authz-service/constants/v1"
 	constants_v2 "github.com/chef/automate/components/authz-service/constants/v2"
 	"github.com/chef/automate/components/authz-service/engine"
@@ -2981,11 +2980,9 @@ func setupV2WithMigrationState(t *testing.T,
 	polV2, _, err := v2.NewPoliciesServer(ctx, l, mem_v2, writer, pl, vChan)
 	require.NoError(t, err)
 
-	eventServiceClient := &testhelpers.MockEventServiceClient{}
-	configMgr, err := config.NewManager("/tmp/.authz-delete-me")
 	require.NoError(t, err)
 	projectsSrv, err := v2.NewProjectsServer(ctx, l, mem_v2,
-		rulesRetriever, eventServiceClient, configMgr, testhelpers.NewMockPolicyRefresher())
+		rulesRetriever, testhelpers.NewMockProjectUpdateManager(), testhelpers.NewMockPolicyRefresher())
 	require.NoError(t, err)
 
 	vSwitch := v2.NewSwitch(vChan)

--- a/components/authz-service/server/v2/project.go
+++ b/components/authz-service/server/v2/project.go
@@ -30,12 +30,12 @@ import (
 	event "github.com/chef/automate/components/event-service/server"
 )
 
-// state holds the server state for projects
-type state struct {
+// ProjectState holds the server state for projects
+type ProjectState struct {
 	log                  logger.Logger
 	store                storage.Storage
 	engine               engine.ProjectRulesRetriever
-	projectUpdateManager ProjectUpdateMgr
+	ProjectUpdateManager ProjectUpdateMgr
 	policyRefresher      PolicyRefresher
 	applyRuleMux         sync.Mutex
 }
@@ -87,7 +87,7 @@ func NewProjectsServer(
 		log:                  l,
 		store:                s,
 		engine:               e,
-		projectUpdateManager: projectUpdateManager,
+		ProjectUpdateManager: projectUpdateManager,
 		policyRefresher:      pr,
 	}, nil
 }

--- a/components/authz-service/server/v2/project_test.go
+++ b/components/authz-service/server/v2/project_test.go
@@ -457,8 +457,10 @@ func setupProjectsAndRules(t *testing.T) (api.ProjectsClient, *cache.Cache, *cac
 	err = os.Remove(configFile)
 	configMgr, err := config.NewManager(configFile)
 	require.NoError(t, err)
-	projectsSrv, err := v2.NewProjectsServer(ctx, l, mem_v2, &testhelpers.TestProjectRulesRetriever{},
-		eventServiceClient, configMgr, testhelpers.NewMockPolicyRefresher())
+	projectUpdateManager := v2.NewProjectUpdateManager(eventServiceClient, configMgr)
+	projectsSrv, err := v2.NewProjectsServer(
+		ctx, l, mem_v2, &testhelpers.TestProjectRulesRetriever{},
+		projectUpdateManager, testhelpers.NewMockPolicyRefresher())
 	require.NoError(t, err)
 
 	serviceCerts := helpers.LoadDevCerts(t, "authz-service")

--- a/components/authz-service/server/v2/project_update_manager.go
+++ b/components/authz-service/server/v2/project_update_manager.go
@@ -36,6 +36,18 @@ type update struct {
 	errc chan error
 }
 
+type ProjectUpdateMgr interface {
+	Cancel() error
+	Start() error
+	ProcessFailEvent(eventMessage *automate_event.EventMsg) error
+	ProcessStatusEvent(eventMessage *automate_event.EventMsg) error
+	Failed() bool
+	FailureMessage() string
+	PercentageComplete() float64
+	EstimatedTimeComplete() time.Time
+	State() string
+}
+
 // ProjectUpdateManager - project update manager
 type ProjectUpdateManager struct {
 	stage              config.ProjectUpdateStage

--- a/components/authz-service/server/v2/rules_property_test.go
+++ b/components/authz-service/server/v2/rules_property_test.go
@@ -49,7 +49,7 @@ func TestCreateRuleProperties(t *testing.T) {
 					return reportErrorAndYieldFalse(t, err)
 				}
 
-				return respRule.Status == "" && // TODO: this is wrong; should be "staged"
+				return respRule.Status == "staged" &&
 					ruleMatches(reqs.rules[0], *respRule)
 			},
 			createProjectAndRuleGen,
@@ -268,7 +268,7 @@ func TestUpdateRuleProperties(t *testing.T) {
 
 				return rApplied.Rule.Status == "applied" &&
 					ruleMatches(updateReq, *rApplied.Rule) &&
-					rStaged.Rule.Status == "" && // TODO: this is wrong; should be "staged"
+					rStaged.Rule.Status == "staged" &&
 					ruleMatches(updateReq, *rStaged.Rule)
 			},
 			createProjectAndRuleGen,
@@ -308,7 +308,7 @@ func TestUpdateRuleProperties(t *testing.T) {
 				}
 
 				return rInitialApplied.Rule.Status == "applied" &&
-					rStaged.Rule.Status == "" && // TODO: this is wrong; should be "staged"
+					rStaged.Rule.Status == "staged" &&
 					rFinalApplied.Rule.Status == "applied" &&
 					ruleMatches(updateReq, *rStaged.Rule) &&
 					ruleMatches(updateReq, *rFinalApplied.Rule)
@@ -356,8 +356,8 @@ func TestUpdateRuleProperties(t *testing.T) {
 					return reportErrorAndYieldFalse(t, err)
 				}
 
-				return rInitialStaged.Rule.Status == "" && // TODO: this is wrong; should be "staged"
-					rFinalStaged.Rule.Status == "" && // TODO: this is wrong; should be "staged"
+				return rInitialStaged.Rule.Status == "staged" &&
+					rFinalStaged.Rule.Status == "staged" &&
 					rApplied.Rule.Status == "applied" &&
 					ruleMatches(updateReq, *rInitialStaged.Rule) &&
 					ruleMatches(updateReq2, *rFinalStaged.Rule) &&

--- a/components/authz-service/server/v2/rules_property_test.go
+++ b/components/authz-service/server/v2/rules_property_test.go
@@ -55,7 +55,7 @@ func TestCreateRuleProperties(t *testing.T) {
 			createProjectAndRuleGen,
 		))
 
-	properties.Property("creating rules with non-unique IDs prohibited",
+	properties.Property("creating rules with non-unique IDs is prohibited",
 		prop.ForAll(
 			func(reqs projectAndRuleReq) bool {
 				defer testDB.Flush(t)
@@ -95,7 +95,7 @@ func TestGetRuleProperties(t *testing.T) {
 	cl, testDB, _, _, seed := testhelpers.SetupProjectsAndRulesWithDB(t)
 	properties := getGopterParams(seed)
 
-	properties.Property("fetching newly created rules are staged",
+	properties.Property("newly created rules are reported as staged",
 		prop.ForAll(
 			func(reqs projectAndRuleReq) bool {
 				defer testDB.Flush(t)
@@ -118,7 +118,7 @@ func TestGetRuleProperties(t *testing.T) {
 			createProjectAndRuleGen,
 		))
 
-	properties.Property("applying rules makes staged rules applied",
+	properties.Property("applied rules are reported as applied",
 		prop.ForAll(
 			func(reqs projectAndRuleReq) bool {
 				defer testDB.Flush(t)
@@ -146,7 +146,7 @@ func TestListRuleProperties(t *testing.T) {
 	cl, testDB, _, _, seed := testhelpers.SetupProjectsAndRulesWithDB(t)
 	properties := getGopterParams(seed)
 
-	properties.Property("reports staged rules as staged",
+	properties.Property("staged rules are reported as staged",
 		prop.ForAll(
 			func(reqs projectAndRuleReq) bool {
 				defer testDB.Flush(t)
@@ -174,7 +174,7 @@ func TestListRuleProperties(t *testing.T) {
 			createProjectAndRuleGen,
 		))
 
-	properties.Property("does not report staged rules as applied",
+	properties.Property("staged rules are not reported as applied",
 		prop.ForAll(
 			func(reqs projectAndRuleReq) bool {
 				defer testDB.Flush(t)
@@ -202,7 +202,7 @@ func TestListRuleProperties(t *testing.T) {
 			createProjectAndRuleGen,
 		))
 
-	properties.Property("reports applied rules as applied",
+	properties.Property("applied rules are reported as applied",
 		prop.ForAll(
 			func(reqs projectAndRuleReq) bool {
 				defer testDB.Flush(t)
@@ -240,7 +240,7 @@ func TestUpdateRuleProperties(t *testing.T) {
 	cl, testDB, _, _, seed := testhelpers.SetupProjectsAndRulesWithDB(t)
 	properties := getGopterParams(seed)
 
-	properties.Property("updating newly created staged rules remain staged",
+	properties.Property("updating newly created rules remain staged",
 		prop.ForAll(
 			func(reqs projectAndRuleReq) bool {
 				defer testDB.Flush(t)
@@ -373,7 +373,7 @@ func TestDeleteRuleProperties(t *testing.T) {
 	cl, testDB, _, _, seed := testhelpers.SetupProjectsAndRulesWithDB(t)
 	properties := getGopterParams(seed)
 
-	properties.Property("deleting newly created staged rules deletes them immediately",
+	properties.Property("deleting newly created rules deletes them immediately",
 		prop.ForAll(
 			func(reqs projectAndRuleReq) bool {
 				defer testDB.Flush(t)

--- a/components/authz-service/server/v2/rules_property_test.go
+++ b/components/authz-service/server/v2/rules_property_test.go
@@ -417,7 +417,6 @@ func TestDeleteRuleProperties(t *testing.T) {
 		))
 
 	properties.TestingRun(t)
-	testFW.Shutdown(t, ctx)
 }
 
 func getGopterParams(seed int64) *gopter.Properties {

--- a/components/authz-service/server/v2/rules_property_test.go
+++ b/components/authz-service/server/v2/rules_property_test.go
@@ -27,103 +27,106 @@ type projectAndRuleReq struct {
 	rules []api.CreateRuleReq
 }
 
-func TestCreateRuleProperties(t *testing.T) {
+func TestGetRuleProperties(t *testing.T) {
 	ctx := context.Background()
 	cl, testDB, _, _, seed := testhelpers.SetupProjectsAndRulesWithDB(t)
 	properties := getGopterParams(seed)
 	createRuleReqGen, createProjectReqGen, createProjectAndRuleGen := getGenerators()
 
-	properties.Property("creates a staged rule", prop.ForAll(
-		func(reqs projectAndRuleReq) bool {
-			defer testDB.Flush(t)
+	properties.Property("creates a staged rule and confirms it is staged",
+		prop.ForAll(
+			func(reqs projectAndRuleReq) bool {
+				defer testDB.Flush(t)
 
-			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			_, err = cl.CreateRule(ctx, &reqs.rules[0])
-			// Note: this could be very noisy, but it's hard to figure out what went
-			// wrong without the error
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err = cl.CreateRule(ctx, &reqs.rules[0])
+				// Note: this could be very noisy, but it's hard to figure out what went
+				// wrong without the error
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			rStaged, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				rStaged, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			// Note: we're ignoring type conversion, as asserting that would require us
-			// to replicate the mapping logic in tests.
-			// Instead, as we add GetRule, ListRules, etc., we can use this
-			// testing approach to write meaningful assertions.
-			return rStaged.Rule.Status == "staged" &&
-				ruleMatches(reqs.rules[0], *rStaged.Rule)
-		},
-		createProjectAndRuleGen,
-	))
+				// Note: we're ignoring type conversion, as asserting that would require us
+				// to replicate the mapping logic in tests.
+				// Instead, as we add GetRule, ListRules, etc., we can use this
+				// testing approach to write meaningful assertions.
+				return rStaged.Rule.Status == "staged" &&
+					ruleMatches(reqs.rules[0], *rStaged.Rule)
+			},
+			createProjectAndRuleGen,
+		))
 
-	properties.Property("creates a staged rule and applies it", prop.ForAll(
-		func(reqs projectAndRuleReq) bool {
-			defer testDB.Flush(t)
+	properties.Property("creates a staged rule and applies it then confirms it is applied",
+		prop.ForAll(
+			func(reqs projectAndRuleReq) bool {
+				defer testDB.Flush(t)
 
-			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			_, err = cl.CreateRule(ctx, &reqs.rules[0])
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err = cl.CreateRule(ctx, &reqs.rules[0])
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
+				cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
-			rApplied, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				rApplied, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			return rApplied.Rule.Status == "applied" &&
-				ruleMatches(reqs.rules[0], *rApplied.Rule)
-		},
-		createProjectAndRuleGen,
-	))
+				return rApplied.Rule.Status == "applied" &&
+					ruleMatches(reqs.rules[0], *rApplied.Rule)
+			},
+			createProjectAndRuleGen,
+		))
 
-	properties.Property("ensures rule IDs are unique", prop.ForAll(
-		func(reqs projectAndRuleReq) bool {
-			defer testDB.Flush(t)
+	properties.Property("ensure creating a rule fails if the rule ID is not unique",
+		prop.ForAll(
+			func(reqs projectAndRuleReq) bool {
+				defer testDB.Flush(t)
 
-			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			if _, err := cl.CreateRule(ctx, &reqs.rules[0]); err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				if _, err := cl.CreateRule(ctx, &reqs.rules[0]); err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			_, err = cl.CreateRule(ctx, &reqs.rules[1])
-			return grpctest.AssertCode(t, codes.AlreadyExists, err)
-		},
-		// TODO(sr): deduplicate with the combinegen above?
-		gopter.CombineGens(
-			createProjectReqGen, createRuleReqGen, createRuleReqGen,
-		).Map(func(vals []interface{}) projectAndRuleReq {
-			p := vals[0].(api.CreateProjectReq)
-			// we "fix" the second req to use the same ID as the first one
-			r0 := vals[1].(api.CreateRuleReq)
-			r1 := vals[2].(api.CreateRuleReq)
-			r1.Id = r0.Id
-			r0.ProjectId = p.Id
-			r1.ProjectId = p.Id
-			return projectAndRuleReq{
-				CreateProjectReq: p,
-				rules:            []api.CreateRuleReq{r0, r1},
-			}
-		}),
-	))
+				_, err = cl.CreateRule(ctx, &reqs.rules[1])
+				return grpctest.AssertCode(t, codes.AlreadyExists, err)
+			},
+			// TODO(sr): deduplicate with the combinegen above?
+			gopter.CombineGens(
+				createProjectReqGen, createRuleReqGen, createRuleReqGen,
+			).Map(func(vals []interface{}) projectAndRuleReq {
+				p := vals[0].(api.CreateProjectReq)
+				// we "fix" the second req to use the same ID as the first one
+				r0 := vals[1].(api.CreateRuleReq)
+				r1 := vals[2].(api.CreateRuleReq)
+				r1.Id = r0.Id
+				r0.ProjectId = p.Id
+				r1.ProjectId = p.Id
+				return projectAndRuleReq{
+					CreateProjectReq: p,
+					rules:            []api.CreateRuleReq{r0, r1},
+				}
+			}),
+		))
 
 	properties.TestingRun(t)
 }
@@ -134,96 +137,98 @@ func TestUpdateRuleProperties(t *testing.T) {
 	properties := getGopterParams(seed)
 	_, _, createProjectAndRuleGen := getGenerators()
 
-	properties.Property("updates a staged rule and applies update", prop.ForAll(
-		func(reqs projectAndRuleReq) bool {
-			defer testDB.Flush(t)
+	properties.Property("updates a staged rule and applies update confirming transition from staged to applied",
+		prop.ForAll(
+			func(reqs projectAndRuleReq) bool {
+				defer testDB.Flush(t)
 
-			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			_, err = cl.CreateRule(ctx, &reqs.rules[0])
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err = cl.CreateRule(ctx, &reqs.rules[0])
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			updateReq := api.UpdateRuleReq{
-				Id:         reqs.rules[0].Id,
-				ProjectId:  reqs.rules[0].ProjectId,
-				Name:       reqs.rules[0].Name + " updated",
-				Type:       reqs.rules[0].Type,
-				Conditions: reqs.rules[0].Conditions,
-			}
-			rUpdated, err := cl.UpdateRule(ctx, &updateReq)
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				updateReq := api.UpdateRuleReq{
+					Id:         reqs.rules[0].Id,
+					ProjectId:  reqs.rules[0].ProjectId,
+					Name:       reqs.rules[0].Name + " updated",
+					Type:       reqs.rules[0].Type,
+					Conditions: reqs.rules[0].Conditions,
+				}
+				rUpdated, err := cl.UpdateRule(ctx, &updateReq)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
+				cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
-			rApplied, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				rApplied, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			return rApplied.Rule.Status == "applied" &&
-				ruleMatches(updateReq, *rApplied.Rule) &&
-				rUpdated.Rule.Status == "" && // TODO: this is wrong; should be "staged"
-				ruleMatches(updateReq, *rUpdated.Rule)
-		},
-		createProjectAndRuleGen,
-	))
+				return rApplied.Rule.Status == "applied" &&
+					ruleMatches(updateReq, *rApplied.Rule) &&
+					rUpdated.Rule.Status == "" && // TODO: this is wrong; should be "staged"
+					ruleMatches(updateReq, *rUpdated.Rule)
+			},
+			createProjectAndRuleGen,
+		))
 
-	properties.Property("updates an applied rule and applies update", prop.ForAll(
-		func(reqs projectAndRuleReq) bool {
-			defer testDB.Flush(t)
+	properties.Property("updates an applied rule and applies update confirming transition from applied to staged to applied",
+		prop.ForAll(
+			func(reqs projectAndRuleReq) bool {
+				defer testDB.Flush(t)
 
-			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			_, err = cl.CreateRule(ctx, &reqs.rules[0])
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err = cl.CreateRule(ctx, &reqs.rules[0])
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
+				cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
-			rApplied, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
-			statusBeforeSecondUpdate := rApplied.Rule.Status
+				rApplied, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
+				statusBeforeUpdate := rApplied.Rule.Status
 
-			updateReq := api.UpdateRuleReq{
-				Id:         reqs.rules[0].Id,
-				ProjectId:  reqs.rules[0].ProjectId,
-				Name:       reqs.rules[0].Name + " updated",
-				Type:       reqs.rules[0].Type,
-				Conditions: reqs.rules[0].Conditions,
-			}
-			rUpdated, err := cl.UpdateRule(ctx, &updateReq)
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				updateReq := api.UpdateRuleReq{
+					Id:         reqs.rules[0].Id,
+					ProjectId:  reqs.rules[0].ProjectId,
+					Name:       reqs.rules[0].Name + " updated",
+					Type:       reqs.rules[0].Type,
+					Conditions: reqs.rules[0].Conditions,
+				}
+				rUpdated, err := cl.UpdateRule(ctx, &updateReq)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
+				cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
-			rApplied, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				rApplied, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			return statusBeforeSecondUpdate == "applied" &&
-				rUpdated.Rule.Status == "" && // TODO: this is wrong; should be "staged"
-				rApplied.Rule.Status == "applied" &&
-				ruleMatches(updateReq, *rApplied.Rule) &&
-				ruleMatches(updateReq, *rUpdated.Rule)
-		},
-		createProjectAndRuleGen,
-	))
+				return statusBeforeUpdate == "applied" &&
+					rUpdated.Rule.Status == "" && // TODO: this is wrong; should be "staged"
+					rApplied.Rule.Status == "applied" &&
+					ruleMatches(updateReq, *rApplied.Rule) &&
+					ruleMatches(updateReq, *rUpdated.Rule)
+			},
+			createProjectAndRuleGen,
+		))
 	properties.TestingRun(t)
 }
 
@@ -233,123 +238,126 @@ func TestDeleteRuleProperties(t *testing.T) {
 	properties := getGopterParams(seed)
 	_, _, createProjectAndRuleGen := getGenerators()
 
-	properties.Property("deletes a staged rule and applies deletion", prop.ForAll(
-		func(reqs projectAndRuleReq) bool {
-			defer testDB.Flush(t)
+	properties.Property("deletes a staged rule and applies deletion confirming rule not found in both states",
+		prop.ForAll(
+			func(reqs projectAndRuleReq) bool {
+				defer testDB.Flush(t)
 
-			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			_, err = cl.CreateRule(ctx, &reqs.rules[0])
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err = cl.CreateRule(ctx, &reqs.rules[0])
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			_, err = cl.DeleteRule(ctx, &api.DeleteRuleReq{Id: reqs.rules[0].Id})
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err = cl.DeleteRule(ctx, &api.DeleteRuleReq{Id: reqs.rules[0].Id})
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			_, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
-			deletedWhenStaged := err != nil && strings.Contains(err.Error(), "could not find")
+				_, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
+				deletedWhenStaged := err != nil && strings.Contains(err.Error(), "could not find")
 
-			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
+				cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
-			_, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
-			deletedWhenApplied := err != nil && strings.Contains(err.Error(), "could not find")
+				_, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
+				deletedWhenApplied := err != nil && strings.Contains(err.Error(), "could not find")
 
-			return deletedWhenStaged && deletedWhenApplied
-		},
-		createProjectAndRuleGen,
-	))
+				return deletedWhenStaged && deletedWhenApplied
+			},
+			createProjectAndRuleGen,
+		))
 
-	properties.Property("deletes an applied rule and applies deletion", prop.ForAll(
-		func(reqs projectAndRuleReq) bool {
-			defer testDB.Flush(t)
+	properties.Property("deletes an applied rule and applies deletion confirming rule still found while deletion is staged but no longer found once deletion is applied",
+		prop.ForAll(
+			func(reqs projectAndRuleReq) bool {
+				defer testDB.Flush(t)
 
-			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			_, err = cl.CreateRule(ctx, &reqs.rules[0])
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err = cl.CreateRule(ctx, &reqs.rules[0])
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
+				cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
-			_, err = cl.DeleteRule(ctx, &api.DeleteRuleReq{Id: reqs.rules[0].Id})
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err = cl.DeleteRule(ctx, &api.DeleteRuleReq{Id: reqs.rules[0].Id})
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			// Can still find a staged-deleted rule if the rule was previously applied!
-			rDeleted, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				// Can still find a staged-deleted rule if the rule was previously applied!
+				rDeleted, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
+				cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
-			_, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
-			deletedWhenApplied := err != nil && strings.Contains(err.Error(), "could not find")
+				_, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
+				deletedWhenApplied := err != nil && strings.Contains(err.Error(), "could not find")
 
-			return deletedWhenApplied &&
-				ruleMatches(reqs.rules[0], *rDeleted.Rule) &&
-				rDeleted.Rule.Status == "applied" && // TODO: wrong!
-				!rDeleted.Rule.Deleted // TODO: wrong!
-		},
-		createProjectAndRuleGen,
-	))
+				return deletedWhenApplied &&
+					ruleMatches(reqs.rules[0], *rDeleted.Rule) &&
+					rDeleted.Rule.Status == "applied" && // TODO: wrong!
+					!rDeleted.Rule.Deleted // TODO: wrong!
+			},
+			createProjectAndRuleGen,
+		))
 
-	properties.Property("deletes an applied and staged rule and applies deletion", prop.ForAll(
-		func(reqs projectAndRuleReq) bool {
-			defer testDB.Flush(t)
+	properties.Property("deletes an applied and staged rule and applies deletion confirming rule found but marked for deletion while deletion staged but rule no longer found once deletion is applied",
+		prop.ForAll(
+			func(reqs projectAndRuleReq) bool {
+				defer testDB.Flush(t)
 
-			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			_, err = cl.CreateRule(ctx, &reqs.rules[0])
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err = cl.CreateRule(ctx, &reqs.rules[0])
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
+				cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
-			updateReq := api.UpdateRuleReq{
-				Id:         reqs.rules[0].Id,
-				ProjectId:  reqs.rules[0].ProjectId,
-				Name:       reqs.rules[0].Name + " updated",
-				Type:       reqs.rules[0].Type,
-				Conditions: reqs.rules[0].Conditions,
-			}
-			_, err = cl.UpdateRule(ctx, &updateReq)
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				updateReq := api.UpdateRuleReq{
+					Id:         reqs.rules[0].Id,
+					ProjectId:  reqs.rules[0].ProjectId,
+					Name:       reqs.rules[0].Name + " updated",
+					Type:       reqs.rules[0].Type,
+					Conditions: reqs.rules[0].Conditions,
+				}
+				_, err = cl.UpdateRule(ctx, &updateReq)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			_, err = cl.DeleteRule(ctx, &api.DeleteRuleReq{Id: reqs.rules[0].Id})
-			if err != nil {
-				return reportErrorAndYieldFalse(t, err)
-			}
+				_, err = cl.DeleteRule(ctx, &api.DeleteRuleReq{Id: reqs.rules[0].Id})
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-			_, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
-			markedforDeletion := err != nil && strings.Contains(err.Error(), "marked for deletion")
+				_, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
+				markedforDeletion := err != nil && strings.Contains(err.Error(), "marked for deletion")
 
-			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
+				cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
-			_, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
-			fullyDeleted := err != nil && strings.Contains(err.Error(), "could not find")
+				_, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
+				fullyDeleted := err != nil && strings.Contains(err.Error(), "could not find")
 
-			return markedforDeletion && fullyDeleted
-		},
-		createProjectAndRuleGen,
-	))
+				return markedforDeletion && fullyDeleted
+			},
+			createProjectAndRuleGen,
+		))
 
 	properties.TestingRun(t)
 	testFW.Shutdown(t, ctx)

--- a/components/authz-service/server/v2/rules_property_test.go
+++ b/components/authz-service/server/v2/rules_property_test.go
@@ -39,22 +39,19 @@ func TestCreateRuleProperties(t *testing.T) {
 
 			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
 			if err != nil {
-				t.Error(err.Error())
-				return false // bad run
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			_, err = cl.CreateRule(ctx, &reqs.rules[0])
 			// Note: this could be very noisy, but it's hard to figure out what went
 			// wrong without the error
 			if err != nil {
-				t.Error(err.Error())
-				return false // bad run
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			rStaged, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			// Note: we're ignoring type conversion, as asserting that would require us
@@ -62,7 +59,7 @@ func TestCreateRuleProperties(t *testing.T) {
 			// Instead, as we add GetRule, ListRules, etc., we can use this
 			// testing approach to write meaningful assertions.
 			return rStaged.Rule.Status == "staged" &&
-				RuleMatches(reqs.rules[0], *rStaged.Rule)
+				ruleMatches(reqs.rules[0], *rStaged.Rule)
 		},
 		createProjectAndRuleGen,
 	))
@@ -73,26 +70,23 @@ func TestCreateRuleProperties(t *testing.T) {
 
 			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			_, err = cl.CreateRule(ctx, &reqs.rules[0])
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
 			rApplied, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			return rApplied.Rule.Status == "applied" &&
-				RuleMatches(reqs.rules[0], *rApplied.Rule)
+				ruleMatches(reqs.rules[0], *rApplied.Rule)
 		},
 		createProjectAndRuleGen,
 	))
@@ -103,13 +97,11 @@ func TestCreateRuleProperties(t *testing.T) {
 
 			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
 			if err != nil {
-				t.Error(err.Error())
-				return false // bad run
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			if _, err := cl.CreateRule(ctx, &reqs.rules[0]); err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			_, err = cl.CreateRule(ctx, &reqs.rules[1])
@@ -148,14 +140,12 @@ func TestUpdateRuleProperties(t *testing.T) {
 
 			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			_, err = cl.CreateRule(ctx, &reqs.rules[0])
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			updateReq := api.UpdateRuleReq{
@@ -167,22 +157,20 @@ func TestUpdateRuleProperties(t *testing.T) {
 			}
 			rUpdated, err := cl.UpdateRule(ctx, &updateReq)
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
 			rApplied, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			return rApplied.Rule.Status == "applied" &&
-				RuleMatches(updateReq, *rApplied.Rule) &&
+				ruleMatches(updateReq, *rApplied.Rule) &&
 				rUpdated.Rule.Status == "" && // TODO: this is wrong; should be "staged"
-				RuleMatches(updateReq, *rUpdated.Rule)
+				ruleMatches(updateReq, *rUpdated.Rule)
 		},
 		createProjectAndRuleGen,
 	))
@@ -193,22 +181,19 @@ func TestUpdateRuleProperties(t *testing.T) {
 
 			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			_, err = cl.CreateRule(ctx, &reqs.rules[0])
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
 			rApplied, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 			statusBeforeSecondUpdate := rApplied.Rule.Status
 
@@ -221,23 +206,21 @@ func TestUpdateRuleProperties(t *testing.T) {
 			}
 			rUpdated, err := cl.UpdateRule(ctx, &updateReq)
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
 			rApplied, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			return statusBeforeSecondUpdate == "applied" &&
 				rUpdated.Rule.Status == "" && // TODO: this is wrong; should be "staged"
 				rApplied.Rule.Status == "applied" &&
-				RuleMatches(updateReq, *rApplied.Rule) &&
-				RuleMatches(updateReq, *rUpdated.Rule)
+				ruleMatches(updateReq, *rApplied.Rule) &&
+				ruleMatches(updateReq, *rUpdated.Rule)
 		},
 		createProjectAndRuleGen,
 	))
@@ -256,20 +239,17 @@ func TestDeleteRuleProperties(t *testing.T) {
 
 			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			_, err = cl.CreateRule(ctx, &reqs.rules[0])
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			_, err = cl.DeleteRule(ctx, &api.DeleteRuleReq{Id: reqs.rules[0].Id})
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			_, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
@@ -291,29 +271,25 @@ func TestDeleteRuleProperties(t *testing.T) {
 
 			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			_, err = cl.CreateRule(ctx, &reqs.rules[0])
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
 			_, err = cl.DeleteRule(ctx, &api.DeleteRuleReq{Id: reqs.rules[0].Id})
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			// Can still find a staged-deleted rule if the rule was previously applied!
 			rDeleted, err := cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
@@ -322,7 +298,7 @@ func TestDeleteRuleProperties(t *testing.T) {
 			deletedWhenApplied := err != nil && strings.Contains(err.Error(), "could not find")
 
 			return deletedWhenApplied &&
-				RuleMatches(reqs.rules[0], *rDeleted.Rule) &&
+				ruleMatches(reqs.rules[0], *rDeleted.Rule) &&
 				rDeleted.Rule.Status == "applied" && // TODO: wrong!
 				!rDeleted.Rule.Deleted // TODO: wrong!
 		},
@@ -335,14 +311,12 @@ func TestDeleteRuleProperties(t *testing.T) {
 
 			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			_, err = cl.CreateRule(ctx, &reqs.rules[0])
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
@@ -356,14 +330,12 @@ func TestDeleteRuleProperties(t *testing.T) {
 			}
 			_, err = cl.UpdateRule(ctx, &updateReq)
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			_, err = cl.DeleteRule(ctx, &api.DeleteRuleReq{Id: reqs.rules[0].Id})
 			if err != nil {
-				t.Error(err.Error())
-				return false
+				return reportErrorAndYieldFalse(t, err)
 			}
 
 			_, err = cl.GetRule(ctx, &api.GetRuleReq{Id: reqs.rules[0].Id})
@@ -386,7 +358,6 @@ func TestDeleteRuleProperties(t *testing.T) {
 func getGopterParams(seed int64) *gopter.Properties {
 	params := gopter.DefaultTestParametersWithSeed(seed)
 	params.MinSize = 1 // otherwise, we'd get zero-length "conditions" slices
-	params.MinSuccessfulTests = 10
 	return gopter.NewProperties(params)
 }
 
@@ -459,7 +430,13 @@ func getGenerators() (gopter.Gen, gopter.Gen, gopter.Gen) {
 	return createRuleReqGen, createProjectReqGen, createProjectAndRuleGen
 }
 
-func RuleMatches(req interface{}, actual api.ProjectRule) bool {
+func reportErrorAndYieldFalse(t *testing.T, err error) bool {
+	t.Helper()
+	t.Error(err.Error())
+	return false
+}
+
+func ruleMatches(req interface{}, actual api.ProjectRule) bool {
 	if _, ok := req.(api.CreateRuleReq); ok {
 		ruleReq, _ := req.(api.CreateRuleReq)
 		return len(actual.Conditions) == len(ruleReq.Conditions) &&

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -979,7 +979,7 @@ func (p *pg) CreateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 		return nil, storage_errors.NewErrTxCommit(err)
 	}
 
-	// Currently, we don't change anything from what is passed in.
+	rule.Status = pgStaged
 	return rule, nil
 }
 
@@ -1029,7 +1029,7 @@ func (p *pg) UpdateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 		return nil, storage_errors.NewErrTxCommit(err)
 	}
 
-	// Currently, we don't change anything from what is passed in.
+	rule.Status = pgStaged
 	return rule, nil
 }
 

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -4332,7 +4332,7 @@ func TestDeleteRule(t *testing.T) {
 			assert.NoError(t, err)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=true`, ruleToDelete.ID))
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=false`, ruleToSave.ID))
-			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions WHERE rule_db_id=(SELECT r.db_id FROM iam_staged_project_rules r WHERE r.id=$1)`, ruleToDelete.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions WHERE rule_db_id=(SELECT r.db_id FROM iam_staged_project_rules r WHERE r.id=$1)`, ruleToDelete.ID))
 		},
 		"when multiple applied rules exist with a matching project filter, mark for delete": func(t *testing.T) {
 			ctx := context.Background()
@@ -4349,7 +4349,7 @@ func TestDeleteRule(t *testing.T) {
 			assert.NoError(t, err)
 			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=true`, ruleToDelete.ID))
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_project_rules WHERE id=$1 AND deleted=false`, ruleToSave.ID))
-			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_staged_rule_conditions`))
 		},
 		"when multiple applied rules exist with a non-matching project filter, do nothing and return NotFoundErr": func(t *testing.T) {
 			ctx := context.Background()
@@ -6665,10 +6665,12 @@ func assertRolesMatch(t *testing.T, db *testhelpers.TestDB, role storage.Role) {
 }
 
 func assertEmpty(t *testing.T, row *sql.Row) {
+	t.Helper()
 	assertCount(t, 0, row)
 }
 
 func assertOne(t *testing.T, row *sql.Row) {
+	t.Helper()
 	assertCount(t, 1, row)
 }
 

--- a/components/authz-service/storage/v2/rule.go
+++ b/components/authz-service/storage/v2/rule.go
@@ -8,7 +8,7 @@ import (
 	storage_errors "github.com/chef/automate/components/authz-service/storage"
 )
 
-// Rule defines a ingest rule for a project.
+// Rule defines an ingest rule for a project.
 type Rule struct {
 	ID         string      `json:"id"`
 	ProjectID  string      `json:"project_id"`


### PR DESCRIPTION
### :nut_and_bolt: Description

Defining property-based tests for rules, checking real DB operations--particularly including the effect of applying rules--while ignoring the ingest service and policy refresher for this first phase.

I have reduced the number of tests from gopter's default of 100 test runs because these tests are rather slow and caused timeouts in CI.

I have also reduced globally the maximum number of things generated for lists (typically generated via `gen.SliceOf` otherwise `ListRules` tests regularly exceed the capacity of the GRPC message size (4194304). I have even further constrained the maximum number of rule conditions locally to a smaller number of items for the same reason.

Here is the contract that these tests are concerned with. I am particularly focussing on staged vs applied rules in these tests.

```
( 1) newly created rules are staged
( 2) creating rules with non-unique IDs prohibited
( 3) fetching newly created rules are staged
( 4) applying rules makes staged rules applied
( 5) reports staged rules as staged
( 6) does not report staged rules as applied
( 7) reports applied rules as applied
( 8) updating newly created staged rules remain staged
( 9) updating applied rules become staged
(10) updating applied and staged rules remain staged
(11) deleting newly created staged rules deletes them immediately
(12) applied rules that are deleted remain available until rule changes applied
(13) deleting applied rules with staged updates are deleted immediately
```

### :+1: Definition of Done

Tests have good coverage and all pass

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
