### PR TITLE
[CI] Tag git repository on promotion to current

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -74,6 +74,12 @@ promote:
           - value_one: "{{target_channel}}"
             operator: equals
             value_two: current
+    - bash:.expeditor/push-git-tag.sh:
+        post_commit: true
+        only_if_conditions:
+          - value_one: "{{target_channel}}"
+            operator: equals
+            value_two: current
     - bash:.expeditor/announce-acceptance.sh:
         post_commit: true
         only_if_conditions:

--- a/.expeditor/push-git-tag.sh
+++ b/.expeditor/push-git-tag.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+manifest_url="https://packages.chef.io/manifests/${EXPEDITOR_TARGET_CHANNEL}/automate/latest.json"
+echo "Downloading latest manifest from $manifest_url"
+curl -o manifest.json "$manifest_url"
+
+echo "Parsing manifest for git SHA and build"
+git_sha="$(jq -r -e ".git_sha" manifest.json)"
+build_version="$(jq -r -e ".build" manifest.json)"
+
+if [[ -z "$git_sha" ]]; then
+    echo "No git sha in latest manifest:"
+    cat manifest.json
+    exit 1
+fi
+
+if [[ -z "$build_version" ]]; then
+    echo "No build version in latest manifest:"
+    cat manifest.json
+    exit 1
+fi
+
+git tag "$build_version" "$git_sha"
+git push origin "$build_version"


### PR DESCRIPTION
Having tags for each release makes it easier to run things like `git
tag --contains SHA` to determine what versions might have a particular
bug or fix.

I've already pushed tags for the previous versions that were released
from this repository:

    20190415203801
    20190422213145
    20190501153509
    20190506101326
    20190513175357
    20190605190944
    20190610211245
    20190617144820
    20190628200755
    20190711110747

Right now these are regular tags; however, we may consider changing
them to annotated tags in the future.

Signed-off-by: Steven Danna <steve@chef.io>