### PR TITLE
Separate storage client and postgres implementation

### DIFF
--- a/components/applications-service/pkg/storage/client.go
+++ b/components/applications-service/pkg/storage/client.go
@@ -75,8 +75,8 @@ func HabitatUpdateStrategyToStorageFormat(strategy habitat.UpdateStrategy) Updat
 }
 
 type Service struct {
-	ID                  int32  `db:"id"`
-	SupMemberID         string `db:"sup_member_id"`
+	ID                  int32
+	SupMemberID         string
 	Origin              string
 	Name                string
 	Version             string
@@ -89,10 +89,10 @@ type Service struct {
 	Environment         string
 	Channel             string
 	Site                string
-	PreviousHealth      string    `db:"previous_health"`
-	UpdateStrategy      string    `db:"update_strategy"`
-	LastEventOccurredAt time.Time `db:"last_event_occurred_at"`
-	HealthUpdatedAt     time.Time `db:"health_updated_at"`
+	PreviousHealth      string
+	UpdateStrategy      string
+	LastEventOccurredAt time.Time
+	HealthUpdatedAt     time.Time
 }
 
 func (s *Service) FullReleaseString() string {

--- a/components/applications-service/pkg/storage/postgres/service_internal_test.go
+++ b/components/applications-service/pkg/storage/postgres/service_internal_test.go
@@ -4,8 +4,38 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/chef/automate/components/applications-service/pkg/storage"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestConvertComposedServiceToStorage(t *testing.T) {
+	expected := &storage.Service{}
+	assert.Equal(t, expected, convertComposedServiceToStorage(&composedService{}))
+
+	expected = &storage.Service{ID: 1, SupMemberID: "foo"}
+	assert.Equal(t, expected, convertComposedServiceToStorage(&composedService{ID: 1, SupMemberID: "foo"}))
+
+	expected = &storage.Service{Application: "abcd", PreviousHealth: "MORE-OR-LESS-OK"}
+	assert.Equal(t, expected, convertComposedServiceToStorage(&composedService{
+		Application: "abcd", PreviousHealth: "MORE-OR-LESS-OK", Status: "",
+	}))
+}
+
+func TestConvertComposedServicesToStorage(t *testing.T) {
+	expected := []*storage.Service{
+		&storage.Service{},
+		&storage.Service{ID: 1, SupMemberID: "foo"},
+		&storage.Service{Application: "abcd", PreviousHealth: "MORE-OR-LESS-OK"},
+	}
+	subject := convertComposedServicesToStorage([]*composedService{
+		&composedService{},
+		&composedService{ID: 1, SupMemberID: "foo"},
+		&composedService{Application: "abcd", PreviousHealth: "MORE-OR-LESS-OK", Status: ""},
+	})
+	for _, e := range expected {
+		assert.Contains(t, subject, e)
+	}
+}
 
 func TestBuildWhereConstraintsFromFiltersNoFilterReturnsEmptyString(t *testing.T) {
 	expected := ""


### PR DESCRIPTION
### :nut_and_bolt: Description
Creates a new `composedService` struct to separating the `storage` go
package that holds **only the client interface and its structs** that define
what a storage client should look like, the actual `postgres` implementation 
should NOT have a dependency on `db:"XYZ"` tags.

### :+1: Definition of Done
The `storage` and `postgres` go packages are decoupled.

### :athletic_shoe: Demo Script / Repro Steps
N/A - Everything should work after this change is merged, build and run tests as usual.

### :chains: Related Resources
N/A

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
