### PR TITLE
[lib/cereal] manager.Stop() should close backend

### DIFF
--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -454,8 +454,15 @@ func (m *Manager) Stop() error {
 	if m.cancel != nil {
 		m.cancel()
 	}
+
 	m.wg.Wait()
-	return nil
+
+	var err error
+	if m.backend != nil {
+		err = m.backend.Close()
+	}
+
+	return err
 }
 
 // CreateWorkflowSchedule creates a recurring workflow based on the recurrence

--- a/tools/cereal-scaffold/main.go
+++ b/tools/cereal-scaffold/main.go
@@ -252,6 +252,7 @@ func runSimpleWorkflow(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer manager.Stop()
 
 	manager.RegisterWorkflowExecutor("simple-workflow", &SimpleWorkflow{})
 	manager.RegisterTaskExecutor("test task", &SimpleTask{}, cereal.TaskExecutorOpts{
@@ -327,6 +328,8 @@ func runScheduleTest(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer manager.Stop()
+
 	manager.RegisterWorkflowExecutor("schedule-test", &ScheduleTestWorkflow{})
 	manager.RegisterTaskExecutor("test task", &ScheduleTestTask{}, cereal.TaskExecutorOpts{
 		Workers: simpleWorkflowOpts.DequeueWorkerCount,


### PR DESCRIPTION
This allows users to defer the close to properly shutdown the db.

Signed-off-by: Steven Danna <steve@chef.io>