### PR TITLE
[CI] Fix nightly a1-migration failures

### DIFF
--- a/components/automate-deployment/a1-migration/install.rb
+++ b/components/automate-deployment/a1-migration/install.rb
@@ -23,7 +23,7 @@ require 'fileutils'
     channel: product['channel'].to_sym,
     product_name: product['product_name'],
     platform: 'ubuntu',
-    platform_version: '14.04',
+    platform_version: '16.04',
     architecture: 'x86_64',
   }
   options['product_version'] = product['version'] if product['version']

--- a/components/automate-deployment/a1-migration/load-artifact
+++ b/components/automate-deployment/a1-migration/load-artifact
@@ -33,7 +33,7 @@ automate-ctl reconfigure --chef-license=accept-no-persist
 # reconfigure doesn't start statistics service tho?
 automate-ctl start
 
-chef-server-ctl reconfigure
+chef-server-ctl reconfigure --chef-license=accept-no-persist
 chef-server-ctl start
 
 function wait_for_healthy_status() {

--- a/components/automate-deployment/a1-migration/load-artifact
+++ b/components/automate-deployment/a1-migration/load-artifact
@@ -28,7 +28,7 @@ cp /a1-migration/delivery.license /var/opt/delivery/license/delivery.license
 
 # loading the data can leave us with incorrect rabbit password among other
 # things, reconfigure fixes it
-automate-ctl reconfigure
+automate-ctl reconfigure --chef-license=accept-no-persist
 
 # reconfigure doesn't start statistics service tho?
 automate-ctl start

--- a/components/automate-deployment/a1-migration/setup.rb
+++ b/components/automate-deployment/a1-migration/setup.rb
@@ -140,7 +140,7 @@ execute 'create migration test users' do
   not_if 'delivery-ctl list-users test | grep bob'
 end
 
-execute 'chef-server-ctl reconfigure' do
+execute 'chef-server-ctl reconfigure --chef-license=accept-no-persist' do
   live_stream true
 end
 


### PR DESCRIPTION
### :nut_and_bolt: Description

a1-migration failures started yesterday as a result of the new Chef Server release.  This
PR resolves the following problems:

- 14.04 artifacts no longer available
- chef-server requires license acceptance

### :+1: Definition of Done

a1-migration pipeline passes