### PR TITLE
Hiding excess logging from info

### DIFF
--- a/components/compliance-service/profiles/db/store.go
+++ b/components/compliance-service/profiles/db/store.go
@@ -76,7 +76,7 @@ func (s *Store) LoadMarketProfiles(path string) error {
 
 	// filename returns an absolute path to the disk
 	for _, diskProfile := range profiles {
-		logrus.Infof("Upload profile %s", diskProfile)
+		logrus.Debugf("Upload profile %s", diskProfile)
 
 		// gather information that we need to store in postgres
 		sha256, tar, info, err := s.GetProfileInfo(diskProfile)


### PR DESCRIPTION
### :nut_and_bolt: Description
Changing the upload of profiles logging from "Info" level to "Debug". This prevents the logs from filling up each time the compliance-service is restarted. 

Only one line is changed. 

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
