### PR TITLE
UI-371-node-lifecycle-bug Signed-Off-By: Tara Black <tblack@chef.io>

### DIFF
--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
@@ -33,9 +33,9 @@
             </chef-td>
             <chef-td class="input">
               <chef-select ngDefaultControl formControlName="unit" (change)="patchUnitValue(missingNodesForm, $event)">
-                <chef-option value='m' [selected]="isUnitValue(missingNodesForm,'Minutes')">Minutes</chef-option>
-                <chef-option value='h' [selected]="isUnitValue(missingNodesForm,'Hours')">Hours</chef-option>
-                <chef-option value='d' [selected]="isUnitValue(missingNodesForm,'Days')">Days</chef-option>
+                <chef-option value='m' [selected]="isUnitValue(missingNodesForm,'m')">Minutes</chef-option>
+                <chef-option value='h' [selected]="isUnitValue(missingNodesForm,'h')">Hours</chef-option>
+                <chef-option value='d' [selected]="isUnitValue(missingNodesForm,'d')">Days</chef-option>
               </chef-select>
             </chef-td>
           </chef-tr>
@@ -54,9 +54,9 @@
             </chef-td>
             <chef-td class="input">
               <chef-select ngDefaultControl formControlName="unit" (change)="patchUnitValue(deleteMissingNodesForm, $event)">
-                <chef-option value='m' [selected]="isUnitValue(missingNodesForm,'Minutes')">Minutes</chef-option>
-                <chef-option value='h' [selected]="isUnitValue(missingNodesForm,'Hours')">Hours</chef-option>
-                <chef-option value='d' [selected]="isUnitValue(missingNodesForm,'Days')">Days</chef-option>
+                <chef-option value='m' [selected]="isUnitValue(deleteMissingNodesForm,'m')">Minutes</chef-option>
+                <chef-option value='h' [selected]="isUnitValue(deleteMissingNodesForm,'h')">Hours</chef-option>
+                <chef-option value='d' [selected]="isUnitValue(deleteMissingNodesForm,'d')">Days</chef-option>
               </chef-select>
             </chef-td>
           </chef-tr>

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
@@ -33,9 +33,9 @@
             </chef-td>
             <chef-td class="input">
               <chef-select ngDefaultControl formControlName="unit" (change)="patchUnitValue(missingNodesForm, $event)">
-                <chef-option value='m'>Minutes</chef-option>
-                <chef-option value='h'>Hours</chef-option>
-                <chef-option value='d' selected>Days</chef-option>
+                <chef-option value='m' [selected]="isUnitValue(missingNodesForm,'Minutes')">Minutes</chef-option>
+                <chef-option value='h' [selected]="isUnitValue(missingNodesForm,'Hours')">Hours</chef-option>
+                <chef-option value='d' [selected]="isUnitValue(missingNodesForm,'Days')">Days</chef-option>
               </chef-select>
             </chef-td>
           </chef-tr>
@@ -54,9 +54,9 @@
             </chef-td>
             <chef-td class="input">
               <chef-select ngDefaultControl formControlName="unit" (change)="patchUnitValue(deleteMissingNodesForm, $event)">
-                <chef-option value='m'>Minutes</chef-option>
-                <chef-option value='h'>Hours</chef-option>
-                <chef-option value='d' selected>Days</chef-option>
+                <chef-option value='m' [selected]="isUnitValue(missingNodesForm,'Minutes')">Minutes</chef-option>
+                <chef-option value='h' [selected]="isUnitValue(missingNodesForm,'Hours')">Hours</chef-option>
+                <chef-option value='d' [selected]="isUnitValue(missingNodesForm,'Days')">Days</chef-option>
               </chef-select>
             </chef-td>
           </chef-tr>

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
@@ -115,6 +115,12 @@ export class AutomateSettingsComponent implements OnInit {
     form.controls['unit'].setValue(event.target.value);
   }
 
+  // isUnitValue is the workaround for the chef-select molecule since it is not
+  // a select field we need to check value to use inside FormGroup
+  public isUnitValue(form, unit: string) {
+    return form.controls['unit'].value === unit;
+  }
+
   // patchDisableValue is the workaround for the chef-checkbox molecule since it is not
   // an input annotation we need to patch the value inside the FormGroup
   public patchDisableValue(form, checked: boolean) {


### PR DESCRIPTION
### :nut_and_bolt: Description
An issue in the UI with the time type options being set back to the original state on refresh.
The config manager on this has changed recently
It looks like it is a problem on the frontend
The backend is updating but the frontend is not showing the change

<img width="1673" alt="Screen Shot 2019-07-09 at 10 40 09 AM" src="https://user-images.githubusercontent.com/4108100/60902886-f9d59000-a235-11e9-8359-701c1c8f8891.png">

### :+1: Definition of Done
Select boxes for units should show selected unit values on refresh

### :athletic_shoe: Repro Steps
Navigate to Settings > Node Lifecycle
Change any of the time type options (minutes, hours, days)
Apply Changes
Refresh the page
Notice that the time type options reset back to what they were

### :chains: Related Resources
https://github.com/chef/automate/issues/371

### :white_check_mark: Checklist
- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
