### PR TITLE
[cereal] Remove unused WorkflowInstanceID from backend.Task

### DIFF
--- a/lib/cereal/backend/backend.go
+++ b/lib/cereal/backend/backend.go
@@ -73,9 +73,8 @@ type WorkflowEvent struct {
 }
 
 type Task struct {
-	Name               string
-	WorkflowInstanceID int64
-	Parameters         []byte
+	Name       string
+	Parameters []byte
 }
 
 type TaskResult struct {

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -221,9 +221,8 @@ func (w *workflowInstanceImpl) EnqueueTask(taskName string, parameters interface
 		return err
 	}
 	w.tasks = append(w.tasks, backend.Task{
-		WorkflowInstanceID: w.instanceID,
-		Name:               taskName,
-		Parameters:         paramsData,
+		Name:       taskName,
+		Parameters: paramsData,
 	})
 	return nil
 }
@@ -586,15 +585,13 @@ func (m *Manager) startTaskExecutors(ctx context.Context) error {
 		}
 
 		for i := 0; i < workerCount; i++ {
-			go m.RunTaskExecutor(ctx, taskName, i, exec.opts.Timeout, exec.executor)
+			go m.runTaskExecutor(ctx, taskName, i, exec.opts.Timeout, exec.executor)
 		}
 	}
 	return nil
 }
 
-// TODO(ssd) 2019-05-10: Why does Task need the WorkflowInstanceID?
-// TODO(jaym): should this be private?
-func (m *Manager) RunTaskExecutor(ctx context.Context, taskName string, workerIdx int, timeout time.Duration, exec TaskExecutor) {
+func (m *Manager) runTaskExecutor(ctx context.Context, taskName string, workerIdx int, timeout time.Duration, exec TaskExecutor) {
 	logctx := logrus.WithFields(logrus.Fields{
 		"worker_name": fmt.Sprintf("%s/%d", taskName, workerIdx),
 	})

--- a/lib/cereal/postgres/postgres.go
+++ b/lib/cereal/postgres/postgres.go
@@ -628,7 +628,7 @@ func (pg *PostgresBackend) dequeueTask(tx *sql.Tx, taskName string) (int64, *bac
 	}
 
 	var tid int64
-	err := row.Scan(&tid, &task.WorkflowInstanceID, &task.Parameters)
+	err := row.Scan(&tid, &task.Parameters)
 	if err == sql.ErrNoRows {
 		return 0, nil, cereal.ErrNoTasks
 	} else if err != nil {

--- a/lib/cereal/postgres/sql_schema.go
+++ b/lib/cereal/postgres/sql_schema.go
@@ -248,7 +248,7 @@ AS $$
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION cereal_dequeue_task(_task_name TEXT)
-RETURNS TABLE(id BIGINT, workflow_instance_id BIGINT, parameters BYTEA)
+RETURNS TABLE(id BIGINT, parameters BYTEA)
 AS $$
 DECLARE
     r cereal_tasks%rowtype;
@@ -261,7 +261,6 @@ BEGIN
         UPDATE cereal_tasks SET task_state = 'running', updated_at = NOW() WHERE cereal_tasks.id = r.id;
 
         id := r.id;
-        workflow_instance_id := r.workflow_instance_id;
         parameters := r.parameters;
         RETURN NEXT;
     END LOOP;


### PR DESCRIPTION
Was going through TODOs and found this. The task completer keeps the
task ID and that is all we need to complete the task since the
workflow ID for that task lives in the cereal_tasks table.

Signed-off-by: Steven Danna <steve@chef.io>