### PR TITLE
[lib/cereal] Cleanup unused variables and comments

### DIFF
--- a/lib/cereal/backend/backend.go
+++ b/lib/cereal/backend/backend.go
@@ -46,10 +46,9 @@ type WorkflowInstance struct {
 type WorkflowEventType string
 
 const (
-	WorkflowStart  WorkflowEventType = "start"
-	TaskComplete   WorkflowEventType = "task_complete"
-	Cancel         WorkflowEventType = "cancel"
-	TasksAbandoned WorkflowEventType = "tasks_abandoned"
+	WorkflowStart WorkflowEventType = "start"
+	TaskComplete  WorkflowEventType = "task_complete"
+	Cancel        WorkflowEventType = "cancel"
 )
 
 type TaskStatusType string
@@ -61,7 +60,6 @@ const (
 )
 
 type WorkflowEvent struct {
-	InstanceID         int64
 	Instance           WorkflowInstance
 	Type               WorkflowEventType
 	EnqueuedTaskCount  int
@@ -109,9 +107,13 @@ type ScheduledWorkflowCompleter interface {
 }
 
 type Schedule struct {
-	// NOTE(ssd) 2019-05-13: Since name and workflow-name are
-	// user-controlled in the case of many scheduled workflows, we
-	// need the ID to create unique workflow names.
+	// TODO(ssd) 2019-07-19: ID was originally placed on backends
+	// because it was unclear whether (workflow_name,
+	// instance_name) can actually be unique in the case of
+	// scheduled workflows. We currently have a unique constraint
+	// on them, so we could remove this, but since it was on this
+	// struct it ended up in a few queries that would need to
+	// change.
 	ID             int64
 	Enabled        bool
 	InstanceName   string

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -138,7 +138,7 @@ func WithResult(obj interface{}) CompleteOpts {
 // workflow instance. A workflow instance keeps state of a currently
 // running workflow, and decides what decisions need to be made
 // based and that state. This will be passed to the callback methods
-// of WorkflowExecutor. Only once instance of a WorkflowInstance can
+// of WorkflowExecutor. Only one instance of a WorkflowInstance can
 // execute at a time.
 type WorkflowInstance interface {
 	// GetPayload unmarshals the payload of the workflow instance into the
@@ -174,8 +174,9 @@ type WorkflowInstance interface {
 	// InstanceName returns the workflow instance name
 	InstanceName() string
 
-	// TotalEnqueuedTasks returns the total number of tasks that been enqueued
-	// for the lifetime of the running workflow instance.
+	// TotalEnqueuedTasks returns the total number of tasks that
+	// have been enqueued for the lifetime of the running workflow
+	// instance.
 	TotalEnqueuedTasks() int
 
 	// TotalCompletedTasks returns the total number of tasks that have finished
@@ -184,10 +185,9 @@ type WorkflowInstance interface {
 }
 
 type workflowInstanceImpl struct {
-	instanceID int64
-	instance   backend.WorkflowInstance
-	tasks      []backend.Task
-	wevt       *backend.WorkflowEvent
+	instance backend.WorkflowInstance
+	tasks    []backend.Task
+	wevt     *backend.WorkflowEvent
 }
 
 func (w *workflowInstanceImpl) GetPayload(obj interface{}) error {
@@ -704,9 +704,8 @@ func (m *Manager) processWorkflow(ctx context.Context, workflowNames []string) b
 	}).Debug("Dequeued Workflow")
 
 	w := &workflowInstanceImpl{
-		instanceID: wevt.InstanceID,
-		instance:   wevt.Instance,
-		wevt:       wevt,
+		instance: wevt.Instance,
+		wevt:     wevt,
 	}
 
 	s.Begin("user")

--- a/lib/cereal/postgres/sql_schema.go
+++ b/lib/cereal/postgres/sql_schema.go
@@ -8,9 +8,8 @@ BEGIN;
 
 -- Workflows
 --
--- Workflows coordinate a set of tasks. For example, a scan job is a
--- workflow that create and then waits for the completion of a number
--- of inspec scan tasks.
+-- Workflows coordinate a set of tasks.
+--
 CREATE TABLE cereal_workflow_schedules (
     id BIGSERIAL PRIMARY KEY,
 
@@ -99,9 +98,6 @@ CREATE TABLE cereal_workflow_results (
 -- Workers dequeue tasks from the task table, do the work related to
 -- that task, and then post their results back.
 --
--- New and Completed tasks also notify a channel that can be
--- subscribed to by the workflows for more timely notification of new
--- task events related to their workflow.
 CREATE TYPE cereal_task_status AS ENUM('success', 'failed', 'lost');
 
 CREATE TYPE cereal_task_state  AS ENUM('queued', 'running');
@@ -130,7 +126,7 @@ CREATE TABLE cereal_task_results (
     result       BYTEA
 );
 
-CREATE TYPE cereal_workflow_event_type AS ENUM('start', 'task_complete', 'cancel', 'tasks_abandoned');
+CREATE TYPE cereal_workflow_event_type AS ENUM('start', 'task_complete', 'cancel');
 
 CREATE TABLE cereal_workflow_events (
     id BIGSERIAL PRIMARY KEY,


### PR DESCRIPTION
- Remove the tasks_abandoned workflow event that is no longer used.
- Remove WorkflowEvent.InstanceID
- Remove workflowInstanceImpl.instanceID
- Comment on ID in backend.Schedule
- Cleanup incorrect comments in SQL
- Reformat some of our SQL string constants

Signed-off-by: Steven Danna <steve@chef.io>