### PR TITLE
[studio] set variable as late as possible

### DIFF
--- a/.studio/golang
+++ b/.studio/golang
@@ -299,9 +299,9 @@ function run_golangci() {
         return 1
     fi
 
-    local pkg=$1
     (
         enter_go_workspace
+        local pkg=$1
         log_line "Running golang-ci ${GOLANGCILINTVERSION} on $pkg"
         "./cache/golangci-lint-${GOLANGCILINTVERSION}-linux-amd64/golangci-lint" run "$pkg"
     )


### PR DESCRIPTION
A bunch of functions use `pkg` as a local variable without the `local`
keyword. Isn't shell fun?

Signed-off-by: Steven Danna <steve@chef.io>