### PR TITLE
scripts/changed_components.rb: fix pkg_deps call

### DIFF
--- a/scripts/changed_components.rb
+++ b/scripts/changed_components.rb
@@ -14,8 +14,7 @@ class Hash
 end
 
 def get_hab_deps(source_dir)
-  plan_path = "#{source_dir}/habitat/plan.sh"
-  depString = `bash -c '. #{plan_path}; echo ${pkg_deps[*]}'`
+  depString = `bash -c 'cd ${source_dir}; PLAN_CONTEXT=habitat . habitat/plan.sh; echo ${pkg_deps[*]}'`
   depString.lines.last.split
 end
 


### PR DESCRIPTION
It didn't matter, but when running this on master, the pkg_build_deps
construction would fail for anything that is looking at
`$PLAN_CONTEXT/...` etc.

    cat: /../.nvmrc: No such file or directory
    core/curl core/coreutils chef/mlsa core/nginx core/jq-static

It didn't matter because the script in question doesn't care for build
deps/
