### PR TITLE
[deployment-service] Avoid hang on shutdown

### DIFF
--- a/components/automate-deployment/pkg/server/server.go
+++ b/components/automate-deployment/pkg/server/server.go
@@ -1486,7 +1486,10 @@ func (s *server) shutItAllDown() error {
 		return err
 	}
 
-	if err := s.target().Stop(ctx); err != nil {
+	// NOTE(ssd) 2019-07-12: We use context.Background here
+	// because we want the hab-sup term command to continue even
+	// after this commands exits.
+	if err := s.target().Stop(context.Background()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
target.Stop() is an asynchronous command because eventually `hab sup
term` will terminate the process itself.  Here, we were passing a
context into Stop that would be cancelled at the end of the function.
In most cases, this meant that `hab sup term` never got a chance to
request that the supervisor terminate and thus the service would not
be shut down until we hit the systemd timeout.

Signed-off-by: Steven Danna <steve@chef.io>