### PR TITLE
[lib/fileutils] Add new LogCloser function

### DIFF
--- a/components/authz-service/storage/v1/postgres/postgres.go
+++ b/components/authz-service/storage/v1/postgres/postgres.go
@@ -15,6 +15,7 @@ import (
 	"github.com/chef/automate/components/authz-service/storage/postgres"
 	"github.com/chef/automate/components/authz-service/storage/postgres/migration"
 	storage "github.com/chef/automate/components/authz-service/storage/v1"
+	"github.com/chef/automate/lib/io/fileutils"
 	"github.com/chef/automate/lib/logger"
 	uuid "github.com/chef/automate/lib/uuid4"
 )
@@ -112,12 +113,7 @@ func (p *pg) ListPolicies(ctx context.Context) ([]*storage.Policy, error) {
 	if err != nil {
 		return nil, p.processError(err)
 	}
-	defer func() {
-		err := rows.Close()
-		if err != nil {
-			p.logger.Errorf("could not close rows. Error: %v", err)
-		}
-	}()
+	defer fileutils.LogClose(rows, p.logger, "could not close rows")
 
 	storagePolicies := []*storage.Policy{}
 	for rows.Next() {
@@ -140,12 +136,7 @@ func (p *pg) ListPoliciesWithSubjects(ctx context.Context) ([]*storage.Policy, e
 	if err != nil {
 		return nil, p.processError(err)
 	}
-	defer func() {
-		err := rows.Close()
-		if err != nil {
-			p.logger.Errorf("could not close rows. Error: %v", err)
-		}
-	}()
+	defer fileutils.LogClose(rows, p.logger, "could not close rows")
 
 	storagePolicies := []*storage.Policy{}
 	for rows.Next() {
@@ -192,11 +183,7 @@ func (p *pg) PurgeSubjectFromPolicies(ctx context.Context, sub string) ([]uuid.U
 	if err != nil {
 		return nil, p.processError(err)
 	}
-	defer func() {
-		if err := rows.Close(); err != nil {
-			p.logger.Errorf("could not close rows. Error: %v", err)
-		}
-	}()
+	defer fileutils.LogClose(rows, p.logger, "could not close rows")
 
 	var polIDs []uuid.UUID
 	for rows.Next() {

--- a/lib/io/fileutils/fileutils.go
+++ b/lib/io/fileutils/fileutils.go
@@ -1,8 +1,18 @@
 package fileutils
 
 import (
+	"io"
 	"os"
+
+	"github.com/sirupsen/logrus"
 )
+
+// LogCLose closes the given io.Closer, logging any error.
+func LogClose(c io.Closer, log logrus.FieldLogger, msg string) {
+	if err := c.Close(); err != nil {
+		log.WithError(err).Error(msg)
+	}
+}
 
 // PathExists returns true if the path exists and false if it doesn't
 // exist. An error is returned if an unexpected error occurs.  Callers


### PR DESCRIPTION
This is a small helper function. It is a bit silly, but I applied it
to one file and I like the cleanup and think it might encourage us to
not ignore this err check more often.

Signed-off-by: Steven Danna <steve@chef.io>