### PR TITLE
Remove disabled webhook URLs from repository completely

### DIFF
--- a/components/automate-workflow-server/apps/notification/test/notification_hand_test_notification_tests.erl
+++ b/components/automate-workflow-server/apps/notification/test/notification_hand_test_notification_tests.erl
@@ -9,7 +9,7 @@ from_json_fixture_test_() ->
     hoax:fixture(?MODULE, "from_json").
 
 from_json_posts_test_notification_to_slack_webhook() ->
-    WebhookURL = <<"https://hooks.slack.com/services/BLARG/BLARGBLARG/FLOOF">>,
+    WebhookURL = <<"https://hooks.slack.com/services/FAKE/FAKE/THISISFAKE">>,
 
     ReqEjson = {[
         {<<"url">>, WebhookURL}
@@ -47,7 +47,7 @@ from_json_posts_test_notification_to_slack_webhook() ->
     ?verifyAll.
 
 from_json_slack_failure_returns_failure_response() ->
-    WebhookURL = <<"https://hooks.slack.com/services/BLARG/BLARGBLARG/FLOOF">>,
+    WebhookURL = <<"https://hooks.slack.com/services/FAKE/FAKE/THISISFAKE">>,
 
     ReqEjson = {[
         {<<"url">>, WebhookURL}
@@ -89,7 +89,7 @@ from_json_slack_failure_returns_failure_response() ->
     ?verifyAll.
 
 from_json_returns_504_when_post_from_server_fails() ->
-    WebhookURL = <<"https://hooks.slack.com/services/BLARG/BLARGBLARG/FLOOF">>,
+    WebhookURL = <<"https://hooks.slack.com/services/FAKE/FAKE/THISISFAKE">>,
 
     ReqEjson = {[
         {<<"url">>, WebhookURL}

--- a/components/automate-workflow-web/test/e2e/specs/org.spec.js
+++ b/components/automate-workflow-web/test/e2e/specs/org.spec.js
@@ -432,7 +432,7 @@ describe('org page', () => {
               response: {
                 body: {
                   webhook: {
-                    url: "https://hooks.slack.com/services/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",
+                    url: "https://hooks.slack.com/services/FAKE/FAKE/THISISFAKE",
                     name: "#delivery-slack-tests",
                     enabled: true
                   }

--- a/components/automate-workflow-web/test/e2e/specs/orgs.spec.js
+++ b/components/automate-workflow-web/test/e2e/specs/orgs.spec.js
@@ -381,7 +381,7 @@ describe('orgs page', () => {
             response: {
               body: {
                 webhook: {
-                  url: "https://hooks.slack.com/services/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",
+                  url: "https://hooks.slack.com/services/FAKE/FAKE/THISISFAKE",
                   name: "#delivery-slack-tests",
                   enabled: true
                 }

--- a/components/notifications-service/server/.iex.exs
+++ b/components/notifications-service/server/.iex.exs
@@ -2,8 +2,18 @@ defmodule H do
   @moduledoc "Various helper functions for use with Notifications in iex"
   @test_data_path "../testdata"
 
-  # This is a private URL, but this is also a private repo.
-  @slack_target_url "https://hooks.slack.com/services/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"
+  @doc """
+  Extract the slack url from the SLACK_URL environment variable.
+  """
+  def get_webhook_url() do
+    case System.get_env("SLACK_URL") do
+      nil ->
+        :no_slack_url_env_var
+      url ->
+        {:ok, url}
+    end
+  end
+
   @doc """
   Set up rules for all event types that will post alerts to Set up rules for all event types
   that will post alerts to #a2-notifications-test"
@@ -11,10 +21,11 @@ defmodule H do
   This function will do nothing if any rules already exist.
   """
   def init_default_slack_rules() do
-    add_rule("ccr-failure-to-slack", :SlackAlert, :CCRFailure,  @slack_target_url )
-    add_rule("ccr-success-to-slack", :SlackAlert, :CCRSuccess,  @slack_target_url)
-    add_rule("comp-success-to-slack", :SlackAlert, :ComplianceSuccess, @slack_target_url)
-    add_rule("comp-failure-to-slack", :SlackAlert, :ComplianceFailure, @slack_target_url)
+    {:ok, webhook_url} = get_webhook_url()
+    add_rule("ccr-failure-to-slack", :SlackAlert, :CCRFailure,  webhook_url)
+    add_rule("ccr-success-to-slack", :SlackAlert, :CCRSuccess,  webhook_url)
+    add_rule("comp-success-to-slack", :SlackAlert, :ComplianceSuccess, webhook_url)
+    add_rule("comp-failure-to-slack", :SlackAlert, :ComplianceFailure, webhook_url)
     :ok
   end
 
@@ -199,4 +210,3 @@ iex> H.levelup
 iex> import H
 
 """
-

--- a/tools/credscan/credscan.go
+++ b/tools/credscan/credscan.go
@@ -102,6 +102,10 @@ var a2Config = config{
 	},
 	contentInclude: []pattern{
 		{
+			description: "slack hooks",
+			regex:       `https://hooks.slack.com`,
+		},
+		{
 			description: "private keys",
 			regex:       `BEGIN.*PRIVATE`,
 		},
@@ -154,6 +158,14 @@ var a2Config = config{
 			description: "OpenJDK PGP key",
 			regex:       "DA1A4A13543B466853BAF164EB9B1D8886F44E2A",
 		},
+		{
+			description: "fake slack webhook 1",
+			regex:       "https://hooks.slack.com/services/FAKE/FAKE/THISISFAKE",
+		},
+		{
+			description: "fake slack webhook 2",
+			regex:       "https://hooks.slack.com/services/T00000000",
+		},
 	},
 }
 
@@ -180,7 +192,7 @@ func main() {
 	// until we need more flexibility.
 	//
 	outbuf := &bytes.Buffer{}
-	gitGrepCmd := fmt.Sprintf("git grep -E \"%s\" | grep -v -E \"%s\"",
+	gitGrepCmd := fmt.Sprintf("git grep -a -E \"%s\" | grep -v -E \"%s\"",
 		toGrepString(a2Config.contentInclude),
 		toGrepString(append(a2Config.contentExclude, a2Config.filenameExclude...)))
 	cmd = exec.Command("bash", "-c", gitGrepCmd)

--- a/tools/credscan/credscan.go
+++ b/tools/credscan/credscan.go
@@ -192,7 +192,7 @@ func main() {
 	// until we need more flexibility.
 	//
 	outbuf := &bytes.Buffer{}
-	gitGrepCmd := fmt.Sprintf("git grep -a -E \"%s\" | grep -v -E \"%s\"",
+	gitGrepCmd := fmt.Sprintf("git grep -a -E \"%s\" | grep -a -v -E \"%s\"",
 		toGrepString(a2Config.contentInclude),
 		toGrepString(append(a2Config.contentExclude, a2Config.filenameExclude...)))
 	cmd = exec.Command("bash", "-c", gitGrepCmd)


### PR DESCRIPTION
This removes old slack webhook URLs. These webhooks have been
disabled, but to make scanning easier, they've been replaced with fake
data that can be excluded in the credscan tool.

Signed-off-by: Steven Danna <steve@chef.io>