### PR TITLE
[workflow-nginx] Pin curl

### DIFF
--- a/components/automate-workflow-nginx/habitat/plan.sh
+++ b/components/automate-workflow-nginx/habitat/plan.sh
@@ -10,7 +10,12 @@ pkg_deps=(
   chef/openresty-noroot
   chef/mlsa
   core/bash
-  core/curl
+  # TODO(ssd) 2019-07-03: PIN PIN PIN
+  #
+  # This is pinned until chef/openresty-noroot is rebuilt, at which
+  # point this pin will break our build again and we'll need to remove
+  # it.
+  core/curl/7.63.0/20190201004909
   core/coreutils
   "${vendor_origin}/automate-workflow-web"
 )


### PR DESCRIPTION
chef/openresty-noroot is out of date and thus depends on an old
openssl. For automate-workflow-nginx to build we need to depend on
this older curl which depends on the same version of openssl as
openresty-noroot.

See chef/chef-server#1697

Signed-off-by: Steven Danna <steve@chef.io>