### PR TITLE
Teach deployment-service how to backup ssl external pg

### DIFF
--- a/components/automate-deployment/pkg/server/server.go
+++ b/components/automate-deployment/pkg/server/server.go
@@ -2017,6 +2017,13 @@ func (s *server) reloadBackupRunner() error {
 	// platformConfig knows how to deal with superuser, and external vs internal PG
 	platformConfig := platform.Config{
 		Config: &papi.Config{
+			Service: &papi.Config_Service{
+				// NOTE (jaym): The below hack is to allow deployment-service to find the
+				// root cert for external postgres.
+				// deployment-service doesn't fully participate in the platform config, and
+				// so it does not get the external postgres root cert automatically
+				Path: "/hab/svc/automate-pg-gateway",
+			},
 			Postgresql: &papi.Config_Postgresql{
 				Ip: s.deployment.Config.GetPgGateway().GetV1().GetSys().GetService().GetHost().GetValue(),
 				Cfg: &papi.Config_Postgresql_Cfg{

--- a/components/automate-pg-gateway/habitat/config/_a2_platform_external_pg_root_ca.crt
+++ b/components/automate-pg-gateway/habitat/config/_a2_platform_external_pg_root_ca.crt
@@ -1,0 +1,1 @@
+{{~ cfg.service.external_postgresql.ssl.root_cert ~}}


### PR DESCRIPTION
deployment-service was using platform config to get a postgres
connection. For services, this sets up everything to connect to internal
or external postgres correctly. deployment-service doesn't have all the
bits to make that work. I've added a hack to allow it to keep using the
platform config library and correctly get the postgres connection
information.