### PR TITLE
[part of #832] use db_id between projects and roles

### DIFF
--- a/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
@@ -40,4 +40,18 @@ CREATE OR REPLACE FUNCTION
 
 $$ LANGUAGE sql;
 
+CREATE FUNCTION
+  role_projects(_role_id TEXT)
+  RETURNS TEXT[] AS $$
+
+  SELECT COALESCE(array_agg(p.id) FILTER (WHERE p.id IS NOT NULL), '{(unassigned)}')
+  FROM iam_roles AS r
+  LEFT JOIN iam_role_projects AS rp
+  ON rp.role_id=r.db_id
+  LEFT JOIN iam_projects AS p
+  ON rp.project_id=p.db_id
+  WHERE r.id=_role_id
+
+$$ LANGUAGE sql;
+
 COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
@@ -74,26 +74,27 @@ CREATE OR REPLACE FUNCTION
 
 $$ LANGUAGE sql;
 
--- helper functions, now made strict: if they don't find anything,
--- a "not found" exception is thrown
-CREATE OR REPLACE FUNCTION project_db_id (_id TEXT, OUT _db_id INTEGER)
-    RETURNS INTEGER
+-- Helper functions, now made strict: if they don't find anything,
+-- a "not found" exception is thrown; if they find more than one thing,
+-- they'll also throw an exception. (The latter should never happen.)
+CREATE OR REPLACE FUNCTION project_db_id (_id iam_projects.id%type, OUT _db_id iam_projects.db_id%type)
+    RETURNS iam_projects.db_id%type
     AS $$
     BEGIN
         SELECT db_id INTO STRICT _db_id
         FROM iam_projects
-        WHERE id = _id;
+        WHERE id=_id;
     END;
 $$
 LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION project_id (_db_id INTEGER, OUT _id TEXT)
-    RETURNS TEXT
+CREATE OR REPLACE FUNCTION project_id (_db_id iam_projects.db_id%type, OUT _id iam_projects.id%type)
+    RETURNS iam_projects.id%type
     AS $$
     BEGIN
         SELECT id INTO STRICT _id
         FROM iam_projects
-        WHERE db_id = _db_id;
+        WHERE db_id=_db_id;
     END;
 $$
 LANGUAGE plpgsql;

--- a/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
@@ -75,4 +75,28 @@ CREATE OR REPLACE FUNCTION
 
 $$ LANGUAGE sql;
 
+-- helper functions, now made strict: if they don't find anything,
+-- a "not found" exception is thrown
+CREATE OR REPLACE FUNCTION project_db_id (_id TEXT, OUT _db_id INTEGER)
+    RETURNS INTEGER
+    AS $$
+    BEGIN
+        SELECT db_id INTO STRICT _db_id
+        FROM iam_projects
+        WHERE id = _id;
+    END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION project_id (_db_id INTEGER, OUT _id TEXT)
+    RETURNS TEXT
+    AS $$
+    BEGIN
+        SELECT id INTO STRICT _id
+        FROM iam_projects
+        WHERE db_id = _db_id;
+    END;
+$$
+LANGUAGE plpgsql;
+
 COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
@@ -20,7 +20,7 @@ ALTER TABLE iam_role_projects
 -- returns NULL if there's no associated projects; the call can decide
 -- (by coalesce'ing) if they want that to be {} or {(unassigned)}.
 
-CREATE OR REPLACE FUNCTION role_projects (_role_id TEXT, OUT _project_ids TEXT[])
+CREATE OR REPLACE FUNCTION role_projects (_role_id iam_roles.id % TYPE, OUT _project_ids TEXT[])
     RETURNS TEXT[]
     AS $$
 DECLARE
@@ -42,7 +42,7 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
-CREATE OR REPLACE FUNCTION query_role (_role_id TEXT)
+CREATE OR REPLACE FUNCTION query_role (_role_id iam_roles.id % TYPE)
     RETURNS json
     AS $$
     SELECT

--- a/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
@@ -31,13 +31,12 @@ CREATE OR REPLACE FUNCTION
       SELECT db_id INTO STRICT role_db_id
       FROM iam_roles AS r
       WHERE r.id=_role_id;
-      IF FOUND THEN
-          SELECT array_agg(p.id) INTO _project_ids
-          FROM iam_role_projects AS rp
-          LEFT JOIN iam_projects AS p
-          ON rp.project_id=p.db_id
-          WHERE rp.role_id=role_db_id;
-     END IF;
+
+      SELECT array_agg(p.id) INTO _project_ids
+      FROM iam_role_projects AS rp
+      JOIN iam_projects AS p
+      ON rp.project_id=p.db_id
+      WHERE rp.role_id=role_db_id;
   END;
 $$ LANGUAGE plpgsql;
 

--- a/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
@@ -2,7 +2,6 @@ BEGIN;
 -- break all references
 ALTER TABLE iam_role_projects
     DROP CONSTRAINT iam_role_projects_project_id_fkey;
-
 ALTER TABLE iam_role_projects RENAME COLUMN project_id TO project_temp_id;
 ALTER TABLE iam_role_projects
     ADD COLUMN project_id INTEGER REFERENCES iam_projects (db_id) ON DELETE CASCADE DEFERRABLE;
@@ -18,85 +17,81 @@ SET
             id = t.project_temp_id);
 ALTER TABLE iam_role_projects
     DROP COLUMN project_temp_id;
-
 -- returns NULL if there's no associated projects; the call can decide
 -- (by coalesce'ing) if they want that to be {} or {(unassigned)}.
-CREATE OR REPLACE FUNCTION
-  role_projects(_role_id TEXT, OUT _project_ids TEXT[])
-  RETURNS TEXT[] AS $$
 
-  DECLARE
-  role_db_id INTEGER;
-  BEGIN
-      SELECT db_id INTO STRICT role_db_id
-      FROM iam_roles AS r
-      WHERE r.id=_role_id;
-
-      SELECT array_agg(p.id) INTO _project_ids
-      FROM iam_role_projects AS rp
-      JOIN iam_projects AS p
-      ON rp.project_id=p.db_id
-      WHERE rp.role_id=role_db_id;
-  END;
-$$ LANGUAGE plpgsql;
-
-
-CREATE OR REPLACE FUNCTION
-  query_role(_role_id TEXT)
-  RETURNS json AS $$
-
-  SELECT json_build_object(
-    'id', r.id,
-    'name', r.name,
-    'type', r.type,
-    'actions', r.actions,
-    'projects', COALESCE(role_projects(r.id), '{}')
-    ) AS role
-  FROM iam_roles AS r
-  WHERE r.id=_role_id
-
-$$ LANGUAGE sql;
-
-CREATE OR REPLACE FUNCTION
-  query_roles(_projects_filter TEXT[])
-  RETURNS setof json AS $$
-
-  SELECT
-    json_build_object(
-      'id', r.id,
-      'name', r.name,
-      'type', r.type,
-      'actions', r.actions,
-      'projects', COALESCE(role_projects(r.id), '{}')
-    ) AS role
-  FROM iam_roles AS r
-  WHERE projects_match(COALESCE(role_projects(r.id), '{(unassigned)}'),  _projects_filter);
-
-$$ LANGUAGE sql;
-
+CREATE OR REPLACE FUNCTION role_projects (_role_id TEXT, OUT _project_ids TEXT[])
+    RETURNS TEXT[]
+    AS $$
+DECLARE
+    role_db_id INTEGER;
+BEGIN
+    SELECT
+        db_id INTO STRICT role_db_id
+    FROM
+        iam_roles AS r
+    WHERE
+        r.id = _role_id;
+    SELECT
+        array_agg(p.id) INTO _project_ids
+    FROM
+        iam_role_projects AS rp
+        JOIN iam_projects AS p ON rp.project_id = p.db_id
+    WHERE
+        rp.role_id = role_db_id;
+END;
+$$
+LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION query_role (_role_id TEXT)
+    RETURNS json
+    AS $$
+    SELECT
+        json_build_object('id', r.id, 'name', r.name, 'type', r.type, 'actions', r.actions, 'projects', COALESCE(role_projects (r.id), '{}')) AS ROLE
+    FROM
+        iam_roles AS r
+    WHERE
+        r.id = _role_id
+$$
+LANGUAGE sql;
+CREATE OR REPLACE FUNCTION query_roles (_projects_filter TEXT[])
+    RETURNS SETOF json
+    AS $$
+    SELECT
+        json_build_object('id', r.id, 'name', r.name, 'type', r.type, 'actions', r.actions, 'projects', COALESCE(role_projects (r.id), '{}')) AS ROLE
+    FROM
+        iam_roles AS r
+    WHERE
+        projects_match (COALESCE(role_projects (r.id), '{(unassigned)}'), _projects_filter);
+$$
+LANGUAGE sql;
 -- Helper functions, now made strict: if they don't find anything,
 -- a "not found" exception is thrown; if they find more than one thing,
 -- they'll also throw an exception. (The latter should never happen.)
-CREATE OR REPLACE FUNCTION project_db_id (_id iam_projects.id%type, OUT _db_id iam_projects.db_id%type)
-    RETURNS iam_projects.db_id%type
+
+CREATE OR REPLACE FUNCTION project_db_id (_id iam_projects.id % TYPE, OUT _db_id iam_projects.db_id % TYPE)
+    RETURNS iam_projects.db_id % TYPE
     AS $$
-    BEGIN
-        SELECT db_id INTO STRICT _db_id
-        FROM iam_projects
-        WHERE id=_id;
-    END;
+BEGIN
+    SELECT
+        db_id INTO STRICT _db_id
+    FROM
+        iam_projects
+    WHERE
+        id = _id;
+END;
 $$
 LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION project_id (_db_id iam_projects.db_id%type, OUT _id iam_projects.id%type)
-    RETURNS iam_projects.id%type
+CREATE OR REPLACE FUNCTION project_id (_db_id iam_projects.db_id % TYPE, OUT _id iam_projects.id % TYPE)
+    RETURNS iam_projects.id % TYPE
     AS $$
-    BEGIN
-        SELECT id INTO STRICT _id
-        FROM iam_projects
-        WHERE db_id=_db_id;
-    END;
+BEGIN
+    SELECT
+        id INTO STRICT _id
+    FROM
+        iam_projects
+    WHERE
+        db_id = _db_id;
+END;
 $$
 LANGUAGE plpgsql;
-
 COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/55_use_project_db_id_in_references_of_project_roles.up.sql
@@ -1,0 +1,43 @@
+BEGIN;
+-- break all references
+ALTER TABLE iam_role_projects
+    DROP CONSTRAINT iam_role_projects_project_id_fkey;
+
+ALTER TABLE iam_role_projects RENAME COLUMN project_id TO project_temp_id;
+ALTER TABLE iam_role_projects
+    ADD COLUMN project_id INTEGER REFERENCES iam_projects (db_id) ON DELETE CASCADE DEFERRABLE;
+UPDATE
+    iam_role_projects t
+SET
+    project_id = (
+        SELECT
+            db_id
+        FROM
+            iam_projects
+        WHERE
+            id = t.project_temp_id);
+ALTER TABLE iam_role_projects
+    DROP COLUMN project_temp_id;
+
+CREATE OR REPLACE FUNCTION
+  query_role(_role_id TEXT)
+  RETURNS json AS $$
+
+  SELECT json_build_object(
+    'id', r.id,
+    'name', r.name,
+    'type', r.type,
+    'actions', r.actions,
+    'projects', COALESCE(json_agg(p.id) FILTER (WHERE p.id IS NOT NULL), '[]')
+    ) AS role
+  FROM iam_roles AS r
+  LEFT JOIN iam_role_projects AS rp
+  ON rp.role_id=r.db_id
+  LEFT JOIN iam_projects AS p
+  ON rp.project_id=p.db_id
+  WHERE r.id=_role_id
+  GROUP BY r.id, r.name, r.type, r.actions
+
+$$ LANGUAGE sql;
+
+COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -54,3 +54,4 @@
 - [`52_add_db_id_members.up.sql`](52_add_db_id_members.up.sql)
 - [`53_add_db_id_to_iam_policies.up.sql`](53_add_db_id_to_iam_policies.up.sql)
 - [`54_use_project_db_id_in_references_of_project_rules.up.sql`](54_use_project_db_id_in_references_of_project_rules.up.sql)
+- [`55_use_project_db_id_in_references_of_project_roles.up.sql`](55_use_project_db_id_in_references_of_project_roles.up.sql)

--- a/components/authz-service/storage/postgres/postgres.go
+++ b/components/authz-service/storage/postgres/postgres.go
@@ -77,6 +77,8 @@ func parsePQError(err *pq.Error) error {
 		return storage.ErrConflict
 	case "23503": // Foreign key violation
 		return storage.ErrForeignKey
+	case "P0002": // Not found in plpgsql ("no_data_found")
+		return storage.ErrNotFound
 	case "20000": // Not found
 		return storage.ErrNotFound
 	case "PRJTR": // Custom code: attempt to change a rule's projects that are immutable

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -890,11 +890,7 @@ func checkIfRoleIntersectsProjectsFilter(ctx context.Context, q Querier,
 	// assuming '{(unassigned)}' in the case that iam_role_projects is empty. If a role of id
 	// doesn't exist, this will return 0 rows which will bubble up to NotFoundErr when passed to processError.
 	row := q.QueryRowContext(ctx,
-		`SELECT COALESCE(array_agg(rp.project_id)
-				FILTER (WHERE rp.project_id IS NOT NULL), '{(unassigned)}') && $2 AS intersection
-			FROM iam_roles AS r
-			LEFT OUTER JOIN iam_role_projects AS rp ON rp.role_id=r.db_id
-			WHERE r.id = $1;`,
+		"SELECT role_projects(id) && $2 AS intersection FROM iam_roles WHERE id=$1",
 		id, pq.Array(projectsFilter))
 
 	var result bool

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -921,8 +921,9 @@ func (p *pg) insertRoleWithQuerier(ctx context.Context, role *v2.Role, q Querier
 
 	for _, project := range role.Projects {
 		_, err := q.ExecContext(ctx,
-			`INSERT INTO iam_role_projects (role_id, project_id) VALUES ($1, $2)`,
-			&dbID, &project)
+			`INSERT INTO iam_role_projects (role_id, project_id)
+			SELECT $1, db_id FROM iam_projects WHERE id=$2`,
+			dbID, project)
 		if err != nil {
 			return p.processError(err)
 		}

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -889,9 +889,7 @@ func checkIfRoleIntersectsProjectsFilter(ctx context.Context, q Querier,
 	// Return true or false if there is intersection between iam_role_projects and projectsFilter,
 	// assuming '{(unassigned)}' in the case that iam_role_projects is empty. If a role of id
 	// doesn't exist, this will return 0 rows which will bubble up to NotFoundErr when passed to processError.
-	row := q.QueryRowContext(ctx,
-		"SELECT role_projects(id) && $2 AS intersection FROM iam_roles WHERE id=$1",
-		id, pq.Array(projectsFilter))
+	row := q.QueryRowContext(ctx, "SELECT projects_match(role_projects($1), $2)", id, pq.Array(projectsFilter))
 
 	var result bool
 	err := row.Scan(&result)

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -1358,7 +1358,7 @@ func (p *pg) CreateProject(ctx context.Context, project *v2.Project) (*v2.Projec
 	}
 
 	if project.Type == v2.Custom {
-		row := tx.QueryRowContext(ctx, ` WITH t as (SELECT id from iam_projects WHERE type='custom') SELECT COUNT(*) FROM t;`)
+		row := tx.QueryRowContext(ctx, "SELECT count(*) FROM iam_projects WHERE type='custom'")
 		var numProjects int64
 		if err := row.Scan(&numProjects); err != nil {
 			return nil, p.processError(err)

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -950,7 +950,7 @@ func (p *pg) CreateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 
 	row := tx.QueryRowContext(ctx,
 		`INSERT INTO iam_staged_project_rules (id, project_id, name, type, deleted)
-		(SELECT $1, db_id, $3, $4, false FROM iam_projects WHERE id=$2)
+		VALUES ($1, project_db_id($2), $3, $4, false)
 		RETURNING db_id`,
 		rule.ID, rule.ProjectID, rule.Name, rule.Type.String())
 	var ruleDbID string
@@ -996,9 +996,6 @@ func (p *pg) UpdateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 		rule.ID, rule.ProjectID, rule.Name, rule.Type.String(), pq.Array(projectsFilter))
 	var ruleDbID int
 	if err := row.Scan(&ruleDbID); err != nil {
-		if err == sql.ErrNoRows {
-			return nil, storage_errors.ErrNotFound
-		}
 		return nil, p.processError(err)
 	}
 

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -6604,8 +6604,7 @@ func assertProjectsMatch(t *testing.T, db *testhelpers.TestDB, project storage.P
 func assertRolesMatch(t *testing.T, db *testhelpers.TestDB, role storage.Role) {
 	t.Helper()
 	dbRole := storage.Role{}
-	err := db.QueryRow(`SELECT query_role($1);`, role.ID).Scan(&dbRole)
-	require.NoError(t, err)
+	require.NoError(t, db.QueryRow(`SELECT query_role($1);`, role.ID).Scan(&dbRole))
 	assert.Equal(t, role, dbRole)
 }
 

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -6604,7 +6604,7 @@ func assertProjectsMatch(t *testing.T, db *testhelpers.TestDB, project storage.P
 func assertRolesMatch(t *testing.T, db *testhelpers.TestDB, role storage.Role) {
 	t.Helper()
 	dbRole := storage.Role{}
-	require.NoError(t, db.QueryRow(`SELECT query_role($1);`, role.ID).Scan(&dbRole))
+	require.NoError(t, db.QueryRow("SELECT query_role($1)", role.ID).Scan(&dbRole))
 	assert.Equal(t, role, dbRole)
 }
 
@@ -6744,12 +6744,10 @@ func insertTestRole(t *testing.T,
 	var dbID string
 	require.NoError(t, row.Scan(&dbID))
 
-	for _, project := range role.Projects {
-		_, err := db.Exec(`INSERT INTO iam_role_projects (role_id, project_id)
-			SELECT $1, db_id FROM iam_projects WHERE id=$2`,
-			&dbID, &project)
-		require.NoError(t, err)
-	}
+	_, err := db.Exec(`INSERT INTO iam_role_projects (role_id, project_id)
+		SELECT $1, db_id FROM iam_projects WHERE id=ANY($2)`,
+		dbID, pq.Array(role.Projects))
+	require.NoError(t, err)
 
 	return role
 }


### PR DESCRIPTION
### :nut_and_bolt: Description

✔️ `iam_project_roles` now refers to `iam_projects` using the latter's `db_id` field, not `id`.

### :chains: Related Resources

#832 

### :white_check_mark: Checklist

- [X] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [X] Code actually executed?
- [X] Vetting performed (unit tests, lint, etc.)?
