### PR TITLE
Consistency improvement and minor bug fixes for auth UI pages

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -22,16 +22,16 @@
               <input chefInput formControlName="id" type="text" (keyup)="handleIDInput($event)" id="id-input">
             </label>
             <chef-error *ngIf="createForm?.controls['id'].hasError('maxlength')">
-              ID must be 64 characters or less
+              ID must be 64 characters or less.
             </chef-error>
             <chef-error *ngIf="createForm?.controls['id'].hasError('required')">
-              ID is required
+              ID is required.
             </chef-error>
             <chef-error *ngIf="createForm?.controls['id'].hasError('pattern')">
               Only lowercase letters, numbers, and hyphens(-) are allowed.
             </chef-error>
             <chef-error *ngIf="conflictError">
-              IDs must be unique--there is already a {{objectNoun}} with ID: {{createForm?.controls['id'].value}}
+              IDs must be unique--{{objectNoun}} with ID "{{createForm?.controls['id'].value}}" already exists.
             </chef-error>
           </chef-form-field>
           <span class="detail">{{ objectNoun | titlecase }} IDs are unique, permanent, and cannot be changed later.</span>

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -21,20 +21,17 @@
               </span>
               <input chefInput formControlName="id" type="text" (keyup)="handleIDInput($event)" id="id-input">
             </label>
-            <chef-error
-              *ngIf="createForm?.controls['id'].hasError('maxlength')">
-              ID must be 64 characters or less.
+            <chef-error *ngIf="createForm?.controls['id'].hasError('maxlength')">
+              ID must be 64 characters or less
             </chef-error>
-            <chef-error
-              *ngIf="createForm?.controls['id'].hasError('required')">
-              ID is required.
+            <chef-error *ngIf="createForm?.controls['id'].hasError('required')">
+              ID is required
             </chef-error>
-             <chef-error
-              *ngIf="createForm?.controls['id'].hasError('pattern')">
+            <chef-error *ngIf="createForm?.controls['id'].hasError('pattern')">
               Only lowercase letters, numbers, and hyphens(-) are allowed.
             </chef-error>
             <chef-error *ngIf="conflictError">
-              IDs must be unique, there is already a {{objectNoun}} with ID: {{createForm?.controls['id'].value}}.
+              IDs must be unique--there is already a {{objectNoun}} with ID: {{createForm?.controls['id'].value}}
             </chef-error>
           </chef-form-field>
           <span class="detail">{{ objectNoun | titlecase }} IDs are unique, permanent, and cannot be changed later.</span>

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -23,9 +23,13 @@
             </label>
             <chef-error
               *ngIf="createForm?.controls['id'].hasError('maxlength')">
-              IDs must be 64 characters or less.
+              ID must be 64 characters or less.
             </chef-error>
             <chef-error
+              *ngIf="createForm?.controls['id'].hasError('required')">
+              ID is required.
+            </chef-error>
+             <chef-error
               *ngIf="createForm?.controls['id'].hasError('pattern')">
               Only lowercase letters, numbers, and hyphens(-) are allowed.
             </chef-error>

--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -1,6 +1,10 @@
 export class Regex {
 
   public static readonly patterns = {
+
+    // all auth IDs use this pattern
+    ID: '[0-9a-z-]+',
+
     // NB: neither \S nor ^\s work inside the brackets in this regex language.
     NON_BLANK: '.*[^ ].*'
   };

--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -1,0 +1,8 @@
+export class Regex {
+
+  public static readonly patterns = {
+    // NB: neither \S nor ^\s work inside the brackets in this regex language.
+    NON_BLANK: '.*[^ ].*'
+  };
+
+}

--- a/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.html
+++ b/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.html
@@ -36,19 +36,19 @@
             <chef-form-field>
               <label for="firstName">First Name *</label>
               <input chefInput name="firstName" id="firstName" formControlName="firstName" type="text" autofocus placeholder="First Name">
-              <chef-error *ngIf="trialForm.get('firstName').hasError('required') && trialForm.get('firstName').dirty">First name required</chef-error>
+              <chef-error *ngIf="trialForm.get('firstName').hasError('required') && trialForm.get('firstName').dirty">First name required.</chef-error>
             </chef-form-field>
             <chef-form-field>
               <label for="firstName">Last Name *</label>
               <input chefInput name="lastName" id="lastName" formControlName="lastName" type="text" placeholder="Last Name">
-              <chef-error *ngIf="trialForm.get('lastName').hasError('required') && trialForm.get('lastName').dirty">Last name required</chef-error>
+              <chef-error *ngIf="trialForm.get('lastName').hasError('required') && trialForm.get('lastName').dirty">Last name required.</chef-error>
             </chef-form-field>
           </div>
           <div class="email-container">
             <chef-form-field>
               <label for="email">Email *</label>
               <input chefInput name="email" id="email" formControlName="email" type="text" placeholder="Email">
-              <chef-error *ngIf="trialForm.get('email').hasError('email') && trialForm.get('email').dirty">Valid email required</chef-error>
+              <chef-error *ngIf="trialForm.get('email').hasError('email') && trialForm.get('email').dirty">Valid email required.</chef-error>
             </chef-form-field>
           </div>
           <chef-checkbox (change)="updateGDPR($event.detail)" [checked]="gdprAgree">I would like to receive email communications from Chef</chef-checkbox>

--- a/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.html
+++ b/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.html
@@ -35,7 +35,7 @@
           <input chefInput formControlName="name" type="text" (keyup)="handleNameChange()">
         </chef-form-field>
       </form>
-      <chef-button primary [disabled]="disableSave || saveInProgress" (click)="saveNameChange()">
+      <chef-button primary [disabled]="!updateNameForm.valid || disableSave || saveInProgress" (click)="saveNameChange()">
         <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
         <ng-container *ngIf="!saveInProgress">
           <span *ngIf="disableSave">Saved</span>

--- a/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.ts
@@ -34,6 +34,7 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
               fb: FormBuilder
               ) {
       this.updateNameForm = fb.group({
+        // Must stay in sync with error checks in api-token-details.component.html
         name: ['', Validators.required]
       });
     }
@@ -65,8 +66,7 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
     }
 
     public handleNameChange(): void {
-      this.disableSave = this.updateNameForm.controls['name'].value === this.token.name ||
-                         this.updateNameForm.controls['name'].value.trim() === '';
+      this.disableSave = this.updateNameForm.controls['name'].value === this.token.name;
     }
 
     public saveNameChange(): void {

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.ts
@@ -58,10 +58,10 @@ export class ApiTokenListComponent implements OnInit {
     this.apiTokenCount$ = store.pipe(select(totalApiTokens));
 
     this.createTokenForm = fb.group({
-      // Make sure these stay in sync with error checks in create-object-modal.component.html
+      // Must stay in sync with error checks in create-object-modal.component.html
       name: ['', Validators.required],
-      id: ['', [
-        Validators.required, Validators.pattern(Regex.patterns.ID), Validators.maxLength(64)]]
+      id: ['',
+        [Validators.required, Validators.pattern(Regex.patterns.ID), Validators.maxLength(64)]]
     });
   }
 

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.ts
@@ -7,6 +7,7 @@ import { filter, takeUntil, map } from 'rxjs/operators';
 import { identity } from 'lodash/fp';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { Regex } from 'app/helpers/auth/regex';
 import { loading, EntityStatus } from 'app/entities/entities';
 import { Type } from 'app/entities/notifications/notification.model';
 import { CreateNotification } from 'app/entities/notifications/notification.actions';
@@ -19,8 +20,6 @@ import {
 } from 'app/entities/api-tokens/api-token.actions';
 import { CreateToken } from 'app/entities/api-tokens/api-token.actions';
 import { saveStatus, saveError } from 'app/entities/api-tokens/api-token.selectors';
-
-const ID_PATTERN = '[0-9a-z-]+';
 
 @Component({
   selector: 'app-api-tokens',
@@ -59,8 +58,10 @@ export class ApiTokenListComponent implements OnInit {
     this.apiTokenCount$ = store.pipe(select(totalApiTokens));
 
     this.createTokenForm = fb.group({
+      // Make sure these stay in sync with error checks in create-object-modal.component.html
       name: ['', Validators.required],
-      id: ['', [Validators.required, Validators.pattern(ID_PATTERN), Validators.maxLength(64)]]
+      id: ['', [
+        Validators.required, Validators.pattern(Regex.patterns.ID), Validators.maxLength(64)]]
     });
   }
 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -22,6 +22,10 @@
               <chef-error *ngIf="unparsableMember">Invalid member expression.</chef-error>
               <chef-error *ngIf="duplicateMember">Member expression already in table.</chef-error>
               <chef-error *ngIf="alreadyPolicyMember">Member already in policy.</chef-error>
+                <chef-error *ngIf="(expressionForm.get('expression').hasError('required') || expressionForm.get('expression').hasError('pattern')) && expressionForm.get('expression').dirty">
+                  A non-blank expression is required
+                </chef-error>
+
             </chef-form-field>
           </form>
           <p><span class="expression">user | team : local | ldap | saml : &lt;name&gt;</span> or <span class="expression">token : &lt;id&gt;</span>, wildcards (*) are allowed.</p>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -18,7 +18,7 @@
           <form [formGroup]="expressionForm">
             <chef-form-field>
               <label>Member expression *</label>
-              <input chefInput formControlName="expression" type="text">
+              <input chefInput formControlName="expression" type="text" (keyup)="resetErrors()" >
               <chef-error *ngIf="unparsableMember">Invalid member expression.</chef-error>
               <chef-error *ngIf="duplicateMember">Member expression already in table.</chef-error>
               <chef-error *ngIf="alreadyPolicyMember">Member already in policy.</chef-error>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -22,10 +22,9 @@
               <chef-error *ngIf="unparsableMember">Invalid member expression.</chef-error>
               <chef-error *ngIf="duplicateMember">Member expression already in table.</chef-error>
               <chef-error *ngIf="alreadyPolicyMember">Member already in policy.</chef-error>
-                <chef-error *ngIf="(expressionForm.get('expression').hasError('required') || expressionForm.get('expression').hasError('pattern')) && expressionForm.get('expression').dirty">
-                  Expression is required
-                </chef-error>
-
+              <chef-error *ngIf="(expressionForm.get('expression').hasError('required') || expressionForm.get('expression').hasError('pattern')) && expressionForm.get('expression').dirty">
+                Expression is required.
+              </chef-error>
             </chef-form-field>
           </form>
           <p><span class="expression">user | team : local | ldap | saml : &lt;name&gt;</span> or <span class="expression">token : &lt;id&gt;</span>, wildcards (*) are allowed.</p>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -23,7 +23,7 @@
               <chef-error *ngIf="duplicateMember">Member expression already in table.</chef-error>
               <chef-error *ngIf="alreadyPolicyMember">Member already in policy.</chef-error>
                 <chef-error *ngIf="(expressionForm.get('expression').hasError('required') || expressionForm.get('expression').hasError('pattern')) && expressionForm.get('expression').dirty">
-                  A non-blank expression is required
+                  Expression is required
                 </chef-error>
 
             </chef-form-field>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -275,10 +275,14 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     return member.name in this.membersToAdd;
   }
 
-  public validateAndAddExpression(): void {
+  public resetErrors(): void {
     this.unparsableMember = false;
     this.duplicateMember = false;
     this.alreadyPolicyMember = false;
+  }
+
+  public validateAndAddExpression(): void {
+    this.resetErrors();
 
     const member = stringToMember(this.expressionForm.value.expression);
 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -287,8 +287,8 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.duplicateMember = member.name in this.membersAvailableMap;
-    if (this.duplicateMember) {
+    if (member.name in this.membersAvailableMap) {
+      this.duplicateMember = true;
       return;
     }
 
@@ -298,9 +298,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
         return;
       }
     });
-    if (this.alreadyPolicyMember) {
-      return;
-    }
 
     this.addAvailableMember(member, true);
     this.addOrRemoveQueuedMember(true, member);

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -73,6 +73,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     fb: FormBuilder) {
 
     this.expressionForm = fb.group({
+      // Must stay in sync with error checks in policy-add-members.component.html
       expression: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
   }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -29,6 +29,7 @@ import {
   GetUsers
 } from 'app/entities/users/user.actions';
 import { User } from 'app/entities/users/user.model';
+import { Regex } from 'app/helpers/auth/regex';
 
 @Component({
   selector: 'app-policy-add-members',
@@ -72,7 +73,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     fb: FormBuilder) {
 
     this.expressionForm = fb.group({
-      expression: ['', Validators.required]
+      expression: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
   }
 

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -54,6 +54,7 @@ export class ProjectDetailsComponent implements OnDestroy {
         this.project = <Project>Object.assign({}, state);
         this.isChefManaged = this.project.type === 'CHEF_MANAGED';
         this.projectForm = fb.group({
+          // Must stay in sync with error checks in project-details.component.html
           name: [this.project.name, Validators.required]
         });
       })).subscribe();

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -72,10 +72,10 @@ export class ProjectListComponent implements OnInit {
     );
 
     this.createProjectForm = fb.group({
-      // Make sure these stay in sync with error checks in create-object-modal.component.html
+      // Must stay in sync with error checks in create-object-modal.component.html
       name: ['', Validators.required],
-      id: ['', [
-        Validators.required, Validators.pattern(Regex.patterns.ID), Validators.maxLength(64)]]
+      id: ['',
+        [Validators.required, Validators.pattern(Regex.patterns.ID), Validators.maxLength(64)]]
     });
   }
 

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -7,6 +7,7 @@ import { map, takeUntil, filter } from 'rxjs/operators';
 import { identity } from 'lodash/fp';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { Regex } from 'app/helpers/auth/regex';
 import { loading, EntityStatus } from 'app/entities/entities';
 import { ProjectService } from 'app/entities/projects/project.service';
 import { iamMajorVersion, iamMinorVersion } from 'app/entities/policies/policy.selectors';
@@ -16,8 +17,6 @@ import {
 import { GetProjects, CreateProject, DeleteProject  } from 'app/entities/projects/project.actions';
 import { Project } from 'app/entities/projects/project.model';
 import { ApplyRulesStatus, ApplyRulesStatusState } from 'app/entities/projects/project.reducer';
-
-const ID_PATTERN = '[0-9a-z-]+';
 
 @Component({
   selector: 'app-project-list',
@@ -73,8 +72,10 @@ export class ProjectListComponent implements OnInit {
     );
 
     this.createProjectForm = fb.group({
+      // Make sure these stay in sync with error checks in create-object-modal.component.html
       name: ['', Validators.required],
-      id: ['', [Validators.required, Validators.pattern(ID_PATTERN), Validators.maxLength(64)]]
+      id: ['', [
+        Validators.required, Validators.pattern(Regex.patterns.ID), Validators.maxLength(64)]]
     });
   }
 

--- a/components/automate-ui/src/app/pages/team-create/team-create.component.html
+++ b/components/automate-ui/src/app/pages/team-create/team-create.component.html
@@ -18,13 +18,13 @@
                 <chef-input ngDefaultControl formControlName="teamId" type="text"></chef-input>
               </label>
               <chef-error *ngIf="teamCreateForm.get('teamId').hasError('required') && teamCreateForm.get('teamId').dirty">
-                Team {{ versionedNameOrId }} is required
+                Team {{ versionedNameOrId }} is required.
               </chef-error>
               <chef-error *ngIf="teamCreateForm.get('teamId').hasError('pattern') && teamCreateForm.get('teamId').dirty">
-                Only lowercase letters, numbers, and hyphens(-) are allowed
+                Only lowercase letters, numbers, and hyphens(-) are allowed.
               </chef-error>
               <chef-error *ngIf="teamCreateForm.get('teamId').hasError('maxlength') && teamCreateForm.get('teamId').dirty">
-                {{ versionedNameOrId }} must be 64 characters or less
+                {{ versionedNameOrId }} must be 64 characters or less.
               </chef-error>
             </chef-form-field>
             <chef-form-field id="create-name">
@@ -33,7 +33,7 @@
                 <chef-input ngDefaultControl formControlName="teamName" type="text"></chef-input>
               </label>
                <chef-error *ngIf="(teamCreateForm.get('teamName').hasError('required') || teamCreateForm.get('teamName').hasError('pattern')) && teamCreateForm.get('teamName').dirty">
-                  Team {{ versionedDescOrName }} is required
+                  Team {{ versionedDescOrName }} is required.
                 </chef-error>
             </chef-form-field>
           </form>

--- a/components/automate-ui/src/app/pages/team-create/team-create.component.html
+++ b/components/automate-ui/src/app/pages/team-create/team-create.component.html
@@ -17,9 +17,15 @@
                 <span class="label">Team {{ versionedNameOrId }}</span>
                 <chef-input ngDefaultControl formControlName="teamId" type="text"></chef-input>
               </label>
-               <chef-error *ngIf="(teamCreateForm.get('teamId').hasError('required') || teamCreateForm.get('teamId').hasError('pattern')) && teamCreateForm.get('teamId').dirty">
-                  A non-blank team {{ versionedNameOrId }} is required
-                </chef-error>
+              <chef-error *ngIf="teamCreateForm.get('teamId').hasError('required') && teamCreateForm.get('teamId').dirty">
+                {{ versionedNameOrId }} is required.
+              </chef-error>
+              <chef-error *ngIf="teamCreateForm.get('teamId').hasError('pattern') && teamCreateForm.get('teamId').dirty">
+                Only lowercase letters, numbers, and hyphens(-) are allowed.
+              </chef-error>
+              <chef-error *ngIf="teamCreateForm.get('teamId').hasError('maxlength') && teamCreateForm.get('teamId').dirty">
+                {{ versionedNameOrId }} must be 64 characters or less.
+              </chef-error>
             </chef-form-field>
             <chef-form-field id="create-name">
               <label>

--- a/components/automate-ui/src/app/pages/team-create/team-create.component.html
+++ b/components/automate-ui/src/app/pages/team-create/team-create.component.html
@@ -18,13 +18,13 @@
                 <chef-input ngDefaultControl formControlName="teamId" type="text"></chef-input>
               </label>
               <chef-error *ngIf="teamCreateForm.get('teamId').hasError('required') && teamCreateForm.get('teamId').dirty">
-                {{ versionedNameOrId }} is required.
+                Team {{ versionedNameOrId }} is required
               </chef-error>
               <chef-error *ngIf="teamCreateForm.get('teamId').hasError('pattern') && teamCreateForm.get('teamId').dirty">
-                Only lowercase letters, numbers, and hyphens(-) are allowed.
+                Only lowercase letters, numbers, and hyphens(-) are allowed
               </chef-error>
               <chef-error *ngIf="teamCreateForm.get('teamId').hasError('maxlength') && teamCreateForm.get('teamId').dirty">
-                {{ versionedNameOrId }} must be 64 characters or less.
+                {{ versionedNameOrId }} must be 64 characters or less
               </chef-error>
             </chef-form-field>
             <chef-form-field id="create-name">
@@ -33,7 +33,7 @@
                 <chef-input ngDefaultControl formControlName="teamName" type="text"></chef-input>
               </label>
                <chef-error *ngIf="(teamCreateForm.get('teamName').hasError('required') || teamCreateForm.get('teamName').hasError('pattern')) && teamCreateForm.get('teamName').dirty">
-                  A non-blank team {{ versionedDescOrName }} is required
+                  Team {{ versionedDescOrName }} is required
                 </chef-error>
             </chef-form-field>
           </form>

--- a/components/automate-ui/src/app/pages/team-create/team-create.component.html
+++ b/components/automate-ui/src/app/pages/team-create/team-create.component.html
@@ -33,7 +33,7 @@
                 <chef-input ngDefaultControl formControlName="teamName" type="text"></chef-input>
               </label>
                <chef-error *ngIf="(teamCreateForm.get('teamName').hasError('required') || teamCreateForm.get('teamName').hasError('pattern')) && teamCreateForm.get('teamName').dirty">
-                  Team {{ versionedDescOrName }} is required.
+                  {{ versionedDescOrName | titlecase }} is required.
                 </chef-error>
             </chef-form-field>
           </form>

--- a/components/automate-ui/src/app/pages/team-create/team-create.component.ts
+++ b/components/automate-ui/src/app/pages/team-create/team-create.component.ts
@@ -1,17 +1,16 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, Validators, FormGroup } from '@angular/forms';
-
 import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { Observable } from 'rxjs';
+
+import { Regex } from 'app/helpers/auth/regex';
 import {
   CreateTeam,
   CreateTeamPayload
 } from 'app/entities/teams/team.actions';
-import { Observable } from 'rxjs';
 import { iamMajorVersion } from 'app/entities/policies/policy.selectors';
 
-// NB: neither \S nor ^\s work inside the brackets in this regex language.
-const NON_BLANK = '.*[^ ].*';
 
 // TODO: We should only allow users to nav to this page if they have
 // permissions on user create.
@@ -31,8 +30,8 @@ export class TeamCreateComponent implements OnInit {
     fb: FormBuilder
   ) {
     this.teamCreateForm = fb.group({
-      teamId: ['', [Validators.required, Validators.pattern(NON_BLANK)]],
-      teamName: ['', [Validators.required, Validators.pattern(NON_BLANK)]]
+      teamId: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      teamName: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
     this.iamMajorVersion$ = store.select(iamMajorVersion);
   }

--- a/components/automate-ui/src/app/pages/team-create/team-create.component.ts
+++ b/components/automate-ui/src/app/pages/team-create/team-create.component.ts
@@ -30,8 +30,11 @@ export class TeamCreateComponent implements OnInit {
     fb: FormBuilder
   ) {
     this.teamCreateForm = fb.group({
-      teamId: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
-      teamName: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
+      // Must stay in sync with error checks in team-create.component.html
+      teamId: ['',
+        [Validators.required, Validators.pattern(Regex.patterns.ID), Validators.maxLength(64)]],
+      teamName: ['',
+        [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
     this.iamMajorVersion$ = store.select(iamMajorVersion);
   }

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -37,7 +37,7 @@
                   <chef-input ngDefaultControl formControlName="teamName" type="text"></chef-input>
                 </label>
                 <chef-error *ngIf="(editForm.get('teamName').hasError('required') || editForm.get('teamName').hasError('pattern')) && editForm.get('teamName').dirty">
-                  A non-blank team {{ versionedDescOrName }} is required
+                  Team {{ versionedDescOrName }} is required
                 </chef-error>
               </chef-form-field>
             </form>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -37,7 +37,7 @@
                   <chef-input ngDefaultControl formControlName="teamName" type="text"></chef-input>
                 </label>
                 <chef-error *ngIf="(editForm.get('teamName').hasError('required') || editForm.get('teamName').hasError('pattern')) && editForm.get('teamName').dirty">
-                  Team {{ versionedDescOrName }} is required.
+                  Team {{ versionedDescOrName | titlecase }} is required.
                 </chef-error>
               </chef-form-field>
             </form>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -37,7 +37,7 @@
                   <chef-input ngDefaultControl formControlName="teamName" type="text"></chef-input>
                 </label>
                 <chef-error *ngIf="(editForm.get('teamName').hasError('required') || editForm.get('teamName').hasError('pattern')) && editForm.get('teamName').dirty">
-                  Team {{ versionedDescOrName }} is required
+                  Team {{ versionedDescOrName }} is required.
                 </chef-error>
               </chef-form-field>
             </form>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -7,6 +7,7 @@ import { filter, map, pluck, takeUntil } from 'rxjs/operators';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams, routeURL } from 'app/route.selectors';
+import { Regex } from 'app/helpers/auth/regex';
 import { EntityStatus } from 'app/entities/entities';
 import { User, HashMapOfUsers } from 'app/entities/users/user.model';
 import { allUsers, userStatus } from 'app/entities/users/user.selectors';
@@ -29,8 +30,6 @@ import {
   UpdateTeam
 } from 'app/entities/teams/team.actions';
 
-// NB: neither \S nor ^\s work inside the brackets in this regex language.
-const NON_BLANK = '.*[^ ].*';
 const TEAM_DETAILS_ROUTE = /^\/settings\/teams/;
 
 @Component({
@@ -150,7 +149,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
 
   private createForms(fb: FormBuilder): void {
     this.editForm = fb.group({
-      teamName: ['', [Validators.required, Validators.pattern(NON_BLANK)]]
+      teamName: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
   }
 

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -149,6 +149,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
 
   private createForms(fb: FormBuilder): void {
     this.editForm = fb.group({
+      // Must stay in sync with error checks in team-details.component.html
       teamName: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
   }

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.html
@@ -28,7 +28,9 @@
                   <span class="label">Full Name</span>
                   <chef-input ngDefaultControl formControlName="fullName"></chef-input>
                 </label>
-                <chef-error *ngIf="editForm.get('fullName').hasError('required') && editForm.get('fullName').dirty">Full Name is required</chef-error>
+                <chef-error *ngIf="editForm.get('fullName').hasError('required') && editForm.get('fullName').dirty">
+                  Full Name is required
+                </chef-error>
               </chef-form-field>
             </form>
           </ng-container>
@@ -69,23 +71,33 @@
             <span class="label">Old Password</span>
             <chef-input ngDefaultControl formControlName="oldPassword" type="password"></chef-input>
           </label>
-          <chef-error *ngIf="passwordForm.get('oldPassword').hasError('required') && passwordForm.get('oldPassword').dirty">Old password is required</chef-error>
-          <chef-error *ngIf="passwordForm.get('oldPassword').hasError('minlength') && passwordForm.get('oldPassword').dirty">Old password must be at least 8 characters</chef-error>
+          <chef-error *ngIf="passwordForm.get('oldPassword').hasError('required') && passwordForm.get('oldPassword').dirty">
+            Old password is required
+          </chef-error>
+          <chef-error *ngIf="passwordForm.get('oldPassword').hasError('minlength') && passwordForm.get('oldPassword').dirty">
+            Old password must be at least 8 characters
+          </chef-error>
         </chef-form-field>
          <chef-form-field class="password">
           <label>
             <span class="label">New Password</span>
             <chef-input ngDefaultControl formControlName="newPassword" type="password"></chef-input>
           </label>
-          <chef-error *ngIf="passwordForm.get('newPassword').hasError('required') && passwordForm.get('newPassword').dirty">Password is required</chef-error>
-          <chef-error *ngIf="passwordForm.get('newPassword').hasError('minlength') && passwordForm.get('newPassword').dirty">Password must be at least 8 characters</chef-error>
+          <chef-error *ngIf="passwordForm.get('newPassword').hasError('required') && passwordForm.get('newPassword').dirty">
+            Password is required
+          </chef-error>
+          <chef-error *ngIf="passwordForm.get('newPassword').hasError('minlength') && passwordForm.get('newPassword').dirty">
+            Password must be at least 8 characters
+          </chef-error>
         </chef-form-field>
         <chef-form-field class="password">
           <label>
             <span class="label">Confirm New Password</span>
             <chef-input ngDefaultControl formControlName="confirmPassword" type="password"></chef-input>
           </label>
-          <chef-error *ngIf="passwordForm.get('confirmPassword').hasError('noMatch') && passwordForm.get('confirmPassword').dirty">Password must match</chef-error>
+          <chef-error *ngIf="passwordForm.get('confirmPassword').hasError('noMatch') && passwordForm.get('confirmPassword').dirty">
+            Passwords must match
+          </chef-error>
         </chef-form-field>
         <chef-button [disabled]="!passwordForm.valid" class="update-password-button" primary (click)="updatePassword()">
           <span>Update Password</span>

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.html
@@ -29,7 +29,7 @@
                   <chef-input ngDefaultControl formControlName="fullName"></chef-input>
                 </label>
                 <chef-error *ngIf="editForm.get('fullName').hasError('required') && editForm.get('fullName').dirty">
-                  Full Name is required
+                  Full Name is required.
                 </chef-error>
               </chef-form-field>
             </form>
@@ -72,10 +72,10 @@
             <chef-input ngDefaultControl formControlName="oldPassword" type="password"></chef-input>
           </label>
           <chef-error *ngIf="passwordForm.get('oldPassword').hasError('required') && passwordForm.get('oldPassword').dirty">
-            Old password is required
+            Old password is required.
           </chef-error>
           <chef-error *ngIf="passwordForm.get('oldPassword').hasError('minlength') && passwordForm.get('oldPassword').dirty">
-            Old password must be at least 8 characters
+            Old password must be at least 8 characters.
           </chef-error>
         </chef-form-field>
          <chef-form-field class="password">
@@ -84,10 +84,10 @@
             <chef-input ngDefaultControl formControlName="newPassword" type="password"></chef-input>
           </label>
           <chef-error *ngIf="passwordForm.get('newPassword').hasError('required') && passwordForm.get('newPassword').dirty">
-            Password is required
+            Password is required.
           </chef-error>
           <chef-error *ngIf="passwordForm.get('newPassword').hasError('minlength') && passwordForm.get('newPassword').dirty">
-            Password must be at least 8 characters
+            Password must be at least 8 characters.
           </chef-error>
         </chef-form-field>
         <chef-form-field class="password">
@@ -96,7 +96,7 @@
             <chef-input ngDefaultControl formControlName="confirmPassword" type="password"></chef-input>
           </label>
           <chef-error *ngIf="passwordForm.get('confirmPassword').hasError('noMatch') && passwordForm.get('confirmPassword').dirty">
-            Passwords must match
+            Passwords must match.
           </chef-error>
         </chef-form-field>
         <chef-button [disabled]="!passwordForm.valid" class="update-password-button" primary (click)="updatePassword()">

--- a/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
@@ -5,7 +5,7 @@
       <input chefInput formControlName="fullname" type="text">
     </label>
     <chef-error *ngIf="(createUserForm.get('fullname').hasError('required') || createUserForm.get('fullname').hasError('pattern')) && createUserForm.get('fullname').dirty">
-      Full name is required
+      Full Name is required.
     </chef-error>
   </chef-form-field>
   <chef-form-field>
@@ -14,7 +14,7 @@
       <input chefInput formControlName="username" type="text">
     </label>
     <chef-error *ngIf="(createUserForm.get('username').hasError('required') || createUserForm.get('username').hasError('pattern')) && createUserForm.get('username').dirty">
-      Invalid username
+      Invalid username.
     </chef-error>
   </chef-form-field>
   <chef-form-field>
@@ -23,10 +23,10 @@
       <input chefInput formControlName="password" type="password">
     </label>
     <chef-error *ngIf="createUserForm.get('password').hasError('required') && createUserForm.get('password').dirty">
-      Password is required
+      Password is required.
     </chef-error>
     <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && createUserForm.get('password').dirty">
-      Password must be at least 8 characters
+      Password must be at least 8 characters.
     </chef-error>
   </chef-form-field>
   <chef-form-field>
@@ -35,7 +35,7 @@
       <input chefInput formControlName="confirmPassword" type="password">
     </label>
     <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && createUserForm.get('confirmPassword').dirty">
-      Passwords must match
+      Passwords must match.
     </chef-error>
   </chef-form-field>
 </form>

--- a/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
@@ -5,7 +5,7 @@
       <input chefInput formControlName="fullname" type="text">
     </label>
     <chef-error *ngIf="(createUserForm.get('fullname').hasError('required') || createUserForm.get('fullname').hasError('pattern')) && createUserForm.get('fullname').dirty">
-      Full Name is required.
+      User's Full Name is required.
     </chef-error>
   </chef-form-field>
   <chef-form-field>
@@ -13,8 +13,11 @@
       <span class="label">Username</span>
       <input chefInput formControlName="username" type="text">
     </label>
-    <chef-error *ngIf="(createUserForm.get('username').hasError('required') || createUserForm.get('username').hasError('pattern')) && createUserForm.get('username').dirty">
-      Invalid username.
+    <chef-error *ngIf="createUserForm.get('username').hasError('required') && createUserForm.get('username').dirty">
+      Username is required.
+    </chef-error>
+    <chef-error *ngIf="createUserForm.get('username').hasError('pattern') && createUserForm.get('username').dirty">
+      Only letters, numbers, and these characters (<strong>_@.+-</strong>) allowed.
     </chef-error>
   </chef-form-field>
   <chef-form-field>

--- a/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
@@ -5,7 +5,7 @@
       <input chefInput formControlName="fullname" type="text">
     </label>
     <chef-error *ngIf="(createUserForm.get('fullname').hasError('required') || createUserForm.get('fullname').hasError('pattern')) && createUserForm.get('fullname').dirty">
-      Full name required
+      Full name is required
     </chef-error>
   </chef-form-field>
   <chef-form-field>
@@ -23,7 +23,7 @@
       <input chefInput formControlName="password" type="password">
     </label>
     <chef-error *ngIf="createUserForm.get('password').hasError('required') && createUserForm.get('password').dirty">
-      Password required
+      Password is required
     </chef-error>
     <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && createUserForm.get('password').dirty">
       Password must be at least 8 characters
@@ -35,7 +35,7 @@
       <input chefInput formControlName="confirmPassword" type="password">
     </label>
     <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && createUserForm.get('confirmPassword').dirty">
-      Password must match
+      Passwords must match
     </chef-error>
   </chef-form-field>
 </form>

--- a/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
@@ -4,33 +4,38 @@
       <span class="label">User's Full Name</span>
       <input chefInput formControlName="fullname" type="text">
     </label>
-    <chef-error *ngIf="createUserForm.get('fullname').hasError('required') && createUserForm.get('fullname').dirty">Full
-      name required</chef-error>
+    <chef-error *ngIf="(createUserForm.get('fullname').hasError('required') || createUserForm.get('fullname').hasError('pattern')) && createUserForm.get('fullname').dirty">
+      Full name required
+    </chef-error>
   </chef-form-field>
   <chef-form-field>
     <label>
       <span class="label">Username</span>
       <input chefInput formControlName="username" type="text">
     </label>
-    <chef-error *ngIf="createUserForm.get('username').hasError('pattern') && createUserForm.get('username').dirty">Invalid
-      username</chef-error>
+    <chef-error *ngIf="(createUserForm.get('username').hasError('required') || createUserForm.get('username').hasError('pattern')) && createUserForm.get('username').dirty">
+      Invalid username
+    </chef-error>
   </chef-form-field>
   <chef-form-field>
     <label>
       <span class="label">Password</span>
       <input chefInput formControlName="password" type="password">
     </label>
-    <chef-error *ngIf="createUserForm.get('password').hasError('required') && createUserForm.get('password').dirty">Password
-      required</chef-error>
-    <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && createUserForm.get('password').dirty">Password
-      must be at least 8 characters</chef-error>
+    <chef-error *ngIf="createUserForm.get('password').hasError('required') && createUserForm.get('password').dirty">
+      Password required
+    </chef-error>
+    <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && createUserForm.get('password').dirty">
+      Password must be at least 8 characters
+    </chef-error>
   </chef-form-field>
   <chef-form-field>
     <label>
       <span class="label">Confirm Password</span>
       <input chefInput formControlName="confirmPassword" type="password">
     </label>
-    <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && createUserForm.get('confirmPassword').dirty">Password
-      must match</chef-error>
+    <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && createUserForm.get('confirmPassword').dirty">
+      Password must match
+    </chef-error>
   </chef-form-field>
 </form>

--- a/components/automate-ui/src/app/pages/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/pages/user-management/user-management.component.ts
@@ -74,7 +74,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
       )));
 
     this.createUserForm = fb.group({
-      // Make sure these stay in sync with error checks in user-form.component.html
+      // Must stay in sync with error checks in user-form.component.html
       fullname: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       username: ['', [Validators.required, Validators.pattern(USERNAME_PATTERN)]],
       // length validator must be consistent with

--- a/components/automate-ui/src/app/pages/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/pages/user-management/user-management.component.ts
@@ -1,14 +1,11 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import {
-  FormBuilder,
-  FormGroup,
-  Validators
-} from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Store } from '@ngrx/store';
 import { Observable ,  Subject } from 'rxjs';
 import { takeUntil, map } from 'rxjs/operators';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { Regex } from 'app/helpers/auth/regex';
 import { EntityStatus, loading } from 'app/entities/entities';
 import { allUsers, userStatus } from 'app/entities/users/user.selectors';
 import {
@@ -77,8 +74,9 @@ export class UserManagementComponent implements OnInit, OnDestroy {
       )));
 
     this.createUserForm = fb.group({
-      fullname: ['', Validators.required],
-      username: ['', Validators.pattern(USERNAME_PATTERN)],
+      // Make sure these stay in sync with error checks in user-form.component.html
+      fullname: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      username: ['', [Validators.required, Validators.pattern(USERNAME_PATTERN)]],
       // length validator must be consistent with
       // backend password rules in local-user-service/password/password.go
       password: ['', [Validators.required, Validators.minLength(8)]],

--- a/components/automate-ui/src/app/pipes/pluralize.pipe.spec.ts
+++ b/components/automate-ui/src/app/pipes/pluralize.pipe.spec.ts
@@ -17,14 +17,28 @@ describe('PluralizePipe', () => {
       ['0', 'team', 's'],
       ['2', 'fox', 'es'],
       ['-5', 'color', 's']
-    ], (value, unit, suffix, _result: string) => {
-      it('pluralizes any NON-unitary value ', () => {
+    ], (value, unit, suffix: string) => {
+      it('pluralizes NON-unitary values with additive-suffix', () => {
         expect(pipe.transform(value, unit, suffix)).toBe(value + ' ' + unit + suffix);
       });
     });
 
-  it('providing UNITARY value returns singular form', () => {
+  using([
+      ['0', 'radius', '<<i', 'radii'],
+      ['4', 'goose', '<<<<eese',  'geese'],
+      ['-5', 'policy', '<ies', 'policies']
+    ], (value, unit, suffix, result: string) => {
+      it('pluralizes NON-unitary values with subtractive-suffix', () => {
+        expect(pipe.transform(value, unit, suffix)).toBe(value + ' ' + result);
+      });
+    });
+
+  it('providing UNITARY value with additive-suffix returns singular form', () => {
     expect(pipe.transform('1', 'team', 's' )).toBe('1 team');
+  });
+
+  it('providing UNITARY value with subtractive-suffix returns singular form', () => {
+    expect(pipe.transform('1', 'policy', '<ies' )).toBe('1 policy');
   });
 
 });

--- a/components/automate-ui/src/app/pipes/pluralize.pipe.ts
+++ b/components/automate-ui/src/app/pipes/pluralize.pipe.ts
@@ -1,11 +1,45 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+/**
+ * Use the pluralize pipe in an Angular template to add an appropriate plural ending
+ * when the quantity requires it, i.e. when *not* equal to 1.
+ * Thus, "1 member", "2 members" or "1 tree", "0 trees".
+ *
+ * The primary argument (before the pipe) is the quantity.
+ * The second argument is the word to be made plural (or not).
+ * The third argument is the plural to apply, e.g. "s" or "es".
+ * An actual code example:
+ *
+ *   {{ membersToAddValues().length | pluralize : 'member' : 's' }} selected
+ *
+ * It gets more interesting for a word like "policy", which would become plural
+ * by dropping the "y" and adding "ies". This is done by indicating how many
+ * characters to drop off the end of the word, in this case 1,
+ * so a single "<" is added at the front of the plural indicator:
+ *
+ *   There are {{ policies.length | pluralize : 'policy' : '<ies' }} selected
+ *
+ * If there are more characters to drop, just add more shifters:
+ *
+ *   There are {{ fowlCount | pluralize : 'goose' : '<<<<eese' }} on the farm.
+ */
+
 @Pipe({
   name: 'pluralize'
 })
 export class PluralizePipe implements PipeTransform {
 
   transform(value, word, suffix: string): string {
-    return value + ' ' + word + ((value && +value === 1) ? '' : suffix);
+    const shiftChar = '<';
+    if (!suffix.includes(shiftChar)) {
+      return value + ' ' + word + ((value && +value === 1) ? '' : suffix);
+    }
+    const shiftChars = suffix.split(shiftChar);
+    const shifters = shiftChars.length - 1;
+    const newSuffix = shiftChars[shifters];
+    return value + ' ' +
+      (value && +value === 1
+        ? word
+        : (word.substr(0, word.length - shifters) + newSuffix));
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description

In the course of acceptance testing, I started noticing some inconsistent wordings, and error triggers. This PR is a general cleanup of a host of little things across policies, projects, users, teams, and tokens (we don't have any forms for roles, so nothing there).

### :+1: Definition of Done

#### Cross-resource concerns
1. Pulled out common validation regexes used in multiple places into a single constants file, helpers/auth/regex.ts.
2. Ensure all error displays do not end in a period.
3. Ensure wording the same for same phrases.
4. Ensure consistent grammar "A team is..." vs. "Team is....".
5. Ensure note for each Validator reminds the developer which template to sync with.
6. Ensure consistent formatting of <chef-error> elements.
7. Ensure "Required" error msg omits the phrase "non-blank" (as it really doesn't add value).

#### Specific resource changes
1. **CreateUser**: now triggers error if the full name is just whitespace.
2. **CreateUser**: now triggers error if the user name is empty. (It turns out that a regex disallowing an empty string is not good enough!)
3. **AddPolicyMember**: reset "active" error (error against state of the data, not a typing error) as soon as user edits the value again. That way, when pressing "Add" again, the error will be able to go from invisible to visible, thus appearing again.
4. **AddPolicyMember**: now triggers error if the member expression is just whitespace.
5. **AddPolicyMember**: now triggers error if the member expression is empty.
6. **CreateTeam**: now triggers error if ID is invalid.
7. **CreateTeam**: now triggers error if ID exceeds 64 characters.
8. **EditToken**: hooked up present--but unused--validator, allowing removing manual check.

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
