### PR TITLE
fix saml in dev and acceptance for inspec and cypress

### DIFF
--- a/.expeditor/buildkite/cypress.sh
+++ b/.expeditor/buildkite/cypress.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 cd /workdir/e2e
 
-data=$(curl --silent https://a2-${CHANNEL}.cd.chef.co/assets/data.json)
-instances_to_test=$(jq -nr --argjson data "$data" '$data[] | select(.tags[] | contains ("e2e")) | .fqdn')
+data=$(curl --silent "https://a2-${CHANNEL}.cd.chef.co/assets/data.json")
+instances_to_test=$(jq -nr --argjson data "$data" '$data[] | select(.tags | any(. == "e2e")) | .fqdn')
 
 for instance in ${instances_to_test[*]}
 do

--- a/.expeditor/buildkite/inspec.sh
+++ b/.expeditor/buildkite/inspec.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 echo -e "$CHEF_CI_SSH_PRIVATE_KEY" > chef-ci-ad-ssh
 
-instances_to_test=$(curl --silent "https://a2-${CHANNEL}.cd.chef.co/assets/data.json" | jq --raw-output 'map(select(.tags[] | contains ("chef-automate-cli"))) | .[] .fqdn')
+instances_to_test=$(curl --silent "https://a2-${CHANNEL}.cd.chef.co/assets/data.json" |\
+  jq --raw-output '.[] | select(.tags | any(. == "chef-automate-cli")) | .fqdn')
 
 for instance in ${instances_to_test[*]}
 do

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -76,7 +76,6 @@ Cypress.Commands.add("logout", () => {
   cy.get('[data-cy=user-profile-button]').click()
   cy.get('[data-cy=sign-out-button]').click()
   cy.url().should('include', '/dex/auth')
-  cy.contains('Choose a method to log in')
 })
 
 // IAM helpers

--- a/inspec/a2-resource-pack/libraries/automate_api_request.rb
+++ b/inspec/a2-resource-pack/libraries/automate_api_request.rb
@@ -91,6 +91,7 @@ class AutomateApiRequest < Inspec.resource(1)
       req = nil
       if loc = resp.headers.location
         # one connector only (local) => we're being redirected
+        req = loc.match(%r'\?req=([^"]+)')[1]
       else
         # pick form URL with request ID from connector selection
         m = resp.body.match(%r'"(/dex/auth/local)\?req=([^"]+)"')


### PR DESCRIPTION
Cleaning up the fall-out of #726. When testing that other PR, 

- I had assumed that the inspec stuff already knew how to deal with single-login method situations.
- Also, I hadn't considered that cypress tests actually attempt to _logout_, spot-checking the specs, I hadn't triggered one that had attempted that.

Well, now, we're good. 😄 