### PR TITLE
[part of #832] flip primary key for iam projects

### DIFF
--- a/components/authz-service/storage/postgres/datamigration/sql/04_v2_set_projects_default.up.sql
+++ b/components/authz-service/storage/postgres/datamigration/sql/04_v2_set_projects_default.up.sql
@@ -11,7 +11,7 @@ INSERT INTO iam_projects (id, name, type, projects)
 
 /* For any statements lacking projects, provide the default of 'all projects' */
 INSERT INTO iam_statement_projects (statement_id, project_id)
-    SELECT id, project_db_id('~~ALL-PROJECTS~~') FROM iam_statements
-    WHERE id NOT IN (SELECT statement_id FROM iam_statement_projects);
+    SELECT db_id, project_db_id('~~ALL-PROJECTS~~') FROM iam_statements
+    WHERE db_id NOT IN (SELECT statement_id FROM iam_statement_projects);
 
 COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/59_use_db_id_as_primary_key_in_iam_projects.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/59_use_db_id_as_primary_key_in_iam_projects.up.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+ALTER TABLE iam_projects
+    DROP CONSTRAINT iam_projects_pkey; -- 'id' primary key
+ALTER TABLE iam_projects
+    ADD PRIMARY KEY (db_id); -- implies unique
+ALTER TABLE iam_projects
+    DROP CONSTRAINT iam_projects_db_id_key CASCADE; -- 'db_id' unique
+ALTER TABLE iam_projects
+    ADD UNIQUE (id);
+
+-- recreate all links
+-- Note: we've done this before; but in the separated steps, we've
+-- relied on the unique
+ALTER TABLE iam_project_rules
+    ADD CONSTRAINT iam_projects_db_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id);
+ALTER TABLE iam_staged_project_rules
+    ADD CONSTRAINT iam_staged_project_rules_project_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id);
+ALTER TABLE iam_role_projects
+    ADD CONSTRAINT iam_role_projects_project_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id);
+ALTER TABLE iam_policy_projects
+    ADD CONSTRAINT iam_policy_projects_project_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id);
+ALTER TABLE iam_statement_projects
+    ADD CONSTRAINT iam_statement_projects_project_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id);
+
+COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/59_use_db_id_as_primary_key_in_iam_projects.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/59_use_db_id_as_primary_key_in_iam_projects.up.sql
@@ -13,14 +13,14 @@ ALTER TABLE iam_projects
 -- Note: we've done this before; but in the separated steps, we've
 -- relied on the unique
 ALTER TABLE iam_project_rules
-    ADD CONSTRAINT iam_projects_db_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id);
+    ADD CONSTRAINT iam_projects_db_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id) ON DELETE CASCADE;
 ALTER TABLE iam_staged_project_rules
-    ADD CONSTRAINT iam_staged_project_rules_project_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id);
+    ADD CONSTRAINT iam_staged_project_rules_project_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id) ON DELETE CASCADE;
 ALTER TABLE iam_role_projects
-    ADD CONSTRAINT iam_role_projects_project_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id);
+    ADD CONSTRAINT iam_role_projects_project_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id) ON DELETE CASCADE;
 ALTER TABLE iam_policy_projects
-    ADD CONSTRAINT iam_policy_projects_project_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id);
+    ADD CONSTRAINT iam_policy_projects_project_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id) ON DELETE CASCADE;
 ALTER TABLE iam_statement_projects
-    ADD CONSTRAINT iam_statement_projects_project_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id);
+    ADD CONSTRAINT iam_statement_projects_project_id_fkey FOREIGN KEY (project_id) REFERENCES iam_projects(db_id) ON DELETE CASCADE;
 
 COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/60_use_db_id_as_primary_key_in_iam_statement_projects.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/60_use_db_id_as_primary_key_in_iam_statement_projects.up.sql
@@ -1,0 +1,165 @@
+BEGIN;
+
+ALTER TABLE iam_statement_projects
+    DROP CONSTRAINT iam_statement_projects_project_id_fkey;
+
+ALTER TABLE iam_statement_projects RENAME COLUMN statement_id TO statement_temp_id;
+
+ALTER TABLE iam_statement_projects ADD COLUMN statement_id INTEGER;
+
+UPDATE
+    iam_statement_projects t
+SET
+    statement_id = (
+        SELECT
+            db_id
+        FROM
+            iam_statements
+        WHERE
+            id = t.statement_temp_id);
+
+ALTER TABLE iam_statement_projects DROP COLUMN statement_temp_id;
+
+ALTER TABLE iam_statement_projects
+    ADD CONSTRAINT iam_statement_projects_statement_id_fkey FOREIGN KEY (statement_id) REFERENCES iam_statements(db_id) ON DELETE CASCADE;
+
+ALTER TABLE iam_statement_projects
+    ADD CONSTRAINT "iam_statement_projects_statement_id_project_id_unique" UNIQUE (statement_id, project_id);
+
+CREATE OR REPLACE FUNCTION query_policy (_policy_id TEXT, _projects_filter TEXT[])
+    RETURNS json
+    AS $$
+    WITH temp AS (
+        SELECT
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type,
+            -- get policy's statements using temporary table
+            ( WITH statement_rows AS (
+                    SELECT
+                        stmt.db_id,
+                        stmt.id,
+                        stmt.effect,
+                        stmt.actions,
+                        stmt.resources,
+                        stmt.role,
+                        (
+                            SELECT
+                                COALESCE(json_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL),
+                                    '[]')
+                                FROM iam_statement_projects AS stmt_projs
+                            LEFT OUTER JOIN iam_projects AS proj ON stmt_projs.statement_id = stmt.db_id WHERE stmt_projs.project_id = proj.db_id) AS projects FROM iam_statements stmt
+                    INNER JOIN iam_policies ON stmt.policy_id = pol.db_id
+                GROUP BY
+                    stmt.db_id,
+                    stmt.id,
+                    stmt.effect,
+                    stmt.actions,
+                    stmt.resources,
+                    stmt.role)
+            SELECT
+                array_agg(statement_rows) FILTER (WHERE statement_rows.id IS NOT NULL)
+            FROM statement_rows) AS statements,
+            -- get policy members
+            (
+            SELECT
+                array_agg(mem) FILTER (WHERE mem.id IS NOT NULL)
+            FROM iam_policy_members AS pol_mems
+        LEFT OUTER JOIN iam_members AS mem ON pol_mems.member_id = mem.db_id WHERE pol_mems.policy_id = pol.db_id) AS members,
+            -- get projects
+            (
+            SELECT
+                array_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL)
+            FROM iam_policy_projects AS pol_projs
+            LEFT OUTER JOIN iam_projects AS proj ON pol_projs.project_id = proj.db_id WHERE pol_projs.policy_id = pol.db_id) AS projects FROM iam_policies AS pol WHERE pol.id = _policy_id
+        GROUP BY
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type
+)
+SELECT
+    json_build_object('id', temp.id, 'name', temp.name, 'type', temp.type, 'statements', COALESCE(temp.statements, '{}'), 'members', COALESCE(temp.members, '{}'), 'projects', COALESCE(temp.projects, '{}')) AS POLICY
+FROM
+    temp
+WHERE
+    projects_match (temp.projects::TEXT[], _projects_filter);
+$$
+LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION query_policies (_projects_filter TEXT[])
+    RETURNS SETOF json
+    AS $$
+    WITH temp AS (
+        SELECT
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type,
+            ( WITH statement_rows AS (
+                    SELECT
+                        stmt.db_id,
+                        stmt.id,
+                        stmt.effect,
+                        stmt.actions,
+                        stmt.resources,
+                        stmt.role,
+                        (
+                            SELECT
+                                COALESCE(json_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL),
+                                    '[]')
+                                FROM iam_statement_projects AS stmt_projs
+                            LEFT OUTER JOIN iam_projects AS proj ON stmt_projs.statement_id = stmt.db_id WHERE stmt_projs.project_id = proj.db_id) AS projects FROM iam_statements stmt
+                    INNER JOIN iam_policies ON stmt.policy_id = pol.db_id
+                GROUP BY
+                    stmt.db_id,
+                    stmt.id,
+                    stmt.effect,
+                    stmt.actions,
+                    stmt.resources,
+                    stmt.role
+)
+            SELECT
+                array_agg(statement_rows) FILTER (WHERE statement_rows.id IS NOT NULL)
+                FROM statement_rows) AS statements,
+            (
+            SELECT
+                array_agg(mem) FILTER (WHERE mem.id IS NOT NULL)
+                FROM iam_policy_members AS pol_mems
+            LEFT OUTER JOIN iam_members AS mem ON pol_mems.member_id = mem.db_id WHERE pol_mems.policy_id = pol.db_id) AS members,
+    (
+    SELECT
+        array_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL)
+        FROM iam_policy_projects AS pol_projs
+        LEFT OUTER JOIN iam_projects AS proj ON pol_projs.project_id = proj.db_id WHERE pol_projs.policy_id = pol.db_id) AS projects FROM iam_policies AS pol
+GROUP BY
+    pol.db_id,
+    pol.id,
+    pol.name,
+    pol.type
+)
+SELECT
+    json_build_object('id', temp.id, 'name', temp.name, 'type', temp.type, 'statements', COALESCE(temp.statements, '{}'), 'members', COALESCE(temp.members, '{}'), 'projects', COALESCE(temp.projects, '{}')) AS POLICY
+FROM
+    temp
+WHERE
+    projects_match (temp.projects::TEXT[], _projects_filter);
+$$
+LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION
+    insert_iam_statement_into_policy(_policy_id TEXT, _statement_id UUID, _statement_effect iam_effect, _statement_actions TEXT[],
+    _statement_resources TEXT[], _statement_role TEXT, _statement_projects TEXT[])
+        RETURNS void AS $$
+            INSERT INTO iam_statements (policy_id, id, effect, actions, resources, role)
+                VALUES (policy_db_id(_policy_id), _statement_id, _statement_effect, _statement_actions, _statement_resources, _statement_role);
+
+            INSERT INTO iam_statement_projects (statement_id, project_id)
+                SELECT statement_db_id(_statement_id) s_id, project_db_id(p_id)
+                FROM UNNEST(_statement_projects) project_db_id(p_id)
+            ON CONFLICT DO NOTHING
+$$
+LANGUAGE sql;
+
+COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/60_use_db_id_as_primary_key_in_iam_statement_projects.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/60_use_db_id_as_primary_key_in_iam_statement_projects.up.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 ALTER TABLE iam_statement_projects
-    DROP CONSTRAINT iam_statement_projects_project_id_fkey;
+    DROP CONSTRAINT iam_statement_projects_statement_id_fkey;
 
 ALTER TABLE iam_statement_projects RENAME COLUMN statement_id TO statement_temp_id;
 

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -58,3 +58,4 @@
 - [`56_add_db_id_statements.up.sql`](56_add_db_id_statements.up.sql)
 - [`57_use_project_db_id_in_references_of_policies.up.sql`](57_use_project_db_id_in_references_of_policies.up.sql)
 - [`58_use_project_db_id_in_references_of_policy_statements.up.sql`](58_use_project_db_id_in_references_of_policy_statements.up.sql)
+- [`59_use_db_id_as_primary_key_in_iam_projects.up.sql`](59_use_db_id_as_primary_key_in_iam_projects.up.sql)

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -59,3 +59,4 @@
 - [`57_use_project_db_id_in_references_of_policies.up.sql`](57_use_project_db_id_in_references_of_policies.up.sql)
 - [`58_use_project_db_id_in_references_of_policy_statements.up.sql`](58_use_project_db_id_in_references_of_policy_statements.up.sql)
 - [`59_use_db_id_as_primary_key_in_iam_projects.up.sql`](59_use_db_id_as_primary_key_in_iam_projects.up.sql)
+- [`60_use_db_id_as_primary_key_in_iam_statement_projects.up.sql`](60_use_db_id_as_primary_key_in_iam_statement_projects.up.sql)

--- a/components/authz-service/testhelpers/testhelpers.go
+++ b/components/authz-service/testhelpers/testhelpers.go
@@ -233,8 +233,13 @@ func SetupTestDB(t *testing.T) (storage.Storage, *TestDB, *prng.Prng, *migration
 }
 
 func (d *TestDB) Flush(t *testing.T) {
-	_, err := d.Exec(`DELETE FROM iam_policies CASCADE; DELETE FROM iam_members CASCADE;
-		DELETE FROM iam_roles CASCADE; DELETE FROM iam_projects CASCADE; DELETE FROM iam_role_projects CASCADE;`)
+	_, err := d.Exec(`DELETE FROM iam_policies CASCADE;
+		DELETE FROM iam_members CASCADE;
+		DELETE FROM iam_roles CASCADE;
+		DELETE FROM iam_role_projects CASCADE;
+		DELETE FROM iam_project_rules;
+		DELETE FROM iam_staged_project_rules;
+		DELETE FROM iam_projects CASCADE;`)
 	require.NoError(t, err)
 }
 

--- a/components/authz-service/testhelpers/testhelpers.go
+++ b/components/authz-service/testhelpers/testhelpers.go
@@ -236,9 +236,6 @@ func (d *TestDB) Flush(t *testing.T) {
 	_, err := d.Exec(`DELETE FROM iam_policies CASCADE;
 		DELETE FROM iam_members CASCADE;
 		DELETE FROM iam_roles CASCADE;
-		DELETE FROM iam_role_projects CASCADE;
-		DELETE FROM iam_project_rules;
-		DELETE FROM iam_staged_project_rules;
 		DELETE FROM iam_projects CASCADE;`)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Last step of #832's subtask for `iam_projects` references. ~~Branched-off of #905, and depends on that to go in first.~~

Also rolled in updating iam_statement_projects to use  iam_statements db_id as well.

### :chains: Related Resources

- #832 
  - #905 

### :white_check_mark: Checklist

- [X] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [X] Code actually executed?
- [X] Vetting performed (unit tests, lint, etc.)?
