### PR TITLE
Revert DRY-ing up of datamigrations that introduced bug

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -729,6 +729,15 @@ steps:
         linux:
           privileged: true
 
+  - label: "[integration] upgrade / reset IAM v2.1"
+    command:
+      - integration/run_test integration/tests/upgrade_reset_iam_v2p1.sh
+    timeout_in_minutes: 20
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+
   - label: "[integration] security"
     command:
       - integration/run_test integration/tests/security.sh

--- a/components/authz-service/storage/postgres/datamigration/datamigration.go
+++ b/components/authz-service/storage/postgres/datamigration/datamigration.go
@@ -1,9 +1,14 @@
 package datamigration
 
 import (
+	"database/sql"
 	"net/url"
 
-	"github.com/chef/automate/lib/db/migrator"
+	"github.com/golang-migrate/migrate"
+	"github.com/golang-migrate/migrate/database/postgres" // make driver available
+	_ "github.com/golang-migrate/migrate/source/file"     // make source available
+	"github.com/pkg/errors"
+
 	"github.com/chef/automate/lib/logger"
 )
 
@@ -18,11 +23,80 @@ type Config struct {
 	Logger logger.Logger
 }
 
-func (*Config) Reset() error {
-	return nil
+type migrationLog struct {
+	logger.Logger
+}
+
+func (migrationLog) Verbose() bool {
+	return false
 }
 
 // Migrate executes all migrations we have
 func (c *Config) Migrate() error {
-	return migrator.MigrateWithMigrationsTable(c.PGURL.String(), c.Path, "data_migrations", c.Logger, false)
+	m, err := c.open()
+	if err != nil {
+		return err
+	}
+
+	err = m.Up()
+	if err != nil && err != migrate.ErrNoChange {
+		return errors.Wrap(err, "execute v2 data migrations")
+	}
+
+	// The first error is trying to Close() the source. For our file source,
+	// that's always nil
+	_, err = m.Close() // nolint: gas
+	return errors.Wrap(err, "close v2 data migrations connection")
+}
+
+// Reset will drop the current state of the migration database.
+// We don't need to reverse migrate since on reset we are just
+// dropping the whole database.
+func (c *Config) Reset() error {
+	m, err := c.open()
+	if err != nil {
+		return err
+	}
+
+	err = m.Down()
+	if err == migrate.ErrNoChange {
+		err = nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// The first error is trying to Close() the source. For our file source,
+	// that's always nil
+	_, err = m.Close() // nolint: gas
+	return errors.Wrap(err, "close v2 data migrations connection")
+}
+
+func (c *Config) open() (*migrate.Migrate, error) {
+	db, err := sql.Open("postgres", c.PGURL.String())
+	if err != nil {
+		return nil, errors.Wrap(err, "init v2 sql client")
+	}
+	driver, err := postgres.WithInstance(db, &postgres.Config{
+		MigrationsTable: "data_migrations",
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "init v2 data migration driver")
+	}
+	m, err := migrate.NewWithDatabaseInstance(
+		addScheme(c.Path),
+		"postgres", driver)
+	if err != nil {
+		return nil, errors.Wrap(err, "init v2 data migration")
+	}
+
+	m.Log = migrationLog{c.Logger} // nolint: govet
+	return m, nil
+}
+
+func addScheme(p string) string {
+	u := url.URL{}
+	u.Scheme = "file"
+	u.Path = p
+	return u.String()
 }

--- a/integration/tests/upgrade_reset_iam_v2p1.sh
+++ b/integration/tests/upgrade_reset_iam_v2p1.sh
@@ -46,7 +46,7 @@ do_test_deploy() {
 
     log_info "v1 -> v2.1"
     expect_iam_upgrade_output "Success: Enabled IAM v2.1" \
-        "$(chef-automate iam upgrade-to-v2 --beta2.1)" || return 1
+        "$(chef-automate iam upgrade-to-v2 --beta2.1 --skip-policy-migration)" || return 1
     expect_iam_version "IAM v2.1" || return 1
 
     log_info "v2.1 -> v1"
@@ -55,7 +55,7 @@ do_test_deploy() {
 
     log_info "v1 -> v2.1"
     expect_iam_upgrade_output "Success: Enabled IAM v2.1" \
-        "$(chef-automate iam upgrade-to-v2 --beta2.1)" || return 1
+        "$(chef-automate iam upgrade-to-v2 --beta2.1 --skip-policy-migration)" || return 1
     expect_iam_version "IAM v2.1" || return 1
 
     do_test_deploy_default

--- a/integration/tests/upgrade_reset_iam_v2p1.sh
+++ b/integration/tests/upgrade_reset_iam_v2p1.sh
@@ -1,0 +1,84 @@
+#shellcheck disable=SC2034
+#shellcheck disable=SC2039
+#shellcheck disable=SC2154
+#shellcheck disable=SC1091
+
+test_name="upgrade / reset IAM v2.1"
+test_deploy_inspec_profiles=(a2-iam-v2p1-only-integration)
+# Note: we can't run diagnostics AND inspec, so skip diagnostics
+test_skip_diagnostics=true
+
+do_setup() {
+    do_setup_default
+
+    # We are defaulting to a umask of 077 to test
+    # installations on systems that are super locked down.
+    # Briefly override that strict default so we can install
+    # packages that non-root users can use (like the hab user
+    # for health checks or this script).
+    local previous_umask
+    previous_umask=$(umask)
+    umask 022
+
+    hab pkg install core/curl
+    hab pkg install -b core/jq-static core/jo
+
+    umask $previous_umask
+}
+
+hab_curl() {
+    hab pkg exec core/curl curl "$@"
+}
+
+do_test_deploy() {
+    local output
+
+    expect_iam_version "IAM v1.0" || return 1
+
+    local token
+    log_info "checking 'chef-automate admin-token'"
+    token="$(chef-automate admin-token)"
+    if grep -q "Error" <<< "$token"; then
+        log_error "expected token, got error:"
+        log_error "$token"
+        return 1
+    fi
+
+    log_info "v1 -> v2.1"
+    expect_iam_upgrade_output "Success: Enabled IAM v2.1" \
+        "$(chef-automate iam upgrade-to-v2 --beta2.1)" || return 1
+    expect_iam_version "IAM v2.1" || return 1
+
+    log_info "v2.1 -> v1"
+    chef-automate iam reset-to-v1 || return 1
+    expect_iam_version "IAM v1.0" || return 1
+
+    log_info "v1 -> v2.1"
+    expect_iam_upgrade_output "Success: Enabled IAM v2.1" \
+        "$(chef-automate iam upgrade-to-v2 --beta2.1)" || return 1
+    expect_iam_version "IAM v2.1" || return 1
+
+    do_test_deploy_default
+}
+
+expect_iam_upgrade_output() {
+    local expected_output="${1}"
+    local actual_output="${2}"
+    if ! grep -q "$expected_output" <<< "$actual_output"; then
+        log_error "unexpected output:"
+        log_error "expected (substring): ${expected_output}"
+        log_error "actual output: ${actual_output}"
+        return 1
+    fi
+}
+
+expect_iam_version() {
+    local expected="${1}"
+    log_info "checking 'chef-automate iam version'"
+    output="$(chef-automate iam version)"
+    if ! grep -q "$expected" <<< "$output"; then
+        log_error "expected \"${expected}\", got output:"
+        log_error "$output"
+        return 1
+    fi
+}


### PR DESCRIPTION
### :nut_and_bolt: Description

This [change](https://github.com/chef/automate/blob/c94572e5ab3cfbaec2230af0afdfde7e0bfff145/components/authz-service/storage/postgres/datamigration/datamigration.go) accidentally removed some Reset code that was special to datamigrations. This code resets the data_migrations table when reset to IAM v1 so that on the next upgrade to 2.x the datamigrations get reapplied. This is different than standard migrations since we never undo schema migrations.

Also added regression tests to the pipeline.

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
