### PR TITLE
[CI] Remove [integration] prefix from some jobs

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -541,7 +541,7 @@ steps:
 
   - wait
 
-  - label: "[integration] automate-ui"
+  - label: "automate-ui"
     command:
       - cd components/automate-ui
       - ./scripts/build_chef_ui_lib
@@ -555,7 +555,7 @@ steps:
       executor:
         docker:
 
-  - label: "[integration] compliance-service db-migrations"
+  - label: "compliance-service db-migrations"
     command:
       - sudo sysctl -w vm.max_map_count=262144 # Needed for ElasticSearch 6
       - export PATH=\$PATH:/usr/local/go/bin:\$HOME/.local/bin:\$HOME/bin
@@ -581,7 +581,7 @@ steps:
       - gopath-checkout#v1.0.1:
           import: github.com/chef/automate
 
-  - label: "[integration] compliance-service scanner"
+  - label: "compliance-service scanner"
     command:
       - sudo sysctl -w vm.max_map_count=262144 # Needed for ElasticSearch 6
       - export PATH=\$PATH:/usr/local/go/bin:\$HOME/.local/bin:\$HOME/bin
@@ -607,7 +607,7 @@ steps:
       - gopath-checkout#v1.0.1:
           import: github.com/chef/automate
 
-  - label: "[integration] compliance-service reporting"
+  - label: "compliance-service reporting"
     command:
       - sudo sysctl -w vm.max_map_count=262144 # Needed for ElasticSearch 6
       - export PATH=\$PATH:/usr/local/go/bin:\$HOME/.local/bin:\$HOME/bin
@@ -632,7 +632,7 @@ steps:
       - gopath-checkout#v1.0.1:
           import: github.com/chef/automate
 
-  - label: "[integration] nodemanager-service run-db-tests"
+  - label: "nodemanager-service run-db-tests"
     command:
       - export PATH=\$PATH:/usr/local/go/bin:\$HOME/.local/bin:\$HOME/bin
       - sudo scripts/install_inspec.sh
@@ -658,7 +658,7 @@ steps:
       - gopath-checkout#v1.0.1:
           import: github.com/chef/automate
 
-  - label: "[integration] compliance-service upgrade from Automate v1"
+  - label: "compliance-service upgrade from Automate v1"
     command:
       - sudo sysctl -w vm.max_map_count=262144 # Needed for ElasticSearch 6
       - export PATH=\$PATH:/usr/local/go/bin:\$HOME/.local/bin:\$HOME/bin
@@ -684,7 +684,7 @@ steps:
       - gopath-checkout#v1.0.1:
           import: github.com/chef/automate
 
-  - label: "[integration] compliance-service upgrade from Automate v2v1"
+  - label: "compliance-service upgrade from Automate v2v1"
     command:
       - sudo sysctl -w vm.max_map_count=262144 # Needed for ElasticSearch 6
       - export PATH=\$PATH:/usr/local/go/bin:\$HOME/.local/bin:\$HOME/bin
@@ -710,7 +710,7 @@ steps:
       - gopath-checkout#v1.0.1:
           import: github.com/chef/automate
 
-  - label: "[integration] compliance-service upgrade from Automate v2v2"
+  - label: "compliance-service upgrade from Automate v2v2"
     command:
       - sudo sysctl -w vm.max_map_count=262144 # Needed for ElasticSearch 6
       - export PATH=\$PATH:/usr/local/go/bin:\$HOME/.local/bin:\$HOME/bin

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -109,7 +109,7 @@ steps:
   # or take a long time.
   - wait
 
-  - label: "[integration] automate-load-balancer"
+  - label: "automate-load-balancer"
     command:
       - . scripts/verify_setup.sh
       - |
@@ -129,7 +129,7 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  - label: "[integration] applications-service"
+  - label: "applications-service"
     command:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh && start_deployment_service && chef-automate dev deploy-some chef/applications-service --with-deps && applications_integration"
@@ -147,7 +147,7 @@ steps:
 
   # The nodemanager tests require access to AWS and Azure accounts as
   # they test against the actual API endpoints of those services.
-  - label: "[integration] nodemanager-integration-tests"
+  - label: "nodemanager-integration-tests"
     command:
       - . scripts/verify_setup.sh
       - |
@@ -188,7 +188,7 @@ steps:
 
   # The license_usage_nodes_test appears to require AWS access. We
   # might consider splitting this into two different tests.
-  - label: "[integration] gateway-integration-tests"
+  - label: "gateway-integration-tests"
     command:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh && start_all_services && go_test components/automate-gateway/integration/license_usage_nodes_test.go && go_test components/automate-gateway/integration/nodes_test.go"
@@ -228,7 +228,7 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  - label: "[integration] automate-gateway-iam-v1"
+  - label: "automate-gateway-iam-v1"
     command:
       - . scripts/verify_setup.sh
       - |
@@ -248,7 +248,7 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  - label: "[integration] automate-gateway-iam-v2"
+  - label: "automate-gateway-iam-v2"
     command:
       - . scripts/verify_setup.sh
       - |
@@ -269,7 +269,7 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  - label: "[integration] secrets-service"
+  - label: "secrets-service"
     command:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh && start_deployment_service && chef-automate dev deploy-some chef/secrets-service --with-deps && secrets_integration"
@@ -282,7 +282,7 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  - label: "[integration] event-feed-service"
+  - label: "event-feed-service"
     command:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh &&
@@ -298,7 +298,7 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  - label: "[integration] es-sidecar-service"
+  - label: "es-sidecar-service"
     command:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh && start_deployment_service && chef-automate dev deploy-some chef/es-sidecar-service --with-deps && es_sidecar_service_integration"
@@ -314,7 +314,7 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  - label: "[integration] ingest-service"
+  - label: "ingest-service"
     command:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh && start_deployment_service && chef-automate dev deploy-some chef/ingest-service --with-deps && ingest_integration"
@@ -331,7 +331,7 @@ steps:
             - HAB_NONINTERACTIVE=true
             - REST_SERVICE=https://localhost:10122
 
-  - label: "[integration] compliance-service"
+  - label: "compliance-service"
     command:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh && start_deployment_service && chef-automate dev deploy-some chef/compliance-service --with-deps && compliance_integration"
@@ -347,7 +347,7 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  - label: "[integration] config-mgmt-service"
+  - label: "config-mgmt-service"
     command:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh && start_deployment_service && chef-automate dev deploy-some chef/automate-elasticsearch --with-deps && config_mgmt_integration"
@@ -363,7 +363,7 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  - label: "[integration] event-service"
+  - label: "event-service"
     command:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh && start_deployment_service && chef-automate dev deployinate && event_integration"
@@ -376,7 +376,7 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  - label: "[integration] event-gateway"
+  - label: "event-gateway"
     command:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh && start_deployment_service && chef-automate dev deployinate && event_gateway_integration"
@@ -389,7 +389,7 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  - label: "[integration] pg-sidecar-service"
+  - label: "pg-sidecar-service"
     command:
       - . scripts/verify_setup.sh
       - |
@@ -414,7 +414,7 @@ steps:
   # end-to-end testing. These tests all test full deployments of
   # Automate in different configurations.
   #
-  - label: "[integration] :cypress: IAMv1"
+  - label: ":cypress: IAMv1"
     command:
       - integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
@@ -440,7 +440,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] :cypress: IAMv2"
+  - label: ":cypress: IAMv2"
     command:
       - IAM=v2 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
@@ -450,7 +450,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] :cypress: IAMv2.1"
+  - label: ":cypress: IAMv2.1"
     command:
       - IAM=v2.1 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
@@ -460,7 +460,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] iam v2 (migrated)"
+  - label: "iam v2 (migrated)"
     command:
       - integration/run_test integration/tests/iam_v2.sh
     timeout_in_minutes: 20
@@ -469,7 +469,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] iam v2 (v2 only)"
+  - label: "iam v2 (v2 only)"
     command:
       - integration/run_test integration/tests/iam_v2_only.sh
     timeout_in_minutes: 20
@@ -482,7 +482,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] iam v2 (v2.1 only)"
+  - label: "iam v2 (v2.1 only)"
     command:
       - integration/run_test integration/tests/iam_v2p1_only.sh
     timeout_in_minutes: 20
@@ -495,7 +495,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] data-lifecycle-service"
+  - label: "data-lifecycle-service"
     command:
       - integration/run_test integration/tests/data_lifecycle.sh
     timeout_in_minutes: 20
@@ -504,7 +504,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] a1migration"
+  - label: "a1migration"
     command:
       - integration/run_test integration/tests/a1migration.sh
     timeout_in_minutes: 20
@@ -514,7 +514,7 @@ steps:
           single-use: true
           privileged: true
 
-  - label: "[integration] airgap a1migration"
+  - label: "airgap a1migration"
     command:
       - integration/run_test integration/tests/airgap_a1migration.sh
     timeout_in_minutes: 20
@@ -524,7 +524,7 @@ steps:
           single-use: true
           privileged: true
 
-  - label: "[integration] product"
+  - label: "product"
     command:
       - integration/run_test integration/tests/product.sh
     timeout_in_minutes: 20
@@ -534,7 +534,7 @@ steps:
           single-use: true
           privileged: true
 
-  - label: "[integration] product deployment stress mode"
+  - label: "product deployment stress mode"
     command:
       - integration/run_test integration/tests/product_deployment_stress.sh
     timeout_in_minutes: 20
@@ -544,7 +544,7 @@ steps:
           single-use: true
           privileged: true
 
-  - label: "[integration] product airgap"
+  - label: "product airgap"
     command:
       - integration/run_test integration/tests/airgap_product.sh
     timeout_in_minutes: 20
@@ -553,7 +553,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] airgap upgrade"
+  - label: "airgap upgrade"
     command:
       - integration/run_test integration/tests/airgap_upgrade.sh
     timeout_in_minutes: 30
@@ -562,7 +562,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] airgap backup"
+  - label: "airgap backup"
     command:
       - integration/run_test integration/tests/airgap_backup.sh
     timeout_in_minutes: 20
@@ -571,7 +571,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] chef server"
+  - label: "chef server"
     command:
       - integration/run_test integration/tests/chef_server.sh
     timeout_in_minutes: 30 # longer timeout for chef-server
@@ -580,7 +580,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] chef server only"
+  - label: "chef server only"
     command:
       - integration/run_test integration/tests/chef_server_only.sh
     timeout_in_minutes: 20
@@ -589,7 +589,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] ha chef server"
+  - label: "ha chef server"
     command:
       - integration/run_test integration/tests/ha_chef_server.sh
     timeout_in_minutes: 35
@@ -599,7 +599,7 @@ steps:
           single-use: true
           privileged: true
 
-  - label: "[integration] workflow"
+  - label: "workflow"
     command:
       - integration/run_test integration/tests/workflow.sh
     timeout_in_minutes: 30 # longer timeout for workflow
@@ -608,7 +608,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] backup to s3"
+  - label: "backup to s3"
     command:
       - integration/run_test integration/tests/backup_s3.sh
     timeout_in_minutes: 20
@@ -618,7 +618,7 @@ steps:
           single-use: true
           privileged: true
 
-  - label: "[integration] ontop backup "
+  - label: "ontop backup "
     command:
       - integration/run_test integration/tests/backup_ontop.sh
     timeout_in_minutes: 20
@@ -628,7 +628,7 @@ steps:
           single-use: true
           privileged: true
 
-  - label: "[integration] backup w external es"
+  - label: "backup w external es"
     command:
       - integration/run_test integration/tests/backup_external_es.sh
     timeout_in_minutes: 25
@@ -638,7 +638,7 @@ steps:
           single-use: true
           privileged: true
 
-  - label: "[integration] upgrade dev -> master"
+  - label: "upgrade dev -> master"
     command:
       - integration/run_test integration/tests/upgrade.sh
     timeout_in_minutes: 25
@@ -647,7 +647,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] upgrade acceptance -> master"
+  - label: "upgrade acceptance -> master"
     command:
       - integration/run_test integration/tests/upgrade_acceptance_master.sh
     timeout_in_minutes: 25
@@ -656,7 +656,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] upgrade current -> master"
+  - label: "upgrade current -> master"
     command:
       - integration/run_test integration/tests/upgrade_current_master.sh
     timeout_in_minutes: 25
@@ -665,7 +665,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] manual upgrade current -> master"
+  - label: "manual upgrade current -> master"
     command:
       - integration/run_test integration/tests/manual_upgrade.sh
     timeout_in_minutes: 25
@@ -674,7 +674,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] deep upgrades"
+  - label: "deep upgrades"
     command:
       - integration/run_test integration/tests/deep_upgrade.sh
     timeout_in_minutes: 25
@@ -683,7 +683,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] deep migrate upgrade"
+  - label: "deep migrate upgrade"
     command:
       - integration/run_test integration/tests/migrate_upgrade.sh
     timeout_in_minutes: 25
@@ -693,7 +693,7 @@ steps:
           single-use: true
           privileged: true
 
-  - label: "[integration] backups"
+  - label: "backups"
     command:
       - integration/run_test integration/tests/backup.sh
     timeout_in_minutes: 20
@@ -702,7 +702,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] reset admin access v1"
+  - label: "reset admin access v1"
     command:
       - integration/run_test integration/tests/reset_admin_access_v1.sh
     timeout_in_minutes: 20
@@ -711,7 +711,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] reset admin access v2"
+  - label: "reset admin access v2"
     command:
       - integration/run_test integration/tests/reset_admin_access_v2.sh
     timeout_in_minutes: 20
@@ -720,7 +720,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] upgrade / reset IAM v2"
+  - label: "upgrade / reset IAM v2"
     command:
       - integration/run_test integration/tests/upgrade_reset_iam_v2.sh
     timeout_in_minutes: 20
@@ -729,7 +729,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] upgrade / reset IAM v2.1"
+  - label: "upgrade / reset IAM v2.1"
     command:
       - integration/run_test integration/tests/upgrade_reset_iam_v2p1.sh
     timeout_in_minutes: 20
@@ -738,7 +738,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] security"
+  - label: "security"
     command:
       - integration/run_test integration/tests/security.sh
     timeout_in_minutes: 20
@@ -747,7 +747,7 @@ steps:
         linux:
           privileged: true
 
-  - label: "[integration] ha data services"
+  - label: "ha data services"
     command:
       - integration/run_test integration/tests/ha_data_services.sh
     timeout_in_minutes: 35


### PR DESCRIPTION
We know that everything in the `post-build` phase of the pipeline is
an integration test. All this does is make it hard to read what failed.

@srenatus gave me the idea. I think the gain in scan-ability is worth any
downside.

Signed-off-by: Steven Danna <steve@chef.io>