### PR TITLE
habitat: pin core/jq-static/1.6

### DIFF
--- a/components/automate-gateway/habitat/plan.sh
+++ b/components/automate-gateway/habitat/plan.sh
@@ -9,7 +9,7 @@ pkg_deps=(
   core/cacerts # communicate with license service over HTTPS
   core/curl
   core/glibc
-  core/jq-static
+  core/jq-static/1.6 # TODO(sr): drop version when erroneous jq-static/1.10 is gone
   chef/mlsa
 )
 pkg_build_deps=(

--- a/components/automate-pg-gateway/habitat/plan.sh
+++ b/components/automate-pg-gateway/habitat/plan.sh
@@ -10,7 +10,7 @@ pkg_version="0.0.1"
 pkg_deps=(
     core/bash
     core/netcat-openbsd
-    core/jq-static
+    core/jq-static/1.6 # TODO(sr): drop version when erroneous jq-static/1.10 is gone
     core/haproxy
 )
 

--- a/components/automate-ui/habitat/plan.sh
+++ b/components/automate-ui/habitat/plan.sh
@@ -9,7 +9,7 @@ pkg_deps=(
   core/coreutils
   chef/mlsa
   core/nginx
-  core/jq-static
+  core/jq-static/1.6 # TODO(sr): drop version when erroneous jq-static/1.10 is gone
 )
 pkg_build_deps=(
   core/git

--- a/components/automate-workflow-server/habitat/plan.sh
+++ b/components/automate-workflow-server/habitat/plan.sh
@@ -22,7 +22,7 @@ pkg_deps=(
   core/postgresql
   core/sqitch_pg
   core/tzdata
-  core/jq-static
+  core/jq-static/1.6 # TODO(sr): drop version when erroneous jq-static/1.10 is gone
   chef/mlsa
 
   # NOTE(ssd) 2019-04-03: Any in-repo dependencies added here MUST be

--- a/components/compliance-service/habitat/plan.sh
+++ b/components/compliance-service/habitat/plan.sh
@@ -8,7 +8,7 @@ pkg_upstream_url="http://github.com/chef/automate/components/compliance-service"
 pkg_build_deps=(
   core/curl
   core/gcc
-  core/jq-static
+  core/jq-static/1.6 # TODO(sr): drop version when erroneous jq-static/1.10 is gone
   core/tar
 )
 pkg_bin_dirs=(bin)
@@ -35,8 +35,9 @@ inspec_release="chef/inspec/3.9.0/20190401200826"
 pkg_deps=(
   core/bash
   core/glibc
-  core/grpcurl              # Used in habitat/hooks/health_check
-  core/jq-static            # Used in habitat/hooks/health_check
+  core/grpcurl       # Used in habitat/hooks/health_check
+  # TODO(sr): drop version when erroneous jq-static/1.10 is gone
+  core/jq-static/1.6 # Used in habitat/hooks/health_check
   ${local_platform_tools_origin:-chef}/automate-platform-tools
   # WARNING: Update with care. The chef/inspec is managed with Expeditor.
 

--- a/components/config-mgmt-service/habitat/plan.sh
+++ b/components/config-mgmt-service/habitat/plan.sh
@@ -8,7 +8,7 @@ pkg_version="0.1.0"
 pkg_deps=(
   core/glibc
   core/grpcurl
-  core/jq-static
+  core/jq-static/1.6 # TODO(sr): drop version when erroneous jq-static/1.10 is gone
   chef/mlsa
 )
 pkg_build_deps=(

--- a/components/ingest-service/habitat/plan.sh
+++ b/components/ingest-service/habitat/plan.sh
@@ -21,7 +21,7 @@ pkg_exposes=(port)
 pkg_deps=(
   core/glibc
   core/grpcurl
-  core/jq-static
+  core/jq-static/1.6 # TODO(sr): drop version when erroneous jq-static/1.10 is gone
   chef/mlsa
 )
 pkg_build_deps=(


### PR DESCRIPTION
This is to be reverted when we've dealt with core/jq-static/1.10.

I believe that if we get this merged, and then pull the erroneous version 1.10 off bldr (or make it private, whatever), we can revert this: `core/jq-static` will then resolve to 1.6, and everything will build OK.