### PR TITLE
[scripts] Add more missing shebang lines

### DIFF
--- a/scripts/verify_build
+++ b/scripts/verify_build
@@ -14,8 +14,9 @@ export HAB_NOCOLORING=true
 export HAB_LICENSE="accept-no-persist"
 
 sudo -E hab pkg install core/ruby
-export PATH=$PATH:$(hab pkg path core/ruby)/bin
-sudo -E $(hab pkg path core/ruby)/bin/gem install toml
+export PATH
+PATH="$PATH:$(hab pkg path core/ruby)/bin"
+sudo -E "$(hab pkg path core/ruby)"/bin/gem install toml
 
 if [[ $EUID -eq 0 ]]; then
     key_cache="/hab/cache/keys"
@@ -35,7 +36,7 @@ curl "https://packages.chef.io/manifests/dev/automate/latest.json" > results/dev
 curl "https://packages.chef.io/manifests/current/automate/latest.json" > results/current.json
 curl "https://packages.chef.io/manifests/acceptance/automate/latest.json" > results/acceptance.json
 
-changed_components=($(./scripts/changed_components))
+mapfile -t changed_components < <(./scripts/changed_components)
 if [[ ${#changed_components[@]} -ne 0 ]]; then
     cat << EOF | buildkite-agent annotate --style "info"
 
@@ -46,8 +47,8 @@ else
     buildkite-agent annotate --style "info" "This change rebuilds no components."
 fi
 
-modified_sql_files=($(git diff --name-status $(./scripts/git_difference_expression) |
-  awk '/^[RMD][0-9]*.*\.sql/{ print $2 }'))
+mapfile -t modified_sql_files < <(git diff --name-status "$(./scripts/git_difference_expression)" | awk '/^[RMD][0-9]*.*\.sql/{ print $2 }')
+
 if [[ ${#modified_sql_files[@]} -ne 0 ]]; then
     cat << EOF | buildkite-agent annotate --append --style "warning"
 

--- a/scripts/verify_setup
+++ b/scripts/verify_setup
@@ -1,8 +1,10 @@
+#!/usr/bin/env sh
+#
+# NOTE: This script is likely sourced in /bin/sh and not bash. Please
+# keep code in this script sh-compatible.
 #
 # verify_setup: Initialize a buildkite host for running a `hab studio
 # run` style integration test.
-#
-# NOTE: This script is likely sourced in /bin/sh and not bash.
 #
 scripts/download_verify_harts
 

--- a/scripts/verify_studio_init
+++ b/scripts/verify_studio_init
@@ -1,10 +1,13 @@
+#!/usr/bin/env sh
+#
+# NOTE: This script is likely sourced in /bin/sh and not bash. Please
+# keep code in this script sh-compatible.
 #
 # verify_studio_init: Setup a `hab studio run` environment to run
 # tests in CI.
 #
 # This script is intended for sourcing directly rather than executing.
 #
-# NOTE: This script is likely sourced in /bin/sh and not bash.
 SUP_LOG_FILE=/hab/sup/default/sup.log
 
 . .studiorc


### PR DESCRIPTION
Not having these shebang lines makes running shellcheck less useful
and makes it harder to use the script in all contexts.

Note that scripts/copy_hartifacts is being fixed in #758

While touching these files, I've run shellcheck on them and fixed all
of the violations.

Signed-off-by: Steven Danna <steve@chef.io>