### PR TITLE
[automate-chef-server] Bump automate-cs package for core/curl rebuild

### DIFF
--- a/.expeditor/update_chef_server.sh
+++ b/.expeditor/update_chef_server.sh
@@ -50,7 +50,7 @@ for i in "${!file_for_pkg[@]}"; do
     file_to_update="${file_for_pkg[$i]}"
 
     echo "Updating pin for $package_name in $file_to_update pins to $new_ident"
-    sed -i -r "s|$package_name/[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]{14}|${new_ident#chef/}|" "$file_to_update"
+    sed -i -r "s|$package_name/[0-9]+(\\.[0-9]+){2,3}/[0-9]{14}|${new_ident#chef/}|" "$file_to_update"
 
     if [[ "$package_name" != "openresty-noroot" ]]; then
         echo "Updating pkg_version in $file_to_update pins to $build"

--- a/components/automate-cs-bookshelf/habitat/plan.sh
+++ b/components/automate-cs-bookshelf/habitat/plan.sh
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/bookshelf/13.0.19/20190709120215"
+  "${vendor_origin}/bookshelf/13.0.19/20190711080332"
 )
 
 pkg_binds=(

--- a/components/automate-cs-nginx/habitat/plan.sh
+++ b/components/automate-cs-nginx/habitat/plan.sh
@@ -15,8 +15,8 @@ pkg_deps=(
   core/bundler
   core/ruby
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/chef-server-nginx/13.0.19/20190709121113"
-  "${vendor_origin}/chef-server-ctl/13.0.19/20190709120215"
+  "${vendor_origin}/chef-server-nginx/13.0.19/20190711081057"
+  "${vendor_origin}/chef-server-ctl/13.0.19/20190711080332"
 )
 
 pkg_bin_dirs=(bin)

--- a/components/automate-cs-oc-bifrost/habitat/plan.sh
+++ b/components/automate-cs-oc-bifrost/habitat/plan.sh
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/oc_bifrost/13.0.19/20190709120413"
+  "${vendor_origin}/oc_bifrost/13.0.19/20190711080330"
 )
 
 pkg_binds=(

--- a/components/automate-cs-oc-erchef/habitat/plan.sh
+++ b/components/automate-cs-oc-erchef/habitat/plan.sh
@@ -16,7 +16,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/oc_erchef/13.0.19/20190709120413"
+  "${vendor_origin}/oc_erchef/13.0.19/20190711080330"
 )
 
 pkg_build_deps=(

--- a/components/automate-workflow-nginx/habitat/plan.sh
+++ b/components/automate-workflow-nginx/habitat/plan.sh
@@ -8,7 +8,7 @@ vendor_origin=${vendor_origin:-"chef"}
 pkg_deps=(
   core/libossp-uuid
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/openresty-noroot/1.13.6.2/20190709120215"
+  "${vendor_origin}/openresty-noroot/1.13.6.2/20190711080332"
   chef/mlsa
   core/bash
   core/curl


### PR DESCRIPTION
The day after we decided to stop pinning, core/curl was promoted again
leading to a nightly breakage.  This PR was created by running

    NO_GIT=true ./.expeditor/update_chef_server.sh unstable

after running a Chef Server build from Buildkite.

Signed-off-by: Steven Danna <steve@chef.io>