### PR TITLE
[cereal] Wire up workflow cancelation

### DIFF
--- a/lib/cereal/backend/backend.go
+++ b/lib/cereal/backend/backend.go
@@ -8,6 +8,7 @@ import (
 type Driver interface {
 	EnqueueWorkflow(ctx context.Context, workflow *WorkflowInstance) error
 	DequeueWorkflow(ctx context.Context, workflowNames []string) (*WorkflowEvent, WorkflowCompleter, error)
+	CancelWorkflow(ctx context.Context, instanceName string, workflowName string) error
 
 	DequeueTask(ctx context.Context, taskName string) (*Task, TaskCompleter, error)
 
@@ -27,6 +28,7 @@ type Driver interface {
 type WorkflowInstanceStatus string
 
 const (
+	WorkflowInstanceStatusStarting  WorkflowInstanceStatus = "starting"
 	WorkflowInstanceStatusRunning   WorkflowInstanceStatus = "running"
 	WorkflowInstanceStatusCompleted WorkflowInstanceStatus = "completed"
 )
@@ -46,9 +48,9 @@ type WorkflowInstance struct {
 type WorkflowEventType string
 
 const (
-	WorkflowStart WorkflowEventType = "start"
-	TaskComplete  WorkflowEventType = "task_complete"
-	Cancel        WorkflowEventType = "cancel"
+	WorkflowStart  WorkflowEventType = "start"
+	TaskComplete   WorkflowEventType = "task_complete"
+	WorkflowCancel WorkflowEventType = "cancel"
 )
 
 type TaskStatusType string
@@ -83,6 +85,7 @@ type TaskResult struct {
 }
 
 type TaskCompleter interface {
+	Context() context.Context
 	Fail(err string) error
 	Succeed(result []byte) error
 }

--- a/lib/cereal/integration/cancel_workflow_test.go
+++ b/lib/cereal/integration/cancel_workflow_test.go
@@ -1,0 +1,69 @@
+// +build integration
+
+package integration_test
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/chef/automate/lib/cereal"
+)
+
+func (suite *CerealTestSuite) TestCancelWorkflow() {
+	taskName := randName("cancel")
+	workflowName := randName("cancel")
+	instanceName := randName("instance")
+
+	wgWorkflowStart := sync.WaitGroup{}
+	wgWorkflowStart.Add(1)
+
+	wgTaskStart := sync.WaitGroup{}
+	wgTaskStart.Add(1)
+
+	wgTaskDone := sync.WaitGroup{}
+	wgTaskDone.Add(1)
+
+	m := suite.newManager(
+		WithTaskExecutorF(
+			taskName,
+			func(ctx context.Context, _ cereal.Task) (interface{}, error) {
+				wgTaskStart.Done()
+				defer wgTaskDone.Done()
+				<-ctx.Done()
+				return nil, nil
+			}),
+		WithWorkflowExecutor(
+			workflowName,
+			&workflowExecutorWrapper{
+				onStart: func(w cereal.WorkflowInstance, ev cereal.StartEvent) cereal.Decision {
+					err := w.EnqueueTask(taskName, nil)
+					suite.Require().NoError(err, "failed to enqueue task")
+					defer wgWorkflowStart.Done()
+					return w.Continue(nil)
+				},
+				onTaskComplete: func(w cereal.WorkflowInstance, ev cereal.TaskCompleteEvent) cereal.Decision {
+					suite.Require().Fail("the task should not have completed")
+					return w.Complete()
+				},
+				onCancel: func(w cereal.WorkflowInstance, ev cereal.CancelEvent) cereal.Decision {
+					return w.Complete()
+				},
+			},
+		),
+	)
+	defer m.Stop()
+	err := m.EnqueueWorkflow(context.Background(), workflowName, instanceName, nil)
+	suite.Require().NoError(err, "Failed to enqueue workflow")
+	wgWorkflowStart.Wait()
+	wgTaskStart.Wait()
+	logrus.Debug("canceling workflow")
+	err = m.CancelWorkflow(context.Background(), workflowName, instanceName)
+	suite.Require().NoError(err, "Failed to cancel workflow")
+	wgTaskDone.Wait()
+	time.Sleep(2 * time.Second)
+	err = m.Stop()
+	suite.NoError(err)
+}

--- a/lib/cereal/integration/workflow_postgres_test.go
+++ b/lib/cereal/integration/workflow_postgres_test.go
@@ -7,6 +7,9 @@ import (
 	"database/sql"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -63,7 +66,7 @@ func runResetDB() error {
 func TestCerealPostgres(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, runResetDB())
-	pgBackend := postgres.NewPostgresBackend(testDBURL())
+	pgBackend := postgres.NewPostgresBackend(testDBURL(), postgres.WithTaskPingInterval(3*time.Second))
 	defer pgBackend.Close()
 	s := &CerealTestSuite{
 		newManager: func(opts ...managerOptFunc) *cereal.Manager {
@@ -89,4 +92,8 @@ func TestCerealPostgres(t *testing.T) {
 	}
 	suite.Run(t, s)
 	require.NoError(t, pgBackend.Close())
+}
+
+func init() {
+	logrus.SetLevel(logrus.DebugLevel)
 }


### PR DESCRIPTION
- Added a cancel workflow signal. Workflows can decide how to handle
this
- If a workflow finishes when outstanding tasks, the context for those
tasks will be canceled the next time they try to ping.
- I changed the task ping interval to 15 seconds so canceled tasks exit
earlier