### PR TITLE
e2e/cypress: disable visibility checking for "Remove Credential"

### DIFF
--- a/e2e/cypress/integration/compliance/01_ssh_scan_job.spec.js
+++ b/e2e/cypress/integration/compliance/01_ssh_scan_job.spec.js
@@ -210,7 +210,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     // delete the credential
     cy.contains(credName).parent().parent().find('chef-control-menu').as('row-menu')
     cy.get('@row-menu').click().then(() => {
-      cy.get('@row-menu').find('[data-cy=delete]').click()
+      cy.get('@row-menu').find('[data-cy=delete]').click({force: true})
     })
   })
   it('can delete the created node', () => {


### PR DESCRIPTION
It seems the checks done by cypress are too cautious -- so, we apply
some force.

Couldn't find a better way; but running this against dev passes the
scanner job specs.

See https://docs.cypress.io/guides/references/error-messages.html#cy-failed-because-the-element-cannot-be-interacted-with
for details.