### PR TITLE
[CI/nightly] Build ALL components during nightly build

### DIFF
--- a/.expeditor/nightly.pipeline.yml
+++ b/.expeditor/nightly.pipeline.yml
@@ -11,10 +11,15 @@ steps:
       - scripts/verify_build.sh
     timeout_in_minutes: 45
     env:
+      BUILD_ALL: true
       ALLOW_LOCAL_PACKAGES: true
       HAB_STUDIO_SUP: false
       HAB_NONINTERACTIVE: true
     expeditor:
+      secrets:
+        HAB_STUDIO_SECRET_GITHUB_TOKEN:
+          account: github/chef-ci
+          field: token
       executor:
         linux:
           privileged: true

--- a/.studio/common
+++ b/.studio/common
@@ -227,22 +227,6 @@ function rebuild() {
   return $err
 }
 
-document "build_all" <<DOC
-  Build every hab package in components/
-DOC
-function build_all() {
-  log_line "Building all components..."
-  for d in /src/components/*/; do
-    [[ -f "$d/habitat/plan.sh" ]] || continue # skip what can't be built
-    if [[ "$d" = "/src/components/automate-chef-io" ]] && [[ -n "$AUTOMATE_OSS_BUILD" ]]; then
-        log_line "Skipping build of $d since AUTOMATE_OSS_BUILD is set."
-        continue
-    fi
-    log_line "Building $d"
-    build "$d" || return 1
-  done;
-}
-
 function verify_component() {
   if [[ "$1" == "deployment-service" || "$1" == "api" || "$1" == "config" ]]; then
     return 0

--- a/scripts/verify_build.sh
+++ b/scripts/verify_build.sh
@@ -36,21 +36,39 @@ curl "https://packages.chef.io/manifests/dev/automate/latest.json" > results/dev
 curl "https://packages.chef.io/manifests/current/automate/latest.json" > results/current.json
 curl "https://packages.chef.io/manifests/acceptance/automate/latest.json" > results/acceptance.json
 
-mapfile -t changed_components < <(./scripts/changed_components.rb)
-if [[ ${#changed_components[@]} -ne 0 ]]; then
-    cat << EOF | buildkite-agent annotate --style "info"
+declare -a changed_components
 
+if [[ "$BUILD_ALL" = "true" ]]; then
+    for d in components/*/; do
+        # Skip the devproxy as you can't build it next to the real automate-ui safely.
+        if [[ "$d" == "components/automate-ui-devproxy/" ]]; then
+            continue
+        fi
+        if [[ -f "$d/habitat/plan.sh" ]]; then
+            changed_components+=("$d")
+        fi
+    done
+
+    buildkite-agent annotate --style "info" << EOF
+This change rebuilds ALL components because BUILD_ALL=$BUILD_ALL:
+$(printf '* %s\n' "${changed_components[@]}")
+EOF
+
+else
+    mapfile -t changed_components < <(./scripts/changed_components.rb)
+    if [[ ${#changed_components[@]} -ne 0 ]]; then
+        buildkite-agent annotate --style "info" << EOF
 This change rebuilds the following components:
 $(printf '* %s\n' "${changed_components[@]}")
 EOF
-else
-    buildkite-agent annotate --style "info" "This change rebuilds no components."
+    else
+        buildkite-agent annotate --style "info" "This change rebuilds no components."
+    fi
 fi
 
 mapfile -t modified_sql_files < <(git diff --name-status "$(./scripts/git_difference_expression.rb)" | awk '/^[RMD][0-9]*.*\.sql/{ print $2 }')
 if [[ ${#modified_sql_files[@]} -ne 0 ]]; then
-    cat << EOF | buildkite-agent annotate --append --style "warning"
-
+    buildkite-agent annotate --append --style "warning" << EOF
 This change modifies the following SQL files:
 $(printf '* %s\n' "${modified_sql_files[@]}")
 EOF


### PR DESCRIPTION
We periodically find that components no longer build because of
dependency changes. We typically find out that these components don't
build when developers are doing cleanup or maintenance work such as
updating dependencies. Only finding build problems during such tasks
increases the cost of starting such tasks and means that we discover
the problems long after the change that produced the problem, making
it harder to debug.

Currently, the nightly builds only rebuild whatever changed in the
latest commit to master, using the same changed components logic that
the rest of our verify pipelines use.

This changes the nightlies to build all components, which should allow
us to discover build issues more promptly, divorced from any
particular change.

Signed-off-by: Steven Danna <steve@chef.io>

### :nut_and_bolt: Description

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
