### PR TITLE
automate-cs-nginx: try different versions

### DIFF
--- a/components/automate-cs-nginx/habitat/plan.sh
+++ b/components/automate-cs-nginx/habitat/plan.sh
@@ -9,7 +9,7 @@ pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=('Chef-MLSA')
 # FIXME: pin the chef server version and use it in the pkg_deps when we can
 # follow a stable channel
-pkg_version="12.19.31"
+pkg_version="13.0.19"
 pkg_deps=(
   chef/mlsa
   core/curl
@@ -17,8 +17,8 @@ pkg_deps=(
   core/ruby/2.5.3/20190305212319
   # FIXME: We're pinned to specific versions of unstable packages
   # until they have a stable pipeline we can pin to.
-  "${vendor_origin}/chef-server-nginx/12.19.31/20190307133720"
-  "${vendor_origin}/chef-server-ctl/12.19.31/20190307134716"
+  "${vendor_origin}/chef-server-nginx/13.0.19/20190709121113"
+  "${vendor_origin}/chef-server-ctl/13.0.19/20190709121113"
 )
 
 pkg_bin_dirs=(bin)

--- a/components/automate-workflow-nginx/habitat/plan.sh
+++ b/components/automate-workflow-nginx/habitat/plan.sh
@@ -10,12 +10,7 @@ pkg_deps=(
   chef/openresty-noroot
   chef/mlsa
   core/bash
-  # TODO(ssd) 2019-07-03: PIN PIN PIN
-  #
-  # This is pinned until chef/openresty-noroot is rebuilt, at which
-  # point this pin will break our build again and we'll need to remove
-  # it.
-  core/curl/7.63.0/20190201004909
+  core/curl
   core/coreutils
   "${vendor_origin}/automate-workflow-web"
 )


### PR DESCRIPTION
Trying to rebuild the world in #810, we've noticed that there's a transitive dependency issue around `core/curl`. This is one attempt to resolve it; after having built new CS packages via https://buildkite.com/chef/chef-chef-server-master-habitat-build/builds/32#49c9309d-4aa6-4fbc-ae88-5cdbc26dd8a4