### PR TITLE
2 fixes for chef-server when using an external automate

### DIFF
--- a/components/automate-cs-nginx/habitat/config/chef_https.conf
+++ b/components/automate-cs-nginx/habitat/config/chef_https.conf
@@ -116,7 +116,7 @@
       rewrite ^(?:/compliance)?/organizations/([^/]+)/owners/([^/]+)/compliance(.*) /compliance/profiles/$2$3 break;
 
       {{~#if cfg.external_automate.root_cert }}
-      proxy_ssl_trusted_certificate {{pkg.svc_config_path}}/external_es_root_cert.crt;
+      proxy_ssl_trusted_certificate {{pkg.svc_config_path}}/external_automate_root_ca.crt;
       {{/if}}
 
       {{~#if cfg.external_automate.server_name }}

--- a/components/automate-cs-oc-erchef/habitat/config/sys.config
+++ b/components/automate-cs-oc-erchef/habitat/config/sys.config
@@ -207,8 +207,8 @@
                                    {ssl_options, [
                                                   {{#if cfg.external_automate.ssl.root_cert}}
                                                   {cacertfile, "{{pkg.svc_config_path}}/external_automate_root_ca.crt"},
-                                                  {{/if ~}}
                                                   {verify, verify_peer}
+                                                  {{/if ~}}
                                                  ]}
                                   ]},
 


### PR DESCRIPTION
### :nut_and_bolt: Description

1.  The nginx config has a typo [here](https://github.com/chef/automate/blob/master/components/automate-cs-nginx/habitat/config/chef_https.conf#L119)   (`es` should be `automate`)

2. The behavior for erchef should be to not verify the SSL cert of the external automate unless an automate root CA is supplied.   The second commit moves the if clause to correct that.

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

Using the instructions from PR #746 

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
