### PR TITLE
deployment-service: try to create admin token using iam v2 if v1 fails

### DIFF
--- a/components/automate-cli/pkg/diagnostics/context.go
+++ b/components/automate-cli/pkg/diagnostics/context.go
@@ -177,7 +177,7 @@ func (c *testContext) adminToken() (string, error) {
 		})
 
 		if err != nil {
-			return "", nil
+			return "", err
 		}
 		c.Globals.CachedToken = resp.ApiToken
 	}

--- a/components/automate-deployment/pkg/server/api_token_test.go
+++ b/components/automate-deployment/pkg/server/api_token_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/chef/automate/api/interservice/authn"
 	"github.com/chef/automate/api/interservice/authz"
+	"github.com/chef/automate/api/interservice/authz/common"
+	authz_v2 "github.com/chef/automate/api/interservice/authz/v2"
 	api "github.com/chef/automate/api/interservice/deployment"
 	"github.com/chef/automate/lib/grpc/grpctest"
 	"github.com/chef/automate/lib/grpc/secureconn"
@@ -31,9 +33,11 @@ func TestGenerateAdminToken(t *testing.T) {
 
 	serviceCerts = helpers.LoadDevCerts(t, "authz-service")
 	mockAuthZ := authz.NewAuthorizationServerMock()
+	mockV2PolicyServer := authz_v2.NewPoliciesServerMock()
 	connFactory = secureconn.NewFactory(*serviceCerts)
 	g = connFactory.NewServer()
 	authz.RegisterAuthorizationServer(g, mockAuthZ)
+	authz_v2.RegisterPoliciesServer(g, mockV2PolicyServer)
 	authzServer := grpctest.NewServer(g)
 	defer authzServer.Close()
 
@@ -145,6 +149,47 @@ func TestGenerateAdminToken(t *testing.T) {
 		resp, err := generateAdminToken(ctx, req, connFactory, authnServer.URL, authzServer.URL)
 		require.Nil(t, resp)
 		require.Error(t, err)
+	})
+
+	t.Run("when API token succeeds but policy creation fails due to precondition, v2 policy creation succeeds", func(t *testing.T) {
+		mockAuthN.CreateTokenFunc = func(
+			_ context.Context, req *authn.CreateTokenReq) (*authn.Token, error) {
+
+			assert.True(t, req.Active)
+			assert.Equal(t, testDescription, req.Description)
+
+			return &authn.Token{
+				Value: testTokenString,
+				Id:    testID,
+			}, nil
+		}
+
+		mockAuthZ.CreatePolicyFunc = func(
+			_ context.Context, req *authz.CreatePolicyReq) (*authz.CreatePolicyResp, error) {
+
+			assert.Equal(t, []string{testSubjectString}, req.Subjects)
+			assert.Equal(t, "*", req.Action)
+			assert.Equal(t, "*", req.Resource)
+
+			st := status.New(codes.FailedPrecondition, "authz-service set to v2")
+			st, _ = st.WithDetails(&common.ErrorShouldUseV2{})
+			return nil, st.Err()
+		}
+
+		mockV2PolicyServer.CreatePolicyFunc = func(
+			_ context.Context, req *authz_v2.CreatePolicyReq) (*authz_v2.Policy, error) {
+
+			assert.Equal(t, "diagnostics-admin-token", req.Id)
+			assert.Equal(t, testDescription, req.Name)
+			assert.Equal(t, authz_v2.Statement_ALLOW, req.Statements[0].Effect)
+
+			return &authz_v2.Policy{}, nil
+		}
+
+		req := &api.GenerateAdminTokenRequest{Description: testDescription}
+		resp, err := generateAdminToken(ctx, req, connFactory, authnServer.URL, authzServer.URL)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
 	})
 
 	t.Run("when API token succeeds but policy creation fails and rollback fails", func(t *testing.T) {


### PR DESCRIPTION
Also:
* diagnostics/context: don't swallow that error

Co-authored-by: Blake Johnson <bstier@chef.io>
Signed-off-by: Stephan Renatus <srenatus@chef.io>