### PR TITLE
[ci] Add a few more log lines

### DIFF
--- a/integration/helpers/testing.sh
+++ b/integration/helpers/testing.sh
@@ -44,3 +44,9 @@ run_inspec_tests() {
         fi
     done
 }
+
+verify_packages() {
+    log_info "Verifying all Habitat Packages"e
+    chef-automate dev verify-packages
+    log_info "Done verifying all Habitat Packages"
+}

--- a/integration/tests/airgap_product.sh
+++ b/integration/tests/airgap_product.sh
@@ -33,5 +33,5 @@ do_deploy() {
 
 do_test_deploy() {
     do_test_deploy_default
-    chef-automate dev verify-packages
+    verify_packages
 }

--- a/integration/tests/backup_s3.sh
+++ b/integration/tests/backup_s3.sh
@@ -58,5 +58,5 @@ do_restore() {
 do_test_restore() {
     do_test_restore_default || return 1
     delete_backup_and_assert_idempotent
-    chef-automate dev verify-packages
+    verify_packages
 }

--- a/integration/tests/product.sh
+++ b/integration/tests/product.sh
@@ -18,17 +18,19 @@ do_test_deploy() {
     # We cannot use 'chef-automate stop' yet because
     # there is no way for that command to return successfully
     # I'd rather not jam a fix in
+    log_info "Restarting chef-automate via chef-automate start/stop"
     chef-automate -d stop
     chef-automate -d start
     wait_for_healthy
+    log_info "Done restarting chef-automate"
 
-    chef-automate dev verify-packages
+    verify_packages
 }
 
 world_writable_files_test() {
     # Check for world writable files
     log_info "checking for world writable files"
-    matching="$(find /hab/ -xdev -perm -0002 -type f -print)" 
+    matching="$(find /hab/ -xdev -perm -0002 -type f -print)"
     if [ ! -z "$matching" ]; then
         log_error "the following files are world writable:"
         echo "$matching"


### PR DESCRIPTION
Based on other work in #90, I think that the stop and start
chef-automate is likely causing a long delay in the tests because at
we effectively have to wait for a timeout to happen before that will
actually complete.

It also looks like verify-packages might occasionally be very slow.
This adds some logging so that we can verify that in the CI logs.

Signed-off-by: Steven Danna <steve@chef.io>