### PR TITLE
quickfix: inspec and saml login

### DIFF
--- a/.expeditor/buildkite/inspec.sh
+++ b/.expeditor/buildkite/inspec.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 
 echo -e "$CHEF_CI_SSH_PRIVATE_KEY" > chef-ci-ad-ssh
 
+# TODO(sr) Until we've fixed the inspec resource to deal with a single
+# login method properly, let's skip those machines for inspec tests.
 instances_to_test=$(curl --silent "https://a2-${CHANNEL}.cd.chef.co/assets/data.json" |\
-  jq --raw-output '.[] | select(.tags | any(. == "chef-automate-cli")) | .fqdn')
+  jq --raw-output '.[] | select(.tags | any(. == "chef-automate-cli")) | select(.tags | any(. == "saml")) | .fqdn')
 
 for instance in ${instances_to_test[*]}
 do

--- a/terraform/test-environments/scenarios/airgapped_single_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/airgapped_single_local_fresh_install.tf
@@ -34,7 +34,6 @@ module "airgapped_single_local_fresh_install" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
-    X-SAML             = "saml"
   }
 }
 


### PR DESCRIPTION
Only scan those machines that have multiple methods, until we've fixed the inspec code for a single login method.

While looking at those machines with a "saml" tag, I've noticed one that had it but didn't deserve it. Fixed.