### PR TITLE
[A2-890] Fix race condition in db with deployments

### DIFF
--- a/components/applications-service/pkg/storage/postgres/schema/sql/07_unique_constraints.up.sql
+++ b/components/applications-service/pkg/storage/postgres/schema/sql/07_unique_constraints.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE deployment ADD CONSTRAINT deployment_unique UNIQUE (app_name, environment);


### PR DESCRIPTION
We allowed non-unique deployments to be inserted, since we ingest in batches this
could end up with duplicates. We applied a uniqueness constraint to prevent duplicates.
Same batches of new service-groups or new deployments are then retried when the unique constraint is hit.

Signed-off-by: kmacgugan <kmacgugan@chef.io>

### :nut_and_bolt: Description

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps
Hard to repro outside of integration tests, but theres a test! 
### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
