### PR TITLE
[lib/cereal] Temporarily pause processing of wayward workflows

### DIFF
--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -377,7 +377,7 @@ type TaskExecutor interface {
 // entered the map. A wayward workflow is a workflow that has
 // experienced some fundamental processing error in the past. To avoid
 // stalling the processing of other workflows, we temporarily skip
-// events for any waywardWords.
+// events for any wayward workflows.
 type waywardWorkflowList map[string]time.Time
 
 // waywardWorkflowTimeout is amount of time we will keep a given
@@ -389,6 +389,7 @@ func (w waywardWorkflowList) Add(workflowName string) {
 		w = make(waywardWorkflowList)
 	}
 	if workflowName != "" {
+		logrus.Warnf("Ignoring workflow %q for the next %s", workflowName, waywardWorkflowTimeout)
 		w[workflowName] = time.Now()
 	}
 }

--- a/lib/cereal/cereal_test.go
+++ b/lib/cereal/cereal_test.go
@@ -1,0 +1,33 @@
+package cereal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaywardWorkflowList(t *testing.T) {
+	waywardWorkflowTimeout = 10 * time.Millisecond
+	t.Run("filter returns the entire list if there are no wayward workflows", func(t *testing.T) {
+		w := make(waywardWorkflowList)
+		in := []string{"a", "b", "c"}
+		out := w.Filter(in)
+		assert.Equal(t, in, out)
+	})
+	t.Run("filter doesn't return wayward workflows", func(t *testing.T) {
+		w := make(waywardWorkflowList)
+		in := []string{"a", "b", "c"}
+		w.Add("b")
+		out := w.Filter(in)
+		assert.Equal(t, []string{"a", "c"}, out)
+	})
+	t.Run("filter returns a previously wayward workflow after expiration", func(t *testing.T) {
+		w := make(waywardWorkflowList)
+		in := []string{"a", "b", "c"}
+		w.Add("b")
+		time.Sleep(2 * waywardWorkflowTimeout)
+		out := w.Filter(in)
+		assert.Equal(t, in, out)
+	})
+}


### PR DESCRIPTION
The processWorkflow event loop has a number of places where errors can
occur. In many cases, the most likely cause of the error is some
transient network problem. In these cases, logging the error, and
retrying may make sense.

Unfortunately, for the case of an unknown workflow event, no amount of
retrying will help. The event types are part of our source code, if we
don't know the event now, we won't know it 10 milliseconds from now
either.

This is especially problematic because it is likely that we'll
continue to select this same workflow event, stopping work on all
other workflows.

This PR attempts to address the problem by temporarily marking such
workflows as "wayward" and removing them from the list of workflows to
select. After some timeout, we start processing them again, in the
hope that the problematic event might have been processed by someone
else.

An alternative would be to drop the event completely. I think that
might make it problematic to add new workflow events in the future.
If a new workflow client is connected and uses some newly introduced
event, we likely want that client to be able to process the event.

Signed-off-by: Steven Danna <steve@chef.io>