### PR TITLE
[automate-867] apply rules integration test

### DIFF
--- a/.expeditor/buildkite/cypress.sh
+++ b/.expeditor/buildkite/cypress.sh
@@ -6,12 +6,20 @@ cd /workdir/e2e
 
 data=$(curl --silent "https://a2-${CHANNEL}.cd.chef.co/assets/data.json")
 instances_to_test=$(jq -nr --argjson data "$data" '$data[] | select(.tags | any(. == "e2e")) | .fqdn')
+versions=(v1 v2 v2.1)
 
 for instance in ${instances_to_test[*]}
 do
   if ! jq -enr --arg fqdn "$instance" --argjson data "$data" '$data[] | select(.fqdn == $fqdn) | .tags | any(. == "saml")'; then
     export CYPRESS_SKIP_SSO=true
   fi
+
+  for version in ${versions[*]}
+  do
+    if jq -enr --arg version "$version" --arg fqdn "$instance" --argjson data "$data" '$data[] | select(.fqdn == $fqdn) | .tags | any(. == $version)'; then
+      export CYPRESS_IAM_VERSION=$version
+    fi
+  done
 
   echo "--- Executing Cypress tests against $instance"
   export CYPRESS_BASE_URL="https://$instance"
@@ -21,6 +29,6 @@ do
 
   if ! npm run cypress:record; then
       buildkite-agent artifact upload "cypress/videos/*;cypress/videos/**/*;cypress/screenshots/*;cypress/screenshots/**/*"
-      return 1
+      exit 1
   fi
 done

--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,6 @@ ec2/mkmf.log
 # cypress screenshots/videos and other folders cypress creates
 e2e/cypress/screenshots
 e2e/cypress/videos
-e2e/cypress/fixtures
 components/automate-grpc/protoc-gen-a2-config/protoc-gen-a2-config
 components/event-gateway/cmd/event-gateway/event-gateway
 tools/bldr-config-gen/bldr-config-gen

--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -3,6 +3,6 @@
   "defaultCommandTimeout": 25000,
   "pageLoadTimeout": 80000,
   "env": {
-    "adminTokenValue": "ZNhnqJyDqgkXVk_bpobS3YhIMz0="
+    "adminTokenValue": ""
   }
 }

--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,5 +1,8 @@
 {
   "projectId": "yvg8zo",
   "defaultCommandTimeout": 25000,
-  "pageLoadTimeout": 80000
+  "pageLoadTimeout": 80000,
+  "env": {
+    "adminTokenValue": "ZNhnqJyDqgkXVk_bpobS3YhIMz0="
+  }
 }

--- a/e2e/cypress/fixtures/converge/avengers1.json
+++ b/e2e/cypress/fixtures/converge/avengers1.json
@@ -1,0 +1,6063 @@
+{
+  "chef_server_fqdn": "chef-server-dev.test",
+  "entity_uuid": "f6a5c33f-bef5-433b-815e-a8f6e69e6b1b",
+  "expanded_run_list": {
+    "id": "_default",
+    "run_list": [
+      {
+        "type": "role",
+        "name": "web",
+        "children": [
+          {
+            "type": "recipe",
+            "name": "chef-client::default",
+            "version": null,
+            "skipped": false
+          },
+          {
+            "type": "recipe",
+            "name": "chef-client::delete_validation",
+            "version": null,
+            "skipped": false
+          },
+          {
+            "type": "recipe",
+            "name": "lamp2::default",
+            "version": null,
+            "skipped": false
+          }
+        ],
+        "missing": null,
+        "error": null,
+        "skipped": null
+      }
+    ]
+  },
+  "id": "7188b88b-2236-4e27-a875-d3a10a70c497",
+  "message_version": "1.1.0",
+  "message_type": "run_converge",
+  "node": {
+    "name": "chef-client-dev.test",
+    "chef_environment": "_default",
+    "json_class": "Chef::Node",
+    "automatic": {
+      "kernel": {
+        "name": "Linux",
+        "release": "4.4.0-75-generic",
+        "version": "#96-Ubuntu SMP Thu Apr 20 09:56:33 UTC 2017",
+        "machine": "x86_64",
+        "processor": "x86_64",
+        "os": "GNU/Linux",
+        "modules": {
+          "vboxsf": {
+            "size": "45056",
+            "refcount": "1",
+            "version": "5.1.21 r115005"
+          },
+          "ppdev": {
+            "size": "20480",
+            "refcount": "0"
+          },
+          "snd_intel8x0": {
+            "size": "40960",
+            "refcount": "0"
+          },
+          "vboxvideo": {
+            "size": "53248",
+            "refcount": "1",
+            "version": "5.1.21 r115005"
+          },
+          "snd_ac97_codec": {
+            "size": "131072",
+            "refcount": "1"
+          },
+          "ac97_bus": {
+            "size": "16384",
+            "refcount": "1"
+          },
+          "ttm": {
+            "size": "94208",
+            "refcount": "1"
+          },
+          "snd_pcm": {
+            "size": "106496",
+            "refcount": "2"
+          },
+          "drm_kms_helper": {
+            "size": "155648",
+            "refcount": "1"
+          },
+          "snd_timer": {
+            "size": "32768",
+            "refcount": "1"
+          },
+          "drm": {
+            "size": "364544",
+            "refcount": "4"
+          },
+          "input_leds": {
+            "size": "16384",
+            "refcount": "0"
+          },
+          "serio_raw": {
+            "size": "16384",
+            "refcount": "0"
+          },
+          "snd": {
+            "size": "81920",
+            "refcount": "4"
+          },
+          "fb_sys_fops": {
+            "size": "16384",
+            "refcount": "1"
+          },
+          "vboxguest": {
+            "size": "282624",
+            "refcount": "3",
+            "version": "5.1.21 r115005"
+          },
+          "syscopyarea": {
+            "size": "16384",
+            "refcount": "2"
+          },
+          "soundcore": {
+            "size": "16384",
+            "refcount": "1"
+          },
+          "i2c_piix4": {
+            "size": "24576",
+            "refcount": "0"
+          },
+          "sysfillrect": {
+            "size": "16384",
+            "refcount": "2"
+          },
+          "sysimgblt": {
+            "size": "16384",
+            "refcount": "2"
+          },
+          "parport_pc": {
+            "size": "32768",
+            "refcount": "0"
+          },
+          "parport": {
+            "size": "49152",
+            "refcount": "2"
+          },
+          "8250_fintek": {
+            "size": "16384",
+            "refcount": "0"
+          },
+          "mac_hid": {
+            "size": "16384",
+            "refcount": "0"
+          },
+          "ib_iser": {
+            "size": "49152",
+            "refcount": "0",
+            "version": "1.6"
+          },
+          "rdma_cm": {
+            "size": "49152",
+            "refcount": "1"
+          },
+          "iw_cm": {
+            "size": "45056",
+            "refcount": "1"
+          },
+          "ib_cm": {
+            "size": "45056",
+            "refcount": "1"
+          },
+          "ib_sa": {
+            "size": "36864",
+            "refcount": "2"
+          },
+          "ib_mad": {
+            "size": "49152",
+            "refcount": "2"
+          },
+          "ib_core": {
+            "size": "106496",
+            "refcount": "6"
+          },
+          "ib_addr": {
+            "size": "20480",
+            "refcount": "2"
+          },
+          "iscsi_tcp": {
+            "size": "20480",
+            "refcount": "0"
+          },
+          "libiscsi_tcp": {
+            "size": "24576",
+            "refcount": "1"
+          },
+          "libiscsi": {
+            "size": "53248",
+            "refcount": "3"
+          },
+          "scsi_transport_iscsi": {
+            "size": "98304",
+            "refcount": "4",
+            "version": "2.0-870"
+          },
+          "sunrpc": {
+            "size": "335872",
+            "refcount": "1"
+          },
+          "autofs4": {
+            "size": "40960",
+            "refcount": "2"
+          },
+          "btrfs": {
+            "size": "987136",
+            "refcount": "0"
+          },
+          "raid10": {
+            "size": "49152",
+            "refcount": "0"
+          },
+          "raid456": {
+            "size": "110592",
+            "refcount": "0"
+          },
+          "async_raid6_recov": {
+            "size": "20480",
+            "refcount": "1"
+          },
+          "async_memcpy": {
+            "size": "16384",
+            "refcount": "2"
+          },
+          "async_pq": {
+            "size": "16384",
+            "refcount": "2"
+          },
+          "async_xor": {
+            "size": "16384",
+            "refcount": "3"
+          },
+          "async_tx": {
+            "size": "16384",
+            "refcount": "5"
+          },
+          "xor": {
+            "size": "24576",
+            "refcount": "2"
+          },
+          "raid6_pq": {
+            "size": "102400",
+            "refcount": "4"
+          },
+          "libcrc32c": {
+            "size": "16384",
+            "refcount": "1"
+          },
+          "raid1": {
+            "size": "36864",
+            "refcount": "0"
+          },
+          "raid0": {
+            "size": "20480",
+            "refcount": "0"
+          },
+          "multipath": {
+            "size": "16384",
+            "refcount": "0"
+          },
+          "linear": {
+            "size": "16384",
+            "refcount": "0"
+          },
+          "crct10dif_pclmul": {
+            "size": "16384",
+            "refcount": "0"
+          },
+          "crc32_pclmul": {
+            "size": "16384",
+            "refcount": "0"
+          },
+          "ghash_clmulni_intel": {
+            "size": "16384",
+            "refcount": "0"
+          },
+          "aesni_intel": {
+            "size": "167936",
+            "refcount": "0"
+          },
+          "aes_x86_64": {
+            "size": "20480",
+            "refcount": "1"
+          },
+          "lrw": {
+            "size": "16384",
+            "refcount": "1"
+          },
+          "gf128mul": {
+            "size": "16384",
+            "refcount": "1"
+          },
+          "glue_helper": {
+            "size": "16384",
+            "refcount": "1"
+          },
+          "ablk_helper": {
+            "size": "16384",
+            "refcount": "1"
+          },
+          "cryptd": {
+            "size": "20480",
+            "refcount": "3"
+          },
+          "psmouse": {
+            "size": "131072",
+            "refcount": "0"
+          },
+          "fjes": {
+            "size": "28672",
+            "refcount": "0",
+            "version": "1.0"
+          },
+          "video": {
+            "size": "40960",
+            "refcount": "0"
+          },
+          "pata_acpi": {
+            "size": "16384",
+            "refcount": "0",
+            "version": "0.2.3"
+          },
+          "ahci": {
+            "size": "36864",
+            "refcount": "2",
+            "version": "3.0"
+          },
+          "libahci": {
+            "size": "32768",
+            "refcount": "1"
+          },
+          "e1000": {
+            "size": "135168",
+            "refcount": "0",
+            "version": "7.3.21-k8-NAPI"
+          }
+        }
+      },
+      "os": "linux",
+      "os_version": "4.4.0-75-generic",
+      "shells": [
+        "/bin/sh",
+        "/bin/dash",
+        "/bin/bash",
+        "/bin/rbash",
+        "/usr/bin/tmux",
+        "/usr/bin/screen"
+      ],
+      "network": {
+        "interfaces": {
+          "lo": {
+            "mtu": "65536",
+            "flags": [
+              "LOOPBACK",
+              "UP",
+              "LOWER_UP"
+            ],
+            "encapsulation": "Loopback",
+            "addresses": {
+              "127.0.0.1": {
+                "family": "inet",
+                "prefixlen": "8",
+                "netmask": "255.0.0.0",
+                "scope": "Node"
+              },
+              "::1": {
+                "family": "inet6",
+                "prefixlen": "128",
+                "scope": "Node",
+                "tags": []
+              }
+            },
+            "state": "unknown"
+          },
+          "enp0s3": {
+            "type": "enp0s",
+            "number": "3",
+            "mtu": "1500",
+            "flags": [
+              "BROADCAST",
+              "MULTICAST",
+              "UP",
+              "LOWER_UP"
+            ],
+            "encapsulation": "Ethernet",
+            "addresses": {
+              "08:00:27:E8:89:C6": {
+                "family": "lladdr"
+              },
+              "10.0.2.15": {
+                "family": "inet",
+                "prefixlen": "24",
+                "netmask": "255.255.255.0",
+                "broadcast": "10.0.2.255",
+                "scope": "Global"
+              },
+              "fe80::a00:27ff:fee8:89c6": {
+                "family": "inet6",
+                "prefixlen": "64",
+                "scope": "Link",
+                "tags": []
+              }
+            },
+            "state": "up",
+            "arp": {
+              "10.0.2.3": "52:54:00:12:35:03",
+              "10.0.2.2": "52:54:00:12:35:02"
+            },
+            "routes": [
+              {
+                "destination": "default",
+                "family": "inet",
+                "via": "10.0.2.2"
+              },
+              {
+                "destination": "10.0.2.0/24",
+                "family": "inet",
+                "scope": "link",
+                "proto": "kernel",
+                "src": "10.0.2.15"
+              },
+              {
+                "destination": "fe80::/64",
+                "family": "inet6",
+                "metric": "256",
+                "proto": "kernel"
+              }
+            ],
+            "link_speed": 1000,
+            "duplex": "Full",
+            "port": "Twisted Pair",
+            "transceiver": "internal",
+            "auto_negotiation": "on",
+            "mdi_x": "off (auto)",
+            "ring_params": {
+              "max_rx": 4096,
+              "max_rx_mini": 0,
+              "max_rx_jumbo": 0,
+              "max_tx": 4096,
+              "current_rx": 256,
+              "current_rx_mini": 0,
+              "current_rx_jumbo": 0,
+              "current_tx": 256
+            }
+          },
+          "enp0s8": {
+            "type": "enp0s",
+            "number": "8",
+            "mtu": "1500",
+            "flags": [
+              "BROADCAST",
+              "MULTICAST",
+              "UP",
+              "LOWER_UP"
+            ],
+            "encapsulation": "Ethernet",
+            "addresses": {
+              "08:00:27:9B:82:89": {
+                "family": "lladdr"
+              },
+              "192.168.33.112": {
+                "family": "inet",
+                "prefixlen": "24",
+                "netmask": "255.255.255.0",
+                "broadcast": "192.168.33.255",
+                "scope": "Global"
+              }
+            },
+            "state": "up",
+            "arp": {
+              "192.168.33.1": "0a:00:27:00:00:01",
+              "192.168.33.111": "08:00:27:76:0c:1e"
+            },
+            "routes": [
+              {
+                "destination": "192.168.33.0/24",
+                "family": "inet",
+                "scope": "link",
+                "proto": "kernel",
+                "src": "192.168.33.112"
+              }
+            ],
+            "link_speed": 1000,
+            "duplex": "Full",
+            "port": "Twisted Pair",
+            "transceiver": "internal",
+            "auto_negotiation": "on",
+            "mdi_x": "off (auto)",
+            "ring_params": {
+              "max_rx": 4096,
+              "max_rx_mini": 0,
+              "max_rx_jumbo": 0,
+              "max_tx": 4096,
+              "current_rx": 256,
+              "current_rx_mini": 0,
+              "current_rx_jumbo": 0,
+              "current_tx": 256
+            }
+          }
+        },
+        "default_interface": "enp0s3",
+        "default_gateway": "10.0.2.2"
+      },
+      "counters": {
+        "network": {
+          "interfaces": {
+            "lo": {
+              "tx": {
+                "queuelen": "1",
+                "bytes": "1552",
+                "packets": "16",
+                "errors": "0",
+                "drop": "0",
+                "carrier": "0",
+                "collisions": "0"
+              },
+              "rx": {
+                "bytes": "1552",
+                "packets": "16",
+                "errors": "0",
+                "drop": "0",
+                "overrun": "0"
+              }
+            },
+            "enp0s3": {
+              "tx": {
+                "queuelen": "1000",
+                "bytes": "384812",
+                "packets": "5489",
+                "errors": "0",
+                "drop": "0",
+                "carrier": "0",
+                "collisions": "0"
+              },
+              "rx": {
+                "bytes": "52560006",
+                "packets": "41543",
+                "errors": "0",
+                "drop": "0",
+                "overrun": "0"
+              }
+            },
+            "enp0s8": {
+              "tx": {
+                "queuelen": "1000",
+                "bytes": "2446854",
+                "packets": "3299",
+                "errors": "0",
+                "drop": "0",
+                "carrier": "0",
+                "collisions": "0"
+              },
+              "rx": {
+                "bytes": "1810260",
+                "packets": "3229",
+                "errors": "0",
+                "drop": "0",
+                "overrun": "0"
+              }
+            }
+          }
+        }
+      },
+      "ipaddress": "10.0.2.15",
+      "macaddress": "08:00:27:E8:89:C6",
+      "languages": {
+        "ruby": {},
+        "c": {
+          "gcc": {
+            "target": "x86_64-linux-gnu",
+            "configured_with": "../src/configure -v --with-pkgversion='Ubuntu 5.4.0-6ubuntu1~16.04.4' --with-bugurl=file:///usr/share/doc/gcc-5/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-5 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-5-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-5-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-5-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu",
+            "thread_model": "posix",
+            "description": "gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4) ",
+            "version": "5.4.0"
+          }
+        },
+        "python": {
+          "version": "2.7.12",
+          "builddate": "Nov 19 2016, 06:48:10"
+        },
+        "perl": {
+          "version": "5.22.1",
+          "archname": "x86_64-linux-gnu-thread-multi"
+        }
+      },
+      "cpu": {
+        "0": {
+          "vendor_id": "GenuineIntel",
+          "family": "6",
+          "model": "70",
+          "model_name": "Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz",
+          "stepping": "1",
+          "mhz": "2793.532",
+          "cache_size": "6144 KB",
+          "physical_id": "0",
+          "core_id": "0",
+          "cores": "2",
+          "flags": [
+            "fpu",
+            "vme",
+            "de",
+            "pse",
+            "tsc",
+            "msr",
+            "pae",
+            "mce",
+            "cx8",
+            "apic",
+            "sep",
+            "mtrr",
+            "pge",
+            "mca",
+            "cmov",
+            "pat",
+            "pse36",
+            "clflush",
+            "mmx",
+            "fxsr",
+            "sse",
+            "sse2",
+            "ht",
+            "syscall",
+            "nx",
+            "rdtscp",
+            "lm",
+            "constant_tsc",
+            "rep_good",
+            "nopl",
+            "xtopology",
+            "nonstop_tsc",
+            "pni",
+            "pclmulqdq",
+            "ssse3",
+            "cx16",
+            "pcid",
+            "sse4_1",
+            "sse4_2",
+            "x2apic",
+            "movbe",
+            "popcnt",
+            "aes",
+            "xsave",
+            "avx",
+            "rdrand",
+            "hypervisor",
+            "lahf_lm",
+            "abm",
+            "fsgsbase",
+            "avx2",
+            "invpcid"
+          ]
+        },
+        "1": {
+          "vendor_id": "GenuineIntel",
+          "family": "6",
+          "model": "70",
+          "model_name": "Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz",
+          "stepping": "1",
+          "mhz": "2793.532",
+          "cache_size": "6144 KB",
+          "physical_id": "0",
+          "core_id": "1",
+          "cores": "2",
+          "flags": [
+            "fpu",
+            "vme",
+            "de",
+            "pse",
+            "tsc",
+            "msr",
+            "pae",
+            "mce",
+            "cx8",
+            "apic",
+            "sep",
+            "mtrr",
+            "pge",
+            "mca",
+            "cmov",
+            "pat",
+            "pse36",
+            "clflush",
+            "mmx",
+            "fxsr",
+            "sse",
+            "sse2",
+            "ht",
+            "syscall",
+            "nx",
+            "rdtscp",
+            "lm",
+            "constant_tsc",
+            "rep_good",
+            "nopl",
+            "xtopology",
+            "nonstop_tsc",
+            "pni",
+            "pclmulqdq",
+            "ssse3",
+            "cx16",
+            "pcid",
+            "sse4_1",
+            "sse4_2",
+            "x2apic",
+            "movbe",
+            "popcnt",
+            "aes",
+            "xsave",
+            "avx",
+            "rdrand",
+            "hypervisor",
+            "lahf_lm",
+            "abm",
+            "fsgsbase",
+            "avx2",
+            "invpcid"
+          ]
+        },
+        "total": 2,
+        "real": 1,
+        "cores": 2
+      },
+      "ip6address": "fe80::a00:27ff:fee8:89c6",
+      "lsb": {
+        "id": "Ubuntu",
+        "description": "Ubuntu 16.04.2 LTS",
+        "release": "16.04",
+        "codename": "xenial"
+      },
+      "platform": "ubuntu",
+      "platform_version": "16.04",
+      "platform_family": "debian",
+      "memory": {
+        "swap": {
+          "cached": "0kB",
+          "total": "1048572kB",
+          "free": "1048572kB"
+        },
+        "hugepages": {
+          "total": "0",
+          "free": "0",
+          "reserved": "0",
+          "surplus": "0"
+        },
+        "total": "4046504kB",
+        "free": "3213536kB",
+        "available": "3668088kB",
+        "buffers": "44156kB",
+        "cached": "587572kB",
+        "active": "211500kB",
+        "inactive": "505704kB",
+        "dirty": "44kB",
+        "writeback": "0kB",
+        "anon_pages": "89136kB",
+        "mapped": "39224kB",
+        "slab": "84196kB",
+        "slab_reclaimable": "68240kB",
+        "slab_unreclaim": "15956kB",
+        "page_tables": "2996kB",
+        "nfs_unstable": "0kB",
+        "bounce": "0kB",
+        "commit_limit": "3071824kB",
+        "committed_as": "328852kB",
+        "vmalloc_total": "34359738367kB",
+        "vmalloc_used": "0kB",
+        "vmalloc_chunk": "0kB",
+        "hugepage_size": "2048kB"
+      },
+      "virtualization": {
+        "systems": {
+          "vbox": "guest"
+        },
+        "system": "vbox",
+        "role": "guest"
+      },
+      "dmi": {
+        "dmidecode_version": "3.0",
+        "smbios_version": "2.5",
+        "structures": {
+          "count": "10",
+          "size": "450"
+        },
+        "table_location": "0x000E1000",
+        "bios": {
+          "all_records": [
+            {
+              "record_id": "0x0000",
+              "size": "0",
+              "application_identifier": "BIOS Information",
+              "Vendor": "innotek GmbH",
+              "Version": "VirtualBox",
+              "Release Date": "12/01/2006",
+              "Address": "0xE0000",
+              "Runtime Size": "128 kB",
+              "ROM Size": "128 kB",
+              "Characteristics": {
+                "ISA is supported": null,
+                "PCI is supported": null,
+                "Boot from CD is supported": null,
+                "Selectable boot is supported": null,
+                "8042 keyboard services are supported (int 9h)": null,
+                "CGA/mono video services are supported (int 10h)": null,
+                "ACPI is supported": null
+              }
+            }
+          ],
+          "vendor": "innotek GmbH",
+          "version": "VirtualBox",
+          "release_date": "12/01/2006",
+          "address": "0xE0000",
+          "runtime_size": "128 kB",
+          "rom_size": "128 kB"
+        },
+        "system": {
+          "all_records": [
+            {
+              "record_id": "0x0001",
+              "size": "1",
+              "application_identifier": "System Information",
+              "Manufacturer": "innotek GmbH",
+              "Product Name": "VirtualBox",
+              "Version": "1.2",
+              "Serial Number": "0",
+              "UUID": "A2796C81-C280-451D-9A20-96C213543F57",
+              "Wake-up Type": "Power Switch",
+              "SKU Number": "Not Specified",
+              "Family": "Virtual Machine"
+            }
+          ],
+          "manufacturer": "innotek GmbH",
+          "product_name": "VirtualBox",
+          "version": "1.2",
+          "serial_number": "0",
+          "uuid": "A2796C81-C280-451D-9A20-96C213543F57",
+          "wake_up_type": "Power Switch",
+          "sku_number": "Not Specified",
+          "family": "Virtual Machine"
+        },
+        "base_board": {
+          "all_records": [
+            {
+              "record_id": "0x0008",
+              "size": "2",
+              "application_identifier": "Base Board Information",
+              "Manufacturer": "Oracle Corporation",
+              "Product Name": "VirtualBox",
+              "Version": "1.2",
+              "Serial Number": "0",
+              "Asset Tag": "Not Specified",
+              "Features": {
+                "Board is a hosting board": null
+              },
+              "Location In Chassis": "Not Specified",
+              "Chassis Handle": "0x0003",
+              "Type": "Motherboard",
+              "Contained Object Handles": "0"
+            }
+          ],
+          "manufacturer": "Oracle Corporation",
+          "product_name": "VirtualBox",
+          "version": "1.2",
+          "serial_number": "0",
+          "asset_tag": "Not Specified",
+          "location_in_chassis": "Not Specified",
+          "chassis_handle": "0x0003",
+          "type": "Motherboard",
+          "contained_object_handles": "0"
+        },
+        "chassis": {
+          "all_records": [
+            {
+              "record_id": "0x0003",
+              "size": "3",
+              "application_identifier": "Chassis Information",
+              "Manufacturer": "Oracle Corporation",
+              "Type": "Other",
+              "Lock": "Not Present",
+              "Version": "Not Specified",
+              "Serial Number": "Not Specified",
+              "Asset Tag": "Not Specified",
+              "Boot-up State": "Safe",
+              "Power Supply State": "Safe",
+              "Thermal State": "Safe",
+              "Security Status": "None"
+            }
+          ],
+          "manufacturer": "Oracle Corporation",
+          "type": "Other",
+          "lock": "Not Present",
+          "version": "Not Specified",
+          "serial_number": "Not Specified",
+          "asset_tag": "Not Specified",
+          "boot_up_state": "Safe",
+          "power_supply_state": "Safe",
+          "thermal_state": "Safe",
+          "security_status": "None"
+        },
+        "oem_strings": {
+          "all_records": [
+            {
+              "record_id": "0x0002",
+              "size": "11",
+              "application_identifier": "OEM Strings",
+              "String 1": "vboxVer_5.2.18",
+              "String 2": "vboxRev_124319"
+            }
+          ],
+          "string_1": "vboxVer_5.2.18",
+          "string_2": "vboxRev_124319"
+        }
+      },
+      "etc": {
+        "passwd": {
+          "root": {
+            "dir": "/root",
+            "gid": 0,
+            "uid": 0,
+            "shell": "/bin/bash",
+            "gecos": "root"
+          },
+          "daemon": {
+            "dir": "/usr/sbin",
+            "gid": 1,
+            "uid": 1,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "daemon"
+          },
+          "bin": {
+            "dir": "/bin",
+            "gid": 2,
+            "uid": 2,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "bin"
+          },
+          "sys": {
+            "dir": "/dev",
+            "gid": 3,
+            "uid": 3,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "sys"
+          },
+          "sync": {
+            "dir": "/bin",
+            "gid": 65534,
+            "uid": 4,
+            "shell": "/bin/sync",
+            "gecos": "sync"
+          },
+          "games": {
+            "dir": "/usr/games",
+            "gid": 60,
+            "uid": 5,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "games"
+          },
+          "man": {
+            "dir": "/var/cache/man",
+            "gid": 12,
+            "uid": 6,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "man"
+          },
+          "lp": {
+            "dir": "/var/spool/lpd",
+            "gid": 7,
+            "uid": 7,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "lp"
+          },
+          "mail": {
+            "dir": "/var/mail",
+            "gid": 8,
+            "uid": 8,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "mail"
+          },
+          "news": {
+            "dir": "/var/spool/news",
+            "gid": 9,
+            "uid": 9,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "news"
+          },
+          "uucp": {
+            "dir": "/var/spool/uucp",
+            "gid": 10,
+            "uid": 10,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "uucp"
+          },
+          "proxy": {
+            "dir": "/bin",
+            "gid": 13,
+            "uid": 13,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "proxy"
+          },
+          "www-data": {
+            "dir": "/var/www",
+            "gid": 33,
+            "uid": 33,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "www-data"
+          },
+          "backup": {
+            "dir": "/var/backups",
+            "gid": 34,
+            "uid": 34,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "backup"
+          },
+          "list": {
+            "dir": "/var/list",
+            "gid": 38,
+            "uid": 38,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "Mailing List Manager"
+          },
+          "irc": {
+            "dir": "/var/run/ircd",
+            "gid": 39,
+            "uid": 39,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "ircd"
+          },
+          "gnats": {
+            "dir": "/var/lib/gnats",
+            "gid": 41,
+            "uid": 41,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "Gnats Bug-Reporting System (admin)"
+          },
+          "nobody": {
+            "dir": "/nonexistent",
+            "gid": 65534,
+            "uid": 65534,
+            "shell": "/usr/sbin/nologin",
+            "gecos": "nobody"
+          },
+          "systemd-timesync": {
+            "dir": "/run/systemd",
+            "gid": 102,
+            "uid": 100,
+            "shell": "/bin/false",
+            "gecos": "systemd Time Synchronization,,,"
+          },
+          "systemd-network": {
+            "dir": "/run/systemd/netif",
+            "gid": 103,
+            "uid": 101,
+            "shell": "/bin/false",
+            "gecos": "systemd Network Management,,,"
+          },
+          "systemd-resolve": {
+            "dir": "/run/systemd/resolve",
+            "gid": 104,
+            "uid": 102,
+            "shell": "/bin/false",
+            "gecos": "systemd Resolver,,,"
+          },
+          "systemd-bus-proxy": {
+            "dir": "/run/systemd",
+            "gid": 105,
+            "uid": 103,
+            "shell": "/bin/false",
+            "gecos": "systemd Bus Proxy,,,"
+          },
+          "syslog": {
+            "dir": "/home/syslog",
+            "gid": 108,
+            "uid": 104,
+            "shell": "/bin/false",
+            "gecos": ""
+          },
+          "_apt": {
+            "dir": "/nonexistent",
+            "gid": 65534,
+            "uid": 105,
+            "shell": "/bin/false",
+            "gecos": ""
+          },
+          "lxd": {
+            "dir": "/var/lib/lxd/",
+            "gid": 65534,
+            "uid": 106,
+            "shell": "/bin/false",
+            "gecos": ""
+          },
+          "messagebus": {
+            "dir": "/var/run/dbus",
+            "gid": 111,
+            "uid": 107,
+            "shell": "/bin/false",
+            "gecos": ""
+          },
+          "uuidd": {
+            "dir": "/run/uuidd",
+            "gid": 112,
+            "uid": 108,
+            "shell": "/bin/false",
+            "gecos": ""
+          },
+          "dnsmasq": {
+            "dir": "/var/lib/misc",
+            "gid": 65534,
+            "uid": 109,
+            "shell": "/bin/false",
+            "gecos": "dnsmasq,,,"
+          },
+          "statd": {
+            "dir": "/var/lib/nfs",
+            "gid": 65534,
+            "uid": 110,
+            "shell": "/bin/false",
+            "gecos": ""
+          },
+          "sshd": {
+            "dir": "/var/run/sshd",
+            "gid": 65534,
+            "uid": 111,
+            "shell": "/usr/sbin/nologin",
+            "gecos": ""
+          },
+          "vagrant": {
+            "dir": "/home/vagrant",
+            "gid": 1000,
+            "uid": 1000,
+            "shell": "/bin/bash",
+            "gecos": "vagrant,,,"
+          },
+          "vboxadd": {
+            "dir": "/var/run/vboxadd",
+            "gid": 1,
+            "uid": 999,
+            "shell": "/bin/false",
+            "gecos": ""
+          }
+        },
+        "group": {
+          "root": {
+            "gid": 0,
+            "members": []
+          },
+          "daemon": {
+            "gid": 1,
+            "members": []
+          },
+          "bin": {
+            "gid": 2,
+            "members": []
+          },
+          "sys": {
+            "gid": 3,
+            "members": []
+          },
+          "adm": {
+            "gid": 4,
+            "members": [
+              "syslog",
+              "vagrant"
+            ]
+          },
+          "tty": {
+            "gid": 5,
+            "members": []
+          },
+          "disk": {
+            "gid": 6,
+            "members": []
+          },
+          "lp": {
+            "gid": 7,
+            "members": []
+          },
+          "mail": {
+            "gid": 8,
+            "members": []
+          },
+          "news": {
+            "gid": 9,
+            "members": []
+          },
+          "uucp": {
+            "gid": 10,
+            "members": []
+          },
+          "man": {
+            "gid": 12,
+            "members": []
+          },
+          "proxy": {
+            "gid": 13,
+            "members": []
+          },
+          "kmem": {
+            "gid": 15,
+            "members": []
+          },
+          "dialout": {
+            "gid": 20,
+            "members": []
+          },
+          "fax": {
+            "gid": 21,
+            "members": []
+          },
+          "voice": {
+            "gid": 22,
+            "members": []
+          },
+          "cdrom": {
+            "gid": 24,
+            "members": [
+              "vagrant"
+            ]
+          },
+          "floppy": {
+            "gid": 25,
+            "members": []
+          },
+          "tape": {
+            "gid": 26,
+            "members": []
+          },
+          "sudo": {
+            "gid": 27,
+            "members": [
+              "vagrant"
+            ]
+          },
+          "audio": {
+            "gid": 29,
+            "members": []
+          },
+          "dip": {
+            "gid": 30,
+            "members": [
+              "vagrant"
+            ]
+          },
+          "www-data": {
+            "gid": 33,
+            "members": []
+          },
+          "backup": {
+            "gid": 34,
+            "members": []
+          },
+          "operator": {
+            "gid": 37,
+            "members": []
+          },
+          "list": {
+            "gid": 38,
+            "members": []
+          },
+          "irc": {
+            "gid": 39,
+            "members": []
+          },
+          "src": {
+            "gid": 40,
+            "members": []
+          },
+          "gnats": {
+            "gid": 41,
+            "members": []
+          },
+          "shadow": {
+            "gid": 42,
+            "members": []
+          },
+          "utmp": {
+            "gid": 43,
+            "members": []
+          },
+          "video": {
+            "gid": 44,
+            "members": []
+          },
+          "sasl": {
+            "gid": 45,
+            "members": []
+          },
+          "plugdev": {
+            "gid": 46,
+            "members": [
+              "vagrant"
+            ]
+          },
+          "staff": {
+            "gid": 50,
+            "members": []
+          },
+          "games": {
+            "gid": 60,
+            "members": []
+          },
+          "users": {
+            "gid": 100,
+            "members": []
+          },
+          "nogroup": {
+            "gid": 65534,
+            "members": []
+          },
+          "systemd-journal": {
+            "gid": 101,
+            "members": []
+          },
+          "systemd-timesync": {
+            "gid": 102,
+            "members": []
+          },
+          "systemd-network": {
+            "gid": 103,
+            "members": []
+          },
+          "systemd-resolve": {
+            "gid": 104,
+            "members": []
+          },
+          "systemd-bus-proxy": {
+            "gid": 105,
+            "members": []
+          },
+          "input": {
+            "gid": 106,
+            "members": []
+          },
+          "crontab": {
+            "gid": 107,
+            "members": []
+          },
+          "syslog": {
+            "gid": 108,
+            "members": []
+          },
+          "netdev": {
+            "gid": 109,
+            "members": []
+          },
+          "lxd": {
+            "gid": 110,
+            "members": [
+              "vagrant"
+            ]
+          },
+          "messagebus": {
+            "gid": 111,
+            "members": []
+          },
+          "uuidd": {
+            "gid": 112,
+            "members": []
+          },
+          "mlocate": {
+            "gid": 113,
+            "members": []
+          },
+          "ssh": {
+            "gid": 114,
+            "members": []
+          },
+          "vagrant": {
+            "gid": 1000,
+            "members": []
+          },
+          "lpadmin": {
+            "gid": 115,
+            "members": [
+              "vagrant"
+            ]
+          },
+          "sambashare": {
+            "gid": 116,
+            "members": [
+              "vagrant"
+            ]
+          },
+          "vboxsf": {
+            "gid": 999,
+            "members": []
+          }
+        }
+      },
+      "current_user": "root",
+      "cloud": null,
+      "hostname": "chef-client-dev",
+      "machinename": "chef-client-dev",
+      "fqdn": "chef-client-dev.test",
+      "domain": "test",
+      "sysconf": {
+        "LINK_MAX": 65000,
+        "_POSIX_LINK_MAX": 65000,
+        "MAX_CANON": 255,
+        "_POSIX_MAX_CANON": 255,
+        "MAX_INPUT": 255,
+        "_POSIX_MAX_INPUT": 255,
+        "NAME_MAX": 255,
+        "_POSIX_NAME_MAX": 255,
+        "PATH_MAX": 4096,
+        "_POSIX_PATH_MAX": 4096,
+        "PIPE_BUF": 4096,
+        "_POSIX_PIPE_BUF": 4096,
+        "SOCK_MAXBUF": null,
+        "_POSIX_ASYNC_IO": null,
+        "_POSIX_CHOWN_RESTRICTED": 1,
+        "_POSIX_NO_TRUNC": 1,
+        "_POSIX_PRIO_IO": null,
+        "_POSIX_SYNC_IO": null,
+        "_POSIX_VDISABLE": 0,
+        "ARG_MAX": 2097152,
+        "ATEXIT_MAX": 2147483647,
+        "CHAR_BIT": 8,
+        "CHAR_MAX": 127,
+        "CHAR_MIN": -128,
+        "CHILD_MAX": 15650,
+        "CLK_TCK": 100,
+        "INT_MAX": 2147483647,
+        "INT_MIN": -2147483648,
+        "IOV_MAX": 1024,
+        "LOGNAME_MAX": 256,
+        "LONG_BIT": 64,
+        "MB_LEN_MAX": 16,
+        "NGROUPS_MAX": 65536,
+        "NL_ARGMAX": 4096,
+        "NL_LANGMAX": 2048,
+        "NL_MSGMAX": 2147483647,
+        "NL_NMAX": 2147483647,
+        "NL_SETMAX": 2147483647,
+        "NL_TEXTMAX": 2147483647,
+        "NSS_BUFLEN_GROUP": 1024,
+        "NSS_BUFLEN_PASSWD": 1024,
+        "NZERO": 20,
+        "OPEN_MAX": 1024,
+        "PAGESIZE": 4096,
+        "PAGE_SIZE": 4096,
+        "PASS_MAX": 8192,
+        "PTHREAD_DESTRUCTOR_ITERATIONS": 4,
+        "PTHREAD_KEYS_MAX": 1024,
+        "PTHREAD_STACK_MIN": 16384,
+        "PTHREAD_THREADS_MAX": null,
+        "SCHAR_MAX": 127,
+        "SCHAR_MIN": -128,
+        "SHRT_MAX": 32767,
+        "SHRT_MIN": -32768,
+        "SSIZE_MAX": 32767,
+        "TTY_NAME_MAX": 32,
+        "TZNAME_MAX": 6,
+        "UCHAR_MAX": 255,
+        "UINT_MAX": 4294967295,
+        "UIO_MAXIOV": 1024,
+        "ULONG_MAX": 18446744073709552000,
+        "USHRT_MAX": 65535,
+        "WORD_BIT": 32,
+        "_AVPHYS_PAGES": 803458,
+        "_NPROCESSORS_CONF": 2,
+        "_NPROCESSORS_ONLN": 2,
+        "_PHYS_PAGES": 1011626,
+        "_POSIX_ARG_MAX": 2097152,
+        "_POSIX_ASYNCHRONOUS_IO": 200809,
+        "_POSIX_CHILD_MAX": 15650,
+        "_POSIX_FSYNC": 200809,
+        "_POSIX_JOB_CONTROL": 1,
+        "_POSIX_MAPPED_FILES": 200809,
+        "_POSIX_MEMLOCK": 200809,
+        "_POSIX_MEMLOCK_RANGE": 200809,
+        "_POSIX_MEMORY_PROTECTION": 200809,
+        "_POSIX_MESSAGE_PASSING": 200809,
+        "_POSIX_NGROUPS_MAX": 65536,
+        "_POSIX_OPEN_MAX": 1024,
+        "_POSIX_PII": null,
+        "_POSIX_PII_INTERNET": null,
+        "_POSIX_PII_INTERNET_DGRAM": null,
+        "_POSIX_PII_INTERNET_STREAM": null,
+        "_POSIX_PII_OSI": null,
+        "_POSIX_PII_OSI_CLTS": null,
+        "_POSIX_PII_OSI_COTS": null,
+        "_POSIX_PII_OSI_M": null,
+        "_POSIX_PII_SOCKET": null,
+        "_POSIX_PII_XTI": null,
+        "_POSIX_POLL": null,
+        "_POSIX_PRIORITIZED_IO": 200809,
+        "_POSIX_PRIORITY_SCHEDULING": 200809,
+        "_POSIX_REALTIME_SIGNALS": 200809,
+        "_POSIX_SAVED_IDS": 1,
+        "_POSIX_SELECT": null,
+        "_POSIX_SEMAPHORES": 200809,
+        "_POSIX_SHARED_MEMORY_OBJECTS": 200809,
+        "_POSIX_SSIZE_MAX": 32767,
+        "_POSIX_STREAM_MAX": 16,
+        "_POSIX_SYNCHRONIZED_IO": 200809,
+        "_POSIX_THREADS": 200809,
+        "_POSIX_THREAD_ATTR_STACKADDR": 200809,
+        "_POSIX_THREAD_ATTR_STACKSIZE": 200809,
+        "_POSIX_THREAD_PRIORITY_SCHEDULING": 200809,
+        "_POSIX_THREAD_PRIO_INHERIT": 200809,
+        "_POSIX_THREAD_PRIO_PROTECT": 200809,
+        "_POSIX_THREAD_ROBUST_PRIO_INHERIT": null,
+        "_POSIX_THREAD_ROBUST_PRIO_PROTECT": null,
+        "_POSIX_THREAD_PROCESS_SHARED": 200809,
+        "_POSIX_THREAD_SAFE_FUNCTIONS": 200809,
+        "_POSIX_TIMERS": 200809,
+        "TIMER_MAX": null,
+        "_POSIX_TZNAME_MAX": 6,
+        "_POSIX_VERSION": 200809,
+        "_T_IOV_MAX": null,
+        "_XOPEN_CRYPT": 1,
+        "_XOPEN_ENH_I18N": 1,
+        "_XOPEN_LEGACY": 1,
+        "_XOPEN_REALTIME": 1,
+        "_XOPEN_REALTIME_THREADS": 1,
+        "_XOPEN_SHM": 1,
+        "_XOPEN_UNIX": 1,
+        "_XOPEN_VERSION": 700,
+        "_XOPEN_XCU_VERSION": 4,
+        "_XOPEN_XPG2": 1,
+        "_XOPEN_XPG3": 1,
+        "_XOPEN_XPG4": 1,
+        "BC_BASE_MAX": 99,
+        "BC_DIM_MAX": 2048,
+        "BC_SCALE_MAX": 99,
+        "BC_STRING_MAX": 1000,
+        "CHARCLASS_NAME_MAX": 2048,
+        "COLL_WEIGHTS_MAX": 255,
+        "EQUIV_CLASS_MAX": null,
+        "EXPR_NEST_MAX": 32,
+        "LINE_MAX": 2048,
+        "POSIX2_BC_BASE_MAX": 99,
+        "POSIX2_BC_DIM_MAX": 2048,
+        "POSIX2_BC_SCALE_MAX": 99,
+        "POSIX2_BC_STRING_MAX": 1000,
+        "POSIX2_CHAR_TERM": 200809,
+        "POSIX2_COLL_WEIGHTS_MAX": 255,
+        "POSIX2_C_BIND": 200809,
+        "POSIX2_C_DEV": 200809,
+        "POSIX2_C_VERSION": 200809,
+        "POSIX2_EXPR_NEST_MAX": 32,
+        "POSIX2_FORT_DEV": null,
+        "POSIX2_FORT_RUN": null,
+        "_POSIX2_LINE_MAX": 2048,
+        "POSIX2_LINE_MAX": 2048,
+        "POSIX2_LOCALEDEF": 200809,
+        "POSIX2_RE_DUP_MAX": 32767,
+        "POSIX2_SW_DEV": 200809,
+        "POSIX2_UPE": null,
+        "POSIX2_VERSION": 200809,
+        "RE_DUP_MAX": 32767,
+        "PATH": "/bin:/usr/bin",
+        "CS_PATH": "/bin:/usr/bin",
+        "LFS_CFLAGS": null,
+        "LFS_LDFLAGS": null,
+        "LFS_LIBS": null,
+        "LFS_LINTFLAGS": null,
+        "LFS64_CFLAGS": "-D_LARGEFILE64_SOURCE",
+        "LFS64_LDFLAGS": null,
+        "LFS64_LIBS": null,
+        "LFS64_LINTFLAGS": "-D_LARGEFILE64_SOURCE",
+        "_XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+        "XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+        "_XBS5_ILP32_OFF32": null,
+        "XBS5_ILP32_OFF32_CFLAGS": null,
+        "XBS5_ILP32_OFF32_LDFLAGS": null,
+        "XBS5_ILP32_OFF32_LIBS": null,
+        "XBS5_ILP32_OFF32_LINTFLAGS": null,
+        "_XBS5_ILP32_OFFBIG": null,
+        "XBS5_ILP32_OFFBIG_CFLAGS": null,
+        "XBS5_ILP32_OFFBIG_LDFLAGS": null,
+        "XBS5_ILP32_OFFBIG_LIBS": null,
+        "XBS5_ILP32_OFFBIG_LINTFLAGS": null,
+        "_XBS5_LP64_OFF64": 1,
+        "XBS5_LP64_OFF64_CFLAGS": "-m64",
+        "XBS5_LP64_OFF64_LDFLAGS": "-m64",
+        "XBS5_LP64_OFF64_LIBS": null,
+        "XBS5_LP64_OFF64_LINTFLAGS": null,
+        "_XBS5_LPBIG_OFFBIG": null,
+        "XBS5_LPBIG_OFFBIG_CFLAGS": null,
+        "XBS5_LPBIG_OFFBIG_LDFLAGS": null,
+        "XBS5_LPBIG_OFFBIG_LIBS": null,
+        "XBS5_LPBIG_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V6_ILP32_OFF32": null,
+        "POSIX_V6_ILP32_OFF32_CFLAGS": null,
+        "POSIX_V6_ILP32_OFF32_LDFLAGS": null,
+        "POSIX_V6_ILP32_OFF32_LIBS": null,
+        "POSIX_V6_ILP32_OFF32_LINTFLAGS": null,
+        "_POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+        "POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+        "_POSIX_V6_ILP32_OFFBIG": null,
+        "POSIX_V6_ILP32_OFFBIG_CFLAGS": null,
+        "POSIX_V6_ILP32_OFFBIG_LDFLAGS": null,
+        "POSIX_V6_ILP32_OFFBIG_LIBS": null,
+        "POSIX_V6_ILP32_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V6_LP64_OFF64": 1,
+        "POSIX_V6_LP64_OFF64_CFLAGS": "-m64",
+        "POSIX_V6_LP64_OFF64_LDFLAGS": "-m64",
+        "POSIX_V6_LP64_OFF64_LIBS": null,
+        "POSIX_V6_LP64_OFF64_LINTFLAGS": null,
+        "_POSIX_V6_LPBIG_OFFBIG": null,
+        "POSIX_V6_LPBIG_OFFBIG_CFLAGS": null,
+        "POSIX_V6_LPBIG_OFFBIG_LDFLAGS": null,
+        "POSIX_V6_LPBIG_OFFBIG_LIBS": null,
+        "POSIX_V6_LPBIG_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V7_ILP32_OFF32": null,
+        "POSIX_V7_ILP32_OFF32_CFLAGS": null,
+        "POSIX_V7_ILP32_OFF32_LDFLAGS": null,
+        "POSIX_V7_ILP32_OFF32_LIBS": null,
+        "POSIX_V7_ILP32_OFF32_LINTFLAGS": null,
+        "_POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+        "POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+        "_POSIX_V7_ILP32_OFFBIG": null,
+        "POSIX_V7_ILP32_OFFBIG_CFLAGS": null,
+        "POSIX_V7_ILP32_OFFBIG_LDFLAGS": null,
+        "POSIX_V7_ILP32_OFFBIG_LIBS": null,
+        "POSIX_V7_ILP32_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V7_LP64_OFF64": 1,
+        "POSIX_V7_LP64_OFF64_CFLAGS": "-m64",
+        "POSIX_V7_LP64_OFF64_LDFLAGS": "-m64",
+        "POSIX_V7_LP64_OFF64_LIBS": null,
+        "POSIX_V7_LP64_OFF64_LINTFLAGS": null,
+        "_POSIX_V7_LPBIG_OFFBIG": null,
+        "POSIX_V7_LPBIG_OFFBIG_CFLAGS": null,
+        "POSIX_V7_LPBIG_OFFBIG_LDFLAGS": null,
+        "POSIX_V7_LPBIG_OFFBIG_LIBS": null,
+        "POSIX_V7_LPBIG_OFFBIG_LINTFLAGS": null,
+        "_POSIX_ADVISORY_INFO": 200809,
+        "_POSIX_BARRIERS": 200809,
+        "_POSIX_BASE": null,
+        "_POSIX_C_LANG_SUPPORT": null,
+        "_POSIX_C_LANG_SUPPORT_R": null,
+        "_POSIX_CLOCK_SELECTION": 200809,
+        "_POSIX_CPUTIME": 200809,
+        "_POSIX_THREAD_CPUTIME": 200809,
+        "_POSIX_DEVICE_SPECIFIC": null,
+        "_POSIX_DEVICE_SPECIFIC_R": null,
+        "_POSIX_FD_MGMT": null,
+        "_POSIX_FIFO": null,
+        "_POSIX_PIPE": null,
+        "_POSIX_FILE_ATTRIBUTES": null,
+        "_POSIX_FILE_LOCKING": null,
+        "_POSIX_FILE_SYSTEM": null,
+        "_POSIX_MONOTONIC_CLOCK": 200809,
+        "_POSIX_MULTI_PROCESS": null,
+        "_POSIX_SINGLE_PROCESS": null,
+        "_POSIX_NETWORKING": null,
+        "_POSIX_READER_WRITER_LOCKS": 200809,
+        "_POSIX_SPIN_LOCKS": 200809,
+        "_POSIX_REGEXP": 1,
+        "_REGEX_VERSION": null,
+        "_POSIX_SHELL": 1,
+        "_POSIX_SIGNALS": null,
+        "_POSIX_SPAWN": 200809,
+        "_POSIX_SPORADIC_SERVER": null,
+        "_POSIX_THREAD_SPORADIC_SERVER": null,
+        "_POSIX_SYSTEM_DATABASE": null,
+        "_POSIX_SYSTEM_DATABASE_R": null,
+        "_POSIX_TIMEOUTS": 200809,
+        "_POSIX_TYPED_MEMORY_OBJECTS": null,
+        "_POSIX_USER_GROUPS": null,
+        "_POSIX_USER_GROUPS_R": null,
+        "POSIX2_PBS": null,
+        "POSIX2_PBS_ACCOUNTING": null,
+        "POSIX2_PBS_LOCATE": null,
+        "POSIX2_PBS_TRACK": null,
+        "POSIX2_PBS_MESSAGE": null,
+        "SYMLOOP_MAX": null,
+        "STREAM_MAX": 16,
+        "AIO_LISTIO_MAX": null,
+        "AIO_MAX": null,
+        "AIO_PRIO_DELTA_MAX": 20,
+        "DELAYTIMER_MAX": 2147483647,
+        "HOST_NAME_MAX": 64,
+        "LOGIN_NAME_MAX": 256,
+        "MQ_OPEN_MAX": null,
+        "MQ_PRIO_MAX": 32768,
+        "_POSIX_DEVICE_IO": null,
+        "_POSIX_TRACE": null,
+        "_POSIX_TRACE_EVENT_FILTER": null,
+        "_POSIX_TRACE_INHERIT": null,
+        "_POSIX_TRACE_LOG": null,
+        "RTSIG_MAX": 32,
+        "SEM_NSEMS_MAX": null,
+        "SEM_VALUE_MAX": 2147483647,
+        "SIGQUEUE_MAX": 15650,
+        "FILESIZEBITS": 64,
+        "POSIX_ALLOC_SIZE_MIN": 4096,
+        "POSIX_REC_INCR_XFER_SIZE": null,
+        "POSIX_REC_MAX_XFER_SIZE": null,
+        "POSIX_REC_MIN_XFER_SIZE": 4096,
+        "POSIX_REC_XFER_ALIGN": 4096,
+        "SYMLINK_MAX": null,
+        "GNU_LIBC_VERSION": "glibc 2.23",
+        "GNU_LIBPTHREAD_VERSION": "NPTL 2.23",
+        "POSIX2_SYMLINKS": 1,
+        "LEVEL1_ICACHE_SIZE": 32768,
+        "LEVEL1_ICACHE_ASSOC": 8,
+        "LEVEL1_ICACHE_LINESIZE": 64,
+        "LEVEL1_DCACHE_SIZE": 32768,
+        "LEVEL1_DCACHE_ASSOC": 8,
+        "LEVEL1_DCACHE_LINESIZE": 64,
+        "LEVEL2_CACHE_SIZE": 262144,
+        "LEVEL2_CACHE_ASSOC": 8,
+        "LEVEL2_CACHE_LINESIZE": 64,
+        "LEVEL3_CACHE_SIZE": 6291456,
+        "LEVEL3_CACHE_ASSOC": 12,
+        "LEVEL3_CACHE_LINESIZE": 64,
+        "LEVEL4_CACHE_SIZE": 134217728,
+        "LEVEL4_CACHE_ASSOC": 16,
+        "LEVEL4_CACHE_LINESIZE": 64,
+        "IPV6": 200809,
+        "RAW_SOCKETS": 200809,
+        "_POSIX_IPV6": 200809,
+        "_POSIX_RAW_SOCKETS": 200809
+      },
+      "machine_id": "cc64668a62249bbb1795e00c5902315e",
+      "block_device": {
+        "sda": {
+          "size": "83886080",
+          "removable": "0",
+          "model": "VBOX HARDDISK",
+          "rev": "1.0",
+          "state": "running",
+          "timeout": "30",
+          "vendor": "ATA",
+          "queue_depth": "31",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "dm-0": {
+          "size": "80781312",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "dm-1": {
+          "size": "2097152",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop0": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop1": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop2": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop3": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop4": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop5": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop6": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop7": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        }
+      },
+      "fips": {
+        "kernel": {
+          "enabled": false
+        }
+      },
+      "hostnamectl": {
+        "static_hostname": "chef-client-dev",
+        "icon_name": "computer-vm",
+        "chassis": "vm",
+        "machine_id": "cc64668a62249bbb1795e00c5902315e",
+        "boot_id": "d773c29962664960b8745617ee7a2ac9",
+        "virtualization": "oracle",
+        "operating_system": "Ubuntu 16.04.2 LTS",
+        "kernel": "Linux 4.4.0-75-generic",
+        "architecture": "x86-64"
+      },
+      "systemd_paths": {
+        "temporary": "/tmp",
+        "temporary-large": "/var/tmp",
+        "system-binaries": "/usr/bin",
+        "system-include": "/usr/include",
+        "system-library-private": "/usr/lib",
+        "system-library-arch": "/usr/lib/x86_64-linux-gnu",
+        "system-shared": "/usr/share",
+        "system-configuration-factory": "/usr/share/factory/etc",
+        "system-state-factory": "/usr/share/factory/var",
+        "system-configuration": "/etc",
+        "system-runtime": "/run",
+        "system-runtime-logs": "/run/log",
+        "system-state-private": "/var/lib",
+        "system-state-logs": "/var/log",
+        "system-state-cache": "/var/cache",
+        "system-state-spool": "/var/spool",
+        "user-binaries": "/home/vagrant/.local/bin",
+        "user-library-private": "/home/vagrant/.local/lib",
+        "user-library-arch": "/home/vagrant/.local/lib/x86_64-linux-gnu",
+        "user-shared": "/home/vagrant/.local/share",
+        "user-configuration": "/home/vagrant/.config",
+        "user-state-cache": "/home/vagrant/.cache",
+        "user": "/home/vagrant",
+        "user-documents": "/home/vagrant",
+        "user-music": "/home/vagrant",
+        "user-pictures": "/home/vagrant",
+        "user-videos": "/home/vagrant",
+        "user-download": "/home/vagrant",
+        "user-public": "/home/vagrant",
+        "user-templates": "/home/vagrant",
+        "user-desktop": "/home/vagrant/Desktop",
+        "search-binaries": "/usr/local/sbin",
+        "search-library-private": "/home/vagrant/.local/lib",
+        "search-library-arch": "/home/vagrant/.local/lib/x86_64-linux-gnu",
+        "search-shared": "/home/vagrant/.local/share",
+        "search-configuration-factory": "/usr/local/share/factory/etc",
+        "search-state-factory": "/usr/local/share/factory/var",
+        "search-configuration": "/home/vagrant/.config"
+      },
+      "ohai_time": 1536871380.802023,
+      "shard_seed": 52126414,
+      "command": {
+        "ps": "ps -ef"
+      },
+      "root_group": "root",
+      "filesystem": {
+        "by_device": {
+          "udev": {
+            "kb_size": "2003252",
+            "kb_used": "0",
+            "kb_available": "2003252",
+            "percent_used": "0%",
+            "total_inodes": "500813",
+            "inodes_used": "423",
+            "inodes_available": "500390",
+            "inodes_percent_used": "1%",
+            "fs_type": "devtmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "relatime",
+              "size=2003252k",
+              "nr_inodes=500813",
+              "mode=755"
+            ],
+            "mounts": [
+              "/dev"
+            ]
+          },
+          "tmpfs": {
+            "kb_size": "404652",
+            "kb_used": "0",
+            "kb_available": "404652",
+            "percent_used": "0%",
+            "total_inodes": "505813",
+            "inodes_used": "4",
+            "inodes_available": "505809",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "relatime",
+              "size=404652k",
+              "mode=700",
+              "uid=1000",
+              "gid=1000"
+            ],
+            "mounts": [
+              "/run",
+              "/dev/shm",
+              "/run/lock",
+              "/sys/fs/cgroup",
+              "/run/user/1000"
+            ]
+          },
+          "/dev/mapper/vagrant--vg-root": {
+            "kb_size": "39625324",
+            "kb_used": "1602012",
+            "kb_available": "35987396",
+            "percent_used": "5%",
+            "total_inodes": "2526384",
+            "inodes_used": "65911",
+            "inodes_available": "2460473",
+            "inodes_percent_used": "3%",
+            "fs_type": "ext4",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "errors=remount-ro",
+              "data=ordered"
+            ],
+            "uuid": "b823f60e-6a87-4d92-b525-0a9b72e64d08",
+            "mounts": [
+              "/"
+            ]
+          },
+          "/dev/sda1": {
+            "kb_size": "482922",
+            "kb_used": "58213",
+            "kb_available": "399775",
+            "percent_used": "13%",
+            "total_inodes": "124928",
+            "inodes_used": "303",
+            "inodes_available": "124625",
+            "inodes_percent_used": "1%",
+            "fs_type": "ext2",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "block_validity",
+              "barrier",
+              "user_xattr",
+              "acl"
+            ],
+            "uuid": "29725d5e-b3e6-4197-b2cc-9f243085b2da",
+            "mounts": [
+              "/boot"
+            ]
+          },
+          "vagrant": {
+            "kb_size": "488347692",
+            "kb_used": "292387700",
+            "kb_available": "195959992",
+            "percent_used": "60%",
+            "total_inodes": "1000",
+            "inodes_used": "0",
+            "inodes_available": "1000",
+            "inodes_percent_used": "0%",
+            "mounts": [
+              "/vagrant"
+            ]
+          },
+          "sysfs": {
+            "fs_type": "sysfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "mounts": [
+              "/sys"
+            ]
+          },
+          "proc": {
+            "fs_type": "proc",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "mounts": [
+              "/proc"
+            ]
+          },
+          "devpts": {
+            "fs_type": "devpts",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "noexec",
+              "relatime",
+              "gid=5",
+              "mode=620",
+              "ptmxmode=000"
+            ],
+            "mounts": [
+              "/dev/pts"
+            ]
+          },
+          "securityfs": {
+            "fs_type": "securityfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "mounts": [
+              "/sys/kernel/security"
+            ]
+          },
+          "cgroup": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "hugetlb"
+            ],
+            "mounts": [
+              "/sys/fs/cgroup/systemd",
+              "/sys/fs/cgroup/cpu,cpuacct",
+              "/sys/fs/cgroup/pids",
+              "/sys/fs/cgroup/devices",
+              "/sys/fs/cgroup/cpuset",
+              "/sys/fs/cgroup/freezer",
+              "/sys/fs/cgroup/perf_event",
+              "/sys/fs/cgroup/net_cls,net_prio",
+              "/sys/fs/cgroup/memory",
+              "/sys/fs/cgroup/blkio",
+              "/sys/fs/cgroup/hugetlb"
+            ]
+          },
+          "pstore": {
+            "fs_type": "pstore",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "mounts": [
+              "/sys/fs/pstore"
+            ]
+          },
+          "systemd-1": {
+            "fs_type": "autofs",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "fd=31",
+              "pgrp=1",
+              "timeout=0",
+              "minproto=5",
+              "maxproto=5",
+              "direct"
+            ],
+            "mounts": [
+              "/proc/sys/fs/binfmt_misc"
+            ]
+          },
+          "mqueue": {
+            "fs_type": "mqueue",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "mounts": [
+              "/dev/mqueue"
+            ]
+          },
+          "debugfs": {
+            "fs_type": "debugfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "mounts": [
+              "/sys/kernel/debug"
+            ]
+          },
+          "hugetlbfs": {
+            "fs_type": "hugetlbfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "mounts": [
+              "/dev/hugepages"
+            ]
+          },
+          "sunrpc": {
+            "fs_type": "rpc_pipefs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "mounts": [
+              "/run/rpc_pipefs"
+            ]
+          },
+          "fusectl": {
+            "fs_type": "fusectl",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "mounts": [
+              "/sys/fs/fuse/connections"
+            ]
+          },
+          "lxcfs": {
+            "fs_type": "fuse.lxcfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "relatime",
+              "user_id=0",
+              "group_id=0",
+              "allow_other"
+            ],
+            "mounts": [
+              "/var/lib/lxcfs"
+            ]
+          },
+          "/vagrant": {
+            "fs_type": "vboxsf",
+            "mount_options": [
+              "rw",
+              "nodev",
+              "relatime"
+            ],
+            "mounts": [
+              "/vagrant"
+            ]
+          },
+          "/dev/sda": {
+            "mounts": []
+          },
+          "/dev/sda2": {
+            "mounts": []
+          },
+          "/dev/sda5": {
+            "fs_type": "LVM2_member",
+            "uuid": "3N7Z0V-Ubze-Lx6p-tesB-AIU7-alJo-GQoVmU",
+            "mounts": []
+          },
+          "/dev/mapper/vagrant--vg-swap_1": {
+            "fs_type": "swap",
+            "uuid": "5a469a8a-e6dc-4118-b1d2-c396c9cd436b",
+            "mounts": []
+          }
+        },
+        "by_mountpoint": {
+          "/dev": {
+            "kb_size": "2003252",
+            "kb_used": "0",
+            "kb_available": "2003252",
+            "percent_used": "0%",
+            "total_inodes": "500813",
+            "inodes_used": "423",
+            "inodes_available": "500390",
+            "inodes_percent_used": "1%",
+            "fs_type": "devtmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "relatime",
+              "size=2003252k",
+              "nr_inodes=500813",
+              "mode=755"
+            ],
+            "devices": [
+              "udev"
+            ]
+          },
+          "/run": {
+            "kb_size": "404652",
+            "kb_used": "5724",
+            "kb_available": "398928",
+            "percent_used": "2%",
+            "total_inodes": "505813",
+            "inodes_used": "549",
+            "inodes_available": "505264",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "noexec",
+              "relatime",
+              "size=404652k",
+              "mode=755"
+            ],
+            "devices": [
+              "tmpfs"
+            ]
+          },
+          "/": {
+            "kb_size": "39625324",
+            "kb_used": "1602012",
+            "kb_available": "35987396",
+            "percent_used": "5%",
+            "total_inodes": "2526384",
+            "inodes_used": "65911",
+            "inodes_available": "2460473",
+            "inodes_percent_used": "3%",
+            "fs_type": "ext4",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "errors=remount-ro",
+              "data=ordered"
+            ],
+            "uuid": "b823f60e-6a87-4d92-b525-0a9b72e64d08",
+            "devices": [
+              "/dev/mapper/vagrant--vg-root"
+            ]
+          },
+          "/dev/shm": {
+            "kb_size": "2023252",
+            "kb_used": "0",
+            "kb_available": "2023252",
+            "percent_used": "0%",
+            "total_inodes": "505813",
+            "inodes_used": "1",
+            "inodes_available": "505812",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev"
+            ],
+            "devices": [
+              "tmpfs"
+            ]
+          },
+          "/run/lock": {
+            "kb_size": "5120",
+            "kb_used": "0",
+            "kb_available": "5120",
+            "percent_used": "0%",
+            "total_inodes": "505813",
+            "inodes_used": "3",
+            "inodes_available": "505810",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "size=5120k"
+            ],
+            "devices": [
+              "tmpfs"
+            ]
+          },
+          "/sys/fs/cgroup": {
+            "kb_size": "2023252",
+            "kb_used": "0",
+            "kb_available": "2023252",
+            "percent_used": "0%",
+            "total_inodes": "505813",
+            "inodes_used": "16",
+            "inodes_available": "505797",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "ro",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "mode=755"
+            ],
+            "devices": [
+              "tmpfs"
+            ]
+          },
+          "/boot": {
+            "kb_size": "482922",
+            "kb_used": "58213",
+            "kb_available": "399775",
+            "percent_used": "13%",
+            "total_inodes": "124928",
+            "inodes_used": "303",
+            "inodes_available": "124625",
+            "inodes_percent_used": "1%",
+            "fs_type": "ext2",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "block_validity",
+              "barrier",
+              "user_xattr",
+              "acl"
+            ],
+            "uuid": "29725d5e-b3e6-4197-b2cc-9f243085b2da",
+            "devices": [
+              "/dev/sda1"
+            ]
+          },
+          "/run/user/1000": {
+            "kb_size": "404652",
+            "kb_used": "0",
+            "kb_available": "404652",
+            "percent_used": "0%",
+            "total_inodes": "505813",
+            "inodes_used": "4",
+            "inodes_available": "505809",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "relatime",
+              "size=404652k",
+              "mode=700",
+              "uid=1000",
+              "gid=1000"
+            ],
+            "devices": [
+              "tmpfs"
+            ]
+          },
+          "/vagrant": {
+            "kb_size": "488347692",
+            "kb_used": "292387700",
+            "kb_available": "195959992",
+            "percent_used": "60%",
+            "total_inodes": "1000",
+            "inodes_used": "0",
+            "inodes_available": "1000",
+            "inodes_percent_used": "0%",
+            "devices": [
+              "vagrant",
+              "/vagrant"
+            ],
+            "fs_type": "vboxsf",
+            "mount_options": [
+              "rw",
+              "nodev",
+              "relatime"
+            ]
+          },
+          "/sys": {
+            "fs_type": "sysfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "devices": [
+              "sysfs"
+            ]
+          },
+          "/proc": {
+            "fs_type": "proc",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "devices": [
+              "proc"
+            ]
+          },
+          "/dev/pts": {
+            "fs_type": "devpts",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "noexec",
+              "relatime",
+              "gid=5",
+              "mode=620",
+              "ptmxmode=000"
+            ],
+            "devices": [
+              "devpts"
+            ]
+          },
+          "/sys/kernel/security": {
+            "fs_type": "securityfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "devices": [
+              "securityfs"
+            ]
+          },
+          "/sys/fs/cgroup/systemd": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "xattr",
+              "release_agent=/lib/systemd/systemd-cgroups-agent",
+              "name=systemd"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/pstore": {
+            "fs_type": "pstore",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "devices": [
+              "pstore"
+            ]
+          },
+          "/sys/fs/cgroup/cpu,cpuacct": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "cpu",
+              "cpuacct"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/pids": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "pids"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/devices": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "devices"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/cpuset": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "cpuset"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/freezer": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "freezer"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/perf_event": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "perf_event"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/net_cls,net_prio": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "net_cls",
+              "net_prio"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/memory": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "memory"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/blkio": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "blkio"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/hugetlb": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "hugetlb"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/proc/sys/fs/binfmt_misc": {
+            "fs_type": "autofs",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "fd=31",
+              "pgrp=1",
+              "timeout=0",
+              "minproto=5",
+              "maxproto=5",
+              "direct"
+            ],
+            "devices": [
+              "systemd-1"
+            ]
+          },
+          "/dev/mqueue": {
+            "fs_type": "mqueue",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "devices": [
+              "mqueue"
+            ]
+          },
+          "/sys/kernel/debug": {
+            "fs_type": "debugfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "devices": [
+              "debugfs"
+            ]
+          },
+          "/dev/hugepages": {
+            "fs_type": "hugetlbfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "devices": [
+              "hugetlbfs"
+            ]
+          },
+          "/run/rpc_pipefs": {
+            "fs_type": "rpc_pipefs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "devices": [
+              "sunrpc"
+            ]
+          },
+          "/sys/fs/fuse/connections": {
+            "fs_type": "fusectl",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "devices": [
+              "fusectl"
+            ]
+          },
+          "/var/lib/lxcfs": {
+            "fs_type": "fuse.lxcfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "relatime",
+              "user_id=0",
+              "group_id=0",
+              "allow_other"
+            ],
+            "devices": [
+              "lxcfs"
+            ]
+          }
+        },
+        "by_pair": {
+          "udev,/dev": {
+            "device": "udev",
+            "kb_size": "2003252",
+            "kb_used": "0",
+            "kb_available": "2003252",
+            "percent_used": "0%",
+            "mount": "/dev",
+            "total_inodes": "500813",
+            "inodes_used": "423",
+            "inodes_available": "500390",
+            "inodes_percent_used": "1%",
+            "fs_type": "devtmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "relatime",
+              "size=2003252k",
+              "nr_inodes=500813",
+              "mode=755"
+            ]
+          },
+          "tmpfs,/run": {
+            "device": "tmpfs",
+            "kb_size": "404652",
+            "kb_used": "5724",
+            "kb_available": "398928",
+            "percent_used": "2%",
+            "mount": "/run",
+            "total_inodes": "505813",
+            "inodes_used": "549",
+            "inodes_available": "505264",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "noexec",
+              "relatime",
+              "size=404652k",
+              "mode=755"
+            ]
+          },
+          "/dev/mapper/vagrant--vg-root,/": {
+            "device": "/dev/mapper/vagrant--vg-root",
+            "kb_size": "39625324",
+            "kb_used": "1602012",
+            "kb_available": "35987396",
+            "percent_used": "5%",
+            "mount": "/",
+            "total_inodes": "2526384",
+            "inodes_used": "65911",
+            "inodes_available": "2460473",
+            "inodes_percent_used": "3%",
+            "fs_type": "ext4",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "errors=remount-ro",
+              "data=ordered"
+            ],
+            "uuid": "b823f60e-6a87-4d92-b525-0a9b72e64d08"
+          },
+          "tmpfs,/dev/shm": {
+            "device": "tmpfs",
+            "kb_size": "2023252",
+            "kb_used": "0",
+            "kb_available": "2023252",
+            "percent_used": "0%",
+            "mount": "/dev/shm",
+            "total_inodes": "505813",
+            "inodes_used": "1",
+            "inodes_available": "505812",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev"
+            ]
+          },
+          "tmpfs,/run/lock": {
+            "device": "tmpfs",
+            "kb_size": "5120",
+            "kb_used": "0",
+            "kb_available": "5120",
+            "percent_used": "0%",
+            "mount": "/run/lock",
+            "total_inodes": "505813",
+            "inodes_used": "3",
+            "inodes_available": "505810",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "size=5120k"
+            ]
+          },
+          "tmpfs,/sys/fs/cgroup": {
+            "device": "tmpfs",
+            "kb_size": "2023252",
+            "kb_used": "0",
+            "kb_available": "2023252",
+            "percent_used": "0%",
+            "mount": "/sys/fs/cgroup",
+            "total_inodes": "505813",
+            "inodes_used": "16",
+            "inodes_available": "505797",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "ro",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "mode=755"
+            ]
+          },
+          "/dev/sda1,/boot": {
+            "device": "/dev/sda1",
+            "kb_size": "482922",
+            "kb_used": "58213",
+            "kb_available": "399775",
+            "percent_used": "13%",
+            "mount": "/boot",
+            "total_inodes": "124928",
+            "inodes_used": "303",
+            "inodes_available": "124625",
+            "inodes_percent_used": "1%",
+            "fs_type": "ext2",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "block_validity",
+              "barrier",
+              "user_xattr",
+              "acl"
+            ],
+            "uuid": "29725d5e-b3e6-4197-b2cc-9f243085b2da"
+          },
+          "tmpfs,/run/user/1000": {
+            "device": "tmpfs",
+            "kb_size": "404652",
+            "kb_used": "0",
+            "kb_available": "404652",
+            "percent_used": "0%",
+            "mount": "/run/user/1000",
+            "total_inodes": "505813",
+            "inodes_used": "4",
+            "inodes_available": "505809",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "relatime",
+              "size=404652k",
+              "mode=700",
+              "uid=1000",
+              "gid=1000"
+            ]
+          },
+          "vagrant,/vagrant": {
+            "device": "vagrant",
+            "kb_size": "488347692",
+            "kb_used": "292387700",
+            "kb_available": "195959992",
+            "percent_used": "60%",
+            "mount": "/vagrant",
+            "total_inodes": "1000",
+            "inodes_used": "0",
+            "inodes_available": "1000",
+            "inodes_percent_used": "0%"
+          },
+          "sysfs,/sys": {
+            "device": "sysfs",
+            "mount": "/sys",
+            "fs_type": "sysfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ]
+          },
+          "proc,/proc": {
+            "device": "proc",
+            "mount": "/proc",
+            "fs_type": "proc",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ]
+          },
+          "devpts,/dev/pts": {
+            "device": "devpts",
+            "mount": "/dev/pts",
+            "fs_type": "devpts",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "noexec",
+              "relatime",
+              "gid=5",
+              "mode=620",
+              "ptmxmode=000"
+            ]
+          },
+          "securityfs,/sys/kernel/security": {
+            "device": "securityfs",
+            "mount": "/sys/kernel/security",
+            "fs_type": "securityfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/systemd": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/systemd",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "xattr",
+              "release_agent=/lib/systemd/systemd-cgroups-agent",
+              "name=systemd"
+            ]
+          },
+          "pstore,/sys/fs/pstore": {
+            "device": "pstore",
+            "mount": "/sys/fs/pstore",
+            "fs_type": "pstore",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/cpu,cpuacct": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/cpu,cpuacct",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "cpu",
+              "cpuacct"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/pids": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/pids",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "pids"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/devices": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/devices",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "devices"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/cpuset": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/cpuset",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "cpuset"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/freezer": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/freezer",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "freezer"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/perf_event": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/perf_event",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "perf_event"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/net_cls,net_prio": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/net_cls,net_prio",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "net_cls",
+              "net_prio"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/memory": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/memory",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "memory"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/blkio": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/blkio",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "blkio"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/hugetlb": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/hugetlb",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "hugetlb"
+            ]
+          },
+          "systemd-1,/proc/sys/fs/binfmt_misc": {
+            "device": "systemd-1",
+            "mount": "/proc/sys/fs/binfmt_misc",
+            "fs_type": "autofs",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "fd=31",
+              "pgrp=1",
+              "timeout=0",
+              "minproto=5",
+              "maxproto=5",
+              "direct"
+            ]
+          },
+          "mqueue,/dev/mqueue": {
+            "device": "mqueue",
+            "mount": "/dev/mqueue",
+            "fs_type": "mqueue",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ]
+          },
+          "debugfs,/sys/kernel/debug": {
+            "device": "debugfs",
+            "mount": "/sys/kernel/debug",
+            "fs_type": "debugfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ]
+          },
+          "hugetlbfs,/dev/hugepages": {
+            "device": "hugetlbfs",
+            "mount": "/dev/hugepages",
+            "fs_type": "hugetlbfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ]
+          },
+          "sunrpc,/run/rpc_pipefs": {
+            "device": "sunrpc",
+            "mount": "/run/rpc_pipefs",
+            "fs_type": "rpc_pipefs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ]
+          },
+          "fusectl,/sys/fs/fuse/connections": {
+            "device": "fusectl",
+            "mount": "/sys/fs/fuse/connections",
+            "fs_type": "fusectl",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ]
+          },
+          "lxcfs,/var/lib/lxcfs": {
+            "device": "lxcfs",
+            "mount": "/var/lib/lxcfs",
+            "fs_type": "fuse.lxcfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "relatime",
+              "user_id=0",
+              "group_id=0",
+              "allow_other"
+            ]
+          },
+          "/vagrant,/vagrant": {
+            "device": "/vagrant",
+            "mount": "/vagrant",
+            "fs_type": "vboxsf",
+            "mount_options": [
+              "rw",
+              "nodev",
+              "relatime"
+            ]
+          },
+          "/dev/sda,": {
+            "device": "/dev/sda"
+          },
+          "/dev/sda2,": {
+            "device": "/dev/sda2"
+          },
+          "/dev/sda5,": {
+            "device": "/dev/sda5",
+            "fs_type": "LVM2_member",
+            "uuid": "3N7Z0V-Ubze-Lx6p-tesB-AIU7-alJo-GQoVmU"
+          },
+          "/dev/mapper/vagrant--vg-swap_1,": {
+            "device": "/dev/mapper/vagrant--vg-swap_1",
+            "fs_type": "swap",
+            "uuid": "5a469a8a-e6dc-4118-b1d2-c396c9cd436b"
+          }
+        }
+      },
+      "packages": {
+        "accountsservice": {
+          "version": "0.6.40-2ubuntu11.3",
+          "arch": "amd64"
+        },
+        "acl": {
+          "version": "2.2.52-3",
+          "arch": "amd64"
+        },
+        "acpid": {
+          "version": "1:2.0.26-1ubuntu2",
+          "arch": "amd64"
+        },
+        "adduser": {
+          "version": "3.113+nmu3ubuntu4",
+          "arch": "all"
+        },
+        "apparmor": {
+          "version": "2.10.95-0ubuntu2.6",
+          "arch": "amd64"
+        },
+        "apport": {
+          "version": "2.20.1-0ubuntu2.5",
+          "arch": "all"
+        },
+        "apport-symptoms": {
+          "version": "0.20",
+          "arch": "all"
+        },
+        "apt": {
+          "version": "1.2.20",
+          "arch": "amd64"
+        },
+        "apt-transport-https": {
+          "version": "1.2.20",
+          "arch": "amd64"
+        },
+        "apt-utils": {
+          "version": "1.2.20",
+          "arch": "amd64"
+        },
+        "at": {
+          "version": "3.1.18-2ubuntu1",
+          "arch": "amd64"
+        },
+        "base-files": {
+          "version": "9.4ubuntu4.4",
+          "arch": "amd64"
+        },
+        "base-passwd": {
+          "version": "3.5.39",
+          "arch": "amd64"
+        },
+        "bash": {
+          "version": "4.3-14ubuntu1.1",
+          "arch": "amd64"
+        },
+        "bash-completion": {
+          "version": "1:2.1-4.2ubuntu1.1",
+          "arch": "all"
+        },
+        "bcache-tools": {
+          "version": "1.0.8-2",
+          "arch": "amd64"
+        },
+        "bind9-host": {
+          "version": "1:9.10.3.dfsg.P4-8ubuntu1.6",
+          "arch": "amd64"
+        },
+        "binutils": {
+          "version": "2.26.1-1ubuntu1~16.04.3",
+          "arch": "amd64"
+        },
+        "bsdmainutils": {
+          "version": "9.0.6ubuntu3",
+          "arch": "amd64"
+        },
+        "bsdutils": {
+          "version": "1:2.27.1-6ubuntu3.2",
+          "arch": "amd64"
+        },
+        "btrfs-tools": {
+          "version": "4.4-1",
+          "arch": "amd64"
+        },
+        "busybox-initramfs": {
+          "version": "1:1.22.0-15ubuntu1",
+          "arch": "amd64"
+        },
+        "busybox-static": {
+          "version": "1:1.22.0-15ubuntu1",
+          "arch": "amd64"
+        },
+        "byobu": {
+          "version": "5.106-0ubuntu1",
+          "arch": "all"
+        },
+        "bzip2": {
+          "version": "1.0.6-8",
+          "arch": "amd64"
+        },
+        "ca-certificates": {
+          "version": "20160104ubuntu1",
+          "arch": "all"
+        },
+        "chef": {
+          "version": "14.4.56-1",
+          "arch": "amd64"
+        },
+        "cloud-guest-utils": {
+          "version": "0.27-0ubuntu24",
+          "arch": "all"
+        },
+        "cloud-initramfs-copymods": {
+          "version": "0.27ubuntu1.3",
+          "arch": "all"
+        },
+        "cloud-initramfs-dyn-netconf": {
+          "version": "0.27ubuntu1.3",
+          "arch": "all"
+        },
+        "console-setup": {
+          "version": "1.108ubuntu15.3",
+          "arch": "all"
+        },
+        "console-setup-linux": {
+          "version": "1.108ubuntu15.3",
+          "arch": "all"
+        },
+        "coreutils": {
+          "version": "8.25-2ubuntu2",
+          "arch": "amd64"
+        },
+        "cpio": {
+          "version": "2.11+dfsg-5ubuntu1",
+          "arch": "amd64"
+        },
+        "cpp": {
+          "version": "4:5.3.1-1ubuntu1",
+          "arch": "amd64"
+        },
+        "cpp-5": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "crda": {
+          "version": "3.13-1",
+          "arch": "amd64"
+        },
+        "cron": {
+          "version": "3.0pl1-128ubuntu2",
+          "arch": "amd64"
+        },
+        "cryptsetup": {
+          "version": "2:1.6.6-5ubuntu2",
+          "arch": "amd64"
+        },
+        "cryptsetup-bin": {
+          "version": "2:1.6.6-5ubuntu2",
+          "arch": "amd64"
+        },
+        "curl": {
+          "version": "7.47.0-1ubuntu2.2",
+          "arch": "amd64"
+        },
+        "dash": {
+          "version": "0.5.8-2.1ubuntu2",
+          "arch": "amd64"
+        },
+        "dbus": {
+          "version": "1.10.6-1ubuntu3.3",
+          "arch": "amd64"
+        },
+        "debconf": {
+          "version": "1.5.58ubuntu1",
+          "arch": "all"
+        },
+        "debconf-i18n": {
+          "version": "1.5.58ubuntu1",
+          "arch": "all"
+        },
+        "debianutils": {
+          "version": "4.7",
+          "arch": "amd64"
+        },
+        "dh-python": {
+          "version": "2.20151103ubuntu1.1",
+          "arch": "all"
+        },
+        "diffutils": {
+          "version": "1:3.3-3",
+          "arch": "amd64"
+        },
+        "distro-info-data": {
+          "version": "0.28ubuntu0.3",
+          "arch": "all"
+        },
+        "dkms": {
+          "version": "2.2.0.3-2ubuntu11.3",
+          "arch": "all"
+        },
+        "dmeventd": {
+          "version": "2:1.02.110-1ubuntu10",
+          "arch": "amd64"
+        },
+        "dmidecode": {
+          "version": "3.0-2ubuntu0.1",
+          "arch": "amd64"
+        },
+        "dmsetup": {
+          "version": "2:1.02.110-1ubuntu10",
+          "arch": "amd64"
+        },
+        "dns-root-data": {
+          "version": "2015052300+h+1",
+          "arch": "all"
+        },
+        "dnsmasq-base": {
+          "version": "2.75-1ubuntu0.16.04.2",
+          "arch": "amd64"
+        },
+        "dnsutils": {
+          "version": "1:9.10.3.dfsg.P4-8ubuntu1.6",
+          "arch": "amd64"
+        },
+        "dosfstools": {
+          "version": "3.0.28-2ubuntu0.1",
+          "arch": "amd64"
+        },
+        "dpkg": {
+          "version": "1.18.4ubuntu1.2",
+          "arch": "amd64"
+        },
+        "e2fslibs": {
+          "version": "1.42.13-1ubuntu1",
+          "arch": "amd64"
+        },
+        "e2fsprogs": {
+          "version": "1.42.13-1ubuntu1",
+          "arch": "amd64"
+        },
+        "ed": {
+          "version": "1.10-2",
+          "arch": "amd64"
+        },
+        "eject": {
+          "version": "2.1.5+deb1+cvs20081104-13.1ubuntu0.16.04.1",
+          "arch": "amd64"
+        },
+        "ethtool": {
+          "version": "1:4.5-1",
+          "arch": "amd64"
+        },
+        "fakeroot": {
+          "version": "1.20.2-1ubuntu1",
+          "arch": "amd64"
+        },
+        "file": {
+          "version": "1:5.25-2ubuntu1",
+          "arch": "amd64"
+        },
+        "findutils": {
+          "version": "4.6.0+git+20160126-2",
+          "arch": "amd64"
+        },
+        "fonts-ubuntu-font-family-console": {
+          "version": "1:0.83-0ubuntu2",
+          "arch": "all"
+        },
+        "ftp": {
+          "version": "0.17-33",
+          "arch": "amd64"
+        },
+        "fuse": {
+          "version": "2.9.4-1ubuntu3.1",
+          "arch": "amd64"
+        },
+        "gawk": {
+          "version": "1:4.1.3+dfsg-0.1",
+          "arch": "amd64"
+        },
+        "gcc": {
+          "version": "4:5.3.1-1ubuntu1",
+          "arch": "amd64"
+        },
+        "gcc-5": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "gcc-5-base": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "gcc-6-base": {
+          "version": "6.0.1-0ubuntu1",
+          "arch": "amd64"
+        },
+        "geoip-database": {
+          "version": "20160408-1",
+          "arch": "all"
+        },
+        "gettext-base": {
+          "version": "0.19.7-2ubuntu3",
+          "arch": "amd64"
+        },
+        "gir1.2-glib-2.0": {
+          "version": "1.46.0-3ubuntu1",
+          "arch": "amd64"
+        },
+        "git": {
+          "version": "1:2.7.4-0ubuntu1",
+          "arch": "amd64"
+        },
+        "git-man": {
+          "version": "1:2.7.4-0ubuntu1",
+          "arch": "all"
+        },
+        "gnupg": {
+          "version": "1.4.20-1ubuntu3.1",
+          "arch": "amd64"
+        },
+        "gpgv": {
+          "version": "1.4.20-1ubuntu3.1",
+          "arch": "amd64"
+        },
+        "grep": {
+          "version": "2.25-1~16.04.1",
+          "arch": "amd64"
+        },
+        "groff-base": {
+          "version": "1.22.3-7",
+          "arch": "amd64"
+        },
+        "grub-common": {
+          "version": "2.02~beta2-36ubuntu3.9",
+          "arch": "amd64"
+        },
+        "grub-gfxpayload-lists": {
+          "version": "0.7",
+          "arch": "amd64"
+        },
+        "grub-legacy-ec2": {
+          "version": "0.7.9-90-g61eb03fe-0ubuntu1~16.04.1",
+          "arch": "all"
+        },
+        "grub-pc": {
+          "version": "2.02~beta2-36ubuntu3.9",
+          "arch": "amd64"
+        },
+        "grub-pc-bin": {
+          "version": "2.02~beta2-36ubuntu3.9",
+          "arch": "amd64"
+        },
+        "grub2-common": {
+          "version": "2.02~beta2-36ubuntu3.9",
+          "arch": "amd64"
+        },
+        "gzip": {
+          "version": "1.6-4ubuntu1",
+          "arch": "amd64"
+        },
+        "hdparm": {
+          "version": "9.48+ds-1",
+          "arch": "amd64"
+        },
+        "hostname": {
+          "version": "3.16ubuntu2",
+          "arch": "amd64"
+        },
+        "ifenslave": {
+          "version": "2.7ubuntu1",
+          "arch": "all"
+        },
+        "ifupdown": {
+          "version": "0.8.10ubuntu1.2",
+          "arch": "amd64"
+        },
+        "info": {
+          "version": "6.1.0.dfsg.1-5",
+          "arch": "amd64"
+        },
+        "init": {
+          "version": "1.29ubuntu4",
+          "arch": "amd64"
+        },
+        "init-system-helpers": {
+          "version": "1.29ubuntu4",
+          "arch": "all"
+        },
+        "initramfs-tools": {
+          "version": "0.122ubuntu8.8",
+          "arch": "all"
+        },
+        "initramfs-tools-bin": {
+          "version": "0.122ubuntu8.8",
+          "arch": "amd64"
+        },
+        "initramfs-tools-core": {
+          "version": "0.122ubuntu8.8",
+          "arch": "all"
+        },
+        "initscripts": {
+          "version": "2.88dsf-59.3ubuntu2",
+          "arch": "amd64"
+        },
+        "insserv": {
+          "version": "1.14.0-5ubuntu3",
+          "arch": "amd64"
+        },
+        "install-info": {
+          "version": "6.1.0.dfsg.1-5",
+          "arch": "amd64"
+        },
+        "iproute2": {
+          "version": "4.3.0-1ubuntu3",
+          "arch": "amd64"
+        },
+        "iptables": {
+          "version": "1.6.0-2ubuntu3",
+          "arch": "amd64"
+        },
+        "iputils-ping": {
+          "version": "3:20121221-5ubuntu2",
+          "arch": "amd64"
+        },
+        "iputils-tracepath": {
+          "version": "3:20121221-5ubuntu2",
+          "arch": "amd64"
+        },
+        "irqbalance": {
+          "version": "1.1.0-2ubuntu1",
+          "arch": "amd64"
+        },
+        "isc-dhcp-client": {
+          "version": "4.3.3-5ubuntu12.6",
+          "arch": "amd64"
+        },
+        "isc-dhcp-common": {
+          "version": "4.3.3-5ubuntu12.6",
+          "arch": "amd64"
+        },
+        "iso-codes": {
+          "version": "3.65-1",
+          "arch": "all"
+        },
+        "iw": {
+          "version": "3.17-1",
+          "arch": "amd64"
+        },
+        "kbd": {
+          "version": "1.15.5-1ubuntu5",
+          "arch": "amd64"
+        },
+        "keyboard-configuration": {
+          "version": "1.108ubuntu15.3",
+          "arch": "all"
+        },
+        "keyutils": {
+          "version": "1.5.9-8ubuntu1",
+          "arch": "amd64"
+        },
+        "klibc-utils": {
+          "version": "2.0.4-8ubuntu1.16.04.3",
+          "arch": "amd64"
+        },
+        "kmod": {
+          "version": "22-1ubuntu4",
+          "arch": "amd64"
+        },
+        "krb5-locales": {
+          "version": "1.13.2+dfsg-5ubuntu2",
+          "arch": "all"
+        },
+        "language-pack-en": {
+          "version": "1:16.04+20161009",
+          "arch": "all"
+        },
+        "language-pack-en-base": {
+          "version": "1:16.04+20160627",
+          "arch": "all"
+        },
+        "language-pack-gnome-en": {
+          "version": "1:16.04+20161009",
+          "arch": "all"
+        },
+        "language-pack-gnome-en-base": {
+          "version": "1:16.04+20160627",
+          "arch": "all"
+        },
+        "language-selector-common": {
+          "version": "0.165.4",
+          "arch": "all"
+        },
+        "laptop-detect": {
+          "version": "0.13.7ubuntu2",
+          "arch": "amd64"
+        },
+        "less": {
+          "version": "481-2.1ubuntu0.1",
+          "arch": "amd64"
+        },
+        "libaccountsservice0": {
+          "version": "0.6.40-2ubuntu11.3",
+          "arch": "amd64"
+        },
+        "libacl1": {
+          "version": "2.2.52-3",
+          "arch": "amd64"
+        },
+        "libapparmor-perl": {
+          "version": "2.10.95-0ubuntu2.6",
+          "arch": "amd64"
+        },
+        "libapparmor1": {
+          "version": "2.10.95-0ubuntu2.6",
+          "arch": "amd64"
+        },
+        "libapt-inst2.0": {
+          "version": "1.2.20",
+          "arch": "amd64"
+        },
+        "libapt-pkg5.0": {
+          "version": "1.2.20",
+          "arch": "amd64"
+        },
+        "libasan2": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "libasn1-8-heimdal": {
+          "version": "1.7~git20150920+dfsg-4ubuntu1",
+          "arch": "amd64"
+        },
+        "libasprintf0v5": {
+          "version": "0.19.7-2ubuntu3",
+          "arch": "amd64"
+        },
+        "libatm1": {
+          "version": "1:2.5.1-1.5",
+          "arch": "amd64"
+        },
+        "libatomic1": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "libattr1": {
+          "version": "1:2.4.47-2",
+          "arch": "amd64"
+        },
+        "libaudit-common": {
+          "version": "1:2.4.5-1ubuntu2",
+          "arch": "all"
+        },
+        "libaudit1": {
+          "version": "1:2.4.5-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libbind9-140": {
+          "version": "1:9.10.3.dfsg.P4-8ubuntu1.6",
+          "arch": "amd64"
+        },
+        "libblkid1": {
+          "version": "2.27.1-6ubuntu3.2",
+          "arch": "amd64"
+        },
+        "libbsd0": {
+          "version": "0.8.2-1",
+          "arch": "amd64"
+        },
+        "libbz2-1.0": {
+          "version": "1.0.6-8",
+          "arch": "amd64"
+        },
+        "libc-bin": {
+          "version": "2.23-0ubuntu7",
+          "arch": "amd64"
+        },
+        "libc-dev-bin": {
+          "version": "2.23-0ubuntu7",
+          "arch": "amd64"
+        },
+        "libc6": {
+          "version": "2.23-0ubuntu7",
+          "arch": "amd64"
+        },
+        "libc6-dev": {
+          "version": "2.23-0ubuntu7",
+          "arch": "amd64"
+        },
+        "libcap-ng0": {
+          "version": "0.7.7-1",
+          "arch": "amd64"
+        },
+        "libcap2": {
+          "version": "1:2.24-12",
+          "arch": "amd64"
+        },
+        "libcap2-bin": {
+          "version": "1:2.24-12",
+          "arch": "amd64"
+        },
+        "libcc1-0": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "libcilkrts5": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "libcomerr2": {
+          "version": "1.42.13-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libcryptsetup4": {
+          "version": "2:1.6.6-5ubuntu2",
+          "arch": "amd64"
+        },
+        "libcurl3-gnutls": {
+          "version": "7.47.0-1ubuntu2.2",
+          "arch": "amd64"
+        },
+        "libdb5.3": {
+          "version": "5.3.28-11",
+          "arch": "amd64"
+        },
+        "libdbus-1-3": {
+          "version": "1.10.6-1ubuntu3.3",
+          "arch": "amd64"
+        },
+        "libdbus-glib-1-2": {
+          "version": "0.106-1",
+          "arch": "amd64"
+        },
+        "libdebconfclient0": {
+          "version": "0.198ubuntu1",
+          "arch": "amd64"
+        },
+        "libdevmapper-event1.02.1": {
+          "version": "2:1.02.110-1ubuntu10",
+          "arch": "amd64"
+        },
+        "libdevmapper1.02.1": {
+          "version": "2:1.02.110-1ubuntu10",
+          "arch": "amd64"
+        },
+        "libdns-export162": {
+          "version": "1:9.10.3.dfsg.P4-8ubuntu1.6",
+          "arch": "amd64"
+        },
+        "libdns162": {
+          "version": "1:9.10.3.dfsg.P4-8ubuntu1.6",
+          "arch": "amd64"
+        },
+        "libdpkg-perl": {
+          "version": "1.18.4ubuntu1.2",
+          "arch": "all"
+        },
+        "libdrm2": {
+          "version": "2.4.70-1~ubuntu16.04.1",
+          "arch": "amd64"
+        },
+        "libdumbnet1": {
+          "version": "1.12-7",
+          "arch": "amd64"
+        },
+        "libedit2": {
+          "version": "3.1-20150325-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libelf1": {
+          "version": "0.165-3ubuntu1",
+          "arch": "amd64"
+        },
+        "liberror-perl": {
+          "version": "0.17-1.2",
+          "arch": "all"
+        },
+        "libestr0": {
+          "version": "0.1.10-1",
+          "arch": "amd64"
+        },
+        "libevent-2.0-5": {
+          "version": "2.0.21-stable-2ubuntu0.16.04.1",
+          "arch": "amd64"
+        },
+        "libexpat1": {
+          "version": "2.1.0-7ubuntu0.16.04.2",
+          "arch": "amd64"
+        },
+        "libfakeroot": {
+          "version": "1.20.2-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libfdisk1": {
+          "version": "2.27.1-6ubuntu3.2",
+          "arch": "amd64"
+        },
+        "libffi6": {
+          "version": "3.2.1-4",
+          "arch": "amd64"
+        },
+        "libfile-fcntllock-perl": {
+          "version": "0.22-3",
+          "arch": "amd64"
+        },
+        "libfreetype6": {
+          "version": "2.6.1-0.1ubuntu2.2",
+          "arch": "amd64"
+        },
+        "libfribidi0": {
+          "version": "0.19.7-1",
+          "arch": "amd64"
+        },
+        "libfuse2": {
+          "version": "2.9.4-1ubuntu3.1",
+          "arch": "amd64"
+        },
+        "libgcc-5-dev": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "libgcc1": {
+          "version": "1:6.0.1-0ubuntu1",
+          "arch": "amd64"
+        },
+        "libgcrypt20": {
+          "version": "1.6.5-2ubuntu0.2",
+          "arch": "amd64"
+        },
+        "libgdbm3": {
+          "version": "1.8.3-13.1",
+          "arch": "amd64"
+        },
+        "libgeoip1": {
+          "version": "1.6.9-1",
+          "arch": "amd64"
+        },
+        "libgirepository-1.0-1": {
+          "version": "1.46.0-3ubuntu1",
+          "arch": "amd64"
+        },
+        "libglib2.0-0": {
+          "version": "2.48.2-0ubuntu1",
+          "arch": "amd64"
+        },
+        "libglib2.0-data": {
+          "version": "2.48.2-0ubuntu1",
+          "arch": "all"
+        },
+        "libgmp10": {
+          "version": "2:6.1.0+dfsg-2",
+          "arch": "amd64"
+        },
+        "libgnutls-openssl27": {
+          "version": "3.4.10-4ubuntu1.2",
+          "arch": "amd64"
+        },
+        "libgnutls30": {
+          "version": "3.4.10-4ubuntu1.2",
+          "arch": "amd64"
+        },
+        "libgomp1": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "libgpg-error0": {
+          "version": "1.21-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libgpm2": {
+          "version": "1.20.4-6.1",
+          "arch": "amd64"
+        },
+        "libgssapi-krb5-2": {
+          "version": "1.13.2+dfsg-5ubuntu2",
+          "arch": "amd64"
+        },
+        "libgssapi3-heimdal": {
+          "version": "1.7~git20150920+dfsg-4ubuntu1",
+          "arch": "amd64"
+        },
+        "libhcrypto4-heimdal": {
+          "version": "1.7~git20150920+dfsg-4ubuntu1",
+          "arch": "amd64"
+        },
+        "libheimbase1-heimdal": {
+          "version": "1.7~git20150920+dfsg-4ubuntu1",
+          "arch": "amd64"
+        },
+        "libheimntlm0-heimdal": {
+          "version": "1.7~git20150920+dfsg-4ubuntu1",
+          "arch": "amd64"
+        },
+        "libhogweed4": {
+          "version": "3.2-1ubuntu0.16.04.1",
+          "arch": "amd64"
+        },
+        "libhx509-5-heimdal": {
+          "version": "1.7~git20150920+dfsg-4ubuntu1",
+          "arch": "amd64"
+        },
+        "libicu55": {
+          "version": "55.1-7ubuntu0.1",
+          "arch": "amd64"
+        },
+        "libidn11": {
+          "version": "1.32-3ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libisc-export160": {
+          "version": "1:9.10.3.dfsg.P4-8ubuntu1.6",
+          "arch": "amd64"
+        },
+        "libisc160": {
+          "version": "1:9.10.3.dfsg.P4-8ubuntu1.6",
+          "arch": "amd64"
+        },
+        "libisccc140": {
+          "version": "1:9.10.3.dfsg.P4-8ubuntu1.6",
+          "arch": "amd64"
+        },
+        "libisccfg140": {
+          "version": "1:9.10.3.dfsg.P4-8ubuntu1.6",
+          "arch": "amd64"
+        },
+        "libisl15": {
+          "version": "0.16.1-1",
+          "arch": "amd64"
+        },
+        "libitm1": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "libjson-c2": {
+          "version": "0.11-4ubuntu2",
+          "arch": "amd64"
+        },
+        "libk5crypto3": {
+          "version": "1.13.2+dfsg-5ubuntu2",
+          "arch": "amd64"
+        },
+        "libkeyutils1": {
+          "version": "1.5.9-8ubuntu1",
+          "arch": "amd64"
+        },
+        "libklibc": {
+          "version": "2.0.4-8ubuntu1.16.04.3",
+          "arch": "amd64"
+        },
+        "libkmod2": {
+          "version": "22-1ubuntu4",
+          "arch": "amd64"
+        },
+        "libkrb5-26-heimdal": {
+          "version": "1.7~git20150920+dfsg-4ubuntu1",
+          "arch": "amd64"
+        },
+        "libkrb5-3": {
+          "version": "1.13.2+dfsg-5ubuntu2",
+          "arch": "amd64"
+        },
+        "libkrb5support0": {
+          "version": "1.13.2+dfsg-5ubuntu2",
+          "arch": "amd64"
+        },
+        "libldap-2.4-2": {
+          "version": "2.4.42+dfsg-2ubuntu3.1",
+          "arch": "amd64"
+        },
+        "liblocale-gettext-perl": {
+          "version": "1.07-1build1",
+          "arch": "amd64"
+        },
+        "liblsan0": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "liblvm2app2.2": {
+          "version": "2.02.133-1ubuntu10",
+          "arch": "amd64"
+        },
+        "liblvm2cmd2.02": {
+          "version": "2.02.133-1ubuntu10",
+          "arch": "amd64"
+        },
+        "liblwres141": {
+          "version": "1:9.10.3.dfsg.P4-8ubuntu1.6",
+          "arch": "amd64"
+        },
+        "liblxc1": {
+          "version": "2.0.7-0ubuntu1~16.04.2",
+          "arch": "amd64"
+        },
+        "liblz4-1": {
+          "version": "0.0~r131-2ubuntu2",
+          "arch": "amd64"
+        },
+        "liblzma5": {
+          "version": "5.1.1alpha+20120614-2ubuntu2",
+          "arch": "amd64"
+        },
+        "liblzo2-2": {
+          "version": "2.08-1.2",
+          "arch": "amd64"
+        },
+        "libmagic1": {
+          "version": "1:5.25-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libmnl0": {
+          "version": "1.0.3-5",
+          "arch": "amd64"
+        },
+        "libmount1": {
+          "version": "2.27.1-6ubuntu3.2",
+          "arch": "amd64"
+        },
+        "libmpc3": {
+          "version": "1.0.3-1",
+          "arch": "amd64"
+        },
+        "libmpdec2": {
+          "version": "2.4.2-1",
+          "arch": "amd64"
+        },
+        "libmpfr4": {
+          "version": "3.1.4-1",
+          "arch": "amd64"
+        },
+        "libmpx0": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "libmspack0": {
+          "version": "0.5-1",
+          "arch": "amd64"
+        },
+        "libncurses5": {
+          "version": "6.0+20160213-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libncursesw5": {
+          "version": "6.0+20160213-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libnetfilter-conntrack3": {
+          "version": "1.0.5-1",
+          "arch": "amd64"
+        },
+        "libnettle6": {
+          "version": "3.2-1ubuntu0.16.04.1",
+          "arch": "amd64"
+        },
+        "libnewt0.52": {
+          "version": "0.52.18-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libnfnetlink0": {
+          "version": "1.0.1-3",
+          "arch": "amd64"
+        },
+        "libnfsidmap2": {
+          "version": "0.25-5",
+          "arch": "amd64"
+        },
+        "libnih1": {
+          "version": "1.0.3-4.3ubuntu1",
+          "arch": "amd64"
+        },
+        "libnl-3-200": {
+          "version": "3.2.27-1",
+          "arch": "amd64"
+        },
+        "libnl-genl-3-200": {
+          "version": "3.2.27-1",
+          "arch": "amd64"
+        },
+        "libnuma1": {
+          "version": "2.0.11-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libp11-kit0": {
+          "version": "0.23.2-5~ubuntu16.04.1",
+          "arch": "amd64"
+        },
+        "libpam-modules": {
+          "version": "1.1.8-3.2ubuntu2",
+          "arch": "amd64"
+        },
+        "libpam-modules-bin": {
+          "version": "1.1.8-3.2ubuntu2",
+          "arch": "amd64"
+        },
+        "libpam-runtime": {
+          "version": "1.1.8-3.2ubuntu2",
+          "arch": "all"
+        },
+        "libpam-systemd": {
+          "version": "229-4ubuntu16",
+          "arch": "amd64"
+        },
+        "libpam0g": {
+          "version": "1.1.8-3.2ubuntu2",
+          "arch": "amd64"
+        },
+        "libparted2": {
+          "version": "3.2-15",
+          "arch": "amd64"
+        },
+        "libpcap0.8": {
+          "version": "1.7.4-2",
+          "arch": "amd64"
+        },
+        "libpci3": {
+          "version": "1:3.3.1-1.1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libpcre3": {
+          "version": "2:8.38-3.1",
+          "arch": "amd64"
+        },
+        "libperl5.22": {
+          "version": "5.22.1-9",
+          "arch": "amd64"
+        },
+        "libpipeline1": {
+          "version": "1.4.1-2",
+          "arch": "amd64"
+        },
+        "libplymouth4": {
+          "version": "0.9.2-3ubuntu13.1",
+          "arch": "amd64"
+        },
+        "libpng12-0": {
+          "version": "1.2.54-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libpolkit-agent-1-0": {
+          "version": "0.105-14.1",
+          "arch": "amd64"
+        },
+        "libpolkit-backend-1-0": {
+          "version": "0.105-14.1",
+          "arch": "amd64"
+        },
+        "libpolkit-gobject-1-0": {
+          "version": "0.105-14.1",
+          "arch": "amd64"
+        },
+        "libpopt0": {
+          "version": "1.16-10",
+          "arch": "amd64"
+        },
+        "libprocps4": {
+          "version": "2:3.3.10-4ubuntu2.3",
+          "arch": "amd64"
+        },
+        "libpython-stdlib": {
+          "version": "2.7.11-1",
+          "arch": "amd64"
+        },
+        "libpython2.7-minimal": {
+          "version": "2.7.12-1ubuntu0~16.04.1",
+          "arch": "amd64"
+        },
+        "libpython2.7-stdlib": {
+          "version": "2.7.12-1ubuntu0~16.04.1",
+          "arch": "amd64"
+        },
+        "libpython3-stdlib": {
+          "version": "3.5.1-3",
+          "arch": "amd64"
+        },
+        "libpython3.5": {
+          "version": "3.5.2-2ubuntu0~16.04.1",
+          "arch": "amd64"
+        },
+        "libpython3.5-minimal": {
+          "version": "3.5.2-2ubuntu0~16.04.1",
+          "arch": "amd64"
+        },
+        "libpython3.5-stdlib": {
+          "version": "3.5.2-2ubuntu0~16.04.1",
+          "arch": "amd64"
+        },
+        "libquadmath0": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "libreadline-dev": {
+          "version": "6.3-8ubuntu2",
+          "arch": "amd64"
+        },
+        "libreadline5": {
+          "version": "5.2+dfsg-3build1",
+          "arch": "amd64"
+        },
+        "libreadline6": {
+          "version": "6.3-8ubuntu2",
+          "arch": "amd64"
+        },
+        "libreadline6-dev": {
+          "version": "6.3-8ubuntu2",
+          "arch": "amd64"
+        },
+        "libroken18-heimdal": {
+          "version": "1.7~git20150920+dfsg-4ubuntu1",
+          "arch": "amd64"
+        },
+        "librtmp1": {
+          "version": "2.4+20151223.gitfa8646d-1build1",
+          "arch": "amd64"
+        },
+        "libsasl2-2": {
+          "version": "2.1.26.dfsg1-14build1",
+          "arch": "amd64"
+        },
+        "libsasl2-modules": {
+          "version": "2.1.26.dfsg1-14build1",
+          "arch": "amd64"
+        },
+        "libsasl2-modules-db": {
+          "version": "2.1.26.dfsg1-14build1",
+          "arch": "amd64"
+        },
+        "libseccomp2": {
+          "version": "2.2.3-3ubuntu3",
+          "arch": "amd64"
+        },
+        "libselinux1": {
+          "version": "2.4-3build2",
+          "arch": "amd64"
+        },
+        "libsemanage-common": {
+          "version": "2.3-1build3",
+          "arch": "all"
+        },
+        "libsemanage1": {
+          "version": "2.3-1build3",
+          "arch": "amd64"
+        },
+        "libsepol1": {
+          "version": "2.4-2",
+          "arch": "amd64"
+        },
+        "libsigsegv2": {
+          "version": "2.10-4",
+          "arch": "amd64"
+        },
+        "libslang2": {
+          "version": "2.3.0-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libsmartcols1": {
+          "version": "2.27.1-6ubuntu3.2",
+          "arch": "amd64"
+        },
+        "libsqlite3-0": {
+          "version": "3.11.0-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libss2": {
+          "version": "1.42.13-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libssl-dev": {
+          "version": "1.0.2g-1ubuntu4.6",
+          "arch": "amd64"
+        },
+        "libssl1.0.0": {
+          "version": "1.0.2g-1ubuntu4.6",
+          "arch": "amd64"
+        },
+        "libstdc++6": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "libsystemd0": {
+          "version": "229-4ubuntu16",
+          "arch": "amd64"
+        },
+        "libtasn1-6": {
+          "version": "4.7-3ubuntu0.16.04.1",
+          "arch": "amd64"
+        },
+        "libtext-charwidth-perl": {
+          "version": "0.04-7build5",
+          "arch": "amd64"
+        },
+        "libtext-iconv-perl": {
+          "version": "1.7-5build4",
+          "arch": "amd64"
+        },
+        "libtext-wrapi18n-perl": {
+          "version": "0.06-7.1",
+          "arch": "all"
+        },
+        "libtinfo-dev": {
+          "version": "6.0+20160213-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libtinfo5": {
+          "version": "6.0+20160213-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libtirpc1": {
+          "version": "0.2.5-1",
+          "arch": "amd64"
+        },
+        "libtsan0": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "libubsan0": {
+          "version": "5.4.0-6ubuntu1~16.04.4",
+          "arch": "amd64"
+        },
+        "libudev1": {
+          "version": "229-4ubuntu16",
+          "arch": "amd64"
+        },
+        "libusb-0.1-4": {
+          "version": "2:0.1.12-28",
+          "arch": "amd64"
+        },
+        "libusb-1.0-0": {
+          "version": "2:1.0.20-1",
+          "arch": "amd64"
+        },
+        "libustr-1.0-1": {
+          "version": "1.0.4-5",
+          "arch": "amd64"
+        },
+        "libutempter0": {
+          "version": "1.1.6-3",
+          "arch": "amd64"
+        },
+        "libuuid1": {
+          "version": "2.27.1-6ubuntu3.2",
+          "arch": "amd64"
+        },
+        "libwind0-heimdal": {
+          "version": "1.7~git20150920+dfsg-4ubuntu1",
+          "arch": "amd64"
+        },
+        "libwrap0": {
+          "version": "7.6.q-25",
+          "arch": "amd64"
+        },
+        "libxau6": {
+          "version": "1:1.0.8-1",
+          "arch": "amd64"
+        },
+        "libxml2": {
+          "version": "2.9.3+dfsg1-1ubuntu0.2",
+          "arch": "amd64"
+        },
+        "libxtables11": {
+          "version": "1.6.0-2ubuntu3",
+          "arch": "amd64"
+        },
+        "linux-base": {
+          "version": "4.0ubuntu1",
+          "arch": "all"
+        },
+        "linux-firmware": {
+          "version": "1.157.8",
+          "arch": "all"
+        },
+        "linux-image-4.4.0-75-generic": {
+          "version": "4.4.0-75.96",
+          "arch": "amd64"
+        },
+        "linux-image-extra-4.4.0-75-generic": {
+          "version": "4.4.0-75.96",
+          "arch": "amd64"
+        },
+        "linux-libc-dev": {
+          "version": "4.4.0-75.96",
+          "arch": "amd64"
+        },
+        "locales": {
+          "version": "2.23-0ubuntu7",
+          "arch": "all"
+        },
+        "login": {
+          "version": "1:4.2-3.1ubuntu5",
+          "arch": "amd64"
+        },
+        "logrotate": {
+          "version": "3.8.7-2ubuntu2",
+          "arch": "amd64"
+        },
+        "lsb-base": {
+          "version": "9.20160110ubuntu0.2",
+          "arch": "all"
+        },
+        "lsb-release": {
+          "version": "9.20160110ubuntu0.2",
+          "arch": "all"
+        },
+        "lshw": {
+          "version": "02.17-1.1ubuntu3.2",
+          "arch": "amd64"
+        },
+        "lsof": {
+          "version": "4.89+dfsg-0.1",
+          "arch": "amd64"
+        },
+        "ltrace": {
+          "version": "0.7.3-5.1ubuntu4",
+          "arch": "amd64"
+        },
+        "lvm2": {
+          "version": "2.02.133-1ubuntu10",
+          "arch": "amd64"
+        },
+        "lxc-common": {
+          "version": "2.0.7-0ubuntu1~16.04.2",
+          "arch": "amd64"
+        },
+        "lxcfs": {
+          "version": "2.0.6-0ubuntu1~16.04.1",
+          "arch": "amd64"
+        },
+        "lxd": {
+          "version": "2.0.9-0ubuntu1~16.04.2",
+          "arch": "amd64"
+        },
+        "lxd-client": {
+          "version": "2.0.9-0ubuntu1~16.04.2",
+          "arch": "amd64"
+        },
+        "make": {
+          "version": "4.1-6",
+          "arch": "amd64"
+        },
+        "makedev": {
+          "version": "2.3.1-93ubuntu2~ubuntu16.04.1",
+          "arch": "all"
+        },
+        "man-db": {
+          "version": "2.7.5-1",
+          "arch": "amd64"
+        },
+        "manpages": {
+          "version": "4.04-2",
+          "arch": "all"
+        },
+        "mawk": {
+          "version": "1.3.3-17ubuntu2",
+          "arch": "amd64"
+        },
+        "mdadm": {
+          "version": "3.3-2ubuntu7.2",
+          "arch": "amd64"
+        },
+        "mime-support": {
+          "version": "3.59ubuntu1",
+          "arch": "all"
+        },
+        "mlocate": {
+          "version": "0.26-1ubuntu2",
+          "arch": "amd64"
+        },
+        "mount": {
+          "version": "2.27.1-6ubuntu3.2",
+          "arch": "amd64"
+        },
+        "mtr-tiny": {
+          "version": "0.86-1ubuntu0.1",
+          "arch": "amd64"
+        },
+        "multiarch-support": {
+          "version": "2.23-0ubuntu7",
+          "arch": "amd64"
+        },
+        "nano": {
+          "version": "2.5.3-2ubuntu2",
+          "arch": "amd64"
+        },
+        "ncurses-base": {
+          "version": "6.0+20160213-1ubuntu1",
+          "arch": "all"
+        },
+        "ncurses-bin": {
+          "version": "6.0+20160213-1ubuntu1",
+          "arch": "amd64"
+        },
+        "ncurses-term": {
+          "version": "6.0+20160213-1ubuntu1",
+          "arch": "all"
+        },
+        "net-tools": {
+          "version": "1.60-26ubuntu1",
+          "arch": "amd64"
+        },
+        "netbase": {
+          "version": "5.3",
+          "arch": "all"
+        },
+        "netcat-openbsd": {
+          "version": "1.105-7ubuntu1",
+          "arch": "amd64"
+        },
+        "nfs-common": {
+          "version": "1:1.2.8-9ubuntu12.1",
+          "arch": "amd64"
+        },
+        "ntfs-3g": {
+          "version": "1:2015.3.14AR.1-1ubuntu0.1",
+          "arch": "amd64"
+        },
+        "open-iscsi": {
+          "version": "2.0.873+git0.3b4b4500-14ubuntu3.3",
+          "arch": "amd64"
+        },
+        "open-vm-tools": {
+          "version": "2:10.0.7-3227872-5ubuntu1~16.04.1",
+          "arch": "amd64"
+        },
+        "openssh-client": {
+          "version": "1:7.2p2-4ubuntu2.1",
+          "arch": "amd64"
+        },
+        "openssh-server": {
+          "version": "1:7.2p2-4ubuntu2.1",
+          "arch": "amd64"
+        },
+        "openssh-sftp-server": {
+          "version": "1:7.2p2-4ubuntu2.1",
+          "arch": "amd64"
+        },
+        "openssl": {
+          "version": "1.0.2g-1ubuntu4.6",
+          "arch": "amd64"
+        },
+        "os-prober": {
+          "version": "1.70ubuntu3.3",
+          "arch": "amd64"
+        },
+        "overlayroot": {
+          "version": "0.27ubuntu1.3",
+          "arch": "all"
+        },
+        "parted": {
+          "version": "3.2-15",
+          "arch": "amd64"
+        },
+        "passwd": {
+          "version": "1:4.2-3.1ubuntu5",
+          "arch": "amd64"
+        },
+        "pastebinit": {
+          "version": "1.5-1",
+          "arch": "all"
+        },
+        "patch": {
+          "version": "2.7.5-1",
+          "arch": "amd64"
+        },
+        "pciutils": {
+          "version": "1:3.3.1-1.1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "perl": {
+          "version": "5.22.1-9",
+          "arch": "amd64"
+        },
+        "perl-base": {
+          "version": "5.22.1-9",
+          "arch": "amd64"
+        },
+        "perl-modules-5.22": {
+          "version": "5.22.1-9",
+          "arch": "all"
+        },
+        "plymouth": {
+          "version": "0.9.2-3ubuntu13.1",
+          "arch": "amd64"
+        },
+        "plymouth-theme-ubuntu-text": {
+          "version": "0.9.2-3ubuntu13.1",
+          "arch": "amd64"
+        },
+        "policykit-1": {
+          "version": "0.105-14.1",
+          "arch": "amd64"
+        },
+        "powermgmt-base": {
+          "version": "1.31+nmu1",
+          "arch": "all"
+        },
+        "procps": {
+          "version": "2:3.3.10-4ubuntu2.3",
+          "arch": "amd64"
+        },
+        "psmisc": {
+          "version": "22.21-2.1build1",
+          "arch": "amd64"
+        },
+        "python": {
+          "version": "2.7.11-1",
+          "arch": "amd64"
+        },
+        "python-apt-common": {
+          "version": "1.1.0~beta1build1",
+          "arch": "all"
+        },
+        "python-minimal": {
+          "version": "2.7.11-1",
+          "arch": "amd64"
+        },
+        "python2.7": {
+          "version": "2.7.12-1ubuntu0~16.04.1",
+          "arch": "amd64"
+        },
+        "python2.7-minimal": {
+          "version": "2.7.12-1ubuntu0~16.04.1",
+          "arch": "amd64"
+        },
+        "python3": {
+          "version": "3.5.1-3",
+          "arch": "amd64"
+        },
+        "python3-apport": {
+          "version": "2.20.1-0ubuntu2.5",
+          "arch": "all"
+        },
+        "python3-apt": {
+          "version": "1.1.0~beta1build1",
+          "arch": "amd64"
+        },
+        "python3-chardet": {
+          "version": "2.3.0-2",
+          "arch": "all"
+        },
+        "python3-dbus": {
+          "version": "1.2.0-3",
+          "arch": "amd64"
+        },
+        "python3-debian": {
+          "version": "0.1.27ubuntu2",
+          "arch": "all"
+        },
+        "python3-distupgrade": {
+          "version": "1:16.04.21",
+          "arch": "all"
+        },
+        "python3-gdbm": {
+          "version": "3.5.1-1",
+          "arch": "amd64"
+        },
+        "python3-gi": {
+          "version": "3.20.0-0ubuntu1",
+          "arch": "amd64"
+        },
+        "python3-minimal": {
+          "version": "3.5.1-3",
+          "arch": "amd64"
+        },
+        "python3-newt": {
+          "version": "0.52.18-1ubuntu2",
+          "arch": "amd64"
+        },
+        "python3-pkg-resources": {
+          "version": "20.7.0-1",
+          "arch": "all"
+        },
+        "python3-problem-report": {
+          "version": "2.20.1-0ubuntu2.5",
+          "arch": "all"
+        },
+        "python3-pycurl": {
+          "version": "7.43.0-1ubuntu1",
+          "arch": "amd64"
+        },
+        "python3-requests": {
+          "version": "2.9.1-3",
+          "arch": "all"
+        },
+        "python3-six": {
+          "version": "1.10.0-3",
+          "arch": "all"
+        },
+        "python3-software-properties": {
+          "version": "0.96.20.5",
+          "arch": "all"
+        },
+        "python3-systemd": {
+          "version": "231-2build1",
+          "arch": "amd64"
+        },
+        "python3-update-manager": {
+          "version": "1:16.04.6",
+          "arch": "all"
+        },
+        "python3-urllib3": {
+          "version": "1.13.1-2ubuntu0.16.04.1",
+          "arch": "all"
+        },
+        "python3.5": {
+          "version": "3.5.2-2ubuntu0~16.04.1",
+          "arch": "amd64"
+        },
+        "python3.5-minimal": {
+          "version": "3.5.2-2ubuntu0~16.04.1",
+          "arch": "amd64"
+        },
+        "readline-common": {
+          "version": "6.3-8ubuntu2",
+          "arch": "all"
+        },
+        "rename": {
+          "version": "0.20-4",
+          "arch": "all"
+        },
+        "resolvconf": {
+          "version": "1.78ubuntu4",
+          "arch": "all"
+        },
+        "rpcbind": {
+          "version": "0.2.3-0.2",
+          "arch": "amd64"
+        },
+        "rsync": {
+          "version": "3.1.1-3ubuntu1",
+          "arch": "amd64"
+        },
+        "rsyslog": {
+          "version": "8.16.0-1ubuntu3",
+          "arch": "amd64"
+        },
+        "run-one": {
+          "version": "1.17-0ubuntu1",
+          "arch": "all"
+        },
+        "screen": {
+          "version": "4.3.1-2build1",
+          "arch": "amd64"
+        },
+        "sed": {
+          "version": "4.2.2-7",
+          "arch": "amd64"
+        },
+        "sensible-utils": {
+          "version": "0.0.9",
+          "arch": "all"
+        },
+        "sgml-base": {
+          "version": "1.26+nmu4ubuntu1",
+          "arch": "all"
+        },
+        "shared-mime-info": {
+          "version": "1.5-2ubuntu0.1",
+          "arch": "amd64"
+        },
+        "snapd": {
+          "version": "2.24.1",
+          "arch": "amd64"
+        },
+        "software-properties-common": {
+          "version": "0.96.20.5",
+          "arch": "all"
+        },
+        "sosreport": {
+          "version": "3.2+git276-g7da50d6-3ubuntu1",
+          "arch": "amd64"
+        },
+        "squashfs-tools": {
+          "version": "1:4.3-3ubuntu2",
+          "arch": "amd64"
+        },
+        "ssh-import-id": {
+          "version": "5.5-0ubuntu1",
+          "arch": "all"
+        },
+        "strace": {
+          "version": "4.11-1ubuntu3",
+          "arch": "amd64"
+        },
+        "sudo": {
+          "version": "1.8.16-0ubuntu1.3",
+          "arch": "amd64"
+        },
+        "systemd": {
+          "version": "229-4ubuntu16",
+          "arch": "amd64"
+        },
+        "systemd-sysv": {
+          "version": "229-4ubuntu16",
+          "arch": "amd64"
+        },
+        "sysv-rc": {
+          "version": "2.88dsf-59.3ubuntu2",
+          "arch": "all"
+        },
+        "sysvinit-utils": {
+          "version": "2.88dsf-59.3ubuntu2",
+          "arch": "amd64"
+        },
+        "tar": {
+          "version": "1.28-2.1ubuntu0.1",
+          "arch": "amd64"
+        },
+        "tasksel": {
+          "version": "3.34ubuntu3",
+          "arch": "all"
+        },
+        "tasksel-data": {
+          "version": "3.34ubuntu3",
+          "arch": "all"
+        },
+        "tcpd": {
+          "version": "7.6.q-25",
+          "arch": "amd64"
+        },
+        "tcpdump": {
+          "version": "4.9.0-1ubuntu1~ubuntu16.04.1",
+          "arch": "amd64"
+        },
+        "telnet": {
+          "version": "0.17-40",
+          "arch": "amd64"
+        },
+        "time": {
+          "version": "1.7-25.1",
+          "arch": "amd64"
+        },
+        "tmux": {
+          "version": "2.1-3build1",
+          "arch": "amd64"
+        },
+        "tzdata": {
+          "version": "2016j-0ubuntu0.16.04",
+          "arch": "all"
+        },
+        "ubuntu-cloudimage-keyring": {
+          "version": "2013.11.11",
+          "arch": "all"
+        },
+        "ubuntu-core-launcher": {
+          "version": "2.24.1",
+          "arch": "amd64"
+        },
+        "ubuntu-keyring": {
+          "version": "2012.05.19",
+          "arch": "all"
+        },
+        "ubuntu-minimal": {
+          "version": "1.361",
+          "arch": "amd64"
+        },
+        "ubuntu-release-upgrader-core": {
+          "version": "1:16.04.21",
+          "arch": "all"
+        },
+        "ubuntu-server": {
+          "version": "1.361",
+          "arch": "amd64"
+        },
+        "ucf": {
+          "version": "3.0036",
+          "arch": "all"
+        },
+        "udev": {
+          "version": "229-4ubuntu16",
+          "arch": "amd64"
+        },
+        "ufw": {
+          "version": "0.35-0ubuntu2",
+          "arch": "all"
+        },
+        "uidmap": {
+          "version": "1:4.2-3.1ubuntu5",
+          "arch": "amd64"
+        },
+        "unattended-upgrades": {
+          "version": "0.90ubuntu0.3",
+          "arch": "all"
+        },
+        "update-manager-core": {
+          "version": "1:16.04.6",
+          "arch": "all"
+        },
+        "update-notifier-common": {
+          "version": "3.168.4",
+          "arch": "all"
+        },
+        "ureadahead": {
+          "version": "0.100.0-19",
+          "arch": "amd64"
+        },
+        "usbutils": {
+          "version": "1:007-4",
+          "arch": "amd64"
+        },
+        "util-linux": {
+          "version": "2.27.1-6ubuntu3.2",
+          "arch": "amd64"
+        },
+        "uuid-runtime": {
+          "version": "2.27.1-6ubuntu3.2",
+          "arch": "amd64"
+        },
+        "vim": {
+          "version": "2:7.4.1689-3ubuntu1.2",
+          "arch": "amd64"
+        },
+        "vim-common": {
+          "version": "2:7.4.1689-3ubuntu1.2",
+          "arch": "amd64"
+        },
+        "vim-runtime": {
+          "version": "2:7.4.1689-3ubuntu1.2",
+          "arch": "all"
+        },
+        "vim-tiny": {
+          "version": "2:7.4.1689-3ubuntu1.2",
+          "arch": "amd64"
+        },
+        "vlan": {
+          "version": "1.9-3.2ubuntu1.16.04.1",
+          "arch": "amd64"
+        },
+        "wget": {
+          "version": "1.17.1-1ubuntu1.2",
+          "arch": "amd64"
+        },
+        "whiptail": {
+          "version": "0.52.18-1ubuntu2",
+          "arch": "amd64"
+        },
+        "wireless-regdb": {
+          "version": "2015.07.20-1ubuntu1",
+          "arch": "all"
+        },
+        "xdg-user-dirs": {
+          "version": "0.15-2ubuntu6",
+          "arch": "amd64"
+        },
+        "xfsprogs": {
+          "version": "4.3.0+nmu1ubuntu1",
+          "arch": "amd64"
+        },
+        "xkb-data": {
+          "version": "2.16-1ubuntu1",
+          "arch": "all"
+        },
+        "xml-core": {
+          "version": "0.13+nmu2",
+          "arch": "all"
+        },
+        "xz-utils": {
+          "version": "5.1.1alpha+20120614-2ubuntu2",
+          "arch": "amd64"
+        },
+        "zerofree": {
+          "version": "1.0.3-1",
+          "arch": "amd64"
+        },
+        "zlib1g": {
+          "version": "1:1.2.8.dfsg-2ubuntu4",
+          "arch": "amd64"
+        },
+        "zlib1g-dev": {
+          "version": "1:1.2.8.dfsg-2ubuntu4",
+          "arch": "amd64"
+        }
+      },
+      "init_package": "systemd",
+      "uptime_seconds": 15173,
+      "uptime": "4 hours 12 minutes 53 seconds",
+      "idletime_seconds": 30241,
+      "idletime": "8 hours 24 minutes 01 seconds",
+      "chef_packages": {
+        "chef": {
+          "version": "14.4.56",
+          "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib"
+        },
+        "ohai": {
+          "version": "14.4.2",
+          "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/ohai-14.4.2/lib/ohai"
+        }
+      },
+      "virtualbox": {
+        "host": {
+          "revision": "124319",
+          "version": "5.2.18"
+        },
+        "guest": {
+          "guest_additions_version": "5.1.21",
+          "guest_additions_revision": "115005"
+        }
+      },
+      "keys": {
+        "ssh": {
+          "host_rsa_public": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDLQuhyxJxgOdQDSg+cG/jrT40Vd8XEWptbizvNtVODcRsdGe8zQPHs3it9lq727bw5nnZvXYqkhoasMnOgwJm6EgG1RuWQCRhH1bPToWZEw8/LK5hADQwF8ft+Iyc2B9C9G80ziq+sW83CGtagGLlYQUjO/7Qd+eSTud2/+oVsfwz5DKX8dDzf624Lxo+Nltn8gFEJssqULgpBfEcIFmKtUnuIwA9DP1Fkk5tgWebzzcaCIakxwCzRC16EDJBwzGx6PlLDb5KT4qjv66DVeEvIeif3AKfHyCWWldNS5lRyHdoFamLUm/SV3Yz2lGvsgDQFO5TDT7wRLh/yJuXqlPtt",
+          "host_dsa_public": "AAAAB3NzaC1kc3MAAACBAJ5C5zNR5x8EqtmcHJOvfoBF2mJC24lG+urhPpezmFmnkvgKpsx0oAabbnnhLqMpr+hS66KC0mcuAHmqOHx/QEJu5rycXPm/5oB8vDguGBGOJdQjsME6gGC05cYIKXswDzE31gpfvRyURRBAuYxkTP37INlj/3xHr4mXB1tH+MkXAAAAFQCw/jmcJAGhHMfO7/wuFqrSZXWD1wAAAIBoIKGRkzuBRWes7Ref/rOfVpAruhVgNakSDp5v+fHny8V4Kte8nbtJC09wG2mTARkAkztBoBJp8T7BW93eHti76Br5fbHrd6Ni6I8nsV24Axrk89DorBgftuZY4c1VCEeV92Ad/hnY3oDOkKMeFoiROZpKY6zEp0yXy20nqJ/8KwAAAIAFeF1OP8c6rb/FO8b6IpEOZCv+HSkGrRIkfxsW/UQPncxARrr9eWu5bOwe/POra0Ll69qAPjJHdXU7ENSqVg5aaY2rSmaj+jvptAQb8gTjUfi2Y6OYNomWibV8qGAXJbLAZNhxj167yAlNkMc0YS4GFV86jW6b1uLpE9D6fr7Uwg==",
+          "host_ecdsa_public": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPypKvgSstMjLdXzI6J8RuWvJ1am/ngZT4YtHkxa7+gDku1Rg/NnSgHS0aR43VrDmHlLaoGTTfTgR1ehYLk7x6I=",
+          "host_ecdsa_type": "ecdsa-sha2-nistp256",
+          "host_ed25519_public": "AAAAC3NzaC1lZDI1NTE5AAAAIEPV5TJrPgxElojmOsIe2r6eNEO8xlkusEysbThexzOL"
+        }
+      },
+      "time": {
+        "timezone": "UTC"
+      },
+      "chef_guid": "f6a5c33f-bef5-433b-815e-a8f6e69e6b1b",
+      "name": "chef-client-dev.test",
+      "chef_environment": "_default",
+      "recipes": [
+        "chef-client",
+        "chef-client::default",
+        "chef-client::delete_validation",
+        "lamp2",
+        "lamp2::default",
+        "chef-client::service",
+        "chef-client::systemd_service",
+        "lamp2::web",
+        "apache2::default",
+        "apache2::mpm_event",
+        "apache2::mod_status",
+        "apache2::mod_alias",
+        "apache2::mod_auth_basic",
+        "apache2::mod_authn_core",
+        "apache2::mod_authn_file",
+        "apache2::mod_authz_core",
+        "apache2::mod_authz_groupfile",
+        "apache2::mod_authz_host",
+        "apache2::mod_authz_user",
+        "apache2::mod_autoindex",
+        "apache2::mod_deflate",
+        "apache2::mod_dir",
+        "apache2::mod_env",
+        "apache2::mod_mime",
+        "apache2::mod_negotiation",
+        "apache2::mod_setenvif",
+        "apache2::mod_php",
+        "lamp2::database"
+      ],
+      "expanded_run_list": [
+        "chef-client::default",
+        "chef-client::delete_validation",
+        "lamp2::default"
+      ],
+      "roles": [
+        "web"
+      ],
+      "cookbooks": {
+        "chef-client": {
+          "version": "11.0.0"
+        },
+        "cron": {
+          "version": "6.2.1"
+        },
+        "logrotate": {
+          "version": "2.2.0"
+        },
+        "lamp2": {
+          "version": "0.1.4"
+        },
+        "apache2": {
+          "version": "3.3.1"
+        },
+        "mysql": {
+          "version": "8.5.1"
+        },
+        "mysql2_chef_gem": {
+          "version": "2.1.0"
+        },
+        "build-essential": {
+          "version": "8.2.1"
+        },
+        "seven_zip": {
+          "version": "3.0.0"
+        },
+        "windows": {
+          "version": "5.1.1"
+        },
+        "mingw": {
+          "version": "2.1.0"
+        },
+        "mariadb": {
+          "version": "1.5.4"
+        },
+        "apt": {
+          "version": "7.1.0"
+        },
+        "selinux_policy": {
+          "version": "2.1.0"
+        },
+        "yum": {
+          "version": "5.1.0"
+        },
+        "yum-epel": {
+          "version": "3.2.0"
+        },
+        "yum-scl": {
+          "version": "0.2.0"
+        },
+        "inifile_chef_gem": {
+          "version": "0.1.0"
+        },
+        "database": {
+          "version": "6.1.1"
+        },
+        "postgresql": {
+          "version": "7.1.0"
+        },
+        "openssl": {
+          "version": "8.5.5"
+        }
+      }
+    },
+    "normal": {
+      "tags": []
+    },
+    "chef_type": "node",
+    "default": {
+      "cron": {
+        "package_name": [
+          "cron"
+        ],
+        "service_name": "cron"
+      },
+      "logrotate": {
+        "package": {
+          "name": "logrotate",
+          "source": null,
+          "version": null,
+          "provider": null,
+          "action": "upgrade"
+        },
+        "directory": "/etc/logrotate.d",
+        "cron": {
+          "install": false,
+          "name": "logrotate",
+          "command": "/usr/sbin/logrotate /etc/logrotate.conf",
+          "minute": 35,
+          "hour": 2
+        },
+        "global": {
+          "weekly": true,
+          "rotate": 4,
+          "create": "",
+          "/var/log/wtmp": {
+            "missingok": true,
+            "monthly": true,
+            "create": "0664 root utmp",
+            "rotate": 1
+          },
+          "/var/log/btmp": {
+            "missingok": true,
+            "monthly": true,
+            "create": "0660 root utmp",
+            "rotate": 1
+          }
+        }
+      },
+      "chef_client": {
+        "config": {
+          "chef_server_url": "https://chef-server-dev.test/organizations/finfrock",
+          "validation_client_name": "lancewf",
+          "node_name": "chef-client-dev.test",
+          "verify_api_cert": true,
+          "client_fork": true,
+          "start_handlers": [],
+          "report_handlers": [],
+          "exception_handlers": []
+        },
+        "log_file": "client.log",
+        "interval": 300,
+        "splay": 60,
+        "conf_dir": "/etc/chef",
+        "bin": "/usr/bin/chef-client",
+        "log_dir": "/var/log/chef",
+        "log_perm": "640",
+        "cron": {
+          "minute": "0",
+          "hour": "0,4,8,12,16,20",
+          "weekday": "*",
+          "path": null,
+          "environment_variables": null,
+          "log_file": "/dev/null",
+          "append_log": false,
+          "use_cron_d": false,
+          "mailto": null
+        },
+        "systemd": {
+          "timer": false,
+          "timeout": false,
+          "restart": "always"
+        },
+        "task": {
+          "frequency": "minute",
+          "frequency_modifier": 5,
+          "user": "SYSTEM",
+          "password": null,
+          "start_time": null,
+          "start_date": null,
+          "name": "chef-client"
+        },
+        "load_gems": {},
+        "reload_config": true,
+        "daemon_options": [],
+        "logrotate": {
+          "rotate": 12,
+          "frequency": "weekly"
+        },
+        "init_style": "systemd",
+        "run_path": "/var/run/chef",
+        "cache_path": "/var/cache/chef",
+        "backup_path": "/var/lib/chef",
+        "chkconfig": {
+          "start_order": 98,
+          "stop_order": 2
+        },
+        "log_rotation": {
+          "options": [
+            "compress"
+          ],
+          "prerotate": null,
+          "postrotate": "systemctl reload chef-client.service >/dev/null || :"
+        }
+      },
+      "ohai": {
+        "disabled_plugins": [],
+        "plugin_path": null
+      },
+      "apache": {
+        "mpm": "event",
+        "version": "2.4",
+        "root_group": "root",
+        "default_site_name": "000-default",
+        "package": "apache2",
+        "perl_pkg": "perl",
+        "devel_package": "apache2-dev",
+        "apachectl": "/usr/sbin/apache2ctl",
+        "dir": "/etc/apache2",
+        "log_dir": "/var/log/apache2",
+        "error_log": "error.log",
+        "access_log": "access.log",
+        "user": "www-data",
+        "group": "www-data",
+        "binary": "/usr/sbin/apache2",
+        "conf_dir": "/etc/apache2",
+        "cgibin_dir": "/usr/lib/cgi-bin",
+        "icondir": "/usr/share/apache2/icons",
+        "cache_dir": "/var/cache/apache2",
+        "run_dir": "/var/run/apache2",
+        "lock_dir": "/var/lock/apache2",
+        "pid_file": "/var/run/apache2/apache2.pid",
+        "docroot_dir": "/var/www/html",
+        "lib_dir": "/usr/lib/apache2",
+        "build_dir": "/usr/share/apache2",
+        "libexec_dir": "/usr/lib/apache2/modules",
+        "service_name": "apache2",
+        "listen": [
+          "*:80"
+        ],
+        "contact": "ops@example.com",
+        "timeout": 300,
+        "keepalive": "On",
+        "keepaliverequests": 100,
+        "keepalivetimeout": 5,
+        "locale": "C",
+        "sysconfig_additional_params": {},
+        "default_site_enabled": false,
+        "default_site_port": "80",
+        "access_file_name": ".htaccess",
+        "default_release": null,
+        "log_level": "warn",
+        "servertokens": "Prod",
+        "serversignature": "On",
+        "traceenable": "Off",
+        "status_allow_list": "127.0.0.1 ::1",
+        "status_url": "http://localhost:80/server-status",
+        "ext_status": false,
+        "info_allow_list": "127.0.0.1 ::1",
+        "mpm_support": [
+          "prefork",
+          "worker",
+          "event"
+        ],
+        "prefork": {
+          "startservers": 16,
+          "minspareservers": 16,
+          "maxspareservers": 32,
+          "serverlimit": 256,
+          "maxrequestworkers": 256,
+          "maxconnectionsperchild": 10000
+        },
+        "worker": {
+          "startservers": 4,
+          "serverlimit": 16,
+          "minsparethreads": 64,
+          "maxsparethreads": 192,
+          "threadlimit": 192,
+          "threadsperchild": 64,
+          "maxrequestworkers": 1024,
+          "maxconnectionsperchild": 0
+        },
+        "event": {
+          "startservers": 4,
+          "serverlimit": 16,
+          "minsparethreads": 64,
+          "maxsparethreads": 192,
+          "threadlimit": 192,
+          "threadsperchild": 64,
+          "maxrequestworkers": 1024,
+          "maxconnectionsperchild": 0
+        },
+        "proxy": {
+          "require": "all denied",
+          "order": "deny,allow",
+          "deny_from": "all",
+          "allow_from": "none"
+        },
+        "default_modules": [
+          "status",
+          "alias",
+          "auth_basic",
+          "authn_core",
+          "authn_file",
+          "authz_core",
+          "authz_groupfile",
+          "authz_host",
+          "authz_user",
+          "autoindex",
+          "deflate",
+          "dir",
+          "env",
+          "mime",
+          "negotiation",
+          "setenvif",
+          "php"
+        ],
+        "mod_auth_cas": {
+          "from_source": false,
+          "source_revision": "v1.0.9.1"
+        },
+        "allowed_openids": [],
+        "mod_auth_openid": {
+          "ref": "v0.8",
+          "version": "0.8",
+          "source_url": "https://github.com/bmuller/mod_auth_openid/archive/v0.8.tar.gz",
+          "cache_dir": "/var/cache/mod_auth_openid",
+          "dblocation": "/var/cache/mod_auth_openid/mod_auth_openid.db",
+          "configure_flags": []
+        },
+        "mod_fastcgi": {
+          "download_url": "http://www.fastcgi.com/dist/mod_fastcgi-current.tar.gz",
+          "install_method": "package",
+          "package": "libapache2-mod-fastcgi"
+        },
+        "mod_php": {
+          "install_method": "package",
+          "module_name": "php7",
+          "so_filename": "libphp7.0.so"
+        },
+        "mod_ssl": {
+          "port": 443,
+          "protocol": "All -SSLv2 -SSLv3",
+          "cipher_suite": "EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:EECDH:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA128-SHA:AES128-SHA",
+          "honor_cipher_order": "On",
+          "insecure_renegotiation": "Off",
+          "strict_sni_vhost_check": "Off",
+          "session_cache": "shmcb:/var/run/apache2/ssl_scache",
+          "session_cache_timeout": 300,
+          "compression": "Off",
+          "use_stapling": "Off",
+          "stapling_responder_timeout": 5,
+          "stapling_return_responder_errors": "Off",
+          "stapling_cache": "shmcb:/var/run/ocsp(128000)",
+          "pass_phrase_dialog": "exec:/usr/share/apache2/ask-for-passphrase",
+          "mutex": "file:/var/run/apache2/ssl_mutex",
+          "directives": {},
+          "pkg_name": "mod_ssl"
+        }
+      },
+      "apache2": {
+        "mod_pagespeed": {
+          "package_link": "https://dl-ssl.google.com/dl/linux/direct/mod-pagespeed-stable_current_amd64.deb"
+        }
+      },
+      "seven_zip": {
+        "url": "https://www.7-zip.org/a/7z1805-x64.msi",
+        "checksum": "898c1ca0015183fe2ba7d55cacf0a1dea35e873bf3f8090f362a6288c6ef08d7",
+        "package_name": "7-Zip 18.05 (x64 edition)",
+        "default_extract_timeout": 600
+      },
+      "msys2": {
+        "url": "http://downloads.sourceforge.net/project/msys2/Base/x86_64/msys2-base-x86_64-20160205.tar.xz",
+        "checksum": "7e97e2af042e1b6f62cf0298fe84839014ef3d4a3e7825cffc6931c66cc0fc20"
+      },
+      "build-essential": {
+        "compile_time": false,
+        "msys2": {
+          "path": "\\msys2"
+        }
+      },
+      "openssl": {
+        "restart_services": []
+      },
+      "apt": {
+        "cacher_dir": "/var/cache/apt-cacher-ng",
+        "cacher_interface": null,
+        "cacher_port": 3142,
+        "compiletime": false,
+        "compile_time_update": false,
+        "key_proxy": "",
+        "periodic_update_min_delay": 86400,
+        "launchpad_api_version": "1.0",
+        "unattended_upgrades": {
+          "enable": false,
+          "update_package_lists": true,
+          "allowed_origins": [
+            "Ubuntu xenial"
+          ],
+          "origins_patterns": [],
+          "package_blacklist": [],
+          "auto_fix_interrupted_dpkg": false,
+          "minimal_steps": false,
+          "install_on_shutdown": false,
+          "mail": null,
+          "mail_only_on_error": true,
+          "remove_unused_dependencies": false,
+          "automatic_reboot": false,
+          "automatic_reboot_time": "now",
+          "dl_limit": null,
+          "random_sleep": null,
+          "syslog_enable": false,
+          "syslog_facility": "daemon"
+        },
+        "cacher_client": {
+          "cacher_server": {}
+        },
+        "confd": {
+          "force_confask": false,
+          "force_confdef": false,
+          "force_confmiss": false,
+          "force_confnew": false,
+          "force_confold": false,
+          "install_recommends": true,
+          "install_suggests": false
+        }
+      },
+      "selinux_policy": {
+        "allow_disabled": true
+      },
+      "yum": {
+        "main": {
+          "cachedir": "/var/cache/yum/$basearch/$releasever",
+          "distroverpkg": "ubuntu-release",
+          "releasever": null,
+          "alwaysprompt": null,
+          "assumeyes": null,
+          "bandwidth": null,
+          "bugtracker_url": null,
+          "clean_requirements_on_remove": null,
+          "color": null,
+          "color_list_available_downgrade": null,
+          "color_list_available_install": null,
+          "color_list_available_reinstall": null,
+          "color_list_available_upgrade": null,
+          "color_list_installed_extra": null,
+          "color_list_installed_newer": null,
+          "color_list_installed_older": null,
+          "color_list_installed_reinstall": null,
+          "color_search_match": null,
+          "color_update_installed": null,
+          "color_update_local": null,
+          "color_update_remote": null,
+          "commands": null,
+          "deltarpm": null,
+          "debuglevel": null,
+          "diskspacecheck": null,
+          "enable_group_conditionals": null,
+          "errorlevel": null,
+          "exactarch": null,
+          "exclude": null,
+          "gpgcheck": true,
+          "group_package_types": null,
+          "groupremove_leaf_only": null,
+          "history_list_view": null,
+          "history_record": null,
+          "history_record_packages": null,
+          "http_caching": null,
+          "installonly_limit": null,
+          "installonlypkgs": null,
+          "installroot": null,
+          "keepalive": null,
+          "keepcache": false,
+          "kernelpkgnames": null,
+          "localpkg_gpgcheck": false,
+          "logfile": "/var/log/yum.log",
+          "max_retries": null,
+          "mdpolicy": null,
+          "metadata_expire": null,
+          "mirrorlist_expire": null,
+          "multilib_policy": null,
+          "obsoletes": null,
+          "overwrite_groups": null,
+          "password": null,
+          "path": "/etc/yum.conf",
+          "persistdir": null,
+          "pluginconfpath": null,
+          "pluginpath": null,
+          "plugins": null,
+          "protected_multilib": null,
+          "protected_packages": null,
+          "proxy": null,
+          "proxy_password": null,
+          "proxy_username": null,
+          "recent": null,
+          "repo_gpgcheck": null,
+          "reposdir": null,
+          "reset_nice": null,
+          "rpmverbosity": null,
+          "showdupesfromrepos": null,
+          "skip_broken": null,
+          "ssl_check_cert_permissions": null,
+          "sslcacert": null,
+          "sslclientcert": null,
+          "sslclientkey": null,
+          "sslverify": null,
+          "syslog_device": null,
+          "syslog_facility": null,
+          "syslog_ident": null,
+          "throttle": null,
+          "timeout": null,
+          "tolerant": false,
+          "tsflags": null,
+          "username": null
+        },
+        "epel-debuginfo": {
+          "repositoryid": "epel-debuginfo",
+          "description": "Extra Packages for 16 - $basearch - Debug",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-16&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-16",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-source": {
+          "repositoryid": "epel-source",
+          "description": "Extra Packages for 16 - $basearch - Source",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-16&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-16",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-testing-debuginfo": {
+          "repositoryid": "epel-testing-debuginfo",
+          "description": "Extra Packages for 16 - $basearch - Testing Debug",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel16&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-16",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-testing-source": {
+          "repositoryid": "epel-testing-source",
+          "description": "Extra Packages for 16 - $basearch - Testing Source",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel16&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-16",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-testing": {
+          "repositoryid": "epel-testing",
+          "description": "Extra Packages for 16 - $basearch - Testing ",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel16&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-16",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel": {
+          "repositoryid": "epel",
+          "description": "Extra Packages for 16 - $basearch",
+          "gpgcheck": true,
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-16&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-16",
+          "failovermethod": "priority",
+          "enabled": true,
+          "managed": true,
+          "make_cache": true
+        }
+      },
+      "yum-epel": {
+        "repos": [
+          "epel",
+          "epel-debuginfo",
+          "epel-source",
+          "epel-testing",
+          "epel-testing-debuginfo",
+          "epel-testing-source"
+        ]
+      },
+      "yum-scl": {
+        "prefer_os_package": true,
+        "enable_testing": false,
+        "enable_source": false,
+        "enable_debuginfo": false,
+        "native_packages": null,
+        "repos": {
+          "default": null,
+          "centos": {
+            ">=6.0": {
+              "centos-sclo-sclo-rh": {
+                "repositoryid": "centos-sclo-rh",
+                "description": "CentOS-16 - SCLo rh",
+                "baseurl": "http://mirror.centos.org/centos/16/sclo/$basearch/rh/",
+                "gpgcheck": true,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": true
+              },
+              "centos-sclo-sclo-rh-testing": {
+                "repositoryid": "centos-sclo-rh-testing",
+                "description": "CentOS-16 - SCLo rh Testing",
+                "baseurl": "http://buildlogs.centos.org/centos/16/sclo/$basearch/rh/",
+                "gpgcheck": false,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": false
+              },
+              "centos-sclo-sclo-rh-source": {
+                "repositoryid": "centos-sclo-rh-source",
+                "description": "CentOS-16 - SCLo rh Sources",
+                "baseurl": "http://buildlogs.centos.org/centos/16/sclo/Source/rh/",
+                "gpgcheck": true,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": false
+              },
+              "centos-sclo-sclo-rh-debuginfo": {
+                "repositoryid": "centos-sclo-rh-debuginfo",
+                "description": "CentOS-16 - SCLo rh Debuginfo",
+                "baseurl": "http://buildlogs.centos.org/centos/16/sclo/Source/rh/",
+                "gpgcheck": true,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": false
+              },
+              "centos-sclo-sclo": {
+                "repositoryid": "centos-sclo-sclo",
+                "description": "CentOS-16 - SCLo",
+                "baseurl": "http://mirror.centos.org/centos/16/sclo/$basearch/sclo/",
+                "gpgcheck": true,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": true
+              },
+              "centos-sclo-sclo-testing": {
+                "repositoryid": "centos-sclo-sclo-testing",
+                "description": "CentOS-16 - SCLo Testing",
+                "baseurl": "http://mirror.centos.org/centos/16/sclo/$basearch/sclo/",
+                "gpgcheck": false,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": false
+              },
+              "centos-sclo-sclo-source": {
+                "repositoryid": "centos-sclo-sclo-source",
+                "description": "CentOS-16 - SCLo Sources",
+                "baseurl": "http://mirror.centos.org/centos/16/sclo/$basearch/sclo/",
+                "gpgcheck": true,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": false
+              },
+              "centos-sclo-sclo-debuginfo": {
+                "repositoryid": "centos-sclo-sclo-debuginfo",
+                "description": "CentOS-16 - SCLo Debuginfo",
+                "baseurl": "http://mirror.centos.org/centos/16/sclo/$basearch/sclo/",
+                "gpgcheck": true,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": false
+              }
+            },
+            "default": null
+          },
+          "scientific": {
+            ">=6.0": {
+              "centos-sclo-sclo-rh": {
+                "repositoryid": "centos-sclo-rh",
+                "description": "CentOS-16 - SCLo rh",
+                "baseurl": "http://mirror.centos.org/centos/16/sclo/$basearch/rh/",
+                "gpgcheck": true,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": true
+              },
+              "centos-sclo-sclo-rh-testing": {
+                "repositoryid": "centos-sclo-rh-testing",
+                "description": "CentOS-16 - SCLo rh Testing",
+                "baseurl": "http://buildlogs.centos.org/centos/16/sclo/$basearch/rh/",
+                "gpgcheck": false,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": false
+              },
+              "centos-sclo-sclo-rh-source": {
+                "repositoryid": "centos-sclo-rh-source",
+                "description": "CentOS-16 - SCLo rh Sources",
+                "baseurl": "http://buildlogs.centos.org/centos/16/sclo/Source/rh/",
+                "gpgcheck": true,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": false
+              },
+              "centos-sclo-sclo-rh-debuginfo": {
+                "repositoryid": "centos-sclo-rh-debuginfo",
+                "description": "CentOS-16 - SCLo rh Debuginfo",
+                "baseurl": "http://buildlogs.centos.org/centos/16/sclo/Source/rh/",
+                "gpgcheck": true,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": false
+              },
+              "centos-sclo-sclo": {
+                "repositoryid": "centos-sclo-sclo",
+                "description": "CentOS-16 - SCLo",
+                "baseurl": "http://mirror.centos.org/centos/16/sclo/$basearch/sclo/",
+                "gpgcheck": true,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": true
+              },
+              "centos-sclo-sclo-testing": {
+                "repositoryid": "centos-sclo-sclo-testing",
+                "description": "CentOS-16 - SCLo Testing",
+                "baseurl": "http://mirror.centos.org/centos/16/sclo/$basearch/sclo/",
+                "gpgcheck": false,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": false
+              },
+              "centos-sclo-sclo-source": {
+                "repositoryid": "centos-sclo-sclo-source",
+                "description": "CentOS-16 - SCLo Sources",
+                "baseurl": "http://mirror.centos.org/centos/16/sclo/$basearch/sclo/",
+                "gpgcheck": true,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": false
+              },
+              "centos-sclo-sclo-debuginfo": {
+                "repositoryid": "centos-sclo-sclo-debuginfo",
+                "description": "CentOS-16 - SCLo Debuginfo",
+                "baseurl": "http://mirror.centos.org/centos/16/sclo/$basearch/sclo/",
+                "gpgcheck": true,
+                "gpgkey": "RPM-GPG-KEY-CentOS-SIG-SCLo",
+                "enabled": false
+              }
+            },
+            "default": null
+          }
+        }
+      },
+      "mariadb": {
+        "configuration": {
+          "path": "/etc/mysql",
+          "includedir": "/etc/mysql/conf.d"
+        },
+        "mysqld": {
+          "socket": "/var/run/mysqld/mysqld.sock",
+          "pid_file": "/var/run/mysqld/mysqld.pid",
+          "service_name": "mysql",
+          "user": "mysql",
+          "port": "3306",
+          "basedir": "/usr",
+          "default_datadir": "/var/lib/mysql",
+          "datadir": "/var/lib/mysql",
+          "tmpdir": "/var/tmp",
+          "lc_messages_dir": "/usr/share/mysql",
+          "lc_messages": "en_US",
+          "skip_external_locking": "true",
+          "skip_log_bin": "false",
+          "skip_name_resolve": "false",
+          "bind_address": "127.0.0.1",
+          "max_connections": "100",
+          "max_statement_time": "",
+          "connect_timeout": "5",
+          "wait_timeout": "600",
+          "max_allowed_packet": "16M",
+          "thread_cache_size": "128",
+          "sort_buffer_size": "4M",
+          "bulk_insert_buffer_size": "16M",
+          "tmp_table_size": "32M",
+          "max_heap_table_size": "32M",
+          "myisam_recover": "BACKUP",
+          "key_buffer_size": "128M",
+          "open_files_limit": "",
+          "table_open_cache": "400",
+          "myisam_sort_buffer_size": "512M",
+          "concurrent_insert": "2",
+          "read_buffer_size": "2M",
+          "read_rnd_buffer_size": "1M",
+          "query_cache_limit": "128K",
+          "query_cache_size": "64M",
+          "query_cache_type": "",
+          "default_storage_engine": "InnoDB",
+          "options": {},
+          "general_log_file": "/var/log/mysql/mysql.log",
+          "general_log": 0,
+          "log_warnings": 2,
+          "slow_query_log": 0,
+          "slow_query_log_file": "/var/log/mysql/mariadb-slow.log",
+          "long_query_time": 10,
+          "log_slow_rate_limit": 1000,
+          "log_slow_verbosity": "query_plan",
+          "log_output": "FILE"
+        },
+        "client": {
+          "socket": "/var/run/mysqld/mysqld.sock",
+          "port": 3306,
+          "options": {},
+          "development_files": true
+        },
+        "mysqld_safe": {
+          "socket": "/var/run/mysqld/mysqld.sock",
+          "options": {}
+        },
+        "sections": [
+          "mysql",
+          "mysqldump",
+          "mysqlcheck",
+          "mysqladmin",
+          "mysqlshow"
+        ],
+        "remove_anonymous_users": true,
+        "remove_test_database": true,
+        "forbid_remote_root": true,
+        "server_root_password": "",
+        "root_my_cnf": false,
+        "allow_root_pass_change": false,
+        "innodb": {
+          "log_file_size": "",
+          "bps_percentage_memory": false,
+          "buffer_pool_size": "256M",
+          "log_buffer_size": "8M",
+          "file_per_table": "1",
+          "open_files": "400",
+          "io_capacity": "400",
+          "flush_method": "O_DIRECT",
+          "options": {}
+        },
+        "galera": {
+          "cluster_name": "galera_cluster",
+          "cluster_search_query": "",
+          "server_id": "100",
+          "wsrep_sst_method": "rsync",
+          "wsrep_sst_auth": "sstuser:some_secret_password",
+          "wsrep_provider": "/usr/lib/galera/libgalera_smm.so",
+          "wsrep_slave_threads": "%{auto}",
+          "innodb_flush_log_at_trx_commit": "2",
+          "wsrep_node_address_interface": "",
+          "wsrep_node_port": "",
+          "wsrep_node_incoming_address_interface": "",
+          "wsrep_provider_options": {
+            "gcache.size": "512M"
+          },
+          "options": {},
+          "cluster_nodes": []
+        },
+        "replication": {
+          "server_id": "",
+          "log_bin": "/var/log/mysql/mariadb-bin",
+          "log_bin_index": "/var/log/mysql/mariadb-bin.index",
+          "sync_binlog": "0",
+          "expire_logs_days": "10",
+          "max_binlog_size": "100M",
+          "options": {}
+        },
+        "mysqldump": {
+          "quick": "true",
+          "quote_names": "true",
+          "max_allowed_packet": "16M"
+        },
+        "isamchk": {
+          "key_buffer": "16M"
+        },
+        "debian": {
+          "user": "debian-sys-maint",
+          "password": "please-change-me",
+          "host": "localhost"
+        },
+        "install": {
+          "type": "package",
+          "version": "10.0",
+          "prefer_os_package": false,
+          "prefer_scl_package": false,
+          "extra_packages": true
+        },
+        "use_default_repository": false,
+        "apt_repository": {
+          "base_url": "ftp.igh.cnrs.fr/pub/mariadb/repo"
+        },
+        "plugins_options": {
+          "auto_install": true
+        },
+        "plugins": {
+          "audit": false
+        },
+        "plugins_loading": {
+          "audit": "server_audit=server_audit.so"
+        },
+        "audit_plugin": {
+          "server_audit_events": "",
+          "server_audit_output_type": "file",
+          "server_audit_syslog_facility": "LOG_USER",
+          "server_audit_syslog_priority": "LOG_INFO",
+          "server_audit_logging": "OFF"
+        },
+        "mysql2_gem": {
+          "mariadb_connector_version": "3.0.4",
+          "mariadb_connector_source_url": "https://github.com/MariaDB/mariadb-connector-c/archive/v3.0.4.tar.gz",
+          "curl_version": "7.59.0",
+          "curl_source_url": "https://github.com/curl/curl/releases/download/curl-7_59_0/curl-7.59.0.tar.gz"
+        }
+      },
+      "lamp": {
+        "web": {
+          "document_root": "/var/www/html/public_html"
+        },
+        "database": {
+          "dbname": "mysql",
+          "admin_username": "admin"
+        }
+      }
+    },
+    "override": {},
+    "run_list": [
+      "role[web]"
+    ]
+  },
+  "node_name": "chef-client-dev.test",
+  "organization_name": "avengers",
+  "resources": [],
+  "run_id": "7188b88b-2236-4e27-a875-d3a10a70c497",
+  "run_list": [
+    "role[web]"
+  ],
+  "policy_name": null,
+  "policy_group": null,
+  "start_time": "2018-09-13T20:43:01Z",
+  "end_time": "2018-09-13T20:43:01Z",
+  "source": "chef_client",
+  "status": "failure",
+  "total_resource_count": 0,
+  "updated_resource_count": 0,
+  "deprecations": [],
+  "error": {
+    "class": "NameError",
+    "message": "undefined local variable or method `passwords' for cookbook: lamp2, recipe: database :Chef::Recipe",
+    "backtrace": [
+      "/var/chef/cache/cookbooks/lamp2/recipes/database.rb:9:in `from_file'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/mixin/from_file.rb:34:in `instance_eval'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/mixin/from_file.rb:34:in `from_file'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/cookbook_version.rb:199:in `load_recipe'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/run_context.rb:350:in `load_recipe'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/run_context.rb:306:in `block in include_recipe'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/run_context.rb:305:in `each'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/run_context.rb:305:in `include_recipe'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/dsl/include_recipe.rb:26:in `include_recipe'",
+      "/var/chef/cache/cookbooks/lamp2/recipes/default.rb:14:in `from_file'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/mixin/from_file.rb:34:in `instance_eval'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/mixin/from_file.rb:34:in `from_file'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/cookbook_version.rb:199:in `load_recipe'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/run_context.rb:350:in `load_recipe'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/run_context/cookbook_compiler.rb:166:in `block in compile_recipes'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/run_context/cookbook_compiler.rb:163:in `each'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/run_context/cookbook_compiler.rb:163:in `compile_recipes'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/run_context/cookbook_compiler.rb:79:in `compile'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/run_context.rb:199:in `load'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/policy_builder/expand_node_object.rb:97:in `setup_run_context'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/client.rb:515:in `setup_run_context'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/client.rb:281:in `run'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/application.rb:303:in `run_with_graceful_exit_option'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/application.rb:279:in `block in run_chef_client'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/local_mode.rb:44:in `with_server_connectivity'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/application.rb:261:in `run_chef_client'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/application/client.rb:440:in `run_application'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/lib/chef/application.rb:66:in `run'",
+      "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.4.56/bin/chef-client:25:in `<top (required)>'",
+      "/usr/bin/chef-client:75:in `load'",
+      "/usr/bin/chef-client:75:in `<main>'"
+    ],
+    "description": {}
+  }
+}

--- a/e2e/cypress/fixtures/converge/avengers2.json
+++ b/e2e/cypress/fixtures/converge/avengers2.json
@@ -1,0 +1,6680 @@
+{
+  "chef_server_fqdn": "chef-server.chef.co",
+  "entity_uuid": "82760210-4686-497e-b039-efca78dee64b",
+  "expanded_run_list": {
+    "id": "manhattan",
+    "run_list": [
+      {
+        "type": "recipe",
+        "name": "opscode-ci::slave",
+        "version": null,
+        "skipped": false
+      }
+    ]
+  },
+  "id": "639844f4-2ce6-42ba-8c9d-853db69adff3",
+  "message_version": "1.1.0",
+  "message_type": "run_converge",
+  "node": {
+    "name": "chefdk-debian-7-tester-2d206b",
+    "chef_environment": "manhattan",
+    "json_class": "Chef::Node",
+    "automatic": {
+      "policy_revision": "policy_revision1",
+      "languages": {
+        "perl": {
+          "version": "5.14.2",
+          "archname": "x86_64-linux-gnu-thread-multi"
+        },
+        "java": {
+          "version": "1.7.0_131",
+          "hotspot": {
+            "name": "OpenJDK 64-Bit Server VM",
+            "build": "24.131-b00, mixed mode"
+          }
+        },
+        "ruby": {
+          "platform": "x86_64-linux",
+          "version": "2.3.1",
+          "release_date": "2016-04-26",
+          "target": "x86_64-pc-linux-gnu",
+          "target_cpu": "x86_64",
+          "target_vendor": "pc",
+          "target_os": "linux",
+          "host": "x86_64-pc-linux-gnu",
+          "host_cpu": "x86_64",
+          "host_os": "linux-gnu",
+          "host_vendor": "pc",
+          "bin_dir": "/opt/chef/embedded/bin",
+          "ruby_bin": "/opt/chef/embedded/bin/ruby",
+          "gems_dir": "/opt/chef/embedded/lib/ruby/gems/2.3.0",
+          "gem_bin": "/opt/chef/embedded/bin/gem"
+        },
+        "python": {
+          "version": "2.7.3",
+          "builddate": "Mar 13 2014, 11:03:55"
+        },
+        "c": {
+          "gcc": {
+            "target": "x86_64-linux-gnu",
+            "configured_with": "../src/configure -v --with-pkgversion='Debian 4.7.2-5' --with-bugurl=file:///usr/share/doc/gcc-4.7/README.Bugs --enable-languages=c,c++,go,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-4.7 --enable-shared --enable-linker-build-id --with-system-zlib --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --with-gxx-include-dir=/usr/include/c++/4.7 --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-gnu-unique-object --enable-plugin --enable-objc-gc --with-arch-32=i586 --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu",
+            "thread_model": "posix",
+            "description": "gcc version 4.7.2 (Debian 4.7.2-5) ",
+            "version": "4.7.2"
+          }
+        }
+      },
+      "kernel": {
+        "name": "Linux",
+        "release": "3.2.0-4-amd64",
+        "version": "#1 SMP Debian 3.2.65-1+deb7u1",
+        "machine": "x86_64",
+        "processor": "unknown",
+        "os": "GNU/Linux",
+        "modules": {
+          "crc32c_intel": {
+            "size": "12747",
+            "refcount": "0"
+          },
+          "ghash_clmulni_intel": {
+            "size": "13130",
+            "refcount": "0"
+          },
+          "psmouse": {
+            "size": "69265",
+            "refcount": "0"
+          },
+          "aesni_intel": {
+            "size": "50667",
+            "refcount": "0"
+          },
+          "i2c_piix4": {
+            "size": "12536",
+            "refcount": "0"
+          },
+          "processor": {
+            "size": "28149",
+            "refcount": "0"
+          },
+          "serio_raw": {
+            "size": "12931",
+            "refcount": "0"
+          },
+          "thermal_sys": {
+            "size": "18040",
+            "refcount": "1"
+          },
+          "i2c_core": {
+            "size": "23876",
+            "refcount": "1"
+          },
+          "evdev": {
+            "size": "17562",
+            "refcount": "0"
+          },
+          "button": {
+            "size": "12937",
+            "refcount": "0"
+          },
+          "aes_x86_64": {
+            "size": "16843",
+            "refcount": "1"
+          },
+          "snd_pcsp": {
+            "size": "13742",
+            "refcount": "0"
+          },
+          "snd_pcm": {
+            "size": "68083",
+            "refcount": "1"
+          },
+          "snd_page_alloc": {
+            "size": "13003",
+            "refcount": "1"
+          },
+          "aes_generic": {
+            "size": "33026",
+            "refcount": "2"
+          },
+          "snd_timer": {
+            "size": "22917",
+            "refcount": "1"
+          },
+          "cryptd": {
+            "size": "14517",
+            "refcount": "2"
+          },
+          "snd": {
+            "size": "52893",
+            "refcount": "3"
+          },
+          "soundcore": {
+            "size": "13065",
+            "refcount": "1"
+          },
+          "ext4": {
+            "size": "350804",
+            "refcount": "1"
+          },
+          "crc16": {
+            "size": "12343",
+            "refcount": "1"
+          },
+          "jbd2": {
+            "size": "62115",
+            "refcount": "1"
+          },
+          "mbcache": {
+            "size": "13114",
+            "refcount": "1"
+          },
+          "ata_generic": {
+            "size": "12479",
+            "refcount": "0",
+            "version": "0.2.15"
+          },
+          "ata_piix": {
+            "size": "29535",
+            "refcount": "0",
+            "version": "2.13"
+          },
+          "libata": {
+            "size": "140630",
+            "refcount": "2",
+            "version": "3.00"
+          },
+          "floppy": {
+            "size": "53134",
+            "refcount": "0"
+          },
+          "xen_netfront": {
+            "size": "21985",
+            "refcount": "0"
+          },
+          "xen_blkfront": {
+            "size": "17398",
+            "refcount": "1"
+          },
+          "scsi_mod": {
+            "size": "162321",
+            "refcount": "1"
+          }
+        }
+      },
+      "network": {
+        "interfaces": {
+          "lo": {
+            "mtu": "16436",
+            "flags": [
+              "LOOPBACK",
+              "UP",
+              "LOWER_UP"
+            ],
+            "encapsulation": "Loopback",
+            "addresses": {
+              "127.0.0.1": {
+                "family": "inet",
+                "prefixlen": "8",
+                "netmask": "255.0.0.0",
+                "scope": "Node"
+              },
+              "::1": {
+                "family": "inet6",
+                "prefixlen": "128",
+                "scope": "Node",
+                "tags": []
+              }
+            },
+            "state": "unknown"
+          },
+          "eth0": {
+            "type": "eth",
+            "number": "0",
+            "mtu": "9001",
+            "flags": [
+              "BROADCAST",
+              "MULTICAST",
+              "UP",
+              "LOWER_UP"
+            ],
+            "encapsulation": "Ethernet",
+            "addresses": {
+              "02:07:F5:70:9F:F0": {
+                "family": "lladdr"
+              },
+              "242.58.187.217": {
+                "family": "inet",
+                "prefixlen": "21",
+                "netmask": "255.255.248.0",
+                "broadcast": "242.58.15.255",
+                "scope": "Global"
+              },
+              "fe80::7:f5ff:fe70:9ff0": {
+                "family": "inet6",
+                "prefixlen": "64",
+                "scope": "Link",
+                "tags": []
+              }
+            },
+            "state": "up",
+            "arp": {
+              "169.254.169.254": "02:a9:5a:b4:15:5a",
+              "242.58.10.3": "02:6a:65:20:3b:99",
+              "242.58.8.1": "02:a9:5a:b4:15:5a"
+            },
+            "routes": [
+              {
+                "destination": "default",
+                "family": "inet",
+                "via": "242.58.8.1"
+              },
+              {
+                "destination": "242.58.8.0/21",
+                "family": "inet",
+                "scope": "link",
+                "proto": "kernel",
+                "src": "242.58.187.217"
+              },
+              {
+                "destination": "169.254.0.0/16",
+                "family": "inet",
+                "scope": "link"
+              },
+              {
+                "destination": "fe80::/64",
+                "family": "inet6",
+                "metric": "256",
+                "proto": "kernel"
+              }
+            ]
+          }
+        },
+        "default_interface": "eth0",
+        "default_gateway": "242.58.8.1"
+      },
+      "counters": {
+        "network": {
+          "interfaces": {
+            "lo": {
+              "rx": {
+                "bytes": "31429732",
+                "packets": "31319",
+                "errors": "0",
+                "drop": "0",
+                "overrun": "0"
+              },
+              "tx": {
+                "bytes": "31429732",
+                "packets": "31319",
+                "errors": "0",
+                "drop": "0",
+                "carrier": "0",
+                "collisions": "0"
+              }
+            },
+            "eth0": {
+              "tx": {
+                "queuelen": "1000",
+                "bytes": "61730478022",
+                "packets": "33127828",
+                "errors": "0",
+                "drop": "0",
+                "carrier": "0",
+                "collisions": "0"
+              },
+              "rx": {
+                "bytes": "57417087460",
+                "packets": "41416006",
+                "errors": "0",
+                "drop": "0",
+                "overrun": "0"
+              }
+            }
+          }
+        }
+      },
+      "ipaddress": "242.58.187.217",
+      "macaddress": "02:07:F5:70:9F:F0",
+      "ip6address": "fe80::7:f5ff:fe70:9ff0",
+      "os": "linux",
+      "os_version": "3.2.0-4-amd64",
+      "memory": {
+        "swap": {
+          "cached": "0kB",
+          "total": "0kB",
+          "free": "0kB"
+        },
+        "hugepages": {
+          "total": "0",
+          "free": "0",
+          "reserved": "0",
+          "surplus": "0"
+        },
+        "total": "3797988kB",
+        "free": "1213780kB",
+        "buffers": "372500kB",
+        "cached": "1701292kB",
+        "active": "1120468kB",
+        "inactive": "1128636kB",
+        "dirty": "20kB",
+        "writeback": "0kB",
+        "anon_pages": "175324kB",
+        "mapped": "21736kB",
+        "slab": "310828kB",
+        "slab_reclaimable": "293784kB",
+        "slab_unreclaim": "17044kB",
+        "page_tables": "2996kB",
+        "nfs_unstable": "0kB",
+        "bounce": "0kB",
+        "commit_limit": "1898992kB",
+        "committed_as": "348472kB",
+        "vmalloc_total": "34359738367kB",
+        "vmalloc_used": "16784kB",
+        "vmalloc_chunk": "34359721339kB",
+        "hugepage_size": "2048kB"
+      },
+      "lsb": {
+        "id": "Debian",
+        "description": "Debian GNU/Linux 7.8 (wheezy)",
+        "release": "7.8",
+        "codename": "wheezy"
+      },
+      "platform": "debian",
+      "platform_version": "7.8",
+      "platform_family": "debian",
+      "uptime_seconds": 12864819,
+      "uptime": "148 days 21 hours 33 minutes 39 seconds",
+      "idletime_seconds": 25689221,
+      "idletime": "297 days 07 hours 53 minutes 41 seconds",
+      "cpu": {
+        "0": {
+          "vendor_id": "GenuineIntel",
+          "family": "6",
+          "model": "63",
+          "model_name": "Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz",
+          "stepping": "2",
+          "mhz": "2400.094",
+          "cache_size": "30720 KB",
+          "physical_id": "0",
+          "core_id": "0",
+          "cores": "2",
+          "flags": [
+            "fpu",
+            "vme",
+            "de",
+            "pse",
+            "tsc",
+            "msr",
+            "pae",
+            "mce",
+            "cx8",
+            "apic",
+            "sep",
+            "mtrr",
+            "pge",
+            "mca",
+            "cmov",
+            "pat",
+            "pse36",
+            "clflush",
+            "mmx",
+            "fxsr",
+            "sse",
+            "sse2",
+            "ht",
+            "syscall",
+            "nx",
+            "rdtscp",
+            "lm",
+            "constant_tsc",
+            "rep_good",
+            "nopl",
+            "xtopology",
+            "pni",
+            "pclmulqdq",
+            "ssse3",
+            "fma",
+            "cx16",
+            "pcid",
+            "sse4_1",
+            "sse4_2",
+            "x2apic",
+            "movbe",
+            "popcnt",
+            "tsc_deadline_timer",
+            "aes",
+            "xsave",
+            "avx",
+            "f16c",
+            "rdrand",
+            "hypervisor",
+            "lahf_lm",
+            "abm",
+            "xsaveopt",
+            "fsgsbase",
+            "smep",
+            "erms"
+          ]
+        },
+        "1": {
+          "vendor_id": "GenuineIntel",
+          "family": "6",
+          "model": "63",
+          "model_name": "Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz",
+          "stepping": "2",
+          "mhz": "2400.094",
+          "cache_size": "30720 KB",
+          "physical_id": "0",
+          "core_id": "1",
+          "cores": "2",
+          "flags": [
+            "fpu",
+            "vme",
+            "de",
+            "pse",
+            "tsc",
+            "msr",
+            "pae",
+            "mce",
+            "cx8",
+            "apic",
+            "sep",
+            "mtrr",
+            "pge",
+            "mca",
+            "cmov",
+            "pat",
+            "pse36",
+            "clflush",
+            "mmx",
+            "fxsr",
+            "sse",
+            "sse2",
+            "ht",
+            "syscall",
+            "nx",
+            "rdtscp",
+            "lm",
+            "constant_tsc",
+            "rep_good",
+            "nopl",
+            "xtopology",
+            "pni",
+            "pclmulqdq",
+            "ssse3",
+            "fma",
+            "cx16",
+            "pcid",
+            "sse4_1",
+            "sse4_2",
+            "x2apic",
+            "movbe",
+            "popcnt",
+            "tsc_deadline_timer",
+            "aes",
+            "xsave",
+            "avx",
+            "f16c",
+            "rdrand",
+            "hypervisor",
+            "lahf_lm",
+            "abm",
+            "xsaveopt",
+            "fsgsbase",
+            "smep",
+            "erms"
+          ]
+        },
+        "total": 2,
+        "real": 1,
+        "cores": 2
+      },
+      "filesystem": {
+        "rootfs": {
+          "kb_size": "30963708",
+          "kb_used": "3927384",
+          "kb_available": "25463744",
+          "percent_used": "14%",
+          "mount": "/",
+          "total_inodes": "1966080",
+          "inodes_used": "264597",
+          "inodes_available": "1701483",
+          "inodes_percent_used": "14%"
+        },
+        "udev": {
+          "kb_size": "10240",
+          "kb_used": "0",
+          "kb_available": "10240",
+          "percent_used": "0%",
+          "mount": "/dev",
+          "total_inodes": "506100",
+          "inodes_used": "252",
+          "inodes_available": "505848",
+          "inodes_percent_used": "1%",
+          "fs_type": "devtmpfs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "size=10240k",
+            "nr_inodes=506100",
+            "mode=755"
+          ]
+        },
+        "tmpfs": {
+          "kb_size": "759580",
+          "kb_used": "0",
+          "kb_available": "759580",
+          "percent_used": "0%",
+          "mount": "/run/shm",
+          "total_inodes": "474748",
+          "inodes_used": "2",
+          "inodes_available": "474746",
+          "inodes_percent_used": "1%",
+          "fs_type": "tmpfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "size=759580k"
+          ]
+        },
+        "/dev/disk/by-uuid/6f816946-42f1-4dcb-90f9-1c8b9daeafe2": {
+          "kb_size": "30963708",
+          "kb_used": "3927384",
+          "kb_available": "25463744",
+          "percent_used": "14%",
+          "mount": "/",
+          "total_inodes": "1966080",
+          "inodes_used": "264597",
+          "inodes_available": "1701483",
+          "inodes_percent_used": "14%",
+          "fs_type": "ext4",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "user_xattr",
+            "barrier=1",
+            "data=ordered"
+          ]
+        },
+        "sysfs": {
+          "mount": "/sys",
+          "fs_type": "sysfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime"
+          ]
+        },
+        "proc": {
+          "mount": "/proc",
+          "fs_type": "proc",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime"
+          ]
+        },
+        "devpts": {
+          "mount": "/dev/pts",
+          "fs_type": "devpts",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "noexec",
+            "relatime",
+            "gid=5",
+            "mode=620",
+            "ptmxmode=000"
+          ]
+        },
+        "/dev/xvda": {
+          "fs_type": "ext4",
+          "uuid": "6f816946-42f1-4dcb-90f9-1c8b9daeafe2"
+        }
+      },
+      "virtualization": {
+        "systems": {
+          "xen": "guest"
+        },
+        "system": "xen",
+        "role": "guest"
+      },
+      "dmi": {
+        "dmidecode_version": "2.11",
+        "smbios_version": "2.4",
+        "structures": {
+          "count": "12",
+          "size": "349"
+        },
+        "bios": {
+          "all_records": [
+            {
+              "record_id": "0x0000",
+              "size": "0",
+              "application_identifier": "BIOS Information",
+              "Vendor": "Xen",
+              "Version": "4.2.amazon",
+              "Release Date": "02/16/2017",
+              "Address": "0xE8000",
+              "Runtime Size": "96 kB",
+              "ROM Size": "64 kB",
+              "Characteristics": {
+                "PCI is supported": null,
+                "EDD is supported": null,
+                "Targeted content distribution is supported": null
+              },
+              "BIOS Revision": "4.2"
+            }
+          ],
+          "vendor": "Xen",
+          "version": "4.2.amazon",
+          "release_date": "02/16/2017",
+          "address": "0xE8000",
+          "runtime_size": "96 kB",
+          "rom_size": "64 kB",
+          "bios_revision": "4.2"
+        },
+        "system": {
+          "all_records": [
+            {
+              "record_id": "0x0100",
+              "size": "1",
+              "application_identifier": "System Information",
+              "Manufacturer": "Xen",
+              "Product Name": "HVM domU",
+              "Version": "4.2.amazon",
+              "Serial Number": "ec261a1a-2a60-5962-4e85-8d3286c7c354",
+              "UUID": "EC261A1A-2A60-5962-4E85-8D3286C7C354",
+              "Wake-up Type": "Power Switch",
+              "SKU Number": "Not Specified",
+              "Family": "Not Specified"
+            }
+          ],
+          "manufacturer": "Xen",
+          "product_name": "HVM domU",
+          "version": "4.2.amazon",
+          "serial_number": "ec261a1a-2a60-5962-4e85-8d3286c7c354",
+          "uuid": "EC261A1A-2A60-5962-4E85-8D3286C7C354",
+          "wake_up_type": "Power Switch",
+          "sku_number": "Not Specified",
+          "family": "Not Specified"
+        },
+        "chassis": {
+          "all_records": [
+            {
+              "record_id": "0x0300",
+              "size": "3",
+              "application_identifier": "Chassis Information",
+              "Manufacturer": "Xen",
+              "Type": "Other",
+              "Lock": "Not Present",
+              "Version": "Not Specified",
+              "Serial Number": "Not Specified",
+              "Asset Tag": "Not Specified",
+              "Boot-up State": "Safe",
+              "Power Supply State": "Safe",
+              "Thermal State": "Safe",
+              "Security Status": "Unknown"
+            }
+          ],
+          "manufacturer": "Xen",
+          "type": "Other",
+          "lock": "Not Present",
+          "version": "Not Specified",
+          "serial_number": "Not Specified",
+          "asset_tag": "Not Specified",
+          "boot_up_state": "Safe",
+          "power_supply_state": "Safe",
+          "thermal_state": "Safe",
+          "security_status": "Unknown"
+        },
+        "processor": {
+          "all_records": [
+            {
+              "record_id": "0x0401",
+              "size": "4",
+              "application_identifier": "Processor Information",
+              "Socket Designation": "CPU 1",
+              "Type": "Central Processor",
+              "Family": "Other",
+              "Manufacturer": "Intel",
+              "ID": "F2 06 03 00 FF FB 89 17",
+              "Version": "Not Specified",
+              "Voltage": "Unknown",
+              "External Clock": "Unknown",
+              "Max Speed": "2400 MHz",
+              "Current Speed": "2400 MHz",
+              "Status": "Populated, Enabled",
+              "Upgrade": "Other"
+            },
+            {
+              "record_id": "0x0402",
+              "size": "4",
+              "application_identifier": "Processor Information",
+              "Socket Designation": "CPU 2",
+              "Type": "Central Processor",
+              "Family": "Other",
+              "Manufacturer": "Intel",
+              "ID": "F2 06 03 00 FF FB 89 17",
+              "Version": "Not Specified",
+              "Voltage": "Unknown",
+              "External Clock": "Unknown",
+              "Max Speed": "2400 MHz",
+              "Current Speed": "2400 MHz",
+              "Status": "Populated, Enabled",
+              "Upgrade": "Other"
+            }
+          ],
+          "type": "Central Processor",
+          "family": "Other",
+          "manufacturer": "Intel",
+          "id": "F2 06 03 00 FF FB 89 17",
+          "version": "Not Specified",
+          "voltage": "Unknown",
+          "external_clock": "Unknown",
+          "max_speed": "2400 MHz",
+          "current_speed": "2400 MHz",
+          "status": "Populated, Enabled",
+          "upgrade": "Other"
+        },
+        "oem_strings": {
+          "all_records": [
+            {
+              "record_id": "0x0B00",
+              "size": "11",
+              "application_identifier": "OEM Strings",
+              "String 1": "Xen"
+            }
+          ],
+          "string_1": "Xen"
+        }
+      },
+      "etc": {
+      },
+      "current_user": "root",
+      "time": {
+        "timezone": "UTC"
+      },
+      "filesystem2": {
+        "by_device": {
+          "rootfs": {
+            "kb_size": "30963708",
+            "kb_used": "3927384",
+            "kb_available": "25463744",
+            "percent_used": "14%",
+            "total_inodes": "1966080",
+            "inodes_used": "264597",
+            "inodes_available": "1701483",
+            "inodes_percent_used": "14%",
+            "mounts": [
+              "/"
+            ]
+          },
+          "udev": {
+            "kb_size": "10240",
+            "kb_used": "0",
+            "kb_available": "10240",
+            "percent_used": "0%",
+            "total_inodes": "506100",
+            "inodes_used": "252",
+            "inodes_available": "505848",
+            "inodes_percent_used": "1%",
+            "fs_type": "devtmpfs",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "size=10240k",
+              "nr_inodes=506100",
+              "mode=755"
+            ],
+            "mounts": [
+              "/dev"
+            ]
+          },
+          "tmpfs": {
+            "kb_size": "759580",
+            "kb_used": "0",
+            "kb_available": "759580",
+            "percent_used": "0%",
+            "total_inodes": "474748",
+            "inodes_used": "2",
+            "inodes_available": "474746",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "size=759580k"
+            ],
+            "mounts": [
+              "/run",
+              "/run/lock",
+              "/run/shm"
+            ]
+          },
+          "/dev/disk/by-uuid/6f816946-42f1-4dcb-90f9-1c8b9daeafe2": {
+            "kb_size": "30963708",
+            "kb_used": "3927384",
+            "kb_available": "25463744",
+            "percent_used": "14%",
+            "total_inodes": "1966080",
+            "inodes_used": "264597",
+            "inodes_available": "1701483",
+            "inodes_percent_used": "14%",
+            "fs_type": "ext4",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "user_xattr",
+              "barrier=1",
+              "data=ordered"
+            ],
+            "mounts": [
+              "/"
+            ]
+          },
+          "sysfs": {
+            "fs_type": "sysfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "mounts": [
+              "/sys"
+            ]
+          },
+          "proc": {
+            "fs_type": "proc",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "mounts": [
+              "/proc"
+            ]
+          },
+          "devpts": {
+            "fs_type": "devpts",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "noexec",
+              "relatime",
+              "gid=5",
+              "mode=620",
+              "ptmxmode=000"
+            ],
+            "mounts": [
+              "/dev/pts"
+            ]
+          },
+          "/dev/xvda": {
+            "fs_type": "ext4",
+            "uuid": "6f816946-42f1-4dcb-90f9-1c8b9daeafe2",
+            "mounts": []
+          }
+        },
+        "by_mountpoint": {
+          "/": {
+            "kb_size": "30963708",
+            "kb_used": "3927384",
+            "kb_available": "25463744",
+            "percent_used": "14%",
+            "total_inodes": "1966080",
+            "inodes_used": "264597",
+            "inodes_available": "1701483",
+            "inodes_percent_used": "14%",
+            "devices": [
+              "rootfs",
+              "/dev/disk/by-uuid/6f816946-42f1-4dcb-90f9-1c8b9daeafe2"
+            ],
+            "fs_type": "ext4",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "user_xattr",
+              "barrier=1",
+              "data=ordered"
+            ]
+          },
+          "/dev": {
+            "kb_size": "10240",
+            "kb_used": "0",
+            "kb_available": "10240",
+            "percent_used": "0%",
+            "total_inodes": "506100",
+            "inodes_used": "252",
+            "inodes_available": "505848",
+            "inodes_percent_used": "1%",
+            "fs_type": "devtmpfs",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "size=10240k",
+              "nr_inodes=506100",
+              "mode=755"
+            ],
+            "devices": [
+              "udev"
+            ]
+          },
+          "/run": {
+            "kb_size": "379800",
+            "kb_used": "128",
+            "kb_available": "379672",
+            "percent_used": "1%",
+            "total_inodes": "481148",
+            "inodes_used": "172",
+            "inodes_available": "480976",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "noexec",
+              "relatime",
+              "size=379800k",
+              "nr_inodes=481148",
+              "mode=755"
+            ],
+            "devices": [
+              "tmpfs"
+            ]
+          },
+          "/run/lock": {
+            "kb_size": "5120",
+            "kb_used": "0",
+            "kb_available": "5120",
+            "percent_used": "0%",
+            "total_inodes": "474748",
+            "inodes_used": "1",
+            "inodes_available": "474747",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "size=5120k"
+            ],
+            "devices": [
+              "tmpfs"
+            ]
+          },
+          "/run/shm": {
+            "kb_size": "759580",
+            "kb_used": "0",
+            "kb_available": "759580",
+            "percent_used": "0%",
+            "total_inodes": "474748",
+            "inodes_used": "2",
+            "inodes_available": "474746",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "size=759580k"
+            ],
+            "devices": [
+              "tmpfs"
+            ]
+          },
+          "/sys": {
+            "fs_type": "sysfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "devices": [
+              "sysfs"
+            ]
+          },
+          "/proc": {
+            "fs_type": "proc",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "devices": [
+              "proc"
+            ]
+          },
+          "/dev/pts": {
+            "fs_type": "devpts",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "noexec",
+              "relatime",
+              "gid=5",
+              "mode=620",
+              "ptmxmode=000"
+            ],
+            "devices": [
+              "devpts"
+            ]
+          }
+        },
+        "by_pair": {
+          "rootfs,/": {
+            "device": "rootfs",
+            "kb_size": "30963708",
+            "kb_used": "3927384",
+            "kb_available": "25463744",
+            "percent_used": "14%",
+            "mount": "/",
+            "total_inodes": "1966080",
+            "inodes_used": "264597",
+            "inodes_available": "1701483",
+            "inodes_percent_used": "14%"
+          },
+          "udev,/dev": {
+            "device": "udev",
+            "kb_size": "10240",
+            "kb_used": "0",
+            "kb_available": "10240",
+            "percent_used": "0%",
+            "mount": "/dev",
+            "total_inodes": "506100",
+            "inodes_used": "252",
+            "inodes_available": "505848",
+            "inodes_percent_used": "1%",
+            "fs_type": "devtmpfs",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "size=10240k",
+              "nr_inodes=506100",
+              "mode=755"
+            ]
+          },
+          "tmpfs,/run": {
+            "device": "tmpfs",
+            "kb_size": "379800",
+            "kb_used": "128",
+            "kb_available": "379672",
+            "percent_used": "1%",
+            "mount": "/run",
+            "total_inodes": "481148",
+            "inodes_used": "172",
+            "inodes_available": "480976",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "noexec",
+              "relatime",
+              "size=379800k",
+              "nr_inodes=481148",
+              "mode=755"
+            ]
+          },
+          "/dev/disk/by-uuid/6f816946-42f1-4dcb-90f9-1c8b9daeafe2,/": {
+            "device": "/dev/disk/by-uuid/6f816946-42f1-4dcb-90f9-1c8b9daeafe2",
+            "kb_size": "30963708",
+            "kb_used": "3927384",
+            "kb_available": "25463744",
+            "percent_used": "14%",
+            "mount": "/",
+            "total_inodes": "1966080",
+            "inodes_used": "264597",
+            "inodes_available": "1701483",
+            "inodes_percent_used": "14%",
+            "fs_type": "ext4",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "user_xattr",
+              "barrier=1",
+              "data=ordered"
+            ]
+          },
+          "tmpfs,/run/lock": {
+            "device": "tmpfs",
+            "kb_size": "5120",
+            "kb_used": "0",
+            "kb_available": "5120",
+            "percent_used": "0%",
+            "mount": "/run/lock",
+            "total_inodes": "474748",
+            "inodes_used": "1",
+            "inodes_available": "474747",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "size=5120k"
+            ]
+          },
+          "tmpfs,/run/shm": {
+            "device": "tmpfs",
+            "kb_size": "759580",
+            "kb_used": "0",
+            "kb_available": "759580",
+            "percent_used": "0%",
+            "mount": "/run/shm",
+            "total_inodes": "474748",
+            "inodes_used": "2",
+            "inodes_available": "474746",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "size=759580k"
+            ]
+          },
+          "sysfs,/sys": {
+            "device": "sysfs",
+            "mount": "/sys",
+            "fs_type": "sysfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ]
+          },
+          "proc,/proc": {
+            "device": "proc",
+            "mount": "/proc",
+            "fs_type": "proc",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ]
+          },
+          "devpts,/dev/pts": {
+            "device": "devpts",
+            "mount": "/dev/pts",
+            "fs_type": "devpts",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "noexec",
+              "relatime",
+              "gid=5",
+              "mode=620",
+              "ptmxmode=000"
+            ]
+          },
+          "/dev/xvda,": {
+            "device": "/dev/xvda",
+            "fs_type": "ext4",
+            "uuid": "6f816946-42f1-4dcb-90f9-1c8b9daeafe2"
+          }
+        }
+      },
+      "packages": {
+        "adduser": {
+          "version": "3.113+nmu3",
+          "arch": "all"
+        },
+        "apt": {
+          "version": "0.9.7.9+deb7u7",
+          "arch": "amd64"
+        },
+        "apt-utils": {
+          "version": "0.9.7.9+deb7u7",
+          "arch": "amd64"
+        },
+        "aptitude": {
+          "version": "0.6.8.2-1",
+          "arch": "amd64"
+        },
+        "aptitude-common": {
+          "version": "0.6.8.2-1",
+          "arch": "all"
+        },
+        "at": {
+          "version": "3.1.13-2+deb7u1",
+          "arch": "amd64"
+        },
+        "autoconf": {
+          "version": "2.69-1",
+          "arch": "all"
+        },
+        "automake": {
+          "version": "1:1.11.6-1",
+          "arch": "all"
+        },
+        "autopoint": {
+          "version": "0.18.1.1-9",
+          "arch": "all"
+        },
+        "autotools-dev": {
+          "version": "20120608.1",
+          "arch": "all"
+        },
+        "base-files": {
+          "version": "7.1wheezy8",
+          "arch": "amd64"
+        },
+        "base-passwd": {
+          "version": "3.5.26",
+          "arch": "amd64"
+        },
+        "bash": {
+          "version": "4.2+dfsg-0.1+deb7u3",
+          "arch": "amd64"
+        },
+        "binutils": {
+          "version": "2.22-8+deb7u3",
+          "arch": "amd64"
+        },
+        "binutils-doc": {
+          "version": "2.22-8+deb7u3",
+          "arch": "all"
+        },
+        "bison": {
+          "version": "1:2.5.dfsg-2.1",
+          "arch": "amd64"
+        },
+        "bsdmainutils": {
+          "version": "9.0.3",
+          "arch": "amd64"
+        },
+        "bsdutils": {
+          "version": "1:2.20.1-5.3",
+          "arch": "amd64"
+        },
+        "build-essential": {
+          "version": "11.5",
+          "arch": "amd64"
+        },
+        "bzip2": {
+          "version": "1.0.6-4",
+          "arch": "amd64"
+        },
+        "ca-certificates": {
+          "version": "20130119+deb7u1",
+          "arch": "all"
+        },
+        "ca-certificates-java": {
+          "version": "20121112+nmu2",
+          "arch": "all"
+        },
+        "chef": {
+          "version": "12.21.3-1",
+          "arch": "amd64"
+        },
+        "chefdk": {
+          "version": "2.4.3-1",
+          "arch": "amd64"
+        },
+        "cloud-init": {
+          "version": "0.7.2-3~bpo70+1",
+          "arch": "all"
+        },
+        "coreutils": {
+          "version": "8.13-3.5",
+          "arch": "amd64"
+        },
+        "cpio": {
+          "version": "2.11+dfsg-0.1+deb7u1",
+          "arch": "amd64"
+        },
+        "cpp": {
+          "version": "4:4.7.2-1",
+          "arch": "amd64"
+        },
+        "cpp-4.7": {
+          "version": "4.7.2-5",
+          "arch": "amd64"
+        },
+        "cron": {
+          "version": "3.0pl1-124",
+          "arch": "amd64"
+        },
+        "curl": {
+          "version": "7.26.0-1+wheezy19",
+          "arch": "amd64"
+        },
+        "dash": {
+          "version": "0.5.7-3",
+          "arch": "amd64"
+        },
+        "dbus": {
+          "version": "1.6.8-1+deb7u6",
+          "arch": "amd64"
+        },
+        "dctrl-tools": {
+          "version": "2.22.2",
+          "arch": "amd64"
+        },
+        "debconf": {
+          "version": "1.5.49",
+          "arch": "all"
+        },
+        "debconf-i18n": {
+          "version": "1.5.49",
+          "arch": "all"
+        },
+        "debhelper": {
+          "version": "9.20120909",
+          "arch": "all"
+        },
+        "debian-archive-keyring": {
+          "version": "2014.3~deb7u1",
+          "arch": "all"
+        },
+        "debian-keyring": {
+          "version": "2013.04.21",
+          "arch": "all"
+        },
+        "debianutils": {
+          "version": "4.3.2",
+          "arch": "amd64"
+        },
+        "devscripts": {
+          "version": "2.12.6+deb7u2",
+          "arch": "amd64"
+        },
+        "dhcpcd": {
+          "version": "1:3.2.3-11",
+          "arch": "amd64"
+        },
+        "diffstat": {
+          "version": "1.55-3",
+          "arch": "amd64"
+        },
+        "diffutils": {
+          "version": "1:3.2-6",
+          "arch": "amd64"
+        },
+        "distro-info-data": {
+          "version": "0.17~deb7u1",
+          "arch": "all"
+        },
+        "dmidecode": {
+          "version": "2.11-9",
+          "arch": "amd64"
+        },
+        "dpkg": {
+          "version": "1.16.15",
+          "arch": "amd64"
+        },
+        "dpkg-dev": {
+          "version": "1.16.18",
+          "arch": "all"
+        },
+        "dput": {
+          "version": "0.9.6.3+nmu2",
+          "arch": "all"
+        },
+        "e2fslibs": {
+          "version": "1.42.5-1.1",
+          "arch": "amd64"
+        },
+        "e2fsprogs": {
+          "version": "1.42.5-1.1",
+          "arch": "amd64"
+        },
+        "equivs": {
+          "version": "2.0.9",
+          "arch": "all"
+        },
+        "exim4-base": {
+          "version": "4.80-7+deb7u4",
+          "arch": "amd64"
+        },
+        "exim4-config": {
+          "version": "4.80-7+deb7u4",
+          "arch": "all"
+        },
+        "exim4-daemon-light": {
+          "version": "4.80-7+deb7u4",
+          "arch": "amd64"
+        },
+        "extlinux": {
+          "version": "2:4.05+dfsg-6+deb7u1",
+          "arch": "amd64"
+        },
+        "fakeroot": {
+          "version": "1.18.4-2",
+          "arch": "amd64"
+        },
+        "file": {
+          "version": "5.11-2+deb7u9",
+          "arch": "amd64"
+        },
+        "findutils": {
+          "version": "4.4.2-4",
+          "arch": "amd64"
+        },
+        "flex": {
+          "version": "2.5.35-10.1",
+          "arch": "amd64"
+        },
+        "fontconfig": {
+          "version": "2.9.0-7.1+deb7u1",
+          "arch": "amd64"
+        },
+        "fontconfig-config": {
+          "version": "2.9.0-7.1+deb7u1",
+          "arch": "all"
+        },
+        "g++": {
+          "version": "4:4.7.2-1",
+          "arch": "amd64"
+        },
+        "g++-4.7": {
+          "version": "4.7.2-5",
+          "arch": "amd64"
+        },
+        "gcc": {
+          "version": "4:4.7.2-1",
+          "arch": "amd64"
+        },
+        "gcc-4.7": {
+          "version": "4.7.2-5",
+          "arch": "amd64"
+        },
+        "gcc-4.7-base": {
+          "version": "4.7.2-5",
+          "arch": "amd64"
+        },
+        "gettext": {
+          "version": "0.18.1.1-9",
+          "arch": "amd64"
+        },
+        "gettext-base": {
+          "version": "0.18.1.1-9",
+          "arch": "amd64"
+        },
+        "git": {
+          "version": "1:1.7.10.4-1+wheezy4",
+          "arch": "amd64"
+        },
+        "git-man": {
+          "version": "1:1.7.10.4-1+wheezy4",
+          "arch": "all"
+        },
+        "gnupg": {
+          "version": "1.4.12-7+deb7u6",
+          "arch": "amd64"
+        },
+        "gpgv": {
+          "version": "1.4.12-7+deb7u6",
+          "arch": "amd64"
+        },
+        "grep": {
+          "version": "2.12-2",
+          "arch": "amd64"
+        },
+        "groff-base": {
+          "version": "1.21-9",
+          "arch": "amd64"
+        },
+        "gzip": {
+          "version": "1.5-1.1",
+          "arch": "amd64"
+        },
+        "hardening-includes": {
+          "version": "2.2",
+          "arch": "all"
+        },
+        "heirloom-mailx": {
+          "version": "12.5-2+deb7u1",
+          "arch": "amd64"
+        },
+        "hicolor-icon-theme": {
+          "version": "0.12-1",
+          "arch": "all"
+        },
+        "hostname": {
+          "version": "3.11",
+          "arch": "amd64"
+        },
+        "html2text": {
+          "version": "1.3.2a-15",
+          "arch": "amd64"
+        },
+        "ifupdown": {
+          "version": "0.7.8",
+          "arch": "amd64"
+        },
+        "info": {
+          "version": "4.13a.dfsg.1-10",
+          "arch": "amd64"
+        },
+        "initramfs-tools": {
+          "version": "0.109.1",
+          "arch": "all"
+        },
+        "initscripts": {
+          "version": "2.88dsf-41+deb7u1",
+          "arch": "amd64"
+        },
+        "insserv": {
+          "version": "1.14.0-5",
+          "arch": "amd64"
+        },
+        "install-info": {
+          "version": "4.13a.dfsg.1-10",
+          "arch": "amd64"
+        },
+        "intltool-debian": {
+          "version": "0.35.0+20060710.1",
+          "arch": "all"
+        },
+        "iproute": {
+          "version": "20120521-3+b3",
+          "arch": "amd64"
+        },
+        "iptables": {
+          "version": "1.4.14-3.1",
+          "arch": "amd64"
+        },
+        "iputils-ping": {
+          "version": "3:20101006-1+b1",
+          "arch": "amd64"
+        },
+        "iso-codes": {
+          "version": "3.41-1",
+          "arch": "all"
+        },
+        "java-common": {
+          "version": "0.47+deb7u2",
+          "arch": "all"
+        },
+        "klibc-utils": {
+          "version": "2.0.1-3.1",
+          "arch": "amd64"
+        },
+        "kmod": {
+          "version": "9-3",
+          "arch": "amd64"
+        },
+        "less": {
+          "version": "444-4",
+          "arch": "amd64"
+        },
+        "libacl1": {
+          "version": "2.2.51-8",
+          "arch": "amd64"
+        },
+        "libalgorithm-diff-perl": {
+          "version": "1.19.02-2",
+          "arch": "all"
+        },
+        "libalgorithm-diff-xs-perl": {
+          "version": "0.04-2+b1",
+          "arch": "amd64"
+        },
+        "libalgorithm-merge-perl": {
+          "version": "0.08-2",
+          "arch": "all"
+        },
+        "libapt-inst1.5": {
+          "version": "0.9.7.9+deb7u7",
+          "arch": "amd64"
+        },
+        "libapt-pkg-perl": {
+          "version": "0.1.26+b1",
+          "arch": "amd64"
+        },
+        "libapt-pkg4.12": {
+          "version": "0.9.7.9+deb7u7",
+          "arch": "amd64"
+        },
+        "libarchive-zip-perl": {
+          "version": "1.30-6",
+          "arch": "all"
+        },
+        "libasound2": {
+          "version": "1.0.25-4",
+          "arch": "amd64"
+        },
+        "libasprintf0c2": {
+          "version": "0.18.1.1-9",
+          "arch": "amd64"
+        },
+        "libasyncns0": {
+          "version": "0.8-4",
+          "arch": "amd64"
+        },
+        "libatk-wrapper-java": {
+          "version": "0.30.4-3",
+          "arch": "all"
+        },
+        "libatk-wrapper-java-jni": {
+          "version": "0.30.4-3",
+          "arch": "amd64"
+        },
+        "libatk1.0-0": {
+          "version": "2.4.0-2",
+          "arch": "amd64"
+        },
+        "libatk1.0-data": {
+          "version": "2.4.0-2",
+          "arch": "all"
+        },
+        "libattr1": {
+          "version": "1:2.4.46-8",
+          "arch": "amd64"
+        },
+        "libavahi-client3": {
+          "version": "0.6.31-2",
+          "arch": "amd64"
+        },
+        "libavahi-common-data": {
+          "version": "0.6.31-2",
+          "arch": "amd64"
+        },
+        "libavahi-common3": {
+          "version": "0.6.31-2",
+          "arch": "amd64"
+        },
+        "libbison-dev": {
+          "version": "1:2.5.dfsg-2.1",
+          "arch": "amd64"
+        },
+        "libblkid1": {
+          "version": "2.20.1-5.3",
+          "arch": "amd64"
+        },
+        "libboost-iostreams1.49.0": {
+          "version": "1.49.0-3.2",
+          "arch": "amd64"
+        },
+        "libbsd0": {
+          "version": "0.4.2-1",
+          "arch": "amd64"
+        },
+        "libbz2-1.0": {
+          "version": "1.0.6-4",
+          "arch": "amd64"
+        },
+        "libc-bin": {
+          "version": "2.13-38+deb7u11",
+          "arch": "amd64"
+        },
+        "libc-dev-bin": {
+          "version": "2.13-38+deb7u11",
+          "arch": "amd64"
+        },
+        "libc6": {
+          "version": "2.13-38+deb7u11",
+          "arch": "amd64"
+        },
+        "libc6-dev": {
+          "version": "2.13-38+deb7u11",
+          "arch": "amd64"
+        },
+        "libcairo2": {
+          "version": "1.12.2-3+deb7u1",
+          "arch": "amd64"
+        },
+        "libcap2": {
+          "version": "1:2.22-1.2",
+          "arch": "amd64"
+        },
+        "libclass-accessor-perl": {
+          "version": "0.34-1",
+          "arch": "all"
+        },
+        "libclass-inspector-perl": {
+          "version": "1.27-1",
+          "arch": "all"
+        },
+        "libclass-isa-perl": {
+          "version": "0.36-3",
+          "arch": "all"
+        },
+        "libclone-perl": {
+          "version": "0.31-1+b2",
+          "arch": "amd64"
+        },
+        "libcomerr2": {
+          "version": "1.42.5-1.1",
+          "arch": "amd64"
+        },
+        "libcommon-sense-perl": {
+          "version": "3.6-1",
+          "arch": "all"
+        },
+        "libconvert-binhex-perl": {
+          "version": "1.119+pristine-3",
+          "arch": "all"
+        },
+        "libcroco3": {
+          "version": "0.6.6-2+deb7u1",
+          "arch": "amd64"
+        },
+        "libcrypt-ssleay-perl": {
+          "version": "0.58-1",
+          "arch": "amd64"
+        },
+        "libcups2": {
+          "version": "1.5.3-5+deb7u6",
+          "arch": "amd64"
+        },
+        "libcurl3": {
+          "version": "7.26.0-1+wheezy19",
+          "arch": "amd64"
+        },
+        "libcurl3-gnutls": {
+          "version": "7.26.0-1+wheezy12",
+          "arch": "amd64"
+        },
+        "libcwidget3": {
+          "version": "0.5.16-3.4",
+          "arch": "amd64"
+        },
+        "libdatrie1": {
+          "version": "0.2.5-3",
+          "arch": "amd64"
+        },
+        "libdb5.1": {
+          "version": "5.1.29-5",
+          "arch": "amd64"
+        },
+        "libdbus-1-3": {
+          "version": "1.6.8-1+deb7u6",
+          "arch": "amd64"
+        },
+        "libdigest-hmac-perl": {
+          "version": "1.03+dfsg-1",
+          "arch": "all"
+        },
+        "libdistro-info-perl": {
+          "version": "0.10",
+          "arch": "all"
+        },
+        "libdpkg-perl": {
+          "version": "1.16.18",
+          "arch": "all"
+        },
+        "libdrm-intel1": {
+          "version": "2.4.40-1~deb7u2",
+          "arch": "amd64"
+        },
+        "libdrm-nouveau1a": {
+          "version": "2.4.40-1~deb7u2",
+          "arch": "amd64"
+        },
+        "libdrm-radeon1": {
+          "version": "2.4.40-1~deb7u2",
+          "arch": "amd64"
+        },
+        "libdrm2": {
+          "version": "2.4.40-1~deb7u2",
+          "arch": "amd64"
+        },
+        "libedit2": {
+          "version": "2.11-20080614-5",
+          "arch": "amd64"
+        },
+        "libemail-valid-perl": {
+          "version": "0.190-1",
+          "arch": "all"
+        },
+        "libencode-locale-perl": {
+          "version": "1.03-1",
+          "arch": "all"
+        },
+        "libept1.4.12": {
+          "version": "1.0.9",
+          "arch": "amd64"
+        },
+        "liberror-perl": {
+          "version": "0.17-1",
+          "arch": "all"
+        },
+        "libexpat1": {
+          "version": "2.1.0-1+deb7u1",
+          "arch": "amd64"
+        },
+        "libexporter-lite-perl": {
+          "version": "0.02-2",
+          "arch": "all"
+        },
+        "libfcgi-perl": {
+          "version": "0.74-1+b1",
+          "arch": "amd64"
+        },
+        "libffi5": {
+          "version": "3.0.10-3",
+          "arch": "amd64"
+        },
+        "libfile-fcntllock-perl": {
+          "version": "0.14-2",
+          "arch": "amd64"
+        },
+        "libfile-listing-perl": {
+          "version": "6.04-1",
+          "arch": "all"
+        },
+        "libflac8": {
+          "version": "1.2.1-6+deb7u1",
+          "arch": "amd64"
+        },
+        "libfont-afm-perl": {
+          "version": "1.20-1",
+          "arch": "all"
+        },
+        "libfontconfig1": {
+          "version": "2.9.0-7.1+deb7u1",
+          "arch": "amd64"
+        },
+        "libfreetype6": {
+          "version": "2.4.9-1.1+deb7u7",
+          "arch": "amd64"
+        },
+        "libgcc1": {
+          "version": "1:4.7.2-5",
+          "arch": "amd64"
+        },
+        "libgcrypt11": {
+          "version": "1.5.0-5+deb7u2",
+          "arch": "amd64"
+        },
+        "libgdbm3": {
+          "version": "1.8.3-11",
+          "arch": "amd64"
+        },
+        "libgdk-pixbuf2.0-0": {
+          "version": "2.26.1-1+deb7u5",
+          "arch": "amd64"
+        },
+        "libgdk-pixbuf2.0-common": {
+          "version": "2.26.1-1+deb7u5",
+          "arch": "all"
+        },
+        "libgettextpo0": {
+          "version": "0.18.1.1-9",
+          "arch": "amd64"
+        },
+        "libgif4": {
+          "version": "4.1.6-10+deb7u1",
+          "arch": "amd64"
+        },
+        "libgl1-mesa-dri": {
+          "version": "8.0.5-4+deb7u2",
+          "arch": "amd64"
+        },
+        "libgl1-mesa-glx": {
+          "version": "8.0.5-4+deb7u2",
+          "arch": "amd64"
+        },
+        "libglapi-mesa": {
+          "version": "8.0.5-4+deb7u2",
+          "arch": "amd64"
+        },
+        "libglib2.0-0": {
+          "version": "2.33.12+really2.32.4-5",
+          "arch": "amd64"
+        },
+        "libglib2.0-data": {
+          "version": "2.33.12+really2.32.4-5",
+          "arch": "all"
+        },
+        "libgmp10": {
+          "version": "2:5.0.5+dfsg-2",
+          "arch": "amd64"
+        },
+        "libgnutls26": {
+          "version": "2.12.20-8+deb7u2",
+          "arch": "amd64"
+        },
+        "libgomp1": {
+          "version": "4.7.2-5",
+          "arch": "amd64"
+        },
+        "libgpg-error0": {
+          "version": "1.10-3.1",
+          "arch": "amd64"
+        },
+        "libgssapi-krb5-2": {
+          "version": "1.10.1+dfsg-5+deb7u2",
+          "arch": "amd64"
+        },
+        "libgtk2.0-0": {
+          "version": "2.24.10-2",
+          "arch": "amd64"
+        },
+        "libgtk2.0-bin": {
+          "version": "2.24.10-2",
+          "arch": "amd64"
+        },
+        "libgtk2.0-common": {
+          "version": "2.24.10-2",
+          "arch": "all"
+        },
+        "libhtml-form-perl": {
+          "version": "6.03-1",
+          "arch": "all"
+        },
+        "libhtml-format-perl": {
+          "version": "2.10-1",
+          "arch": "all"
+        },
+        "libhtml-parser-perl": {
+          "version": "3.69-2",
+          "arch": "amd64"
+        },
+        "libhtml-tagset-perl": {
+          "version": "3.20-2",
+          "arch": "all"
+        },
+        "libhtml-template-perl": {
+          "version": "2.91-1",
+          "arch": "all"
+        },
+        "libhtml-tree-perl": {
+          "version": "5.02-1",
+          "arch": "all"
+        },
+        "libhttp-cookies-perl": {
+          "version": "6.00-2",
+          "arch": "all"
+        },
+        "libhttp-daemon-perl": {
+          "version": "6.01-1",
+          "arch": "all"
+        },
+        "libhttp-date-perl": {
+          "version": "6.02-1",
+          "arch": "all"
+        },
+        "libhttp-message-perl": {
+          "version": "6.03-1",
+          "arch": "all"
+        },
+        "libhttp-negotiate-perl": {
+          "version": "6.00-2",
+          "arch": "all"
+        },
+        "libice-dev": {
+          "version": "2:1.0.8-2",
+          "arch": "amd64"
+        },
+        "libice6": {
+          "version": "2:1.0.8-2",
+          "arch": "amd64"
+        },
+        "libidn11": {
+          "version": "1.25-2",
+          "arch": "amd64"
+        },
+        "libio-pty-perl": {
+          "version": "1:1.08-1+b2",
+          "arch": "amd64"
+        },
+        "libio-socket-ip-perl": {
+          "version": "0.16-2",
+          "arch": "all"
+        },
+        "libio-socket-ssl-perl": {
+          "version": "1.76-2",
+          "arch": "all"
+        },
+        "libio-string-perl": {
+          "version": "1.08-2",
+          "arch": "all"
+        },
+        "libio-stringy-perl": {
+          "version": "2.110-5",
+          "arch": "all"
+        },
+        "libipc-run-perl": {
+          "version": "0.92-1",
+          "arch": "all"
+        },
+        "libitm1": {
+          "version": "4.7.2-5",
+          "arch": "amd64"
+        },
+        "libjasper1": {
+          "version": "1.900.1-13+deb7u6",
+          "arch": "amd64"
+        },
+        "libjbig0": {
+          "version": "2.0-2+deb7u1",
+          "arch": "amd64"
+        },
+        "libjpeg8": {
+          "version": "8d-1+deb7u1",
+          "arch": "amd64"
+        },
+        "libjson-perl": {
+          "version": "2.53-1",
+          "arch": "all"
+        },
+        "libjson-xs-perl": {
+          "version": "2.320-1+b1",
+          "arch": "amd64"
+        },
+        "libjson0": {
+          "version": "0.10-1.2",
+          "arch": "amd64"
+        },
+        "libk5crypto3": {
+          "version": "1.10.1+dfsg-5+deb7u2",
+          "arch": "amd64"
+        },
+        "libkeyutils1": {
+          "version": "1.5.5-3+deb7u1",
+          "arch": "amd64"
+        },
+        "libklibc": {
+          "version": "2.0.1-3.1",
+          "arch": "amd64"
+        },
+        "libkmod2": {
+          "version": "9-3",
+          "arch": "amd64"
+        },
+        "libkrb5-3": {
+          "version": "1.10.1+dfsg-5+deb7u2",
+          "arch": "amd64"
+        },
+        "libkrb5support0": {
+          "version": "1.10.1+dfsg-5+deb7u2",
+          "arch": "amd64"
+        },
+        "liblcms2-2": {
+          "version": "2.2+git20110628-2.2+deb7u2",
+          "arch": "amd64"
+        },
+        "libldap-2.4-2": {
+          "version": "2.4.31-1+nmu2",
+          "arch": "amd64"
+        },
+        "liblocale-gettext-perl": {
+          "version": "1.05-7+b1",
+          "arch": "amd64"
+        },
+        "liblockfile-bin": {
+          "version": "1.09-5",
+          "arch": "amd64"
+        },
+        "liblockfile1": {
+          "version": "1.09-5",
+          "arch": "amd64"
+        },
+        "liblwp-mediatypes-perl": {
+          "version": "6.02-1",
+          "arch": "all"
+        },
+        "liblwp-protocol-https-perl": {
+          "version": "6.03-1",
+          "arch": "all"
+        },
+        "liblzma5": {
+          "version": "5.1.1alpha+20120614-2",
+          "arch": "amd64"
+        },
+        "libmagic1": {
+          "version": "5.11-2+deb7u9",
+          "arch": "amd64"
+        },
+        "libmail-sendmail-perl": {
+          "version": "0.79.16-1",
+          "arch": "all"
+        },
+        "libmailtools-perl": {
+          "version": "2.09-1",
+          "arch": "all"
+        },
+        "libmime-tools-perl": {
+          "version": "5.503-1",
+          "arch": "all"
+        },
+        "libmount1": {
+          "version": "2.20.1-5.3",
+          "arch": "amd64"
+        },
+        "libmpc2": {
+          "version": "0.9-4",
+          "arch": "amd64"
+        },
+        "libmpfr4": {
+          "version": "3.1.0-5",
+          "arch": "amd64"
+        },
+        "libncurses5": {
+          "version": "5.9-10",
+          "arch": "amd64"
+        },
+        "libncurses5-dev": {
+          "version": "5.9-10",
+          "arch": "amd64"
+        },
+        "libncursesw5": {
+          "version": "5.9-10",
+          "arch": "amd64"
+        },
+        "libnet-dns-perl": {
+          "version": "0.66-2+b2",
+          "arch": "amd64"
+        },
+        "libnet-domain-tld-perl": {
+          "version": "1.69-1",
+          "arch": "all"
+        },
+        "libnet-http-perl": {
+          "version": "6.03-2",
+          "arch": "all"
+        },
+        "libnet-ip-perl": {
+          "version": "1.25-3",
+          "arch": "all"
+        },
+        "libnet-ssleay-perl": {
+          "version": "1.48-1+b1",
+          "arch": "amd64"
+        },
+        "libnewt0.52": {
+          "version": "0.52.14-11.1",
+          "arch": "amd64"
+        },
+        "libnfnetlink0": {
+          "version": "1.0.0-1.1",
+          "arch": "amd64"
+        },
+        "libnspr4": {
+          "version": "2:4.12-1+deb7u1",
+          "arch": "amd64"
+        },
+        "libnss3": {
+          "version": "2:3.26-1+debu7u4",
+          "arch": "amd64"
+        },
+        "libogg0": {
+          "version": "1.3.0-4",
+          "arch": "amd64"
+        },
+        "libopts25": {
+          "version": "1:5.12-0.1",
+          "arch": "amd64"
+        },
+        "libossp-uuid-perl": {
+          "version": "1.6.2-1.3",
+          "arch": "amd64"
+        },
+        "libossp-uuid16": {
+          "version": "1.6.2-1.3",
+          "arch": "amd64"
+        },
+        "libp11-kit0": {
+          "version": "0.12-3",
+          "arch": "amd64"
+        },
+        "libpam-modules": {
+          "version": "1.1.3-7.1",
+          "arch": "amd64"
+        },
+        "libpam-modules-bin": {
+          "version": "1.1.3-7.1",
+          "arch": "amd64"
+        },
+        "libpam-runtime": {
+          "version": "1.1.3-7.1",
+          "arch": "all"
+        },
+        "libpam0g": {
+          "version": "1.1.3-7.1",
+          "arch": "amd64"
+        },
+        "libpango1.0-0": {
+          "version": "1.30.0-1",
+          "arch": "amd64"
+        },
+        "libparse-debcontrol-perl": {
+          "version": "2.005-3",
+          "arch": "all"
+        },
+        "libparse-debianchangelog-perl": {
+          "version": "1.2.0-1",
+          "arch": "all"
+        },
+        "libpciaccess0": {
+          "version": "0.13.1-2",
+          "arch": "amd64"
+        },
+        "libpcre3": {
+          "version": "1:8.30-5",
+          "arch": "amd64"
+        },
+        "libpcsclite1": {
+          "version": "1.8.4-1+deb7u2",
+          "arch": "amd64"
+        },
+        "libpipeline1": {
+          "version": "1.2.1-1",
+          "arch": "amd64"
+        },
+        "libpixman-1-0": {
+          "version": "0.26.0-4+deb7u2",
+          "arch": "amd64"
+        },
+        "libpng12-0": {
+          "version": "1.2.49-1+deb7u2",
+          "arch": "amd64"
+        },
+        "libpopt0": {
+          "version": "1.16-7",
+          "arch": "amd64"
+        },
+        "libprocps0": {
+          "version": "1:3.3.3-3",
+          "arch": "amd64"
+        },
+        "libpthread-stubs0": {
+          "version": "0.3-3",
+          "arch": "amd64"
+        },
+        "libpthread-stubs0-dev": {
+          "version": "0.3-3",
+          "arch": "amd64"
+        },
+        "libpulse0": {
+          "version": "2.0-6.1",
+          "arch": "amd64"
+        },
+        "libquadmath0": {
+          "version": "4.7.2-5",
+          "arch": "amd64"
+        },
+        "libreadline6": {
+          "version": "6.2+dfsg-0.1",
+          "arch": "amd64"
+        },
+        "librtmp0": {
+          "version": "2.4+20111222.git4e06e21-1",
+          "arch": "amd64"
+        },
+        "libsasl2-2": {
+          "version": "2.1.25.dfsg1-6+deb7u1",
+          "arch": "amd64"
+        },
+        "libsctp1": {
+          "version": "1.0.11+dfsg-2",
+          "arch": "amd64"
+        },
+        "libselinux1": {
+          "version": "2.1.9-5",
+          "arch": "amd64"
+        },
+        "libsemanage-common": {
+          "version": "2.1.6-6",
+          "arch": "all"
+        },
+        "libsemanage1": {
+          "version": "2.1.6-6",
+          "arch": "amd64"
+        },
+        "libsepol1": {
+          "version": "2.1.4-3",
+          "arch": "amd64"
+        },
+        "libsigc++-2.0-0c2a": {
+          "version": "2.2.10-0.2",
+          "arch": "amd64"
+        },
+        "libslang2": {
+          "version": "2.2.4-15",
+          "arch": "amd64"
+        },
+        "libsm-dev": {
+          "version": "2:1.2.1-2",
+          "arch": "amd64"
+        },
+        "libsm6": {
+          "version": "2:1.2.1-2",
+          "arch": "amd64"
+        },
+        "libsndfile1": {
+          "version": "1.0.25-9.1+deb7u2",
+          "arch": "amd64"
+        },
+        "libsoap-lite-perl": {
+          "version": "0.714-1+deb7u1",
+          "arch": "all"
+        },
+        "libsocket-perl": {
+          "version": "2.002-1",
+          "arch": "amd64"
+        },
+        "libsqlite3-0": {
+          "version": "3.7.13-1+deb7u1",
+          "arch": "amd64"
+        },
+        "libss2": {
+          "version": "1.42.5-1.1",
+          "arch": "amd64"
+        },
+        "libssh2-1": {
+          "version": "1.4.2-1.1",
+          "arch": "amd64"
+        },
+        "libssl1.0.0": {
+          "version": "1.0.1e-2+deb7u14",
+          "arch": "amd64"
+        },
+        "libstdc++6": {
+          "version": "4.7.2-5",
+          "arch": "amd64"
+        },
+        "libstdc++6-4.7-dev": {
+          "version": "4.7.2-5",
+          "arch": "amd64"
+        },
+        "libsub-name-perl": {
+          "version": "0.05-1+b2",
+          "arch": "amd64"
+        },
+        "libswitch-perl": {
+          "version": "2.16-2",
+          "arch": "all"
+        },
+        "libsys-hostname-long-perl": {
+          "version": "1.4-2",
+          "arch": "all"
+        },
+        "libsystemd-login0": {
+          "version": "44-11+deb7u5",
+          "arch": "amd64"
+        },
+        "libtask-weaken-perl": {
+          "version": "1.03-1",
+          "arch": "all"
+        },
+        "libtasn1-3": {
+          "version": "2.13-2+deb7u1",
+          "arch": "amd64"
+        },
+        "libtext-charwidth-perl": {
+          "version": "0.04-7+b1",
+          "arch": "amd64"
+        },
+        "libtext-iconv-perl": {
+          "version": "1.7-5",
+          "arch": "amd64"
+        },
+        "libtext-wrapi18n-perl": {
+          "version": "0.06-7",
+          "arch": "all"
+        },
+        "libthai-data": {
+          "version": "0.1.18-2",
+          "arch": "all"
+        },
+        "libthai0": {
+          "version": "0.1.18-2",
+          "arch": "amd64"
+        },
+        "libtie-ixhash-perl": {
+          "version": "1.21-2",
+          "arch": "all"
+        },
+        "libtiff4": {
+          "version": "3.9.6-11+deb7u5",
+          "arch": "amd64"
+        },
+        "libtimedate-perl": {
+          "version": "1.2000-1",
+          "arch": "all"
+        },
+        "libtinfo-dev": {
+          "version": "5.9-10",
+          "arch": "amd64"
+        },
+        "libtinfo5": {
+          "version": "5.9-10",
+          "arch": "amd64"
+        },
+        "libudev0": {
+          "version": "175-7.2",
+          "arch": "amd64"
+        },
+        "libunistring0": {
+          "version": "0.9.3-5",
+          "arch": "amd64"
+        },
+        "liburi-perl": {
+          "version": "1.60-1",
+          "arch": "all"
+        },
+        "libusb-0.1-4": {
+          "version": "2:0.1.12-20+nmu1",
+          "arch": "amd64"
+        },
+        "libustr-1.0-1": {
+          "version": "1.0.4-3",
+          "arch": "amd64"
+        },
+        "libuuid-perl": {
+          "version": "0.02-5",
+          "arch": "amd64"
+        },
+        "libuuid1": {
+          "version": "2.20.1-5.3",
+          "arch": "amd64"
+        },
+        "libvorbis0a": {
+          "version": "1.3.2-1.3",
+          "arch": "amd64"
+        },
+        "libvorbisenc2": {
+          "version": "1.3.2-1.3",
+          "arch": "amd64"
+        },
+        "libwrap0": {
+          "version": "7.6.q-24",
+          "arch": "amd64"
+        },
+        "libwww-perl": {
+          "version": "6.04-1",
+          "arch": "all"
+        },
+        "libwww-robotrules-perl": {
+          "version": "6.01-1",
+          "arch": "all"
+        },
+        "libx11-6": {
+          "version": "2:1.5.0-1+deb7u4",
+          "arch": "amd64"
+        },
+        "libx11-data": {
+          "version": "2:1.5.0-1+deb7u4",
+          "arch": "all"
+        },
+        "libx11-dev": {
+          "version": "2:1.5.0-1+deb7u4",
+          "arch": "amd64"
+        },
+        "libx11-doc": {
+          "version": "2:1.5.0-1+deb7u4",
+          "arch": "all"
+        },
+        "libx11-xcb1": {
+          "version": "2:1.5.0-1+deb7u4",
+          "arch": "amd64"
+        },
+        "libxapian22": {
+          "version": "1.2.12-2",
+          "arch": "amd64"
+        },
+        "libxau-dev": {
+          "version": "1:1.0.7-1",
+          "arch": "amd64"
+        },
+        "libxau6": {
+          "version": "1:1.0.7-1",
+          "arch": "amd64"
+        },
+        "libxcb-glx0": {
+          "version": "1.8.1-2+deb7u1",
+          "arch": "amd64"
+        },
+        "libxcb-render0": {
+          "version": "1.8.1-2+deb7u1",
+          "arch": "amd64"
+        },
+        "libxcb-shm0": {
+          "version": "1.8.1-2+deb7u1",
+          "arch": "amd64"
+        },
+        "libxcb1": {
+          "version": "1.8.1-2+deb7u1",
+          "arch": "amd64"
+        },
+        "libxcb1-dev": {
+          "version": "1.8.1-2+deb7u1",
+          "arch": "amd64"
+        },
+        "libxcomposite1": {
+          "version": "1:0.4.3-2",
+          "arch": "amd64"
+        },
+        "libxcursor1": {
+          "version": "1:1.1.13-1+deb7u1",
+          "arch": "amd64"
+        },
+        "libxdamage1": {
+          "version": "1:1.1.3-2",
+          "arch": "amd64"
+        },
+        "libxdmcp-dev": {
+          "version": "1:1.1.1-1",
+          "arch": "amd64"
+        },
+        "libxdmcp6": {
+          "version": "1:1.1.1-1",
+          "arch": "amd64"
+        },
+        "libxext6": {
+          "version": "2:1.3.1-2+deb7u1",
+          "arch": "amd64"
+        },
+        "libxfixes3": {
+          "version": "1:5.0-4+deb7u2",
+          "arch": "amd64"
+        },
+        "libxft2": {
+          "version": "2.3.1-1",
+          "arch": "amd64"
+        },
+        "libxi6": {
+          "version": "2:1.6.1-1+deb7u3",
+          "arch": "amd64"
+        },
+        "libxinerama1": {
+          "version": "2:1.1.2-1+deb7u1",
+          "arch": "amd64"
+        },
+        "libxml-namespacesupport-perl": {
+          "version": "1.09-3",
+          "arch": "all"
+        },
+        "libxml-parser-perl": {
+          "version": "2.41-1+b1",
+          "arch": "amd64"
+        },
+        "libxml-sax-base-perl": {
+          "version": "1.07-1",
+          "arch": "all"
+        },
+        "libxml-sax-expat-perl": {
+          "version": "0.40-2",
+          "arch": "all"
+        },
+        "libxml-sax-perl": {
+          "version": "0.99+dfsg-2",
+          "arch": "all"
+        },
+        "libxml-simple-perl": {
+          "version": "2.20-1",
+          "arch": "all"
+        },
+        "libxml2": {
+          "version": "2.8.0+dfsg1-7+wheezy7",
+          "arch": "amd64"
+        },
+        "libxrandr2": {
+          "version": "2:1.3.2-2+deb7u2",
+          "arch": "amd64"
+        },
+        "libxrender1": {
+          "version": "1:0.9.7-1+deb7u3",
+          "arch": "amd64"
+        },
+        "libxt-dev": {
+          "version": "1:1.1.3-1+deb7u1",
+          "arch": "amd64"
+        },
+        "libxt6": {
+          "version": "1:1.1.3-1+deb7u1",
+          "arch": "amd64"
+        },
+        "libxtst6": {
+          "version": "2:1.2.1-1+deb7u2",
+          "arch": "amd64"
+        },
+        "libxxf86vm1": {
+          "version": "1:1.1.2-1+deb7u1",
+          "arch": "amd64"
+        },
+        "libyaml-0-2": {
+          "version": "0.1.4-2+deb7u5",
+          "arch": "amd64"
+        },
+        "lintian": {
+          "version": "2.5.10.4",
+          "arch": "all"
+        },
+        "linux-base": {
+          "version": "3.5",
+          "arch": "all"
+        },
+        "linux-image-3.2.0-4-amd64": {
+          "version": "3.2.65-1+deb7u1",
+          "arch": "amd64"
+        },
+        "linux-image-amd64": {
+          "version": "3.2+46",
+          "arch": "amd64"
+        },
+        "linux-libc-dev": {
+          "version": "3.2.88-1",
+          "arch": "amd64"
+        },
+        "lksctp-tools": {
+          "version": "1.0.11+dfsg-2",
+          "arch": "amd64"
+        },
+        "locales": {
+          "version": "2.13-38+deb7u7",
+          "arch": "all"
+        },
+        "lockfile-progs": {
+          "version": "0.1.17",
+          "arch": "amd64"
+        },
+        "login": {
+          "version": "1:4.1.5.1-1",
+          "arch": "amd64"
+        },
+        "logrotate": {
+          "version": "3.8.1-4",
+          "arch": "amd64"
+        },
+        "lsb-base": {
+          "version": "4.1+Debian8+deb7u1",
+          "arch": "all"
+        },
+        "lsb-release": {
+          "version": "4.1+Debian8+deb7u1",
+          "arch": "all"
+        },
+        "m4": {
+          "version": "1.4.16-3",
+          "arch": "amd64"
+        },
+        "make": {
+          "version": "3.81-8.2",
+          "arch": "amd64"
+        },
+        "man-db": {
+          "version": "2.6.2-1",
+          "arch": "amd64"
+        },
+        "manpages": {
+          "version": "3.44-1",
+          "arch": "all"
+        },
+        "manpages-dev": {
+          "version": "3.44-1",
+          "arch": "all"
+        },
+        "mawk": {
+          "version": "1.3.3-17",
+          "arch": "amd64"
+        },
+        "mime-support": {
+          "version": "3.52-1+deb7u1",
+          "arch": "all"
+        },
+        "mount": {
+          "version": "2.20.1-5.3",
+          "arch": "amd64"
+        },
+        "multiarch-support": {
+          "version": "2.13-38+deb7u7",
+          "arch": "amd64"
+        },
+        "nano": {
+          "version": "2.2.6-1+b1",
+          "arch": "amd64"
+        },
+        "ncurses-base": {
+          "version": "5.9-10",
+          "arch": "all"
+        },
+        "ncurses-bin": {
+          "version": "5.9-10",
+          "arch": "amd64"
+        },
+        "net-tools": {
+          "version": "1.60-24.2",
+          "arch": "amd64"
+        },
+        "netbase": {
+          "version": "5.0",
+          "arch": "all"
+        },
+        "netcat-traditional": {
+          "version": "1.10-40",
+          "arch": "amd64"
+        },
+        "ntp": {
+          "version": "1:4.2.6.p5+dfsg-2+deb7u7",
+          "arch": "amd64"
+        },
+        "ntpdate": {
+          "version": "1:4.2.6.p5+dfsg-2+deb7u7",
+          "arch": "amd64"
+        },
+        "omnibus-toolchain": {
+          "version": "1.1.73-1",
+          "arch": "amd64"
+        },
+        "openjdk-7-jdk": {
+          "version": "7u131-2.6.9-2~deb7u1",
+          "arch": "amd64"
+        },
+        "openjdk-7-jre": {
+          "version": "7u131-2.6.9-2~deb7u1",
+          "arch": "amd64"
+        },
+        "openjdk-7-jre-headless": {
+          "version": "7u131-2.6.9-2~deb7u1",
+          "arch": "amd64"
+        },
+        "openssh-client": {
+          "version": "1:6.0p1-4+deb7u2",
+          "arch": "amd64"
+        },
+        "openssh-server": {
+          "version": "1:6.0p1-4+deb7u2",
+          "arch": "amd64"
+        },
+        "openssl": {
+          "version": "1.0.1e-2+deb7u14",
+          "arch": "amd64"
+        },
+        "passwd": {
+          "version": "1:4.1.5.1-1",
+          "arch": "amd64"
+        },
+        "patch": {
+          "version": "2.6.1-3",
+          "arch": "amd64"
+        },
+        "patchutils": {
+          "version": "0.3.2-1.1",
+          "arch": "amd64"
+        },
+        "perl": {
+          "version": "5.14.2-21+deb7u5",
+          "arch": "amd64"
+        },
+        "perl-base": {
+          "version": "5.14.2-21+deb7u5",
+          "arch": "amd64"
+        },
+        "perl-modules": {
+          "version": "5.14.2-21+deb7u5",
+          "arch": "all"
+        },
+        "po-debconf": {
+          "version": "1.0.16+nmu2",
+          "arch": "all"
+        },
+        "procps": {
+          "version": "1:3.3.3-3",
+          "arch": "amd64"
+        },
+        "psmisc": {
+          "version": "22.19-1+deb7u1",
+          "arch": "amd64"
+        },
+        "python": {
+          "version": "2.7.3-4+deb7u1",
+          "arch": "all"
+        },
+        "python-apt": {
+          "version": "0.8.8.2",
+          "arch": "amd64"
+        },
+        "python-apt-common": {
+          "version": "0.8.8.2",
+          "arch": "all"
+        },
+        "python-boto": {
+          "version": "2.3.0-1",
+          "arch": "all"
+        },
+        "python-chardet": {
+          "version": "2.0.1-2",
+          "arch": "all"
+        },
+        "python-cheetah": {
+          "version": "2.4.4-3",
+          "arch": "amd64"
+        },
+        "python-configobj": {
+          "version": "4.7.2+ds-4",
+          "arch": "all"
+        },
+        "python-debian": {
+          "version": "0.1.21",
+          "arch": "all"
+        },
+        "python-gnupginterface": {
+          "version": "0.3.2-9.1",
+          "arch": "all"
+        },
+        "python-magic": {
+          "version": "5.11-2+deb7u9",
+          "arch": "amd64"
+        },
+        "python-minimal": {
+          "version": "2.7.3-4+deb7u1",
+          "arch": "all"
+        },
+        "python-oauth": {
+          "version": "1.0.1-3",
+          "arch": "all"
+        },
+        "python-prettytable": {
+          "version": "0.6.1-1",
+          "arch": "all"
+        },
+        "python-pycurl": {
+          "version": "7.19.0-5",
+          "arch": "amd64"
+        },
+        "python-requests": {
+          "version": "0.12.1-1",
+          "arch": "all"
+        },
+        "python-six": {
+          "version": "1.1.0-2",
+          "arch": "all"
+        },
+        "python-software-properties": {
+          "version": "0.82.7.1debian1",
+          "arch": "all"
+        },
+        "python-support": {
+          "version": "1.0.15",
+          "arch": "all"
+        },
+        "python-yaml": {
+          "version": "3.10-4+deb7u1",
+          "arch": "amd64"
+        },
+        "python2.7": {
+          "version": "2.7.3-6+deb7u2",
+          "arch": "amd64"
+        },
+        "python2.7-minimal": {
+          "version": "2.7.3-6+deb7u2",
+          "arch": "amd64"
+        },
+        "readline-common": {
+          "version": "6.2+dfsg-0.1",
+          "arch": "all"
+        },
+        "rsync": {
+          "version": "3.0.9-4",
+          "arch": "amd64"
+        },
+        "rsyslog": {
+          "version": "5.8.11-3+deb7u2",
+          "arch": "amd64"
+        },
+        "sed": {
+          "version": "4.2.1-10",
+          "arch": "amd64"
+        },
+        "sensible-utils": {
+          "version": "0.0.7",
+          "arch": "all"
+        },
+        "sgml-base": {
+          "version": "1.26+nmu4",
+          "arch": "all"
+        },
+        "shared-mime-info": {
+          "version": "1.0-1+b1",
+          "arch": "amd64"
+        },
+        "strace": {
+          "version": "4.5.20-2.3",
+          "arch": "amd64"
+        },
+        "sudo": {
+          "version": "1.8.5p2-1+nmu1",
+          "arch": "amd64"
+        },
+        "sysv-rc": {
+          "version": "2.88dsf-41+deb7u1",
+          "arch": "all"
+        },
+        "sysvinit": {
+          "version": "2.88dsf-41+deb7u1",
+          "arch": "amd64"
+        },
+        "sysvinit-utils": {
+          "version": "2.88dsf-41+deb7u1",
+          "arch": "amd64"
+        },
+        "tar": {
+          "version": "1.26+dfsg-0.1",
+          "arch": "amd64"
+        },
+        "tasksel": {
+          "version": "3.14.1",
+          "arch": "all"
+        },
+        "tasksel-data": {
+          "version": "3.14.1",
+          "arch": "all"
+        },
+        "traceroute": {
+          "version": "1:2.0.18-3",
+          "arch": "amd64"
+        },
+        "ttf-dejavu-core": {
+          "version": "2.33-3",
+          "arch": "all"
+        },
+        "ttf-dejavu-extra": {
+          "version": "2.33-3",
+          "arch": "all"
+        },
+        "tzdata": {
+          "version": "2017b-0+deb7u1",
+          "arch": "all"
+        },
+        "tzdata-java": {
+          "version": "2017b-0+deb7u1",
+          "arch": "all"
+        },
+        "ucf": {
+          "version": "3.0025+nmu3",
+          "arch": "all"
+        },
+        "udev": {
+          "version": "175-7.2",
+          "arch": "amd64"
+        },
+        "unattended-upgrades": {
+          "version": "0.79.5+wheezy1",
+          "arch": "all"
+        },
+        "unzip": {
+          "version": "6.0-8+deb7u6",
+          "arch": "amd64"
+        },
+        "util-linux": {
+          "version": "2.20.1-5.3",
+          "arch": "amd64"
+        },
+        "vim-common": {
+          "version": "2:7.3.547-7",
+          "arch": "amd64"
+        },
+        "vim-tiny": {
+          "version": "2:7.3.547-7",
+          "arch": "amd64"
+        },
+        "wdiff": {
+          "version": "1.1.2-1",
+          "arch": "amd64"
+        },
+        "wget": {
+          "version": "1.13.4-3+deb7u2",
+          "arch": "amd64"
+        },
+        "whiptail": {
+          "version": "0.52.14-11.1",
+          "arch": "amd64"
+        },
+        "x11-common": {
+          "version": "1:7.7+3~deb7u1",
+          "arch": "all"
+        },
+        "x11proto-core-dev": {
+          "version": "7.0.23-1",
+          "arch": "all"
+        },
+        "x11proto-input-dev": {
+          "version": "2.2-1",
+          "arch": "all"
+        },
+        "x11proto-kb-dev": {
+          "version": "1.0.6-2",
+          "arch": "all"
+        },
+        "xml-core": {
+          "version": "0.13+nmu2",
+          "arch": "all"
+        },
+        "xorg-sgml-doctools": {
+          "version": "1:1.10-1",
+          "arch": "all"
+        },
+        "xtrans-dev": {
+          "version": "1.2.7-1",
+          "arch": "all"
+        },
+        "xz-utils": {
+          "version": "5.1.1alpha+20120614-2",
+          "arch": "amd64"
+        },
+        "zlib1g": {
+          "version": "1:1.2.7.dfsg-13",
+          "arch": "amd64"
+        },
+        "zlib1g-dev": {
+          "version": "1:1.2.7.dfsg-13",
+          "arch": "amd64"
+        }
+      },
+      "ec2": {
+        "ami_id": "ami-431a4273",
+        "ami_launch_index": "0",
+        "ami_manifest_path": "(unknown)",
+        "block_device_mapping_ami": "/dev/xvda",
+        "block_device_mapping_root": "/dev/xvda",
+        "hostname": "ip-242-58-187-217.us-west-2.compute.internal",
+        "instance_action": "none",
+        "instance_id": "i-090dc5353822119f7",
+        "instance_type": "t2.medium",
+        "local_hostname": "ip-242-58-187-217.us-west-2.compute.internal",
+        "local_ipv4": "242.58.187.217",
+        "mac": "02:07:f5:70:9f:f0",
+        "metrics_vhostmd": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "network_interfaces_macs": {
+          "02:07:f5:70:9f:f0": {
+            "device_number": "0",
+            "interface_id": "eni-6cd56b46",
+            "local_hostname": "ip-242-58-187-217.us-west-2.compute.internal",
+            "local_ipv4s": "242.58.187.217",
+            "mac": "02:07:f5:70:9f:f0",
+            "owner_id": "999999999999",
+            "security_group_ids": "sg-96274af3",
+            "security_groups": "default",
+            "subnet_id": "subnet-19ac017c",
+            "subnet_ipv4_cidr_block": "242.58.8.0/21",
+            "vpc_id": "vpc-2229ff47",
+            "vpc_ipv4_cidr_block": "242.58.0.0/16",
+            "vpc_ipv4_cidr_blocks": "242.58.0.0/16"
+          }
+        },
+        "placement_availability_zone": "us-west-2a",
+        "profile": "default-hvm",
+        "reservation_id": "r-020a5a0ce566ed4cd",
+        "security_groups": [
+          "default"
+        ],
+        "services_domain": "amazonaws.com",
+        "services_partition": "aws",
+        "userdata": "#!/bin/sh\n\n# Ensure CA bundle is up-to-date\nsudo apt-get update\nsudo apt-get install ca-certificates -y\nsudo apt-get install curl -y\n",
+        "account_id": "999999999999",
+        "availability_zone": "us-west-2a",
+        "region": "us-west-2"
+      },
+      "json?": "{\n  \"privateIp\" : \"242.58.187.217\",\n  \"devpayProductCodes\" : null,\n  \"availabilityZone\" : \"us-west-2a\",\n  \"version\" : \"2010-08-31\",\n  \"pendingTime\" : \"2017-06-05T23:19:43Z\",\n  \"instanceId\" : \"i-090dc5353822119f7\",\n  \"billingProducts\" : null,\n  \"instanceType\" : \"t2.medium\",\n  \"accountId\" : \"999999999999\",\n  \"architecture\" : \"x86_64\",\n  \"kernelId\" : null,\n  \"ramdiskId\" : null,\n  \"imageId\" : \"ami-431a4273\",\n  \"region\" : \"us-west-2\"\n}",
+      "cloud": {
+        "public_ips": [
+          null
+        ],
+        "private_ips": [
+          "242.58.187.217"
+        ],
+        "public_ipv4": null,
+        "public_hostname": null,
+        "local_ipv4": "242.58.187.217",
+        "local_hostname": "ip-242-58-187-217.us-west-2.compute.internal",
+        "provider": "ec2"
+      },
+      "init_package": "init",
+      "keys": {
+        "ssh": {
+          "host_rsa_public": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDbxICh2E8+qP5vK70GH+YLCIFJxKZBJtz0+6Gr2hsLa/DtZPf2OuaaOyN9cCkhrh/91S5OtedzfV+L7HRZ8oQFPfSSQlyzkiP5PJif0lHjFb6QwAnDqCuYAN9laO0XzI+TgZDB4ehW4Ba7mq8cGlvVvHbaBPUJZDbrhpLQf5paca72cqBKabv8F5DEEtuBVU252uMAqq3bA1BkplGdX9NwLjlWk7rjuge6nwx919+9MZpjf0LunIrS8yHjA1AmkAV2oiEFu6blngrDaQwFVV9cwmkxFRoFCn8c7Y0QBGjrunTT2puxfutbh7QigJRCd6fS7vlwINMT/oy/TTkNxJ/b",
+          "host_dsa_public": "AAAAB3NzaC1kc3MAAACBAKfVmlUMK3AK2HGwhfgdSWBo9LYVjkKPpkbFRIUeq4xPa/40fY/1bSifgmKKUD0+s8t7CHUGwljGf+bmlHwhIbbRV7YywXchTngIkHa++Yv6jbcdjvSFyxavHPbElg6SWm2+Lc1mGfHuKyGuVv0KEmWVwSrIRFNFLp+M5HNimlsbAAAAFQDVbFm/aqqIzD+LEkehMq6QU9mf3wAAAIB1+wqs4QZGIy4GUn/27J7FxmBj9NY6VA19GJ8eVg7GChoUJYxYtQwXdevUkCFXJJBoxOmRsJomQs71Zzcm29pVVbhA6b1Yndehc2DmNUmItc1CsVnDxO4GSeQA8PITi+RN6SFa/XVnaa+8gBS7S4aGLsUyEct0W8JqcsOfq44k+gAAAIAt+YMmxa0kMTiRyXXoYFWahmf4FZKSKRrIhcY2N6+YcNxjZ/s+GohXNsvUwtrSWln/NYhClN/9QI/sa0Ei9jRVJcKWiBuv/FS3VyueorGADYoY6HQIfSBKoGSRz92ztk6dtHH7nnL7qg14cRMvk/Jx83+4pgAj0C/bFKFbBYBF7A==",
+          "host_ecdsa_public": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJcd62DZjaGarxcnhw9BinVX07hS6sj0bmY2r8rIKDrSsfuNJgtyqlubPgda4nnG54zIkacJ4Lfnx2oss0B1c7E=",
+          "host_ecdsa_type": "ecdsa-sha2-nistp256"
+        }
+      },
+      "hostname": "ip-242-58-187-217",
+      "machinename": "ip-242-58-187-217",
+      "fqdn": "ip-242-58-187-217.us-west-2.compute.internal",
+      "domain": "us-west-2.compute.internal",
+      "root_group": "root",
+      "fips": {
+        "kernel": {
+          "enabled": false
+        }
+      },
+      "command": {
+        "ps": "ps -ef"
+      },
+      "ohai_time": 1509569930.4779391,
+      "cloud_v2": {
+        "local_ipv4_addrs": [
+          "242.58.187.217"
+        ],
+        "provider": "ec2",
+        "local_hostname": "ip-242-58-187-217.us-west-2.compute.internal",
+        "local_ipv4": "242.58.187.217"
+      },
+      "machine_id": "b692aca8710cf323a5c03ad85935e81e",
+      "block_device": {
+        "xvda": {
+          "size": "62914560",
+          "removable": "0",
+          "rotational": "0",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        }
+      },
+      "hostnamectl": {},
+      "shard_seed": 47797454,
+      "shells": [
+        "/bin/sh",
+        "/bin/dash",
+        "/bin/bash",
+        "/bin/rbash"
+      ],
+      "sysconf": {
+        "LINK_MAX": 32000,
+        "_POSIX_LINK_MAX": 32000,
+        "MAX_CANON": 255,
+        "_POSIX_MAX_CANON": 255,
+        "MAX_INPUT": 255,
+        "_POSIX_MAX_INPUT": 255,
+        "NAME_MAX": 255,
+        "_POSIX_NAME_MAX": 255,
+        "PATH_MAX": 4096,
+        "_POSIX_PATH_MAX": 4096,
+        "PIPE_BUF": 4096,
+        "_POSIX_PIPE_BUF": 4096,
+        "SOCK_MAXBUF": null,
+        "_POSIX_ASYNC_IO": null,
+        "_POSIX_CHOWN_RESTRICTED": 1,
+        "_POSIX_NO_TRUNC": 1,
+        "_POSIX_PRIO_IO": null,
+        "_POSIX_SYNC_IO": null,
+        "_POSIX_VDISABLE": 0,
+        "ARG_MAX": 2097152,
+        "ATEXIT_MAX": 2147483647,
+        "CHAR_BIT": 8,
+        "CHAR_MAX": 127,
+        "CHAR_MIN": -128,
+        "CHILD_MAX": 31631,
+        "CLK_TCK": 100,
+        "INT_MAX": 2147483647,
+        "INT_MIN": -2147483648,
+        "IOV_MAX": 1024,
+        "LOGNAME_MAX": 256,
+        "LONG_BIT": 64,
+        "MB_LEN_MAX": 16,
+        "NGROUPS_MAX": 65536,
+        "NL_ARGMAX": 4096,
+        "NL_LANGMAX": 2048,
+        "NL_MSGMAX": 2147483647,
+        "NL_NMAX": 2147483647,
+        "NL_SETMAX": 2147483647,
+        "NL_TEXTMAX": 2147483647,
+        "NSS_BUFLEN_GROUP": 1024,
+        "NSS_BUFLEN_PASSWD": 1024,
+        "NZERO": 20,
+        "OPEN_MAX": 1024,
+        "PAGESIZE": 4096,
+        "PAGE_SIZE": 4096,
+        "PASS_MAX": 8192,
+        "PTHREAD_DESTRUCTOR_ITERATIONS": 4,
+        "PTHREAD_KEYS_MAX": 1024,
+        "PTHREAD_STACK_MIN": 16384,
+        "PTHREAD_THREADS_MAX": null,
+        "SCHAR_MAX": 127,
+        "SCHAR_MIN": -128,
+        "SHRT_MAX": 32767,
+        "SHRT_MIN": -32768,
+        "SSIZE_MAX": 32767,
+        "TTY_NAME_MAX": 32,
+        "TZNAME_MAX": 6,
+        "UCHAR_MAX": 255,
+        "UINT_MAX": 4294967295,
+        "UIO_MAXIOV": 1024,
+        "ULONG_MAX": 18446744073709551615,
+        "USHRT_MAX": 65535,
+        "WORD_BIT": 32,
+        "_AVPHYS_PAGES": 301482,
+        "_NPROCESSORS_CONF": 2,
+        "_NPROCESSORS_ONLN": 2,
+        "_PHYS_PAGES": 949497,
+        "_POSIX_ARG_MAX": 2097152,
+        "_POSIX_ASYNCHRONOUS_IO": 200809,
+        "_POSIX_CHILD_MAX": 31631,
+        "_POSIX_FSYNC": 200809,
+        "_POSIX_JOB_CONTROL": 1,
+        "_POSIX_MAPPED_FILES": 200809,
+        "_POSIX_MEMLOCK": 200809,
+        "_POSIX_MEMLOCK_RANGE": 200809,
+        "_POSIX_MEMORY_PROTECTION": 200809,
+        "_POSIX_MESSAGE_PASSING": 200809,
+        "_POSIX_NGROUPS_MAX": 65536,
+        "_POSIX_OPEN_MAX": 1024,
+        "_POSIX_PII": null,
+        "_POSIX_PII_INTERNET": null,
+        "_POSIX_PII_INTERNET_DGRAM": null,
+        "_POSIX_PII_INTERNET_STREAM": null,
+        "_POSIX_PII_OSI": null,
+        "_POSIX_PII_OSI_CLTS": null,
+        "_POSIX_PII_OSI_COTS": null,
+        "_POSIX_PII_OSI_M": null,
+        "_POSIX_PII_SOCKET": null,
+        "_POSIX_PII_XTI": null,
+        "_POSIX_POLL": null,
+        "_POSIX_PRIORITIZED_IO": 200809,
+        "_POSIX_PRIORITY_SCHEDULING": 200809,
+        "_POSIX_REALTIME_SIGNALS": 200809,
+        "_POSIX_SAVED_IDS": 1,
+        "_POSIX_SELECT": null,
+        "_POSIX_SEMAPHORES": 200809,
+        "_POSIX_SHARED_MEMORY_OBJECTS": 200809,
+        "_POSIX_SSIZE_MAX": 32767,
+        "_POSIX_STREAM_MAX": 16,
+        "_POSIX_SYNCHRONIZED_IO": 200809,
+        "_POSIX_THREADS": 200809,
+        "_POSIX_THREAD_ATTR_STACKADDR": 200809,
+        "_POSIX_THREAD_ATTR_STACKSIZE": 200809,
+        "_POSIX_THREAD_PRIORITY_SCHEDULING": 200809,
+        "_POSIX_THREAD_PRIO_INHERIT": 200809,
+        "_POSIX_THREAD_PRIO_PROTECT": 200809,
+        "_POSIX_THREAD_ROBUST_PRIO_INHERIT": null,
+        "_POSIX_THREAD_ROBUST_PRIO_PROTECT": null,
+        "_POSIX_THREAD_PROCESS_SHARED": 200809,
+        "_POSIX_THREAD_SAFE_FUNCTIONS": 200809,
+        "_POSIX_TIMERS": 200809,
+        "TIMER_MAX": null,
+        "_POSIX_TZNAME_MAX": 6,
+        "_POSIX_VERSION": 200809,
+        "_T_IOV_MAX": null,
+        "_XOPEN_CRYPT": 1,
+        "_XOPEN_ENH_I18N": 1,
+        "_XOPEN_LEGACY": 1,
+        "_XOPEN_REALTIME": 1,
+        "_XOPEN_REALTIME_THREADS": 1,
+        "_XOPEN_SHM": 1,
+        "_XOPEN_UNIX": 1,
+        "_XOPEN_VERSION": 700,
+        "_XOPEN_XCU_VERSION": 4,
+        "_XOPEN_XPG2": 1,
+        "_XOPEN_XPG3": 1,
+        "_XOPEN_XPG4": 1,
+        "BC_BASE_MAX": 99,
+        "BC_DIM_MAX": 2048,
+        "BC_SCALE_MAX": 99,
+        "BC_STRING_MAX": 1000,
+        "CHARCLASS_NAME_MAX": 2048,
+        "COLL_WEIGHTS_MAX": 255,
+        "EQUIV_CLASS_MAX": null,
+        "EXPR_NEST_MAX": 32,
+        "LINE_MAX": 2048,
+        "POSIX2_BC_BASE_MAX": 99,
+        "POSIX2_BC_DIM_MAX": 2048,
+        "POSIX2_BC_SCALE_MAX": 99,
+        "POSIX2_BC_STRING_MAX": 1000,
+        "POSIX2_CHAR_TERM": 200809,
+        "POSIX2_COLL_WEIGHTS_MAX": 255,
+        "POSIX2_C_BIND": 200809,
+        "POSIX2_C_DEV": 200809,
+        "POSIX2_C_VERSION": null,
+        "POSIX2_EXPR_NEST_MAX": 32,
+        "POSIX2_FORT_DEV": null,
+        "POSIX2_FORT_RUN": null,
+        "_POSIX2_LINE_MAX": 2048,
+        "POSIX2_LINE_MAX": 2048,
+        "POSIX2_LOCALEDEF": 200809,
+        "POSIX2_RE_DUP_MAX": 32767,
+        "POSIX2_SW_DEV": 200809,
+        "POSIX2_UPE": null,
+        "POSIX2_VERSION": 200809,
+        "RE_DUP_MAX": 32767,
+        "PATH": "/bin:/usr/bin",
+        "CS_PATH": "/bin:/usr/bin",
+        "LFS_CFLAGS": null,
+        "LFS_LDFLAGS": null,
+        "LFS_LIBS": null,
+        "LFS_LINTFLAGS": null,
+        "LFS64_CFLAGS": "-D_LARGEFILE64_SOURCE",
+        "LFS64_LDFLAGS": null,
+        "LFS64_LIBS": null,
+        "LFS64_LINTFLAGS": "-D_LARGEFILE64_SOURCE",
+        "_XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+        "XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+        "_XBS5_ILP32_OFF32": null,
+        "XBS5_ILP32_OFF32_CFLAGS": null,
+        "XBS5_ILP32_OFF32_LDFLAGS": null,
+        "XBS5_ILP32_OFF32_LIBS": null,
+        "XBS5_ILP32_OFF32_LINTFLAGS": null,
+        "_XBS5_ILP32_OFFBIG": null,
+        "XBS5_ILP32_OFFBIG_CFLAGS": null,
+        "XBS5_ILP32_OFFBIG_LDFLAGS": null,
+        "XBS5_ILP32_OFFBIG_LIBS": null,
+        "XBS5_ILP32_OFFBIG_LINTFLAGS": null,
+        "_XBS5_LP64_OFF64": 1,
+        "XBS5_LP64_OFF64_CFLAGS": "-m64",
+        "XBS5_LP64_OFF64_LDFLAGS": "-m64",
+        "XBS5_LP64_OFF64_LIBS": null,
+        "XBS5_LP64_OFF64_LINTFLAGS": null,
+        "_XBS5_LPBIG_OFFBIG": null,
+        "XBS5_LPBIG_OFFBIG_CFLAGS": null,
+        "XBS5_LPBIG_OFFBIG_LDFLAGS": null,
+        "XBS5_LPBIG_OFFBIG_LIBS": null,
+        "XBS5_LPBIG_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V6_ILP32_OFF32": null,
+        "POSIX_V6_ILP32_OFF32_CFLAGS": null,
+        "POSIX_V6_ILP32_OFF32_LDFLAGS": null,
+        "POSIX_V6_ILP32_OFF32_LIBS": null,
+        "POSIX_V6_ILP32_OFF32_LINTFLAGS": null,
+        "_POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+        "POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+        "_POSIX_V6_ILP32_OFFBIG": null,
+        "POSIX_V6_ILP32_OFFBIG_CFLAGS": null,
+        "POSIX_V6_ILP32_OFFBIG_LDFLAGS": null,
+        "POSIX_V6_ILP32_OFFBIG_LIBS": null,
+        "POSIX_V6_ILP32_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V6_LP64_OFF64": 1,
+        "POSIX_V6_LP64_OFF64_CFLAGS": "-m64",
+        "POSIX_V6_LP64_OFF64_LDFLAGS": "-m64",
+        "POSIX_V6_LP64_OFF64_LIBS": null,
+        "POSIX_V6_LP64_OFF64_LINTFLAGS": null,
+        "_POSIX_V6_LPBIG_OFFBIG": null,
+        "POSIX_V6_LPBIG_OFFBIG_CFLAGS": null,
+        "POSIX_V6_LPBIG_OFFBIG_LDFLAGS": null,
+        "POSIX_V6_LPBIG_OFFBIG_LIBS": null,
+        "POSIX_V6_LPBIG_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V7_ILP32_OFF32": null,
+        "POSIX_V7_ILP32_OFF32_CFLAGS": null,
+        "POSIX_V7_ILP32_OFF32_LDFLAGS": null,
+        "POSIX_V7_ILP32_OFF32_LIBS": null,
+        "POSIX_V7_ILP32_OFF32_LINTFLAGS": null,
+        "_POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+        "POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+        "_POSIX_V7_ILP32_OFFBIG": null,
+        "POSIX_V7_ILP32_OFFBIG_CFLAGS": null,
+        "POSIX_V7_ILP32_OFFBIG_LDFLAGS": null,
+        "POSIX_V7_ILP32_OFFBIG_LIBS": null,
+        "POSIX_V7_ILP32_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V7_LP64_OFF64": 1,
+        "POSIX_V7_LP64_OFF64_CFLAGS": "-m64",
+        "POSIX_V7_LP64_OFF64_LDFLAGS": "-m64",
+        "POSIX_V7_LP64_OFF64_LIBS": null,
+        "POSIX_V7_LP64_OFF64_LINTFLAGS": null,
+        "_POSIX_V7_LPBIG_OFFBIG": null,
+        "POSIX_V7_LPBIG_OFFBIG_CFLAGS": null,
+        "POSIX_V7_LPBIG_OFFBIG_LDFLAGS": null,
+        "POSIX_V7_LPBIG_OFFBIG_LIBS": null,
+        "POSIX_V7_LPBIG_OFFBIG_LINTFLAGS": null,
+        "_POSIX_ADVISORY_INFO": 200809,
+        "_POSIX_BARRIERS": 200809,
+        "_POSIX_BASE": null,
+        "_POSIX_C_LANG_SUPPORT": null,
+        "_POSIX_C_LANG_SUPPORT_R": null,
+        "_POSIX_CLOCK_SELECTION": 200809,
+        "_POSIX_CPUTIME": 200809,
+        "_POSIX_THREAD_CPUTIME": 200809,
+        "_POSIX_DEVICE_SPECIFIC": null,
+        "_POSIX_DEVICE_SPECIFIC_R": null,
+        "_POSIX_FD_MGMT": null,
+        "_POSIX_FIFO": null,
+        "_POSIX_PIPE": null,
+        "_POSIX_FILE_ATTRIBUTES": null,
+        "_POSIX_FILE_LOCKING": null,
+        "_POSIX_FILE_SYSTEM": null,
+        "_POSIX_MONOTONIC_CLOCK": 200809,
+        "_POSIX_MULTI_PROCESS": null,
+        "_POSIX_SINGLE_PROCESS": null,
+        "_POSIX_NETWORKING": null,
+        "_POSIX_READER_WRITER_LOCKS": 200809,
+        "_POSIX_SPIN_LOCKS": 200809,
+        "_POSIX_REGEXP": 1,
+        "_REGEX_VERSION": null,
+        "_POSIX_SHELL": 1,
+        "_POSIX_SIGNALS": null,
+        "_POSIX_SPAWN": 200809,
+        "_POSIX_SPORADIC_SERVER": null,
+        "_POSIX_THREAD_SPORADIC_SERVER": null,
+        "_POSIX_SYSTEM_DATABASE": null,
+        "_POSIX_SYSTEM_DATABASE_R": null,
+        "_POSIX_TIMEOUTS": 200809,
+        "_POSIX_TYPED_MEMORY_OBJECTS": null,
+        "_POSIX_USER_GROUPS": null,
+        "_POSIX_USER_GROUPS_R": null,
+        "POSIX2_PBS": null,
+        "POSIX2_PBS_ACCOUNTING": null,
+        "POSIX2_PBS_LOCATE": null,
+        "POSIX2_PBS_TRACK": null,
+        "POSIX2_PBS_MESSAGE": null,
+        "SYMLOOP_MAX": null,
+        "STREAM_MAX": 16,
+        "AIO_LISTIO_MAX": null,
+        "AIO_MAX": null,
+        "AIO_PRIO_DELTA_MAX": 20,
+        "DELAYTIMER_MAX": 2147483647,
+        "HOST_NAME_MAX": 64,
+        "LOGIN_NAME_MAX": 256,
+        "MQ_OPEN_MAX": null,
+        "MQ_PRIO_MAX": 32768,
+        "_POSIX_DEVICE_IO": null,
+        "_POSIX_TRACE": null,
+        "_POSIX_TRACE_EVENT_FILTER": null,
+        "_POSIX_TRACE_INHERIT": null,
+        "_POSIX_TRACE_LOG": null,
+        "RTSIG_MAX": 32,
+        "SEM_NSEMS_MAX": null,
+        "SEM_VALUE_MAX": 2147483647,
+        "SIGQUEUE_MAX": 31631,
+        "FILESIZEBITS": 64,
+        "POSIX_ALLOC_SIZE_MIN": 4096,
+        "POSIX_REC_INCR_XFER_SIZE": null,
+        "POSIX_REC_MAX_XFER_SIZE": null,
+        "POSIX_REC_MIN_XFER_SIZE": 4096,
+        "POSIX_REC_XFER_ALIGN": 4096,
+        "SYMLINK_MAX": null,
+        "GNU_LIBC_VERSION": "glibc 2.13",
+        "GNU_LIBPTHREAD_VERSION": "NPTL 2.13",
+        "POSIX2_SYMLINKS": 1,
+        "LEVEL1_ICACHE_SIZE": 32768,
+        "LEVEL1_ICACHE_ASSOC": 8,
+        "LEVEL1_ICACHE_LINESIZE": 64,
+        "LEVEL1_DCACHE_SIZE": 32768,
+        "LEVEL1_DCACHE_ASSOC": 8,
+        "LEVEL1_DCACHE_LINESIZE": 64,
+        "LEVEL2_CACHE_SIZE": 262144,
+        "LEVEL2_CACHE_ASSOC": 8,
+        "LEVEL2_CACHE_LINESIZE": 64,
+        "LEVEL3_CACHE_SIZE": 31457280,
+        "LEVEL3_CACHE_ASSOC": 20,
+        "LEVEL3_CACHE_LINESIZE": 64,
+        "LEVEL4_CACHE_SIZE": 0,
+        "LEVEL4_CACHE_ASSOC": 0,
+        "LEVEL4_CACHE_LINESIZE": 0,
+        "IPV6": 200809,
+        "RAW_SOCKETS": 200809
+      },
+      "chef_packages": {
+        "chef": {
+          "version": "12.21.3",
+          "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib"
+        },
+        "ohai": {
+          "version": "8.24.0",
+          "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.3.0/gems/ohai-8.24.0/lib/ohai"
+        }
+      },
+      "recipes": [
+        "opscode-ci::slave",
+        "opscode-ci::_build_support",
+        "chef-sugar::default",
+        "opscode-ci::_platform_tweaks",
+        "opscode-ci::_migration",
+        "omnibus::default",
+        "omnibus::_common",
+        "omnibus::_user",
+        "omnibus::_omnibus_toolchain",
+        "omnibus::_compile",
+        "build-essential::default",
+        "omnibus::_git",
+        "omnibus::_github",
+        "omnibus::_libffi",
+        "omnibus::_packaging",
+        "omnibus::_selinux",
+        "omnibus::_environment",
+        "opscode-ci::_github",
+        "opscode-ci::_ntp",
+        "ntp::default",
+        "opscode-ci::_package_signing",
+        "opscode-ci::_rubygems",
+        "opscode-ci::_aws",
+        "opscode-ci::_users",
+        "opscode-ci::_sudo",
+        "sudo::default",
+        "opscode-ci::_java",
+        "aws::default",
+        "opscode-ci::_omnibus"
+      ],
+      "expanded_run_list": [
+        "opscode-ci::slave"
+      ],
+      "roles": [
+        "test",
+        "test1"
+      ],
+      "cookbooks": {
+        "opscode-ci": {
+          "version": "5.15.127"
+        },
+        "apt": {
+          "version": "6.1.4"
+        },
+        "chef-sugar": {
+          "version": "3.4.0"
+        },
+        "freebsd": {
+          "version": "1.0.2"
+        },
+        "lvm": {
+          "version": "4.1.9"
+        },
+        "omnibus": {
+          "version": "5.2.2"
+        },
+        "build-essential": {
+          "version": "8.0.3"
+        },
+        "seven_zip": {
+          "version": "2.0.2"
+        },
+        "windows": {
+          "version": "2.0.2"
+        },
+        "mingw": {
+          "version": "2.0.1"
+        },
+        "chef-ingredient": {
+          "version": "2.1.10"
+        },
+        "git": {
+          "version": "6.1.0"
+        },
+        "dmg": {
+          "version": "4.0.0"
+        },
+        "yum-epel": {
+          "version": "2.1.2"
+        },
+        "compat_resource": {
+          "version": "12.19.0"
+        },
+        "homebrew": {
+          "version": "4.2.0"
+        },
+        "remote_install": {
+          "version": "1.0.2"
+        },
+        "wix": {
+          "version": "3.0.0"
+        },
+        "windows-sdk": {
+          "version": "1.0.2"
+        },
+        "ntp": {
+          "version": "3.5.2"
+        },
+        "route53": {
+          "version": "2.0.0"
+        },
+        "rsyslog": {
+          "version": "5.1.0"
+        },
+        "sudo": {
+          "version": "3.5.3"
+        },
+        "redhat_subscription_manager": {
+          "version": "0.6.0"
+        },
+        "aws": {
+          "version": "3.3.3"
+        },
+        "ohai": {
+          "version": "3.0.1"
+        },
+        "jenkins": {
+          "version": "2.6.0"
+        },
+        "runit": {
+          "version": "1.8.0"
+        },
+        "packagecloud": {
+          "version": "0.3.0"
+        },
+        "yum": {
+          "version": "3.13.0"
+        },
+        "chef_nginx": {
+          "version": "2.9.0"
+        },
+        "bluepill": {
+          "version": "3.0.0"
+        },
+        "zypper": {
+          "version": "0.4.0"
+        },
+        "rubygems": {
+          "version": "1.0.2"
+        }
+      }
+    },
+    "normal": {
+      "tags": [
+        "chefdk",
+        "slave",
+        "tester"
+      ],
+      "omnibus": {
+        "build_user": "jenkins",
+        "build_user_password": "$1$4PauyzMX$ew5qtMVnZG8SBGdwjxt/X1",
+        "build_user_group": "jenkins",
+        "build_user_home": "/home/jenkins",
+        "ruby_version": "2.1.8"
+      },
+      "authorization": {
+        "sudo": {
+          "sudoers_defaults": [
+            "exempt_group += jenkins",
+            "secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\""
+          ],
+          "agent_forwarding": true,
+          "include_sudoers_d": true
+        }
+      },
+      "jenkins": {
+        "master": {
+          "endpoint": "http://example.com"
+        }
+      }
+    },
+    "chef_type": "node",
+    "default": {
+      "apt": {
+        "cacher_dir": "/var/cache/apt-cacher-ng",
+        "cacher_interface": null,
+        "cacher_port": 3142,
+        "compiletime": false,
+        "compile_time_update": false,
+        "key_proxy": "",
+        "periodic_update_min_delay": 86400,
+        "launchpad_api_version": "1.0",
+        "unattended_upgrades": {
+          "enable": false,
+          "update_package_lists": true,
+          "allowed_origins": [
+            "Debian wheezy"
+          ],
+          "origins_patterns": [],
+          "package_blacklist": [],
+          "auto_fix_interrupted_dpkg": false,
+          "minimal_steps": false,
+          "install_on_shutdown": false,
+          "mail": null,
+          "mail_only_on_error": true,
+          "remove_unused_dependencies": false,
+          "automatic_reboot": false,
+          "automatic_reboot_time": "now",
+          "dl_limit": null,
+          "random_sleep": null
+        },
+        "cacher_client": {
+          "cacher_server": {}
+        },
+        "confd": {
+          "force_confask": false,
+          "force_confdef": false,
+          "force_confmiss": false,
+          "force_confnew": false,
+          "force_confold": false,
+          "install_recommends": true,
+          "install_suggests": false
+        }
+      },
+      "ohai": {
+        "plugin_path": "/etc/chef/ohai_plugins",
+        "plugins": {
+          "ohai": "plugins"
+        },
+        "hints_path": "/etc/chef/ohai/hints"
+      },
+      "aws": {
+        "aws_sdk_version": "~> 2.2",
+        "databag_name": null,
+        "databag_entry": null,
+        "mfa_code": null
+      },
+      "chef-ingredient": {
+        "mixlib-install": {
+          "git_ref": null
+        }
+      },
+      "rsyslog": {
+        "local_host_name": null,
+        "default_log_dir": "/var/log",
+        "log_dir": "/srv/rsyslog",
+        "working_dir": "/var/spool/rsyslog",
+        "server": false,
+        "use_relp": false,
+        "relp_port": 20514,
+        "protocol": "tcp",
+        "bind": "*",
+        "port": 514,
+        "server_ip": null,
+        "server_search": "role:loghost",
+        "remote_logs": true,
+        "per_host_dir": "%$YEAR%/%$MONTH%/%$DAY%/%HOSTNAME%",
+        "max_message_size": "2k",
+        "preserve_fqdn": "off",
+        "high_precision_timestamps": false,
+        "repeated_msg_reduction": "on",
+        "logs_to_forward": "*.*",
+        "enable_imklog": true,
+        "config_prefix": "/etc",
+        "default_file_template": null,
+        "default_remote_template": null,
+        "rate_limit_interval": null,
+        "rate_limit_burst": null,
+        "enable_tls": false,
+        "action_queue_max_disk_space": "1G",
+        "tls_ca_file": null,
+        "tls_certificate_file": null,
+        "tls_key_file": null,
+        "tls_auth_mode": "anon",
+        "tls_permitted_peer": null,
+        "use_local_ipv4": false,
+        "allow_non_local": false,
+        "custom_remote": [],
+        "additional_directives": {},
+        "templates": [],
+        "service_name": "rsyslog",
+        "user": "root",
+        "group": "adm",
+        "priv_seperation": false,
+        "priv_user": null,
+        "priv_group": null,
+        "modules": [
+          "imuxsock",
+          "imklog"
+        ],
+        "file_create_mode": "0640",
+        "dir_create_mode": "0755",
+        "umask": "0022",
+        "dir_owner": "root",
+        "dir_group": "adm",
+        "default_facility_logs": {
+          "auth,authpriv.*": "/var/log/auth.log",
+          "*.*;auth,authpriv.none": "-/var/log/syslog",
+          "daemon.*": "-/var/log/daemon.log",
+          "kern.*": "-/var/log/kern.log",
+          "mail.*": "-/var/log/mail.log",
+          "user.*": "-/var/log/user.log",
+          "mail.info": "-/var/log/mail.info",
+          "mail.warn": "-/var/log/mail.warn",
+          "mail.err": "/var/log/mail.err",
+          "news.crit": "/var/log/news/news.crit",
+          "news.err": "/var/log/news/news.err",
+          "news.notice": "-/var/log/news/news.notice",
+          "*.=debug;auth,authpriv.none;news.none;mail.none": "-/var/log/debug",
+          "*.=info;*.=notice;*.=warn;auth,authpriv.none;cron,daemon.none;mail,news.none": "-/var/log/messages",
+          "*.emerg": ":omusrmsg:*"
+        }
+      },
+      "bluepill": {
+        "bin": "/opt/chef/embedded/bin/bluepill",
+        "logfile": "/var/log/bluepill.log",
+        "pid_dir": "/var/run/bluepill",
+        "state_dir": "/var/lib/bluepill",
+        "group": 0,
+        "use_rsyslog": false,
+        "init_dir": "/etc/init.d",
+        "conf_dir": "/etc/bluepill",
+        "defaults_dir": "/etc/default"
+      },
+      "windows": {
+        "rubyzipversion": null
+      },
+      "seven_zip": {
+        "url": "http://www.7-zip.org/a/7z1514-x64.msi",
+        "checksum": "cefe1a9092d8a6be68468c33910d6206b40e934fb63cab686c5cccf369fbf712",
+        "package_name": "7-Zip 15.14 (x64 edition)",
+        "default_extract_timeout": 600
+      },
+      "build-essential": {
+        "compile_time": false,
+        "msys2": {
+          "path": "\\msys2"
+        }
+      },
+      "packagecloud": {
+        "base_repo_path": "/install/repositories/",
+        "gpg_key_path": "/gpgkey",
+        "hostname_override": null,
+        "proxy_host": null,
+        "proxy_port": null,
+        "default_type": "deb"
+      },
+      "yum-epel": {
+        "repos": [
+          "epel",
+          "epel-debuginfo",
+          "epel-source",
+          "epel-testing",
+          "epel-testing-debuginfo",
+          "epel-testing-source"
+        ]
+      },
+      "yum": {
+        "epel-debuginfo": {
+          "repositoryid": "epel-debuginfo",
+          "description": "Extra Packages for 7 - $basearch - Debug",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-7&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-source": {
+          "repositoryid": "epel-source",
+          "description": "Extra Packages for 7 - $basearch - Source",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-7&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-testing-debuginfo": {
+          "repositoryid": "epel-testing-debuginfo",
+          "description": "Extra Packages for 7 - $basearch - Testing Debug",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel7&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-testing-source": {
+          "repositoryid": "epel-testing-source",
+          "description": "Extra Packages for 7 - $basearch - Testing Source",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel7&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-testing": {
+          "repositoryid": "epel-testing",
+          "description": "Extra Packages for 7 - $basearch - Testing ",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel7&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel": {
+          "repositoryid": "epel",
+          "description": "Extra Packages for 7 - $basearch",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": true,
+          "managed": true,
+          "make_cache": true
+        },
+        "main": {
+          "cachedir": "/var/cache/yum/$basearch/$releasever",
+          "distroverpkg": "debian-release",
+          "releasever": null,
+          "alwaysprompt": null,
+          "assumeyes": null,
+          "bandwidth": null,
+          "bugtracker_url": null,
+          "clean_requirements_on_remove": null,
+          "color": null,
+          "color_list_available_downgrade": null,
+          "color_list_available_install": null,
+          "color_list_available_reinstall": null,
+          "color_list_available_upgrade": null,
+          "color_list_installed_extra": null,
+          "color_list_installed_newer": null,
+          "color_list_installed_older": null,
+          "color_list_installed_reinstall": null,
+          "color_search_match": null,
+          "color_update_installed": null,
+          "color_update_local": null,
+          "color_update_remote": null,
+          "commands": null,
+          "deltarpm": null,
+          "debuglevel": null,
+          "diskspacecheck": null,
+          "enable_group_conditionals": null,
+          "errorlevel": null,
+          "exactarch": null,
+          "exclude": null,
+          "gpgcheck": true,
+          "group_package_types": null,
+          "groupremove_leaf_only": null,
+          "history_list_view": null,
+          "history_record": null,
+          "history_record_packages": null,
+          "http_caching": null,
+          "installonly_limit": null,
+          "installonlypkgs": null,
+          "installroot": null,
+          "keepalive": null,
+          "keepcache": false,
+          "kernelpkgnames": null,
+          "localpkg_gpgcheck": false,
+          "logfile": "/var/log/yum.log",
+          "max_retries": null,
+          "mdpolicy": null,
+          "metadata_expire": null,
+          "mirrorlist_expire": null,
+          "multilib_policy": null,
+          "obsoletes": null,
+          "overwrite_groups": null,
+          "password": null,
+          "path": "/etc/yum.conf",
+          "persistdir": null,
+          "pluginconfpath": null,
+          "pluginpath": null,
+          "plugins": null,
+          "protected_multilib": null,
+          "protected_packages": null,
+          "proxy": null,
+          "proxy_password": null,
+          "proxy_username": null,
+          "recent": null,
+          "repo_gpgcheck": null,
+          "reposdir": null,
+          "reset_nice": null,
+          "rpmverbosity": null,
+          "showdupesfromrepos": null,
+          "skip_broken": null,
+          "ssl_check_cert_permissions": null,
+          "sslcacert": null,
+          "sslclientcert": null,
+          "sslclientkey": null,
+          "sslverify": null,
+          "syslog_device": null,
+          "syslog_facility": null,
+          "syslog_ident": null,
+          "throttle": null,
+          "timeout": null,
+          "tolerant": false,
+          "tsflags": null,
+          "username": null
+        }
+      },
+      "runit": {
+        "sv_bin": "/usr/bin/sv",
+        "chpst_bin": "/usr/bin/chpst",
+        "service_dir": "/etc/service",
+        "sv_dir": "/etc/sv",
+        "lsb_init_dir": "/etc/init.d",
+        "executable": "/sbin/runit",
+        "start": "runsvdir-start",
+        "stop": "",
+        "reload": ""
+      },
+      "zypper": {
+        "smt_host": null
+      },
+      "nginx": {
+        "version": "1.10.1",
+        "package_name": "nginx",
+        "port": "80",
+        "dir": "/etc/nginx",
+        "script_dir": "/usr/sbin",
+        "log_dir": "/var/log/nginx",
+        "log_dir_perm": "0750",
+        "binary": "/usr/sbin/nginx",
+        "default_root": "/var/www/nginx-default",
+        "ulimit": "1024",
+        "pid": "/var/run/nginx.pid",
+        "user": "www-data",
+        "init_style": "runit",
+        "upstart": {
+          "runlevels": "2345",
+          "respawn_limit": null,
+          "foreground": true
+        },
+        "group": "www-data",
+        "gzip": "on",
+        "gzip_static": "off",
+        "gzip_http_version": "1.0",
+        "gzip_comp_level": "2",
+        "gzip_proxied": "any",
+        "gzip_vary": "off",
+        "gzip_buffers": null,
+        "gzip_types": [
+          "text/plain",
+          "text/css",
+          "application/x-javascript",
+          "text/xml",
+          "application/xml",
+          "application/rss+xml",
+          "application/atom+xml",
+          "text/javascript",
+          "application/javascript",
+          "application/json",
+          "text/mathml"
+        ],
+        "gzip_min_length": 1000,
+        "gzip_disable": "MSIE [1-6]\\.",
+        "keepalive": "on",
+        "keepalive_requests": 100,
+        "keepalive_timeout": 65,
+        "worker_processes": 2,
+        "worker_connections": 1024,
+        "worker_rlimit_nofile": null,
+        "multi_accept": false,
+        "event": null,
+        "accept_mutex_delay": null,
+        "server_tokens": null,
+        "server_names_hash_bucket_size": 64,
+        "variables_hash_max_size": 1024,
+        "variables_hash_bucket_size": 64,
+        "sendfile": "on",
+        "underscores_in_headers": null,
+        "tcp_nodelay": "on",
+        "tcp_nopush": "on",
+        "access_log_options": null,
+        "error_log_options": null,
+        "disable_access_log": false,
+        "log_formats": {},
+        "install_method": "package",
+        "default_site_enabled": true,
+        "types_hash_max_size": 2048,
+        "types_hash_bucket_size": 64,
+        "proxy_read_timeout": null,
+        "client_body_buffer_size": null,
+        "client_max_body_size": null,
+        "large_client_header_buffers": null,
+        "default": {
+          "modules": []
+        },
+        "extra_configs": {},
+        "auth_request": {
+          "url": "http://mdounin.ru/hg/ngx_http_auth_request_module/archive/662785733552.tar.gz",
+          "checksum": "2057bdefd2137a5000d9dbdbfca049d1ba7832ad2b9f8855a88ea5dfa70bd8c1"
+        },
+        "devel": {
+          "version": "0.3.0",
+          "url": "https://github.com/simpl/ngx_devel_kit/archive/v0.3.0.tar.gz",
+          "checksum": "88e05a99a8a7419066f5ae75966fb1efc409bad4522d14986da074554ae61619"
+        },
+        "echo": {
+          "version": "0.59",
+          "url": "https://github.com/openresty/echo-nginx-module/archive/v0.59.tar.gz",
+          "checksum": "9b319ad7836202883128d2b9c24ed818082541df57ef7f2065b7557085c603cd"
+        },
+        "geoip": {
+          "path": "/srv/geoip",
+          "enable_city": true,
+          "country_dat_url": "http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz",
+          "country_dat_checksum": null,
+          "city_dat_url": "http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz",
+          "city_dat_checksum": null,
+          "lib_version": "1.6.9",
+          "lib_url": "https://github.com/maxmind/geoip-api-c/releases/download/v1.6.9/GeoIP-1.6.9.tar.gz",
+          "lib_checksum": "4b446491843de67c1af9b887da17a3e5939e0aeed4826923a5f4bf09d845096f"
+        },
+        "headers_more": {
+          "version": "0.30",
+          "source_url": "https://github.com/openresty/headers-more-nginx-module/archive/v0.30.tar.gz",
+          "source_checksum": "2aad309a9313c21c7c06ee4e71a39c99d4d829e31c8b3e7d76f8c964ea8047f5"
+        },
+        "lua": {
+          "version": "0.10.3",
+          "url": "https://github.com/chaoslawful/lua-nginx-module/archive/v0.10.3.tar.gz",
+          "checksum": "a69504c25de67bce968242d331d2e433c021405a6dba7bca0306e6e0b040bb50"
+        },
+        "luajit": {
+          "version": "2.0.4",
+          "url": "http://luajit.org/download/LuaJIT-2.0.4.tar.gz",
+          "checksum": "620fa4eb12375021bef6e4f237cbd2dd5d49e56beb414bee052c746beef1807d"
+        },
+        "naxsi": {
+          "version": "0.54",
+          "url": "https://github.com/nbs-system/naxsi/archive/0.54.tar.gz",
+          "checksum": "9cc2c09405bc71f78ef26a8b6d70afcea3fccbe8125df70cb0cfc480133daba5"
+        },
+        "openssl_source": {
+          "version": "1.0.1t",
+          "url": "http://www.openssl.org/source/openssl-1.0.1t.tar.gz"
+        },
+        "pagespeed": {
+          "version": "1.11.33.2",
+          "url": "https://github.com/pagespeed/ngx_pagespeed/archive/release-1.11.33.2-beta.tar.gz",
+          "packages": {
+            "rhel": [
+              "pcre-dev",
+              "pcre-devel",
+              "zlib-devel"
+            ],
+            "debian": [
+              "zlib1g-dev",
+              "libpcre3",
+              "libpcre3-dev"
+            ]
+          }
+        },
+        "psol": {
+          "url": "https://dl.google.com/dl/page-speed/psol/1.11.33.2.tar.gz"
+        },
+        "passenger": {
+          "version": "4.0.57",
+          "root": "/opt/chef/embedded/lib/ruby/gems/2.3.0/gems/passenger-4.0.57",
+          "ruby": "/opt/chef/embedded/bin/ruby",
+          "packages": {
+            "rhel": [
+              "ruby-devel",
+              "curl-devel"
+            ],
+            "fedora": [
+              "ruby-devel",
+              "libcurl-devel"
+            ],
+            "debian": [
+              "ruby-dev",
+              "libcurl4-gnutls-dev"
+            ]
+          },
+          "install_rake": true,
+          "spawn_method": "smart-lv2",
+          "buffer_response": "on",
+          "max_pool_size": 6,
+          "min_instances": 1,
+          "max_instances_per_app": 0,
+          "pool_idle_time": 300,
+          "max_requests": 0,
+          "gem_binary": null,
+          "nodejs": null
+        },
+        "enable_rate_limiting": false,
+        "rate_limiting_zone_name": "default",
+        "rate_limiting_backoff": "10m",
+        "rate_limit": "1r/s",
+        "upstream_repository": "http://nginx.org/packages/debian",
+        "set_misc": {
+          "version": "0.30",
+          "url": "https://github.com/agentzh/set-misc-nginx-module/archive/v0.30.tar.gz",
+          "checksum": "59920dd3f92c2be32627121605751b52eae32b5884be09f2e4c53fb2fae8aabc"
+        },
+        "socketproxy": {
+          "root": "/usr/share/nginx/apps",
+          "app_owner": "root",
+          "logname": "socketproxy",
+          "log_level": "error"
+        },
+        "source": {
+          "version": "1.10.1",
+          "prefix": "/opt/nginx-1.10.1",
+          "conf_path": "/etc/nginx/nginx.conf",
+          "sbin_path": "/opt/nginx-1.10.1/sbin/nginx",
+          "default_configure_flags": [
+            "--prefix=/opt/nginx-1.10.1",
+            "--conf-path=/etc/nginx/nginx.conf",
+            "--sbin-path=/opt/nginx-1.10.1/sbin/nginx"
+          ],
+          "url": "http://nginx.org/download/nginx-1.10.1.tar.gz",
+          "checksum": "1fd35846566485e03c0e318989561c135c598323ff349c503a6c14826487a801",
+          "modules": [
+            "chef_nginx::http_ssl_module",
+            "chef_nginx::http_gzip_static_module"
+          ],
+          "use_existing_user": false
+        },
+        "configure_flags": [],
+        "status": {
+          "port": "8090"
+        },
+        "syslog": {
+          "git_repo": "https://github.com/yaoweibin/nginx_syslog_patch.git",
+          "git_revision": "master"
+        },
+        "upload_progress": {
+          "url": "https://github.com/masterzen/nginx-upload-progress-module/tarball/v0.9.0",
+          "checksum": "3fb903dab595cf6656fa0fc5743a48daffbba2f6b5c554836be630800eaad4e2",
+          "javascript_output": true,
+          "zone_name": "proxied",
+          "zone_size": "1m"
+        }
+      },
+      "freebsd": {
+        "compiletime_portsnap": false
+      },
+      "jenkins": {
+        "java": "java",
+        "executor": {
+          "timeout": 60,
+          "private_key": null,
+          "proxy": null,
+          "jvm_options": null
+        },
+        "master": {
+          "install_method": "package",
+          "version": null,
+          "mirror": "http://mirrors.jenkins-ci.org",
+          "source": "http://mirrors.jenkins-ci.org/war/latest/jenkins.war",
+          "checksum": null,
+          "jvm_options": null,
+          "jenkins_args": null,
+          "user": "jenkins",
+          "group": "jenkins",
+          "use_system_accounts": true,
+          "host": "localhost",
+          "listen_address": "0.0.0.0",
+          "port": 8080,
+          "endpoint": "http://localhost:8080",
+          "home": "/var/lib/jenkins",
+          "log_directory": "/var/log/jenkins",
+          "runit": {
+            "sv_timeout": 7
+          },
+          "repository": "http://pkg.jenkins-ci.org/debian",
+          "repository_key": "http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key",
+          "repository_keyserver": null
+        }
+      },
+      "lvm": {
+        "chef-ruby-lvm": {
+          "version": "0.3.0"
+        },
+        "chef-ruby-lvm-attrib": {
+          "version": "0.2.1"
+        },
+        "cleanup_old_gems": true,
+        "rubysource": "https://rubygems.org"
+      },
+      "ntp": {
+        "servers": [
+          "0.pool.ntp.org",
+          "1.pool.ntp.org",
+          "2.pool.ntp.org",
+          "3.pool.ntp.org"
+        ],
+        "peers": [],
+        "pools": [],
+        "restrictions": [],
+        "tinker": {
+          "panic": 0,
+          "allan": 1500,
+          "dispersion": 15,
+          "step": 0.128,
+          "stepout": 900
+        },
+        "restrict_default": "kod notrap nomodify nopeer noquery",
+        "packages": [
+          "ntp"
+        ],
+        "service": "ntp",
+        "varlibdir": "/var/lib/ntp",
+        "driftfile": "/var/lib/ntp/ntp.drift",
+        "logfile": null,
+        "conffile": "/etc/ntp.conf",
+        "statsdir": "/var/log/ntpstats/",
+        "conf_owner": "root",
+        "conf_group": "root",
+        "var_owner": "ntp",
+        "var_group": "ntp",
+        "leapfile": "/etc/ntp.leapseconds",
+        "sync_clock": false,
+        "sync_hw_clock": false,
+        "listen": null,
+        "listen_network": null,
+        "ignore": null,
+        "apparmor_enabled": false,
+        "monitor": false,
+        "statistics": true,
+        "conf_restart_immediate": false,
+        "keys": null,
+        "trustedkey": null,
+        "requestkey": null,
+        "disable_tinker_panic_on_virtualization_guest": true,
+        "peer": {
+          "key": null,
+          "use_iburst": true,
+          "use_burst": false,
+          "minpoll": 6,
+          "maxpoll": 10
+        },
+        "server": {
+          "prefer": "",
+          "use_iburst": true,
+          "use_burst": false,
+          "minpoll": 6,
+          "maxpoll": 10
+        },
+        "orphan": {
+          "enabled": false,
+          "stratum": 5
+        },
+        "localhost": {
+          "noquery": false
+        },
+        "use_cmos": false
+      },
+      "git": {
+        "prefix": "/usr/local",
+        "version": "2.8.1",
+        "url": "https://nodeload.github.com/git/git/tar.gz/v%{version}",
+        "checksum": "e08503ecaf5d3ac10c40f22871c996a392256c8d038d16f52ebf974cba29ae42",
+        "use_pcre": false,
+        "server": {
+          "base_path": "/srv/git",
+          "export_all": true
+        }
+      },
+      "homebrew": {
+        "owner": null,
+        "auto-update": true,
+        "casks": [],
+        "formulas": [],
+        "taps": [],
+        "installer": {
+          "url": "https://raw.githubusercontent.com/Homebrew/install/master/install",
+          "checksum": null
+        },
+        "enable-analytics": true
+      },
+      "windows-sdk": {
+        "install_path": null
+      },
+      "wix": {
+        "download_id": "1540241",
+        "checksum": "03b8f46cb3abf1465fe8f9975a94a4e0f75c77267ff4d1fcb6d5b6a97567f549",
+        "home": "\\wix"
+      },
+      "omnibus": {
+        "build_user": "omnibus",
+        "build_user_home": null,
+        "install_dir": null,
+        "toolchain_name": "omnibus-toolchain",
+        "toolchain_version": "1.1.73",
+        "toolchain_channel": "stable",
+        "git_version": "2.6.2",
+        "ruby_version": "2.1.8",
+        "build_user_group": "omnibus",
+        "base_dir": "/var/cache/omnibus",
+        "git_checksum": "34dfc06b44880df91940dc318a2d3c83b79e67b6f05319c7c71e94d30893636d",
+        "build_user_password": "$1$QTCj0tQy$C60hWNmo8wZo.ctvDSy9p/"
+      },
+      "rubygems": {
+        "gem_disable_default": false,
+        "gem_sources": [
+          "https://rubygems.org"
+        ],
+        "chef_gem_disable_default": false,
+        "chef_gem_sources": [
+          "https://rubygems.org"
+        ]
+      },
+      "authorization": {
+        "sudo": {
+          "groups": [
+            "sysadmin"
+          ],
+          "users": [],
+          "passwordless": false,
+          "setenv": false,
+          "include_sudoers_d": false,
+          "agent_forwarding": false,
+          "sudoers_defaults": [
+            "!lecture,tty_tickets,!fqdn"
+          ],
+          "command_aliases": [],
+          "env_keep_add": [],
+          "env_keep_subtract": [],
+          "custom_commands": {
+            "users": [],
+            "groups": []
+          },
+          "prefix": "/etc"
+        }
+      },
+      "opscode-ci": {
+        "user": "jenkins",
+        "user_home": null,
+        "group": "jenkins",
+        "master": {
+          "host_name": null,
+          "port": 8080,
+          "jnlp_port": 38529,
+          "pipeline_types": [],
+          "executors": 2,
+          "jvm_memory_size": "2278792K",
+          "use_lvm": false,
+          "ebs_vols": [
+            {
+              "device": "/dev/xvdj",
+              "size": 500
+            }
+          ],
+          "days_to_keep_builds": null,
+          "builds_to_keep": null,
+          "days_to_keep_artifacts": 15,
+          "artifacts_to_keep": null
+        },
+        "email": {
+          "system_address": "CHEF CI <ci-notifications@getchef.com>",
+          "list_id": "ci-notifications.getchef.com"
+        },
+        "monitoring": {
+          "jmx_hostname": "localhost",
+          "jmx_port": 9010
+        },
+        "artifactory": {
+          "endpoint": "http://example.com"
+        },
+        "omnibus-cache": {
+          "profile_name": "omnibus-cache"
+        }
+      },
+      "java": {
+        "jdk_version": "7"
+      }
+    },
+    "override": {
+      "opscode-ci": {
+        "artifactory": {
+          "endpoint": "http://example.com:8081"
+        },
+        "omnitruck": {
+          "packages_bucket": "opscode-omnibus-packages",
+          "metadata_bucket": "opscode-omnibus-package-metadata"
+        },
+        "master": {
+          "host_name": "example.com",
+          "pipeline_types": [
+            "client_build",
+            "releng"
+          ],
+          "artifacts_to_keep": null,
+          "days_to_keep_artifacts": 15
+        }
+      }
+    },
+    "run_list": [
+      "recipe[opscode-ci::slave]"
+    ]
+  },
+  "node_name": "chefdk-debian-7-tester-2d206b",
+  "organization_name": "avengers",
+  "policy_name": "policy_name1",
+  "policy_group": "policy_group1",
+  "resources": [
+    {
+      "type": "chef_gem",
+      "name": "chef-sugar",
+      "id": "chef-sugar",
+      "after": {
+        "package_name": "chef-sugar",
+        "version": "3.4.0"
+      },
+      "before": {
+        "package_name": "chef-sugar",
+        "version": "3.4.0"
+      },
+      "duration": "132",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "chef-sugar",
+      "cookbook_version": "3.4.0",
+      "recipe_name": "default"
+    },
+    {
+      "type": "chef_gem",
+      "name": "chef-sugar",
+      "id": "chef-sugar",
+      "after": {
+        "package_name": "chef-sugar",
+        "version": "3.4.0"
+      },
+      "before": {
+        "package_name": "chef-sugar",
+        "version": "3.4.0"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "chef-sugar",
+      "cookbook_version": "3.4.0",
+      "recipe_name": "default"
+    },
+    {
+      "type": "directory",
+      "name": "/usr/local/bin",
+      "id": "/usr/local/bin",
+      "after": {
+        "group": "staff",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "staff",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "link",
+      "name": "/usr/local/bin/git",
+      "id": "/usr/local/bin/git",
+      "after": {
+        "to": "/opt/omnibus-toolchain/embedded/bin/git",
+        "owner": null,
+        "group": null
+      },
+      "before": {
+        "to": "/opt/omnibus-toolchain/embedded/bin/git",
+        "owner": "root",
+        "group": "root"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "apt_repository",
+      "name": "openjdk-r",
+      "id": "openjdk-r",
+      "after": {},
+      "before": {},
+      "duration": "2686",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "remove",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "apt_update",
+      "name": "update",
+      "id": "update",
+      "after": {},
+      "before": {},
+      "duration": "2563",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "update",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "apt_package",
+      "name": "wget",
+      "id": "wget",
+      "after": {
+        "package_name": "wget"
+      },
+      "before": {
+        "package_name": "wget",
+        "version": [
+          "1.13.4-3+deb7u2"
+        ]
+      },
+      "duration": "23",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "file",
+      "name": "/etc/profile.d/rbenv.sh",
+      "id": "/etc/profile.d/rbenv.sh",
+      "after": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/etc/profile.d/rbenv.sh"
+      },
+      "before": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/etc/profile.d/rbenv.sh"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_migration"
+    },
+    {
+      "type": "directory",
+      "name": "/opt/rbenv",
+      "id": "/opt/rbenv",
+      "after": {
+        "group": null,
+        "mode": null,
+        "owner": null
+      },
+      "before": {
+        "group": null,
+        "mode": null,
+        "owner": null
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_migration"
+    },
+    {
+      "type": "directory",
+      "name": "/opt/rubies",
+      "id": "/opt/rubies",
+      "after": {
+        "group": null,
+        "mode": null,
+        "owner": null
+      },
+      "before": {
+        "group": null,
+        "mode": null,
+        "owner": null
+      },
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_migration"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.bashrc.d/chruby-default.sh",
+      "id": "/home/jenkins/.bashrc.d/chruby-default.sh",
+      "after": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/home/jenkins/.bashrc.d/chruby-default.sh"
+      },
+      "before": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/home/jenkins/.bashrc.d/chruby-default.sh"
+      },
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_migration"
+    },
+    {
+      "type": "chef_ingredient",
+      "name": "omnibus-toolchain",
+      "id": "omnibus-toolchain",
+      "after": {
+        "product_name": "omnibus-toolchain",
+        "version": "1.1.73",
+        "channel": "stable",
+        "platform_version_compatibility_mode": true,
+        "platform": "debian",
+        "platform_version": "7",
+        "architecture": "x86_64"
+      },
+      "before": {},
+      "duration": "775",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "upgrade",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_omnibus_toolchain"
+    },
+    {
+      "type": "directory",
+      "name": "/export/home",
+      "id": "/export/home",
+      "after": {
+        "group": "root",
+        "mode": null,
+        "owner": "root"
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "skipped",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "group",
+      "name": "create jenkins group",
+      "id": "jenkins",
+      "after": {
+        "members": []
+      },
+      "before": {
+        "members": [
+          "jenkins"
+        ]
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user"
+    },
+    {
+      "type": "execute",
+      "name": "chsec_login_shell",
+      "id": "chsec -f /etc/security/login.cfg -s usw -a 'shells=/bin/sh,/bin/bsh,/bin/csh,/bin/ksh,/bin/tsh,/bin/ksh93,/usr/bin/sh,/usr/bin/bsh,/usr/bin/csh,/usr/bin/ksh,/usr/bin/tsh,/usr/bin/ksh93,/usr/bin/rksh,/usr/bin/rksh93,/usr/sbin/uucp/uucico,/usr/sbin/sliplogin,/usr/sbin/snappd,/usr/bin/bash,/opt/omnibus-toolchain/bin/bash'",
+      "after": {
+        "command": "chsec -f /etc/security/login.cfg -s usw -a 'shells=/bin/sh,/bin/bsh,/bin/csh,/bin/ksh,/bin/tsh,/bin/ksh93,/usr/bin/sh,/usr/bin/bsh,/usr/bin/csh,/usr/bin/ksh,/usr/bin/tsh,/usr/bin/ksh93,/usr/bin/rksh,/usr/bin/rksh93,/usr/sbin/uucp/uucico,/usr/sbin/sliplogin,/usr/sbin/snappd,/usr/bin/bash,/opt/omnibus-toolchain/bin/bash'",
+        "user": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "skipped",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "linux_user",
+      "name": "jenkins",
+      "id": "jenkins",
+      "after": {
+        "uid": null,
+        "gid": 1001,
+        "home": "/home/jenkins"
+      },
+      "before": {
+        "uid": 1001,
+        "gid": 1001,
+        "home": "/home/jenkins"
+      },
+      "duration": "9",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user"
+    },
+    {
+      "type": "group",
+      "name": "jenkins",
+      "id": "jenkins",
+      "after": {
+        "members": [
+          "jenkins"
+        ]
+      },
+      "before": {
+        "members": [
+          "jenkins"
+        ]
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "modify",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins",
+      "id": "/home/jenkins",
+      "after": {
+        "group": "jenkins",
+        "mode": "0755",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0755",
+        "owner": "jenkins"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user"
+    },
+    {
+      "type": "directory",
+      "name": "/var/chef/cache",
+      "id": "/var/chef/cache",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_common"
+    },
+    {
+      "type": "directory",
+      "name": "/usr/local/bin",
+      "id": "/usr/local/bin",
+      "after": {
+        "group": null,
+        "mode": "0755",
+        "owner": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "skipped",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_common",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "directory",
+      "name": "/var/cache/omnibus",
+      "id": "/var/cache/omnibus",
+      "after": {
+        "group": "jenkins",
+        "mode": "0755",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0755",
+        "owner": "jenkins"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_common"
+    },
+    {
+      "type": "build_essential",
+      "name": "install_packages",
+      "id": "install_packages",
+      "after": {
+        "compile_time": false
+      },
+      "before": {},
+      "duration": "219",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "build-essential",
+      "cookbook_version": "8.0.3",
+      "recipe_name": "default"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.gitconfig",
+      "id": "/home/jenkins/.gitconfig",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0644",
+        "path": "/home/jenkins/.gitconfig",
+        "verifications": [],
+        "checksum": "1d2b317206411daeb7adbfa5a0b1bf4c621e2ae62dedec4f1e5ffa6ede412028"
+      },
+      "before": {
+        "checksum": "cd94951406a630c64541144079d31d3581d9871cf2b4bbe4ac513ff19060c4fb",
+        "owner": "jenkins",
+        "group": "root",
+        "mode": "0644",
+        "path": "/home/jenkins/.gitconfig"
+      },
+      "duration": "11",
+      "delta": "--- /home/jenkins/.gitconfig\t2017-11-01 20:55:38.580713329 +0000\\n+++ /home/jenkins/.chef-.gitconfig20171101-6763-kzpg7e.gitconfig\t2017-11-01 20:59:12.492966103 +0000\\n@@ -20,6 +20,4 @@\\n   autosetuprebase = always\\n [pull]\\n   rebase = preserve\\n-[http]\\n-\tsslCAinfo = /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "updated",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_git"
+    },
+    {
+      "type": "execute",
+      "name": "/opt/omnibus-toolchain/bin/git config --global http.sslCAinfo /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem",
+      "id": "/opt/omnibus-toolchain/bin/git config --global http.sslCAinfo /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem",
+      "after": {
+        "command": "/opt/omnibus-toolchain/bin/git config --global http.sslCAinfo /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem",
+        "user": "jenkins"
+      },
+      "before": {},
+      "duration": "18",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_git"
+    },
+    {
+      "type": "ruby_block",
+      "name": "disable strict host key checking for github.com",
+      "id": "disable strict host key checking for github.com",
+      "after": {
+        "block_name": "disable strict host key checking for github.com"
+      },
+      "before": {},
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "ruby_block",
+      "name": "make sudo honor ssh_auth_sock",
+      "id": "make sudo honor ssh_auth_sock",
+      "after": {
+        "block_name": "make sudo honor ssh_auth_sock"
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "apt_package",
+      "name": "devscripts",
+      "id": "devscripts",
+      "after": {
+        "package_name": "devscripts"
+      },
+      "before": {
+        "package_name": "devscripts",
+        "version": [
+          "2.12.6+deb7u2"
+        ]
+      },
+      "duration": "25",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_packaging"
+    },
+    {
+      "type": "apt_package",
+      "name": "dpkg-dev",
+      "id": "dpkg-dev",
+      "after": {
+        "package_name": "dpkg-dev"
+      },
+      "before": {
+        "package_name": "dpkg-dev",
+        "version": [
+          "1.16.18"
+        ]
+      },
+      "duration": "24",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_packaging"
+    },
+    {
+      "type": "apt_package",
+      "name": "ncurses-dev",
+      "id": "ncurses-dev",
+      "after": {
+        "package_name": "ncurses-dev"
+      },
+      "before": {
+        "package_name": "ncurses-dev",
+        "version": [
+          "5.9-10"
+        ]
+      },
+      "duration": "67",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_packaging"
+    },
+    {
+      "type": "apt_package",
+      "name": "zlib1g-dev",
+      "id": "zlib1g-dev",
+      "after": {
+        "package_name": "zlib1g-dev"
+      },
+      "before": {
+        "package_name": "zlib1g-dev",
+        "version": [
+          "1:1.2.7.dfsg-13"
+        ]
+      },
+      "duration": "23",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_packaging"
+    },
+    {
+      "type": "apt_package",
+      "name": "fakeroot",
+      "id": "fakeroot",
+      "after": {
+        "package_name": "fakeroot"
+      },
+      "before": {
+        "package_name": "fakeroot",
+        "version": [
+          "1.18.4-2"
+        ]
+      },
+      "duration": "23",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_packaging"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/load-omnibus-toolchain.sh",
+      "id": "/home/jenkins/load-omnibus-toolchain.sh",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0755",
+        "path": "/home/jenkins/load-omnibus-toolchain.sh",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "1a590716d649641db92e4fe6ce790c04806589556e4ac2448b0be5ddaf3f2f9e",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0755",
+        "path": "/home/jenkins/load-omnibus-toolchain.sh"
+      },
+      "duration": "5",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_environment"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins/.ssh",
+      "id": "/home/jenkins/.ssh",
+      "after": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "cookbook_file",
+      "name": "/home/jenkins/.ssh/known_hosts",
+      "id": "/home/jenkins/.ssh/known_hosts",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0644",
+        "path": "/home/jenkins/.ssh/known_hosts",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "029aa31c902d2d49468a4584f65d69757696f68c92166dea1bacddee22d990ee",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0644",
+        "path": "/home/jenkins/.ssh/known_hosts"
+      },
+      "duration": "6",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.ssh/github",
+      "id": "/home/jenkins/.ssh/github",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/github",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "c8fa3ddfe43f79cac2abfe110cc163ee45642571c17f03617fdcb548b777114a",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/github"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.ssh/config",
+      "id": "/home/jenkins/.ssh/config",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/config",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "fd3930562ec0c2c46049673f068cb2b2f38b045b339c4dd9efa3e46d0c781336",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/config"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "apt_package",
+      "name": "ntp",
+      "id": "ntp",
+      "after": {
+        "package_name": "ntp"
+      },
+      "before": {
+        "package_name": "ntp",
+        "version": [
+          "1:4.2.6.p5+dfsg-2+deb7u7"
+        ]
+      },
+      "duration": "25",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "apt_package",
+      "name": "Remove ntpdate",
+      "id": "ntpdate",
+      "after": {
+        "package_name": "ntpdate"
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "remove",
+      "status": "skipped",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "directory",
+      "name": "/var/lib/ntp",
+      "id": "/var/lib/ntp",
+      "after": {
+        "group": "ntp",
+        "mode": "0755",
+        "owner": "ntp"
+      },
+      "before": {
+        "group": "ntp",
+        "mode": "0755",
+        "owner": "ntp"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "directory",
+      "name": "/var/log/ntpstats/",
+      "id": "/var/log/ntpstats/",
+      "after": {
+        "group": "ntp",
+        "mode": "0755",
+        "owner": "ntp"
+      },
+      "before": {
+        "group": "ntp",
+        "mode": "0755",
+        "owner": "ntp"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "cookbook_file",
+      "name": "/etc/ntp.leapseconds",
+      "id": "/etc/ntp.leapseconds",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/ntp.leapseconds",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "cd3e23bc9fd5119f37bb58bb7e0310b71a726424186a1c57343f3cfd1031d42e",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/ntp.leapseconds"
+      },
+      "duration": "6",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "template",
+      "name": "/etc/ntp.conf",
+      "id": "/etc/ntp.conf",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/ntp.conf",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "5eba70b7b575a1e02fb498ef3d443b8a3cf55ab7190532b40934bf6ca77511fc",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/ntp.conf"
+      },
+      "duration": "32",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "execute",
+      "name": "Force sync hardware clock with system clock",
+      "id": "hwclock --systohc",
+      "after": {
+        "command": "hwclock --systohc",
+        "user": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "skipped",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "service",
+      "name": "ntp",
+      "id": "ntp",
+      "after": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "before": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "duration": "14",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "enable",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "service",
+      "name": "ntp",
+      "id": "ntp",
+      "after": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "before": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "duration": "12",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "start",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "log",
+      "name": "Package signing not implemented for this platform_family",
+      "id": "Package signing not implemented for this platform_family",
+      "after": {
+        "message": "Package signing not implemented for this platform_family"
+      },
+      "before": {},
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "write",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_package_signing"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins/.gem",
+      "id": "/home/jenkins/.gem",
+      "after": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.gem/credentials",
+      "id": "/home/jenkins/.gem/credentials",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.gem/credentials",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "08be5634d5030e591aab6c513c7a24abfb3e17afab3828741b077f396be5deda",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.gem/credentials"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "gemrc",
+      "name": "global",
+      "id": "global",
+      "after": {
+        "user": "jenkins",
+        "group": "jenkins",
+        "values": {
+          "sources": [
+            "https://rubygems.org/"
+          ]
+        }
+      },
+      "before": {
+        "path": "/opt/chef/embedded/etc/gemrc",
+        "values": {
+          "sources": [
+            "https://rubygems.org/"
+          ]
+        }
+      },
+      "duration": "40",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "gemrc",
+      "name": "/home/jenkins/.gemrc",
+      "id": "/home/jenkins/.gemrc",
+      "after": {
+        "user": "jenkins",
+        "group": "jenkins",
+        "values": {
+          "sources": [
+            "https://rubygems.org/"
+          ]
+        }
+      },
+      "before": {
+        "path": "/home/jenkins/.gemrc",
+        "values": {
+          "sources": [
+            "https://rubygems.org/"
+          ]
+        }
+      },
+      "duration": "14",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.bundle/config",
+      "id": "/home/jenkins/.bundle/config",
+      "after": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/home/jenkins/.bundle/config"
+      },
+      "before": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/home/jenkins/.bundle/config"
+      },
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins/.aws",
+      "id": "/home/jenkins/.aws",
+      "after": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_aws"
+    },
+    {
+      "type": "template",
+      "name": "/home/jenkins/.aws/credentials",
+      "id": "/home/jenkins/.aws/credentials",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.aws/credentials",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "e03da2ff59a16921fa0cb84568c077502e2d832aa640efa0d2a4cd4d625cfbb0",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.aws/credentials"
+      },
+      "duration": "5",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_aws"
+    },
+    {
+      "type": "linux_user",
+      "name": "root",
+      "id": "root",
+      "after": {
+        "uid": 0,
+        "gid": 0,
+        "home": "/root"
+      },
+      "before": {
+        "uid": 0,
+        "gid": 0,
+        "home": "/root"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_users"
+    },
+    {
+      "type": "apt_package",
+      "name": "sudo",
+      "id": "sudo",
+      "after": {
+        "package_name": "sudo"
+      },
+      "before": {},
+      "duration": "5",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "skipped",
+      "cookbook_name": "sudo",
+      "cookbook_version": "3.5.3",
+      "recipe_name": "default",
+      "conditional": "not_if \"which sudo\""
+    },
+    {
+      "type": "directory",
+      "name": "/etc/sudoers.d",
+      "id": "/etc/sudoers.d",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "sudo",
+      "cookbook_version": "3.5.3",
+      "recipe_name": "default"
+    },
+    {
+      "type": "cookbook_file",
+      "name": "/etc/sudoers.d/README",
+      "id": "/etc/sudoers.d/README",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0440",
+        "path": "/etc/sudoers.d/README",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "9ded172910845bd115fbe469d87cab80a215e756a973e5d09c0e58a19a1bfe81",
+        "owner": "root",
+        "group": "root",
+        "mode": "0440",
+        "path": "/etc/sudoers.d/README"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "sudo",
+      "cookbook_version": "3.5.3",
+      "recipe_name": "default"
+    },
+    {
+      "type": "template",
+      "name": "/etc/sudoers",
+      "id": "/etc/sudoers",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0440",
+        "path": "/etc/sudoers",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "4520ba18debe05aaea860c0fef2d11aa0c6c1b8e7ee0eaa7c7e4360e659d1047",
+        "owner": "root",
+        "group": "root",
+        "mode": "0440",
+        "path": "/etc/sudoers"
+      },
+      "duration": "6",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "sudo",
+      "cookbook_version": "3.5.3",
+      "recipe_name": "default"
+    },
+    {
+      "type": "sudo",
+      "name": "jenkins",
+      "id": "jenkins",
+      "after": {
+        "user": "jenkins",
+        "commands": [
+          "ALL"
+        ],
+        "host": "ALL",
+        "runas": "ALL",
+        "nopasswd": true,
+        "command_aliases": [],
+        "env_keep_add": [],
+        "env_keep_subtract": []
+      },
+      "before": {},
+      "duration": "21",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo"
+    },
+    {
+      "type": "sudo",
+      "name": "sysadmin",
+      "id": "sysadmin",
+      "after": {
+        "group": "sysadmin",
+        "commands": [
+          "ALL"
+        ],
+        "host": "ALL",
+        "runas": "ALL",
+        "nopasswd": true,
+        "command_aliases": [],
+        "env_keep_add": [],
+        "env_keep_subtract": []
+      },
+      "before": {},
+      "duration": "22",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo"
+    },
+    {
+      "type": "sudo",
+      "name": "build",
+      "id": "build",
+      "after": {
+        "user": "build",
+        "nopasswd": true
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "sudo",
+      "name": "vagrant",
+      "id": "vagrant",
+      "after": {
+        "user": "vagrant",
+        "nopasswd": true
+      },
+      "before": {},
+      "duration": "6",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "sudo",
+      "name": "ubuntu",
+      "id": "ubuntu",
+      "after": {
+        "user": "ubuntu",
+        "nopasswd": true
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "sudo",
+      "name": "ec2-user",
+      "id": "ec2-user",
+      "after": {
+        "user": "ec2-user",
+        "nopasswd": true
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "apt_repository",
+      "name": "openjdk-r",
+      "id": "openjdk-r",
+      "after": {
+        "uri": "http://ppa.launchpad.net/openjdk-r/ppa/ubuntu",
+        "distribution": "wheezy",
+        "components": [
+          "main"
+        ],
+        "deb_src": true,
+        "keyserver": "keyserver.ubuntu.com",
+        "key": "DA1A4A13543B466853BAF164EB9B1D8886F44E2A"
+      },
+      "before": {},
+      "duration": "6654",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "add",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_java"
+    },
+    {
+      "type": "apt_package",
+      "name": "openjdk-7-jdk",
+      "id": "openjdk-7-jdk",
+      "after": {
+        "package_name": "openjdk-7-jdk"
+      },
+      "before": {
+        "package_name": "openjdk-7-jdk",
+        "version": [
+          "7u131-2.6.9-2~deb7u1"
+        ]
+      },
+      "duration": "1040",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_java"
+    },
+    {
+      "type": "git",
+      "name": "/var/chef/cache/artifactory",
+      "id": "/var/chef/cache/artifactory",
+      "after": {
+        "revision": "v2.8.2"
+      },
+      "before": {
+        "revision": "ee0af35496c0809c5b7445f951ee324f37e2679b"
+      },
+      "duration": "100",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "sync",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "execute",
+      "name": "build-artifactory-gem",
+      "id": "rm -rf artifactory-*.gem && gem build artifactory.gemspec",
+      "after": {
+        "command": "rm -rf artifactory-*.gem && gem build artifactory.gemspec",
+        "user": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "nothing",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus",
+      "conditional": "not_if { action == :nothing }"
+    },
+    {
+      "type": "execute",
+      "name": "install-artifactory-gem",
+      "id": "gem install artifactory-*.gem --no-ri --no-rdoc",
+      "after": {
+        "command": "gem install artifactory-*.gem --no-ri --no-rdoc",
+        "user": null
+      },
+      "before": {},
+      "duration": "625",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "git",
+      "name": "/var/chef/cache/omnibus",
+      "id": "/var/chef/cache/omnibus",
+      "after": {
+        "revision": "ced452379e27b85b9958421f258b5fbe22e3760a"
+      },
+      "before": {
+        "revision": "ced452379e27b85b9958421f258b5fbe22e3760a"
+      },
+      "duration": "7",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "sync",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "execute",
+      "name": "build-omnibus-gem",
+      "id": "rm -rf omnibus-*.gem && gem build omnibus.gemspec",
+      "after": {
+        "command": "rm -rf omnibus-*.gem && gem build omnibus.gemspec",
+        "user": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "nothing",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus",
+      "conditional": "not_if { action == :nothing }"
+    },
+    {
+      "type": "execute",
+      "name": "install-omnibus-gem",
+      "id": "gem install omnibus-*.gem --no-ri --no-rdoc",
+      "after": {
+        "command": "gem install omnibus-*.gem --no-ri --no-rdoc",
+        "user": null
+      },
+      "before": {},
+      "duration": "3032",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/omnibus-publish.rb",
+      "id": "/home/jenkins/omnibus-publish.rb",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/omnibus-publish.rb",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "246ba2cc9ba4fc07025deba38bd05895ddf7ad86878b2287a2cfc050e40366f8",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/omnibus-publish.rb"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins/.ssh",
+      "id": "/home/jenkins/.ssh",
+      "after": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "slave"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.ssh/authorized_keys",
+      "id": "/home/jenkins/.ssh/authorized_keys",
+      "after": {
+        "owner": "jenkins",
+        "group": "root",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/authorized_keys",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "0cbbb3b0e104f5c5deb49091126fbc35e352f4d4222c598eeff9170f9a2028e8",
+        "owner": "jenkins",
+        "group": "root",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/authorized_keys"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "slave"
+    },
+    {
+      "type": "remote_file",
+      "name": "/var/chef/cache/jenkins-cli.jar",
+      "id": "/var/chef/cache/jenkins-cli.jar",
+      "after": {
+        "checksum": null,
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/chef/cache/jenkins-cli.jar"
+      },
+      "before": {
+        "checksum": "f3c325f20fadb64a50c387cc3ad9429e34669de7ddf9e842bb65d4a1ddc982b4",
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/chef/cache/jenkins-cli.jar"
+      },
+      "duration": "9",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "remote_file",
+      "name": "/var/chef/cache/update-center.json",
+      "id": "/var/chef/cache/update-center.json",
+      "after": {
+        "checksum": null,
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/var/chef/cache/update-center.json"
+      },
+      "before": {
+        "checksum": "10bbc899f774f2d4524844848b245a9d8346b58d58dff034409f06325740ddc0",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/var/chef/cache/update-center.json"
+      },
+      "duration": "656",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "file",
+      "name": "/var/chef/cache/extracted-update-center.json",
+      "id": "/var/chef/cache/extracted-update-center.json",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/var/chef/cache/extracted-update-center.json",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "738ecb38401bedcf605a75e421013f7a16314f5c68152abefad85732dc327c1a",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/var/chef/cache/extracted-update-center.json"
+      },
+      "duration": "12",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "file",
+      "name": "/var/chef/cache/jenkins-key",
+      "id": "/var/chef/cache/jenkins-key",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0600",
+        "path": "/var/chef/cache/jenkins-key",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "ced9d2204cc71246b2a6b440829167aa024c2c7662d3c2451acf20ece4bc319d",
+        "owner": "root",
+        "group": "root",
+        "mode": "0600",
+        "path": "/var/chef/cache/jenkins-key"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "jenkins_private_key_credentials",
+      "name": "jenkins",
+      "id": "jenkins",
+      "after": {
+        "description": "Credentials for jenkins - created by Chef",
+        "username": "jenkins",
+        "private_key": "EXAMPLEKEY"
+      },
+      "before": {
+        "id": "2e269a3f-71ba-4b22-8882-40790a8582e8",
+        "description": "Credentials for jenkins - created by Chef",
+        "username": "jenkins",
+        "private_key": "EXAMPLEKEY"
+      },
+      "duration": "2012",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "slave"
+    },
+    {
+      "type": "jenkins_ssh_slave",
+      "name": "chefdk-debian-7-tester-2d206b",
+      "id": "chefdk-debian-7-tester-2d206b",
+      "after": {
+        "slave_name": "chefdk-debian-7-tester-2d206b",
+        "description": "debian 7.8 [ GNU/Linux 3.2.0-4-amd64 x86_64 ]",
+        "remote_fs": "/home/jenkins",
+        "usage_mode": "normal",
+        "labels": [
+          "3.2.0-4-amd64",
+          "7",
+          "7.8",
+          "chefdk",
+          "debian",
+          "debian-7",
+          "debian-7.8",
+          "linux",
+          "slave",
+          "tester",
+          "x86_64"
+        ],
+        "environment": {
+          "LIBPATH": "",
+          "OMNIBUS_FIPS_MODE": "false"
+        },
+        "user": "jenkins",
+        "java_path": "java",
+        "host": "242.58.187.217",
+        "credentials": {
+          "json_class": "Chef::Resource::JenkinsPrivateKeyCredentials",
+          "instance_vars": {
+            "name": "jenkins",
+            "noop": null,
+            "before": null,
+            "params": {},
+            "provider": null,
+            "allowed_actions": [
+              "nothing",
+              "create",
+              "delete"
+            ],
+            "action": [
+              "create"
+            ],
+            "updated": false,
+            "updated_by_last_action": false,
+            "supports": {},
+            "ignore_failure": false,
+            "retries": 0,
+            "retry_delay": 2,
+            "source_line": "/var/chef/cache/cookbooks/opscode-ci/recipes/slave.rb:69:in `from_file'",
+            "guard_interpreter": null,
+            "default_guard_interpreter": "default",
+            "elapsed_time": 2.012877455,
+            "sensitive": true,
+            "declared_type": "jenkins_private_key_credentials",
+            "cookbook_name": "opscode-ci",
+            "recipe_name": "slave",
+            "private_key": "EXAMPLEKEY",
+            "username": "jenkins",
+            "description": "Credentials for jenkins - created by Chef"
+          }
+        },
+        "command_prefix": "env HOME=/home/jenkins PATH=/opt/omnibus-toolchain/embedded/bin::/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin JENKINS_HOME=/home/jenkins sh -c '",
+        "command_suffix": "'"
+      },
+      "before": {
+        "slave_name": "chefdk-debian-7-tester-2d206b",
+        "description": "debian 7.8 [ GNU/Linux 3.2.0-4-amd64 x86_64 ]",
+        "remote_fs": "/home/jenkins",
+        "executors": 1,
+        "labels": [
+          "3.2.0-4-amd64",
+          "7",
+          "7.8",
+          "chefdk",
+          "debian",
+          "debian-7",
+          "debian-7.8",
+          "linux",
+          "slave",
+          "tester",
+          "x86_64"
+        ],
+        "java_path": "java",
+        "host": "242.58.187.217",
+        "port": 22,
+        "credentials": "jenkins"
+      },
+      "duration": "2310",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "slave"
+    },
+    {
+      "type": "linux_user",
+      "name": "chefautomate",
+      "id": "chefautomate",
+      "after": {
+        "uid": null,
+        "gid": null,
+        "home": "/var/opt/chef"
+      },
+      "before": {
+        "uid": 7209,
+        "gid": 7209,
+        "home": "/var/opt/chef"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "directory",
+      "name": "/var/opt/chef/bin",
+      "id": "/var/opt/chef/bin",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "directory",
+      "name": "/var/opt/chef/etc",
+      "id": "/var/opt/chef/etc",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "directory",
+      "name": "/var/log/chef/automate-liveness-agent",
+      "id": "/var/log/chef/automate-liveness-agent",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "chefautomate"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "chefautomate"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "file",
+      "name": "/var/opt/chef/bin/automate-liveness-agent",
+      "id": "/var/opt/chef/bin/automate-liveness-agent",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/opt/chef/bin/automate-liveness-agent",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "d7ad5dd68ab384e8e7f6c34ecb9c57b6c463a0d9625152c53c3deb7023a67e73",
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/opt/chef/bin/automate-liveness-agent"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "file",
+      "name": "/var/opt/chef/etc/config.json",
+      "id": "/var/opt/chef/etc/config.json",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/opt/chef/etc/config.json",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "47922279c973502edbf2a1a9cb2d116639d96ae561a9b9c90dfb4ffed1efa119",
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/opt/chef/etc/config.json"
+      },
+      "duration": "5",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "file",
+      "name": "/etc/init.d/automate-liveness-agent",
+      "id": "/etc/init.d/automate-liveness-agent",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0744",
+        "path": "/etc/init.d/automate-liveness-agent",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "8a39aa2bccd95ae7f4f47b6c6702af5a4c068c45b0bfa943f814fb49492fd75a",
+        "owner": "root",
+        "group": "root",
+        "mode": "0744",
+        "path": "/etc/init.d/automate-liveness-agent"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "service",
+      "name": "automate-liveness-agent",
+      "id": "automate-liveness-agent",
+      "after": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "before": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "duration": "8",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "enable",
+      "status": "up-to-date"
+    },
+    {
+      "type": "service",
+      "name": "automate-liveness-agent",
+      "id": "automate-liveness-agent",
+      "after": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "before": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "duration": "7",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "start",
+      "status": "up-to-date"
+    }
+  ],
+  "run_id": "639844f4-2ce6-42ba-8c9d-853db69adff3",
+  "run_list": [
+    "recipe[opscode-ci::slave]"
+  ],
+  "start_time": "2017-11-01T20:58:52Z",
+  "end_time": "2017-11-01T20:59:31Z",
+  "source": "chef_client",
+  "status": "success",
+  "total_resource_count": 352,
+  "updated_resource_count": 11,
+  "deprecations": [
+    {
+      "message": "Chef::Platform.set is deprecated",
+      "url": "https://docs.chef.io/deprecations_chef_platform_methods.html",
+      "location": "/var/chef/cache/cookbooks/jenkins/libraries/plugin.rb:443:in `<top (required)>'"
+    },
+    {
+      "message": "Chef::Platform.set is deprecated",
+      "url": "https://docs.chef.io/deprecations_chef_platform_methods.html",
+      "location": "/var/chef/cache/cookbooks/jenkins/libraries/slave.rb:410:in `<top (required)>'"
+    },
+    {
+      "message": "Chef::Platform.set is deprecated",
+      "url": "https://docs.chef.io/deprecations_chef_platform_methods.html",
+      "location": "/var/chef/cache/cookbooks/jenkins/libraries/user.rb:183:in `<top (required)>'"
+    },
+    {
+      "message": "Property `sensitive` of resource `rhsm_register` overwrites an existing method. Please use a different property name. This will raise an exception in Chef 13.",
+      "url": "https://docs.chef.io/deprecations_property_name_collision.html",
+      "location": "/var/chef/cache/cookbooks/redhat_subscription_manager/libraries/rhsm_register.rb:34:in `<class:RhsmRegister>'"
+    },
+    {
+      "message": "method access to node attributes (node.foo.bar) is deprecated and will be removed in Chef 13, please use bracket syntax (node[\"foo\"][\"bar\"])",
+      "url": "https://docs.chef.io/deprecations_attributes.html",
+      "location": "/opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-sugar-3.6.0/lib/chef/sugar/node.rb:162:in `method_missing'"
+    },
+    {
+      "message": "Property `sensitive` of resource `aws_s3_file` overwrites an existing method. Please use a different property name. This will raise an exception in Chef 13.",
+      "url": "https://docs.chef.io/deprecations_property_name_collision.html",
+      "location": "/var/chef/cache/cookbooks/aws/resources/s3_file.rb:36:in `class_from_file'"
+    },
+    {
+      "message": "Property `sensitive` of resource `yum_repository` overwrites an existing method. Please use a different property name. This will raise an exception in Chef 13.",
+      "url": "https://docs.chef.io/deprecations_property_name_collision.html",
+      "location": "/var/chef/cache/cookbooks/yum/resources/repository.rb:59:in `class_from_file'"
+    },
+    {
+      "message": "Cloning resource attributes for directory[/usr/local/bin] from prior resource\nPrevious directory[/usr/local/bin]: /var/chef/cache/cookbooks/opscode-ci/recipes/_platform_tweaks.rb:23:in `from_file'\nCurrent  directory[/usr/local/bin]: /var/chef/cache/cookbooks/omnibus/recipes/_common.rb:49:in `from_file'",
+      "url": "https://docs.chef.io/deprecations_resource_cloning.html",
+      "location": "/var/chef/cache/cookbooks/omnibus/recipes/_common.rb:49:in `from_file'"
+    },
+    {
+      "message": "Cloning resource attributes for apt_repository[openjdk-r] from prior resource\nPrevious apt_repository[openjdk-r]: /var/chef/cache/cookbooks/opscode-ci/recipes/_platform_tweaks.rb:37:in `from_file'\nCurrent  apt_repository[openjdk-r]: /var/chef/cache/cookbooks/opscode-ci/recipes/_java.rb:22:in `from_file'",
+      "url": "https://docs.chef.io/deprecations_resource_cloning.html",
+      "location": "/var/chef/cache/cookbooks/opscode-ci/recipes/_java.rb:22:in `from_file'"
+    },
+    {
+      "message": "Cloning resource attributes for directory[/home/jenkins/.ssh] from prior resource\nPrevious directory[/home/jenkins/.ssh]: /var/chef/cache/cookbooks/opscode-ci/recipes/_github.rb:12:in `from_file'\nCurrent  directory[/home/jenkins/.ssh]: /var/chef/cache/cookbooks/opscode-ci/recipes/slave.rb:58:in `from_file'",
+      "url": "https://docs.chef.io/deprecations_resource_cloning.html",
+      "location": "/var/chef/cache/cookbooks/opscode-ci/recipes/slave.rb:58:in `from_file'"
+    }
+  ]
+}

--- a/e2e/cypress/fixtures/converge/xmen1.json
+++ b/e2e/cypress/fixtures/converge/xmen1.json
@@ -1,0 +1,10850 @@
+{
+  "chef_server_fqdn": "chef-server.chef.co",
+  "entity_uuid": "9c139ad0-89a5-44bc-942c-d7f248b155ba",
+  "expanded_run_list": {
+    "id": "manhattan",
+    "run_list": [
+      {
+        "type": "recipe",
+        "name": "opscode-ci::slave",
+        "version": null,
+        "skipped": false
+      }
+    ]
+  },
+  "id": "75c2376e-d07e-4d2b-ab43-d658c6250a62",
+  "message_version": "1.1.0",
+  "message_type": "run_converge",
+  "node": {
+    "name": "chefdk-sles-12-tester-a51a61",
+    "chef_environment": "manhattan",
+    "json_class": "Chef::Node",
+    "automatic": {
+      "languages": {
+        "lua": {
+          "version": "5.2.2"
+        },
+        "java": {
+          "version": "1.7.0",
+          "runtime": {
+            "name": "Java(TM) SE Runtime Environment",
+            "build": "pxa6470_27sr3fp40-20160422_01(SR3 FP40)"
+          }
+        },
+        "ruby": {
+          "platform": "x86_64-linux-gnu",
+          "version": "2.1.2",
+          "release_date": "2014-05-08",
+          "target": "x86_64-suse-linux-gnu",
+          "target_cpu": "x86_64",
+          "target_vendor": "suse",
+          "target_os": "linux-gnu",
+          "host": "x86_64-suse-linux-gnu",
+          "host_cpu": "x86_64",
+          "host_os": "linux-gnu",
+          "host_vendor": "suse",
+          "bin_dir": "/usr/bin",
+          "ruby_bin": "/usr/bin/ruby.ruby2.1",
+          "gems_dir": "/usr/lib64/ruby/gems/2.1.0",
+          "gem_bin": "/usr/bin/gem.ruby2.1"
+        },
+        "c": {
+          "gcc": {
+            "target": "x86_64-suse-linux",
+            "configured_with": "../configure --prefix=/usr --infodir=/usr/share/info --mandir=/usr/share/man --libdir=/usr/lib64 --libexecdir=/usr/lib64 --enable-languages=c,c++,objc,fortran,obj-c++,java,ada --enable-checking=release --with-gxx-include-dir=/usr/include/c++/4.8 --enable-ssp --disable-libssp --disable-plugin --with-bugurl=http://bugs.opensuse.org/ --with-pkgversion='SUSE Linux' --disable-libgcj --disable-libmudflap --with-slibdir=/lib64 --with-system-zlib --enable-__cxa_atexit --enable-libstdcxx-allocator=new --disable-libstdcxx-pch --enable-version-specific-runtime-libs --enable-linker-build-id --enable-linux-futex --program-suffix=-4.8 --without-system-libunwind --with-arch-32=i586 --with-tune=generic --build=x86_64-suse-linux --host=x86_64-suse-linux",
+            "thread_model": "posix",
+            "description": "gcc version 4.8.5 (SUSE Linux) ",
+            "version": "4.8.5"
+          },
+          "glibc": {
+            "version": "2.19",
+            "description": "GNU C Library (GNU libc) stable release version 2.19 (git 9a869d822025), by Roland McGrath et al."
+          }
+        },
+        "perl": {
+          "version": "5.18.2",
+          "archname": "x86_64-linux-thread-multi"
+        },
+        "python": {
+          "version": "2.7.9",
+          "builddate": "Dec 21 2014, 11:02:59"
+        }
+      },
+      "cpu": {
+        "0": {
+          "vendor_id": "GenuineIntel",
+          "family": "6",
+          "model": "63",
+          "model_name": "Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz",
+          "stepping": "2",
+          "mhz": "2399.988",
+          "cache_size": "30720 KB",
+          "physical_id": "0",
+          "core_id": "0",
+          "cores": "2",
+          "flags": [
+            "fpu",
+            "vme",
+            "de",
+            "pse",
+            "tsc",
+            "msr",
+            "pae",
+            "mce",
+            "cx8",
+            "apic",
+            "sep",
+            "mtrr",
+            "pge",
+            "mca",
+            "cmov",
+            "pat",
+            "pse36",
+            "clflush",
+            "mmx",
+            "fxsr",
+            "sse",
+            "sse2",
+            "ht",
+            "syscall",
+            "nx",
+            "rdtscp",
+            "lm",
+            "constant_tsc",
+            "rep_good",
+            "nopl",
+            "xtopology",
+            "eagerfpu",
+            "pni",
+            "pclmulqdq",
+            "ssse3",
+            "fma",
+            "cx16",
+            "pcid",
+            "sse4_1",
+            "sse4_2",
+            "x2apic",
+            "movbe",
+            "popcnt",
+            "tsc_deadline_timer",
+            "aes",
+            "xsave",
+            "avx",
+            "f16c",
+            "rdrand",
+            "hypervisor",
+            "lahf_lm",
+            "abm",
+            "xsaveopt",
+            "fsgsbase",
+            "bmi1",
+            "avx2",
+            "smep",
+            "bmi2",
+            "erms",
+            "invpcid"
+          ]
+        },
+        "1": {
+          "vendor_id": "GenuineIntel",
+          "family": "6",
+          "model": "63",
+          "model_name": "Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz",
+          "stepping": "2",
+          "mhz": "2399.988",
+          "cache_size": "30720 KB",
+          "physical_id": "0",
+          "core_id": "1",
+          "cores": "2",
+          "flags": [
+            "fpu",
+            "vme",
+            "de",
+            "pse",
+            "tsc",
+            "msr",
+            "pae",
+            "mce",
+            "cx8",
+            "apic",
+            "sep",
+            "mtrr",
+            "pge",
+            "mca",
+            "cmov",
+            "pat",
+            "pse36",
+            "clflush",
+            "mmx",
+            "fxsr",
+            "sse",
+            "sse2",
+            "ht",
+            "syscall",
+            "nx",
+            "rdtscp",
+            "lm",
+            "constant_tsc",
+            "rep_good",
+            "nopl",
+            "xtopology",
+            "eagerfpu",
+            "pni",
+            "pclmulqdq",
+            "ssse3",
+            "fma",
+            "cx16",
+            "pcid",
+            "sse4_1",
+            "sse4_2",
+            "x2apic",
+            "movbe",
+            "popcnt",
+            "tsc_deadline_timer",
+            "aes",
+            "xsave",
+            "avx",
+            "f16c",
+            "rdrand",
+            "hypervisor",
+            "lahf_lm",
+            "abm",
+            "xsaveopt",
+            "fsgsbase",
+            "bmi1",
+            "avx2",
+            "smep",
+            "bmi2",
+            "erms",
+            "invpcid"
+          ]
+        },
+        "total": 2,
+        "real": 1,
+        "cores": 2
+      },
+      "memory": {
+        "swap": {
+          "cached": "0kB",
+          "total": "0kB",
+          "free": "0kB"
+        },
+        "hugepages": {
+          "total": "0",
+          "free": "0",
+          "reserved": "0",
+          "surplus": "0"
+        },
+        "total": "3790852kB",
+        "free": "931704kB",
+        "buffers": "419408kB",
+        "cached": "1848792kB",
+        "active": "1270020kB",
+        "inactive": "1178312kB",
+        "dirty": "0kB",
+        "writeback": "0kB",
+        "anon_pages": "180252kB",
+        "mapped": "29348kB",
+        "slab": "370120kB",
+        "slab_reclaimable": "346180kB",
+        "slab_unreclaim": "23940kB",
+        "page_tables": "4460kB",
+        "nfs_unstable": "0kB",
+        "bounce": "0kB",
+        "commit_limit": "1895424kB",
+        "committed_as": "628564kB",
+        "vmalloc_total": "34359738367kB",
+        "vmalloc_used": "12580kB",
+        "vmalloc_chunk": "34359720699kB",
+        "hugepage_size": "2048kB"
+      },
+      "network": {
+        "interfaces": {
+          "lo": {
+            "mtu": "65536",
+            "flags": [
+              "LOOPBACK",
+              "UP",
+              "LOWER_UP"
+            ],
+            "encapsulation": "Loopback",
+            "addresses": {
+              "127.0.0.1": {
+                "family": "inet",
+                "prefixlen": "8",
+                "netmask": "255.0.0.0",
+                "scope": "Node"
+              },
+              "::1": {
+                "family": "inet6",
+                "prefixlen": "128",
+                "scope": "Node",
+                "tags": []
+              }
+            },
+            "state": "unknown"
+          },
+          "eth0": {
+            "type": "eth",
+            "number": "0",
+            "mtu": "9000",
+            "flags": [
+              "BROADCAST",
+              "MULTICAST",
+              "UP",
+              "LOWER_UP"
+            ],
+            "encapsulation": "Ethernet",
+            "addresses": {
+              "02:27:27:84:E4:0E": {
+                "family": "lladdr"
+              },
+              "68.103.81.158": {
+                "family": "inet",
+                "prefixlen": "21",
+                "netmask": "255.255.248.0",
+                "broadcast": "68.103.15.255",
+                "scope": "Global"
+              },
+              "fe80::27:27ff:fe84:e40e": {
+                "family": "inet6",
+                "prefixlen": "64",
+                "scope": "Link",
+                "tags": []
+              }
+            },
+            "state": "unknown",
+            "arp": {
+              "68.103.8.1": "02:a9:5a:b4:15:5a",
+              "68.103.81.3": "02:6a:65:20:3b:99"
+            },
+            "routes": [
+              {
+                "destination": "default",
+                "family": "inet",
+                "via": "68.103.8.1",
+                "proto": "dhcp"
+              },
+              {
+                "destination": "68.103.8.0/21",
+                "family": "inet",
+                "scope": "link",
+                "proto": "kernel",
+                "src": "68.103.81.158"
+              },
+              {
+                "destination": "fe80::/64",
+                "family": "inet6",
+                "metric": "256",
+                "proto": "kernel"
+              }
+            ],
+            "ring_params": {}
+          }
+        },
+        "default_interface": "eth0",
+        "default_gateway": "68.103.8.1"
+      },
+      "counters": {
+        "network": {
+          "interfaces": {
+            "lo": {
+              "rx": {
+                "bytes": "31373004",
+                "packets": "30229",
+                "errors": "0",
+                "drop": "0",
+                "overrun": "0"
+              },
+              "tx": {
+                "bytes": "31373004",
+                "packets": "30229",
+                "errors": "0",
+                "drop": "0",
+                "carrier": "0",
+                "collisions": "0"
+              }
+            },
+            "eth0": {
+              "tx": {
+                "queuelen": "1000",
+                "bytes": "72392143167",
+                "packets": "42818178",
+                "errors": "0",
+                "drop": "0",
+                "carrier": "0",
+                "collisions": "0"
+              },
+              "rx": {
+                "bytes": "61834047807",
+                "packets": "47344376",
+                "errors": "0",
+                "drop": "0",
+                "overrun": "0"
+              }
+            }
+          }
+        }
+      },
+      "ipaddress": "68.103.81.158",
+      "macaddress": "02:27:27:84:E4:0E",
+      "ip6address": "fe80::27:27ff:fe84:e40e",
+      "kernel": {
+        "name": "Linux",
+        "release": "3.12.48-52.27-default",
+        "version": "#1 SMP Mon Oct 5 10:08:10 UTC 2015 (314f0e3)",
+        "machine": "x86_64",
+        "processor": "x86_64",
+        "os": "GNU/Linux",
+        "modules": {
+          "iscsi_ibft": {
+            "size": "12862",
+            "refcount": "0",
+            "version": "0.5.0"
+          },
+          "iscsi_boot_sysfs": {
+            "size": "16051",
+            "refcount": "1"
+          },
+          "af_packet": {
+            "size": "39847",
+            "refcount": "0"
+          },
+          "crct10dif_pclmul": {
+            "size": "14307",
+            "refcount": "0"
+          },
+          "crc32_pclmul": {
+            "size": "13133",
+            "refcount": "0"
+          },
+          "crc32c_intel": {
+            "size": "22094",
+            "refcount": "0"
+          },
+          "ghash_clmulni_intel": {
+            "size": "13230",
+            "refcount": "0"
+          },
+          "aesni_intel": {
+            "size": "52860",
+            "refcount": "0"
+          },
+          "aes_x86_64": {
+            "size": "17131",
+            "refcount": "1"
+          },
+          "lrw": {
+            "size": "13286",
+            "refcount": "1"
+          },
+          "gf128mul": {
+            "size": "14951",
+            "refcount": "1"
+          },
+          "glue_helper": {
+            "size": "13990",
+            "refcount": "1"
+          },
+          "ablk_helper": {
+            "size": "13597",
+            "refcount": "1"
+          },
+          "cryptd": {
+            "size": "16263",
+            "refcount": "3"
+          },
+          "ppdev": {
+            "size": "17671",
+            "refcount": "0"
+          },
+          "parport_pc": {
+            "size": "41414",
+            "refcount": "0"
+          },
+          "floppy": {
+            "size": "73522",
+            "refcount": "0"
+          },
+          "parport": {
+            "size": "46395",
+            "refcount": "2"
+          },
+          "i2c_piix4": {
+            "size": "22166",
+            "refcount": "0"
+          },
+          "processor": {
+            "size": "44678",
+            "refcount": "0"
+          },
+          "button": {
+            "size": "13971",
+            "refcount": "0"
+          },
+          "serio_raw": {
+            "size": "13434",
+            "refcount": "0"
+          },
+          "pcspkr": {
+            "size": "12718",
+            "refcount": "0"
+          },
+          "sg": {
+            "size": "40629",
+            "refcount": "0",
+            "version": "3.5.34"
+          },
+          "dm_mod": {
+            "size": "110780",
+            "refcount": "0"
+          },
+          "ext4": {
+            "size": "591044",
+            "refcount": "1"
+          },
+          "crc16": {
+            "size": "12675",
+            "refcount": "1"
+          },
+          "mbcache": {
+            "size": "14958",
+            "refcount": "1"
+          },
+          "jbd2": {
+            "size": "111278",
+            "refcount": "1"
+          },
+          "ata_generic": {
+            "size": "12923",
+            "refcount": "0",
+            "version": "0.2.15"
+          },
+          "ata_piix": {
+            "size": "35052",
+            "refcount": "0",
+            "version": "2.13"
+          },
+          "ahci": {
+            "size": "29929",
+            "refcount": "0",
+            "version": "3.0"
+          },
+          "libahci": {
+            "size": "36105",
+            "refcount": "1"
+          },
+          "xen_vnif": {
+            "size": "42105",
+            "refcount": "0"
+          },
+          "xen_balloon": {
+            "size": "18837",
+            "refcount": "1"
+          },
+          "xen_vbd": {
+            "size": "31331",
+            "refcount": "2"
+          },
+          "cirrus": {
+            "size": "29538",
+            "refcount": "1"
+          },
+          "syscopyarea": {
+            "size": "12529",
+            "refcount": "1"
+          },
+          "sysfillrect": {
+            "size": "12701",
+            "refcount": "1"
+          },
+          "sysimgblt": {
+            "size": "12640",
+            "refcount": "1"
+          },
+          "drm_kms_helper": {
+            "size": "56976",
+            "refcount": "1"
+          },
+          "libata": {
+            "size": "236041",
+            "refcount": "4",
+            "version": "3.00"
+          },
+          "xen_platform_pci": {
+            "size": "103544",
+            "refcount": "3"
+          },
+          "ttm": {
+            "size": "100596",
+            "refcount": "1"
+          },
+          "drm": {
+            "size": "322623",
+            "refcount": "3"
+          },
+          "scsi_mod": {
+            "size": "244354",
+            "refcount": "2"
+          },
+          "autofs4": {
+            "size": "42930",
+            "refcount": "2"
+          }
+        }
+      },
+      "lsb": {},
+      "os": "linux",
+      "os_version": "3.12.48-52.27-default",
+      "platform_version": "12.0",
+      "platform": "suse",
+      "platform_family": "suse",
+      "dmi": {
+        "dmidecode_version": "2.12",
+        "smbios_version": "2.4",
+        "structures": {
+          "count": "12",
+          "size": "349"
+        },
+        "bios": {
+          "all_records": [
+            {
+              "record_id": "0x0000",
+              "size": "0",
+              "application_identifier": "BIOS Information",
+              "Vendor": "Xen",
+              "Version": "4.2.amazon",
+              "Release Date": "02/16/2017",
+              "Address": "0xE8000",
+              "Runtime Size": "96 kB",
+              "ROM Size": "64 kB",
+              "Characteristics": {
+                "PCI is supported": null,
+                "EDD is supported": null,
+                "Targeted content distribution is supported": null
+              },
+              "BIOS Revision": "4.2"
+            }
+          ],
+          "vendor": "Xen",
+          "version": "4.2.amazon",
+          "release_date": "02/16/2017",
+          "address": "0xE8000",
+          "runtime_size": "96 kB",
+          "rom_size": "64 kB",
+          "bios_revision": "4.2"
+        },
+        "system": {
+          "all_records": [
+            {
+              "record_id": "0x0100",
+              "size": "1",
+              "application_identifier": "System Information",
+              "Manufacturer": "Xen",
+              "Product Name": "HVM domU",
+              "Version": "4.2.amazon",
+              "Serial Number": "ec2104f1-f3b4-87ce-cc32-6d2049336ab5",
+              "UUID": "EC2104F1-F3B4-87CE-CC32-6D2049336AB5",
+              "Wake-up Type": "Power Switch",
+              "SKU Number": "Not Specified",
+              "Family": "Not Specified"
+            }
+          ],
+          "manufacturer": "Xen",
+          "product_name": "HVM domU",
+          "version": "4.2.amazon",
+          "serial_number": "ec2104f1-f3b4-87ce-cc32-6d2049336ab5",
+          "uuid": "EC2104F1-F3B4-87CE-CC32-6D2049336AB5",
+          "wake_up_type": "Power Switch",
+          "sku_number": "Not Specified",
+          "family": "Not Specified"
+        },
+        "chassis": {
+          "all_records": [
+            {
+              "record_id": "0x0300",
+              "size": "3",
+              "application_identifier": "Chassis Information",
+              "Manufacturer": "Xen",
+              "Type": "Other",
+              "Lock": "Not Present",
+              "Version": "Not Specified",
+              "Serial Number": "Not Specified",
+              "Asset Tag": "Not Specified",
+              "Boot-up State": "Safe",
+              "Power Supply State": "Safe",
+              "Thermal State": "Safe",
+              "Security Status": "Unknown"
+            }
+          ],
+          "manufacturer": "Xen",
+          "type": "Other",
+          "lock": "Not Present",
+          "version": "Not Specified",
+          "serial_number": "Not Specified",
+          "asset_tag": "Not Specified",
+          "boot_up_state": "Safe",
+          "power_supply_state": "Safe",
+          "thermal_state": "Safe",
+          "security_status": "Unknown"
+        },
+        "processor": {
+          "all_records": [
+            {
+              "record_id": "0x0401",
+              "size": "4",
+              "application_identifier": "Processor Information",
+              "Socket Designation": "CPU 1",
+              "Type": "Central Processor",
+              "Family": "Other",
+              "Manufacturer": "Intel",
+              "ID": "F2 06 03 00 FF FB 89 17",
+              "Version": "Not Specified",
+              "Voltage": "Unknown",
+              "External Clock": "Unknown",
+              "Max Speed": "2400 MHz",
+              "Current Speed": "2400 MHz",
+              "Status": "Populated, Enabled",
+              "Upgrade": "Other"
+            },
+            {
+              "record_id": "0x0402",
+              "size": "4",
+              "application_identifier": "Processor Information",
+              "Socket Designation": "CPU 2",
+              "Type": "Central Processor",
+              "Family": "Other",
+              "Manufacturer": "Intel",
+              "ID": "F2 06 03 00 FF FB 89 17",
+              "Version": "Not Specified",
+              "Voltage": "Unknown",
+              "External Clock": "Unknown",
+              "Max Speed": "2400 MHz",
+              "Current Speed": "2400 MHz",
+              "Status": "Populated, Enabled",
+              "Upgrade": "Other"
+            }
+          ],
+          "type": "Central Processor",
+          "family": "Other",
+          "manufacturer": "Intel",
+          "id": "F2 06 03 00 FF FB 89 17",
+          "version": "Not Specified",
+          "voltage": "Unknown",
+          "external_clock": "Unknown",
+          "max_speed": "2400 MHz",
+          "current_speed": "2400 MHz",
+          "status": "Populated, Enabled",
+          "upgrade": "Other"
+        },
+        "oem_strings": {
+          "all_records": [
+            {
+              "record_id": "0x0B00",
+              "size": "11",
+              "application_identifier": "OEM Strings",
+              "String 1": "Xen"
+            }
+          ],
+          "string_1": "Xen"
+        }
+      },
+      "etc": {
+      },
+      "current_user": "root",
+      "virtualization": {
+        "systems": {
+          "xen": "guest"
+        },
+        "system": "xen",
+        "role": "guest"
+      },
+      "init_package": "systemd",
+      "ec2": {
+        "ami_id": "ami-d51607b4",
+        "ami_launch_index": "0",
+        "ami_manifest_path": "(unknown)",
+        "block_device_mapping_ami": "/dev/sda1",
+        "block_device_mapping_root": "/dev/sda1",
+        "hostname": "ip-68-103-81-158.us-west-2.compute.internal",
+        "instance_action": "none",
+        "instance_id": "i-020a849f773619448",
+        "instance_type": "t2.medium",
+        "local_hostname": "ip-68-103-81-158.us-west-2.compute.internal",
+        "local_ipv4": "68.103.81.158",
+        "mac": "02:27:27:84:e4:0e",
+        "metrics_vhostmd": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "network_interfaces_macs": {
+          "02:27:27:84:e4:0e": {
+            "device_number": "0",
+            "interface_id": "eni-e928aec3",
+            "local_hostname": "ip-68-103-81-158.us-west-2.compute.internal",
+            "local_ipv4s": "68.103.81.158",
+            "mac": "02:27:27:84:e4:0e",
+            "owner_id": "999999999999",
+            "security_group_ids": "sg-96274af3",
+            "security_groups": "default",
+            "subnet_id": "subnet-19ac017c",
+            "subnet_ipv4_cidr_block": "68.103.8.0/21",
+            "vpc_id": "vpc-2229ff47",
+            "vpc_ipv4_cidr_block": "68.103.0.0/16",
+            "vpc_ipv4_cidr_blocks": "68.103.0.0/16"
+          }
+        },
+        "placement_availability_zone": "us-west-2a",
+        "profile": "default-hvm",
+        "reservation_id": "r-02ff47e1737828d38",
+        "security_groups": [
+          "default"
+        ],
+        "services_domain": "amazonaws.com",
+        "services_partition": "aws",
+        "userdata": null,
+        "account_id": "999999999999",
+        "availability_zone": "us-west-2a",
+        "region": "us-west-2"
+      },
+      "json?": "{\n  \"privateIp\" : \"68.103.81.158\",\n  \"devpayProductCodes\" : null,\n  \"availabilityZone\" : \"us-west-2a\",\n  \"version\" : \"2010-08-31\",\n  \"pendingTime\" : \"2017-06-06T19:22:58Z\",\n  \"instanceId\" : \"i-020a849f773619448\",\n  \"billingProducts\" : [ \"bp-6ca54005\" ],\n  \"instanceType\" : \"t2.medium\",\n  \"accountId\" : \"999999999999\",\n  \"architecture\" : \"x86_64\",\n  \"kernelId\" : null,\n  \"ramdiskId\" : null,\n  \"imageId\" : \"ami-d51607b4\",\n  \"region\" : \"us-west-2\"\n}",
+      "cloud_v2": {
+        "local_ipv4_addrs": [
+          "68.103.81.158"
+        ],
+        "provider": "ec2",
+        "local_hostname": "ip-68-103-81-158.us-west-2.compute.internal",
+        "local_ipv4": "68.103.81.158"
+      },
+      "filesystem": {
+        "/dev/hda1": {
+          "kb_size": "30829600",
+          "kb_used": "3821404",
+          "kb_available": "25628856",
+          "percent_used": "13%",
+          "mount": "/",
+          "total_inodes": "1966080",
+          "inodes_used": "200058",
+          "inodes_available": "1766022",
+          "inodes_percent_used": "11%",
+          "fs_type": "ext4",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "data=ordered"
+          ],
+          "uuid": "2393d56d-ab36-4969-a1b2-57039d02f3db"
+        },
+        "devtmpfs": {
+          "kb_size": "2017340",
+          "kb_used": "8",
+          "kb_available": "2017332",
+          "percent_used": "1%",
+          "mount": "/dev",
+          "total_inodes": "504335",
+          "inodes_used": "346",
+          "inodes_available": "503989",
+          "inodes_percent_used": "1%",
+          "fs_type": "devtmpfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "size=2017340k",
+            "nr_inodes=504335",
+            "mode=755"
+          ]
+        },
+        "tmpfs": {
+          "kb_size": "2026496",
+          "kb_used": "0",
+          "kb_available": "2026496",
+          "percent_used": "0%",
+          "mount": "/sys/fs/cgroup",
+          "total_inodes": "506624",
+          "inodes_used": "12",
+          "inodes_available": "506612",
+          "inodes_percent_used": "1%",
+          "fs_type": "tmpfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "size=2026496k",
+            "nr_inodes=506624",
+            "mode=755"
+          ]
+        },
+        "sysfs": {
+          "mount": "/sys",
+          "fs_type": "sysfs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ]
+        },
+        "proc": {
+          "mount": "/proc",
+          "fs_type": "proc",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ]
+        },
+        "securityfs": {
+          "mount": "/sys/kernel/security",
+          "fs_type": "securityfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime"
+          ]
+        },
+        "devpts": {
+          "mount": "/dev/pts",
+          "fs_type": "devpts",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "gid=5",
+            "mode=620",
+            "ptmxmode=000"
+          ]
+        },
+        "cgroup": {
+          "mount": "/sys/fs/cgroup/hugetlb",
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "hugetlb"
+          ]
+        },
+        "pstore": {
+          "mount": "/sys/fs/pstore",
+          "fs_type": "pstore",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime"
+          ]
+        },
+        "systemd-1": {
+          "mount": "/proc/sys/fs/binfmt_misc",
+          "fs_type": "autofs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "fd=28",
+            "pgrp=1",
+            "timeout=300",
+            "minproto=5",
+            "maxproto=5",
+            "direct"
+          ]
+        },
+        "hugetlbfs": {
+          "mount": "/dev/hugepages",
+          "fs_type": "hugetlbfs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ]
+        },
+        "mqueue": {
+          "mount": "/dev/mqueue",
+          "fs_type": "mqueue",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ]
+        },
+        "debugfs": {
+          "mount": "/sys/kernel/debug",
+          "fs_type": "debugfs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ]
+        },
+        "none": {
+          "mount": "/var/lib/ntp/proc",
+          "fs_type": "proc",
+          "mount_options": [
+            "ro",
+            "nosuid",
+            "nodev",
+            "relatime"
+          ]
+        },
+        "rootfs": {
+          "mount": "/",
+          "fs_type": "rootfs",
+          "mount_options": [
+            "rw"
+          ]
+        }
+      },
+      "time": {
+        "timezone": "UTC"
+      },
+      "uptime_seconds": 12793118,
+      "uptime": "148 days 01 hours 38 minutes 38 seconds",
+      "idletime_seconds": 25542335,
+      "idletime": "295 days 15 hours 05 minutes 35 seconds",
+      "hostname": "ip-68-103-81-158",
+      "machinename": "ip-68-103-81-158.us-west-2.compute.internal",
+      "fqdn": "ip-68-103-81-158.us-west-2.compute.internal",
+      "domain": "us-west-2.compute.internal",
+      "chef_packages": {
+        "chef": {
+          "version": "12.21.3",
+          "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib"
+        },
+        "ohai": {
+          "version": "8.24.0",
+          "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.3.0/gems/ohai-8.24.0/lib/ohai"
+        }
+      },
+      "fips": {
+        "kernel": {
+          "enabled": false
+        }
+      },
+      "packages": {
+        "gcc-c++": {
+          "epoch": "0",
+          "version": "4.8",
+          "release": "6.189",
+          "installdate": "1496777281",
+          "arch": "x86_64"
+        },
+        "libxcb-dri2-0": {
+          "epoch": "0",
+          "version": "1.10",
+          "release": "1.21",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "libgtk-3-0": {
+          "epoch": "0",
+          "version": "3.10.9",
+          "release": "4.46",
+          "installdate": "1447418280",
+          "arch": "x86_64"
+        },
+        "which": {
+          "epoch": "0",
+          "version": "2.20",
+          "release": "3.180",
+          "installdate": "1447418247",
+          "arch": "x86_64"
+        },
+        "perl-gettext": {
+          "epoch": "0",
+          "version": "1.05",
+          "release": "163.126",
+          "installdate": "1447418252",
+          "arch": "x86_64"
+        },
+        "yast2-security": {
+          "epoch": "0",
+          "version": "3.1.11.2",
+          "release": "5.1",
+          "installdate": "1447418280",
+          "arch": "noarch"
+        },
+        "crash": {
+          "epoch": "0",
+          "version": "7.0.5",
+          "release": "7.12",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "perl-Sub-Uplevel": {
+          "epoch": "0",
+          "version": "0.240.0",
+          "release": "11.19",
+          "installdate": "1447418252",
+          "arch": "noarch"
+        },
+        "yast2-update": {
+          "epoch": "0",
+          "version": "3.1.23",
+          "release": "1.43",
+          "installdate": "1447418281",
+          "arch": "x86_64"
+        },
+        "libustr-1_0-1": {
+          "epoch": "0",
+          "version": "1.0.4",
+          "release": "31.197",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "google-opensans-fonts": {
+          "epoch": "0",
+          "version": "1.0",
+          "release": "9.128",
+          "installdate": "1447418252",
+          "arch": "noarch"
+        },
+        "yast2-inetd": {
+          "epoch": "0",
+          "version": "3.1.10",
+          "release": "6.1",
+          "installdate": "1447418281",
+          "arch": "noarch"
+        },
+        "zsh": {
+          "epoch": "0",
+          "version": "5.0.5",
+          "release": "4.63",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "libvorbisfile3": {
+          "epoch": "0",
+          "version": "1.3.3",
+          "release": "8.23",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "pciutils": {
+          "epoch": "0",
+          "version": "3.2.1",
+          "release": "5.1",
+          "installdate": "1447418263",
+          "arch": "x86_64"
+        },
+        "ca-certificates": {
+          "epoch": "0",
+          "version": "1_201403302107",
+          "release": "6.2",
+          "installdate": "1447418268",
+          "arch": "noarch"
+        },
+        "libXcomposite1": {
+          "epoch": "0",
+          "version": "0.4.4",
+          "release": "7.53",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "bind-utils": {
+          "epoch": "0",
+          "version": "9.9.6P1",
+          "release": "26.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "ncurses-utils": {
+          "epoch": "0",
+          "version": "5.9",
+          "release": "40.124",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "chef": {
+          "epoch": "0",
+          "version": "12.21.3",
+          "release": "1.sles12",
+          "installdate": "1502912532",
+          "arch": "x86_64"
+        },
+        "perl-X500-DN": {
+          "epoch": "0",
+          "version": "0.29",
+          "release": "106.14",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "rpm-python": {
+          "epoch": "0",
+          "version": "4.11.2",
+          "release": "10.1",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "cyrus-sasl-plain": {
+          "epoch": "0",
+          "version": "2.1.26",
+          "release": "7.1",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "libXxf86vm1": {
+          "epoch": "0",
+          "version": "1.1.3",
+          "release": "3.54",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "libprocps3": {
+          "epoch": "0",
+          "version": "3.3.9",
+          "release": "4.2",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "rubygem-hiera": {
+          "epoch": "0",
+          "version": "1.2.1",
+          "release": "4.8",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "gpg2": {
+          "epoch": "0",
+          "version": "2.0.24",
+          "release": "1.5",
+          "installdate": "1447418230",
+          "arch": "x86_64"
+        },
+        "libdrm_radeon1": {
+          "epoch": "0",
+          "version": "2.4.52",
+          "release": "2.12",
+          "installdate": "1447418248",
+          "arch": "x86_64"
+        },
+        "cpio": {
+          "epoch": "0",
+          "version": "2.11",
+          "release": "29.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "genisoimage": {
+          "epoch": "0",
+          "version": "1.1.11",
+          "release": "19.46",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "python-lxml": {
+          "epoch": "0",
+          "version": "3.2.3",
+          "release": "4.55",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "libXrender1": {
+          "epoch": "0",
+          "version": "0.9.8",
+          "release": "3.56",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "libasound2": {
+          "epoch": "0",
+          "version": "1.0.27.2",
+          "release": "11.10",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "libcap-ng0": {
+          "epoch": "0",
+          "version": "0.7.3",
+          "release": "4.125",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "ruby2.1-rubygem-excon": {
+          "epoch": "0",
+          "version": "0.39.6",
+          "release": "6.1",
+          "installdate": "1447418273",
+          "arch": "x86_64"
+        },
+        "libgpgme11": {
+          "epoch": "0",
+          "version": "1.5.1",
+          "release": "1.12",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libxslt-tools": {
+          "epoch": "0",
+          "version": "1.1.28",
+          "release": "6.57",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "systemd": {
+          "epoch": "0",
+          "version": "210",
+          "release": "70.25.1",
+          "installdate": "1447418224",
+          "arch": "x86_64"
+        },
+        "libncurses6": {
+          "epoch": "0",
+          "version": "5.9",
+          "release": "40.124",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "growpart": {
+          "epoch": "0",
+          "version": "0.27",
+          "release": "1.13",
+          "installdate": "1447418269",
+          "arch": "noarch"
+        },
+        "perl-Bit-Vector": {
+          "epoch": "0",
+          "version": "7.3",
+          "release": "3.171",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "libpng12-0": {
+          "epoch": "0",
+          "version": "1.2.50",
+          "release": "8.21",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "pigz": {
+          "epoch": "0",
+          "version": "2.3",
+          "release": "5.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "yast2-services-manager": {
+          "epoch": "0",
+          "version": "3.1.34.1",
+          "release": "6.1",
+          "installdate": "1447418276",
+          "arch": "noarch"
+        },
+        "m4": {
+          "epoch": "0",
+          "version": "1.4.16",
+          "release": "15.74",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "perl-Digest-MD4": {
+          "epoch": "0",
+          "version": "1.9",
+          "release": "3.203",
+          "installdate": "1447418252",
+          "arch": "x86_64"
+        },
+        "gpg2-lang": {
+          "epoch": "0",
+          "version": "2.0.24",
+          "release": "1.5",
+          "installdate": "1447418241",
+          "arch": "noarch"
+        },
+        "recode": {
+          "epoch": "0",
+          "version": "3.6",
+          "release": "663.62",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "libatk-bridge-2_0-0": {
+          "epoch": "0",
+          "version": "2.10.2",
+          "release": "3.4",
+          "installdate": "1447418271",
+          "arch": "x86_64"
+        },
+        "libsqlite3-0": {
+          "epoch": "0",
+          "version": "3.8.3.1",
+          "release": "2.3.1",
+          "installdate": "1447418257",
+          "arch": "x86_64"
+        },
+        "nfs-kernel-server": {
+          "epoch": "0",
+          "version": "1.3.0",
+          "release": "9.1",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "sg3_utils": {
+          "epoch": "0",
+          "version": "1.38",
+          "release": "10.9",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "yast2-support": {
+          "epoch": "0",
+          "version": "3.1.4",
+          "release": "1.96",
+          "installdate": "1447418279",
+          "arch": "noarch"
+        },
+        "metamail": {
+          "epoch": "0",
+          "version": "2.7.19",
+          "release": "1265.76",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "yast2-ycp-ui-bindings": {
+          "epoch": "0",
+          "version": "3.1.7",
+          "release": "1.11",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "libgssglue1": {
+          "epoch": "0",
+          "version": "0.4",
+          "release": "3.83",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "gptfdisk": {
+          "epoch": "0",
+          "version": "0.8.8",
+          "release": "1.38",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "python-ec2uploadimg": {
+          "epoch": "0",
+          "version": "0.7.0",
+          "release": "2.1",
+          "installdate": "1447418275",
+          "arch": "noarch"
+        },
+        "libgbm1": {
+          "epoch": "0",
+          "version": "10.0.2",
+          "release": "90.17",
+          "installdate": "1447418260",
+          "arch": "x86_64"
+        },
+        "libatspi0": {
+          "epoch": "0",
+          "version": "2.10.2",
+          "release": "5.7",
+          "installdate": "1447418268",
+          "arch": "x86_64"
+        },
+        "attr": {
+          "epoch": "0",
+          "version": "2.4.47",
+          "release": "3.143",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "autoyast2-installation": {
+          "epoch": "0",
+          "version": "3.1.69.9",
+          "release": "7.1",
+          "installdate": "1447418281",
+          "arch": "noarch"
+        },
+        "ruby": {
+          "epoch": "0",
+          "version": "2.1",
+          "release": "1.6",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "libffi4": {
+          "epoch": "0",
+          "version": "5.2.1+r226025",
+          "release": "4.1",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "libreiserfs-0_3-0": {
+          "epoch": "0",
+          "version": "0.3.0.5",
+          "release": "166.13",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "libgoa-1_0-0": {
+          "epoch": "0",
+          "version": "3.10.5",
+          "release": "1.11",
+          "installdate": "1447418270",
+          "arch": "x86_64"
+        },
+        "libpdb0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "libmozjs-17_0": {
+          "epoch": "0",
+          "version": "17.0",
+          "release": "8.1",
+          "installdate": "1447418263",
+          "arch": "x86_64"
+        },
+        "git-core": {
+          "epoch": "0",
+          "version": "1.8.5.6",
+          "release": "11.10",
+          "installdate": "1447418272",
+          "arch": "x86_64"
+        },
+        "libcamgm100": {
+          "epoch": "0",
+          "version": "1.0.7",
+          "release": "1.4",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "lio-utils": {
+          "epoch": "0",
+          "version": "4.1",
+          "release": "15.3.3",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "libcolord2": {
+          "epoch": "0",
+          "version": "1.1.7",
+          "release": "5.3",
+          "installdate": "1447418273",
+          "arch": "x86_64"
+        },
+        "timezone": {
+          "epoch": "0",
+          "version": "2015g",
+          "release": "0.26.1",
+          "installdate": "1447418258",
+          "arch": "x86_64"
+        },
+        "sle-sdk-release-POOL": {
+          "epoch": "0",
+          "version": "12",
+          "release": "1.138",
+          "installdate": "1447418217",
+          "arch": "x86_64"
+        },
+        "perl-Carp-Clan": {
+          "epoch": "0",
+          "version": "6.04",
+          "release": "23.11",
+          "installdate": "1447418254",
+          "arch": "noarch"
+        },
+        "opensc": {
+          "epoch": "0",
+          "version": "0.13.0",
+          "release": "1.122",
+          "installdate": "1447418280",
+          "arch": "x86_64"
+        },
+        "sle-module-public-cloud-release-POOL": {
+          "epoch": "0",
+          "version": "12",
+          "release": "3.1",
+          "installdate": "1447418217",
+          "arch": "x86_64"
+        },
+        "binutils": {
+          "epoch": "0",
+          "version": "2.25.0",
+          "release": "13.1",
+          "installdate": "1447418255",
+          "arch": "x86_64"
+        },
+        "libnfnetlink0": {
+          "epoch": "0",
+          "version": "1.0.1",
+          "release": "6.58",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libdbus-1-3": {
+          "epoch": "0",
+          "version": "1.8.16",
+          "release": "14.1",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "krb5-client": {
+          "epoch": "0",
+          "version": "1.12.1",
+          "release": "19.1",
+          "installdate": "1447418255",
+          "arch": "x86_64"
+        },
+        "libp11-kit0": {
+          "epoch": "0",
+          "version": "0.20.3",
+          "release": "4.1",
+          "installdate": "1447418262",
+          "arch": "x86_64"
+        },
+        "perl-base": {
+          "epoch": "0",
+          "version": "5.18.2",
+          "release": "3.7",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "libhavege1": {
+          "epoch": "0",
+          "version": "1.9.1",
+          "release": "8.1",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "libqrencode3": {
+          "epoch": "0",
+          "version": "3.4.3",
+          "release": "1.31",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "libpng16-16": {
+          "epoch": "0",
+          "version": "1.6.8",
+          "release": "5.1",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "nfsidmap": {
+          "epoch": "0",
+          "version": "0.25",
+          "release": "5.13",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "libidn11": {
+          "epoch": "0",
+          "version": "1.28",
+          "release": "2.34",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "lvm2": {
+          "epoch": "0",
+          "version": "2.02.98",
+          "release": "54.1",
+          "installdate": "1447418257",
+          "arch": "x86_64"
+        },
+        "libasan0": {
+          "epoch": "0",
+          "version": "4.8.5",
+          "release": "27.1",
+          "installdate": "1496777186",
+          "arch": "x86_64"
+        },
+        "libattr1": {
+          "epoch": "0",
+          "version": "2.4.47",
+          "release": "3.143",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "pciutils-ids": {
+          "epoch": "0",
+          "version": "2015.09.01",
+          "release": "8.1",
+          "installdate": "1447418257",
+          "arch": "noarch"
+        },
+        "gettext-tools": {
+          "epoch": "0",
+          "version": "0.19.2",
+          "release": "1.103",
+          "installdate": "1496777206",
+          "arch": "x86_64"
+        },
+        "expat": {
+          "epoch": "0",
+          "version": "2.1.0",
+          "release": "13.232",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "util-linux-systemd": {
+          "epoch": "0",
+          "version": "2.25",
+          "release": "22.1",
+          "installdate": "1447418258",
+          "arch": "x86_64"
+        },
+        "kernel-devel": {
+          "epoch": "0",
+          "version": "3.12.60",
+          "release": "52.54.1",
+          "installdate": "1496777277",
+          "arch": "noarch"
+        },
+        "bash": {
+          "epoch": "0",
+          "version": "4.2",
+          "release": "75.2",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "libFLAC8": {
+          "epoch": "0",
+          "version": "1.3.0",
+          "release": "6.1",
+          "installdate": "1447418259",
+          "arch": "x86_64"
+        },
+        "insserv-compat": {
+          "epoch": "0",
+          "version": "0.1",
+          "release": "11.80",
+          "installdate": "1447418217",
+          "arch": "noarch"
+        },
+        "java-1_7_1-ibm-devel": {
+          "epoch": "0",
+          "version": "1.7.1_sr3.40",
+          "release": "25.1",
+          "installdate": "1496777312",
+          "arch": "x86_64"
+        },
+        "gzip": {
+          "epoch": "0",
+          "version": "1.6",
+          "release": "7.392",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "sles-manuals_en": {
+          "epoch": "0",
+          "version": "12",
+          "release": "34.2",
+          "installdate": "1447418261",
+          "arch": "noarch"
+        },
+        "yast2-nfs-common": {
+          "epoch": "0",
+          "version": "3.1.7",
+          "release": "1.102",
+          "installdate": "1447418247",
+          "arch": "noarch"
+        },
+        "libxml2-2": {
+          "epoch": "0",
+          "version": "2.9.1",
+          "release": "10.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "openldap2-client": {
+          "epoch": "0",
+          "version": "2.4.41",
+          "release": "18.3.1",
+          "installdate": "1447418261",
+          "arch": "x86_64"
+        },
+        "libmng1": {
+          "epoch": "0",
+          "version": "1.0.10",
+          "release": "113.5",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "sle-module-adv-systems-management-release": {
+          "epoch": "0",
+          "version": "12",
+          "release": "3.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "haveged": {
+          "epoch": "0",
+          "version": "1.9.1",
+          "release": "8.1",
+          "installdate": "1447418262",
+          "arch": "x86_64"
+        },
+        "libsasl2-3": {
+          "epoch": "0",
+          "version": "2.1.26",
+          "release": "7.1",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "file": {
+          "epoch": "0",
+          "version": "5.19",
+          "release": "9.1",
+          "installdate": "1447418221",
+          "arch": "x86_64"
+        },
+        "rpcbind": {
+          "epoch": "0",
+          "version": "0.2.1_rc4",
+          "release": "13.3.1",
+          "installdate": "1447418263",
+          "arch": "x86_64"
+        },
+        "libhogweed2": {
+          "epoch": "0",
+          "version": "2.7.1",
+          "release": "5.20",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "libsolv-tools": {
+          "epoch": "0",
+          "version": "0.6.14",
+          "release": "2.13.1",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "sysconfig": {
+          "epoch": "0",
+          "version": "0.83.8",
+          "release": "7.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "ruby2.1-rubygem-gem2rpm": {
+          "epoch": "0",
+          "version": "0.10.1",
+          "release": "2.1",
+          "installdate": "1447418268",
+          "arch": "x86_64"
+        },
+        "suse-module-tools": {
+          "epoch": "0",
+          "version": "12.3",
+          "release": "14.14",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "sharutils": {
+          "epoch": "0",
+          "version": "4.11.1",
+          "release": "14.64",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "acl": {
+          "epoch": "0",
+          "version": "2.2.52",
+          "release": "3.148",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "shadow": {
+          "epoch": "0",
+          "version": "4.1.5.1",
+          "release": "17.3",
+          "installdate": "1447418224",
+          "arch": "x86_64"
+        },
+        "python-ec2utilsbase": {
+          "epoch": "0",
+          "version": "0.3.0",
+          "release": "4.1",
+          "installdate": "1447418266",
+          "arch": "noarch"
+        },
+        "vim": {
+          "epoch": "0",
+          "version": "7.4.326",
+          "release": "2.62",
+          "installdate": "1447418252",
+          "arch": "x86_64"
+        },
+        "xen-kmp-default": {
+          "epoch": "0",
+          "version": "4.4.3_02_k3.12.48_52.27",
+          "release": "22.12.1",
+          "installdate": "1447418229",
+          "arch": "x86_64"
+        },
+        "libcom_err2": {
+          "epoch": "0",
+          "version": "1.42.11",
+          "release": "7.1",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "ruby2.1-rubygem-hiera": {
+          "epoch": "0",
+          "version": "1.2.1",
+          "release": "4.8",
+          "installdate": "1447418270",
+          "arch": "x86_64"
+        },
+        "dos2unix": {
+          "epoch": "0",
+          "version": "6.0.4",
+          "release": "1.133",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "netcat-openbsd": {
+          "epoch": "0",
+          "version": "1.89",
+          "release": "91.69",
+          "installdate": "1447418249",
+          "arch": "x86_64"
+        },
+        "libldap-2_4-2": {
+          "epoch": "0",
+          "version": "2.4.41",
+          "release": "18.3.1",
+          "installdate": "1447418221",
+          "arch": "x86_64"
+        },
+        "less": {
+          "epoch": "0",
+          "version": "458",
+          "release": "5.13",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "python-PrettyTable": {
+          "epoch": "0",
+          "version": "0.7.2",
+          "release": "8.5",
+          "installdate": "1447418267",
+          "arch": "noarch"
+        },
+        "libXdamage1": {
+          "epoch": "0",
+          "version": "1.1.4",
+          "release": "7.54",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "libestr0": {
+          "epoch": "0",
+          "version": "0.1.9",
+          "release": "1.54",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libadns1": {
+          "epoch": "0",
+          "version": "1.4",
+          "release": "101.65",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "facter": {
+          "epoch": "0",
+          "version": "2.0.2",
+          "release": "6.1",
+          "installdate": "1447418273",
+          "arch": "x86_64"
+        },
+        "liblockdev1": {
+          "epoch": "0",
+          "version": "1.0.3_git201003141408",
+          "release": "27.1",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "vlock": {
+          "epoch": "0",
+          "version": "2.2.3",
+          "release": "11.12",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "dracut": {
+          "epoch": "0",
+          "version": "037",
+          "release": "51.13.1",
+          "installdate": "1447418224",
+          "arch": "x86_64"
+        },
+        "libparted0": {
+          "epoch": "0",
+          "version": "3.1",
+          "release": "13.1",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "ruby2.1-rubygem-ruby-dbus": {
+          "epoch": "0",
+          "version": "0.9.3",
+          "release": "3.6",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "bind-libs": {
+          "epoch": "0",
+          "version": "9.9.6P1",
+          "release": "26.1",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "libx86-1": {
+          "epoch": "0",
+          "version": "1.1",
+          "release": "42.51",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "libksba8": {
+          "epoch": "0",
+          "version": "1.3.0",
+          "release": "9.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "polkit-default-privs": {
+          "epoch": "0",
+          "version": "13.2",
+          "release": "10.1",
+          "installdate": "1447418276",
+          "arch": "noarch"
+        },
+        "pptp": {
+          "epoch": "0",
+          "version": "1.7.2",
+          "release": "43.64",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "gnu-unifont-bitmap-fonts": {
+          "epoch": "0",
+          "version": "20080123",
+          "release": "83.182",
+          "installdate": "1447418252",
+          "arch": "noarch"
+        },
+        "iputils": {
+          "epoch": "0",
+          "version": "s20121221",
+          "release": "2.19",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "python-solv": {
+          "epoch": "0",
+          "version": "0.6.14",
+          "release": "2.13.1",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "os-prober": {
+          "epoch": "0",
+          "version": "1.61",
+          "release": "13.3",
+          "installdate": "1447418271",
+          "arch": "x86_64"
+        },
+        "libyaml-0-2": {
+          "epoch": "0",
+          "version": "0.1.6",
+          "release": "7.1",
+          "installdate": "1447418257",
+          "arch": "x86_64"
+        },
+        "libgobject-2_0-0": {
+          "epoch": "0",
+          "version": "2.38.2",
+          "release": "5.12",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "libutempter0": {
+          "epoch": "0",
+          "version": "1.1.6",
+          "release": "5.114",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "yast2-printer": {
+          "epoch": "0",
+          "version": "3.1.1",
+          "release": "11.23",
+          "installdate": "1447418279",
+          "arch": "x86_64"
+        },
+        "python-jsonpointer": {
+          "epoch": "0",
+          "version": "1.0",
+          "release": "8.5",
+          "installdate": "1447418267",
+          "arch": "noarch"
+        },
+        "libXtst6": {
+          "epoch": "0",
+          "version": "1.2.2",
+          "release": "3.60",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "libjson-c2": {
+          "epoch": "0",
+          "version": "0.11",
+          "release": "2.22",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "regionServiceClientConfigEC2": {
+          "epoch": "0",
+          "version": "1.0.0",
+          "release": "1.12",
+          "installdate": "1447418268",
+          "arch": "noarch"
+        },
+        "yast2": {
+          "epoch": "0",
+          "version": "3.1.108.7",
+          "release": "7.1",
+          "installdate": "1447418275",
+          "arch": "x86_64"
+        },
+        "release-notes-sles": {
+          "epoch": "0",
+          "version": "12.0.20151013",
+          "release": "44.3",
+          "installdate": "1447418261",
+          "arch": "noarch"
+        },
+        "libao4": {
+          "epoch": "0",
+          "version": "1.2.0",
+          "release": "1.13",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "cyrus-sasl-saslauthd": {
+          "epoch": "0",
+          "version": "2.1.26",
+          "release": "7.1",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "yast2-http-server": {
+          "epoch": "0",
+          "version": "3.1.4",
+          "release": "1.23",
+          "installdate": "1447418281",
+          "arch": "noarch"
+        },
+        "libpango-1_0-0": {
+          "epoch": "0",
+          "version": "1.36.3",
+          "release": "4.14",
+          "installdate": "1447418270",
+          "arch": "x86_64"
+        },
+        "libicu52_1-data": {
+          "epoch": "0",
+          "version": "52.1",
+          "release": "7.1",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "libsnappy1": {
+          "epoch": "0",
+          "version": "1.1.1",
+          "release": "1.43",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "libsoup-2_4-1": {
+          "epoch": "0",
+          "version": "2.44.2",
+          "release": "1.46",
+          "installdate": "1447418271",
+          "arch": "x86_64"
+        },
+        "libnetapi0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "man-pages": {
+          "epoch": "0",
+          "version": "3.69",
+          "release": "1.61",
+          "installdate": "1447418245",
+          "arch": "noarch"
+        },
+        "python-boto": {
+          "epoch": "0",
+          "version": "2.34.0",
+          "release": "4.1",
+          "installdate": "1447418273",
+          "arch": "noarch"
+        },
+        "libdrm2": {
+          "epoch": "0",
+          "version": "2.4.52",
+          "release": "2.12",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "rsh": {
+          "epoch": "0",
+          "version": "0.17",
+          "release": "731.12",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "SUSEConnect": {
+          "epoch": "0",
+          "version": "0.2.14.42",
+          "release": "9.3.1",
+          "installdate": "1447418274",
+          "arch": "x86_64"
+        },
+        "vlan": {
+          "epoch": "0",
+          "version": "1.9",
+          "release": "142.1",
+          "installdate": "1447418258",
+          "arch": "x86_64"
+        },
+        "telnet": {
+          "epoch": "0",
+          "version": "1.2",
+          "release": "165.63",
+          "installdate": "1447418246",
+          "arch": "x86_64"
+        },
+        "polkit": {
+          "epoch": "0",
+          "version": "0.113",
+          "release": "4.1",
+          "installdate": "1447418275",
+          "arch": "x86_64"
+        },
+        "yast2-bootloader": {
+          "epoch": "0",
+          "version": "3.1.94.7",
+          "release": "1.1",
+          "installdate": "1447418280",
+          "arch": "x86_64"
+        },
+        "yast2-schema": {
+          "epoch": "0",
+          "version": "3.1.0",
+          "release": "1.474",
+          "installdate": "1447418247",
+          "arch": "noarch"
+        },
+        "yast2-slp-server": {
+          "epoch": "0",
+          "version": "3.1.1.1",
+          "release": "3.10",
+          "installdate": "1447418276",
+          "arch": "noarch"
+        },
+        "libnuma1": {
+          "epoch": "0",
+          "version": "2.0.9",
+          "release": "4.8",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libX11-xcb1": {
+          "epoch": "0",
+          "version": "1.6.2",
+          "release": "4.12",
+          "installdate": "1447418247",
+          "arch": "x86_64"
+        },
+        "samba-libs": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418277",
+          "arch": "x86_64"
+        },
+        "libply2": {
+          "epoch": "0",
+          "version": "0.9.0",
+          "release": "25.1",
+          "installdate": "1447418262",
+          "arch": "x86_64"
+        },
+        "shared-mime-info": {
+          "epoch": "0",
+          "version": "1.2",
+          "release": "1.52",
+          "installdate": "1447418249",
+          "arch": "x86_64"
+        },
+        "libgensec0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "supportutils": {
+          "epoch": "0",
+          "version": "3.0",
+          "release": "68.1",
+          "installdate": "1447418263",
+          "arch": "noarch"
+        },
+        "libcloog-isl4": {
+          "epoch": "0",
+          "version": "0.18.1",
+          "release": "1.124",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "libsmbldap0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "p11-kit": {
+          "epoch": "0",
+          "version": "0.20.3",
+          "release": "4.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "libnetfilter_conntrack3": {
+          "epoch": "0",
+          "version": "1.0.4",
+          "release": "3.60",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "yast2-tftp-server": {
+          "epoch": "0",
+          "version": "3.1.1",
+          "release": "1.140",
+          "installdate": "1447418279",
+          "arch": "noarch"
+        },
+        "libitm1": {
+          "epoch": "0",
+          "version": "5.3.1+r233831",
+          "release": "9.1",
+          "installdate": "1496777202",
+          "arch": "x86_64"
+        },
+        "reiserfs": {
+          "epoch": "0",
+          "version": "3.6.24",
+          "release": "5.47",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "yast2-nfs-server": {
+          "epoch": "0",
+          "version": "3.1.7",
+          "release": "1.102",
+          "installdate": "1447418279",
+          "arch": "noarch"
+        },
+        "icmpinfo": {
+          "epoch": "0",
+          "version": "1.11",
+          "release": "710.63",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "yast2-iscsi-client": {
+          "epoch": "0",
+          "version": "3.1.17",
+          "release": "1.29",
+          "installdate": "1447418280",
+          "arch": "noarch"
+        },
+        "libxcb-render0": {
+          "epoch": "0",
+          "version": "1.10",
+          "release": "1.21",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "lua": {
+          "epoch": "0",
+          "version": "5.2.2",
+          "release": "4.2",
+          "installdate": "1496777301",
+          "arch": "x86_64"
+        },
+        "sle-module-toolchain-release-POOL": {
+          "epoch": "0",
+          "version": "12",
+          "release": "1.11",
+          "installdate": "1447418217",
+          "arch": "x86_64"
+        },
+        "yast2-online-update-frontend": {
+          "epoch": "0",
+          "version": "3.1.7",
+          "release": "1.34",
+          "installdate": "1447418280",
+          "arch": "noarch"
+        },
+        "yast2-core": {
+          "epoch": "0",
+          "version": "3.1.11",
+          "release": "1.9",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "zip": {
+          "epoch": "0",
+          "version": "3.0",
+          "release": "15.18",
+          "installdate": "1447418247",
+          "arch": "x86_64"
+        },
+        "gvfs-backends": {
+          "epoch": "0",
+          "version": "1.18.3",
+          "release": "7.3",
+          "installdate": "1447418281",
+          "arch": "x86_64"
+        },
+        "perl-X11-Protocol": {
+          "epoch": "0",
+          "version": "0.56",
+          "release": "12.19",
+          "installdate": "1447418252",
+          "arch": "x86_64"
+        },
+        "libtool": {
+          "epoch": "0",
+          "version": "2.4.2",
+          "release": "14.60",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "yast2-add-on": {
+          "epoch": "0",
+          "version": "3.1.9",
+          "release": "1.29",
+          "installdate": "1447418281",
+          "arch": "noarch"
+        },
+        "perl-Config-Crontab": {
+          "epoch": "0",
+          "version": "1.33",
+          "release": "8.19",
+          "installdate": "1447418252",
+          "arch": "noarch"
+        },
+        "libpcre1": {
+          "epoch": "0",
+          "version": "8.33",
+          "release": "3.314",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "yast2-sudo": {
+          "epoch": "0",
+          "version": "3.1.1",
+          "release": "1.348",
+          "installdate": "1447418281",
+          "arch": "noarch"
+        },
+        "xtables-plugins": {
+          "epoch": "0",
+          "version": "1.4.21",
+          "release": "2.10",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "libvorbis0": {
+          "epoch": "0",
+          "version": "1.3.3",
+          "release": "8.23",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "libsndfile1": {
+          "epoch": "0",
+          "version": "1.0.25",
+          "release": "21.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "libXext6": {
+          "epoch": "0",
+          "version": "1.3.2",
+          "release": "3.61",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "libgio-2_0-0": {
+          "epoch": "0",
+          "version": "2.38.2",
+          "release": "5.12",
+          "installdate": "1447418268",
+          "arch": "x86_64"
+        },
+        "nfs-client": {
+          "epoch": "0",
+          "version": "1.3.0",
+          "release": "9.1",
+          "installdate": "1447418265",
+          "arch": "x86_64"
+        },
+        "perl-XML-SAX": {
+          "epoch": "0",
+          "version": "0.99",
+          "release": "22.8",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "info": {
+          "epoch": "0",
+          "version": "4.13a",
+          "release": "37.229",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "grub2-x86_64-xen": {
+          "epoch": "0",
+          "version": "2.02~beta2",
+          "release": "54.1",
+          "installdate": "1447418217",
+          "arch": "x86_64"
+        },
+        "iptables": {
+          "epoch": "0",
+          "version": "1.4.21",
+          "release": "2.10",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "perl-XML-SAX-Base": {
+          "epoch": "0",
+          "version": "1.08",
+          "release": "8.20",
+          "installdate": "1447418252",
+          "arch": "noarch"
+        },
+        "ofl": {
+          "epoch": "0",
+          "version": "20140325",
+          "release": "1.13",
+          "installdate": "1447418247",
+          "arch": "x86_64"
+        },
+        "krb5": {
+          "epoch": "0",
+          "version": "1.12.1",
+          "release": "19.1",
+          "installdate": "1447418230",
+          "arch": "x86_64"
+        },
+        "libsecret-1-0": {
+          "epoch": "0",
+          "version": "0.18",
+          "release": "1.67",
+          "installdate": "1447418270",
+          "arch": "x86_64"
+        },
+        "perl-Bootloader-YAML": {
+          "epoch": "0",
+          "version": "0.824",
+          "release": "1.1",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "fastjar": {
+          "epoch": "0",
+          "version": "0.98",
+          "release": "20.66",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "rpm": {
+          "epoch": "0",
+          "version": "4.11.2",
+          "release": "10.1",
+          "installdate": "1447418221",
+          "arch": "x86_64"
+        },
+        "liblua5_1": {
+          "epoch": "0",
+          "version": "5.1.5",
+          "release": "7.127",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "libLLVM": {
+          "epoch": "0",
+          "version": "3.4",
+          "release": "7.7",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "perl-XML-Twig": {
+          "epoch": "0",
+          "version": "3.44",
+          "release": "3.12",
+          "installdate": "1447418253",
+          "arch": "noarch"
+        },
+        "libdrm_intel1": {
+          "epoch": "0",
+          "version": "2.4.52",
+          "release": "2.12",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "libexif12": {
+          "epoch": "0",
+          "version": "0.6.21",
+          "release": "6.4",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libgvfscommon0": {
+          "epoch": "0",
+          "version": "1.18.3",
+          "release": "7.3",
+          "installdate": "1447418273",
+          "arch": "x86_64"
+        },
+        "libatk-1_0-0": {
+          "epoch": "0",
+          "version": "2.10.0",
+          "release": "1.84",
+          "installdate": "1447418268",
+          "arch": "x86_64"
+        },
+        "libltdl7": {
+          "epoch": "0",
+          "version": "2.4.2",
+          "release": "14.60",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "dbus-1": {
+          "epoch": "0",
+          "version": "1.8.16",
+          "release": "14.1",
+          "installdate": "1447418229",
+          "arch": "x86_64"
+        },
+        "bzip2": {
+          "epoch": "0",
+          "version": "1.0.6",
+          "release": "27.1129",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "libpcre16-0": {
+          "epoch": "0",
+          "version": "8.33",
+          "release": "3.314",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "curl": {
+          "epoch": "0",
+          "version": "7.37.0",
+          "release": "15.1",
+          "installdate": "1447418255",
+          "arch": "x86_64"
+        },
+        "perl-XML-NamespaceSupport": {
+          "epoch": "0",
+          "version": "1.11",
+          "release": "21.13",
+          "installdate": "1447418252",
+          "arch": "x86_64"
+        },
+        "libxslt1": {
+          "epoch": "0",
+          "version": "1.1.28",
+          "release": "6.57",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "yast2-metapackage-handler": {
+          "epoch": "0",
+          "version": "3.1.4",
+          "release": "3.2",
+          "installdate": "1447418277",
+          "arch": "noarch"
+        },
+        "libgdk_pixbuf-2_0-0": {
+          "epoch": "0",
+          "version": "2.30.6",
+          "release": "1.23",
+          "installdate": "1447418270",
+          "arch": "x86_64"
+        },
+        "procinfo": {
+          "epoch": "0",
+          "version": "18",
+          "release": "219.60",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "ksh": {
+          "epoch": "0",
+          "version": "93v",
+          "release": "2.35",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "kbd": {
+          "epoch": "0",
+          "version": "1.15.5",
+          "release": "8.4.1",
+          "installdate": "1447418221",
+          "arch": "x86_64"
+        },
+        "python-requests": {
+          "epoch": "0",
+          "version": "2.3.0",
+          "release": "6.5.2",
+          "installdate": "1447418266",
+          "arch": "noarch"
+        },
+        "mozilla-nspr": {
+          "epoch": "0",
+          "version": "4.10.10",
+          "release": "9.1",
+          "installdate": "1447418257",
+          "arch": "x86_64"
+        },
+        "inst-source-utils": {
+          "epoch": "0",
+          "version": "2014.3.18",
+          "release": "1.13",
+          "installdate": "1447418253",
+          "arch": "noarch"
+        },
+        "libmpc3": {
+          "epoch": "0",
+          "version": "1.0.2",
+          "release": "1.123",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "yast2-isns": {
+          "epoch": "0",
+          "version": "3.1.4",
+          "release": "1.21",
+          "installdate": "1447418279",
+          "arch": "noarch"
+        },
+        "plymouth-plugin-label": {
+          "epoch": "0",
+          "version": "0.9.0",
+          "release": "25.1",
+          "installdate": "1447418273",
+          "arch": "x86_64"
+        },
+        "python-colorama": {
+          "epoch": "0",
+          "version": "0.2.7",
+          "release": "1.9",
+          "installdate": "1447418267",
+          "arch": "noarch"
+        },
+        "libldapcpp1": {
+          "epoch": "0",
+          "version": "0.3.1",
+          "release": "4.75",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "procps": {
+          "epoch": "0",
+          "version": "3.3.9",
+          "release": "4.2",
+          "installdate": "1447418230",
+          "arch": "x86_64"
+        },
+        "SuSEfirewall2": {
+          "epoch": "0",
+          "version": "3.6.312",
+          "release": "1.3",
+          "installdate": "1447418268",
+          "arch": "noarch"
+        },
+        "perl-XML-LibXML": {
+          "epoch": "0",
+          "version": "2.0019",
+          "release": "5.3",
+          "installdate": "1447418261",
+          "arch": "x86_64"
+        },
+        "glibc-i18ndata": {
+          "epoch": "0",
+          "version": "2.19",
+          "release": "22.7.1",
+          "installdate": "1447418255",
+          "arch": "noarch"
+        },
+        "ruby2.1-rubygem-ruby-shadow": {
+          "epoch": "0",
+          "version": "2.3.2",
+          "release": "3.29",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "yast2-users": {
+          "epoch": "0",
+          "version": "3.1.37",
+          "release": "10.1",
+          "installdate": "1447418281",
+          "arch": "x86_64"
+        },
+        "libndr0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "yast2-transfer": {
+          "epoch": "0",
+          "version": "3.1.1",
+          "release": "1.64",
+          "installdate": "1447418270",
+          "arch": "x86_64"
+        },
+        "libvpx1": {
+          "epoch": "0",
+          "version": "1.3.0",
+          "release": "1.31",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "libHX28": {
+          "epoch": "0",
+          "version": "3.18",
+          "release": "1.19",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "dbus-1-python": {
+          "epoch": "0",
+          "version": "1.2.0",
+          "release": "4.194",
+          "installdate": "1447418271",
+          "arch": "x86_64"
+        },
+        "python-xml": {
+          "epoch": "0",
+          "version": "2.7.9",
+          "release": "14.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "open-iscsi": {
+          "epoch": "0",
+          "version": "2.0.873",
+          "release": "30.3",
+          "installdate": "1447418257",
+          "arch": "x86_64"
+        },
+        "vorbis-tools": {
+          "epoch": "0",
+          "version": "1.4.0",
+          "release": "26.1",
+          "installdate": "1447418273",
+          "arch": "x86_64"
+        },
+        "filesystem": {
+          "epoch": "0",
+          "version": "13.1",
+          "release": "11.13",
+          "installdate": "1447418217",
+          "arch": "x86_64"
+        },
+        "yast2-firewall": {
+          "epoch": "0",
+          "version": "3.1.1",
+          "release": "2.247",
+          "installdate": "1447418279",
+          "arch": "noarch"
+        },
+        "cryptconfig": {
+          "epoch": "0",
+          "version": "0.3",
+          "release": "92.14",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "sle-module-adv-systems-management-release-POOL": {
+          "epoch": "0",
+          "version": "12",
+          "release": "3.1",
+          "installdate": "1447418217",
+          "arch": "x86_64"
+        },
+        "liblogging0": {
+          "epoch": "0",
+          "version": "1.0.4",
+          "release": "1.6",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "apparmor-parser": {
+          "epoch": "0",
+          "version": "2.8.2",
+          "release": "36.1",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "libgcc_s1": {
+          "epoch": "0",
+          "version": "5.2.1+r226025",
+          "release": "4.1",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "xdg-utils": {
+          "epoch": "0",
+          "version": "20140630",
+          "release": "5.1",
+          "installdate": "1447418261",
+          "arch": "noarch"
+        },
+        "iscsiuio": {
+          "epoch": "0",
+          "version": "0.7.8.2",
+          "release": "30.3",
+          "installdate": "1447418255",
+          "arch": "x86_64"
+        },
+        "update-alternatives": {
+          "epoch": "0",
+          "version": "1.16.10",
+          "release": "6.109",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "autoyast2": {
+          "epoch": "0",
+          "version": "3.1.69.9",
+          "release": "7.1",
+          "installdate": "1447418281",
+          "arch": "noarch"
+        },
+        "libfuse2": {
+          "epoch": "0",
+          "version": "2.9.3",
+          "release": "5.1",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "libseccomp2": {
+          "epoch": "0",
+          "version": "2.1.1",
+          "release": "2.13",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "libx86emu1": {
+          "epoch": "0",
+          "version": "1.1",
+          "release": "21.50",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "libpci3": {
+          "epoch": "0",
+          "version": "3.2.1",
+          "release": "5.1",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "libkmod2": {
+          "epoch": "0",
+          "version": "17",
+          "release": "1.18",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "prctl": {
+          "epoch": "0",
+          "version": "1.5",
+          "release": "17.61",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "libyajl2": {
+          "epoch": "0",
+          "version": "2.0.1",
+          "release": "17.1",
+          "installdate": "1447418257",
+          "arch": "x86_64"
+        },
+        "libbz2-1": {
+          "epoch": "0",
+          "version": "1.0.6",
+          "release": "27.1129",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "libgomp1": {
+          "epoch": "0",
+          "version": "5.3.1+r233831",
+          "release": "9.1",
+          "installdate": "1496777200",
+          "arch": "x86_64"
+        },
+        "openslp": {
+          "epoch": "0",
+          "version": "2.0.0",
+          "release": "5.1",
+          "installdate": "1447418257",
+          "arch": "x86_64"
+        },
+        "libselinux1": {
+          "epoch": "0",
+          "version": "2.3",
+          "release": "2.75",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "rpm-build": {
+          "epoch": "0",
+          "version": "4.11.2",
+          "release": "10.1",
+          "installdate": "1496777208",
+          "arch": "x86_64"
+        },
+        "unzip": {
+          "epoch": "0",
+          "version": "6.00",
+          "release": "32.1",
+          "installdate": "1447418258",
+          "arch": "x86_64"
+        },
+        "libsemanage1": {
+          "epoch": "0",
+          "version": "2.3",
+          "release": "1.340",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "kernel-default-devel": {
+          "epoch": "0",
+          "version": "3.12.60",
+          "release": "52.54.2",
+          "installdate": "1496777280",
+          "arch": "x86_64"
+        },
+        "ruby-common": {
+          "epoch": "0",
+          "version": "2.1",
+          "release": "14.1",
+          "installdate": "1447418265",
+          "arch": "noarch"
+        },
+        "sles-release": {
+          "epoch": "0",
+          "version": "12",
+          "release": "1.377",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "mutt": {
+          "epoch": "0",
+          "version": "1.5.21",
+          "release": "49.1",
+          "installdate": "1447418259",
+          "arch": "x86_64"
+        },
+        "tcpd": {
+          "epoch": "0",
+          "version": "7.6",
+          "release": "883.68",
+          "installdate": "1447418246",
+          "arch": "x86_64"
+        },
+        "sle-sdk-release": {
+          "epoch": "0",
+          "version": "12",
+          "release": "1.138",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "dbus-1-x11": {
+          "epoch": "0",
+          "version": "1.8.16",
+          "release": "14.1",
+          "installdate": "1447418260",
+          "arch": "x86_64"
+        },
+        "sle-module-legacy-release-POOL": {
+          "epoch": "0",
+          "version": "12",
+          "release": "3.1",
+          "installdate": "1447418217",
+          "arch": "x86_64"
+        },
+        "findutils": {
+          "epoch": "0",
+          "version": "4.5.12",
+          "release": "5.124",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "libyui-ncurses-pkg6": {
+          "epoch": "0",
+          "version": "2.46.1",
+          "release": "3.4",
+          "installdate": "1447418261",
+          "arch": "x86_64"
+        },
+        "Mesa-libGL1": {
+          "epoch": "0",
+          "version": "10.0.2",
+          "release": "90.17",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "libopenssl1_0_0": {
+          "epoch": "0",
+          "version": "1.0.1i",
+          "release": "27.3.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "perl-Net-DNS": {
+          "epoch": "0",
+          "version": "0.73",
+          "release": "4.1",
+          "installdate": "1447418261",
+          "arch": "x86_64"
+        },
+        "at": {
+          "epoch": "0",
+          "version": "3.1.14",
+          "release": "2.1",
+          "installdate": "1447418247",
+          "arch": "x86_64"
+        },
+        "libgcrypt20": {
+          "epoch": "0",
+          "version": "1.6.1",
+          "release": "16.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "multipath-tools": {
+          "epoch": "0",
+          "version": "0.5.0",
+          "release": "40.1",
+          "installdate": "1447418261",
+          "arch": "x86_64"
+        },
+        "pkg-config": {
+          "epoch": "0",
+          "version": "0.28",
+          "release": "6.98",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "sle-module-public-cloud-release": {
+          "epoch": "0",
+          "version": "12",
+          "release": "3.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "btrfsprogs": {
+          "epoch": "0",
+          "version": "3.18.2",
+          "release": "10.1",
+          "installdate": "1447418262",
+          "arch": "x86_64"
+        },
+        "libharfbuzz0": {
+          "epoch": "0",
+          "version": "0.9.26",
+          "release": "1.15",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "grep": {
+          "epoch": "0",
+          "version": "2.16",
+          "release": "3.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "libjasper1": {
+          "epoch": "0",
+          "version": "1.900.1",
+          "release": "170.1",
+          "installdate": "1447418262",
+          "arch": "x86_64"
+        },
+        "librpcsecgss3": {
+          "epoch": "0",
+          "version": "0.19",
+          "release": "16.56",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "libssh2-1": {
+          "epoch": "0",
+          "version": "1.4.3",
+          "release": "11.1",
+          "installdate": "1447418221",
+          "arch": "x86_64"
+        },
+        "sqlite3": {
+          "epoch": "0",
+          "version": "3.8.3.1",
+          "release": "2.3.1",
+          "installdate": "1447418263",
+          "arch": "x86_64"
+        },
+        "libkeyutils1": {
+          "epoch": "0",
+          "version": "1.5.9",
+          "release": "3.29",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "elfutils": {
+          "epoch": "0",
+          "version": "0.158",
+          "release": "6.1",
+          "installdate": "1447418221",
+          "arch": "x86_64"
+        },
+        "xen-libs": {
+          "epoch": "0",
+          "version": "4.4.3_02",
+          "release": "22.12.1",
+          "installdate": "1447418263",
+          "arch": "x86_64"
+        },
+        "python-configobj": {
+          "epoch": "0",
+          "version": "4.7.2",
+          "release": "18.10",
+          "installdate": "1447418268",
+          "arch": "noarch"
+        },
+        "glibc-locale": {
+          "epoch": "0",
+          "version": "2.19",
+          "release": "22.7.1",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "ntp": {
+          "epoch": "0",
+          "version": "4.2.6p5",
+          "release": "44.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "man": {
+          "epoch": "0",
+          "version": "2.6.6",
+          "release": "1.32",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "sle-module-toolchain-release": {
+          "epoch": "0",
+          "version": "12",
+          "release": "1.11",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "python": {
+          "epoch": "0",
+          "version": "2.7.9",
+          "release": "14.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "libassuan0": {
+          "epoch": "0",
+          "version": "2.1.1",
+          "release": "3.217",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "sysvinit-tools": {
+          "epoch": "0",
+          "version": "2.88+",
+          "release": "94.13",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "p11-kit-tools": {
+          "epoch": "0",
+          "version": "0.20.3",
+          "release": "4.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "syslog-service": {
+          "epoch": "0",
+          "version": "2.0",
+          "release": "778.1",
+          "installdate": "1447418268",
+          "arch": "noarch"
+        },
+        "pam-config": {
+          "epoch": "0",
+          "version": "0.88",
+          "release": "1.1",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "sysconfig-netconfig": {
+          "epoch": "0",
+          "version": "0.83.8",
+          "release": "7.1",
+          "installdate": "1447418265",
+          "arch": "x86_64"
+        },
+        "libxcb-glx0": {
+          "epoch": "0",
+          "version": "1.10",
+          "release": "1.21",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "util-linux": {
+          "epoch": "0",
+          "version": "2.25",
+          "release": "22.1",
+          "installdate": "1447418224",
+          "arch": "x86_64"
+        },
+        "terminfo": {
+          "epoch": "0",
+          "version": "5.9",
+          "release": "40.124",
+          "installdate": "1447418246",
+          "arch": "x86_64"
+        },
+        "pinentry": {
+          "epoch": "0",
+          "version": "0.8.3",
+          "release": "4.27",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "libcryptsetup4": {
+          "epoch": "0",
+          "version": "1.6.4",
+          "release": "2.10",
+          "installdate": "1447418224",
+          "arch": "x86_64"
+        },
+        "sle-module-web-scripting-release-POOL": {
+          "epoch": "0",
+          "version": "12",
+          "release": "3.1",
+          "installdate": "1447418217",
+          "arch": "x86_64"
+        },
+        "atk-lang": {
+          "epoch": "0",
+          "version": "2.10.0",
+          "release": "1.84",
+          "installdate": "1447418269",
+          "arch": "noarch"
+        },
+        "udev": {
+          "epoch": "0",
+          "version": "210",
+          "release": "70.25.1",
+          "installdate": "1447418225",
+          "arch": "x86_64"
+        },
+        "python-Jinja2": {
+          "epoch": "0",
+          "version": "2.7.3",
+          "release": "15.1",
+          "installdate": "1447418266",
+          "arch": "noarch"
+        },
+        "perl-URI": {
+          "epoch": "0",
+          "version": "1.60",
+          "release": "7.19",
+          "installdate": "1447418252",
+          "arch": "noarch"
+        },
+        "libusb-1_0-0": {
+          "epoch": "0",
+          "version": "1.0.18",
+          "release": "2.6",
+          "installdate": "1447418230",
+          "arch": "x86_64"
+        },
+        "libxcb1": {
+          "epoch": "0",
+          "version": "1.10",
+          "release": "1.21",
+          "installdate": "1447418248",
+          "arch": "x86_64"
+        },
+        "sle-module-legacy-release": {
+          "epoch": "0",
+          "version": "12",
+          "release": "3.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "cryptsetup": {
+          "epoch": "0",
+          "version": "1.6.4",
+          "release": "2.10",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "libz1": {
+          "epoch": "0",
+          "version": "1.2.8",
+          "release": "5.1",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "gsettings-desktop-schemas": {
+          "epoch": "0",
+          "version": "3.10.1",
+          "release": "2.1",
+          "installdate": "1447418271",
+          "arch": "x86_64"
+        },
+        "fdupes": {
+          "epoch": "0",
+          "version": "1.50",
+          "release": "5.97",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "fontconfig": {
+          "epoch": "0",
+          "version": "2.11.0",
+          "release": "4.19",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "libpcap1": {
+          "epoch": "0",
+          "version": "1.5.3",
+          "release": "2.18",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "kexec-tools": {
+          "epoch": "0",
+          "version": "2.0.5",
+          "release": "9.22",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "liboggkate1": {
+          "epoch": "0",
+          "version": "0.4.1",
+          "release": "20.65",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "dirmngr": {
+          "epoch": "0",
+          "version": "1.1.1",
+          "release": "4.1",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "libXau6": {
+          "epoch": "0",
+          "version": "1.0.8",
+          "release": "4.58",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "libgpg-error0": {
+          "epoch": "0",
+          "version": "1.13",
+          "release": "1.79",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "libwbclient0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418272",
+          "arch": "x86_64"
+        },
+        "libdm0": {
+          "epoch": "0",
+          "version": "2.2.12",
+          "release": "1.16",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "python-M2Crypto": {
+          "epoch": "0",
+          "version": "0.21.1",
+          "release": "16.59",
+          "installdate": "1447418268",
+          "arch": "x86_64"
+        },
+        "perl-Test-Exception": {
+          "epoch": "0",
+          "version": "0.32",
+          "release": "3.14",
+          "installdate": "1447418253",
+          "arch": "noarch"
+        },
+        "libgdbm4": {
+          "epoch": "0",
+          "version": "1.10",
+          "release": "9.70",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libsmi2": {
+          "epoch": "0",
+          "version": "0.4.8",
+          "release": "18.63",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "aaa_base": {
+          "epoch": "0",
+          "version": "13.2+git20140911.61c1681",
+          "release": "9.1",
+          "installdate": "1447418224",
+          "arch": "x86_64"
+        },
+        "libkate1": {
+          "epoch": "0",
+          "version": "0.4.1",
+          "release": "20.65",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libzio1": {
+          "epoch": "0",
+          "version": "1.00",
+          "release": "9.188",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "python-botocore": {
+          "epoch": "0",
+          "version": "1.2.10",
+          "release": "10.1",
+          "installdate": "1447418274",
+          "arch": "noarch"
+        },
+        "libmnl0": {
+          "epoch": "0",
+          "version": "1.0.3",
+          "release": "9.18",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libXft2": {
+          "epoch": "0",
+          "version": "2.3.1",
+          "release": "9.32",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "perl-XML-SAX-Expat": {
+          "epoch": "0",
+          "version": "0.50",
+          "release": "3.8",
+          "installdate": "1447418254",
+          "arch": "noarch"
+        },
+        "libnscd1": {
+          "epoch": "0",
+          "version": "2.0.2",
+          "release": "134.13",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libX11-6": {
+          "epoch": "0",
+          "version": "1.6.2",
+          "release": "4.12",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "libcurl4": {
+          "epoch": "0",
+          "version": "7.37.0",
+          "release": "15.1",
+          "installdate": "1447418230",
+          "arch": "x86_64"
+        },
+        "libpipeline1": {
+          "epoch": "0",
+          "version": "1.2.6",
+          "release": "1.20",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "gawk": {
+          "epoch": "0",
+          "version": "4.1.0",
+          "release": "3.663",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "libndr-standard0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418276",
+          "arch": "x86_64"
+        },
+        "libspeex1": {
+          "epoch": "0",
+          "version": "1.1.999_1.2rc1",
+          "release": "22.64",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "pango-modules": {
+          "epoch": "0",
+          "version": "1.36.3",
+          "release": "4.14",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "kpartx": {
+          "epoch": "0",
+          "version": "0.5.0",
+          "release": "40.1",
+          "installdate": "1447418255",
+          "arch": "x86_64"
+        },
+        "lsof": {
+          "epoch": "0",
+          "version": "4.84",
+          "release": "20.65",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "perl-Parse-RecDescent": {
+          "epoch": "0",
+          "version": "1.967009",
+          "release": "7.19",
+          "installdate": "1447418252",
+          "arch": "x86_64"
+        },
+        "fd0ssh": {
+          "epoch": "0",
+          "version": "20140325",
+          "release": "1.13",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "net-tools": {
+          "epoch": "0",
+          "version": "1.60",
+          "release": "764.185",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "sed": {
+          "epoch": "0",
+          "version": "4.2.2",
+          "release": "6.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "libtevent-util0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "psmisc": {
+          "epoch": "0",
+          "version": "22.21",
+          "release": "3.19",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "dbus-1-glib": {
+          "epoch": "0",
+          "version": "0.100.2",
+          "release": "3.58",
+          "installdate": "1447418271",
+          "arch": "x86_64"
+        },
+        "libply-boot-client2": {
+          "epoch": "0",
+          "version": "0.9.0",
+          "release": "25.1",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "Mesa": {
+          "epoch": "0",
+          "version": "10.0.2",
+          "release": "90.17",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "libvorbisenc2": {
+          "epoch": "0",
+          "version": "1.3.3",
+          "release": "8.23",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "libX11-data": {
+          "epoch": "0",
+          "version": "1.6.2",
+          "release": "4.12",
+          "installdate": "1447418242",
+          "arch": "noarch"
+        },
+        "python-ec2metadata": {
+          "epoch": "0",
+          "version": "1.5.3",
+          "release": "3.1",
+          "installdate": "1447418266",
+          "arch": "noarch"
+        },
+        "pam": {
+          "epoch": "0",
+          "version": "1.1.8",
+          "release": "14.1",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "puppet": {
+          "epoch": "0",
+          "version": "3.6.2",
+          "release": "3.62",
+          "installdate": "1447418279",
+          "arch": "x86_64"
+        },
+        "wicked-service": {
+          "epoch": "0",
+          "version": "0.6.20",
+          "release": "18.5.1",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "ca-certificates-mozilla": {
+          "epoch": "0",
+          "version": "2.2",
+          "release": "7.1",
+          "installdate": "1447418272",
+          "arch": "noarch"
+        },
+        "patch": {
+          "epoch": "0",
+          "version": "2.7.5",
+          "release": "7.1",
+          "installdate": "1447418257",
+          "arch": "x86_64"
+        },
+        "rsync": {
+          "epoch": "0",
+          "version": "3.1.0",
+          "release": "2.7",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "perl-Config-IniFiles": {
+          "epoch": "0",
+          "version": "2.82",
+          "release": "3.14",
+          "installdate": "1447418253",
+          "arch": "noarch"
+        },
+        "libgc1": {
+          "epoch": "0",
+          "version": "7.2d",
+          "release": "3.77",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "python-pyasn1": {
+          "epoch": "0",
+          "version": "0.1.7",
+          "release": "5.7",
+          "installdate": "1447418267",
+          "arch": "noarch"
+        },
+        "netcfg": {
+          "epoch": "0",
+          "version": "11.5",
+          "release": "24.13",
+          "installdate": "1447418224",
+          "arch": "noarch"
+        },
+        "yast2-audit-laf": {
+          "epoch": "0",
+          "version": "3.1.2",
+          "release": "1.59",
+          "installdate": "1447418280",
+          "arch": "noarch"
+        },
+        "python-Cheetah": {
+          "epoch": "0",
+          "version": "2.4.4",
+          "release": "8.22",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "docker": {
+          "epoch": "0",
+          "version": "1.8.3",
+          "release": "49.1",
+          "installdate": "1447418274",
+          "arch": "x86_64"
+        },
+        "perl-YAML-LibYAML": {
+          "epoch": "0",
+          "version": "0.38",
+          "release": "10.1",
+          "installdate": "1447418259",
+          "arch": "x86_64"
+        },
+        "python-docutils": {
+          "epoch": "0",
+          "version": "0.11",
+          "release": "1.11",
+          "installdate": "1447418268",
+          "arch": "noarch"
+        },
+        "yast2-perl-bindings": {
+          "epoch": "0",
+          "version": "3.1.2",
+          "release": "1.11",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "liblzo2-2": {
+          "epoch": "0",
+          "version": "2.08",
+          "release": "1.13",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "orbit2": {
+          "epoch": "0",
+          "version": "2.14.19",
+          "release": "17.28",
+          "installdate": "1447418268",
+          "arch": "x86_64"
+        },
+        "libusb-0_1-4": {
+          "epoch": "0",
+          "version": "0.1.13",
+          "release": "29.13",
+          "installdate": "1447418230",
+          "arch": "x86_64"
+        },
+        "yast2-docker": {
+          "epoch": "0",
+          "version": "3.1.7",
+          "release": "23.1",
+          "installdate": "1447418280",
+          "arch": "noarch"
+        },
+        "python-rsa": {
+          "epoch": "0",
+          "version": "3.1.2",
+          "release": "1.7",
+          "installdate": "1447418269",
+          "arch": "noarch"
+        },
+        "yast2-sysconfig": {
+          "epoch": "0",
+          "version": "3.1.2.2",
+          "release": "7.1",
+          "installdate": "1447418276",
+          "arch": "noarch"
+        },
+        "cronie": {
+          "epoch": "0",
+          "version": "1.4.11",
+          "release": "58.3",
+          "installdate": "1447418261",
+          "arch": "x86_64"
+        },
+        "ruby2.1-rubygem-json_pure": {
+          "epoch": "0",
+          "version": "1.8.1",
+          "release": "2.8",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "libarchive13": {
+          "epoch": "0",
+          "version": "3.1.2",
+          "release": "9.1",
+          "installdate": "1447418255",
+          "arch": "x86_64"
+        },
+        "libpcreposix0": {
+          "epoch": "0",
+          "version": "8.33",
+          "release": "3.314",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libao-plugins4": {
+          "epoch": "0",
+          "version": "1.2.0",
+          "release": "1.13",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "fping": {
+          "epoch": "0",
+          "version": "3.5",
+          "release": "3.64",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "yast2-samba-server": {
+          "epoch": "0",
+          "version": "3.1.12",
+          "release": "8.1",
+          "installdate": "1447418281",
+          "arch": "noarch"
+        },
+        "libudisks2-0": {
+          "epoch": "0",
+          "version": "2.1.3",
+          "release": "1.14",
+          "installdate": "1447418270",
+          "arch": "x86_64"
+        },
+        "libsamdb0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "autofs": {
+          "epoch": "0",
+          "version": "5.0.9",
+          "release": "8.1",
+          "installdate": "1447418263",
+          "arch": "x86_64"
+        },
+        "at-spi2-core": {
+          "epoch": "0",
+          "version": "2.10.2",
+          "release": "5.7",
+          "installdate": "1447418271",
+          "arch": "x86_64"
+        },
+        "libpython2_7-1_0": {
+          "epoch": "0",
+          "version": "2.7.9",
+          "release": "14.1",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "libxtables10": {
+          "epoch": "0",
+          "version": "1.4.21",
+          "release": "2.10",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "libgudev-1_0-0": {
+          "epoch": "0",
+          "version": "210",
+          "release": "70.25.1",
+          "installdate": "1447418271",
+          "arch": "x86_64"
+        },
+        "libaio1": {
+          "epoch": "0",
+          "version": "0.3.109",
+          "release": "17.15",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "mtools": {
+          "epoch": "0",
+          "version": "4.0.18",
+          "release": "4.379",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "ruby2.1-rubygem-suse-connect": {
+          "epoch": "0",
+          "version": "0.2.14.42",
+          "release": "9.3.1",
+          "installdate": "1447418273",
+          "arch": "x86_64"
+        },
+        "gtk3-tools": {
+          "epoch": "0",
+          "version": "3.10.9",
+          "release": "4.46",
+          "installdate": "1447418279",
+          "arch": "x86_64"
+        },
+        "procmail": {
+          "epoch": "0",
+          "version": "3.22",
+          "release": "267.12",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "libpolkit0": {
+          "epoch": "0",
+          "version": "0.113",
+          "release": "4.1",
+          "installdate": "1447418273",
+          "arch": "x86_64"
+        },
+        "screen": {
+          "epoch": "0",
+          "version": "4.0.4",
+          "release": "18.1",
+          "installdate": "1447418258",
+          "arch": "x86_64"
+        },
+        "strace": {
+          "epoch": "0",
+          "version": "4.8",
+          "release": "6.15",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "libsmbconf0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418274",
+          "arch": "x86_64"
+        },
+        "libglib-2_0-0": {
+          "epoch": "0",
+          "version": "2.38.2",
+          "release": "5.12",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "tcl": {
+          "epoch": "0",
+          "version": "8.6.1",
+          "release": "2.10",
+          "installdate": "1447418246",
+          "arch": "x86_64"
+        },
+        "postfix": {
+          "epoch": "0",
+          "version": "2.11.6",
+          "release": "19.1",
+          "installdate": "1447418275",
+          "arch": "x86_64"
+        },
+        "yast2-online-update": {
+          "epoch": "0",
+          "version": "3.1.7",
+          "release": "1.34",
+          "installdate": "1447418280",
+          "arch": "noarch"
+        },
+        "vim-data": {
+          "epoch": "0",
+          "version": "7.4.326",
+          "release": "2.62",
+          "installdate": "1447418247",
+          "arch": "noarch"
+        },
+        "cloud-init": {
+          "epoch": "0",
+          "version": "0.7.6",
+          "release": "17.1",
+          "installdate": "1447418275",
+          "arch": "x86_64"
+        },
+        "openssh": {
+          "epoch": "0",
+          "version": "6.6p1",
+          "release": "29.1",
+          "installdate": "1447418260",
+          "arch": "x86_64"
+        },
+        "xinetd": {
+          "epoch": "0",
+          "version": "2.3.15",
+          "release": "7.7",
+          "installdate": "1447418247",
+          "arch": "x86_64"
+        },
+        "plymouth-branding-SLE": {
+          "epoch": "0",
+          "version": "12",
+          "release": "11.3.1",
+          "installdate": "1447418276",
+          "arch": "noarch"
+        },
+        "libmtp9": {
+          "epoch": "0",
+          "version": "1.1.6",
+          "release": "5.29",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "yast2-trans-stats": {
+          "epoch": "0",
+          "version": "2.19.0",
+          "release": "15.22",
+          "installdate": "1447418247",
+          "arch": "noarch"
+        },
+        "cloud-regionsrv-client": {
+          "epoch": "0",
+          "version": "6.4.2",
+          "release": "23.1",
+          "installdate": "1447418276",
+          "arch": "noarch"
+        },
+        "yast2-samba-client": {
+          "epoch": "0",
+          "version": "3.1.15",
+          "release": "8.1",
+          "installdate": "1447418281",
+          "arch": "noarch"
+        },
+        "libcryptmount0": {
+          "epoch": "0",
+          "version": "2.14",
+          "release": "3.68",
+          "installdate": "1447418247",
+          "arch": "x86_64"
+        },
+        "yast2-proxy": {
+          "epoch": "0",
+          "version": "3.1.2",
+          "release": "4.1",
+          "installdate": "1447418276",
+          "arch": "noarch"
+        },
+        "libavahi-glib1": {
+          "epoch": "0",
+          "version": "0.6.31",
+          "release": "22.4",
+          "installdate": "1447418261",
+          "arch": "x86_64"
+        },
+        "audit": {
+          "epoch": "0",
+          "version": "2.3.6",
+          "release": "3.7",
+          "installdate": "1447418248",
+          "arch": "x86_64"
+        },
+        "gvfs-lang": {
+          "epoch": "0",
+          "version": "1.18.3",
+          "release": "7.3",
+          "installdate": "1447418276",
+          "arch": "noarch"
+        },
+        "libpixman-1-0": {
+          "epoch": "0",
+          "version": "0.32.6",
+          "release": "1.13",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "libdrm_nouveau2": {
+          "epoch": "0",
+          "version": "2.4.52",
+          "release": "2.12",
+          "installdate": "1447418248",
+          "arch": "x86_64"
+        },
+        "libsamba-util0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "yast2-ftp-server": {
+          "epoch": "0",
+          "version": "3.1.8",
+          "release": "6.1",
+          "installdate": "1447418281",
+          "arch": "noarch"
+        },
+        "libpyglib-gi-2_0-python2-0": {
+          "epoch": "0",
+          "version": "3.10.2",
+          "release": "2.22",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "libsamba-credentials0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "ruby2.1-stdlib": {
+          "epoch": "0",
+          "version": "2.1.2",
+          "release": "9.1",
+          "installdate": "1447418263",
+          "arch": "x86_64"
+        },
+        "libIDL-2-0": {
+          "epoch": "0",
+          "version": "0.8.14",
+          "release": "19.58",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "libdcerpc-binding0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "kdump": {
+          "epoch": "0",
+          "version": "0.8.15",
+          "release": "14.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "lockdev": {
+          "epoch": "0",
+          "version": "1.0.3_git201003141408",
+          "release": "27.1",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "libndr-krb5pac0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "python-pycrypto": {
+          "epoch": "0",
+          "version": "2.6.1",
+          "release": "2.2",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "libedit0": {
+          "epoch": "0",
+          "version": "3.1.snap20140620",
+          "release": "1.13",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "cpp": {
+          "epoch": "0",
+          "version": "4.8",
+          "release": "6.189",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "gpg-pubkey": {
+          "epoch": "0",
+          "version": "50a3dd1c",
+          "release": "50f35137",
+          "installdate": "1447418282",
+          "arch": "(none)"
+        },
+        "irqbalance": {
+          "epoch": "0",
+          "version": "1.0.7",
+          "release": "3.6",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "icedax": {
+          "epoch": "0",
+          "version": "1.1.11",
+          "release": "19.46",
+          "installdate": "1447418279",
+          "arch": "x86_64"
+        },
+        "libatomic1": {
+          "epoch": "0",
+          "version": "5.3.1+r233831",
+          "release": "9.1",
+          "installdate": "1496777200",
+          "arch": "x86_64"
+        },
+        "pcre-tools": {
+          "epoch": "0",
+          "version": "8.33",
+          "release": "3.314",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "yast2-storage": {
+          "epoch": "0",
+          "version": "3.1.45",
+          "release": "1.12",
+          "installdate": "1447418279",
+          "arch": "x86_64"
+        },
+        "systemd-rpm-macros": {
+          "epoch": "0",
+          "version": "2.1",
+          "release": "8.3.1",
+          "installdate": "1496777204",
+          "arch": "noarch"
+        },
+        "makedumpfile": {
+          "epoch": "0",
+          "version": "1.5.6",
+          "release": "2.1",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "yast2-pam": {
+          "epoch": "0",
+          "version": "3.1.1",
+          "release": "1.264",
+          "installdate": "1447418279",
+          "arch": "noarch"
+        },
+        "gcc": {
+          "epoch": "0",
+          "version": "4.8",
+          "release": "6.189",
+          "installdate": "1496777207",
+          "arch": "x86_64"
+        },
+        "iproute2": {
+          "epoch": "0",
+          "version": "3.12",
+          "release": "5.36",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "yast2-iscsi-lio-server": {
+          "epoch": "0",
+          "version": "3.1.11",
+          "release": "1.24",
+          "installdate": "1447418279",
+          "arch": "noarch"
+        },
+        "flex": {
+          "epoch": "0",
+          "version": "2.5.37",
+          "release": "6.208",
+          "installdate": "1496777274",
+          "arch": "x86_64"
+        },
+        "expect": {
+          "epoch": "0",
+          "version": "5.45",
+          "release": "15.89",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "yast2-dbus-server": {
+          "epoch": "0",
+          "version": "3.1.1",
+          "release": "1.61",
+          "installdate": "1447418280",
+          "arch": "x86_64"
+        },
+        "gcc48-c++": {
+          "epoch": "0",
+          "version": "4.8.5",
+          "release": "24.1",
+          "installdate": "1496777279",
+          "arch": "x86_64"
+        },
+        "javapackages-tools": {
+          "epoch": "0",
+          "version": "2.0.1",
+          "release": "6.10",
+          "installdate": "1496777301",
+          "arch": "x86_64"
+        },
+        "omnibus-toolchain": {
+          "epoch": "0",
+          "version": "1.1.73",
+          "release": "1.el6",
+          "installdate": "1506611851",
+          "arch": "x86_64"
+        },
+        "cifs-utils": {
+          "epoch": "0",
+          "version": "6.4",
+          "release": "3.5",
+          "installdate": "1447418280",
+          "arch": "x86_64"
+        },
+        "plymouth-scripts": {
+          "epoch": "0",
+          "version": "0.9.0",
+          "release": "25.1",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "java-1_7_1-ibm": {
+          "epoch": "0",
+          "version": "1.7.1_sr3.40",
+          "release": "25.1",
+          "installdate": "1496777308",
+          "arch": "x86_64"
+        },
+        "cyrus-sasl-gssapi": {
+          "epoch": "0",
+          "version": "2.1.26",
+          "release": "7.1",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "yast2-tune": {
+          "epoch": "0",
+          "version": "3.1.5",
+          "release": "1.52",
+          "installdate": "1447418280",
+          "arch": "x86_64"
+        },
+        "libuuid1": {
+          "epoch": "0",
+          "version": "2.25",
+          "release": "22.1",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "perl-XML-Parser": {
+          "epoch": "0",
+          "version": "2.41",
+          "release": "21.140",
+          "installdate": "1447418252",
+          "arch": "x86_64"
+        },
+        "yast2-installation": {
+          "epoch": "0",
+          "version": "3.1.116.5",
+          "release": "10.1",
+          "installdate": "1447418281",
+          "arch": "noarch"
+        },
+        "libcdio_cdda1": {
+          "epoch": "0",
+          "version": "10.2+0.90",
+          "release": "3.51",
+          "installdate": "1447418248",
+          "arch": "x86_64"
+        },
+        "perl-Digest-SHA1": {
+          "epoch": "0",
+          "version": "2.13",
+          "release": "17.216",
+          "installdate": "1447418252",
+          "arch": "x86_64"
+        },
+        "yast2-dns-server": {
+          "epoch": "0",
+          "version": "3.1.11",
+          "release": "6.1",
+          "installdate": "1447418281",
+          "arch": "noarch"
+        },
+        "python-ply": {
+          "epoch": "0",
+          "version": "3.4",
+          "release": "1.6",
+          "installdate": "1447418267",
+          "arch": "noarch"
+        },
+        "gettext-runtime": {
+          "epoch": "0",
+          "version": "0.19.2",
+          "release": "1.103",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "yast2-dhcp-server": {
+          "epoch": "0",
+          "version": "3.1.4",
+          "release": "1.21",
+          "installdate": "1447418282",
+          "arch": "noarch"
+        },
+        "libexpat1": {
+          "epoch": "0",
+          "version": "2.1.0",
+          "release": "13.232",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "libXpm4": {
+          "epoch": "0",
+          "version": "3.5.11",
+          "release": "3.60",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "cups-libs": {
+          "epoch": "0",
+          "version": "1.7.5",
+          "release": "9.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "libtevent0": {
+          "epoch": "0",
+          "version": "0.9.21",
+          "release": "2.4",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "pam_mount": {
+          "epoch": "0",
+          "version": "2.14",
+          "release": "3.68",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "cracklib-dict-full": {
+          "epoch": "0",
+          "version": "2.8.12",
+          "release": "63.17",
+          "installdate": "1447418217",
+          "arch": "x86_64"
+        },
+        "python-jsonpatch": {
+          "epoch": "0",
+          "version": "1.1",
+          "release": "8.5",
+          "installdate": "1447418269",
+          "arch": "noarch"
+        },
+        "automake": {
+          "epoch": "0",
+          "version": "1.13.4",
+          "release": "4.56",
+          "installdate": "1447418253",
+          "arch": "noarch"
+        },
+        "xfsprogs": {
+          "epoch": "0",
+          "version": "3.2.1",
+          "release": "1.3",
+          "installdate": "1447418247",
+          "arch": "x86_64"
+        },
+        "diffutils": {
+          "epoch": "0",
+          "version": "3.3",
+          "release": "5.40",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "kernel-default": {
+          "epoch": "0",
+          "version": "3.12.48",
+          "release": "52.27.1",
+          "installdate": "1447418229",
+          "arch": "x86_64"
+        },
+        "quota": {
+          "epoch": "0",
+          "version": "4.01",
+          "release": "4.11",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "perl-Error": {
+          "epoch": "0",
+          "version": "0.17021",
+          "release": "1.18",
+          "installdate": "1447418252",
+          "arch": "noarch"
+        },
+        "deltarpm": {
+          "epoch": "0",
+          "version": "3.6",
+          "release": "3.58",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "libsepol1": {
+          "epoch": "0",
+          "version": "2.3",
+          "release": "1.476",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "glib-networking": {
+          "epoch": "0",
+          "version": "2.38.2",
+          "release": "1.41",
+          "installdate": "1447418271",
+          "arch": "x86_64"
+        },
+        "klogd": {
+          "epoch": "0",
+          "version": "1.4.1",
+          "release": "778.1",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "libyui-ncurses6": {
+          "epoch": "0",
+          "version": "2.46.6",
+          "release": "1.56",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "sle-module-containers-release": {
+          "epoch": "0",
+          "version": "12",
+          "release": "2.1",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "libelf0": {
+          "epoch": "0",
+          "version": "0.8.13",
+          "release": "18.64",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "python-dateutil": {
+          "epoch": "0",
+          "version": "2.1",
+          "release": "10.7",
+          "installdate": "1447418268",
+          "arch": "noarch"
+        },
+        "perl-Crypt-SmbHash": {
+          "epoch": "0",
+          "version": "0.12",
+          "release": "156.12",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "chefdk": {
+          "epoch": "0",
+          "version": "2.4.3",
+          "release": "1.sles12",
+          "installdate": "1509563888",
+          "arch": "x86_64"
+        },
+        "liblcms2-2": {
+          "epoch": "0",
+          "version": "2.5",
+          "release": "4.20",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libproxy1": {
+          "epoch": "0",
+          "version": "0.4.11",
+          "release": "11.2",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "ruby2.1-rubygem-docker-api": {
+          "epoch": "0",
+          "version": "1.17.0",
+          "release": "6.1",
+          "installdate": "1447418275",
+          "arch": "x86_64"
+        },
+        "libogg0": {
+          "epoch": "0",
+          "version": "1.3.0",
+          "release": "9.61",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "cyrus-sasl-digestmd5": {
+          "epoch": "0",
+          "version": "2.1.26",
+          "release": "7.1",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "libzypp": {
+          "epoch": "0",
+          "version": "14.42.3",
+          "release": "2.31.1",
+          "installdate": "1447418230",
+          "arch": "x86_64"
+        },
+        "libtdb1": {
+          "epoch": "0",
+          "version": "1.3.0",
+          "release": "1.7",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "gio-branding-SLE": {
+          "epoch": "0",
+          "version": "12",
+          "release": "6.9",
+          "installdate": "1447418269",
+          "arch": "noarch"
+        },
+        "libebl1": {
+          "epoch": "0",
+          "version": "0.158",
+          "release": "6.1",
+          "installdate": "1447418255",
+          "arch": "x86_64"
+        },
+        "opie": {
+          "epoch": "0",
+          "version": "2.4",
+          "release": "724.65",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "openssl": {
+          "epoch": "0",
+          "version": "1.0.1i",
+          "release": "27.3.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "libndr-nbt0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "libply-splash-graphics2": {
+          "epoch": "0",
+          "version": "0.9.0",
+          "release": "25.1",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "libXfixes3": {
+          "epoch": "0",
+          "version": "5.0.1",
+          "release": "3.53",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "libauparse0": {
+          "epoch": "0",
+          "version": "2.3.6",
+          "release": "3.103",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "dmraid": {
+          "epoch": "0",
+          "version": "1.0.0.rc16",
+          "release": "31.5",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "rsyslog": {
+          "epoch": "0",
+          "version": "8.4.0",
+          "release": "8.3",
+          "installdate": "1447418273",
+          "arch": "x86_64"
+        },
+        "tar": {
+          "epoch": "0",
+          "version": "1.27.1",
+          "release": "4.1",
+          "installdate": "1447418258",
+          "arch": "x86_64"
+        },
+        "python-oauth": {
+          "epoch": "0",
+          "version": "1.0.1",
+          "release": "1.5",
+          "installdate": "1447418267",
+          "arch": "noarch"
+        },
+        "systemd-sysvinit": {
+          "epoch": "0",
+          "version": "210",
+          "release": "70.25.1",
+          "installdate": "1447418224",
+          "arch": "x86_64"
+        },
+        "yast2-country": {
+          "epoch": "0",
+          "version": "3.1.13",
+          "release": "1.16",
+          "installdate": "1447418280",
+          "arch": "x86_64"
+        },
+        "scout": {
+          "epoch": "0",
+          "version": "0.1.0",
+          "release": "57.8",
+          "installdate": "1447418268",
+          "arch": "noarch"
+        },
+        "Mesa-libglapi0": {
+          "epoch": "0",
+          "version": "10.0.2",
+          "release": "90.17",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "libnet9": {
+          "epoch": "0",
+          "version": "1.2~rc3",
+          "release": "1.18",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "python-paramiko": {
+          "epoch": "0",
+          "version": "1.12.0",
+          "release": "1.6",
+          "installdate": "1447418269",
+          "arch": "noarch"
+        },
+        "yast2-packager": {
+          "epoch": "0",
+          "version": "3.1.52",
+          "release": "6.11",
+          "installdate": "1447418276",
+          "arch": "x86_64"
+        },
+        "e2fsprogs": {
+          "epoch": "0",
+          "version": "1.42.11",
+          "release": "7.1",
+          "installdate": "1447418262",
+          "arch": "x86_64"
+        },
+        "yast2-ruby-bindings": {
+          "epoch": "0",
+          "version": "3.1.24",
+          "release": "1.8",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "hicolor-icon-theme": {
+          "epoch": "0",
+          "version": "0.13",
+          "release": "1.15",
+          "installdate": "1447418241",
+          "arch": "noarch"
+        },
+        "yast2-mail": {
+          "epoch": "0",
+          "version": "3.1.4",
+          "release": "1.16",
+          "installdate": "1447418282",
+          "arch": "noarch"
+        },
+        "libgirepository-1_0-1": {
+          "epoch": "0",
+          "version": "1.38.0",
+          "release": "3.17",
+          "installdate": "1447418271",
+          "arch": "x86_64"
+        },
+        "libtirpc1": {
+          "epoch": "0",
+          "version": "0.2.3",
+          "release": "8.1",
+          "installdate": "1447418257",
+          "arch": "x86_64"
+        },
+        "Mesa-libEGL1": {
+          "epoch": "0",
+          "version": "10.0.2",
+          "release": "90.17",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "ruby2.1-rubygem-archive-tar-minitar": {
+          "epoch": "0",
+          "version": "0.5.2",
+          "release": "6.1",
+          "installdate": "1447418273",
+          "arch": "x86_64"
+        },
+        "yast2-squid": {
+          "epoch": "0",
+          "version": "3.1.3",
+          "release": "1.134",
+          "installdate": "1447418279",
+          "arch": "x86_64"
+        },
+        "sle-module-containers-release-POOL": {
+          "epoch": "0",
+          "version": "12",
+          "release": "2.1",
+          "installdate": "1447418216",
+          "arch": "x86_64"
+        },
+        "libXevie1": {
+          "epoch": "0",
+          "version": "1.0.3",
+          "release": "10.58",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "libisl10": {
+          "epoch": "0",
+          "version": "0.12.2",
+          "release": "1.121",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "file-magic": {
+          "epoch": "0",
+          "version": "5.19",
+          "release": "9.1",
+          "installdate": "1447418217",
+          "arch": "x86_64"
+        },
+        "perl-Date-Calc": {
+          "epoch": "0",
+          "version": "6.3",
+          "release": "22.9",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "yast2-pkg-bindings": {
+          "epoch": "0",
+          "version": "3.1.20.2",
+          "release": "8.1",
+          "installdate": "1447418260",
+          "arch": "x86_64"
+        },
+        "libsmartcols1": {
+          "epoch": "0",
+          "version": "2.25",
+          "release": "22.1",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "ethtool": {
+          "epoch": "0",
+          "version": "3.12.1",
+          "release": "5.1",
+          "installdate": "1447418255",
+          "arch": "x86_64"
+        },
+        "yast2-nis-client": {
+          "epoch": "0",
+          "version": "3.1.10",
+          "release": "1.49",
+          "installdate": "1447418281",
+          "arch": "x86_64"
+        },
+        "libstdc++6": {
+          "epoch": "0",
+          "version": "5.2.1+r226025",
+          "release": "4.1",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "libext2fs2": {
+          "epoch": "0",
+          "version": "1.42.11",
+          "release": "7.1",
+          "installdate": "1447418255",
+          "arch": "x86_64"
+        },
+        "libsmbios2": {
+          "epoch": "0",
+          "version": "2.2.28",
+          "release": "10.142",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "libsgutils2-2": {
+          "epoch": "0",
+          "version": "1.38",
+          "release": "10.9",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "libmpfr4": {
+          "epoch": "0",
+          "version": "3.1.2",
+          "release": "7.1",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "lsscsi": {
+          "epoch": "0",
+          "version": "0.27",
+          "release": "4.17",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "liblzma5": {
+          "epoch": "0",
+          "version": "5.0.5",
+          "release": "4.852",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "libtasn1-6": {
+          "epoch": "0",
+          "version": "3.7",
+          "release": "4.1",
+          "installdate": "1447418257",
+          "arch": "x86_64"
+        },
+        "readline-doc": {
+          "epoch": "0",
+          "version": "6.2",
+          "release": "75.2",
+          "installdate": "1447418245",
+          "arch": "noarch"
+        },
+        "libcap2": {
+          "epoch": "0",
+          "version": "2.22",
+          "release": "11.709",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "nscd": {
+          "epoch": "0",
+          "version": "2.19",
+          "release": "22.7.1",
+          "installdate": "1447418257",
+          "arch": "x86_64"
+        },
+        "libtsan0": {
+          "epoch": "0",
+          "version": "5.3.1+r233831",
+          "release": "9.1",
+          "installdate": "1496777202",
+          "arch": "x86_64"
+        },
+        "libncurses5": {
+          "epoch": "0",
+          "version": "5.9",
+          "release": "40.124",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "tcsh": {
+          "epoch": "0",
+          "version": "6.18.01",
+          "release": "7.4",
+          "installdate": "1447418258",
+          "arch": "x86_64"
+        },
+        "bison": {
+          "epoch": "0",
+          "version": "2.7",
+          "release": "6.107",
+          "installdate": "1496777274",
+          "arch": "x86_64"
+        },
+        "libreadline6": {
+          "epoch": "0",
+          "version": "6.2",
+          "release": "75.2",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "yp-tools": {
+          "epoch": "0",
+          "version": "2.14",
+          "release": "6.1",
+          "installdate": "1447418258",
+          "arch": "x86_64"
+        },
+        "liblua5_2": {
+          "epoch": "0",
+          "version": "5.2.2",
+          "release": "4.2",
+          "installdate": "1496777301",
+          "arch": "x86_64"
+        },
+        "cracklib": {
+          "epoch": "0",
+          "version": "2.9.0",
+          "release": "3.244",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "libwicked-0-6": {
+          "epoch": "0",
+          "version": "0.6.20",
+          "release": "18.5.1",
+          "installdate": "1447418260",
+          "arch": "x86_64"
+        },
+        "python-six": {
+          "epoch": "0",
+          "version": "1.9.0",
+          "release": "9.7.1",
+          "installdate": "1447418266",
+          "arch": "noarch"
+        },
+        "libcrack2": {
+          "epoch": "0",
+          "version": "2.9.0",
+          "release": "3.244",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "libXi6": {
+          "epoch": "0",
+          "version": "1.7.4",
+          "release": "9.2",
+          "installdate": "1447418261",
+          "arch": "x86_64"
+        },
+        "libelf1": {
+          "epoch": "0",
+          "version": "0.158",
+          "release": "6.1",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "libmount1": {
+          "epoch": "0",
+          "version": "2.25",
+          "release": "22.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "libavahi-client3": {
+          "epoch": "0",
+          "version": "0.6.31",
+          "release": "22.4",
+          "installdate": "1447418262",
+          "arch": "x86_64"
+        },
+        "perl": {
+          "epoch": "0",
+          "version": "5.18.2",
+          "release": "3.7",
+          "installdate": "1447418249",
+          "arch": "x86_64"
+        },
+        "coreutils": {
+          "epoch": "0",
+          "version": "8.22",
+          "release": "9.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "libfreetype6": {
+          "epoch": "0",
+          "version": "2.5.5",
+          "release": "7.5.1",
+          "installdate": "1447418262",
+          "arch": "x86_64"
+        },
+        "python-ecdsa": {
+          "epoch": "0",
+          "version": "0.10",
+          "release": "1.6",
+          "installdate": "1447418267",
+          "arch": "noarch"
+        },
+        "permissions": {
+          "epoch": "0",
+          "version": "2015.09.28.1626",
+          "release": "3.1",
+          "installdate": "1447418221",
+          "arch": "x86_64"
+        },
+        "mozilla-nss-certs": {
+          "epoch": "0",
+          "version": "3.19.2.1",
+          "release": "29.1",
+          "installdate": "1447418263",
+          "arch": "x86_64"
+        },
+        "libaudit1": {
+          "epoch": "0",
+          "version": "2.3.6",
+          "release": "3.103",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "fipscheck": {
+          "epoch": "0",
+          "version": "1.2.0",
+          "release": "9.3",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "python-PyYAML": {
+          "epoch": "0",
+          "version": "3.10",
+          "release": "15.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "syslinux": {
+          "epoch": "0",
+          "version": "4.04",
+          "release": "32.14",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "kmod": {
+          "epoch": "0",
+          "version": "17",
+          "release": "1.18",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "sles-release-POOL": {
+          "epoch": "0",
+          "version": "12",
+          "release": "1.377",
+          "installdate": "1447418217",
+          "arch": "x86_64"
+        },
+        "command-not-found": {
+          "epoch": "0",
+          "version": "0.1.0",
+          "release": "57.8",
+          "installdate": "1447418269",
+          "arch": "noarch"
+        },
+        "systemd-presets-branding-SLE": {
+          "epoch": "0",
+          "version": "12.0",
+          "release": "14.7.1",
+          "installdate": "1447418224",
+          "arch": "noarch"
+        },
+        "yast2-trans-en_US": {
+          "epoch": "0",
+          "version": "3.0.0",
+          "release": "26.5",
+          "installdate": "1447418247",
+          "arch": "noarch"
+        },
+        "libmagic1": {
+          "epoch": "0",
+          "version": "5.19",
+          "release": "9.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "zypper": {
+          "epoch": "0",
+          "version": "1.11.42",
+          "release": "2.25.2",
+          "installdate": "1447418230",
+          "arch": "x86_64"
+        },
+        "x86info": {
+          "epoch": "0",
+          "version": "1.29",
+          "release": "11.55",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "numactl": {
+          "epoch": "0",
+          "version": "2.0.9",
+          "release": "4.8",
+          "installdate": "1447418252",
+          "arch": "x86_64"
+        },
+        "groff": {
+          "epoch": "0",
+          "version": "1.22.2",
+          "release": "5.429",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "libpth20": {
+          "epoch": "0",
+          "version": "2.0.7",
+          "release": "139.67",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "python-gobject": {
+          "epoch": "0",
+          "version": "3.10.2",
+          "release": "2.22",
+          "installdate": "1447418271",
+          "arch": "x86_64"
+        },
+        "libbluetooth3": {
+          "epoch": "0",
+          "version": "5.13",
+          "release": "1.33",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "libnl3-200": {
+          "epoch": "0",
+          "version": "3.2.23",
+          "release": "2.21",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "perl-Bootloader": {
+          "epoch": "0",
+          "version": "0.824",
+          "release": "1.1",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "libiptc0": {
+          "epoch": "0",
+          "version": "1.4.21",
+          "release": "2.10",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libstorage5": {
+          "epoch": "0",
+          "version": "2.25.16",
+          "release": "1.1",
+          "installdate": "1447418268",
+          "arch": "x86_64"
+        },
+        "libXcursor1": {
+          "epoch": "0",
+          "version": "1.1.14",
+          "release": "3.60",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "libnettle4": {
+          "epoch": "0",
+          "version": "2.7.1",
+          "release": "5.20",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "xz": {
+          "epoch": "0",
+          "version": "5.0.5",
+          "release": "4.852",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "python-ec2deprecateimg": {
+          "epoch": "0",
+          "version": "2.1.2",
+          "release": "2.2",
+          "installdate": "1447418275",
+          "arch": "noarch"
+        },
+        "libreiserfscore0": {
+          "epoch": "0",
+          "version": "3.6.24",
+          "release": "5.47",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "perl-camgm": {
+          "epoch": "0",
+          "version": "1.0.7",
+          "release": "1.4",
+          "installdate": "1447418252",
+          "arch": "x86_64"
+        },
+        "bridge-utils": {
+          "epoch": "0",
+          "version": "1.5",
+          "release": "17.56",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "master-boot-code": {
+          "epoch": "0",
+          "version": "1.22",
+          "release": "16.27",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "yast2-country-data": {
+          "epoch": "0",
+          "version": "3.1.13",
+          "release": "1.16",
+          "installdate": "1447418270",
+          "arch": "x86_64"
+        },
+        "libgraphite2-3": {
+          "epoch": "0",
+          "version": "1.3.1",
+          "release": "3.1",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "xen-tools-domU": {
+          "epoch": "0",
+          "version": "4.4.3_02",
+          "release": "22.12.1",
+          "installdate": "1447418265",
+          "arch": "x86_64"
+        },
+        "libaugeas0": {
+          "epoch": "0",
+          "version": "1.2.0",
+          "release": "3.1",
+          "installdate": "1447418221",
+          "arch": "x86_64"
+        },
+        "libdcerpc0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "wicked": {
+          "epoch": "0",
+          "version": "0.6.20",
+          "release": "18.5.1",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "yast2-xml": {
+          "epoch": "0",
+          "version": "3.1.1",
+          "release": "1.46",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "libdb-4_8": {
+          "epoch": "0",
+          "version": "4.8.30",
+          "release": "27.206",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "logrotate": {
+          "epoch": "0",
+          "version": "3.8.7",
+          "release": "3.21",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "yast2-hardware-detection": {
+          "epoch": "0",
+          "version": "3.1.7",
+          "release": "6.1",
+          "installdate": "1447418273",
+          "arch": "x86_64"
+        },
+        "usbutils": {
+          "epoch": "0",
+          "version": "007",
+          "release": "6.1",
+          "installdate": "1447418258",
+          "arch": "x86_64"
+        },
+        "python-simplejson": {
+          "epoch": "0",
+          "version": "3.3.1",
+          "release": "1.45",
+          "installdate": "1447418268",
+          "arch": "x86_64"
+        },
+        "device-mapper": {
+          "epoch": "0",
+          "version": "1.02.78",
+          "release": "54.1",
+          "installdate": "1447418225",
+          "arch": "x86_64"
+        },
+        "cdrkit-cdrtools-compat": {
+          "epoch": "0",
+          "version": "1.1.11",
+          "release": "19.46",
+          "installdate": "1447418280",
+          "arch": "x86_64"
+        },
+        "gdk-pixbuf-query-loaders": {
+          "epoch": "0",
+          "version": "2.30.6",
+          "release": "1.23",
+          "installdate": "1447418268",
+          "arch": "x86_64"
+        },
+        "boost-license1_54_0": {
+          "epoch": "0",
+          "version": "1.54.0",
+          "release": "13.1",
+          "installdate": "1447418255",
+          "arch": "noarch"
+        },
+        "libnl1": {
+          "epoch": "0",
+          "version": "1.1.4",
+          "release": "4.21",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "glib2-tools": {
+          "epoch": "0",
+          "version": "2.38.2",
+          "release": "5.12",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "plymouth": {
+          "epoch": "0",
+          "version": "0.9.0",
+          "release": "25.1",
+          "installdate": "1447418277",
+          "arch": "x86_64"
+        },
+        "libtiff5": {
+          "epoch": "0",
+          "version": "4.0.4",
+          "release": "12.2",
+          "installdate": "1447418262",
+          "arch": "x86_64"
+        },
+        "gtk3-data": {
+          "epoch": "0",
+          "version": "3.10.9",
+          "release": "4.46",
+          "installdate": "1447418270",
+          "arch": "noarch"
+        },
+        "keyutils": {
+          "epoch": "0",
+          "version": "1.5.9",
+          "release": "3.29",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "python-jmespath": {
+          "epoch": "0",
+          "version": "0.7.1",
+          "release": "7.1",
+          "installdate": "1447418272",
+          "arch": "noarch"
+        },
+        "mailx": {
+          "epoch": "0",
+          "version": "12.5",
+          "release": "25.15",
+          "installdate": "1447418257",
+          "arch": "x86_64"
+        },
+        "pam-modules": {
+          "epoch": "0",
+          "version": "12.1",
+          "release": "23.12",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "grub2": {
+          "epoch": "0",
+          "version": "2.02~beta2",
+          "release": "54.1",
+          "installdate": "1447418274",
+          "arch": "x86_64"
+        },
+        "yast2-ntp-client": {
+          "epoch": "0",
+          "version": "3.1.12",
+          "release": "1.28",
+          "installdate": "1447418279",
+          "arch": "noarch"
+        },
+        "suse-build-key": {
+          "epoch": "0",
+          "version": "12.0",
+          "release": "4.1",
+          "installdate": "1447418245",
+          "arch": "noarch"
+        },
+        "python-ec2publishimg": {
+          "epoch": "0",
+          "version": "0.1.0",
+          "release": "2.1",
+          "installdate": "1447418275",
+          "arch": "noarch"
+        },
+        "liblcms1": {
+          "epoch": "0",
+          "version": "1.19",
+          "release": "17.31",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "wodim": {
+          "epoch": "0",
+          "version": "1.1.11",
+          "release": "19.46",
+          "installdate": "1447418247",
+          "arch": "x86_64"
+        },
+        "aws-cli": {
+          "epoch": "0",
+          "version": "1.8.12",
+          "release": "10.1",
+          "installdate": "1447418276",
+          "arch": "noarch"
+        },
+        "tcpdump": {
+          "epoch": "0",
+          "version": "4.5.1",
+          "release": "7.1",
+          "installdate": "1447418261",
+          "arch": "x86_64"
+        },
+        "yast2-theme-SLE": {
+          "epoch": "0",
+          "version": "3.1.31",
+          "release": "1.6",
+          "installdate": "1447418247",
+          "arch": "noarch"
+        },
+        "yast2-nfs-client": {
+          "epoch": "0",
+          "version": "3.1.9.4",
+          "release": "8.20",
+          "installdate": "1447418276",
+          "arch": "noarch"
+        },
+        "yast2-nis-server": {
+          "epoch": "0",
+          "version": "3.1.2",
+          "release": "1.145",
+          "installdate": "1447418281",
+          "arch": "noarch"
+        },
+        "cyrus-sasl": {
+          "epoch": "0",
+          "version": "2.1.26",
+          "release": "7.1",
+          "installdate": "1447418248",
+          "arch": "x86_64"
+        },
+        "libsamba-hostconfig0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "libtalloc2": {
+          "epoch": "0",
+          "version": "2.1.1",
+          "release": "2.5",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "libgmodule-2_0-0": {
+          "epoch": "0",
+          "version": "2.38.2",
+          "release": "5.12",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "libsmbclient-raw0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "libply-splash-core2": {
+          "epoch": "0",
+          "version": "0.9.0",
+          "release": "25.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "w3m": {
+          "epoch": "0",
+          "version": "0.5.3",
+          "release": "153.145",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "pcsc-lite": {
+          "epoch": "0",
+          "version": "1.8.10",
+          "release": "3.7",
+          "installdate": "1447418279",
+          "arch": "x86_64"
+        },
+        "linux-glibc-devel": {
+          "epoch": "0",
+          "version": "3.12",
+          "release": "3.98",
+          "installdate": "1496777186",
+          "arch": "noarch"
+        },
+        "parted": {
+          "epoch": "0",
+          "version": "3.1",
+          "release": "13.1",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "yast2-slp": {
+          "epoch": "0",
+          "version": "3.1.7",
+          "release": "1.24",
+          "installdate": "1447418279",
+          "arch": "x86_64"
+        },
+        "gcc48": {
+          "epoch": "0",
+          "version": "4.8.5",
+          "release": "24.1",
+          "installdate": "1496777205",
+          "arch": "x86_64"
+        },
+        "hwinfo": {
+          "epoch": "0",
+          "version": "21.6",
+          "release": "1.50",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "yast2-ca-management": {
+          "epoch": "0",
+          "version": "3.1.5",
+          "release": "1.11",
+          "installdate": "1447418280",
+          "arch": "noarch"
+        },
+        "libstdc++48-devel": {
+          "epoch": "0",
+          "version": "4.8.5",
+          "release": "24.1",
+          "installdate": "1496777275",
+          "arch": "x86_64"
+        },
+        "libxcb-xfixes0": {
+          "epoch": "0",
+          "version": "1.10",
+          "release": "1.21",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "sudo": {
+          "epoch": "0",
+          "version": "1.8.10p3",
+          "release": "1.62",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "openct": {
+          "epoch": "0",
+          "version": "0.6.20",
+          "release": "21.12",
+          "installdate": "1447418280",
+          "arch": "x86_64"
+        },
+        "libcdio_paranoia1": {
+          "epoch": "0",
+          "version": "10.2+0.90",
+          "release": "3.51",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "python-MarkupSafe": {
+          "epoch": "0",
+          "version": "0.18",
+          "release": "5.1",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "yast2-network": {
+          "epoch": "0",
+          "version": "3.1.112.10",
+          "release": "2.19.1",
+          "installdate": "1447418280",
+          "arch": "x86_64"
+        },
+        "perl-XML-Writer": {
+          "epoch": "0",
+          "version": "0.623",
+          "release": "3.19",
+          "installdate": "1447418252",
+          "arch": "noarch"
+        },
+        "libblkid1": {
+          "epoch": "0",
+          "version": "2.25",
+          "release": "22.1",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "yast2-ldap": {
+          "epoch": "0",
+          "version": "3.1.12",
+          "release": "1.19",
+          "installdate": "1447418281",
+          "arch": "x86_64"
+        },
+        "perl-List-MoreUtils": {
+          "epoch": "0",
+          "version": "0.33",
+          "release": "7.63",
+          "installdate": "1447418252",
+          "arch": "x86_64"
+        },
+        "libgthread-2_0-0": {
+          "epoch": "0",
+          "version": "2.38.2",
+          "release": "5.12",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "yast2-registration": {
+          "epoch": "0",
+          "version": "3.1.129.2",
+          "release": "21.1",
+          "installdate": "1447418281",
+          "arch": "noarch"
+        },
+        "dejavu-fonts": {
+          "epoch": "0",
+          "version": "2.34",
+          "release": "3.189",
+          "installdate": "1447418253",
+          "arch": "noarch"
+        },
+        "pytalloc": {
+          "epoch": "0",
+          "version": "2.1.1",
+          "release": "2.5",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "libldb1": {
+          "epoch": "0",
+          "version": "1.1.17",
+          "release": "3.1",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "fillup": {
+          "epoch": "0",
+          "version": "1.42",
+          "release": "270.64",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "python-pyserial": {
+          "epoch": "0",
+          "version": "2.7",
+          "release": "2.2",
+          "installdate": "1447418264",
+          "arch": "noarch"
+        },
+        "perl-XML-XPath": {
+          "epoch": "0",
+          "version": "1.13",
+          "release": "99.19",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "yast2-branding-SLE": {
+          "epoch": "0",
+          "version": "3.1.0",
+          "release": "2.6",
+          "installdate": "1447418251",
+          "arch": "noarch"
+        },
+        "sysfsutils": {
+          "epoch": "0",
+          "version": "2.1.0",
+          "release": "151.65",
+          "installdate": "1447418246",
+          "arch": "x86_64"
+        },
+        "perl-Digest-HMAC": {
+          "epoch": "0",
+          "version": "1.03",
+          "release": "18.16",
+          "installdate": "1447418253",
+          "arch": "noarch"
+        },
+        "ruby2.1-rubygem-fast_gettext": {
+          "epoch": "0",
+          "version": "0.8.1",
+          "release": "2.9",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "ruby2.1": {
+          "epoch": "0",
+          "version": "2.1.2",
+          "release": "9.1",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "libudev1": {
+          "epoch": "0",
+          "version": "210",
+          "release": "70.25.1",
+          "installdate": "1447418224",
+          "arch": "x86_64"
+        },
+        "libdw1": {
+          "epoch": "0",
+          "version": "0.158",
+          "release": "6.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "libasm1": {
+          "epoch": "0",
+          "version": "0.158",
+          "release": "6.1",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "bc": {
+          "epoch": "0",
+          "version": "1.06.95",
+          "release": "6.56",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "autoconf": {
+          "epoch": "0",
+          "version": "2.69",
+          "release": "9.71",
+          "installdate": "1447418253",
+          "arch": "noarch"
+        },
+        "libcroco-0_6-3": {
+          "epoch": "0",
+          "version": "0.6.8",
+          "release": "6.62",
+          "installdate": "1447418250",
+          "arch": "x86_64"
+        },
+        "initviocons": {
+          "epoch": "0",
+          "version": "0.5",
+          "release": "101.62",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "cpp48": {
+          "epoch": "0",
+          "version": "4.8.5",
+          "release": "24.1",
+          "installdate": "1447418271",
+          "arch": "x86_64"
+        },
+        "libpulse0": {
+          "epoch": "0",
+          "version": "5.0",
+          "release": "2.7",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "libcdio14": {
+          "epoch": "0",
+          "version": "0.90",
+          "release": "4.82",
+          "installdate": "1447418242",
+          "arch": "x86_64"
+        },
+        "libfipscheck1": {
+          "epoch": "0",
+          "version": "1.2.0",
+          "release": "9.3",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "libmodman1": {
+          "epoch": "0",
+          "version": "2.0.1",
+          "release": "15.75",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "libjbig2": {
+          "epoch": "0",
+          "version": "2.0",
+          "release": "12.13",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libXinerama1": {
+          "epoch": "0",
+          "version": "1.1.3",
+          "release": "3.55",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "libxcb-shm0": {
+          "epoch": "0",
+          "version": "1.10",
+          "release": "1.21",
+          "installdate": "1447418251",
+          "arch": "x86_64"
+        },
+        "libnl-config": {
+          "epoch": "0",
+          "version": "3.2.23",
+          "release": "2.21",
+          "installdate": "1447418243",
+          "arch": "noarch"
+        },
+        "gvfs": {
+          "epoch": "0",
+          "version": "1.18.3",
+          "release": "7.3",
+          "installdate": "1447418275",
+          "arch": "x86_64"
+        },
+        "libstorage-ruby": {
+          "epoch": "0",
+          "version": "2.25.16",
+          "release": "1.1",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "libsmi": {
+          "epoch": "0",
+          "version": "0.4.8",
+          "release": "18.63",
+          "installdate": "1447418244",
+          "arch": "x86_64"
+        },
+        "dmidecode": {
+          "epoch": "0",
+          "version": "2.12",
+          "release": "5.20",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "sle-module-web-scripting-release": {
+          "epoch": "0",
+          "version": "12",
+          "release": "3.1",
+          "installdate": "1447418220",
+          "arch": "x86_64"
+        },
+        "mingetty": {
+          "epoch": "0",
+          "version": "1.0.8s",
+          "release": "19.63",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "libjpeg8": {
+          "epoch": "0",
+          "version": "8.0.2",
+          "release": "30.3",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "libyui6": {
+          "epoch": "0",
+          "version": "3.1.4",
+          "release": "1.34",
+          "installdate": "1447418253",
+          "arch": "x86_64"
+        },
+        "libboost_regex1_54_0": {
+          "epoch": "0",
+          "version": "1.54.0",
+          "release": "13.1",
+          "installdate": "1447418265",
+          "arch": "x86_64"
+        },
+        "libsmbclient0": {
+          "epoch": "0",
+          "version": "4.1.12",
+          "release": "16.1",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "gd": {
+          "epoch": "0",
+          "version": "2.1.0",
+          "release": "5.1",
+          "installdate": "1447418272",
+          "arch": "x86_64"
+        },
+        "plymouth-plugin-script": {
+          "epoch": "0",
+          "version": "0.9.0",
+          "release": "25.1",
+          "installdate": "1447418266",
+          "arch": "x86_64"
+        },
+        "libesmtp": {
+          "epoch": "0",
+          "version": "1.0.6",
+          "release": "14.55",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "kmod-compat": {
+          "epoch": "0",
+          "version": "17",
+          "release": "1.18",
+          "installdate": "1447418223",
+          "arch": "x86_64"
+        },
+        "libbluray1": {
+          "epoch": "0",
+          "version": "0.4.0",
+          "release": "3.17",
+          "installdate": "1447418267",
+          "arch": "x86_64"
+        },
+        "wget": {
+          "epoch": "0",
+          "version": "1.14",
+          "release": "7.1",
+          "installdate": "1447418258",
+          "arch": "x86_64"
+        },
+        "perl-Net-DBus": {
+          "epoch": "0",
+          "version": "1.0.0",
+          "release": "8.53",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "python-argparse": {
+          "epoch": "0",
+          "version": "1.2.1",
+          "release": "15.8",
+          "installdate": "1447418268",
+          "arch": "noarch"
+        },
+        "zisofs-tools": {
+          "epoch": "0",
+          "version": "1.0.8",
+          "release": "20.61",
+          "installdate": "1447418280",
+          "arch": "x86_64"
+        },
+        "grub2-i386-pc": {
+          "epoch": "0",
+          "version": "2.02~beta2",
+          "release": "54.1",
+          "installdate": "1447418276",
+          "arch": "x86_64"
+        },
+        "libcairo2": {
+          "epoch": "0",
+          "version": "1.12.16",
+          "release": "6.17",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "libopenct1": {
+          "epoch": "0",
+          "version": "0.6.20",
+          "release": "21.12",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "dosfstools": {
+          "epoch": "0",
+          "version": "3.0.26",
+          "release": "2.4",
+          "installdate": "1447418241",
+          "arch": "x86_64"
+        },
+        "libcairo-gobject2": {
+          "epoch": "0",
+          "version": "1.12.16",
+          "release": "6.17",
+          "installdate": "1447418269",
+          "arch": "x86_64"
+        },
+        "python-base": {
+          "epoch": "0",
+          "version": "2.7.9",
+          "release": "14.1",
+          "installdate": "1447418263",
+          "arch": "x86_64"
+        },
+        "libmspack0": {
+          "epoch": "0",
+          "version": "0.4",
+          "release": "10.1",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "girepository-1_0": {
+          "epoch": "0",
+          "version": "1.38.0",
+          "release": "3.17",
+          "installdate": "1447418271",
+          "arch": "x86_64"
+        },
+        "libicu52_1": {
+          "epoch": "0",
+          "version": "52.1",
+          "release": "7.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "libgphoto2-6": {
+          "epoch": "0",
+          "version": "2.5.4.1",
+          "release": "3.12",
+          "installdate": "1447418278",
+          "arch": "x86_64"
+        },
+        "python-bcdoc": {
+          "epoch": "0",
+          "version": "0.14.0",
+          "release": "5.1",
+          "installdate": "1447418272",
+          "arch": "noarch"
+        },
+        "libgnutls28": {
+          "epoch": "0",
+          "version": "3.2.15",
+          "release": "11.1",
+          "installdate": "1447418264",
+          "arch": "x86_64"
+        },
+        "libevent-2_0-5": {
+          "epoch": "0",
+          "version": "2.0.21",
+          "release": "4.1",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libXrandr2": {
+          "epoch": "0",
+          "version": "1.4.2",
+          "release": "3.56",
+          "installdate": "1447418254",
+          "arch": "x86_64"
+        },
+        "terminfo-base": {
+          "epoch": "0",
+          "version": "5.9",
+          "release": "40.124",
+          "installdate": "1447418217",
+          "arch": "x86_64"
+        },
+        "blktrace": {
+          "epoch": "0",
+          "version": "1.0.5",
+          "release": "7.3",
+          "installdate": "1447418259",
+          "arch": "x86_64"
+        },
+        "perl-XML-Simple": {
+          "epoch": "0",
+          "version": "2.20",
+          "release": "4.2",
+          "installdate": "1447418254",
+          "arch": "noarch"
+        },
+        "glibc": {
+          "epoch": "0",
+          "version": "2.19",
+          "release": "22.7.1",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "yast2-kdump": {
+          "epoch": "0",
+          "version": "3.1.19",
+          "release": "1.34",
+          "installdate": "1447418280",
+          "arch": "x86_64"
+        },
+        "cron": {
+          "epoch": "0",
+          "version": "4.2",
+          "release": "58.3",
+          "installdate": "1447418255",
+          "arch": "x86_64"
+        },
+        "libapparmor1": {
+          "epoch": "0",
+          "version": "2.8.2",
+          "release": "36.1",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "libpciaccess0": {
+          "epoch": "0",
+          "version": "0.13.2",
+          "release": "3.59",
+          "installdate": "1447418243",
+          "arch": "x86_64"
+        },
+        "libavahi-common3": {
+          "epoch": "0",
+          "version": "0.6.31",
+          "release": "22.4",
+          "installdate": "1447418255",
+          "arch": "x86_64"
+        },
+        "libwrap0": {
+          "epoch": "0",
+          "version": "7.6",
+          "release": "883.68",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "libtasn1": {
+          "epoch": "0",
+          "version": "3.7",
+          "release": "4.1",
+          "installdate": "1447418263",
+          "arch": "x86_64"
+        },
+        "libjpeg62": {
+          "epoch": "0",
+          "version": "62.1.0",
+          "release": "30.1",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "libpopt0": {
+          "epoch": "0",
+          "version": "1.16",
+          "release": "26.128",
+          "installdate": "1447418218",
+          "arch": "x86_64"
+        },
+        "mdadm": {
+          "epoch": "0",
+          "version": "3.3.1",
+          "release": "5.28",
+          "installdate": "1447418245",
+          "arch": "x86_64"
+        },
+        "libruby2_1-2_1": {
+          "epoch": "0",
+          "version": "2.1.2",
+          "release": "9.1",
+          "installdate": "1447418256",
+          "arch": "x86_64"
+        },
+        "libgmp10": {
+          "epoch": "0",
+          "version": "5.1.3",
+          "release": "2.121",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "make": {
+          "epoch": "0",
+          "version": "4.0",
+          "release": "4.1",
+          "installdate": "1447418257",
+          "arch": "x86_64"
+        },
+        "hardlink": {
+          "epoch": "0",
+          "version": "1.0",
+          "release": "6.45",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "glibc-devel": {
+          "epoch": "0",
+          "version": "2.19",
+          "release": "22.16.2",
+          "installdate": "1496777204",
+          "arch": "x86_64"
+        },
+        "snmp-mibs": {
+          "epoch": "0",
+          "version": "5.7.2.1",
+          "release": "4.6.1",
+          "installdate": "1447418258",
+          "arch": "x86_64"
+        },
+        "libacl1": {
+          "epoch": "0",
+          "version": "2.2.52",
+          "release": "3.148",
+          "installdate": "1447418219",
+          "arch": "x86_64"
+        },
+        "kernel-macros": {
+          "epoch": "0",
+          "version": "3.12.60",
+          "release": "52.54.1",
+          "installdate": "1496777274",
+          "arch": "noarch"
+        },
+        "wallpaper-branding-SLE": {
+          "epoch": "0",
+          "version": "12",
+          "release": "11.3.1",
+          "installdate": "1447418258",
+          "arch": "noarch"
+        }
+      },
+      "command": {
+        "ps": "ps -ef"
+      },
+      "shells": [
+        "/bin/ash",
+        "/bin/bash",
+        "/bin/csh",
+        "/bin/dash",
+        "/bin/false",
+        "/bin/ksh",
+        "/bin/ksh93",
+        "/bin/mksh",
+        "/bin/pdksh",
+        "/bin/sh",
+        "/bin/tcsh",
+        "/bin/true",
+        "/bin/zsh",
+        "/usr/bin/csh",
+        "/usr/bin/dash",
+        "/usr/bin/ksh",
+        "/usr/bin/ksh93",
+        "/usr/bin/mksh",
+        "/usr/bin/passwd",
+        "/usr/bin/pdksh",
+        "/usr/bin/bash",
+        "/usr/bin/tcsh",
+        "/usr/bin/zsh"
+      ],
+      "cloud": {
+        "public_ips": [
+          null
+        ],
+        "private_ips": [
+          "68.103.81.158"
+        ],
+        "public_ipv4": null,
+        "public_hostname": null,
+        "local_ipv4": "68.103.81.158",
+        "local_hostname": "ip-68-103-81-158.us-west-2.compute.internal",
+        "provider": "ec2"
+      },
+      "machine_id": "cc4a4ac0a9664b72bb0ed46cb8a940f2",
+      "shard_seed": 158143912,
+      "keys": {
+      },
+      "block_device": {
+        "hda": {
+          "size": "62914560",
+          "removable": "0",
+          "rotational": "0",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        }
+      },
+      "hostnamectl": {
+        "static_hostname": "ip-68-103-81-158.us-west-2.compute.internal",
+        "icon_name": "computer-vm",
+        "chassis": "vm",
+        "machine_id": "cc4a4ac0a9664b72bb0ed46cb8a940f2",
+        "boot_id": "aefa26e971c146f39c5d4d4a08bf6232",
+        "virtualization": "xen",
+        "operating_system": "SUSE Linux Enterprise Server 12",
+        "cpe_os_name": "cpe",
+        "kernel": "Linux 3.12.48-52.27-default",
+        "architecture": "x86-64"
+      },
+      "sessions": {
+        "by_session": {
+          "2": {
+            "session": "2",
+            "uid": "1001",
+            "user": "jenkins",
+            "seat": null
+          },
+          "c2": {
+            "session": "c2",
+            "uid": "0",
+            "user": "root",
+            "seat": null
+          },
+          "14236": {
+            "session": "14236",
+            "uid": "7101",
+            "user": "schisamo",
+            "seat": null
+          }
+        },
+        "by_user": {
+          "jenkins": [
+            {
+              "session": "2",
+              "uid": "1001",
+              "user": "jenkins",
+              "seat": null
+            }
+          ],
+          "root": [
+            {
+              "session": "c2",
+              "uid": "0",
+              "user": "root",
+              "seat": null
+            }
+          ],
+          "schisamo": [
+            {
+              "session": "14236",
+              "uid": "7101",
+              "user": "schisamo",
+              "seat": null
+            }
+          ]
+        }
+      },
+      "filesystem2": {
+        "by_device": {
+          "/dev/hda1": {
+            "kb_size": "30829600",
+            "kb_used": "3821404",
+            "kb_available": "25628856",
+            "percent_used": "13%",
+            "total_inodes": "1966080",
+            "inodes_used": "200058",
+            "inodes_available": "1766022",
+            "inodes_percent_used": "11%",
+            "fs_type": "ext4",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "data=ordered"
+            ],
+            "uuid": "2393d56d-ab36-4969-a1b2-57039d02f3db",
+            "mounts": [
+              "/"
+            ]
+          },
+          "devtmpfs": {
+            "kb_size": "2017340",
+            "kb_used": "8",
+            "kb_available": "2017332",
+            "percent_used": "1%",
+            "total_inodes": "504335",
+            "inodes_used": "346",
+            "inodes_available": "503989",
+            "inodes_percent_used": "1%",
+            "fs_type": "devtmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "size=2017340k",
+              "nr_inodes=504335",
+              "mode=755"
+            ],
+            "mounts": [
+              "/dev"
+            ]
+          },
+          "tmpfs": {
+            "kb_size": "2026496",
+            "kb_used": "0",
+            "kb_available": "2026496",
+            "percent_used": "0%",
+            "total_inodes": "506624",
+            "inodes_used": "12",
+            "inodes_available": "506612",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "size=2026496k",
+              "nr_inodes=506624",
+              "mode=755"
+            ],
+            "mounts": [
+              "/dev/shm",
+              "/run",
+              "/sys/fs/cgroup"
+            ]
+          },
+          "sysfs": {
+            "fs_type": "sysfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "mounts": [
+              "/sys"
+            ]
+          },
+          "proc": {
+            "fs_type": "proc",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "mounts": [
+              "/proc"
+            ]
+          },
+          "securityfs": {
+            "fs_type": "securityfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "mounts": [
+              "/sys/kernel/security"
+            ]
+          },
+          "devpts": {
+            "fs_type": "devpts",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "gid=5",
+              "mode=620",
+              "ptmxmode=000"
+            ],
+            "mounts": [
+              "/dev/pts"
+            ]
+          },
+          "cgroup": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "hugetlb"
+            ],
+            "mounts": [
+              "/sys/fs/cgroup/systemd",
+              "/sys/fs/cgroup/cpuset",
+              "/sys/fs/cgroup/cpu,cpuacct",
+              "/sys/fs/cgroup/memory",
+              "/sys/fs/cgroup/devices",
+              "/sys/fs/cgroup/freezer",
+              "/sys/fs/cgroup/blkio",
+              "/sys/fs/cgroup/perf_event",
+              "/sys/fs/cgroup/hugetlb"
+            ]
+          },
+          "pstore": {
+            "fs_type": "pstore",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "mounts": [
+              "/sys/fs/pstore"
+            ]
+          },
+          "systemd-1": {
+            "fs_type": "autofs",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "fd=28",
+              "pgrp=1",
+              "timeout=300",
+              "minproto=5",
+              "maxproto=5",
+              "direct"
+            ],
+            "mounts": [
+              "/proc/sys/fs/binfmt_misc"
+            ]
+          },
+          "hugetlbfs": {
+            "fs_type": "hugetlbfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "mounts": [
+              "/dev/hugepages"
+            ]
+          },
+          "mqueue": {
+            "fs_type": "mqueue",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "mounts": [
+              "/dev/mqueue"
+            ]
+          },
+          "debugfs": {
+            "fs_type": "debugfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "mounts": [
+              "/sys/kernel/debug"
+            ]
+          },
+          "none": {
+            "fs_type": "proc",
+            "mount_options": [
+              "ro",
+              "nosuid",
+              "nodev",
+              "relatime"
+            ],
+            "mounts": [
+              "/var/lib/ntp/proc"
+            ]
+          },
+          "/dev/hda": {},
+          "rootfs": {
+            "fs_type": "rootfs",
+            "mount_options": [
+              "rw"
+            ],
+            "mounts": [
+              "/"
+            ]
+          }
+        },
+        "by_mountpoint": {
+          "/": {
+            "kb_size": "30829600",
+            "kb_used": "3821404",
+            "kb_available": "25628856",
+            "percent_used": "13%",
+            "total_inodes": "1966080",
+            "inodes_used": "200058",
+            "inodes_available": "1766022",
+            "inodes_percent_used": "11%",
+            "fs_type": "rootfs",
+            "mount_options": [
+              "rw"
+            ],
+            "uuid": "2393d56d-ab36-4969-a1b2-57039d02f3db",
+            "devices": [
+              "/dev/hda1",
+              "rootfs"
+            ]
+          },
+          "/dev": {
+            "kb_size": "2017340",
+            "kb_used": "8",
+            "kb_available": "2017332",
+            "percent_used": "1%",
+            "total_inodes": "504335",
+            "inodes_used": "346",
+            "inodes_available": "503989",
+            "inodes_percent_used": "1%",
+            "fs_type": "devtmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "size=2017340k",
+              "nr_inodes=504335",
+              "mode=755"
+            ],
+            "devices": [
+              "devtmpfs"
+            ]
+          },
+          "/dev/shm": {
+            "kb_size": "2026496",
+            "kb_used": "0",
+            "kb_available": "2026496",
+            "percent_used": "0%",
+            "total_inodes": "506624",
+            "inodes_used": "1",
+            "inodes_available": "506623",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "size=2026496k",
+              "nr_inodes=506624"
+            ],
+            "devices": [
+              "tmpfs"
+            ]
+          },
+          "/run": {
+            "kb_size": "2026496",
+            "kb_used": "91644",
+            "kb_available": "1934852",
+            "percent_used": "5%",
+            "total_inodes": "506624",
+            "inodes_used": "414",
+            "inodes_available": "506210",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "size=2026496k",
+              "nr_inodes=506624",
+              "mode=755"
+            ],
+            "devices": [
+              "tmpfs"
+            ]
+          },
+          "/sys/fs/cgroup": {
+            "kb_size": "2026496",
+            "kb_used": "0",
+            "kb_available": "2026496",
+            "percent_used": "0%",
+            "total_inodes": "506624",
+            "inodes_used": "12",
+            "inodes_available": "506612",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "size=2026496k",
+              "nr_inodes=506624",
+              "mode=755"
+            ],
+            "devices": [
+              "tmpfs"
+            ]
+          },
+          "/sys": {
+            "fs_type": "sysfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "devices": [
+              "sysfs"
+            ]
+          },
+          "/proc": {
+            "fs_type": "proc",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "devices": [
+              "proc"
+            ]
+          },
+          "/sys/kernel/security": {
+            "fs_type": "securityfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "devices": [
+              "securityfs"
+            ]
+          },
+          "/dev/pts": {
+            "fs_type": "devpts",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "gid=5",
+              "mode=620",
+              "ptmxmode=000"
+            ],
+            "devices": [
+              "devpts"
+            ]
+          },
+          "/sys/fs/cgroup/systemd": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "xattr",
+              "release_agent=/usr/lib/systemd/systemd-cgroups-agent",
+              "name=systemd"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/pstore": {
+            "fs_type": "pstore",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ],
+            "devices": [
+              "pstore"
+            ]
+          },
+          "/sys/fs/cgroup/cpuset": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "cpuset"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/cpu,cpuacct": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "cpuacct",
+              "cpu"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/memory": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "memory"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/devices": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "devices"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/freezer": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "freezer"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/blkio": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "blkio"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/perf_event": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "perf_event"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/sys/fs/cgroup/hugetlb": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "hugetlb"
+            ],
+            "devices": [
+              "cgroup"
+            ]
+          },
+          "/proc/sys/fs/binfmt_misc": {
+            "fs_type": "autofs",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "fd=28",
+              "pgrp=1",
+              "timeout=300",
+              "minproto=5",
+              "maxproto=5",
+              "direct"
+            ],
+            "devices": [
+              "systemd-1"
+            ]
+          },
+          "/dev/hugepages": {
+            "fs_type": "hugetlbfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "devices": [
+              "hugetlbfs"
+            ]
+          },
+          "/dev/mqueue": {
+            "fs_type": "mqueue",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "devices": [
+              "mqueue"
+            ]
+          },
+          "/sys/kernel/debug": {
+            "fs_type": "debugfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ],
+            "devices": [
+              "debugfs"
+            ]
+          },
+          "/var/lib/ntp/proc": {
+            "fs_type": "proc",
+            "mount_options": [
+              "ro",
+              "nosuid",
+              "nodev",
+              "relatime"
+            ],
+            "devices": [
+              "none"
+            ]
+          }
+        },
+        "by_pair": {
+          "/dev/hda1,/": {
+            "device": "/dev/hda1",
+            "kb_size": "30829600",
+            "kb_used": "3821404",
+            "kb_available": "25628856",
+            "percent_used": "13%",
+            "mount": "/",
+            "total_inodes": "1966080",
+            "inodes_used": "200058",
+            "inodes_available": "1766022",
+            "inodes_percent_used": "11%",
+            "fs_type": "ext4",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "data=ordered"
+            ],
+            "uuid": "2393d56d-ab36-4969-a1b2-57039d02f3db"
+          },
+          "devtmpfs,/dev": {
+            "device": "devtmpfs",
+            "kb_size": "2017340",
+            "kb_used": "8",
+            "kb_available": "2017332",
+            "percent_used": "1%",
+            "mount": "/dev",
+            "total_inodes": "504335",
+            "inodes_used": "346",
+            "inodes_available": "503989",
+            "inodes_percent_used": "1%",
+            "fs_type": "devtmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "size=2017340k",
+              "nr_inodes=504335",
+              "mode=755"
+            ]
+          },
+          "tmpfs,/dev/shm": {
+            "device": "tmpfs",
+            "kb_size": "2026496",
+            "kb_used": "0",
+            "kb_available": "2026496",
+            "percent_used": "0%",
+            "mount": "/dev/shm",
+            "total_inodes": "506624",
+            "inodes_used": "1",
+            "inodes_available": "506623",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "size=2026496k",
+              "nr_inodes=506624"
+            ]
+          },
+          "tmpfs,/run": {
+            "device": "tmpfs",
+            "kb_size": "2026496",
+            "kb_used": "91644",
+            "kb_available": "1934852",
+            "percent_used": "5%",
+            "mount": "/run",
+            "total_inodes": "506624",
+            "inodes_used": "414",
+            "inodes_available": "506210",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "size=2026496k",
+              "nr_inodes=506624",
+              "mode=755"
+            ]
+          },
+          "tmpfs,/sys/fs/cgroup": {
+            "device": "tmpfs",
+            "kb_size": "2026496",
+            "kb_used": "0",
+            "kb_available": "2026496",
+            "percent_used": "0%",
+            "mount": "/sys/fs/cgroup",
+            "total_inodes": "506624",
+            "inodes_used": "12",
+            "inodes_available": "506612",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "size=2026496k",
+              "nr_inodes=506624",
+              "mode=755"
+            ]
+          },
+          "sysfs,/sys": {
+            "device": "sysfs",
+            "mount": "/sys",
+            "fs_type": "sysfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ]
+          },
+          "proc,/proc": {
+            "device": "proc",
+            "mount": "/proc",
+            "fs_type": "proc",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ]
+          },
+          "securityfs,/sys/kernel/security": {
+            "device": "securityfs",
+            "mount": "/sys/kernel/security",
+            "fs_type": "securityfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ]
+          },
+          "devpts,/dev/pts": {
+            "device": "devpts",
+            "mount": "/dev/pts",
+            "fs_type": "devpts",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "gid=5",
+              "mode=620",
+              "ptmxmode=000"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/systemd": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/systemd",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "xattr",
+              "release_agent=/usr/lib/systemd/systemd-cgroups-agent",
+              "name=systemd"
+            ]
+          },
+          "pstore,/sys/fs/pstore": {
+            "device": "pstore",
+            "mount": "/sys/fs/pstore",
+            "fs_type": "pstore",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/cpuset": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/cpuset",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "cpuset"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/cpu,cpuacct": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/cpu,cpuacct",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "cpuacct",
+              "cpu"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/memory": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/memory",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "memory"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/devices": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/devices",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "devices"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/freezer": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/freezer",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "freezer"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/blkio": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/blkio",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "blkio"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/perf_event": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/perf_event",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "perf_event"
+            ]
+          },
+          "cgroup,/sys/fs/cgroup/hugetlb": {
+            "device": "cgroup",
+            "mount": "/sys/fs/cgroup/hugetlb",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev",
+              "noexec",
+              "relatime",
+              "hugetlb"
+            ]
+          },
+          "systemd-1,/proc/sys/fs/binfmt_misc": {
+            "device": "systemd-1",
+            "mount": "/proc/sys/fs/binfmt_misc",
+            "fs_type": "autofs",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "fd=28",
+              "pgrp=1",
+              "timeout=300",
+              "minproto=5",
+              "maxproto=5",
+              "direct"
+            ]
+          },
+          "hugetlbfs,/dev/hugepages": {
+            "device": "hugetlbfs",
+            "mount": "/dev/hugepages",
+            "fs_type": "hugetlbfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ]
+          },
+          "mqueue,/dev/mqueue": {
+            "device": "mqueue",
+            "mount": "/dev/mqueue",
+            "fs_type": "mqueue",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ]
+          },
+          "debugfs,/sys/kernel/debug": {
+            "device": "debugfs",
+            "mount": "/sys/kernel/debug",
+            "fs_type": "debugfs",
+            "mount_options": [
+              "rw",
+              "relatime"
+            ]
+          },
+          "none,/var/lib/ntp/proc": {
+            "device": "none",
+            "mount": "/var/lib/ntp/proc",
+            "fs_type": "proc",
+            "mount_options": [
+              "ro",
+              "nosuid",
+              "nodev",
+              "relatime"
+            ]
+          },
+          "/dev/hda,": {
+            "device": "/dev/hda"
+          },
+          "rootfs,/": {
+            "device": "rootfs",
+            "mount": "/",
+            "fs_type": "rootfs",
+            "mount_options": [
+              "rw"
+            ]
+          }
+        }
+      },
+      "ohai_time": 1509570476.41925,
+      "sysconf": {
+        "LINK_MAX": 65000,
+        "_POSIX_LINK_MAX": 65000,
+        "MAX_CANON": 255,
+        "_POSIX_MAX_CANON": 255,
+        "MAX_INPUT": 255,
+        "_POSIX_MAX_INPUT": 255,
+        "NAME_MAX": 255,
+        "_POSIX_NAME_MAX": 255,
+        "PATH_MAX": 4096,
+        "_POSIX_PATH_MAX": 4096,
+        "PIPE_BUF": 4096,
+        "_POSIX_PIPE_BUF": 4096,
+        "SOCK_MAXBUF": null,
+        "_POSIX_ASYNC_IO": null,
+        "_POSIX_CHOWN_RESTRICTED": 1,
+        "_POSIX_NO_TRUNC": 1,
+        "_POSIX_PRIO_IO": null,
+        "_POSIX_SYNC_IO": null,
+        "_POSIX_VDISABLE": 0,
+        "ARG_MAX": 2097152,
+        "ATEXIT_MAX": 2147483647,
+        "CHAR_BIT": 8,
+        "CHAR_MAX": 127,
+        "CHAR_MIN": -128,
+        "CHILD_MAX": 31520,
+        "CLK_TCK": 100,
+        "INT_MAX": 2147483647,
+        "INT_MIN": -2147483648,
+        "IOV_MAX": 1024,
+        "LOGNAME_MAX": 256,
+        "LONG_BIT": 64,
+        "MB_LEN_MAX": 16,
+        "NGROUPS_MAX": 65536,
+        "NL_ARGMAX": 4096,
+        "NL_LANGMAX": 2048,
+        "NL_MSGMAX": 2147483647,
+        "NL_NMAX": 2147483647,
+        "NL_SETMAX": 2147483647,
+        "NL_TEXTMAX": 2147483647,
+        "NSS_BUFLEN_GROUP": 1024,
+        "NSS_BUFLEN_PASSWD": 1024,
+        "NZERO": 20,
+        "OPEN_MAX": 1024,
+        "PAGESIZE": 4096,
+        "PAGE_SIZE": 4096,
+        "PASS_MAX": 8192,
+        "PTHREAD_DESTRUCTOR_ITERATIONS": 4,
+        "PTHREAD_KEYS_MAX": 1024,
+        "PTHREAD_STACK_MIN": 16384,
+        "PTHREAD_THREADS_MAX": null,
+        "SCHAR_MAX": 127,
+        "SCHAR_MIN": -128,
+        "SHRT_MAX": 32767,
+        "SHRT_MIN": -32768,
+        "SSIZE_MAX": 32767,
+        "TTY_NAME_MAX": 32,
+        "TZNAME_MAX": 6,
+        "UCHAR_MAX": 255,
+        "UINT_MAX": 4294967295,
+        "UIO_MAXIOV": 1024,
+        "ULONG_MAX": 18446744073709551615,
+        "USHRT_MAX": 65535,
+        "WORD_BIT": 32,
+        "_AVPHYS_PAGES": 229777,
+        "_NPROCESSORS_CONF": 2,
+        "_NPROCESSORS_ONLN": 2,
+        "_PHYS_PAGES": 947713,
+        "_POSIX_ARG_MAX": 2097152,
+        "_POSIX_ASYNCHRONOUS_IO": 200809,
+        "_POSIX_CHILD_MAX": 31520,
+        "_POSIX_FSYNC": 200809,
+        "_POSIX_JOB_CONTROL": 1,
+        "_POSIX_MAPPED_FILES": 200809,
+        "_POSIX_MEMLOCK": 200809,
+        "_POSIX_MEMLOCK_RANGE": 200809,
+        "_POSIX_MEMORY_PROTECTION": 200809,
+        "_POSIX_MESSAGE_PASSING": 200809,
+        "_POSIX_NGROUPS_MAX": 65536,
+        "_POSIX_OPEN_MAX": 1024,
+        "_POSIX_PII": null,
+        "_POSIX_PII_INTERNET": null,
+        "_POSIX_PII_INTERNET_DGRAM": null,
+        "_POSIX_PII_INTERNET_STREAM": null,
+        "_POSIX_PII_OSI": null,
+        "_POSIX_PII_OSI_CLTS": null,
+        "_POSIX_PII_OSI_COTS": null,
+        "_POSIX_PII_OSI_M": null,
+        "_POSIX_PII_SOCKET": null,
+        "_POSIX_PII_XTI": null,
+        "_POSIX_POLL": null,
+        "_POSIX_PRIORITIZED_IO": 200809,
+        "_POSIX_PRIORITY_SCHEDULING": 200809,
+        "_POSIX_REALTIME_SIGNALS": 200809,
+        "_POSIX_SAVED_IDS": 1,
+        "_POSIX_SELECT": null,
+        "_POSIX_SEMAPHORES": 200809,
+        "_POSIX_SHARED_MEMORY_OBJECTS": 200809,
+        "_POSIX_SSIZE_MAX": 32767,
+        "_POSIX_STREAM_MAX": 16,
+        "_POSIX_SYNCHRONIZED_IO": 200809,
+        "_POSIX_THREADS": 200809,
+        "_POSIX_THREAD_ATTR_STACKADDR": 200809,
+        "_POSIX_THREAD_ATTR_STACKSIZE": 200809,
+        "_POSIX_THREAD_PRIORITY_SCHEDULING": 200809,
+        "_POSIX_THREAD_PRIO_INHERIT": 200809,
+        "_POSIX_THREAD_PRIO_PROTECT": 200809,
+        "_POSIX_THREAD_ROBUST_PRIO_INHERIT": null,
+        "_POSIX_THREAD_ROBUST_PRIO_PROTECT": null,
+        "_POSIX_THREAD_PROCESS_SHARED": 200809,
+        "_POSIX_THREAD_SAFE_FUNCTIONS": 200809,
+        "_POSIX_TIMERS": 200809,
+        "TIMER_MAX": null,
+        "_POSIX_TZNAME_MAX": 6,
+        "_POSIX_VERSION": 200809,
+        "_T_IOV_MAX": null,
+        "_XOPEN_CRYPT": 1,
+        "_XOPEN_ENH_I18N": 1,
+        "_XOPEN_LEGACY": 1,
+        "_XOPEN_REALTIME": 1,
+        "_XOPEN_REALTIME_THREADS": 1,
+        "_XOPEN_SHM": 1,
+        "_XOPEN_UNIX": 1,
+        "_XOPEN_VERSION": 700,
+        "_XOPEN_XCU_VERSION": 4,
+        "_XOPEN_XPG2": 1,
+        "_XOPEN_XPG3": 1,
+        "_XOPEN_XPG4": 1,
+        "BC_BASE_MAX": 99,
+        "BC_DIM_MAX": 2048,
+        "BC_SCALE_MAX": 99,
+        "BC_STRING_MAX": 1000,
+        "CHARCLASS_NAME_MAX": 2048,
+        "COLL_WEIGHTS_MAX": 255,
+        "EQUIV_CLASS_MAX": null,
+        "EXPR_NEST_MAX": 32,
+        "LINE_MAX": 2048,
+        "POSIX2_BC_BASE_MAX": 99,
+        "POSIX2_BC_DIM_MAX": 2048,
+        "POSIX2_BC_SCALE_MAX": 99,
+        "POSIX2_BC_STRING_MAX": 1000,
+        "POSIX2_CHAR_TERM": 200809,
+        "POSIX2_COLL_WEIGHTS_MAX": 255,
+        "POSIX2_C_BIND": 200809,
+        "POSIX2_C_DEV": 200809,
+        "POSIX2_C_VERSION": null,
+        "POSIX2_EXPR_NEST_MAX": 32,
+        "POSIX2_FORT_DEV": null,
+        "POSIX2_FORT_RUN": null,
+        "_POSIX2_LINE_MAX": 2048,
+        "POSIX2_LINE_MAX": 2048,
+        "POSIX2_LOCALEDEF": 200809,
+        "POSIX2_RE_DUP_MAX": 32767,
+        "POSIX2_SW_DEV": 200809,
+        "POSIX2_UPE": null,
+        "POSIX2_VERSION": 200809,
+        "RE_DUP_MAX": 32767,
+        "PATH": "/bin:/usr/bin",
+        "CS_PATH": "/bin:/usr/bin",
+        "LFS_CFLAGS": null,
+        "LFS_LDFLAGS": null,
+        "LFS_LIBS": null,
+        "LFS_LINTFLAGS": null,
+        "LFS64_CFLAGS": "-D_LARGEFILE64_SOURCE",
+        "LFS64_LDFLAGS": null,
+        "LFS64_LIBS": null,
+        "LFS64_LINTFLAGS": "-D_LARGEFILE64_SOURCE",
+        "_XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+        "XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+        "_XBS5_ILP32_OFF32": null,
+        "XBS5_ILP32_OFF32_CFLAGS": null,
+        "XBS5_ILP32_OFF32_LDFLAGS": null,
+        "XBS5_ILP32_OFF32_LIBS": null,
+        "XBS5_ILP32_OFF32_LINTFLAGS": null,
+        "_XBS5_ILP32_OFFBIG": null,
+        "XBS5_ILP32_OFFBIG_CFLAGS": null,
+        "XBS5_ILP32_OFFBIG_LDFLAGS": null,
+        "XBS5_ILP32_OFFBIG_LIBS": null,
+        "XBS5_ILP32_OFFBIG_LINTFLAGS": null,
+        "_XBS5_LP64_OFF64": 1,
+        "XBS5_LP64_OFF64_CFLAGS": "-m64",
+        "XBS5_LP64_OFF64_LDFLAGS": "-m64",
+        "XBS5_LP64_OFF64_LIBS": null,
+        "XBS5_LP64_OFF64_LINTFLAGS": null,
+        "_XBS5_LPBIG_OFFBIG": null,
+        "XBS5_LPBIG_OFFBIG_CFLAGS": null,
+        "XBS5_LPBIG_OFFBIG_LDFLAGS": null,
+        "XBS5_LPBIG_OFFBIG_LIBS": null,
+        "XBS5_LPBIG_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V6_ILP32_OFF32": null,
+        "POSIX_V6_ILP32_OFF32_CFLAGS": null,
+        "POSIX_V6_ILP32_OFF32_LDFLAGS": null,
+        "POSIX_V6_ILP32_OFF32_LIBS": null,
+        "POSIX_V6_ILP32_OFF32_LINTFLAGS": null,
+        "_POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+        "POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+        "_POSIX_V6_ILP32_OFFBIG": null,
+        "POSIX_V6_ILP32_OFFBIG_CFLAGS": null,
+        "POSIX_V6_ILP32_OFFBIG_LDFLAGS": null,
+        "POSIX_V6_ILP32_OFFBIG_LIBS": null,
+        "POSIX_V6_ILP32_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V6_LP64_OFF64": 1,
+        "POSIX_V6_LP64_OFF64_CFLAGS": "-m64",
+        "POSIX_V6_LP64_OFF64_LDFLAGS": "-m64",
+        "POSIX_V6_LP64_OFF64_LIBS": null,
+        "POSIX_V6_LP64_OFF64_LINTFLAGS": null,
+        "_POSIX_V6_LPBIG_OFFBIG": null,
+        "POSIX_V6_LPBIG_OFFBIG_CFLAGS": null,
+        "POSIX_V6_LPBIG_OFFBIG_LDFLAGS": null,
+        "POSIX_V6_LPBIG_OFFBIG_LIBS": null,
+        "POSIX_V6_LPBIG_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V7_ILP32_OFF32": null,
+        "POSIX_V7_ILP32_OFF32_CFLAGS": null,
+        "POSIX_V7_ILP32_OFF32_LDFLAGS": null,
+        "POSIX_V7_ILP32_OFF32_LIBS": null,
+        "POSIX_V7_ILP32_OFF32_LINTFLAGS": null,
+        "_POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+        "POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+        "_POSIX_V7_ILP32_OFFBIG": null,
+        "POSIX_V7_ILP32_OFFBIG_CFLAGS": null,
+        "POSIX_V7_ILP32_OFFBIG_LDFLAGS": null,
+        "POSIX_V7_ILP32_OFFBIG_LIBS": null,
+        "POSIX_V7_ILP32_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V7_LP64_OFF64": 1,
+        "POSIX_V7_LP64_OFF64_CFLAGS": "-m64",
+        "POSIX_V7_LP64_OFF64_LDFLAGS": "-m64",
+        "POSIX_V7_LP64_OFF64_LIBS": null,
+        "POSIX_V7_LP64_OFF64_LINTFLAGS": null,
+        "_POSIX_V7_LPBIG_OFFBIG": null,
+        "POSIX_V7_LPBIG_OFFBIG_CFLAGS": null,
+        "POSIX_V7_LPBIG_OFFBIG_LDFLAGS": null,
+        "POSIX_V7_LPBIG_OFFBIG_LIBS": null,
+        "POSIX_V7_LPBIG_OFFBIG_LINTFLAGS": null,
+        "_POSIX_ADVISORY_INFO": 200809,
+        "_POSIX_BARRIERS": 200809,
+        "_POSIX_BASE": null,
+        "_POSIX_C_LANG_SUPPORT": null,
+        "_POSIX_C_LANG_SUPPORT_R": null,
+        "_POSIX_CLOCK_SELECTION": 200809,
+        "_POSIX_CPUTIME": 200809,
+        "_POSIX_THREAD_CPUTIME": 200809,
+        "_POSIX_DEVICE_SPECIFIC": null,
+        "_POSIX_DEVICE_SPECIFIC_R": null,
+        "_POSIX_FD_MGMT": null,
+        "_POSIX_FIFO": null,
+        "_POSIX_PIPE": null,
+        "_POSIX_FILE_ATTRIBUTES": null,
+        "_POSIX_FILE_LOCKING": null,
+        "_POSIX_FILE_SYSTEM": null,
+        "_POSIX_MONOTONIC_CLOCK": 200809,
+        "_POSIX_MULTI_PROCESS": null,
+        "_POSIX_SINGLE_PROCESS": null,
+        "_POSIX_NETWORKING": null,
+        "_POSIX_READER_WRITER_LOCKS": 200809,
+        "_POSIX_SPIN_LOCKS": 200809,
+        "_POSIX_REGEXP": 1,
+        "_REGEX_VERSION": null,
+        "_POSIX_SHELL": 1,
+        "_POSIX_SIGNALS": null,
+        "_POSIX_SPAWN": 200809,
+        "_POSIX_SPORADIC_SERVER": null,
+        "_POSIX_THREAD_SPORADIC_SERVER": null,
+        "_POSIX_SYSTEM_DATABASE": null,
+        "_POSIX_SYSTEM_DATABASE_R": null,
+        "_POSIX_TIMEOUTS": 200809,
+        "_POSIX_TYPED_MEMORY_OBJECTS": null,
+        "_POSIX_USER_GROUPS": null,
+        "_POSIX_USER_GROUPS_R": null,
+        "POSIX2_PBS": null,
+        "POSIX2_PBS_ACCOUNTING": null,
+        "POSIX2_PBS_LOCATE": null,
+        "POSIX2_PBS_TRACK": null,
+        "POSIX2_PBS_MESSAGE": null,
+        "SYMLOOP_MAX": null,
+        "STREAM_MAX": 16,
+        "AIO_LISTIO_MAX": null,
+        "AIO_MAX": null,
+        "AIO_PRIO_DELTA_MAX": 20,
+        "DELAYTIMER_MAX": 2147483647,
+        "HOST_NAME_MAX": 64,
+        "LOGIN_NAME_MAX": 256,
+        "MQ_OPEN_MAX": null,
+        "MQ_PRIO_MAX": 32768,
+        "_POSIX_DEVICE_IO": null,
+        "_POSIX_TRACE": null,
+        "_POSIX_TRACE_EVENT_FILTER": null,
+        "_POSIX_TRACE_INHERIT": null,
+        "_POSIX_TRACE_LOG": null,
+        "RTSIG_MAX": 32,
+        "SEM_NSEMS_MAX": null,
+        "SEM_VALUE_MAX": 2147483647,
+        "SIGQUEUE_MAX": 31520,
+        "FILESIZEBITS": 64,
+        "POSIX_ALLOC_SIZE_MIN": 4096,
+        "POSIX_REC_INCR_XFER_SIZE": null,
+        "POSIX_REC_MAX_XFER_SIZE": null,
+        "POSIX_REC_MIN_XFER_SIZE": 4096,
+        "POSIX_REC_XFER_ALIGN": 4096,
+        "SYMLINK_MAX": null,
+        "GNU_LIBC_VERSION": "glibc 2.19",
+        "GNU_LIBPTHREAD_VERSION": "NPTL 2.19",
+        "POSIX2_SYMLINKS": 1,
+        "LEVEL1_ICACHE_SIZE": 32768,
+        "LEVEL1_ICACHE_ASSOC": 8,
+        "LEVEL1_ICACHE_LINESIZE": 64,
+        "LEVEL1_DCACHE_SIZE": 32768,
+        "LEVEL1_DCACHE_ASSOC": 8,
+        "LEVEL1_DCACHE_LINESIZE": 64,
+        "LEVEL2_CACHE_SIZE": 262144,
+        "LEVEL2_CACHE_ASSOC": 8,
+        "LEVEL2_CACHE_LINESIZE": 64,
+        "LEVEL3_CACHE_SIZE": 31457280,
+        "LEVEL3_CACHE_ASSOC": 20,
+        "LEVEL3_CACHE_LINESIZE": 64,
+        "LEVEL4_CACHE_SIZE": 0,
+        "LEVEL4_CACHE_ASSOC": 0,
+        "LEVEL4_CACHE_LINESIZE": 0,
+        "IPV6": 200809,
+        "RAW_SOCKETS": 200809
+      },
+      "root_group": "root",
+      "recipes": [
+        "opscode-ci::slave",
+        "opscode-ci::_build_support",
+        "chef-sugar::default",
+        "opscode-ci::_platform_tweaks",
+        "opscode-ci::_migration",
+        "omnibus::default",
+        "omnibus::_common",
+        "omnibus::_user",
+        "omnibus::_omnibus_toolchain",
+        "omnibus::_compile",
+        "build-essential::default",
+        "omnibus::_git",
+        "omnibus::_github",
+        "omnibus::_libffi",
+        "omnibus::_packaging",
+        "omnibus::_selinux",
+        "omnibus::_environment",
+        "opscode-ci::_github",
+        "opscode-ci::_ntp",
+        "ntp::default",
+        "opscode-ci::_package_signing",
+        "opscode-ci::_rubygems",
+        "opscode-ci::_aws",
+        "opscode-ci::_users",
+        "opscode-ci::_sudo",
+        "sudo::default",
+        "opscode-ci::_java",
+        "aws::default",
+        "opscode-ci::_omnibus"
+      ],
+      "expanded_run_list": [
+        "opscode-ci::slave"
+      ],
+      "roles": [],
+      "cookbooks": {
+        "opscode-ci": {
+          "version": "5.15.127"
+        },
+        "apt": {
+          "version": "6.1.4"
+        },
+        "chef-sugar": {
+          "version": "3.4.0"
+        },
+        "freebsd": {
+          "version": "1.0.2"
+        },
+        "lvm": {
+          "version": "4.1.9"
+        },
+        "omnibus": {
+          "version": "5.2.2"
+        },
+        "build-essential": {
+          "version": "8.0.3"
+        },
+        "seven_zip": {
+          "version": "2.0.2"
+        },
+        "windows": {
+          "version": "2.0.2"
+        },
+        "mingw": {
+          "version": "2.0.1"
+        },
+        "chef-ingredient": {
+          "version": "2.1.10"
+        },
+        "git": {
+          "version": "6.1.0"
+        },
+        "dmg": {
+          "version": "4.0.0"
+        },
+        "yum-epel": {
+          "version": "2.1.2"
+        },
+        "compat_resource": {
+          "version": "12.19.0"
+        },
+        "homebrew": {
+          "version": "4.2.0"
+        },
+        "remote_install": {
+          "version": "1.0.2"
+        },
+        "wix": {
+          "version": "3.0.0"
+        },
+        "windows-sdk": {
+          "version": "1.0.2"
+        },
+        "ntp": {
+          "version": "3.5.2"
+        },
+        "route53": {
+          "version": "2.0.0"
+        },
+        "rsyslog": {
+          "version": "5.1.0"
+        },
+        "sudo": {
+          "version": "3.5.3"
+        },
+        "redhat_subscription_manager": {
+          "version": "0.6.0"
+        },
+        "aws": {
+          "version": "3.3.3"
+        },
+        "ohai": {
+          "version": "3.0.1"
+        },
+        "jenkins": {
+          "version": "2.6.0"
+        },
+        "runit": {
+          "version": "1.8.0"
+        },
+        "packagecloud": {
+          "version": "0.3.0"
+        },
+        "yum": {
+          "version": "3.13.0"
+        },
+        "chef_nginx": {
+          "version": "2.9.0"
+        },
+        "bluepill": {
+          "version": "3.0.0"
+        },
+        "zypper": {
+          "version": "0.4.0"
+        },
+        "rubygems": {
+          "version": "1.0.2"
+        }
+      }
+    },
+    "normal": {
+      "tags": [
+        "chefdk",
+        "slave",
+        "tester"
+      ],
+      "omnibus": {
+        "build_user": "jenkins",
+        "build_user_password": "$1$4PauyzMX$ew5qtMVnZG8SBGdwjxt/X1",
+        "build_user_group": "jenkins",
+        "build_user_home": "/home/jenkins",
+        "ruby_version": "2.1.8"
+      },
+      "authorization": {
+        "sudo": {
+          "sudoers_defaults": [
+            "exempt_group += jenkins",
+            "secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\""
+          ],
+          "agent_forwarding": true,
+          "include_sudoers_d": true
+        }
+      },
+      "jenkins": {
+        "master": {
+          "endpoint": "http://example.com"
+        }
+      }
+    },
+    "chef_type": "node",
+    "default": {
+      "apt": {
+        "cacher_dir": "/var/cache/apt-cacher-ng",
+        "cacher_interface": null,
+        "cacher_port": 3142,
+        "compiletime": false,
+        "compile_time_update": false,
+        "key_proxy": "",
+        "periodic_update_min_delay": 86400,
+        "launchpad_api_version": "1.0",
+        "unattended_upgrades": {
+          "enable": false,
+          "update_package_lists": true,
+          "allowed_origins": [
+            "Suse "
+          ],
+          "origins_patterns": [],
+          "package_blacklist": [],
+          "auto_fix_interrupted_dpkg": false,
+          "minimal_steps": false,
+          "install_on_shutdown": false,
+          "mail": null,
+          "mail_only_on_error": true,
+          "remove_unused_dependencies": false,
+          "automatic_reboot": false,
+          "automatic_reboot_time": "now",
+          "dl_limit": null,
+          "random_sleep": null
+        },
+        "cacher_client": {
+          "cacher_server": {}
+        },
+        "confd": {
+          "force_confask": false,
+          "force_confdef": false,
+          "force_confmiss": false,
+          "force_confnew": false,
+          "force_confold": false,
+          "install_recommends": true,
+          "install_suggests": false
+        }
+      },
+      "ohai": {
+        "plugin_path": "/etc/chef/ohai_plugins",
+        "plugins": {
+          "ohai": "plugins"
+        },
+        "hints_path": "/etc/chef/ohai/hints"
+      },
+      "aws": {
+        "aws_sdk_version": "~> 2.2",
+        "databag_name": null,
+        "databag_entry": null,
+        "mfa_code": null
+      },
+      "chef-ingredient": {
+        "mixlib-install": {
+          "git_ref": null
+        }
+      },
+      "rsyslog": {
+        "local_host_name": null,
+        "default_log_dir": "/var/log",
+        "log_dir": "/srv/rsyslog",
+        "working_dir": "/var/spool/rsyslog",
+        "server": false,
+        "use_relp": false,
+        "relp_port": 20514,
+        "protocol": "tcp",
+        "bind": "*",
+        "port": 514,
+        "server_ip": null,
+        "server_search": "role:loghost",
+        "remote_logs": true,
+        "per_host_dir": "%$YEAR%/%$MONTH%/%$DAY%/%HOSTNAME%",
+        "max_message_size": "2k",
+        "preserve_fqdn": "off",
+        "high_precision_timestamps": false,
+        "repeated_msg_reduction": "on",
+        "logs_to_forward": "*.*",
+        "enable_imklog": true,
+        "config_prefix": "/etc",
+        "default_file_template": null,
+        "default_remote_template": null,
+        "rate_limit_interval": null,
+        "rate_limit_burst": null,
+        "enable_tls": false,
+        "action_queue_max_disk_space": "1G",
+        "tls_ca_file": null,
+        "tls_certificate_file": null,
+        "tls_key_file": null,
+        "tls_auth_mode": "anon",
+        "tls_permitted_peer": null,
+        "use_local_ipv4": false,
+        "allow_non_local": false,
+        "custom_remote": [],
+        "additional_directives": {},
+        "templates": [],
+        "service_name": "syslog",
+        "user": "root",
+        "group": "root",
+        "priv_seperation": false,
+        "priv_user": null,
+        "priv_group": null,
+        "modules": [
+          "imuxsock",
+          "imklog"
+        ],
+        "file_create_mode": "0640",
+        "dir_create_mode": "0755",
+        "umask": "0022",
+        "dir_owner": "root",
+        "dir_group": "adm",
+        "default_facility_logs": {
+          "*.emerg": ":omusrmsg:*",
+          "mail.*": "-/var/log/mail.log",
+          "mail.info": "-/var/log/mail.info",
+          "mail.warning": "-/var/log/mail.warn",
+          "mail.err": "/var/log/mail.err",
+          "news.crit": "/var/log/news/news.crit",
+          "news.err": "/var/log/news/news.err",
+          "news.notice": "-/var/log/news/news.notice",
+          "*.=warning;*.=err": "-/var/log/warn",
+          "*.crit": "/var/log/warn",
+          "*.*;mail.none;news.none": "/var/log/messages",
+          "local0.*;local1.*": "-/var/log/localmessages",
+          "local2.*;local3.*": "-/var/log/localmessages",
+          "local4.*;local5.*": "-/var/log/localmessages",
+          "local6.*;local7.*": "-/var/log/localmessages"
+        }
+      },
+      "bluepill": {
+        "bin": "/usr/bin/bluepill",
+        "logfile": "/var/log/bluepill.log",
+        "pid_dir": "/var/run/bluepill",
+        "state_dir": "/var/lib/bluepill",
+        "group": 0,
+        "use_rsyslog": false,
+        "init_dir": "/etc/init.d",
+        "conf_dir": "/etc/bluepill"
+      },
+      "windows": {
+        "rubyzipversion": null
+      },
+      "seven_zip": {
+        "url": "http://www.7-zip.org/a/7z1514-x64.msi",
+        "checksum": "cefe1a9092d8a6be68468c33910d6206b40e934fb63cab686c5cccf369fbf712",
+        "package_name": "7-Zip 15.14 (x64 edition)",
+        "default_extract_timeout": 600
+      },
+      "build-essential": {
+        "compile_time": false,
+        "msys2": {
+          "path": "\\msys2"
+        }
+      },
+      "packagecloud": {
+        "base_repo_path": "/install/repositories/",
+        "gpg_key_path": "/gpgkey",
+        "hostname_override": null,
+        "proxy_host": null,
+        "proxy_port": null,
+        "default_type": null
+      },
+      "yum-epel": {
+        "repos": [
+          "epel",
+          "epel-debuginfo",
+          "epel-source",
+          "epel-testing",
+          "epel-testing-debuginfo",
+          "epel-testing-source"
+        ]
+      },
+      "yum": {
+        "epel-debuginfo": {
+          "repositoryid": "epel-debuginfo",
+          "description": "Extra Packages for 12 - $basearch - Debug",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-12&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-12",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-source": {
+          "repositoryid": "epel-source",
+          "description": "Extra Packages for 12 - $basearch - Source",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-12&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-12",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-testing-debuginfo": {
+          "repositoryid": "epel-testing-debuginfo",
+          "description": "Extra Packages for 12 - $basearch - Testing Debug",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel12&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-12",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-testing-source": {
+          "repositoryid": "epel-testing-source",
+          "description": "Extra Packages for 12 - $basearch - Testing Source",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel12&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-12",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-testing": {
+          "repositoryid": "epel-testing",
+          "description": "Extra Packages for 12 - $basearch - Testing ",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel12&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-12",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel": {
+          "repositoryid": "epel",
+          "description": "Extra Packages for 12 - $basearch",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-12&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-12",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": true,
+          "managed": true,
+          "make_cache": true
+        },
+        "main": {
+          "cachedir": "/var/cache/yum/$basearch/$releasever",
+          "distroverpkg": "suse-release",
+          "releasever": null,
+          "alwaysprompt": null,
+          "assumeyes": null,
+          "bandwidth": null,
+          "bugtracker_url": null,
+          "clean_requirements_on_remove": null,
+          "color": null,
+          "color_list_available_downgrade": null,
+          "color_list_available_install": null,
+          "color_list_available_reinstall": null,
+          "color_list_available_upgrade": null,
+          "color_list_installed_extra": null,
+          "color_list_installed_newer": null,
+          "color_list_installed_older": null,
+          "color_list_installed_reinstall": null,
+          "color_search_match": null,
+          "color_update_installed": null,
+          "color_update_local": null,
+          "color_update_remote": null,
+          "commands": null,
+          "deltarpm": null,
+          "debuglevel": null,
+          "diskspacecheck": null,
+          "enable_group_conditionals": null,
+          "errorlevel": null,
+          "exactarch": null,
+          "exclude": null,
+          "gpgcheck": true,
+          "group_package_types": null,
+          "groupremove_leaf_only": null,
+          "history_list_view": null,
+          "history_record": null,
+          "history_record_packages": null,
+          "http_caching": null,
+          "installonly_limit": null,
+          "installonlypkgs": null,
+          "installroot": null,
+          "keepalive": null,
+          "keepcache": false,
+          "kernelpkgnames": null,
+          "localpkg_gpgcheck": false,
+          "logfile": "/var/log/yum.log",
+          "max_retries": null,
+          "mdpolicy": null,
+          "metadata_expire": null,
+          "mirrorlist_expire": null,
+          "multilib_policy": null,
+          "obsoletes": null,
+          "overwrite_groups": null,
+          "password": null,
+          "path": "/etc/yum.conf",
+          "persistdir": null,
+          "pluginconfpath": null,
+          "pluginpath": null,
+          "plugins": null,
+          "protected_multilib": null,
+          "protected_packages": null,
+          "proxy": null,
+          "proxy_password": null,
+          "proxy_username": null,
+          "recent": null,
+          "repo_gpgcheck": null,
+          "reposdir": null,
+          "reset_nice": null,
+          "rpmverbosity": null,
+          "showdupesfromrepos": null,
+          "skip_broken": null,
+          "ssl_check_cert_permissions": null,
+          "sslcacert": null,
+          "sslclientcert": null,
+          "sslclientkey": null,
+          "sslverify": null,
+          "syslog_device": null,
+          "syslog_facility": null,
+          "syslog_ident": null,
+          "throttle": null,
+          "timeout": null,
+          "tolerant": false,
+          "tsflags": null,
+          "username": null
+        }
+      },
+      "zypper": {
+        "smt_host": null
+      },
+      "nginx": {
+        "version": "1.10.1",
+        "package_name": "nginx",
+        "port": "80",
+        "dir": "/etc/nginx",
+        "script_dir": "/usr/sbin",
+        "log_dir": "/var/log/nginx",
+        "log_dir_perm": "0750",
+        "binary": "/usr/sbin/nginx",
+        "default_root": "/var/www/nginx-default",
+        "ulimit": "1024",
+        "pid": "/var/run/nginx.pid",
+        "user": "wwwrun",
+        "init_style": "init",
+        "group": "www",
+        "upstart": {
+          "runlevels": "2345",
+          "respawn_limit": null,
+          "foreground": true
+        },
+        "gzip": "on",
+        "gzip_static": "off",
+        "gzip_http_version": "1.0",
+        "gzip_comp_level": "2",
+        "gzip_proxied": "any",
+        "gzip_vary": "off",
+        "gzip_buffers": null,
+        "gzip_types": [
+          "text/plain",
+          "text/css",
+          "application/x-javascript",
+          "text/xml",
+          "application/xml",
+          "application/rss+xml",
+          "application/atom+xml",
+          "text/javascript",
+          "application/javascript",
+          "application/json",
+          "text/mathml"
+        ],
+        "gzip_min_length": 1000,
+        "gzip_disable": "MSIE [1-6]\\.",
+        "keepalive": "on",
+        "keepalive_requests": 100,
+        "keepalive_timeout": 65,
+        "worker_processes": 2,
+        "worker_connections": 1024,
+        "worker_rlimit_nofile": null,
+        "multi_accept": false,
+        "event": null,
+        "accept_mutex_delay": null,
+        "server_tokens": null,
+        "server_names_hash_bucket_size": 64,
+        "variables_hash_max_size": 1024,
+        "variables_hash_bucket_size": 64,
+        "sendfile": "on",
+        "underscores_in_headers": null,
+        "tcp_nodelay": "on",
+        "tcp_nopush": "on",
+        "access_log_options": null,
+        "error_log_options": null,
+        "disable_access_log": false,
+        "log_formats": {},
+        "install_method": "package",
+        "default_site_enabled": true,
+        "types_hash_max_size": 2048,
+        "types_hash_bucket_size": 64,
+        "proxy_read_timeout": null,
+        "client_body_buffer_size": null,
+        "client_max_body_size": null,
+        "large_client_header_buffers": null,
+        "default": {
+          "modules": []
+        },
+        "extra_configs": {},
+        "auth_request": {
+          "url": "http://mdounin.ru/hg/ngx_http_auth_request_module/archive/662785733552.tar.gz",
+          "checksum": "2057bdefd2137a5000d9dbdbfca049d1ba7832ad2b9f8855a88ea5dfa70bd8c1"
+        },
+        "devel": {
+          "version": "0.3.0",
+          "url": "https://github.com/simpl/ngx_devel_kit/archive/v0.3.0.tar.gz",
+          "checksum": "88e05a99a8a7419066f5ae75966fb1efc409bad4522d14986da074554ae61619"
+        },
+        "echo": {
+          "version": "0.59",
+          "url": "https://github.com/openresty/echo-nginx-module/archive/v0.59.tar.gz",
+          "checksum": "9b319ad7836202883128d2b9c24ed818082541df57ef7f2065b7557085c603cd"
+        },
+        "geoip": {
+          "path": "/srv/geoip",
+          "enable_city": true,
+          "country_dat_url": "http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz",
+          "country_dat_checksum": null,
+          "city_dat_url": "http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz",
+          "city_dat_checksum": null,
+          "lib_version": "1.6.9",
+          "lib_url": "https://github.com/maxmind/geoip-api-c/releases/download/v1.6.9/GeoIP-1.6.9.tar.gz",
+          "lib_checksum": "4b446491843de67c1af9b887da17a3e5939e0aeed4826923a5f4bf09d845096f"
+        },
+        "headers_more": {
+          "version": "0.30",
+          "source_url": "https://github.com/openresty/headers-more-nginx-module/archive/v0.30.tar.gz",
+          "source_checksum": "2aad309a9313c21c7c06ee4e71a39c99d4d829e31c8b3e7d76f8c964ea8047f5"
+        },
+        "lua": {
+          "version": "0.10.3",
+          "url": "https://github.com/chaoslawful/lua-nginx-module/archive/v0.10.3.tar.gz",
+          "checksum": "a69504c25de67bce968242d331d2e433c021405a6dba7bca0306e6e0b040bb50"
+        },
+        "luajit": {
+          "version": "2.0.4",
+          "url": "http://luajit.org/download/LuaJIT-2.0.4.tar.gz",
+          "checksum": "620fa4eb12375021bef6e4f237cbd2dd5d49e56beb414bee052c746beef1807d"
+        },
+        "naxsi": {
+          "version": "0.54",
+          "url": "https://github.com/nbs-system/naxsi/archive/0.54.tar.gz",
+          "checksum": "9cc2c09405bc71f78ef26a8b6d70afcea3fccbe8125df70cb0cfc480133daba5"
+        },
+        "openssl_source": {
+          "version": "1.0.1t",
+          "url": "http://www.openssl.org/source/openssl-1.0.1t.tar.gz"
+        },
+        "pagespeed": {
+          "version": "1.11.33.2",
+          "url": "https://github.com/pagespeed/ngx_pagespeed/archive/release-1.11.33.2-beta.tar.gz",
+          "packages": {
+            "rhel": [
+              "pcre-dev",
+              "pcre-devel",
+              "zlib-devel"
+            ],
+            "debian": [
+              "zlib1g-dev",
+              "libpcre3",
+              "libpcre3-dev"
+            ]
+          }
+        },
+        "psol": {
+          "url": "https://dl.google.com/dl/page-speed/psol/1.11.33.2.tar.gz"
+        },
+        "passenger": {
+          "version": "4.0.57",
+          "root": "/usr/lib64/ruby/gems/2.1.0/gems/passenger-4.0.57",
+          "ruby": "/usr/bin/ruby.ruby2.1",
+          "packages": {
+            "rhel": [
+              "ruby-devel",
+              "curl-devel"
+            ],
+            "fedora": [
+              "ruby-devel",
+              "libcurl-devel"
+            ],
+            "debian": [
+              "ruby-dev",
+              "libcurl4-gnutls-dev"
+            ]
+          },
+          "install_rake": true,
+          "spawn_method": "smart-lv2",
+          "buffer_response": "on",
+          "max_pool_size": 6,
+          "min_instances": 1,
+          "max_instances_per_app": 0,
+          "pool_idle_time": 300,
+          "max_requests": 0,
+          "gem_binary": null,
+          "nodejs": null
+        },
+        "enable_rate_limiting": false,
+        "rate_limiting_zone_name": "default",
+        "rate_limiting_backoff": "10m",
+        "rate_limit": "1r/s",
+        "set_misc": {
+          "version": "0.30",
+          "url": "https://github.com/agentzh/set-misc-nginx-module/archive/v0.30.tar.gz",
+          "checksum": "59920dd3f92c2be32627121605751b52eae32b5884be09f2e4c53fb2fae8aabc"
+        },
+        "socketproxy": {
+          "root": "/usr/share/nginx/apps",
+          "app_owner": "root",
+          "logname": "socketproxy",
+          "log_level": "error"
+        },
+        "source": {
+          "version": "1.10.1",
+          "prefix": "/opt/nginx-1.10.1",
+          "conf_path": "/etc/nginx/nginx.conf",
+          "sbin_path": "/opt/nginx-1.10.1/sbin/nginx",
+          "default_configure_flags": [
+            "--prefix=/opt/nginx-1.10.1",
+            "--conf-path=/etc/nginx/nginx.conf",
+            "--sbin-path=/opt/nginx-1.10.1/sbin/nginx"
+          ],
+          "url": "http://nginx.org/download/nginx-1.10.1.tar.gz",
+          "checksum": "1fd35846566485e03c0e318989561c135c598323ff349c503a6c14826487a801",
+          "modules": [
+            "chef_nginx::http_ssl_module",
+            "chef_nginx::http_gzip_static_module"
+          ],
+          "use_existing_user": false
+        },
+        "configure_flags": [],
+        "status": {
+          "port": "8090"
+        },
+        "syslog": {
+          "git_repo": "https://github.com/yaoweibin/nginx_syslog_patch.git",
+          "git_revision": "master"
+        },
+        "upload_progress": {
+          "url": "https://github.com/masterzen/nginx-upload-progress-module/tarball/v0.9.0",
+          "checksum": "3fb903dab595cf6656fa0fc5743a48daffbba2f6b5c554836be630800eaad4e2",
+          "javascript_output": true,
+          "zone_name": "proxied",
+          "zone_size": "1m"
+        }
+      },
+      "freebsd": {
+        "compiletime_portsnap": false
+      },
+      "jenkins": {
+        "java": "java",
+        "executor": {
+          "timeout": 60,
+          "private_key": null,
+          "proxy": null,
+          "jvm_options": null
+        },
+        "master": {
+          "install_method": "war",
+          "version": null,
+          "mirror": "http://mirrors.jenkins-ci.org",
+          "source": "http://mirrors.jenkins-ci.org/war/latest/jenkins.war",
+          "checksum": null,
+          "jvm_options": null,
+          "jenkins_args": null,
+          "user": "jenkins",
+          "group": "jenkins",
+          "use_system_accounts": true,
+          "host": "localhost",
+          "listen_address": "0.0.0.0",
+          "port": 8080,
+          "endpoint": "http://localhost:8080",
+          "home": "/var/lib/jenkins",
+          "log_directory": "/var/log/jenkins",
+          "runit": {
+            "sv_timeout": 7
+          },
+          "repository": null,
+          "repository_key": null,
+          "repository_keyserver": null
+        }
+      },
+      "lvm": {
+        "chef-ruby-lvm": {
+          "version": "0.3.0"
+        },
+        "chef-ruby-lvm-attrib": {
+          "version": "0.2.1"
+        },
+        "cleanup_old_gems": true,
+        "rubysource": "https://rubygems.org"
+      },
+      "ntp": {
+        "servers": [
+          "0.pool.ntp.org",
+          "1.pool.ntp.org",
+          "2.pool.ntp.org",
+          "3.pool.ntp.org"
+        ],
+        "peers": [],
+        "pools": [],
+        "restrictions": [],
+        "tinker": {
+          "panic": 0,
+          "allan": 1500,
+          "dispersion": 15,
+          "step": 0.128,
+          "stepout": 900
+        },
+        "restrict_default": "kod notrap nomodify nopeer noquery",
+        "packages": [
+          "ntp"
+        ],
+        "service": "ntpd",
+        "varlibdir": "/var/lib/ntp",
+        "driftfile": "/var/lib/ntp/ntp.drift",
+        "logfile": null,
+        "conffile": "/etc/ntp.conf",
+        "statsdir": "/var/log/ntpstats/",
+        "conf_owner": "root",
+        "conf_group": "root",
+        "var_owner": "ntp",
+        "var_group": "ntp",
+        "leapfile": "/etc/ntp.leapseconds",
+        "sync_clock": false,
+        "sync_hw_clock": false,
+        "listen": null,
+        "listen_network": null,
+        "ignore": null,
+        "apparmor_enabled": false,
+        "monitor": false,
+        "statistics": true,
+        "conf_restart_immediate": false,
+        "keys": null,
+        "trustedkey": null,
+        "requestkey": null,
+        "disable_tinker_panic_on_virtualization_guest": true,
+        "peer": {
+          "key": null,
+          "use_iburst": true,
+          "use_burst": false,
+          "minpoll": 6,
+          "maxpoll": 10
+        },
+        "server": {
+          "prefer": "",
+          "use_iburst": true,
+          "use_burst": false,
+          "minpoll": 6,
+          "maxpoll": 10
+        },
+        "orphan": {
+          "enabled": false,
+          "stratum": 5
+        },
+        "localhost": {
+          "noquery": false
+        },
+        "use_cmos": false
+      },
+      "git": {
+        "prefix": "/usr/local",
+        "version": "2.8.1",
+        "url": "https://nodeload.github.com/git/git/tar.gz/v%{version}",
+        "checksum": "e08503ecaf5d3ac10c40f22871c996a392256c8d038d16f52ebf974cba29ae42",
+        "use_pcre": false,
+        "server": {
+          "base_path": "/srv/git",
+          "export_all": true
+        }
+      },
+      "homebrew": {
+        "owner": null,
+        "auto-update": true,
+        "casks": [],
+        "formulas": [],
+        "taps": [],
+        "installer": {
+          "url": "https://raw.githubusercontent.com/Homebrew/install/master/install",
+          "checksum": null
+        },
+        "enable-analytics": true
+      },
+      "windows-sdk": {
+        "install_path": null
+      },
+      "wix": {
+        "download_id": "1540241",
+        "checksum": "03b8f46cb3abf1465fe8f9975a94a4e0f75c77267ff4d1fcb6d5b6a97567f549",
+        "home": "\\wix"
+      },
+      "omnibus": {
+        "build_user": "omnibus",
+        "build_user_home": null,
+        "install_dir": null,
+        "toolchain_name": "omnibus-toolchain",
+        "toolchain_version": "1.1.73",
+        "toolchain_channel": "stable",
+        "git_version": "2.6.2",
+        "ruby_version": "2.1.8",
+        "build_user_group": "omnibus",
+        "base_dir": "/var/cache/omnibus",
+        "git_checksum": "34dfc06b44880df91940dc318a2d3c83b79e67b6f05319c7c71e94d30893636d",
+        "build_user_password": "$1$QTCj0tQy$C60hWNmo8wZo.ctvDSy9p/"
+      },
+      "rubygems": {
+        "gem_disable_default": false,
+        "gem_sources": [
+          "https://rubygems.org"
+        ],
+        "chef_gem_disable_default": false,
+        "chef_gem_sources": [
+          "https://rubygems.org"
+        ]
+      },
+      "authorization": {
+        "sudo": {
+          "groups": [
+            "sysadmin"
+          ],
+          "users": [],
+          "passwordless": false,
+          "setenv": false,
+          "include_sudoers_d": false,
+          "agent_forwarding": false,
+          "sudoers_defaults": [
+            "!lecture,tty_tickets,!fqdn"
+          ],
+          "command_aliases": [],
+          "env_keep_add": [],
+          "env_keep_subtract": [],
+          "custom_commands": {
+            "users": [],
+            "groups": []
+          },
+          "prefix": "/etc"
+        }
+      },
+      "opscode-ci": {
+        "user": "jenkins",
+        "user_home": null,
+        "group": "jenkins",
+        "master": {
+          "host_name": null,
+          "port": 8080,
+          "jnlp_port": 38529,
+          "pipeline_types": [],
+          "executors": 2,
+          "jvm_memory_size": "2274511K",
+          "use_lvm": false,
+          "ebs_vols": [
+            {
+              "device": "/dev/xvdj",
+              "size": 500
+            }
+          ],
+          "days_to_keep_builds": null,
+          "builds_to_keep": null,
+          "days_to_keep_artifacts": 15,
+          "artifacts_to_keep": null
+        },
+        "email": {
+          "system_address": "CHEF CI <ci-notifications@getchef.com>",
+          "list_id": "ci-notifications.getchef.com"
+        },
+        "monitoring": {
+          "jmx_hostname": "localhost",
+          "jmx_port": 9010
+        },
+        "artifactory": {
+          "endpoint": "http://example.com"
+        },
+        "omnibus-cache": {
+          "profile_name": "omnibus-cache"
+        }
+      },
+      "java": {
+        "jdk_version": "7"
+      }
+    },
+    "override": {
+      "opscode-ci": {
+        "artifactory": {
+          "endpoint": "http://example.com:8081"
+        },
+        "omnitruck": {
+          "packages_bucket": "opscode-omnibus-packages",
+          "metadata_bucket": "opscode-omnibus-package-metadata"
+        },
+        "master": {
+          "host_name": "example.com",
+          "pipeline_types": [
+            "client_build",
+            "releng"
+          ],
+          "artifacts_to_keep": null,
+          "days_to_keep_artifacts": 15
+        }
+      }
+    },
+    "run_list": [
+      "recipe[opscode-ci::slave]"
+    ]
+  },
+  "node_name": "chefdk-sles-12-tester-a51a61",
+  "organization_name": "xmen",
+  "resources": [
+    {
+      "type": "chef_gem",
+      "name": "chef-sugar",
+      "id": "chef-sugar",
+      "after": {
+        "package_name": "chef-sugar",
+        "version": "3.4.0"
+      },
+      "before": {
+        "package_name": "chef-sugar",
+        "version": "3.4.0"
+      },
+      "duration": "133",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "chef-sugar",
+      "cookbook_version": "3.4.0",
+      "recipe_name": "default"
+    },
+    {
+      "type": "chef_gem",
+      "name": "chef-sugar",
+      "id": "chef-sugar",
+      "after": {
+        "package_name": "chef-sugar",
+        "version": "3.4.0"
+      },
+      "before": {
+        "package_name": "chef-sugar",
+        "version": "3.4.0"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "chef-sugar",
+      "cookbook_version": "3.4.0",
+      "recipe_name": "default"
+    },
+    {
+      "type": "directory",
+      "name": "/usr/local/bin",
+      "id": "/usr/local/bin",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "link",
+      "name": "/usr/local/bin/git",
+      "id": "/usr/local/bin/git",
+      "after": {
+        "to": "/opt/omnibus-toolchain/embedded/bin/git",
+        "owner": null,
+        "group": null
+      },
+      "before": {
+        "to": "/opt/omnibus-toolchain/embedded/bin/git",
+        "owner": "root",
+        "group": "root"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "zypper_package",
+      "name": "gettext-runtime-mini",
+      "id": "gettext-runtime-mini",
+      "after": {
+        "package_name": "gettext-runtime-mini"
+      },
+      "before": {
+        "package_name": "gettext-runtime-mini",
+        "version": [
+          null
+        ]
+      },
+      "duration": "1134",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "remove",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "zypper_package",
+      "name": "rpm-build",
+      "id": "rpm-build",
+      "after": {
+        "package_name": "rpm-build"
+      },
+      "before": {
+        "package_name": "rpm-build",
+        "version": [
+          "4.11.2-10.1"
+        ]
+      },
+      "duration": "674",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "file",
+      "name": "/etc/profile.d/rbenv.sh",
+      "id": "/etc/profile.d/rbenv.sh",
+      "after": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/etc/profile.d/rbenv.sh"
+      },
+      "before": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/etc/profile.d/rbenv.sh"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_migration"
+    },
+    {
+      "type": "directory",
+      "name": "/opt/rbenv",
+      "id": "/opt/rbenv",
+      "after": {
+        "group": null,
+        "mode": null,
+        "owner": null
+      },
+      "before": {
+        "group": null,
+        "mode": null,
+        "owner": null
+      },
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_migration"
+    },
+    {
+      "type": "directory",
+      "name": "/opt/rubies",
+      "id": "/opt/rubies",
+      "after": {
+        "group": null,
+        "mode": null,
+        "owner": null
+      },
+      "before": {
+        "group": null,
+        "mode": null,
+        "owner": null
+      },
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_migration"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.bashrc.d/chruby-default.sh",
+      "id": "/home/jenkins/.bashrc.d/chruby-default.sh",
+      "after": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/home/jenkins/.bashrc.d/chruby-default.sh"
+      },
+      "before": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/home/jenkins/.bashrc.d/chruby-default.sh"
+      },
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_migration"
+    },
+    {
+      "type": "chef_ingredient",
+      "name": "omnibus-toolchain",
+      "id": "omnibus-toolchain",
+      "after": {
+        "product_name": "omnibus-toolchain",
+        "version": "1.1.73",
+        "channel": "stable",
+        "platform_version_compatibility_mode": true,
+        "platform": "el",
+        "platform_version": "6",
+        "architecture": "x86_64"
+      },
+      "before": {},
+      "duration": "781",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "upgrade",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_omnibus_toolchain"
+    },
+    {
+      "type": "directory",
+      "name": "/export/home",
+      "id": "/export/home",
+      "after": {
+        "group": "root",
+        "mode": null,
+        "owner": "root"
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "skipped",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "group",
+      "name": "create jenkins group",
+      "id": "jenkins",
+      "after": {
+        "members": []
+      },
+      "before": {
+        "members": [
+          "jenkins"
+        ]
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user"
+    },
+    {
+      "type": "execute",
+      "name": "chsec_login_shell",
+      "id": "chsec -f /etc/security/login.cfg -s usw -a 'shells=/bin/sh,/bin/bsh,/bin/csh,/bin/ksh,/bin/tsh,/bin/ksh93,/usr/bin/sh,/usr/bin/bsh,/usr/bin/csh,/usr/bin/ksh,/usr/bin/tsh,/usr/bin/ksh93,/usr/bin/rksh,/usr/bin/rksh93,/usr/sbin/uucp/uucico,/usr/sbin/sliplogin,/usr/sbin/snappd,/usr/bin/bash,/opt/omnibus-toolchain/bin/bash'",
+      "after": {
+        "command": "chsec -f /etc/security/login.cfg -s usw -a 'shells=/bin/sh,/bin/bsh,/bin/csh,/bin/ksh,/bin/tsh,/bin/ksh93,/usr/bin/sh,/usr/bin/bsh,/usr/bin/csh,/usr/bin/ksh,/usr/bin/tsh,/usr/bin/ksh93,/usr/bin/rksh,/usr/bin/rksh93,/usr/sbin/uucp/uucico,/usr/sbin/sliplogin,/usr/sbin/snappd,/usr/bin/bash,/opt/omnibus-toolchain/bin/bash'",
+        "user": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "skipped",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "linux_user",
+      "name": "jenkins",
+      "id": "jenkins",
+      "after": {
+        "uid": null,
+        "gid": 1000,
+        "home": "/home/jenkins"
+      },
+      "before": {
+        "uid": 1001,
+        "gid": 1000,
+        "home": "/home/jenkins"
+      },
+      "duration": "6",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user"
+    },
+    {
+      "type": "group",
+      "name": "jenkins",
+      "id": "jenkins",
+      "after": {
+        "members": [
+          "jenkins"
+        ]
+      },
+      "before": {
+        "members": [
+          "jenkins"
+        ]
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "modify",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins",
+      "id": "/home/jenkins",
+      "after": {
+        "group": "jenkins",
+        "mode": "0755",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0755",
+        "owner": "jenkins"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user"
+    },
+    {
+      "type": "directory",
+      "name": "/var/chef/cache",
+      "id": "/var/chef/cache",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_common"
+    },
+    {
+      "type": "directory",
+      "name": "/usr/local/bin",
+      "id": "/usr/local/bin",
+      "after": {
+        "group": null,
+        "mode": "0755",
+        "owner": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "skipped",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_common",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "directory",
+      "name": "/var/cache/omnibus",
+      "id": "/var/cache/omnibus",
+      "after": {
+        "group": "jenkins",
+        "mode": "0755",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0755",
+        "owner": "jenkins"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_common"
+    },
+    {
+      "type": "build_essential",
+      "name": "install_packages",
+      "id": "install_packages",
+      "after": {
+        "compile_time": false
+      },
+      "before": {},
+      "duration": "5380",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "build-essential",
+      "cookbook_version": "8.0.3",
+      "recipe_name": "default"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.gitconfig",
+      "id": "/home/jenkins/.gitconfig",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0644",
+        "path": "/home/jenkins/.gitconfig",
+        "verifications": [],
+        "checksum": "f4a6f63a2bbcf021ae189644e3e819df1bad786292908c4de68337eee02b1e89"
+      },
+      "before": {
+        "checksum": "7a96018cec02ccac7a0743a0ec583e096fe3a85836beb561e0a77597816edc42",
+        "owner": "jenkins",
+        "group": "root",
+        "mode": "0644",
+        "path": "/home/jenkins/.gitconfig"
+      },
+      "duration": "7",
+      "delta": "--- /home/jenkins/.gitconfig\t2017-11-01 14:53:08.008920128 +0000\\n+++ /home/jenkins/.chef-.gitconfig20171101-3778-14eow4x.gitconfig\t2017-11-01 21:08:23.036308211 +0000\\n@@ -20,6 +20,4 @@\\n   autosetuprebase = always\\n [pull]\\n   rebase = preserve\\n-[http]\\n-\tsslCAinfo = /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "updated",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_git"
+    },
+    {
+      "type": "execute",
+      "name": "/opt/omnibus-toolchain/bin/git config --global http.sslCAinfo /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem",
+      "id": "/opt/omnibus-toolchain/bin/git config --global http.sslCAinfo /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem",
+      "after": {
+        "command": "/opt/omnibus-toolchain/bin/git config --global http.sslCAinfo /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem",
+        "user": "jenkins"
+      },
+      "before": {},
+      "duration": "18",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_git"
+    },
+    {
+      "type": "ruby_block",
+      "name": "disable strict host key checking for github.com",
+      "id": "disable strict host key checking for github.com",
+      "after": {
+        "block_name": "disable strict host key checking for github.com"
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "ruby_block",
+      "name": "make sudo honor ssh_auth_sock",
+      "id": "make sudo honor ssh_auth_sock",
+      "after": {
+        "block_name": "make sudo honor ssh_auth_sock"
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/load-omnibus-toolchain.sh",
+      "id": "/home/jenkins/load-omnibus-toolchain.sh",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0755",
+        "path": "/home/jenkins/load-omnibus-toolchain.sh",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "1a590716d649641db92e4fe6ce790c04806589556e4ac2448b0be5ddaf3f2f9e",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0755",
+        "path": "/home/jenkins/load-omnibus-toolchain.sh"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_environment"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins/.ssh",
+      "id": "/home/jenkins/.ssh",
+      "after": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "cookbook_file",
+      "name": "/home/jenkins/.ssh/known_hosts",
+      "id": "/home/jenkins/.ssh/known_hosts",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0644",
+        "path": "/home/jenkins/.ssh/known_hosts",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "029aa31c902d2d49468a4584f65d69757696f68c92166dea1bacddee22d990ee",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0644",
+        "path": "/home/jenkins/.ssh/known_hosts"
+      },
+      "duration": "6",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.ssh/github",
+      "id": "/home/jenkins/.ssh/github",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/github",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "c8fa3ddfe43f79cac2abfe110cc163ee45642571c17f03617fdcb548b777114a",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/github"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.ssh/config",
+      "id": "/home/jenkins/.ssh/config",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/config",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "fd3930562ec0c2c46049673f068cb2b2f38b045b339c4dd9efa3e46d0c781336",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/config"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "zypper_package",
+      "name": "ntp",
+      "id": "ntp",
+      "after": {
+        "package_name": "ntp"
+      },
+      "before": {
+        "package_name": "ntp",
+        "version": [
+          "4.2.8p8-46.8.1"
+        ]
+      },
+      "duration": "670",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "zypper_package",
+      "name": "Remove ntpdate",
+      "id": "ntpdate",
+      "after": {
+        "package_name": "ntpdate"
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "remove",
+      "status": "skipped",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "directory",
+      "name": "/var/lib/ntp",
+      "id": "/var/lib/ntp",
+      "after": {
+        "group": "ntp",
+        "mode": "0755",
+        "owner": "ntp"
+      },
+      "before": {
+        "group": "ntp",
+        "mode": "0755",
+        "owner": "ntp"
+      },
+      "duration": "5",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "directory",
+      "name": "/var/log/ntpstats/",
+      "id": "/var/log/ntpstats/",
+      "after": {
+        "group": "ntp",
+        "mode": "0755",
+        "owner": "ntp"
+      },
+      "before": {
+        "group": "ntp",
+        "mode": "0755",
+        "owner": "ntp"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "cookbook_file",
+      "name": "/etc/ntp.leapseconds",
+      "id": "/etc/ntp.leapseconds",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/ntp.leapseconds",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "cd3e23bc9fd5119f37bb58bb7e0310b71a726424186a1c57343f3cfd1031d42e",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/ntp.leapseconds"
+      },
+      "duration": "5",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "template",
+      "name": "/etc/ntp.conf",
+      "id": "/etc/ntp.conf",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/ntp.conf",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "5eba70b7b575a1e02fb498ef3d443b8a3cf55ab7190532b40934bf6ca77511fc",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/ntp.conf"
+      },
+      "duration": "31",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "execute",
+      "name": "Force sync hardware clock with system clock",
+      "id": "hwclock --systohc",
+      "after": {
+        "command": "hwclock --systohc",
+        "user": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "skipped",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "service",
+      "name": "ntpd",
+      "id": "ntpd",
+      "after": {
+        "enabled": true,
+        "running": true,
+        "masked": false
+      },
+      "before": {
+        "enabled": true,
+        "running": true,
+        "masked": false
+      },
+      "duration": "68",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "enable",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "service",
+      "name": "ntpd",
+      "id": "ntpd",
+      "after": {
+        "enabled": true,
+        "running": true,
+        "masked": false
+      },
+      "before": {
+        "enabled": true,
+        "running": true,
+        "masked": false
+      },
+      "duration": "76",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "start",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "file",
+      "name": "/var/chef/cache/package-signing-key",
+      "id": "/var/chef/cache/package-signing-key",
+      "after": {
+        "owner": "jenkins",
+        "group": "root",
+        "mode": "0600",
+        "path": "/var/chef/cache/package-signing-key",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "44d8e2a81f02434c39fbc7db1f7e871741d26237595b1518b7db392a186ac7a1",
+        "owner": "jenkins",
+        "group": "root",
+        "mode": "0600",
+        "path": "/var/chef/cache/package-signing-key"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_package_signing"
+    },
+    {
+      "type": "execute",
+      "name": "gpg-import-key",
+      "id": "gpg --allow-secret-key-import --homedir /home/jenkins/.gnupg --import /var/chef/cache/package-signing-key",
+      "after": {
+        "command": "gpg --allow-secret-key-import --homedir /home/jenkins/.gnupg --import /var/chef/cache/package-signing-key",
+        "user": "jenkins"
+      },
+      "before": {},
+      "duration": "39",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_package_signing",
+      "conditional": "not_if \"gpg --homedir /home/jenkins/.gnupg -K | grep 'Opscode Packages'\""
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.rpmmacros",
+      "id": "/home/jenkins/.rpmmacros",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0644",
+        "path": "/home/jenkins/.rpmmacros",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "1393128069754f1e92a4b60381d1ba35f34bfccae0accd8a237424c3cff9cc78",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0644",
+        "path": "/home/jenkins/.rpmmacros"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_package_signing"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins/.gem",
+      "id": "/home/jenkins/.gem",
+      "after": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.gem/credentials",
+      "id": "/home/jenkins/.gem/credentials",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.gem/credentials",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "08be5634d5030e591aab6c513c7a24abfb3e17afab3828741b077f396be5deda",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.gem/credentials"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "gemrc",
+      "name": "global",
+      "id": "global",
+      "after": {
+        "user": "jenkins",
+        "group": "jenkins",
+        "values": {
+          "sources": [
+            "https://rubygems.org/"
+          ]
+        }
+      },
+      "before": {
+        "path": "/opt/chef/embedded/etc/gemrc",
+        "values": {
+          "sources": [
+            "https://rubygems.org/"
+          ]
+        }
+      },
+      "duration": "24",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "gemrc",
+      "name": "/home/jenkins/.gemrc",
+      "id": "/home/jenkins/.gemrc",
+      "after": {
+        "user": "jenkins",
+        "group": "jenkins",
+        "values": {
+          "sources": [
+            "https://rubygems.org/"
+          ]
+        }
+      },
+      "before": {
+        "path": "/home/jenkins/.gemrc",
+        "values": {
+          "sources": [
+            "https://rubygems.org/"
+          ]
+        }
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.bundle/config",
+      "id": "/home/jenkins/.bundle/config",
+      "after": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/home/jenkins/.bundle/config"
+      },
+      "before": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/home/jenkins/.bundle/config"
+      },
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins/.aws",
+      "id": "/home/jenkins/.aws",
+      "after": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_aws"
+    },
+    {
+      "type": "template",
+      "name": "/home/jenkins/.aws/credentials",
+      "id": "/home/jenkins/.aws/credentials",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.aws/credentials",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "e03da2ff59a16921fa0cb84568c077502e2d832aa640efa0d2a4cd4d625cfbb0",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.aws/credentials"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_aws"
+    },
+    {
+      "type": "linux_user",
+      "name": "root",
+      "id": "root",
+      "after": {
+        "uid": 0,
+        "gid": 0,
+        "home": "/root"
+      },
+      "before": {
+        "uid": 0,
+        "gid": 0,
+        "home": "/root"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_users"
+    },
+    {
+      "type": "zypper_package",
+      "name": "sudo",
+      "id": "sudo",
+      "after": {
+        "package_name": "sudo"
+      },
+      "before": {},
+      "duration": "6",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "skipped",
+      "cookbook_name": "sudo",
+      "cookbook_version": "3.5.3",
+      "recipe_name": "default",
+      "conditional": "not_if \"which sudo\""
+    },
+    {
+      "type": "directory",
+      "name": "/etc/sudoers.d",
+      "id": "/etc/sudoers.d",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "sudo",
+      "cookbook_version": "3.5.3",
+      "recipe_name": "default"
+    },
+    {
+      "type": "cookbook_file",
+      "name": "/etc/sudoers.d/README",
+      "id": "/etc/sudoers.d/README",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0440",
+        "path": "/etc/sudoers.d/README",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "9ded172910845bd115fbe469d87cab80a215e756a973e5d09c0e58a19a1bfe81",
+        "owner": "root",
+        "group": "root",
+        "mode": "0440",
+        "path": "/etc/sudoers.d/README"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "sudo",
+      "cookbook_version": "3.5.3",
+      "recipe_name": "default"
+    },
+    {
+      "type": "template",
+      "name": "/etc/sudoers",
+      "id": "/etc/sudoers",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0440",
+        "path": "/etc/sudoers",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "4520ba18debe05aaea860c0fef2d11aa0c6c1b8e7ee0eaa7c7e4360e659d1047",
+        "owner": "root",
+        "group": "root",
+        "mode": "0440",
+        "path": "/etc/sudoers"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "sudo",
+      "cookbook_version": "3.5.3",
+      "recipe_name": "default"
+    },
+    {
+      "type": "sudo",
+      "name": "jenkins",
+      "id": "jenkins",
+      "after": {
+        "user": "jenkins",
+        "commands": [
+          "ALL"
+        ],
+        "host": "ALL",
+        "runas": "ALL",
+        "nopasswd": true,
+        "command_aliases": [],
+        "env_keep_add": [],
+        "env_keep_subtract": []
+      },
+      "before": {},
+      "duration": "19",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo"
+    },
+    {
+      "type": "sudo",
+      "name": "sysadmin",
+      "id": "sysadmin",
+      "after": {
+        "group": "sysadmin",
+        "commands": [
+          "ALL"
+        ],
+        "host": "ALL",
+        "runas": "ALL",
+        "nopasswd": true,
+        "command_aliases": [],
+        "env_keep_add": [],
+        "env_keep_subtract": []
+      },
+      "before": {},
+      "duration": "30",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo"
+    },
+    {
+      "type": "sudo",
+      "name": "build",
+      "id": "build",
+      "after": {
+        "user": "build",
+        "nopasswd": true
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "sudo",
+      "name": "vagrant",
+      "id": "vagrant",
+      "after": {
+        "user": "vagrant",
+        "nopasswd": true
+      },
+      "before": {},
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "sudo",
+      "name": "ubuntu",
+      "id": "ubuntu",
+      "after": {
+        "user": "ubuntu",
+        "nopasswd": true
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "sudo",
+      "name": "ec2-user",
+      "id": "ec2-user",
+      "after": {
+        "user": "ec2-user",
+        "commands": [
+          "ALL"
+        ],
+        "host": "ALL",
+        "runas": "ALL",
+        "nopasswd": true,
+        "command_aliases": [],
+        "env_keep_add": [],
+        "env_keep_subtract": []
+      },
+      "before": {},
+      "duration": "30",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo"
+    },
+    {
+      "type": "zypper_package",
+      "name": "java-1_7_1-ibm",
+      "id": "java-1_7_1-ibm",
+      "after": {
+        "package_name": "java-1_7_1-ibm"
+      },
+      "before": {
+        "package_name": "java-1_7_1-ibm",
+        "version": [
+          "1.7.1_sr3.40-25.1"
+        ]
+      },
+      "duration": "666",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_java"
+    },
+    {
+      "type": "zypper_package",
+      "name": "java-1_7_1-ibm-devel",
+      "id": "java-1_7_1-ibm-devel",
+      "after": {
+        "package_name": "java-1_7_1-ibm-devel"
+      },
+      "before": {
+        "package_name": "java-1_7_1-ibm-devel",
+        "version": [
+          "1.7.1_sr3.40-25.1"
+        ]
+      },
+      "duration": "671",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_java"
+    },
+    {
+      "type": "git",
+      "name": "/var/chef/cache/artifactory",
+      "id": "/var/chef/cache/artifactory",
+      "after": {
+        "revision": "v2.8.2"
+      },
+      "before": {
+        "revision": "ee0af35496c0809c5b7445f951ee324f37e2679b"
+      },
+      "duration": "120",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "sync",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "execute",
+      "name": "build-artifactory-gem",
+      "id": "rm -rf artifactory-*.gem && gem build artifactory.gemspec",
+      "after": {
+        "command": "rm -rf artifactory-*.gem && gem build artifactory.gemspec",
+        "user": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "nothing",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus",
+      "conditional": "not_if { action == :nothing }"
+    },
+    {
+      "type": "execute",
+      "name": "install-artifactory-gem",
+      "id": "gem install artifactory-*.gem --no-ri --no-rdoc",
+      "after": {
+        "command": "gem install artifactory-*.gem --no-ri --no-rdoc",
+        "user": null
+      },
+      "before": {},
+      "duration": "481",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "git",
+      "name": "/var/chef/cache/omnibus",
+      "id": "/var/chef/cache/omnibus",
+      "after": {
+        "revision": "ced452379e27b85b9958421f258b5fbe22e3760a"
+      },
+      "before": {
+        "revision": "ced452379e27b85b9958421f258b5fbe22e3760a"
+      },
+      "duration": "7",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "sync",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "execute",
+      "name": "build-omnibus-gem",
+      "id": "rm -rf omnibus-*.gem && gem build omnibus.gemspec",
+      "after": {
+        "command": "rm -rf omnibus-*.gem && gem build omnibus.gemspec",
+        "user": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "nothing",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus",
+      "conditional": "not_if { action == :nothing }"
+    },
+    {
+      "type": "execute",
+      "name": "install-omnibus-gem",
+      "id": "gem install omnibus-*.gem --no-ri --no-rdoc",
+      "after": {
+        "command": "gem install omnibus-*.gem --no-ri --no-rdoc",
+        "user": null
+      },
+      "before": {},
+      "duration": "2973",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/omnibus-publish.rb",
+      "id": "/home/jenkins/omnibus-publish.rb",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/omnibus-publish.rb",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "fd1b38949f0ae02b68e76bfdbac56df45fdd4c22e64d20ac26388a8bd3590c61",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/omnibus-publish.rb"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins/.ssh",
+      "id": "/home/jenkins/.ssh",
+      "after": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "slave"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.ssh/authorized_keys",
+      "id": "/home/jenkins/.ssh/authorized_keys",
+      "after": {
+        "owner": "jenkins",
+        "group": "root",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/authorized_keys",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "0cbbb3b0e104f5c5deb49091126fbc35e352f4d4222c598eeff9170f9a2028e8",
+        "owner": "jenkins",
+        "group": "root",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/authorized_keys"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "slave"
+    },
+    {
+      "type": "remote_file",
+      "name": "/var/chef/cache/jenkins-cli.jar",
+      "id": "/var/chef/cache/jenkins-cli.jar",
+      "after": {
+        "checksum": null,
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/chef/cache/jenkins-cli.jar"
+      },
+      "before": {
+        "checksum": "f3c325f20fadb64a50c387cc3ad9429e34669de7ddf9e842bb65d4a1ddc982b4",
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/chef/cache/jenkins-cli.jar"
+      },
+      "duration": "7",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "remote_file",
+      "name": "/var/chef/cache/update-center.json",
+      "id": "/var/chef/cache/update-center.json",
+      "after": {
+        "checksum": "64a0fd3fd4f00350bbe1c05b5588b4fd0224b61f7277952e1da943af1619e480",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/var/chef/cache/update-center.json",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "a1654b369edbd1847ceb1e132cd4bec32b8f0d3fd06d9236e0c4c6582915b87d",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/var/chef/cache/update-center.json"
+      },
+      "duration": "2026",
+      "delta": "suppressed sensitive resource",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "updated"
+    },
+    {
+      "type": "file",
+      "name": "/var/chef/cache/extracted-update-center.json",
+      "id": "/var/chef/cache/extracted-update-center.json",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/var/chef/cache/extracted-update-center.json",
+        "verifications": [],
+        "checksum": "3c0c442fde018f24a83863409de92032d1db1da65ccf576e761f376243c62c35"
+      },
+      "before": {
+        "checksum": "b12da39a17fd4c874c6634d7c26484bd785bbfa90a5d29a7c1ade138e6318a2b",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/var/chef/cache/extracted-update-center.json"
+      },
+      "duration": "17",
+      "delta": "suppressed sensitive resource",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "updated"
+    },
+    {
+      "type": "file",
+      "name": "/var/chef/cache/jenkins-key",
+      "id": "/var/chef/cache/jenkins-key",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0600",
+        "path": "/var/chef/cache/jenkins-key",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "ced9d2204cc71246b2a6b440829167aa024c2c7662d3c2451acf20ece4bc319d",
+        "owner": "root",
+        "group": "root",
+        "mode": "0600",
+        "path": "/var/chef/cache/jenkins-key"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "jenkins_private_key_credentials",
+      "name": "jenkins",
+      "id": "jenkins",
+      "after": {
+        "description": "Credentials for jenkins - created by Chef",
+        "username": "jenkins",
+        "private_key": "EXAMPLEKEY"
+      },
+      "before": {
+        "id": "2e269a3f-71ba-4b22-8882-40790a8582e8",
+        "description": "Credentials for jenkins - created by Chef",
+        "username": "jenkins",
+        "private_key": "EXAMPLEKEY"
+      },
+      "duration": "3986",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "slave"
+    },
+    {
+      "type": "jenkins_ssh_slave",
+      "name": "chefdk-sles-12-tester-a51a61",
+      "id": "chefdk-sles-12-tester-a51a61",
+      "after": {
+        "slave_name": "chefdk-sles-12-tester-a51a61",
+        "description": "suse 12.0 [ GNU/Linux 3.12.48-52.27-default x86_64 ]",
+        "remote_fs": "/home/jenkins",
+        "usage_mode": "normal",
+        "labels": [
+          "12",
+          "12.0",
+          "3.12.48-52.27-default",
+          "chefdk",
+          "linux",
+          "slave",
+          "sles",
+          "sles-12",
+          "sles-12.0",
+          "suse",
+          "suse-12.0",
+          "tester",
+          "x86_64"
+        ],
+        "environment": {
+          "LIBPATH": "",
+          "OMNIBUS_FIPS_MODE": "false"
+        },
+        "user": "jenkins",
+        "java_path": "java",
+        "host": "68.103.81.158",
+        "credentials": {
+          "json_class": "Chef::Resource::JenkinsPrivateKeyCredentials",
+          "instance_vars": {
+            "name": "jenkins",
+            "noop": null,
+            "before": null,
+            "params": {},
+            "provider": null,
+            "allowed_actions": [
+              "nothing",
+              "create",
+              "delete"
+            ],
+            "action": [
+              "create"
+            ],
+            "updated": false,
+            "updated_by_last_action": false,
+            "supports": {},
+            "ignore_failure": false,
+            "retries": 0,
+            "retry_delay": 2,
+            "source_line": "/var/chef/cache/cookbooks/opscode-ci/recipes/slave.rb:69:in `from_file'",
+            "guard_interpreter": null,
+            "default_guard_interpreter": "default",
+            "elapsed_time": 3.986388127,
+            "sensitive": true,
+            "declared_type": "jenkins_private_key_credentials",
+            "cookbook_name": "opscode-ci",
+            "recipe_name": "slave",
+            "private_key": "EXAMPLEKEY",
+            "username": "jenkins",
+            "description": "Credentials for jenkins - created by Chef"
+          }
+        },
+        "command_prefix": "env HOME=/home/jenkins PATH=/opt/omnibus-toolchain/embedded/bin::/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin JENKINS_HOME=/home/jenkins sh -c '",
+        "command_suffix": "'"
+      },
+      "before": {
+        "slave_name": "chefdk-sles-12-tester-a51a61",
+        "description": "suse 12.0 [ GNU/Linux 3.12.48-52.27-default x86_64 ]",
+        "remote_fs": "/home/jenkins",
+        "executors": 1,
+        "labels": [
+          "12",
+          "12.0",
+          "3.12.48-52.27-default",
+          "chefdk",
+          "linux",
+          "slave",
+          "sles",
+          "sles-12",
+          "sles-12.0",
+          "suse",
+          "suse-12.0",
+          "tester",
+          "x86_64"
+        ],
+        "java_path": "java",
+        "host": "68.103.81.158",
+        "port": 22,
+        "credentials": "jenkins"
+      },
+      "duration": "4432",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "slave"
+    },
+    {
+      "type": "linux_user",
+      "name": "chefautomate",
+      "id": "chefautomate",
+      "after": {
+        "uid": null,
+        "gid": null,
+        "home": "/var/opt/chef"
+      },
+      "before": {
+        "uid": 7209,
+        "gid": 100,
+        "home": "/var/opt/chef"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "directory",
+      "name": "/var/opt/chef/bin",
+      "id": "/var/opt/chef/bin",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "directory",
+      "name": "/var/opt/chef/etc",
+      "id": "/var/opt/chef/etc",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "directory",
+      "name": "/var/log/chef/automate-liveness-agent",
+      "id": "/var/log/chef/automate-liveness-agent",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "chefautomate"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "chefautomate"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "file",
+      "name": "/var/opt/chef/bin/automate-liveness-agent",
+      "id": "/var/opt/chef/bin/automate-liveness-agent",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/opt/chef/bin/automate-liveness-agent",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "d7ad5dd68ab384e8e7f6c34ecb9c57b6c463a0d9625152c53c3deb7023a67e73",
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/opt/chef/bin/automate-liveness-agent"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "file",
+      "name": "/var/opt/chef/etc/config.json",
+      "id": "/var/opt/chef/etc/config.json",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/opt/chef/etc/config.json",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "bd612cdb9cf837f15917fbf37c582eea3ed2a5c090cb033eb80bfe5c4f3fb8b6",
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/opt/chef/etc/config.json"
+      },
+      "duration": "8",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "file",
+      "name": "/etc/init.d/automate-liveness-agent",
+      "id": "/etc/init.d/automate-liveness-agent",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0744",
+        "path": "/etc/init.d/automate-liveness-agent",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "8a39aa2bccd95ae7f4f47b6c6702af5a4c068c45b0bfa943f814fb49492fd75a",
+        "owner": "root",
+        "group": "root",
+        "mode": "0744",
+        "path": "/etc/init.d/automate-liveness-agent"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "service",
+      "name": "automate-liveness-agent",
+      "id": "automate-liveness-agent",
+      "after": {
+        "enabled": true,
+        "running": true,
+        "masked": false
+      },
+      "before": {
+        "enabled": true,
+        "running": true,
+        "masked": false
+      },
+      "duration": "140",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "enable",
+      "status": "up-to-date"
+    },
+    {
+      "type": "service",
+      "name": "automate-liveness-agent",
+      "id": "automate-liveness-agent",
+      "after": {
+        "enabled": true,
+        "running": true,
+        "masked": false
+      },
+      "before": {
+        "enabled": true,
+        "running": true,
+        "masked": false
+      },
+      "duration": "138",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "start",
+      "status": "up-to-date"
+    }
+  ],
+  "run_id": "75c2376e-d07e-4d2b-ab43-d658c6250a62",
+  "run_list": [
+    "recipe[opscode-ci::slave]"
+  ],
+  "start_time": "2017-11-01T21:07:58Z",
+  "end_time": "2017-11-01T21:08:40Z",
+  "source": "chef_client",
+  "status": "success",
+  "total_resource_count": 348,
+  "updated_resource_count": 9,
+  "deprecations": [
+    {
+      "message": "Chef::Platform.set is deprecated",
+      "url": "https://docs.chef.io/deprecations_chef_platform_methods.html",
+      "location": "/var/chef/cache/cookbooks/jenkins/libraries/plugin.rb:443:in `<top (required)>'"
+    },
+    {
+      "message": "Chef::Platform.set is deprecated",
+      "url": "https://docs.chef.io/deprecations_chef_platform_methods.html",
+      "location": "/var/chef/cache/cookbooks/jenkins/libraries/slave.rb:410:in `<top (required)>'"
+    },
+    {
+      "message": "Chef::Platform.set is deprecated",
+      "url": "https://docs.chef.io/deprecations_chef_platform_methods.html",
+      "location": "/var/chef/cache/cookbooks/jenkins/libraries/user.rb:183:in `<top (required)>'"
+    },
+    {
+      "message": "Property `sensitive` of resource `rhsm_register` overwrites an existing method. Please use a different property name. This will raise an exception in Chef 13.",
+      "url": "https://docs.chef.io/deprecations_property_name_collision.html",
+      "location": "/var/chef/cache/cookbooks/redhat_subscription_manager/libraries/rhsm_register.rb:34:in `<class:RhsmRegister>'"
+    },
+    {
+      "message": "method access to node attributes (node.foo.bar) is deprecated and will be removed in Chef 13, please use bracket syntax (node[\"foo\"][\"bar\"])",
+      "url": "https://docs.chef.io/deprecations_attributes.html",
+      "location": "/opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-sugar-3.6.0/lib/chef/sugar/node.rb:162:in `method_missing'"
+    },
+    {
+      "message": "Property `sensitive` of resource `aws_s3_file` overwrites an existing method. Please use a different property name. This will raise an exception in Chef 13.",
+      "url": "https://docs.chef.io/deprecations_property_name_collision.html",
+      "location": "/var/chef/cache/cookbooks/aws/resources/s3_file.rb:36:in `class_from_file'"
+    },
+    {
+      "message": "Property `sensitive` of resource `yum_repository` overwrites an existing method. Please use a different property name. This will raise an exception in Chef 13.",
+      "url": "https://docs.chef.io/deprecations_property_name_collision.html",
+      "location": "/var/chef/cache/cookbooks/yum/resources/repository.rb:59:in `class_from_file'"
+    },
+    {
+      "message": "Cloning resource attributes for directory[/usr/local/bin] from prior resource\nPrevious directory[/usr/local/bin]: /var/chef/cache/cookbooks/opscode-ci/recipes/_platform_tweaks.rb:23:in `from_file'\nCurrent  directory[/usr/local/bin]: /var/chef/cache/cookbooks/omnibus/recipes/_common.rb:49:in `from_file'",
+      "url": "https://docs.chef.io/deprecations_resource_cloning.html",
+      "location": "/var/chef/cache/cookbooks/omnibus/recipes/_common.rb:49:in `from_file'"
+    },
+    {
+      "message": "Cloning resource attributes for directory[/home/jenkins/.ssh] from prior resource\nPrevious directory[/home/jenkins/.ssh]: /var/chef/cache/cookbooks/opscode-ci/recipes/_github.rb:12:in `from_file'\nCurrent  directory[/home/jenkins/.ssh]: /var/chef/cache/cookbooks/opscode-ci/recipes/slave.rb:58:in `from_file'",
+      "url": "https://docs.chef.io/deprecations_resource_cloning.html",
+      "location": "/var/chef/cache/cookbooks/opscode-ci/recipes/slave.rb:58:in `from_file'"
+    }
+  ]
+}

--- a/e2e/cypress/fixtures/converge/xmen2.json
+++ b/e2e/cypress/fixtures/converge/xmen2.json
@@ -1,0 +1,7908 @@
+{
+  "chef_server_fqdn": "chef-server.chef.co",
+  "entity_uuid": "6453a764-2415-4934-8cee-2a008834a74a",
+  "expanded_run_list": {
+    "id": "manhattan",
+    "run_list": [
+      {
+        "type": "recipe",
+        "name": "opscode-ci::slave",
+        "version": null,
+        "skipped": false
+      }
+    ]
+  },
+  "id": "da60e383-67f6-4501-b726-1f28e03bf6ea",
+  "message_version": "1.1.0",
+  "message_type": "run_converge",
+  "node": {
+    "name": "chefdk-ubuntu-14.04-tester-05b95c",
+    "chef_environment": "manhattan",
+    "json_class": "Chef::Node",
+    "automatic": {
+      "virtualization": {
+        "systems": {
+          "xen": "guest"
+        },
+        "system": "xen",
+        "role": "guest"
+      },
+      "kernel": {
+        "name": "Linux",
+        "release": "3.13.0-53-generic",
+        "version": "#89-Ubuntu SMP Wed May 20 10:34:39 UTC 2015",
+        "machine": "x86_64",
+        "processor": "x86_64",
+        "os": "GNU/Linux",
+        "modules": {
+          "dm_crypt": {
+            "size": "23177",
+            "refcount": "0"
+          },
+          "crct10dif_pclmul": {
+            "size": "14289",
+            "refcount": "0"
+          },
+          "crc32_pclmul": {
+            "size": "13113",
+            "refcount": "0"
+          },
+          "ghash_clmulni_intel": {
+            "size": "13216",
+            "refcount": "0"
+          },
+          "serio_raw": {
+            "size": "13462",
+            "refcount": "0"
+          },
+          "isofs": {
+            "size": "39837",
+            "refcount": "0"
+          },
+          "aesni_intel": {
+            "size": "55624",
+            "refcount": "0"
+          },
+          "aes_x86_64": {
+            "size": "17131",
+            "refcount": "1"
+          },
+          "glue_helper": {
+            "size": "13990",
+            "refcount": "1"
+          },
+          "lrw": {
+            "size": "13286",
+            "refcount": "1"
+          },
+          "gf128mul": {
+            "size": "14951",
+            "refcount": "1"
+          },
+          "ablk_helper": {
+            "size": "13597",
+            "refcount": "1"
+          },
+          "cryptd": {
+            "size": "20359",
+            "refcount": "3"
+          },
+          "floppy": {
+            "size": "69418",
+            "refcount": "0"
+          },
+          "psmouse": {
+            "size": "106590",
+            "refcount": "0"
+          }
+        }
+      },
+      "os": "linux",
+      "os_version": "3.13.0-53-generic",
+      "lsb": {
+        "id": "Ubuntu",
+        "description": "Ubuntu 14.04.2 LTS",
+        "release": "14.04",
+        "codename": "trusty"
+      },
+      "platform": "ubuntu",
+      "platform_version": "14.04",
+      "platform_family": "debian",
+      "filesystem": {
+        "/dev/xvda1": {
+          "kb_size": "30822592",
+          "kb_used": "3235164",
+          "kb_available": "26229828",
+          "percent_used": "11%",
+          "mount": "/",
+          "total_inodes": "1966080",
+          "inodes_used": "188643",
+          "inodes_available": "1777437",
+          "inodes_percent_used": "10%",
+          "fs_type": "ext4",
+          "mount_options": [
+            "rw",
+            "discard"
+          ],
+          "uuid": "771646b6-78e5-4445-9599-f2f407484a9a",
+          "label": "cloudimg-rootfs"
+        },
+        "none": {
+          "kb_size": "102400",
+          "kb_used": "0",
+          "kb_available": "102400",
+          "percent_used": "0%",
+          "mount": "/sys/fs/pstore",
+          "total_inodes": "505861",
+          "inodes_used": "4",
+          "inodes_available": "505857",
+          "inodes_percent_used": "1%",
+          "fs_type": "pstore",
+          "mount_options": [
+            "rw"
+          ]
+        },
+        "udev": {
+          "kb_size": "2018488",
+          "kb_used": "12",
+          "kb_available": "2018476",
+          "percent_used": "1%",
+          "mount": "/dev",
+          "total_inodes": "504622",
+          "inodes_used": "387",
+          "inodes_available": "504235",
+          "inodes_percent_used": "1%",
+          "fs_type": "devtmpfs",
+          "mount_options": [
+            "rw",
+            "mode=0755"
+          ]
+        },
+        "tmpfs": {
+          "kb_size": "404692",
+          "kb_used": "348",
+          "kb_available": "404344",
+          "percent_used": "1%",
+          "mount": "/run",
+          "total_inodes": "505861",
+          "inodes_used": "306",
+          "inodes_available": "505555",
+          "inodes_percent_used": "1%",
+          "fs_type": "tmpfs",
+          "mount_options": [
+            "rw",
+            "noexec",
+            "nosuid",
+            "size=10%",
+            "mode=0755"
+          ]
+        },
+        "proc": {
+          "mount": "/proc",
+          "fs_type": "proc",
+          "mount_options": [
+            "rw",
+            "noexec",
+            "nosuid",
+            "nodev"
+          ]
+        },
+        "sysfs": {
+          "mount": "/sys",
+          "fs_type": "sysfs",
+          "mount_options": [
+            "rw",
+            "noexec",
+            "nosuid",
+            "nodev"
+          ]
+        },
+        "devpts": {
+          "mount": "/dev/pts",
+          "fs_type": "devpts",
+          "mount_options": [
+            "rw",
+            "noexec",
+            "nosuid",
+            "gid=5",
+            "mode=0620"
+          ]
+        },
+        "systemd": {
+          "mount": "/sys/fs/cgroup/systemd",
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "noexec",
+            "nosuid",
+            "nodev",
+            "none",
+            "name=systemd"
+          ]
+        },
+        "rootfs": {
+          "mount": "/",
+          "fs_type": "rootfs",
+          "mount_options": [
+            "rw"
+          ]
+        },
+        "/dev/disk/by-uuid/771646b6-78e5-4445-9599-f2f407484a9a": {
+          "mount": "/",
+          "fs_type": "ext4",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "discard",
+            "data=ordered"
+          ]
+        }
+      },
+      "fips": {
+        "kernel": {
+          "enabled": false
+        }
+      },
+      "memory": {
+        "swap": {
+          "cached": "0kB",
+          "total": "0kB",
+          "free": "0kB"
+        },
+        "hugepages": {
+          "total": "0",
+          "free": "0",
+          "reserved": "0",
+          "surplus": "0"
+        },
+        "total": "4046888kB",
+        "free": "1151420kB",
+        "buffers": "399288kB",
+        "cached": "1876884kB",
+        "active": "1401160kB",
+        "inactive": "1096884kB",
+        "dirty": "88kB",
+        "writeback": "0kB",
+        "anon_pages": "221864kB",
+        "mapped": "23652kB",
+        "slab": "361792kB",
+        "slab_reclaimable": "338880kB",
+        "slab_unreclaim": "22912kB",
+        "page_tables": "4060kB",
+        "nfs_unstable": "0kB",
+        "bounce": "0kB",
+        "commit_limit": "2023444kB",
+        "committed_as": "357268kB",
+        "vmalloc_total": "34359738367kB",
+        "vmalloc_used": "9696kB",
+        "vmalloc_chunk": "34359721964kB",
+        "hugepage_size": "2048kB"
+      },
+      "cpu": {
+        "0": {
+          "vendor_id": "GenuineIntel",
+          "family": "6",
+          "model": "63",
+          "model_name": "Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz",
+          "stepping": "2",
+          "mhz": "2400.060",
+          "cache_size": "30720 KB",
+          "physical_id": "0",
+          "core_id": "0",
+          "cores": "2",
+          "flags": [
+            "fpu",
+            "vme",
+            "de",
+            "pse",
+            "tsc",
+            "msr",
+            "pae",
+            "mce",
+            "cx8",
+            "apic",
+            "sep",
+            "mtrr",
+            "pge",
+            "mca",
+            "cmov",
+            "pat",
+            "pse36",
+            "clflush",
+            "mmx",
+            "fxsr",
+            "sse",
+            "sse2",
+            "ht",
+            "syscall",
+            "nx",
+            "rdtscp",
+            "lm",
+            "constant_tsc",
+            "rep_good",
+            "nopl",
+            "xtopology",
+            "eagerfpu",
+            "pni",
+            "pclmulqdq",
+            "ssse3",
+            "fma",
+            "cx16",
+            "pcid",
+            "sse4_1",
+            "sse4_2",
+            "x2apic",
+            "movbe",
+            "popcnt",
+            "tsc_deadline_timer",
+            "aes",
+            "xsave",
+            "avx",
+            "f16c",
+            "rdrand",
+            "hypervisor",
+            "lahf_lm",
+            "abm",
+            "xsaveopt",
+            "fsgsbase",
+            "bmi1",
+            "avx2",
+            "smep",
+            "bmi2",
+            "erms",
+            "invpcid"
+          ]
+        },
+        "1": {
+          "vendor_id": "GenuineIntel",
+          "family": "6",
+          "model": "63",
+          "model_name": "Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz",
+          "stepping": "2",
+          "mhz": "2400.060",
+          "cache_size": "30720 KB",
+          "physical_id": "0",
+          "core_id": "1",
+          "cores": "2",
+          "flags": [
+            "fpu",
+            "vme",
+            "de",
+            "pse",
+            "tsc",
+            "msr",
+            "pae",
+            "mce",
+            "cx8",
+            "apic",
+            "sep",
+            "mtrr",
+            "pge",
+            "mca",
+            "cmov",
+            "pat",
+            "pse36",
+            "clflush",
+            "mmx",
+            "fxsr",
+            "sse",
+            "sse2",
+            "ht",
+            "syscall",
+            "nx",
+            "rdtscp",
+            "lm",
+            "constant_tsc",
+            "rep_good",
+            "nopl",
+            "xtopology",
+            "eagerfpu",
+            "pni",
+            "pclmulqdq",
+            "ssse3",
+            "fma",
+            "cx16",
+            "pcid",
+            "sse4_1",
+            "sse4_2",
+            "x2apic",
+            "movbe",
+            "popcnt",
+            "tsc_deadline_timer",
+            "aes",
+            "xsave",
+            "avx",
+            "f16c",
+            "rdrand",
+            "hypervisor",
+            "lahf_lm",
+            "abm",
+            "xsaveopt",
+            "fsgsbase",
+            "bmi1",
+            "avx2",
+            "smep",
+            "bmi2",
+            "erms",
+            "invpcid"
+          ]
+        },
+        "total": 2,
+        "real": 1,
+        "cores": 2
+      },
+      "network": {
+        "interfaces": {
+          "lo": {
+            "mtu": "65536",
+            "flags": [
+              "LOOPBACK",
+              "UP",
+              "LOWER_UP"
+            ],
+            "encapsulation": "Loopback",
+            "addresses": {
+              "127.0.0.1": {
+                "family": "inet",
+                "prefixlen": "8",
+                "netmask": "255.0.0.0",
+                "scope": "Node"
+              },
+              "::1": {
+                "family": "inet6",
+                "prefixlen": "128",
+                "scope": "Node",
+                "tags": []
+              }
+            },
+            "state": "unknown"
+          },
+          "eth0": {
+            "type": "eth",
+            "number": "0",
+            "mtu": "9001",
+            "flags": [
+              "BROADCAST",
+              "MULTICAST",
+              "UP",
+              "LOWER_UP"
+            ],
+            "encapsulation": "Ethernet",
+            "addresses": {
+              "02:24:AF:C6:71:9E": {
+                "family": "lladdr"
+              },
+              "196.140.227.170": {
+                "family": "inet",
+                "prefixlen": "21",
+                "netmask": "255.255.248.0",
+                "broadcast": "196.140.15.255",
+                "scope": "Global"
+              },
+              "fe80::24:afff:fec6:719e": {
+                "family": "inet6",
+                "prefixlen": "64",
+                "scope": "Link",
+                "tags": []
+              }
+            },
+            "state": "up",
+            "arp": {
+              "196.140.8.1": "02:a9:5a:b4:15:5a",
+              "196.140.10.3": "02:6a:65:20:3b:99"
+            },
+            "routes": [
+              {
+                "destination": "default",
+                "family": "inet",
+                "via": "196.140.8.1"
+              },
+              {
+                "destination": "196.140.8.0/21",
+                "family": "inet",
+                "scope": "link",
+                "proto": "kernel",
+                "src": "196.140.227.170"
+              },
+              {
+                "destination": "fe80::/64",
+                "family": "inet6",
+                "metric": "256",
+                "proto": "kernel"
+              }
+            ],
+            "ring_params": {}
+          }
+        },
+        "default_interface": "eth0",
+        "default_gateway": "196.140.8.1"
+      },
+      "counters": {
+        "network": {
+          "interfaces": {
+            "lo": {
+              "rx": {
+                "bytes": "31369368",
+                "packets": "30240",
+                "errors": "0",
+                "drop": "0",
+                "overrun": "0"
+              },
+              "tx": {
+                "bytes": "31369368",
+                "packets": "30240",
+                "errors": "0",
+                "drop": "0",
+                "carrier": "0",
+                "collisions": "0"
+              }
+            },
+            "eth0": {
+              "tx": {
+                "queuelen": "1000",
+                "bytes": "61429705734",
+                "packets": "58794272",
+                "errors": "0",
+                "drop": "0",
+                "carrier": "0",
+                "collisions": "0"
+              },
+              "rx": {
+                "bytes": "55888066877",
+                "packets": "52461996",
+                "errors": "0",
+                "drop": "0",
+                "overrun": "0"
+              }
+            }
+          }
+        }
+      },
+      "ipaddress": "196.140.227.170",
+      "macaddress": "02:24:AF:C6:71:9E",
+      "ip6address": "fe80::24:afff:fec6:719e",
+      "languages": {
+        "ruby": {
+          "platform": "x86_64-linux",
+          "version": "2.3.1",
+          "release_date": "2016-04-26",
+          "target": "x86_64-pc-linux-gnu",
+          "target_cpu": "x86_64",
+          "target_vendor": "pc",
+          "target_os": "linux",
+          "host": "x86_64-pc-linux-gnu",
+          "host_cpu": "x86_64",
+          "host_os": "linux-gnu",
+          "host_vendor": "pc",
+          "bin_dir": "/opt/chef/embedded/bin",
+          "ruby_bin": "/opt/chef/embedded/bin/ruby",
+          "gems_dir": "/opt/chef/embedded/lib/ruby/gems/2.3.0",
+          "gem_bin": "/opt/chef/embedded/bin/gem"
+        },
+        "python": {
+          "version": "2.7.6",
+          "builddate": "Mar 22 2014, 22:59:56"
+        },
+        "c": {
+          "gcc": {
+            "target": "x86_64-linux-gnu",
+            "configured_with": "../src/configure -v --with-pkgversion='Ubuntu 4.8.4-2ubuntu1~14.04.3' --with-bugurl=file:///usr/share/doc/gcc-4.8/README.Bugs --enable-languages=c,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-4.8 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --with-gxx-include-dir=/usr/include/c++/4.8 --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-gnu-unique-object --disable-libmudflap --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-4.8-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-4.8-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-4.8-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu",
+            "thread_model": "posix",
+            "description": "gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04.3) ",
+            "version": "4.8.4"
+          }
+        },
+        "perl": {
+          "version": "5.18.2",
+          "archname": "x86_64-linux-gnu-thread-multi"
+        },
+        "java": {
+          "version": "1.7.0_131",
+          "hotspot": {
+            "name": "OpenJDK 64-Bit Server VM",
+            "build": "24.131-b00, mixed mode"
+          }
+        }
+      },
+      "uptime_seconds": 12792574,
+      "uptime": "148 days 01 hours 29 minutes 34 seconds",
+      "idletime_seconds": 25544517,
+      "idletime": "295 days 15 hours 41 minutes 57 seconds",
+      "hostnamectl": {
+        "static_hostname": "ip-196-140-227-170",
+        "icon_name": "computer-vm",
+        "chassis": "vm",
+        "boot_id": "0c884d6aaa6e45d885287993fd97d0ea",
+        "virtualization": "xen",
+        "operating_system": "Ubuntu 14.04.2 LTS",
+        "kernel": "Linux 3.13.0-53-generic",
+        "architecture": "x86_64"
+      },
+      "filesystem2": {
+        "by_device": {
+          "/dev/xvda1": {
+            "kb_size": "30822592",
+            "kb_used": "3235164",
+            "kb_available": "26229828",
+            "percent_used": "11%",
+            "total_inodes": "1966080",
+            "inodes_used": "188643",
+            "inodes_available": "1777437",
+            "inodes_percent_used": "10%",
+            "fs_type": "ext4",
+            "mount_options": [
+              "rw",
+              "discard"
+            ],
+            "uuid": "771646b6-78e5-4445-9599-f2f407484a9a",
+            "label": "cloudimg-rootfs",
+            "mounts": [
+              "/"
+            ]
+          },
+          "none": {
+            "kb_size": "102400",
+            "kb_used": "0",
+            "kb_available": "102400",
+            "percent_used": "0%",
+            "total_inodes": "505861",
+            "inodes_used": "4",
+            "inodes_available": "505857",
+            "inodes_percent_used": "1%",
+            "fs_type": "pstore",
+            "mount_options": [
+              "rw"
+            ],
+            "mounts": [
+              "/sys/fs/cgroup",
+              "/run/lock",
+              "/run/shm",
+              "/run/user",
+              "/sys/fs/fuse/connections",
+              "/sys/kernel/debug",
+              "/sys/kernel/security",
+              "/sys/fs/pstore"
+            ]
+          },
+          "udev": {
+            "kb_size": "2018488",
+            "kb_used": "12",
+            "kb_available": "2018476",
+            "percent_used": "1%",
+            "total_inodes": "504622",
+            "inodes_used": "387",
+            "inodes_available": "504235",
+            "inodes_percent_used": "1%",
+            "fs_type": "devtmpfs",
+            "mount_options": [
+              "rw",
+              "mode=0755"
+            ],
+            "mounts": [
+              "/dev"
+            ]
+          },
+          "tmpfs": {
+            "kb_size": "404692",
+            "kb_used": "348",
+            "kb_available": "404344",
+            "percent_used": "1%",
+            "total_inodes": "505861",
+            "inodes_used": "306",
+            "inodes_available": "505555",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "size=10%",
+              "mode=0755"
+            ],
+            "mounts": [
+              "/run"
+            ]
+          },
+          "proc": {
+            "fs_type": "proc",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "nodev"
+            ],
+            "mounts": [
+              "/proc"
+            ]
+          },
+          "sysfs": {
+            "fs_type": "sysfs",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "nodev"
+            ],
+            "mounts": [
+              "/sys"
+            ]
+          },
+          "devpts": {
+            "fs_type": "devpts",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "gid=5",
+              "mode=0620"
+            ],
+            "mounts": [
+              "/dev/pts"
+            ]
+          },
+          "systemd": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "nodev",
+              "none",
+              "name=systemd"
+            ],
+            "mounts": [
+              "/sys/fs/cgroup/systemd"
+            ]
+          },
+          "/dev/xvda": {},
+          "rootfs": {
+            "fs_type": "rootfs",
+            "mount_options": [
+              "rw"
+            ],
+            "mounts": [
+              "/"
+            ]
+          },
+          "/dev/disk/by-uuid/771646b6-78e5-4445-9599-f2f407484a9a": {
+            "fs_type": "ext4",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "discard",
+              "data=ordered"
+            ],
+            "mounts": [
+              "/"
+            ]
+          }
+        },
+        "by_mountpoint": {
+          "/": {
+            "kb_size": "30822592",
+            "kb_used": "3235164",
+            "kb_available": "26229828",
+            "percent_used": "11%",
+            "total_inodes": "1966080",
+            "inodes_used": "188643",
+            "inodes_available": "1777437",
+            "inodes_percent_used": "10%",
+            "fs_type": "ext4",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "discard",
+              "data=ordered"
+            ],
+            "uuid": "771646b6-78e5-4445-9599-f2f407484a9a",
+            "label": "cloudimg-rootfs",
+            "devices": [
+              "/dev/xvda1",
+              "rootfs",
+              "/dev/disk/by-uuid/771646b6-78e5-4445-9599-f2f407484a9a"
+            ]
+          },
+          "/sys/fs/cgroup": {
+            "kb_size": "4",
+            "kb_used": "0",
+            "kb_available": "4",
+            "percent_used": "0%",
+            "total_inodes": "505861",
+            "inodes_used": "2",
+            "inodes_available": "505859",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw"
+            ],
+            "devices": [
+              "none"
+            ]
+          },
+          "/dev": {
+            "kb_size": "2018488",
+            "kb_used": "12",
+            "kb_available": "2018476",
+            "percent_used": "1%",
+            "total_inodes": "504622",
+            "inodes_used": "387",
+            "inodes_available": "504235",
+            "inodes_percent_used": "1%",
+            "fs_type": "devtmpfs",
+            "mount_options": [
+              "rw",
+              "mode=0755"
+            ],
+            "devices": [
+              "udev"
+            ]
+          },
+          "/run": {
+            "kb_size": "404692",
+            "kb_used": "348",
+            "kb_available": "404344",
+            "percent_used": "1%",
+            "total_inodes": "505861",
+            "inodes_used": "306",
+            "inodes_available": "505555",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "size=10%",
+              "mode=0755"
+            ],
+            "devices": [
+              "tmpfs"
+            ]
+          },
+          "/run/lock": {
+            "kb_size": "5120",
+            "kb_used": "0",
+            "kb_available": "5120",
+            "percent_used": "0%",
+            "total_inodes": "505861",
+            "inodes_used": "1",
+            "inodes_available": "505860",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "nodev",
+              "size=5242880"
+            ],
+            "devices": [
+              "none"
+            ]
+          },
+          "/run/shm": {
+            "kb_size": "2023444",
+            "kb_used": "0",
+            "kb_available": "2023444",
+            "percent_used": "0%",
+            "total_inodes": "505861",
+            "inodes_used": "1",
+            "inodes_available": "505860",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev"
+            ],
+            "devices": [
+              "none"
+            ]
+          },
+          "/run/user": {
+            "kb_size": "102400",
+            "kb_used": "0",
+            "kb_available": "102400",
+            "percent_used": "0%",
+            "total_inodes": "505861",
+            "inodes_used": "4",
+            "inodes_available": "505857",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "nodev",
+              "size=104857600",
+              "mode=0755"
+            ],
+            "devices": [
+              "none"
+            ]
+          },
+          "/proc": {
+            "fs_type": "proc",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "nodev"
+            ],
+            "devices": [
+              "proc"
+            ]
+          },
+          "/sys": {
+            "fs_type": "sysfs",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "nodev"
+            ],
+            "devices": [
+              "sysfs"
+            ]
+          },
+          "/sys/fs/fuse/connections": {
+            "fs_type": "fusectl",
+            "mount_options": [
+              "rw"
+            ],
+            "devices": [
+              "none"
+            ]
+          },
+          "/sys/kernel/debug": {
+            "fs_type": "debugfs",
+            "mount_options": [
+              "rw"
+            ],
+            "devices": [
+              "none"
+            ]
+          },
+          "/sys/kernel/security": {
+            "fs_type": "securityfs",
+            "mount_options": [
+              "rw"
+            ],
+            "devices": [
+              "none"
+            ]
+          },
+          "/dev/pts": {
+            "fs_type": "devpts",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "gid=5",
+              "mode=0620"
+            ],
+            "devices": [
+              "devpts"
+            ]
+          },
+          "/sys/fs/pstore": {
+            "fs_type": "pstore",
+            "mount_options": [
+              "rw"
+            ],
+            "devices": [
+              "none"
+            ]
+          },
+          "/sys/fs/cgroup/systemd": {
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "nodev",
+              "none",
+              "name=systemd"
+            ],
+            "devices": [
+              "systemd"
+            ]
+          }
+        },
+        "by_pair": {
+          "/dev/xvda1,/": {
+            "device": "/dev/xvda1",
+            "kb_size": "30822592",
+            "kb_used": "3235164",
+            "kb_available": "26229828",
+            "percent_used": "11%",
+            "mount": "/",
+            "total_inodes": "1966080",
+            "inodes_used": "188643",
+            "inodes_available": "1777437",
+            "inodes_percent_used": "10%",
+            "fs_type": "ext4",
+            "mount_options": [
+              "rw",
+              "discard"
+            ],
+            "uuid": "771646b6-78e5-4445-9599-f2f407484a9a",
+            "label": "cloudimg-rootfs"
+          },
+          "none,/sys/fs/cgroup": {
+            "device": "none",
+            "kb_size": "4",
+            "kb_used": "0",
+            "kb_available": "4",
+            "percent_used": "0%",
+            "mount": "/sys/fs/cgroup",
+            "total_inodes": "505861",
+            "inodes_used": "2",
+            "inodes_available": "505859",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw"
+            ]
+          },
+          "udev,/dev": {
+            "device": "udev",
+            "kb_size": "2018488",
+            "kb_used": "12",
+            "kb_available": "2018476",
+            "percent_used": "1%",
+            "mount": "/dev",
+            "total_inodes": "504622",
+            "inodes_used": "387",
+            "inodes_available": "504235",
+            "inodes_percent_used": "1%",
+            "fs_type": "devtmpfs",
+            "mount_options": [
+              "rw",
+              "mode=0755"
+            ]
+          },
+          "tmpfs,/run": {
+            "device": "tmpfs",
+            "kb_size": "404692",
+            "kb_used": "348",
+            "kb_available": "404344",
+            "percent_used": "1%",
+            "mount": "/run",
+            "total_inodes": "505861",
+            "inodes_used": "306",
+            "inodes_available": "505555",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "size=10%",
+              "mode=0755"
+            ]
+          },
+          "none,/run/lock": {
+            "device": "none",
+            "kb_size": "5120",
+            "kb_used": "0",
+            "kb_available": "5120",
+            "percent_used": "0%",
+            "mount": "/run/lock",
+            "total_inodes": "505861",
+            "inodes_used": "1",
+            "inodes_available": "505860",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "nodev",
+              "size=5242880"
+            ]
+          },
+          "none,/run/shm": {
+            "device": "none",
+            "kb_size": "2023444",
+            "kb_used": "0",
+            "kb_available": "2023444",
+            "percent_used": "0%",
+            "mount": "/run/shm",
+            "total_inodes": "505861",
+            "inodes_used": "1",
+            "inodes_available": "505860",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "nosuid",
+              "nodev"
+            ]
+          },
+          "none,/run/user": {
+            "device": "none",
+            "kb_size": "102400",
+            "kb_used": "0",
+            "kb_available": "102400",
+            "percent_used": "0%",
+            "mount": "/run/user",
+            "total_inodes": "505861",
+            "inodes_used": "4",
+            "inodes_available": "505857",
+            "inodes_percent_used": "1%",
+            "fs_type": "tmpfs",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "nodev",
+              "size=104857600",
+              "mode=0755"
+            ]
+          },
+          "proc,/proc": {
+            "device": "proc",
+            "mount": "/proc",
+            "fs_type": "proc",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "nodev"
+            ]
+          },
+          "sysfs,/sys": {
+            "device": "sysfs",
+            "mount": "/sys",
+            "fs_type": "sysfs",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "nodev"
+            ]
+          },
+          "none,/sys/fs/fuse/connections": {
+            "device": "none",
+            "mount": "/sys/fs/fuse/connections",
+            "fs_type": "fusectl",
+            "mount_options": [
+              "rw"
+            ]
+          },
+          "none,/sys/kernel/debug": {
+            "device": "none",
+            "mount": "/sys/kernel/debug",
+            "fs_type": "debugfs",
+            "mount_options": [
+              "rw"
+            ]
+          },
+          "none,/sys/kernel/security": {
+            "device": "none",
+            "mount": "/sys/kernel/security",
+            "fs_type": "securityfs",
+            "mount_options": [
+              "rw"
+            ]
+          },
+          "devpts,/dev/pts": {
+            "device": "devpts",
+            "mount": "/dev/pts",
+            "fs_type": "devpts",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "gid=5",
+              "mode=0620"
+            ]
+          },
+          "none,/sys/fs/pstore": {
+            "device": "none",
+            "mount": "/sys/fs/pstore",
+            "fs_type": "pstore",
+            "mount_options": [
+              "rw"
+            ]
+          },
+          "systemd,/sys/fs/cgroup/systemd": {
+            "device": "systemd",
+            "mount": "/sys/fs/cgroup/systemd",
+            "fs_type": "cgroup",
+            "mount_options": [
+              "rw",
+              "noexec",
+              "nosuid",
+              "nodev",
+              "none",
+              "name=systemd"
+            ]
+          },
+          "/dev/xvda,": {
+            "device": "/dev/xvda"
+          },
+          "rootfs,/": {
+            "device": "rootfs",
+            "mount": "/",
+            "fs_type": "rootfs",
+            "mount_options": [
+              "rw"
+            ]
+          },
+          "/dev/disk/by-uuid/771646b6-78e5-4445-9599-f2f407484a9a,/": {
+            "device": "/dev/disk/by-uuid/771646b6-78e5-4445-9599-f2f407484a9a",
+            "mount": "/",
+            "fs_type": "ext4",
+            "mount_options": [
+              "rw",
+              "relatime",
+              "discard",
+              "data=ordered"
+            ]
+          }
+        }
+      },
+      "block_device": {
+        "ram0": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram1": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram2": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram3": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram4": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram5": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram6": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram7": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram8": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram9": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "xvda": {
+          "size": "62914560",
+          "removable": "0",
+          "rotational": "0",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop0": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop1": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop2": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop3": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop4": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop5": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop6": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "loop7": {
+          "size": "0",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram10": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram11": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram12": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram13": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram14": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        },
+        "ram15": {
+          "size": "131072",
+          "removable": "0",
+          "rotational": "1",
+          "physical_block_size": "512",
+          "logical_block_size": "512"
+        }
+      },
+      "sessions": {
+        "by_session": {},
+        "by_user": {}
+      },
+      "machine_id": "f60565d29552f365e7380162556f6674",
+      "packages": {
+        "accountsservice": {
+          "version": "0.6.35-0ubuntu7.2",
+          "arch": "amd64"
+        },
+        "acpid": {
+          "version": "1:2.0.21-1ubuntu2",
+          "arch": "amd64"
+        },
+        "adduser": {
+          "version": "3.113+nmu3ubuntu3",
+          "arch": "all"
+        },
+        "apparmor": {
+          "version": "2.8.95~2430-0ubuntu5.1",
+          "arch": "amd64"
+        },
+        "apport": {
+          "version": "2.14.1-0ubuntu3.11",
+          "arch": "all"
+        },
+        "apport-symptoms": {
+          "version": "0.20",
+          "arch": "all"
+        },
+        "apt": {
+          "version": "1.0.1ubuntu2.8",
+          "arch": "amd64"
+        },
+        "apt-transport-https": {
+          "version": "1.0.1ubuntu2.8",
+          "arch": "amd64"
+        },
+        "apt-utils": {
+          "version": "1.0.1ubuntu2.8",
+          "arch": "amd64"
+        },
+        "apt-xapian-index": {
+          "version": "0.45ubuntu4",
+          "arch": "all"
+        },
+        "aptitude": {
+          "version": "0.6.8.2-1ubuntu4",
+          "arch": "amd64"
+        },
+        "aptitude-common": {
+          "version": "0.6.8.2-1ubuntu4",
+          "arch": "all"
+        },
+        "at": {
+          "version": "3.1.14-1ubuntu1",
+          "arch": "amd64"
+        },
+        "autoconf": {
+          "version": "2.69-6",
+          "arch": "all"
+        },
+        "automake": {
+          "version": "1:1.14.1-2ubuntu1",
+          "arch": "all"
+        },
+        "autotools-dev": {
+          "version": "20130810.1",
+          "arch": "all"
+        },
+        "base-files": {
+          "version": "7.2ubuntu5.2",
+          "arch": "amd64"
+        },
+        "base-passwd": {
+          "version": "3.5.33",
+          "arch": "amd64"
+        },
+        "bash": {
+          "version": "4.3-7ubuntu1.5",
+          "arch": "amd64"
+        },
+        "bash-completion": {
+          "version": "1:2.1-4",
+          "arch": "all"
+        },
+        "bc": {
+          "version": "1.06.95-8ubuntu1",
+          "arch": "amd64"
+        },
+        "bind9-host": {
+          "version": "1:9.9.5.dfsg-3ubuntu0.2",
+          "arch": "amd64"
+        },
+        "binutils": {
+          "version": "2.24-5ubuntu14.2",
+          "arch": "amd64"
+        },
+        "binutils-doc": {
+          "version": "2.24-5ubuntu14.2",
+          "arch": "all"
+        },
+        "bison": {
+          "version": "2:3.0.2.dfsg-2",
+          "arch": "amd64"
+        },
+        "bsdmainutils": {
+          "version": "9.0.5ubuntu1",
+          "arch": "amd64"
+        },
+        "bsdutils": {
+          "version": "1:2.20.1-5.1ubuntu20.4",
+          "arch": "amd64"
+        },
+        "build-essential": {
+          "version": "11.6ubuntu6",
+          "arch": "amd64"
+        },
+        "busybox-initramfs": {
+          "version": "1:1.21.0-1ubuntu1",
+          "arch": "amd64"
+        },
+        "busybox-static": {
+          "version": "1:1.21.0-1ubuntu1",
+          "arch": "amd64"
+        },
+        "byobu": {
+          "version": "5.77-0ubuntu1.2",
+          "arch": "all"
+        },
+        "bzip2": {
+          "version": "1.0.6-5",
+          "arch": "amd64"
+        },
+        "ca-certificates": {
+          "version": "20160104ubuntu0.14.04.1",
+          "arch": "all"
+        },
+        "ca-certificates-java": {
+          "version": "20130815ubuntu1",
+          "arch": "all"
+        },
+        "chef": {
+          "version": "12.21.3-1",
+          "arch": "amd64"
+        },
+        "chefdk": {
+          "version": "2.4.3-1",
+          "arch": "amd64"
+        },
+        "cloud-guest-utils": {
+          "version": "0.27-0ubuntu9.1",
+          "arch": "all"
+        },
+        "cloud-init": {
+          "version": "0.7.5-0ubuntu1.5",
+          "arch": "all"
+        },
+        "command-not-found": {
+          "version": "0.3ubuntu12",
+          "arch": "all"
+        },
+        "command-not-found-data": {
+          "version": "0.3ubuntu12",
+          "arch": "amd64"
+        },
+        "console-setup": {
+          "version": "1.70ubuntu8",
+          "arch": "all"
+        },
+        "coreutils": {
+          "version": "8.21-1ubuntu5.1",
+          "arch": "amd64"
+        },
+        "cpio": {
+          "version": "2.11+dfsg-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "cpp": {
+          "version": "4:4.8.2-1ubuntu6",
+          "arch": "amd64"
+        },
+        "cpp-4.8": {
+          "version": "4.8.4-2ubuntu1~14.04.3",
+          "arch": "amd64"
+        },
+        "cron": {
+          "version": "3.0pl1-124ubuntu2",
+          "arch": "amd64"
+        },
+        "cryptsetup": {
+          "version": "2:1.6.1-1ubuntu1",
+          "arch": "amd64"
+        },
+        "cryptsetup-bin": {
+          "version": "2:1.6.1-1ubuntu1",
+          "arch": "amd64"
+        },
+        "curl": {
+          "version": "7.35.0-1ubuntu2.5",
+          "arch": "amd64"
+        },
+        "dash": {
+          "version": "0.5.7-4ubuntu1",
+          "arch": "amd64"
+        },
+        "dbus": {
+          "version": "1.6.18-0ubuntu4.3",
+          "arch": "amd64"
+        },
+        "dctrl-tools": {
+          "version": "2.23ubuntu1",
+          "arch": "amd64"
+        },
+        "debconf": {
+          "version": "1.5.51ubuntu2",
+          "arch": "all"
+        },
+        "debconf-i18n": {
+          "version": "1.5.51ubuntu2",
+          "arch": "all"
+        },
+        "debianutils": {
+          "version": "4.4",
+          "arch": "amd64"
+        },
+        "devscripts": {
+          "version": "2.14.1ubuntu0.1",
+          "arch": "amd64"
+        },
+        "dh-python": {
+          "version": "1.20140128-1ubuntu8",
+          "arch": "all"
+        },
+        "diffstat": {
+          "version": "1.58-1",
+          "arch": "amd64"
+        },
+        "diffutils": {
+          "version": "1:3.3-1",
+          "arch": "amd64"
+        },
+        "distro-info-data": {
+          "version": "0.18ubuntu0.7",
+          "arch": "all"
+        },
+        "dmidecode": {
+          "version": "2.12-2",
+          "arch": "amd64"
+        },
+        "dmsetup": {
+          "version": "2:1.02.77-6ubuntu2",
+          "arch": "amd64"
+        },
+        "dnsutils": {
+          "version": "1:9.9.5.dfsg-3ubuntu0.2",
+          "arch": "amd64"
+        },
+        "dosfstools": {
+          "version": "3.0.26-1",
+          "arch": "amd64"
+        },
+        "dpkg": {
+          "version": "1.17.5ubuntu5.4",
+          "arch": "amd64"
+        },
+        "dpkg-dev": {
+          "version": "1.17.5ubuntu5.7",
+          "arch": "all"
+        },
+        "dput": {
+          "version": "0.9.6.4ubuntu1.1",
+          "arch": "all"
+        },
+        "e2fslibs": {
+          "version": "1.42.9-3ubuntu1.2",
+          "arch": "amd64"
+        },
+        "e2fsprogs": {
+          "version": "1.42.9-3ubuntu1.2",
+          "arch": "amd64"
+        },
+        "eatmydata": {
+          "version": "26-2",
+          "arch": "amd64"
+        },
+        "ed": {
+          "version": "1.9-2",
+          "arch": "amd64"
+        },
+        "eject": {
+          "version": "2.1.5+deb1+cvs20081104-13.1",
+          "arch": "amd64"
+        },
+        "ethtool": {
+          "version": "1:3.13-1",
+          "arch": "amd64"
+        },
+        "fakeroot": {
+          "version": "1.20-3ubuntu2",
+          "arch": "amd64"
+        },
+        "file": {
+          "version": "1:5.14-2ubuntu3.3",
+          "arch": "amd64"
+        },
+        "findutils": {
+          "version": "4.4.2-7",
+          "arch": "amd64"
+        },
+        "flex": {
+          "version": "2.5.35-10.1ubuntu2",
+          "arch": "amd64"
+        },
+        "fontconfig": {
+          "version": "2.11.0-0ubuntu4.2",
+          "arch": "amd64"
+        },
+        "fontconfig-config": {
+          "version": "2.11.0-0ubuntu4.2",
+          "arch": "all"
+        },
+        "fonts-dejavu-core": {
+          "version": "2.34-1ubuntu1",
+          "arch": "all"
+        },
+        "fonts-dejavu-extra": {
+          "version": "2.34-1ubuntu1",
+          "arch": "all"
+        },
+        "fonts-ubuntu-font-family-console": {
+          "version": "0.80-0ubuntu6",
+          "arch": "all"
+        },
+        "friendly-recovery": {
+          "version": "0.2.25",
+          "arch": "all"
+        },
+        "ftp": {
+          "version": "0.17-28",
+          "arch": "amd64"
+        },
+        "fuse": {
+          "version": "2.9.2-4ubuntu4.14.04.1",
+          "arch": "amd64"
+        },
+        "g++": {
+          "version": "4:4.8.2-1ubuntu6",
+          "arch": "amd64"
+        },
+        "g++-4.8": {
+          "version": "4.8.4-2ubuntu1~14.04.3",
+          "arch": "amd64"
+        },
+        "gawk": {
+          "version": "1:4.0.1+dfsg-2.1ubuntu2",
+          "arch": "amd64"
+        },
+        "gcc": {
+          "version": "4:4.8.2-1ubuntu6",
+          "arch": "amd64"
+        },
+        "gcc-4.8": {
+          "version": "4.8.4-2ubuntu1~14.04.3",
+          "arch": "amd64"
+        },
+        "gcc-4.8-base": {
+          "version": "4.8.4-2ubuntu1~14.04.3",
+          "arch": "amd64"
+        },
+        "gcc-4.9-base": {
+          "version": "4.9.1-0ubuntu1",
+          "arch": "amd64"
+        },
+        "gdisk": {
+          "version": "0.8.8-1build1",
+          "arch": "amd64"
+        },
+        "geoip-database": {
+          "version": "20140313-1",
+          "arch": "all"
+        },
+        "gettext": {
+          "version": "0.18.3.1-1ubuntu3",
+          "arch": "amd64"
+        },
+        "gettext-base": {
+          "version": "0.18.3.1-1ubuntu3",
+          "arch": "amd64"
+        },
+        "gir1.2-glib-2.0": {
+          "version": "1.40.0-1ubuntu0.2",
+          "arch": "amd64"
+        },
+        "gnupg": {
+          "version": "1.4.16-1ubuntu2.3",
+          "arch": "amd64"
+        },
+        "gpgv": {
+          "version": "1.4.16-1ubuntu2.3",
+          "arch": "amd64"
+        },
+        "grep": {
+          "version": "2.16-1",
+          "arch": "amd64"
+        },
+        "groff-base": {
+          "version": "1.22.2-5",
+          "arch": "amd64"
+        },
+        "grub-common": {
+          "version": "2.02~beta2-9ubuntu1.2",
+          "arch": "amd64"
+        },
+        "grub-gfxpayload-lists": {
+          "version": "0.6",
+          "arch": "amd64"
+        },
+        "grub-legacy-ec2": {
+          "version": "0.7.5-0ubuntu1.5",
+          "arch": "all"
+        },
+        "grub-pc": {
+          "version": "2.02~beta2-9ubuntu1.2",
+          "arch": "amd64"
+        },
+        "grub-pc-bin": {
+          "version": "2.02~beta2-9ubuntu1.2",
+          "arch": "amd64"
+        },
+        "grub2-common": {
+          "version": "2.02~beta2-9ubuntu1.2",
+          "arch": "amd64"
+        },
+        "gzip": {
+          "version": "1.6-3ubuntu1",
+          "arch": "amd64"
+        },
+        "hardening-includes": {
+          "version": "2.5ubuntu2.1",
+          "arch": "all"
+        },
+        "hdparm": {
+          "version": "9.43-1ubuntu3",
+          "arch": "amd64"
+        },
+        "hicolor-icon-theme": {
+          "version": "0.13-1",
+          "arch": "all"
+        },
+        "hostname": {
+          "version": "3.15ubuntu1",
+          "arch": "amd64"
+        },
+        "ifupdown": {
+          "version": "0.7.47.2ubuntu4.1",
+          "arch": "amd64"
+        },
+        "info": {
+          "version": "5.2.0.dfsg.1-2",
+          "arch": "amd64"
+        },
+        "init-system-helpers": {
+          "version": "1.14",
+          "arch": "all"
+        },
+        "initramfs-tools": {
+          "version": "0.103ubuntu4.2",
+          "arch": "all"
+        },
+        "initramfs-tools-bin": {
+          "version": "0.103ubuntu4.2",
+          "arch": "amd64"
+        },
+        "initscripts": {
+          "version": "2.88dsf-41ubuntu6.1",
+          "arch": "amd64"
+        },
+        "insserv": {
+          "version": "1.14.0-5ubuntu2",
+          "arch": "amd64"
+        },
+        "install-info": {
+          "version": "5.2.0.dfsg.1-2",
+          "arch": "amd64"
+        },
+        "intltool-debian": {
+          "version": "0.35.0+20060710.1",
+          "arch": "all"
+        },
+        "iproute2": {
+          "version": "3.12.0-2",
+          "arch": "amd64"
+        },
+        "iptables": {
+          "version": "1.4.21-1ubuntu1",
+          "arch": "amd64"
+        },
+        "iputils-ping": {
+          "version": "3:20121221-4ubuntu1.1",
+          "arch": "amd64"
+        },
+        "iputils-tracepath": {
+          "version": "3:20121221-4ubuntu1.1",
+          "arch": "amd64"
+        },
+        "irqbalance": {
+          "version": "1.0.6-2ubuntu0.14.04.1",
+          "arch": "amd64"
+        },
+        "isc-dhcp-client": {
+          "version": "4.2.4-7ubuntu12.2",
+          "arch": "amd64"
+        },
+        "isc-dhcp-common": {
+          "version": "4.2.4-7ubuntu12.2",
+          "arch": "amd64"
+        },
+        "iso-codes": {
+          "version": "3.52-1",
+          "arch": "all"
+        },
+        "java-common": {
+          "version": "0.51",
+          "arch": "all"
+        },
+        "kbd": {
+          "version": "1.15.5-1ubuntu1",
+          "arch": "amd64"
+        },
+        "keyboard-configuration": {
+          "version": "1.70ubuntu8",
+          "arch": "all"
+        },
+        "klibc-utils": {
+          "version": "2.0.3-0ubuntu1",
+          "arch": "amd64"
+        },
+        "kmod": {
+          "version": "15-0ubuntu6",
+          "arch": "amd64"
+        },
+        "krb5-locales": {
+          "version": "1.12+dfsg-2ubuntu5.1",
+          "arch": "all"
+        },
+        "landscape-client": {
+          "version": "14.12-0ubuntu0.14.04",
+          "arch": "amd64"
+        },
+        "landscape-common": {
+          "version": "14.12-0ubuntu0.14.04",
+          "arch": "amd64"
+        },
+        "language-selector-common": {
+          "version": "0.129.3",
+          "arch": "all"
+        },
+        "laptop-detect": {
+          "version": "0.13.7ubuntu2",
+          "arch": "amd64"
+        },
+        "less": {
+          "version": "458-2",
+          "arch": "amd64"
+        },
+        "libaccountsservice0": {
+          "version": "0.6.35-0ubuntu7.2",
+          "arch": "amd64"
+        },
+        "libacl1": {
+          "version": "2.2.52-1",
+          "arch": "amd64"
+        },
+        "libalgorithm-diff-perl": {
+          "version": "1.19.02-3",
+          "arch": "all"
+        },
+        "libalgorithm-diff-xs-perl": {
+          "version": "0.04-2build4",
+          "arch": "amd64"
+        },
+        "libalgorithm-merge-perl": {
+          "version": "0.08-2",
+          "arch": "all"
+        },
+        "libapparmor-perl": {
+          "version": "2.8.95~2430-0ubuntu5.1",
+          "arch": "amd64"
+        },
+        "libapparmor1": {
+          "version": "2.8.95~2430-0ubuntu5.1",
+          "arch": "amd64"
+        },
+        "libapt-inst1.5": {
+          "version": "1.0.1ubuntu2.8",
+          "arch": "amd64"
+        },
+        "libapt-pkg-perl": {
+          "version": "0.1.29build1",
+          "arch": "amd64"
+        },
+        "libapt-pkg4.12": {
+          "version": "1.0.1ubuntu2.8",
+          "arch": "amd64"
+        },
+        "libarchive-extract-perl": {
+          "version": "0.70-1",
+          "arch": "all"
+        },
+        "libarchive-zip-perl": {
+          "version": "1.30-7",
+          "arch": "all"
+        },
+        "libasan0": {
+          "version": "4.8.4-2ubuntu1~14.04.3",
+          "arch": "amd64"
+        },
+        "libasn1-8-heimdal": {
+          "version": "1.6~git20131207+dfsg-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libasound2": {
+          "version": "1.0.27.2-3ubuntu7",
+          "arch": "amd64"
+        },
+        "libasound2-data": {
+          "version": "1.0.27.2-3ubuntu7",
+          "arch": "all"
+        },
+        "libasprintf-dev": {
+          "version": "0.18.3.1-1ubuntu3",
+          "arch": "amd64"
+        },
+        "libasprintf0c2": {
+          "version": "0.18.3.1-1ubuntu3",
+          "arch": "amd64"
+        },
+        "libasyncns0": {
+          "version": "0.8-4ubuntu2",
+          "arch": "amd64"
+        },
+        "libatk-wrapper-java": {
+          "version": "0.30.4-4",
+          "arch": "all"
+        },
+        "libatk-wrapper-java-jni": {
+          "version": "0.30.4-4",
+          "arch": "amd64"
+        },
+        "libatk1.0-0": {
+          "version": "2.10.0-2ubuntu2",
+          "arch": "amd64"
+        },
+        "libatk1.0-data": {
+          "version": "2.10.0-2ubuntu2",
+          "arch": "all"
+        },
+        "libatomic1": {
+          "version": "4.8.4-2ubuntu1~14.04.3",
+          "arch": "amd64"
+        },
+        "libattr1": {
+          "version": "1:2.4.47-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libaudit-common": {
+          "version": "1:2.3.2-2ubuntu1",
+          "arch": "all"
+        },
+        "libaudit1": {
+          "version": "1:2.3.2-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libauthen-sasl-perl": {
+          "version": "2.1500-1",
+          "arch": "all"
+        },
+        "libautodie-perl": {
+          "version": "2.23-1",
+          "arch": "all"
+        },
+        "libavahi-client3": {
+          "version": "0.6.31-4ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libavahi-common-data": {
+          "version": "0.6.31-4ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libavahi-common3": {
+          "version": "0.6.31-4ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libbind9-90": {
+          "version": "1:9.9.5.dfsg-3ubuntu0.2",
+          "arch": "amd64"
+        },
+        "libbison-dev": {
+          "version": "2:3.0.2.dfsg-2",
+          "arch": "amd64"
+        },
+        "libblkid1": {
+          "version": "2.20.1-5.1ubuntu20.4",
+          "arch": "amd64"
+        },
+        "libboost-iostreams1.54.0": {
+          "version": "1.54.0-4ubuntu3.1",
+          "arch": "amd64"
+        },
+        "libbsd0": {
+          "version": "0.6.0-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libbz2-1.0": {
+          "version": "1.0.6-5",
+          "arch": "amd64"
+        },
+        "libc-bin": {
+          "version": "2.19-0ubuntu6.6",
+          "arch": "amd64"
+        },
+        "libc-dev-bin": {
+          "version": "2.19-0ubuntu6.11",
+          "arch": "amd64"
+        },
+        "libc6": {
+          "version": "2.19-0ubuntu6.11",
+          "arch": "amd64"
+        },
+        "libc6-dev": {
+          "version": "2.19-0ubuntu6.11",
+          "arch": "amd64"
+        },
+        "libcairo2": {
+          "version": "1.13.0~20140204-0ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libcap-ng0": {
+          "version": "0.7.3-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libcap2": {
+          "version": "1:2.24-0ubuntu2",
+          "arch": "amd64"
+        },
+        "libcap2-bin": {
+          "version": "1:2.24-0ubuntu2",
+          "arch": "amd64"
+        },
+        "libcgmanager0": {
+          "version": "0.24-0ubuntu7.3",
+          "arch": "amd64"
+        },
+        "libck-connector0": {
+          "version": "0.4.5-3.1ubuntu2",
+          "arch": "amd64"
+        },
+        "libclass-accessor-perl": {
+          "version": "0.34-1",
+          "arch": "all"
+        },
+        "libclone-perl": {
+          "version": "0.36-1",
+          "arch": "amd64"
+        },
+        "libcloog-isl4": {
+          "version": "0.18.2-1",
+          "arch": "amd64"
+        },
+        "libcomerr2": {
+          "version": "1.42.9-3ubuntu1.2",
+          "arch": "amd64"
+        },
+        "libcommon-sense-perl": {
+          "version": "3.72-2build1",
+          "arch": "amd64"
+        },
+        "libcroco3": {
+          "version": "0.6.8-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libcryptsetup4": {
+          "version": "2:1.6.1-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libcups2": {
+          "version": "1.7.2-0ubuntu1.8",
+          "arch": "amd64"
+        },
+        "libcurl3": {
+          "version": "7.35.0-1ubuntu2.5",
+          "arch": "amd64"
+        },
+        "libcurl3-gnutls": {
+          "version": "7.35.0-1ubuntu2.5",
+          "arch": "amd64"
+        },
+        "libcwidget3": {
+          "version": "0.5.16-3.5ubuntu1",
+          "arch": "amd64"
+        },
+        "libdatrie1": {
+          "version": "0.2.8-1",
+          "arch": "amd64"
+        },
+        "libdb5.3": {
+          "version": "5.3.28-3ubuntu3",
+          "arch": "amd64"
+        },
+        "libdbus-1-3": {
+          "version": "1.6.18-0ubuntu4.3",
+          "arch": "amd64"
+        },
+        "libdbus-glib-1-2": {
+          "version": "0.100.2-1",
+          "arch": "amd64"
+        },
+        "libdebconfclient0": {
+          "version": "0.187ubuntu1",
+          "arch": "amd64"
+        },
+        "libdevmapper1.02.1": {
+          "version": "2:1.02.77-6ubuntu2",
+          "arch": "amd64"
+        },
+        "libdigest-hmac-perl": {
+          "version": "1.03+dfsg-1",
+          "arch": "all"
+        },
+        "libdistro-info-perl": {
+          "version": "0.12",
+          "arch": "all"
+        },
+        "libdns100": {
+          "version": "1:9.9.5.dfsg-3ubuntu0.2",
+          "arch": "amd64"
+        },
+        "libdpkg-perl": {
+          "version": "1.17.5ubuntu5.7",
+          "arch": "all"
+        },
+        "libdrm-intel1": {
+          "version": "2.4.67-1ubuntu0.14.04.1",
+          "arch": "amd64"
+        },
+        "libdrm-nouveau2": {
+          "version": "2.4.67-1ubuntu0.14.04.1",
+          "arch": "amd64"
+        },
+        "libdrm-radeon1": {
+          "version": "2.4.67-1ubuntu0.14.04.1",
+          "arch": "amd64"
+        },
+        "libdrm2": {
+          "version": "2.4.60-2~ubuntu14.04.1",
+          "arch": "amd64"
+        },
+        "libdumbnet1": {
+          "version": "1.12-4build1",
+          "arch": "amd64"
+        },
+        "libedit2": {
+          "version": "3.1-20130712-2",
+          "arch": "amd64"
+        },
+        "libelf1": {
+          "version": "0.158-0ubuntu5.2",
+          "arch": "amd64"
+        },
+        "libemail-valid-perl": {
+          "version": "1.192-1",
+          "arch": "all"
+        },
+        "libencode-locale-perl": {
+          "version": "1.03-1",
+          "arch": "all"
+        },
+        "libept1.4.12": {
+          "version": "1.0.12",
+          "arch": "amd64"
+        },
+        "liberror-perl": {
+          "version": "0.17-1.1",
+          "arch": "all"
+        },
+        "libestr0": {
+          "version": "0.1.9-0ubuntu2",
+          "arch": "amd64"
+        },
+        "libevent-2.0-5": {
+          "version": "2.0.21-stable-1ubuntu1.14.04.1",
+          "arch": "amd64"
+        },
+        "libexpat1": {
+          "version": "2.1.0-4ubuntu1",
+          "arch": "amd64"
+        },
+        "libexporter-lite-perl": {
+          "version": "0.02-2",
+          "arch": "all"
+        },
+        "libfakeroot": {
+          "version": "1.20-3ubuntu2",
+          "arch": "amd64"
+        },
+        "libffi6": {
+          "version": "3.1~rc1+r3.0.13-12",
+          "arch": "amd64"
+        },
+        "libfile-basedir-perl": {
+          "version": "0.03-1fakesync1",
+          "arch": "all"
+        },
+        "libfile-fcntllock-perl": {
+          "version": "0.14-2build1",
+          "arch": "amd64"
+        },
+        "libfile-listing-perl": {
+          "version": "6.04-1",
+          "arch": "all"
+        },
+        "libfl-dev": {
+          "version": "2.5.35-10.1ubuntu2",
+          "arch": "amd64"
+        },
+        "libflac8": {
+          "version": "1.3.0-2ubuntu0.14.04.1",
+          "arch": "amd64"
+        },
+        "libfont-afm-perl": {
+          "version": "1.20-1",
+          "arch": "all"
+        },
+        "libfontconfig1": {
+          "version": "2.11.0-0ubuntu4.2",
+          "arch": "amd64"
+        },
+        "libfreetype6": {
+          "version": "2.5.2-1ubuntu2.4",
+          "arch": "amd64"
+        },
+        "libfribidi0": {
+          "version": "0.19.6-1",
+          "arch": "amd64"
+        },
+        "libfuse2": {
+          "version": "2.9.2-4ubuntu4.14.04.1",
+          "arch": "amd64"
+        },
+        "libgc1c2": {
+          "version": "1:7.2d-5ubuntu2",
+          "arch": "amd64"
+        },
+        "libgcc-4.8-dev": {
+          "version": "4.8.4-2ubuntu1~14.04.3",
+          "arch": "amd64"
+        },
+        "libgcc1": {
+          "version": "1:4.9.1-0ubuntu1",
+          "arch": "amd64"
+        },
+        "libgck-1-0": {
+          "version": "3.10.1-1",
+          "arch": "amd64"
+        },
+        "libgcr-3-common": {
+          "version": "3.10.1-1",
+          "arch": "all"
+        },
+        "libgcr-base-3-1": {
+          "version": "3.10.1-1",
+          "arch": "amd64"
+        },
+        "libgcrypt11": {
+          "version": "1.5.3-2ubuntu4.2",
+          "arch": "amd64"
+        },
+        "libgdbm3": {
+          "version": "1.8.3-12build1",
+          "arch": "amd64"
+        },
+        "libgdk-pixbuf2.0-0": {
+          "version": "2.30.7-0ubuntu1.6",
+          "arch": "amd64"
+        },
+        "libgdk-pixbuf2.0-common": {
+          "version": "2.30.7-0ubuntu1.6",
+          "arch": "all"
+        },
+        "libgeoip1": {
+          "version": "1.6.0-1",
+          "arch": "amd64"
+        },
+        "libgettextpo-dev": {
+          "version": "0.18.3.1-1ubuntu3",
+          "arch": "amd64"
+        },
+        "libgettextpo0": {
+          "version": "0.18.3.1-1ubuntu3",
+          "arch": "amd64"
+        },
+        "libgif4": {
+          "version": "4.1.6-11",
+          "arch": "amd64"
+        },
+        "libgirepository-1.0-1": {
+          "version": "1.40.0-1ubuntu0.2",
+          "arch": "amd64"
+        },
+        "libgl1-mesa-dri": {
+          "version": "10.1.3-0ubuntu0.6",
+          "arch": "amd64"
+        },
+        "libgl1-mesa-glx": {
+          "version": "10.1.3-0ubuntu0.6",
+          "arch": "amd64"
+        },
+        "libglapi-mesa": {
+          "version": "10.1.3-0ubuntu0.6",
+          "arch": "amd64"
+        },
+        "libglib2.0-0": {
+          "version": "2.40.2-0ubuntu1",
+          "arch": "amd64"
+        },
+        "libglib2.0-data": {
+          "version": "2.40.2-0ubuntu1",
+          "arch": "all"
+        },
+        "libgmp10": {
+          "version": "2:5.1.3+dfsg-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libgnutls-openssl27": {
+          "version": "2.12.23-12ubuntu2.2",
+          "arch": "amd64"
+        },
+        "libgnutls26": {
+          "version": "2.12.23-12ubuntu2.2",
+          "arch": "amd64"
+        },
+        "libgomp1": {
+          "version": "4.8.4-2ubuntu1~14.04.3",
+          "arch": "amd64"
+        },
+        "libgpg-error0": {
+          "version": "1.12-0.2ubuntu1",
+          "arch": "amd64"
+        },
+        "libgpm2": {
+          "version": "1.20.4-6.1",
+          "arch": "amd64"
+        },
+        "libgraphite2-3": {
+          "version": "1.3.6-1ubuntu0.14.04.1",
+          "arch": "amd64"
+        },
+        "libgssapi-krb5-2": {
+          "version": "1.12+dfsg-2ubuntu5.1",
+          "arch": "amd64"
+        },
+        "libgssapi3-heimdal": {
+          "version": "1.6~git20131207+dfsg-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libgtk2.0-0": {
+          "version": "2.24.23-0ubuntu1.4",
+          "arch": "amd64"
+        },
+        "libgtk2.0-bin": {
+          "version": "2.24.23-0ubuntu1.4",
+          "arch": "amd64"
+        },
+        "libgtk2.0-common": {
+          "version": "2.24.23-0ubuntu1.4",
+          "arch": "all"
+        },
+        "libharfbuzz0b": {
+          "version": "0.9.27-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libhcrypto4-heimdal": {
+          "version": "1.6~git20131207+dfsg-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libheimbase1-heimdal": {
+          "version": "1.6~git20131207+dfsg-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libheimntlm0-heimdal": {
+          "version": "1.6~git20131207+dfsg-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libhtml-form-perl": {
+          "version": "6.03-1",
+          "arch": "all"
+        },
+        "libhtml-format-perl": {
+          "version": "2.11-1",
+          "arch": "all"
+        },
+        "libhtml-parser-perl": {
+          "version": "3.71-1build1",
+          "arch": "amd64"
+        },
+        "libhtml-tagset-perl": {
+          "version": "3.20-2",
+          "arch": "all"
+        },
+        "libhtml-tree-perl": {
+          "version": "5.03-1",
+          "arch": "all"
+        },
+        "libhttp-cookies-perl": {
+          "version": "6.00-2",
+          "arch": "all"
+        },
+        "libhttp-daemon-perl": {
+          "version": "6.01-1",
+          "arch": "all"
+        },
+        "libhttp-date-perl": {
+          "version": "6.02-1",
+          "arch": "all"
+        },
+        "libhttp-message-perl": {
+          "version": "6.06-1",
+          "arch": "all"
+        },
+        "libhttp-negotiate-perl": {
+          "version": "6.00-2",
+          "arch": "all"
+        },
+        "libhx509-5-heimdal": {
+          "version": "1.6~git20131207+dfsg-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libice-dev": {
+          "version": "2:1.0.8-2",
+          "arch": "amd64"
+        },
+        "libice6": {
+          "version": "2:1.0.8-2",
+          "arch": "amd64"
+        },
+        "libicu52": {
+          "version": "52.1-3ubuntu0.3",
+          "arch": "amd64"
+        },
+        "libidn11": {
+          "version": "1.28-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libio-html-perl": {
+          "version": "1.00-1",
+          "arch": "all"
+        },
+        "libio-pty-perl": {
+          "version": "1:1.08-1build4",
+          "arch": "amd64"
+        },
+        "libio-socket-inet6-perl": {
+          "version": "2.71-1",
+          "arch": "all"
+        },
+        "libio-socket-ssl-perl": {
+          "version": "1.965-1ubuntu1",
+          "arch": "all"
+        },
+        "libio-string-perl": {
+          "version": "1.08-3",
+          "arch": "all"
+        },
+        "libio-stringy-perl": {
+          "version": "2.110-5",
+          "arch": "all"
+        },
+        "libipc-run-perl": {
+          "version": "0.92-1",
+          "arch": "all"
+        },
+        "libipc-system-simple-perl": {
+          "version": "1.25-2",
+          "arch": "all"
+        },
+        "libisc95": {
+          "version": "1:9.9.5.dfsg-3ubuntu0.2",
+          "arch": "amd64"
+        },
+        "libisccc90": {
+          "version": "1:9.9.5.dfsg-3ubuntu0.2",
+          "arch": "amd64"
+        },
+        "libisccfg90": {
+          "version": "1:9.9.5.dfsg-3ubuntu0.2",
+          "arch": "amd64"
+        },
+        "libisl10": {
+          "version": "0.12.2-1",
+          "arch": "amd64"
+        },
+        "libitm1": {
+          "version": "4.8.4-2ubuntu1~14.04.3",
+          "arch": "amd64"
+        },
+        "libjasper1": {
+          "version": "1.900.1-14ubuntu3.4",
+          "arch": "amd64"
+        },
+        "libjbig0": {
+          "version": "2.0-2ubuntu4.1",
+          "arch": "amd64"
+        },
+        "libjpeg-turbo8": {
+          "version": "1.3.0-0ubuntu2",
+          "arch": "amd64"
+        },
+        "libjpeg8": {
+          "version": "8c-2ubuntu8",
+          "arch": "amd64"
+        },
+        "libjson-c2": {
+          "version": "0.11-3ubuntu1.2",
+          "arch": "amd64"
+        },
+        "libjson-perl": {
+          "version": "2.61-1",
+          "arch": "all"
+        },
+        "libjson-xs-perl": {
+          "version": "2.340-1build1",
+          "arch": "amd64"
+        },
+        "libjson0": {
+          "version": "0.11-3ubuntu1.2",
+          "arch": "amd64"
+        },
+        "libk5crypto3": {
+          "version": "1.12+dfsg-2ubuntu5.1",
+          "arch": "amd64"
+        },
+        "libkeyutils1": {
+          "version": "1.5.6-1",
+          "arch": "amd64"
+        },
+        "libklibc": {
+          "version": "2.0.3-0ubuntu1",
+          "arch": "amd64"
+        },
+        "libkmod2": {
+          "version": "15-0ubuntu6",
+          "arch": "amd64"
+        },
+        "libkrb5-26-heimdal": {
+          "version": "1.6~git20131207+dfsg-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libkrb5-3": {
+          "version": "1.12+dfsg-2ubuntu5.1",
+          "arch": "amd64"
+        },
+        "libkrb5support0": {
+          "version": "1.12+dfsg-2ubuntu5.1",
+          "arch": "amd64"
+        },
+        "liblcms2-2": {
+          "version": "2.5-0ubuntu4.1",
+          "arch": "amd64"
+        },
+        "libldap-2.4-2": {
+          "version": "2.4.31-1+nmu2ubuntu8.1",
+          "arch": "amd64"
+        },
+        "liblist-moreutils-perl": {
+          "version": "0.33-1build3",
+          "arch": "amd64"
+        },
+        "libllvm3.4": {
+          "version": "1:3.4-1ubuntu3",
+          "arch": "amd64"
+        },
+        "liblocale-gettext-perl": {
+          "version": "1.05-7build3",
+          "arch": "amd64"
+        },
+        "liblockfile-bin": {
+          "version": "1.09-6ubuntu1",
+          "arch": "amd64"
+        },
+        "liblockfile1": {
+          "version": "1.09-6ubuntu1",
+          "arch": "amd64"
+        },
+        "liblog-message-simple-perl": {
+          "version": "0.10-1",
+          "arch": "all"
+        },
+        "liblwp-mediatypes-perl": {
+          "version": "6.02-1",
+          "arch": "all"
+        },
+        "liblwp-protocol-https-perl": {
+          "version": "6.04-2ubuntu0.1",
+          "arch": "all"
+        },
+        "liblwres90": {
+          "version": "1:9.9.5.dfsg-3ubuntu0.2",
+          "arch": "amd64"
+        },
+        "liblzma5": {
+          "version": "5.1.1alpha+20120614-2ubuntu2",
+          "arch": "amd64"
+        },
+        "libmagic1": {
+          "version": "1:5.14-2ubuntu3.3",
+          "arch": "amd64"
+        },
+        "libmailtools-perl": {
+          "version": "2.12-1",
+          "arch": "all"
+        },
+        "libmodule-pluggable-perl": {
+          "version": "5.1-1",
+          "arch": "all"
+        },
+        "libmount1": {
+          "version": "2.20.1-5.1ubuntu20.4",
+          "arch": "amd64"
+        },
+        "libmpc3": {
+          "version": "1.0.1-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libmpdec2": {
+          "version": "2.4.0-6",
+          "arch": "amd64"
+        },
+        "libmpfr4": {
+          "version": "3.1.2-1",
+          "arch": "amd64"
+        },
+        "libncurses5": {
+          "version": "5.9+20140118-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libncurses5-dev": {
+          "version": "5.9+20140118-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libncursesw5": {
+          "version": "5.9+20140118-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libnet-dns-perl": {
+          "version": "0.68-1.2build1",
+          "arch": "amd64"
+        },
+        "libnet-domain-tld-perl": {
+          "version": "1.70-1",
+          "arch": "all"
+        },
+        "libnet-http-perl": {
+          "version": "6.06-1",
+          "arch": "all"
+        },
+        "libnet-ip-perl": {
+          "version": "1.26-1",
+          "arch": "all"
+        },
+        "libnet-smtp-ssl-perl": {
+          "version": "1.01-3",
+          "arch": "all"
+        },
+        "libnet-ssleay-perl": {
+          "version": "1.58-1",
+          "arch": "amd64"
+        },
+        "libnewt0.52": {
+          "version": "0.52.15-2ubuntu5",
+          "arch": "amd64"
+        },
+        "libnfnetlink0": {
+          "version": "1.0.1-2",
+          "arch": "amd64"
+        },
+        "libnih-dbus1": {
+          "version": "1.0.3-4ubuntu25",
+          "arch": "amd64"
+        },
+        "libnih1": {
+          "version": "1.0.3-4ubuntu25",
+          "arch": "amd64"
+        },
+        "libnspr4": {
+          "version": "2:4.13.1-0ubuntu0.14.04.1",
+          "arch": "amd64"
+        },
+        "libnss3": {
+          "version": "2:3.28.4-0ubuntu0.14.04.1",
+          "arch": "amd64"
+        },
+        "libnss3-nssdb": {
+          "version": "2:3.28.4-0ubuntu0.14.04.1",
+          "arch": "all"
+        },
+        "libnuma1": {
+          "version": "2.0.9~rc5-1ubuntu3",
+          "arch": "amd64"
+        },
+        "libogg0": {
+          "version": "1.3.1-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libopts25": {
+          "version": "1:5.18-2ubuntu2",
+          "arch": "amd64"
+        },
+        "libp11-kit0": {
+          "version": "0.20.2-2ubuntu2",
+          "arch": "amd64"
+        },
+        "libpam-cap": {
+          "version": "1:2.24-0ubuntu2",
+          "arch": "amd64"
+        },
+        "libpam-modules": {
+          "version": "1.1.8-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libpam-modules-bin": {
+          "version": "1.1.8-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libpam-runtime": {
+          "version": "1.1.8-1ubuntu2",
+          "arch": "all"
+        },
+        "libpam-systemd": {
+          "version": "204-5ubuntu20.12",
+          "arch": "amd64"
+        },
+        "libpam0g": {
+          "version": "1.1.8-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libpango-1.0-0": {
+          "version": "1.36.3-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libpangocairo-1.0-0": {
+          "version": "1.36.3-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libpangoft2-1.0-0": {
+          "version": "1.36.3-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libparse-debcontrol-perl": {
+          "version": "2.005-4",
+          "arch": "all"
+        },
+        "libparse-debianchangelog-perl": {
+          "version": "1.2.0-1ubuntu1",
+          "arch": "all"
+        },
+        "libparted0debian1": {
+          "version": "2.3-19ubuntu1",
+          "arch": "amd64"
+        },
+        "libpcap0.8": {
+          "version": "1.5.3-2",
+          "arch": "amd64"
+        },
+        "libpci3": {
+          "version": "1:3.2.1-1ubuntu5",
+          "arch": "amd64"
+        },
+        "libpciaccess0": {
+          "version": "0.13.2-1",
+          "arch": "amd64"
+        },
+        "libpcre3": {
+          "version": "1:8.31-2ubuntu2",
+          "arch": "amd64"
+        },
+        "libpcsclite1": {
+          "version": "1.8.10-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libperlio-gzip-perl": {
+          "version": "0.18-1build3",
+          "arch": "amd64"
+        },
+        "libpipeline1": {
+          "version": "1.3.0-1",
+          "arch": "amd64"
+        },
+        "libpixman-1-0": {
+          "version": "0.30.2-2ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libplymouth2": {
+          "version": "0.8.8-0ubuntu17.1",
+          "arch": "amd64"
+        },
+        "libpng12-0": {
+          "version": "1.2.50-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libpod-latex-perl": {
+          "version": "0.61-1",
+          "arch": "all"
+        },
+        "libpolkit-agent-1-0": {
+          "version": "0.105-4ubuntu2.14.04.1",
+          "arch": "amd64"
+        },
+        "libpolkit-backend-1-0": {
+          "version": "0.105-4ubuntu2.14.04.1",
+          "arch": "amd64"
+        },
+        "libpolkit-gobject-1-0": {
+          "version": "0.105-4ubuntu2.14.04.1",
+          "arch": "amd64"
+        },
+        "libpopt0": {
+          "version": "1.16-8ubuntu1",
+          "arch": "amd64"
+        },
+        "libprocps3": {
+          "version": "1:3.3.9-1ubuntu2.2",
+          "arch": "amd64"
+        },
+        "libpthread-stubs0-dev": {
+          "version": "0.3-4",
+          "arch": "amd64"
+        },
+        "libpulse0": {
+          "version": "1:4.0-0ubuntu11.1",
+          "arch": "amd64"
+        },
+        "libpython-stdlib": {
+          "version": "2.7.5-5ubuntu3",
+          "arch": "amd64"
+        },
+        "libpython2.7": {
+          "version": "2.7.6-8",
+          "arch": "amd64"
+        },
+        "libpython2.7-minimal": {
+          "version": "2.7.6-8",
+          "arch": "amd64"
+        },
+        "libpython2.7-stdlib": {
+          "version": "2.7.6-8",
+          "arch": "amd64"
+        },
+        "libpython3-stdlib": {
+          "version": "3.4.0-0ubuntu2",
+          "arch": "amd64"
+        },
+        "libpython3.4-minimal": {
+          "version": "3.4.0-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libpython3.4-stdlib": {
+          "version": "3.4.0-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libquadmath0": {
+          "version": "4.8.4-2ubuntu1~14.04.3",
+          "arch": "amd64"
+        },
+        "libreadline6": {
+          "version": "6.3-4ubuntu2",
+          "arch": "amd64"
+        },
+        "libroken18-heimdal": {
+          "version": "1.6~git20131207+dfsg-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "librtmp0": {
+          "version": "2.4+20121230.gitdf6c518-1",
+          "arch": "amd64"
+        },
+        "libsasl2-2": {
+          "version": "2.1.25.dfsg1-17build1",
+          "arch": "amd64"
+        },
+        "libsasl2-modules": {
+          "version": "2.1.25.dfsg1-17build1",
+          "arch": "amd64"
+        },
+        "libsasl2-modules-db": {
+          "version": "2.1.25.dfsg1-17build1",
+          "arch": "amd64"
+        },
+        "libsctp1": {
+          "version": "1.0.15+dfsg-1",
+          "arch": "amd64"
+        },
+        "libselinux1": {
+          "version": "2.2.2-1ubuntu0.1",
+          "arch": "amd64"
+        },
+        "libsemanage-common": {
+          "version": "2.2-1",
+          "arch": "all"
+        },
+        "libsemanage1": {
+          "version": "2.2-1",
+          "arch": "amd64"
+        },
+        "libsepol1": {
+          "version": "2.2-1ubuntu0.1",
+          "arch": "amd64"
+        },
+        "libsigc++-2.0-0c2a": {
+          "version": "2.2.10-0.2ubuntu2",
+          "arch": "amd64"
+        },
+        "libsigsegv2": {
+          "version": "2.10-2",
+          "arch": "amd64"
+        },
+        "libslang2": {
+          "version": "2.2.4-15ubuntu1",
+          "arch": "amd64"
+        },
+        "libsm-dev": {
+          "version": "2:1.2.1-2",
+          "arch": "amd64"
+        },
+        "libsm6": {
+          "version": "2:1.2.1-2",
+          "arch": "amd64"
+        },
+        "libsndfile1": {
+          "version": "1.0.25-7ubuntu2.2",
+          "arch": "amd64"
+        },
+        "libsocket6-perl": {
+          "version": "0.25-1",
+          "arch": "amd64"
+        },
+        "libsqlite3-0": {
+          "version": "3.8.2-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libss2": {
+          "version": "1.42.9-3ubuntu1.2",
+          "arch": "amd64"
+        },
+        "libssl1.0.0": {
+          "version": "1.0.1f-1ubuntu2.12",
+          "arch": "amd64"
+        },
+        "libstdc++-4.8-dev": {
+          "version": "4.8.4-2ubuntu1~14.04.3",
+          "arch": "amd64"
+        },
+        "libstdc++6": {
+          "version": "4.8.4-2ubuntu1~14.04.3",
+          "arch": "amd64"
+        },
+        "libsub-identify-perl": {
+          "version": "0.04-1build3",
+          "arch": "amd64"
+        },
+        "libsub-name-perl": {
+          "version": "0.05-1build4",
+          "arch": "amd64"
+        },
+        "libsystemd-daemon0": {
+          "version": "204-5ubuntu20.12",
+          "arch": "amd64"
+        },
+        "libsystemd-login0": {
+          "version": "204-5ubuntu20.12",
+          "arch": "amd64"
+        },
+        "libtasn1-6": {
+          "version": "3.4-3ubuntu0.3",
+          "arch": "amd64"
+        },
+        "libterm-ui-perl": {
+          "version": "0.42-1",
+          "arch": "all"
+        },
+        "libtext-charwidth-perl": {
+          "version": "0.04-7build3",
+          "arch": "amd64"
+        },
+        "libtext-iconv-perl": {
+          "version": "1.7-5build2",
+          "arch": "amd64"
+        },
+        "libtext-levenshtein-perl": {
+          "version": "0.06~01-2",
+          "arch": "all"
+        },
+        "libtext-soundex-perl": {
+          "version": "3.4-1build1",
+          "arch": "amd64"
+        },
+        "libtext-wrapi18n-perl": {
+          "version": "0.06-7",
+          "arch": "all"
+        },
+        "libthai-data": {
+          "version": "0.1.20-3",
+          "arch": "all"
+        },
+        "libthai0": {
+          "version": "0.1.20-3",
+          "arch": "amd64"
+        },
+        "libtie-ixhash-perl": {
+          "version": "1.23-1",
+          "arch": "all"
+        },
+        "libtiff5": {
+          "version": "4.0.3-7ubuntu0.7",
+          "arch": "amd64"
+        },
+        "libtimedate-perl": {
+          "version": "2.3000-1",
+          "arch": "all"
+        },
+        "libtinfo-dev": {
+          "version": "5.9+20140118-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libtinfo5": {
+          "version": "5.9+20140118-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libtsan0": {
+          "version": "4.8.4-2ubuntu1~14.04.3",
+          "arch": "amd64"
+        },
+        "libtxc-dxtn-s2tc0": {
+          "version": "0~git20131104-1.1",
+          "arch": "amd64"
+        },
+        "libudev1": {
+          "version": "204-5ubuntu20.12",
+          "arch": "amd64"
+        },
+        "libunistring0": {
+          "version": "0.9.3-5ubuntu3",
+          "arch": "amd64"
+        },
+        "liburi-perl": {
+          "version": "1.60-1",
+          "arch": "all"
+        },
+        "libusb-0.1-4": {
+          "version": "2:0.1.12-23.3ubuntu1",
+          "arch": "amd64"
+        },
+        "libusb-1.0-0": {
+          "version": "2:1.0.17-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libustr-1.0-1": {
+          "version": "1.0.4-3ubuntu2",
+          "arch": "amd64"
+        },
+        "libuuid1": {
+          "version": "2.20.1-5.1ubuntu20.4",
+          "arch": "amd64"
+        },
+        "libvorbis0a": {
+          "version": "1.3.2-1.3ubuntu1",
+          "arch": "amd64"
+        },
+        "libvorbisenc2": {
+          "version": "1.3.2-1.3ubuntu1",
+          "arch": "amd64"
+        },
+        "libwind0-heimdal": {
+          "version": "1.6~git20131207+dfsg-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libwrap0": {
+          "version": "7.6.q-25",
+          "arch": "amd64"
+        },
+        "libwww-perl": {
+          "version": "6.05-2",
+          "arch": "all"
+        },
+        "libwww-robotrules-perl": {
+          "version": "6.01-1",
+          "arch": "all"
+        },
+        "libx11-6": {
+          "version": "2:1.6.2-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libx11-data": {
+          "version": "2:1.6.2-1ubuntu2",
+          "arch": "all"
+        },
+        "libx11-dev": {
+          "version": "2:1.6.2-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libx11-doc": {
+          "version": "2:1.6.2-1ubuntu2",
+          "arch": "all"
+        },
+        "libx11-xcb1": {
+          "version": "2:1.6.2-1ubuntu2",
+          "arch": "amd64"
+        },
+        "libxapian22": {
+          "version": "1.2.16-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libxau-dev": {
+          "version": "1:1.0.8-1",
+          "arch": "amd64"
+        },
+        "libxau6": {
+          "version": "1:1.0.8-1",
+          "arch": "amd64"
+        },
+        "libxcb-dri2-0": {
+          "version": "1.10-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libxcb-dri3-0": {
+          "version": "1.10-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libxcb-glx0": {
+          "version": "1.10-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libxcb-present0": {
+          "version": "1.10-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libxcb-render0": {
+          "version": "1.10-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libxcb-shm0": {
+          "version": "1.10-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libxcb-sync1": {
+          "version": "1.10-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libxcb1": {
+          "version": "1.10-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libxcb1-dev": {
+          "version": "1.10-2ubuntu1",
+          "arch": "amd64"
+        },
+        "libxcomposite1": {
+          "version": "1:0.4.4-1",
+          "arch": "amd64"
+        },
+        "libxcursor1": {
+          "version": "1:1.1.14-1",
+          "arch": "amd64"
+        },
+        "libxdamage1": {
+          "version": "1:1.1.4-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libxdmcp-dev": {
+          "version": "1:1.1.1-1",
+          "arch": "amd64"
+        },
+        "libxdmcp6": {
+          "version": "1:1.1.1-1",
+          "arch": "amd64"
+        },
+        "libxext6": {
+          "version": "2:1.3.2-1ubuntu0.0.14.04.1",
+          "arch": "amd64"
+        },
+        "libxfixes3": {
+          "version": "1:5.0.1-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libxi6": {
+          "version": "2:1.7.1.901-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "libxinerama1": {
+          "version": "2:1.1.3-1",
+          "arch": "amd64"
+        },
+        "libxml2": {
+          "version": "2.9.1+dfsg1-3ubuntu4.4",
+          "arch": "amd64"
+        },
+        "libxmuu1": {
+          "version": "2:1.1.1-1",
+          "arch": "amd64"
+        },
+        "libxrandr2": {
+          "version": "2:1.5.0-1~trusty1",
+          "arch": "amd64"
+        },
+        "libxrender1": {
+          "version": "1:0.9.8-1build0.14.04.1",
+          "arch": "amd64"
+        },
+        "libxshmfence1": {
+          "version": "1.1-2",
+          "arch": "amd64"
+        },
+        "libxt-dev": {
+          "version": "1:1.1.4-1",
+          "arch": "amd64"
+        },
+        "libxt6": {
+          "version": "1:1.1.4-1",
+          "arch": "amd64"
+        },
+        "libxtables10": {
+          "version": "1.4.21-1ubuntu1",
+          "arch": "amd64"
+        },
+        "libxtst6": {
+          "version": "2:1.2.2-1",
+          "arch": "amd64"
+        },
+        "libxxf86vm1": {
+          "version": "1:1.1.3-1",
+          "arch": "amd64"
+        },
+        "libyaml-0-2": {
+          "version": "0.1.4-3ubuntu3.1",
+          "arch": "amd64"
+        },
+        "lintian": {
+          "version": "2.5.22ubuntu1",
+          "arch": "all"
+        },
+        "linux-headers-3.13.0-53": {
+          "version": "3.13.0-53.89",
+          "arch": "all"
+        },
+        "linux-headers-3.13.0-53-generic": {
+          "version": "3.13.0-53.89",
+          "arch": "amd64"
+        },
+        "linux-headers-generic": {
+          "version": "3.13.0.53.60",
+          "arch": "amd64"
+        },
+        "linux-headers-virtual": {
+          "version": "3.13.0.53.60",
+          "arch": "amd64"
+        },
+        "linux-image-3.13.0-53-generic": {
+          "version": "3.13.0-53.89",
+          "arch": "amd64"
+        },
+        "linux-image-virtual": {
+          "version": "3.13.0.53.60",
+          "arch": "amd64"
+        },
+        "linux-libc-dev": {
+          "version": "3.13.0-119.166",
+          "arch": "amd64"
+        },
+        "linux-virtual": {
+          "version": "3.13.0.53.60",
+          "arch": "amd64"
+        },
+        "lksctp-tools": {
+          "version": "1.0.15+dfsg-1",
+          "arch": "amd64"
+        },
+        "locales": {
+          "version": "2.13+git20120306-12.1",
+          "arch": "all"
+        },
+        "lockfile-progs": {
+          "version": "0.1.17",
+          "arch": "amd64"
+        },
+        "login": {
+          "version": "1:4.1.5.1-1ubuntu9",
+          "arch": "amd64"
+        },
+        "logrotate": {
+          "version": "3.8.7-1ubuntu1",
+          "arch": "amd64"
+        },
+        "lsb-base": {
+          "version": "4.1+Debian11ubuntu6",
+          "arch": "all"
+        },
+        "lsb-release": {
+          "version": "4.1+Debian11ubuntu6",
+          "arch": "all"
+        },
+        "lshw": {
+          "version": "02.16-2ubuntu1.2",
+          "arch": "amd64"
+        },
+        "lsof": {
+          "version": "4.86+dfsg-1ubuntu2",
+          "arch": "amd64"
+        },
+        "ltrace": {
+          "version": "0.7.3-4ubuntu5.1",
+          "arch": "amd64"
+        },
+        "m4": {
+          "version": "1.4.17-2ubuntu1",
+          "arch": "amd64"
+        },
+        "make": {
+          "version": "3.81-8.2ubuntu3",
+          "arch": "amd64"
+        },
+        "makedev": {
+          "version": "2.3.1-93ubuntu1",
+          "arch": "all"
+        },
+        "man-db": {
+          "version": "2.6.7.1-1ubuntu1",
+          "arch": "amd64"
+        },
+        "manpages": {
+          "version": "3.54-1ubuntu1",
+          "arch": "all"
+        },
+        "manpages-dev": {
+          "version": "3.54-1ubuntu1",
+          "arch": "all"
+        },
+        "mawk": {
+          "version": "1.3.3-17ubuntu2",
+          "arch": "amd64"
+        },
+        "mime-support": {
+          "version": "3.54ubuntu1.1",
+          "arch": "all"
+        },
+        "mlocate": {
+          "version": "0.26-1ubuntu1",
+          "arch": "amd64"
+        },
+        "module-init-tools": {
+          "version": "15-0ubuntu6",
+          "arch": "all"
+        },
+        "mount": {
+          "version": "2.20.1-5.1ubuntu20.4",
+          "arch": "amd64"
+        },
+        "mountall": {
+          "version": "2.53",
+          "arch": "amd64"
+        },
+        "mtr-tiny": {
+          "version": "0.85-2",
+          "arch": "amd64"
+        },
+        "multiarch-support": {
+          "version": "2.19-0ubuntu6.6",
+          "arch": "amd64"
+        },
+        "nano": {
+          "version": "2.2.6-1ubuntu1",
+          "arch": "amd64"
+        },
+        "ncurses-base": {
+          "version": "5.9+20140118-1ubuntu1",
+          "arch": "all"
+        },
+        "ncurses-bin": {
+          "version": "5.9+20140118-1ubuntu1",
+          "arch": "amd64"
+        },
+        "ncurses-term": {
+          "version": "5.9+20140118-1ubuntu1",
+          "arch": "all"
+        },
+        "net-tools": {
+          "version": "1.60-25ubuntu2.1",
+          "arch": "amd64"
+        },
+        "netbase": {
+          "version": "5.2",
+          "arch": "all"
+        },
+        "netcat-openbsd": {
+          "version": "1.105-7ubuntu1",
+          "arch": "amd64"
+        },
+        "ntfs-3g": {
+          "version": "1:2013.1.13AR.1-2ubuntu2",
+          "arch": "amd64"
+        },
+        "ntp": {
+          "version": "1:4.2.6.p5+dfsg-3ubuntu2.14.04.10",
+          "arch": "amd64"
+        },
+        "ntpdate": {
+          "version": "1:4.2.6.p5+dfsg-3ubuntu2.14.04.3",
+          "arch": "amd64"
+        },
+        "omnibus-toolchain": {
+          "version": "1.1.73-1",
+          "arch": "amd64"
+        },
+        "open-vm-tools": {
+          "version": "2:9.4.0-1280544-5ubuntu6.2",
+          "arch": "amd64"
+        },
+        "openjdk-7-jdk": {
+          "version": "7u131-2.6.9-0ubuntu0.14.04.2",
+          "arch": "amd64"
+        },
+        "openjdk-7-jre": {
+          "version": "7u131-2.6.9-0ubuntu0.14.04.2",
+          "arch": "amd64"
+        },
+        "openjdk-7-jre-headless": {
+          "version": "7u131-2.6.9-0ubuntu0.14.04.2",
+          "arch": "amd64"
+        },
+        "openssh-client": {
+          "version": "1:6.6p1-2ubuntu2",
+          "arch": "amd64"
+        },
+        "openssh-server": {
+          "version": "1:6.6p1-2ubuntu2",
+          "arch": "amd64"
+        },
+        "openssh-sftp-server": {
+          "version": "1:6.6p1-2ubuntu2",
+          "arch": "amd64"
+        },
+        "openssl": {
+          "version": "1.0.1f-1ubuntu2.12",
+          "arch": "amd64"
+        },
+        "os-prober": {
+          "version": "1.63ubuntu1",
+          "arch": "amd64"
+        },
+        "overlayroot": {
+          "version": "0.25ubuntu1",
+          "arch": "all"
+        },
+        "parted": {
+          "version": "2.3-19ubuntu1",
+          "arch": "amd64"
+        },
+        "passwd": {
+          "version": "1:4.1.5.1-1ubuntu9",
+          "arch": "amd64"
+        },
+        "patch": {
+          "version": "2.7.1-4ubuntu2",
+          "arch": "amd64"
+        },
+        "patchutils": {
+          "version": "0.3.2-3",
+          "arch": "amd64"
+        },
+        "pciutils": {
+          "version": "1:3.2.1-1ubuntu5",
+          "arch": "amd64"
+        },
+        "perl": {
+          "version": "5.18.2-2ubuntu1",
+          "arch": "amd64"
+        },
+        "perl-base": {
+          "version": "5.18.2-2ubuntu1",
+          "arch": "amd64"
+        },
+        "perl-modules": {
+          "version": "5.18.2-2ubuntu1",
+          "arch": "all"
+        },
+        "plymouth": {
+          "version": "0.8.8-0ubuntu17.1",
+          "arch": "amd64"
+        },
+        "plymouth-theme-ubuntu-text": {
+          "version": "0.8.8-0ubuntu17.1",
+          "arch": "amd64"
+        },
+        "policykit-1": {
+          "version": "0.105-4ubuntu2.14.04.1",
+          "arch": "amd64"
+        },
+        "pollinate": {
+          "version": "4.7-0ubuntu1.2",
+          "arch": "all"
+        },
+        "popularity-contest": {
+          "version": "1.57ubuntu1",
+          "arch": "all"
+        },
+        "powermgmt-base": {
+          "version": "1.31build1",
+          "arch": "amd64"
+        },
+        "ppp": {
+          "version": "2.4.5-5.1ubuntu2.2",
+          "arch": "amd64"
+        },
+        "pppconfig": {
+          "version": "2.3.19ubuntu1",
+          "arch": "all"
+        },
+        "pppoeconf": {
+          "version": "1.20ubuntu1",
+          "arch": "all"
+        },
+        "procps": {
+          "version": "1:3.3.9-1ubuntu2.2",
+          "arch": "amd64"
+        },
+        "psmisc": {
+          "version": "22.20-1ubuntu2",
+          "arch": "amd64"
+        },
+        "python": {
+          "version": "2.7.5-5ubuntu3",
+          "arch": "amd64"
+        },
+        "python-apt": {
+          "version": "0.9.3.5ubuntu1",
+          "arch": "amd64"
+        },
+        "python-apt-common": {
+          "version": "0.9.3.5ubuntu1",
+          "arch": "all"
+        },
+        "python-chardet": {
+          "version": "2.0.1-2build2",
+          "arch": "all"
+        },
+        "python-cheetah": {
+          "version": "2.4.4-3.fakesyncbuild1",
+          "arch": "amd64"
+        },
+        "python-configobj": {
+          "version": "4.7.2+ds-5build1",
+          "arch": "all"
+        },
+        "python-debian": {
+          "version": "0.1.21+nmu2ubuntu2",
+          "arch": "all"
+        },
+        "python-gdbm": {
+          "version": "2.7.5-1ubuntu1",
+          "arch": "amd64"
+        },
+        "python-json-pointer": {
+          "version": "1.0-2build1",
+          "arch": "all"
+        },
+        "python-jsonpatch": {
+          "version": "1.3-4",
+          "arch": "all"
+        },
+        "python-minimal": {
+          "version": "2.7.5-5ubuntu3",
+          "arch": "amd64"
+        },
+        "python-oauth": {
+          "version": "1.0.1-3build2",
+          "arch": "all"
+        },
+        "python-openssl": {
+          "version": "0.13-2ubuntu6",
+          "arch": "amd64"
+        },
+        "python-pam": {
+          "version": "0.4.2-13.1ubuntu3",
+          "arch": "amd64"
+        },
+        "python-pkg-resources": {
+          "version": "3.3-1ubuntu1",
+          "arch": "all"
+        },
+        "python-prettytable": {
+          "version": "0.7.2-2ubuntu2",
+          "arch": "all"
+        },
+        "python-pycurl": {
+          "version": "7.19.3-0ubuntu3",
+          "arch": "amd64"
+        },
+        "python-requests": {
+          "version": "2.2.1-1ubuntu0.2",
+          "arch": "all"
+        },
+        "python-serial": {
+          "version": "2.6-1build1",
+          "arch": "all"
+        },
+        "python-six": {
+          "version": "1.5.2-1",
+          "arch": "all"
+        },
+        "python-twisted-bin": {
+          "version": "13.2.0-1ubuntu1",
+          "arch": "amd64"
+        },
+        "python-twisted-core": {
+          "version": "13.2.0-1ubuntu1",
+          "arch": "all"
+        },
+        "python-twisted-names": {
+          "version": "13.2.0-1ubuntu1",
+          "arch": "all"
+        },
+        "python-twisted-web": {
+          "version": "13.2.0-1ubuntu1",
+          "arch": "all"
+        },
+        "python-urllib3": {
+          "version": "1.7.1-1ubuntu3",
+          "arch": "all"
+        },
+        "python-xapian": {
+          "version": "1.2.16-2ubuntu1",
+          "arch": "amd64"
+        },
+        "python-yaml": {
+          "version": "3.10-4ubuntu0.1",
+          "arch": "amd64"
+        },
+        "python-zope.interface": {
+          "version": "4.0.5-1ubuntu4",
+          "arch": "amd64"
+        },
+        "python2.7": {
+          "version": "2.7.6-8",
+          "arch": "amd64"
+        },
+        "python2.7-minimal": {
+          "version": "2.7.6-8",
+          "arch": "amd64"
+        },
+        "python3": {
+          "version": "3.4.0-0ubuntu2",
+          "arch": "amd64"
+        },
+        "python3-apport": {
+          "version": "2.14.1-0ubuntu3.11",
+          "arch": "all"
+        },
+        "python3-apt": {
+          "version": "0.9.3.5ubuntu1",
+          "arch": "amd64"
+        },
+        "python3-chardet": {
+          "version": "2.2.1-2~ubuntu1",
+          "arch": "all"
+        },
+        "python3-commandnotfound": {
+          "version": "0.3ubuntu12",
+          "arch": "all"
+        },
+        "python3-dbus": {
+          "version": "1.2.0-2build2",
+          "arch": "amd64"
+        },
+        "python3-debian": {
+          "version": "0.1.21+nmu2ubuntu2",
+          "arch": "all"
+        },
+        "python3-distupgrade": {
+          "version": "1:0.220.7",
+          "arch": "all"
+        },
+        "python3-gdbm": {
+          "version": "3.4.0-0ubuntu1",
+          "arch": "amd64"
+        },
+        "python3-gi": {
+          "version": "3.12.0-1ubuntu1",
+          "arch": "amd64"
+        },
+        "python3-magic": {
+          "version": "1:5.14-2ubuntu3.3",
+          "arch": "all"
+        },
+        "python3-minimal": {
+          "version": "3.4.0-0ubuntu2",
+          "arch": "amd64"
+        },
+        "python3-newt": {
+          "version": "0.52.15-2ubuntu5",
+          "arch": "amd64"
+        },
+        "python3-pkg-resources": {
+          "version": "3.3-1ubuntu2",
+          "arch": "all"
+        },
+        "python3-problem-report": {
+          "version": "2.14.1-0ubuntu3.11",
+          "arch": "all"
+        },
+        "python3-pycurl": {
+          "version": "7.19.3-0ubuntu3",
+          "arch": "amd64"
+        },
+        "python3-six": {
+          "version": "1.5.2-1ubuntu1",
+          "arch": "all"
+        },
+        "python3-software-properties": {
+          "version": "0.92.37.3",
+          "arch": "all"
+        },
+        "python3-update-manager": {
+          "version": "1:0.196.13",
+          "arch": "all"
+        },
+        "python3.4": {
+          "version": "3.4.0-2ubuntu1",
+          "arch": "amd64"
+        },
+        "python3.4-minimal": {
+          "version": "3.4.0-2ubuntu1",
+          "arch": "amd64"
+        },
+        "readline-common": {
+          "version": "6.3-4ubuntu2",
+          "arch": "all"
+        },
+        "resolvconf": {
+          "version": "1.69ubuntu1.1",
+          "arch": "all"
+        },
+        "rsync": {
+          "version": "3.1.0-2ubuntu0.1",
+          "arch": "amd64"
+        },
+        "rsyslog": {
+          "version": "7.4.4-1ubuntu2.6",
+          "arch": "amd64"
+        },
+        "run-one": {
+          "version": "1.17-0ubuntu1",
+          "arch": "all"
+        },
+        "screen": {
+          "version": "4.1.0~20120320gitdb59704-9",
+          "arch": "amd64"
+        },
+        "sed": {
+          "version": "4.2.2-4ubuntu1",
+          "arch": "amd64"
+        },
+        "sensible-utils": {
+          "version": "0.0.9",
+          "arch": "all"
+        },
+        "sgml-base": {
+          "version": "1.26+nmu4ubuntu1",
+          "arch": "all"
+        },
+        "shared-mime-info": {
+          "version": "1.2-0ubuntu3",
+          "arch": "amd64"
+        },
+        "software-properties-common": {
+          "version": "0.92.37.3",
+          "arch": "all"
+        },
+        "ssh-import-id": {
+          "version": "3.21-0ubuntu1",
+          "arch": "all"
+        },
+        "strace": {
+          "version": "4.8-1ubuntu5",
+          "arch": "amd64"
+        },
+        "sudo": {
+          "version": "1.8.9p5-1ubuntu1.1",
+          "arch": "amd64"
+        },
+        "systemd-services": {
+          "version": "204-5ubuntu20.12",
+          "arch": "amd64"
+        },
+        "systemd-shim": {
+          "version": "6-2bzr1",
+          "arch": "amd64"
+        },
+        "sysv-rc": {
+          "version": "2.88dsf-41ubuntu6.1",
+          "arch": "all"
+        },
+        "sysvinit-utils": {
+          "version": "2.88dsf-41ubuntu6.1",
+          "arch": "amd64"
+        },
+        "t1utils": {
+          "version": "1.37-2ubuntu1.1",
+          "arch": "amd64"
+        },
+        "tar": {
+          "version": "1.27.1-1",
+          "arch": "amd64"
+        },
+        "tasksel": {
+          "version": "2.88ubuntu15",
+          "arch": "all"
+        },
+        "tasksel-data": {
+          "version": "2.88ubuntu15",
+          "arch": "all"
+        },
+        "tcpd": {
+          "version": "7.6.q-25",
+          "arch": "amd64"
+        },
+        "tcpdump": {
+          "version": "4.5.1-2ubuntu1.2",
+          "arch": "amd64"
+        },
+        "telnet": {
+          "version": "0.17-36build2",
+          "arch": "amd64"
+        },
+        "time": {
+          "version": "1.7-24",
+          "arch": "amd64"
+        },
+        "tmux": {
+          "version": "1.8-5",
+          "arch": "amd64"
+        },
+        "tzdata": {
+          "version": "2016j-0ubuntu0.14.04",
+          "arch": "all"
+        },
+        "tzdata-java": {
+          "version": "2016j-0ubuntu0.14.04",
+          "arch": "all"
+        },
+        "ubuntu-keyring": {
+          "version": "2012.05.19",
+          "arch": "all"
+        },
+        "ubuntu-minimal": {
+          "version": "1.325",
+          "arch": "amd64"
+        },
+        "ubuntu-release-upgrader-core": {
+          "version": "1:0.220.7",
+          "arch": "all"
+        },
+        "ubuntu-standard": {
+          "version": "1.325",
+          "arch": "amd64"
+        },
+        "ucf": {
+          "version": "3.0027+nmu1",
+          "arch": "all"
+        },
+        "udev": {
+          "version": "204-5ubuntu20.12",
+          "arch": "amd64"
+        },
+        "ufw": {
+          "version": "0.34~rc-0ubuntu2",
+          "arch": "all"
+        },
+        "unattended-upgrades": {
+          "version": "0.82.1ubuntu2.2",
+          "arch": "all"
+        },
+        "unzip": {
+          "version": "6.0-9ubuntu1.5",
+          "arch": "amd64"
+        },
+        "update-manager-core": {
+          "version": "1:0.196.13",
+          "arch": "all"
+        },
+        "update-notifier-common": {
+          "version": "0.154.1ubuntu1",
+          "arch": "all"
+        },
+        "upstart": {
+          "version": "1.12.1-0ubuntu4.2",
+          "arch": "amd64"
+        },
+        "ureadahead": {
+          "version": "0.100.0-16",
+          "arch": "amd64"
+        },
+        "usbutils": {
+          "version": "1:007-2ubuntu1",
+          "arch": "amd64"
+        },
+        "util-linux": {
+          "version": "2.20.1-5.1ubuntu20.4",
+          "arch": "amd64"
+        },
+        "uuid-runtime": {
+          "version": "2.20.1-5.1ubuntu20.4",
+          "arch": "amd64"
+        },
+        "vim": {
+          "version": "2:7.4.052-1ubuntu3",
+          "arch": "amd64"
+        },
+        "vim-common": {
+          "version": "2:7.4.052-1ubuntu3",
+          "arch": "amd64"
+        },
+        "vim-runtime": {
+          "version": "2:7.4.052-1ubuntu3",
+          "arch": "all"
+        },
+        "vim-tiny": {
+          "version": "2:7.4.052-1ubuntu3",
+          "arch": "amd64"
+        },
+        "w3m": {
+          "version": "0.5.3-15",
+          "arch": "amd64"
+        },
+        "wdiff": {
+          "version": "1.2.1-2",
+          "arch": "amd64"
+        },
+        "wget": {
+          "version": "1.15-1ubuntu1.14.04.1",
+          "arch": "amd64"
+        },
+        "whiptail": {
+          "version": "0.52.15-2ubuntu5",
+          "arch": "amd64"
+        },
+        "x11-common": {
+          "version": "1:7.7+1ubuntu8.1",
+          "arch": "all"
+        },
+        "x11proto-core-dev": {
+          "version": "7.0.26-1~ubuntu2",
+          "arch": "all"
+        },
+        "x11proto-input-dev": {
+          "version": "2.3-1",
+          "arch": "all"
+        },
+        "x11proto-kb-dev": {
+          "version": "1.0.6-2",
+          "arch": "all"
+        },
+        "xauth": {
+          "version": "1:1.0.7-1ubuntu1",
+          "arch": "amd64"
+        },
+        "xkb-data": {
+          "version": "2.10.1-1ubuntu1",
+          "arch": "all"
+        },
+        "xml-core": {
+          "version": "0.13+nmu2",
+          "arch": "all"
+        },
+        "xorg-sgml-doctools": {
+          "version": "1:1.11-1",
+          "arch": "all"
+        },
+        "xtrans-dev": {
+          "version": "1.3.5-1~ubuntu14.04.1",
+          "arch": "all"
+        },
+        "xz-utils": {
+          "version": "5.1.1alpha+20120614-2ubuntu2",
+          "arch": "amd64"
+        },
+        "zerofree": {
+          "version": "1.0.2-1ubuntu1",
+          "arch": "amd64"
+        },
+        "zlib1g": {
+          "version": "1:1.2.8.dfsg-1ubuntu1",
+          "arch": "amd64"
+        },
+        "zlib1g-dev": {
+          "version": "1:1.2.8.dfsg-1ubuntu1",
+          "arch": "amd64"
+        }
+      },
+      "dmi": {
+        "dmidecode_version": "2.12",
+        "smbios_version": "2.4",
+        "structures": {
+          "count": "12",
+          "size": "349"
+        },
+        "bios": {
+          "all_records": [
+            {
+              "record_id": "0x0000",
+              "size": "0",
+              "application_identifier": "BIOS Information",
+              "Vendor": "Xen",
+              "Version": "4.2.amazon",
+              "Release Date": "02/16/2017",
+              "Address": "0xE8000",
+              "Runtime Size": "96 kB",
+              "ROM Size": "64 kB",
+              "Characteristics": {
+                "PCI is supported": null,
+                "EDD is supported": null,
+                "Targeted content distribution is supported": null
+              },
+              "BIOS Revision": "4.2"
+            }
+          ],
+          "vendor": "Xen",
+          "version": "4.2.amazon",
+          "release_date": "02/16/2017",
+          "address": "0xE8000",
+          "runtime_size": "96 kB",
+          "rom_size": "64 kB",
+          "bios_revision": "4.2"
+        },
+        "system": {
+          "all_records": [
+            {
+              "record_id": "0x0100",
+              "size": "1",
+              "application_identifier": "System Information",
+              "Manufacturer": "Xen",
+              "Product Name": "HVM domU",
+              "Version": "4.2.amazon",
+              "Serial Number": "ec29f07b-2d72-b7f2-e8cd-b11c3a70b895",
+              "UUID": "EC29F07B-2D72-B7F2-E8CD-B11C3A70B895",
+              "Wake-up Type": "Power Switch",
+              "SKU Number": "Not Specified",
+              "Family": "Not Specified"
+            }
+          ],
+          "manufacturer": "Xen",
+          "product_name": "HVM domU",
+          "version": "4.2.amazon",
+          "serial_number": "ec29f07b-2d72-b7f2-e8cd-b11c3a70b895",
+          "uuid": "EC29F07B-2D72-B7F2-E8CD-B11C3A70B895",
+          "wake_up_type": "Power Switch",
+          "sku_number": "Not Specified",
+          "family": "Not Specified"
+        },
+        "chassis": {
+          "all_records": [
+            {
+              "record_id": "0x0300",
+              "size": "3",
+              "application_identifier": "Chassis Information",
+              "Manufacturer": "Xen",
+              "Type": "Other",
+              "Lock": "Not Present",
+              "Version": "Not Specified",
+              "Serial Number": "Not Specified",
+              "Asset Tag": "Not Specified",
+              "Boot-up State": "Safe",
+              "Power Supply State": "Safe",
+              "Thermal State": "Safe",
+              "Security Status": "Unknown"
+            }
+          ],
+          "manufacturer": "Xen",
+          "type": "Other",
+          "lock": "Not Present",
+          "version": "Not Specified",
+          "serial_number": "Not Specified",
+          "asset_tag": "Not Specified",
+          "boot_up_state": "Safe",
+          "power_supply_state": "Safe",
+          "thermal_state": "Safe",
+          "security_status": "Unknown"
+        },
+        "processor": {
+          "all_records": [
+            {
+              "record_id": "0x0401",
+              "size": "4",
+              "application_identifier": "Processor Information",
+              "Socket Designation": "CPU 1",
+              "Type": "Central Processor",
+              "Family": "Other",
+              "Manufacturer": "Intel",
+              "ID": "F2 06 03 00 FF FB 89 17",
+              "Version": "Not Specified",
+              "Voltage": "Unknown",
+              "External Clock": "Unknown",
+              "Max Speed": "2400 MHz",
+              "Current Speed": "2400 MHz",
+              "Status": "Populated, Enabled",
+              "Upgrade": "Other"
+            },
+            {
+              "record_id": "0x0402",
+              "size": "4",
+              "application_identifier": "Processor Information",
+              "Socket Designation": "CPU 2",
+              "Type": "Central Processor",
+              "Family": "Other",
+              "Manufacturer": "Intel",
+              "ID": "F2 06 03 00 FF FB 89 17",
+              "Version": "Not Specified",
+              "Voltage": "Unknown",
+              "External Clock": "Unknown",
+              "Max Speed": "2400 MHz",
+              "Current Speed": "2400 MHz",
+              "Status": "Populated, Enabled",
+              "Upgrade": "Other"
+            }
+          ],
+          "type": "Central Processor",
+          "family": "Other",
+          "manufacturer": "Intel",
+          "id": "F2 06 03 00 FF FB 89 17",
+          "version": "Not Specified",
+          "voltage": "Unknown",
+          "external_clock": "Unknown",
+          "max_speed": "2400 MHz",
+          "current_speed": "2400 MHz",
+          "status": "Populated, Enabled",
+          "upgrade": "Other"
+        },
+        "oem_strings": {
+          "all_records": [
+            {
+              "record_id": "0x0B00",
+              "size": "11",
+              "application_identifier": "OEM Strings",
+              "String 1": "Xen"
+            }
+          ],
+          "string_1": "Xen"
+        }
+      },
+      "etc": {
+      },
+      "current_user": "root",
+      "keys": {
+      },
+      "init_package": "init",
+      "chef_packages": {
+        "chef": {
+          "version": "12.21.3",
+          "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib"
+        },
+        "ohai": {
+          "version": "8.24.0",
+          "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.3.0/gems/ohai-8.24.0/lib/ohai"
+        }
+      },
+      "sysconf": {
+        "LINK_MAX": 65000,
+        "_POSIX_LINK_MAX": 65000,
+        "MAX_CANON": 255,
+        "_POSIX_MAX_CANON": 255,
+        "MAX_INPUT": 255,
+        "_POSIX_MAX_INPUT": 255,
+        "NAME_MAX": 255,
+        "_POSIX_NAME_MAX": 255,
+        "PATH_MAX": 4096,
+        "_POSIX_PATH_MAX": 4096,
+        "PIPE_BUF": 4096,
+        "_POSIX_PIPE_BUF": 4096,
+        "SOCK_MAXBUF": null,
+        "_POSIX_ASYNC_IO": null,
+        "_POSIX_CHOWN_RESTRICTED": 1,
+        "_POSIX_NO_TRUNC": 1,
+        "_POSIX_PRIO_IO": null,
+        "_POSIX_SYNC_IO": null,
+        "_POSIX_VDISABLE": 0,
+        "ARG_MAX": 2097152,
+        "ATEXIT_MAX": 2147483647,
+        "CHAR_BIT": 8,
+        "CHAR_MAX": 127,
+        "CHAR_MIN": -128,
+        "CHILD_MAX": 31538,
+        "CLK_TCK": 100,
+        "INT_MAX": 2147483647,
+        "INT_MIN": -2147483648,
+        "IOV_MAX": 1024,
+        "LOGNAME_MAX": 256,
+        "LONG_BIT": 64,
+        "MB_LEN_MAX": 16,
+        "NGROUPS_MAX": 65536,
+        "NL_ARGMAX": 4096,
+        "NL_LANGMAX": 2048,
+        "NL_MSGMAX": 2147483647,
+        "NL_NMAX": 2147483647,
+        "NL_SETMAX": 2147483647,
+        "NL_TEXTMAX": 2147483647,
+        "NSS_BUFLEN_GROUP": 1024,
+        "NSS_BUFLEN_PASSWD": 1024,
+        "NZERO": 20,
+        "OPEN_MAX": 1024,
+        "PAGESIZE": 4096,
+        "PAGE_SIZE": 4096,
+        "PASS_MAX": 8192,
+        "PTHREAD_DESTRUCTOR_ITERATIONS": 4,
+        "PTHREAD_KEYS_MAX": 1024,
+        "PTHREAD_STACK_MIN": 16384,
+        "PTHREAD_THREADS_MAX": null,
+        "SCHAR_MAX": 127,
+        "SCHAR_MIN": -128,
+        "SHRT_MAX": 32767,
+        "SHRT_MIN": -32768,
+        "SSIZE_MAX": 32767,
+        "TTY_NAME_MAX": 32,
+        "TZNAME_MAX": 6,
+        "UCHAR_MAX": 255,
+        "UINT_MAX": 4294967295,
+        "UIO_MAXIOV": 1024,
+        "ULONG_MAX": 18446744073709551615,
+        "USHRT_MAX": 65535,
+        "WORD_BIT": 32,
+        "_AVPHYS_PAGES": 286469,
+        "_NPROCESSORS_CONF": 2,
+        "_NPROCESSORS_ONLN": 2,
+        "_PHYS_PAGES": 1011722,
+        "_POSIX_ARG_MAX": 2097152,
+        "_POSIX_ASYNCHRONOUS_IO": 200809,
+        "_POSIX_CHILD_MAX": 31538,
+        "_POSIX_FSYNC": 200809,
+        "_POSIX_JOB_CONTROL": 1,
+        "_POSIX_MAPPED_FILES": 200809,
+        "_POSIX_MEMLOCK": 200809,
+        "_POSIX_MEMLOCK_RANGE": 200809,
+        "_POSIX_MEMORY_PROTECTION": 200809,
+        "_POSIX_MESSAGE_PASSING": 200809,
+        "_POSIX_NGROUPS_MAX": 65536,
+        "_POSIX_OPEN_MAX": 1024,
+        "_POSIX_PII": null,
+        "_POSIX_PII_INTERNET": null,
+        "_POSIX_PII_INTERNET_DGRAM": null,
+        "_POSIX_PII_INTERNET_STREAM": null,
+        "_POSIX_PII_OSI": null,
+        "_POSIX_PII_OSI_CLTS": null,
+        "_POSIX_PII_OSI_COTS": null,
+        "_POSIX_PII_OSI_M": null,
+        "_POSIX_PII_SOCKET": null,
+        "_POSIX_PII_XTI": null,
+        "_POSIX_POLL": null,
+        "_POSIX_PRIORITIZED_IO": 200809,
+        "_POSIX_PRIORITY_SCHEDULING": 200809,
+        "_POSIX_REALTIME_SIGNALS": 200809,
+        "_POSIX_SAVED_IDS": 1,
+        "_POSIX_SELECT": null,
+        "_POSIX_SEMAPHORES": 200809,
+        "_POSIX_SHARED_MEMORY_OBJECTS": 200809,
+        "_POSIX_SSIZE_MAX": 32767,
+        "_POSIX_STREAM_MAX": 16,
+        "_POSIX_SYNCHRONIZED_IO": 200809,
+        "_POSIX_THREADS": 200809,
+        "_POSIX_THREAD_ATTR_STACKADDR": 200809,
+        "_POSIX_THREAD_ATTR_STACKSIZE": 200809,
+        "_POSIX_THREAD_PRIORITY_SCHEDULING": 200809,
+        "_POSIX_THREAD_PRIO_INHERIT": 200809,
+        "_POSIX_THREAD_PRIO_PROTECT": 200809,
+        "_POSIX_THREAD_ROBUST_PRIO_INHERIT": null,
+        "_POSIX_THREAD_ROBUST_PRIO_PROTECT": null,
+        "_POSIX_THREAD_PROCESS_SHARED": 200809,
+        "_POSIX_THREAD_SAFE_FUNCTIONS": 200809,
+        "_POSIX_TIMERS": 200809,
+        "TIMER_MAX": null,
+        "_POSIX_TZNAME_MAX": 6,
+        "_POSIX_VERSION": 200809,
+        "_T_IOV_MAX": null,
+        "_XOPEN_CRYPT": 1,
+        "_XOPEN_ENH_I18N": 1,
+        "_XOPEN_LEGACY": 1,
+        "_XOPEN_REALTIME": 1,
+        "_XOPEN_REALTIME_THREADS": 1,
+        "_XOPEN_SHM": 1,
+        "_XOPEN_UNIX": 1,
+        "_XOPEN_VERSION": 700,
+        "_XOPEN_XCU_VERSION": 4,
+        "_XOPEN_XPG2": 1,
+        "_XOPEN_XPG3": 1,
+        "_XOPEN_XPG4": 1,
+        "BC_BASE_MAX": 99,
+        "BC_DIM_MAX": 2048,
+        "BC_SCALE_MAX": 99,
+        "BC_STRING_MAX": 1000,
+        "CHARCLASS_NAME_MAX": 2048,
+        "COLL_WEIGHTS_MAX": 255,
+        "EQUIV_CLASS_MAX": null,
+        "EXPR_NEST_MAX": 32,
+        "LINE_MAX": 2048,
+        "POSIX2_BC_BASE_MAX": 99,
+        "POSIX2_BC_DIM_MAX": 2048,
+        "POSIX2_BC_SCALE_MAX": 99,
+        "POSIX2_BC_STRING_MAX": 1000,
+        "POSIX2_CHAR_TERM": 200809,
+        "POSIX2_COLL_WEIGHTS_MAX": 255,
+        "POSIX2_C_BIND": 200809,
+        "POSIX2_C_DEV": 200809,
+        "POSIX2_C_VERSION": null,
+        "POSIX2_EXPR_NEST_MAX": 32,
+        "POSIX2_FORT_DEV": null,
+        "POSIX2_FORT_RUN": null,
+        "_POSIX2_LINE_MAX": 2048,
+        "POSIX2_LINE_MAX": 2048,
+        "POSIX2_LOCALEDEF": 200809,
+        "POSIX2_RE_DUP_MAX": 32767,
+        "POSIX2_SW_DEV": 200809,
+        "POSIX2_UPE": null,
+        "POSIX2_VERSION": 200809,
+        "RE_DUP_MAX": 32767,
+        "PATH": "/bin:/usr/bin",
+        "CS_PATH": "/bin:/usr/bin",
+        "LFS_CFLAGS": null,
+        "LFS_LDFLAGS": null,
+        "LFS_LIBS": null,
+        "LFS_LINTFLAGS": null,
+        "LFS64_CFLAGS": "-D_LARGEFILE64_SOURCE",
+        "LFS64_LDFLAGS": null,
+        "LFS64_LIBS": null,
+        "LFS64_LINTFLAGS": "-D_LARGEFILE64_SOURCE",
+        "_XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+        "XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+        "_XBS5_ILP32_OFF32": null,
+        "XBS5_ILP32_OFF32_CFLAGS": null,
+        "XBS5_ILP32_OFF32_LDFLAGS": null,
+        "XBS5_ILP32_OFF32_LIBS": null,
+        "XBS5_ILP32_OFF32_LINTFLAGS": null,
+        "_XBS5_ILP32_OFFBIG": null,
+        "XBS5_ILP32_OFFBIG_CFLAGS": null,
+        "XBS5_ILP32_OFFBIG_LDFLAGS": null,
+        "XBS5_ILP32_OFFBIG_LIBS": null,
+        "XBS5_ILP32_OFFBIG_LINTFLAGS": null,
+        "_XBS5_LP64_OFF64": 1,
+        "XBS5_LP64_OFF64_CFLAGS": "-m64",
+        "XBS5_LP64_OFF64_LDFLAGS": "-m64",
+        "XBS5_LP64_OFF64_LIBS": null,
+        "XBS5_LP64_OFF64_LINTFLAGS": null,
+        "_XBS5_LPBIG_OFFBIG": null,
+        "XBS5_LPBIG_OFFBIG_CFLAGS": null,
+        "XBS5_LPBIG_OFFBIG_LDFLAGS": null,
+        "XBS5_LPBIG_OFFBIG_LIBS": null,
+        "XBS5_LPBIG_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V6_ILP32_OFF32": null,
+        "POSIX_V6_ILP32_OFF32_CFLAGS": null,
+        "POSIX_V6_ILP32_OFF32_LDFLAGS": null,
+        "POSIX_V6_ILP32_OFF32_LIBS": null,
+        "POSIX_V6_ILP32_OFF32_LINTFLAGS": null,
+        "_POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+        "POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+        "_POSIX_V6_ILP32_OFFBIG": null,
+        "POSIX_V6_ILP32_OFFBIG_CFLAGS": null,
+        "POSIX_V6_ILP32_OFFBIG_LDFLAGS": null,
+        "POSIX_V6_ILP32_OFFBIG_LIBS": null,
+        "POSIX_V6_ILP32_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V6_LP64_OFF64": 1,
+        "POSIX_V6_LP64_OFF64_CFLAGS": "-m64",
+        "POSIX_V6_LP64_OFF64_LDFLAGS": "-m64",
+        "POSIX_V6_LP64_OFF64_LIBS": null,
+        "POSIX_V6_LP64_OFF64_LINTFLAGS": null,
+        "_POSIX_V6_LPBIG_OFFBIG": null,
+        "POSIX_V6_LPBIG_OFFBIG_CFLAGS": null,
+        "POSIX_V6_LPBIG_OFFBIG_LDFLAGS": null,
+        "POSIX_V6_LPBIG_OFFBIG_LIBS": null,
+        "POSIX_V6_LPBIG_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V7_ILP32_OFF32": null,
+        "POSIX_V7_ILP32_OFF32_CFLAGS": null,
+        "POSIX_V7_ILP32_OFF32_LDFLAGS": null,
+        "POSIX_V7_ILP32_OFF32_LIBS": null,
+        "POSIX_V7_ILP32_OFF32_LINTFLAGS": null,
+        "_POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+        "POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+        "_POSIX_V7_ILP32_OFFBIG": null,
+        "POSIX_V7_ILP32_OFFBIG_CFLAGS": null,
+        "POSIX_V7_ILP32_OFFBIG_LDFLAGS": null,
+        "POSIX_V7_ILP32_OFFBIG_LIBS": null,
+        "POSIX_V7_ILP32_OFFBIG_LINTFLAGS": null,
+        "_POSIX_V7_LP64_OFF64": 1,
+        "POSIX_V7_LP64_OFF64_CFLAGS": "-m64",
+        "POSIX_V7_LP64_OFF64_LDFLAGS": "-m64",
+        "POSIX_V7_LP64_OFF64_LIBS": null,
+        "POSIX_V7_LP64_OFF64_LINTFLAGS": null,
+        "_POSIX_V7_LPBIG_OFFBIG": null,
+        "POSIX_V7_LPBIG_OFFBIG_CFLAGS": null,
+        "POSIX_V7_LPBIG_OFFBIG_LDFLAGS": null,
+        "POSIX_V7_LPBIG_OFFBIG_LIBS": null,
+        "POSIX_V7_LPBIG_OFFBIG_LINTFLAGS": null,
+        "_POSIX_ADVISORY_INFO": 200809,
+        "_POSIX_BARRIERS": 200809,
+        "_POSIX_BASE": null,
+        "_POSIX_C_LANG_SUPPORT": null,
+        "_POSIX_C_LANG_SUPPORT_R": null,
+        "_POSIX_CLOCK_SELECTION": 200809,
+        "_POSIX_CPUTIME": 200809,
+        "_POSIX_THREAD_CPUTIME": 200809,
+        "_POSIX_DEVICE_SPECIFIC": null,
+        "_POSIX_DEVICE_SPECIFIC_R": null,
+        "_POSIX_FD_MGMT": null,
+        "_POSIX_FIFO": null,
+        "_POSIX_PIPE": null,
+        "_POSIX_FILE_ATTRIBUTES": null,
+        "_POSIX_FILE_LOCKING": null,
+        "_POSIX_FILE_SYSTEM": null,
+        "_POSIX_MONOTONIC_CLOCK": 200809,
+        "_POSIX_MULTI_PROCESS": null,
+        "_POSIX_SINGLE_PROCESS": null,
+        "_POSIX_NETWORKING": null,
+        "_POSIX_READER_WRITER_LOCKS": 200809,
+        "_POSIX_SPIN_LOCKS": 200809,
+        "_POSIX_REGEXP": 1,
+        "_REGEX_VERSION": null,
+        "_POSIX_SHELL": 1,
+        "_POSIX_SIGNALS": null,
+        "_POSIX_SPAWN": 200809,
+        "_POSIX_SPORADIC_SERVER": null,
+        "_POSIX_THREAD_SPORADIC_SERVER": null,
+        "_POSIX_SYSTEM_DATABASE": null,
+        "_POSIX_SYSTEM_DATABASE_R": null,
+        "_POSIX_TIMEOUTS": 200809,
+        "_POSIX_TYPED_MEMORY_OBJECTS": null,
+        "_POSIX_USER_GROUPS": null,
+        "_POSIX_USER_GROUPS_R": null,
+        "POSIX2_PBS": null,
+        "POSIX2_PBS_ACCOUNTING": null,
+        "POSIX2_PBS_LOCATE": null,
+        "POSIX2_PBS_TRACK": null,
+        "POSIX2_PBS_MESSAGE": null,
+        "SYMLOOP_MAX": null,
+        "STREAM_MAX": 16,
+        "AIO_LISTIO_MAX": null,
+        "AIO_MAX": null,
+        "AIO_PRIO_DELTA_MAX": 20,
+        "DELAYTIMER_MAX": 2147483647,
+        "HOST_NAME_MAX": 64,
+        "LOGIN_NAME_MAX": 256,
+        "MQ_OPEN_MAX": null,
+        "MQ_PRIO_MAX": 32768,
+        "_POSIX_DEVICE_IO": null,
+        "_POSIX_TRACE": null,
+        "_POSIX_TRACE_EVENT_FILTER": null,
+        "_POSIX_TRACE_INHERIT": null,
+        "_POSIX_TRACE_LOG": null,
+        "RTSIG_MAX": 32,
+        "SEM_NSEMS_MAX": null,
+        "SEM_VALUE_MAX": 2147483647,
+        "SIGQUEUE_MAX": 31538,
+        "FILESIZEBITS": 64,
+        "POSIX_ALLOC_SIZE_MIN": 4096,
+        "POSIX_REC_INCR_XFER_SIZE": null,
+        "POSIX_REC_MAX_XFER_SIZE": null,
+        "POSIX_REC_MIN_XFER_SIZE": 4096,
+        "POSIX_REC_XFER_ALIGN": 4096,
+        "SYMLINK_MAX": null,
+        "GNU_LIBC_VERSION": "glibc 2.19",
+        "GNU_LIBPTHREAD_VERSION": "NPTL 2.19",
+        "POSIX2_SYMLINKS": 1,
+        "LEVEL1_ICACHE_SIZE": 32768,
+        "LEVEL1_ICACHE_ASSOC": 8,
+        "LEVEL1_ICACHE_LINESIZE": 64,
+        "LEVEL1_DCACHE_SIZE": 32768,
+        "LEVEL1_DCACHE_ASSOC": 8,
+        "LEVEL1_DCACHE_LINESIZE": 64,
+        "LEVEL2_CACHE_SIZE": 262144,
+        "LEVEL2_CACHE_ASSOC": 8,
+        "LEVEL2_CACHE_LINESIZE": 64,
+        "LEVEL3_CACHE_SIZE": 31457280,
+        "LEVEL3_CACHE_ASSOC": 20,
+        "LEVEL3_CACHE_LINESIZE": 64,
+        "LEVEL4_CACHE_SIZE": 0,
+        "LEVEL4_CACHE_ASSOC": 0,
+        "LEVEL4_CACHE_LINESIZE": 0,
+        "IPV6": 200809,
+        "RAW_SOCKETS": 200809
+      },
+      "hostname": "ip-196-140-227-170",
+      "machinename": "ip-196-140-227-170",
+      "fqdn": "ip-196-140-227-170.us-west-2.compute.internal",
+      "domain": "us-west-2.compute.internal",
+      "shard_seed": 243270578,
+      "shells": [
+        "/bin/sh",
+        "/bin/dash",
+        "/bin/bash",
+        "/bin/rbash",
+        "/usr/bin/tmux",
+        "/usr/bin/screen"
+      ],
+      "command": {
+        "ps": "ps -ef"
+      },
+      "root_group": "root",
+      "time": {
+        "timezone": "UTC"
+      },
+      "ec2": {
+        "ami_id": "ami-7f675e4f",
+        "ami_launch_index": "0",
+        "ami_manifest_path": "(unknown)",
+        "block_device_mapping_ami": "/dev/sda1",
+        "block_device_mapping_ephemeral0": "sdb",
+        "block_device_mapping_ephemeral1": "sdc",
+        "block_device_mapping_root": "/dev/sda1",
+        "hostname": "ip-196-140-227-170.us-west-2.compute.internal",
+        "instance_action": "none",
+        "instance_id": "i-0fc25da3017a6ce33",
+        "instance_type": "t2.medium",
+        "local_hostname": "ip-196-140-227-170.us-west-2.compute.internal",
+        "local_ipv4": "196.140.227.170",
+        "mac": "02:24:af:c6:71:9e",
+        "metrics_vhostmd": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "network_interfaces_macs": {
+          "02:24:af:c6:71:9e": {
+            "device_number": "0",
+            "interface_id": "eni-b1c4459b",
+            "local_hostname": "ip-196-140-227-170.us-west-2.compute.internal",
+            "local_ipv4s": "196.140.227.170",
+            "mac": "02:24:af:c6:71:9e",
+            "owner_id": "999999999999",
+            "security_group_ids": "sg-96274af3",
+            "security_groups": "default",
+            "subnet_id": "subnet-19ac017c",
+            "subnet_ipv4_cidr_block": "196.140.8.0/21",
+            "vpc_id": "vpc-2229ff47",
+            "vpc_ipv4_cidr_block": "196.140.0.0/16",
+            "vpc_ipv4_cidr_blocks": "196.140.0.0/16"
+          }
+        },
+        "placement_availability_zone": "us-west-2a",
+        "profile": "default-hvm",
+        "reservation_id": "r-0f0683863de96271e",
+        "security_groups": [
+          "default"
+        ],
+        "services_domain": "amazonaws.com",
+        "services_partition": "aws",
+        "userdata": "#!/bin/sh\n\n# Ensure CA bundle is up-to-date\nsudo apt-get update\nsudo apt-get install ca-certificates -y\n",
+        "account_id": "999999999999",
+        "availability_zone": "us-west-2a",
+        "region": "us-west-2"
+      },
+      "json?": "{\n  \"devpayProductCodes\" : null,\n  \"privateIp\" : \"196.140.227.170\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"version\" : \"2010-08-31\",\n  \"instanceId\" : \"i-0fc25da3017a6ce33\",\n  \"billingProducts\" : null,\n  \"instanceType\" : \"t2.medium\",\n  \"accountId\" : \"999999999999\",\n  \"architecture\" : \"x86_64\",\n  \"kernelId\" : null,\n  \"ramdiskId\" : null,\n  \"imageId\" : \"ami-7f675e4f\",\n  \"pendingTime\" : \"2017-06-06T19:33:54Z\",\n  \"region\" : \"us-west-2\"\n}",
+      "cloud_v2": {
+        "local_ipv4_addrs": [
+          "196.140.227.170"
+        ],
+        "provider": "ec2",
+        "local_hostname": "ip-196-140-227-170.us-west-2.compute.internal",
+        "local_ipv4": "196.140.227.170"
+      },
+      "cloud": {
+        "public_ips": [
+          null
+        ],
+        "private_ips": [
+          "196.140.227.170"
+        ],
+        "public_ipv4": null,
+        "public_hostname": null,
+        "local_ipv4": "196.140.227.170",
+        "local_hostname": "ip-196-140-227-170.us-west-2.compute.internal",
+        "provider": "ec2"
+      },
+      "ohai_time": 1509570528.7704346,
+      "recipes": [
+        "opscode-ci::slave",
+        "opscode-ci::_build_support",
+        "chef-sugar::default",
+        "opscode-ci::_platform_tweaks",
+        "opscode-ci::_migration",
+        "omnibus::default",
+        "omnibus::_common",
+        "omnibus::_user",
+        "omnibus::_omnibus_toolchain",
+        "omnibus::_compile",
+        "build-essential::default",
+        "omnibus::_git",
+        "omnibus::_github",
+        "omnibus::_libffi",
+        "omnibus::_packaging",
+        "omnibus::_selinux",
+        "omnibus::_environment",
+        "opscode-ci::_github",
+        "opscode-ci::_ntp",
+        "ntp::default",
+        "ntp::apparmor",
+        "opscode-ci::_package_signing",
+        "opscode-ci::_rubygems",
+        "opscode-ci::_aws",
+        "opscode-ci::_users",
+        "opscode-ci::_sudo",
+        "sudo::default",
+        "opscode-ci::_java",
+        "aws::default",
+        "opscode-ci::_omnibus"
+      ],
+      "expanded_run_list": [
+        "opscode-ci::slave"
+      ],
+      "roles": [],
+      "cookbooks": {
+        "opscode-ci": {
+          "version": "5.15.127"
+        },
+        "apt": {
+          "version": "6.1.4"
+        },
+        "chef-sugar": {
+          "version": "3.4.0"
+        },
+        "freebsd": {
+          "version": "1.0.2"
+        },
+        "lvm": {
+          "version": "4.1.9"
+        },
+        "omnibus": {
+          "version": "5.2.2"
+        },
+        "build-essential": {
+          "version": "8.0.3"
+        },
+        "seven_zip": {
+          "version": "2.0.2"
+        },
+        "windows": {
+          "version": "2.0.2"
+        },
+        "mingw": {
+          "version": "2.0.1"
+        },
+        "chef-ingredient": {
+          "version": "2.1.10"
+        },
+        "git": {
+          "version": "6.1.0"
+        },
+        "dmg": {
+          "version": "4.0.0"
+        },
+        "yum-epel": {
+          "version": "2.1.2"
+        },
+        "compat_resource": {
+          "version": "12.19.0"
+        },
+        "homebrew": {
+          "version": "4.2.0"
+        },
+        "remote_install": {
+          "version": "1.0.2"
+        },
+        "wix": {
+          "version": "3.0.0"
+        },
+        "windows-sdk": {
+          "version": "1.0.2"
+        },
+        "ntp": {
+          "version": "3.5.2"
+        },
+        "route53": {
+          "version": "2.0.0"
+        },
+        "rsyslog": {
+          "version": "5.1.0"
+        },
+        "sudo": {
+          "version": "3.5.3"
+        },
+        "redhat_subscription_manager": {
+          "version": "0.6.0"
+        },
+        "aws": {
+          "version": "3.3.3"
+        },
+        "ohai": {
+          "version": "3.0.1"
+        },
+        "jenkins": {
+          "version": "2.6.0"
+        },
+        "runit": {
+          "version": "1.8.0"
+        },
+        "packagecloud": {
+          "version": "0.3.0"
+        },
+        "yum": {
+          "version": "3.13.0"
+        },
+        "chef_nginx": {
+          "version": "2.9.0"
+        },
+        "bluepill": {
+          "version": "3.0.0"
+        },
+        "zypper": {
+          "version": "0.4.0"
+        },
+        "rubygems": {
+          "version": "1.0.2"
+        }
+      }
+    },
+    "normal": {
+      "tags": [
+        "chefdk",
+        "slave",
+        "tester"
+      ],
+      "omnibus": {
+        "build_user": "jenkins",
+        "build_user_password": "$1$4PauyzMX$ew5qtMVnZG8SBGdwjxt/X1",
+        "build_user_group": "jenkins",
+        "build_user_home": "/home/jenkins",
+        "ruby_version": "2.1.8"
+      },
+      "authorization": {
+        "sudo": {
+          "sudoers_defaults": [
+            "exempt_group += jenkins",
+            "secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\""
+          ],
+          "agent_forwarding": true,
+          "include_sudoers_d": true
+        }
+      },
+      "jenkins": {
+        "master": {
+          "endpoint": "http://example.com"
+        }
+      }
+    },
+    "chef_type": "node",
+    "default": {
+      "apt": {
+        "cacher_dir": "/var/cache/apt-cacher-ng",
+        "cacher_interface": null,
+        "cacher_port": 3142,
+        "compiletime": false,
+        "compile_time_update": false,
+        "key_proxy": "",
+        "periodic_update_min_delay": 86400,
+        "launchpad_api_version": "1.0",
+        "unattended_upgrades": {
+          "enable": false,
+          "update_package_lists": true,
+          "allowed_origins": [
+            "Ubuntu trusty"
+          ],
+          "origins_patterns": [],
+          "package_blacklist": [],
+          "auto_fix_interrupted_dpkg": false,
+          "minimal_steps": false,
+          "install_on_shutdown": false,
+          "mail": null,
+          "mail_only_on_error": true,
+          "remove_unused_dependencies": false,
+          "automatic_reboot": false,
+          "automatic_reboot_time": "now",
+          "dl_limit": null,
+          "random_sleep": null
+        },
+        "cacher_client": {
+          "cacher_server": {}
+        },
+        "confd": {
+          "force_confask": false,
+          "force_confdef": false,
+          "force_confmiss": false,
+          "force_confnew": false,
+          "force_confold": false,
+          "install_recommends": true,
+          "install_suggests": false
+        }
+      },
+      "ohai": {
+        "plugin_path": "/etc/chef/ohai_plugins",
+        "plugins": {
+          "ohai": "plugins"
+        },
+        "hints_path": "/etc/chef/ohai/hints"
+      },
+      "aws": {
+        "aws_sdk_version": "~> 2.2",
+        "databag_name": null,
+        "databag_entry": null,
+        "mfa_code": null
+      },
+      "chef-ingredient": {
+        "mixlib-install": {
+          "git_ref": null
+        }
+      },
+      "rsyslog": {
+        "local_host_name": null,
+        "default_log_dir": "/var/log",
+        "log_dir": "/srv/rsyslog",
+        "working_dir": "/var/spool/rsyslog",
+        "server": false,
+        "use_relp": false,
+        "relp_port": 20514,
+        "protocol": "tcp",
+        "bind": "*",
+        "port": 514,
+        "server_ip": null,
+        "server_search": "role:loghost",
+        "remote_logs": true,
+        "per_host_dir": "%$YEAR%/%$MONTH%/%$DAY%/%HOSTNAME%",
+        "max_message_size": "2k",
+        "preserve_fqdn": "off",
+        "high_precision_timestamps": false,
+        "repeated_msg_reduction": "on",
+        "logs_to_forward": "*.*",
+        "enable_imklog": true,
+        "config_prefix": "/etc",
+        "default_file_template": null,
+        "default_remote_template": null,
+        "rate_limit_interval": null,
+        "rate_limit_burst": null,
+        "enable_tls": false,
+        "action_queue_max_disk_space": "1G",
+        "tls_ca_file": null,
+        "tls_certificate_file": null,
+        "tls_key_file": null,
+        "tls_auth_mode": "anon",
+        "tls_permitted_peer": null,
+        "use_local_ipv4": false,
+        "allow_non_local": false,
+        "custom_remote": [],
+        "additional_directives": {},
+        "templates": [],
+        "service_name": "rsyslog",
+        "user": "syslog",
+        "group": "adm",
+        "priv_seperation": true,
+        "priv_user": null,
+        "priv_group": "syslog",
+        "modules": [
+          "imuxsock",
+          "imklog"
+        ],
+        "file_create_mode": "0640",
+        "dir_create_mode": "0755",
+        "umask": "0022",
+        "dir_owner": "root",
+        "dir_group": "adm",
+        "default_facility_logs": {
+          "auth,authpriv.*": "/var/log/auth.log",
+          "*.*;auth,authpriv.none": "-/var/log/syslog",
+          "daemon.*": "-/var/log/daemon.log",
+          "kern.*": "-/var/log/kern.log",
+          "mail.*": "-/var/log/mail.log",
+          "user.*": "-/var/log/user.log",
+          "mail.info": "-/var/log/mail.info",
+          "mail.warn": "-/var/log/mail.warn",
+          "mail.err": "/var/log/mail.err",
+          "news.crit": "/var/log/news/news.crit",
+          "news.err": "/var/log/news/news.err",
+          "news.notice": "-/var/log/news/news.notice",
+          "*.=debug;auth,authpriv.none;news.none;mail.none": "-/var/log/debug",
+          "*.=info;*.=notice;*.=warn;auth,authpriv.none;cron,daemon.none;mail,news.none": "-/var/log/messages",
+          "*.emerg": ":omusrmsg:*"
+        }
+      },
+      "bluepill": {
+        "bin": "/opt/chef/embedded/bin/bluepill",
+        "logfile": "/var/log/bluepill.log",
+        "pid_dir": "/var/run/bluepill",
+        "state_dir": "/var/lib/bluepill",
+        "group": 0,
+        "use_rsyslog": false,
+        "init_dir": "/etc/init.d",
+        "conf_dir": "/etc/bluepill",
+        "defaults_dir": "/etc/default"
+      },
+      "windows": {
+        "rubyzipversion": null
+      },
+      "seven_zip": {
+        "url": "http://www.7-zip.org/a/7z1514-x64.msi",
+        "checksum": "cefe1a9092d8a6be68468c33910d6206b40e934fb63cab686c5cccf369fbf712",
+        "package_name": "7-Zip 15.14 (x64 edition)",
+        "default_extract_timeout": 600
+      },
+      "build-essential": {
+        "compile_time": false,
+        "msys2": {
+          "path": "\\msys2"
+        }
+      },
+      "packagecloud": {
+        "base_repo_path": "/install/repositories/",
+        "gpg_key_path": "/gpgkey",
+        "hostname_override": null,
+        "proxy_host": null,
+        "proxy_port": null,
+        "default_type": "deb"
+      },
+      "yum-epel": {
+        "repos": [
+          "epel",
+          "epel-debuginfo",
+          "epel-source",
+          "epel-testing",
+          "epel-testing-debuginfo",
+          "epel-testing-source"
+        ]
+      },
+      "yum": {
+        "epel-debuginfo": {
+          "repositoryid": "epel-debuginfo",
+          "description": "Extra Packages for 14 - $basearch - Debug",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-14&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-14",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-source": {
+          "repositoryid": "epel-source",
+          "description": "Extra Packages for 14 - $basearch - Source",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-14&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-14",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-testing-debuginfo": {
+          "repositoryid": "epel-testing-debuginfo",
+          "description": "Extra Packages for 14 - $basearch - Testing Debug",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel14&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-14",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-testing-source": {
+          "repositoryid": "epel-testing-source",
+          "description": "Extra Packages for 14 - $basearch - Testing Source",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel14&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-14",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel-testing": {
+          "repositoryid": "epel-testing",
+          "description": "Extra Packages for 14 - $basearch - Testing ",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel14&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-14",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": false,
+          "managed": false,
+          "make_cache": true
+        },
+        "epel": {
+          "repositoryid": "epel",
+          "description": "Extra Packages for 14 - $basearch",
+          "mirrorlist": "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-14&arch=$basearch",
+          "gpgkey": "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-14",
+          "failovermethod": "priority",
+          "gpgcheck": true,
+          "enabled": true,
+          "managed": true,
+          "make_cache": true
+        },
+        "main": {
+          "cachedir": "/var/cache/yum/$basearch/$releasever",
+          "distroverpkg": "ubuntu-release",
+          "releasever": null,
+          "alwaysprompt": null,
+          "assumeyes": null,
+          "bandwidth": null,
+          "bugtracker_url": null,
+          "clean_requirements_on_remove": null,
+          "color": null,
+          "color_list_available_downgrade": null,
+          "color_list_available_install": null,
+          "color_list_available_reinstall": null,
+          "color_list_available_upgrade": null,
+          "color_list_installed_extra": null,
+          "color_list_installed_newer": null,
+          "color_list_installed_older": null,
+          "color_list_installed_reinstall": null,
+          "color_search_match": null,
+          "color_update_installed": null,
+          "color_update_local": null,
+          "color_update_remote": null,
+          "commands": null,
+          "deltarpm": null,
+          "debuglevel": null,
+          "diskspacecheck": null,
+          "enable_group_conditionals": null,
+          "errorlevel": null,
+          "exactarch": null,
+          "exclude": null,
+          "gpgcheck": true,
+          "group_package_types": null,
+          "groupremove_leaf_only": null,
+          "history_list_view": null,
+          "history_record": null,
+          "history_record_packages": null,
+          "http_caching": null,
+          "installonly_limit": null,
+          "installonlypkgs": null,
+          "installroot": null,
+          "keepalive": null,
+          "keepcache": false,
+          "kernelpkgnames": null,
+          "localpkg_gpgcheck": false,
+          "logfile": "/var/log/yum.log",
+          "max_retries": null,
+          "mdpolicy": null,
+          "metadata_expire": null,
+          "mirrorlist_expire": null,
+          "multilib_policy": null,
+          "obsoletes": null,
+          "overwrite_groups": null,
+          "password": null,
+          "path": "/etc/yum.conf",
+          "persistdir": null,
+          "pluginconfpath": null,
+          "pluginpath": null,
+          "plugins": null,
+          "protected_multilib": null,
+          "protected_packages": null,
+          "proxy": null,
+          "proxy_password": null,
+          "proxy_username": null,
+          "recent": null,
+          "repo_gpgcheck": null,
+          "reposdir": null,
+          "reset_nice": null,
+          "rpmverbosity": null,
+          "showdupesfromrepos": null,
+          "skip_broken": null,
+          "ssl_check_cert_permissions": null,
+          "sslcacert": null,
+          "sslclientcert": null,
+          "sslclientkey": null,
+          "sslverify": null,
+          "syslog_device": null,
+          "syslog_facility": null,
+          "syslog_ident": null,
+          "throttle": null,
+          "timeout": null,
+          "tolerant": false,
+          "tsflags": null,
+          "username": null
+        }
+      },
+      "runit": {
+        "sv_bin": "/usr/bin/sv",
+        "chpst_bin": "/usr/bin/chpst",
+        "service_dir": "/etc/service",
+        "sv_dir": "/etc/sv",
+        "lsb_init_dir": "/etc/init.d",
+        "executable": "/sbin/runit",
+        "start": "start runsvdir",
+        "stop": "stop runsvdir",
+        "reload": "reload runsvdir"
+      },
+      "zypper": {
+        "smt_host": null
+      },
+      "nginx": {
+        "version": "1.10.1",
+        "package_name": "nginx",
+        "port": "80",
+        "dir": "/etc/nginx",
+        "script_dir": "/usr/sbin",
+        "log_dir": "/var/log/nginx",
+        "log_dir_perm": "0750",
+        "binary": "/usr/sbin/nginx",
+        "default_root": "/var/www/nginx-default",
+        "ulimit": "1024",
+        "pid": "/var/run/nginx.pid",
+        "user": "www-data",
+        "init_style": "runit",
+        "upstart": {
+          "runlevels": "2345",
+          "respawn_limit": null,
+          "foreground": true
+        },
+        "group": "www-data",
+        "gzip": "on",
+        "gzip_static": "off",
+        "gzip_http_version": "1.0",
+        "gzip_comp_level": "2",
+        "gzip_proxied": "any",
+        "gzip_vary": "off",
+        "gzip_buffers": null,
+        "gzip_types": [
+          "text/plain",
+          "text/css",
+          "application/x-javascript",
+          "text/xml",
+          "application/xml",
+          "application/rss+xml",
+          "application/atom+xml",
+          "text/javascript",
+          "application/javascript",
+          "application/json",
+          "text/mathml"
+        ],
+        "gzip_min_length": 1000,
+        "gzip_disable": "MSIE [1-6]\\.",
+        "keepalive": "on",
+        "keepalive_requests": 100,
+        "keepalive_timeout": 65,
+        "worker_processes": 2,
+        "worker_connections": 1024,
+        "worker_rlimit_nofile": null,
+        "multi_accept": false,
+        "event": null,
+        "accept_mutex_delay": null,
+        "server_tokens": null,
+        "server_names_hash_bucket_size": 64,
+        "variables_hash_max_size": 1024,
+        "variables_hash_bucket_size": 64,
+        "sendfile": "on",
+        "underscores_in_headers": null,
+        "tcp_nodelay": "on",
+        "tcp_nopush": "on",
+        "access_log_options": null,
+        "error_log_options": null,
+        "disable_access_log": false,
+        "log_formats": {},
+        "install_method": "package",
+        "default_site_enabled": true,
+        "types_hash_max_size": 2048,
+        "types_hash_bucket_size": 64,
+        "proxy_read_timeout": null,
+        "client_body_buffer_size": null,
+        "client_max_body_size": null,
+        "large_client_header_buffers": null,
+        "default": {
+          "modules": []
+        },
+        "extra_configs": {},
+        "auth_request": {
+          "url": "http://mdounin.ru/hg/ngx_http_auth_request_module/archive/662785733552.tar.gz",
+          "checksum": "2057bdefd2137a5000d9dbdbfca049d1ba7832ad2b9f8855a88ea5dfa70bd8c1"
+        },
+        "devel": {
+          "version": "0.3.0",
+          "url": "https://github.com/simpl/ngx_devel_kit/archive/v0.3.0.tar.gz",
+          "checksum": "88e05a99a8a7419066f5ae75966fb1efc409bad4522d14986da074554ae61619"
+        },
+        "echo": {
+          "version": "0.59",
+          "url": "https://github.com/openresty/echo-nginx-module/archive/v0.59.tar.gz",
+          "checksum": "9b319ad7836202883128d2b9c24ed818082541df57ef7f2065b7557085c603cd"
+        },
+        "geoip": {
+          "path": "/srv/geoip",
+          "enable_city": true,
+          "country_dat_url": "http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz",
+          "country_dat_checksum": null,
+          "city_dat_url": "http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz",
+          "city_dat_checksum": null,
+          "lib_version": "1.6.9",
+          "lib_url": "https://github.com/maxmind/geoip-api-c/releases/download/v1.6.9/GeoIP-1.6.9.tar.gz",
+          "lib_checksum": "4b446491843de67c1af9b887da17a3e5939e0aeed4826923a5f4bf09d845096f"
+        },
+        "headers_more": {
+          "version": "0.30",
+          "source_url": "https://github.com/openresty/headers-more-nginx-module/archive/v0.30.tar.gz",
+          "source_checksum": "2aad309a9313c21c7c06ee4e71a39c99d4d829e31c8b3e7d76f8c964ea8047f5"
+        },
+        "lua": {
+          "version": "0.10.3",
+          "url": "https://github.com/chaoslawful/lua-nginx-module/archive/v0.10.3.tar.gz",
+          "checksum": "a69504c25de67bce968242d331d2e433c021405a6dba7bca0306e6e0b040bb50"
+        },
+        "luajit": {
+          "version": "2.0.4",
+          "url": "http://luajit.org/download/LuaJIT-2.0.4.tar.gz",
+          "checksum": "620fa4eb12375021bef6e4f237cbd2dd5d49e56beb414bee052c746beef1807d"
+        },
+        "naxsi": {
+          "version": "0.54",
+          "url": "https://github.com/nbs-system/naxsi/archive/0.54.tar.gz",
+          "checksum": "9cc2c09405bc71f78ef26a8b6d70afcea3fccbe8125df70cb0cfc480133daba5"
+        },
+        "openssl_source": {
+          "version": "1.0.1t",
+          "url": "http://www.openssl.org/source/openssl-1.0.1t.tar.gz"
+        },
+        "pagespeed": {
+          "version": "1.11.33.2",
+          "url": "https://github.com/pagespeed/ngx_pagespeed/archive/release-1.11.33.2-beta.tar.gz",
+          "packages": {
+            "rhel": [
+              "pcre-dev",
+              "pcre-devel",
+              "zlib-devel"
+            ],
+            "debian": [
+              "zlib1g-dev",
+              "libpcre3",
+              "libpcre3-dev"
+            ]
+          }
+        },
+        "psol": {
+          "url": "https://dl.google.com/dl/page-speed/psol/1.11.33.2.tar.gz"
+        },
+        "passenger": {
+          "version": "4.0.57",
+          "root": "/opt/chef/embedded/lib/ruby/gems/2.3.0/gems/passenger-4.0.57",
+          "ruby": "/opt/chef/embedded/bin/ruby",
+          "packages": {
+            "rhel": [
+              "ruby-devel",
+              "curl-devel"
+            ],
+            "fedora": [
+              "ruby-devel",
+              "libcurl-devel"
+            ],
+            "debian": [
+              "ruby-dev",
+              "libcurl4-gnutls-dev"
+            ]
+          },
+          "install_rake": true,
+          "spawn_method": "smart-lv2",
+          "buffer_response": "on",
+          "max_pool_size": 6,
+          "min_instances": 1,
+          "max_instances_per_app": 0,
+          "pool_idle_time": 300,
+          "max_requests": 0,
+          "gem_binary": null,
+          "nodejs": null
+        },
+        "enable_rate_limiting": false,
+        "rate_limiting_zone_name": "default",
+        "rate_limiting_backoff": "10m",
+        "rate_limit": "1r/s",
+        "upstream_repository": "http://nginx.org/packages/ubuntu",
+        "set_misc": {
+          "version": "0.30",
+          "url": "https://github.com/agentzh/set-misc-nginx-module/archive/v0.30.tar.gz",
+          "checksum": "59920dd3f92c2be32627121605751b52eae32b5884be09f2e4c53fb2fae8aabc"
+        },
+        "socketproxy": {
+          "root": "/usr/share/nginx/apps",
+          "app_owner": "root",
+          "logname": "socketproxy",
+          "log_level": "error"
+        },
+        "source": {
+          "version": "1.10.1",
+          "prefix": "/opt/nginx-1.10.1",
+          "conf_path": "/etc/nginx/nginx.conf",
+          "sbin_path": "/opt/nginx-1.10.1/sbin/nginx",
+          "default_configure_flags": [
+            "--prefix=/opt/nginx-1.10.1",
+            "--conf-path=/etc/nginx/nginx.conf",
+            "--sbin-path=/opt/nginx-1.10.1/sbin/nginx"
+          ],
+          "url": "http://nginx.org/download/nginx-1.10.1.tar.gz",
+          "checksum": "1fd35846566485e03c0e318989561c135c598323ff349c503a6c14826487a801",
+          "modules": [
+            "chef_nginx::http_ssl_module",
+            "chef_nginx::http_gzip_static_module"
+          ],
+          "use_existing_user": false
+        },
+        "configure_flags": [],
+        "status": {
+          "port": "8090"
+        },
+        "syslog": {
+          "git_repo": "https://github.com/yaoweibin/nginx_syslog_patch.git",
+          "git_revision": "master"
+        },
+        "upload_progress": {
+          "url": "https://github.com/masterzen/nginx-upload-progress-module/tarball/v0.9.0",
+          "checksum": "3fb903dab595cf6656fa0fc5743a48daffbba2f6b5c554836be630800eaad4e2",
+          "javascript_output": true,
+          "zone_name": "proxied",
+          "zone_size": "1m"
+        }
+      },
+      "freebsd": {
+        "compiletime_portsnap": false
+      },
+      "jenkins": {
+        "java": "java",
+        "executor": {
+          "timeout": 60,
+          "private_key": null,
+          "proxy": null,
+          "jvm_options": null
+        },
+        "master": {
+          "install_method": "package",
+          "version": null,
+          "mirror": "http://mirrors.jenkins-ci.org",
+          "source": "http://mirrors.jenkins-ci.org/war/latest/jenkins.war",
+          "checksum": null,
+          "jvm_options": null,
+          "jenkins_args": null,
+          "user": "jenkins",
+          "group": "jenkins",
+          "use_system_accounts": true,
+          "host": "localhost",
+          "listen_address": "0.0.0.0",
+          "port": 8080,
+          "endpoint": "http://localhost:8080",
+          "home": "/var/lib/jenkins",
+          "log_directory": "/var/log/jenkins",
+          "runit": {
+            "sv_timeout": 7
+          },
+          "repository": "http://pkg.jenkins-ci.org/debian",
+          "repository_key": "http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key",
+          "repository_keyserver": null
+        }
+      },
+      "lvm": {
+        "chef-ruby-lvm": {
+          "version": "0.3.0"
+        },
+        "chef-ruby-lvm-attrib": {
+          "version": "0.2.1"
+        },
+        "cleanup_old_gems": true,
+        "rubysource": "https://rubygems.org"
+      },
+      "ntp": {
+        "servers": [
+          "0.pool.ntp.org",
+          "1.pool.ntp.org",
+          "2.pool.ntp.org",
+          "3.pool.ntp.org"
+        ],
+        "peers": [],
+        "pools": [],
+        "restrictions": [],
+        "tinker": {
+          "panic": 0,
+          "allan": 1500,
+          "dispersion": 15,
+          "step": 0.128,
+          "stepout": 900
+        },
+        "restrict_default": "kod notrap nomodify nopeer noquery",
+        "packages": [
+          "ntp"
+        ],
+        "service": "ntp",
+        "varlibdir": "/var/lib/ntp",
+        "driftfile": "/var/lib/ntp/ntp.drift",
+        "logfile": null,
+        "conffile": "/etc/ntp.conf",
+        "statsdir": "/var/log/ntpstats/",
+        "conf_owner": "root",
+        "conf_group": "root",
+        "var_owner": "ntp",
+        "var_group": "ntp",
+        "leapfile": "/etc/ntp.leapseconds",
+        "sync_clock": false,
+        "sync_hw_clock": false,
+        "listen": null,
+        "listen_network": null,
+        "ignore": null,
+        "apparmor_enabled": true,
+        "monitor": false,
+        "statistics": true,
+        "conf_restart_immediate": false,
+        "keys": null,
+        "trustedkey": null,
+        "requestkey": null,
+        "disable_tinker_panic_on_virtualization_guest": true,
+        "peer": {
+          "key": null,
+          "use_iburst": true,
+          "use_burst": false,
+          "minpoll": 6,
+          "maxpoll": 10
+        },
+        "server": {
+          "prefer": "",
+          "use_iburst": true,
+          "use_burst": false,
+          "minpoll": 6,
+          "maxpoll": 10
+        },
+        "orphan": {
+          "enabled": false,
+          "stratum": 5
+        },
+        "localhost": {
+          "noquery": false
+        },
+        "use_cmos": false
+      },
+      "git": {
+        "prefix": "/usr/local",
+        "version": "2.8.1",
+        "url": "https://nodeload.github.com/git/git/tar.gz/v%{version}",
+        "checksum": "e08503ecaf5d3ac10c40f22871c996a392256c8d038d16f52ebf974cba29ae42",
+        "use_pcre": false,
+        "server": {
+          "base_path": "/srv/git",
+          "export_all": true
+        }
+      },
+      "homebrew": {
+        "owner": null,
+        "auto-update": true,
+        "casks": [],
+        "formulas": [],
+        "taps": [],
+        "installer": {
+          "url": "https://raw.githubusercontent.com/Homebrew/install/master/install",
+          "checksum": null
+        },
+        "enable-analytics": true
+      },
+      "windows-sdk": {
+        "install_path": null
+      },
+      "wix": {
+        "download_id": "1540241",
+        "checksum": "03b8f46cb3abf1465fe8f9975a94a4e0f75c77267ff4d1fcb6d5b6a97567f549",
+        "home": "\\wix"
+      },
+      "omnibus": {
+        "build_user": "omnibus",
+        "build_user_home": null,
+        "install_dir": null,
+        "toolchain_name": "omnibus-toolchain",
+        "toolchain_version": "1.1.73",
+        "toolchain_channel": "stable",
+        "git_version": "2.6.2",
+        "ruby_version": "2.1.8",
+        "build_user_group": "omnibus",
+        "base_dir": "/var/cache/omnibus",
+        "git_checksum": "34dfc06b44880df91940dc318a2d3c83b79e67b6f05319c7c71e94d30893636d",
+        "build_user_password": "$1$QTCj0tQy$C60hWNmo8wZo.ctvDSy9p/"
+      },
+      "rubygems": {
+        "gem_disable_default": false,
+        "gem_sources": [
+          "https://rubygems.org"
+        ],
+        "chef_gem_disable_default": false,
+        "chef_gem_sources": [
+          "https://rubygems.org"
+        ]
+      },
+      "authorization": {
+        "sudo": {
+          "groups": [
+            "sysadmin"
+          ],
+          "users": [],
+          "passwordless": false,
+          "setenv": false,
+          "include_sudoers_d": false,
+          "agent_forwarding": false,
+          "sudoers_defaults": [
+            "!lecture,tty_tickets,!fqdn"
+          ],
+          "command_aliases": [],
+          "env_keep_add": [],
+          "env_keep_subtract": [],
+          "custom_commands": {
+            "users": [],
+            "groups": []
+          },
+          "prefix": "/etc"
+        }
+      },
+      "opscode-ci": {
+        "user": "jenkins",
+        "user_home": null,
+        "group": "jenkins",
+        "master": {
+          "host_name": null,
+          "port": 8080,
+          "jnlp_port": 38529,
+          "pipeline_types": [],
+          "executors": 2,
+          "jvm_memory_size": "2428132K",
+          "use_lvm": false,
+          "ebs_vols": [
+            {
+              "device": "/dev/xvdj",
+              "size": 500
+            }
+          ],
+          "days_to_keep_builds": null,
+          "builds_to_keep": null,
+          "days_to_keep_artifacts": 15,
+          "artifacts_to_keep": null
+        },
+        "email": {
+          "system_address": "CHEF CI <ci-notifications@getchef.com>",
+          "list_id": "ci-notifications.getchef.com"
+        },
+        "monitoring": {
+          "jmx_hostname": "localhost",
+          "jmx_port": 9010
+        },
+        "artifactory": {
+          "endpoint": "http://example.com"
+        },
+        "omnibus-cache": {
+          "profile_name": "omnibus-cache"
+        }
+      },
+      "java": {
+        "jdk_version": "7"
+      }
+    },
+    "override": {
+      "opscode-ci": {
+        "artifactory": {
+          "endpoint": "http://example.com:8081"
+        },
+        "omnitruck": {
+          "packages_bucket": "opscode-omnibus-packages",
+          "metadata_bucket": "opscode-omnibus-package-metadata"
+        },
+        "master": {
+          "host_name": "example.com",
+          "pipeline_types": [
+            "client_build",
+            "releng"
+          ],
+          "artifacts_to_keep": null,
+          "days_to_keep_artifacts": 15
+        }
+      }
+    },
+    "run_list": [
+      "recipe[opscode-ci::slave]"
+    ]
+  },
+  "node_name": "chefdk-ubuntu-14.04-tester-05b95c",
+  "organization_name": "xmen",
+  "resources": [
+    {
+      "type": "chef_gem",
+      "name": "chef-sugar",
+      "id": "chef-sugar",
+      "after": {
+        "package_name": "chef-sugar",
+        "version": "3.4.0"
+      },
+      "before": {
+        "package_name": "chef-sugar",
+        "version": "3.4.0"
+      },
+      "duration": "134",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "chef-sugar",
+      "cookbook_version": "3.4.0",
+      "recipe_name": "default"
+    },
+    {
+      "type": "chef_gem",
+      "name": "chef-sugar",
+      "id": "chef-sugar",
+      "after": {
+        "package_name": "chef-sugar",
+        "version": "3.4.0"
+      },
+      "before": {
+        "package_name": "chef-sugar",
+        "version": "3.4.0"
+      },
+      "duration": "5",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "chef-sugar",
+      "cookbook_version": "3.4.0",
+      "recipe_name": "default"
+    },
+    {
+      "type": "directory",
+      "name": "/usr/local/bin",
+      "id": "/usr/local/bin",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "link",
+      "name": "/usr/local/bin/git",
+      "id": "/usr/local/bin/git",
+      "after": {
+        "to": "/opt/omnibus-toolchain/embedded/bin/git",
+        "owner": null,
+        "group": null
+      },
+      "before": {
+        "to": "/opt/omnibus-toolchain/embedded/bin/git",
+        "owner": "root",
+        "group": "root"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "apt_repository",
+      "name": "openjdk-r",
+      "id": "openjdk-r",
+      "after": {},
+      "before": {},
+      "duration": "3480",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "remove",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "apt_update",
+      "name": "update",
+      "id": "update",
+      "after": {},
+      "before": {},
+      "duration": "3675",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "update",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "apt_package",
+      "name": "wget",
+      "id": "wget",
+      "after": {
+        "package_name": "wget"
+      },
+      "before": {
+        "package_name": "wget",
+        "version": [
+          "1.15-1ubuntu1.14.04.1"
+        ]
+      },
+      "duration": "23",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_platform_tweaks"
+    },
+    {
+      "type": "file",
+      "name": "/etc/profile.d/rbenv.sh",
+      "id": "/etc/profile.d/rbenv.sh",
+      "after": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/etc/profile.d/rbenv.sh"
+      },
+      "before": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/etc/profile.d/rbenv.sh"
+      },
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_migration"
+    },
+    {
+      "type": "directory",
+      "name": "/opt/rbenv",
+      "id": "/opt/rbenv",
+      "after": {
+        "group": null,
+        "mode": null,
+        "owner": null
+      },
+      "before": {
+        "group": null,
+        "mode": null,
+        "owner": null
+      },
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_migration"
+    },
+    {
+      "type": "directory",
+      "name": "/opt/rubies",
+      "id": "/opt/rubies",
+      "after": {
+        "group": null,
+        "mode": null,
+        "owner": null
+      },
+      "before": {
+        "group": null,
+        "mode": null,
+        "owner": null
+      },
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_migration"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.bashrc.d/chruby-default.sh",
+      "id": "/home/jenkins/.bashrc.d/chruby-default.sh",
+      "after": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/home/jenkins/.bashrc.d/chruby-default.sh"
+      },
+      "before": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/home/jenkins/.bashrc.d/chruby-default.sh"
+      },
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_migration"
+    },
+    {
+      "type": "chef_ingredient",
+      "name": "omnibus-toolchain",
+      "id": "omnibus-toolchain",
+      "after": {
+        "product_name": "omnibus-toolchain",
+        "version": "1.1.73",
+        "channel": "stable",
+        "platform_version_compatibility_mode": true,
+        "platform": "ubuntu",
+        "platform_version": "14.04",
+        "architecture": "x86_64"
+      },
+      "before": {},
+      "duration": "764",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "upgrade",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_omnibus_toolchain"
+    },
+    {
+      "type": "directory",
+      "name": "/export/home",
+      "id": "/export/home",
+      "after": {
+        "group": "root",
+        "mode": null,
+        "owner": "root"
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "skipped",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "group",
+      "name": "create jenkins group",
+      "id": "jenkins",
+      "after": {
+        "members": []
+      },
+      "before": {
+        "members": [
+          "jenkins"
+        ]
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user"
+    },
+    {
+      "type": "execute",
+      "name": "chsec_login_shell",
+      "id": "chsec -f /etc/security/login.cfg -s usw -a 'shells=/bin/sh,/bin/bsh,/bin/csh,/bin/ksh,/bin/tsh,/bin/ksh93,/usr/bin/sh,/usr/bin/bsh,/usr/bin/csh,/usr/bin/ksh,/usr/bin/tsh,/usr/bin/ksh93,/usr/bin/rksh,/usr/bin/rksh93,/usr/sbin/uucp/uucico,/usr/sbin/sliplogin,/usr/sbin/snappd,/usr/bin/bash,/opt/omnibus-toolchain/bin/bash'",
+      "after": {
+        "command": "chsec -f /etc/security/login.cfg -s usw -a 'shells=/bin/sh,/bin/bsh,/bin/csh,/bin/ksh,/bin/tsh,/bin/ksh93,/usr/bin/sh,/usr/bin/bsh,/usr/bin/csh,/usr/bin/ksh,/usr/bin/tsh,/usr/bin/ksh93,/usr/bin/rksh,/usr/bin/rksh93,/usr/sbin/uucp/uucico,/usr/sbin/sliplogin,/usr/sbin/snappd,/usr/bin/bash,/opt/omnibus-toolchain/bin/bash'",
+        "user": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "skipped",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "linux_user",
+      "name": "jenkins",
+      "id": "jenkins",
+      "after": {
+        "uid": null,
+        "gid": 1001,
+        "home": "/home/jenkins"
+      },
+      "before": {
+        "uid": 1001,
+        "gid": 1001,
+        "home": "/home/jenkins"
+      },
+      "duration": "6",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user"
+    },
+    {
+      "type": "group",
+      "name": "jenkins",
+      "id": "jenkins",
+      "after": {
+        "members": [
+          "jenkins"
+        ]
+      },
+      "before": {
+        "members": [
+          "jenkins"
+        ]
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "modify",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins",
+      "id": "/home/jenkins",
+      "after": {
+        "group": "jenkins",
+        "mode": "0755",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0755",
+        "owner": "jenkins"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_user"
+    },
+    {
+      "type": "directory",
+      "name": "/var/chef/cache",
+      "id": "/var/chef/cache",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_common"
+    },
+    {
+      "type": "directory",
+      "name": "/usr/local/bin",
+      "id": "/usr/local/bin",
+      "after": {
+        "group": null,
+        "mode": "0755",
+        "owner": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "skipped",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_common",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "directory",
+      "name": "/var/cache/omnibus",
+      "id": "/var/cache/omnibus",
+      "after": {
+        "group": "jenkins",
+        "mode": "0755",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0755",
+        "owner": "jenkins"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_common"
+    },
+    {
+      "type": "build_essential",
+      "name": "install_packages",
+      "id": "install_packages",
+      "after": {
+        "compile_time": false
+      },
+      "before": {},
+      "duration": "231",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "build-essential",
+      "cookbook_version": "8.0.3",
+      "recipe_name": "default"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.gitconfig",
+      "id": "/home/jenkins/.gitconfig",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0644",
+        "path": "/home/jenkins/.gitconfig",
+        "verifications": [],
+        "checksum": "da99b45d1bdded86624ef816c39d36322f2b6e1beb42524dc369ed5275b98e98"
+      },
+      "before": {
+        "checksum": "b6e92383b55f6982a663ccc4b609ccf6b560b4b595e62fd94a0268e2632a94ec",
+        "owner": "jenkins",
+        "group": "root",
+        "mode": "0644",
+        "path": "/home/jenkins/.gitconfig"
+      },
+      "duration": "7",
+      "delta": "--- /home/jenkins/.gitconfig\t2017-11-01 14:54:12.701769620 +0000\\n+++ /home/jenkins/.chef-.gitconfig20171101-2935-193pzx1.gitconfig\t2017-11-01 21:09:14.392438785 +0000\\n@@ -20,6 +20,4 @@\\n   autosetuprebase = always\\n [pull]\\n   rebase = preserve\\n-[http]\\n-\tsslCAinfo = /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "updated",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_git"
+    },
+    {
+      "type": "execute",
+      "name": "/opt/omnibus-toolchain/bin/git config --global http.sslCAinfo /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem",
+      "id": "/opt/omnibus-toolchain/bin/git config --global http.sslCAinfo /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem",
+      "after": {
+        "command": "/opt/omnibus-toolchain/bin/git config --global http.sslCAinfo /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem",
+        "user": "jenkins"
+      },
+      "before": {},
+      "duration": "18",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_git"
+    },
+    {
+      "type": "ruby_block",
+      "name": "disable strict host key checking for github.com",
+      "id": "disable strict host key checking for github.com",
+      "after": {
+        "block_name": "disable strict host key checking for github.com"
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "ruby_block",
+      "name": "make sudo honor ssh_auth_sock",
+      "id": "make sudo honor ssh_auth_sock",
+      "after": {
+        "block_name": "make sudo honor ssh_auth_sock"
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "apt_package",
+      "name": "devscripts",
+      "id": "devscripts",
+      "after": {
+        "package_name": "devscripts"
+      },
+      "before": {
+        "package_name": "devscripts",
+        "version": [
+          "2.14.1ubuntu0.1"
+        ]
+      },
+      "duration": "24",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_packaging"
+    },
+    {
+      "type": "apt_package",
+      "name": "dpkg-dev",
+      "id": "dpkg-dev",
+      "after": {
+        "package_name": "dpkg-dev"
+      },
+      "before": {
+        "package_name": "dpkg-dev",
+        "version": [
+          "1.17.5ubuntu5.7"
+        ]
+      },
+      "duration": "24",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_packaging"
+    },
+    {
+      "type": "apt_package",
+      "name": "ncurses-dev",
+      "id": "ncurses-dev",
+      "after": {
+        "package_name": "ncurses-dev"
+      },
+      "before": {
+        "package_name": "ncurses-dev",
+        "version": [
+          "5.9+20140118-1ubuntu1"
+        ]
+      },
+      "duration": "72",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_packaging"
+    },
+    {
+      "type": "apt_package",
+      "name": "zlib1g-dev",
+      "id": "zlib1g-dev",
+      "after": {
+        "package_name": "zlib1g-dev"
+      },
+      "before": {
+        "package_name": "zlib1g-dev",
+        "version": [
+          "1:1.2.8.dfsg-1ubuntu1"
+        ]
+      },
+      "duration": "24",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_packaging"
+    },
+    {
+      "type": "apt_package",
+      "name": "fakeroot",
+      "id": "fakeroot",
+      "after": {
+        "package_name": "fakeroot"
+      },
+      "before": {
+        "package_name": "fakeroot",
+        "version": [
+          "1.20-3ubuntu2"
+        ]
+      },
+      "duration": "24",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_packaging"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/load-omnibus-toolchain.sh",
+      "id": "/home/jenkins/load-omnibus-toolchain.sh",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0755",
+        "path": "/home/jenkins/load-omnibus-toolchain.sh",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "1a590716d649641db92e4fe6ce790c04806589556e4ac2448b0be5ddaf3f2f9e",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0755",
+        "path": "/home/jenkins/load-omnibus-toolchain.sh"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "omnibus",
+      "cookbook_version": "5.2.2",
+      "recipe_name": "_environment"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins/.ssh",
+      "id": "/home/jenkins/.ssh",
+      "after": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "cookbook_file",
+      "name": "/home/jenkins/.ssh/known_hosts",
+      "id": "/home/jenkins/.ssh/known_hosts",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0644",
+        "path": "/home/jenkins/.ssh/known_hosts",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "029aa31c902d2d49468a4584f65d69757696f68c92166dea1bacddee22d990ee",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0644",
+        "path": "/home/jenkins/.ssh/known_hosts"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.ssh/github",
+      "id": "/home/jenkins/.ssh/github",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/github",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "c8fa3ddfe43f79cac2abfe110cc163ee45642571c17f03617fdcb548b777114a",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/github"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.ssh/config",
+      "id": "/home/jenkins/.ssh/config",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/config",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "fd3930562ec0c2c46049673f068cb2b2f38b045b339c4dd9efa3e46d0c781336",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/config"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_github"
+    },
+    {
+      "type": "apt_package",
+      "name": "ntp",
+      "id": "ntp",
+      "after": {
+        "package_name": "ntp"
+      },
+      "before": {
+        "package_name": "ntp",
+        "version": [
+          "1:4.2.6.p5+dfsg-3ubuntu2.14.04.10"
+        ]
+      },
+      "duration": "26",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "apt_package",
+      "name": "Remove ntpdate",
+      "id": "ntpdate",
+      "after": {
+        "package_name": "ntpdate"
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "remove",
+      "status": "skipped",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "directory",
+      "name": "/var/lib/ntp",
+      "id": "/var/lib/ntp",
+      "after": {
+        "group": "ntp",
+        "mode": "0755",
+        "owner": "ntp"
+      },
+      "before": {
+        "group": "ntp",
+        "mode": "0755",
+        "owner": "ntp"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "directory",
+      "name": "/var/log/ntpstats/",
+      "id": "/var/log/ntpstats/",
+      "after": {
+        "group": "ntp",
+        "mode": "0755",
+        "owner": "ntp"
+      },
+      "before": {
+        "group": "ntp",
+        "mode": "0755",
+        "owner": "ntp"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "cookbook_file",
+      "name": "/etc/ntp.leapseconds",
+      "id": "/etc/ntp.leapseconds",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/ntp.leapseconds",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "cd3e23bc9fd5119f37bb58bb7e0310b71a726424186a1c57343f3cfd1031d42e",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/ntp.leapseconds"
+      },
+      "duration": "25",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "service",
+      "name": "apparmor",
+      "id": "apparmor",
+      "after": {
+        "enabled": null,
+        "running": null,
+        "masked": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "nothing",
+      "status": "skipped",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "apparmor",
+      "conditional": "not_if { action == :nothing }"
+    },
+    {
+      "type": "cookbook_file",
+      "name": "/etc/apparmor.d/usr.sbin.ntpd",
+      "id": "/etc/apparmor.d/usr.sbin.ntpd",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/apparmor.d/usr.sbin.ntpd",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "c639f1dc0bdcf21eaa39fc5d72b7def53af85ab768218eb31532db1f0391d4e4",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/apparmor.d/usr.sbin.ntpd"
+      },
+      "duration": "6",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "apparmor"
+    },
+    {
+      "type": "template",
+      "name": "/etc/ntp.conf",
+      "id": "/etc/ntp.conf",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/ntp.conf",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "5eba70b7b575a1e02fb498ef3d443b8a3cf55ab7190532b40934bf6ca77511fc",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/etc/ntp.conf"
+      },
+      "duration": "27",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "execute",
+      "name": "Force sync hardware clock with system clock",
+      "id": "hwclock --systohc",
+      "after": {
+        "command": "hwclock --systohc",
+        "user": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "skipped",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "service",
+      "name": "ntp",
+      "id": "ntp",
+      "after": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "before": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "duration": "59",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "enable",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "service",
+      "name": "ntp",
+      "id": "ntp",
+      "after": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "before": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "duration": "22",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "start",
+      "status": "up-to-date",
+      "cookbook_name": "ntp",
+      "cookbook_version": "3.5.2",
+      "recipe_name": "default"
+    },
+    {
+      "type": "log",
+      "name": "Package signing not implemented for this platform_family",
+      "id": "Package signing not implemented for this platform_family",
+      "after": {
+        "message": "Package signing not implemented for this platform_family"
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "write",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_package_signing"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins/.gem",
+      "id": "/home/jenkins/.gem",
+      "after": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.gem/credentials",
+      "id": "/home/jenkins/.gem/credentials",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.gem/credentials",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "08be5634d5030e591aab6c513c7a24abfb3e17afab3828741b077f396be5deda",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.gem/credentials"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "gemrc",
+      "name": "global",
+      "id": "global",
+      "after": {
+        "user": "jenkins",
+        "group": "jenkins",
+        "values": {
+          "sources": [
+            "https://rubygems.org/"
+          ]
+        }
+      },
+      "before": {
+        "path": "/opt/chef/embedded/etc/gemrc",
+        "values": {
+          "sources": [
+            "https://rubygems.org/"
+          ]
+        }
+      },
+      "duration": "17",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "gemrc",
+      "name": "/home/jenkins/.gemrc",
+      "id": "/home/jenkins/.gemrc",
+      "after": {
+        "user": "jenkins",
+        "group": "jenkins",
+        "values": {
+          "sources": [
+            "https://rubygems.org/"
+          ]
+        }
+      },
+      "before": {
+        "path": "/home/jenkins/.gemrc",
+        "values": {
+          "sources": [
+            "https://rubygems.org/"
+          ]
+        }
+      },
+      "duration": "5",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.bundle/config",
+      "id": "/home/jenkins/.bundle/config",
+      "after": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/home/jenkins/.bundle/config"
+      },
+      "before": {
+        "owner": null,
+        "group": null,
+        "mode": null,
+        "path": "/home/jenkins/.bundle/config"
+      },
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "delete",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_rubygems"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins/.aws",
+      "id": "/home/jenkins/.aws",
+      "after": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_aws"
+    },
+    {
+      "type": "template",
+      "name": "/home/jenkins/.aws/credentials",
+      "id": "/home/jenkins/.aws/credentials",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.aws/credentials",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "e03da2ff59a16921fa0cb84568c077502e2d832aa640efa0d2a4cd4d625cfbb0",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/.aws/credentials"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_aws"
+    },
+    {
+      "type": "linux_user",
+      "name": "root",
+      "id": "root",
+      "after": {
+        "uid": 0,
+        "gid": 0,
+        "home": "/root"
+      },
+      "before": {
+        "uid": 0,
+        "gid": 0,
+        "home": "/root"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_users"
+    },
+    {
+      "type": "apt_package",
+      "name": "sudo",
+      "id": "sudo",
+      "after": {
+        "package_name": "sudo"
+      },
+      "before": {},
+      "duration": "5",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "skipped",
+      "cookbook_name": "sudo",
+      "cookbook_version": "3.5.3",
+      "recipe_name": "default",
+      "conditional": "not_if \"which sudo\""
+    },
+    {
+      "type": "directory",
+      "name": "/etc/sudoers.d",
+      "id": "/etc/sudoers.d",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "sudo",
+      "cookbook_version": "3.5.3",
+      "recipe_name": "default"
+    },
+    {
+      "type": "cookbook_file",
+      "name": "/etc/sudoers.d/README",
+      "id": "/etc/sudoers.d/README",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0440",
+        "path": "/etc/sudoers.d/README",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "9ded172910845bd115fbe469d87cab80a215e756a973e5d09c0e58a19a1bfe81",
+        "owner": "root",
+        "group": "root",
+        "mode": "0440",
+        "path": "/etc/sudoers.d/README"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "sudo",
+      "cookbook_version": "3.5.3",
+      "recipe_name": "default"
+    },
+    {
+      "type": "template",
+      "name": "/etc/sudoers",
+      "id": "/etc/sudoers",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0440",
+        "path": "/etc/sudoers",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "4520ba18debe05aaea860c0fef2d11aa0c6c1b8e7ee0eaa7c7e4360e659d1047",
+        "owner": "root",
+        "group": "root",
+        "mode": "0440",
+        "path": "/etc/sudoers"
+      },
+      "duration": "8",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "sudo",
+      "cookbook_version": "3.5.3",
+      "recipe_name": "default"
+    },
+    {
+      "type": "sudo",
+      "name": "jenkins",
+      "id": "jenkins",
+      "after": {
+        "user": "jenkins",
+        "commands": [
+          "ALL"
+        ],
+        "host": "ALL",
+        "runas": "ALL",
+        "nopasswd": true,
+        "command_aliases": [],
+        "env_keep_add": [],
+        "env_keep_subtract": []
+      },
+      "before": {},
+      "duration": "16",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo"
+    },
+    {
+      "type": "sudo",
+      "name": "sysadmin",
+      "id": "sysadmin",
+      "after": {
+        "group": "sysadmin",
+        "commands": [
+          "ALL"
+        ],
+        "host": "ALL",
+        "runas": "ALL",
+        "nopasswd": true,
+        "command_aliases": [],
+        "env_keep_add": [],
+        "env_keep_subtract": []
+      },
+      "before": {},
+      "duration": "15",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo"
+    },
+    {
+      "type": "sudo",
+      "name": "build",
+      "id": "build",
+      "after": {
+        "user": "build",
+        "nopasswd": true
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "sudo",
+      "name": "vagrant",
+      "id": "vagrant",
+      "after": {
+        "user": "vagrant",
+        "nopasswd": true
+      },
+      "before": {},
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "sudo",
+      "name": "ubuntu",
+      "id": "ubuntu",
+      "after": {
+        "user": "ubuntu",
+        "commands": [
+          "ALL"
+        ],
+        "host": "ALL",
+        "runas": "ALL",
+        "nopasswd": true,
+        "command_aliases": [],
+        "env_keep_add": [],
+        "env_keep_subtract": []
+      },
+      "before": {},
+      "duration": "15",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo"
+    },
+    {
+      "type": "sudo",
+      "name": "ec2-user",
+      "id": "ec2-user",
+      "after": {
+        "user": "ec2-user",
+        "nopasswd": true
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_sudo",
+      "conditional": "only_if { #code block }"
+    },
+    {
+      "type": "apt_repository",
+      "name": "openjdk-r",
+      "id": "openjdk-r",
+      "after": {
+        "uri": "http://ppa.launchpad.net/openjdk-r/ppa/ubuntu",
+        "distribution": "trusty",
+        "components": [
+          "main"
+        ],
+        "deb_src": true,
+        "keyserver": "keyserver.ubuntu.com",
+        "key": "DA1A4A13543B466853BAF164EB9B1D8886F44E2A"
+      },
+      "before": {},
+      "duration": "5941",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "add",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_java"
+    },
+    {
+      "type": "apt_package",
+      "name": "openjdk-7-jdk",
+      "id": "openjdk-7-jdk",
+      "after": {
+        "package_name": "openjdk-7-jdk"
+      },
+      "before": {
+        "package_name": "openjdk-7-jdk",
+        "version": [
+          "7u131-2.6.9-0ubuntu0.14.04.2"
+        ]
+      },
+      "duration": "24",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "install",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_java"
+    },
+    {
+      "type": "git",
+      "name": "/var/chef/cache/artifactory",
+      "id": "/var/chef/cache/artifactory",
+      "after": {
+        "revision": "v2.8.2"
+      },
+      "before": {
+        "revision": "ee0af35496c0809c5b7445f951ee324f37e2679b"
+      },
+      "duration": "89",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "sync",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "execute",
+      "name": "build-artifactory-gem",
+      "id": "rm -rf artifactory-*.gem && gem build artifactory.gemspec",
+      "after": {
+        "command": "rm -rf artifactory-*.gem && gem build artifactory.gemspec",
+        "user": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "nothing",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus",
+      "conditional": "not_if { action == :nothing }"
+    },
+    {
+      "type": "execute",
+      "name": "install-artifactory-gem",
+      "id": "gem install artifactory-*.gem --no-ri --no-rdoc",
+      "after": {
+        "command": "gem install artifactory-*.gem --no-ri --no-rdoc",
+        "user": null
+      },
+      "before": {},
+      "duration": "500",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "git",
+      "name": "/var/chef/cache/omnibus",
+      "id": "/var/chef/cache/omnibus",
+      "after": {
+        "revision": "ced452379e27b85b9958421f258b5fbe22e3760a"
+      },
+      "before": {
+        "revision": "ced452379e27b85b9958421f258b5fbe22e3760a"
+      },
+      "duration": "6",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "sync",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "execute",
+      "name": "build-omnibus-gem",
+      "id": "rm -rf omnibus-*.gem && gem build omnibus.gemspec",
+      "after": {
+        "command": "rm -rf omnibus-*.gem && gem build omnibus.gemspec",
+        "user": null
+      },
+      "before": {},
+      "duration": "0",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "nothing",
+      "status": "skipped",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus",
+      "conditional": "not_if { action == :nothing }"
+    },
+    {
+      "type": "execute",
+      "name": "install-omnibus-gem",
+      "id": "gem install omnibus-*.gem --no-ri --no-rdoc",
+      "after": {
+        "command": "gem install omnibus-*.gem --no-ri --no-rdoc",
+        "user": null
+      },
+      "before": {},
+      "duration": "2956",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "run",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/omnibus-publish.rb",
+      "id": "/home/jenkins/omnibus-publish.rb",
+      "after": {
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/omnibus-publish.rb",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "0d1fdcd4e2d53721b936617ea33f68318953bbcd0ddb540f8a27069f14bcdac3",
+        "owner": "jenkins",
+        "group": "jenkins",
+        "mode": "0600",
+        "path": "/home/jenkins/omnibus-publish.rb"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "_omnibus"
+    },
+    {
+      "type": "directory",
+      "name": "/home/jenkins/.ssh",
+      "id": "/home/jenkins/.ssh",
+      "after": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "before": {
+        "group": "jenkins",
+        "mode": "0700",
+        "owner": "jenkins"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "slave"
+    },
+    {
+      "type": "file",
+      "name": "/home/jenkins/.ssh/authorized_keys",
+      "id": "/home/jenkins/.ssh/authorized_keys",
+      "after": {
+        "owner": "jenkins",
+        "group": "root",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/authorized_keys",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "0cbbb3b0e104f5c5deb49091126fbc35e352f4d4222c598eeff9170f9a2028e8",
+        "owner": "jenkins",
+        "group": "root",
+        "mode": "0600",
+        "path": "/home/jenkins/.ssh/authorized_keys"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "slave"
+    },
+    {
+      "type": "remote_file",
+      "name": "/var/chef/cache/jenkins-cli.jar",
+      "id": "/var/chef/cache/jenkins-cli.jar",
+      "after": {
+        "checksum": null,
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/chef/cache/jenkins-cli.jar"
+      },
+      "before": {
+        "checksum": "f3c325f20fadb64a50c387cc3ad9429e34669de7ddf9e842bb65d4a1ddc982b4",
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/chef/cache/jenkins-cli.jar"
+      },
+      "duration": "8",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "remote_file",
+      "name": "/var/chef/cache/update-center.json",
+      "id": "/var/chef/cache/update-center.json",
+      "after": {
+        "checksum": "64a0fd3fd4f00350bbe1c05b5588b4fd0224b61f7277952e1da943af1619e480",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/var/chef/cache/update-center.json",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "a1654b369edbd1847ceb1e132cd4bec32b8f0d3fd06d9236e0c4c6582915b87d",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/var/chef/cache/update-center.json"
+      },
+      "duration": "1665",
+      "delta": "suppressed sensitive resource",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "updated"
+    },
+    {
+      "type": "file",
+      "name": "/var/chef/cache/extracted-update-center.json",
+      "id": "/var/chef/cache/extracted-update-center.json",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/var/chef/cache/extracted-update-center.json",
+        "verifications": [],
+        "checksum": "3c0c442fde018f24a83863409de92032d1db1da65ccf576e761f376243c62c35"
+      },
+      "before": {
+        "checksum": "b12da39a17fd4c874c6634d7c26484bd785bbfa90a5d29a7c1ade138e6318a2b",
+        "owner": "root",
+        "group": "root",
+        "mode": "0644",
+        "path": "/var/chef/cache/extracted-update-center.json"
+      },
+      "duration": "17",
+      "delta": "suppressed sensitive resource",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "updated"
+    },
+    {
+      "type": "file",
+      "name": "/var/chef/cache/jenkins-key",
+      "id": "/var/chef/cache/jenkins-key",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0600",
+        "path": "/var/chef/cache/jenkins-key",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "ced9d2204cc71246b2a6b440829167aa024c2c7662d3c2451acf20ece4bc319d",
+        "owner": "root",
+        "group": "root",
+        "mode": "0600",
+        "path": "/var/chef/cache/jenkins-key"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "jenkins_private_key_credentials",
+      "name": "jenkins",
+      "id": "jenkins",
+      "after": {
+        "description": "Credentials for jenkins - created by Chef",
+        "username": "jenkins",
+        "private_key": "EXAMPLEKEY"
+      },
+      "before": {
+        "id": "2e269a3f-71ba-4b22-8882-40790a8582e8",
+        "description": "Credentials for jenkins - created by Chef",
+        "username": "jenkins",
+        "private_key": "EXAMPLEKEY"
+      },
+      "duration": "2684",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "slave"
+    },
+    {
+      "type": "jenkins_ssh_slave",
+      "name": "chefdk-ubuntu-14.04-tester-05b95c",
+      "id": "chefdk-ubuntu-14.04-tester-05b95c",
+      "after": {
+        "slave_name": "chefdk-ubuntu-14.04-tester-05b95c",
+        "description": "ubuntu 14.04 [ GNU/Linux 3.13.0-53-generic x86_64 ]",
+        "remote_fs": "/home/jenkins",
+        "usage_mode": "normal",
+        "labels": [
+          "14.04",
+          "3.13.0-53-generic",
+          "chefdk",
+          "debian",
+          "linux",
+          "slave",
+          "tester",
+          "ubuntu",
+          "ubuntu-14.04",
+          "x86_64"
+        ],
+        "environment": {
+          "LIBPATH": "",
+          "OMNIBUS_FIPS_MODE": "false"
+        },
+        "user": "jenkins",
+        "java_path": "java",
+        "host": "196.140.227.170",
+        "credentials": {
+          "json_class": "Chef::Resource::JenkinsPrivateKeyCredentials",
+          "instance_vars": {
+            "name": "jenkins",
+            "noop": null,
+            "before": null,
+            "params": {},
+            "provider": null,
+            "allowed_actions": [
+              "nothing",
+              "create",
+              "delete"
+            ],
+            "action": [
+              "create"
+            ],
+            "updated": false,
+            "updated_by_last_action": false,
+            "supports": {},
+            "ignore_failure": false,
+            "retries": 0,
+            "retry_delay": 2,
+            "source_line": "/var/chef/cache/cookbooks/opscode-ci/recipes/slave.rb:69:in `from_file'",
+            "guard_interpreter": null,
+            "default_guard_interpreter": "default",
+            "elapsed_time": 2.684923586,
+            "sensitive": true,
+            "declared_type": "jenkins_private_key_credentials",
+            "cookbook_name": "opscode-ci",
+            "recipe_name": "slave",
+            "private_key": "EXAMPLEKEY",
+            "username": "jenkins",
+            "description": "Credentials for jenkins - created by Chef"
+          }
+        },
+        "command_prefix": "env HOME=/home/jenkins PATH=/opt/omnibus-toolchain/embedded/bin::/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin JENKINS_HOME=/home/jenkins sh -c '",
+        "command_suffix": "'"
+      },
+      "before": {
+        "slave_name": "chefdk-ubuntu-14.04-tester-05b95c",
+        "description": "ubuntu 14.04 [ GNU/Linux 3.13.0-53-generic x86_64 ]",
+        "remote_fs": "/home/jenkins",
+        "executors": 1,
+        "labels": [
+          "14.04",
+          "3.13.0-53-generic",
+          "chefdk",
+          "debian",
+          "linux",
+          "slave",
+          "tester",
+          "ubuntu",
+          "ubuntu-14.04",
+          "x86_64"
+        ],
+        "java_path": "java",
+        "host": "196.140.227.170",
+        "port": 22,
+        "credentials": "jenkins"
+      },
+      "duration": "2378",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "updated",
+      "cookbook_name": "opscode-ci",
+      "cookbook_version": "5.15.127",
+      "recipe_name": "slave"
+    },
+    {
+      "type": "linux_user",
+      "name": "chefautomate",
+      "id": "chefautomate",
+      "after": {
+        "uid": null,
+        "gid": null,
+        "home": "/var/opt/chef"
+      },
+      "before": {
+        "uid": 7209,
+        "gid": 7209,
+        "home": "/var/opt/chef"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "directory",
+      "name": "/var/opt/chef/bin",
+      "id": "/var/opt/chef/bin",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "directory",
+      "name": "/var/opt/chef/etc",
+      "id": "/var/opt/chef/etc",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "root"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "directory",
+      "name": "/var/log/chef/automate-liveness-agent",
+      "id": "/var/log/chef/automate-liveness-agent",
+      "after": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "chefautomate"
+      },
+      "before": {
+        "group": "root",
+        "mode": "0755",
+        "owner": "chefautomate"
+      },
+      "duration": "1",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "file",
+      "name": "/var/opt/chef/bin/automate-liveness-agent",
+      "id": "/var/opt/chef/bin/automate-liveness-agent",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/opt/chef/bin/automate-liveness-agent",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "d7ad5dd68ab384e8e7f6c34ecb9c57b6c463a0d9625152c53c3deb7023a67e73",
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/opt/chef/bin/automate-liveness-agent"
+      },
+      "duration": "3",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "file",
+      "name": "/var/opt/chef/etc/config.json",
+      "id": "/var/opt/chef/etc/config.json",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/opt/chef/etc/config.json",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "d3ea07fb61f7ae83ff4720bdb22611a59684fd00a6117ca705b19fb9c02a5f9b",
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+        "path": "/var/opt/chef/etc/config.json"
+      },
+      "duration": "4",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "file",
+      "name": "/etc/init.d/automate-liveness-agent",
+      "id": "/etc/init.d/automate-liveness-agent",
+      "after": {
+        "owner": "root",
+        "group": "root",
+        "mode": "0744",
+        "path": "/etc/init.d/automate-liveness-agent",
+        "verifications": []
+      },
+      "before": {
+        "checksum": "8a39aa2bccd95ae7f4f47b6c6702af5a4c068c45b0bfa943f814fb49492fd75a",
+        "owner": "root",
+        "group": "root",
+        "mode": "0744",
+        "path": "/etc/init.d/automate-liveness-agent"
+      },
+      "duration": "2",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "create",
+      "status": "up-to-date"
+    },
+    {
+      "type": "service",
+      "name": "automate-liveness-agent",
+      "id": "automate-liveness-agent",
+      "after": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "before": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "duration": "20",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "enable",
+      "status": "up-to-date"
+    },
+    {
+      "type": "service",
+      "name": "automate-liveness-agent",
+      "id": "automate-liveness-agent",
+      "after": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "before": {
+        "enabled": true,
+        "running": true,
+        "masked": null
+      },
+      "duration": "16",
+      "delta": "",
+      "ignore_failure": false,
+      "result": "start",
+      "status": "up-to-date"
+    }
+  ],
+  "run_id": "da60e383-67f6-4501-b726-1f28e03bf6ea",
+  "run_list": [
+    "recipe[opscode-ci::slave]"
+  ],
+  "start_time": "2017-11-01T21:08:50Z",
+  "end_time": "2017-11-01T21:09:31Z",
+  "source": "chef_client",
+  "status": "success",
+  "total_resource_count": 354,
+  "updated_resource_count": 13,
+  "deprecations": [
+    {
+      "message": "Chef::Platform.set is deprecated",
+      "url": "https://docs.chef.io/deprecations_chef_platform_methods.html",
+      "location": "/var/chef/cache/cookbooks/jenkins/libraries/plugin.rb:443:in `<top (required)>'"
+    },
+    {
+      "message": "Chef::Platform.set is deprecated",
+      "url": "https://docs.chef.io/deprecations_chef_platform_methods.html",
+      "location": "/var/chef/cache/cookbooks/jenkins/libraries/slave.rb:410:in `<top (required)>'"
+    },
+    {
+      "message": "Chef::Platform.set is deprecated",
+      "url": "https://docs.chef.io/deprecations_chef_platform_methods.html",
+      "location": "/var/chef/cache/cookbooks/jenkins/libraries/user.rb:183:in `<top (required)>'"
+    },
+    {
+      "message": "Property `sensitive` of resource `rhsm_register` overwrites an existing method. Please use a different property name. This will raise an exception in Chef 13.",
+      "url": "https://docs.chef.io/deprecations_property_name_collision.html",
+      "location": "/var/chef/cache/cookbooks/redhat_subscription_manager/libraries/rhsm_register.rb:34:in `<class:RhsmRegister>'"
+    },
+    {
+      "message": "method access to node attributes (node.foo.bar) is deprecated and will be removed in Chef 13, please use bracket syntax (node[\"foo\"][\"bar\"])",
+      "url": "https://docs.chef.io/deprecations_attributes.html",
+      "location": "/opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-sugar-3.6.0/lib/chef/sugar/node.rb:162:in `method_missing'"
+    },
+    {
+      "message": "Property `sensitive` of resource `aws_s3_file` overwrites an existing method. Please use a different property name. This will raise an exception in Chef 13.",
+      "url": "https://docs.chef.io/deprecations_property_name_collision.html",
+      "location": "/var/chef/cache/cookbooks/aws/resources/s3_file.rb:36:in `class_from_file'"
+    },
+    {
+      "message": "Property `sensitive` of resource `yum_repository` overwrites an existing method. Please use a different property name. This will raise an exception in Chef 13.",
+      "url": "https://docs.chef.io/deprecations_property_name_collision.html",
+      "location": "/var/chef/cache/cookbooks/yum/resources/repository.rb:59:in `class_from_file'"
+    },
+    {
+      "message": "Cloning resource attributes for directory[/usr/local/bin] from prior resource\nPrevious directory[/usr/local/bin]: /var/chef/cache/cookbooks/opscode-ci/recipes/_platform_tweaks.rb:23:in `from_file'\nCurrent  directory[/usr/local/bin]: /var/chef/cache/cookbooks/omnibus/recipes/_common.rb:49:in `from_file'",
+      "url": "https://docs.chef.io/deprecations_resource_cloning.html",
+      "location": "/var/chef/cache/cookbooks/omnibus/recipes/_common.rb:49:in `from_file'"
+    },
+    {
+      "message": "Cloning resource attributes for apt_repository[openjdk-r] from prior resource\nPrevious apt_repository[openjdk-r]: /var/chef/cache/cookbooks/opscode-ci/recipes/_platform_tweaks.rb:37:in `from_file'\nCurrent  apt_repository[openjdk-r]: /var/chef/cache/cookbooks/opscode-ci/recipes/_java.rb:22:in `from_file'",
+      "url": "https://docs.chef.io/deprecations_resource_cloning.html",
+      "location": "/var/chef/cache/cookbooks/opscode-ci/recipes/_java.rb:22:in `from_file'"
+    },
+    {
+      "message": "Cloning resource attributes for directory[/home/jenkins/.ssh] from prior resource\nPrevious directory[/home/jenkins/.ssh]: /var/chef/cache/cookbooks/opscode-ci/recipes/_github.rb:12:in `from_file'\nCurrent  directory[/home/jenkins/.ssh]: /var/chef/cache/cookbooks/opscode-ci/recipes/slave.rb:58:in `from_file'",
+      "url": "https://docs.chef.io/deprecations_resource_cloning.html",
+      "location": "/var/chef/cache/cookbooks/opscode-ci/recipes/slave.rb:58:in `from_file'"
+    }
+  ]
+}

--- a/e2e/cypress/index.d.ts
+++ b/e2e/cypress/index.d.ts
@@ -6,5 +6,6 @@ declare namespace Cypress {
     logout(): Cypress.Chainable<Object>
     saveStorage(): void
     restoreStorage(): void
+    generateAdminToken(idToken: string): void
   }
 }

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -88,6 +88,18 @@ describe('projects API', () => {
             })
           }
 
+          let totalNodes = 0
+          cy.request({
+            headers: {
+              'api-token': admin_token,
+              'projects': '(unassigned)'
+            },
+            method: 'GET',
+            url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+          }).then((response) => {
+            totalNodes = response.body.length
+          })
+
           cy.fixture('converge/avengers1.json').then(node1 => {
             cy.fixture('converge/avengers2.json').then(node2 => {
               cy.fixture('converge/xmen1.json').then(node3 => {
@@ -104,8 +116,7 @@ describe('projects API', () => {
               })
             })
           })
-
-          cy.wait(5000)  // TODO replace with polling apply status request
+          waitForNodes(totalNodes)
 
           // confirm nodes are unassigned
           cy.request({
@@ -158,10 +169,10 @@ describe('projects API', () => {
           url: 'api/v0/ingest/events/chef/node-multiple-deletes',
           body: {
             node_ids: [
-              "7188b88b-2236-4e27-a875-d3a10a70c497",
-              "639844f4-2ce6-42ba-8c9d-853db69adff3",
-              "75c2376e-d07e-4d2b-ab43-d658c6250a62",
-              "da60e383-67f6-4501-b726-1f28e03bf6ea"
+              "f6a5c33f-bef5-433b-815e-a8f6e69e6b1b", 
+              "82760210-4686-497e-b039-efca78dee64b", 
+              "9c139ad0-89a5-44bc-942c-d7f248b155ba", 
+              "6453a764-2415-4934-8cee-2a008834a74a"
             ]
           }
         })
@@ -203,7 +214,8 @@ describe('projects API', () => {
           method: 'POST',
           url: '/apis/iam/v2beta/apply-rules'
         })
-        cy.wait(5000) // TODO replace with polling apply status request
+        // waitForSuccessfulApply()
+        cy.wait(5000) 
 
         // confirm rules are applied
         for (let project of [avengers_project, xmen_project]) {
@@ -265,7 +277,8 @@ describe('projects API', () => {
           method: 'POST',
           url: '/apis/iam/v2beta/apply-rules'
         })
-        cy.wait(5000) // TODO replace with polling apply status request
+        // waitForSuccessfulApply()
+        cy.wait(5000) 
 
         cy.request({
           headers: {
@@ -292,7 +305,8 @@ describe('projects API', () => {
           method: 'POST',
           url: '/apis/iam/v2beta/apply-rules'
         })
-        cy.wait(5000)  // TODO replace with polling apply status request
+        // waitForSuccessfulApply()
+        cy.wait(5000) 
 
         cy.request({
           headers: {
@@ -319,3 +333,38 @@ describe('projects API', () => {
     })
   }
 })
+
+// TODO fix
+// function waitForSuccessfulApply() {
+//   cy
+//     .request({
+//       headers: {
+//         'api-token': admin_token      
+//       },
+//       method: 'GET',
+//       url: '/apis/iam/v2beta/apply-rules'
+//     })
+//     .then((resp: Cypress.ObjectLike) => {
+//       if (resp.body.percentage_complete == 1 && resp.body.state == "not_running" && !resp.body.failed)
+//         return
+
+//       waitForSuccessfulApply()
+//     })
+// }
+
+function waitForNodes(totalNodes: number) {
+  cy
+    .request({
+      headers: {
+        'api-token': admin_token
+      },
+      method: 'GET',
+      url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+    })
+    .then((resp: Cypress.ObjectLike) => {
+      if (resp.body.length == totalNodes + 4)
+        return
+
+      waitForNodes(totalNodes)
+    })
+}

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -113,7 +113,7 @@ describe('projects API', () => {
               })
             })
           })
-          const maxRetries = 20
+          const maxRetries = 50
           waitForNodes(admin.id_token, totalNodes, 0, maxRetries)
 
           // confirm nodes are unassigned

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -1,16 +1,16 @@
-const admin_token = 'ZNhnqJyDqgkXVk_bpobS3YhIMz0='
-const admin_token_obj = {
+const adminToken = 'ZNhnqJyDqgkXVk_bpobS3YhIMz0='
+const adminTokenObj = {
   id: `test-token-${Cypress.moment().format('MMDDYYhhmm')}`,
   name: "cypress-api-test-admin-token",
-  value: admin_token
+  value: adminToken
 }
 
-const avengers_project = {
+const avengersProject = {
   id: `avengers-project-${Cypress.moment().format('MMDDYYhhmm')}`,
   name: "Test Avengers Project"
 }
 
-const xmen_project = {
+const xmenProject = {
   id: `xmen-project-${Cypress.moment().format('MMDDYYhhmm')}`,
   name: "Test X-men Project"
 }
@@ -19,7 +19,7 @@ let avengersRule = {
   id: "avengers-rule-1",
   name: "first rule of avengers project",
   type: "NODE",
-  project_id: avengers_project.id,
+  project_id: avengersProject.id,
   conditions: [
     {
       attribute: "CHEF_ORGS",
@@ -29,11 +29,11 @@ let avengersRule = {
   ]
 }
 
-const xmen_rule = {
+const xmenRule = {
   id: "xmen-rule-1",
   name: "first rule of xmen project",
   type: "NODE",
-  project_id: xmen_project.id,
+  project_id: xmenProject.id,
   conditions: [
     {
       attribute: "CHEF_ORGS",
@@ -61,7 +61,7 @@ describe('projects API', () => {
             method: 'POST',
             url: '/apis/iam/v2beta/tokens',
             failOnStatusCode: false,
-            body: admin_token_obj
+            body: adminTokenObj
           }).then((response) => {
             expect([200, 409]).to.include(response.status)
           })
@@ -71,14 +71,14 @@ describe('projects API', () => {
             method: 'POST',
             url: '/apis/iam/v2beta/policies/administrator-access/members:add',
             body: {
-              members: [`token:${admin_token_obj.id}`]
+              members: [`token:${adminTokenObj.id}`]
             }
           })
 
           // create projects or confirm they already exist
-          for (let project of [avengers_project, xmen_project]) {
+          for (let project of [avengersProject, xmenProject]) {
             cy.request({
-              headers: { 'api-token': admin_token },
+              headers: { 'api-token': adminToken },
               method: 'POST',
               url: '/apis/iam/v2beta/projects',
               failOnStatusCode: false,
@@ -91,8 +91,8 @@ describe('projects API', () => {
           let totalNodes = 0
           cy.request({
             headers: {
-              'api-token': admin_token,
-              'projects': '(unassigned)'
+              'api-token': adminToken,
+              projects: '(unassigned)'
             },
             method: 'GET',
             url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
@@ -106,7 +106,7 @@ describe('projects API', () => {
                 cy.fixture('converge/xmen2.json').then(node4 => {
                   for (let node of [node1, node2, node3, node4]) {
                     cy.request({
-                      headers: { 'api-token': admin_token },
+                      headers: { 'api-token': adminToken },
                       method: 'POST',
                       url: '/data-collector/v0',
                       body: node
@@ -121,8 +121,8 @@ describe('projects API', () => {
           // confirm nodes are unassigned
           cy.request({
             headers: {
-              'api-token': admin_token,
-              'projects': '(unassigned)'
+              'api-token': adminToken,
+              projects: '(unassigned)'
             },
             method: 'GET',
             url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
@@ -132,8 +132,8 @@ describe('projects API', () => {
 
           cy.request({
             headers: {
-              'api-token': admin_token,
-              'projects': avengers_project.id
+              'api-token': adminToken,
+              projects: avengersProject.id
             },
             method: 'GET',
             url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
@@ -143,8 +143,8 @@ describe('projects API', () => {
 
           cy.request({
             headers: {
-              'api-token': admin_token,
-              'projects': xmen_project.id
+              'api-token': adminToken,
+              projects: xmenProject.id
             },
             method: 'GET',
             url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
@@ -155,16 +155,16 @@ describe('projects API', () => {
       })
 
       after(() => {
-        for (let project of [avengers_project, xmen_project]) {
+        for (let project of [avengersProject, xmenProject]) {
           cy.request({
-            headers: { 'api-token': admin_token },
+            headers: { 'api-token': adminToken },
             method: 'DELETE',
             url: `/apis/iam/v2beta/projects/${project.id}`
           })
         }
 
         cy.request({
-          headers: { 'api-token': admin_token },
+          headers: { 'api-token': adminToken },
           method: 'POST',
           url: 'api/v0/ingest/events/chef/node-multiple-deletes',
           body: {
@@ -178,17 +178,17 @@ describe('projects API', () => {
         })
 
         cy.request({
-          headers: { 'api-token': admin_token },
+          headers: { 'api-token': adminToken },
           method: 'DELETE',
-          url: `/apis/iam/v2beta/tokens/${admin_token_obj.id}`
+          url: `/apis/iam/v2beta/tokens/${adminTokenObj.id}`
         })
       })
 
       it('new rules get applied to nodes', () => {
 
-        for (let rule of [avengersRule, xmen_rule]) {
+        for (let rule of [avengersRule, xmenRule]) {
           cy.request({
-            headers: { 'api-token': admin_token },
+            headers: { 'api-token': adminToken },
             method: 'POST',
             url: '/apis/iam/v2beta/rules',
             body: rule
@@ -196,9 +196,9 @@ describe('projects API', () => {
         }
 
         // confirm rules are staged
-        for (let project of [avengers_project, xmen_project]) {
+        for (let project of [avengersProject, xmenProject]) {
           cy.request({
-            headers: { 'api-token': admin_token },
+            headers: { 'api-token': adminToken },
             method: 'GET',
             url: `/apis/iam/v2beta/projects/${project.id}/rules`
           }).then((response) => {
@@ -210,7 +210,7 @@ describe('projects API', () => {
         }
 
         cy.request({
-          headers: { 'api-token': admin_token },
+          headers: { 'api-token': adminToken },
           method: 'POST',
           url: '/apis/iam/v2beta/apply-rules'
         })
@@ -218,9 +218,9 @@ describe('projects API', () => {
         cy.wait(5000) 
 
         // confirm rules are applied
-        for (let project of [avengers_project, xmen_project]) {
+        for (let project of [avengersProject, xmenProject]) {
           cy.request({
-            headers: { 'api-token': admin_token },
+            headers: { 'api-token': adminToken },
             method: 'GET',
             url: `/apis/iam/v2beta/projects/${project.id}/rules`
           }).then((response) => {
@@ -234,8 +234,8 @@ describe('projects API', () => {
         // confirm nodes are assigned to projects correctly
         cy.request({
           headers: {
-            'api-token': admin_token,
-            'projects': avengers_project.id
+            'api-token': adminToken,
+            projects: avengersProject.id
           },
           method: 'GET',
           url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
@@ -245,8 +245,8 @@ describe('projects API', () => {
 
         cy.request({
           headers: {
-            'api-token': admin_token,
-            'projects': xmen_project.id
+            'api-token': adminToken,
+            projects: xmenProject.id
           },
           method: 'GET',
           url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
@@ -266,14 +266,14 @@ describe('projects API', () => {
         ]
 
         cy.request({
-          headers: { 'api-token': admin_token },
+          headers: { 'api-token': adminToken },
           method: 'PUT',
           url: `/apis/iam/v2beta/rules/${avengersRule.id}`,
           body: avengersRule
         })
 
         cy.request({
-          headers: { 'api-token': admin_token },
+          headers: { 'api-token': adminToken },
           method: 'POST',
           url: '/apis/iam/v2beta/apply-rules'
         })
@@ -282,8 +282,8 @@ describe('projects API', () => {
 
         cy.request({
           headers: {
-            'api-token': admin_token,
-            'projects': avengers_project.id
+            'api-token': adminToken,
+            projects: avengersProject.id
           },
           method: 'GET',
           url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
@@ -294,14 +294,14 @@ describe('projects API', () => {
 
       it('deleted rules get applied to nodes', () => {
         cy.request({
-          headers: { 'api-token': admin_token },
+          headers: { 'api-token': adminToken },
           method: 'DELETE',
           url: `/apis/iam/v2beta/rules/${avengersRule.id}`,
           body: avengersRule
         })
 
         cy.request({
-          headers: { 'api-token': admin_token },
+          headers: { 'api-token': adminToken },
           method: 'POST',
           url: '/apis/iam/v2beta/apply-rules'
         })
@@ -310,8 +310,8 @@ describe('projects API', () => {
 
         cy.request({
           headers: {
-            'api-token': admin_token,
-            'projects': avengers_project.id
+            'api-token': adminToken,
+            projects: avengersProject.id
           },
           method: 'GET',
           url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
@@ -321,8 +321,8 @@ describe('projects API', () => {
 
         cy.request({
           headers: {
-            'api-token': admin_token,
-            'projects': '(unassigned)'
+            'api-token': adminToken,
+            projects: '(unassigned)'
           },
           method: 'GET',
           url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
@@ -339,7 +339,7 @@ describe('projects API', () => {
 //   cy
 //     .request({
 //       headers: {
-//         'api-token': admin_token      
+//         'api-token': adminToken      
 //       },
 //       method: 'GET',
 //       url: '/apis/iam/v2beta/apply-rules'
@@ -356,7 +356,7 @@ function waitForNodes(totalNodes: number) {
   cy
     .request({
       headers: {
-        'api-token': admin_token
+        'api-token': adminToken
       },
       method: 'GET',
       url: '/api/v0/cfgmgmt/nodes?pagination.size=10'

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -184,7 +184,7 @@ describe('projects API', () => {
         })
         // adding a wait here instead of a request poll since the apply status 
         // does not have precise enough timing for such a small data set
-        cy.wait(4000)        
+        cy.wait(5000)        
 
         // confirm rules are applied
         for (let project of [avengersProject, xmenProject]) {
@@ -249,7 +249,7 @@ describe('projects API', () => {
           method: 'POST',
           url: '/apis/iam/v2beta/apply-rules'
         })
-        cy.wait(4000) 
+        cy.wait(5000) 
 
         cy.request({
           headers: {
@@ -277,7 +277,7 @@ describe('projects API', () => {
           method: 'POST',
           url: '/apis/iam/v2beta/apply-rules'
         })
-        cy.wait(4000) 
+        cy.wait(5000) 
 
         cy.request({
           headers: {

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -44,77 +44,255 @@ const xmen_rule = {
 }
 
 describe('projects API', () => {
-  describe('applying project rules', () => {
 
-    before(() => {
-      // TODO skip if not on 2.1
+  if (Cypress.env('IAM_VERSION') != 'v2.1') {
+    describe('applying project rules', () => {
+      it.skip('must be run on IAM v2.1')
+    })
+  } else {
+    describe('applying project rules', () => {
+      before(() => {
+        cy.adminLogin('/').then(() => {
+          let admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'))
 
-      cy.adminLogin('/').then(() => {
-        let admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'))
-
-        // generate admin API token
-        cy.request({
-          auth: { bearer: admin.id_token },
-          method: 'POST',
-          url: '/apis/iam/v2beta/tokens',
-          failOnStatusCode: false,
-          body: admin_token_obj
-        }).then((response) => {
-          expect([200, 409]).to.include(response.status)
-        })
-
-        cy.request({
-          auth: { bearer: admin.id_token },
-          method: 'POST',
-          url: '/apis/iam/v2beta/policies/administrator-access/members:add',
-          body: {
-            members: [`token:${admin_token_obj.id}`]
-          }
-        })
-
-        // create projects or confirm they already exist
-        for (let project of [avengers_project, xmen_project]) {
+          // generate admin API token
           cy.request({
-            headers: { 'api-token': admin_token },
+            auth: { bearer: admin.id_token },
             method: 'POST',
-            url: '/apis/iam/v2beta/projects',
+            url: '/apis/iam/v2beta/tokens',
             failOnStatusCode: false,
-            body: project
+            body: admin_token_obj
           }).then((response) => {
             expect([200, 409]).to.include(response.status)
           })
-        }
 
-        cy.fixture('converge/avengers1.json').then(node1 => {
-          cy.fixture('converge/avengers2.json').then(node2 => {
-            cy.fixture('converge/xmen1.json').then(node3 => {
-              cy.fixture('converge/xmen2.json').then(node4 => {
-                for (let node of [node1, node2, node3, node4]) {
-                  cy.request({
-                    headers: { 'api-token': admin_token },
-                    method: 'POST',
-                    url: '/data-collector/v0',
-                    body: node
-                  })
-                }
+          cy.request({
+            auth: { bearer: admin.id_token },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies/administrator-access/members:add',
+            body: {
+              members: [`token:${admin_token_obj.id}`]
+            }
+          })
+
+          // create projects or confirm they already exist
+          for (let project of [avengers_project, xmen_project]) {
+            cy.request({
+              headers: { 'api-token': admin_token },
+              method: 'POST',
+              url: '/apis/iam/v2beta/projects',
+              failOnStatusCode: false,
+              body: project
+            }).then((response) => {
+              expect([200, 409]).to.include(response.status)
+            })
+          }
+
+          cy.fixture('converge/avengers1.json').then(node1 => {
+            cy.fixture('converge/avengers2.json').then(node2 => {
+              cy.fixture('converge/xmen1.json').then(node3 => {
+                cy.fixture('converge/xmen2.json').then(node4 => {
+                  for (let node of [node1, node2, node3, node4]) {
+                    cy.request({
+                      headers: { 'api-token': admin_token },
+                      method: 'POST',
+                      url: '/data-collector/v0',
+                      body: node
+                    })
+                  }
+                })
               })
             })
           })
+
+          cy.wait(5000)  // TODO replace with polling apply status request
+
+          // confirm nodes are unassigned
+          cy.request({
+            headers: {
+              'api-token': admin_token,
+              'projects': '(unassigned)'
+            },
+            method: 'GET',
+            url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+          }).then((response) => {
+            expect(response.body).to.have.length(4)
+          })
+
+          cy.request({
+            headers: {
+              'api-token': admin_token,
+              'projects': avengers_project.id
+            },
+            method: 'GET',
+            url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+          }).then((response) => {
+            expect(response.body).to.have.length(0)
+          })
+
+          cy.request({
+            headers: {
+              'api-token': admin_token,
+              'projects': xmen_project.id
+            },
+            method: 'GET',
+            url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+          }).then((response) => {
+            expect(response.body).to.have.length(0)
+          })
+        })
+      })
+
+      after(() => {
+        for (let project of [avengers_project, xmen_project]) {
+          cy.request({
+            headers: { 'api-token': admin_token },
+            method: 'DELETE',
+            url: `/apis/iam/v2beta/projects/${project.id}`
+          })
+        }
+
+        cy.request({
+          headers: { 'api-token': admin_token },
+          method: 'POST',
+          url: 'api/v0/ingest/events/chef/node-multiple-deletes',
+          body: {
+            node_ids: [
+              "7188b88b-2236-4e27-a875-d3a10a70c497",
+              "639844f4-2ce6-42ba-8c9d-853db69adff3",
+              "75c2376e-d07e-4d2b-ab43-d658c6250a62",
+              "da60e383-67f6-4501-b726-1f28e03bf6ea"
+            ]
+          }
         })
 
-        cy.wait(5000)  // TODO replace with polling apply status request
+        cy.request({
+          headers: { 'api-token': admin_token },
+          method: 'DELETE',
+          url: `/apis/iam/v2beta/tokens/${admin_token_obj.id}`
+        })
+      })
 
-        // confirm nodes are unassigned
+      it('new rules get applied to nodes', () => {
+
+        for (let rule of [avengersRule, xmen_rule]) {
+          cy.request({
+            headers: { 'api-token': admin_token },
+            method: 'POST',
+            url: '/apis/iam/v2beta/rules',
+            body: rule
+          })
+        }
+
+        // confirm rules are staged
+        for (let project of [avengers_project, xmen_project]) {
+          cy.request({
+            headers: { 'api-token': admin_token },
+            method: 'GET',
+            url: `/apis/iam/v2beta/projects/${project.id}/rules`
+          }).then((response) => {
+            expect(response.body.rules).to.have.length(1)
+            for (let rule of response.body.rules) {
+              expect(rule).to.have.property('status', 'STAGED')
+            }
+          })
+        }
+
+        cy.request({
+          headers: { 'api-token': admin_token },
+          method: 'POST',
+          url: '/apis/iam/v2beta/apply-rules'
+        })
+        cy.wait(5000) // TODO replace with polling apply status request
+
+        // confirm rules are applied
+        for (let project of [avengers_project, xmen_project]) {
+          cy.request({
+            headers: { 'api-token': admin_token },
+            method: 'GET',
+            url: `/apis/iam/v2beta/projects/${project.id}/rules`
+          }).then((response) => {
+            expect(response.body.rules).to.have.length(1)
+            for (let rule of response.body.rules) {
+              expect(rule).to.have.property('status', 'APPLIED')
+            }
+          })
+        }
+
+        // confirm nodes are assigned to projects correctly
         cy.request({
           headers: {
             'api-token': admin_token,
-            'projects': '(unassigned)'
+            'projects': avengers_project.id
+          },
+          method: 'GET',
+          url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+        }).then((response) => {
+          expect(response.body).to.have.length(2)
+        })
+
+        cy.request({
+          headers: {
+            'api-token': admin_token,
+            'projects': xmen_project.id
+          },
+          method: 'GET',
+          url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+        }).then((response) => {
+          expect(response.body).to.have.length(2)
+        })
+      })
+
+      it('rules with updated conditions get applied to nodes', () => {
+        // change avengers rule to include both organizations
+        avengersRule.conditions = [
+          {
+            attribute: "CHEF_ORGS",
+            operator: "MEMBER_OF",
+            values: ["avengers", "xmen"]
+          }
+        ]
+
+        cy.request({
+          headers: { 'api-token': admin_token },
+          method: 'PUT',
+          url: `/apis/iam/v2beta/rules/${avengersRule.id}`,
+          body: avengersRule
+        })
+
+        cy.request({
+          headers: { 'api-token': admin_token },
+          method: 'POST',
+          url: '/apis/iam/v2beta/apply-rules'
+        })
+        cy.wait(5000) // TODO replace with polling apply status request
+
+        cy.request({
+          headers: {
+            'api-token': admin_token,
+            'projects': avengers_project.id
           },
           method: 'GET',
           url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
         }).then((response) => {
           expect(response.body).to.have.length(4)
         })
+      })
+
+      it('deleted rules get applied to nodes', () => {
+        cy.request({
+          headers: { 'api-token': admin_token },
+          method: 'DELETE',
+          url: `/apis/iam/v2beta/rules/${avengersRule.id}`,
+          body: avengersRule
+        })
+
+        cy.request({
+          headers: { 'api-token': admin_token },
+          method: 'POST',
+          url: '/apis/iam/v2beta/apply-rules'
+        })
+        cy.wait(5000)  // TODO replace with polling apply status request
 
         cy.request({
           headers: {
@@ -130,188 +308,14 @@ describe('projects API', () => {
         cy.request({
           headers: {
             'api-token': admin_token,
-            'projects': xmen_project.id
+            'projects': '(unassigned)'
           },
           method: 'GET',
           url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
         }).then((response) => {
-          expect(response.body).to.have.length(0)
+          expect(response.body).to.have.length(2)
         })
       })
     })
-
-    after(() => {
-      for (let project of [avengers_project, xmen_project]) {
-        cy.request({
-          headers: { 'api-token': admin_token },
-          method: 'DELETE',
-          url: `/apis/iam/v2beta/projects/${project.id}`
-        })
-      }
-
-      cy.request({
-          headers: { 'api-token': admin_token },
-          method: 'POST',
-          url: 'api/v0/ingest/events/chef/node-multiple-deletes',
-          body: {
-            node_ids: [
-              "7188b88b-2236-4e27-a875-d3a10a70c497",
-              "639844f4-2ce6-42ba-8c9d-853db69adff3", 
-              "75c2376e-d07e-4d2b-ab43-d658c6250a62",
-              "da60e383-67f6-4501-b726-1f28e03bf6ea"
-            ]
-          }
-        })
-
-      cy.request({
-        headers: { 'api-token': admin_token },
-        method: 'DELETE',
-        url: `/apis/iam/v2beta/tokens/${admin_token_obj.id}`
-      })
-    })
-
-    it('new rules get applied to nodes', () => {
-
-      for (let rule of [avengersRule, xmen_rule]) {
-        cy.request({
-          headers: { 'api-token': admin_token },
-          method: 'POST',
-          url: '/apis/iam/v2beta/rules',
-          body: rule
-        })
-      }
-
-      // confirm rules are staged
-      for (let project of [avengers_project, xmen_project]) {
-        cy.request({
-          headers: { 'api-token': admin_token },
-          method: 'GET',
-          url: `/apis/iam/v2beta/projects/${project.id}/rules`
-        }).then((response) => {
-          expect(response.body.rules).to.have.length(1)
-          for (let rule of response.body.rules) {
-            expect(rule).to.have.property('status', 'STAGED')
-          }
-        })
-      }
-
-      cy.request({
-        headers: { 'api-token': admin_token },
-        method: 'POST',
-        url: '/apis/iam/v2beta/apply-rules'
-      })
-      cy.wait(5000) // TODO replace with polling apply status request
-
-      // confirm rules are applied
-      for (let project of [avengers_project, xmen_project]) {
-        cy.request({
-          headers: { 'api-token': admin_token },
-          method: 'GET',
-          url: `/apis/iam/v2beta/projects/${project.id}/rules`
-        }).then((response) => {
-          expect(response.body.rules).to.have.length(1)
-          for (let rule of response.body.rules) {
-            expect(rule).to.have.property('status', 'APPLIED')
-          }
-        })
-      }
-
-      // confirm nodes are assigned to projects correctly
-      cy.request({
-        headers: {
-          'api-token': admin_token,
-          'projects': avengers_project.id
-        },
-        method: 'GET',
-        url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
-      }).then((response) => {
-        expect(response.body).to.have.length(2)
-      })
-
-      cy.request({
-        headers: {
-          'api-token': admin_token,
-          'projects': xmen_project.id
-        },
-        method: 'GET',
-        url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
-      }).then((response) => {
-        expect(response.body).to.have.length(2)
-      })
-    })
-
-    it('rules with updated conditions get applied to nodes', () => {
-      // change avengers rule to include both organizations
-      avengersRule.conditions = [
-        {
-        attribute: "CHEF_ORGS",
-        operator: "MEMBER_OF",
-        values: ["avengers", "xmen"]
-      }
-    ]
-
-      cy.request({
-        headers: { 'api-token': admin_token },
-        method: 'PUT',
-        url: `/apis/iam/v2beta/rules/${avengersRule.id}`,
-        body: avengersRule
-      })
-
-      cy.request({
-        headers: { 'api-token': admin_token },
-        method: 'POST',
-        url: '/apis/iam/v2beta/apply-rules'
-      })
-      cy.wait(5000) // TODO replace with polling apply status request
-
-      cy.request({
-        headers: {
-          'api-token': admin_token,
-          'projects': avengers_project.id
-        },
-        method: 'GET',
-        url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
-      }).then((response) => {
-        expect(response.body).to.have.length(4)
-      })
-    })
-
-    it('deleted rules get applied to nodes', () => {
-      cy.request({
-        headers: { 'api-token': admin_token },
-        method: 'DELETE',
-        url: `/apis/iam/v2beta/rules/${avengersRule.id}`,
-        body: avengersRule
-      })
-      
-      cy.request({
-        headers: { 'api-token': admin_token },
-        method: 'POST',
-        url: '/apis/iam/v2beta/apply-rules'
-      })
-      cy.wait(5000)  // TODO replace with polling apply status request
-      
-      cy.request({
-        headers: {
-          'api-token': admin_token,
-          'projects': avengers_project.id
-        },
-        method: 'GET',
-        url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
-      }).then((response) => {
-        expect(response.body).to.have.length(0)
-      })
-
-      cy.request({
-        headers: {
-          'api-token': admin_token,
-          'projects': '(unassigned)'
-        },
-        method: 'GET',
-        url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
-      }).then((response) => {
-        expect(response.body).to.have.length(2)
-      })
-    })
-  })
+  }
 })

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -68,14 +68,14 @@ describe('projects API', () => {
             failOnStatusCode: false,
           })
 
-          // user our Admin user's ID token to generate an admin-level API token
-          // for use in the tests
+          // use our Admin user's ID token to generate an admin-level API token
+          // for use in the tests as Cypress.env('adminTokenValue')
           cy.generateAdminToken(admin.id_token)
 
           // create projects or confirm they already exist
           for (let project of [avengersProject, xmenProject]) {
             cy.request({
-              headers: { 'api-token': Cypress.env('adminTokenValue') },
+              auth: { bearer: admin.id_token },
               method: 'POST',
               url: '/apis/iam/v2beta/projects',
               failOnStatusCode: false,
@@ -87,8 +87,8 @@ describe('projects API', () => {
 
           let totalNodes = 0
           cy.request({
+            auth: { bearer: admin.id_token },
             headers: {
-              'api-token': Cypress.env('adminTokenValue'),
               projects: '(unassigned)'
             },
             method: 'GET',
@@ -103,7 +103,7 @@ describe('projects API', () => {
                 cy.fixture('converge/xmen2.json').then(node4 => {
                   for (let node of [node1, node2, node3, node4]) {
                     cy.request({
-                      headers: { 'api-token': Cypress.env('adminTokenValue') },
+                      auth: { bearer: admin.id_token },
                       method: 'POST',
                       url: '/data-collector/v0',
                       body: node
@@ -118,8 +118,8 @@ describe('projects API', () => {
 
           // confirm nodes are unassigned
           cy.request({
+            auth: { bearer: admin.id_token },
             headers: {
-              'api-token': Cypress.env('adminTokenValue'),
               projects: '(unassigned)'
             },
             method: 'GET',
@@ -129,8 +129,8 @@ describe('projects API', () => {
           })
 
           cy.request({
+            auth: { bearer: admin.id_token },
             headers: {
-              'api-token': Cypress.env('adminTokenValue'),
               projects: avengersProject.id
             },
             method: 'GET',
@@ -140,8 +140,8 @@ describe('projects API', () => {
           })
 
           cy.request({
+            auth: { bearer: admin.id_token },
             headers: {
-              'api-token': Cypress.env('adminTokenValue'),
               projects: xmenProject.id
             },
             method: 'GET',

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -1,62 +1,64 @@
+const admin_token = 'ZNhnqJyDqgkXVk_bpobS3YhIMz0='
+const admin_token_obj = {
+  id: `test-token-${Cypress.moment().format('MMDDYYhhmm')}`,
+  name: "cypress-api-test-admin-token",
+  value: admin_token
+}
+
+const avengers_project = {
+  id: `avengers-project-${Cypress.moment().format('MMDDYYhhmm')}`,
+  name: "Test Avengers Project"
+}
+
+const xmen_project = {
+  id: `xmen-project-${Cypress.moment().format('MMDDYYhhmm')}`,
+  name: "Test X-men Project"
+}
+
+const avengers_rule = {
+  id: "avengers-rule-1",
+  name: "first rule of avengers project",
+  type: "NODE",
+  project_id: avengers_project.id,
+  conditions: [
+    {
+      attribute: "CHEF_ORGS",
+      operator: "EQUALS",
+      values: ["avengers"]
+    }
+  ]
+}
+
+const xmen_rule = {
+  id: "xmen-rule-1",
+  name: "first rule of xmen project",
+  type: "NODE",
+  project_id: xmen_project.id,
+  conditions: [
+    {
+      attribute: "CHEF_ORGS",
+      operator: "EQUALS",
+      values: ["xmen"]
+    }
+  ]
+}
+
 describe('projects API', () => {
   describe('applying project rules', () => {
 
-    const admin_token = 'ZNhnqJyDqgkXVk_bpobS3YhIMz0='
-
-    const avengers_project = {
-      id: `avengers-project-${Cypress.moment().format('MMDDYYhhmm')}`,
-      name: "Test Avengers Project"
-    }
-
-    const xmen_project = {
-      id: `xmen-project-${Cypress.moment().format('MMDDYYhhmm')}`,
-      name: "Test X-men Project"
-    }
-
-    const avengers_rule = {
-      id: "avengers-rule-1",
-      name: "first rule of avengers project",
-      type: "NODE",
-      project_id: avengers_project.id,
-      conditions: [
-        {
-          attribute: "CHEF_ORGS",
-          operator: "EQUALS",
-          values: ["avengers"]
-        }
-      ]
-    }
-
-    const xmen_rule = {
-      id: "xmen-rule-1",
-      name: "first rule of xmen project",
-      type: "NODE",
-      project_id: xmen_project.id,
-      conditions: [
-        {
-          attribute: "CHEF_ORGS",
-          operator: "EQUALS",
-          values: ["xmen"]
-        }
-      ]
-    }
-
     before(() => {
+      // TODO skip if not on 2.1
+
       cy.adminLogin('/').then(() => {
         let admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'))
 
         // generate admin API token
-        let token_id = `test-token-${Cypress.moment().format('MMDDYYhhmm')}`
         cy.request({
           auth: { bearer: admin.id_token },
           method: 'POST',
           url: '/apis/iam/v2beta/tokens',
           failOnStatusCode: false,
-          body: {
-            id: token_id,
-            name: "cypress-api-test-admin-token",
-            value: admin_token
-          }
+          body: admin_token_obj
         }).then((response) => {
           expect([200, 409]).to.include(response.status)
         })
@@ -66,39 +68,59 @@ describe('projects API', () => {
           method: 'POST',
           url: '/apis/iam/v2beta/policies/administrator-access/members:add',
           body: {
-            members: [`token:${token_id}`]
+            members: [`token:${admin_token_obj.id}`]
           }
         })
 
-        // TODO fix this type
-        const nodes = <any>[]
-
-        Cypress.Promise.all([
-          cy.fixture('converge/avengers1.json').then(node => nodes.push(node)),
-          cy.fixture('converge/avengers2.json').then(node => nodes.push(node)),
-          cy.fixture('converge/xmen1.json').then(node => nodes.push(node)),
-          cy.fixture('converge/xmen2.json').then(node => nodes.push(node))
-        ]).then((node) => {
-          const [avengers1, avengers2, xmen1, xmen2] = nodes
-        })
-
-        for (let node of nodes) {
+        // create projects or confirm they already exist
+        for (let project of [avengers_project, xmen_project]) {
           cy.request({
             headers: { 'api-token': admin_token },
             method: 'POST',
-            url: `/data-collector/v0`,
-            body: node
+            url: '/apis/iam/v2beta/projects',
+            failOnStatusCode: false,
+            body: project
+          }).then((response) => {
+            expect([200, 409]).to.include(response.status)
           })
         }
 
+        cy.fixture('converge/avengers1.json').then(node1 => {
+          cy.fixture('converge/avengers2.json').then(node2 => {
+            cy.fixture('converge/xmen1.json').then(node3 => {
+              cy.fixture('converge/xmen2.json').then(node4 => {
+                for (let node of [node1, node2, node3, node4]) {
+                  cy.request({
+                    headers: { 'api-token': admin_token },
+                    method: 'POST',
+                    url: '/data-collector/v0',
+                    body: node
+                  })
+                }
+              })
+            })
+          })
+        })
+
         // confirm nodes are unassigned
         cy.request({
-          headers: { 
+          headers: {
             'api-token': admin_token,
-            'projects': avengers_project.id  
+            'projects': '(unassigned)'
           },
           method: 'GET',
-          url: `/api/v0/cfgmgmt/nodes?pagination.size=10`
+          url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+        }).then((response) => {
+          expect(response.body).to.have.length(4)
+        })
+
+        cy.request({
+          headers: {
+            'api-token': admin_token,
+            'projects': avengers_project.id
+          },
+          method: 'GET',
+          url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
         }).then((response) => {
           expect(response.body).to.have.length(0)
         })
@@ -109,23 +131,40 @@ describe('projects API', () => {
             'projects': xmen_project.id
           },
           method: 'GET',
-          url: `/api/v0/cfgmgmt/nodes?pagination.size=10`
+          url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
         }).then((response) => {
           expect(response.body).to.have.length(0)
         })
+      })
+    })
 
-        // create projects or confirm them already exist
-        for (let project of [avengers_project, xmen_project]) {
-          cy.request({
-            headers: { 'api-token': admin_token },
-            method: 'POST',
-            url: `/apis/iam/v2beta/projects`,
-            failOnStatusCode: false,
-            body: project
-          }).then((response) => {
-            expect([200, 409]).to.include(response.status)
-          })
-        }
+    after(() => {
+      for (let project of [avengers_project, xmen_project]) {
+        cy.request({
+          headers: { 'api-token': admin_token },
+          method: 'DELETE',
+          url: `/apis/iam/v2beta/projects/${project.id}`
+        })
+      }
+
+      cy.request({
+          headers: { 'api-token': admin_token },
+          method: 'POST',
+          url: 'api/v0/ingest/events/chef/node-multiple-deletes',
+          body: {
+            node_ids: [
+              "7188b88b-2236-4e27-a875-d3a10a70c497",
+              "639844f4-2ce6-42ba-8c9d-853db69adff3", 
+              "75c2376e-d07e-4d2b-ab43-d658c6250a62",
+              "da60e383-67f6-4501-b726-1f28e03bf6ea"
+            ]
+          }
+        })
+      
+      cy.request({
+        headers: { 'api-token': admin_token },
+        method: 'DELETE',
+        url: `/apis/iam/v2beta/tokens/${admin_token_obj.id}`
       })
     })
 
@@ -135,14 +174,69 @@ describe('projects API', () => {
         cy.request({
           headers: { 'api-token': admin_token },
           method: 'POST',
-          url: `/apis/iam/v2beta/rules`,
+          url: '/apis/iam/v2beta/rules',
           body: rule
         })
       }
-        
-      // apply rules
-      // confirm nodes are assigned to projects correctly
 
+      // confirm rules are staged
+      for (let project of [avengers_project, xmen_project]) {
+        cy.request({
+          headers: { 'api-token': admin_token },
+          method: 'GET',
+          url: `/apis/iam/v2beta/projects/${project.id}/rules`
+        }).then((response) => {
+          expect(response.body.rules).to.have.length(1)
+          for (let rule of response.body.rules) {
+            expect(rule).to.have.property('status', 'STAGED')
+          }
+        })
+      }
+        
+      cy.request({
+        headers: { 'api-token': admin_token },
+        method: 'POST',
+        url: '/apis/iam/v2beta/apply-rules'
+      })
+      cy.wait(5000)
+      // TODO check status until ready
+
+      // confirm rules are applied
+      for (let project of [avengers_project, xmen_project]) {
+        cy.request({
+          headers: { 'api-token': admin_token },
+          method: 'GET',
+          url: `/apis/iam/v2beta/projects/${project.id}/rules`
+        }).then((response) => {
+          expect(response.body.rules).to.have.length(1)
+          for (let rule of response.body.rules) {
+            expect(rule).to.have.property('status', 'APPLIED')
+          }
+        })
+      }
+
+      // confirm nodes are assigned to projects correctly
+      cy.request({
+        headers: {
+          'api-token': admin_token,
+          'projects': avengers_project.id
+        },
+        method: 'GET',
+        url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+      }).then((response) => {
+        expect(response.body).to.have.length(2)
+      })
+
+      cy.request({
+        headers: {
+          'api-token': admin_token,
+          'projects': xmen_project.id
+        },
+        method: 'GET',
+        url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+      }).then((response) => {
+        expect(response.body).to.have.length(2)
+      })
     })
 
     it('rules with updated conditions get applied to nodes', () => {

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -241,12 +241,14 @@ describe('projects API', () => {
     })
 
     it('rules with updated conditions get applied to nodes', () => {
-      // Add condition to avengers rule
-      avengersRule.conditions.push({
+      // change avengers rule to include both organizations
+      avengersRule.conditions = [
+        {
         attribute: "CHEF_ORGS",
-        operator: "EQUALS",
-        values: ["xmen"]
-      })
+        operator: "MEMBER_OF",
+        values: ["avengers", "xmen"]
+      }
+    ]
 
       cy.request({
         headers: { 'api-token': admin_token },
@@ -262,7 +264,6 @@ describe('projects API', () => {
       })
       cy.wait(5000) // TODO replace with polling apply status request
 
-      // TODO investigate failure by repro locally
       cy.request({
         headers: {
           'api-token': admin_token,

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -113,7 +113,7 @@ describe('projects API', () => {
               })
             })
           })
-          const maxRetries = 50
+          const maxRetries = 75
           waitForNodes(admin.id_token, totalNodes, 0, maxRetries)
 
           // confirm nodes are unassigned

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -1,0 +1,166 @@
+describe('projects API', () => {
+  describe('applying project rules', () => {
+
+    const admin_token = 'ZNhnqJyDqgkXVk_bpobS3YhIMz0='
+
+    const avengers_project = {
+      id: `avengers-project-${Cypress.moment().format('MMDDYYhhmm')}`,
+      name: "Test Avengers Project"
+    }
+
+    const xmen_project = {
+      id: `xmen-project-${Cypress.moment().format('MMDDYYhhmm')}`,
+      name: "Test X-men Project"
+    }
+
+    const avengers_rule = {
+      id: "avengers-rule-1",
+      name: "first rule of avengers project",
+      type: "NODE",
+      project_id: avengers_project.id,
+      conditions: [
+        {
+          attribute: "CHEF_ORGS",
+          operator: "EQUALS",
+          values: ["avengers"]
+        }
+      ]
+    }
+
+    const xmen_rule = {
+      id: "xmen-rule-1",
+      name: "first rule of xmen project",
+      type: "NODE",
+      project_id: xmen_project.id,
+      conditions: [
+        {
+          attribute: "CHEF_ORGS",
+          operator: "EQUALS",
+          values: ["xmen"]
+        }
+      ]
+    }
+
+    before(() => {
+      cy.adminLogin('/').then(() => {
+        let admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'))
+
+        // generate admin API token
+        let token_id = `test-token-${Cypress.moment().format('MMDDYYhhmm')}`
+        cy.request({
+          auth: { bearer: admin.id_token },
+          method: 'POST',
+          url: '/apis/iam/v2beta/tokens',
+          failOnStatusCode: false,
+          body: {
+            id: token_id,
+            name: "cypress-api-test-admin-token",
+            value: admin_token
+          }
+        }).then((response) => {
+          expect([200, 409]).to.include(response.status)
+        })
+
+        cy.request({
+          auth: { bearer: admin.id_token },
+          method: 'POST',
+          url: '/apis/iam/v2beta/policies/administrator-access/members:add',
+          body: {
+            members: [`token:${token_id}`]
+          }
+        })
+
+        // TODO fix this type
+        const nodes = <any>[]
+
+        Cypress.Promise.all([
+          cy.fixture('converge/avengers1.json').then(node => nodes.push(node)),
+          cy.fixture('converge/avengers2.json').then(node => nodes.push(node)),
+          cy.fixture('converge/xmen1.json').then(node => nodes.push(node)),
+          cy.fixture('converge/xmen2.json').then(node => nodes.push(node))
+        ]).then((node) => {
+          const [avengers1, avengers2, xmen1, xmen2] = nodes
+        })
+
+        for (let node of nodes) {
+          cy.request({
+            headers: { 'api-token': admin_token },
+            method: 'POST',
+            url: `/data-collector/v0`,
+            body: node
+          })
+        }
+
+        // confirm nodes are unassigned
+        cy.request({
+          headers: { 
+            'api-token': admin_token,
+            'projects': avengers_project.id  
+          },
+          method: 'GET',
+          url: `/api/v0/cfgmgmt/nodes?pagination.size=10`
+        }).then((response) => {
+          expect(response.body).to.have.length(0)
+        })
+
+        cy.request({
+          headers: {
+            'api-token': admin_token,
+            'projects': xmen_project.id
+          },
+          method: 'GET',
+          url: `/api/v0/cfgmgmt/nodes?pagination.size=10`
+        }).then((response) => {
+          expect(response.body).to.have.length(0)
+        })
+
+        // create projects or confirm them already exist
+        for (let project of [avengers_project, xmen_project]) {
+          cy.request({
+            headers: { 'api-token': admin_token },
+            method: 'POST',
+            url: `/apis/iam/v2beta/projects`,
+            failOnStatusCode: false,
+            body: project
+          }).then((response) => {
+            expect([200, 409]).to.include(response.status)
+          })
+        }
+      })
+    })
+
+    it('new rules get applied to nodes', () => {
+
+      for (let rule of [avengers_rule, xmen_rule]) {
+        cy.request({
+          headers: { 'api-token': admin_token },
+          method: 'POST',
+          url: `/apis/iam/v2beta/rules`,
+          body: rule
+        })
+      }
+        
+      // apply rules
+      // confirm nodes are assigned to projects correctly
+
+    })
+
+    it('rules with updated conditions get applied to nodes', () => {
+
+      // update first rule to add another condition to add more nodes to the project
+      // apply rules
+      // confirm new nodes added to project
+
+      // update the same rule to remove the first condition to remove nodes from the project
+      // apply rules
+      // confirm nodes removed from the project
+    })
+
+    it('deleted rules get applied to nodes', () => {
+
+      // delete other rule
+      // apply rules
+      // confirm its nodes go back to unassigned
+    })
+  })
+})

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -69,18 +69,24 @@ Cypress.Commands.add("restoreStorage", () => {
 Cypress.Commands.add("generateAdminToken", (idToken: string) => {
   const adminTokenObj = {
     id: "cypress-api-test-admin-token",
-    name: "cypress-api-test-admin-token",
-    value: Cypress.env('adminTokenValue')
+    name: "cypress-api-test-admin-token"
   }
+
+  // cleanup token from previous test
+  cy.request({
+    auth: { bearer: idToken },
+    method: 'DELETE',
+    url: '/apis/iam/v2beta/tokens/cypress-api-test-admin-token',
+    failOnStatusCode: false
+  })
 
   cy.request({
     auth: { bearer: idToken },
     method: 'POST',
     url: '/apis/iam/v2beta/tokens',
-    failOnStatusCode: false,
     body: adminTokenObj
-  }).then((response) => {
-    expect([200, 409]).to.include(response.status)
+  }).then((response: Cypress.ObjectLike) => {
+    Cypress.env('adminTokenValue', response.body.token.value)
   })
   cy.request({
     auth: { bearer: idToken },

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -66,6 +66,32 @@ Cypress.Commands.add("restoreStorage", () => {
   })
 })
 
+Cypress.Commands.add("generateAdminToken", (idToken: string) => {
+  const adminTokenObj = {
+    id: "cypress-api-test-admin-token",
+    name: "cypress-api-test-admin-token",
+    value: Cypress.env('adminTokenValue')
+  }
+
+  cy.request({
+    auth: { bearer: idToken },
+    method: 'POST',
+    url: '/apis/iam/v2beta/tokens',
+    failOnStatusCode: false,
+    body: adminTokenObj
+  }).then((response) => {
+    expect([200, 409]).to.include(response.status)
+  })
+  cy.request({
+    auth: { bearer: idToken },
+    method: 'POST',
+    url: '/apis/iam/v2beta/policies/administrator-access/members:add',
+    body: {
+      members: [`token:${adminTokenObj.id}`]
+    }
+  })
+})
+
 // helpers
 
 function LoginHelper(username: string) {

--- a/integration/tests/cypress_e2e.sh
+++ b/integration/tests/cypress_e2e.sh
@@ -16,6 +16,8 @@ do_deploy() {
     chef-automate license apply "$A2_LICENSE"
 
     case $IAM in
+        v1)
+            export CYPRESS_IAM_VERSION='v1'
         v2)
             log_info "run chef-automate iam upgrade-to-v2 --skip-policy-migration"
             if ! output=$(chef-automate iam upgrade-to-v2 --skip-policy-migration); then
@@ -23,6 +25,7 @@ do_deploy() {
                 log_error "$output"
                 return 1
             fi
+            export CYPRESS_IAM_VERSION='v2'
             ;;
         v2.1)
             log_info "run chef-automate iam upgrade-to-v2 --skip-policy-migration --beta2.1"
@@ -31,6 +34,7 @@ do_deploy() {
                 log_error "$output"
                 return 1
             fi
+            export CYPRESS_IAM_VERSION='v2.1'
             ;;
     esac
 
@@ -47,6 +51,6 @@ do_test_deploy() {
     npm install # get dependencies defined in e2e/package.json
     if ! npm run cypress:run; then
         buildkite-agent artifact upload "cypress/videos/*;cypress/videos/**/*;cypress/screenshots/*;cypress/screenshots/**/*"
-        return 1
+        exit 1
     fi
 }

--- a/integration/tests/cypress_e2e.sh
+++ b/integration/tests/cypress_e2e.sh
@@ -49,6 +49,6 @@ do_test_deploy() {
     npm install # get dependencies defined in e2e/package.json
     if ! npm run cypress:run; then
         buildkite-agent artifact upload "cypress/videos/*;cypress/videos/**/*;cypress/screenshots/*;cypress/screenshots/**/*"
-        exit 1
+        return 1
     fi
 }

--- a/integration/tests/cypress_e2e.sh
+++ b/integration/tests/cypress_e2e.sh
@@ -16,8 +16,6 @@ do_deploy() {
     chef-automate license apply "$A2_LICENSE"
 
     case $IAM in
-        v1)
-            export CYPRESS_IAM_VERSION='v1'
         v2)
             log_info "run chef-automate iam upgrade-to-v2 --skip-policy-migration"
             if ! output=$(chef-automate iam upgrade-to-v2 --skip-policy-migration); then
@@ -25,7 +23,6 @@ do_deploy() {
                 log_error "$output"
                 return 1
             fi
-            export CYPRESS_IAM_VERSION='v2'
             ;;
         v2.1)
             log_info "run chef-automate iam upgrade-to-v2 --skip-policy-migration --beta2.1"
@@ -34,9 +31,10 @@ do_deploy() {
                 log_error "$output"
                 return 1
             fi
-            export CYPRESS_IAM_VERSION='v2.1'
             ;;
     esac
+
+    export CYPRESS_IAM_VERSION=$IAM
 
     log_info "fixing dns resolution for '${CONTAINER_HOSTNAME}'"
     echo "127.0.0.1 ${CONTAINER_HOSTNAME}" >> /etc/hosts

--- a/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
@@ -35,6 +35,7 @@ module "performance_test_single_local_inplace_upgrade" {
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
     X-CI-Test          = "e2e"
+    X-IAM              = "v1"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_fresh_install.tf
@@ -35,6 +35,7 @@ module "single_local_fresh_install" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-CI-Test          = "e2e"
+    X-IAM              = "v1"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_iamv2_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2_fresh_install.tf
@@ -35,6 +35,7 @@ module "single_local_iamv2_fresh_install" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-CI-Test          = "e2e"
+    X-IAM              = "v2"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_iamv2_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2_inplace_upgrade.tf
@@ -35,6 +35,7 @@ module "single_local_iamv2_inplace_upgrade" {
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
     X-CI-Test          = "e2e"
+    X-IAM              = "v2"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_iamv2p1_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2p1_fresh_install.tf
@@ -35,6 +35,7 @@ module "single_local_iamv2p1_fresh_install" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-CI-Test          = "e2e"
+    X-IAM              = "v2.1"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_iamv2p1_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_iamv2p1_inplace_upgrade.tf
@@ -34,6 +34,7 @@ module "single_local_iamv2p1_inplace_upgrade" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-CI-Test          = "e2e"
+    X-IAM              = "v2.1"
   }
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description

We've been using inspec for a while to meet our API integration test needs, but it is not always the most ideal tool for such tests.

Since we've had a good experience using Cypress to test the UI so far, we decided to try out Cypress for our API integration test needs, starting with testing out the flow for applying project rules to nodes.

### :+1: Definition of Done

- [x] using Cypress, we can run an API-only integration test to ensure rule changes get applied to nodes as expected
    - [x] when a project gets a new rule and all rule changes are applied, the nodes affected by those rules can be filtered by the rule's project 
    - [x] when a project's rules are updated and all rule changes are applied, the nodes affected by those rules react accordingly to the new filter rules
    - [x] when a project's is deleted and all rule changes are applied, the nodes affected by those rules can 
 *no longer* be filtered by the deleted rule's project 

TODO:
- [x] fix failing update rule test
- [x] skip if not on v2.1

### :athletic_shoe: Demo Script / Repro Steps
- run cypress locally by [following these steps](https://github.com/chef/automate/blob/master/e2e/README.md#running-cypress-locally)

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
