### PR TITLE
Remove CBC ciphers from nginx and golang configuration

### DIFF
--- a/api/config/shared/tls.go
+++ b/api/config/shared/tls.go
@@ -6,10 +6,11 @@ import "strings"
 // external configurations. These uses OpenSSLs identifiers so they
 // can be passed to software that takes an OpenSSL cipher list.
 //
-// This list was generated using the "modern" profile in Mozilla's SSL
+// This list was generated using the "intermediate" profile in Mozilla's SSL
 // Configuration Generator
 //
 // https://mozilla.github.io/server-side-tls/ssl-config-generator/
+
 var commonCiphers = []string{
 	"ECDHE-ECDSA-AES256-GCM-SHA384",
 	"ECDHE-RSA-AES256-GCM-SHA384",
@@ -17,9 +18,8 @@ var commonCiphers = []string{
 	"ECDHE-RSA-CHACHA20-POLY1305",
 	"ECDHE-ECDSA-AES128-GCM-SHA256",
 	"ECDHE-RSA-AES128-GCM-SHA256",
-	"ECDHE-ECDSA-AES256-SHA384",
-	"ECDHE-RSA-AES256-SHA384",
-	"ECDHE-ECDSA-AES128-SHA256",
+	"DHE-RSA-AES128-GCM-SHA256",
+	"DHE-RSA-AES256-GCM-SHA384",
 }
 
 // commonExcludes are exclude directives to be included in SSL cipher
@@ -43,10 +43,7 @@ var InternalCipherSuite = toCipherString(append(commonCiphers, commonExcludes...
 var ExternalCipherSuite = toCipherString(append(
 	append(commonCiphers, commonExcludes...),
 	// Added to support AWS "classic" ELB
-	"AES256-GCM-SHA384",
-	// Added for compatibility even though our scanner flags
-	// 128bit CBC mode ciphers
-	"ECDHE-RSA-AES128-SHA256"))
+	"AES256-GCM-SHA384"))
 
 func toCipherString(l []string) string {
 	return strings.Join(l, ":")

--- a/integration/helpers/ssl_filters.jq
+++ b/integration/helpers/ssl_filters.jq
@@ -17,6 +17,7 @@ map(select(
          (.id != "cert_trust" or .port != "443") and            # Test uses self-signed cert
          (.id != "cert_caIssuers" or .port != "443") and        # Test uses self-signed cert
          (.id != "cert_chain_of_trust" or .port != "443") and   # Test uses self-signed cert
+         (.id != "cert_validityPeriod" or .port != "443") and   # Test uses self-signed cert
 
          # security headers
          #
@@ -31,13 +32,15 @@ map(select(
          (.id != "security_headers" or .port != "10161") and
          (.id != "security_headers" or .port != "10200") and
 
-         # TODO
-         (.id != "cipherlist_128Bit" or (.port != "10116" and .port != "10117")) and
+         # TODO Submit PR to dexip/dex to improve ciphersuite defaults
+         (.id != "cipherlist_AVERAGE" or (.port != "10116" and .port != "10117")) and
          (.id != "cipherlist_3DES_IDEA" or (.port != "10116" and .port != "10117")) and
          (.id != "SWEET32" or (.port != "10116" and .port != "10117")) and
+         (.id != "LUCKY13" or (.port != "10116" and .port != "10117")) and
 
          # automate-cs erlang-services
          # TODO: erlang services use common prime
          (.id != "LOGJAM-common_primes" or (.port != "10201" and .port != "10202" and .port != "10203")) and
-         (.id != "cipherlist_128Bit" or (.port != "10201" and .port != "10202" and .port != "10203"))
+         (.id != "cipherlist_AVERAGE" or (.port != "10201" and .port != "10202" and .port != "10203"))
+         (.id != "LUCKY13" or (.port != "10201" and .port != "10202" and .port != "10203"))
 ))

--- a/integration/helpers/ssl_filters.jq
+++ b/integration/helpers/ssl_filters.jq
@@ -41,6 +41,6 @@ map(select(
          # automate-cs erlang-services
          # TODO: erlang services use common prime
          (.id != "LOGJAM-common_primes" or (.port != "10201" and .port != "10202" and .port != "10203")) and
-         (.id != "cipherlist_AVERAGE" or (.port != "10201" and .port != "10202" and .port != "10203"))
+         (.id != "cipherlist_AVERAGE" or (.port != "10201" and .port != "10202" and .port != "10203")) and
          (.id != "LUCKY13" or (.port != "10201" and .port != "10202" and .port != "10203"))
 ))

--- a/integration/helpers/ssl_filters.jq
+++ b/integration/helpers/ssl_filters.jq
@@ -1,8 +1,9 @@
 map(select(
          # General Exceptions
-         (.id != "LUCKY13") and                           # CBC Ciphers still in use in Golang and Nginx
          (.id != "cert_revocation") and                   # We don't do cert revocation
          (.id != "scanTime") and                          # Unsure why we get this
+         (.id != "sessionresumption_ID") and              # Go doesn't implement session resumption IDs
+         (.severity != "DEBUG") and
 
          # These are either hard to check with client auth enabled or
          # are HTTP only vulnerabilities so we check them on 443 only
@@ -16,44 +17,24 @@ map(select(
          (.id != "cert_trust" or .port != "443") and            # Test uses self-signed cert
          (.id != "cert_caIssuers" or .port != "443") and        # Test uses self-signed cert
          (.id != "cert_chain_of_trust" or .port != "443") and   # Test uses self-signed cert
-         (.id != "cipherlist_128Bit" or .port != "443") and     # For browser compatibility (untested)
 
-         # automate-gateway
+         # security headers
+         #
+         # automate-lb is responsible for adding required headers for
+         # now
          (.id != "HSTS" or .port != "2000") and                 # HSTS doesn't seem relevant for this API
+         (.id != "HSTS" or .port != "10115") and
+         (.id != "HSTS" or .port != "10117") and
+         (.id != "HSTS" or .port != "10161") and
+         (.id != "HSTS" or .port != "10143") and
+         (.id != "HSTS" or .port != "10200") and
+         (.id != "security_headers" or .port != "10161") and
+         (.id != "security_headers" or .port != "10200") and
 
-         # automate-ui
-         (.id != "HSTS" or .port != "10161") and                # TODO (maybe solve in automate-lb instead)
-         (.id != "security_headers" or .port != "10161") and    # TODO (maybe solve in automate-lb instead)
-
-         # session-service
-         (.id != "HSTS" or .port != "10115") and                # TODO (maybe solve in automate-lb instead)
-
-         # automate-cs-nginx
-         (.id != "HSTS" or .port != "10200") and                # TODO (maybe solve in automate-lb instead)
-         (.id != "security_headers" or .port != "10200") and    # TODO (maybe solve in automate-lb instead)
-
-         # automate-dex
-         (.id != "HSTS" or .port != "10117") and                # TODO (maybe solve in automate-lb instead)
          # TODO
          (.id != "cipherlist_128Bit" or (.port != "10116" and .port != "10117")) and
-         (.id != "cipherlist_3DES" or (.port != "10116" and .port != "10117")) and
+         (.id != "cipherlist_3DES_IDEA" or (.port != "10116" and .port != "10117")) and
          (.id != "SWEET32" or (.port != "10116" and .port != "10117")) and
-
-         # backup-gateway
-         #
-         # minio specifies a rather restricted cipher list that is
-         # even stronger than the "HIGH" list in our SSL checker:
-         #
-         # https://github.com/minio/minio/blob/3e124315c8abd0e1fd33ffd9a7ca3c6314ad1032/cmd/http/server.go#L163-L213
-         #
-         # since the SSL checker has a fixme next to this, we ignore
-         # it:
-         #
-         # https://github.com/drwetter/testssl.sh/blob/7f8a0f2c8bdea8feba2ff57494fbb49784a80682/testssl.sh#L3069-L3071
-         #
-         #
-         (.id != "cipherlist_HIGH" or .port != "10143") and
-         (.id != "HSTS" or .port != "10143") and
 
          # automate-cs erlang-services
          # TODO: erlang services use common prime

--- a/integration/helpers/ssl_tests.sh
+++ b/integration/helpers/ssl_tests.sh
@@ -4,13 +4,11 @@ run_ssl_scan() {
     install_testssl_prereqs
     if [[ ! -d "/testssl.sh" ]]; then
        pushd "/"
-         hab pkg exec core/git git clone -n https://github.com/drwetter/testssl.sh.git
+         hab pkg exec core/git git clone --depth 1 https://github.com/drwetter/testssl.sh.git
        popd
     fi
     local testssl_last_commit
     pushd /testssl.sh
-      # Pin testssl.sh to last known good version. PH Feb 11 2019
-      hab pkg exec core/git git checkout 691ca28bb9f63ab586a2b0b711cd19d456f0df7a
       testssl_last_commit=$(hab pkg exec core/git git log -1 --format=%cd)
       fixup_testssl
       hostfile=$(write_host_file)

--- a/lib/grpc/secureconn/factory.go
+++ b/lib/grpc/secureconn/factory.go
@@ -179,16 +179,17 @@ func initCipherSuites() {
 		}
 	}
 	commonCiphers := []uint16{
-		// Disabled since our new SSL scanner disallows anything with 128 Bit CBC
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		// Disabled since our new SSL scanner disallows anything with CBC
 		//
 		// tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
 		// tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		// tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		// tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
 		// tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		// tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		//
 		// Golang enables these but we disable them
 		// because 3DES makes scanners unhappy
 		//


### PR DESCRIPTION
- Nginx configuration synced with the most recent "intermediate"
  Mozilla advice.

- CBC ciphers disabled in default Go configuration based on recent
  advice:
  https://blog.qualys.com/technology/2019/04/22/zombie-poodle-and-goldendoodle-vulnerabilities#comment-303227

- Move back to master of testssl

Note that we still aren't configuring TLS ciphers for our elixir or
erlang services. That would be a nice thing to pick up at some point.

Signed-off-by: Steven Danna <steve@chef.io>