### PR TITLE
[automate-832] Use role db_id in iam_statements (final part)

### DIFF
--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -536,15 +536,15 @@ func (s *policyServer) MigrateToV2(ctx context.Context,
 		return nil, status.Errorf(codes.Internal, "retrieve default policies: %s", err.Error())
 	}
 
-	for _, pol := range defaultPolicies {
-		if _, err := s.store.CreatePolicy(ctx, &pol); err != nil {
-			return nil, status.Errorf(codes.Internal, "reset to default policies: %s", err.Error())
-		}
-	}
-
 	for _, role := range storage.DefaultRoles() {
 		if _, err := s.store.CreateRole(ctx, &role); err != nil {
 			return nil, status.Errorf(codes.Internal, "reset to default roles: %s", err.Error())
+		}
+	}
+
+	for _, pol := range defaultPolicies {
+		if _, err := s.store.CreatePolicy(ctx, &pol); err != nil {
+			return nil, status.Errorf(codes.Internal, "reset to default policies: %s", err.Error())
 		}
 	}
 

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -169,6 +169,8 @@ func (s *policyServer) CreatePolicy(
 	case storage_errors.ErrConflict:
 		return nil, status.Errorf(codes.AlreadyExists,
 			"policy with id %q already exists", req.Id)
+	case storage_errors.ErrRoleMustExistForStatement:
+		return nil, status.Error(codes.InvalidArgument, "a statement contained a role that does not exist")
 	default:
 		return nil, status.Errorf(codes.Internal,
 			"creating policy %q: %s", req.Id, err.Error())
@@ -273,6 +275,8 @@ func (s *policyServer) UpdatePolicy(
 			return nil, status.Errorf(codes.AlreadyExists, "policy with name %q already exists", req.Name)
 		case storage_errors.ErrNotFound:
 			return nil, status.Errorf(codes.NotFound, "no policy with ID %q found", req.Id)
+		case storage_errors.ErrRoleMustExistForStatement:
+			return nil, status.Error(codes.InvalidArgument, "a statement contained a role that does not exist")
 		}
 		return nil, err
 	}

--- a/components/authz-service/storage/errors.go
+++ b/components/authz-service/storage/errors.go
@@ -40,6 +40,10 @@ var (
 	// ErrChangeTypeForRule indicates that an update operation attempted to change
 	// the type for a rule, which is not allowed.
 	ErrChangeTypeForRule = errors.New("cannot change rule type")
+
+	// ErrRoleMustExistForStatement indicates that the user attempted to insert a role that
+	// does not exist into a new or updated policy statement
+	ErrRoleMustExistForStatement = errors.New("role must exist")
 )
 
 // ErrTxCommit occurs when the database attempts to commit a transaction and

--- a/components/authz-service/storage/errors.go
+++ b/components/authz-service/storage/errors.go
@@ -40,11 +40,21 @@ var (
 	// ErrChangeTypeForRule indicates that an update operation attempted to change
 	// the type for a rule, which is not allowed.
 	ErrChangeTypeForRule = errors.New("cannot change rule type")
-
-	// ErrRoleMustExistForStatement indicates that the user attempted to insert a role that
-	// does not exist into a new or updated policy statement
-	ErrRoleMustExistForStatement = errors.New("role must exist")
 )
+
+// ErrRoleMustExistForStatement indicates that the user attempted to insert a role that
+// does not exist into a new or updated policy statement
+type ErrRoleMustExistForStatement struct {
+	pgErrMessage string
+}
+
+func NewErrRoleMustExistForStatement(pgErrMessage string) error {
+	return &ErrRoleMustExistForStatement{pgErrMessage: pgErrMessage}
+}
+
+func (e *ErrRoleMustExistForStatement) Error() string {
+	return e.pgErrMessage
+}
 
 // ErrTxCommit occurs when the database attempts to commit a transaction and
 // fails.

--- a/components/authz-service/storage/errors.go
+++ b/components/authz-service/storage/errors.go
@@ -57,7 +57,7 @@ func NewErrTxCommit(e error) error {
 }
 
 func (e *ErrTxCommit) Error() string {
-	return "commit db transaction: " + e.Error()
+	return "commit db transaction: " + e.underlying.Error()
 }
 
 // ErrMissingField occurs when a required field was not passed.

--- a/components/authz-service/storage/errors_test.go
+++ b/components/authz-service/storage/errors_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/chef/automate/components/authz-service/storage"
 )
 
-func TestNewProject(t *testing.T) {
+func TestNewErrTxCommit(t *testing.T) {
 	t.Run("ErrTxCommit.Error() does not cause an infinite loop", func(t *testing.T) {
 		errStr := "this is some transaction error"
 		err := errors.New(errStr)

--- a/components/authz-service/storage/errors_test.go
+++ b/components/authz-service/storage/errors_test.go
@@ -17,3 +17,11 @@ func TestNewErrTxCommit(t *testing.T) {
 		assert.Equal(t, "commit db transaction: "+errStr, txErr.Error())
 	})
 }
+
+func TestNewErrRoleMustExistForStatement(t *testing.T) {
+	t.Run("ErrTxCommit.Error() does not cause an infinite loop", func(t *testing.T) {
+		pgErrStr := "role must exist to be inserted into a policy statement, missing role with ID: missing"
+		err := storage.NewErrRoleMustExistForStatement(pgErrStr)
+		assert.Equal(t, pgErrStr, err.Error())
+	})
+}

--- a/components/authz-service/storage/errors_test.go
+++ b/components/authz-service/storage/errors_test.go
@@ -1,0 +1,19 @@
+package storage_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/chef/automate/components/authz-service/storage"
+)
+
+func TestNewProject(t *testing.T) {
+	t.Run("ErrTxCommit.Error() does not cause an infinite loop", func(t *testing.T) {
+		errStr := "this is some transaction error"
+		err := errors.New(errStr)
+		txErr := storage.NewErrTxCommit(err)
+		assert.Equal(t, "commit db transaction: "+errStr, txErr.Error())
+	})
+}

--- a/components/authz-service/storage/postgres/datamigration/sql/01_v2_data_migrations.up.sql
+++ b/components/authz-service/storage/postgres/datamigration/sql/01_v2_data_migrations.up.sql
@@ -10,9 +10,9 @@ UPDATE iam_members
 
 UPDATE iam_statements
     SET
-        role = 'editor'
+        role_id = role_db_id('editor')
     WHERE
-        role = 'operator';
+        role_id = role_db_id('operator');
 
 UPDATE iam_statements
     SET resources = array_replace(resources, 'team:local:operator', 'team:local:editor');

--- a/components/authz-service/storage/postgres/datamigration/sql/02_v2_rename_all_actions.up.sql
+++ b/components/authz-service/storage/postgres/datamigration/sql/02_v2_rename_all_actions.up.sql
@@ -2,9 +2,9 @@ BEGIN;
 
 UPDATE iam_statements
     SET
-        role = 'owner'
+        role_id = role_db_id('owner')
     WHERE
-        role = 'all-actions';
+        role_id = role_db_id('all-actions');
 
 UPDATE iam_roles
     SET

--- a/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
@@ -1,5 +1,12 @@
 BEGIN;
 
+-- there was previously a bug that allowed NULL values to be inserted into
+-- the database for actions (and maybe resources). clean up any such instances.
+UPDATE iam_statements t SET actions = '{}' WHERE actions IS NULL;
+ALTER  TABLE iam_statements ALTER COLUMN actions SET NOT NULL;
+UPDATE iam_statements t SET resources = '{}' WHERE resources IS NULL;
+ALTER  TABLE iam_statements ALTER COLUMN resources SET NOT NULL;
+
 ALTER TABLE iam_statements ADD COLUMN role_id INTEGER;
 
 -- populate role_id in all statements that have a role

--- a/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
@@ -31,7 +31,7 @@ ALTER TABLE iam_statements
 -- the trigger works it's magic below.
 ALTER TABLE iam_statements ALTER CONSTRAINT iam_statements_role_id_fkey DEFERRABLE INITIALLY DEFERRED;
 
--- i wanted use the above FKEY constraint with ON DELETE to clean up any statement where the
+-- i wanted to use the above FKEY constraint with ON DELETE to clean up any statement where the
 -- role getting removed would result in a NULL role_id in iam_statements. that is doable, but
 -- what becomes tricky is adding the additional logic to completely remove the statement if the affected
 -- policy would also have no actions. so instead of splitting that logic up, let's handle it all in a trigger.

--- a/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
@@ -1,0 +1,199 @@
+BEGIN;
+
+ALTER TABLE iam_statements ADD COLUMN role_id INTEGER;
+
+-- populate role_id in all statements that have a role
+UPDATE iam_statements t
+  SET role_id = (SELECT db_id FROM iam_roles WHERE id = t.role)
+  WHERE role != '';
+
+ALTER TABLE iam_statements DROP COLUMN role;
+
+-- TODO: using trigger instead of constraint but leaving for reference for a sec.
+-- ALTER TABLE iam_statements
+--     ADD CONSTRAINT iam_statements_role_id_fkey FOREIGN KEY (role_id) REFERENCES iam_roles(db_id);
+
+-- i wanted use an FKEY constraint and ON DELETE to clean up any statement where the
+-- role getting removed would result in a NULL role_id in iam_statements. that is doable, but
+-- what becomes tricky is adding the additional logic to completely remove the statement if the affected
+-- policy would also have no actions. so instead of splitting that logic up, let's handle it all in a trigger.
+
+-- TODO: let's add a database test for this
+CREATE OR REPLACE FUNCTION purge_statements_with_no_actions_or_role() RETURNS TRIGGER AS $$
+  BEGIN
+    -- for statements that will still have actions, simply remove the role since those
+    -- statements are still valid
+    UPDATE iam_statements SET role_id=NULL WHERE role_id=OLD.db_id AND actions != '{}';
+
+    -- for statements that become invalid (no role or actions), delete them
+    DELETE FROM iam_statements WHERE role_id=OLD.db_id AND actions = '{}';
+
+    -- if as a result, if a policy now has no statements, remove the policy unless it's
+    -- chef-managed (chef-managed case should never happen since chef-managed roles can't be
+    -- deleted, but just to be safe adding it in)
+    DELETE FROM iam_policies USING iam_policies AS p
+      LEFT OUTER JOIN iam_statements AS s ON p.db_id=s.policy_id
+      WHERE s.policy_id IS NULL AND iam_policies.id=p.id AND p.type != 'chef-managed';
+
+    RETURN NULL;
+  END
+$$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER on_role_deletion AFTER DELETE ON iam_roles
+FOR EACH ROW
+EXECUTE PROCEDURE purge_statements_with_no_actions_or_role();
+
+CREATE OR REPLACE FUNCTION role_db_id (_id TEXT)
+    RETURNS INTEGER
+    AS $$
+    SELECT
+        db_id
+    FROM
+        iam_roles
+    WHERE
+        id = _id;
+$$
+LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION query_policy (_policy_id TEXT, _projects_filter TEXT[])
+    RETURNS json
+    AS $$
+    WITH temp AS (
+        SELECT
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type,
+            -- get policy's statements using temporary table
+            ( WITH statement_rows AS (
+                    SELECT
+                        stmt.db_id,
+                        stmt.id,
+                        stmt.effect,
+                        stmt.actions,
+                        stmt.resources,
+                        (
+                          SELECT COALESCE((SELECT id FROM iam_roles WHERE db_id=stmt.role_id), '') AS role
+                        ),
+                        (
+                            SELECT
+                                COALESCE(json_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL),
+                                    '[]')
+                                FROM iam_statement_projects AS stmt_projs
+                            LEFT OUTER JOIN iam_projects AS proj ON stmt_projs.statement_id = stmt.db_id WHERE stmt_projs.project_id = proj.db_id) AS projects FROM iam_statements stmt
+                    INNER JOIN iam_policies ON stmt.policy_id = pol.db_id
+                GROUP BY
+                    stmt.db_id,
+                    stmt.id,
+                    stmt.effect,
+                    stmt.actions,
+                    stmt.resources,
+                    stmt.role_id)
+            SELECT
+                array_agg(statement_rows) FILTER (WHERE statement_rows.id IS NOT NULL)
+            FROM statement_rows) AS statements,
+            -- get policy members
+            (
+            SELECT
+                array_agg(mem) FILTER (WHERE mem.id IS NOT NULL)
+            FROM iam_policy_members AS pol_mems
+        LEFT OUTER JOIN iam_members AS mem ON pol_mems.member_id = mem.db_id WHERE pol_mems.policy_id = pol.db_id) AS members,
+            -- get projects
+            (
+            SELECT
+                array_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL)
+            FROM iam_policy_projects AS pol_projs
+            LEFT OUTER JOIN iam_projects AS proj ON pol_projs.project_id = proj.db_id WHERE pol_projs.policy_id = pol.db_id) AS projects FROM iam_policies AS pol WHERE pol.id = _policy_id
+        GROUP BY
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type
+)
+SELECT
+    json_build_object('id', temp.id, 'name', temp.name, 'type', temp.type, 'statements', COALESCE(temp.statements, '{}'), 'members', COALESCE(temp.members, '{}'), 'projects', COALESCE(temp.projects, '{}')) AS POLICY
+FROM
+    temp
+WHERE
+    projects_match (temp.projects::TEXT[], _projects_filter);
+$$
+LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION query_policies (_projects_filter TEXT[])
+    RETURNS SETOF json
+    AS $$
+    WITH temp AS (
+        SELECT
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type,
+            ( WITH statement_rows AS (
+                    SELECT
+                        stmt.db_id,
+                        stmt.id,
+                        stmt.effect,
+                        stmt.actions,
+                        stmt.resources,
+                        (
+                          SELECT COALESCE((SELECT id FROM iam_roles WHERE db_id=stmt.role_id), '') AS role
+                        ),
+                        (
+                            SELECT
+                                COALESCE(json_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL),
+                                    '[]')
+                                FROM iam_statement_projects AS stmt_projs
+                            LEFT OUTER JOIN iam_projects AS proj ON stmt_projs.statement_id = stmt.db_id WHERE stmt_projs.project_id = proj.db_id) AS projects FROM iam_statements stmt
+                    INNER JOIN iam_policies ON stmt.policy_id = pol.db_id
+                GROUP BY
+                    stmt.db_id,
+                    stmt.id,
+                    stmt.effect,
+                    stmt.actions,
+                    stmt.resources,
+                    stmt.role_id
+)
+            SELECT
+                array_agg(statement_rows) FILTER (WHERE statement_rows.id IS NOT NULL)
+                FROM statement_rows) AS statements,
+            (
+            SELECT
+                array_agg(mem) FILTER (WHERE mem.id IS NOT NULL)
+                FROM iam_policy_members AS pol_mems
+            LEFT OUTER JOIN iam_members AS mem ON pol_mems.member_id = mem.db_id WHERE pol_mems.policy_id = pol.db_id) AS members,
+    (
+    SELECT
+        array_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL)
+        FROM iam_policy_projects AS pol_projs
+        LEFT OUTER JOIN iam_projects AS proj ON pol_projs.project_id = proj.db_id WHERE pol_projs.policy_id = pol.db_id) AS projects FROM iam_policies AS pol
+GROUP BY
+    pol.db_id,
+    pol.id,
+    pol.name,
+    pol.type
+)
+SELECT
+    json_build_object('id', temp.id, 'name', temp.name, 'type', temp.type, 'statements', COALESCE(temp.statements, '{}'), 'members', COALESCE(temp.members, '{}'), 'projects', COALESCE(temp.projects, '{}')) AS POLICY
+FROM
+    temp
+WHERE
+    projects_match (temp.projects::TEXT[], _projects_filter);
+$$
+LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION
+    insert_iam_statement_into_policy(_policy_id TEXT, _statement_id UUID, _statement_effect iam_effect, _statement_actions TEXT[],
+    _statement_resources TEXT[], _statement_role TEXT, _statement_projects TEXT[])
+        RETURNS void AS $$
+            INSERT INTO iam_statements (policy_id, id, effect, actions, resources, role_id)
+                VALUES (policy_db_id(_policy_id), _statement_id, _statement_effect, _statement_actions, _statement_resources, role_db_id(_statement_role));
+
+            INSERT INTO iam_statement_projects (statement_id, project_id)
+                SELECT statement_db_id(_statement_id) s_id, project_db_id(p_id)
+                FROM UNNEST(_statement_projects) project_db_id(p_id)
+            ON CONFLICT DO NOTHING
+$$
+LANGUAGE sql;
+
+COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
@@ -125,7 +125,12 @@ CREATE OR REPLACE FUNCTION query_policy (_policy_id TEXT, _projects_filter TEXT[
             SELECT
                 array_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL)
             FROM iam_policy_projects AS pol_projs
-            LEFT OUTER JOIN iam_projects AS proj ON pol_projs.project_id = proj.db_id WHERE pol_projs.policy_id = pol.db_id) AS projects FROM iam_policies AS pol WHERE pol.id = _policy_id
+            LEFT OUTER JOIN iam_projects AS proj
+            ON pol_projs.project_id = proj.db_id
+            WHERE pol_projs.policy_id = pol.db_id
+        ) AS projects
+    FROM iam_policies AS pol
+    WHERE pol.id = _policy_id
         GROUP BY
             pol.db_id,
             pol.id,

--- a/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
@@ -3,9 +3,17 @@ BEGIN;
 -- there was previously a bug that allowed NULL values to be inserted into
 -- the database for actions (and maybe resources). clean up any such instances.
 UPDATE iam_statements t SET actions = '{}' WHERE actions IS NULL;
-ALTER  TABLE iam_statements ALTER COLUMN actions SET NOT NULL;
+ALTER TABLE iam_statements ALTER COLUMN actions SET NOT NULL;
 UPDATE iam_statements t SET resources = '{}' WHERE resources IS NULL;
-ALTER  TABLE iam_statements ALTER COLUMN resources SET NOT NULL;
+ALTER TABLE iam_statements ALTER COLUMN resources SET NOT NULL;
+
+-- also set policy_id to NOT NULL since a statement can't exist
+-- outside of a policy. there should not be any instances of
+-- orphaned statements, but adding the delete line just in case
+-- so migrations don't explode if there are any somehow (they
+-- are useless if they exist anyway).
+DELETE FROM iam_statements WHERE policy_id IS NULL;
+ALTER TABLE iam_statements ALTER COLUMN policy_id SET NOT NULL;
 
 ALTER TABLE iam_statements ADD COLUMN role_id INTEGER;
 

--- a/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
@@ -27,7 +27,7 @@ ALTER TABLE iam_statements DROP COLUMN role;
 ALTER TABLE iam_statements
     ADD CONSTRAINT iam_statements_role_id_fkey FOREIGN KEY (role_id) REFERENCES iam_roles(db_id);
 
--- This need to be DEFERRABLE INITIALLY DEFERRED so that we don't get a FKEY error before
+-- This needs to be DEFERRABLE INITIALLY DEFERRED so that we don't get a FKEY error before
 -- the trigger works it's magic below.
 ALTER TABLE iam_statements ALTER CONSTRAINT iam_statements_role_id_fkey DEFERRABLE INITIALLY DEFERRED;
 

--- a/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
@@ -98,7 +98,11 @@ CREATE OR REPLACE FUNCTION query_policy (_policy_id TEXT, _projects_filter TEXT[
                                 COALESCE(json_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL),
                                     '[]')
                                 FROM iam_statement_projects AS stmt_projs
-                            LEFT OUTER JOIN iam_projects AS proj ON stmt_projs.statement_id = stmt.db_id WHERE stmt_projs.project_id = proj.db_id) AS projects FROM iam_statements stmt
+                            LEFT OUTER JOIN iam_projects AS proj
+                            ON stmt_projs.statement_id = stmt.db_id
+                            WHERE stmt_projs.project_id = proj.db_id
+                        ) AS projects 
+                    FROM iam_statements stmt
                     INNER JOIN iam_policies ON stmt.policy_id = pol.db_id
                 GROUP BY
                     stmt.db_id,

--- a/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/61_use_role_db_id_in_iam_statements.up.sql
@@ -200,7 +200,7 @@ CREATE OR REPLACE FUNCTION
                 ELSE
                     IF role_db_id(_statement_role) IS NULL
                     THEN
-                        RAISE EXCEPTION 'no role exists with ID %', _statement_role;
+                        RAISE EXCEPTION 'no role exists with ID %', _statement_role USING ERRCODE = 'RDNES';
                     END IF;
 
                     INSERT INTO iam_statements (policy_id, id, effect, actions, resources, role_id)

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -60,3 +60,4 @@
 - [`58_use_project_db_id_in_references_of_policy_statements.up.sql`](58_use_project_db_id_in_references_of_policy_statements.up.sql)
 - [`59_use_db_id_as_primary_key_in_iam_projects.up.sql`](59_use_db_id_as_primary_key_in_iam_projects.up.sql)
 - [`60_use_db_id_as_primary_key_in_iam_statement_projects.up.sql`](60_use_db_id_as_primary_key_in_iam_statement_projects.up.sql)
+- [`61_use_role_db_id_in_iam_statements.up.sql`](61_use_role_db_id_in_iam_statements.up.sql)

--- a/components/authz-service/storage/postgres/postgres.go
+++ b/components/authz-service/storage/postgres/postgres.go
@@ -87,6 +87,8 @@ func parsePQError(err *pq.Error) error {
 		return storage.ErrMarkedForDeletion
 	case "RLTYP": // Custom code: attempt to update a rule's type that is immutable
 		return storage.ErrChangeTypeForRule
+	case "RDNES": // Custom code: attempt to create a policy statement with a role that does not exist
+		return storage.ErrRoleMustExistForStatement
 	}
 
 	return storage.ErrDatabase

--- a/components/authz-service/storage/postgres/postgres.go
+++ b/components/authz-service/storage/postgres/postgres.go
@@ -88,7 +88,7 @@ func parsePQError(err *pq.Error) error {
 	case "RLTYP": // Custom code: attempt to update a rule's type that is immutable
 		return storage.ErrChangeTypeForRule
 	case "RDNES": // Custom code: attempt to create a policy statement with a role that does not exist
-		return storage.ErrRoleMustExistForStatement
+		return storage.NewErrRoleMustExistForStatement(err.Message)
 	}
 
 	return storage.ErrDatabase

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -1114,7 +1114,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			resp, err := store.CreatePolicy(ctx, &pol)
-			assert.Error(t, err)
+			assert.Equal(t, storage_errors.ErrRoleMustExistForStatement, err)
 			assert.Nil(t, resp)
 
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_policies WHERE id=$1`, polID))

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -453,7 +453,7 @@ func TestListPolicies(t *testing.T) {
 			polID := insertTestPolicy(t, db, "testpolicy")
 
 			s0Actions := []string{"iam:users:delete', 'iam:users:create"}
-			s0Resources := []string{"iam:users"}
+			s0Resources := []string{"*"}
 			sID0 := insertTestStatement(t, db, polID, "allow", "", s0Actions, s0Resources)
 
 			s1Actions := []string{"compliance:profiles:download", "compliance:profiles:delete"}
@@ -493,7 +493,7 @@ func TestListPolicies(t *testing.T) {
 
 			polID0 := insertTestPolicy(t, db, "01testpolicy")
 			s0Actions := []string{"iam:users:delete', 'iam:users:create"}
-			s0Resources := []string{"iam:users"}
+			s0Resources := []string{"*"}
 			sID0 := insertTestStatement(t, db, polID0, "allow", "", s0Actions, s0Resources)
 
 			polID1 := insertTestPolicy(t, db, "02testpolicy")
@@ -1114,7 +1114,11 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			resp, err := store.CreatePolicy(ctx, &pol)
-			assert.Equal(t, storage_errors.ErrRoleMustExistForStatement, err)
+			err, wasCorrectError := err.(*storage_errors.ErrRoleMustExistForStatement)
+
+			assert.True(t, wasCorrectError)
+			assert.Equal(t,
+				fmt.Sprintf("role must exist to be inserted into a policy statement, missing role with ID: %s", role), err.Error())
 			assert.Nil(t, resp)
 
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_policies WHERE id=$1`, polID))

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -97,21 +97,17 @@ func TestGetPolicy(t *testing.T) {
 		},
 		"policy with two statements found": func(t *testing.T) {
 			ctx := context.Background()
-			// Note (sr): Is it ugly to put the SQL statement in here, with no
-			// variables or any helper methods? Sure! It also helps isolate this test
-			// case from the others. Let's refactor this if can't bear it anymore, but
-			// maybe roll with it for now...
-			sID0 := genUUID(t)
-			sID1 := genUUID(t)
-			polID := genSimpleID(t, prngSeed)
 
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($3, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id)),
-				   	   ($2, 'deny'::iam_effect, array['compliance:profiles:download', 'compliance:profiles:delete'], array['compliance:profiles'], (SELECT * FROM policy_db_id));`, sID0, sID1, polID)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, "testpolicy")
+
+			s0Actions := []string{"iam:users:delete", "iam:users:create"}
+			s0Resources := []string{"iam:users"}
+			sID0 := insertTestStatement(t, db, polID, "allow", "", s0Actions, s0Resources)
+
+			s1Actions := []string{"compliance:profiles:download", "compliance:profiles:delete"}
+			s1Resources := []string{"compliance:profiles"}
+			sID1 := insertTestStatement(t, db, polID, "deny", "", s1Actions, s1Resources)
+
 			member := insertTestPolicyMember(t, db, polID, "user:local:albertine")
 			assertCount(t, 2, db.QueryRow(`SELECT count(*) FROM iam_statements`))
 			resp, err := store.GetPolicy(ctx, polID)
@@ -125,15 +121,15 @@ func TestGetPolicy(t *testing.T) {
 					{
 						ID:        sID0,
 						Effect:    storage.Allow,
-						Resources: []string{"iam:users"},
-						Actions:   []string{"iam:users:delete", "iam:users:create"},
+						Resources: s0Resources,
+						Actions:   s0Actions,
 						Projects:  []string{},
 					},
 					{
 						ID:        sID1,
 						Effect:    storage.Deny,
-						Resources: []string{"compliance:profiles"},
-						Actions:   []string{"compliance:profiles:download", "compliance:profiles:delete"},
+						Resources: s1Resources,
+						Actions:   s1Actions,
 						Projects:  []string{},
 					},
 				},
@@ -142,24 +138,19 @@ func TestGetPolicy(t *testing.T) {
 		},
 		"policy with two statements and three members, among other policy": func(t *testing.T) {
 			ctx := context.Background()
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES (uuid_generate_v4(), 'firstpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES (uuid_generate_v4(), 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id)),
-				   	   (uuid_generate_v4(), 'deny'::iam_effect, array['compliance:profiles:download', 'compliance:profiles:delete'], array['compliance:profiles'], (SELECT * FROM policy_db_id));`)
-			require.NoError(t, err)
+			s0Actions := []string{"iam:users:delete", "iam:users:create"}
+			s0Resources := []string{"iam:users"}
+			s1Actions := []string{"compliance:profiles:download", "compliance:profiles:delete"}
+			s1Resources := []string{"compliance:profiles"}
 
-			sID0 := genUUID(t)
-			sID1 := genUUID(t)
-			polID := genSimpleID(t, prngSeed)
-			_, err = db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($3, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id)),
-				   	   ($2, 'deny'::iam_effect, array['compliance:profiles:download', 'compliance:profiles:delete'], array['compliance:profiles'], (SELECT * FROM policy_db_id));`, sID0, sID1, polID)
-			require.NoError(t, err)
+			firstPolID := insertTestPolicy(t, db, "firstpolicy")
+			insertTestStatement(t, db, firstPolID, "allow", "", s0Actions, s0Resources)
+			insertTestStatement(t, db, firstPolID, "deny", "", s1Actions, s1Resources)
+
+			polID := insertTestPolicy(t, db, "testpolicy")
+			sID0 := insertTestStatement(t, db, polID, "allow", "", s0Actions, s0Resources)
+			sID1 := insertTestStatement(t, db, polID, "deny", "", s1Actions, s1Resources)
+
 			member0 := insertTestPolicyMember(t, db, polID, "user:local:albertine")
 			member1 := insertTestPolicyMember(t, db, polID, "user:local:charmander")
 			member2 := insertTestPolicyMember(t, db, polID, "user:local:charizard")
@@ -175,15 +166,15 @@ func TestGetPolicy(t *testing.T) {
 					{
 						ID:        sID0,
 						Effect:    storage.Allow,
-						Resources: []string{"iam:users"},
-						Actions:   []string{"iam:users:delete", "iam:users:create"},
+						Resources: s0Resources,
+						Actions:   s0Actions,
 						Projects:  []string{},
 					},
 					{
 						ID:        sID1,
 						Effect:    storage.Deny,
-						Resources: []string{"compliance:profiles"},
-						Actions:   []string{"compliance:profiles:download", "compliance:profiles:delete"},
+						Resources: s1Resources,
+						Actions:   s1Actions,
 						Projects:  []string{},
 					},
 				},
@@ -192,29 +183,25 @@ func TestGetPolicy(t *testing.T) {
 		},
 		"policy with two statements, both with projects, and three members, among other policy": func(t *testing.T) {
 			ctx := context.Background()
-			projID0, projID1 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
-			polID := genSimpleID(t, prngSeed)
-			sID0, sID1 := genUUID(t), genUUID(t)
 
-			// insert projects
+			projID0, projID1 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
 			project0 := insertTestProject(t, db, projID0, "test project 1", storage.Custom)
 			project1 := insertTestProject(t, db, projID1, "test project 2", storage.Custom)
 
-			// insert policy with statements
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($3, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id)),
-				   	   ($2, 'deny'::iam_effect, array['infra:nodes:delete', 'infra:nodes:rerun'], array['infra:nodes'], (SELECT * FROM policy_db_id));`, sID0, sID1, polID)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, "testpolicy")
 
-			// insert projects in statements
+			s0Actions := []string{"iam:users:delete", "iam:users:create"}
+			s0Resources := []string{"iam:users"}
+			sID0 := insertTestStatement(t, db, polID, "allow", "", s0Actions, s0Resources)
+
+			s1Actions := []string{"infra:nodes:delete", "infra:nodes:rerun"}
+			s1Resources := []string{"infra:nodes"}
+			sID1 := insertTestStatement(t, db, polID, "deny", "", s1Actions, s1Resources)
+
 			insertStatementProject(t, db, sID0, projID0)
 			insertStatementProject(t, db, sID1, projID0)
 			insertStatementProject(t, db, sID1, projID1)
 
-			// insert members
 			member0 := insertTestPolicyMember(t, db, polID, "user:local:charmander")
 			member1 := insertTestPolicyMember(t, db, polID, "user:local:charmeleon")
 			member2 := insertTestPolicyMember(t, db, polID, "user:local:charizard")
@@ -230,15 +217,15 @@ func TestGetPolicy(t *testing.T) {
 					{
 						ID:        sID0,
 						Effect:    storage.Allow,
-						Resources: []string{"iam:users"},
-						Actions:   []string{"iam:users:delete", "iam:users:create"},
+						Resources: s0Resources,
+						Actions:   s0Actions,
 						Projects:  []string{project0.ID},
 					},
 					{
 						ID:        sID1,
 						Effect:    storage.Deny,
-						Resources: []string{"infra:nodes"},
-						Actions:   []string{"infra:nodes:delete", "infra:nodes:rerun"},
+						Resources: s1Resources,
+						Actions:   s1Actions,
 						Projects:  []string{project0.ID, project1.ID},
 					},
 				},
@@ -346,17 +333,12 @@ func TestListPolicyMembers(t *testing.T) {
 			assert.Equal(t, []storage.Member{member}, members)
 		},
 		"policy with multiple members and statements returns alphabetically by name": func(t *testing.T) {
-			sID0 := genUUID(t)
-			sID1 := genUUID(t)
-			polID := genSimpleID(t, prngSeed)
+			polID := insertTestPolicy(t, db, "testpolicy")
+			insertTestStatement(t, db,
+				polID, "allow", "", []string{"iam:users:delete', 'iam:users:create"}, []string{"iam:users"})
+			insertTestStatement(t, db,
+				polID, "deny", "", []string{"infra:nodes:delete", "infra:nodes:rerun"}, []string{"infra:nodes"})
 
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($3, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id)),
-				   	   ($2, 'deny'::iam_effect, array['infra:nodes:delete', 'infra:nodes:rerun'], array['infra:nodes'], (SELECT * FROM policy_db_id));`, sID0, sID1, polID)
-			require.NoError(t, err)
 			member0 := insertTestPolicyMember(t, db, polID, "user:local:c")
 			member1 := insertTestPolicyMember(t, db, polID, "user:local:a")
 			member2 := insertTestPolicyMember(t, db, polID, "user:local:b")
@@ -467,17 +449,17 @@ func TestListPolicies(t *testing.T) {
 		},
 		"policy with two statements found": func(t *testing.T) {
 			ctx := context.Background()
-			sID0 := genUUID(t)
-			sID1 := genUUID(t)
-			polID := genSimpleID(t, prngSeed)
 
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($3, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id)),
-				   	   ($2, 'deny'::iam_effect, array['compliance:profiles:download', 'compliance:profiles:delete'], array['compliance:profiles'], (SELECT * FROM policy_db_id));`, sID0, sID1, polID)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, "testpolicy")
+
+			s0Actions := []string{"iam:users:delete', 'iam:users:create"}
+			s0Resources := []string{"iam:users"}
+			sID0 := insertTestStatement(t, db, polID, "allow", "", s0Actions, s0Resources)
+
+			s1Actions := []string{"compliance:profiles:download", "compliance:profiles:delete"}
+			s1Resources := []string{"compliance:profiles"}
+			sID1 := insertTestStatement(t, db, polID, "deny", "", s1Actions, s1Resources)
+
 			member := insertTestPolicyMember(t, db, polID, "user:local:albertine")
 
 			resp, err := store.ListPolicies(ctx)
@@ -491,15 +473,15 @@ func TestListPolicies(t *testing.T) {
 					{
 						ID:        sID0,
 						Effect:    storage.Allow,
-						Resources: []string{"iam:users"},
-						Actions:   []string{"iam:users:delete", "iam:users:create"},
+						Resources: s0Resources,
+						Actions:   s0Actions,
 						Projects:  []string{},
 					},
 					{
 						ID:        sID1,
 						Effect:    storage.Deny,
-						Resources: []string{"compliance:profiles"},
-						Actions:   []string{"compliance:profiles:download", "compliance:profiles:delete"},
+						Resources: s1Resources,
+						Actions:   s1Actions,
 						Projects:  []string{},
 					},
 				},
@@ -508,20 +490,17 @@ func TestListPolicies(t *testing.T) {
 		},
 		"two policies, with one statement each": func(t *testing.T) {
 			ctx := context.Background()
-			sID0, sID1, polID0, polID1 := genUUID(t), genUUID(t), genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
 
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($2, '01testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id));`, sID0, polID0)
-			require.NoError(t, err)
-			_, err = db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($2, '02testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'deny'::iam_effect, array['compliance:profiles:update'], array['compliance:profiles'], (SELECT * FROM policy_db_id));`, sID1, polID1)
-			require.NoError(t, err)
+			polID0 := insertTestPolicy(t, db, "01testpolicy")
+			s0Actions := []string{"iam:users:delete', 'iam:users:create"}
+			s0Resources := []string{"iam:users"}
+			sID0 := insertTestStatement(t, db, polID0, "allow", "", s0Actions, s0Resources)
+
+			polID1 := insertTestPolicy(t, db, "02testpolicy")
+			s1Actions := []string{"compliance:profiles:update"}
+			s1Resources := []string{"compliance:profiles"}
+			sID1 := insertTestStatement(t, db, polID1, "deny", "", s1Actions, s1Resources)
+
 			member0 := insertTestPolicyMember(t, db, polID0, "user:local:albertine0")
 			member1 := insertTestPolicyMember(t, db, polID1, "user:local:albertine1")
 
@@ -537,8 +516,8 @@ func TestListPolicies(t *testing.T) {
 						{
 							ID:        sID0,
 							Effect:    storage.Allow,
-							Resources: []string{"iam:users"},
-							Actions:   []string{"iam:users:delete", "iam:users:create"},
+							Resources: s0Resources,
+							Actions:   s0Actions,
 							Projects:  []string{},
 						},
 					},
@@ -552,8 +531,8 @@ func TestListPolicies(t *testing.T) {
 						{
 							ID:        sID1,
 							Effect:    storage.Deny,
-							Resources: []string{"compliance:profiles"},
-							Actions:   []string{"compliance:profiles:update"},
+							Resources: s1Resources,
+							Actions:   s1Actions,
 							Projects:  []string{},
 						},
 					},
@@ -563,32 +542,26 @@ func TestListPolicies(t *testing.T) {
 		},
 		"two policies, each with one statement that contains 1+ projects": func(t *testing.T) {
 			ctx := context.Background()
-			sID0, sID1 := genUUID(t), genUUID(t)
-			polID0, polID1 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
-			projID0, projID1 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
 
 			// insert projects
+			projID0, projID1 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
 			project0 := insertTestProject(t, db, projID0, "test project 1", storage.Custom)
 			project1 := insertTestProject(t, db, projID1, "test project 2", storage.Custom)
 
 			// insert first policy with statement
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($2, '01testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id));`, sID0, polID0)
-			require.NoError(t, err)
+			polID0 := insertTestPolicy(t, db, "01testpolicy")
+			s0Actions := []string{"iam:users:delete', 'iam:users:create"}
+			s0Resources := []string{"iam:users"}
+			sID0 := insertTestStatement(t, db, polID0, "allow", "", s0Actions, s0Resources)
 
 			// associate statement with project
 			insertStatementProject(t, db, sID0, projID0)
 
 			// insert second policy with statement
-			_, err = db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($2, '02testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'deny'::iam_effect, array['compliance:profiles:update'], array['compliance:profiles'], (SELECT * FROM policy_db_id));`, sID1, polID1)
-			require.NoError(t, err)
+			polID1 := insertTestPolicy(t, db, "02testpolicy")
+			s1Actions := []string{"compliance:profiles:update"}
+			s1Resources := []string{"compliance:profiles"}
+			sID1 := insertTestStatement(t, db, polID1, "deny", "", s1Actions, s1Resources)
 
 			// associate statement with projects
 			insertStatementProject(t, db, sID1, projID0)
@@ -609,8 +582,8 @@ func TestListPolicies(t *testing.T) {
 						{
 							ID:        sID0,
 							Effect:    storage.Allow,
-							Resources: []string{"iam:users"},
-							Actions:   []string{"iam:users:delete", "iam:users:create"},
+							Resources: s0Resources,
+							Actions:   s0Actions,
 							Projects:  []string{project0.ID},
 						},
 					},
@@ -624,8 +597,8 @@ func TestListPolicies(t *testing.T) {
 						{
 							ID:        sID1,
 							Effect:    storage.Deny,
-							Resources: []string{"compliance:profiles"},
-							Actions:   []string{"compliance:profiles:update"},
+							Resources: s1Resources,
+							Actions:   s1Actions,
 							Projects:  []string{project0.ID, project1.ID},
 						},
 					},
@@ -635,11 +608,9 @@ func TestListPolicies(t *testing.T) {
 		},
 		"two policies, one with projects, one without": func(t *testing.T) {
 			ctx := context.Background()
-			polID1, polID2 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
 			name1, name2 := "testPolicy", "anotherTestPolicy"
-			_, err := db.Exec(`INSERT INTO iam_policies (id, name) VALUES ($1, $2), ($3, $4)`,
-				polID1, name1, polID2, name2)
-			require.NoError(t, err)
+			polID1 := insertTestPolicy(t, db, name1)
+			polID2 := insertTestPolicy(t, db, name2)
 
 			projID := "special-project"
 			insertTestProject(t, db, projID, "too special", storage.Custom)
@@ -673,11 +644,9 @@ func TestListPolicies(t *testing.T) {
 		},
 		"two policies with projects": func(t *testing.T) {
 			ctx := context.Background()
-			polID1, polID2 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
 			name1, name2 := "testPolicy", "anotherTestPolicy"
-			_, err := db.Exec(`INSERT INTO iam_policies (id, name) VALUES ($1, $2), ($3, $4)`,
-				polID1, name1, polID2, name2)
-			require.NoError(t, err)
+			polID1 := insertTestPolicy(t, db, name1)
+			polID2 := insertTestPolicy(t, db, name2)
 
 			projID := "special-project"
 			insertTestProject(t, db, projID, "too special", storage.Custom)
@@ -711,11 +680,9 @@ func TestListPolicies(t *testing.T) {
 		},
 		"when the list is filtered by a policy list, return intersection": func(t *testing.T) {
 			ctx := context.Background()
-			polID1, polID2 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
 			name1, name2 := "testPolicy", "anotherTestPolicy"
-			_, err := db.Exec(`INSERT INTO iam_policies (id, name) VALUES ($1, $2), ($3, $4)`,
-				polID1, name1, polID2, name2)
-			require.NoError(t, err)
+			polID1 := insertTestPolicy(t, db, name1)
+			polID2 := insertTestPolicy(t, db, name2)
 
 			projID := "special-project"
 			insertTestProject(t, db, projID, "too special", storage.Custom)
@@ -742,11 +709,9 @@ func TestListPolicies(t *testing.T) {
 		},
 		"when the list is filtered by a policy list of *, return everything": func(t *testing.T) {
 			ctx := context.Background()
-			polID1, polID2 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
 			name1, name2 := "testPolicy", "anotherTestPolicy"
-			_, err := db.Exec(`INSERT INTO iam_policies (id, name) VALUES ($1, $2), ($3, $4)`,
-				polID1, name1, polID2, name2)
-			require.NoError(t, err)
+			polID1 := insertTestPolicy(t, db, name1)
+			polID2 := insertTestPolicy(t, db, name2)
 
 			projID := "special-project"
 			insertTestProject(t, db, projID, "too special", storage.Custom)
@@ -778,11 +743,9 @@ func TestListPolicies(t *testing.T) {
 		},
 		"when the list is filtered by a policy list of (unassigned), return policies with no projects": func(t *testing.T) {
 			ctx := context.Background()
-			polID1, polID2 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
 			name1, name2 := "testPolicy", "anotherTestPolicy"
-			_, err := db.Exec(`INSERT INTO iam_policies (id, name) VALUES ($1, $2), ($3, $4)`,
-				polID1, name1, polID2, name2)
-			require.NoError(t, err)
+			polID1 := insertTestPolicy(t, db, name1)
+			polID2 := insertTestPolicy(t, db, name2)
 
 			projID := "special-project"
 			insertTestProject(t, db, projID, "too special", storage.Custom)
@@ -806,11 +769,10 @@ func TestListPolicies(t *testing.T) {
 		},
 		"when the list is filtered by a project list of (unassigned) and another project, return matched policies": func(t *testing.T) {
 			ctx := context.Background()
-			polID1, polID2, polID3 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
 			name1, name2, name3 := "testPolicy", "anotherTestPolicy", "pika"
-			_, err := db.Exec(`INSERT INTO iam_policies (id, name) VALUES ($1, $2), ($3, $4), ($5, $6)`,
-				polID1, name1, polID2, name2, polID3, name3)
-			require.NoError(t, err)
+			polID1 := insertTestPolicy(t, db, name1)
+			polID2 := insertTestPolicy(t, db, name2)
+			polID3 := insertTestPolicy(t, db, name3)
 
 			projID := "special-project"
 			insertTestProject(t, db, projID, "too special", storage.Custom)
@@ -846,11 +808,10 @@ func TestListPolicies(t *testing.T) {
 		},
 		"when there is no intersection between projects filter and projects, return empty list": func(t *testing.T) {
 			ctx := context.Background()
-			polID1, polID2, polID3 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
 			name1, name2, name3 := "testPolicy", "anotherTestPolicy", "pika"
-			_, err := db.Exec(`INSERT INTO iam_policies (id, name) VALUES ($1, $2), ($3, $4), ($5, $6)`,
-				polID1, name1, polID2, name2, polID3, name3)
-			require.NoError(t, err)
+			polID1 := insertTestPolicy(t, db, name1)
+			insertTestPolicy(t, db, name2)
+			polID3 := insertTestPolicy(t, db, name3)
 
 			projID := "special-project"
 			insertTestProject(t, db, projID, "too special", storage.Custom)
@@ -896,16 +857,11 @@ func TestDeletePolicy(t *testing.T) {
 		"policy not found with existing policies in store": func(t *testing.T) {
 			ctx := context.Background()
 			// Add a different policy
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES (uuid_generate_v4(), 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'deny'::iam_effect, array['iam:users:create', 'iam:users:delete'], array['iam:users'], (SELECT * FROM policy_db_id));`, genUUID(t))
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, "testpolicy")
+			insertTestStatement(t, db, polID, "allow", "", []string{"iam:users:delete", "iam:users:create"}, []string{"iam:users"})
 
-			polID := genSimpleID(t, prngSeed)
 			assertNoPolicyChange(t, store, func() {
-				err = store.DeletePolicy(ctx, polID)
+				err := store.DeletePolicy(ctx, genSimpleID(t, prngSeed))
 				assert.Equal(t, storage_errors.ErrNotFound, err)
 			})
 		},
@@ -936,15 +892,13 @@ func TestDeletePolicy(t *testing.T) {
 		},
 		"only one unattached policy with two statements": func(t *testing.T) {
 			ctx := context.Background()
-			sID0, sID1, polID := genUUID(t), genUUID(t), genSimpleID(t, prngSeed)
 
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($3, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id)),
-				   	   ($2, 'deny'::iam_effect, array['infra:nodes:delete', 'infra:nodes:rerun'], array['infra:nodes'], (SELECT * FROM policy_db_id));`, sID0, sID1, polID)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, "testpolicy")
+			sID0 := insertTestStatement(t, db,
+				polID, "allow", "", []string{"iam:users:delete', 'iam:users:create"}, []string{"iam:users"})
+			sID1 := insertTestStatement(t, db,
+				polID, "deny", "", []string{"infra:nodes:delete", "infra:nodes:rerun"}, []string{"infra:nodes"})
+
 			insertTestPolicyMember(t, db, polID, "user:local:albertine")
 
 			assertPolicyChange(t, store, func() {
@@ -958,26 +912,19 @@ func TestDeletePolicy(t *testing.T) {
 		},
 		"unattached policy with two statements, next to other policy": func(t *testing.T) {
 			ctx := context.Background()
-			polID0 := genSimpleID(t, prngSeed)
 
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($1, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES (uuid_generate_v4(), 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id)),
-				   	   (uuid_generate_v4(), 'deny'::iam_effect, array['compliance:profiles:download', 'compliance:profiles:delete'], array['compliance:profiles'], (SELECT * FROM policy_db_id));`, polID0)
-			require.NoError(t, err)
+			polID0 := insertTestPolicy(t, db, "firstpolicy")
+			insertTestStatement(t, db,
+				polID0, "allow", "", []string{"iam:users:delete', 'iam:users:create"}, []string{"iam:users"})
+			insertTestStatement(t, db,
+				polID0, "deny", "", []string{"compliance:profiles:download", "compliance:profiles:delete"}, []string{"compliance:profiles"})
 			insertTestPolicyMember(t, db, polID0, "user:local:albertine")
 
-			sID0, sID1, polID1 := genUUID(t), genUUID(t), genSimpleID(t, prngSeed)
-
-			_, err = db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($3, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id)),
-				   	   ($2, 'deny'::iam_effect, array['infra:nodes:delete', 'infra:nodes:rerun'], array['infra:nodes'], (SELECT * FROM policy_db_id));`, sID0, sID1, polID1)
-			require.NoError(t, err)
+			polID1 := insertTestPolicy(t, db, "testpolicy")
+			sID0 := insertTestStatement(t, db,
+				polID1, "allow", "", []string{"iam:users:delete', 'iam:users:create"}, []string{"iam:users"})
+			sID1 := insertTestStatement(t, db,
+				polID1, "deny", "", []string{"infra:nodes:delete'", "infra:nodes:rerun"}, []string{"infra:nodes"})
 			member := insertTestPolicyMember(t, db, polID1, "user:local:charmander")
 
 			assertPolicyChange(t, store, func() {
@@ -996,22 +943,15 @@ func TestDeletePolicy(t *testing.T) {
 		},
 		"only one unattached policy with one statement with projects": func(t *testing.T) {
 			ctx := context.Background()
-			sID0, polID := genUUID(t), genSimpleID(t, prngSeed)
-			projID0, projID1 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
 
-			// insert projects
+			projID0, projID1 := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
 			insertTestProject(t, db, projID0, "let's go eevee - prod", storage.Custom)
 			insertTestProject(t, db, projID1, "let's go eevee - dev", storage.Custom)
 
-			// insert policy with statements
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($2, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id));`, sID0, polID)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, "testpolicy")
+			sID0 := insertTestStatement(t, db,
+				polID, "allow", "", []string{"iam:users:delete', 'iam:users:create"}, []string{"iam:users"})
 
-			// insert project into statements
 			insertStatementProject(t, db, sID0, projID0)
 			insertStatementProject(t, db, sID0, projID1)
 
@@ -1370,21 +1310,15 @@ func TestCreatePolicy(t *testing.T) {
 			assertMembers(t, db, polID, []storage.Member{member})
 		},
 		"policy with statement ID already used in other policy's statements": func(t *testing.T) {
-			// Note(sr): implementation detail worth noting (reconsidering?)
-			sID, polID, failedPolID := genUUID(t), genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
-
 			// add a policy using that statement
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($2, 'originalpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id));`, sID, polID)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, "originalpolicy")
+			resources, actions := []string{"iam:users"}, []string{"iam:users:delete", "iam:users:create"}
+			sID := insertTestStatement(t, db, polID, "allow", "", actions, resources)
 			insertTestPolicyMember(t, db, polID, "user:local:albertine")
 
 			// try to add another one using that statement
+			failedPolID := genSimpleID(t, prngSeed)
 			name, typeVal := "toBeCreated", storage.Custom
-			resources, actions := []string{"iam:users"}, []string{"iam:users:delete", "iam:users:create"}
 			member1 := genMember(t, "user:local:otheruser")
 			pol := storage.Policy{
 				ID:      failedPolID,
@@ -2520,20 +2454,15 @@ func TestUpdatePolicy(t *testing.T) {
 		"policy not found with existing policies in store": func(t *testing.T) {
 			ctx := context.Background()
 			// Add a different policy
-			polID0 := genSimpleID(t, prngSeed)
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-			INSERT INTO iam_policies (id, name) VALUES ($2, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-			VALUES ($1, 'deny'::iam_effect, array['iam:users:create', 'iam:users:delete'], array['iam:users'], (SELECT * FROM policy_db_id));`, genUUID(t), polID0)
-			require.NoError(t, err)
+			polID0 := insertTestPolicy(t, db, "testpolicy")
+			insertTestStatement(t, db,
+				polID0, "allow", "", []string{"iam:users:delete', 'iam:users:create"}, []string{"iam:users"})
 			insertTestPolicyMember(t, db, polID0, "user:local:albertine")
 
-			polID := genSimpleID(t, prngSeed)
 			name, typeVal := "somename", storage.Custom
 			member := genMember(t, "user:local:albertine")
 			pol := storage.Policy{
-				ID:      polID,
+				ID:      genSimpleID(t, prngSeed),
 				Name:    name,
 				Type:    typeVal,
 				Members: []storage.Member{member},
@@ -2574,14 +2503,7 @@ func TestUpdatePolicy(t *testing.T) {
 		},
 		"policy with no statements, changing the type": func(t *testing.T) {
 			ctx := context.Background()
-			row := db.QueryRow(`INSERT INTO iam_policies
-        (id, name, type)
-        VALUES (uuid_generate_v4(), 'testpolicy', 'custom')
-        RETURNING id`)
-			require.NotNil(t, row)
-			var polID string
-			err := row.Scan(&polID)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, "testpolicy")
 			insertTestPolicyMember(t, db, polID, "user:local:albertine")
 
 			name, typeVal := "new-name", storage.ChefManaged
@@ -2654,15 +2576,12 @@ func TestUpdatePolicy(t *testing.T) {
 		},
 		"policy with two statements, removing one statement": func(t *testing.T) {
 			ctx := context.Background()
-			polID, sID0, sID1 := genSimpleID(t, prngSeed), genUUID(t), genUUID(t)
 
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($3, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id)),
-				   	   ($2, 'deny'::iam_effect, array['infra:nodes:delete', 'infra:nodes:rerun'], array['infra:nodes'], (SELECT * FROM policy_db_id));`, sID0, sID1, polID)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, "testpolicy")
+			sID0 := insertTestStatement(t, db,
+				polID, "allow", "", []string{"iam:users:delete', 'iam:users:create"}, []string{"iam:users"})
+			sID1 := insertTestStatement(t, db,
+				polID, "deny", "", []string{"infra:nodes:delete", "infra:nodes:rerun"}, []string{"infra:nodes"})
 			insertTestPolicyMember(t, db, polID, "user:local:albertine")
 
 			resources, actions := []string{"iam:users"}, []string{"iam:users:create", "iam:users:delete"}
@@ -2699,33 +2618,25 @@ func TestUpdatePolicy(t *testing.T) {
 			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_members WHERE id=$1 AND name=$2`, member.ID, member.Name))
 		},
 		"policy statement conflict with existing policies in store, triggering rollback": func(t *testing.T) {
-			ctx := context.Background()
 			// Note(sr): test case only serves to demonstrate transaction fix for update
-			sID, polID, originalPolID := genUUID(t), genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
-
+			ctx := context.Background()
 			// add a policy using that statement
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($2, 'firstpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'deny'::iam_effect, array['iam:users:create', 'iam:users:delete'], array['iam:users'], (SELECT * FROM policy_db_id));`, sID, originalPolID)
-			require.NoError(t, err)
+			originalPolID := insertTestPolicy(t, db, "firstpolicy")
+			sID := insertTestStatement(t, db,
+				originalPolID, "deny", "", []string{"iam:users:create", "iam:users:delete"}, []string{"iam:users"})
 			member0 := insertTestPolicyMember(t, db, originalPolID, "user:local:albertine")
 
 			// Add a different policy
-			sID0, sID1 := genUUID(t), genUUID(t)
-			_, err = db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($2, 'otherpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'deny'::iam_effect, array['compliance:profiles:update'], array['compliance:profiles'], (SELECT * FROM policy_db_id));`, sID0, polID)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, "otherpolicy")
+			insertTestStatement(t, db,
+				polID, "deny", "", []string{"compliance:profiles:update"}, []string{"compliance:profiles"})
 			member1 := insertTestPolicyMember(t, db, polID, "user:local:albert")
 
 			// update second policy with statement conflicting with other policy
 			member := genMember(t, "user:local:new_member")
 			resources, actions := []string{"iam:users"}, []string{"iam:users:create", "iam:users:delete"}
 			resources1, actions1 := []string{"iam:teams"}, []string{"iam:teams:create"}
+			sID1 := genUUID(t)
 			statement0 := storage.Statement{
 				ID:        sID1, // fresh
 				Effect:    storage.Deny,
@@ -2773,16 +2684,12 @@ func TestUpdatePolicy(t *testing.T) {
 		},
 		"policy with one statement, adding existing project to statement": func(t *testing.T) {
 			ctx := context.Background()
-			polID, projID := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
-			sID := genUUID(t)
 
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($2, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'deny'::iam_effect, array['compliance:profiles:download', 'compliance:profiles:delete'], array['compliance:profiles'], (SELECT * FROM policy_db_id));`, sID, polID)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, "testpolicy")
+			sID := insertTestStatement(t, db,
+				polID, "deny", "", []string{"compliance:profiles:download", "compliance:profiles:delete"}, []string{"compliance:profiles"})
 
+			projID := genSimpleID(t, prngSeed)
 			member := insertTestPolicyMember(t, db, polID, "user:local:totodile")
 			insertTestProject(t, db, projID, "pokemon crystal", storage.Custom)
 
@@ -2822,17 +2729,13 @@ func TestUpdatePolicy(t *testing.T) {
 		},
 		"policy with one statement, adding non-existent project to statement fails": func(t *testing.T) {
 			ctx := context.Background()
-			polID, projID := genSimpleID(t, prngSeed), genSimpleID(t, prngSeed)
-			sID := genUUID(t)
 			resources, actions := []string{"compliance:profiles"}, []string{"compliance:profiles:download"}
 			assertEmpty(t, db.QueryRow("SELECT count(*) FROM iam_statements"))
 
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($2, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES ($1, 'allow'::iam_effect, array['compliance:profiles:download'], array['compliance:profiles'], (SELECT * FROM policy_db_id));`, sID, polID)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, "testpolicy")
+			sID := insertTestStatement(t, db, polID, "allow", "", actions, resources)
+
+			projID := genSimpleID(t, prngSeed)
 			member := insertTestPolicyMember(t, db, polID, "user:local:totodile")
 
 			statement := storage.Statement{
@@ -2874,11 +2777,8 @@ func TestUpdatePolicy(t *testing.T) {
 		},
 		"policy with no projects to some projects": func(t *testing.T) {
 			ctx := context.Background()
-			polID := genSimpleID(t, prngSeed)
 			name := "testPolicy"
-			_, err := db.Exec(`INSERT INTO iam_policies (id, name) VALUES ($1, $2)`, polID, name)
-			require.NoError(t, err)
-			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_policy_projects WHERE policy_id=policy_db_id($1)`, polID))
+			polID := insertTestPolicy(t, db, name)
 
 			projID := "special-project"
 			insertTestProject(t, db, projID, "too special", storage.Custom)
@@ -2902,10 +2802,8 @@ func TestUpdatePolicy(t *testing.T) {
 		},
 		"policy with project to no projects": func(t *testing.T) {
 			ctx := context.Background()
-			polID := genSimpleID(t, prngSeed)
 			name := "testPolicy"
-			_, err := db.Exec(`INSERT INTO iam_policies (id, name) VALUES ($1, $2)`, polID, name)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, name)
 
 			projID := "special-project"
 			insertTestProject(t, db, projID, "too special", storage.Custom)
@@ -2934,10 +2832,8 @@ func TestUpdatePolicy(t *testing.T) {
 			ctx := context.Background()
 			// TODO optimize/opt-out if they're the same?
 
-			polID := genSimpleID(t, prngSeed)
 			name := "testPolicy"
-			_, err := db.Exec(`INSERT INTO iam_policies (id, name) VALUES ($1, $2)`, polID, name)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, name)
 
 			projID := "special-project"
 			insertTestProject(t, db, projID, "too special", storage.Custom)
@@ -2969,10 +2865,9 @@ func TestUpdatePolicy(t *testing.T) {
 		},
 		"policy with single project to diff project": func(t *testing.T) {
 			ctx := context.Background()
-			polID := genSimpleID(t, prngSeed)
 			name := "testPolicy"
-			_, err := db.Exec(`INSERT INTO iam_policies (id, name) VALUES ($1, $2)`, polID, name)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, name)
+
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_policy_projects WHERE policy_id=policy_db_id($1)`, polID))
 
 			projID := "special-project"
@@ -3003,11 +2898,9 @@ func TestUpdatePolicy(t *testing.T) {
 		},
 		"policy with one project to additional project": func(t *testing.T) {
 			ctx := context.Background()
-			polID := genSimpleID(t, prngSeed)
 			name := "testPolicy"
-			_, err := db.Exec(`INSERT INTO iam_policies (id, name) VALUES ($1, $2)`, polID, name)
+			polID := insertTestPolicy(t, db, name)
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_policy_projects WHERE policy_id=policy_db_id($1)`, polID))
-			require.NoError(t, err)
 
 			projID := "special-project"
 			insertTestProject(t, db, projID, "too special", storage.Custom)
@@ -3040,10 +2933,8 @@ func TestUpdatePolicy(t *testing.T) {
 		},
 		"policy with project to add non-existent project fails": func(t *testing.T) {
 			ctx := context.Background()
-			polID := genSimpleID(t, prngSeed)
 			name := "testPolicy"
-			_, err := db.Exec(`INSERT INTO iam_policies (id, name) VALUES ($1, $2)`, polID, name)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, name)
 
 			projID := "special-project"
 			insertTestProject(t, db, projID, "too special", storage.Custom)
@@ -5634,7 +5525,7 @@ func TestGetRole(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
-	store, db, prngSeed, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 	ctx := context.Background()
@@ -5654,14 +5545,11 @@ func TestReset(t *testing.T) {
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_projects`))
 		},
 		"non-empty database, a policy with two statements and members": func(t *testing.T) {
-			polID := genSimpleID(t, prngSeed)
-			_, err := db.Exec(`
-			WITH policy_db_id AS (
-				INSERT INTO iam_policies (id, name) VALUES ($1, 'testpolicy') RETURNING db_id
-			) INSERT INTO iam_statements (id, effect, actions, resources, policy_id)
-				VALUES (uuid_generate_v4(), 'allow'::iam_effect, array['iam:users:delete', 'iam:users:create'], array['iam:users'], (SELECT * FROM policy_db_id)),
-				   	   (uuid_generate_v4(), 'deny'::iam_effect, array['compliance:profiles:download', 'compliance:profiles:delete'], array['compliance:profiles'], (SELECT * FROM policy_db_id));`, polID)
-			require.NoError(t, err)
+			polID := insertTestPolicy(t, db, "firstpolicy")
+			insertTestStatement(t, db,
+				polID, "allow", "", []string{"iam:users:delete', 'iam:users:create"}, []string{"iam:users"})
+			insertTestStatement(t, db,
+				polID, "deny", "", []string{"compliance:profiles:download", "compliance:profiles:delete"}, []string{"compliance:profiles"})
 			insertTestPolicyMember(t, db, polID, "user:local:albertine")
 			insertTestPolicyMember(t, db, polID, "user:local:othermember")
 
@@ -5680,7 +5568,7 @@ func TestReset(t *testing.T) {
 }
 
 func TestDeleteRole(t *testing.T) {
-	store, db, prngSeed, _ := testhelpers.SetupTestDB(t)
+	store, db, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
 
@@ -5742,7 +5630,7 @@ func TestDeleteRole(t *testing.T) {
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_roles WHERE id=$1`, role.ID))
 			assertCount(t, 3, db.QueryRow(`SELECT count(*) FROM iam_roles`))
 		},
-		"when statements contains a role and no actions and are the last statements in a custom policy, on role deltion the policy is deleted": func(t *testing.T) {
+		"when statements contains a role and no actions and are the last statements in a policy, on role deletion the policy is deleted": func(t *testing.T) {
 			ctx := context.Background()
 			project1 := storage.Project{
 				ID:       "project-1",
@@ -5756,35 +5644,13 @@ func TestDeleteRole(t *testing.T) {
 			roleDeleted := insertTestRole(t, db, "my-id-1", "name", []string{"action1"}, []string{project1.ID})
 			roleRemaining := insertTestRole(t, db, "my-id-2", "name", []string{"action2"}, []string{project1.ID})
 
-			sID0 := genUUID(t)
-			sID1 := genUUID(t)
-			polID := genSimpleID(t, prngSeed)
-			_, err = db.Exec(`
-				WITH policy_db_id AS (
-					INSERT INTO iam_policies (id, name) VALUES ($3, 'testpolicy') RETURNING db_id
-				) INSERT INTO iam_statements (id, effect, actions, role_id, resources, policy_id)
-					VALUES ($1, 'allow'::iam_effect, '{}', role_db_id($4), array['iam:users'], (SELECT * FROM policy_db_id)),
-								($2, 'deny'::iam_effect, '{}', role_db_id($4), array['compliance:profiles'], (SELECT * FROM policy_db_id));`,
-				sID0, sID1, polID, roleDeleted.ID)
-			require.NoError(t, err)
-			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_policies WHERE id=$1`, polID))
-			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1`, sID0))
-			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1`, sID1))
+			polID := insertTestPolicy(t, db, "testpolicy")
+			sID0 := insertTestStatement(t, db, polID, "allow", roleDeleted.ID, []string{}, []string{"iam:users"})
+			sID1 := insertTestStatement(t, db, polID, "deny", roleDeleted.ID, []string{}, []string{"compliance:profiles"})
 
-			sID0WrongRole := genUUID(t)
-			sID1WrongRole := genUUID(t)
-			polIDWrongRole := genSimpleID(t, prngSeed)
-			_, err = db.Exec(`
-				WITH policy_db_id AS (
-					INSERT INTO iam_policies (id, name) VALUES ($3, 'testpolicy') RETURNING db_id
-				) INSERT INTO iam_statements (id, effect, actions, role_id, resources, policy_id)
-					VALUES ($1, 'allow'::iam_effect, '{}', role_db_id($4), array['iam:users'], (SELECT * FROM policy_db_id)),
-								($2, 'deny'::iam_effect, '{}', role_db_id($4), array['compliance:profiles'], (SELECT * FROM policy_db_id));`,
-				sID0WrongRole, sID1WrongRole, polIDWrongRole, roleRemaining.ID)
-			require.NoError(t, err)
-			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_policies WHERE id=$1`, polIDWrongRole))
-			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1`, sID0WrongRole))
-			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1`, sID1WrongRole))
+			polIDWrongRole := insertTestPolicy(t, db, "testpolicy2")
+			sID0WrongRole := insertTestStatement(t, db, polIDWrongRole, "allow", roleRemaining.ID, []string{}, []string{"iam:users"})
+			sID1WrongRole := insertTestStatement(t, db, polIDWrongRole, "deny", roleRemaining.ID, []string{}, []string{"compliance:profiles"})
 
 			err = store.DeleteRole(ctx, roleDeleted.ID)
 
@@ -5797,10 +5663,46 @@ func TestDeleteRole(t *testing.T) {
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1`, sID1))
 
 			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_policies WHERE id=$1`, polIDWrongRole))
-			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1`, sID0WrongRole))
-			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1`, sID1WrongRole))
+			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1 AND role_id=role_db_id($2)`, sID0WrongRole, roleRemaining.ID))
+			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1 AND role_id=role_db_id($2)`, sID1WrongRole, roleRemaining.ID))
 		},
-		// TODO (tc): Test rest of trigger cases
+		"when one statement contains a role and as well as actions but one statement contains no actions, on role deletion there is only one modified statement remaining": func(t *testing.T) {
+			ctx := context.Background()
+			project1 := storage.Project{
+				ID:       "project-1",
+				Name:     "name1",
+				Type:     storage.Custom,
+				Projects: []string{"project-1"},
+			}
+			_, err := store.CreateProject(ctx, &project1)
+			require.NoError(t, err)
+
+			roleDeleted := insertTestRole(t, db, "my-id-1", "name", []string{"action1"}, []string{project1.ID})
+			roleRemaining := insertTestRole(t, db, "my-id-2", "name", []string{"action2"}, []string{project1.ID})
+
+			polID := insertTestPolicy(t, db, "testpolicy")
+			sID0 := insertTestStatement(t, db, polID, "allow", roleDeleted.ID, []string{}, []string{"iam:users"})
+			actions := []string{"compliance:profiles:download"}
+			sID1 := insertTestStatement(t, db, polID, "deny", roleDeleted.ID, actions, []string{"compliance:profiles"})
+
+			polIDWrongRole := insertTestPolicy(t, db, "testpolicy2")
+			sID0WrongRole := insertTestStatement(t, db, polIDWrongRole, "allow", roleRemaining.ID, []string{}, []string{"iam:users"})
+			sID1WrongRole := insertTestStatement(t, db, polIDWrongRole, "deny", roleRemaining.ID, []string{}, []string{"compliance:profiles"})
+
+			err = store.DeleteRole(ctx, roleDeleted.ID)
+
+			require.NoError(t, err)
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_roles WHERE id=$1`, roleDeleted.ID))
+			assertCount(t, 1, db.QueryRow(`SELECT count(*) FROM iam_roles`))
+
+			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_policies WHERE id=$1`, polID))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1`, sID0))
+			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1 AND actions=$2 AND role_id IS NULL`, sID1, pq.Array(actions)))
+
+			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_policies WHERE id=$1`, polIDWrongRole))
+			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1 AND role_id=role_db_id($2)`, sID0WrongRole, roleRemaining.ID))
+			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1 AND role_id=role_db_id($2)`, sID1WrongRole, roleRemaining.ID))
+		},
 		"deletes role with several roles in database when projects filter has intersection": func(t *testing.T) {
 			ctx := context.Background()
 			project1 := storage.Project{
@@ -6672,6 +6574,47 @@ func insertTestPolicy(t *testing.T, db *testhelpers.TestDB, policyName string) s
 	var polID string
 	require.NoError(t, row.Scan(&polID))
 	return polID
+}
+
+// pass "" as roleID if you do not wish to populate a role
+func insertTestStatement(t *testing.T, db *testhelpers.TestDB,
+	policyID, effect, roleID string, actions, resources []string) uuid.UUID {
+
+	var id string
+	if roleID != "" {
+		row := db.QueryRow(`
+		INSERT INTO iam_statements (id, policy_id, effect, role_id, actions, resources)
+			VALUES (uuid_generate_v4(), policy_db_id($1), $2::iam_effect, role_db_id($3), $4, $5) RETURNING id`,
+			policyID, effect, roleID, pq.Array(actions), pq.Array(resources))
+		require.NoError(t, row.Scan(&id))
+
+		assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE
+			id=$1 AND
+			policy_id=policy_db_id($2) AND
+			effect=$3 AND
+			actions=$4 AND
+			resources=$5 AND
+			role_id=role_db_id($6)`,
+			id, policyID, effect, pq.Array(actions), pq.Array(resources), roleID))
+	} else {
+		row := db.QueryRow(`
+		INSERT INTO iam_statements (id, policy_id, effect, actions, resources)
+			VALUES (uuid_generate_v4(), policy_db_id($1), $2::iam_effect, $3, $4) RETURNING id`,
+			policyID, effect, pq.Array(actions), pq.Array(resources))
+		require.NoError(t, row.Scan(&id))
+
+		assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE
+			id=$1 AND
+			policy_id=policy_db_id($2) AND
+			effect=$3 AND
+			actions=$4 AND
+			resources=$5 AND
+			role_id IS NULL`,
+			id, policyID, effect, pq.Array(actions), pq.Array(resources)))
+	}
+	uuid, err := uuid.FromString(id)
+	require.NoError(t, err)
+	return uuid
 }
 
 // Will fail on conflict with existing name.

--- a/components/authz-service/storage/v2/statement.go
+++ b/components/authz-service/storage/v2/statement.go
@@ -24,6 +24,9 @@ func NewStatement(effect Effect, role string, projects, resources, actions []str
 	if actions == nil {
 		actions = []string{}
 	}
+	if resources == nil {
+		resources = []string{}
+	}
 
 	if role == "" && len(actions) == 0 {
 		return Statement{},

--- a/components/authz-service/storage/v2/statement.go
+++ b/components/authz-service/storage/v2/statement.go
@@ -21,6 +21,10 @@ type Statement struct {
 // validation around what a valid statement is in terms of our storage layer.
 // It also generates a new ID for our statement.
 func NewStatement(effect Effect, role string, projects, resources, actions []string) (Statement, error) {
+	if actions == nil {
+		actions = []string{}
+	}
+
 	if role == "" && len(actions) == 0 {
 		return Statement{},
 			errors.New("unsupported statement variant: you must pass a role, a non-empty array of actions, or both")

--- a/components/automate-cli/pkg/diagnostics/integration/iam_v2.go
+++ b/components/automate-cli/pkg/diagnostics/integration/iam_v2.go
@@ -22,7 +22,7 @@ const roleCreateTemplateStr = `
 {
   "id": "{{ .ID }}",
   "name": "{{ .Name }}",
-	"actions": ["test:svc:someroleaction", "test:svc:someotherroleaction"]
+  "actions": ["test:svc:someroleaction", "test:svc:someotherroleaction"]
 }
 `
 

--- a/inspec/a2-iam-v2-integration/controls/iam_v2.rb
+++ b/inspec/a2-iam-v2-integration/controls/iam_v2.rb
@@ -22,6 +22,16 @@ control 'iam-v2-1' do
 
   describe 'v2beta policy API' do
     before(:all) do
+      resp = automate_api_request("/apis/iam/v2beta/roles",
+        http_method: 'POST',
+        request_body: {
+          id: CUSTOM_ROLE_ID,
+          name: "display name !#$#",
+          actions: ["test:some:action", "test:other:action"]
+        }.to_json
+      )
+      expect(resp.http_status).to eq 200
+
       resp = automate_api_request("/apis/iam/v2beta/policies",
         http_method: 'POST',
         request_body: {
@@ -31,7 +41,7 @@ control 'iam-v2-1' do
           statements: [
             {
               effect: "DENY",
-              role: "test"
+              role: CUSTOM_ROLE_ID
             },
             {
               effect: "ALLOW",
@@ -45,6 +55,9 @@ control 'iam-v2-1' do
 
     after(:all) do
       resp = automate_api_request("/apis/iam/v2beta/policies/#{CUSTOM_POLICY_ID}", http_method: 'DELETE')
+      expect(resp.http_status).to eq 200
+
+      resp = automate_api_request("/apis/iam/v2beta/roles/#{CUSTOM_ROLE_ID}", http_method: 'DELETE')
       expect(resp.http_status).to eq 200
     end
 
@@ -63,7 +76,7 @@ control 'iam-v2-1' do
           statements: [
             {
               effect: "DENY",
-              role: "test"
+              role: CUSTOM_ROLE_ID
             },
           ]
         }.to_json()
@@ -84,7 +97,7 @@ control 'iam-v2-1' do
         "effect": "DENY",
         "actions": [
         ],
-        "role": "test",
+        "role": "#{CUSTOM_ROLE_ID}",
         "resources": [
           "*"
         ],
@@ -118,7 +131,7 @@ EOF
           statements: [
             {
               effect: "DENY",
-              role: "test"
+              role: CUSTOM_ROLE_ID
             },
           ]
         }.to_json()
@@ -155,7 +168,7 @@ EOF
             {
               effect: "DENY",
               resources: ["compliance:foo1","compliance:bar1"],
-              role: "test"
+              role: CUSTOM_ROLE_ID
             },
           ]
         }.to_json()


### PR DESCRIPTION
### :nut_and_bolt: Description

Updated the `iam_statements` table to have a foreign key to role's via `db_id`. Also, since things are now properly relational, if you delete a role, policies will now remove the role from their statement. If removing the role would result in the statement having no role or actions, then the statement is removed. If that results in an empty custom policy, the policy is removed.

I also added a `insertTestStatement` helper and updated the postgres tests to use it.

**Also found and fixed a few bugs:**
* Resources and actions in the iam_statements didn't have `NOT NULL` constraints and could have resulted in null values. I've populated any NULLs with `'{}'` and added `NOT NULL` constraints.
* Fixed a bug where errors on db transactions would cause an infinite loop and crash authz-service.

### :athletic_shoe: Demo Script / Repro Steps

##### Setup

```
start_all_services
rebuild components/authz-service
export TOK=`chef-automate iam token create my-token --admin`
```

##### Create a role and some policies that use it

```
curl -kH "api-token: $TOK" -XPOST -d '{"id":"my-custom-role", "name": "pika p", "actions":["iam:projects:list"]}' https://localhost/apis/iam/v2beta/roles
```

`policy1.json` contains a single statement with actions and the role:

```
{
  "name": "Test Policy 1",
  "id": "test-policy-1",
  "members": [ "user:local:*", "token:*" ],
  "statements": [
    {
      "effect": "ALLOW",
      "actions": [ "iam:*" ],
      "role": "my-custom-role"
    }
  ]
}
```

`policy2.json` contains a single statement with no actions and the role:

```
{
  "name": "Test Policy 2",
  "id": "test-policy-2",
  "members": [ "user:local:*", "token:*" ],
  "statements": [
    {
      "effect": "ALLOW",
      "role": "my-custom-role"
    }
  ]
}
```

`policy3.json` contains a multiple statement but one has no actions and the role:

```
{
  "name": "Test Policy 3",
  "id": "test-policy-3",
  "members": [ "user:local:*", "token:*" ],
  "statements": [
    {
      "effect": "ALLOW",
      "role": "my-custom-role"
    },
      {
      "effect": "ALLOW",
      "actions": [ "iam:*" ]
    }
  ]
}
```

Create them all:

```
curl -kH "api-token: $TOK" -XPOST -d @policy1.json https://localhost/apis/iam/v2beta/policies
curl -kH "api-token: $TOK" -XPOST -d @policy2.json https://localhost/apis/iam/v2beta/policies
curl -kH "api-token: $TOK" -XPOST -d @policy3.json https://localhost/apis/iam/v2beta/policies
```

List and get should return the role as part of the statement:

```
# curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/policies/test-policy-3 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   313  100   313    0     0  15650      0 --:--:-- --:--:-- --:--:-- 15650
{
  "policy": {
    "name": "Test Policy 3",
    "id": "test-policy-3",
    "type": "CUSTOM",
    "members": [
      "user:local:*",
      "token:*"
    ],
    "statements": [
      {
        "effect": "ALLOW",
        "actions": [],
        "role": "my-custom-role",
        "resources": [
          "*"
        ],
        "projects": [
          "*"
        ]
      },
      {
        "effect": "ALLOW",
        "actions": [
          "iam:*"
        ],
        "role": "",
        "resources": [
          "*"
        ],
        "projects": [
          "*"
        ]
      }
    ],
    "projects": []
  }
}
```

##### Delete the role and the policies should be updated correctly:

```
curl -kH "api-token: $TOK" -XDELETE https://localhost/apis/iam/v2beta/roles/my-custom-role
```

`test-policy-1` still has a single statement with its actions but the role is removed:

```
# curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/policies/test-policy-1 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   222  100   222    0     0  11684      0 --:--:-- --:--:-- --:--:-- 12333
{
  "policy": {
    "name": "Test Policy 1",
    "id": "test-policy-1",
    "type": "CUSTOM",
    "members": [
      "user:local:*",
      "token:*"
    ],
    "statements": [
      {
        "effect": "ALLOW",
        "actions": [
          "iam:*"
        ],
        "role": "",
        "resources": [
          "*"
        ],
        "projects": [
          "*"
        ]
      }
    ],
    "projects": []
  }
}
```

`test-policy-2` is now gone because its only statement had the role that was deleted and no actions:

```
[21][default:/src:0]# curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/policies/test-policy-2 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   129    0   129    0     0   6450      0 --:--:-- --:--:-- --:--:--  6450
{
  "error": "no policy with ID \"test-policy-2\" found",
  "message": "no policy with ID \"test-policy-2\" found",
  "code": 5,
  "details": []
}
```

`test-policy-3` lost the statement with no actions and the role but still has a valid second statement so it still exists:

```
# curl -kH "api-token: $TOK" https://localhost/apis/iam/v2beta/policies/test-policy-3 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   222  100   222    0     0   8880      0 --:--:-- --:--:-- --:--:--  8880
{
  "policy": {
    "name": "Test Policy 3",
    "id": "test-policy-3",
    "type": "CUSTOM",
    "members": [
      "user:local:*",
      "token:*"
    ],
    "statements": [
      {
        "effect": "ALLOW",
        "actions": [
          "iam:*"
        ],
        "role": "",
        "resources": [
          "*"
        ],
        "projects": [
          "*"
        ]
      }
    ],
    "projects": []
  }
}
```

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
