### PR TITLE
[event-feed-service] Add es-gateway to NOPROXY

### DIFF
--- a/components/event-feed-service/habitat/hooks/run
+++ b/components/event-feed-service/habitat/hooks/run
@@ -1,9 +1,17 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
+set -e
+
 exec 2>&1
 
 # Call the script to block until user accepts the MLSA via the package's config
 {{pkgPathFor "chef/mlsa"}}/bin/accept {{cfg.mlsa.accept}}
+
+{{#eachAlive bind.automate-es-gateway.members as |member|}}
+{{~#if member.cfg.http-host}}
+addNoProxy {{member.sys.ip}}
+{{~/if}}
+{{~/eachAlive}}
 
 # Start our service
 exec event-feed-service serve --config {{pkg.svc_config_path}}/config.toml


### PR DESCRIPTION
We need to add es-gateway to NOPROXY. 

We've discussed a few other solutions to this in the past

- Always adding the system IP to our default no-proxy configuration
- Always adding the system IP to our no-proxy configuration regardless of user config
- Only talking to es-gateway over localhost

But here I have just continued the existing pattern.

Signed-off-by: Steven Danna <steve@chef.io>