### PR TITLE
[event-feed-service] Apply golangci-lint

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -328,7 +328,7 @@ steps:
 
   - label: "[unit] event-feed-service"
     command:
-      - hab studio run "source .studiorc && go_component_unit event-feed-service && go_component_static_tests event-feed-service"
+      - hab studio run "source .studiorc && go_component_unit event-feed-service && go_component_static_tests event-feed-service && go_component_lint event-feed-service"
     timeout_in_minutes: 10
     retry:
       automatic:

--- a/.studio/golang
+++ b/.studio/golang
@@ -19,7 +19,7 @@ document "go_component_unit" <<DOC
   Example: Run the unit tests for the authz-service with verbosity enabled
   ----------------------------------------------------
   $ go_component_unit -v config-mgmt-service
-  
+
   The command provides tab-completion, so if you type this...
 
   $ go_component_unit<space><tab><tab>
@@ -45,7 +45,7 @@ function go_component_unit() {
   log_line "Running '${YELLOW}$1${NC}' unit tests"
   pushd "$scaffolding_go_pkg_path" >/dev/null
     if [[ "$1" == "api" ]]; then
-      SPEC=./api/... 
+      SPEC=./api/...
     else
       SPEC=./components/$1/...
     fi
@@ -259,6 +259,53 @@ function go_component_static_tests() {
 }
 # Adding auto tab complete
 complete -F _component_auto_complete go_component_static_tests
+
+document "go_component_lint" <<DOC
+  Runs the golangci linter for a component
+DOC
+function go_component_lint() {
+  [ "x$1" == "x" ] && error "Missing component name argument; try 'describe ${FUNCNAME[0]}'" && return 1
+  verify_component $1 || return $?
+  local component=$1
+  install_golangci && run_golangci components/$component/...
+}
+
+complete -F _component_auto_complete go_component_lint
+
+function install_golangci() {
+    if [[ -z $GOLANGCILINTVERSION ]]; then
+        error "GOLANGCILINTVERSION must be set"
+        return 1
+    fi
+    (
+        enter_go_workspace
+        local lint_bin="./cache/golangci-lint-${GOLANGCILINTVERSION}-linux-amd64/golangci-lint"
+        local lint_tarball="./cache/golangci-lint-${GOLANGCILINTVERSION}-linux-amd64.tar.gz"
+        if [[ ! -f  "$lint_bin" ]]; then
+            log_line "Unpacking golang-ci ${GOLANGCILINTVERSION}"
+            if [[ ! -f "$lint_tarball" ]]; then
+                error "Could not find $lint_tarball, did you vendor this version of golangci-lint?"
+                return 1
+            fi
+            tar zxf "$lint_tarball" -C cache/
+            touch "$lint_bin"
+        fi
+    )
+}
+
+function run_golangci() {
+    if [[ -z $GOLANGCILINTVERSION ]]; then
+        error "GOLANGCILINTVERSION must be set"
+        return 1
+    fi
+
+    local pkg=$1
+    (
+        enter_go_workspace
+        log_line "Running golang-ci ${GOLANGCILINTVERSION} on $pkg"
+        "./cache/golangci-lint-${GOLANGCILINTVERSION}-linux-amd64/golangci-lint" run "$pkg"
+    )
+}
 
 document "go_component_make" <<DOC
   Runs the given make target(s) for the given component inside the scaffolding_go_pkg_path

--- a/.studiorc
+++ b/.studiorc
@@ -11,6 +11,9 @@ scaffolding_go_import_path="${scaffolding_go_base_path}/${scaffolding_go_repo_na
 export HAB_ORIGIN=${HAB_ORIGIN:-chef}
 # Bring ci-studio-common to life
 RECOMMENDED_HAB_VERSION="0.77.0"
+
+GOLANGCILINTVERSION=1.16.0
+
 # shellcheck disable=1090
 if [ -d "${CI_STUDIO_COMMON:-}" ]; then
   echo "CI_STUDIO_COMMON override in effect; using $CI_STUDIO_COMMON, not chef/ci-studio-common habitat package"

--- a/components/event-feed-service/pkg/grpc/grpc.go
+++ b/components/event-feed-service/pkg/grpc/grpc.go
@@ -3,10 +3,12 @@ package grpc
 import (
 	"context"
 	"fmt"
+	"net"
+
+	"github.com/olivere/elastic"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
-	"net"
 
 	"github.com/chef/automate/api/interservice/event_feed"
 	"github.com/chef/automate/components/event-feed-service/pkg/config"
@@ -14,8 +16,6 @@ import (
 	"github.com/chef/automate/components/event-feed-service/pkg/server"
 	"github.com/chef/automate/lib/grpc/health"
 	"github.com/chef/automate/lib/grpc/secureconn"
-
-	"github.com/olivere/elastic"
 )
 
 // Spawn starts a grpc server using the provided host and port.

--- a/components/event-feed-service/pkg/server/server.go
+++ b/components/event-feed-service/pkg/server/server.go
@@ -2,18 +2,18 @@ package server
 
 import (
 	"context"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+
 	automate_event "github.com/chef/automate/api/interservice/event"
 	"github.com/chef/automate/api/interservice/event_feed"
 	"github.com/chef/automate/components/event-feed-service/pkg/errors"
 	"github.com/chef/automate/components/event-feed-service/pkg/persistence"
 	"github.com/chef/automate/components/event-feed-service/pkg/util"
 	"github.com/chef/automate/lib/grpc/health"
-	"time"
-
-	"github.com/golang/protobuf/ptypes"
-	"google.golang.org/grpc/codes"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // EventFeedServer is the interface to this component.
@@ -244,7 +244,7 @@ func fromInternalFormat(entry *util.FeedEntry) (*event_feed.FeedEntry, error) {
 
 func fromInternalFormatSummary(s *util.FeedSummary) *event_feed.FeedSummaryResponse {
 	totalEntries := int64(0)
-	var counts []*event_feed.EntryCount
+	counts := make([]*event_feed.EntryCount, 0, len(s.Counts))
 	for k, v := range s.Counts {
 		ec := event_feed.EntryCount{Category: k, Count: v}
 		counts = append(counts, &ec)


### PR DESCRIPTION
This project was already very close to being lint clean, so I've
applied the linter to it and added a studio function for running the
linter.

This unfortunately duplicates some of the functionality of we have in
Makefile.common_go, but I didn't want to wade into the task of fixing
the curious blend of Makefiles, shell scripts, and studio functions
that various parts of the repository uses.

We may want to have go_component_static_tests run the linter; however,
I'll defer that until all the projects that use
go_component_static_tests are passing the linter.

Signed-off-by: Steven Danna <steve@chef.io>