### PR TITLE
Use the postgres11 client tools for backup/restore

### DIFF
--- a/components/automate-deployment/habitat/plan.sh
+++ b/components/automate-deployment/habitat/plan.sh
@@ -26,6 +26,9 @@ pkg_deps=(
   core/rsync
   core/tar
   chef/mlsa
+  # deployment-service uses the postgres11 client to backup/restore postgres.
+  # we need pg11 because the ha backend uses postgres 11
+  core/postgresql11-client
 )
 pkg_build_deps=(
   core/gcc

--- a/integration/run_test
+++ b/integration/run_test
@@ -69,6 +69,35 @@ then
     )
 fi
 
+cleanup() {
+    if [ ${#test_external_services[@]} -ne 0 ]; then
+        log_info "Cleaning Up External Services"
+
+        for external_service in "${test_external_services[@]}"
+        do
+            log_info "Dumping logs for $external_service"
+            ${external_service}_dump_logs
+            log_info "Stopping $external_service"
+            ${external_service}_teardown
+        done
+
+        destroy_services_config_path
+    fi
+    echo "Attempting to clean up docker container $test_container_name"
+    docker stop "$test_container_name"
+}
+
+cleanup_ci() {
+    # We condition this on CI so that in CI we always cleanup, even on failure
+    if [[ "$CI" = "true" ]]; then
+        cleanup
+    else
+        echo "Not cleaning up because CI=$CI"
+    fi
+}
+
+trap cleanup_ci EXIT
+
 if [ ${#test_external_services[@]} -ne 0 ]; then
     log_info "Start External Services"
     source integration/services/common.sh
@@ -94,36 +123,6 @@ fi
 echo "${docker_run_args[*]}"
 
 docker run "${docker_run_args[@]}" chefes/a2-integration:latest
-
-cleanup() {
-    echo "Attempting to clean up docker container $test_container_name"
-    docker stop "$test_container_name"
-
-    if [ ${#test_external_services[@]} -ne 0 ]; then
-        log_info "Cleaning Up External Services"
-
-        for external_service in "${test_external_services[@]}"
-        do
-            log_info "Dumping logs for $external_service"
-            ${external_service}_dump_logs
-            log_info "Stopping $external_service"
-            ${external_service}_teardown
-        done
-
-        destroy_services_config_path
-    fi
-}
-
-cleanup_ci() {
-    # We condition this on CI so that in CI we always cleanup, even on failure
-    if [[ "$CI" = "true" ]]; then
-        cleanup
-    else
-        echo "Not cleaning up because CI=$CI"
-    fi
-}
-
-trap cleanup_ci EXIT
 
 if [ $CI != "true" ]; then
     secret_origin_key=$(hab origin key export --type secret $HAB_ORIGIN)

--- a/integration/services/common.sh
+++ b/integration/services/common.sh
@@ -13,7 +13,7 @@ create_services_config_path() {
 destroy_services_config_path() {
     if [ -n "$SERVICES_CONFIG_PATH" ]; then
         log_info "Removing services config path $SERVICES_CONFIG_PATH"
-        rm -r "$SERVICES_CONFIG_PATH"
+        sudo rm -rf "$SERVICES_CONFIG_PATH"
     fi
 }
 

--- a/integration/services/ha_backend/init.sh
+++ b/integration/services/ha_backend/init.sh
@@ -14,6 +14,7 @@ ha_backend_config=$(service_config_path "ha_backend.toml")
 ha_backend_setup() {
     mkdir -p "$ha_backend_private"
     mkdir -p "$(dirname "$ha_backend_config")"
+    mkdir -p $(service_config_path "ha_backend_backups")
     local peer_ring_file
     peer_ring_file=$(service_config_path "ha_backend_peers")
     touch "$peer_ring_file"
@@ -102,6 +103,10 @@ ha_backend_setup() {
 [global.v1.external.elasticsearch]
 enable = true
 nodes = ["https://${ha_backend_container1_ip}:9200", "https://${ha_backend_container2_ip}:9200"]
+
+[global.v1.external.elasticsearch.backup]
+enable = true
+location = "fs"
 
 [global.v1.external.elasticsearch.auth]
 scheme = "basic_auth"

--- a/integration/services/ha_backend/init.sh
+++ b/integration/services/ha_backend/init.sh
@@ -15,7 +15,8 @@ ha_backend_setup() {
     mkdir -p "$ha_backend_private"
     mkdir -p "$(dirname "$ha_backend_config")"
     mkdir -p $(service_config_path "ha_backend_backups")
-    chmod 0777 $(service_config_path "ha_backend_backups")
+    chmod -R 0777 $(service_config_path "ha_backend_backups")
+    chmod -R 0777 $(service_config_path "")
     local peer_ring_file
     peer_ring_file=$(service_config_path "ha_backend_peers")
     touch "$peer_ring_file"

--- a/integration/services/ha_backend/init.sh
+++ b/integration/services/ha_backend/init.sh
@@ -15,6 +15,7 @@ ha_backend_setup() {
     mkdir -p "$ha_backend_private"
     mkdir -p "$(dirname "$ha_backend_config")"
     mkdir -p $(service_config_path "ha_backend_backups")
+    chmod 0777 $(service_config_path "ha_backend_backups")
     local peer_ring_file
     peer_ring_file=$(service_config_path "ha_backend_peers")
     touch "$peer_ring_file"

--- a/integration/services/ha_backend/setup.sh
+++ b/integration/services/ha_backend/setup.sh
@@ -94,6 +94,9 @@ host = "_site_"
 [es_yaml.bootstrap]
 memory_lock = false
 
+[es_yaml.path]
+repo = "/services/ha_backend_backups"
+
 [es_yaml.discovery.zen.ping.unicast]
 hosts = ["$(head -n 1 /services/ha_backend_peers)"]
 [es_yaml.cluster.routing.allocation.disk.watermark]

--- a/integration/services/ha_backend/setup.sh
+++ b/integration/services/ha_backend/setup.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+echo "Listing stuff"
+ls -lah /services
 echo "Doing sysctl stuff"
 cat > /etc/sysctl.d/00-chef.conf <<EOF
 vm.swappiness=10

--- a/integration/services/ha_backend/setup.sh
+++ b/integration/services/ha_backend/setup.sh
@@ -34,6 +34,7 @@ After=network-online.target
 
 [Service]
 Environment=HAB_LICENSE=accept-no-persist
+Environment=RUST_LOG=debug
 Type=simple
 ExecStartPre=-/bin/rm -f /hab/sup/default/LOCK
 ExecStart=/bin/hab sup run --peer-watch-file /services/ha_backend_peers

--- a/integration/services/ha_backend/setup.sh
+++ b/integration/services/ha_backend/setup.sh
@@ -107,6 +107,9 @@ low = "95%"
 high = "98%"
 flood_stage = "99%"
 
+[es_yaml.opendistro_security]
+enable_snapshot_restore_privilege = true
+
 [opendistro_ssl]
 
 # root pem cert that signed the two cert/key pairs below

--- a/integration/tests/ha_data_services.sh
+++ b/integration/tests/ha_data_services.sh
@@ -3,8 +3,8 @@
 #shellcheck disable=SC2034
 test_name="ha_data_services"
 test_external_services=(ha_backend)
-#test_backup_restore=true
 test_diagnostics_filters="~iam-v2"
+test_backup_restore=true
 
 do_deploy() {
     #shellcheck disable=SC2154

--- a/integration/tests/ha_data_services.sh
+++ b/integration/tests/ha_data_services.sh
@@ -4,7 +4,7 @@
 test_name="ha_data_services"
 test_external_services=(ha_backend)
 test_diagnostics_filters="~iam-v2"
-#test_backup_restore=true
+test_backup_restore=true
 
 do_deploy() {
     #shellcheck disable=SC2154

--- a/integration/tests/ha_data_services.sh
+++ b/integration/tests/ha_data_services.sh
@@ -4,7 +4,7 @@
 test_name="ha_data_services"
 test_external_services=(ha_backend)
 test_diagnostics_filters="~iam-v2"
-test_backup_restore=true
+#test_backup_restore=true
 
 do_deploy() {
     #shellcheck disable=SC2154

--- a/lib/platform/pg/exporter.go
+++ b/lib/platform/pg/exporter.go
@@ -16,13 +16,13 @@ import (
 
 // PGDumpCmd is the command we will run for pg_dump. This self-test
 // harness replaces this with a stub.
-var PGDumpCmd = []string{"hab", "pkg", "exec", "chef/automate-postgresql", "pg_dump"}
+var PGDumpCmd = []string{"hab", "pkg", "exec", "core/postgresql11-client", "pg_dump"}
 
 // PGRestoreCmd is the command we will run for pg_restore.
-var PGRestoreCmd = []string{"hab", "pkg", "exec", "chef/automate-postgresql", "pg_restore"}
+var PGRestoreCmd = []string{"hab", "pkg", "exec", "core/postgresql11-client", "pg_restore"}
 
 // PSQLCmd is the command we will run for psql.
-var PSQLCmd = []string{"hab", "pkg", "exec", "chef/automate-postgresql", "psql"}
+var PSQLCmd = []string{"hab", "pkg", "exec", "core/postgresql11-client", "psql"}
 
 // DatabaseExporter knows how to export and import a database. See
 // Export and Import for further details.

--- a/lib/platform/pg/exporter_test.go
+++ b/lib/platform/pg/exporter_test.go
@@ -99,7 +99,7 @@ func TestExport(t *testing.T) {
 	}
 
 	connURI := connURI("test_database")
-	stdArgs := []string{"pkg", "exec", "chef/automate-postgresql", "pg_dump", "--if-exists", "--verbose", "--clean", "--file", "test_database.sql", "--no-privileges", "--no-owner", connURI}
+	stdArgs := []string{"pkg", "exec", "core/postgresql11-client", "pg_dump", "--if-exists", "--verbose", "--clean", "--file", "test_database.sql", "--no-privileges", "--no-owner", connURI}
 
 	tests := []struct {
 		desc           string
@@ -112,16 +112,16 @@ func TestExport(t *testing.T) {
 	}{
 		{"it exports the db with pg_dump", "", []string{}, stdArgs, nil, false, false},
 		{"it runs pg_dump with the right --exclude-table options", "", []string{"table1", "table2"},
-			[]string{"pkg", "exec", "chef/automate-postgresql", "pg_dump",
+			[]string{"pkg", "exec", "core/postgresql11-client", "pg_dump",
 				"--if-exists", "--verbose", "--clean", "--file", "test_database.sql", "--no-privileges", "--no-owner",
 				"--exclude-table", "table1", "--exclude-table", "table2",
 				connURI},
 			nil, false, false},
 		{"it runs pg_dump without --no-privileges and --no-owner if User is set", "testuser", []string{},
-			[]string{"pkg", "exec", "chef/automate-postgresql", "pg_dump", "--if-exists", "--verbose", "--clean", "--file", "test_database.sql", connURI},
+			[]string{"pkg", "exec", "core/postgresql11-client", "pg_dump", "--if-exists", "--verbose", "--clean", "--file", "test_database.sql", connURI},
 			nil, false, false},
 		{"it runs pg_dump with -Fc when UseCustomFormat is set to true", "testuser", []string{},
-			[]string{"pkg", "exec", "chef/automate-postgresql", "pg_dump", "--if-exists",
+			[]string{"pkg", "exec", "core/postgresql11-client", "pg_dump", "--if-exists",
 				"--verbose", "--clean", "--file", "test_database.fc", "-Fc", connURI},
 			nil, false, true},
 		{"it returns an error in psql resturns an error", "", []string{}, stdArgs, errors.New("test-error"), true, false},
@@ -190,7 +190,7 @@ func TestImport(t *testing.T) {
 
 		mockExec.Expect("Run", command.ExpectedCommand{
 			Cmd: "hab",
-			Args: []string{"pkg", "exec", "chef/automate-postgresql", "psql", "-f", exportFile,
+			Args: []string{"pkg", "exec", "core/postgresql11-client", "psql", "-f", exportFile,
 				"-v", "ON_ERROR_STOP=true", connURI("test_database")},
 			Env: testExpectedEnv,
 		}).Return(nil)
@@ -210,7 +210,7 @@ func TestImport(t *testing.T) {
 
 		mockExec.Expect("Run", command.ExpectedCommand{
 			Cmd: "hab",
-			Args: []string{"pkg", "exec", "chef/automate-postgresql", "psql", "-f", exportFile,
+			Args: []string{"pkg", "exec", "core/postgresql11-client", "psql", "-f", exportFile,
 				connURI("test_database")},
 			Env: testExpectedEnv,
 		}).Return(nil)
@@ -231,7 +231,7 @@ func TestImport(t *testing.T) {
 
 		mockExec.Expect("Run", command.ExpectedCommand{
 			Cmd: "hab",
-			Args: []string{"pkg", "exec", "chef/automate-postgresql", "psql", "-f", exportFile,
+			Args: []string{"pkg", "exec", "core/postgresql11-client", "psql", "-f", exportFile,
 				"-v", "ON_ERROR_STOP=true", connURI("test_database")},
 			Env: testExpectedEnv,
 		}).Return(nil)
@@ -253,7 +253,7 @@ func TestImport(t *testing.T) {
 
 		mockExec.Expect("Run", command.ExpectedCommand{
 			Cmd: "hab",
-			Args: []string{"pkg", "exec", "chef/automate-postgresql", "psql", "-f", exportFile,
+			Args: []string{"pkg", "exec", "core/postgresql11-client", "psql", "-f", exportFile,
 				"-v", "ON_ERROR_STOP=true", connURI("test_database")},
 			Env: testExpectedEnv,
 		}).Return(nil)
@@ -271,7 +271,7 @@ func TestImport(t *testing.T) {
 
 		mockExec.Expect("Run", command.ExpectedCommand{
 			Cmd: "hab",
-			Args: []string{"pkg", "exec", "chef/automate-postgresql", "psql", "-f", exportFile, "-v", "ON_ERROR_STOP=true",
+			Args: []string{"pkg", "exec", "core/postgresql11-client", "psql", "-f", exportFile, "-v", "ON_ERROR_STOP=true",
 				connURI("test_database")},
 			Env: testExpectedEnv,
 		}).Return(nil)
@@ -288,7 +288,7 @@ func TestImport(t *testing.T) {
 
 		mockExec.Expect("Run", command.ExpectedCommand{
 			Cmd: "hab",
-			Args: []string{"pkg", "exec", "chef/automate-postgresql", "psql", "-f", exportFile,
+			Args: []string{"pkg", "exec", "core/postgresql11-client", "psql", "-f", exportFile,
 				"-v", "ON_ERROR_STOP=true", connURI("test_database")},
 			Env: testExpectedEnv,
 		}).Return(nil)
@@ -307,7 +307,7 @@ func TestImport(t *testing.T) {
 
 		mockExec.Expect("Run", command.ExpectedCommand{
 			Cmd: "hab",
-			Args: []string{"pkg", "exec", "chef/automate-postgresql", "psql", "-f", exportFile,
+			Args: []string{"pkg", "exec", "core/postgresql11-client", "psql", "-f", exportFile,
 				"-v", "ON_ERROR_STOP=true", connURI("test_database")},
 			Env: testExpectedEnv,
 		}).Return(nil)
@@ -326,7 +326,7 @@ func TestImport(t *testing.T) {
 
 		mockExec.Expect("Run", command.ExpectedCommand{
 			Cmd: "hab",
-			Args: []string{"pkg", "exec", "chef/automate-postgresql", "psql", "-f", exportFile,
+			Args: []string{"pkg", "exec", "core/postgresql11-client", "psql", "-f", exportFile,
 				"-v", "ON_ERROR_STOP=true", connURI("test_database")},
 			Env: testExpectedEnv,
 		}).Return(errors.New("test-error"))
@@ -344,7 +344,7 @@ func TestImport(t *testing.T) {
 
 		mockExec.Expect("Run", command.ExpectedCommand{
 			Cmd: "hab",
-			Args: []string{"pkg", "exec", "chef/automate-postgresql", "pg_restore", "-Fc", "-d",
+			Args: []string{"pkg", "exec", "core/postgresql11-client", "pg_restore", "-Fc", "-d",
 				connURI("test_database"), "-e", "--no-owner", "--no-acl", exportFile,
 			},
 			Env: testExpectedEnv,


### PR DESCRIPTION
The HA backend cluster is using postgres 11. The 9.6 tools do not like
this and error out with a version mismatch.