### PR TITLE
[lib/cereal] Handle a few more TODOs

### DIFF
--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -229,8 +229,10 @@ func (w *workflowInstanceImpl) EnqueueTask(taskName string, parameters interface
 
 func (w *workflowInstanceImpl) Complete(opts ...CompleteOpts) Decision {
 	if len(w.tasks) > 0 {
-		panic("cannot call EnqueueTask and Complete() in same workflow step!")
+		logrus.Errorf("cannot call EnqueueTask and Complete in same workflow step! failing workflow")
+		return Decision{failed: true, err: errors.New("EnqueueTask and Complete called in same workflow step")}
 	}
+
 	d := Decision{
 		complete: true,
 	}
@@ -769,29 +771,24 @@ func (m *Manager) processWorkflow(ctx context.Context, workflowNames []string) b
 		if err != nil {
 			logctx.WithError(err).Error("failed to complete workflow")
 		}
-
 		s.End("complete")
 	} else if decision.continuing {
 		s.Begin("enqueue_task")
 		for _, t := range decision.tasks {
 			err := completer.EnqueueTask(&t, backend.TaskEnqueueOpts{})
 			if err != nil {
-				// TODO(ssd) 2019-05-15: What do we
-				// want to do here? I think we need to
-				// rollback and have the workflow run
-				// again.
 				logrus.WithError(err).Error("failed to enqueue task!")
+				return true
 			}
 		}
 		s.End("enqueue_task")
 		s.Begin("continue")
 		jsonPayload, err := jsonify(decision.payload)
 		if err != nil {
-			logrus.WithError(err).Error("could not marshal payload to JSON, completing workflow")
-			// TODO: We need to fail workflows
-			err := completer.Done(nil)
+			logrus.WithError(err).Error("could not marshal payload to JSON, failing workflow")
+			err := completer.Fail(err)
 			if err != nil {
-				logrus.WithError(err).Error("failed to complete workflow after JSON marshal failure")
+				logrus.WithError(err).Error("failed to fail workflow after JSON marshal failure")
 			}
 		} else {
 			err := completer.Continue(jsonPayload)
@@ -801,8 +798,8 @@ func (m *Manager) processWorkflow(ctx context.Context, workflowNames []string) b
 		}
 		s.End("continue")
 	}
-	logrus.Debugf("Processed Workflow: %s", s)
 
+	logrus.Debugf("Processed Workflow: %s", s)
 	return false
 }
 

--- a/lib/cereal/integration/workflow_error_test.go
+++ b/lib/cereal/integration/workflow_error_test.go
@@ -41,7 +41,74 @@ func (suite *CerealTestSuite) TestWorkflowFail() {
 	suite.NoError(err)
 	suite.Error(w.Err())
 	suite.False(w.IsRunning())
-	suite.Equal(w.Err().Error(), "expected test error")
+	suite.Equal("expected test error", w.Err().Error())
+	err = m.Stop()
+	suite.NoError(err)
+}
+
+func (suite *CerealTestSuite) TestWorkflowFailOnBadEnqueue() {
+	workflowName := randName("failing")
+	instanceName := randName("instance")
+
+	doneChan := make(chan struct{})
+	m := suite.newManager(
+		WithWorkflowExecutor(
+			workflowName,
+			&workflowExecutorWrapper{
+				onStart: func(w cereal.WorkflowInstance, ev cereal.StartEvent) cereal.Decision {
+					close(doneChan)
+					w.EnqueueTask("foo", nil)
+					return w.Complete(nil)
+				},
+				onTaskComplete: func(w cereal.WorkflowInstance, ev cereal.TaskCompleteEvent) cereal.Decision {
+					return w.Complete()
+				},
+			},
+		),
+	)
+	defer m.Stop()
+	err := m.EnqueueWorkflow(context.Background(), workflowName, instanceName, nil)
+	suite.Require().NoError(err, "Failed to enqueue workflow")
+	<-doneChan
+	time.Sleep(20 * time.Millisecond)
+	w, err := m.GetWorkflowInstanceByName(context.Background(), instanceName, workflowName)
+	suite.NoError(err)
+	suite.Error(w.Err())
+	suite.False(w.IsRunning())
+	suite.Equal("EnqueueTask and Complete called in same workflow step", w.Err().Error())
+	err = m.Stop()
+	suite.NoError(err)
+}
+
+func (suite *CerealTestSuite) TestWorkflowFailOnUnmarshableJSON() {
+	workflowName := randName("failing")
+	instanceName := randName("instance")
+
+	doneChan := make(chan struct{})
+	m := suite.newManager(
+		WithWorkflowExecutor(
+			workflowName,
+			&workflowExecutorWrapper{
+				onStart: func(w cereal.WorkflowInstance, ev cereal.StartEvent) cereal.Decision {
+					close(doneChan)
+					return w.Continue(doneChan) // channels can't be marshalled
+				},
+				onTaskComplete: func(w cereal.WorkflowInstance, ev cereal.TaskCompleteEvent) cereal.Decision {
+					return w.Complete()
+				},
+			},
+		),
+	)
+	defer m.Stop()
+	err := m.EnqueueWorkflow(context.Background(), workflowName, instanceName, nil)
+	suite.Require().NoError(err, "Failed to enqueue workflow")
+	<-doneChan
+	time.Sleep(20 * time.Millisecond)
+	w, err := m.GetWorkflowInstanceByName(context.Background(), instanceName, workflowName)
+	suite.NoError(err)
+	suite.Error(w.Err())
+	suite.False(w.IsRunning())
+	suite.Equal("json: unsupported type: chan struct {}", w.Err().Error())
 	err = m.Stop()
 	suite.NoError(err)
 }


### PR DESCRIPTION
- Return, thus canceling the transaction and rolling back the workflow
  on Enqueue Task failures.

- Fail rather than Complete workflow on jsonify error

- Fail workflow when EnqueueTask and Complete have been called in the
  same workflow step.

I wrote tests for 2 out of 3 of these cases. We really need a good way
to inject postgresql failures.

Signed-off-by: Steven Danna <steve@chef.io>