### PR TITLE
Fix integration tests to run locally

### DIFF
--- a/integration/base.sh
+++ b/integration/base.sh
@@ -108,6 +108,8 @@ do_build() {
 }
 
 do_build_default() {
+    previous_umask=$(umask)
+    umask 022
     if [[ "$BUILDKITE" = "true" ]]; then
        log_info "Downloading pre-build artifacts"
        download_hartifacts
@@ -134,6 +136,7 @@ do_build_default() {
     build_tools
     log_info "Copying packages to hab artifact cache"
     copy_hartifacts "$test_hartifacts_path"
+    umask "$previous_umask"
 }
 
 do_create_config() {

--- a/integration/helpers/build.sh
+++ b/integration/helpers/build.sh
@@ -2,7 +2,7 @@
 
 build_changed() {
     hab pkg install core/ruby
-    PATH=$PATH:$(hab pkg path core/ruby)/bin
+    PATH=$(hab pkg path core/ruby)/bin:$PATH
     export PATH
     sudo "$(hab pkg path core/ruby)/bin/gem" install toml
 

--- a/scripts/verify_build.sh
+++ b/scripts/verify_build.sh
@@ -15,7 +15,7 @@ export HAB_LICENSE="accept-no-persist"
 
 sudo -E hab pkg install core/ruby
 export PATH
-PATH="$PATH:$(hab pkg path core/ruby)/bin"
+PATH="$(hab pkg path core/ruby)/bin:$PATH"
 sudo -E "$(hab pkg path core/ruby)"/bin/gem install toml
 
 if [[ $EUID -eq 0 ]]; then


### PR DESCRIPTION
do_build was messed up
- the build changed components script was using the wrong ruby
- we need to be careful about the umasks we use when calling hab pkg install