### PR TITLE
[deployment] Add guard rails around upgrading deployments done with airgap bundles

### DIFF
--- a/components/automate-chef-io/content/docs/airgapped-installation.md
+++ b/components/automate-chef-io/content/docs/airgapped-installation.md
@@ -96,6 +96,7 @@ To send data from your Chef Server or Chef Clients to Chef Automate 2, the proce
 See [Configure Data Collection]({{< relref "data-collection.md" >}}) for more information.
 
 ### Upgrades
+To upgrade an airgapped install, you must supply an airgap bundle.
 
 On an internet-connected host, follow the steps in [Create an Airgap
 Installation Bundle]({{< relref "#create-an-airgap-installation-bundle" >}}) to upgrade your

--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -60,6 +60,11 @@ func runUpgradeCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	offlineMode := upgradeRunCmdFlags.airgap != ""
+
+	if airgap.AirgapInUse() && !offlineMode {
+		return status.New(status.InvalidCommandArgsError, "To upgrade a deployment created with an airgap bundle, use --airgap-bundle to specify a bundle to use for the upgrade.")
+	}
+
 	if upgradeRunCmdFlags.version != "" && offlineMode {
 		return status.New(status.InvalidCommandArgsError, "--version and --airgap-bundle cannot be used together")
 	}


### PR DESCRIPTION
### :nut_and_bolt: Description
Supply a useful error when a user does not provide an airgap bundle when upgrading a deployment that was created with one.

Fixes #955

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps
1.  Build an airgap bundle: `chef-automate airgap bundle create ./today.aib`.
2. Run `chef-automate airgap bundle create ./today.aib` to deploy.
3. Once the deploy has completed successfully, run `chef-automate upgrade run`. This will fail with an error `To upgrade a deployment created with an airgap bundle, use --airgap-bundle to specify a bundle to use for the upgrade.`.

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [x] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
