### PR TITLE
[cereal] Periodically cleanup workflow results

### DIFF
--- a/tools/cereal-scaffold/main.go
+++ b/tools/cereal-scaffold/main.go
@@ -17,15 +17,19 @@ import (
 	"github.com/chef/automate/lib/platform/pg"
 )
 
-var opts = struct {
+var opts struct {
 	Debug bool
-}{}
+}
 
 var simpleWorkflowOpts struct {
 	DequeueWorkerCount int
 	TaskCount          int
 	SlowTasks          bool
 	NoEnqueue          bool
+}
+
+var scheduleOpts struct {
+	Name string
 }
 
 func main() {
@@ -99,6 +103,13 @@ func main() {
 		SilenceErrors: true,
 		RunE:          runScheduleTest,
 	}
+
+	scheduleCmd.PersistentFlags().StringVar(
+		&scheduleOpts.Name,
+		"schedule-name",
+		"every minute",
+		"Name to use for the scheduled workflow",
+	)
 
 	cmd.AddCommand(simpleWorkflowCmd)
 	cmd.AddCommand(resetDBCmd)
@@ -358,7 +369,7 @@ func runScheduleTest(_ *cobra.Command, args []string) error {
 	}
 
 	err = manager.CreateWorkflowSchedule(
-		"every minute", "schedule-test", "youfail", true, recRule)
+		scheduleOpts.Name, "schedule-test", "youfail", true, recRule)
 	if err != nil {
 		if err == cereal.ErrWorkflowScheduleExists {
 			logrus.Info("workflow schedule exists...ignoring")


### PR DESCRIPTION
Currently, the workflow results table grows without bound. This
imposes a limit of 10,000 rows that we attempt to enforce
periodically.

To avoid having to think too hard about the implications of DELETE and
our default transaction level, we take a postgresql advisory lock.

Note that we "over delete" to try to avoid deleting on every
interation once we hit the limit.

Signed-off-by: Steven Danna <steve@chef.io>