### PR TITLE
[automate-workflow-server] Unpin core/git

### DIFF
--- a/components/automate-workflow-server/habitat/plan.sh
+++ b/components/automate-workflow-server/habitat/plan.sh
@@ -10,7 +10,7 @@ pkg_upstream_url="https://www.chef.io/automate"
 pkg_deps=(
   core/bash
   core/coreutils
-  core/curl/7.63.0/20190305215321 # same as core/git/2.20.1/20190305233956
+  core/curl
   core/erlang18
   core/gawk
   core/gcc


### PR DESCRIPTION
core/git has been updated with a new version of core. I've removed
the min rather bumping this pin since it feels like having conflicting
core/curl and core/git packages in stable would be something we want
to raise with the hab team rather than ignore.

Signed-off-by: Steven Danna <steve@chef.io>