### PR TITLE
[pg-gateway] Set server-fin timeout

### DIFF
--- a/components/automate-pg-gateway/habitat/config/haproxy.conf
+++ b/components/automate-pg-gateway/habitat/config/haproxy.conf
@@ -14,18 +14,16 @@ defaults
     timeout tunnel 300s
     # Client inactivity connections for half-closed connections (i.e
     # the server has closed the connection and but the client has
-    # not).  The HAProxy documentation recommends setting this
-    # whenever `timeout tunnel` is also set.
-    timeout client-fin 50s
+    # not). The HAProxy documentation recommends setting this whenever
+    # `timeout tunnel` is also set.
+    timeout client-fin 1s
     # NOTE(ssd) 2019-07-10: The HAProxy documentation says that this
     # setting should not be needed; however, we have observed that
     # when a postgresql client disconnects uncleanly, HAProxy does not
     # immediately close the backend until the connection times out. If
     # a service is failing in a loop, this can quickly lead to the
     # exhaustion of available ports.
-    #
-    # This number was chosen with very little thought.
-    timeout server-fin 5s
+    timeout server-fin 1s
     # Client and server inactivity timeouts. Per the HAProxy
     # documentation, the tunnel timeout above superceeds these once
     # bidirection communication is established.

--- a/components/automate-pg-gateway/habitat/config/haproxy.conf
+++ b/components/automate-pg-gateway/habitat/config/haproxy.conf
@@ -17,6 +17,15 @@ defaults
     # not).  The HAProxy documentation recommends setting this
     # whenever `timeout tunnel` is also set.
     timeout client-fin 50s
+    # NOTE(ssd) 2019-07-10: The HAProxy documentation says that this
+    # setting should not be needed; however, we have observed that
+    # when a postgresql client disconnects uncleanly, HAProxy does not
+    # immediately close the backend until the connection times out. If
+    # a service is failing in a loop, this can quickly lead to the
+    # exhaustion of available ports.
+    #
+    # This number was chosen with very little thought.
+    timeout server-fin 5s
     # Client and server inactivity timeouts. Per the HAProxy
     # documentation, the tunnel timeout above superceeds these once
     # bidirection communication is established.


### PR DESCRIPTION
When a go process dies because of a signal or a panic, defer'd
database closes may not execute. In this case, HAProxy will keep the
client side connection in CLOSE-WAIT and the server-side connection in
ESTAB. Setting `server-fin` times out the server-side connection
quickly, avoiding a leaked process. Without this, the process would
not close for 5 minutes until the tunnel timeout is hit.

Signed-off-by: Steven Danna <steve@chef.io>