### PR TITLE
Client Runs page's node export infinite loop

### DIFF
--- a/components/config-mgmt-service/grpcserver/node_export.go
+++ b/components/config-mgmt-service/grpcserver/node_export.go
@@ -71,8 +71,14 @@ func (s *CfgMgmtServer) NodeExport(request *pRequest.NodeExport, stream service.
 	if err != nil {
 		return err
 	}
-
-	return s.exportNodes(stream.Context(), request, exporter)
+	streamCtx := stream.Context()
+	deadline, ok := streamCtx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(time.Minute)
+	}
+	ctx, cancel := context.WithDeadline(streamCtx, deadline)
+	defer cancel()
+	return s.exportNodes(ctx, request, exporter)
 }
 
 func getExportHandler(outputType string, stream service.CfgMgmt_NodeExportServer) (exportHandler, error) {


### PR DESCRIPTION
### :nut_and_bolt: Description
Preventing the Client Runs page's node export from going into an infinite loop. To cause the infinite loop when using the node export, a user needs to have nodes with the same name that has uppercase characters. This bug is caused by using the Elasticsearch SearchAfter API with non-matching curser values. When requesting the second page of values the last value from the first page's node name is used in the request. For the node-state index, the node name values are matched as lower-case, but the code was sending the values with uppercase. When this happens, SearchAfter API will return the first page again. 

I have not seen that this infinite loop timeout in any way. Therefore a context deadline of one minute was added to prevent this from happening again. 

### :athletic_shoe: Demo Script / Repro Steps

1. `build components/config-mgmt-service && start_all_services`
1. Create 101 nodes with the same name but different UUIDs `for i in {1..101}; do send_chef_run_example; done`
1. Open https://a2-dev.test/client-runs and export the nodes

### :chains: Related Resources

https://github.com/chef/automate/issues/747

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
