### PR TITLE
Update all chef-server pins to the latest

### DIFF
--- a/.expeditor/update_chef_server.sh
+++ b/.expeditor/update_chef_server.sh
@@ -33,7 +33,7 @@ echo "Found Chef Server $build"
 while read -r line; do
     pkg_name=$(echo "$line" | cut -d/ -f2)
     hab_packages[$pkg_name]=$line
-done < <(jq -rn --argjson manifest "$manifest_content" '$manifest.packages | .[]')
+done < <(jq -rn --argjson manifest "$manifest_content" '$manifest.packages[]')
 
 file_for_pkg=(
     [chef-server-ctl]="components/automate-cs-nginx/habitat/plan.sh"
@@ -50,7 +50,7 @@ for i in "${!file_for_pkg[@]}"; do
     file_to_update="${file_for_pkg[$i]}"
 
     echo "Updating pin for $package_name in $file_to_update pins to $new_ident"
-    sed -i -r "s|\\\$\\{vendor_origin\\}/$package_name/[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]{14}|\\\$\\{vendor_origin\\}/${new_ident#chef/}|" "$file_to_update"
+    sed -i -r "s|$package_name/[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]{14}|${new_ident#chef/}|" "$file_to_update"
 
     if [[ "$package_name" != "openresty-noroot" ]]; then
         echo "Updating pkg_version in $file_to_update pins to $build"

--- a/.expeditor/update_chef_server.sh
+++ b/.expeditor/update_chef_server.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# bump_chef_server.sh: Update various Habitat pins with the packages
+# from the latest build in the given channel.
+#
+# Usage:
+#
+#    bump_chef_server.sh CHANNEL
+#
+set -eo pipefail
+
+CHANNEL=${1:-stable}
+NO_GIT=${NO_GIT:-false}
+
+if [[ "$NO_GIT" != "true" ]]; then
+    branch="expeditor/bump-chef-server"
+    git checkout -b "$branch"
+fi
+
+declare -A hab_packages
+declare -A file_for_pkg
+
+manifest_for_channel() {
+    local channel="$1"
+    local url="https://packages.chef.io/manifests/$channel/chef-server/latest.json"
+    curl "$url"
+}
+
+echo "Retrieving and parsing chef-server release manifest from $CHANNEL"
+manifest_content="$(manifest_for_channel "$CHANNEL")"
+build="$(jq -rn --argjson manifest "$manifest_content" '$manifest.build')"
+echo "Found Chef Server $build"
+while read -r line; do
+    pkg_name=$(echo "$line" | cut -d/ -f2)
+    hab_packages[$pkg_name]=$line
+done < <(jq -rn --argjson manifest "$manifest_content" '$manifest.packages | .[]')
+
+file_for_pkg=(
+    [chef-server-ctl]="components/automate-cs-nginx/habitat/plan.sh"
+    [chef-server-nginx]="components/automate-cs-nginx/habitat/plan.sh"
+    [bookshelf]="components/automate-cs-bookshelf/habitat/plan.sh"
+    [oc_bifrost]="components/automate-cs-oc-bifrost/habitat/plan.sh"
+    [oc_erchef]="components/automate-cs-oc-erchef/habitat/plan.sh"
+    [openresty-noroot]="components/automate-workflow-nginx/habitat/plan.sh"
+)
+
+for i in "${!file_for_pkg[@]}"; do
+    package_name="$i"
+    new_ident="${hab_packages[$i]}"
+    file_to_update="${file_for_pkg[$i]}"
+
+    echo "Updating pin for $package_name in $file_to_update pins to $new_ident"
+    sed -i -r "s|\\\$\\{vendor_origin\\}/$package_name/[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]{14}|\\\$\\{vendor_origin\\}/${new_ident#chef/}|" "$file_to_update"
+
+    if [[ "$package_name" != "openresty-noroot" ]]; then
+        echo "Updating pkg_version in $file_to_update pins to $build"
+        sed -i -r "s|pkg_version=\".*\"|pkg_version=\"$build\"|" "$file_to_update"
+    fi
+done
+
+if [[ "$NO_GIT" != "true" ]]; then
+    git add --all
+
+    git commit --message "Bump Chef Server package versions" \
+        --message "This pull request was triggered automatically via Expeditor." \
+        --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
+
+    open_pull_request
+
+    # Get back to master and cleanup the leftovers - any changed files
+    # left over at the end of this script will get committed to
+    # master.
+    git checkout -
+    git branch -D "$branch"
+fi

--- a/components/automate-cs-bookshelf/habitat/plan.sh
+++ b/components/automate-cs-bookshelf/habitat/plan.sh
@@ -5,7 +5,8 @@
 pkg_name="automate-cs-bookshelf"
 pkg_description="Wrapper package for chef/bookshelf"
 pkg_origin="chef"
-pkg_version="12.19.31"
+# WARNING: Version managed by .expeditor/update_chef_server.sh
+pkg_version="13.0.19"
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
@@ -13,9 +14,8 @@ pkg_upstream_url="https://www.chef.io/automate"
 pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
-  # FIXME: We're pinned to specific versions of unstable packages
-  # until they have a stable pipeline we can pin to.
-  "${vendor_origin}/bookshelf/12.19.31/20190307134327"
+  # WARNING: Version pin managed by .expeditor/update_chef_server.sh
+  "${vendor_origin}/bookshelf/13.0.19/20190709120215"
 )
 
 pkg_binds=(

--- a/components/automate-cs-nginx/habitat/plan.sh
+++ b/components/automate-cs-nginx/habitat/plan.sh
@@ -7,18 +7,16 @@ pkg_origin=chef
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=('Chef-MLSA')
-# FIXME: pin the chef server version and use it in the pkg_deps when we can
-# follow a stable channel
-pkg_version="12.19.31"
+# WARNING: Version managed by .expeditor/update_chef_server.sh
+pkg_version="13.0.19"
 pkg_deps=(
   chef/mlsa
-  core/curl/7.63.0/20190305215321
-  core/bundler/1.17.3/20190305221319
-  core/ruby/2.5.3/20190305212319
-  # FIXME: We're pinned to specific versions of unstable packages
-  # until they have a stable pipeline we can pin to.
-  "${vendor_origin}/chef-server-nginx/12.19.31/20190307133720"
-  "${vendor_origin}/chef-server-ctl/12.19.31/20190307134716"
+  core/curl
+  core/bundler
+  core/ruby
+  # WARNING: Version pin managed by .expeditor/update_chef_server.sh
+  "${vendor_origin}/chef-server-nginx/13.0.19/20190709121113"
+  "${vendor_origin}/chef-server-ctl/13.0.19/20190709120215"
 )
 
 pkg_bin_dirs=(bin)

--- a/components/automate-cs-oc-bifrost/habitat/plan.sh
+++ b/components/automate-cs-oc-bifrost/habitat/plan.sh
@@ -5,7 +5,8 @@
 pkg_name="automate-cs-oc-bifrost"
 pkg_description="Wrapper package for chef/oc_bifrost"
 pkg_origin="chef"
-pkg_version="12.19.31"
+# WARNING: Version managed by .expeditor/update_chef_server.sh
+pkg_version="13.0.19"
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
@@ -13,7 +14,8 @@ pkg_upstream_url="https://www.chef.io/automate"
 pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
-  "${vendor_origin}/oc_bifrost/12.19.31/20190307135121"
+  # WARNING: Version pin managed by .expeditor/update_chef_server.sh
+  "${vendor_origin}/oc_bifrost/13.0.19/20190709120413"
 )
 
 pkg_binds=(

--- a/components/automate-cs-oc-erchef/habitat/plan.sh
+++ b/components/automate-cs-oc-erchef/habitat/plan.sh
@@ -5,7 +5,8 @@
 pkg_name="automate-cs-oc-erchef"
 pkg_description="Wrapper package for chef/oc_erchef"
 pkg_origin="chef"
-pkg_version="12.19.31"
+# WARNING: Version managed by .expeditor/update_chef_server.sh
+pkg_version="13.0.19"
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
@@ -14,9 +15,8 @@ pkg_deps=(
   core/runit
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
-  # FIXME: We're pinned to specific versions of unstable packages
-  # until they have a stable pipeline we can pin to.
-  "${vendor_origin}/oc_erchef/12.19.31/20190307135503"
+  # WARNING: Version pin managed by .expeditor/update_chef_server.sh
+  "${vendor_origin}/oc_erchef/13.0.19/20190709120413"
 )
 
 pkg_build_deps=(
@@ -55,4 +55,3 @@ scaffolding_go_binary_list=(
 )
 
 chef_automate_hab_binding_mode="relaxed"
-

--- a/components/automate-workflow-nginx/habitat/plan.sh
+++ b/components/automate-workflow-nginx/habitat/plan.sh
@@ -7,15 +7,11 @@ vendor_origin=${vendor_origin:-"chef"}
 
 pkg_deps=(
   core/libossp-uuid
-  chef/openresty-noroot
+  # WARNING: Version pin managed by .expeditor/update_chef_server.sh
+  "${vendor_origin}/openresty-noroot/1.13.6.2/20190709120215"
   chef/mlsa
   core/bash
-  # TODO(ssd) 2019-07-03: PIN PIN PIN
-  #
-  # This is pinned until chef/openresty-noroot is rebuilt, at which
-  # point this pin will break our build again and we'll need to remove
-  # it.
-  core/curl/7.63.0/20190201004909
+  core/curl
   core/coreutils
   "${vendor_origin}/automate-workflow-web"
 )


### PR DESCRIPTION
This updates all pins for packages published by chef/chef-server and
introduces a script that can be used to update the pins in the
future. The script can be used as follows:

    NO_GIT=true ./.expeditor/update_chef_server.sh unstable

and can also be wired into expeditor. We have not added expeditor
configuration for it yet as I think we need to decide what channel we
want to follow. If we want to follow `stable` then the script will
need additional logic to ensure either that:

1) We never roll these pins backwards when currently pinned to
unstable, or

2) Updates all transitive dependencies pins as well.

Signed-off-by: Steven Danna <steve@chef.io>