### PR TITLE
Gopter and GRPC capacity diagnostics

### DIFF
--- a/components/authz-service/server/v2/project.go
+++ b/components/authz-service/server/v2/project.go
@@ -3,7 +3,9 @@ package v2
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
+	"unsafe"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
@@ -454,7 +456,41 @@ func (s *ProjectState) listRulesWithFunction(ctx context.Context, req *api.ListR
 		rules[i] = apiRule
 	}
 
+	s.dumpRules(rules)
 	return &api.ListRulesResp{Rules: rules}, nil
+}
+
+func (s *ProjectState) dumpRules(rules []*api.ProjectRule) {
+	// we have the request object but we want to measure the response object,
+	// so adding in deleted (bool) and status ("applied|staged")
+	// The ListRulesResp object also contains 3 more fields:
+	// XXX_NoUnkeyedLiteral, XXX_unrecognized, XXX_sizecache. The last one is 4 bytes but not sure on the first two.
+	// Those unknown bits are greatly exacerbated in that each rule in the payload also has those 3 fields,
+	// and each condition of each rule does also!
+	for _, r := range rules {
+		cSize, cSizeStr := conditionSize(r.Conditions)
+		s.log.Infof("Rule size |%d|: %d+%d+%d+%d+%s+%d+%d(+%d+%d+%d)",
+			size(r.Id)+size(r.ProjectId)+size(r.Name)+int(unsafe.Sizeof(r.Type))+cSize+int(unsafe.Sizeof(r.Deleted))+size(r.Status)+int(unsafe.Sizeof(r.XXX_NoUnkeyedLiteral))+len(r.XXX_unrecognized)+int(unsafe.Sizeof(r.XXX_sizecache)),
+			size(r.Id), size(r.ProjectId), size(r.Name), unsafe.Sizeof(r.Type), cSizeStr, unsafe.Sizeof(r.Deleted), size(r.Status), unsafe.Sizeof(r.XXX_NoUnkeyedLiteral), len(r.XXX_unrecognized), unsafe.Sizeof(r.XXX_sizecache))
+	}
+}
+
+func conditionSize(conditions []*api.Condition) (int, string) {
+	var cList []string
+	cSize := 0
+	for _, c := range conditions {
+		vSize := 0
+		for _, v := range c.Values {
+			vSize += size(v)
+		}
+		cList = append(cList, fmt.Sprintf("{%d+%d+%d(+%d+%d+%d)}", unsafe.Sizeof(c.Attribute), unsafe.Sizeof(c.Operator), vSize, unsafe.Sizeof(c.XXX_NoUnkeyedLiteral), len(c.XXX_unrecognized), unsafe.Sizeof(c.XXX_sizecache)))
+		cSize += int(unsafe.Sizeof(c.Attribute)) + int(unsafe.Sizeof(c.Operator)) + vSize + int(unsafe.Sizeof(c.XXX_NoUnkeyedLiteral)) + len(c.XXX_unrecognized) + int(unsafe.Sizeof(c.XXX_sizecache))
+	}
+	return cSize, "[ " + strings.Join(cList, ", ") + " ]"
+}
+
+func size(s string) int {
+	return len([]byte(s))
 }
 
 func (s *ProjectState) ListRulesForProject(ctx context.Context, req *api.ListRulesForProjectReq) (*api.ListRulesForProjectResp, error) {

--- a/components/authz-service/server/v2/rules_property_test.go
+++ b/components/authz-service/server/v2/rules_property_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 	"unicode"
-	"unsafe"
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/gen"
@@ -23,7 +22,7 @@ import (
 
 const (
 	idRegex        = "^[a-z0-9-]{1,64}$"
-	conditionLimit = 25 // avoid the grpc limit of 4194304
+	conditionLimit = 10 // help avoid the grpc limit of 4194304
 )
 
 type projectAndRuleReq struct {
@@ -175,63 +174,63 @@ func TestListRuleProperties(t *testing.T) {
 			createProjectAndRuleGen,
 		))
 
-	// properties.Property("staged rules are not reported as applied",
-	// 	prop.ForAll(
-	// 		func(reqs projectAndRuleReq) bool {
-	// 			defer testDB.Flush(t)
+	properties.Property("staged rules are not reported as applied",
+		prop.ForAll(
+			func(reqs projectAndRuleReq) bool {
+				defer testDB.Flush(t)
 
-	// 			reportRules(t, reqs.rules)
+				reportRules(t, reqs.rules)
 
-	// 			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
-	// 			if err != nil {
-	// 				return reportErrorAndYieldFalse(t, err)
-	// 			}
+				_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-	// 			reqs.rules, err = createRules(ctx, cl, reqs.rules)
-	// 			if err != nil {
-	// 				return reportErrorAndYieldFalse(t, err)
-	// 			}
+				reqs.rules, err = createRules(ctx, cl, reqs.rules)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-	// 			resp, err := cl.ListRules(ctx, &api.ListRulesReq{IncludeStaged: false})
-	// 			if err != nil {
-	// 				return reportErrorAndYieldFalse(t, err)
-	// 			}
+				resp, err := cl.ListRules(ctx, &api.ListRulesReq{IncludeStaged: false})
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-	// 			return len(resp.Rules) == 0
+				return len(resp.Rules) == 0
 
-	// 		},
-	// 		createProjectAndRuleGen,
-	// 	))
+			},
+			createProjectAndRuleGen,
+		))
 
-	// properties.Property("applied rules are reported as applied",
-	// 	prop.ForAll(
-	// 		func(reqs projectAndRuleReq) bool {
-	// 			defer testDB.Flush(t)
+	properties.Property("applied rules are reported as applied",
+		prop.ForAll(
+			func(reqs projectAndRuleReq) bool {
+				defer testDB.Flush(t)
 
-	// 			reportRules(t, reqs.rules)
+				reportRules(t, reqs.rules)
 
-	// 			_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
-	// 			if err != nil {
-	// 				return reportErrorAndYieldFalse(t, err)
-	// 			}
+				_, err := cl.CreateProject(ctx, &reqs.CreateProjectReq)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-	// 			reqs.rules, err = createRules(ctx, cl, reqs.rules)
-	// 			if err != nil {
-	// 				return reportErrorAndYieldFalse(t, err)
-	// 			}
+				reqs.rules, err = createRules(ctx, cl, reqs.rules)
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-	// 			cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
+				cl.ApplyRulesStart(ctx, &api.ApplyRulesStartReq{})
 
-	// 			resp, err := cl.ListRules(ctx, &api.ListRulesReq{})
-	// 			if err != nil {
-	// 				return reportErrorAndYieldFalse(t, err)
-	// 			}
+				resp, err := cl.ListRules(ctx, &api.ListRulesReq{})
+				if err != nil {
+					return reportErrorAndYieldFalse(t, err)
+				}
 
-	// 			return rulesMatch(reqs.rules, resp)
+				return rulesMatch(reqs.rules, resp)
 
-	// 		},
-	// 		createProjectAndRuleGen,
-	// 	))
+			},
+			createProjectAndRuleGen,
+		))
 
 	properties.TestingRun(t)
 }
@@ -469,8 +468,8 @@ func TestDeleteRuleProperties(t *testing.T) {
 
 func getGopterParams(seed int64) *gopter.Properties {
 	params := gopter.DefaultTestParametersWithSeed(seed)
-	params.MinSize = 1 // otherwise, we'd get zero-length "conditions" slices
-	// params.MaxSize = 25            // otherwise, we may exceed GRPC capacity in ListRules
+	params.MinSize = 1             // otherwise, we'd get zero-length "conditions" slices
+	params.MaxSize = 25            // otherwise, we may exceed GRPC capacity in ListRules
 	params.MinSuccessfulTests = 25 // reduced from default 100 to avoid timeouts in CI!
 	return gopter.NewProperties(params)
 }
@@ -634,42 +633,23 @@ func createRules(ctx context.Context, cl api.ProjectsClient, rules []api.CreateR
 
 func reportRules(t *testing.T, rules []api.CreateRuleReq) {
 	t.Helper()
-	outputs := make([]string, len(rules))
-	for i, rule := range rules {
-		outputs[i] = fmt.Sprintf("%d", len(rule.Conditions))
-	}
-	t.Logf("%d rules with condition counts: %s", len(rules), strings.Join(outputs, ", "))
-	dumpRules(t, rules)
-}
-
-func dumpRules(t *testing.T, rules []api.CreateRuleReq) {
-	// we have the request object but we want to measure the response object,
-	// so adding in deleted (bool) and status ("applied|staged")
-	// The ListRulesResp object also contains 3 more fields:
-	// XXX_NoUnkeyedLiteral, XXX_unrecognized, XXX_sizecache. The last one is 4 bytes but not sure on the first two.
-	// Those unknown bits are greatly exacerbated in that each rule in the payload also has those 3 fields,
-	// and each condition of each rule does also!
-	for _, r := range rules {
-		t.Logf("rule size in one swoop = %d", r.XXX_Size())
-		cSize, cSizeStr := conditionSize(r.Conditions)
-		t.Logf("Rule size |%d|: %d+%d+%d+%d+%s+%d+%d",
-			size(r.Id)+size(r.ProjectId)+size(r.Name)+int(unsafe.Sizeof(r.Type))+cSize+int(unsafe.Sizeof(true))+size("applied"),
-			size(r.Id), size(r.ProjectId), size(r.Name), unsafe.Sizeof(r.Type), cSizeStr, unsafe.Sizeof(true), size("applied"))
-	}
-}
-
-func conditionSize(conditions []*api.Condition) (int, string) {
-	var cList []string
-	cSize := 0
-	for _, c := range conditions {
-		vSize := 0
-		for _, v := range c.Values {
-			vSize += size(v)
+	condCount := 0
+	valueCount := 0
+	ruleBytes := 0
+	valueBytes := 0
+	for _, rule := range rules {
+		condCount += len(rule.Conditions)
+		ruleBytes += rule.XXX_Size()
+		for _, c := range rule.Conditions {
+			valueCount += len(c.Values)
+			for _, v := range c.Values {
+				valueBytes += size(v)
+			}
 		}
-		cList = append(cList, fmt.Sprintf("{%d+%d+%d}", unsafe.Sizeof(c.Attribute), unsafe.Sizeof(c.Operator), vSize))
-		cSize += int(unsafe.Sizeof(c.Attribute)) + int(unsafe.Sizeof(c.Operator)) + vSize
 	}
-	return cSize, "[ " + strings.Join(cList, ", ") + " ]"
+	t.Logf("===> %d rules, bytes=%d, avg/rule=%d, %d conditions, avg/rule=%d, %d values, avg/rule=%d, avg/cond=%d, bytes=%d, avg/value=%d",
+		len(rules), ruleBytes, (ruleBytes / len(rules)),
+		condCount, condCount/len(rules), valueCount, valueCount/len(rules), valueCount/condCount, valueBytes, valueBytes/valueCount)
 }
 
 func size(s string) int {

--- a/components/authz-service/server/v2/rules_property_test.go
+++ b/components/authz-service/server/v2/rules_property_test.go
@@ -650,6 +650,7 @@ func dumpRules(t *testing.T, rules []api.CreateRuleReq) {
 	// Those unknown bits are greatly exacerbated in that each rule in the payload also has those 3 fields,
 	// and each condition of each rule does also!
 	for _, r := range rules {
+		t.Logf("rule size in one swoop = %d", r.XXX_Size())
 		cSize, cSizeStr := conditionSize(r.Conditions)
 		t.Logf("Rule size |%d|: %d+%d+%d+%d+%s+%d+%d",
 			size(r.Id)+size(r.ProjectId)+size(r.Name)+int(unsafe.Sizeof(r.Type))+cSize+int(unsafe.Sizeof(true))+size("applied"),


### PR DESCRIPTION
### :nut_and_bolt: Description

This is exploratory code to attempt to measure the size of GRPC messages from ListRules.
I started by adding `dumpRules` into rules_property_test.go, an imperfect place to do it, but it provides the convenience of being able to show output to the console during a test run. I have the request object there, when in fact I want to measure the size of a response object. So I just interpolated the couple missing fields, `Deleted` and `Status`. That essentially provides all the "user facing" fields of the response object. Took a little bit of figuring out on how to size various things in Go. There is a handy `SizeOf` method in the `unsafe` library but that does not really do what one might think; it returns the size of the container rather than its contents, so that was only useful for certain data types. String-length was useful for strings, but only after converting number-of-characters into number-of-bytes...

From that I observed that data on the order of 150KB by my computation generated a GRPC message exceeding the 4MB (from 4MB to 6MB in my several trials). That means that the actual "user facing" data was roughly only about 2% to 4% of the GRPC message size!!

OK, so that means that either (a) GRPC itself is inflating the message size, or (b) the "non-user-facing" fields are causing the inflation. By "non-user-facing" fields I mean the three fields you find in most every protobuf-generated type: `XXX_NoUnkeyedLiteral`, `XXX_unrecognized`, and `XXX_sizecache`.
Those appear in the top level `ListRulesResp` object, again in every rule within `ListRulesResp.Rules[*]` and again in every condition in `ListRulesResp.Rules[*].Conditions[*]`.

I tried to debug through the vendor code for GRPC to try to see what was in an actual message, by setting a breakpoint here (vendor/google.golang.org/grpc/rpc_util.go::L522) because that is where my error message was generated, ("grpc: received message larger than max (4974254 vs. 4194304)"). But I did not see anything immediately useful going through the available stack trace.

---

... After a fresh look sometime later, here is the wrap-up for this. First, here is a slice of the raw data from a gopter test run:
```
===> 1 rules, bytes=32, avg/rule=32, 1 conditions, avg/rule=1, 1 values, avg/rule=1, avg/cond=1, bytes=3, avg/value=3
===> 3 rules, bytes=128, avg/rule=42, 3 conditions, avg/rule=1, 5 values, avg/rule=1, avg/cond=1, bytes=34, avg/value=6
===> 1 rules, bytes=246, avg/rule=246, 3 conditions, avg/rule=3, 11 values, avg/rule=11, avg/cond=3, bytes=177, avg/value=16
===> 6 rules, bytes=6112, avg/rule=1018, 39 conditions, avg/rule=6, 261 values, avg/rule=43, avg/cond=6, bytes=5255, avg/value=20
===> 5 rules, bytes=6036, avg/rule=1207, 26 conditions, avg/rule=5, 202 values, avg/rule=40, avg/cond=7, bytes=5318, avg/value=26
===> 13 rules, bytes=44344, avg/rule=3411, 125 conditions, avg/rule=9, 1216 values, avg/rule=93, avg/cond=9, bytes=40830, avg/value=33
===> 16 rules, bytes=59634, avg/rule=3727, 109 conditions, avg/rule=6, 1404 values, avg/rule=87, avg/cond=12, bytes=55431, avg/value=39
===> 22 rules, bytes=194925, avg/rule=8860, 268 conditions, avg/rule=12, 3851 values, avg/rule=175, avg/cond=14, bytes=184885, avg/value=48
===> 20 rules, bytes=237034, avg/rule=11851, 267 conditions, avg/rule=13, 4164 values, avg/rule=208, avg/cond=15, bytes=226336, avg/value=54
===> 31 rules, bytes=584878, avg/rule=18867, 526 conditions, avg/rule=16, 9211 values, avg/rule=297, avg/cond=17, bytes=562543, avg/value=61
===> 13 rules, bytes=298606, avg/rule=22969, 238 conditions, avg/rule=18, 4232 values, avg/rule=325, avg/cond=17, bytes=288206, avg/value=68
===> 30 rules, bytes=829653, avg/rule=27655, 478 conditions, avg/rule=15, 10656 values, avg/rule=355, avg/cond=22, bytes=802531, avg/value=75
===> 18 rules, bytes=729259, avg/rule=40514, 371 conditions, avg/rule=20, 8691 values, avg/rule=482, avg/cond=23, bytes=707122, avg/value=81
===> 34 rules, bytes=1636541, avg/rule=48133, 710 conditions, avg/rule=20, 17987 values, avg/rule=529, avg/cond=25, bytes=1589370, avg/value=88
===> 27 rules, bytes=1531491, avg/rule=56721, 545 conditions, avg/rule=20, 15736 values, avg/rule=582, avg/cond=28, bytes=1490548, avg/value=94
===> 25 rules, bytes=1397342, avg/rule=55893, 430 conditions, avg/rule=17, 13438 values, avg/rule=537, avg/cond=31, bytes=1360889, avg/value=101
===> 26 rules, bytes=1751082, avg/rule=67349, 483 conditions, avg/rule=18, 15814 values, avg/rule=608, avg/cond=32, bytes=1708381, avg/value=108
===> 14 rules, bytes=1199321, avg/rule=85665, 303 conditions, avg/rule=21, 10130 values, avg/rule=723, avg/cond=33, bytes=1171917, avg/value=115
===> 36 rules, bytes=3369199, avg/rule=93588, 761 conditions, avg/rule=21, 27008 values, avg/rule=750, avg/cond=35, bytes=3294518, avg/value=121
===> 17 rules, bytes=1480524, avg/rule=87089, 297 conditions, avg/rule=17, 11152 values, avg/rule=656, avg/cond=37, bytes=1448697, avg/value=129
===> 65 rules, bytes=7458526, avg/rule=114746, 1360 conditions, avg/rule=20, 53740 values, avg/rule=826, avg/cond=39, bytes=7308477, avg/value=135
```

Each line represents a single gopter test. The fourth line, for example, generated 6 rules with a total of 6,112 bytes. Those 6 rules had 39 conditions and 261 values amongst those 39 conditions. Because I determined it is these condition values taking up most all of the space, there are more specs on them. On average there are 43 values per rule and 6 values per condition. And all the condition values together take up 5,255 bytes (86% of the total payload), averaging 20 bytes per value.

The last row is the one that exceeded the GRPC capacity. Only from that one--because the error message gives me the info--can we compare the size of the accounted-for-data with the size that the GRPC error is complaining about. In this test run, you'll see there are 65 rules with a total of 7,458,526 bytes. GRPC reported 7,459,305, a lot less than 1% difference. (The huge differences I thought I was seeing when last reported was, well, PEBKAC.)

Observations:
(1) I think it is safe to say there is no unaccounted for overhead in the GRPC layer.
(2) Gopter's `MaxSize` parameter is for slices and maps, not for strings. It could get some lengthy strings in there and there is no way to rein that in that I can see.
(3) It takes a whole heck of a lot of rules, conditions and particularly condition _values_ to exceed the 4MB GRPC limit, so I think it is also safe to say that this is not a problem.