### PR TITLE
[part of 832]/add db id to statements

### DIFF
--- a/components/authz-service/storage/postgres/datamigration/sql/01_v2_data_migrations.up.sql
+++ b/components/authz-service/storage/postgres/datamigration/sql/01_v2_data_migrations.up.sql
@@ -1,7 +1,6 @@
 BEGIN;
 
 SET CONSTRAINTS iam_policy_members_policy_id_fkey DEFERRED;
-SET CONSTRAINTS iam_policy_statements_policy_id_fkey DEFERRED;
 
 UPDATE iam_members
     SET
@@ -26,7 +25,6 @@ UPDATE iam_roles
         id = 'operator';
 
 UPDATE iam_policies SET id='editor-access', name='Editors' WHERE id='operator-access';
-UPDATE iam_policy_statements SET policy_id = 'editor-access' WHERE policy_id='operator-access';
 
 UPDATE iam_roles
     SET

--- a/components/authz-service/storage/postgres/migration/sql/56_add_db_id_statements.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/56_add_db_id_statements.up.sql
@@ -1,0 +1,180 @@
+BEGIN;
+ALTER TABLE iam_policy_statements
+    DROP CONSTRAINT iam_policy_statements_pkey,
+    DROP CONSTRAINT iam_policy_statements_policy_id_fkey;
+ALTER TABLE iam_statement_projects
+    DROP CONSTRAINT iam_statement_projects_statement_id_fkey;
+ALTER TABLE iam_policy_statements
+    ADD COLUMN policy_db_id SERIAL;
+UPDATE
+    iam_policy_statements ips
+SET
+    policy_db_id = (
+        SELECT
+            db_id
+        FROM
+            iam_policies
+        WHERE
+            id = ips.policy_id);
+ALTER TABLE iam_statements
+    DROP CONSTRAINT iam_statements_pkey;
+ALTER TABLE iam_statements
+    ADD COLUMN db_id SERIAL PRIMARY KEY UNIQUE,
+    ADD COLUMN policy_id INTEGER REFERENCES iam_policies(db_id) ON DELETE CASCADE DEFERRABLE,
+    ADD UNIQUE (id);
+UPDATE
+    iam_statements iams
+SET
+    policy_id = (
+        SELECT
+            policy_db_id
+        FROM
+            iam_policy_statements
+        WHERE
+            statement_id = iams.id);
+DROP TABLE iam_policy_statements CASCADE;
+ALTER TABLE iam_statement_projects
+    ADD UNIQUE (statement_id, project_id),
+    ADD CONSTRAINT iam_statement_projects_statement_id_fkey FOREIGN KEY (statement_id) REFERENCES iam_statements(id) ON DELETE CASCADE DEFERRABLE;
+
+-- add helper for statement db_id lookup
+CREATE FUNCTION statement_db_id (_id UUID)
+    RETURNS INTEGER
+    AS $$
+    SELECT
+        db_id
+    FROM
+        iam_statements
+    WHERE
+        id = _id;
+$$
+LANGUAGE SQL;
+
+ CREATE OR REPLACE FUNCTION query_policy (_policy_id TEXT, _projects_filter TEXT[])
+    RETURNS json
+    AS $$
+    WITH temp AS (
+        SELECT
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type,
+            -- get policy's statements using temporary table
+            ( WITH statement_rows AS (
+                    SELECT
+                        stmt.id,
+                        stmt.effect,
+                        stmt.actions,
+                        stmt.resources,
+                        stmt.role,
+                        -- get each statement's projects by cross-referencing iam_policy_statements and iam_statement_projects
+                        (
+                            SELECT
+                                COALESCE(json_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL),
+                                    '[]')
+                                FROM iam_statement_projects AS stmt_projs
+                            LEFT OUTER JOIN iam_projects AS proj ON stmt_projs.statement_id = stmt.id WHERE stmt_projs.project_id = proj.id) AS projects
+                    FROM iam_statements stmt
+                    INNER JOIN iam_policies
+                    ON stmt.policy_id=pol.db_id
+                GROUP BY
+                    stmt.id, stmt.effect, stmt.actions, stmt.resources, stmt.role)
+            SELECT
+                array_agg(statement_rows) FILTER (WHERE statement_rows.id IS NOT NULL)
+            FROM statement_rows) AS statements,
+            -- get policy members
+            (
+            SELECT
+                array_agg(mem) FILTER (WHERE mem.id IS NOT NULL)
+            FROM iam_policy_members AS pol_mems
+        LEFT OUTER JOIN iam_members AS mem ON pol_mems.member_id = mem.db_id WHERE pol_mems.policy_id = pol.db_id) AS members,
+            -- get projects
+            (
+            SELECT
+                array_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL)
+            FROM iam_policy_projects AS pol_projs
+            LEFT OUTER JOIN iam_projects AS proj ON pol_projs.project_id = proj.id WHERE pol_projs.policy_id = pol.db_id) AS projects FROM iam_policies AS pol WHERE pol.id = _policy_id
+        GROUP BY
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type
+)
+SELECT
+    json_build_object('id', temp.id, 'name', temp.name, 'type', temp.type, 'statements', COALESCE(temp.statements, '{}'), 'members', COALESCE(temp.members, '{}'), 'projects', COALESCE(temp.projects, '{}')) AS POLICY
+FROM
+    temp
+WHERE
+    projects_match (temp.projects::TEXT[], _projects_filter);
+$$
+LANGUAGE sql;
+
+ CREATE OR REPLACE FUNCTION query_policies (_projects_filter TEXT[])
+    RETURNS SETOF json
+    AS $$
+    WITH temp AS (
+        SELECT
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type,
+            ( WITH statement_rows AS (
+                    SELECT
+                        stmt.id,
+                        stmt.effect,
+                        stmt.actions,
+                        stmt.resources,
+                        stmt.role,
+                        (
+                            SELECT
+                                COALESCE(json_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL),
+                                    '[]')
+                                FROM iam_statement_projects AS stmt_projs
+                            LEFT OUTER JOIN iam_projects AS proj ON stmt_projs.statement_id = stmt.id WHERE stmt_projs.project_id = proj.id) AS projects
+                    FROM iam_statements stmt
+                    INNER JOIN iam_policies
+                    ON stmt.policy_id=pol.db_id
+                GROUP BY
+                    stmt.id, stmt.effect, stmt.actions, stmt.resources, stmt.role
+)
+            SELECT
+                array_agg(statement_rows) FILTER (WHERE statement_rows.id IS NOT NULL)
+                FROM statement_rows) AS statements,
+            (
+            SELECT
+                array_agg(mem) FILTER (WHERE mem.id IS NOT NULL)
+                FROM iam_policy_members AS pol_mems
+            LEFT OUTER JOIN iam_members AS mem ON pol_mems.member_id = mem.db_id WHERE pol_mems.policy_id = pol.db_id) AS members,
+    (
+    SELECT
+        array_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL)
+        FROM iam_policy_projects AS pol_projs
+        LEFT OUTER JOIN iam_projects AS proj ON pol_projs.project_id = proj.id WHERE pol_projs.policy_id = pol.db_id) AS projects FROM iam_policies AS pol
+GROUP BY
+    pol.db_id,
+    pol.id,
+    pol.name,
+    pol.type
+)
+SELECT
+    json_build_object('id', temp.id, 'name', temp.name, 'type', temp.type, 'statements', COALESCE(temp.statements, '{}'), 'members', COALESCE(temp.members, '{}'), 'projects', COALESCE(temp.projects, '{}')) AS POLICY
+FROM
+    temp
+WHERE
+    projects_match (temp.projects::TEXT[], _projects_filter);
+$$
+LANGUAGE sql;
+
+ CREATE OR REPLACE FUNCTION
+  insert_iam_statement_into_policy(_policy_id TEXT, _statement_id UUID, _statement_effect iam_effect, _statement_actions TEXT[],
+  _statement_resources TEXT[], _statement_role TEXT, _statement_projects TEXT[])
+  RETURNS void AS $$
+    INSERT INTO iam_statements (policy_id, id, effect, actions, resources, role)
+      VALUES (policy_db_id(_policy_id), _statement_id, _statement_effect, _statement_actions, _statement_resources, _statement_role);
+
+     INSERT INTO iam_statement_projects (statement_id, project_id) 
+    SELECT _statement_id s_id, p_id
+    FROM UNNEST(_statement_projects) p_id ON CONFLICT DO NOTHING
+
+ $$ LANGUAGE sql;
+COMMIT; 

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -55,3 +55,4 @@
 - [`53_add_db_id_to_iam_policies.up.sql`](53_add_db_id_to_iam_policies.up.sql)
 - [`54_use_project_db_id_in_references_of_project_rules.up.sql`](54_use_project_db_id_in_references_of_project_rules.up.sql)
 - [`55_use_project_db_id_in_references_of_project_roles.up.sql`](55_use_project_db_id_in_references_of_project_roles.up.sql)
+- [`56_add_db_id_statements.up.sql`](56_add_db_id_statements.up.sql)

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -239,7 +239,7 @@ func (p *pg) UpdatePolicy(ctx context.Context, pol *v2.Policy) (*v2.Policy, erro
 	//
 	// This will cascade delete all related statements.
 	if _, err := tx.ExecContext(ctx,
-		"DELETE FROM iam_policy_statements WHERE policy_id=$1",
+		"DELETE FROM iam_statements WHERE policy_id=policy_db_id($1)",
 		pol.ID,
 	); err != nil {
 		if err := p.processError(err); err != storage_errors.ErrNotFound {

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -2527,7 +2527,6 @@ func TestUpdatePolicy(t *testing.T) {
 			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
 			VALUES ($1, 'deny'::iam_effect, array['iam:users:create', 'iam:users:delete'], array['iam:users'], (SELECT * FROM policy_db_id));`, genUUID(t), polID0)
 			require.NoError(t, err)
-			require.NoError(t, err)
 			insertTestPolicyMember(t, db, polID0, "user:local:albertine")
 
 			polID := genSimpleID(t, prngSeed)


### PR DESCRIPTION
### :nut_and_bolt: Description

Adds `db_id` _and_ `policy_id` (db_id) to iam_statements, allowing the removal of the superfluous `iam_policy_statements` table. Given that policy: statement is one: many, we didn't need the associations table.

I've left adding the new statement db_id as the new foreign key to `iam_statement_projects` as the PR's tests (and a gnarly, unfortunate rebase) made this PR unwieldy. 

### :+1: Definition of Done

Tests pass. 

### :athletic_shoe: Demo Script / Repro Steps

Bring up hab studio, rebuild `components/authz-service`, CURL to create, delete, update, get policies with statements:

In ui, create new user coolbean, pw chefautomate

`curl -XPOST -d '{"name":"test", "id":"newpolicy", "members":["user:local:coolbean"], "statements":[{"effect":"ALLOW", "actions":["*"] }]}' -H "api-token: $TOK" https://a2-dev.test/apis/iam/v2beta/policies --insecure`

(Logged in as coolbean, with legacy polices deleted, should see Users (and be able to create/update/delete them) 

`curl -H "api-token: $TOK" https://a2-dev.test/apis/iam/v2beta/policies/newpolicy  --insecure`

`curl -XPUT -d '{"name":"test", "members":["user:local:coolbean"], "statements":[{"effect":"ALLOW", "actions":["*"] }, {"effect":"DENY", "actions":["iam:users:delete"]}]}' -H "api-token: $TOK" https://a2-dev.test/apis/iam/v2beta/policies --insecure`

`curl -H "api-token: $TOK" https://a2-dev.test/apis/iam/v2beta/policies/newpolicy  --insecure`

(Coolbean should now not be able to delete users)

`curl -XDELETE -H "api-token: $TOK" https://a2-dev.test/apis/iam/v2beta/policies/newpolicy  --insecure`

`curl -H "api-token: $TOK" https://a2-dev.test/apis/iam/v2beta/policies/newpolicy  --insecure (not found)`

(Coolbean can't do a darn thing)

### :chains: Related Resources

- #832
### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
