### PR TITLE
[lib/cereal] Ignore missing task results

### DIFF
--- a/lib/cereal/backend/backend.go
+++ b/lib/cereal/backend/backend.go
@@ -56,9 +56,10 @@ const (
 type TaskStatusType string
 
 const (
-	TaskStatusSuccess TaskStatusType = "success"
-	TaskStatusFailed  TaskStatusType = "failed"
-	TaskStatusLost    TaskStatusType = "lost"
+	TaskStatusSuccess        TaskStatusType = "success"
+	TaskStatusFailed         TaskStatusType = "failed"
+	TaskStatusLost           TaskStatusType = "lost"
+	TaskStatusUnusableResult TaskStatusType = "unusable_result"
 )
 
 type WorkflowEvent struct {

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -111,6 +111,8 @@ func (r *taskResult) Err() error {
 		return errors.New(r.backendResult.ErrorText)
 	case backend.TaskStatusLost:
 		return ErrTaskLost
+	case backend.TaskStatusUnusableResult:
+		return errors.New(r.backendResult.ErrorText)
 	default:
 		return nil
 	}


### PR DESCRIPTION
The risk with this error return location and other similar locations
is that by simply returning the error, we will be aborting the
transaction, effectively placing the same workflow event on the queue.

This means that if the error is _not_ a transient error, we are
completely stuck.

Here, I've handled at least one non-transient error. Any other error
will continue to be retries. I think that some of this might be made
easier if we moved away from QueryRowContext since then Scan errors
and other errors wouldn't be intermingled.

Signed-off-by: Steven Danna <steve@chef.io>
