### PR TITLE
[CI] Move BUILD_ALL into changed_components.rb

### DIFF
--- a/scripts/changed_components.rb
+++ b/scripts/changed_components.rb
@@ -22,7 +22,7 @@ config = TOML.load_file(".bldr.toml")
 
 changed_files = `git diff --name-only $(scripts/git_difference_expression.rb)`.split("\n")
 
-build_all = (ENV["BUILDKITE_BRANCH"] || "").include?("verify-rebuild-all")
+build_all = (ENV["BUILDKITE_BRANCH"] || "").include?("verify-rebuild-all") || ENV["BUILD_ALL"] == "true"
 
 #
 # The goal here is to produce the same builds that Expeditor would produce

--- a/scripts/verify_build.sh
+++ b/scripts/verify_build.sh
@@ -36,34 +36,14 @@ curl "https://packages.chef.io/manifests/dev/automate/latest.json" > results/dev
 curl "https://packages.chef.io/manifests/current/automate/latest.json" > results/current.json
 curl "https://packages.chef.io/manifests/acceptance/automate/latest.json" > results/acceptance.json
 
-declare -a changed_components
-
-if [[ "$BUILD_ALL" = "true" ]]; then
-    for d in components/*/; do
-        # Skip the devproxy as you can't build it next to the real automate-ui safely.
-        if [[ "$d" == "components/automate-ui-devproxy/" ]]; then
-            continue
-        fi
-        if [[ -f "$d/habitat/plan.sh" ]]; then
-            changed_components+=("$d")
-        fi
-    done
-
+mapfile -t changed_components < <(./scripts/changed_components.rb)
+if [[ ${#changed_components[@]} -ne 0 ]]; then
     buildkite-agent annotate --style "info" << EOF
-This change rebuilds ALL components because BUILD_ALL=$BUILD_ALL:
-$(printf '* %s\n' "${changed_components[@]}")
-EOF
-
-else
-    mapfile -t changed_components < <(./scripts/changed_components.rb)
-    if [[ ${#changed_components[@]} -ne 0 ]]; then
-        buildkite-agent annotate --style "info" << EOF
 This change rebuilds the following components:
 $(printf '* %s\n' "${changed_components[@]}")
 EOF
-    else
-        buildkite-agent annotate --style "info" "This change rebuilds no components."
-    fi
+else
+    buildkite-agent annotate --style "info" "This change rebuilds no components."
 fi
 
 mapfile -t modified_sql_files < <(git diff --name-status "$(./scripts/git_difference_expression.rb)" | awk '/^[RMD][0-9]*.*\.sql/{ print $2 }')


### PR DESCRIPTION
I originally put this in verify_build because I wanted the buildkite
annotation to be different. But, the problem with that implementation
is using file-glob ordering is completely wrong and
changed_components.rb is also the part of the system that produces the
correct dependency-based ordering.

Signed-off-by: Steven Danna <steve@chef.io>