### PR TITLE
Fix ui-lib deprecation warnings

### DIFF
--- a/components/chef-ui-library/src/atoms/chef-clipboard/chef-clipboard.tsx
+++ b/components/chef-ui-library/src/atoms/chef-clipboard/chef-clipboard.tsx
@@ -83,7 +83,7 @@ export class ChefClipboard {
   }
 
   @Method()
-  copy(value: string): boolean {
+  async copy(value: string): Promise<boolean> {
     // setup
     const el = document.createElement('textarea');
     el.value = value;
@@ -95,7 +95,7 @@ export class ChefClipboard {
     const copied = document.execCommand('copy');
     // cleanup
     document.body.removeChild(el);
-    return copied;
+    return Promise.resolve(copied);
   }
 
   get buttonProps() {

--- a/components/chef-ui-library/src/atoms/chef-option/chef-option.tsx
+++ b/components/chef-ui-library/src/atoms/chef-option/chef-option.tsx
@@ -121,12 +121,14 @@ export class ChefOption {
     this.optionId = this.optionId || `chef-option${id}`;
   }
 
-  @Method() getContent(): string {
-    return this.el.querySelector('.option-content').innerHTML;
+  @Method()
+  async getContent(): Promise<string> {
+    return Promise.resolve(this.el.querySelector('.option-content').innerHTML);
   }
 
-  @Method() getWidth(): number {
-    return this.width;
+  @Method()
+  async getWidth(): Promise<number> {
+    return Promise.resolve(this.width);
   }
 
   componentWillLoad() {


### PR DESCRIPTION
### :nut_and_bolt: Description

This PR fixes any remaining deprecation warnings in `chef-ui-library` build output:

![](https://user-images.githubusercontent.com/479121/61501655-716d9280-a98d-11e9-8b30-8b50146964bd.png)

This code needs to be updated in order to upgrade to Stencil 1.0: [change doc](https://github.com/ionic-team/stencil/blob/7b7d0725618b2a17181389096ac60de08e1c766f/BREAKING_CHANGES.md#all-void-methods-return-promise-right-now-method-void-is-valid)

> Until Stencil 1.0, public component methods decorated with @Method() could only return Promise<...> or void. Now, only the async methods are supported, meaning that retuning void is not valid.

Requiring all public methods to be async was problematic in `chef-option` since `chef-select`'s `render`+`hostData` methods can only execute synchronously but are calling some `chef-option` methods that must now be executed asynchronously. This person ran into [the same issue](https://github.com/ionic-team/stencil/issues/1250); I went with the recommendation to move the necessary logic from `render` into `componentWillUpdate` which can be executed synchronously or asynchronously. 

### :+1: Definition of Done

`chef-ui-library` build output has no deprecation warnings.

![](https://user-images.githubusercontent.com/479121/61501660-77fc0a00-a98d-11e9-8501-13a12afb184f.png)


### :chains: Related Resources

https://github.com/chef/automate/issues/186

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
