### PR TITLE
Remove shadow and add border to top-nav and left nav

### DIFF
--- a/components/automate-ui/src/app/components/sidebar-no-shade/sidebar-no-shade.component.scss
+++ b/components/automate-ui/src/app/components/sidebar-no-shade/sidebar-no-shade.component.scss
@@ -10,8 +10,8 @@
   overflow-x: hidden;
   overflow-y: auto;
   width: $sidebar-width;
-  background-color: #fff;
-  border-right: 1px solid #dfe3e5;
+  background-color: #FFF;
+  border-right: 1px solid #DFE3E5;
 
   .sidebar-selector {
 

--- a/components/automate-ui/src/app/components/sidebar-no-shade/sidebar-no-shade.component.scss
+++ b/components/automate-ui/src/app/components/sidebar-no-shade/sidebar-no-shade.component.scss
@@ -10,7 +10,8 @@
   overflow-x: hidden;
   overflow-y: auto;
   width: $sidebar-width;
-  background-color: $chef-lightest-grey;
+  background-color: #fff;
+  border-right: 1px solid #dfe3e5;
 
   .sidebar-selector {
 

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.scss
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.scss
@@ -9,9 +9,9 @@
   z-index: 101;
   overflow-x: hidden;
   overflow-y: auto;
-  width: $sidebar-width;
-  background-color: $chef-lightest-grey;
-  box-shadow: 0 10px 48px 0 rgba(63, 83, 100, 0.2);
+  width: $sidebar-width + 1px;
+  background-color: #fff;
+  border-right: 1px solid #dfe3e5;
 
   .sidebar-selector {
 

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.scss
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.scss
@@ -10,8 +10,8 @@
   overflow-x: hidden;
   overflow-y: auto;
   width: $sidebar-width + 1px;
-  background-color: #fff;
-  border-right: 1px solid #dfe3e5;
+  background-color: #FFF;
+  border-right: 1px solid #DFE3E5;
 
   .sidebar-selector {
 

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.scss
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.scss
@@ -37,7 +37,7 @@ header {
     left: 0;
     right: 0;
     height: $navigation-height;
-    border-bottom: 1px solid #DFE3E5; 
+    border-bottom: 1px solid #DFE3E5;
 
     .left-nav {
       display: flex;

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.scss
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.scss
@@ -37,7 +37,7 @@ header {
     left: 0;
     right: 0;
     height: $navigation-height;
-    border-bottom: 1px solid #dfe3e5;
+    border-bottom: 1px solid #DFE3E5; 
 
     .left-nav {
       display: flex;

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.scss
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.scss
@@ -30,7 +30,6 @@ header {
     justify-content: space-between;
     padding-top: 2px 36px 0 0;
     background-color: $white;
-    box-shadow: 0 0 6px $gray-pale;
     box-sizing: padding-box;
     z-index: 200;
     position: fixed;
@@ -38,6 +37,7 @@ header {
     left: 0;
     right: 0;
     height: $navigation-height;
+    border-bottom: 1px solid #dfe3e5;
 
     .left-nav {
       display: flex;

--- a/components/automate-ui/src/app/page-components/server-org-filter-sidebar/server-org-filter-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/server-org-filter-sidebar/server-org-filter-sidebar.component.scss
@@ -8,7 +8,6 @@
   left: $sidebar-width + 1px;
   background-color: $white;
   z-index: 100;
-  box-shadow: 3px 0 14px $gray-less-pale;
   overflow-y: auto;
   padding: 1em;
   transform: translateX(-100%);


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description
**Overview**
To increase the ease on human eyeballs we want to reduce the number of shadows used in Automate. This task also prepares for the removal of the background gray color on our pages.

**Design Details**
Remove the shadow from the top nav and add a border-bottom: 1px solid #dfe3e5
Remove the shadow from the left nav and add a border-right: 1px solid #dfe3e5
Set the background color of the left-nav to #fff

### :+1: Definition of Done
screenshots of changes
![Screenshot from 2019-07-18 19-43-50](https://user-images.githubusercontent.com/12297653/61464830-90235780-a994-11e9-9fde-72bd67735940.png)
![Screenshot from 2019-07-18 19-43-43](https://user-images.githubusercontent.com/12297653/61465129-163f9e00-a995-11e9-8286-21f4d169f8c4.png)

### :chains: Related Resources
https://github.com/chef/automate/issues/680
