### PR TITLE
UI-267 UI-268 Project Rules Signed-Off-By: Tara Black<tblack@chef.io>

### DIFF
--- a/components/automate-ui/e2e/admin.e2e-spec.ts
+++ b/components/automate-ui/e2e/admin.e2e-spec.ts
@@ -1477,13 +1477,10 @@ describe('Admin pages', () => {
         expect(idHeader.getText()).toBe('my-project');
       });
 
-      it('displays the type in the header', () => {
-        const typeHeader = $('header td:nth-child(2)');
-        expect(typeHeader.getText()).toBe('Custom');
-      });
-
       describe('before any typing occurs', () => {
         it('displays the project name in the input and the save button is disabled', () => {
+          const detailsLink = $('#chef-option2');
+          detailsLink.click();
           const projectNameInput = $('app-project-details section form chef-form-field input');
           expect(projectNameInput.getAttribute('value')).toBe('My Project');
 
@@ -1514,6 +1511,8 @@ describe('Admin pages', () => {
 
         it('enables the save button, updates the project, and notes the save, ' +
         'and then removes note once more typing occurs', () => {
+          const detailsLink = $('#chef-option2');
+          detailsLink.click();
           const projectSaveButton = $('app-project-details section #button-bar button');
           const projectNameInput = $('app-project-details section form chef-form-field input');
           expect(projectSaveButton.getAttribute('disabled')).toBe('true');
@@ -1683,6 +1682,8 @@ describe('Admin pages', () => {
     describe('Chef-managed project details', () => {
       it('the input is disabled, the save button is hidden, and the no changes allowed ' +
         'span is displayed', () => {
+        const detailsLink = $('#chef-option2');
+        detailsLink.click();
         const projectSaveButton = $('app-project-details section #button-bar button');
         const projectNameInput = $('app-project-details section form chef-form-field input');
         const projectNoChangesSpan = $('app-project-details section form #changes-not-allowed');

--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -111,7 +111,8 @@ const routes: Routes = [
         },
         {
           path: 'policies/:id/add-members',
-          component: PolicyAddMembersComponent
+          component: PolicyAddMembersComponent,
+          data: { hideNavBar: true }
         },
         {
           path: 'projects',
@@ -123,11 +124,13 @@ const routes: Routes = [
         },
         {
           path: 'projects/:id/rules',
-          component: ProjectRulesComponent
+          component: ProjectRulesComponent,
+          data: { hideNavBar: true }
         },
         {
           path: 'projects/:id/rules/:ruleid',
-          component: ProjectRulesComponent
+          component: ProjectRulesComponent,
+          data: { hideNavBar: true }
         },
         {
           path: 'roles',

--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -35,6 +35,7 @@ import { PolicyDetailsComponent } from './pages/policy/details/policy-details.co
 import { PolicyAddMembersComponent } from './pages/policy/add-members/policy-add-members.component';
 import { ProjectDetailsComponent } from './pages/project/details/project-details.component';
 import { ProjectListComponent } from './pages/project/list/project-list.component';
+import { ProjectRulesComponent } from './pages/project/rules/project-rules.component';
 import { RolesListComponent } from './pages/roles/list/roles-list.component';
 import { RoleDetailsComponent } from './pages/roles/details/role-details.component';
 import { UIComponent } from 'app/ui.component';
@@ -119,6 +120,14 @@ const routes: Routes = [
         {
           path: 'projects/:id',
           component: ProjectDetailsComponent
+        },
+        {
+          path: 'projects/:id/rules',
+          component: ProjectRulesComponent
+        },
+        {
+          path: 'projects/:id/rules/:ruleid',
+          component: ProjectRulesComponent
         },
         {
           path: 'roles',

--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -72,6 +72,7 @@ import { ProfileRequests } from './entities/profiles/profile.requests';
 import { ProjectRequests } from './entities/projects/project.requests';
 import { ServiceGroupsRequests } from './entities/service-groups/service-groups.requests';
 import { RoleRequests } from './entities/roles/role.requests';
+import { RuleRequests } from './entities/rules/rule.requests';
 import { TeamRequests } from './entities/teams/team.requests';
 import { UserPermsRequests } from './entities/userperms/userperms.requests';
 import { UserRequests } from './entities/users/user.requests';
@@ -325,6 +326,7 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     ProjectsFilterRequests,
     ProjectsFilterService,
     RoleRequests,
+    RuleRequests,
     { provide: RouterStateSerializer, useClass: RouterSerializer },
     RulesService,
     RunHistoryStore,

--- a/components/automate-ui/src/app/components/delete-object-modal/delete-object-modal.component.html
+++ b/components/automate-ui/src/app/components/delete-object-modal/delete-object-modal.component.html
@@ -2,11 +2,11 @@
   <h2 slot="title">Delete {{objectNoun | titlecase}}?</h2>
   <div>
     <span *ngIf="moreDetails">
-      Deleting {{objectNoun}} {{objectName}} <b>cannot be undone</b><br>
+      Deleting {{objectNoun}} {{objectName}} <strong>cannot be undone</strong><br>
       {{moreDetails}}.
     </span>
     <span *ngIf="!moreDetails">
-      Deleting {{objectNoun}} {{objectName}} <b>cannot be undone</b>.
+      Deleting {{objectNoun}} {{objectName}} <strong>cannot be undone</strong>.
     </span>
   </div>
 

--- a/components/automate-ui/src/app/components/delete-object-modal/delete-object-modal.component.html
+++ b/components/automate-ui/src/app/components/delete-object-modal/delete-object-modal.component.html
@@ -2,11 +2,11 @@
   <h2 slot="title">Delete {{objectNoun | titlecase}}?</h2>
   <div>
     <span *ngIf="moreDetails">
-      Deleting {{objectNoun}} {{objectName}} cannot be undone<br>
+      Deleting {{objectNoun}} {{objectName}} <b>cannot be undone</b><br>
       {{moreDetails}}.
     </span>
     <span *ngIf="!moreDetails">
-      Deleting {{objectNoun}} {{objectName}} cannot be undone.
+      Deleting {{objectNoun}} {{objectName}} <b>cannot be undone</b>.
     </span>
   </div>
 

--- a/components/automate-ui/src/app/entities/rules/rule.actions.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.actions.ts
@@ -25,7 +25,7 @@ export interface RuleSuccessPayload {
   rule: Rule;
 }
 
-export class GetRules implements Action {
+export class GetRulesForProject implements Action {
   readonly type = RuleActionTypes.GET_ALL;
 
   constructor(public payload: { project_id: string }) { }
@@ -117,7 +117,7 @@ export class UpdateRuleFailure implements Action {
 }
 
 export type RuleActions =
-  | GetRules
+  | GetRulesForProject
   | GetRulesSuccess
   | GetRulesFailure
   | GetRule

--- a/components/automate-ui/src/app/entities/rules/rule.actions.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.actions.ts
@@ -1,0 +1,134 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Action } from '@ngrx/store';
+
+import { Rule } from './rule.model';
+
+export enum RuleActionTypes {
+  GET_ALL         = 'RULES::GET_ALL',
+  GET_ALL_SUCCESS = 'RULES::GET_ALL::SUCCESS',
+  GET_ALL_FAILURE = 'RULES::GET_ALL::FAILURE',
+  GET             = 'RULES::GET',
+  GET_SUCCESS     = 'RULES::GET::SUCCESS',
+  GET_FAILURE     = 'RULES::GET::FAILURE',
+  CREATE          = 'RULES::CREATE',
+  CREATE_SUCCESS  = 'RULES::CREATE::SUCCESS',
+  CREATE_FAILURE  = 'RULES::CREATE::FAILURE',
+  DELETE          = 'RULES::DELETE',
+  DELETE_SUCCESS  = 'RULES::DELETE::SUCCESS',
+  DELETE_FAILURE  = 'RULES::DELETE::FAILURE',
+  UPDATE          = 'RULES::UPDATE',
+  UPDATE_SUCCESS  = 'RULES::UPDATE::SUCCESS',
+  UPDATE_FAILURE  = 'RULES::UPDATE::FAILURE'
+}
+
+export interface RuleSuccessPayload {
+  rule: Rule;
+}
+
+export class GetRules implements Action {
+  readonly type = RuleActionTypes.GET_ALL;
+
+  constructor(public payload: { project_id: string }) { }
+}
+
+export interface GetRulesSuccessPayload {
+  rules: Rule[];
+}
+
+export class GetRulesSuccess implements Action {
+  readonly type = RuleActionTypes.GET_ALL_SUCCESS;
+
+  constructor(public payload: GetRulesSuccessPayload) { }
+}
+
+export class GetRulesFailure implements Action {
+  readonly type = RuleActionTypes.GET_ALL_FAILURE;
+
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export class GetRule implements Action {
+  readonly type = RuleActionTypes.GET;
+
+  constructor(public payload: { id: string }) { }
+}
+
+export class GetRuleSuccess implements Action {
+  readonly type = RuleActionTypes.GET_SUCCESS;
+
+  constructor(public payload: RuleSuccessPayload) { }
+}
+
+export class GetRuleFailure implements Action {
+  readonly type = RuleActionTypes.GET_FAILURE;
+
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export class CreateRule implements Action {
+  readonly type = RuleActionTypes.CREATE;
+  constructor(public payload: {project_id: string, rule: Rule}) { }
+}
+
+export class CreateRuleSuccess implements Action {
+  readonly type = RuleActionTypes.CREATE_SUCCESS;
+  constructor(public payload: RuleSuccessPayload) { }
+}
+
+export class CreateRuleFailure implements Action {
+  readonly type = RuleActionTypes.CREATE_FAILURE;
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export class DeleteRule implements Action {
+  readonly type = RuleActionTypes.DELETE;
+
+  constructor(public payload: { id: string }) { }
+}
+
+export class DeleteRuleSuccess implements Action {
+  readonly type = RuleActionTypes.DELETE_SUCCESS;
+
+  constructor(public payload: { id: string }) { }
+}
+
+export class DeleteRuleFailure implements Action {
+  readonly type = RuleActionTypes.DELETE_FAILURE;
+
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export class UpdateRule implements Action {
+  readonly type = RuleActionTypes.UPDATE;
+
+  constructor(public payload: { rule: Rule }) { }
+}
+
+export class UpdateRuleSuccess implements Action {
+  readonly type = RuleActionTypes.UPDATE_SUCCESS;
+
+  constructor(public payload: RuleSuccessPayload) { }
+}
+
+export class UpdateRuleFailure implements Action {
+  readonly type = RuleActionTypes.UPDATE_FAILURE;
+
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export type RuleActions =
+  | GetRules
+  | GetRulesSuccess
+  | GetRulesFailure
+  | GetRule
+  | GetRuleSuccess
+  | GetRuleFailure
+  | CreateRule
+  | CreateRuleSuccess
+  | CreateRuleFailure
+  | DeleteRule
+  | DeleteRuleSuccess
+  | DeleteRuleFailure
+  | UpdateRule
+  | UpdateRuleSuccess
+  | UpdateRuleFailure;

--- a/components/automate-ui/src/app/entities/rules/rule.effects.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.effects.ts
@@ -1,0 +1,156 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { of as observableOf } from 'rxjs';
+import { catchError, mergeMap, map, filter } from 'rxjs/operators';
+
+import { HttpStatus } from 'app/types/types';
+import { CreateNotification } from 'app/entities/notifications/notification.actions';
+import { Type } from 'app/entities/notifications/notification.model';
+
+import {
+  GetRules,
+  GetRulesSuccess,
+  GetRulesSuccessPayload,
+  GetRulesFailure,
+  GetRule,
+  GetRuleSuccess,
+  GetRuleFailure,
+  CreateRule,
+  CreateRuleSuccess,
+  CreateRuleFailure,
+  DeleteRule,
+  DeleteRuleSuccess,
+  DeleteRuleFailure,
+  UpdateRule,
+  UpdateRuleFailure,
+  UpdateRuleSuccess,
+  RuleSuccessPayload,
+  RuleActionTypes
+} from './rule.actions';
+
+import {
+  RuleRequests
+} from './rule.requests';
+
+@Injectable()
+export class RuleEffects {
+  constructor(
+    private actions$: Actions,
+    private requests: RuleRequests
+  ) { }
+
+  @Effect()
+  getRules$ = this.actions$.pipe(
+      ofType(RuleActionTypes.GET_ALL),
+      mergeMap(({ payload: { project_id } }: GetRules) =>
+        this.requests.getRules(project_id).pipe(
+          map((resp: GetRulesSuccessPayload) => new GetRulesSuccess(resp)),
+          catchError((error: HttpErrorResponse) => observableOf(new GetRulesFailure(error))))));
+
+  @Effect()
+  getRulesFailure$ = this.actions$.pipe(
+      ofType(RuleActionTypes.GET_ALL_FAILURE),
+      map(({ payload }: GetRulesFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not get rules: ${msg || payload.error}`
+        });
+      }));
+
+  @Effect()
+  getRule$ = this.actions$.pipe(
+      ofType(RuleActionTypes.GET),
+      mergeMap(({ payload: { id } }: GetRule) =>
+        this.requests.getRule(id).pipe(
+          map((resp: RuleSuccessPayload) => new GetRuleSuccess(resp)),
+          catchError((error: HttpErrorResponse) => observableOf(new GetRuleFailure(error))))));
+
+ @Effect()
+  getRuleFailure$ = this.actions$.pipe(
+      ofType(RuleActionTypes.GET_FAILURE),
+      map(({ payload }: GetRuleFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not get rule: ${msg || payload.error}`
+        });
+      }));
+
+  @Effect()
+  createRule$ = this.actions$.pipe(
+      ofType(RuleActionTypes.CREATE),
+      mergeMap(({ payload: { project_id, rule } }: CreateRule) =>
+      this.requests.createRule(project_id, rule).pipe(
+        map((resp: RuleSuccessPayload) => new CreateRuleSuccess(resp)),
+        catchError((error: HttpErrorResponse) => observableOf(new CreateRuleFailure(error))))));
+
+  @Effect()
+  createRuleSuccess$ = this.actions$.pipe(
+      ofType(RuleActionTypes.CREATE_SUCCESS),
+      map(({ payload: { rule } }: CreateRuleSuccess) => new CreateNotification({
+      type: Type.info,
+      message: `Created rule ${rule.id}`
+    })));
+
+  @Effect()
+  createRuleFailure$ = this.actions$.pipe(
+    ofType(RuleActionTypes.CREATE_FAILURE),
+    filter(({ payload }: CreateRuleFailure) => payload.status !== HttpStatus.CONFLICT),
+    map(({ payload }: CreateRuleFailure) => new CreateNotification({
+        type: Type.error,
+        message: `Could not create rule: ${payload.error.error || payload}`
+      })));
+
+  @Effect()
+  deleteRule$ = this.actions$.pipe(
+      ofType(RuleActionTypes.DELETE),
+      mergeMap(({ payload: { id } }: DeleteRule) =>
+        this.requests.deleteRule(id).pipe(
+          map(() => new DeleteRuleSuccess({id})),
+          catchError((error: HttpErrorResponse) =>
+            observableOf(new DeleteRuleFailure(error))))));
+
+  @Effect()
+  deleteRuleSuccess$ = this.actions$.pipe(
+      ofType(RuleActionTypes.DELETE_SUCCESS),
+      map(({ payload: { id } }: DeleteRuleSuccess) => {
+        return new CreateNotification({
+          type: Type.info,
+          message: `Deleted rule ${id}.`
+        });
+      }));
+
+  @Effect()
+  deleteRuleFailure$ = this.actions$.pipe(
+      ofType(RuleActionTypes.DELETE_FAILURE),
+      map(({ payload }: DeleteRuleFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not delete rule: ${msg || payload.error}`
+        });
+      }));
+
+  @Effect()
+  updateRule$ = this.actions$.pipe(
+      ofType(RuleActionTypes.UPDATE),
+      mergeMap(({ payload: { rule } }: UpdateRule) =>
+        this.requests.updateRule(rule).pipe(
+          map((resp: RuleSuccessPayload) => new UpdateRuleSuccess(resp)),
+          catchError((error: HttpErrorResponse) =>
+            observableOf(new UpdateRuleFailure(error))))));
+
+  @Effect()
+  updateRuleFailure$ = this.actions$.pipe(
+      ofType(RuleActionTypes.UPDATE_FAILURE),
+      map(({ payload }: UpdateRuleFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not update rule: ${msg || payload.error}`
+        });
+      }));
+}
+

--- a/components/automate-ui/src/app/entities/rules/rule.effects.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.effects.ts
@@ -9,7 +9,7 @@ import { CreateNotification } from 'app/entities/notifications/notification.acti
 import { Type } from 'app/entities/notifications/notification.model';
 
 import {
-  GetRules,
+  GetRulesForProject,
   GetRulesSuccess,
   GetRulesSuccessPayload,
   GetRulesFailure,
@@ -41,10 +41,10 @@ export class RuleEffects {
   ) { }
 
   @Effect()
-  getRules$ = this.actions$.pipe(
+  getRulesForProject$ = this.actions$.pipe(
       ofType(RuleActionTypes.GET_ALL),
-      mergeMap(({ payload: { project_id } }: GetRules) =>
-        this.requests.getRules(project_id).pipe(
+      mergeMap(({ payload: { project_id } }: GetRulesForProject) =>
+        this.requests.getRulesForProject(project_id).pipe(
           map((resp: GetRulesSuccessPayload) => new GetRulesSuccess(resp)),
           catchError((error: HttpErrorResponse) => observableOf(new GetRulesFailure(error))))));
 

--- a/components/automate-ui/src/app/entities/rules/rule.model.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.model.ts
@@ -1,0 +1,21 @@
+export interface Rule {
+  id?: string;
+  project_id?: string;
+  name: string;
+  type: string;
+  edits: string;
+  conditions: Condition[];
+}
+
+export interface Condition {
+  attribute: string;
+  values: any;
+  operator: string;
+}
+
+export class RuleConstants {
+  static readonly UNASSIGNED_PROJECT_ID = '(unassigned)';
+  static readonly UNASSIGNED_PROJECT_LABEL = '(unassigned)';
+  static readonly ALL_PROJECTS_LABEL = 'All projects';
+  static readonly MULTIPLE_PROJECTS_LABEL = 'Multiple projects';
+}

--- a/components/automate-ui/src/app/entities/rules/rule.model.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.model.ts
@@ -12,10 +12,3 @@ export interface Condition {
   values: any;
   operator: string;
 }
-
-export class RuleConstants {
-  static readonly UNASSIGNED_PROJECT_ID = '(unassigned)';
-  static readonly UNASSIGNED_PROJECT_LABEL = '(unassigned)';
-  static readonly ALL_PROJECTS_LABEL = 'All projects';
-  static readonly MULTIPLE_PROJECTS_LABEL = 'Multiple projects';
-}

--- a/components/automate-ui/src/app/entities/rules/rule.reducer.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.reducer.ts
@@ -23,7 +23,7 @@ const CREATE_ERROR = 'createError';
 const DELETE_STATUS = 'deleteStatus';
 const UPDATE_STATUS = 'updateStatus';
 
-export const Attributes = {
+export const ruleAttributes = {
   node: [
     {
       key: 'CHEF_ORGS',
@@ -69,54 +69,13 @@ export const Attributes = {
 export const ruleEntityAdapter: EntityAdapter<Rule> = createEntityAdapter<Rule>();
 
 export const RuleEntityInitialState: RuleEntityState = ruleEntityAdapter.getInitialState({
+  getAttributes: ruleAttributes,
   getAllStatus: EntityStatus.notLoaded,
   getStatus: EntityStatus.notLoaded,
   createStatus: EntityStatus.notLoaded,
   createError: null,
   deleteStatus: EntityStatus.notLoaded,
-  updateStatus: EntityStatus.notLoaded,
-  getAttributes: {
-    node: [
-      {
-        key: 'CHEF_ORGS',
-        value: 'Chef Organization'
-      },
-      {
-        key: 'CHEF_SERVER',
-        value: 'Chef Server'
-      },
-      {
-        key: 'CHEF_ENV',
-        value: 'Environment'
-      },
-      {
-        key: 'CHEF_ROLE',
-        value: 'Chef Role'
-      },
-      {
-        key: 'CHEF_TAG',
-        value: 'Chef Tag'
-      },
-      {
-        key: 'CHEF_POLICY_NAME',
-        value: 'Chef Policy Name'
-      },
-      {
-        key: 'CHEF_POLICY_GROUP',
-        value: 'Chef Policy Group'
-      }
-    ],
-    event: [
-      {
-        key: 'CHEF_ORGS',
-        value: 'Chef Organization'
-      },
-      {
-        key: 'CHEF_SERVER',
-        value: 'Chef Server'
-      }
-    ]
-  }
+  updateStatus: EntityStatus.notLoaded
 });
 
 export function ruleEntityReducer(

--- a/components/automate-ui/src/app/entities/rules/rule.reducer.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.reducer.ts
@@ -1,0 +1,102 @@
+import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
+import { HttpErrorResponse } from '@angular/common/http';
+import { set, pipe, unset } from 'lodash/fp';
+
+import { EntityStatus } from 'app/entities/entities';
+import { RuleActionTypes, RuleActions } from './rule.actions';
+import { Rule } from './rule.model';
+
+export interface RuleEntityState extends EntityState<Rule> {
+  getAllStatus: EntityStatus;
+  getStatus: EntityStatus;
+  createStatus: EntityStatus;
+  createError: HttpErrorResponse;
+  updateStatus: EntityStatus;
+  deleteStatus: EntityStatus;
+}
+
+const GET_ALL_STATUS = 'getAllStatus';
+const GET_STATUS = 'getStatus';
+const CREATE_STATUS = 'createStatus';
+const CREATE_ERROR = 'createError';
+const DELETE_STATUS = 'deleteStatus';
+const UPDATE_STATUS = 'updateStatus';
+
+export const ruleEntityAdapter: EntityAdapter<Rule> = createEntityAdapter<Rule>();
+
+export const RuleEntityInitialState: RuleEntityState = ruleEntityAdapter.getInitialState({
+  getAllStatus: EntityStatus.notLoaded,
+  getStatus: EntityStatus.notLoaded,
+  createStatus: EntityStatus.notLoaded,
+  createError: null,
+  deleteStatus: EntityStatus.notLoaded,
+  updateStatus: EntityStatus.notLoaded
+});
+
+export function ruleEntityReducer(
+  state: RuleEntityState = RuleEntityInitialState,
+  action: RuleActions): RuleEntityState {
+
+  switch (action.type) {
+    case RuleActionTypes.GET_ALL:
+      return set(GET_ALL_STATUS, EntityStatus.loading, state);
+
+    case RuleActionTypes.GET_ALL_SUCCESS:
+      return set(GET_ALL_STATUS, EntityStatus.loadingSuccess,
+        ruleEntityAdapter.addAll(action.payload.rules, state));
+
+    case RuleActionTypes.GET_ALL_FAILURE:
+      return set(GET_ALL_STATUS, EntityStatus.loadingFailure, state);
+
+    case RuleActionTypes.GET:
+      return set(GET_STATUS, EntityStatus.loading, state);
+
+    case RuleActionTypes.GET_SUCCESS:
+      return set(GET_STATUS, EntityStatus.loadingSuccess,
+        ruleEntityAdapter.addOne(action.payload.rule, state));
+
+    case RuleActionTypes.GET_FAILURE:
+      return set(GET_STATUS, EntityStatus.loadingFailure, state);
+
+    case RuleActionTypes.CREATE:
+      return set(CREATE_STATUS, EntityStatus.loading, state);
+
+    case RuleActionTypes.CREATE_SUCCESS:
+      return pipe(
+        set(CREATE_STATUS, EntityStatus.loadingSuccess),
+        unset(CREATE_ERROR)
+      )(ruleEntityAdapter.addOne(action.payload.rule, state)) as RuleEntityState;
+
+    case RuleActionTypes.CREATE_FAILURE:
+      return pipe(
+        set(CREATE_STATUS, EntityStatus.loadingFailure),
+        set(CREATE_ERROR, action.payload)
+      )(state) as RuleEntityState;
+
+    case RuleActionTypes.DELETE:
+      return set(DELETE_STATUS, EntityStatus.loading, state);
+
+    case RuleActionTypes.DELETE_SUCCESS:
+      return set(DELETE_STATUS, EntityStatus.loadingSuccess,
+        ruleEntityAdapter.removeOne(action.payload.id, state));
+
+    case RuleActionTypes.DELETE_FAILURE:
+      return set(DELETE_STATUS, EntityStatus.loadingFailure, state);
+
+    case RuleActionTypes.UPDATE:
+      return set(UPDATE_STATUS, EntityStatus.loading, state);
+
+    case RuleActionTypes.UPDATE_SUCCESS:
+      return set(UPDATE_STATUS, EntityStatus.loadingSuccess,
+        ruleEntityAdapter.updateOne({
+          id: action.payload.rule.id,
+          changes: action.payload.rule
+        }, state));
+
+    case RuleActionTypes.UPDATE_FAILURE:
+      return set(UPDATE_STATUS, EntityStatus.loadingFailure, state);
+
+    default:
+      return state;
+  }
+}

--- a/components/automate-ui/src/app/entities/rules/rule.reducer.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.reducer.ts
@@ -7,6 +7,7 @@ import { RuleActionTypes, RuleActions } from './rule.actions';
 import { Rule } from './rule.model';
 
 export interface RuleEntityState extends EntityState<Rule> {
+  getAttributes: any;
   getAllStatus: EntityStatus;
   getStatus: EntityStatus;
   createStatus: EntityStatus;
@@ -22,6 +23,49 @@ const CREATE_ERROR = 'createError';
 const DELETE_STATUS = 'deleteStatus';
 const UPDATE_STATUS = 'updateStatus';
 
+export const Attributes = {
+  node: [
+    {
+      key: 'CHEF_ORGS',
+      value: 'Chef Organization'
+    },
+    {
+      key: 'CHEF_SERVER',
+      value: 'Chef Server'
+    },
+    {
+      key: 'CHEF_ENV',
+      value: 'Environment'
+    },
+    {
+      key: 'CHEF_ROLE',
+      value: 'Chef Role'
+    },
+    {
+      key: 'CHEF_TAG',
+      value: 'Chef Tag'
+    },
+    {
+      key: 'CHEF_POLICY_NAME',
+      value: 'Chef Policy Name'
+    },
+    {
+      key: 'CHEF_POLICY_GROUP',
+      value: 'Chef Policy Group'
+    }
+  ],
+  event: [
+    {
+      key: 'CHEF_ORGS',
+      value: 'Chef Organization'
+    },
+    {
+      key: 'CHEF_SERVER',
+      value: 'Chef Server'
+    }
+  ]
+};
+
 export const ruleEntityAdapter: EntityAdapter<Rule> = createEntityAdapter<Rule>();
 
 export const RuleEntityInitialState: RuleEntityState = ruleEntityAdapter.getInitialState({
@@ -30,7 +74,49 @@ export const RuleEntityInitialState: RuleEntityState = ruleEntityAdapter.getInit
   createStatus: EntityStatus.notLoaded,
   createError: null,
   deleteStatus: EntityStatus.notLoaded,
-  updateStatus: EntityStatus.notLoaded
+  updateStatus: EntityStatus.notLoaded,
+  getAttributes: {
+    node: [
+      {
+        key: 'CHEF_ORGS',
+        value: 'Chef Organization'
+      },
+      {
+        key: 'CHEF_SERVER',
+        value: 'Chef Server'
+      },
+      {
+        key: 'CHEF_ENV',
+        value: 'Environment'
+      },
+      {
+        key: 'CHEF_ROLE',
+        value: 'Chef Role'
+      },
+      {
+        key: 'CHEF_TAG',
+        value: 'Chef Tag'
+      },
+      {
+        key: 'CHEF_POLICY_NAME',
+        value: 'Chef Policy Name'
+      },
+      {
+        key: 'CHEF_POLICY_GROUP',
+        value: 'Chef Policy Group'
+      }
+    ],
+    event: [
+      {
+        key: 'CHEF_ORGS',
+        value: 'Chef Organization'
+      },
+      {
+        key: 'CHEF_SERVER',
+        value: 'Chef Server'
+      }
+    ]
+  }
 });
 
 export function ruleEntityReducer(

--- a/components/automate-ui/src/app/entities/rules/rule.requests.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.requests.ts
@@ -17,29 +17,13 @@ export interface RulesResponse {
 export class RuleRequests {
 
   // Mocked Rule data until API's are finished.
-
-  rules: Rule[] = [
-    // {
-    //   id: 'rule-1',
-    //   project_id: 'project-1',
-    //   name: 'Rule 1',
-    //   type: 'NODE',
-    //   edits: 'staging',
-    //   conditions: [
-    //       {
-    //       attribute: 'CHEF_SERVER',
-    //       values: ['adad','asdasd'],
-    //       operator: 'MEMBER_OF'
-    //     }
-    //   ]
-    // }
-  ];
+  rules: Rule[] = [];
 
   // TODO use http constructor when we hook up the backend
   // constructor(private http: HttpClient) { }
   constructor() { }
 
-  public getRules(project_id: string): Observable<GetRulesSuccessPayload> {
+  public getRulesForProject(project_id: string): Observable<GetRulesSuccessPayload> {
     // return this.http.get<GetRulesSuccessPayload>(
       // `${env.auth_v2_url}/project/${project_id}/rules`);
     const rules: any = filter(this.rules, ['project_id', project_id]);

--- a/components/automate-ui/src/app/entities/rules/rule.requests.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.requests.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+// import { environment as env } from 'environments/environment';
+import { find, filter } from 'lodash';
+import { Rule } from './rule.model';
+
+import {
+  GetRulesSuccessPayload, RuleSuccessPayload
+} from './rule.actions';
+
+export interface RulesResponse {
+  rules: Rule[];
+}
+
+@Injectable()
+export class RuleRequests {
+
+  // Mocked Rule data until API's are finished.
+
+  rules: Rule[] = [
+    // {
+    //   id: 'rule-1',
+    //   project_id: 'project-1',
+    //   name: 'Rule 1',
+    //   type: 'NODE',
+    //   edits: 'staging',
+    //   conditions: [
+    //       {
+    //       attribute: 'CHEF_SERVER',
+    //       values: ['adad','asdasd'],
+    //       operator: 'MEMBER_OF'
+    //     }
+    //   ]
+    // }
+  ];
+
+  constructor(private http: HttpClient) { }
+
+  public getRules(project_id: string): Observable<GetRulesSuccessPayload> {
+    // return this.http.get<GetRulesSuccessPayload>(
+      // `${env.auth_v2_url}/project/${project_id}/rules`);
+    const rules: any = filter(this.rules, ['project_id', project_id]);
+    return of({ rules: rules });
+  }
+
+  public getRule(id: string): Observable<RuleSuccessPayload> {
+    // return this.http.get<RuleSuccessPayload>(`${env.auth_v2_url}/rules/${id}`);
+    const rule: any = find(this.rules, ['id', id]);
+    return of({ rule: rule });
+  }
+
+  public createRule(project_id, rule: Rule): Observable<RuleSuccessPayload> {
+    // return this.http.post<RuleSuccessPayload>(
+    //   `${env.auth_v2_url}/project/${project_id}/rules`,
+    //   { rule });
+    rule.id = `rule-${this.rules.length}`;
+    rule.project_id = project_id;
+    rule.edits = 'staging';
+    this.rules.push(rule);
+    return of({ rule: rule });
+  }
+
+  public deleteRule(id: string): Observable<{}> {
+    // return this.http.delete(`${env.auth_v2_url}/rules/${id}`);
+    return of({ id: id });
+  }
+
+  public updateRule(rule: Rule): Observable<RuleSuccessPayload> {
+    // return this.http.put<RuleSuccessPayload>(
+    //   `${env.auth_v2_url}/project/${rule.project_id}/rules/${rule.id}`,
+    //   { rule });
+    let updatedRule: any = find(this.rules, ['id', rule.id]);
+    updatedRule = rule;
+    return of({ rule: updatedRule });
+  }
+}

--- a/components/automate-ui/src/app/entities/rules/rule.requests.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.requests.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+// import { HttpClient } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 // import { environment as env } from 'environments/environment';
 import { find, filter } from 'lodash';
@@ -35,7 +35,9 @@ export class RuleRequests {
     // }
   ];
 
-  constructor(private http: HttpClient) { }
+  // TODO use http constructor when we hook up the backend
+  // constructor(private http: HttpClient) { }
+  constructor() { }
 
   public getRules(project_id: string): Observable<GetRulesSuccessPayload> {
     // return this.http.get<GetRulesSuccessPayload>(

--- a/components/automate-ui/src/app/entities/rules/rule.selectors.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.selectors.ts
@@ -1,0 +1,44 @@
+
+import { createSelector, createFeatureSelector } from '@ngrx/store';
+
+import { routeParams } from 'app/route.selectors';
+import { RuleEntityState, ruleEntityAdapter } from './rule.reducer';
+
+export const ruleState = createFeatureSelector<RuleEntityState>('rules');
+
+export const {
+  selectAll: allRules,
+  selectEntities: ruleEntities
+} = ruleEntityAdapter.getSelectors(ruleState);
+
+export const getAllStatus = createSelector(
+  ruleState,
+  (state) => state.getAllStatus
+);
+
+export const getStatus = createSelector(
+  ruleState,
+  (state) => state.getStatus
+);
+
+export const createStatus = createSelector(
+  ruleState,
+  (state) => state.createStatus
+);
+
+export const createError = createSelector(
+  ruleState,
+  (state) => state.createError
+);
+
+
+export const updateStatus = createSelector(
+  ruleState,
+  (state) => state.updateStatus
+);
+
+export const ruleFromRoute = createSelector(
+  ruleEntities,
+  routeParams,
+  (state, { ruleid }) => state[ruleid]
+);

--- a/components/automate-ui/src/app/entities/rules/rule.selectors.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.selectors.ts
@@ -11,6 +11,11 @@ export const {
   selectEntities: ruleEntities
 } = ruleEntityAdapter.getSelectors(ruleState);
 
+export const getRuleAttributes = createSelector(
+  ruleState,
+  (state) => state.getAttributes
+);
+
 export const getAllStatus = createSelector(
   ruleState,
   (state) => state.getAllStatus

--- a/components/automate-ui/src/app/ngrx.effects.ts
+++ b/components/automate-ui/src/app/ngrx.effects.ts
@@ -17,6 +17,7 @@ import { ProfileEffects } from './entities/profiles/profile.effects';
 import { ProjectEffects } from './entities/projects/project.effects';
 import { ProjectsFilterEffects } from './services/projects-filter/projects-filter.effects';
 import { RoleEffects } from './entities/roles/role.effects';
+import { RuleEffects } from './entities/rules/rule.effects';
 import { ServiceGroupsEffects } from './entities/service-groups/service-groups.effects';
 import { ScannerEffects } from './pages/+compliance/+scanner/state/scanner.effects';
 import { SidebarEffects } from './services/sidebar/sidebar.effects';
@@ -41,6 +42,7 @@ import { UserPermEffects } from './entities/userperms/userperms.effects';
       ProjectEffects,
       ProjectsFilterEffects,
       RoleEffects,
+      RuleEffects,
       ServiceGroupsEffects,
       ScannerEffects,
       SidebarEffects,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -51,6 +51,7 @@ import { PolicyEntityState, policyEntityReducer } from './entities/policies/poli
 import { ProfileEntityState, profileEntityReducer } from './entities/profiles/profile.reducer';
 import { ProjectEntityState, projectEntityReducer } from './entities/projects/project.reducer';
 import { RoleEntityState, roleEntityReducer } from './entities/roles/role.reducer';
+import { RuleEntityState, ruleEntityReducer } from './entities/rules/rule.reducer';
 import {
   ServiceGroupEntityState,
   serviceGroupEntityReducer
@@ -88,6 +89,7 @@ export interface NgrxStateAtom {
   profiles: ProfileEntityState;
   projects: ProjectEntityState;
   roles: RoleEntityState;
+  rules: RuleEntityState;
   serviceGroups: ServiceGroupEntityState;
   teams: TeamEntityState;
   userperms: PermEntityState;
@@ -180,6 +182,7 @@ export const ngrxReducers = {
   profiles: profileEntityReducer,
   projects: projectEntityReducer,
   roles: roleEntityReducer,
+  rules: ruleEntityReducer,
   serviceGroups: serviceGroupEntityReducer,
   teams: teamEntityReducer,
   userperms: permEntityReducer,

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -12,13 +12,11 @@
         <thead>
           <tr class="detail-row">
             <th class="id-column">ID</th>
-            <th class="type-column">Type</th>
           </tr>
         </thead>
         <tbody>
           <tr class="detail-row">
             <td class="id-column">{{ project?.id }}</td>
-            <td class="type-column">{{ project?.type | iamType }}</td>
           </tr>
         </tbody>
       </table>
@@ -27,7 +25,7 @@
         <chef-option value='details'>Details</chef-option>
       </chef-tab-selector>
     </chef-page-header>
-    <section class="page-body" *ngIf="showTab('details')">
+    <section class="page-body" [hidden]="showTab('rules')">
       <form [formGroup]="projectForm">
         <chef-form-field>
           <label>
@@ -39,7 +37,7 @@
               (keyup)="keyPressed()">
           </label>
         </chef-form-field>
-        <span *ngIf="isChefManaged" id="changes-not-allowed">
+        <span [hidden]="!isChefManaged" id="changes-not-allowed">
           Name changes are not allowed for the default project.
         </span>
         <div id="button-bar" *ngIf="!isChefManaged">
@@ -53,7 +51,7 @@
         </div>
       </form>
     </section>
-    <section class="page-body" *ngIf="showTab('rules')">
+    <section class="page-body" [hidden]="showTab('details')">
       <ng-container *ngIf="showRulesTable()">
         <chef-toolbar>
           <app-authorized [allOf]="['/iam/v2beta/projects', 'post']">

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -22,11 +22,12 @@
           </tr>
         </tbody>
       </table>
-      <chef-tab-selector>
+      <chef-tab-selector [value]="selectedTab" (change)="onTabChange($event)">
+        <chef-option value='rules'>Ingest Rules</chef-option>
         <chef-option value='details'>Details</chef-option>
       </chef-tab-selector>
     </chef-page-header>
-    <section class="page-body">
+    <section class="page-body" *ngIf="selectedTab === 'details'">
       <form [formGroup]="projectForm">
         <chef-form-field>
           <label>
@@ -52,5 +53,73 @@
         </div>
       </form>
     </section>
+    <section class="page-body" *ngIf="selectedTab === 'rules'">
+      <ng-container *ngIf="(rules$ | async)?.length > 0">
+        <chef-toolbar>
+          <app-authorized [allOf]="['/iam/v2beta/projects', 'post']">
+            <chef-button [routerLink]="['/settings', 'projects', project?.id, 'rules']" id="create-button" primary>Create Rule</chef-button>
+          </app-authorized>
+          <small *ngIf="hasEditsPending(rules$ | async)">Edits pending, update <a [routerLink]="['/settings/projects']">projects</a> to apply edits.</small>
+        </chef-toolbar>
+        <app-authorized [allOf]="['/iam/v2beta/projects', 'get']">
+          <chef-table>
+            <chef-thead>
+              <chef-tr>
+                <chef-th>Name</chef-th>
+                <chef-th>Resource Type</chef-th>
+                <chef-th>Conditions</chef-th>
+                <chef-th>Edits</chef-th>
+                <chef-th class="controls"></chef-th>
+              </chef-tr>
+            </chef-thead>
+            <chef-tbody>
+              <chef-tr *ngFor="let rule of rules$ | async">
+                <chef-td>
+                  <a [routerLink]="['/settings', 'projects', project?.id, 'rules', rule.id]">{{ rule.name }}</a>
+                </chef-td>
+                <chef-td>{{ rule.type | titlecase }}</chef-td>
+                <chef-td>{{ rule.conditions.length }} conditions</chef-td>
+                <chef-td>{{ getEditStatus(rule.edits) }}</chef-td>
+                <chef-td class="controls">
+                  <app-authorized [allOf]="['/iam/v2beta/projects/{id}', 'delete', project?.id]">
+                    <chef-control-menu>
+                      <chef-option (click)="startRuleDelete(rule)">Delete Rule</chef-option>
+                    </chef-control-menu>
+                  </app-authorized>
+                </chef-td>
+              </chef-tr>
+            </chef-tbody>
+          </chef-table>
+        </app-authorized>
+      </ng-container>
+      <ng-container class="" *ngIf="(rules$ | async)?.length === 0">
+        <app-authorized [allOf]="['/iam/v2beta/projects', 'post']">
+          <div class="empty-case-container">
+            <p>Create the first ingest rule to get started!</p>
+          </div>
+          <div class="empty-case-container">
+              <chef-button primary [routerLink]="['/settings', 'projects', project?.id, 'rules']">Create Rule</chef-button>
+          </div>
+        </app-authorized>
+        <app-authorized not [allOf]="['/iam/v2beta/projects', 'post']">
+          <div class="empty-case-container">
+            <p>It looks like no one has created any projects yet and you<br/>
+              don't have permission to create them.<br/><br/>
+              If this is a mistake, then reach out to your administrator.
+            </p>
+          </div>
+        </app-authorized>
+      </ng-container>
+    </section>
+
+    <app-delete-object-modal
+      [visible]="deleteModalVisible"
+      objectNoun="rule"
+      [objectName]="ruleToDelete?.name"
+      [moreDetails]="inUseMessage()"
+      (close)="closeDeleteModal()"
+      (deleteClicked)="deleteRule()">
+    </app-delete-object-modal>
+
   </main>
 </div>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -78,7 +78,7 @@
                   <a [routerLink]="['/settings', 'projects', project?.id, 'rules', rule.id]">{{ rule.name }}</a>
                 </chef-td>
                 <chef-td>{{ rule.type | titlecase }}</chef-td>
-                <chef-td>{{ getConditionsText(rule.conditions.length) }}</chef-td>
+                <chef-td>{{ rule.conditions.length | pluralize : 'condition' : 's' }}</chef-td>
                 <chef-td>{{ getEditStatus(rule.edits) }}</chef-td>
                 <chef-td class="controls">
                   <app-authorized [allOf]="['/iam/v2beta/projects/{id}', 'delete', project?.id]">

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -78,7 +78,7 @@
                   <a [routerLink]="['/settings', 'projects', project?.id, 'rules', rule.id]">{{ rule.name }}</a>
                 </chef-td>
                 <chef-td>{{ rule.type | titlecase }}</chef-td>
-                <chef-td>{{ rule.conditions.length }} conditions</chef-td>
+                <chef-td>{{ getConditionsText(rule.conditions.length) }}</chef-td>
                 <chef-td>{{ getEditStatus(rule.edits) }}</chef-td>
                 <chef-td class="controls">
                   <app-authorized [allOf]="['/iam/v2beta/projects/{id}', 'delete', project?.id]">
@@ -116,7 +116,6 @@
       [visible]="deleteModalVisible"
       objectNoun="rule"
       [objectName]="ruleToDelete?.name"
-      [moreDetails]="inUseMessage()"
       (close)="closeDeleteModal()"
       (deleteClicked)="deleteRule()">
     </app-delete-object-modal>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -27,7 +27,7 @@
         <chef-option value='details'>Details</chef-option>
       </chef-tab-selector>
     </chef-page-header>
-    <section class="page-body" *ngIf="selectedTab === 'details'">
+    <section class="page-body" *ngIf="showTab('details')">
       <form [formGroup]="projectForm">
         <chef-form-field>
           <label>
@@ -53,16 +53,16 @@
         </div>
       </form>
     </section>
-    <section class="page-body" *ngIf="selectedTab === 'rules'">
-      <ng-container *ngIf="(rules$ | async)?.length > 0">
+    <section class="page-body" *ngIf="showTab('rules')">
+      <ng-container *ngIf="showRulesTable()">
         <chef-toolbar>
           <app-authorized [allOf]="['/iam/v2beta/projects', 'post']">
             <chef-button [routerLink]="['/settings', 'projects', project?.id, 'rules']" id="create-button" primary>Create Rule</chef-button>
           </app-authorized>
-          <small *ngIf="hasEditsPending(rules$ | async)">Edits pending, update <a [routerLink]="['/settings/projects']">projects</a> to apply edits.</small>
+          <small *ngIf="showProjectLink()">Edits pending, update <a [routerLink]="['/settings/projects']">projects</a> to apply edits.</small>
         </chef-toolbar>
         <app-authorized [allOf]="['/iam/v2beta/projects', 'get']">
-          <chef-table>
+          <chef-table id="project-rules-table">
             <chef-thead>
               <chef-tr>
                 <chef-th>Name</chef-th>
@@ -73,7 +73,7 @@
               </chef-tr>
             </chef-thead>
             <chef-tbody>
-              <chef-tr *ngFor="let rule of rules$ | async">
+              <chef-tr *ngFor="let rule of rules">
                 <chef-td>
                   <a [routerLink]="['/settings', 'projects', project?.id, 'rules', rule.id]">{{ rule.name }}</a>
                 </chef-td>
@@ -83,7 +83,7 @@
                 <chef-td class="controls">
                   <app-authorized [allOf]="['/iam/v2beta/projects/{id}', 'delete', project?.id]">
                     <chef-control-menu>
-                      <chef-option (click)="startRuleDelete(rule)">Delete Rule</chef-option>
+                      <chef-option *ngIf="showDeleteRule(rule)" class="delete-rule" (click)="startRuleDelete(rule)">Delete Rule</chef-option>
                     </chef-control-menu>
                   </app-authorized>
                 </chef-td>
@@ -92,21 +92,13 @@
           </chef-table>
         </app-authorized>
       </ng-container>
-      <ng-container class="" *ngIf="(rules$ | async)?.length === 0">
+      <ng-container *ngIf="showFirstRuleMessage()">
         <app-authorized [allOf]="['/iam/v2beta/projects', 'post']">
           <div class="empty-case-container">
             <p>Create the first ingest rule to get started!</p>
           </div>
           <div class="empty-case-container">
               <chef-button primary [routerLink]="['/settings', 'projects', project?.id, 'rules']">Create Rule</chef-button>
-          </div>
-        </app-authorized>
-        <app-authorized not [allOf]="['/iam/v2beta/projects', 'post']">
-          <div class="empty-case-container">
-            <p>It looks like no one has created any projects yet and you<br/>
-              don't have permission to create them.<br/><br/>
-              If this is a mistake, then reach out to your administrator.
-            </p>
           </div>
         </app-authorized>
       </ng-container>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.scss
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.scss
@@ -4,6 +4,19 @@ chef-page-header {
   padding-bottom: 0;
 }
 
+chef-toolbar {
+  display: block;
+  position: relative;
+  margin-bottom: 5px;
+
+  small {
+    bottom: 2px;
+    color: $chef-dark-grey;
+    position: absolute;
+    right: 0;
+  }
+}
+
 chef-tab-selector {
   chef-option {
     margin-right: 16px;
@@ -80,4 +93,26 @@ tbody > .detail-row {
   width: 66%;
   padding-top: 0px;
   padding-left: 0px;
+}
+
+chef-table {
+  .controls {
+    justify-content: flex-end;
+  }
+}
+
+.empty-case-container {
+  display: flex;
+  justify-content: center;
+
+  p {
+    margin-top: 42px;
+    font-size: 18px;
+    margin-bottom: 0;
+    text-align: center;
+  }
+
+  chef-button {
+    margin-top: 18px;
+  }
 }

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -1,0 +1,199 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { StoreModule, Store } from '@ngrx/store';
+import { MockComponent } from 'ng2-mock-component';
+
+import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { customMatchers } from 'app/testing/custom-matchers';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+import { IAMType } from 'app/entities/policies/policy.model';
+import { GetProjectSuccess } from 'app/entities/projects/project.actions';
+import { GetRulesSuccess } from 'app/entities/rules/rule.actions';
+import { projectEntityReducer } from 'app/entities/projects/project.reducer';
+import { ProjectDetailsComponent } from './project-details.component';
+
+describe('ProjectListComponent', () => {
+  let component: ProjectDetailsComponent;
+  let fixture: ComponentFixture<ProjectDetailsComponent>;
+
+  const project = {
+    id: 'uuid-1', name: 'Default',
+    type: <IAMType>'CHEF_MANAGED'
+  };
+  const rules = [
+    {
+      id: 'rule-1',
+      project_id: 'uuid-1',
+      name: 'Rule 1',
+      type: 'NODE',
+      edits: 'staging',
+      conditions: [
+        {
+          attribute: 'CHEF_ORGS',
+          values: 'My value',
+          operator: 'EQUALS'
+        }
+      ]
+    },
+    {
+      id: 'rule-2',
+      project_id: 'uuid-1',
+      name: 'Rule 2',
+      type: 'EVENT',
+      edits: 'applied',
+      conditions: [
+        {
+          attribute: 'CHEF_ORGS',
+          values: '["My value"]',
+          operator: 'MEMBER_OF'
+        }
+      ]
+    }
+  ];
+
+  beforeEach(async(() => {
+
+    TestBed.configureTestingModule({
+      declarations: [
+        MockComponent({
+          selector: 'chef-toolbar',
+          template: '<ng-content></ng-content>'
+        }),
+         MockComponent({
+          selector: 'app-authorized',
+          inputs: ['allOf', 'not'],
+          template: '<ng-content></ng-content>'
+        }),
+        MockComponent({ selector: 'app-admin-sidebar' }),
+        MockComponent({
+          selector: 'app-delete-object-modal',
+          inputs: ['visible', 'objectNoun', 'objectName'],
+          outputs: ['close', 'deleteClicked']
+        }),
+        MockComponent({ selector: 'chef-control-menu' }),
+        MockComponent({ selector: 'chef-form-field'}),
+        MockComponent({ selector: 'chef-breadcrumbs'}),
+        MockComponent({ selector: 'chef-breadcrumb', inputs: ['link'] }),
+        MockComponent({ selector: 'chef-tab-selector', inputs: ['value'] }),
+        MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),
+        MockComponent({ selector: 'chef-heading' }),
+        MockComponent({ selector: 'chef-loading-spinner' }),
+        MockComponent({ selector: 'chef-option' }),
+        MockComponent({ selector: 'chef-page-header' }),
+        MockComponent({ selector: 'chef-subheading' }),
+        MockComponent({ selector: 'chef-table' }),
+        MockComponent({ selector: 'chef-thead' }),
+        MockComponent({ selector: 'chef-tbody' }),
+        MockComponent({ selector: 'chef-tr' }),
+        MockComponent({ selector: 'chef-th' }),
+        MockComponent({ selector: 'chef-td' }),
+        MockComponent({ selector: 'ng-container', inputs: ['hidden'] }),
+        ProjectDetailsComponent
+      ],
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        ChefPipesModule,
+        StoreModule.forRoot({
+          router: () => ({
+            state: {
+              url: '/projects/uuid-1',
+              queryParams: {},
+              params: {},
+              fragment: '',
+              path: ['/']
+            },
+            previousRoute: {},
+            navigationId: 0
+          }),
+          projects: projectEntityReducer
+        })
+      ],
+      providers: [
+        FeatureFlagsService
+      ]
+    }).compileComponents();
+  }));
+
+  let store: Store<NgrxStateAtom>;
+  beforeEach(() => {
+    store = TestBed.get(Store);
+
+    store.dispatch(new GetProjectSuccess({
+      project: {
+        id: 'uuid-1', name: 'Default',
+        type: <IAMType>'CHEF_MANAGED'
+      }
+    }));
+
+    jasmine.addMatchers(customMatchers);
+    fixture = TestBed.createComponent(ProjectDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('when there are no rules', () => {
+    beforeEach(() => {
+      store.dispatch(new GetRulesSuccess({
+          rules: []
+      }));
+      component.rules = [];
+      fixture.detectChanges();
+    });
+
+    it('rules array should be empty', () => {
+      expect(component.rules.length).toBe(0);
+    });
+
+    it('show rules section when rules tab is selected', () => {
+      component.onTabChange({ target: { value: 'rules'} });
+      expect(component.showTab('rules')).toBeTruthy();
+    });
+
+    it('should not display rule table when no rules', () => {
+      expect(component.showRulesTable()).toBeFalsy();
+    });
+
+    it('the create your first rule message should display', () => {
+      expect(component.showFirstRuleMessage()).toBeTruthy();
+    });
+  });
+
+  describe('when there are rules', () => {
+    beforeEach(() => {
+      store.dispatch(new GetRulesSuccess({
+          rules: rules
+      }));
+      component.project = project;
+      component.rules = rules;
+      fixture.detectChanges();
+    });
+
+    it('rules array should have two rules', () => {
+      expect(component.rules.length).toBe(2);
+    });
+
+    it('show rules section when rules tab is selected', () => {
+      component.onTabChange({ target: { value: 'rules'} });
+      expect(component.showTab('rules')).toBeTruthy();
+    });
+
+    it('should display rule table', () => {
+      expect(component.showRulesTable()).toBeTruthy();
+    });
+
+    it('the create your first rule message should not display', () => {
+      expect(component.showFirstRuleMessage()).toBeFalsy();
+    });
+
+    it('show a link back to project when a rule is in "edits pending" state', () => {
+      expect(component.showProjectLink()).toBeTruthy();
+    });
+
+    it('disable delete rule button when a rule is in "staging" state', () => {
+      expect(component.showDeleteRule(component.rules[0])).toBeFalsy();
+    });
+  });
+});

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -119,12 +119,6 @@ export class ProjectDetailsComponent implements OnDestroy {
       : 'Applied';
   }
 
-  getConditionsText(conditions: number): string {
-    return conditions > 1
-      ? conditions + ' conditions'
-      : conditions + ' condition';
-  }
-
   hasEditsPending(rules: Rule[]): boolean {
     return _find(rules, ['edits', 'staging']) ? true : false;
   }

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -14,7 +14,7 @@ import {
 } from 'app/entities/projects/project.selectors';
 import { Project } from 'app/entities/projects/project.model';
 import { GetProject, UpdateProject } from 'app/entities/projects/project.actions';
-import { GetRules, DeleteRule } from 'app/entities/rules/rule.actions';
+import { GetRulesForProject, DeleteRule } from 'app/entities/rules/rule.actions';
 import { Rule } from 'app/entities/rules/rule.model';
 import {
   allRules
@@ -32,21 +32,6 @@ export class ProjectDetailsComponent implements OnDestroy {
   public saveSuccessful = false;
   public isChefManaged = false;
   public rules$: Observable<Rule[]>;
-  // public sortedRules$ = [];
-  // public sortedRules$ = [
-  //   {
-  //     name: 'Rule 1',
-  //     type: 'Node',
-  //     conditions: '3 conditions',
-  //     edits: 'Edits Pending'
-  //   },
-  //   {
-  //     name: 'Rule 2',
-  //     type: 'Event',
-  //     conditions: '1 condition',
-  //     edits: 'Applied'
-  //   }
-  // ];
   public selectedTab: 'rules' | 'details' = 'rules';
   public ruleToDelete: any;
   public deleteModalVisible = false;
@@ -83,7 +68,7 @@ export class ProjectDetailsComponent implements OnDestroy {
       takeUntil(this.isDestroyed),
       map((state) => {
         this.project = <Project>Object.assign({}, state);
-        this.store.dispatch(new GetRules({ project_id: this.project.id }));
+        this.store.dispatch(new GetRulesForProject({ project_id: this.project.id }));
         this.rules$ = store.select(allRules);
         this.isChefManaged = this.project.type === 'CHEF_MANAGED';
         this.projectForm = fb.group({
@@ -134,13 +119,14 @@ export class ProjectDetailsComponent implements OnDestroy {
       : 'Applied';
   }
 
-  hasEditsPending(rules: Rule[]): boolean {
-    return _find(rules, ['edits', 'staging']) ? true : false;
+  getConditionsText(conditions: number): string {
+    return conditions > 1
+      ? conditions + ' conditions'
+      : conditions + ' condition';
   }
 
-  // Note: This will be dealt with later, right now, we don't check if it's used
-  inUseMessage(): string {
-    return '';
+  hasEditsPending(rules: Rule[]): boolean {
+    return _find(rules, ['edits', 'staging']) ? true : false;
   }
 
   saveProject() {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -4,7 +4,7 @@ import { Store } from '@ngrx/store';
 import { Subject, Observable, combineLatest } from 'rxjs';
 import { identity } from 'lodash/fp';
 import { find as _find } from 'lodash';
-import { filter, map, pluck, takeUntil, find } from 'rxjs/operators';
+import { filter, map, pluck, takeUntil } from 'rxjs/operators';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams } from 'app/route.selectors';

--- a/components/automate-ui/src/app/pages/project/project.module.ts
+++ b/components/automate-ui/src/app/pages/project/project.module.ts
@@ -13,13 +13,15 @@ import {
 import {
   ConfirmApplyStopModalComponent
 } from './confirm-apply-stop-modal/confirm-apply-stop-modal.component';
+import { ProjectRulesComponent } from './rules/project-rules.component';
 
 @NgModule({
   declarations: [
     ProjectDetailsComponent,
     ProjectListComponent,
     ConfirmApplyStartModalComponent,
-    ConfirmApplyStopModalComponent
+    ConfirmApplyStopModalComponent,
+    ProjectRulesComponent
   ],
   imports: [
     AppRoutingModule,

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -32,7 +32,7 @@
           <chef-error
             *ngIf="ruleForm.get('type').hasError('required') && ruleForm.get('type').dirty"
           >Resource Type is required</chef-error>
-          <small>Resource types cannot be changed after the rule is created.</small>
+          <small class="help">Resource types cannot be changed after the rule is created.</small>
         </chef-form-field>
 
         <div id="add-condition">
@@ -82,12 +82,12 @@
                 ></chef-input>
               </label>
 
-              <small 
+              <small class="help"
                 *ngIf="condition.controls.operator.value === 'EQUALS'">
                   Case sensitive, must match exactly.
               </small>
 
-              <small
+              <small class="help"
                 *ngIf="condition.controls.operator.value === 'MEMBER_OF'">
                   Comma-separated list, at least one must match exactly.
               </small>
@@ -95,9 +95,11 @@
             </chef-form-field>
             <chef-form-field class="attribute-field">
               <label>
-                <span *ngIf="(i + 1) < ruleForm.get('conditions').controls.length" class="label">AND</span>
+                <span *ngIf="showAndLabel(i)" class="label">AND</span>
               </label>
-              <chef-icon (click)="deleteCondition(i)">delete</chef-icon>
+              <chef-button tertiary *ngIf="showDelete(i)" (click)="deleteCondition(i)">
+                <chef-icon>delete</chef-icon>
+              </chef-button>
             </chef-form-field>
 
           </div>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -49,7 +49,7 @@
 
             <chef-form-field class="attribute-field">
               <label>
-                <span class="label">{{ ruleForm.get('type').value | uppercase }} Attribute</span>
+                <span class="label">{{ getAttributeLabel() }}</span>
                 <select ngDefaultControl formControlName="attribute">
                   <option 
                     *ngFor="let option of attributes[ruleForm.get('type').value.toLowerCase()]; let i = index"
@@ -77,7 +77,7 @@
                 <span class="label">Value</span>
                 <chef-input ngDefaultControl
                   formControlName="values"
-                  [value]="getCommaList(condition.controls.values.value)"
+                  [value]="getConditionValue(condition.controls.values.value)"
                   (change)="updateConditionValues(condition)"
                 ></chef-input>
               </label>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -51,8 +51,10 @@
               <label>
                 <span class="label">{{ ruleForm.get('type').value | uppercase }} Attribute</span>
                 <select ngDefaultControl formControlName="attribute">
-                  <option value='CHEF_SERVER'>Chef Server</option>
-                  <option value='CHEF_ORGS'>Chef Organization</option>
+                  <option 
+                    *ngFor="let option of attributes[ruleForm.get('type').value.toLowerCase()]; let i = index"
+                    [value]="option.key"
+                  >{{ option.value }}</option>
                 </select>
               </label>
             </chef-form-field>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -1,0 +1,106 @@
+<chef-page
+  subheading="Resources that match the type and all conditions are included in the project."
+  confirm-btn-text="Save Rule"
+  [attr.heading]="getHeading()"
+  [attr.disable-confirm]="!ruleForm.valid"
+  [attr.page-loading]="isLoading"
+  [attr.confirm-loading]="saving"
+  (confirm)="saveRule()"
+  (close)="closePage()">
+  <div *ngIf="!isLoading">
+    <ng-container>
+      <form id="ruleForm" [formGroup]="ruleForm" (ngSubmit)="saveRule()">
+
+        <chef-form-field class="display3">
+          <label>
+            <span class="label">Rule Name</span>
+            <chef-input id="ruleName" ngDefaultControl formControlName="name"></chef-input>
+          </label>
+          <chef-error
+            *ngIf="ruleForm.get('name').hasError('required') && ruleForm.get('name').dirty"
+          >Name is required</chef-error>
+        </chef-form-field>
+
+        <chef-form-field class="display3">
+          <label>
+            <span class="label">Resource Type</span>
+            <select id="resourceType" ngDefaultControl formControlName="type">
+              <option value='NODE'>Node</option>
+              <option value='EVENT'>Event</option>
+            </select>
+          </label>
+          <chef-error
+            *ngIf="ruleForm.get('type').hasError('required') && ruleForm.get('type').dirty"
+          >Resource Type is required</chef-error>
+          <small>Resource types cannot be changed after the rule is created.</small>
+        </chef-form-field>
+
+        <div id="add-condition">
+          <div class="label">Conditions</div>
+          <small>All conditions must be true for the rule to be true.</small>
+          <chef-button primary (click)="addCondition()">Add Condition</chef-button>
+        </div>
+
+        <div id="condition-list" formArrayName="conditions">
+
+          <div class="condition-item"
+            [formGroupName]="i"
+            *ngFor="let condition of ruleForm.get('conditions').controls; let i = index">
+
+            <chef-form-field class="attribute-field">
+              <label>
+                <span class="label">{{ ruleForm.get('type').value | uppercase }} Attribute</span>
+                <select ngDefaultControl formControlName="attribute">
+                  <option value='CHEF_SERVER'>Chef Server</option>
+                  <option value='CHEF_ORGS'>Chef Organization</option>
+                </select>
+              </label>
+            </chef-form-field>
+
+            <chef-form-field class="attribute-field">
+              <label>
+                <span class="label">Operator</span>
+                <select ngDefaultControl
+                  formControlName="operator"
+                  (change)="updateConditionValues(condition)"
+                >
+                  <option value='EQUALS'>equals</option>
+                  <option value='MEMBER_OF'>member of</option>
+                </select>
+              </label>
+            </chef-form-field>
+            
+            <chef-form-field class="attribute-field">
+              <label>
+                <span class="label">Value</span>
+                <chef-input ngDefaultControl
+                  formControlName="values"
+                  [value]="getCommaList(condition.controls.values.value)"
+                  (change)="updateConditionValues(condition)"
+                ></chef-input>
+              </label>
+
+              <small 
+                *ngIf="condition.controls.operator.value === 'EQUALS'">
+                  Case sensitive, must match exactly.
+              </small>
+
+              <small
+                *ngIf="condition.controls.operator.value === 'MEMBER_OF'">
+                  Comma-separated list, at least one must match exactly.
+              </small>
+
+            </chef-form-field>
+            <chef-form-field class="attribute-field">
+              <label>
+                <span *ngIf="(i + 1) < ruleForm.get('conditions').controls.length" class="label">AND</span>
+              </label>
+              <chef-icon (click)="deleteCondition(i)">delete</chef-icon>
+            </chef-form-field>
+
+          </div>
+        </div>
+      </form>
+    </ng-container>
+  </div>
+</chef-page>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -5,6 +5,10 @@ chef-page {
   small {
     color: $chef-dark-grey;
     font-size: 14px;
+
+    &.help {
+      font-size: 12px;
+    }
   }
 
   form {
@@ -23,7 +27,7 @@ chef-page {
 
   chef-form-field {
     .label {
-      font-size: 12px;
+      font-size: 16px;
     }
 
     &.attribute-field {
@@ -40,11 +44,15 @@ chef-page {
           display: inline-block;
         }
 
-        chef-icon {
-          cursor: pointer;
-          font-size: 1.2rem;
+        chef-button {
           position: absolute;
           right: 0;
+          top: -14px;
+
+          chef-icon {
+            color: $chef-primary-dark;
+            font-size: 1.2rem;
+          }
         }
       }
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -1,0 +1,130 @@
+@import "~styles/variables";
+
+chef-page {
+
+  chef-modal {
+    #{--modal-width}: 777px;
+
+    h2 {
+      text-align: center;
+    }
+
+    #left-align {
+      margin-left: 150px;
+
+      chef-form-field {
+        margin-top: 20px;
+        padding-right: 150px;
+      }
+
+      p {
+        size: 11px;
+        margin-top: 11px;
+        margin-bottom: 11px;
+      }
+
+      .expression {
+        background-color: $chef-light-grey;
+        padding-left: 0.3em;
+        padding-right: 0.3em;
+      }
+    }
+
+    #align-buttons {
+      text-align: center;
+    }
+  }
+
+  small {
+    color: $chef-dark-grey;
+    font-size: 14px;
+  }
+
+  chef-input {
+    height: 45px;
+  }
+
+  form {
+    height: calc(100vh - 350px);
+    overflow-y: scroll;
+  }
+
+  chef-form-field.attribute-field {
+    display: inline-block;
+    position: relative;
+    vertical-align: top;
+    width: 27%;
+
+    &:last-child {
+      margin: 2.5rem 0px;
+      width: 18%;
+
+      label {
+        display: inline-block;
+      }
+
+      chef-icon {
+        position: absolute;
+        right: 0;
+        font-size: 1.2rem;
+      }
+    }
+
+    .label {
+      color: $chef-dark-grey;
+      font-weight: 100;
+      text-transform: uppercase;
+    }
+
+    chef-select,
+    chef-input {
+      min-width: 0;
+      width: 95%;
+    }
+  }
+
+  #ruleName,
+  #resourceType {
+    width: 340px;
+  }
+
+  #add-condition {
+    margin: 1rem 0;
+
+    small {
+      display: block;
+    }
+
+    chef-button {
+      margin-left: 0;
+    }
+  }
+
+  #no-members-container {
+    position: relative;
+    top: 70px;
+    text-align: center;
+  }
+
+  #table-container {
+
+    #members-selected {
+      font-size: 12px;
+      color: $chef-dark-grey;
+      margin-bottom: 5px;
+    }
+
+    #inner-container {
+      chef-table {
+        chef-tbody {
+          height: calc(100vh - 350px);
+          overflow-y: scroll;
+        }
+
+        .checkbox-row {
+          max-width: 50px;
+        }
+      }
+    }
+  }
+}

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -64,9 +64,10 @@ chef-page {
       }
 
       chef-icon {
+        cursor: pointer;
+        font-size: 1.2rem;
         position: absolute;
         right: 0;
-        font-size: 1.2rem;
       }
     }
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -2,46 +2,9 @@
 
 chef-page {
 
-  chef-modal {
-    #{--modal-width}: 777px;
-
-    h2 {
-      text-align: center;
-    }
-
-    #left-align {
-      margin-left: 150px;
-
-      chef-form-field {
-        margin-top: 20px;
-        padding-right: 150px;
-      }
-
-      p {
-        size: 11px;
-        margin-top: 11px;
-        margin-bottom: 11px;
-      }
-
-      .expression {
-        background-color: $chef-light-grey;
-        padding-left: 0.3em;
-        padding-right: 0.3em;
-      }
-    }
-
-    #align-buttons {
-      text-align: center;
-    }
-  }
-
   small {
     color: $chef-dark-grey;
     font-size: 14px;
-  }
-
-  chef-input {
-    height: 45px;
   }
 
   form {
@@ -49,44 +12,55 @@ chef-page {
     overflow-y: scroll;
   }
 
-  chef-form-field.attribute-field {
-    display: inline-block;
-    position: relative;
-    vertical-align: top;
-    width: 27%;
-
-    &:last-child {
-      margin: 2.5rem 0px;
-      width: 18%;
-
-      label {
-        display: inline-block;
-      }
-
-      chef-icon {
-        cursor: pointer;
-        font-size: 1.2rem;
-        position: absolute;
-        right: 0;
-      }
-    }
-
-    .label {
-      color: $chef-dark-grey;
-      font-weight: 100;
-      text-transform: uppercase;
-    }
-
-    chef-select,
-    chef-input {
-      min-width: 0;
-      width: 95%;
-    }
+  chef-input {
+    height: 45px;
   }
 
   #ruleName,
   #resourceType {
     width: 340px;
+  }
+
+  chef-form-field {
+    .label {
+      font-size: 12px;
+    }
+
+    &.attribute-field {
+      display: inline-block;
+      position: relative;
+      vertical-align: top;
+      width: 27%;
+
+      &:last-child {
+        margin: 2.5rem 0px;
+        width: 18%;
+
+        label {
+          display: inline-block;
+        }
+
+        chef-icon {
+          cursor: pointer;
+          font-size: 1.2rem;
+          position: absolute;
+          right: 0;
+        }
+      }
+
+      .label {
+        color: $chef-dark-grey;
+        text-transform: uppercase;
+        font-weight: 100;
+      }
+
+      chef-select,
+      chef-input {
+        min-width: 0;
+        width: 95%;
+      }
+    }
+
   }
 
   #add-condition {
@@ -98,34 +72,6 @@ chef-page {
 
     chef-button {
       margin-left: 0;
-    }
-  }
-
-  #no-members-container {
-    position: relative;
-    top: 70px;
-    text-align: center;
-  }
-
-  #table-container {
-
-    #members-selected {
-      font-size: 12px;
-      color: $chef-dark-grey;
-      margin-bottom: 5px;
-    }
-
-    #inner-container {
-      chef-table {
-        chef-tbody {
-          height: calc(100vh - 350px);
-          overflow-y: scroll;
-        }
-
-        .checkbox-row {
-          max-width: 50px;
-        }
-      }
     }
   }
 }

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -185,13 +185,15 @@ describe('ProjectRulesComponent', () => {
     it('should have attribute label with NODE type', () => {
       component.ruleForm.get('type').setValue('NODE');
       const attributeLabel = component.getAttributeLabel();
-      expect(attributeLabel).toBe('node attribute');
+      expect(attributeLabel)
+        .toBe('node attribute'); // specifically should be lowercase for screen reader
     });
 
     it('should have attribute label with EVENT type', () => {
       component.ruleForm.get('type').setValue('EVENT');
       const attributeLabel = component.getAttributeLabel();
-      expect(attributeLabel).toBe('event attribute');
+      expect(attributeLabel)
+        .toBe('event attribute'); // specifically should be lowercase for screen reader
     });
 
     it('should not show add label with one condition', () => {

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -1,0 +1,197 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { StoreModule } from '@ngrx/store';
+import { MockComponent } from 'ng2-mock-component';
+
+import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
+import { customMatchers } from 'app/testing/custom-matchers';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+import { IAMType } from 'app/entities/policies/policy.model';
+import { projectEntityReducer } from 'app/entities/projects/project.reducer';
+import { ProjectRulesComponent } from './project-rules.component';
+import { Rule } from 'app/entities/rules/rule.model';
+import { ruleEntityReducer } from 'app/entities/rules/rule.reducer';
+
+describe('ProjectRulesComponent', () => {
+  let component: ProjectRulesComponent;
+  let fixture: ComponentFixture<ProjectRulesComponent>;
+
+  const project = {
+    id: 'uuid-1', name: 'Default',
+    type: <IAMType>'CHEF_MANAGED'
+  };
+  
+  beforeEach(async(() => {
+
+    TestBed.configureTestingModule({
+      declarations: [
+        MockComponent({
+          selector: 'chef-toolbar',
+          template: '<ng-content></ng-content>'
+        }),
+         MockComponent({
+          selector: 'app-authorized',
+          inputs: ['allOf', 'not'],
+          template: '<ng-content></ng-content>'
+        }),
+        MockComponent({ selector: 'app-admin-sidebar' }),
+        MockComponent({
+          selector: 'app-delete-object-modal',
+          inputs: ['visible', 'objectNoun', 'objectName'],
+          outputs: ['close', 'deleteClicked']
+        }),
+        MockComponent({ selector: 'chef-control-menu' }),
+        MockComponent({ selector: 'chef-form-field'}),
+        MockComponent({ selector: 'chef-breadcrumbs'}),
+        MockComponent({ selector: 'chef-breadcrumb', inputs: ['link'] }),
+        MockComponent({ selector: 'chef-tab-selector', inputs: ['value'] }),
+        MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),
+        MockComponent({ selector: 'chef-heading' }),
+        MockComponent({ selector: 'chef-icon' }),
+        MockComponent({ selector: 'chef-input', inputs: ['value'] }),
+        MockComponent({ selector: 'chef-error'}),
+        MockComponent({ selector: 'chef-loading-spinner' }),
+        MockComponent({ selector: 'chef-option' }),
+        MockComponent({ selector: 'chef-page',
+          inputs: [
+            'subheading',
+            'confirm-btn-text',
+            'heading',
+            'disable-confirm',
+            'page-loading',
+            'confirm-loading'
+          ],
+          outputs: ['confirm', 'close']
+        }),
+        MockComponent({ selector: 'chef-page-header' }),
+        MockComponent({ selector: 'chef-subheading' }),
+        MockComponent({ selector: 'chef-table' }),
+        MockComponent({ selector: 'chef-thead' }),
+        MockComponent({ selector: 'chef-tbody' }),
+        MockComponent({ selector: 'chef-tr' }),
+        MockComponent({ selector: 'chef-th' }),
+        MockComponent({ selector: 'chef-td' }),
+        MockComponent({ selector: 'ng-container', inputs: ['hidden'] }),
+        ProjectRulesComponent
+      ],
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        ChefPipesModule,
+        StoreModule.forRoot({
+          router: () => ({
+            state: {
+              url: '/projects/uuid-1/rules',
+              queryParams: {},
+              params: {},
+              fragment: '',
+              path: ['/']
+            },
+            previousRoute: {},
+            navigationId: 0
+          }),
+          projects: projectEntityReducer,
+          rules: ruleEntityReducer
+        })
+      ],
+      providers: [
+        FeatureFlagsService
+      ]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    jasmine.addMatchers(customMatchers);
+    fixture = TestBed.createComponent(ProjectRulesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('when creating a new rule', () => {
+    beforeEach(() => {
+      component.project = project;
+      component.rule = <Rule>{};
+      component.isLoading = false;
+      fixture.detectChanges();
+    });
+
+    it('the heading should show <Project Name>: Rule', () => {
+      const heading = `${component.project.name}: Rule`;
+      const compHeading = component.getHeading();
+      expect(heading).toBe(compHeading);
+    });
+
+    it('the heading should change to <Project Name>: <Rule Name>', () => {
+      const ruleName = "My Rule";
+      component.ruleForm.get('name').setValue(ruleName);
+      const heading = `${component.project.name}: ${ruleName}`;
+      const compHeading = component.getHeading();
+      expect(heading).toBe(compHeading);
+    });
+
+    it('should have a backroute to project page', () => {
+      const backRoute = ['/settings', 'projects', component.project.id];
+      const compBackRoute = component.backRoute();
+      expect(backRoute).toEqual(compBackRoute);
+    });
+
+    it('the formgroup should have one condition', () => {
+      const conditions = component.ruleForm.get('conditions').value.length;
+      expect(conditions).toBe(1);
+    });
+
+    it('should create a condition', () => {
+      component.addCondition();
+      const conditions = component.ruleForm.get('conditions').value.length;
+      expect(conditions).toBe(2);
+    });
+
+    it('should delete a condition', () => {
+      let conditions = component.ruleForm.get('conditions').value.length;
+      expect(conditions).toBe(1);
+      component.deleteCondition(0);
+      conditions = component.ruleForm.get('conditions').value.length;
+      expect(conditions).toBe(0);
+    });
+
+    it('should return condition value of string', () => {
+      const conditionValue = component.getConditionValue('adasd');
+      expect(typeof conditionValue === 'string').toBeTruthy();
+    });
+
+    it('should return condition value of array', () => {
+      const conditionValue = component.getConditionValue(['adasd']);
+      expect(typeof conditionValue === 'string').toBeTruthy();
+    });
+
+    it('form should be invalid', () => {
+      expect(component.ruleForm.valid).toBeFalsy();
+    });
+
+    it('should enable submit when valid', () => {
+      component.ruleForm.get('name').setValue('My Rule');
+      component.ruleForm.get('type').setValue('NODE');
+      component.ruleForm.get('conditions').setValue([
+        {
+          attribute: 'CHEF_ORGS',
+          operator: 'EQUAL',
+          values: 'my value'
+        }
+      ]);
+      expect(component.ruleForm.valid).toBeTruthy();
+    });
+
+    it('should have attribute label with NODE type', () => {
+      component.ruleForm.get('type').setValue('NODE');
+      const attributeLabel = component.getAttributeLabel();
+      expect(attributeLabel).toBe('NODE Attribute');
+    });
+
+    it('should have attribute label with EVENT type', () => {
+      component.ruleForm.get('type').setValue('EVENT');
+      const attributeLabel = component.getAttributeLabel();
+      expect(attributeLabel).toBe('EVENT Attribute');
+    });
+  });
+});

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -185,13 +185,35 @@ describe('ProjectRulesComponent', () => {
     it('should have attribute label with NODE type', () => {
       component.ruleForm.get('type').setValue('NODE');
       const attributeLabel = component.getAttributeLabel();
-      expect(attributeLabel).toBe('NODE Attribute');
+      expect(attributeLabel).toBe('node attribute');
     });
 
     it('should have attribute label with EVENT type', () => {
       component.ruleForm.get('type').setValue('EVENT');
       const attributeLabel = component.getAttributeLabel();
-      expect(attributeLabel).toBe('EVENT Attribute');
+      expect(attributeLabel).toBe('event attribute');
+    });
+
+    it('should not show add label with one condition', () => {
+      const showAndLabel = component.showAndLabel(0);
+      expect(showAndLabel).toBeFalsy();
+    });
+
+    it('should not show delete button with one condition', () => {
+      const showDelete = component.showDelete(0);
+      expect(showDelete).toBeFalsy();
+    });
+
+    it('should show add label with two conditions', () => {
+      component.addCondition();
+      const showAndLabel = component.showAndLabel(0);
+      expect(showAndLabel).toBeTruthy();
+    });
+
+    it('should show delete button with two conditions', () => {
+      component.addCondition();
+      const showDelete = component.showDelete(0);
+      expect(showDelete).toBeTruthy();
     });
   });
 });

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -21,7 +21,7 @@ describe('ProjectRulesComponent', () => {
     id: 'uuid-1', name: 'Default',
     type: <IAMType>'CHEF_MANAGED'
   };
-  
+
   beforeEach(async(() => {
 
     TestBed.configureTestingModule({
@@ -123,7 +123,7 @@ describe('ProjectRulesComponent', () => {
     });
 
     it('the heading should change to <Project Name>: <Rule Name>', () => {
-      const ruleName = "My Rule";
+      const ruleName = 'My Rule';
       component.ruleForm.get('name').setValue(ruleName);
       const heading = `${component.project.name}: ${ruleName}`;
       const compHeading = component.getHeading();

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -115,6 +115,10 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     return `${this.project.name}: ` + (this.ruleForm.value.name || 'Rule');
   }
 
+  getAttributeLabel() {
+    return `${this.ruleForm.get('type').value} Attribute`;
+  }
+
   backRoute(): string[] {
     return ['/settings', 'projects', this.project.id];
   }
@@ -169,7 +173,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     }
   }
 
-  getCommaList(value): string {
+  getConditionValue(value): string {
     return (typeof value === 'string') ? value : value.join(', ');
   }
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -116,7 +116,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   }
 
   getAttributeLabel() {
-    return `${this.ruleForm.get('type').value} Attribute`;
+    return `${this.ruleForm.get('type').value.toLowerCase()} attribute`;
   }
 
   backRoute(): string[] {
@@ -143,6 +143,16 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   deleteCondition(index: number) {
     const conditions = this.ruleForm.get('conditions') as FormArray;
     conditions.removeAt(index);
+  }
+
+  showAndLabel(i: number): boolean {
+    const conditions = this.ruleForm.get('conditions') as FormArray;
+    return (i + 1) < conditions.length;
+  }
+
+  showDelete(i: number): boolean {
+    const conditions = this.ruleForm.get('conditions') as FormArray;
+    return (i + 1) < conditions.length;
   }
 
   populateConditions() {

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -1,0 +1,193 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { FormBuilder, FormGroup, FormArray, Validators } from '@angular/forms';
+import { Router, ActivatedRoute } from '@angular/router';
+import { EntityStatus, loading } from 'app/entities/entities';
+import { Store } from '@ngrx/store';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { routeParams } from 'app/route.selectors';
+import { Subject, combineLatest } from 'rxjs';
+import { map, takeUntil, pluck, filter } from 'rxjs/operators';
+import { identity } from 'lodash/fp';
+import { Rule } from 'app/entities/rules/rule.model';
+import { GetRule, GetRules, CreateRule, UpdateRule } from 'app/entities/rules/rule.actions';
+import { getStatus, updateStatus, ruleFromRoute } from 'app/entities/rules/rule.selectors';
+import { projectFromRoute } from 'app/entities/projects/project.selectors';
+import { Project } from 'app/entities/projects/project.model';
+import { GetProject } from 'app/entities/projects/project.actions';
+
+@Component({
+  selector: 'app-project-rules',
+  templateUrl: './project-rules.component.html',
+  styleUrls: ['./project-rules.component.scss']
+})
+export class ProjectRulesComponent implements OnInit, OnDestroy {
+  public project: Project;
+  public ruleId: string;
+  public ruleForm: FormGroup;
+  public rule: Rule = <Rule>{};
+  public conditions: any[];
+  public isLoading = true;
+  public saving = false;
+  private isDestroyed: Subject<boolean> = new Subject<boolean>();
+
+  constructor(
+    private store: Store<NgrxStateAtom>,
+    private router: Router,
+    private route: ActivatedRoute,
+    private fb: FormBuilder) {
+
+      combineLatest(
+        this.store.select(getStatus),
+        this.store.select(updateStatus)
+      ).pipe(
+        takeUntil(this.isDestroyed),
+        map(([gStatus, uStatus]) => {
+          const routeId = this.route.snapshot.paramMap.get('ruleid');
+          this.isLoading =
+            routeId
+            ? (gStatus !== EntityStatus.loadingSuccess) ||
+              (uStatus === EntityStatus.loading)
+            : false;
+        })).subscribe();
+
+      this.store.select(routeParams).pipe(
+        pluck('ruleid'),
+        filter(identity),
+        takeUntil(this.isDestroyed))
+        .subscribe((id: string) => {
+          this.store.dispatch(new GetRule({ id }));
+        });
+
+      this.store.select(routeParams).pipe(
+        pluck('id'),
+        filter(identity),
+        takeUntil(this.isDestroyed))
+        .subscribe((id: string) => {
+          this.store.dispatch(new GetProject({ id }));
+        });
+
+      this.store.select(ruleFromRoute).pipe(
+        filter(identity),
+        takeUntil(this.isDestroyed),
+        map((state) => {
+          this.rule = <Rule>Object.assign({}, state);
+        })
+        ).subscribe();
+
+      this.store.select(projectFromRoute).pipe(
+        filter(identity),
+        takeUntil(this.isDestroyed),
+        map((state) => {
+          this.project = <Project>Object.assign({}, state);
+        })
+        ).subscribe();
+  }
+
+  ngOnInit(): void {
+    this.ruleForm = this.fb.group({
+      name: [this.rule.name || '', Validators.required],
+      type: [this.rule.type || '', Validators.required],
+      conditions: this.fb.array(this.populateConditions())
+    });
+  }
+
+  ngOnDestroy() {
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
+  }
+
+  getHeading() {
+    return (this.ruleForm.value.name || !this.project)
+      ? `${this.ruleForm.value.name}`
+      : `${this.project.name}: Rule`;
+  }
+
+  backRoute(): string[] {
+    return ['/settings', 'projects', this.project.id];
+  }
+
+  closePage() {
+    this.router.navigate(this.backRoute());
+  }
+
+  createCondition(attribute = '', operator = '', values = ''): FormGroup {
+    return this.fb.group({
+      attribute: [attribute, Validators.required],
+      operator: [operator, Validators.required],
+      values: [values, Validators.required]
+    });
+  }
+
+  addCondition(): void {
+    const conditions = this.ruleForm.get('conditions') as FormArray;
+    conditions.push(this.createCondition());
+  }
+
+  deleteCondition(index: number) {
+    const conditions = this.ruleForm.get('conditions') as FormArray;
+    conditions.removeAt(index);
+  }
+
+  populateConditions() {
+    this.conditions = [];
+
+    if (this.rule.conditions && this.rule.conditions.length !== 0) {
+      this.rule.conditions.forEach(c => {
+        this.conditions.push(this.createCondition(c.attribute, c.operator, c.values));
+      });
+    } else {
+      this.conditions.push(this.createCondition());
+    }
+
+    return this.conditions;
+  }
+
+  updateConditionValues(condition): void {
+    if (condition.controls.operator.value === 'MEMBER_OF') {
+      condition.controls.values.value =
+        (typeof condition.controls.values.value === 'string')
+          ? [condition.controls.values.value]
+          : condition.controls.values.value.split(',').map((v) => v.trim());
+    } else {
+      condition.controls.values.value =
+        (typeof condition.controls.values.value === 'string')
+          ? condition.controls.values.value
+          : condition.controls.values.value.join(' ');
+    }
+  }
+
+  getCommaList(value): string {
+    return (typeof value === 'string') ? value : value.join(', ');
+  }
+
+  createRule() {
+    this.store.dispatch(new CreateRule({project_id: this.project.id, rule: this.ruleForm.value}));
+  }
+
+  updateRule() {
+    const updatedRule = this.ruleForm.value;
+    updatedRule.id = this.rule.id;
+    updatedRule.project_id = this.rule.project_id;
+    this.store.dispatch(new UpdateRule({ rule: updatedRule }));
+    this.store.dispatch(new GetRules({ project_id: this.rule.project_id }));
+  }
+
+  saveRule() {
+    if (this.ruleForm.valid) {
+      this.saving = true;
+      this.rule.id ? this.updateRule() : this.createRule();
+      const pendingSave = new Subject<boolean>();
+      this.store.select(updateStatus).pipe(
+        filter(identity),
+        takeUntil(pendingSave))
+        .subscribe((state) => {
+          if (!loading(state)) {
+            pendingSave.next(true);
+            pendingSave.complete();
+            this.saving = false;
+            this.closePage();
+          }
+        });
+    }
+  }
+}

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -116,6 +116,8 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   }
 
   getAttributeLabel() {
+    // Important for this to be all lower case for screen readers!
+    // (All uppercase is typically read as an acronym.)
     return `${this.ruleForm.get('type').value.toLowerCase()} attribute`;
   }
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -9,8 +9,18 @@ import { Subject, combineLatest } from 'rxjs';
 import { map, takeUntil, pluck, filter } from 'rxjs/operators';
 import { identity } from 'lodash/fp';
 import { Rule } from 'app/entities/rules/rule.model';
-import { GetRule, GetRules, CreateRule, UpdateRule } from 'app/entities/rules/rule.actions';
-import { getStatus, updateStatus, ruleFromRoute } from 'app/entities/rules/rule.selectors';
+import {
+  GetRule,
+  GetRulesForProject,
+  CreateRule,
+  UpdateRule
+} from 'app/entities/rules/rule.actions';
+import {
+  getRuleAttributes,
+  getStatus,
+  updateStatus,
+  ruleFromRoute
+} from 'app/entities/rules/rule.selectors';
 import { projectFromRoute } from 'app/entities/projects/project.selectors';
 import { Project } from 'app/entities/projects/project.model';
 import { GetProject } from 'app/entities/projects/project.actions';
@@ -21,13 +31,14 @@ import { GetProject } from 'app/entities/projects/project.actions';
   styleUrls: ['./project-rules.component.scss']
 })
 export class ProjectRulesComponent implements OnInit, OnDestroy {
-  public project: Project;
+  public project: Project = <Project>{};
   public ruleId: string;
   public ruleForm: FormGroup;
   public rule: Rule = <Rule>{};
   public conditions: any[];
   public isLoading = true;
   public saving = false;
+  public attributes: object;
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
   constructor(
@@ -81,6 +92,10 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
           this.project = <Project>Object.assign({}, state);
         })
         ).subscribe();
+
+      this.store.select(getRuleAttributes).subscribe((attributes) => {
+        this.attributes = attributes;
+      });
   }
 
   ngOnInit(): void {
@@ -97,9 +112,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   }
 
   getHeading() {
-    return (this.ruleForm.value.name || !this.project)
-      ? `${this.ruleForm.value.name}`
-      : `${this.project.name}: Rule`;
+    return `${this.project.name}: ` + (this.ruleForm.value.name || 'Rule');
   }
 
   backRoute(): string[] {
@@ -169,7 +182,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     updatedRule.id = this.rule.id;
     updatedRule.project_id = this.rule.project_id;
     this.store.dispatch(new UpdateRule({ rule: updatedRule }));
-    this.store.dispatch(new GetRules({ project_id: this.rule.project_id }));
+    this.store.dispatch(new GetRulesForProject({ project_id: this.rule.project_id }));
   }
 
   saveRule() {

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, ActivationStart } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
+import { filter } from 'rxjs/operators';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Feature } from 'app/services/feature-flags/types';
@@ -39,7 +40,7 @@ export class UIComponent implements OnInit {
 
   licenseApplyReason: LicenseApplyReason;
 
-  renderNavbar: true;
+  renderNavbar = true;
 
   constructor(
     private store: Store<NgrxStateAtom>,
@@ -49,12 +50,12 @@ export class UIComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.router.events.subscribe((event: any) => {
-      console.log('routerval', event);
-      this.renderNavbar = event.snapshot
-        && event.snapshot.data
-        ? event.snapshot.data.hideNavBar
-        : this.renderNavbar;
+    this.router.events.pipe(
+        filter(event => event instanceof ActivationStart)
+    ).subscribe((event: any) => {
+      this.renderNavbar = event.snapshot.data.hideNavBar
+        ? false
+        : true;
     });
 
     this.store.dispatch(new GetIamVersion());

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
@@ -7,7 +8,6 @@ import { Feature } from 'app/services/feature-flags/types';
 
 import { GetIamVersion } from 'app/entities/policies/policy.actions';
 import { notificationState } from 'app/entities/notifications/notification.selectors';
-import { routeURL } from './route.selectors';
 import { Notification } from 'app/entities/notifications/notification.model';
 import { DeleteNotification } from 'app/entities/notifications/notification.actions';
 import { LicenseApplyReason } from 'app/page-components/license-apply/license-apply.component';
@@ -39,21 +39,24 @@ export class UIComponent implements OnInit {
 
   licenseApplyReason: LicenseApplyReason;
 
-  // TODO(sr) 2018/12/03: This is specific to the policies page and should be
-  // handled differently. Unfortunately, I don't know how; but this isn't the
-  // correct way ;)
-  renderNavbar = window.location.pathname.split('/').pop() !== 'add-members';
+  renderNavbar: true;
 
   constructor(
-    private store: Store<NgrxStateAtom>
+    private store: Store<NgrxStateAtom>,
+    private router: Router
   ) {
     this.notifications$ = store.select(notificationState);
   }
 
   ngOnInit(): void {
-    this.store.select(routeURL).subscribe((url: string) => {
-      this.renderNavbar = url.split('/').pop() !== 'add-members';
+    this.router.events.subscribe((event: any) => {
+      console.log('routerval', event);
+      this.renderNavbar = event.snapshot
+        && event.snapshot.data
+        ? event.snapshot.data.hideNavBar
+        : this.renderNavbar;
     });
+
     this.store.dispatch(new GetIamVersion());
   }
 

--- a/components/chef-ui-library/src/atoms/chef-button/chef-button.tsx
+++ b/components/chef-ui-library/src/atoms/chef-button/chef-button.tsx
@@ -377,6 +377,11 @@ export class ChefButton {
   @Prop({ reflectToAttr: true }) type: 'submit' | 'reset' | 'button' = 'button';
 
   /**
+   * Name for form to submit
+   */
+  @Prop({ reflectToAttr: true }) form: string;
+
+  /**
    * Create a primary button
    */
   @Prop({ reflectToAttr: true }) primary = false;
@@ -428,6 +433,7 @@ export class ChefButton {
       return (
         <button
           type={this.type}
+          form={this.form}
           disabled={this.disabled}
           aria-disabled={this.disabled}>
           <slot />

--- a/components/chef-ui-library/src/templates/chef-page/chef-page.tsx
+++ b/components/chef-ui-library/src/templates/chef-page/chef-page.tsx
@@ -152,7 +152,7 @@ export class ChefPage {
                   {this.getLoading()}
                   <ng-container>{this.confirmBtnText}</ng-container>
                 </chef-button>
-              : <chef-button primary onClick={this.handleConfirm.bind(this)}>
+              : <chef-button type="submit" form="ruleForm" primary onClick={this.handleConfirm.bind(this)}>
                   <ng-container>{this.confirmBtnText}</ng-container>
                 </chef-button>
             }


### PR DESCRIPTION
<img width="1481" alt="Screen Shot 2019-07-01 at 4 17 47 PM" src="https://user-images.githubusercontent.com/4108100/60467459-51637280-9c1c-11e9-8f62-2520817e7054.png">
<img width="1678" alt="Screen Shot 2019-07-01 at 4 18 17 PM" src="https://user-images.githubusercontent.com/4108100/60467460-51fc0900-9c1c-11e9-9060-25e8197be514.png">
<img width="1660" alt="Screen Shot 2019-07-01 at 4 19 09 PM" src="https://user-images.githubusercontent.com/4108100/60467437-427cc000-9c1c-11e9-9651-b0092c197fa2.png">
<img width="1479" alt="Screen Shot 2019-07-01 at 4 19 28 PM" src="https://user-images.githubusercontent.com/4108100/60467408-2ed15980-9c1c-11e9-800d-e9240c8d5548.png">
<img width="1480" alt="Screen Shot 2019-07-01 at 4 19 41 PM" src="https://user-images.githubusercontent.com/4108100/60467392-24af5b00-9c1c-11e9-92e4-30ffa33731d6.png">

### :nut_and_bolt: Description
**A2-825** makes the visual updates to the projects detail pages. Most data should be mocked until the Auth team can come back and connect it to the backend.

Please leverage the already implemented designs of the full-page designs (A2-827) when adding members to a policy.(Ideally, this should re-use the same component as the create page (A2-826), with a few conditionals or variables to allow it to cover both create and update cases.)

**A2-826** This task makes the visual updates to the project create ingest rule page. Most data should be mocked until the Auth team can come back and connect it to the backend.

**Separate story for the chef-select boxes styling** https://chefio.atlassian.net/browse/A2-826

### :+1: Definition of Done

**PROJECT DETAILS PAGE**:

Empty State

When no ingest rules exist.. display the empty state pattern

Message: Create the first ingest rule to get started!

Create Rule primary button

Ingest Rules table

Use mocked data until Auth can come back and connect it to the backend

Use the `chef-toolbar` with always enabled primary Create Rule button

The table has 4 columns: Name, Resource Type, Conditions, and Edits.

Name displays the human created name of the rule as a link

Resource Type displays Node or Event

Conditions displays the count of conditions associated with that rule, the number displayed first followed by condition in the single case or conditions when more than one conditions.

Edits communicates either Edits pending when there are edits in staging or Applied when the edits have been applied.

The control menu at the end of the row is dynamic. If the rule is not currently being applied then it should have the option to Delete Rule.

If any of the rules are in the Edits pending state then text with a link back to projects should be displayed: Edits pending, update projects to apply edits.

Delete Rule

This should only appear in the control menu when an update is not in progress

Includes a confirmation with the text _Deleting rule "<rule name>" <strong>cannot be undone</strong>. and primary button Delete Rule

**PROJECTS CREATE RULE**:
Please leverage the already implemented designs of the full-page designs (A2-827) when adding members to a policy. (Ideally, this should re-use the same component as the create page (A2-825), with a few conditionals or variables to allow it cover both create and update cases.)

On create the heading should be <Project Name>: Rule, but once they have entered characters in the rule name it should dynamically change to update Rule to match the rule's name

For now, the only options in Resource Type are Node and Event.

Condition column headers are ATTRIBUTE, OPERATOR, and VALUE – please use `text-transform` to achieve the uppercase letters

Note: Once a resource type is selected, the attribute column header should change to ATTRIBUTE <resource type>

On create an initial (empty) condition should automatically be displayed. For additional conditions, the user will need to use the Add Condition button. Conditions should be added to the bottom of the list.When more than 1 condition, the word AND should be displayed at the end of the condition row (except for on the last condition)

The only current operators are equals and member of: the user enters a string for equals and a comma-separated list for member of, but there is no visual distinction required in the input field other than the help text, given below.

The delete button removes the condition without any kind of confirmation

Save Rule should only become enabled when a name, resource type and value for at least one condition are provided.

Help text...

equals: Case sensitive, must match exactly.

member of: Comma-separated list, at least one must match exactly.

### :athletic_shoe: Demo Script / Repro Steps
make update-ui-lib // Update chef-ui library coomponents
chef-automate iam upgrade-to-v2 --beta2.1 // Add projects
Settings > Projects

### :chains: Related Resources
https://chefio.atlassian.net/browse/A2-825
https://chefio.atlassian.net/browse/A2-826
https://github.com/chef/automate/issues/267
https://github.com/chef/automate/issues/268

### :white_check_mark: Checklist
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
