### PR TITLE
[lib/cereal] Remove unused UpdateWorkflowScheduleByID

### DIFF
--- a/lib/cereal/backend/backend.go
+++ b/lib/cereal/backend/backend.go
@@ -12,13 +12,11 @@ type Driver interface {
 	DequeueTask(ctx context.Context, taskName string) (*Task, TaskCompleter, error)
 
 	CreateWorkflowSchedule(ctx context.Context, instanceName string, workflowName string, parameters []byte, enabled bool, recurrence string, nextRunAt time.Time) error
+	ListWorkflowSchedules(ctx context.Context) ([]*Schedule, error)
 	GetDueScheduledWorkflow(ctx context.Context) (*Schedule, ScheduledWorkflowCompleter, error)
 	GetNextScheduledWorkflow(ctx context.Context) (*Schedule, error)
-	UpdateWorkflowScheduleByID(ctx context.Context, id int64, opts WorkflowScheduleUpdateOpts) error
-	UpdateWorkflowScheduleByName(ctx context.Context, instanceName string, workflowName string, opts WorkflowScheduleUpdateOpts) error
-
 	GetWorkflowScheduleByName(ctx context.Context, instanceName string, workflowName string) (*Schedule, error)
-	ListWorkflowSchedules(ctx context.Context) ([]*Schedule, error)
+	UpdateWorkflowScheduleByName(ctx context.Context, instanceName string, workflowName string, opts WorkflowScheduleUpdateOpts) error
 
 	GetWorkflowInstanceByName(ctx context.Context, instanceName string, workflowName string) (*WorkflowInstance, error)
 

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -25,6 +25,7 @@ var (
 	ErrNoScheduledWorkflows     = errors.New("no workflows are scheduled")
 	ErrInvalidSchedule          = errors.New("workflow schedule is not valid")
 	ErrWorkflowInstanceNotFound = errors.New("workflow instance not found")
+	ErrWorkflowScheduleNotFound = errors.New("workflow schedule not found")
 	ErrWorkflowNotComplete      = errors.New("workflow instance is still running")
 	ErrTaskLost                 = errors.New("task lost before reporting its status")
 )


### PR DESCRIPTION
This removes the unused UpdateWorkflowScheduleByID function. While
here, it also takes care of a TODO to correctly return a not-found
error when attempting to update a non-existent workflow.

Signed-off-by: Steven Danna <steve@chef.io>