### PR TITLE
automate-gateway: make unknown data cause an error

### DIFF
--- a/components/automate-gateway/gateway/services.go
+++ b/components/automate-gateway/gateway/services.go
@@ -331,6 +331,10 @@ func muxFromRegisterMap(grpcURI string, dopts []grpc.DialOption, localEndpoints 
 	gwmux := runtime.NewServeMux(opts...)
 	ctx := context.Background()
 
+	// Don't just ignore request JSON fields we cannot map to protobuf message
+	// fields.
+	runtime.DisallowUnknownFields()
+
 	// register each endpoint with runtime.ServeMux
 	for ep, register := range localEndpoints {
 		log.Infof("Register %s to REST Gateway %s", ep, grpcURI)

--- a/inspec/a2-api-integration/controls/authz_api.rb
+++ b/inspec/a2-api-integration/controls/authz_api.rb
@@ -61,7 +61,6 @@ control 'authz-api-crud-1' do
       hash[:action]   = policy_action   unless policy_action.nil?
       hash[:subjects] = policy_subjects unless policy_subjects.nil?
       hash[:resource] = policy_resource unless policy_resource.nil?
-      hash[:effect]   = policy_effect   unless policy_effect.nil?
       hash
     end
 
@@ -73,18 +72,13 @@ control 'authz-api-crud-1' do
       "#{TEST_POLICY_ACTION_PREFIX}#{SecureRandom.hex.tr('0-9', '')}"
     end
 
-    let(:policy_subjects) {
-        ["team:local:team1", "team:local:team2"]
-    }
+    let(:policy_subjects) do
+      ["team:local:team1", "team:local:team2"]
+    end
 
-    let(:policy_resource) {
-        "test:resource"
-    }
-
-    # all policies are `allow`
-    let(:policy_effect) {
-        "allow"
-    }
+    let(:policy_resource) do
+      "test:resource"
+    end
 
     let(:filtered_list) do
       filtered_policies = []
@@ -102,32 +96,32 @@ control 'authz-api-crud-1' do
       "#{TEST_POLICY_ACTION_PREFIX}#{SecureRandom.hex.tr('0-9', '')}"
     end
 
-    let(:policy_subjects2) {
-        ["team:local:team3", "team:local:team4"]
-    }
+    let(:policy_subjects2) do
+      ["team:local:team3", "team:local:team4"]
+    end
 
-    let(:policy_resource2) {
-        "test:resource2"
-    }
+    let(:policy_resource2) do
+      "test:resource2"
+    end
 
     let(:create_request2) do
       automate_api_request(
         '/api/v0/auth/policies',
         http_method: 'POST',
         request_body: {
-          "action": policy_action2,
-          "subjects": policy_subjects2,
-          "resource": policy_resource2,
+          action: policy_action2,
+          subjects: policy_subjects2,
+          resource: policy_resource2,
         }.to_json
       )
     end
 
     describe "when creating a policy" do
       shared_examples "when a field is missing" do
-          it "fails with a 400" do
-            expect(create_request.http_status).to eq(400)
-            expect(create_request.parsed_response_body[:error] || "").not_to eq("")
-          end
+        it "fails with a 400" do
+          expect(create_request.http_status).to eq 400
+          expect(create_request.parsed_response_body[:error] || "").not_to eq("")
+        end
       end
 
       context "when the action field is not specified" do
@@ -136,9 +130,9 @@ control 'authz-api-crud-1' do
       end
 
       context "when the action field is empty" do
-          let(:policy_action) { '' }
-          include_examples "when a field is missing"
-        end
+        let(:policy_action) { '' }
+        include_examples "when a field is missing"
+      end
 
       context "when the subjects field is not specified" do
         let(:policy_subjects) { nil }
@@ -166,9 +160,10 @@ control 'authz-api-crud-1' do
           expect(create_request.parsed_response_body[:action]).to eq(policy_action)
           expect(create_request.parsed_response_body[:subjects]).to eq(policy_subjects)
           expect(create_request.parsed_response_body[:resource]).to eq(policy_resource)
-          expect(create_request.parsed_response_body[:effect]).to eq(policy_effect)
+          expect(create_request.parsed_response_body[:effect]).to eq("allow")
           expect(create_request.parsed_response_body[:id]).to_not be_nil
           expect(create_request.parsed_response_body[:created_at]).to_not be_nil
+          expect(create_request.parsed_response_body[:updated_at]).to be_nil
         end
       end
     end
@@ -192,7 +187,7 @@ control 'authz-api-crud-1' do
           expect(filtered_list[0][:action]).to eq(policy_action)
           expect(filtered_list[0][:subjects]).to eq(policy_subjects)
           expect(filtered_list[0][:resource]).to eq(policy_resource)
-          expect(filtered_list[0][:effect]).to eq(policy_effect)
+          expect(filtered_list[0][:effect]).to eq("allow")
           expect(filtered_list[0][:id]).to_not be_nil
           expect(filtered_list[0][:created_at]).to_not be_nil
         end
@@ -208,23 +203,25 @@ control 'authz-api-crud-1' do
           expect(list_request.http_status).to eq(200)
           expect(filtered_list.length).to eq(2)
 
-          expect(filtered_list.find { |policy|
+          expect(filtered_list.any? { |policy|
             policy[:action] == policy_action &&
             policy[:subjects] == policy_subjects &&
             policy[:resource] == policy_resource &&
-            policy[:effect] == policy_effect &&
+            policy[:effect] == "allow" &&
             !policy[:id].nil? &&
-            !policy[:created_at].nil?
-          }).to_not be_nil
+            !policy[:created_at].nil? &&
+            policy[:updated_at].nil?
+          }).to be(true)
 
-          expect(filtered_list.find { |policy|
+          expect(filtered_list.any? { |policy|
             policy[:action] == policy_action2 &&
             policy[:subjects] == policy_subjects2 &&
             policy[:resource] == policy_resource2 &&
-            policy[:effect] == policy_effect &&
+            policy[:effect] == "allow" &&
             !policy[:id].nil? &&
-            !policy[:created_at].nil?
-          }).to_not be_nil
+            !policy[:created_at].nil? &&
+            policy[:updated_at].nil?
+          }).to be(true)
         end
       end
     end
@@ -283,7 +280,7 @@ control 'authz-api-crud-1' do
             expect(delete_request.parsed_response_body[:action]).to eq(policy_action)
             expect(delete_request.parsed_response_body[:subjects]).to eq(policy_subjects)
             expect(delete_request.parsed_response_body[:resource]).to eq(policy_resource)
-            expect(delete_request.parsed_response_body[:effect]).to eq(policy_effect)
+            expect(delete_request.parsed_response_body[:effect]).to eq("allow")
             expect(delete_request.parsed_response_body[:id]).to_not be_nil
             expect(delete_request.parsed_response_body[:created_at]).to_not be_nil
             expect(filtered_list.length).to eq(1)

--- a/inspec/a2-api-integration/controls/cfgmgmt.rb
+++ b/inspec/a2-api-integration/controls/cfgmgmt.rb
@@ -64,6 +64,7 @@ control 'config-mgmt-ccr-1' do
         end
 
         it 'should ingest the data successfully' do
+          expect(api_request.parsed_response_body).to eq({})
           expect(api_request.http_status).to eq 200
         end
       end

--- a/inspec/a2-api-integration/controls/iam_v2.rb
+++ b/inspec/a2-api-integration/controls/iam_v2.rb
@@ -744,7 +744,6 @@ EOF
             request_body: {
               name: updatedName,
               password: "newpassword",
-              previous_password: "wrongagain"
             }.to_json
           )
           expect(resp.http_status).to eq 404

--- a/inspec/a2-api-integration/controls/iam_v2.rb
+++ b/inspec/a2-api-integration/controls/iam_v2.rb
@@ -102,6 +102,28 @@ EOF
       expect(resp.http_status).to eq 200
     end
 
+    # Note: all endpoints provided by grpc-gateway satisfy this. We're using
+    # this specific test case as a canary.
+    it "returns an error if there's superfluous data in the request body" do
+      id = "inspec-test-policy-0-#{Time.now.utc.to_i}"
+      resp = automate_api_request("/apis/iam/v2beta/policies",
+        http_method: 'POST',
+        request_body: {
+          id: id,
+          foo: 'bar', # <--- that's the unknown field
+          name: 'Name',
+          members: ["user:local:member"],
+          statements: [
+            {
+              effect: "DENY",
+              role: "test"
+            },
+          ]
+        }.to_json()
+      )
+      expect(resp.http_status).to eq 400
+    end
+
     it "CREATE and DELETE policy properly respond to happy path inputs" do
       resp = automate_api_request("/apis/iam/v2beta/policies")
       expect(resp.http_status).to eq 200

--- a/inspec/a2-iam-v2-integration/controls/base.rb
+++ b/inspec/a2-iam-v2-integration/controls/base.rb
@@ -134,13 +134,13 @@ EOF
     # compliance:profiles for client calls should be permitted by default
     describe '/api/v0/compliance/profiles/search as client' do
       it "api/v0/compliance/profiles/search returns the correct response code for client" do
-        expect(
-          automate_client_api_request(
+        resp = automate_client_api_request(
             "/api/v0/compliance/profiles/search",
             TEST_TOKEN_V2,
             http_method: 'POST'
-          ).http_status
-        ).to eq(200)
+        )
+        expect(resp.parsed_response_body).to eq({}) # XXX just want to see the error
+        expect(resp.http_status).to eq(200)
       end
     end
 
@@ -151,13 +151,13 @@ EOF
       ).each do |url|
         { 'GET': 200, 'POST': 400 }.each do |method, status|
           it "#{method} #{url} returns the correct response code for client" do
-            expect(
-              automate_client_api_request(
+            resp = automate_client_api_request(
                 url,
                 TEST_TOKEN_V2,
                 http_method: method,
-              ).http_status
-            ).to eq(status)
+            )
+            expect(resp.parsed_response_body).to eq({}) # XXX just want to see the error
+            expect(resp.http_status).to eq(status)
           end
         end
       end

--- a/inspec/a2-iam-v2-integration/controls/base.rb
+++ b/inspec/a2-iam-v2-integration/controls/base.rb
@@ -87,45 +87,45 @@ EOF
   ]
 
   NON_ADMIN_USERNAME_V2 = 'inspec_test_non_admin_with_iam_v2'
+  TEST_TOKEN_ID_V2 = 'inspec_test_token_with_iam_v2'
 
   DEFAULT_PROJECT_ID = "default"
 
   describe 'AuthZ access control' do
     before(:all) do
       create_non_admin_request = automate_api_request(
-        '/api/v0/auth/users',
+        '/apis/iam/v2beta/users',
         http_method: 'POST',
         request_body: {
-          'name': NON_ADMIN_USERNAME_V2,
-          'username': NON_ADMIN_USERNAME_V2,
-          'password': ENV['AUTOMATE_API_DEFAULT_PASSWORD'] || 'chefautomate',
+          id: NON_ADMIN_USERNAME_V2,
+          name: NON_ADMIN_USERNAME_V2,
+          password: ENV['AUTOMATE_API_DEFAULT_PASSWORD'] || 'chefautomate',
         }.to_json
       )
       expect(create_non_admin_request.http_status.to_s).to match(/200|409/)
 
       test_token_request = automate_api_request(
-        '/api/v0/auth/tokens',
+        '/apis/iam/v2beta/tokens',
         http_method: 'POST',
         request_body: {
-          'description': 'inspec_test_token',
-          'active': true
+          id: TEST_TOKEN_ID_V2,
+          description: 'inspec_test_token',
         }.to_json
       )
       TEST_TOKEN_V2 = test_token_request.parsed_response_body[:value]
-      TEST_TOKEN_ID_V2= test_token_request.parsed_response_body[:id]
 
       expect(test_token_request.http_status).to eq(200)
     end
 
     after(:all) do
       delete_non_admin_request = automate_api_request(
-        "/api/v0/auth/users/#{NON_ADMIN_USERNAME_V2}",
+        "/apis/iam/v2beta/users/#{NON_ADMIN_USERNAME_V2}",
         http_method: 'DELETE',
       )
       expect(delete_non_admin_request.http_status.to_s).to match(/200|404/)
 
       delete_token_request = automate_api_request(
-        "/api/v0/auth/tokens/#{TEST_TOKEN_ID_V2}",
+        "/apis/iam/v2beta/tokens/#{TEST_TOKEN_ID_V2}",
         http_method: 'DELETE',
       )
       expect(delete_token_request.http_status.to_s).to match(/200|404/)

--- a/inspec/a2-iam-v2-integration/controls/base.rb
+++ b/inspec/a2-iam-v2-integration/controls/base.rb
@@ -102,6 +102,7 @@ EOF
           password: ENV['AUTOMATE_API_DEFAULT_PASSWORD'] || 'chefautomate',
         }.to_json
       )
+      expect(create_non_admin_request.parsed_response_body).to eq({})
       expect(create_non_admin_request.http_status.to_s).to match(/200|409/)
 
       test_token_request = automate_api_request(
@@ -114,6 +115,7 @@ EOF
       )
       TEST_TOKEN_V2 = test_token_request.parsed_response_body[:value]
 
+      expect(test_token_request.parsed_response_body).to eq({})
       expect(test_token_request.http_status).to eq(200)
     end
 

--- a/inspec/a2-iam-v2-integration/controls/base.rb
+++ b/inspec/a2-iam-v2-integration/controls/base.rb
@@ -109,7 +109,7 @@ EOF
         http_method: 'POST',
         request_body: {
           id: TEST_TOKEN_ID_V2,
-          description: 'inspec_test_token',
+          name: 'inspec_test_token',
         }.to_json
       )
       TEST_TOKEN_V2 = test_token_request.parsed_response_body[:value]

--- a/inspec/a2-iam-v2-integration/controls/base.rb
+++ b/inspec/a2-iam-v2-integration/controls/base.rb
@@ -259,7 +259,6 @@ EOF
               user: user,
               request_body: {
                 name: "inspec-test-policy-#{Time.now.utc.to_i}",
-                description: 'trying to update this chef-managed policy',
                 members: []
               }.to_json
             )
@@ -310,7 +309,6 @@ EOF
               user: user,
               request_body: {
                 name: "inspec-test-policy-#{Time.now.utc.to_i}",
-                description: 'trying to update this chef-managed role',
                 members: []
               }.to_json
             )

--- a/inspec/a2-iam-v2p1-only-integration/controls/role_projects.rb
+++ b/inspec/a2-iam-v2p1-only-integration/controls/role_projects.rb
@@ -27,22 +27,19 @@ control 'iam-v2-projects-1' do
           id: CUSTOM_ROLE_ID_1,
           name: "Test Role 1",
           actions: ["test:some:action", "test:other:action"],
-          projects: [CUSTOM_PROJECT_ID_1, CUSTOM_PROJECT_ID_2],
-          type: "CUSTOM"
+          projects: [CUSTOM_PROJECT_ID_1, CUSTOM_PROJECT_ID_2]
   }
   CUSTOM_ROLE_2 = {
           id: CUSTOM_ROLE_ID_2,
           name: "Test Role 2",
           actions: ["test:other:action"],
-          projects: [CUSTOM_PROJECT_ID_2],
-          type: "CUSTOM"
+          projects: [CUSTOM_PROJECT_ID_2]
   }
   CUSTOM_ROLE_3 = {
           id: CUSTOM_ROLE_ID_3,
           name: "Test Role 2",
           actions: ["test:other:action"],
-          projects: [],
-          type: "CUSTOM"
+          projects: []
   }
 
   CUSTOM_ROLES = [ CUSTOM_ROLE_1, CUSTOM_ROLE_2, CUSTOM_ROLE_3 ]


### PR DESCRIPTION
Before, if you (for example) POST

    { "foo": "bar", "baz": 300 }

where the protobuf message this is to be converted into only has a field

    string foo = 1;

this would silently be ignored.

Now, it's an error:

    {
      "error": "unknown field \"bar\" in request.CreateProjectReq",
      "message": "unknown field \"bar\" in request.CreateProjectReq",
      "code": 3,
      "details": []
    }
