### PR TITLE
Compliance: swap around wrong actual and expected asserts

### DIFF
--- a/components/compliance-service/api/tests/02_nodes_spec.rb
+++ b/components/compliance-service/api/tests/02_nodes_spec.rb
@@ -1296,7 +1296,7 @@ describe File.basename(__FILE__) do
             }
         ]
     }
-    assert_equal_json_sorted(actual_node.to_json, expected_node.to_json)
+    assert_equal_json_sorted( expected_node.to_json, actual_node.to_json)
 
     # sort by node name ASC when a profile filter is used
     resp = GRPC reporting, :list_nodes, Reporting::Query.new(filters: [

--- a/components/compliance-service/api/tests/03_deep_reports_spec.rb
+++ b/components/compliance-service/api/tests/03_deep_reports_spec.rb
@@ -591,7 +591,7 @@ describe File.basename(__FILE__) do
       assert_equal(4, res['profiles'][0]['controls'].length)
 
       control_ids = res['profiles'][0]['controls'].map {|c| c.id}
-      assert_equal(control_ids, ["nginx-01", "nginx-02", "nginx-03", "nginx-04"])
+      assert_equal(["nginx-01", "nginx-02", "nginx-03", "nginx-04"], control_ids)
 
       assert_equal(Reporting::Report, res.class)
 
@@ -687,9 +687,7 @@ describe File.basename(__FILE__) do
       assert_equal(1, res['profiles'][0]['controls'].length)
 
       control_ids = res['profiles'][0]['controls'].map {|c| c.id}
-      assert_equal([
-                       "apache-01"
-                   ], control_ids)
+      assert_equal(["apache-01"], control_ids)
 
       assert_equal(Reporting::Report, res.class)
 

--- a/components/compliance-service/api/tests/03_reports_spec.rb
+++ b/components/compliance-service/api/tests/03_reports_spec.rb
@@ -491,7 +491,7 @@ describe File.basename(__FILE__) do
     resp = GRPC reporting, :list_reports, Reporting::Query.new(filters: [
         Reporting::ListFilter.new(type: 'environment', values: ['missing-in-action'])
     ])
-    assert_equal resp, Reporting::Reports.new()
+    assert_equal(Reporting::Reports.new(), resp)
 
 
     # Get all reports for these two nodes, one missing
@@ -652,7 +652,7 @@ describe File.basename(__FILE__) do
       assert_equal(4, res['profiles'][0]['controls'].length)
 
       control_ids = res['profiles'][0]['controls'].map {|c| c.id}
-      assert_equal(control_ids, ["nginx-01", "nginx-02", "nginx-03", "nginx-04"])
+      assert_equal(["nginx-01", "nginx-02", "nginx-03", "nginx-04"], control_ids)
 
       assert_equal(Reporting::Report, res.class)
 

--- a/components/compliance-service/api/tests/09_profiles_spec.rb
+++ b/components/compliance-service/api/tests/09_profiles_spec.rb
@@ -246,7 +246,7 @@ describe File.basename(__FILE__) do
         name: 'windows-baseline',
         version: '1.1.0'
     )
-    assert_equal actual, Google::Protobuf::Empty.new()
+    assert_equal Google::Protobuf::Empty.new(), actual
   end
 
   it "returns an error getting the metadata for a deleted profile" do
@@ -377,7 +377,7 @@ describe File.basename(__FILE__) do
         name: 'windows-baseline',
         version: '1.1.0'
     )
-    assert_equal actual, Google::Protobuf::Empty.new()
+    assert_equal Google::Protobuf::Empty.new(), actual
   end
 
   it "returns the data for an uninstalled market profile" do

--- a/components/compliance-service/api/tests/20_secrets_spec.rb
+++ b/components/compliance-service/api/tests/20_secrets_spec.rb
@@ -126,7 +126,7 @@ describe File.basename(__FILE__) do
 
     ##### GRPC Success tests #####
     actual = SS_GRPC secrets, :list, Secrets::Query.new()
-    assert_equal actual, Secrets::Secrets.new(secrets: [], total: 0)
+    assert_equal Secrets::Secrets.new(secrets: [], total: 0), actual
 
     # Add a secret without tags or type
     secret1 = SS_GRPC secrets, :create, Secrets::Secret.new(

--- a/components/compliance-service/api/tests/25_nodes_spec.rb
+++ b/components/compliance-service/api/tests/25_nodes_spec.rb
@@ -49,7 +49,7 @@ describe File.basename(__FILE__) do
 
     ##### GRPC Success tests #####
     actual = MANAGER_GRPC nodes, :list, Nodes::Query.new(page: 1)
-    assert_equal actual, Nodes::Nodes.new(nodes: [], total: 0)
+    assert_equal Nodes::Nodes.new(nodes: [], total: 0), actual
 
     secret = SS_GRPC secrets, :create, Secrets::Secret.new(
       name:"My WinRM Cred",

--- a/components/compliance-service/api/tests/30_jobs_docker_spec.rb
+++ b/components/compliance-service/api/tests/30_jobs_docker_spec.rb
@@ -577,7 +577,7 @@ describe File.basename(__FILE__) do
         Common::Filter.new(key: "job_type", values: ["exec"])
       ]
     )
-    assert_equal actual, Jobs::Jobs.new(jobs: [], total: 0)
+    assert_equal Jobs::Jobs.new(jobs: [], total: 0), actual
 
     # Testing jobs list filtered by job_type = 'bogus_job_type' expect 400 bad request
     assert_grpc_error("Invalid job_type filter: bogus_job_type. job_type must be one of the following: \'detect\' or \'exec\'", 3) do

--- a/components/compliance-service/api/tests/50_scheduler_spec.rb
+++ b/components/compliance-service/api/tests/50_scheduler_spec.rb
@@ -119,13 +119,13 @@ describe File.basename(__FILE__) do
 
     all_jobs = GRPC jobs, :list, Jobs::Query.new()
     # we should have three jobs now
-    assert_equal(all_jobs.total, 3)
+    assert_equal(3, all_jobs.total)
 
     first_job = GRPC jobs, :read, Jobs::Id.new(id: job_id1)
     # the parent job should have status scheduled
-    assert_equal(first_job.status, "scheduled")
-    assert_equal(first_job.parent_id, "")
-    assert_equal(first_job.job_count, 0)
+    assert_equal("scheduled", first_job.status)
+    assert_equal("", first_job.parent_id)
+    assert_equal(0, first_job.job_count)
 
     job_id2 = (GRPC jobs, :create, Jobs::Job.new(
       name: "My exec job2",
@@ -142,47 +142,47 @@ describe File.basename(__FILE__) do
     all_jobs = GRPC jobs, :list, Jobs::Query.new()
 
     # we should have four jobs now, the three from above and our new scheduled-for-the-future one
-    assert_equal(all_jobs.total >= 4, true)
+    assert_equal(true, all_jobs.total >= 4)
 
     job2 = GRPC jobs, :read, Jobs::Id.new(id: job_id2)
     # since job is scheduled for future, it should have status scheduled
-    assert_equal(job2.status, "scheduled")
-    assert_equal(job2.recurrence, "FREQ=HOURLY;INTERVAL=1;COUNT=5;DTSTART=20290101T000000Z")
+    assert_equal("scheduled", job2.status)
+    assert_equal("FREQ=HOURLY;INTERVAL=1;COUNT=5;DTSTART=20290101T000000Z", job2.recurrence)
 
     # and no parent_id
-    assert_equal(job2.parent_id, "")
+    assert_equal("", job2.parent_id)
     # scheduled datetime should be same as dtstart value
-    assert_equal(job2.scheduled_time, Google::Protobuf::Timestamp.new(seconds: 1861920000, nanos: 0))
+    assert_equal(Google::Protobuf::Timestamp.new(seconds: 1861920000, nanos: 0), job2.scheduled_time)
 
     sleep 60
     all_jobs = GRPC jobs, :list, Jobs::Query.new()
     # we should have seven jobs now, the three from above, our scheduled-for-the-future one,
     # our child job from the first one, our child job from the test_count_max_job job
     # and our child job from the date_only job
-    assert_equal(all_jobs.total >= 7, true)
+    assert_equal(true, all_jobs.total >= 7)
 
     # ensure parent job 1 has a job_count of 1
     first_job = GRPC jobs, :read, Jobs::Id.new(id: job_id1)
-    assert_equal(first_job.job_count >= 1, true)
+    assert_equal(true, first_job.job_count >= 1)
 
     # ensure test_count_max_job has a job_count of 1, status of completed
     test_count_max_job = GRPC jobs, :read, Jobs::Id.new(id: test_count_max_job_id)
-    assert_equal(test_count_max_job.job_count, 1)
-    assert_equal(test_count_max_job.status, "completed")
+    assert_equal(1, test_count_max_job.job_count)
+    assert_equal("completed", test_count_max_job.status)
 
     # ensure date_only_job has a job_count of 1, status of completed
     date_only_job = GRPC jobs, :read, Jobs::Id.new(id: date_only_job_id)
-    assert_equal(date_only_job.job_count, 1)
-    assert_equal(date_only_job.status, "completed")
+    assert_equal(1, date_only_job.job_count)
+    assert_equal("completed", date_only_job.status)
 
     # ensure child job has job_count 0 and parent_id of job1
     all_jobs.jobs.each { |job|
       if job.parent_id != ""
-        assert_equal(job.job_count, 0)
+        assert_equal(0, job.job_count)
         if job.parent_id == job_id1 || job.parent_id == test_count_max_job_id || job['parent_id'] == date_only_job_id
           job.parent_id = "good"
         end
-        assert_equal(job.parent_id, "good")
+        assert_equal("good", job.parent_id)
       end
     }
 
@@ -202,7 +202,7 @@ describe File.basename(__FILE__) do
         Common::Filter.new( key:  "parent_job", values: ["00000000-34fb-4022-72ae-8847b54d4ea0"])
       ]
     )
-    assert_equal(type_jobs_json, Jobs::Jobs.new())
+    assert_equal(Jobs::Jobs.new(), type_jobs_json)
 
     type_jobs_json = GRPC jobs, :list, Jobs::Query.new(
       filters: [
@@ -210,10 +210,10 @@ describe File.basename(__FILE__) do
         Common::Filter.new( key:  "parent_job", values: [job_id1])
       ]
     )
-    assert_equal(type_jobs_json.jobs.class, Google::Protobuf::RepeatedField)
+    assert_equal(Google::Protobuf::RepeatedField, type_jobs_json.jobs.class)
     if type_jobs_json.jobs.class == Google::Protobuf::RepeatedField && type_jobs_json.jobs.length > 0
-      assert_equal(type_jobs_json.jobs[0]['parent_id'], job_id1)
-      assert_equal(type_jobs_json.jobs[0]['name'], 'My exec job1 - run 1')
+      assert_equal(job_id1, type_jobs_json.jobs[0]['parent_id'])
+      assert_equal('My exec job1 - run 1', type_jobs_json.jobs[0]['name'])
     end
 
     # Testing jobs list with parent_job filter == "" (when you want no child jobs in the list)
@@ -222,7 +222,7 @@ describe File.basename(__FILE__) do
         Common::Filter.new( key: "parent_job", values: [""])
       ]
     )
-    assert_equal(no_child_jobs['total'], 4)
+    assert_equal(4, no_child_jobs['total'])
 
     # Test we cannot rerun a scheduled job
     assert_grpc_error("Unable to rerun a scheduled job", 3) do

--- a/components/compliance-service/api/tests/poll_test.rb
+++ b/components/compliance-service/api/tests/poll_test.rb
@@ -51,7 +51,7 @@ while node_status != "reachable" do
   sleep 5
   node_status = (MANAGER_GRPC nodes, :read, Nodes::Id.new(id: node.id)).status
 end
-assert_equal(node_status, "reachable")
+assert_equal("reachable", node_status)
 
 puts "\n##################"
 puts "status of node is reachable"
@@ -63,7 +63,7 @@ while node_status != "unreachable" do
   sleep 5
   node_status = (MANAGER_GRPC nodes, :read, Nodes::Id.new(id: node.id)).status
 end
-assert_equal(node_status, "unreachable")
+assert_equal("unreachable", node_status)
 
 puts "\n##################"
 puts "status of node is unreachable"
@@ -75,7 +75,7 @@ while node_status != "reachable" do
   sleep 5
   node_status = (MANAGER_GRPC nodes, :read, Nodes::Id.new(id: node.id)).status
 end
-assert_equal(node_status, "reachable")
+assert_equal("reachable", node_status)
 
 puts "\n##################"
 puts "status of node is reachable"
@@ -90,7 +90,7 @@ while node_status != "unreachable" do
   sleep 5
   node_status = (MANAGER_GRPC nodes, :read, Nodes::Id.new(id: node.id)).status
 end
-assert_equal(node_status, "unreachable")
+assert_equal("unreachable", node_status)
 
 puts "\n##################"
 puts "status of node is unreachable"

--- a/components/compliance-service/api/tests/test_ingest_to_mgr_conn.rb
+++ b/components/compliance-service/api/tests/test_ingest_to_mgr_conn.rb
@@ -14,18 +14,18 @@ describe File.basename(__FILE__) do
     original_manually_managed_nodes = MANAGER_GRPC nodes, :list, Nodes::Query.new(filters: [Common::Filter.new(key: "manager_id", values: ["e69dc612-7e67-43f2-9b19-256afd385820"])])
 
     # since we are running this as part of the `make test-reporting` command, we expect to have
-    # seven nodes to start with, because there are seven reports sent in as part of the ingest-reports-into-es 
+    # seven nodes to start with, because there are seven reports sent in as part of the ingest-reports-into-es
     # command. as part of the makefile task that runs this test, we send in three reports, two of which are for the
     # same node. so we expect the total here to be 9 nodes.
     nodes_list = MANAGER_GRPC nodes, :list, Nodes::Query.new()
-    assert_equal(nodes_list.total, 9)
+    assert_equal(9, nodes_list.total)
 
     state_nodes = MANAGER_GRPC nodes, :list, Nodes::Query.new(filters:[Common::Filter.new(key: "state", values: ["RUNNING", "STOPPED", ""])])
-    assert_equal(state_nodes.total, 9)
+    assert_equal(9, state_nodes.total)
 
     # those nodes should not have been added to the manual node manager, as they were ingested nodes, not manually added nodes
     manually_managed_nodes = MANAGER_GRPC nodes, :list, Nodes::Query.new(filters: [Common::Filter.new(key: "manager_id", values: ["e69dc612-7e67-43f2-9b19-256afd385820"])])
-    assert_equal(manually_managed_nodes.total, original_manually_managed_nodes.total)
+    assert_equal(original_manually_managed_nodes.total, manually_managed_nodes.total)
   end
 
   it "nodes have scan data" do


### PR DESCRIPTION
Thank you @stevendanna for letting me know we still had swapped `actual` & `expected` values in tests.
Hopefully, they are all fixed now with this PR.