### PR TITLE
Implemented new compliance searchbar

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
@@ -1,33 +1,62 @@
-<div class="reporting-search">
+<div class="reporting-search" (focusout)="handleFocusOut()">
   <div *ngIf="selectedType" class="reporting-search-prefix">
-    <strong>{{ selectedType.title }}:</strong>
+    <strong *ngIf="selectedType">{{ selectedType.title }}:</strong>
   </div>
 
   <input
     #keyInput
+    id="keyInput"
     class="reporting-search-input"
     type="text"
-    list="key-list"
     [hidden]="!keyInputVisible"
     placeholder="Filter reports by..."
-    (change)="onKeyChange($event)" />
-  <datalist id="key-list">
-    <option *ngFor="let type of filterTypes" [value]="type.title">{{ type.title }}</option>
-  </datalist>
+    (click)="handleFocus($event)"
+    (focus)="handleFocus($event)"
+    (change)="onKeyChange($event)"
+    (keyup)="handleInput($event.key, keyInput.value)" />
+  <div *ngIf="suggestionsVisible && !selectedType" class="input-dropdown categories">
+    <ul>
+      <li *ngIf="filterTypes.length === 0" class="no-category-items">
+        Not a Valid Filter Type
+      </li>
+      <li *ngFor="let type of filterTypes; let i = index"
+          (click)="filterClick(type, $event)"
+          (mouseenter)="handleSuggestionItemOnMouseOver(i)"
+          class="list-item category {{ highlightedIndex == i ? 'selected' : '' }}">
+        {{ type.title }}
+        <chef-icon>add</chef-icon>
+      </li>
+    </ul>
+  </div>
 
   <input
     #valInput
+    id="valInput"
     class="reporting-search-input"
     type="text"
-    list="val-list"
     [hidden]="!valInputVisible"
     [placeholder]="selectedType?.placeholder"
     (change)="onValChange($event)"
-    (input)="onValInput($event)"
-    (keydown)="onValKeydown($event)" />
-  <datalist id="val-list">
-    <option *ngFor="let value of filterValues" [value]="value.title">{{ value.title }}</option>
-  </datalist>
+    (input)="onValInputAndFocus($event)"
+    (focus)="onValInputAndFocus($event)"
+    [value]="inputText"
+    (keyup)="handleInput($event.key, valInput.value)"/>
+  <div *ngIf="suggestionsVisible && selectedType" class="input-dropdown suggestions">
+    <ul>
+      <li *ngIf="inputText !== '' && isLoadingSuggestions" class="suggestion-status">
+          Loading...
+      </li>
+      <li *ngIf="inputText !== '' && delayForNoSuggestions && !filterValues.length > 0" class="no-category-items">
+        No mactching result found
+      </li>
+      <li *ngFor="let value of filterValues; let i = index"
+          (click)="valueClick(value, $event)"
+          (mouseenter)="handleSuggestionItemOnMouseOver(i)"
+          class="list-item category {{ highlightedIndex == i ? 'selected' : '' }}">
+        {{ value.title }}
+      </li>
+    </ul>
+  </div>
 
   <div class="reporting-search-suffix">
     <chef-button class="filter-btn" *ngIf="filters.length > 0" secondary (click)="toggleFilters()">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.scss
@@ -8,17 +8,17 @@
   align-items: center;
   justify-content: space-between;
   flex-grow: 1;
-  border: 1px solid $chef-grey;
+  border: 1px solid $chef-light-grey;
   border-radius: $global-radius;
 
   .reporting-search-input {
-    padding: 1em;
+    padding: 1.25em;
     width: 100%;
     border: none;
     border-radius: $global-radius;
     background-color: $chef-white;
     font-family: inherit;
-    font-size: 14px;
+    font-size: 13px;
   }
 
   .reporting-search-prefix {
@@ -130,4 +130,16 @@
       float: right;
     }
   }
+}
+
+::placeholder {
+  color: lightgray;
+} 
+
+:-ms-input-placeholder { 
+  color: lightgray;
+} 
+
+::-ms-input-placeholder { 
+  color: lightgray;
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.scss
@@ -60,3 +60,74 @@
   border-radius: $global-radius;
   padding: 0.5em;
 }
+
+.input-dropdown {
+  @include base-box-shadow();
+  border: 1px solid lightgrey;
+  border-radius: 3px;
+  background-color: $white;
+  position: absolute;
+  z-index: 99;
+  width: 232px;
+  font-size: 13px;
+  top: 171px;
+
+  &.categories {
+    width: 232px;
+  }
+
+  &.suggestions {
+    width: 400px;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+  }
+
+  li {
+    list-style: none;
+    padding: 8px 10px;
+    border-bottom: 1px solid lightGrey;
+
+    &.list-item {
+      &.selected {
+        color: $white;
+        cursor: pointer;
+        background-color: $chef-primary-bright;
+
+        &:last-child {
+          border-top-left-radius: 3px;
+          border-top-right-radius: 3px;
+        }
+
+        &:last-child {
+          border-bottom-left-radius: 3px;
+          border-bottom-right-radius: 3px;
+        }
+
+        &.category::after {
+          color: $white;
+        }
+      }
+    }
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    &.suggestion-status {
+      color: $chef-dark-grey;
+    }
+
+    &.no-category-items {
+      font-size: 13px;
+      color: $chef-critical;
+    }
+
+    chef-icon {
+      color: $chef-primary-bright;
+      float: right;
+    }
+  }
+}

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.scss
@@ -134,12 +134,12 @@
 
 ::placeholder {
   color: lightgray;
-} 
+}
 
-:-ms-input-placeholder { 
+:-ms-input-placeholder {
   color: lightgray;
-} 
+}
 
-::-ms-input-placeholder { 
+::-ms-input-placeholder {
   color: lightgray;
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
@@ -1,4 +1,13 @@
-import { Component, EventEmitter, Input, OnInit, Output, ViewChild, ElementRef, Renderer2} from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ViewChild,
+  ElementRef,
+  Renderer2
+} from '@angular/core';
 import { clamp } from 'lodash';
 import { Subject, Observable, of as observableOf } from 'rxjs';
 import {
@@ -22,8 +31,8 @@ export class ReportingSearchbarComponent implements OnInit {
   @Output() filterAdded = new EventEmitter();
   @Output() dateChanged = new EventEmitter();
 
-  @ViewChild('keyInput') keyInput:ElementRef;
-  @ViewChild('valInput') valInput:ElementRef;
+  @ViewChild('keyInput') keyInput: ElementRef;
+  @ViewChild('valInput') valInput: ElementRef;
 
   private suggestionsVisibleStream = new Subject<boolean>();
   private suggestionSearchTermDebounce = new Subject<any>();
@@ -66,10 +75,10 @@ export class ReportingSearchbarComponent implements OnInit {
       }
       this.isLoadingSuggestions = true;
       setTimeout(() => {
-        this.isLoadingSuggestions = false;  
+        this.isLoadingSuggestions = false;
       }, 500);
       setTimeout(() => {
-        this.delayForNoSuggestions = true;  
+        this.delayForNoSuggestions = true;
       }, 800);
     });
   }
@@ -222,7 +231,7 @@ export class ReportingSearchbarComponent implements OnInit {
       }
     }
     this.showKeyInput();
-    setTimeout(() => { this.renderer.selectRootElement('#keyInput').focus();}, 10);
+    setTimeout(() => { this.renderer.selectRootElement('#keyInput').focus(); }, 10);
   }
 
   pressDefaultText(currentText: string): void {
@@ -261,7 +270,7 @@ export class ReportingSearchbarComponent implements OnInit {
       }
     } else {
       if (this.keyInput.nativeElement.value === '') {
-        this.clearFilterCategories()
+        this.clearFilterCategories();
       } else {
         this.updateVisibleCategories(currentText);
       }
@@ -307,12 +316,12 @@ export class ReportingSearchbarComponent implements OnInit {
         value: value
       }
     });
-    
+
     event.stopPropagation();
     this.showKeyInput();
     this.inputText = '';
     this.keyInput.nativeElement.value = '';
-    setTimeout(() => { this.renderer.selectRootElement('#keyInput').focus();}, 10);
+    setTimeout(() => { this.renderer.selectRootElement('#keyInput').focus(); }, 10);
     this.suggestionsVisibleStream.next(false);
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
@@ -1,4 +1,9 @@
-import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, ViewChild, ElementRef, Renderer2} from '@angular/core';
+import { clamp } from 'lodash';
+import { Subject, Observable, of as observableOf } from 'rxjs';
+import {
+  debounceTime, switchMap, distinctUntilChanged
+} from 'rxjs/operators';
 
 @Component({
   selector: 'app-reporting-searchbar',
@@ -17,18 +22,65 @@ export class ReportingSearchbarComponent implements OnInit {
   @Output() filterAdded = new EventEmitter();
   @Output() dateChanged = new EventEmitter();
 
+  @ViewChild('keyInput') keyInput:ElementRef;
+  @ViewChild('valInput') valInput:ElementRef;
+
+  private suggestionsVisibleStream = new Subject<boolean>();
+  private suggestionSearchTermDebounce = new Subject<any>();
+
+  filterTypesCategories = [];
   calendarVisible = false;
   keyInputVisible = true;
   valInputVisible = false;
   filtersVisible = true;
+  suggestionsVisible = false;
+  isLoadingSuggestions = false;
   visibleDate;
   selectedType;
+  highlightedIndex = -1;
+  inputText = '';
+  delayForNoSuggestions = false;
 
-  @ViewChild('keyInput') keyInput;
-  @ViewChild('valInput') valInput;
+  constructor(private renderer: Renderer2) {
+    // This is needed because focus is lost when clicking items.
+    this.suggestionsVisibleStream.pipe(
+      // wait 0.2 seconds after each lost and gain focus
+      debounceTime(300),
+      // switch to the latest focus change
+      switchMap((active: boolean): Observable<boolean> => {
+        return observableOf(active);
+      })
+    ).subscribe((active: boolean) => {
+      this.delayForNoSuggestions = false;
+      this.suggestionsVisible = active;
+    });
+
+    this.suggestionSearchTermDebounce.pipe(
+      // wait 1/3 second after each keystroke before considering the term
+      debounceTime(300),
+      // ignore new term if same as previous term
+      distinctUntilChanged()
+    ).subscribe((c: any) => {
+      if (c.text && c.text.length > 0) {
+        this.suggestValues.emit({ detail: c});
+      }
+      this.isLoadingSuggestions = true;
+      setTimeout(() => {
+        this.isLoadingSuggestions = false;  
+      }, 500);
+      setTimeout(() => {
+        this.delayForNoSuggestions = true;  
+      }, 800);
+    });
+  }
 
   ngOnInit() {
+    this.isLoadingSuggestions = false;
     this.visibleDate = new Date(this.date);
+    this.filterTypesCategories = JSON.parse(JSON.stringify(this.filterTypes));
+  }
+
+  ngOnChange() {
   }
 
   toggleFilters() {
@@ -55,17 +107,222 @@ export class ReportingSearchbarComponent implements OnInit {
     this.calendarVisible = true;
   }
 
+  handleFocus(event: Event): void {
+    event.stopPropagation();
+    this.suggestionsVisibleStream.next(true);
+  }
+
+  handleSuggestionItemOnMouseOver(index: number): void {
+    this.highlightedIndex = index;
+  }
+
+  handleInput(key, currentText): void {
+    switch (key.toLowerCase()) {
+      case 'arrowdown':
+        this.pressArrowDown();
+        break;
+      case 'arrowup':
+        this.pressArrowUp();
+        break;
+      case 'arrowleft':
+        this.suggestionsVisible = true;
+        break;
+      case 'arrowright':
+        this.suggestionsVisible = true;
+        break;
+      case 'enter':
+        this.pressEnter(currentText);
+        break;
+      case 'backspace':
+        this.pressBackspace(currentText);
+        break;
+      case 'escape':
+        this.suggestionsVisible = false;
+        break;
+      default:
+        this.pressDefaultText(currentText);
+        break;
+    }
+  }
+
+  pressArrowDown(): void {
+    const downList =
+      (this.selectedType) ? this.filterValues : this.filterTypes;
+    this.highlightedIndex = clamp(
+      this.highlightedIndex + 1,
+      -1,
+      downList.length - 1
+    );
+    this.suggestionsVisible = true;
+  }
+
+  pressArrowUp(): void {
+    const upList =
+      (this.selectedType) ? this.filterValues : this.filterTypes;
+    this.highlightedIndex = clamp(
+      this.highlightedIndex + -1,
+      -1,
+      upList.length - 1
+    );
+    this.suggestionsVisible = true;
+  }
+
+  pressEnter(currentText: string): void {
+    if (this.selectedType) {
+      this.pressEnterCategorySelected(currentText);
+    } else {
+      if (this.filterTypes.length > 0) {
+        if (this.highlightedIndex >= 0) {
+          const type = this.filterTypes[this.highlightedIndex];
+          this.categorySelected(type);
+        } else if (this.filterTypes.length === 1) {
+          const type = this.filterTypes[0];
+          this.categorySelected(type);
+        }
+        this.suggestionsVisible = true;
+        this.showValInput();
+      }
+    }
+  }
+
+  pressEnterCategorySelected(currentText: string): void {
+    if (this.highlightedIndex >= 0) {
+      const search = this.filterValues[this.highlightedIndex];
+      const type = this.selectedType;
+      this.ClearAll();
+      this.filterAdded.emit({
+        detail: {
+          value: search,
+          type: type
+        }
+      });
+    } else {
+      if (currentText.indexOf('?') >= 0 || currentText.indexOf('*') >= 0) {
+        const type = this.selectedType;
+        this.ClearAll();
+        this.filterAdded.emit({
+          detail: {
+            value: currentText,
+            type: type
+          }
+        });
+      } else if (this.filterValues.length > 0) {
+        const foundSuggestion = this.filterValues.find((suggestion: string,
+          _key: number, _iter: any) => suggestion === currentText);
+        if (foundSuggestion) {
+          const type = this.selectedType;
+          this.ClearAll();
+          this.filterAdded.emit({
+            detail: {
+              value: foundSuggestion,
+              type: type
+            }
+          });
+        }
+      }
+    }
+    this.showKeyInput();
+    setTimeout(() => { this.renderer.selectRootElement('#keyInput').focus();}, 10);
+  }
+
+  pressDefaultText(currentText: string): void {
+    if (this.selectedType) {
+      const type = this.selectedType.name;
+      this.clearSuggestions();
+      this.requestForSuggestions({
+        text: currentText,
+        type: type
+      });
+      this.inputText = currentText;
+    } else {
+      this.updateVisibleCategories(currentText);
+    }
+    this.suggestionsVisible = true;
+  }
+
+  pressBackspace(currentText: string): void {
+    if (this.selectedType) {
+      if (this.inputText === '') {
+          this.clearFilterCategories();
+          this.showKeyInput();
+          setTimeout(() => {
+            this.keyInput.nativeElement.value = currentText;
+            this.keyInput.nativeElement.focus();
+          }, 10);
+      } else {
+        const type = this.selectedType.name;
+        this.clearSuggestions();
+        this.requestForSuggestions({
+          text: currentText,
+          type: type
+        });
+        this.showValInput();
+        this.inputText = currentText;
+      }
+    } else {
+      if (this.keyInput.nativeElement.value === '') {
+        this.clearFilterCategories()
+      } else {
+        this.updateVisibleCategories(currentText);
+      }
+      this.showKeyInput();
+      this.keyInput.nativeElement.value = currentText;
+    }
+  }
+
+  updateVisibleCategories(currentText: string): void {
+    this.highlightedIndex = -1;
+    this.filterTypes = JSON.parse(JSON.stringify(this.filterTypesCategories));
+    this.filterTypes = this.filterTypes.filter(cat => {
+      return cat.title.toLowerCase().indexOf(currentText.toLowerCase()) !== -1;
+    });
+  }
+
+  categorySelected(type: any): void {
+    this.selectedType = type;
+    this.highlightedIndex = -1;
+    this.inputText = '';
+    setTimeout(() => {
+      this.keyInput.nativeElement.value = '';
+      this.valInput.nativeElement.focus();
+    }, 10);
+  }
+
+  filterClick(type, event: Event) {
+    if (!this.selectedType) {
+      this.categorySelected(type);
+    }
+    event.stopPropagation();
+    this.showValInput();
+    this.suggestionsVisible = false;
+    setTimeout(() => this.renderer.selectRootElement('#valInput').focus(), 10);
+  }
+
+  valueClick(value: string, event: Event) {
+    const type = this.selectedType;
+    this.ClearAll();
+    this.filterAdded.emit({
+      detail: {
+        type: type,
+        value: value
+      }
+    });
+    
+    event.stopPropagation();
+    this.showKeyInput();
+    this.inputText = '';
+    this.keyInput.nativeElement.value = '';
+    setTimeout(() => { this.renderer.selectRootElement('#keyInput').focus();}, 10);
+    this.suggestionsVisibleStream.next(false);
+  }
+
   onKeyChange(e) {
     const type = this.filterTypes.filter(t => t.title === e.target.value)[0];
     const text = '';
-
     if (type) {
       this.selectedType = type;
-      this.suggestValues.emit({ detail: { type: type.name, text }});
-
-      this.keyInputVisible = false;
-      this.valInputVisible = true;
-
+      this.suggestValues.emit({ detail: { type: type.name, text } });
+      this.showValInput();
       setTimeout(() => {
         this.valInput.nativeElement.focus();
       }, 10);
@@ -74,13 +331,9 @@ export class ReportingSearchbarComponent implements OnInit {
 
   onValKeydown(e) {
     const text = e.target.value;
-
     if (e.keyCode === 8 && text.length === 0) {
-      this.selectedType = null;
-
-      this.keyInputVisible = true;
-      this.valInputVisible = false;
-
+      this.selectedType = undefined;
+      this.showKeyInput();
       setTimeout(() => {
         this.keyInput.nativeElement.value = '';
         this.keyInput.nativeElement.focus();
@@ -88,25 +341,28 @@ export class ReportingSearchbarComponent implements OnInit {
     }
   }
 
-  onValInput(e) {
+  onValInputAndFocus(e) {
+    this.delayForNoSuggestions = false;
     const type = this.selectedType.name;
     const text = e.target.value;
-
+    this.clearSuggestions();
     if (text.length > 0) {
-      this.suggestValues.emit({ detail: { type, text }});
+      this.requestForSuggestions({
+        text: text,
+        type: type
+      });
     }
+    this.suggestionsVisibleStream.next(true);
   }
 
   onValChange(e) {
     const type = this.selectedType;
     const text: string = e.target.value;
     const suggestionValue = this.filterValues.filter(v => v.title === text)[0];
-
     if (this.containsWildcardChar(text)) {
-      const wildcardValue = {text, title: text};
-
+      const wildcardValue = { text, title: text };
       this.addNewFilter(type, wildcardValue);
-    } else if (suggestionValue) {
+    } else if (suggestionValue && suggestionValue === undefined) {
       this.addNewFilter(type, suggestionValue);
     }
   }
@@ -116,14 +372,14 @@ export class ReportingSearchbarComponent implements OnInit {
   }
 
   private addNewFilter(type, value) {
-    this.filterAdded.emit({ detail: { type, value }});
-
-    this.selectedType = null;
-    this.keyInputVisible = true;
-    this.valInputVisible = false;
-
-    this.keyInput.nativeElement.value = '';
-    this.valInput.nativeElement.value = '';
+    this.filterAdded.emit({ detail: { type, value } });
+    this.selectedType = undefined;
+    this.showKeyInput();
+    this.inputText = '';
+    setTimeout(() => {
+      this.keyInput.nativeElement.value = '';
+      this.valInput.nativeElement.focus();
+    }, 10);
   }
 
   onClearClick() {
@@ -142,5 +398,42 @@ export class ReportingSearchbarComponent implements OnInit {
   onDaySelect(day) {
     this.visibleDate.setDate(day);
     this.dateChanged.emit({ detail: new Date(this.visibleDate) });
+  }
+
+  handleFocusOut() {
+    this.suggestionsVisibleStream.next(false);
+  }
+
+  clearSuggestions(): void {
+    this.filterValues = [];
+    this.highlightedIndex = -1;
+  }
+
+  clearFilterCategories(): void {
+    this.selectedType = undefined;
+    this.filterTypes = JSON.parse(JSON.stringify(this.filterTypesCategories));
+    this.highlightedIndex = -1;
+  }
+
+  ClearAll() {
+    this.clearFilterCategories();
+    this.clearSuggestions();
+    this.highlightedIndex = -1;
+  }
+
+  requestForSuggestions(c: any): void {
+    this.suggestionSearchTermDebounce.next(c);
+  }
+
+  // hide value input and show key input
+  showKeyInput() {
+    this.valInputVisible = false;
+    this.keyInputVisible = true;
+  }
+
+  // hide key input and show value input
+  showValInput() {
+    this.keyInputVisible = false;
+    this.valInputVisible = true;
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -174,7 +174,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
       }),
       takeUntil(this.isDestroyed)
     )
-      .subscribe(suggestions => this.availableFilterValues = suggestions);
+      .subscribe(suggestions => this.availableFilterValues = suggestions.filter(e => e.text));
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description
In an effort to drive parity across the app, we'd like to make the compliance search bar be the same as the client runs search bar.
### :+1: Definition of Done
Compliance search bar is the same format as the client runs.
### :athletic_shoe: Demo Script / Repro Steps
![Screenshot from 2019-07-15 14-46-45](https://user-images.githubusercontent.com/12297653/61206194-9d7be000-a70f-11e9-959f-3833fa20eb90.png)
![Screenshot from 2019-07-15 14-47-04](https://user-images.githubusercontent.com/12297653/61206201-a10f6700-a70f-11e9-8c3e-395509d1224a.png)

### :chains: Related Resources
https://github.com/chef/automate/issues/405