### PR TITLE
 Protect compliance integration tests against fast completing jobs

### DIFF
--- a/components/compliance-service/api/tests/03_reports_spec.rb
+++ b/components/compliance-service/api/tests/03_reports_spec.rb
@@ -674,7 +674,7 @@ describe File.basename(__FILE__) do
 
     # Get a specific report
     # actual_data = GRPC reporting, :read_report, Reporting::Query.new(id: 'bb93e1b2-36d6-439e-ac70-cccccccccc05')
-    # assert_assert_equal(actual_data.class, Reporting::Report)
+    # assert_assert_equal(Reporting::Report, actual_data.class)
     #
     # expected_json = {
     #   "id" => "bb93e1b2-36d6-439e-ac70-cccccccccc05",

--- a/components/compliance-service/api/tests/30_jobs_docker_spec.rb
+++ b/components/compliance-service/api/tests/30_jobs_docker_spec.rb
@@ -232,9 +232,9 @@ describe File.basename(__FILE__) do
     # Get job by id with all details
     job1 = GRPC jobs, :read, Jobs::Id.new(id: job_id1)
     assert_equal(true, TimeStuff.checkTimestampAndAdjustIfNeeded(test_start_time, job1, 'start_time'))
-    job1['status'] = 'GOOOOD'
     job1_hash = job1.to_hash
-    job1_hash[:results] = ["GOOOOOOOOD"]
+    job1_hash[:status] = 'GOOOOD'
+    job1_hash[:results] = ['GOOOOOOOOD']
     job1_hash[:end_time] = 'GOOOOD'
     job1_hash[:scheduled_time] = 'GOOOOD'
     expected_job1 = {
@@ -274,9 +274,9 @@ describe File.basename(__FILE__) do
     # Get job by id with all details
     job2 = GRPC jobs, :read, Jobs::Id.new(id: job_id2)
     assert_equal(true, TimeStuff.checkTimestampAndAdjustIfNeeded(test_start_time, job2, 'start_time'))
-    job2['status'] = 'GOOOOD'
     job2_hash = job2.to_hash
-    job2_hash[:results] = ["GOOOOOOOOD"]
+    job2_hash[:status] = 'GOOOOD'
+    job2_hash[:results] = ['GOOOOOOOOD']
     job2_hash[:end_time] = 'GOOOOD'
     job2_hash[:scheduled_time] = 'GOOOOD'
     expected_job2 = {

--- a/components/compliance-service/api/tests/30_jobs_docker_spec.rb
+++ b/components/compliance-service/api/tests/30_jobs_docker_spec.rb
@@ -232,7 +232,11 @@ describe File.basename(__FILE__) do
     # Get job by id with all details
     job1 = GRPC jobs, :read, Jobs::Id.new(id: job_id1)
     assert_equal(true, TimeStuff.checkTimestampAndAdjustIfNeeded(test_start_time, job1, 'start_time'))
-    job1['status'] = 'GOOOOD' if job1['status'] == 'running' || job1['status'] == 'scheduled'
+    job1['status'] = 'GOOOOD'
+    job1_hash = job1.to_hash
+    job1_hash[:results] = ["GOOOOOOOOD"]
+    job1_hash[:end_time] = 'GOOOOD'
+    job1_hash[:scheduled_time] = 'GOOOOD'
     expected_job1 = {
       "id": job_id1,
       "name": "my Detect Job For two nodes",
@@ -248,38 +252,59 @@ describe File.basename(__FILE__) do
           "value": "Spain"
         }
       ],
-      "endTime": "0001-01-01T00:00:00Z",
+      "end_time": "GOOOOD",
       "status": "GOOOOD",
       "retries": 1,
-      "retriesLeft": 1,
+      "retries_left": 1,
       "nodes": [@docker_node_id1, @docker_node_id2],
-      "nodeCount": 2,
-      "scheduledTime": "0001-01-01T00:00:00Z",
-      "parentId": "123"
+      "node_count": 2,
+      "scheduled_time": "GOOOOD",
+      "parent_id": "123",
+      "node_selectors"=>[],
+      "profile_count"=>0,
+      "profiles"=>[],
+      "recurrence"=>"",
+      "start_time"=>nil,
+      "job_count"=>0,
+      "deleted"=>false,
+      "results": ["GOOOOOOOOD"],
     }
-    assert_equal_json_sorted(expected_job1.to_json, job1.to_json)
+    assert_equal_json_sorted(expected_job1.to_json, job1_hash.to_json)
 
     # Get job by id with all details
     job2 = GRPC jobs, :read, Jobs::Id.new(id: job_id2)
     assert_equal(true, TimeStuff.checkTimestampAndAdjustIfNeeded(test_start_time, job2, 'start_time'))
-    job2['status'] = 'good' if job2['status'] == 'running' || job2['status'] == 'scheduled'
+    job2['status'] = 'GOOOOD'
+    job2_hash = job2.to_hash
+    job2_hash[:results] = ["GOOOOOOOOD"]
+    job2_hash[:end_time] = 'GOOOOD'
+    job2_hash[:scheduled_time] = 'GOOOOD'
     expected_job2 = {
       "id": job_id2,
       "name": "My Exec Job For Existing node",
       "type": "exec",
       "timeout": 7200,
-      "endTime": "0001-01-01T00:00:00Z",
-      "status": "good",
+      "end_time": "GOOOOD",
+      "status": "GOOOOD",
       "retries": 1,
-      "retriesLeft": 1,
+      "retries_left": 1,
       "nodes": [@docker_node_id1],
       "profiles": [
         "https://github.com/dev-sec/apache-baseline/archive/master.tar.gz"
       ],
-      "nodeCount": 1,
-      "scheduledTime": "0001-01-01T00:00:00Z"
+      "node_count": 1,
+      "node_selectors"=>[],
+      "profile_count"=>0,
+      "recurrence"=>"",
+      "scheduled_time": "GOOOOD",
+      "start_time"=>nil,
+      "job_count"=>0,
+      "deleted"=>false,
+      "parent_id": "",
+      "tags"=>[],
+      "results": ["GOOOOOOOOD"],
     }
-    assert_equal(expected_job2.to_json, job2.to_json)
+    assert_equal_json_sorted(expected_job2.to_json, job2_hash.to_json)
 
     # give the jobs some time to reach a conclusion
     job1 = GRPC jobs, :read, Jobs::Id.new(id: job_id1)

--- a/components/compliance-service/api/tests/40_jobs_ssh_spec.rb
+++ b/components/compliance-service/api/tests/40_jobs_ssh_spec.rb
@@ -55,7 +55,7 @@ describe File.basename(__FILE__) do
 
     ##### Success tests #####
     actual = GRPC jobs, :list, Jobs::Query.new()
-    assert_equal actual, Jobs::Jobs.new()
+    assert_equal Jobs::Jobs.new(), actual
 
     secret_id1 = (SS_GRPC secrets, :create, Secrets::Secret.new(
       name: "My SSH Login secrets",


### PR DESCRIPTION
Fixing random test failure reported by @srenatus 

https://buildkite.com/chef-oss/chef-automate-master-verify/builds/2972#149d2df2-67ef-45df-9f01-fa05428f57fa/148-626

```
1) Failure:
30_jobs_docker_spec.rb#test_0005_works [/var/lib/buildkite-agent/builds/single-use-privileged-i-07adbaf986d5b3195-1/chef-oss/.golang/chef-automate-master-verify/src/github.com/chef/automate/components/compliance-service/api/tests/30_jobs_docker_spec.rb:260]:
expected
actual
@@ -6,6 +6,13 @@
   ["d141c925-110a-4c99-8530-d8b12af6a106",
    "e56cb2be-5c82-4332-ba5b-2f8b70cfe5c7"],
  "parentId"=>"123",
+ "results"=>
+  [{"endTime"=>"2019-07-11T13:20:17Z",
+    "nodeId"=>"d141c925-110a-4c99-8530-d8b12af6a106",
+    "result"=>
+     "{\"arch\":\"x86_64\",\"families\":[\"debian\",\"linux\",\"unix\",\"os\"],\"name\":\"debian\",\"release\":\"9.7\"}",
+    "startTime"=>"2019-07-11T13:20:15Z",
+    "status"=>"completed"}],
  "retries"=>1,
  "retriesLeft"=>1,
  "scheduledTime"=>"0001-01-01T00:00:00Z",
```

and

```
 1) Failure:
40_jobs_ssh_spec.rb#test_0001_works [/var/lib/buildkite-agent/builds/single-use-privileged-i-07adbaf986d5b3195-1/chef-oss/.golang/chef-automate-master-verify/src/github.com/chef/automate/components/compliance-service/api/tests/40_jobs_ssh_spec.rb:310]:
expected
actual
@@ -1,3 +1,4 @@
 ["2b0f1b91-e9f7-480e-84bf-ca1174de843b",
  "926e34e1-6b79-4347-9216-7d53797eb49d",
+ "d141c925-110a-4c99-8530-d8b12af6a106",
  "f7d1e81f-e46a-4784-897b-dfb4dc53ae41"]
```

The second failure is caused by the first one in `30_jobs_docker_spec.rb`