### PR TITLE
[integration] Allow users to specify filters that are always used.

### DIFF
--- a/integration/base.sh
+++ b/integration/base.sh
@@ -20,6 +20,7 @@ test_deploy_inspec_profiles=()
 test_upgrade_inspec_profiles=()
 test_skip_diagnostics=false
 test_diagnostics_filters=""
+test_diagnostics_pre_upgrade_filters=""
 test_external_services=()
 
 # test_detect_broken_cli detects if we broke the cli. There was a
@@ -197,7 +198,7 @@ do_test_deploy() {
 
 do_test_deploy_default() {
     if [ $test_skip_diagnostics = false ]; then
-        run_diagnostics_pre_upgrade $test_loadbalancer_url "$test_diagnostics_filters"
+        run_diagnostics_pre_upgrade $test_loadbalancer_url "$test_diagnostics_filters" "$test_diagnostics_pre_upgrade_filters"
     fi
 
     run_inspec_tests "$A2_ROOT_DIR" "${test_deploy_inspec_profiles[@]}"
@@ -227,7 +228,7 @@ do_test_upgrade() {
 
 do_test_upgrade_default() {
     if [ $test_skip_diagnostics = false ]; then
-        run_diagnostics_post_upgrade $test_loadbalancer_url "$test_diagnostics_filters"
+        run_diagnostics_post_upgrade $test_loadbalancer_url "$test_diagnostics_filters" "$test_diagnostics_pre_upgrade_filters"
     fi
 
     run_inspec_tests "$A2_ROOT_DIR" "${test_upgrade_inspec_profiles[@]}"
@@ -280,7 +281,8 @@ do_test_restore() {
 }
 
 do_test_restore_default() {
-    chef-automate diagnostics run ~remove-this-tag-after-merge --skip-generate
+    # shellcheck disable=SC2086
+    chef-automate diagnostics run $test_diagnostics_filters ~remove-this-tag-after-merge --skip-generate
 }
 
 do_cleanup() {

--- a/integration/helpers/build.sh
+++ b/integration/helpers/build.sh
@@ -57,12 +57,10 @@ sync_a1_migration_data() {
 
     hab sup run &
 
-    set +x
     until hab svc status &> /dev/null; do
       echo "waiting for hab-sup to come up"
       sleep 1
     done
-    set -x
 
     DATA_PACKAGE_RELEASE="20181206000427"
     # hab pkg install "$(a2_root_dir)/results/devchef-a1-migration-data-minimal-0.0.1-${DATA_PACKAGE_RELEASE}-x86_64-linux.hart"

--- a/integration/helpers/testing.sh
+++ b/integration/helpers/testing.sh
@@ -3,29 +3,22 @@
 run_diagnostics_pre_upgrade() {
     local loadbalancer_url="$1"
     local filters="$2"
+    local pre_upgrade_filters="$3"
     # shellcheck disable=SC2086
-    chef-automate diagnostics run $filters --lb-url "$loadbalancer_url" --skip-cleanup
-}
-
-run_diagnostics_pre_deep_upgrade() {
-    # Our CI scripts run diagnostics using the latest `chef-automate` executable.
-    # Not all current tests will run correctly against an old A2, so we tag unsafe tests
-    # and run the rest.
-    local loadbalancer_url="$1"
-    local filters="$2"
-    # shellcheck disable=SC2086
-    chef-automate diagnostics run $filters --lb-url "$loadbalancer_url" --skip-cleanup
+    chef-automate diagnostics run $filters $pre_upgrade_filters --lb-url "$loadbalancer_url" --skip-cleanup
 }
 
 run_diagnostics_post_upgrade() {
     local loadbalancer_url="$1"
     local filters="$2"
+    local pre_upgrade_filters="$2"
     # Verify the old data made it
     # shellcheck disable=SC2086
-    chef-automate diagnostics run $filters --lb-url "$loadbalancer_url" --skip-generate
+    chef-automate diagnostics run $filters $pre_upgrade_filters --lb-url "$loadbalancer_url" --skip-generate
 
     # Make sure we can exercise the entirety of the tests post upgrade
-    chef-automate diagnostics run --lb-url "$loadbalancer_url" --skip-cleanup
+    # shellcheck disable=SC2086
+    chef-automate diagnostics run $filters --lb-url "$loadbalancer_url" --skip-cleanup
 }
 
 run_inspec_tests() {

--- a/integration/helpers/testing.sh
+++ b/integration/helpers/testing.sh
@@ -11,7 +11,7 @@ run_diagnostics_pre_upgrade() {
 run_diagnostics_post_upgrade() {
     local loadbalancer_url="$1"
     local filters="$2"
-    local pre_upgrade_filters="$2"
+    local pre_upgrade_filters="$3"
     # Verify the old data made it
     # shellcheck disable=SC2086
     chef-automate diagnostics run $filters $pre_upgrade_filters --lb-url "$loadbalancer_url" --skip-generate

--- a/integration/tests/airgap_upgrade.sh
+++ b/integration/tests/airgap_upgrade.sh
@@ -1,6 +1,5 @@
 test_name="airgap_upgrade"
 test_upgrades=true
-test_diagnostics_filters="~remove-this-tag-after-merge"
 
 do_build() {
     do_build_default

--- a/integration/tests/backup_repo_permissions.sh
+++ b/integration/tests/backup_repo_permissions.sh
@@ -7,7 +7,6 @@ test_skip_diagnostics=true
 do_test_deploy() {
   # Make sure the default settings work as expected
   # do_test_deploy_default
-  set -x
 
   local base_backup_dir="/tmp/$test_build_slug/backups"
   local hab_backup_dir="$base_backup_dir/hab"

--- a/integration/tests/deep_upgrade.sh
+++ b/integration/tests/deep_upgrade.sh
@@ -3,7 +3,7 @@ test_upgrades=true
 test_upgrade_strategy="none"
 test_loadbalancer_url="https://localhost:4443"
 upgrade_scaffold_pid_file="/tmp/upgrade-scaffold-pid"
-test_diagnostics_filters="~skip-for-deep-upgrade"
+test_diagnostics_pre_upgrade_filters="~skip-for-deep-upgrade"
 
 # The version deployed here has a bug where it's possible for it to
 # serve a CLI that is incomplete. We can't go back in time and fix it,

--- a/integration/tests/migrate_upgrade.sh
+++ b/integration/tests/migrate_upgrade.sh
@@ -4,7 +4,7 @@ test_name="deep_migrate_upgrade"
 test_container_name="a1-migration.test"
 test_upgrades=true
 test_upgrade_strategy="none"
-test_diagnostics_filters="~skip-for-deep-upgrade"
+test_diagnostics_pre_upgrade_filters="~skip-for-deep-upgrade"
 
 # The version deployed here has a bug where it's possible for it to
 # serve a CLI that is incomplete. We can't go back in time and fix it,

--- a/integration/tests/upgrade_acceptance_master.sh
+++ b/integration/tests/upgrade_acceptance_master.sh
@@ -1,5 +1,4 @@
 test_name="upgrade_acceptance_master"
 test_upgrades=true
 test_upgrade_inspec_profiles=()
-test_diagnostics_filters="~skip-for-deep-upgrade"
 test_upgrade_begin_manifest="acceptance.json"

--- a/integration/tests/upgrade_current_acceptance.sh
+++ b/integration/tests/upgrade_current_acceptance.sh
@@ -1,7 +1,6 @@
 test_name="upgrade_current_acceptance"
 test_upgrades=true
 test_upgrade_inspec_profiles=()
-test_diagnostics_filters="~skip-for-deep-upgrade"
 test_upgrade_begin_manifest="current.json"
 
 do_prepare_upgrade() {

--- a/integration/tests/upgrade_current_master.sh
+++ b/integration/tests/upgrade_current_master.sh
@@ -1,5 +1,4 @@
 test_name="upgrade_current_master"
 test_upgrades=true
 test_upgrade_inspec_profiles=()
-test_diagnostics_filters="~skip-for-deep-upgrade"
 test_upgrade_begin_manifest="current.json"


### PR DESCRIPTION
This makes a new variable:

`test_diagnostics_pre_upgrade_filters`

which should be used on any diagnostics run on an _old_ version.  The
existing variable

`test_diagnostics_filters`

should be applied to *every* invocation of `diagnostics run`.

I've also removed some uses of skip-for-deep-upgrades that didn't make
sense to me. The tests should show if they are needed.

Finally, it isn't clear to me that we are properly managing the
`~remove-this-tag-after-merge` tag anymore.

Signed-off-by: Steven Danna <steve@chef.io>