### PR TITLE
[deployment-service] Log stdout from systemctl status command

### DIFF
--- a/components/automate-deployment/pkg/target/local_target.go
+++ b/components/automate-deployment/pkg/target/local_target.go
@@ -851,8 +851,10 @@ func (t *LocalTarget) SystemdRunning() (bool, error) {
 // required.
 func (t *LocalTarget) SystemdReloadRequired() (bool, error) {
 	stderrBuff := new(strings.Builder)
-	err := t.Executor.Run("systemctl", command.Args("status", "chef-automate.service"), command.Stderr(stderrBuff))
+	out, err := t.Executor.Output("systemctl", command.Args("status", "chef-automate.service"),
+		command.Stderr(stderrBuff))
 	if err != nil {
+		logrus.Debugf("systemctl status failed with standard output: %s", out)
 		return false, errors.Wrapf(err, "systemctl status chef-automate.service failed: %s", stderrBuff.String())
 	}
 


### PR DESCRIPTION
In CI we are seeing systemctl status fail with an exit code 3 but no
useful error message. This function is pretty suspect (string
matching error output), so it is possible that systemd behavior has
change subtly or that this function was always incorrect.

Signed-off-by: Steven Danna <steve@chef.io>