### PR TITLE
[lib/cereal] Handle error cases in scheduler code

### DIFF
--- a/lib/cereal/backend/backend.go
+++ b/lib/cereal/backend/backend.go
@@ -105,7 +105,8 @@ type WorkflowCompleter interface {
 }
 
 type ScheduledWorkflowCompleter interface {
-	EnqueueScheduledWorkflow(s *Schedule) error
+	EnqueueAndUpdateScheduledWorkflow(s *Schedule) error
+	DisableSchedule(s *Schedule) error
 	Close()
 }
 


### PR DESCRIPTION
We had two cases with some TODOs around error handling in this
code.

1. We now attempt to disable scheduled workflows with invalid
   recurrence rules.

2. I've attempted to comment the existing code to indicate why we
   think the current error & sleep logic is correct. Namely, we only
   sleep when we think that not sleeping would result in an immediate
   retry of the same schedule workflow.

Signed-off-by: Steven Danna <steve@chef.io>