### PR TITLE
compile_go_protobuf_component recommend only working targets

### DIFF
--- a/.studio/common
+++ b/.studio/common
@@ -11,7 +11,23 @@ document "compile_go_protobuf_component" <<DOC
 DOC
 function compile_go_protobuf_component() {
   [ "x$1" == "x" ] && error "Missing component name argument; try 'describe ${FUNCNAME[0]}'" && return 1
-  verify_component "$1" || return $?
+
+  # Note: while we remove all pb-derived files before regenerating, we're
+  # actually cheating a bit: the protoc-gen-* executables built above do partly
+  # depend on them.
+  local path
+  if [ "$1" == "api" ]; then
+    path=api
+  elif [ "$1" == "config" ]; then
+    path=api/config
+  else
+    path="components/$1"
+    if [ ! -f "/src/$path/scripts/grpc.sh" ]; then
+      error "Compile go protobuf target is invalid."
+      display_valid_protobuf_targets
+      return 1
+    fi
+  fi
 
   # prep policy generation (only automate-gateway needs that right now)
   # Note: the actual generation is triggered by a call to protoc with the
@@ -27,18 +43,6 @@ function compile_go_protobuf_component() {
     install_go_tool "${proto_go_tools[@]}"
     GO_TOOL_VENDOR=true install_go_tool github.com/lyft/protoc-gen-validate
   )
-
-  # Note: while we remove all pb-derived files before regenerating, we're
-  # actually cheating a bit: the protoc-gen-* executables built above do partly
-  # depend on them.
-  local path
-  if [ "$1" == "api" ]; then
-    path=api
-  elif [ "$1" == "config" ]; then
-    path=api/config
-  else
-    path="components/$1"
-  fi
 
   # "api" doesn't compile the config directory so let's not delete the config directory in that case
   if [ "$path" == "api" ]; then
@@ -251,7 +255,12 @@ function verify_component() {
 }
 
 function display_available_components() {
-  log_line "Available targets:"
+  log_line "Available components:"
+  ls -1 /src/components | awk '{print "* "$1}'
+}
+
+function display_valid_protobuf_targets() {
+  log_line "Valid targets:"
   echo "  * api"
   echo "  * config"
   ls -1 /src/components/*/scripts/grpc.sh | awk -F/ '{ print "  * "$4 }'

--- a/.studio/common
+++ b/.studio/common
@@ -254,7 +254,7 @@ function display_available_components() {
   log_line "Available targets:"
   echo "  * api"
   echo "  * config"
-  ls -1 /src/components/*/scripts/grpc.sh | sed -r 's/\/src\/components\/(.*)\/scripts\/grpc.sh/  * \1/g'
+  ls -1 /src/components/*/scripts/grpc.sh | awk -F/ '{ print "  * "$4 }'
 }
 
 document "generate_dev_root_ca" <<DOC

--- a/.studio/common
+++ b/.studio/common
@@ -251,8 +251,10 @@ function verify_component() {
 }
 
 function display_available_components() {
-  log_line "Available components:"
-  ls -1 /src/components | awk '{print "* "$1}'
+  log_line "Available targets:"
+  echo "  * api"
+  echo "  * config"
+  ls -1 /src/components/*/scripts/grpc.sh | sed -r 's/\/src\/components\/(.*)\/scripts\/grpc.sh/  * \1/g'
 }
 
 document "generate_dev_root_ca" <<DOC


### PR DESCRIPTION
**Before:** 

```
[1][default:/src:0]# compile_go_protobuf_component bla
  ERROR: Component 'bla' not found.

  hab-studio: Available components:
* applications-service
* authn-service
* authz-service
* automate-chef-io
* automate-cli
* automate-cs-bookshelf
* automate-cs-nginx
* automate-cs-oc-bifrost
* automate-cs-oc-erchef
* automate-debug
* automate-deployment
* automate-dex
* automate-elasticsearch
* automate-es-gateway
* automate-gateway
* automate-grpc
* automate-load-balancer
* automate-pg-gateway
* automate-platform-tools
* automate-postgresql
* automate-prometheus
* automate-scaffolding
* automate-scaffolding-go
* automate-ui
* automate-ui-devproxy
* automate-workflow-ctl
* automate-workflow-nginx
* automate-workflow-server
* automate-workflow-web
* backup-gateway
* chef-ui-library
* compliance-service
* config-mgmt-service
* data-feed-service
* data-lifecycle-service
* es-sidecar-service
* event-feed-service
* event-gateway
* event-service
* ingest-service
* license-control-service
* local-user-service
* nodemanager-service
* notifications-client
* notifications-service
* pg-sidecar-service
* release-mgmt-dashboard
* secrets-service
* session-service
* teams-service
* trial-license-service
```

**Majority of the services listed here won't work because of the lack of `scripts/grpc.sh` inside. They will fail like this:**
```
[1][default:/src:0]# compile_go_protobuf_component applications-service
  hab-studio: Configuring Go Workspace
  hab-studio: Loading Base Scaffolding /hab/pkgs/core/scaffolding-go/0.1.0/20190602235616/lib/scaffolding.sh
  hab-studio: Loading Wrapper Scaffolding /hab/pkgs/chef/scaffolding-go/0.1.0/20190624183505/lib/scaffolding_overrides.sh
  hab-studio: Available scaffolding variables:
...
github.com/chef/automate/vendor/github.com/lyft/protoc-gen-validate/templates
github.com/chef/automate/vendor/github.com/lyft/protoc-gen-validate/module
github.com/chef/automate/vendor/github.com/lyft/protoc-gen-validate
  ERROR: components/applications-service/scripts/grpc.sh doesn't exist or is not executable!
  WARN: Most internal protobufs have moved into the api folder.
  WARN: Did you mean: compile_go_protobuf_component api
```

**With the changes in this PR, we get this:**
```
[3][default:/src:130]# compile_go_protobuf_component x
  ERROR: Component 'x' not found.

  hab-studio: Available targets:
  * api
  * config
  * automate-deployment
  * automate-gateway
  * automate-grpc
  * compliance-service
  * data-lifecycle-service
  * nodemanager-service
```