### PR TITLE
Manual conversion of protobufs in gateway

### DIFF
--- a/components/automate-gateway/handler/applications.go
+++ b/components/automate-gateway/handler/applications.go
@@ -52,18 +52,14 @@ func (a *Applications) GetServiceGroups(
 // GetServices returns a list of services
 func (a *Applications) GetServices(
 	ctx context.Context,
-	in *applications.ServicesReq) (*applications.ServicesRes, error) {
+	request *applications.ServicesReq) (*applications.ServicesRes, error) {
 
-	inDomain := &applications.ServicesReq{}
-	out := &applications.ServicesRes{}
-	f := func() (proto.Message, error) {
-		return a.client.GetServices(ctx, inDomain)
-	}
-	err := protobuf.CallDomainService(in, inDomain, f, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	log.WithFields(log.Fields{
+		"request": request.String(),
+		"func":    nameOfFunc(),
+	}).Debug("rpc call")
+
+	return a.client.GetServices(ctx, request)
 }
 
 // GetServicesBySG returns a list of services within a service-group
@@ -71,16 +67,12 @@ func (a *Applications) GetServicesBySG(
 	ctx context.Context,
 	in *applications.ServicesBySGReq) (*applications.ServicesBySGRes, error) {
 
-	inDomain := &applications.ServicesBySGReq{}
-	out := &applications.ServicesBySGRes{}
-	f := func() (proto.Message, error) {
-		return a.client.GetServicesBySG(ctx, inDomain)
-	}
-	err := protobuf.CallDomainService(in, inDomain, f, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	log.WithFields(log.Fields{
+		"request": request.String(),
+		"func":    nameOfFunc(),
+	}).Debug("rpc call")
+
+	return a.client.GetServicesBySG(ctx, request)
 }
 
 func (a *Applications) GetServicesStats(

--- a/components/automate-gateway/handler/applications.go
+++ b/components/automate-gateway/handler/applications.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/chef/automate/api/external/applications"
 	version "github.com/chef/automate/api/external/common/version"
-	"github.com/chef/automate/components/automate-gateway/protobuf"
 
-	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -65,7 +63,7 @@ func (a *Applications) GetServices(
 // GetServicesBySG returns a list of services within a service-group
 func (a *Applications) GetServicesBySG(
 	ctx context.Context,
-	in *applications.ServicesBySGReq) (*applications.ServicesBySGRes, error) {
+	request *applications.ServicesBySGReq) (*applications.ServicesBySGRes, error) {
 
 	log.WithFields(log.Fields{
 		"request": request.String(),
@@ -89,18 +87,14 @@ func (a *Applications) GetServicesStats(
 
 func (a *Applications) GetDisconnectedServices(
 	ctx context.Context,
-	in *applications.DisconnectedServicesReq) (*applications.ServicesRes, error) {
+	request *applications.DisconnectedServicesReq) (*applications.ServicesRes, error) {
 
-	inDomain := &applications.DisconnectedServicesReq{}
-	out := &applications.ServicesRes{}
-	f := func() (proto.Message, error) {
-		return a.client.GetDisconnectedServices(ctx, inDomain)
-	}
-	err := protobuf.CallDomainService(in, inDomain, f, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	log.WithFields(log.Fields{
+		"request": request.String(),
+		"func":    nameOfFunc(),
+	}).Debug("rpc call")
+
+	return a.client.GetDisconnectedServices(ctx, request)
 }
 
 // GetVersion fetches the version of team service

--- a/components/automate-gateway/handler/applications.go
+++ b/components/automate-gateway/handler/applications.go
@@ -6,7 +6,9 @@ import (
 	"github.com/chef/automate/api/external/applications"
 	version "github.com/chef/automate/api/external/common/version"
 	"github.com/chef/automate/components/automate-gateway/protobuf"
+
 	"github.com/golang/protobuf/proto"
+	log "github.com/sirupsen/logrus"
 )
 
 // Applications - the applications service data structure
@@ -24,18 +26,24 @@ func NewApplicationsHandler(applicationsClient applications.ApplicationsServiceC
 // GetServiceGroupsHealthCounts returns the health counts from all service groups
 func (a *Applications) GetServiceGroupsHealthCounts(
 	ctx context.Context,
-	in *applications.ServiceGroupsHealthCountsReq) (*applications.HealthCounts, error) {
+	request *applications.ServiceGroupsHealthCountsReq) (*applications.HealthCounts, error) {
 
-	inDomain := &applications.ServiceGroupsHealthCountsReq{}
-	out := &applications.HealthCounts{}
-	f := func() (proto.Message, error) {
-		return a.client.GetServiceGroupsHealthCounts(ctx, inDomain)
-	}
-	err := protobuf.CallDomainService(in, inDomain, f, out)
+	log.WithFields(log.Fields{
+		"request": request.String(),
+		"func":    nameOfFunc(),
+	}).Debug("rpc call")
+
+	response, err := a.client.GetServiceGroupsHealthCounts(ctx, &applications.ServiceGroupsHealthCountsReq{})
 	if err != nil {
 		return nil, err
 	}
-	return out, nil
+	return &applications.HealthCounts{
+		Total:    response.Total,
+		Ok:       response.Ok,
+		Warning:  response.Warning,
+		Critical: response.Critical,
+		Unknown:  response.Unknown,
+	}, nil
 }
 
 // GetServiceGroups returns a list of service groups

--- a/components/automate-gateway/handler/applications.go
+++ b/components/automate-gateway/handler/applications.go
@@ -33,17 +33,7 @@ func (a *Applications) GetServiceGroupsHealthCounts(
 		"func":    nameOfFunc(),
 	}).Debug("rpc call")
 
-	response, err := a.client.GetServiceGroupsHealthCounts(ctx, &applications.ServiceGroupsHealthCountsReq{})
-	if err != nil {
-		return nil, err
-	}
-	return &applications.HealthCounts{
-		Total:    response.Total,
-		Ok:       response.Ok,
-		Warning:  response.Warning,
-		Critical: response.Critical,
-		Unknown:  response.Unknown,
-	}, nil
+	return a.client.GetServiceGroupsHealthCounts(ctx, request)
 }
 
 // GetServiceGroups returns a list of service groups

--- a/components/automate-gateway/handler/applications.go
+++ b/components/automate-gateway/handler/applications.go
@@ -77,18 +77,14 @@ func (a *Applications) GetServicesBySG(
 
 func (a *Applications) GetServicesStats(
 	ctx context.Context,
-	in *applications.ServicesStatsReq) (*applications.ServicesStatsRes, error) {
+	request *applications.ServicesStatsReq) (*applications.ServicesStatsRes, error) {
 
-	inDomain := &applications.ServicesStatsReq{}
-	out := &applications.ServicesStatsRes{}
-	f := func() (proto.Message, error) {
-		return a.client.GetServicesStats(ctx, inDomain)
-	}
-	err := protobuf.CallDomainService(in, inDomain, f, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	log.WithFields(log.Fields{
+		"request": request.String(),
+		"func":    nameOfFunc(),
+	}).Debug("rpc call")
+
+	return a.client.GetServicesStats(ctx, request)
 }
 
 func (a *Applications) GetDisconnectedServices(

--- a/components/automate-gateway/handler/applications.go
+++ b/components/automate-gateway/handler/applications.go
@@ -49,18 +49,14 @@ func (a *Applications) GetServiceGroupsHealthCounts(
 // GetServiceGroups returns a list of service groups
 func (a *Applications) GetServiceGroups(
 	ctx context.Context,
-	in *applications.ServiceGroupsReq) (*applications.ServiceGroups, error) {
+	request *applications.ServiceGroupsReq) (*applications.ServiceGroups, error) {
 
-	inDomain := &applications.ServiceGroupsReq{}
-	out := &applications.ServiceGroups{}
-	f := func() (proto.Message, error) {
-		return a.client.GetServiceGroups(ctx, inDomain)
-	}
-	err := protobuf.CallDomainService(in, inDomain, f, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	log.WithFields(log.Fields{
+		"request": request.String(),
+		"func":    nameOfFunc(),
+	}).Debug("rpc call")
+
+	return a.client.GetServiceGroups(ctx, request)
 }
 
 // GetServices returns a list of services


### PR DESCRIPTION
### :nut_and_bolt: Description
Currently every **"conversion"** done by `proto. CallDomainService()` does a multi conversion from:
```
Protobuf => JSON => Protobuf
```

The icing of the cake is that **[grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway)** does already a conversion from `JSON => Protobuf`, and therefore, we end up with:
```
JSON => Protobuf => JSON => Protobuf
```

![tenor-74810411](https://user-images.githubusercontent.com/5712253/61199195-4eb55280-a6dd-11e9-8964-ad7f08f4b476.gif)

### :+1: Definition of Done
Reduction of complexity and increase the speed of RPC functions in the gateway (the ones that belong to the `applications-service`) by avoiding unnecessary conversions.

List of functions:
- [x] GetServiceGroupsHealthCounts
- [x] GetServiceGroups
- [x] GetServices
- [x] GetServicesBySG
- [x] GetServicesStats
- [x] GetDisconnectedServices
- [x] GetVersion

### :athletic_shoe: Demo Script / Repro Steps
N/A - All the code should compile and integrations tests should pass as before.

### :chains: Related Resources
N/A - **Chore**

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
