### PR TITLE
dev/acceptance envs: remove saml lies and deal with the fallout

### DIFF
--- a/.expeditor/buildkite/cypress.sh
+++ b/.expeditor/buildkite/cypress.sh
@@ -15,6 +15,10 @@ instances_to_test=( \
 
 for instance in ${instances_to_test[*]}
 do
+  # these machines have no SAML setup
+  if grep -Eq 'fresh-install|iamv2p1' <<< "$instance"; then
+    export CYPRESS_SKIP_SSO=true
+  fi
   echo "--- Executing Cypress tests against $instance"
   export CYPRESS_BASE_URL="https://$instance"
   export CYPRESS_RECORD_KEY="$CYPRESS_RECORD_KEY"

--- a/.expeditor/buildkite/cypress.sh
+++ b/.expeditor/buildkite/cypress.sh
@@ -4,21 +4,15 @@ set -euo pipefail
 
 cd /workdir/e2e
 
-instances_to_test=( \
-    "a2-iamv2-local-fresh-install-${CHANNEL}.cd.chef.co" \
-    "a2-iamv2-local-inplace-upgrade-${CHANNEL}.cd.chef.co" \
-    "a2-iamv2p1-local-fresh-install-${CHANNEL}.cd.chef.co" \
-    "a2-iamv2p1-local-inplace-upgrade-${CHANNEL}.cd.chef.co" \
-    "a2-local-fresh-install-${CHANNEL}.cd.chef.co" \
-    "a2-perf-test-single-local-inplace-upgrade-${CHANNEL}.cd.chef.co" \
-)
+data=$(curl --silent https://a2-${CHANNEL}.cd.chef.co/assets/data.json)
+instances_to_test=$(jq -nr --argjson data "$data" '$data[] | select(.tags[] | contains ("e2e")) | .fqdn')
 
 for instance in ${instances_to_test[*]}
 do
-  # these machines have no SAML setup
-  if grep -Eq 'fresh-install|iamv2p1' <<< "$instance"; then
+  if !jq -enr --arg fqdn "$instance" --argjson data "$data" '$data[] | select(.fqdn == $fqdn) as $i | "saml" | IN($i.tags[])'; then
     export CYPRESS_SKIP_SSO=true
   fi
+
   echo "--- Executing Cypress tests against $instance"
   export CYPRESS_BASE_URL="https://$instance"
   export CYPRESS_RECORD_KEY="$CYPRESS_RECORD_KEY"

--- a/.expeditor/buildkite/cypress.sh
+++ b/.expeditor/buildkite/cypress.sh
@@ -9,7 +9,7 @@ instances_to_test=$(jq -nr --argjson data "$data" '$data[] | select(.tags[] | co
 
 for instance in ${instances_to_test[*]}
 do
-  if !jq -enr --arg fqdn "$instance" --argjson data "$data" '$data[] | select(.fqdn == $fqdn) as $i | "saml" | IN($i.tags[])'; then
+  if !jq -enr --arg fqdn "$instance" --argjson data "$data" '$data[] | select(.fqdn == $fqdn) | .tags | any(. == "saml")'; then
     export CYPRESS_SKIP_SSO=true
   fi
 

--- a/.expeditor/buildkite/cypress.sh
+++ b/.expeditor/buildkite/cypress.sh
@@ -9,7 +9,7 @@ instances_to_test=$(jq -nr --argjson data "$data" '$data[] | select(.tags[] | co
 
 for instance in ${instances_to_test[*]}
 do
-  if !jq -enr --arg fqdn "$instance" --argjson data "$data" '$data[] | select(.fqdn == $fqdn) | .tags | any(. == "saml")'; then
+  if ! jq -enr --arg fqdn "$instance" --argjson data "$data" '$data[] | select(.fqdn == $fqdn) | .tags | any(. == "saml")'; then
     export CYPRESS_SKIP_SSO=true
   fi
 

--- a/e2e/cypress/integration/01_login.spec.js
+++ b/e2e/cypress/integration/01_login.spec.js
@@ -1,128 +1,133 @@
 // CYPRESS_BASE_URL environment variable must be set
 
-describe('login and logout', () => {
+if (Cypress.env('SKIP_SSO')) {
+  describe('SSO', () => {
+    it.skip('is disabled')
+  })
+} else {
+  describe('login and logout', () => {
 
-  describe('presents SSO login capabilities', () => {
-    before(() => {
-      cy.visit('/')
-    })
-
-    it('greets with SSO page', () => {
-      cy.url()
-        .should('include', '/dex/auth?')
-        .should('include', 'client_id=automate-session')
-        .should('include', 'redirect_uri')
-      cy.contains('Choose a method to log in')
-      cy.contains('Log in with Username')
-      cy.contains('Log in with SAML')
-    })
-
-    it('selecting username sign-on transits to local page', () => {
-      cy.contains('Log in with Username').click().then(() => {
-        cy.url().should('include', '/dex/auth/')
-        cy.contains('Log in to Your Account')
-        cy.contains('Username')
-        cy.contains('Password')
-        cy.contains('Log In')
+    describe('presents SSO login capabilities', () => {
+      before(() => {
+        cy.visit('/')
       })
-    })
 
-    it('back button returns to SSO login page', () => {
-      cy.contains('Back').click().then(() => {
+      it('greets with SSO page', () => {
+        cy.url()
+          .should('include', '/dex/auth?')
+          .should('include', 'client_id=automate-session')
+          .should('include', 'redirect_uri')
         cy.contains('Choose a method to log in')
+        cy.contains('Log in with Username')
+        cy.contains('Log in with SAML')
       })
-    })
-  })
 
-  describe('fails to login with wrong credentials', () => {
-
-    before(() => {
-      cy.visit('/')
-    })
-
-    it('displays error with wrong credentials entered', () => {
-      cy.contains('Log in with Username').click().then(() => {
-
-        cy.get('#login').type('admin')
-        cy.get('#password').type('wrong')
-
-        cy.get('[type=submit]').click().then(() => {
-          cy.contains('Username or password is incorrect.')
-          cy.get('#login').clear()
-          cy.get('#password').clear()
+      it('selecting username sign-on transits to local page', () => {
+        cy.contains('Log in with Username').click().then(() => {
+          cy.url().should('include', '/dex/auth/')
+          cy.contains('Log in to Your Account')
+          cy.contains('Username')
+          cy.contains('Password')
+          cy.contains('Log In')
         })
       })
-    })
-  })
 
-  describe('can login/logout as admin', () => {
-    before(() => {
-      cy.visit('/')
-    })
-
-    it('can login and welcome modal appears', () => {
-      cy.contains('Log in with Username').click().then(() => {
-        cy.get('#login').type('admin')
-        cy.get('#password').type('chefautomate')
-
-        cy.get('[type=submit]').click().then(() => {
-          cy.get('[data-cy=welcome-title]').should('exist')
-          cy.url().should('include', '/event-feed') // default landing page
-          cy.contains('Local Administrator') // current user name
-          // cy.screenshot()
-        })
-      })
-    })
-
-    it('can close modal with main button', () => {
-      cy.get('[data-cy=welcome-title]').should('exist')
-      cy.get('[data-cy=close-welcome]').click().then(() => {
-        cy.get('[data-cy=welcome-title]').should('not.exist')
-      })
-    })
-
-    it('has expected profile menu choices', () => {
-      const menuChoices = [
-        'Signed in as Local Administrator',
-
-        'Profile',
-        'Version',
-        'About',
-        'License',
-        'Release Notes',
-        'Sign Out'
-      ]
-      cy.get('[data-cy=user-profile-button]').click().then(() => {
-        cy.get('ul.dropdown-list li')
-          .should('have.length', menuChoices.length)
-          .each(($li, index) => {
-            expect($li.text()).to.contains(menuChoices[index])
-          })
-        cy.get('[data-cy=user-profile-button]').click() // close profile menu
-      })
-    })
-
-    it('can reopen welcome modal from profile menu', () => {
-      cy.get('[data-cy=user-profile-button]').click().then(() => {
-        cy.get('[data-cy=welcome-modal-button]').click().then(() => {
-          cy.get('[data-cy=welcome-title]').should('exist')
-        })
-      })
-    })
-
-    it('can close welcome modal with "X" button', () => {
-      cy.get('[data-cy=close-x]').click().then(() => {
-        cy.get('[data-cy=welcome-title]').should('not.exist')
-      })
-    })
-
-    it('can log out and return to SSO page', () => {
-      cy.get('[data-cy=user-profile-button]').click().then(() => {
-        cy.get('[data-cy=sign-out-button]').click().then(() => {
-          cy.url().should('include', '/dex/auth')
+      it('back button returns to SSO login page', () => {
+        cy.contains('Back').click().then(() => {
           cy.contains('Choose a method to log in')
         })
       })
     })
+
+    describe('fails to login with wrong credentials', () => {
+
+      before(() => {
+        cy.visit('/')
+      })
+
+      it('displays error with wrong credentials entered', () => {
+        cy.contains('Log in with Username').click().then(() => {
+
+          cy.get('#login').type('admin')
+          cy.get('#password').type('wrong')
+
+          cy.get('[type=submit]').click().then(() => {
+            cy.contains('Username or password is incorrect.')
+            cy.get('#login').clear()
+            cy.get('#password').clear()
+          })
+        })
+      })
+    })
+
+    describe('can login/logout as admin', () => {
+      before(() => {
+        cy.visit('/')
+      })
+
+      it('can login and welcome modal appears', () => {
+        cy.contains('Log in with Username').click().then(() => {
+          cy.get('#login').type('admin')
+          cy.get('#password').type('chefautomate')
+
+          cy.get('[type=submit]').click().then(() => {
+            cy.get('[data-cy=welcome-title]').should('exist')
+            cy.url().should('include', '/event-feed') // default landing page
+            cy.contains('Local Administrator') // current user name
+            // cy.screenshot()
+          })
+        })
+      })
+
+      it('can close modal with main button', () => {
+        cy.get('[data-cy=welcome-title]').should('exist')
+        cy.get('[data-cy=close-welcome]').click().then(() => {
+          cy.get('[data-cy=welcome-title]').should('not.exist')
+        })
+      })
+
+      it('has expected profile menu choices', () => {
+        const menuChoices = [
+          'Signed in as Local Administrator',
+          'Profile',
+          'Version',
+          'About',
+          'License',
+          'Release Notes',
+          'Sign Out'
+        ]
+        cy.get('[data-cy=user-profile-button]').click().then(() => {
+          cy.get('ul.dropdown-list li')
+            .should('have.length', menuChoices.length)
+            .each(($li, index) => {
+              expect($li.text()).to.contains(menuChoices[index])
+            })
+          cy.get('[data-cy=user-profile-button]').click() // close profile menu
+        })
+      })
+
+      it('can reopen welcome modal from profile menu', () => {
+        cy.get('[data-cy=user-profile-button]').click().then(() => {
+          cy.get('[data-cy=welcome-modal-button]').click().then(() => {
+            cy.get('[data-cy=welcome-title]').should('exist')
+          })
+        })
+      })
+
+      it('can close welcome modal with "X" button', () => {
+        cy.get('[data-cy=close-x]').click().then(() => {
+          cy.get('[data-cy=welcome-title]').should('not.exist')
+        })
+      })
+
+      it('can log out and return to SSO page', () => {
+        cy.get('[data-cy=user-profile-button]').click().then(() => {
+          cy.get('[data-cy=sign-out-button]').click().then(() => {
+            cy.url().should('include', '/dex/auth')
+            cy.contains('Choose a method to log in')
+          })
+        })
+      })
+    })
   })
-})
+}

--- a/terraform/test-environments/README.md
+++ b/terraform/test-environments/README.md
@@ -27,6 +27,6 @@ You can use this environment to test changes to the Terraform code and the chef-
 1. Download and configure the [okta_aws utility](https://github.com/chef/okta_aws) - you'll use this to get credentials to the appropriate AWS account.
 2. Run `okta_aws chef-cd` to authenticate against the chef-cd AWS account.
 3. Allocate a `TF_ENVIRONMENT_INDEX` for yourself - reach out in the #releng-support channel to determine which number you should use.
-3. Run `make plan` in the `terraform/` directory to ensure that the plan will execute accordingly.
+3. Run `make plan` in the `terraform/test-environments` directory to ensure that the plan will execute accordingly.
 4. Run `make apply` to stand up your environment.
 5. When complete, run `make destroy` to tear down your environment. **There is no automatic reaping of these environments.**

--- a/terraform/test-environments/README.md
+++ b/terraform/test-environments/README.md
@@ -26,7 +26,7 @@ You can use this environment to test changes to the Terraform code and the chef-
 
 1. Download and configure the [okta_aws utility](https://github.com/chef/okta_aws) - you'll use this to get credentials to the appropriate AWS account.
 2. Run `okta_aws chef-cd` to authenticate against the chef-cd AWS account.
-3. Allocate a `TF_ENVIRONMENT_INDEX` for yourself - reach out in the #acc-support channel to determine which number you should use.
+3. Allocate a `TF_ENVIRONMENT_INDEX` for yourself - reach out in the #releng-support channel to determine which number you should use.
 3. Run `make plan` in the `terraform/` directory to ensure that the plan will execute accordingly.
 4. Run `make apply` to stand up your environment.
 5. When complete, run `make destroy` to tear down your environment. **There is no automatic reaping of these environments.**

--- a/terraform/test-environments/modules/chef_automate_install/main.tf
+++ b/terraform/test-environments/modules/chef_automate_install/main.tf
@@ -54,6 +54,39 @@ module "chef_baseline" {
   chef_environment  = "${var.chef_environment}"
 }
 
+locals {
+  saml_config = <<SAML
+[dex.v1]
+  [dex.v1.sys]
+    [dex.v1.sys.connectors.saml]
+      ca_contents = """-----BEGIN CERTIFICATE-----
+MIIDnjCCAoagAwIBAgIGAUtB26KcMA0GCSqGSIb3DQEBBQUAMIGPMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+MBIGA1UECwwLU1NPUHJvdmlkZXIxEDAOBgNVBAMMB2dldGNoZWYxHDAaBgkqhkiG9w0BCQEWDWlu
+Zm9Ab2t0YS5jb20wHhcNMTUwMTMxMjExNzA4WhcNNDUwMTMxMjExODA4WjCBjzELMAkGA1UEBhMC
+VVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNVBAoM
+BE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRAwDgYDVQQDDAdnZXRjaGVmMRwwGgYJKoZIhvcN
+AQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvaLXQkwf
+XxRu8NBruKXftYwVo9+WuH2iw/6cZB1u1sxbXHDlDxGPA5e9kecQNRB/LE/My7byr/gNakAsNIg3
+nTINxBe8pwKCGrNghzrCEbBxA0iphk/mYcM7+pkSqNZpRGPBUn8AIgxtihfUz/f56v2YhA15huO8
+k8fJoUyjwXu9/BGCkCP16ksJ50r9IHI+qabTq4c1lMOGxZGbZ7tQjbpKdiAPclgaTzSdQ/9lomnR
+uCvrnVwciDp60tGuAATdt68Re5X/5uOizlNh6k9snUWH9TQmIdyYn5bNtDa+3STXj0mIMVaAfiqQ
+5pyrWRRXXb4Uqx4/9lQM1/Lh/O8yeQIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQCgSlK+ZlmQsYtz
+A30/rbU5ZlW8/FtgcH7FjrSfYmfxi79Wtff3mHYDZjpPQQsncGnf+9BxwOEoBXVOoqwd+OSeWIJa
+pSRbDj8Iog7ldXRLo3/+PzRrnjhrP6xj8VwPDFpzdj6Hn/QBhk0qjXd6gV7mrrAJzss3XwHKWPoC
+8m2vkhGDLhmQBKCz18cVn+Z4Xhs0s9l9iWG+Ic9NBZu1KwxXI1e7yR2+xZRDPnBggDa410uDkXSb
+bDZqKKny7qHKs4bioZ/HtS9NfgFV+pz1GpI50nw6ojItCPhqhgaFwtvf2brq9BHSK/DUmA3vF7/d
+XoB1V6vwQXRubclyH8Ei2+1j
+-----END CERTIFICATE-----
+"""
+     sso_url = "https://chef.okta.com/app/chefsoftware_a2localfreshinstallunstable_1/exk1d6ztz4rioEOYA1d8/sso/saml"
+     entity_issuer = "https://automate.chef.co/dex/callback"
+     email_attr = "email"
+     username_attr = "email"
+     groups_attr = "groups"
+SAML
+}
+
 resource "null_resource" "chef_automate_cli_deploy" {
   count = "${var.instance_count}"
 
@@ -243,34 +276,7 @@ EOF
   [license_control.v1.sys.telemetry]
     url = "https://telemetry-acceptance.chef.io"
 
-[dex.v1]
-  [dex.v1.sys]
-    [dex.v1.sys.connectors.saml]
-      ca_contents = """-----BEGIN CERTIFICATE-----
-MIIDnjCCAoagAwIBAgIGAUtB26KcMA0GCSqGSIb3DQEBBQUAMIGPMQswCQYDVQQGEwJVUzETMBEG
-A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
-MBIGA1UECwwLU1NPUHJvdmlkZXIxEDAOBgNVBAMMB2dldGNoZWYxHDAaBgkqhkiG9w0BCQEWDWlu
-Zm9Ab2t0YS5jb20wHhcNMTUwMTMxMjExNzA4WhcNNDUwMTMxMjExODA4WjCBjzELMAkGA1UEBhMC
-VVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNVBAoM
-BE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRAwDgYDVQQDDAdnZXRjaGVmMRwwGgYJKoZIhvcN
-AQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvaLXQkwf
-XxRu8NBruKXftYwVo9+WuH2iw/6cZB1u1sxbXHDlDxGPA5e9kecQNRB/LE/My7byr/gNakAsNIg3
-nTINxBe8pwKCGrNghzrCEbBxA0iphk/mYcM7+pkSqNZpRGPBUn8AIgxtihfUz/f56v2YhA15huO8
-k8fJoUyjwXu9/BGCkCP16ksJ50r9IHI+qabTq4c1lMOGxZGbZ7tQjbpKdiAPclgaTzSdQ/9lomnR
-uCvrnVwciDp60tGuAATdt68Re5X/5uOizlNh6k9snUWH9TQmIdyYn5bNtDa+3STXj0mIMVaAfiqQ
-5pyrWRRXXb4Uqx4/9lQM1/Lh/O8yeQIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQCgSlK+ZlmQsYtz
-A30/rbU5ZlW8/FtgcH7FjrSfYmfxi79Wtff3mHYDZjpPQQsncGnf+9BxwOEoBXVOoqwd+OSeWIJa
-pSRbDj8Iog7ldXRLo3/+PzRrnjhrP6xj8VwPDFpzdj6Hn/QBhk0qjXd6gV7mrrAJzss3XwHKWPoC
-8m2vkhGDLhmQBKCz18cVn+Z4Xhs0s9l9iWG+Ic9NBZu1KwxXI1e7yR2+xZRDPnBggDa410uDkXSb
-bDZqKKny7qHKs4bioZ/HtS9NfgFV+pz1GpI50nw6ojItCPhqhgaFwtvf2brq9BHSK/DUmA3vF7/d
-XoB1V6vwQXRubclyH8Ei2+1j
------END CERTIFICATE-----
-"""
-     sso_url = "https://chef.okta.com/app/chefsoftware_a2localfreshinstallunstable_1/exk1d6ztz4rioEOYA1d8/sso/saml"
-     entity_issuer = "https://automate.chef.co/dex/callback"
-     email_attr = "email"
-     username_attr = "email"
-     groups_attr = "groups"
+${var.saml == "true" ? local.saml_config : ""}
 
 [ingest]
   [ingest.v1]

--- a/terraform/test-environments/modules/chef_automate_install/variables.tf
+++ b/terraform/test-environments/modules/chef_automate_install/variables.tf
@@ -111,6 +111,11 @@ variable "iam_version" {
   description = "Enable major/minor versions of A2 IAM."
 }
 
+variable "saml" {
+  default     = "false"
+  description = "Enable SAML login"
+}
+
 variable "enable_workflow" {
   default     = "false"
   description = "Enable A2 Workflow feature."

--- a/terraform/test-environments/scenarios/airgapped_single_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/airgapped_single_local_fresh_install.tf
@@ -11,7 +11,7 @@ module "airgapped_single_local_fresh_install" {
 
   # Metadata
   meta_title       = "Airgapped Single Local (Fresh Install)"
-  meta_description = "A2 stack (using SAML) deployed locally from an airgap bundle on a single host using the chef-automate CLI."
+  meta_description = "A2 stack deployed locally from an airgap bundle on a single host using the chef-automate CLI."
   meta_type        = "habitat"
 
   # AWS Instance Configuration

--- a/terraform/test-environments/scenarios/airgapped_single_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/airgapped_single_local_fresh_install.tf
@@ -34,6 +34,7 @@ module "airgapped_single_local_fresh_install" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-SAML             = "saml"
   }
 }
 

--- a/terraform/test-environments/scenarios/airgapped_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/airgapped_single_local_inplace_upgrade.tf
@@ -87,4 +87,7 @@ module "airgapped_single_local_inplace_upgrade_deploy" {
   channel         = "${var.channel}"
   deployment_type = "local"
   upgrade         = "true"
+
+  # SAML
+  saml = "true"
 }

--- a/terraform/test-environments/scenarios/airgapped_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/airgapped_single_local_inplace_upgrade.tf
@@ -33,6 +33,7 @@ module "airgapped_single_local_inplace_upgrade" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-SAML             = "saml"
   }
 }
 

--- a/terraform/test-environments/scenarios/chef-server_performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/chef-server_performance_test_single_local_inplace_upgrade.tf
@@ -11,7 +11,7 @@ module "chef_server_performance_test_single_local_inplace_upgrade" {
 
   # Metadata
   meta_title       = "Performance Test A2 Chef Server Single Local (Inplace Upgrade)"
-  meta_description = "Performance test A2 Chef Server (inplace upgrade)."
+  meta_description = "Performance test A2 Chef Server (inplace upgrade, using SAML)."
   meta_type        = "habitat"
 
   # AWS Instance Configuration

--- a/terraform/test-environments/scenarios/chef-server_performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/chef-server_performance_test_single_local_inplace_upgrade.tf
@@ -90,6 +90,9 @@ module "chef_server_performance_test_single_local_inplace_upgrade_deploy" {
   deployment_type = "local"
   upgrade         = "true"
 
+  # SAML
+  saml = "true"
+
   # Enable A2 Chef Server feature
   enable_chef_server = "true"
 

--- a/terraform/test-environments/scenarios/chef-server_performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/chef-server_performance_test_single_local_inplace_upgrade.tf
@@ -33,6 +33,7 @@ module "chef_server_performance_test_single_local_inplace_upgrade" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-SAML             = "saml"
   }
 }
 

--- a/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
@@ -33,6 +33,7 @@ module "performance_test_single_local_inplace_upgrade" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-SAML             = "saml"
   }
 }
 

--- a/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
@@ -11,7 +11,7 @@ module "performance_test_single_local_inplace_upgrade" {
 
   # Metadata
   meta_title       = "Performance Test Single Local (Inplace Upgrade)"
-  meta_description = "Performance test A2 (inplace upgrade). A2_Performance_Test_${var.dns_suffix} CloudWatch dashboard is available in the chef-cd AWS account. Contact #helpdesk for okta access."
+  meta_description = "Performance test A2 (inplace upgrade, using SAML). A2_Performance_Test_${var.dns_suffix} CloudWatch dashboard is available in the chef-cd AWS account. Contact #helpdesk for okta access."
   meta_type        = "habitat"
 
   # AWS Instance Configuration

--- a/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
@@ -91,6 +91,9 @@ module "performance_test_single_local_inplace_upgrade_deploy" {
   enable_eas_dashboard = "true"
   upgrade              = "true"
 
+  # SAML
+  saml = "true"
+
   # Create admin-token
   create_admin_token = "true"
 

--- a/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
@@ -34,6 +34,7 @@ module "performance_test_single_local_inplace_upgrade" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
+    X-CI-Test          = "e2e"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_hardened_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_hardened_local_fresh_install.tf
@@ -12,7 +12,7 @@ module "single_hardened_local_fresh_install" {
 
   # Metadata
   meta_title       = "Hardened Single Local (Fresh Install)"
-  meta_description = "A2 stack (using SAML) deployed locally as Habitat packages on a single host with hardened security using the chef-automate CLI."
+  meta_description = "A2 stack deployed locally as Habitat packages on a single host with hardened security using the chef-automate CLI."
   meta_type        = "habitat"
 
   # AWS Instance Configuration

--- a/terraform/test-environments/scenarios/single_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_fresh_install.tf
@@ -34,6 +34,7 @@ module "single_local_fresh_install" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-CI-Test          = "e2e"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_fresh_install.tf
@@ -11,7 +11,7 @@ module "single_local_fresh_install" {
 
   # Metadata
   meta_title       = "Single Local (Fresh Install)"
-  meta_description = "A2 stack (using SAML) deployed locally as Habitat packages on a single host using the chef-automate CLI."
+  meta_description = "A2 stack deployed locally as Habitat packages on a single host using the chef-automate CLI."
   meta_type        = "habitat"
 
   # AWS Instance Configuration

--- a/terraform/test-environments/scenarios/single_local_iamv2_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2_fresh_install.tf
@@ -34,6 +34,7 @@ module "single_local_iamv2_fresh_install" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-CI-Test          = "e2e"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_iamv2_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2_fresh_install.tf
@@ -11,7 +11,7 @@ module "single_local_iamv2_fresh_install" {
 
   # Metadata
   meta_title       = "Single Local (Fresh Install) with IAMv2"
-  meta_description = "A2 stack with IAMv2 (using SAML) deployed locally as Habitat packages on a single host using the chef-automate CLI."
+  meta_description = "A2 stack with IAMv2 deployed locally as Habitat packages on a single host using the chef-automate CLI."
   meta_type        = "habitat"
 
   # AWS Instance Configuration

--- a/terraform/test-environments/scenarios/single_local_iamv2_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2_inplace_upgrade.tf
@@ -33,6 +33,7 @@ module "single_local_iamv2_inplace_upgrade" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-SAML             = "saml"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_iamv2_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2_inplace_upgrade.tf
@@ -34,6 +34,7 @@ module "single_local_iamv2_inplace_upgrade" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
+    X-CI-Test          = "e2e"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_iamv2_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2_inplace_upgrade.tf
@@ -54,4 +54,5 @@ module "single_local_iamv2_inplace_upgrade_deploy" {
   deployment_type = "local"
   upgrade         = "true"
   iam_version     = "v2"
+  saml            = "true"
 }

--- a/terraform/test-environments/scenarios/single_local_iamv2p1_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2p1_fresh_install.tf
@@ -34,6 +34,7 @@ module "single_local_iamv2p1_fresh_install" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-CI-Test          = "e2e"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_iamv2p1_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2p1_fresh_install.tf
@@ -11,7 +11,7 @@ module "single_local_iamv2p1_fresh_install" {
 
   # Metadata
   meta_title       = "Single Local (Fresh Install) with IAMv2p1"
-  meta_description = "A2 stack with IAMv2p1 (using SAML) deployed locally as Habitat packages on a single host using the chef-automate CLI."
+  meta_description = "A2 stack with IAMv2p1 deployed locally as Habitat packages on a single host using the chef-automate CLI."
   meta_type        = "habitat"
 
   # AWS Instance Configuration

--- a/terraform/test-environments/scenarios/single_local_iamv2p1_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2p1_inplace_upgrade.tf
@@ -33,6 +33,7 @@ module "single_local_iamv2p1_inplace_upgrade" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-CI-Test          = "e2e"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_iamv2p1_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2p1_inplace_upgrade.tf
@@ -11,7 +11,7 @@ module "single_local_iamv2p1_inplace_upgrade" {
 
   # Metadata
   meta_title       = "Single Local (Inplace Upgrade) with IAMv2p1"
-  meta_description = "A2 stack with IAMv2p1 (using SAML) deployed locally as Habitat packages on a single host using the chef-automate CLI."
+  meta_description = "A2 stack with IAMv2p1 deployed locally as Habitat packages on a single host using the chef-automate CLI."
   meta_type        = "habitat"
 
   # AWS Instance Configuration

--- a/terraform/test-environments/scenarios/single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_inplace_upgrade.tf
@@ -33,6 +33,7 @@ module "single_local_inplace_upgrade" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-SAML             = "saml"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_inplace_upgrade.tf
@@ -53,4 +53,7 @@ module "single_local_inplace_upgrade_deploy" {
   channel         = "${var.channel}"
   deployment_type = "local"
   upgrade         = "true"
+
+  # SAML
+  saml = "true"
 }

--- a/terraform/test-environments/scenarios/single_local_workflow_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_workflow_fresh_install.tf
@@ -11,7 +11,7 @@ module "single_local_workflow_fresh_install" {
 
   # Metadata
   meta_title       = "Single Local (Fresh Install) with Workflow"
-  meta_description = "A2 stack with Workflow (using SAML) deployed locally as Habitat packages on a single host using the chef-automate CLI."
+  meta_description = "A2 stack with Workflow deployed locally as Habitat packages on a single host using the chef-automate CLI."
   meta_type        = "habitat"
 
   # AWS Instance Configuration

--- a/terraform/test-environments/scenarios/single_local_workflow_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_workflow_inplace_upgrade.tf
@@ -56,4 +56,7 @@ module "single_local_workflow_inplace_upgrade_deploy" {
   enable_chef_server  = "true"
   enable_workflow     = "true"
   workflow_enterprise = "demo"
+
+  # SAML
+  saml = "true"
 }

--- a/terraform/test-environments/scenarios/single_local_workflow_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_workflow_inplace_upgrade.tf
@@ -33,6 +33,7 @@ module "single_local_workflow_inplace_upgrade" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-SAML             = "saml"
   }
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description

It's gotten confusing that all envs claim to do SAML when just a small subset of them do. (It's got to do with some limitation on Okta, not our code.)

- [X] only have those envs _claim_ to do SAML that actually do
- [X] only have those envs configure SAML where it has been set up in Okta
- [X] adjust the e2e cypress specs to work with both SAML and local-only login pages
- [x] fill out this preamble
- [x] verify the terraform stuff works
- [x] if time permits, drive the cypress e2e tests from tags, not the bash script

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
