### PR TITLE
Fix expeditor swagger syncing

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -123,7 +123,7 @@ subscriptions:
       - bash:.expeditor/generate-automate-api-docs.sh:
           post_commit: false
           only_if_modified:
-            - /api/external/**/*.swagger.json
+            - api/external/**/*.swagger.json
             - components/automate-gateway/api/**/*.swagger.json
       - trigger_pipeline:habitat/build:
           post_commit: true

--- a/components/automate-chef-io/data/docs/api_chef_automate/applications/applications.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/applications/applications.swagger.json
@@ -211,6 +211,22 @@
         ]
       }
     },
+    "/beta/applications/stats": {
+      "get": {
+        "operationId": "GetServicesStats",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/applicationsServicesStatsRes"
+            }
+          }
+        },
+        "tags": [
+          "ApplicationsService"
+        ]
+      }
+    },
     "/beta/applications/version": {
       "get": {
         "operationId": "GetVersion",
@@ -260,9 +276,11 @@
         "OK",
         "WARNING",
         "CRITICAL",
-        "UNKNOWN"
+        "UNKNOWN",
+        "NONE"
       ],
       "default": "OK",
+      "description": "- NONE: The representation of NO health check status\nTODO @afiune how much effort would be to change\nthe OK enum to be NONE",
       "title": "The HealthStatus enum matches the habitat implementation for health-check status:\n=\u003e https://www.habitat.sh/docs/reference/#health-check"
     },
     "applicationsService": {
@@ -296,6 +314,12 @@
           "type": "string"
         },
         "site": {
+          "type": "string"
+        },
+        "previous_health_check": {
+          "$ref": "#/definitions/applicationsHealthStatus"
+        },
+        "current_health_since": {
           "type": "string"
         }
       }
@@ -384,6 +408,23 @@
           "items": {
             "$ref": "#/definitions/applicationsService"
           }
+        }
+      }
+    },
+    "applicationsServicesStatsRes": {
+      "type": "object",
+      "properties": {
+        "total_service_groups": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_services": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_supervisors": {
+          "type": "integer",
+          "format": "int32"
         }
       }
     },


### PR DESCRIPTION
I recently made a change to the script expeditor runs when swagger files are updated (https://github.com/chef/automate/pull/711). The most recent time that script was run was June 28th (https://buildkite.com/chef-oss/chef-automate-master-verify/builds/2629). A PR was merged July 3rd that I would have expected to trigger this script and didn't (https://github.com/chef/automate/pull/713). I think I screwed up by including a leading `/` in the path of the files to monitor for changes in the expeditor config.