### PR TITLE
inspec: fix automate_api_request for single-method login

### DIFF
--- a/.expeditor/buildkite/inspec.sh
+++ b/.expeditor/buildkite/inspec.sh
@@ -4,10 +4,8 @@ set -euo pipefail
 
 echo -e "$CHEF_CI_SSH_PRIVATE_KEY" > chef-ci-ad-ssh
 
-# TODO(sr) Until we've fixed the inspec resource to deal with a single
-# login method properly, let's skip those machines for inspec tests.
 instances_to_test=$(curl --silent "https://a2-${CHANNEL}.cd.chef.co/assets/data.json" |\
-  jq --raw-output '.[] | select(.tags | any(. == "chef-automate-cli")) | select(.tags | any(. == "saml")) | .fqdn')
+  jq --raw-output '.[] | select(.tags | any(. == "chef-automate-cli")) | .fqdn')
 
 for instance in ${instances_to_test[*]}
 do


### PR DESCRIPTION
This finishes #743 and #745.

Now, when run locally against a dev env machine with only one method, it'll pass:

```
[35][default:/src:100]# inspec exec inspec/a2-api-smoke --key-files tmpkey -t ssh://srenatus@a2-local-fresh-install-dev.cd.chef.co
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled

Profile: InSpec Automate REST API Smoke Profile (a2-api-smoke)
Version: 0.1.0
Target:  ssh://srenatus@a2-local-fresh-install-dev.cd.chef.co:22

  ✔  automate-smoke-0: GET /api/v0/auth/tokens
     ✔  automate_api_request http_status should eq 200
     ✔  automate_api_request parsed_response_body should include {}
  ✔  automate-smoke-1: GET /api/v0/auth/policies/version
     ✔  automate_api_request http_status should eq 200
     ✔  automate_api_request parsed_response_body should include {:name => "authz-service"}
  ✔  automate-smoke-2: GET /api/v0/cfgmgmt/version
     ✔  automate_api_request http_status should eq 200
     ✔  automate_api_request parsed_response_body should include {:name => "config-mgmt-service"}
  ✔  automate-smoke-3: GET /api/v0/compliance/reporting/version
     ✔  automate_api_request http_status should eq 200
     ✔  automate_api_request parsed_response_body should include {:name => "compliance"}
  ✔  automate-smoke-4: GET /api/v0/ingest/version
     ✔  automate_api_request http_status should eq 200
     ✔  automate_api_request parsed_response_body should include {:name => "ingest-service"}
  ✔  automate-smoke-5: GET /api/v0/auth/users
     ✔  automate_api_request http_status should eq 200
     ✔  automate_api_request parsed_response_body should include {}
  ✔  automate-smoke-6: GET /api/v0/notifications/version
     ✔  automate_api_request http_status should eq 200
     ✔  automate_api_request parsed_response_body should include {:version => "1.0.0"}
  ✔  automate-smoke-7: GET /api/v0/auth/teams/version
     ✔  automate_api_request http_status should eq 200
     ✔  automate_api_request parsed_response_body should include {:name => "teams-service"}
  ✔  automate-smoke-8: GET /api/v0/gateway/version
     ✔  automate_api_request http_status should eq 200
     ✔  automate_api_request parsed_response_body should include {:name => "automate-gateway"}


Profile: InSpec Automate Resource Pack (a2-resource-pack)
Version: 0.1.0
Target:  ssh://srenatus@a2-local-fresh-install-dev.cd.chef.co:22

     No tests executed.

Profile Summary: 9 successful controls, 0 control failures, 0 controls skipped
Test Summary: 18 successful, 0 failures, 0 skipped
[36][default:/src:0]#
```

before (using inspec code on master), I could replicate the issue we saw on buildkite:
```
[36][default:/src:0]# inspec exec inspec/a2-api-smoke --key-files tmpkey -t ssh://srenatus@a2-local-fresh-install-dev.cd.chef.co
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled
Ignoring `enable_remote_worker` option, the `http` resource
remote worker is enabled by default for remote targets and
cannot be disabled

Profile: InSpec Automate REST API Smoke Profile (a2-api-smoke)
Version: 0.1.0
Target:  ssh://srenatus@a2-local-fresh-install-dev.cd.chef.co:22

  ×  automate-smoke-0: GET /api/v0/auth/tokens (2 failed)
     ×  automate_api_request http_status
     AUTHN FAILED: {login: admin, pass: chefautomate}
     ×  automate_api_request parsed_response_body
     AUTHN FAILED: {login: admin, pass: chefautomate}
  ×  automate-smoke-1: GET /api/v0/auth/policies/version (2 failed)
     ×  automate_api_request http_status
     AUTHN FAILED: {login: admin, pass: chefautomate}
     ×  automate_api_request parsed_response_body
     AUTHN FAILED: {login: admin, pass: chefautomate}
  ×  automate-smoke-2: GET /api/v0/cfgmgmt/version (2 failed)
     ×  automate_api_request http_status
     AUTHN FAILED: {login: admin, pass: chefautomate}
     ×  automate_api_request parsed_response_body
     AUTHN FAILED: {login: admin, pass: chefautomate}
  ×  automate-smoke-3: GET /api/v0/compliance/reporting/version (2 failed)
     ×  automate_api_request http_status
     AUTHN FAILED: {login: admin, pass: chefautomate}
     ×  automate_api_request parsed_response_body
     AUTHN FAILED: {login: admin, pass: chefautomate}
  ×  automate-smoke-4: GET /api/v0/ingest/version (2 failed)
     ×  automate_api_request http_status
     AUTHN FAILED: {login: admin, pass: chefautomate}
     ×  automate_api_request parsed_response_body
     AUTHN FAILED: {login: admin, pass: chefautomate}
  ×  automate-smoke-5: GET /api/v0/auth/users (2 failed)
     ×  automate_api_request http_status
     AUTHN FAILED: {login: admin, pass: chefautomate}
     ×  automate_api_request parsed_response_body
     AUTHN FAILED: {login: admin, pass: chefautomate}
  ×  automate-smoke-6: GET /api/v0/notifications/version (2 failed)
     ×  automate_api_request http_status
     AUTHN FAILED: {login: admin, pass: chefautomate}
     ×  automate_api_request parsed_response_body
     AUTHN FAILED: {login: admin, pass: chefautomate}
  ×  automate-smoke-7: GET /api/v0/auth/teams/version (2 failed)
     ×  automate_api_request http_status
     AUTHN FAILED: {login: admin, pass: chefautomate}
     ×  automate_api_request parsed_response_body
     AUTHN FAILED: {login: admin, pass: chefautomate}
  ×  automate-smoke-8: GET /api/v0/gateway/version (2 failed)
     ×  automate_api_request http_status
     AUTHN FAILED: {login: admin, pass: chefautomate}
     ×  automate_api_request parsed_response_body
     AUTHN FAILED: {login: admin, pass: chefautomate}


Profile: InSpec Automate Resource Pack (a2-resource-pack)
Version: 0.1.0
Target:  ssh://srenatus@a2-local-fresh-install-dev.cd.chef.co:22

     No tests executed.

Profile Summary: 0 successful controls, 9 control failures, 0 controls skipped
Test Summary: 0 successful, 18 failures, 0 skipped
```