### PR TITLE
[cereal] Add GetWorkflowScheduleByName

### DIFF
--- a/lib/cereal/backend/backend.go
+++ b/lib/cereal/backend/backend.go
@@ -17,8 +17,7 @@ type Driver interface {
 	UpdateWorkflowScheduleByID(ctx context.Context, id int64, opts WorkflowScheduleUpdateOpts) error
 	UpdateWorkflowScheduleByName(ctx context.Context, instanceName string, workflowName string, opts WorkflowScheduleUpdateOpts) error
 
-	GetScheduledWorkflowParameters(ctx context.Context, instanceName string, workflowName string) ([]byte, error)
-	GetScheduledWorkflowRecurrence(ctx context.Context, instanceName string, workflowName string) (string, error)
+	GetWorkflowScheduleByName(ctx context.Context, instanceName string, workflowName string) (*Schedule, error)
 	ListWorkflowSchedules(ctx context.Context) ([]*Schedule, error)
 
 	GetWorkflowInstanceByName(ctx context.Context, instanceName string, workflowName string) (*WorkflowInstance, error)


### PR DESCRIPTION
This removes the other "Getters" in favor of a function that returns
the entire schedule to you.

Also, while I was here, I added a missing error check.

Signed-off-by: Steven Danna <steve@chef.io>