### PR TITLE
diagnostics: don't freak out if admin token v2 policy already exists

### DIFF
--- a/components/automate-deployment/pkg/server/api_token.go
+++ b/components/automate-deployment/pkg/server/api_token.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/chef/automate/api/interservice/authn"
@@ -89,7 +90,7 @@ func generateAdminToken(ctx context.Context,
 			Members: []string{fmt.Sprintf("token:%s", response.Id)},
 		})
 	}
-	if err != nil {
+	if err != nil && status.Convert(err).Code() != codes.AlreadyExists {
 		// Attempt to be transactional
 		_, deleteTokenError := authnClient.DeleteToken(ctx, &authn.DeleteTokenReq{
 			Id: response.Id,


### PR DESCRIPTION
This makes me think that we're creating one v1 policy per run of
diagnostics, and never clean them up.

At least in IAM v2, we won't do that, but graciously ignore
"AlreadyExists" errors.

Follow-up to the discussion of #946.