### PR TITLE
Start linting our studio code

### DIFF
--- a/.studio/automate-gateway
+++ b/.studio/automate-gateway
@@ -27,7 +27,8 @@ function gateway_integration() {
   log_line "The automate-gateway version"
   gateway_version || return 1
 
-  local viewer_token="$(get_api_token_with_policy viewer-access)"
+  local viewer_token
+  viewer_token="$(get_api_token_with_policy viewer-access)"
 
   log_line "Sending 30 Chef Action Messages"
   for i in {1..30}; do
@@ -116,7 +117,8 @@ function send_chef_action_example() {
   local endpoint="/events/data-collector"
   local examples_path="/src/components/ingest-service/examples"
   local tmp_action_json
-  local rfc_time=$(date --rfc-3339=seconds  -d "$(($RANDOM % 144)) hour ago" | sed 's/ /T/' | sed 's/\+.*/Z/')
+  local rfc_time
+  rfc_time=$(date --rfc-3339=seconds  -d "$(($RANDOM % 144)) hour ago" | sed 's/ /T/' | sed 's/\+.*/Z/')
 
   # Update the 'recorded_at' time from the ChefAction Example; and set entity_type and task
   tmp_action_json="$(jq --arg event_task "$event_task" --arg rfc_time "$rfc_time" --arg event_type "$event_type" \
@@ -131,7 +133,7 @@ function send_chef_action_example() {
 document "send_chef_run_example" <<DOC
   Send the example chef run message to the chef run rest endpoint.
 
-  Options: by default the message is send directly to the gateway chef/run endpoint 
+  Options: by default the message is send directly to the gateway chef/run endpoint
     legacy - send the message directly to the gateway legacy endpoint
     lb - send the message through the load balancer
 
@@ -177,9 +179,9 @@ function send_chef_run_example() {
 document "send_chef_run_start_example" <<DOC
   Send the example chef run start message to the chef run rest endpoint.
 
-  Arguments: by default the message is send directly to the gateway chef/run endpoint 
+  Arguments: by default the message is send directly to the gateway chef/run endpoint
     legacy - send the message directly to the gateway legacy endpoint
-    lb - send the message through the load balancer 
+    lb - send the message through the load balancer
 
   Example: Send a Chef Run start to the legacy endpoint:
   --------------------------------------------------------
@@ -223,10 +225,14 @@ function send_chef_run_failure_example() {
   install_if_missing core/curl curl
   install_if_missing core/jq-static jq
 
-  local run_uuid=$(uuidgen)
-  local node_uuid=$(uuidgen)
+  local run_uuid
+  run_uuid=$(uuidgen)
+  local node_uuid
+  node_uuid=$(uuidgen)
+
   local node_name="node_failed_$(($RANDOM % 100))"
-  local rfc_time=$(date +%FT%TZ -d "$(($RANDOM % 144)) hour ago")
+  local rfc_time
+  rfc_time=$(date +%FT%TZ -d "$(($RANDOM % 144)) hour ago")
 
   local examples_path="/src/components/ingest-service/examples";
   [[ "$1" == "legacy" ]] && endpoint="/events/data-collector" || endpoint="/ingest/events/chef/run"
@@ -283,9 +289,12 @@ function send_inspec_example() {
   local endpoint="/events/data-collector"
   local examples_json_path=${JSON_FILE:-/src/components/compliance-service/ingest/examples/compliance-success-tiny-report.json};
 
-  local uuid=$(uuidgen)
-  local report_uuid=$(uuidgen)
-  local rfc_time=$(date +%FT%TZ -d "$(($RANDOM % 144)) hour ago")
+  local uuid
+  local report_uuid
+  local rfc_time
+  uuid=$(uuidgen)
+  report_uuid=$(uuidgen)
+  rfc_time=$(date +%FT%TZ -d "$(($RANDOM % 144)) hour ago")
 
   tmp_inspec_json="$(jq --arg id "$uuid" --arg report_uuid "$report_uuid" --arg rfc_time "$rfc_time" '.node_uuid = $id | .report_uuid = $report_uuid | .end_time = $rfc_time' <$examples_json_path)"
 
@@ -301,7 +310,8 @@ function send_inspec_failure_example() {
 
   local examples_path="/src/components/compliance-service/ingest/examples"
   local endpoint="/events/data-collector"
-  local uuid=$(uuidgen)
+  local uuid
+  uuid=$(uuidgen)
 
   # Update the 'report_uuid'
   tmp_report_json="$(jq --arg uuid "$uuid" '.report_uuid = $uuid' <$examples_path/compliance-failure-big-report.json)"
@@ -429,7 +439,7 @@ document "gateway_create_notification_rule" <<DOC
   Create a notification rule
 DOC
 function gateway_create_notification_rule() {
-  install_if_missing core/curl curl;	
+  install_if_missing core/curl curl;
   install_if_missing core/jq-static jq;
 
   endpoint="/notifications/rules"
@@ -544,7 +554,8 @@ function get_api_token_with_policy() {
   check_if_deployinate_started || return 1
 
   local policy=${1:?"usage: get_api_token_with_policy POLICYNAME"}
-  local iam_version="$(chef-automate iam version | awk '{print $2}')"
+  local iam_version
+  iam_version="$(chef-automate iam version | awk '{print $2}')"
   local token_description="api-token-$$-${policy}"
   local token_file="/tmp/api_token_${iam_version}_${policy}"
 
@@ -557,7 +568,9 @@ function get_api_token_with_policy() {
       # create standard api token
       chef-automate iam token create "$token_description" >"$token_file" || return 1
       # retrieve the tokens' ID
-      local token_id="$(curl -fsS --insecure -H "api-token: $(get_admin_token)" \
+      local token_id
+      token_id="$(curl -fsS --insecure -H "api-token: $(get_admin_token)" \
+
        "${GATEWAY_URL}/auth/tokens" |\
          jq -er --arg token "$token_description" '[.tokens[] | select(.description == $token) | .id] | first' )"
       # and add it to policy

--- a/.studio/automate-gateway
+++ b/.studio/automate-gateway
@@ -56,7 +56,7 @@ document "gateway_version" <<DOC
   => curl $GATEWAY_URL/version
 DOC
 function gateway_version() {
-  install_if_missing core/jq-static jq;
+  install_if_missing core/jq-static jq
 
   log_line "Gateway"
   gateway_get /gateway/version | jq .
@@ -155,7 +155,7 @@ DOC
 function send_chef_run_example() {
   install_if_missing core/curl curl
 
-  local examples_json_path=${JSON_FILE:-/src/components/ingest-service/examples/converge-success-report.json};
+  local examples_json_path=${JSON_FILE:-/src/components/ingest-service/examples/converge-success-report.json}
 
   if [[ "$1" == "legacy" ]]; then
     endpoint=${GATEWAY_URL}"/events/data-collector"
@@ -192,9 +192,9 @@ document "send_chef_run_start_example" <<DOC
   # send_chef_run_start_example lb
 DOC
 function send_chef_run_start_example() {
-  install_if_missing core/curl curl;
+  install_if_missing core/curl curl
 
-  local examples_path="/src/components/ingest-service/examples";
+  local examples_path="/src/components/ingest-service/examples"
   if [[ "$1" == "legacy" ]]; then
     endpoint=${GATEWAY_URL}"/events/data-collector"
   elif [[ "$1" == "lb" ]]; then
@@ -234,7 +234,7 @@ function send_chef_run_failure_example() {
   local rfc_time
   rfc_time=$(date +%FT%TZ -d "$(($RANDOM % 144)) hour ago")
 
-  local examples_path="/src/components/ingest-service/examples";
+  local examples_path="/src/components/ingest-service/examples"
   [[ "$1" == "legacy" ]] && endpoint="/events/data-collector" || endpoint="/ingest/events/chef/run"
 
   # Update the IDs, names, and dates
@@ -253,9 +253,9 @@ document "send_chef_liveness_example" <<DOC
   # send_chef_liveness_example legacy
 DOC
 function send_chef_liveness_example() {
-  install_if_missing core/curl curl;
+  install_if_missing core/curl curl
 
-  local examples_path="/src/components/ingest-service/examples";
+  local examples_path="/src/components/ingest-service/examples"
   [[ "$1" == "legacy" ]] && endpoint="/events/data-collector" || endpoint="/ingest/events/chef/liveness"
 
   curl -f --insecure -H "api-token: $(get_api_token)" \
@@ -284,10 +284,10 @@ document "send_inspec_example" <<DOC
   Send the example inspec message to the inspec rest endpoint.
 DOC
 function send_inspec_example() {
-  install_if_missing core/curl curl;
+  install_if_missing core/curl curl
 
   local endpoint="/events/data-collector"
-  local examples_json_path=${JSON_FILE:-/src/components/compliance-service/ingest/examples/compliance-success-tiny-report.json};
+  local examples_json_path=${JSON_FILE:-/src/components/compliance-service/ingest/examples/compliance-success-tiny-report.json}
 
   local uuid
   local report_uuid
@@ -306,7 +306,7 @@ document "send_inspec_failure_example" <<DOC
   Send the example failure inspec message to the inspec rest endpoint.
 DOC
 function send_inspec_failure_example() {
-  install_if_missing core/curl curl;
+  install_if_missing core/curl curl
 
   local examples_path="/src/components/compliance-service/ingest/examples"
   local endpoint="/events/data-collector"
@@ -331,8 +331,8 @@ document "gateway_list_secrets" <<DOC
   List the secrets stored in the secrets service
 DOC
 function gateway_list_secrets() {
-  install_if_missing core/curl curl;
-  install_if_missing core/jq-static jq;
+  install_if_missing core/curl curl
+  install_if_missing core/jq-static jq
 
   endpoint="/secrets/search"
 
@@ -349,8 +349,8 @@ function gateway_create_secret() {
   local username=${1:-"default"}
   local password=${2:-"super_secret"}
 
-  install_if_missing core/curl curl;
-  install_if_missing core/jq-static jq;
+  install_if_missing core/curl curl
+  install_if_missing core/jq-static jq
 
   endpoint="/secrets"
 
@@ -365,9 +365,9 @@ document "gateway_delete_secret" <<DOC
   arg 1 - ID required
 DOC
 function gateway_delete_secret() {
-  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1;
+  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1
 
-  install_if_missing core/curl curl;
+  install_if_missing core/curl curl
   local id=$1
 
   endpoint="/secrets/id/$id"
@@ -383,11 +383,11 @@ document "gateway_read_secret" <<DOC
   arg 1 - ID required
 DOC
 function gateway_read_secret() {
-  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1;
+  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1
   local id=$1
 
-  install_if_missing core/curl curl;
-  install_if_missing core/jq-static jq;
+  install_if_missing core/curl curl
+  install_if_missing core/jq-static jq
 
   endpoint="/secrets/id/$id"
 
@@ -404,7 +404,7 @@ document "gateway_update_secret" <<DOC
   art 3 - password optional
 DOC
 function gateway_update_secret() {
-  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1;
+  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1
   local id=$1
   local username=${2:-"default"}
   local password=${3:-"super_secret"}
@@ -422,11 +422,11 @@ document "gateway_delete_notification_rule" <<DOC
   arg 1 - ID required
 DOC
 function gateway_delete_notification_rule() {
-  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1;
+  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1
   local id=$1
 
-  install_if_missing core/curl curl;
-  install_if_missing core/jq-static jq;
+  install_if_missing core/curl curl
+  install_if_missing core/jq-static jq
 
   endpoint="/notifications/rules/$id"
 
@@ -439,8 +439,8 @@ document "gateway_create_notification_rule" <<DOC
   Create a notification rule
 DOC
 function gateway_create_notification_rule() {
-  install_if_missing core/curl curl;
-  install_if_missing core/jq-static jq;
+  install_if_missing core/curl curl
+  install_if_missing core/jq-static jq
 
   endpoint="/notifications/rules"
 
@@ -455,11 +455,11 @@ document "gateway_get_notification_rule" <<DOC
   arg 1 - ID required
 DOC
 function gateway_get_notification_rule() {
-  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1;
+  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1
   local id=$1
 
-  install_if_missing core/curl curl;
-  install_if_missing core/jq-static jq;
+  install_if_missing core/curl curl
+  install_if_missing core/jq-static jq
 
   endpoint="/notifications/rules/$id"
 
@@ -475,10 +475,10 @@ document "gateway_notification_validate_connection" <<DOC
   arg 1 - URL required
 DOC
 function gateway_notification_validate_connection() {
-  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1;
+  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1
   local url=$1
 
-  install_if_missing core/curl curl;
+  install_if_missing core/curl curl
 
   endpoint="/notifications/webhook"
 

--- a/.studio/common
+++ b/.studio/common
@@ -173,7 +173,7 @@ function wait_for_svc_to_stop() {
   while hab_svc_up $1; do
     echo -n ".";
     [ $COUNTER -ge $SECONDS_WAITING ] && return 1
-    let COUNTER=COUNTER+1;
+    COUNTER=$((COUNTER+1))
     sleep 1;
   done;
 }
@@ -236,7 +236,7 @@ function verify_component() {
     error "Component '$1' not found.\\n"
     display_available_components
     return 1
-  fi;
+  fi
   return 0
 }
 
@@ -299,7 +299,7 @@ _component_auto_complete()
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     opts=$(ls /src/components | tr "\\n" " ")
 
-    if [[ ${cur} == * ]] ; then
+    if [[ ${cur} == * ]]; then
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
         return 0
     fi
@@ -310,7 +310,7 @@ function check_service_running_or_exit() {
   if ! service_running "$1"; then
     error "The component '$1' must be already running."
     return 1
-  fi;
+  fi
 }
 
 document "service_running" <<DOC
@@ -350,7 +350,7 @@ function build_all_changed_components() {
   ln -sv "$(hab pkg path core/coreutils)/bin/env" /usr/bin/env 2>/dev/null
 
   build_commands=""
-  pushd /src >/dev/null;
+  pushd /src >/dev/null
     for component in $(./scripts/changed_components.rb)
     do
       if [[ -n "$AUTOMATE_OSS_BUILD" ]] && [[ "$component" = "components/automate-chef-io" ]]; then
@@ -368,5 +368,5 @@ function build_all_changed_components() {
         build $component
       fi
     done
-  popd >/dev/null;
+  popd >/dev/null
 }

--- a/.studio/common
+++ b/.studio/common
@@ -207,14 +207,14 @@ document "rebuild" <<EOF
   build time
 EOF
 function rebuild() {
-  output=$(set -o pipefail; NO_INSTALL_DEPS=1 build $@ | tee /dev/stderr)
+  output=$(set -o pipefail; NO_INSTALL_DEPS=1 build "$@" | tee /dev/stderr)
   err=$?
   if [[ $err != 0 ]]
   then
     echo $output | grep "Resolving '.*' failed" > /dev/null
     if [[ $? == 0 ]]
     then
-      build $@
+      build "$@"
       err=$?
     fi
   fi

--- a/.studio/common
+++ b/.studio/common
@@ -125,9 +125,10 @@ function link_component_bin() {
   if [[ $component == "deployment-service" ]]; then
       component_dir="automate-deployment"
   fi
-  for d in $(ls -d components/$component_dir/cmd/* 2>/dev/null); do
-    local cmd_bin=$(basename $d)
-    hab pkg binlink --force $HAB_ORIGIN/$component $cmd_bin
+  for d in components/$component_dir/cmd/*/; do
+    local cmd_bin
+    cmd_bin=$(basename "$d")
+    hab pkg binlink --force "$HAB_ORIGIN/$component" "$cmd_bin"
   done
   return 0
 }

--- a/.studio/compliance-service
+++ b/.studio/compliance-service
@@ -27,7 +27,8 @@ function compliance_unit_tests() {
   setup_go_workspace
   # Run the tests
   pushd $scaffolding_go_pkg_path >/dev/null;
-    local GO_PACKAGES=$(go list ./components/compliance-service/... |  grep -v '/examples/');
+    local GO_PACKAGES
+    GO_PACKAGES=$(go list ./components/compliance-service/... |  grep -v '/examples/');
     log_line "Executing Go test";
     eval go test -v $GO_PACKAGES -cover;
     local EXIT_CODE=$?;

--- a/.studio/compliance-service
+++ b/.studio/compliance-service
@@ -26,15 +26,15 @@ DOC
 function compliance_unit_tests() {
   setup_go_workspace
   # Run the tests
-  pushd $scaffolding_go_pkg_path >/dev/null;
+  pushd $scaffolding_go_pkg_path >/dev/null
     local GO_PACKAGES
-    GO_PACKAGES=$(go list ./components/compliance-service/... |  grep -v '/examples/');
-    log_line "Executing Go test";
-    eval go test -v $GO_PACKAGES -cover;
-    local EXIT_CODE=$?;
-  popd >/dev/null;
+    GO_PACKAGES=$(go list ./components/compliance-service/... |  grep -v '/examples/')
+    log_line "Executing Go test"
+    eval go test -v $GO_PACKAGES -cover
+    local EXIT_CODE=$?
+  popd >/dev/null
 
-  return $EXIT_CODE;
+  return $EXIT_CODE
 }
 
 document "compliance_integration" <<DOC

--- a/.studio/debugging
+++ b/.studio/debugging
@@ -30,7 +30,8 @@ function debug_go_service() {
           ;;
   esac
 
-  local pid=$(echo "$status_output" | awk "{print \$$needed_col}")
+  local pid
+  pid=$(echo "$status_output" | awk "{print \$$needed_col}")
   if [[ $pid == "" ]]; then
     log_error "Couldn't find running service ($1)"
     return 1

--- a/.studio/debugging
+++ b/.studio/debugging
@@ -7,7 +7,7 @@ function debug_go_service() {
   if [[ "$1" == "" ]]; then
     log_error "Missing the service name; try 'describe ${FUNCNAME[0]}'"
     return 1
-  fi;
+  fi
 
   status_output=$(hab svc status | grep $1)
   if [[ $status_output == "" ]]; then
@@ -35,9 +35,9 @@ function debug_go_service() {
   if [[ $pid == "" ]]; then
     log_error "Couldn't find running service ($1)"
     return 1
-  fi;
+  fi
 
-  GO_TOOL_METHOD="get" install_go_tool github.com/derekparker/delve/cmd/dlv;
+  GO_TOOL_METHOD="get" install_go_tool github.com/derekparker/delve/cmd/dlv
 
   dlv attach --headless -l ":${GO_DEBUG_PORT:-2345}" "$pid" --log=true --api-version=2
 }

--- a/.studio/golang
+++ b/.studio/golang
@@ -62,7 +62,7 @@ function go_test() {
   install_if_missing core/git git
 
   pushd "$scaffolding_go_pkg_path" >/dev/null
-    log_line "Executing Go test";
+    log_line "Executing Go test"
     # The default behavior is to run the package at the root of the
     # repository which is just as if we run: 'go test -cover'
     go test "$@" -cover $VERBOSE_TESTS
@@ -105,7 +105,7 @@ document "go_build_component" <<DOC
   A wrapper around the go_build to build a specific component.
 DOC
 function go_build_component() {
-  [[ "$1" == "" ]] && error "Missing component name argument; try 'describe ${FUNCNAME[0]}'" && return 1;
+  [[ "$1" == "" ]] && error "Missing component name argument; try 'describe ${FUNCNAME[0]}'" && return 1
   verify_component $1 || return $?
   local component=$1
 
@@ -173,7 +173,7 @@ function go_update_component() {
   local component=$1
 
   hab pkg path $HAB_ORIGIN/$component 2>/dev/null 1>&2 || hab pkg path chef/$component 2>/dev/null 1>&2
-  if [ $? -eq 0 ] ; then
+  if [ $? -eq 0 ]; then
     go_build_component $component
     reload_component_binary $component
   else
@@ -191,9 +191,9 @@ document "kill_running_service" <<DOC
       kill_running_service ingest-service
 DOC
 function kill_running_service() {
-  [[ "$1" == "" ]] && error "Missing component name argument" && return 1;
+  [[ "$1" == "" ]] && error "Missing component name argument" && return 1
   verify_component $1 || return $?
-  local component=$1;
+  local component=$1
   SERVICE_PID=$(grep_component_pid $component)
   if [[ ! -z ${SERVICE_PID} ]]; then
     kill $SERVICE_PID
@@ -215,7 +215,7 @@ DOC
 function auto_go_update_component() {
   [ "x$1" == "x" ] && error "Missing component name argument; try 'describe ${FUNCNAME[0]}'" && return 1
   verify_component $1 || return $?
-  local component=$1;
+  local component=$1
 
   setup_go_workspace
 
@@ -243,7 +243,7 @@ function go_component_static_tests() {
 
   log_line "Collecting ${component}'s go files"
   local gofiles
-  gofiles=$(find components/$component/ -maxdepth 3 -name '*.go');
+  gofiles=$(find components/$component/ -maxdepth 3 -name '*.go')
   [ -z "$gofiles" ] && return 0
 
   log_line "Installing gofmt"
@@ -318,7 +318,7 @@ document "go_component_make" <<DOC
   Runs the given make target(s) for the given component inside the scaffolding_go_pkg_path
 DOC
 function go_component_make() {
-  [[ "$1" == "" ]] && error "Missing component name argument" && return 1;
+  [[ "$1" == "" ]] && error "Missing component name argument" && return 1
   setup_go_workspace
   local component_relpath=$1
   local component_path="$GOPATH/src/github.com/chef/automate/$component_relpath"

--- a/.studio/golang
+++ b/.studio/golang
@@ -242,7 +242,8 @@ function go_component_static_tests() {
   local component=$1
 
   log_line "Collecting ${component}'s go files"
-  local gofiles=$(find components/$component/ -maxdepth 3 -name '*.go');
+  local gofiles
+  gofiles=$(find components/$component/ -maxdepth 3 -name '*.go');
   [ -z "$gofiles" ] && return 0
 
   log_line "Installing gofmt"

--- a/.studio/secrets-service
+++ b/.studio/secrets-service
@@ -67,7 +67,7 @@ document "secrets_update_secret" <<DOC
   art 3 - password optional
 DOC
 function secrets_update_secret() {
-  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1;
+  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1
   local username=${2:-"default"}
   local password=${3:-"super_secret"}
 
@@ -84,7 +84,7 @@ document "secrets_delete_secret" <<DOC
   arg 1 - ID required
 DOC
 function secrets_delete_secret() {
-  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1;
+  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1
 
   echo '{"id": "'$1'"}' | grpcurl --insecure \
     -cert /hab/svc/secrets-service/config/service.crt \
@@ -99,7 +99,7 @@ document "secrets_read_secret" <<DOC
   arg 1 - ID required
 DOC
 function secrets_read_secret() {
-  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1;
+  [[ "$1" == "" ]] && error "Missing ID argument; try 'describe ${FUNCNAME[0]}'" && return 1
 
   echo '{"id": "'$1'"}' | grpcurl --insecure \
     -cert /hab/svc/secrets-service/config/service.crt \
@@ -112,7 +112,7 @@ document "secrets_psql" <<DOC
   Enter psql with the secrets-service database
 DOC
 function secrets_psql() {
-  chef-automate dev psql secrets_service;
+  chef-automate dev psql secrets_service
 }
 
 document "secrets_list_secrets_from_db" <<DOC
@@ -167,10 +167,10 @@ function secrets_reload_A1_data() {
   check_service_running_or_exit automate-postgresql || return 1
 
   if [[ ! -f $DUMP_PATH ]]; then
-    install_if_missing core/gzip gunzip;
+    install_if_missing core/gzip gunzip
     cp /src/components/compliance-service/generator/a1-data/${DUMP_NAME}.gz $DUMP_DIR
     gunzip ${DUMP_PATH}.gz
-  fi;
+  fi
 
   # The A1 secret_key is being migrated from the deployment-service at:
   # => https://github.com/chef/automate/blob/dc2e9abeaf09ad3577e922d0e8afec9f6713cc4e/components/automate-deployment/pkg/client/deployer.go#L1433

--- a/.studio/secrets-service
+++ b/.studio/secrets-service
@@ -119,9 +119,10 @@ document "secrets_list_secrets_from_db" <<DOC
   Read all secrets directly from the database
 DOC
 function secrets_list_secrets_from_db() {
-  local DBNAME=$(grep -w database /src/components/secrets-service/habitat/default.toml | cut -f2 -d\")
-  install_if_missing core/postgresql psql;
-  psql $DBNAME -c 'SELECT * FROM s_secrets'
+  local DBNAME
+  DBNAME=$(grep -w database /src/components/secrets-service/habitat/default.toml | cut -f2 -d\")
+  install_if_missing core/postgresql psql
+  psql "$DBNAME" -c 'SELECT * FROM s_secrets'
 }
 
 ############## ############## ############## ##############
@@ -181,7 +182,7 @@ function secrets_reload_A1_data() {
   fi
 
   postgresql_load_env
-  install_if_missing core/postgresql psql;
+  install_if_missing core/postgresql psql
   psql -c "DROP DATABASE IF EXISTS ${DBNAME}"
   psql -c "CREATE DATABASE ${DBNAME}"
   psql ${DBNAME} -f ${DUMP_PATH}
@@ -193,8 +194,10 @@ document "secrets_test_A1_migration" <<DOC
 DOC
 function secrets_test_A1_migration() {
   local COMPONENT=secrets-service
-  local DBNAME=$(grep -w database /src/components/${COMPONENT}/habitat/default.toml | cut -f2 -d\")
-  local PKG_IDENT=$(hab sup status 2>/dev/null | grep ${COMPONENT} | awk -F/ '{print $1"/"$2}')
+  local DBNAME
+  DBNAME=$(grep -w database /src/components/${COMPONENT}/habitat/default.toml | cut -f2 -d\")
+  local PKG_IDENT
+  PKG_IDENT=$(hab sup status 2>/dev/null | grep ${COMPONENT} | awk -F/ '{print $1"/"$2}')
 
   # Verify that the secrets-service is already running
   check_service_running_or_exit secrets-service || return 1
@@ -223,8 +226,10 @@ document "secrets_test_A2_migration" <<DOC
 DOC
 function secrets_test_A2_migration() {
   local COMPONENT=secrets-service
-  local DBNAME=$(grep -w database /src/components/${COMPONENT}/habitat/default.toml | cut -f2 -d\")
-  local PKG_IDENT=$(hab sup status 2>/dev/null | grep ${COMPONENT} | awk -F/ '{print $1"/"$2}')
+  local DBNAME
+  DBNAME=$(grep -w database /src/components/${COMPONENT}/habitat/default.toml | cut -f2 -d\")
+  local PKG_IDENT
+  PKG_IDENT=$(hab sup status 2>/dev/null | grep ${COMPONENT} | awk -F/ '{print $1"/"$2}')
 
   # Verify that the secrets-service is already running
   check_service_running_or_exit secrets-service || return 1
@@ -266,7 +271,7 @@ function secrets_reload_A2_data() {
   fi
 
   postgresql_load_env
-  install_if_missing core/postgresql psql;
+  install_if_missing core/postgresql psql
   psql -c "DROP DATABASE IF EXISTS ${DBNAME}"
   psql -c "CREATE DATABASE ${DBNAME}"
   install_if_missing core/postgresql pg_restore;

--- a/scripts/repo_health.sh
+++ b/scripts/repo_health.sh
@@ -53,5 +53,7 @@ shellcheck -s bash -ax \
   scripts/*.sh \
   integration/**/*.sh
 
+shellcheck -s bash -ax -S error .studiorc .studio/*
+
 echo "Checking for possible credentials in the source code"
 go run ./tools/credscan


### PR DESCRIPTION
- Enables all of shellcheck's "error" level linters for the studio. 
- Fixes SC2068 which was required to enable error level linters
- Fixes SC2155 which looked pretty easy to solve
- Fix a few miscellaneous issues that were in the vicinity of the other issues.
- In files otherwise touched by this change, remove unnecessary `;`s
