### PR TITLE
[deployment-service] Fix small bug in unit tests

### DIFF
--- a/components/automate-deployment/pkg/bootstrapbundle/bundle_creator_test.go
+++ b/components/automate-deployment/pkg/bootstrapbundle/bundle_creator_test.go
@@ -42,7 +42,7 @@ func createBundleCreator(t *testing.T) *Creator {
 	for gid := range gids {
 		g, err := user.LookupGroupId(strconv.Itoa(int(gid)))
 		require.NoError(t, err)
-		allowedGroups = append(allowedUsers, g.Name)
+		allowedGroups = append(allowedGroups, g.Name)
 	}
 
 	return &Creator{


### PR DESCRIPTION
We were appending the wrong array. This probably worked out on
machines where uid's and gid's match up.

Signed-off-by: Steven Danna <steve@chef.io>