### PR TITLE
deployment-service: reconcile this code with automate-cli usage

### DIFF
--- a/components/automate-deployment/pkg/server/api_token_test.go
+++ b/components/automate-deployment/pkg/server/api_token_test.go
@@ -179,8 +179,8 @@ func TestGenerateAdminToken(t *testing.T) {
 		mockV2PolicyServer.CreatePolicyFunc = func(
 			_ context.Context, req *authz_v2.CreatePolicyReq) (*authz_v2.Policy, error) {
 
-			assert.Equal(t, "diagnostics-admin-token", req.Id)
-			assert.Equal(t, testDescription, req.Name)
+			assert.Equal(t, "admin-token-"+testID, req.Id)
+			assert.Equal(t, "admin policy for token "+testID, req.Name)
 			assert.Equal(t, authz_v2.Statement_ALLOW, req.Statements[0].Effect)
 
 			return &authz_v2.Policy{}, nil
@@ -220,8 +220,8 @@ func TestGenerateAdminToken(t *testing.T) {
 		mockV2PolicyServer.CreatePolicyFunc = func(
 			_ context.Context, req *authz_v2.CreatePolicyReq) (*authz_v2.Policy, error) {
 
-			assert.Equal(t, "diagnostics-admin-token", req.Id)
-			assert.Equal(t, testDescription, req.Name)
+			assert.Equal(t, "admin-token-"+testID, req.Id)
+			assert.Equal(t, "admin policy for token "+testID, req.Name)
 			assert.Equal(t, authz_v2.Statement_ALLOW, req.Statements[0].Effect)
 
 			return nil, status.Error(codes.AlreadyExists, "policy with id \"diagnostics-admin-token\" already exists")


### PR DESCRIPTION
For reasons that might have disappeared from everyone's memory, the d-s
code was also what drove `chef-automate admin-token`. So, I've removed
any "diagnostics"-related wording from the V2 policy data.

Note that `chef-automate admin-token` first checks if the system uses
v2, so that code path we've recently added for diagnostics should NOT be
executed in that scenario. It still felt cleaner to remove the
"diagnostics" words.

Furthermore, this changes `GenerateAdminToken` so that in the
diagnostics+iam-v2 use case, it can be run twice: once before the
upgrade, once after; without triggering any policy conflicts.

Before this commit, the second run would have not failed completely, but
the already existing policy would not have referenced the proper token
ID. Now, the v2 code is analogous to the v1 code: one policy per token.
While we could do something more clever, this is enough for the limited
use case I'm after.

If we did do something more clever, we might as well make `chef-automate
admin-token` not freak out if A2 is running on IAMv2.
