### PR TITLE
Bring up services in the order they are required during mitigation

### DIFF
--- a/components/automate-deployment/pkg/converge/compiler.go
+++ b/components/automate-deployment/pkg/converge/compiler.go
@@ -498,7 +498,7 @@ func (phase *RunningPhase) Run(writer *eventWriter) error {
 
 		// Reload the service if we are not already deployed
 		// or if we are out of date.
-		reloadNeeded := !deployed || pkgOutOfDate(deployedService, step.pkg)
+		reloadNeeded := !deployed || pkgOutOfDate(deployedService, step.pkg) || restartMitigation.IsStopped(step.pkg)
 
 		// Also reload the service if it requires a reload to
 		// safely reconfigure.

--- a/components/automate-deployment/pkg/converge/stop_mitigation.go
+++ b/components/automate-deployment/pkg/converge/stop_mitigation.go
@@ -154,6 +154,16 @@ func (r *safeServiceRestartRunner) RestartServices() error {
 	return finalError
 }
 
+func (r *safeServiceRestartRunner) IsStopped(pkg habpkg.VersionedPackage) bool {
+	for _, svc := range r.stoppedServices {
+		if svc.Name() == pkg.Name() {
+			return true
+		}
+	}
+
+	return false
+}
+
 func mitigationRequiredForPkg(t target.Target, pkg habpkg.VersionedPackage) (bool, error) {
 	// Because this mitigation is expensive, we only do this for
 	// our main data services.


### PR DESCRIPTION
If deployment service takes down something core like postgres, it first
has to take down all the services that connect to it. Those services
aren't brought up until the end of the run converge part, which was
causing automate-pg-gateway to come up really late in the game. This in
turn causes a bunch of healt checks to fail and causes general slowness
as hab has to service a bunch of services that will just keep dying.

This change will reload any stopped services due to the mitigation when
they are required.

I left the RestartServices at the end. It just call `hab svc start`. I'm
not sure it is needed as we run through the list of services in a
topologically sorted order.
