### PR TITLE
[part of #832] db_id for projects and policies

### DIFF
--- a/components/authz-service/storage/postgres/migration/sql/57_use_project_db_id_in_references_of_policies.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/57_use_project_db_id_in_references_of_policies.up.sql
@@ -1,0 +1,157 @@
+BEGIN;
+ALTER TABLE iam_policy_projects
+    DROP CONSTRAINT iam_policy_projects_project_id_fkey;
+ALTER TABLE iam_policy_projects RENAME COLUMN project_id TO project_temp_id;
+ALTER TABLE iam_policy_projects ADD COLUMN project_id SERIAL;
+
+UPDATE iam_policy_projects t
+SET
+    project_id = (
+        SELECT
+            db_id
+        FROM
+            iam_projects
+        WHERE
+            id = t.project_temp_id);
+ALTER TABLE iam_policy_projects
+    DROP COLUMN project_temp_id;
+
+ALTER TABLE iam_policy_projects ADD CONSTRAINT "iam_policy_projects_policy_id_project_id_unique" UNIQUE (policy_id, project_id);
+
+CREATE OR REPLACE FUNCTION policy_projects(_policy_id iam_policies.id%TYPE, OUT _project_ids TEXT[])
+    RETURNS TEXT[]
+    AS $$
+DECLARE
+    policy_db_id INTEGER;
+BEGIN
+    SELECT
+        db_id INTO STRICT policy_db_id
+    FROM
+        iam_policies AS pol
+    WHERE
+        pol.id = _policy_id;
+    SELECT
+        array_agg(p.id) INTO _project_ids
+    FROM
+        iam_policy_projects AS pp
+        JOIN iam_projects AS p ON pp.project_id = p.db_id
+    WHERE
+        pp.policy_id = policy_db_id;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION query_policy (_policy_id TEXT, _projects_filter TEXT[])
+    RETURNS json
+    AS $$
+    WITH temp AS (
+        SELECT
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type,
+            -- get policy's statements using temporary table
+            ( WITH statement_rows AS (
+                    SELECT
+                        stmt.id,
+                        stmt.effect,
+                        stmt.actions,
+                        stmt.resources,
+                        stmt.role,
+                        -- get each statement's projects by cross-referencing iam_policy_statements and iam_statement_projects
+                        (
+                            SELECT
+                                COALESCE(json_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL),
+                                    '[]')
+                                FROM iam_statement_projects AS stmt_projs
+                            LEFT OUTER JOIN iam_projects AS proj ON stmt_projs.statement_id = stmt.id WHERE stmt_projs.project_id = proj.id) AS projects
+                    FROM iam_statements stmt
+                    INNER JOIN iam_policies
+                    ON stmt.policy_id=pol.db_id
+                GROUP BY
+                    stmt.id, stmt.effect, stmt.actions, stmt.resources, stmt.role)
+            SELECT
+                array_agg(statement_rows) FILTER (WHERE statement_rows.id IS NOT NULL)
+            FROM statement_rows) AS statements,
+            -- get policy members
+            (
+            SELECT
+                array_agg(mem) FILTER (WHERE mem.id IS NOT NULL)
+            FROM iam_policy_members AS pol_mems
+        LEFT OUTER JOIN iam_members AS mem ON pol_mems.member_id = mem.db_id WHERE pol_mems.policy_id = pol.db_id) AS members,
+            -- get projects
+            (
+            SELECT
+                array_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL)
+            FROM iam_policy_projects AS pol_projs
+            LEFT OUTER JOIN iam_projects AS proj ON pol_projs.project_id = proj.db_id WHERE pol_projs.policy_id = pol.db_id) AS projects FROM iam_policies AS pol WHERE pol.id = _policy_id
+        GROUP BY
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type
+)
+SELECT
+    json_build_object('id', temp.id, 'name', temp.name, 'type', temp.type, 'statements', COALESCE(temp.statements, '{}'), 'members', COALESCE(temp.members, '{}'), 'projects', COALESCE(temp.projects, '{}')) AS POLICY
+FROM
+    temp
+WHERE
+    projects_match (temp.projects::TEXT[], _projects_filter);
+$$
+LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION query_policies (_projects_filter TEXT[])
+    RETURNS SETOF json
+    AS $$
+    WITH temp AS (
+        SELECT
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type,
+            ( WITH statement_rows AS (
+                    SELECT
+                        stmt.id,
+                        stmt.effect,
+                        stmt.actions,
+                        stmt.resources,
+                        stmt.role,
+                        (
+                            SELECT
+                                COALESCE(json_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL),
+                                    '[]')
+                                FROM iam_statement_projects AS stmt_projs
+                            LEFT OUTER JOIN iam_projects AS proj ON stmt_projs.statement_id = stmt.id WHERE stmt_projs.project_id = proj.id) AS projects
+                    FROM iam_statements stmt
+                    INNER JOIN iam_policies
+                    ON stmt.policy_id=pol.db_id
+                GROUP BY
+                    stmt.id, stmt.effect, stmt.actions, stmt.resources, stmt.role
+)
+            SELECT
+                array_agg(statement_rows) FILTER (WHERE statement_rows.id IS NOT NULL)
+                FROM statement_rows) AS statements,
+            (
+            SELECT
+                array_agg(mem) FILTER (WHERE mem.id IS NOT NULL)
+                FROM iam_policy_members AS pol_mems
+            LEFT OUTER JOIN iam_members AS mem ON pol_mems.member_id = mem.db_id WHERE pol_mems.policy_id = pol.db_id) AS members,
+    (
+    SELECT
+        array_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL)
+        FROM iam_policy_projects AS pol_projs
+        LEFT OUTER JOIN iam_projects AS proj ON pol_projs.project_id = proj.db_id WHERE pol_projs.policy_id = pol.db_id) AS projects FROM iam_policies AS pol
+GROUP BY
+    pol.db_id,
+    pol.id,
+    pol.name,
+    pol.type
+)
+SELECT
+    json_build_object('id', temp.id, 'name', temp.name, 'type', temp.type, 'statements', COALESCE(temp.statements, '{}'), 'members', COALESCE(temp.members, '{}'), 'projects', COALESCE(temp.projects, '{}')) AS POLICY
+FROM
+    temp
+WHERE
+    projects_match (temp.projects::TEXT[], _projects_filter);
+$$
+LANGUAGE sql;
+COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -56,3 +56,4 @@
 - [`54_use_project_db_id_in_references_of_project_rules.up.sql`](54_use_project_db_id_in_references_of_project_rules.up.sql)
 - [`55_use_project_db_id_in_references_of_project_roles.up.sql`](55_use_project_db_id_in_references_of_project_roles.up.sql)
 - [`56_add_db_id_statements.up.sql`](56_add_db_id_statements.up.sql)
+- [`57_use_project_db_id_in_references_of_policies.up.sql`](57_use_project_db_id_in_references_of_policies.up.sql)

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -358,13 +358,13 @@ func (p *pg) associatePolicyWithProjects(ctx context.Context,
 	// TODO this might be simplified as we modify how projects are assigned
 	// Drop any existing associations.
 	_, err := q.ExecContext(ctx,
-		`DELETE FROM iam_policy_projects WHERE policy_id=policy_db_id($1);`, policyID)
+		"DELETE FROM iam_policy_projects WHERE policy_id=policy_db_id($1)", policyID)
 	if err != nil {
 		return err
 	}
 	for _, project := range inProjects {
 		_, err := q.ExecContext(ctx,
-			`INSERT INTO iam_policy_projects (policy_id, project_id) VALUES (policy_db_id($1), $2)`,
+			`INSERT INTO iam_policy_projects (policy_id, project_id) VALUES (policy_db_id($1), project_db_id($2))`,
 			&policyID, &project)
 		if err != nil {
 			err = p.processError(err)
@@ -401,10 +401,8 @@ func (p *pg) queryPolicy(ctx context.Context, id string, q Querier) (*v2.Policy,
 	}
 
 	var pol v2.Policy
-	row := q.QueryRowContext(ctx,
-		`SELECT query_policy from query_policy($1, $2);`, id, pq.Array(projectsFilter))
-	err = row.Scan(&pol)
-	if err != nil {
+	if err := q.QueryRowContext(ctx, "SELECT query_policy($1, $2)", id, pq.Array(projectsFilter)).
+		Scan(&pol); err != nil {
 		return nil, err
 	}
 	return &pol, nil

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -6529,9 +6529,9 @@ func assertPolicy(t *testing.T, expectedPolicy, returnedPolicy *storage.Policy) 
 	assert.Equal(t, expectedPolicy.ID, returnedPolicy.ID)
 	assert.Equal(t, expectedPolicy.Name, returnedPolicy.Name)
 	assert.Equal(t, expectedPolicy.Type, returnedPolicy.Type)
-	assert.ElementsMatch(t, expectedPolicy.Members, returnedPolicy.Members)
-	assert.ElementsMatch(t, expectedPolicy.Projects, returnedPolicy.Projects)
-	assert.ElementsMatch(t, expectedPolicy.Statements, returnedPolicy.Statements)
+	assert.ElementsMatch(t, expectedPolicy.Projects, returnedPolicy.Projects, "projects match")
+	assert.ElementsMatch(t, expectedPolicy.Members, returnedPolicy.Members, "members match")
+	assert.ElementsMatch(t, expectedPolicy.Statements, returnedPolicy.Statements, "statements match")
 }
 
 func assertPolicies(t *testing.T, expectedPolicies, returnedPolicies []*storage.Policy) {
@@ -6649,8 +6649,7 @@ func insertTestProject(t *testing.T, db *testhelpers.TestDB, id string, name str
 
 func insertPolicyProject(t *testing.T, db *testhelpers.TestDB, policyID string, projectId string) {
 	t.Helper()
-	_, err := db.Exec(`
-			INSERT INTO iam_policy_projects (policy_id, project_id) VALUES (policy_db_id($1), $2);`,
+	_, err := db.Exec("INSERT INTO iam_policy_projects (policy_id, project_id) VALUES (policy_db_id($1), project_db_id($2))",
 		policyID, projectId)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
### :nut_and_bolt: Description

`iam_policies` used to reference `iam_projects` using the latter's `id` column; now it's `db_id`.

Note: this does nothing else; the nearby references that need to be fixed are different subtasks.

~⚠️ branched off of #855; needs to be rebased when that is merged. 👉 [This is what changed over @blakestier's PR](https://github.com/chef/automate/compare/47e9a01e030347b30ab25db31288443027e846cb...sr/issue-832/db_id_for_projects_and_policies)~ ✔️ rebased

### :+1: Definition of Done

Tests pass 😄 References are different.

### :athletic_shoe: Demo Script / Repro Steps

NA

### :chains: Related Resources

- #832 
  - #855

### :white_check_mark: Checklist

- [X] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [X] Code actually executed?
- [X] Vetting performed (unit tests, lint, etc.)?
