### PR TITLE
Project details and rules completion

### DIFF
--- a/components/automate-ui/src/app/entities/rules/rule.model.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.model.ts
@@ -1,7 +1,8 @@
 export type RuleStatus = 'applied' | 'staged';
 export type RuleType = 'node' | 'event';
+export type ConditionOperator = 'MEMBER_OF' | 'EQUALS';
 
-interface KVPair {
+export interface KVPair {
   key: string;
   value: string;
 }
@@ -22,6 +23,6 @@ export interface Rule {
 
 export interface Condition {
   attribute: string;
-  values: any;
-  operator: string;
+  operator: ConditionOperator;
+  values: string[];
 }

--- a/components/automate-ui/src/app/entities/rules/rule.model.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.model.ts
@@ -3,7 +3,7 @@ export interface Rule {
   project_id?: string;
   name: string;
   type: string;
-  edits: string;
+  status: string;
   conditions: Condition[];
 }
 

--- a/components/automate-ui/src/app/entities/rules/rule.model.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.model.ts
@@ -1,10 +1,11 @@
 export type RuleStatus = 'applied' | 'staged';
+export type RuleType = 'node' | 'event';
 
 export interface Rule {
   id?: string;
   project_id?: string;
   name: string;
-  type: string;
+  type: RuleType;
   status: RuleStatus;
   conditions: Condition[];
 }

--- a/components/automate-ui/src/app/entities/rules/rule.model.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.model.ts
@@ -2,7 +2,7 @@ export type RuleStatus = 'applied' | 'staged';
 export type RuleType = 'node' | 'event';
 export type ConditionOperator = 'MEMBER_OF' | 'EQUALS';
 
-export interface KVPair {
+interface KVPair {
   key: string;
   value: string;
 }

--- a/components/automate-ui/src/app/entities/rules/rule.model.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.model.ts
@@ -1,6 +1,16 @@
 export type RuleStatus = 'applied' | 'staged';
 export type RuleType = 'node' | 'event';
 
+interface KVPair {
+  key: string;
+  value: string;
+}
+
+// Using array of pairs instead of a hashmap to allow ordering
+export type RuleTypeMappedObject = {
+  [K in 'node' | 'event']: KVPair[]
+};
+
 export interface Rule {
   id?: string;
   project_id?: string;

--- a/components/automate-ui/src/app/entities/rules/rule.model.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.model.ts
@@ -1,9 +1,11 @@
+export type RuleStatus = 'applied' | 'staged';
+
 export interface Rule {
   id?: string;
   project_id?: string;
   name: string;
   type: string;
-  status: string;
+  status: RuleStatus;
   conditions: Condition[];
 }
 

--- a/components/automate-ui/src/app/entities/rules/rule.reducer.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.reducer.ts
@@ -4,10 +4,10 @@ import { set, pipe, unset } from 'lodash/fp';
 
 import { EntityStatus } from 'app/entities/entities';
 import { RuleActionTypes, RuleActions } from './rule.actions';
-import { Rule } from './rule.model';
+import { Rule, RuleTypeMappedObject } from './rule.model';
 
 export interface RuleEntityState extends EntityState<Rule> {
-  getAttributes: any;
+  getAttributes: RuleTypeMappedObject;
   getAllStatus: EntityStatus;
   getStatus: EntityStatus;
   createStatus: EntityStatus;
@@ -23,7 +23,7 @@ const CREATE_ERROR = 'createError';
 const DELETE_STATUS = 'deleteStatus';
 const UPDATE_STATUS = 'updateStatus';
 
-export const ruleAttributes = {
+export const ruleAttributes: RuleTypeMappedObject = {
   node: [
     {
       key: 'CHEF_ORGS',

--- a/components/automate-ui/src/app/entities/rules/rule.requests.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.requests.ts
@@ -40,6 +40,10 @@ export class RuleRequests {
     // return this.http.post<RuleSuccessPayload>(
     //   `${env.auth_v2_url}/project/${project_id}/rules`,
     //   { rule });
+
+    // needed to compile now, but delete this line when uncommenting above
+    rule.project_id = project_id;
+
     this.rules.push(rule);
     return of({ rule: rule });
   }

--- a/components/automate-ui/src/app/entities/rules/rule.requests.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.requests.ts
@@ -42,7 +42,7 @@ export class RuleRequests {
     //   { rule });
     rule.id = `rule-${this.rules.length}`;
     rule.project_id = project_id;
-    rule.edits = 'staging';
+    rule.status = 'staged';
     this.rules.push(rule);
     return of({ rule: rule });
   }

--- a/components/automate-ui/src/app/entities/rules/rule.requests.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.requests.ts
@@ -40,9 +40,6 @@ export class RuleRequests {
     // return this.http.post<RuleSuccessPayload>(
     //   `${env.auth_v2_url}/project/${project_id}/rules`,
     //   { rule });
-    rule.id = `rule-${this.rules.length}`;
-    rule.project_id = project_id;
-    rule.status = 'staged';
     this.rules.push(rule);
     return of({ rule: rule });
   }

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -27,15 +27,17 @@
     </chef-page-header>
     <section class="page-body" [hidden]="showTab('rules')">
       <form [formGroup]="projectForm">
-        <chef-form-field>
+        <chef-form-field id="update-name">
           <label>
-            <span class="label">Name
-              <span aria-hidden="true">*</span>
-            </span>
+            <span class="label">Name <span aria-hidden="true">*</span></span>
             <input chefInput formControlName="name" type="text"
               [attr.disabled]="(isChefManaged || isLoading) ? true : null"
               (keyup)="keyPressed()">
           </label>
+          <chef-error
+            *ngIf="(projectForm.get('name').hasError('required') || projectForm.get('name').hasError('pattern')) && projectForm.get('name').dirty">
+            Name is required.
+          </chef-error>
         </chef-form-field>
         <span [hidden]="!isChefManaged" id="changes-not-allowed">
           Name changes are not allowed for the default project.

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -66,6 +66,7 @@
             <chef-thead>
               <chef-tr>
                 <chef-th>Name</chef-th>
+                <chef-th>ID</chef-th>
                 <chef-th>Resource Type</chef-th>
                 <chef-th>Conditions</chef-th>
                 <chef-th>Edits</chef-th>
@@ -77,6 +78,7 @@
                 <chef-td>
                   <a [routerLink]="['/settings', 'projects', project?.id, 'rules', rule.id]">{{ rule.name }}</a>
                 </chef-td>
+                <chef-td>{{ rule.id }}</chef-td>
                 <chef-td>{{ rule.type | titlecase }}</chef-td>
                 <chef-td>{{ rule.conditions.length | pluralize : 'condition' : 's' }}</chef-td>
                 <chef-td>{{ getEditStatus(rule) }}</chef-td>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -79,7 +79,7 @@
                 </chef-td>
                 <chef-td>{{ rule.type | titlecase }}</chef-td>
                 <chef-td>{{ rule.conditions.length | pluralize : 'condition' : 's' }}</chef-td>
-                <chef-td>{{ getEditStatus(rule.edits) }}</chef-td>
+                <chef-td>{{ getEditStatus(rule) }}</chef-td>
                 <chef-td class="controls">
                   <app-authorized [allOf]="['/iam/v2beta/projects/{id}', 'delete', project?.id]">
                     <chef-control-menu>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -83,7 +83,7 @@
                 <chef-td class="controls">
                   <app-authorized [allOf]="['/iam/v2beta/projects/{id}', 'delete', project?.id]">
                     <chef-control-menu>
-                      <chef-option *ngIf="showDeleteRule(rule)" class="delete-rule" (click)="startRuleDelete(rule)">Delete Rule</chef-option>
+                      <chef-option *ngIf="showDeleteRule()" class="delete-rule" (click)="startRuleDelete(rule)">Delete Rule</chef-option>
                     </chef-control-menu>
                   </app-authorized>
                 </chef-td>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.scss
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.scss
@@ -25,6 +25,11 @@ chef-tab-selector {
 }
 
 form {
+
+  #update-name {
+    width: 240px;
+  }
+
   input {
     font-size: 1em;
     width: 240px;

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -26,7 +26,7 @@ describe('ProjectDetailsComponent', () => {
       id: 'rule-1',
       project_id: 'uuid-1',
       name: 'Rule 1',
-      type: 'NODE',
+      type: 'node',
       status: 'staged',
       conditions: [
         {
@@ -40,7 +40,7 @@ describe('ProjectDetailsComponent', () => {
       id: 'rule-2',
       project_id: 'uuid-1',
       name: 'Rule 2',
-      type: 'EVENT',
+      type: 'event',
       status: 'applied',
       conditions: [
         {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -11,7 +11,7 @@ import { IAMType } from 'app/entities/policies/policy.model';
 import { GetProjectSuccess } from 'app/entities/projects/project.actions';
 import { GetRulesSuccess } from 'app/entities/rules/rule.actions';
 import { projectEntityReducer } from 'app/entities/projects/project.reducer';
-import { ProjectDetailsComponent } from './project-details.component';
+import { ProjectDetailsComponent, ProjectTabNames } from './project-details.component';
 
 describe('ProjectDetailsComponent', () => {
   let component: ProjectDetailsComponent;
@@ -146,16 +146,25 @@ describe('ProjectDetailsComponent', () => {
       expect(component.rules.length).toBe(0);
     });
 
-    it('show rules section when rules tab is selected', () => {
-      component.onTabChange({ target: { value: 'rules'} });
-      expect(component.showTab('rules')).toBeTruthy();
+   it('defaults to showing rules section', () => {
+      expect(component.showTab(ProjectTabNames.Rules)).toBeTruthy();
+      expect(component.showTab(ProjectTabNames.Details)).toBeFalsy();
     });
 
-    it('should not display rule table when no rules', () => {
+    it('shows/hides sections when based on selection', () => {
+      component.onTabChange({ target: { value: ProjectTabNames.Details } });
+      expect(component.showTab(ProjectTabNames.Rules)).toBeFalsy();
+      expect(component.showTab(ProjectTabNames.Details)).toBeTruthy();
+      component.onTabChange({ target: { value: ProjectTabNames.Rules } });
+      expect(component.showTab(ProjectTabNames.Rules)).toBeTruthy();
+      expect(component.showTab(ProjectTabNames.Details)).toBeFalsy();
+    });
+
+    it('does not display rule table', () => {
       expect(component.showRulesTable()).toBeFalsy();
     });
 
-    it('the create your first rule message should display', () => {
+    it('displays create-your-first-rule message', () => {
       expect(component.showFirstRuleMessage()).toBeTruthy();
     });
   });
@@ -174,20 +183,29 @@ describe('ProjectDetailsComponent', () => {
       expect(component.rules.length).toBe(2);
     });
 
-    it('show rules section when rules tab is selected', () => {
-      component.onTabChange({ target: { value: 'rules'} });
-      expect(component.showTab('rules')).toBeTruthy();
+    it('defaults to showing rules section', () => {
+      expect(component.showTab(ProjectTabNames.Rules)).toBeTruthy();
+      expect(component.showTab(ProjectTabNames.Details)).toBeFalsy();
     });
 
-    it('should display rule table', () => {
+    it('shows/hides sections when based on selection', () => {
+      component.onTabChange({ target: { value: ProjectTabNames.Details } });
+      expect(component.showTab(ProjectTabNames.Rules)).toBeFalsy();
+      expect(component.showTab(ProjectTabNames.Details)).toBeTruthy();
+      component.onTabChange({ target: { value: ProjectTabNames.Rules } });
+      expect(component.showTab(ProjectTabNames.Rules)).toBeTruthy();
+      expect(component.showTab(ProjectTabNames.Details)).toBeFalsy();
+    });
+
+    it('displays rule table', () => {
       expect(component.showRulesTable()).toBeTruthy();
     });
 
-    it('the create your first rule message should not display', () => {
+    it('does not display create-your-first-rule message', () => {
       expect(component.showFirstRuleMessage()).toBeFalsy();
     });
 
-    it('show a link back to project when a rule is in "edits pending" state', () => {
+    it('shows a link back to project when a rule is in "edits pending" state', () => {
       expect(component.showProjectLink()).toBeTruthy();
     });
 

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -6,7 +6,6 @@ import { MockComponent } from 'ng2-mock-component';
 
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { customMatchers } from 'app/testing/custom-matchers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { IAMType } from 'app/entities/policies/policy.model';
 import { GetProjectSuccess } from 'app/entities/projects/project.actions';
@@ -128,7 +127,6 @@ describe('ProjectListComponent', () => {
       }
     }));
 
-    jasmine.addMatchers(customMatchers);
     fixture = TestBed.createComponent(ProjectDetailsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -11,7 +11,7 @@ import { GetProjectSuccess } from 'app/entities/projects/project.actions';
 import { projectEntityReducer } from 'app/entities/projects/project.reducer';
 import { Project } from 'app/entities/projects/project.model';
 import { Rule } from 'app/entities/rules/rule.model';
-import { ProjectDetailsComponent } from './project-details.component';
+import { ProjectDetailsComponent, ProjectTabName } from './project-details.component';
 
 describe('ProjectDetailsComponent', () => {
   let component: ProjectDetailsComponent;
@@ -145,11 +145,14 @@ describe('ProjectDetailsComponent', () => {
     });
 
     it('shows/hides sections when based on selection', () => {
-      component.onTabChange({ target: { value: 'details' } });
+      let tabName: ProjectTabName = 'details';
+      component.onTabChange({ target: { value: tabName } });
+      expect(component.showTab(tabName)).toBeTruthy();
       expect(component.showTab('rules')).toBeFalsy();
-      expect(component.showTab('details')).toBeTruthy();
-      component.onTabChange({ target: { value: 'rules' } });
-      expect(component.showTab('rules')).toBeTruthy();
+
+      tabName = 'rules';
+      component.onTabChange({ target: { value: tabName } });
+      expect(component.showTab(tabName)).toBeTruthy();
       expect(component.showTab('details')).toBeFalsy();
     });
 

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -9,9 +9,9 @@ import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { IAMType } from 'app/entities/policies/policy.model';
 import { GetProjectSuccess } from 'app/entities/projects/project.actions';
-import { GetRulesSuccess } from 'app/entities/rules/rule.actions';
 import { projectEntityReducer } from 'app/entities/projects/project.reducer';
-import { ProjectDetailsComponent, ProjectTabNames, RuleStatus } from './project-details.component';
+import { Rule } from 'app/entities/rules/rule.model';
+import { ProjectDetailsComponent, ProjectTabNames } from './project-details.component';
 
 describe('ProjectDetailsComponent', () => {
   let component: ProjectDetailsComponent;
@@ -22,12 +22,12 @@ describe('ProjectDetailsComponent', () => {
     type: <IAMType>'CHEF_MANAGED'
   };
   const rules = [
-    {
+    <Rule>{
       id: 'rule-1',
       project_id: 'uuid-1',
       name: 'Rule 1',
       type: 'NODE',
-      status: RuleStatus.Staged,
+      status: 'staged',
       conditions: [
         {
           attribute: 'CHEF_ORGS',
@@ -36,12 +36,12 @@ describe('ProjectDetailsComponent', () => {
         }
       ]
     },
-    {
+    <Rule>{
       id: 'rule-2',
       project_id: 'uuid-1',
       name: 'Rule 2',
       type: 'EVENT',
-      status: RuleStatus.Applied,
+      status: 'applied',
       conditions: [
         {
           attribute: 'CHEF_ORGS',

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -11,7 +11,7 @@ import { IAMType } from 'app/entities/policies/policy.model';
 import { GetProjectSuccess } from 'app/entities/projects/project.actions';
 import { projectEntityReducer } from 'app/entities/projects/project.reducer';
 import { Rule } from 'app/entities/rules/rule.model';
-import { ProjectDetailsComponent, ProjectTabNames } from './project-details.component';
+import { ProjectDetailsComponent } from './project-details.component';
 
 describe('ProjectDetailsComponent', () => {
   let component: ProjectDetailsComponent;
@@ -139,17 +139,17 @@ describe('ProjectDetailsComponent', () => {
     });
 
    it('defaults to showing rules section', () => {
-      expect(component.showTab(ProjectTabNames.Rules)).toBeTruthy();
-      expect(component.showTab(ProjectTabNames.Details)).toBeFalsy();
+      expect(component.showTab('rules')).toBeTruthy();
+      expect(component.showTab('details')).toBeFalsy();
     });
 
     it('shows/hides sections when based on selection', () => {
-      component.onTabChange({ target: { value: ProjectTabNames.Details } });
-      expect(component.showTab(ProjectTabNames.Rules)).toBeFalsy();
-      expect(component.showTab(ProjectTabNames.Details)).toBeTruthy();
-      component.onTabChange({ target: { value: ProjectTabNames.Rules } });
-      expect(component.showTab(ProjectTabNames.Rules)).toBeTruthy();
-      expect(component.showTab(ProjectTabNames.Details)).toBeFalsy();
+      component.onTabChange({ target: { value: 'details' } });
+      expect(component.showTab('rules')).toBeFalsy();
+      expect(component.showTab('details')).toBeTruthy();
+      component.onTabChange({ target: { value: 'rules' } });
+      expect(component.showTab('rules')).toBeTruthy();
+      expect(component.showTab('details')).toBeFalsy();
     });
 
     it('does not display rule table', () => {
@@ -168,17 +168,17 @@ describe('ProjectDetailsComponent', () => {
     });
 
     it('defaults to showing rules section', () => {
-      expect(component.showTab(ProjectTabNames.Rules)).toBeTruthy();
-      expect(component.showTab(ProjectTabNames.Details)).toBeFalsy();
+      expect(component.showTab('rules')).toBeTruthy();
+      expect(component.showTab('details')).toBeFalsy();
     });
 
     it('shows/hides sections when based on selection', () => {
-      component.onTabChange({ target: { value: ProjectTabNames.Details } });
-      expect(component.showTab(ProjectTabNames.Rules)).toBeFalsy();
-      expect(component.showTab(ProjectTabNames.Details)).toBeTruthy();
-      component.onTabChange({ target: { value: ProjectTabNames.Rules } });
-      expect(component.showTab(ProjectTabNames.Rules)).toBeTruthy();
-      expect(component.showTab(ProjectTabNames.Details)).toBeFalsy();
+      component.onTabChange({ target: { value: 'details' } });
+      expect(component.showTab('rules')).toBeFalsy();
+      expect(component.showTab('details')).toBeTruthy();
+      component.onTabChange({ target: { value: 'rules' } });
+      expect(component.showTab('rules')).toBeTruthy();
+      expect(component.showTab('details')).toBeFalsy();
     });
 
     it('displays rule table', () => {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -31,7 +31,7 @@ describe('ProjectDetailsComponent', () => {
       conditions: [
         {
           attribute: 'CHEF_ORGS',
-          values: 'My value',
+          values: ['My value'],
           operator: 'EQUALS'
         }
       ]
@@ -45,7 +45,7 @@ describe('ProjectDetailsComponent', () => {
       conditions: [
         {
           attribute: 'CHEF_ORGS',
-          values: '["My value"]',
+          values: ['Value one', 'Value two'],
           operator: 'MEMBER_OF'
         }
       ]

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -22,8 +22,8 @@ describe('ProjectDetailsComponent', () => {
     name: 'Default',
     type: 'CHEF_MANAGED'
   };
-  const rules = [
-    <Rule>{
+  const rules: Rule[] = [
+    {
       id: 'rule-1',
       project_id: 'uuid-1',
       name: 'Rule 1',
@@ -37,7 +37,7 @@ describe('ProjectDetailsComponent', () => {
         }
       ]
     },
-    <Rule>{
+    {
       id: 'rule-2',
       project_id: 'uuid-1',
       name: 'Rule 2',
@@ -145,14 +145,12 @@ describe('ProjectDetailsComponent', () => {
     });
 
     it('shows/hides sections when based on selection', () => {
-      let tabName: ProjectTabName = 'details';
-      component.onTabChange({ target: { value: tabName } });
-      expect(component.showTab(tabName)).toBeTruthy();
+      component.onTabChange({ target: { value: 'details' } });
+      expect(component.showTab('details')).toBeTruthy();
       expect(component.showTab('rules')).toBeFalsy();
 
-      tabName = 'rules';
-      component.onTabChange({ target: { value: tabName } });
-      expect(component.showTab(tabName)).toBeTruthy();
+      component.onTabChange({ target: { value: 'rules' } });
+      expect(component.showTab('rules')).toBeTruthy();
       expect(component.showTab('details')).toBeFalsy();
     });
 

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -135,15 +135,7 @@ describe('ProjectDetailsComponent', () => {
 
   describe('when there are no rules', () => {
     beforeEach(() => {
-      store.dispatch(new GetRulesSuccess({
-          rules: []
-      }));
       component.rules = [];
-      fixture.detectChanges();
-    });
-
-    it('rules array should be empty', () => {
-      expect(component.rules.length).toBe(0);
     });
 
    it('defaults to showing rules section', () => {
@@ -171,16 +163,8 @@ describe('ProjectDetailsComponent', () => {
 
   describe('when there are rules', () => {
     beforeEach(() => {
-      store.dispatch(new GetRulesSuccess({
-          rules: rules
-      }));
       component.project = project;
       component.rules = rules;
-      fixture.detectChanges();
-    });
-
-    it('rules array should have two rules', () => {
-      expect(component.rules.length).toBe(2);
     });
 
     it('defaults to showing rules section', () => {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -74,6 +74,7 @@ describe('ProjectDetailsComponent', () => {
         MockComponent({ selector: 'chef-control-menu' }),
         MockComponent({ selector: 'chef-form-field'}),
         MockComponent({ selector: 'chef-breadcrumbs'}),
+        MockComponent({ selector: 'chef-error'}),
         MockComponent({ selector: 'chef-breadcrumb', inputs: ['link'] }),
         MockComponent({ selector: 'chef-tab-selector', inputs: ['value'] }),
         MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -189,12 +189,12 @@ describe('ProjectDetailsComponent', () => {
       expect(component.showFirstRuleMessage()).toBeFalsy();
     });
 
-    it('shows a link back to project when a rule is in "edits pending" state', () => {
+    it('shows a link back to project when a rule has edits pending', () => {
       expect(component.showProjectLink()).toBeTruthy();
     });
 
-    it('disable delete rule button when a rule is in "staging" state', () => {
-      expect(component.showDeleteRule(component.rules[0])).toBeFalsy();
+    it('enables delete-rule button when a rule has edits pending', () => {
+      expect(component.showDeleteRule()).toBeTruthy();
     });
   });
 });

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -13,7 +13,7 @@ import { GetRulesSuccess } from 'app/entities/rules/rule.actions';
 import { projectEntityReducer } from 'app/entities/projects/project.reducer';
 import { ProjectDetailsComponent } from './project-details.component';
 
-describe('ProjectListComponent', () => {
+describe('ProjectDetailsComponent', () => {
   let component: ProjectDetailsComponent;
   let fixture: ComponentFixture<ProjectDetailsComponent>;
 

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -11,7 +11,7 @@ import { IAMType } from 'app/entities/policies/policy.model';
 import { GetProjectSuccess } from 'app/entities/projects/project.actions';
 import { GetRulesSuccess } from 'app/entities/rules/rule.actions';
 import { projectEntityReducer } from 'app/entities/projects/project.reducer';
-import { ProjectDetailsComponent, ProjectTabNames } from './project-details.component';
+import { ProjectDetailsComponent, ProjectTabNames, RuleStatus } from './project-details.component';
 
 describe('ProjectDetailsComponent', () => {
   let component: ProjectDetailsComponent;
@@ -27,7 +27,7 @@ describe('ProjectDetailsComponent', () => {
       project_id: 'uuid-1',
       name: 'Rule 1',
       type: 'NODE',
-      edits: 'staging',
+      status: RuleStatus.Staged,
       conditions: [
         {
           attribute: 'CHEF_ORGS',
@@ -41,7 +41,7 @@ describe('ProjectDetailsComponent', () => {
       project_id: 'uuid-1',
       name: 'Rule 2',
       type: 'EVENT',
-      edits: 'applied',
+      status: RuleStatus.Applied,
       conditions: [
         {
           attribute: 'CHEF_ORGS',

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -7,9 +7,9 @@ import { MockComponent } from 'ng2-mock-component';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { IAMType } from 'app/entities/policies/policy.model';
 import { GetProjectSuccess } from 'app/entities/projects/project.actions';
 import { projectEntityReducer } from 'app/entities/projects/project.reducer';
+import { Project } from 'app/entities/projects/project.model';
 import { Rule } from 'app/entities/rules/rule.model';
 import { ProjectDetailsComponent } from './project-details.component';
 
@@ -17,9 +17,10 @@ describe('ProjectDetailsComponent', () => {
   let component: ProjectDetailsComponent;
   let fixture: ComponentFixture<ProjectDetailsComponent>;
 
-  const project = {
-    id: 'uuid-1', name: 'Default',
-    type: <IAMType>'CHEF_MANAGED'
+  const project: Project = {
+    id: 'uuid-1',
+    name: 'Default',
+    type: 'CHEF_MANAGED'
   };
   const rules = [
     <Rule>{
@@ -124,7 +125,7 @@ describe('ProjectDetailsComponent', () => {
     store.dispatch(new GetProjectSuccess({
       project: {
         id: 'uuid-1', name: 'Default',
-        type: <IAMType>'CHEF_MANAGED'
+        type: 'CHEF_MANAGED'
       }
     }));
 

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -11,7 +11,7 @@ import { GetProjectSuccess } from 'app/entities/projects/project.actions';
 import { projectEntityReducer } from 'app/entities/projects/project.reducer';
 import { Project } from 'app/entities/projects/project.model';
 import { Rule } from 'app/entities/rules/rule.model';
-import { ProjectDetailsComponent, ProjectTabName } from './project-details.component';
+import { ProjectDetailsComponent } from './project-details.component';
 
 describe('ProjectDetailsComponent', () => {
   let component: ProjectDetailsComponent;

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -20,10 +20,7 @@ import {
   allRules
 } from 'app/entities/rules/rule.selectors';
 
-export enum ProjectTabNames {
-  Rules = 'rules',
-  Details = 'details'
-}
+type ProjectTabNames = 'rules' | 'details';
 
 @Component({
   selector: 'app-project-details',
@@ -37,7 +34,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   public saveSuccessful = false;
   public isChefManaged = false;
   public rules: Rule[] = [];
-  public selectedTab: ProjectTabNames.Rules | ProjectTabNames.Details = ProjectTabNames.Rules;
+  public selectedTab: ProjectTabNames = 'rules';
   public ruleToDelete: any;
   public deleteModalVisible = false;
   public createModalVisible = false;
@@ -107,7 +104,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
     this.selectedTab = event.target.value;
   }
 
-  showTab(tabName: string): boolean {
+  showTab(tabName: ProjectTabNames): boolean {
     return this.selectedTab === tabName;
   }
 

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -15,7 +15,7 @@ import {
 import { Project } from 'app/entities/projects/project.model';
 import { GetProject, UpdateProject } from 'app/entities/projects/project.actions';
 import { GetRulesForProject, DeleteRule } from 'app/entities/rules/rule.actions';
-import { Rule } from 'app/entities/rules/rule.model';
+import { Rule, RuleStatus } from 'app/entities/rules/rule.model';
 import {
   allRules
 } from 'app/entities/rules/rule.selectors';
@@ -23,11 +23,6 @@ import {
 export enum ProjectTabNames {
   Rules = 'rules',
   Details = 'details'
-}
-
-export enum RuleStatus {
-  Applied = 'applied',
-  Staged = 'staged'
 }
 
 @Component({
@@ -139,7 +134,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   }
 
   getEditStatus(rule: Rule): string {
-    return rule.status === RuleStatus.Staged ? 'Edits pending' : 'Applied';
+    return rule.status === 'staged' ? 'Edits pending' : 'Applied';
   }
 
   showDeleteRule(): boolean {
@@ -147,7 +142,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   }
 
   showProjectLink(): boolean {
-    return find(['status', RuleStatus.Staged], this.rules) ? true : false;
+    return find(['status', <RuleStatus>'staged'], this.rules) ? true : false;
   }
 
   saveProject() {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -21,6 +21,11 @@ import {
   allRules
 } from 'app/entities/rules/rule.selectors';
 
+export enum ProjectTabNames {
+  Rules = 'rules',
+  Details = 'details'
+}
+
 @Component({
   selector: 'app-project-details',
   templateUrl: './project-details.component.html',
@@ -33,7 +38,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   public saveSuccessful = false;
   public isChefManaged = false;
   public rules: Rule[] = [];
-  public selectedTab: 'rules' | 'details' = 'rules';
+  public selectedTab: ProjectTabNames.Rules | ProjectTabNames.Details = ProjectTabNames.Rules;
   public ruleToDelete: any;
   public deleteModalVisible = false;
   public createModalVisible = false;

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -3,8 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Store } from '@ngrx/store';
 import { Subject, combineLatest } from 'rxjs';
 import { filter, map, pluck, takeUntil } from 'rxjs/operators';
-import { identity } from 'lodash/fp';
-import { find as _find } from 'lodash';
+import { identity, find } from 'lodash/fp';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams } from 'app/route.selectors';
@@ -24,6 +23,11 @@ import {
 export enum ProjectTabNames {
   Rules = 'rules',
   Details = 'details'
+}
+
+export enum RuleStatus {
+  Applied = 'applied',
+  Staged = 'staged'
 }
 
 @Component({
@@ -134,10 +138,8 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
     this.closeDeleteModal();
   }
 
-  getEditStatus(status: string): string {
-    return status === 'staging'
-      ? 'Edits pending'
-      : 'Applied';
+  getEditStatus(rule: Rule): string {
+    return rule.status === RuleStatus.Staged ? 'Edits pending' : 'Applied';
   }
 
   showDeleteRule(rule: Rule): boolean {
@@ -145,7 +147,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   }
 
   showProjectLink(): boolean {
-    return _find(this.rules, ['edits', 'staging']) ? true : false;
+    return find(['status', RuleStatus.Staged], this.rules) ? true : false;
   }
 
   saveProject() {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -3,7 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Store } from '@ngrx/store';
 import { Subject, combineLatest } from 'rxjs';
 import { filter, map, pluck, takeUntil } from 'rxjs/operators';
-import { identity, find } from 'lodash/fp';
+import { identity, some } from 'lodash/fp';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams } from 'app/route.selectors';
@@ -139,7 +139,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   }
 
   showProjectLink(): boolean {
-    return find(['status', <RuleStatus>'staged'], this.rules) ? true : false;
+    return some(['status', <RuleStatus>'staged'], this.rules);
   }
 
   saveProject() {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -128,13 +128,13 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
     this.deleteModalVisible = false;
   }
 
-  startRuleDelete(r: any): void {
+  startRuleDelete(rule: Rule): void {
     this.deleteModalVisible = true;
-    this.ruleToDelete = r;
+    this.ruleToDelete = rule;
   }
 
   deleteRule(): void {
-    this.store.dispatch(new DeleteRule({id: this.ruleToDelete.id}));
+    this.store.dispatch(new DeleteRule({ id: this.ruleToDelete.id }));
     this.closeDeleteModal();
   }
 
@@ -142,8 +142,8 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
     return rule.status === RuleStatus.Staged ? 'Edits pending' : 'Applied';
   }
 
-  showDeleteRule(rule: Rule): boolean {
-    return rule.edits !== 'staging';
+  showDeleteRule(): boolean {
+    return true; // TODO: return false when *project* status is "updating..."
   }
 
   showProjectLink(): boolean {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -100,7 +100,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
     this.saveSuccessful = false;
   }
 
-  onTabChange(event) {
+  onTabChange(event: { target: { value: ProjectTabName } }) {
     this.selectedTab = event.target.value;
   }
 

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -56,9 +56,16 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   constructor(
     private fb: FormBuilder,
     private store: Store<NgrxStateAtom>
-  ) {
+  ) { }
 
-   combineLatest(
+  ngOnInit(): void {
+
+    this.projectForm = this.fb.group({
+      // Must stay in sync with error checks in project-details.component.html
+      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
+    });
+
+    combineLatest(
       this.store.select(getStatus),
       this.store.select(updateStatus)
     ).pipe(
@@ -76,7 +83,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
       map((state) => {
         this.project = <Project>Object.assign({}, state);
         this.store.dispatch(new GetRulesForProject({ project_id: this.project.id }));
-        store.select(allRules).subscribe((rules) => {
+        this.store.select(allRules).subscribe((rules) => {
           this.rules = rules;
         });
         this.isChefManaged = this.project.type === 'CHEF_MANAGED';
@@ -90,13 +97,6 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
       .subscribe((id: string) => {
         this.store.dispatch(new GetProject({ id }));
       });
-  }
-
-  ngOnInit(): void {
-    this.projectForm = this.fb.group({
-      // Must stay in sync with error checks in project-details.component.html
-      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
-    });
   }
 
   ngOnDestroy() {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -43,7 +43,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   // isLoading represents the initial load as well as subsequent updates in progress.
   public isLoading = true;
   public saving = false;
-  private isDestroyed: Subject<boolean> = new Subject<boolean>();
+  private isDestroyed = new Subject<boolean>();
 
   constructor(
     private fb: FormBuilder,
@@ -139,7 +139,9 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   }
 
   showProjectLink(): boolean {
-    return some(['status', <RuleStatus>'staged'], this.rules);
+    const statusPropertyName = 'status';
+    const ruleStatus: RuleStatus = 'staged';
+    return some([statusPropertyName, ruleStatus], this.rules);
   }
 
   saveProject() {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -20,7 +20,7 @@ import {
   allRules
 } from 'app/entities/rules/rule.selectors';
 
-type ProjectTabNames = 'rules' | 'details';
+export type ProjectTabName = 'rules' | 'details';
 
 @Component({
   selector: 'app-project-details',
@@ -34,7 +34,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   public saveSuccessful = false;
   public isChefManaged = false;
   public rules: Rule[] = [];
-  public selectedTab: ProjectTabNames = 'rules';
+  public selectedTab: ProjectTabName = 'rules';
   public ruleToDelete: any;
   public deleteModalVisible = false;
   public createModalVisible = false;
@@ -104,7 +104,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
     this.selectedTab = event.target.value;
   }
 
-  showTab(tabName: ProjectTabNames): boolean {
+  showTab(tabName: ProjectTabName): boolean {
     return this.selectedTab === tabName;
   }
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -17,7 +17,7 @@
             <chef-input ngDefaultControl formControlName="name"></chef-input>
           </label>
           <chef-error
-            *ngIf="ruleForm.get('name').hasError('required') && ruleForm.get('name').dirty"
+            *ngIf="(ruleForm.get('name').hasError('required') || ruleForm.get('name').hasError('pattern')) && ruleForm.get('name').dirty"
           >Rule Name is required</chef-error>
         </chef-form-field>
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -14,12 +14,40 @@
         <chef-form-field id="create-name">
           <label>
             <span class="label">Rule Name <span aria-hidden="true">*</span></span>
-            <chef-input ngDefaultControl formControlName="name"></chef-input>
+            <chef-input ngDefaultControl formControlName="name" (keyup)="handleNameInput($event)"></chef-input>
           </label>
           <chef-error
             *ngIf="(ruleForm.get('name').hasError('required') || ruleForm.get('name').hasError('pattern')) && ruleForm.get('name').dirty"
           >Rule Name is required.</chef-error>
         </chef-form-field>
+
+        <div *ngIf="modifyID">
+          <chef-form-field id="create-id">
+            <label>
+              <span class="label">ID <span aria-hidden="true">*</span> </span>
+              <chef-input ngDefaultControl formControlName="id" (keyup)="handleIDInput($event)"></chef-input>
+            </label>
+            <chef-error *ngIf="ruleForm.controls['id'].hasError('maxlength')">
+              ID must be 64 characters or less.
+            </chef-error>
+            <chef-error *ngIf="ruleForm.controls['id'].hasError('required')">
+              ID is required.
+            </chef-error>
+            <chef-error *ngIf="ruleForm.controls['id'].hasError('pattern')">
+              Only lowercase letters, numbers, and hyphens(-) are allowed.
+            </chef-error>
+            <chef-error *ngIf="conflictError">
+              IDs must be unique--Rule with ID "{{ruleForm.controls.id.value}}" already exists.
+            </chef-error>
+          </chef-form-field>
+          <small class="help">Rule IDs are unique, permanent, and cannot be changed later.</small>
+        </div>
+        <div *ngIf="!modifyID" id="create-id-static">
+          <span class="key-label">ID:&nbsp;</span><span class="key-value">{{ this.ruleForm.value.id }}</span>
+          <chef-toolbar>
+            <chef-button tertiary (click)="modifyID=true;">Edit ID</chef-button>
+          </chef-toolbar>
+        </div>
 
         <chef-form-field id="create-type">
           <label>
@@ -41,11 +69,11 @@
           <chef-button primary (click)="addCondition()">Add Condition</chef-button>
 
           <div id="condition-list" formArrayName="conditions">
-  
+
             <div class="condition-item"
               [formGroupName]="i"
               *ngFor="let condition of ruleForm.get('conditions').controls; let i = index">
-  
+
               <chef-form-field class="attribute-field">
                 <label>
                   <span class="label">{{ getAttributeLabel() }}</span>
@@ -60,7 +88,7 @@
                   *ngIf="ruleForm.get('conditions').controls[i].get('attribute').hasError('required') && ruleForm.get('conditions').controls[i].get('attribute').touched"
                 >Attribute is required.</chef-error>
               </chef-form-field>
-  
+
               <chef-form-field class="attribute-field">
                 <label>
                   <span class="label">Operator</span>
@@ -74,7 +102,7 @@
                   *ngIf="ruleForm.get('conditions').controls[i].get('operator').hasError('required') && ruleForm.get('conditions').controls[i].get('operator').touched"
                 >Operator is required.</chef-error>
               </chef-form-field>
-  
+
               <chef-form-field class="attribute-field">
                 <label>
                   <span class="label">Value</span>
@@ -95,14 +123,14 @@
                     Comma-separated list, at least one must match exactly.
                 </small>
               </chef-form-field>
-  
+
               <div class="end-row-items">
                 <span *ngIf="showAndLabel(i)" class="label">AND</span>
                 <chef-button tertiary *ngIf="showDelete()" (click)="deleteCondition(i)">
                   <chef-icon>delete</chef-icon>
                 </chef-button>
               </div>
-  
+
             </div>
           </div>
         </div>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -81,7 +81,7 @@
                 <span class="label">Value</span>
                 <chef-input ngDefaultControl
                   formControlName="values"
-                  [value]="getConditionValue(condition.controls.values.value)"
+                  [value]="condition.controls.values.value"
                 ></chef-input>
               </label>
               <chef-error

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -57,6 +57,9 @@
                   >{{ option.value }}</option>
                 </select>
               </label>
+              <chef-error
+                *ngIf="ruleForm.get('conditions').controls[i].get('attribute').hasError('required') && ruleForm.get('conditions').controls[i].get('attribute').touched"
+              >Attribute is required</chef-error>
             </chef-form-field>
 
             <chef-form-field class="attribute-field">
@@ -70,6 +73,9 @@
                   <option value='MEMBER_OF'>member of</option>
                 </select>
               </label>
+              <chef-error
+                *ngIf="ruleForm.get('conditions').controls[i].get('operator').hasError('required') && ruleForm.get('conditions').controls[i].get('operator').touched"
+              >Operator is required</chef-error>
             </chef-form-field>
 
             <chef-form-field class="attribute-field">
@@ -81,18 +87,19 @@
                   (change)="updateConditionValues(condition)"
                 ></chef-input>
               </label>
-
+              <chef-error
+                *ngIf="(ruleForm.get('conditions').controls[i].get('values').hasError('required') || ruleForm.get('conditions').controls[i].get('values').hasError('pattern')) && ruleForm.get('conditions').controls[i].get('values').dirty"
+              >Value is required</chef-error>
               <small class="help"
                 *ngIf="condition.controls.operator.value === 'EQUALS'">
                   Case sensitive, must match exactly.
               </small>
-
               <small class="help"
                 *ngIf="condition.controls.operator.value === 'MEMBER_OF'">
                   Comma-separated list, at least one must match exactly.
               </small>
-
             </chef-form-field>
+
             <chef-form-field class="attribute-field">
               <label>
                 <span *ngIf="showAndLabel(i)" class="label">AND</span>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -104,7 +104,7 @@
               <label>
                 <span *ngIf="showAndLabel(i)" class="label">AND</span>
               </label>
-              <chef-button tertiary *ngIf="showDelete(i)" (click)="deleteCondition(i)">
+              <chef-button tertiary *ngIf="showDelete()" (click)="deleteCondition(i)">
                 <chef-icon>delete</chef-icon>
               </chef-button>
             </chef-form-field>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -65,12 +65,10 @@
             <chef-form-field class="attribute-field">
               <label>
                 <span class="label">Operator</span>
-                <select ngDefaultControl
-                  formControlName="operator"
-                  (change)="updateConditionValues(condition)"
-                >
-                  <option value='EQUALS'>equals</option>
-                  <option value='MEMBER_OF'>member of</option>
+                <select ngDefaultControl formControlName="operator">
+                  <option *ngFor="let operator of operators"
+                    [value]="operator.key"
+                  >{{ operator.value }}</option>
                 </select>
               </label>
               <chef-error
@@ -84,7 +82,6 @@
                 <chef-input ngDefaultControl
                   formControlName="values"
                   [value]="getConditionValue(condition.controls.values.value)"
-                  (change)="updateConditionValues(condition)"
                 ></chef-input>
               </label>
               <chef-error

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -11,20 +11,20 @@
     <ng-container>
       <form id="ruleForm" [formGroup]="ruleForm" (ngSubmit)="saveRule()">
 
-        <chef-form-field class="display3">
+        <chef-form-field id="create-name">
           <label>
             <span class="label">Rule Name</span>
-            <chef-input id="ruleName" ngDefaultControl formControlName="name"></chef-input>
+            <chef-input ngDefaultControl formControlName="name"></chef-input>
           </label>
           <chef-error
             *ngIf="ruleForm.get('name').hasError('required') && ruleForm.get('name').dirty"
-          >Name is required</chef-error>
+          >Rule Name is required</chef-error>
         </chef-form-field>
 
-        <chef-form-field class="display3">
+        <chef-form-field id="create-type">
           <label>
             <span class="label">Resource Type</span>
-            <select id="resourceType" ngDefaultControl formControlName="type">
+            <select id="create-type-dropdown" ngDefaultControl formControlName="type">
               <option value='NODE'>Node</option>
               <option value='EVENT'>Event</option>
             </select>
@@ -51,7 +51,7 @@
               <label>
                 <span class="label">{{ getAttributeLabel() }}</span>
                 <select ngDefaultControl formControlName="attribute">
-                  <option 
+                  <option
                     *ngFor="let option of attributes[ruleForm.get('type').value.toLowerCase()]; let i = index"
                     [value]="option.key"
                   >{{ option.value }}</option>
@@ -71,7 +71,7 @@
                 </select>
               </label>
             </chef-form-field>
-            
+
             <chef-form-field class="attribute-field">
               <label>
                 <span class="label">Value</span>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -32,8 +32,8 @@
           <chef-error
             *ngIf="ruleForm.get('type').hasError('required') && ruleForm.get('type').touched"
           >Resource Type is required</chef-error>
-          <small class="help">Resource types cannot be changed after the rule is created.</small>
         </chef-form-field>
+        <small class="help">Resource types cannot be changed after the rule is created.</small>
 
         <div id="add-condition">
           <div class="label">Conditions</div>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -18,7 +18,7 @@
           </label>
           <chef-error
             *ngIf="(ruleForm.get('name').hasError('required') || ruleForm.get('name').hasError('pattern')) && ruleForm.get('name').dirty"
-          >Rule Name is required</chef-error>
+          >Rule Name is required.</chef-error>
         </chef-form-field>
 
         <chef-form-field id="create-type">
@@ -31,7 +31,7 @@
           </label>
           <chef-error
             *ngIf="ruleForm.get('type').hasError('required') && ruleForm.get('type').touched"
-          >Resource Type is required</chef-error>
+          >Resource Type is required.</chef-error>
         </chef-form-field>
         <small class="help">Resource types cannot be changed after the rule is created.</small>
 
@@ -59,7 +59,7 @@
               </label>
               <chef-error
                 *ngIf="ruleForm.get('conditions').controls[i].get('attribute').hasError('required') && ruleForm.get('conditions').controls[i].get('attribute').touched"
-              >Attribute is required</chef-error>
+              >Attribute is required.</chef-error>
             </chef-form-field>
 
             <chef-form-field class="attribute-field">
@@ -73,7 +73,7 @@
               </label>
               <chef-error
                 *ngIf="ruleForm.get('conditions').controls[i].get('operator').hasError('required') && ruleForm.get('conditions').controls[i].get('operator').touched"
-              >Operator is required</chef-error>
+              >Operator is required.</chef-error>
             </chef-form-field>
 
             <chef-form-field class="attribute-field">
@@ -86,7 +86,7 @@
               </label>
               <chef-error
                 *ngIf="(ruleForm.get('conditions').controls[i].get('values').hasError('required') || ruleForm.get('conditions').controls[i].get('values').hasError('pattern')) && ruleForm.get('conditions').controls[i].get('values').dirty"
-              >Value is required</chef-error>
+              >Value is required.</chef-error>
               <small class="help"
                 *ngIf="condition.controls.operator.value === 'EQUALS'">
                   Case sensitive, must match exactly.

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -30,7 +30,7 @@
             </select>
           </label>
           <chef-error
-            *ngIf="ruleForm.get('type').hasError('required') && ruleForm.get('type').dirty"
+            *ngIf="ruleForm.get('type').hasError('required') && ruleForm.get('type').touched"
           >Resource Type is required</chef-error>
           <small class="help">Resource types cannot be changed after the rule is created.</small>
         </chef-form-field>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -97,14 +97,12 @@
               </small>
             </chef-form-field>
 
-            <chef-form-field class="attribute-field">
-              <label>
-                <span *ngIf="showAndLabel(i)" class="label">AND</span>
-              </label>
+            <div class="end-row-items">
+              <span *ngIf="showAndLabel(i)" class="label">AND</span>
               <chef-button tertiary *ngIf="showDelete()" (click)="deleteCondition(i)">
                 <chef-icon>delete</chef-icon>
               </chef-button>
-            </chef-form-field>
+            </div>
 
           </div>
         </div>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -13,7 +13,7 @@
 
         <chef-form-field id="create-name">
           <label>
-            <span class="label">Rule Name</span>
+            <span class="label">Rule Name <span aria-hidden="true">*</span></span>
             <chef-input ngDefaultControl formControlName="name"></chef-input>
           </label>
           <chef-error
@@ -23,7 +23,7 @@
 
         <chef-form-field id="create-type">
           <label>
-            <span class="label">Resource Type</span>
+            <span class="label">Resource Type <span aria-hidden="true">*</span></span>
             <select id="create-type-dropdown" ngDefaultControl formControlName="type">
               <option value='NODE'>Node</option>
               <option value='EVENT'>Event</option>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -35,75 +35,75 @@
         </chef-form-field>
         <small class="help">Resource types cannot be changed after the rule is created.</small>
 
-        <div id="add-condition">
+        <div id="condition-section" *ngIf="ruleForm.get('type').value">
           <div class="label">Conditions</div>
           <small>All conditions must be true for the rule to be true.</small>
           <chef-button primary (click)="addCondition()">Add Condition</chef-button>
-        </div>
 
-        <div id="condition-list" formArrayName="conditions">
-
-          <div class="condition-item"
-            [formGroupName]="i"
-            *ngFor="let condition of ruleForm.get('conditions').controls; let i = index">
-
-            <chef-form-field class="attribute-field">
-              <label>
-                <span class="label">{{ getAttributeLabel() }}</span>
-                <select ngDefaultControl formControlName="attribute">
-                  <option
-                    *ngFor="let option of attributes[ruleForm.get('type').value.toLowerCase()]; let i = index"
-                    [value]="option.key"
-                  >{{ option.value }}</option>
-                </select>
-              </label>
-              <chef-error
-                *ngIf="ruleForm.get('conditions').controls[i].get('attribute').hasError('required') && ruleForm.get('conditions').controls[i].get('attribute').touched"
-              >Attribute is required.</chef-error>
-            </chef-form-field>
-
-            <chef-form-field class="attribute-field">
-              <label>
-                <span class="label">Operator</span>
-                <select ngDefaultControl formControlName="operator">
-                  <option *ngFor="let operator of operators"
-                    [value]="operator.key"
-                  >{{ operator.value }}</option>
-                </select>
-              </label>
-              <chef-error
-                *ngIf="ruleForm.get('conditions').controls[i].get('operator').hasError('required') && ruleForm.get('conditions').controls[i].get('operator').touched"
-              >Operator is required.</chef-error>
-            </chef-form-field>
-
-            <chef-form-field class="attribute-field">
-              <label>
-                <span class="label">Value</span>
-                <chef-input ngDefaultControl
-                  formControlName="values"
-                  [value]="condition.controls.values.value"
-                ></chef-input>
-              </label>
-              <chef-error
-                *ngIf="(ruleForm.get('conditions').controls[i].get('values').hasError('required') || ruleForm.get('conditions').controls[i].get('values').hasError('pattern')) && ruleForm.get('conditions').controls[i].get('values').dirty"
-              >Value is required.</chef-error>
-              <small class="help"
-                *ngIf="condition.controls.operator.value === 'EQUALS'">
-                  Case sensitive, must match exactly.
-              </small>
-              <small class="help"
-                *ngIf="condition.controls.operator.value === 'MEMBER_OF'">
-                  Comma-separated list, at least one must match exactly.
-              </small>
-            </chef-form-field>
-
-            <div class="end-row-items">
-              <span *ngIf="showAndLabel(i)" class="label">AND</span>
-              <chef-button tertiary *ngIf="showDelete()" (click)="deleteCondition(i)">
-                <chef-icon>delete</chef-icon>
-              </chef-button>
+          <div id="condition-list" formArrayName="conditions">
+  
+            <div class="condition-item"
+              [formGroupName]="i"
+              *ngFor="let condition of ruleForm.get('conditions').controls; let i = index">
+  
+              <chef-form-field class="attribute-field">
+                <label>
+                  <span class="label">{{ getAttributeLabel() }}</span>
+                  <select ngDefaultControl formControlName="attribute">
+                    <option
+                      *ngFor="let option of attributes[ruleForm.get('type').value.toLowerCase()]; let i = index"
+                      [value]="option.key"
+                    >{{ option.value }}</option>
+                  </select>
+                </label>
+                <chef-error
+                  *ngIf="ruleForm.get('conditions').controls[i].get('attribute').hasError('required') && ruleForm.get('conditions').controls[i].get('attribute').touched"
+                >Attribute is required.</chef-error>
+              </chef-form-field>
+  
+              <chef-form-field class="attribute-field">
+                <label>
+                  <span class="label">Operator</span>
+                  <select ngDefaultControl formControlName="operator">
+                    <option *ngFor="let operator of operators"
+                      [value]="operator.key"
+                    >{{ operator.value }}</option>
+                  </select>
+                </label>
+                <chef-error
+                  *ngIf="ruleForm.get('conditions').controls[i].get('operator').hasError('required') && ruleForm.get('conditions').controls[i].get('operator').touched"
+                >Operator is required.</chef-error>
+              </chef-form-field>
+  
+              <chef-form-field class="attribute-field">
+                <label>
+                  <span class="label">Value</span>
+                  <chef-input ngDefaultControl
+                    formControlName="values"
+                    [value]="condition.controls.values.value"
+                  ></chef-input>
+                </label>
+                <chef-error
+                  *ngIf="(ruleForm.get('conditions').controls[i].get('values').hasError('required') || ruleForm.get('conditions').controls[i].get('values').hasError('pattern')) && ruleForm.get('conditions').controls[i].get('values').dirty"
+                >Value is required.</chef-error>
+                <small class="help"
+                  *ngIf="condition.controls.operator.value === 'EQUALS'">
+                    Case sensitive, must match exactly.
+                </small>
+                <small class="help"
+                  *ngIf="condition.controls.operator.value === 'MEMBER_OF'">
+                    Comma-separated list, at least one must match exactly.
+                </small>
+              </chef-form-field>
+  
+              <div class="end-row-items">
+                <span *ngIf="showAndLabel(i)" class="label">AND</span>
+                <chef-button tertiary *ngIf="showDelete()" (click)="deleteCondition(i)">
+                  <chef-icon>delete</chef-icon>
+                </chef-button>
+              </div>
+  
             </div>
-
           </div>
         </div>
       </form>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -25,8 +25,8 @@
           <label>
             <span class="label">Resource Type <span aria-hidden="true">*</span></span>
             <select id="create-type-dropdown" ngDefaultControl formControlName="type">
-              <option value='NODE'>Node</option>
-              <option value='EVENT'>Event</option>
+              <option value='node'>Node</option>
+              <option value='event'>Event</option>
             </select>
           </label>
           <chef-error

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -36,8 +36,18 @@ chef-page {
     padding-top: 26px;
   }
 
-  #add-condition {
+  #condition-section {
+    margin: 1rem 0;
     padding-top: 7px;
+
+    small {
+      display: block;
+      font-size: 12px;
+    }
+
+    chef-button {
+      margin-left: 0;
+    }
   }
 
   .label {
@@ -77,11 +87,11 @@ chef-page {
   }
 
   .end-row-items {
+    display: inline-block;
     margin-top: 21px; // match labels in other columns
     height: 45px; // match "values" input height
     vertical-align: middle;
     width: 18%;
-    display: inline-block;
 
     span {
       display: inline-block;
@@ -101,16 +111,4 @@ chef-page {
     }
   }
 
-  #add-condition {
-    margin: 1rem 0;
-
-    small {
-      display: block;
-      font-size: 12px;
-    }
-
-    chef-button {
-      margin-left: 0;
-    }
-  }
 }

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -18,11 +18,12 @@ chef-page {
 
   chef-input {
     height: 45px;
+    width: 100%;
   }
 
-  #ruleName,
-  #resourceType {
+  #create-name, #create-type, #create-type-dropdown {
     width: 340px;
+    max-width: 340px;
   }
 
   chef-form-field {

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -56,6 +56,10 @@ chef-page {
     }
   }
 
+  #condition-list {
+    padding-top: 4px;
+  }
+
   .label, .key-label {
     font-size: 14px;
     font-weight: 600;

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -26,9 +26,28 @@ chef-page {
     max-width: 340px;
   }
 
+  #create-name {
+    padding-top: 9px;
+  }
+
+  #create-type {
+    padding-top: 26px;
+  }
+
+  #add-condition {
+    padding-top: 7px;
+  }
+
+  .label {
+    font-size: 14px;
+    font-weight: 600;
+    padding-bottom: 0;
+  }
+
   chef-form-field {
-    .label {
-      font-size: 16px;
+
+    label {
+      padding-bottom: 0;
     }
 
     &.attribute-field {
@@ -60,7 +79,8 @@ chef-page {
       .label {
         color: $chef-dark-grey;
         text-transform: uppercase;
-        font-weight: 100;
+        font-size: 12px;
+        font-weight: 200;
       }
 
       chef-select,
@@ -77,6 +97,7 @@ chef-page {
 
     small {
       display: block;
+      font-size: 12px;
     }
 
     chef-button {

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -22,6 +22,7 @@ chef-page {
   }
 
   #create-name,
+  #create-id,
   #create-type,
   #create-type-dropdown {
     width: 340px;
@@ -32,8 +33,13 @@ chef-page {
     padding-top: 9px;
   }
 
-  #create-type {
+  #create-id,
+  #create-id-static {
     padding-top: 26px;
+  }
+
+  #create-type {
+    padding-top: 20px;
   }
 
   #condition-section {
@@ -50,10 +56,18 @@ chef-page {
     }
   }
 
-  .label {
+  .label, .key-label {
     font-size: 14px;
     font-weight: 600;
     padding-bottom: 0;
+  }
+
+  .key-label {
+    display: inline-block;
+  }
+
+  .key-value {
+    font-size: 14px;
   }
 
   .condition-item {

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -21,7 +21,9 @@ chef-page {
     width: 100%;
   }
 
-  #create-name, #create-type, #create-type-dropdown {
+  #create-name,
+  #create-type,
+  #create-type-dropdown {
     width: 340px;
     max-width: 340px;
   }
@@ -44,8 +46,11 @@ chef-page {
     padding-bottom: 0;
   }
 
-  chef-form-field {
+  .condition-item {
+    margin-bottom: 20px;
+  }
 
+  chef-form-field {
     label {
       padding-bottom: 0;
     }
@@ -55,26 +60,6 @@ chef-page {
       position: relative;
       vertical-align: top;
       width: 27%;
-
-      &:last-child {
-        margin: 2.5rem 0px;
-        width: 18%;
-
-        label {
-          display: inline-block;
-        }
-
-        chef-button {
-          position: absolute;
-          right: 0;
-          top: -14px;
-
-          chef-icon {
-            color: $chef-primary-dark;
-            font-size: 1.2rem;
-          }
-        }
-      }
 
       .label {
         color: $chef-dark-grey;
@@ -89,7 +74,31 @@ chef-page {
         width: 95%;
       }
     }
+  }
 
+  .end-row-items {
+    margin-top: 21px; // match labels in other columns
+    height: 45px; // match "values" input height
+    vertical-align: middle;
+    width: 18%;
+    display: inline-block;
+
+    span {
+      display: inline-block;
+      margin-top: 10px;
+      font-size: 12px;
+      font-weight: 200;
+    }
+
+    chef-button {
+      margin-top: 2px;
+      float: right;
+
+      chef-icon {
+        color: $chef-primary-dark;
+        font-size: 1.2rem;
+      }
+    }
   }
 
   #add-condition {

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -7,19 +7,20 @@ import { MockComponent } from 'ng2-mock-component';
 import { using } from 'app/testing/spec-helpers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { IAMType } from 'app/entities/policies/policy.model';
 import { projectEntityReducer } from 'app/entities/projects/project.reducer';
-import { ProjectRulesComponent } from './project-rules.component';
 import { Rule, Condition, ConditionOperator, RuleType } from 'app/entities/rules/rule.model';
 import { ruleEntityReducer } from 'app/entities/rules/rule.reducer';
+import { Project } from 'app/entities/projects/project.model';
+import { ProjectRulesComponent } from './project-rules.component';
 
 describe('ProjectRulesComponent', () => {
   let component: ProjectRulesComponent;
   let fixture: ComponentFixture<ProjectRulesComponent>;
 
-  const project = {
-    id: 'uuid-1', name: 'Default',
-    type: <IAMType>'CHEF_MANAGED'
+  const project = <Project>{
+    id: 'uuid-1',
+    name: 'Default',
+    type: 'CHEF_MANAGED'
   };
 
   beforeEach(async(() => {
@@ -167,10 +168,11 @@ describe('ProjectRulesComponent', () => {
     it('should enable submit when valid', () => {
       component.ruleForm.get('name').setValue('My Rule');
       component.ruleForm.get('type').setValue('NODE');
+      const operator: ConditionOperator  = 'EQUALS';
       component.ruleForm.get('conditions').setValue([
         {
           attribute: 'CHEF_ORGS',
-          operator: <ConditionOperator>'EQUALS',
+          operator: operator,
           values: 'my value'
         }
       ]);
@@ -178,14 +180,16 @@ describe('ProjectRulesComponent', () => {
     });
 
     it('should have attribute label with NODE type', () => {
-      component.ruleForm.get('type').setValue(<RuleType>'node');
+      const ruleType: RuleType = 'node';
+      component.ruleForm.get('type').setValue(ruleType);
       const attributeLabel = component.getAttributeLabel();
       expect(attributeLabel)
         .toBe('node attribute'); // specifically should be lowercase for screen reader
     });
 
     it('should have attribute label with EVENT type', () => {
-      component.ruleForm.get('type').setValue(<RuleType>'event');
+      const ruleType: RuleType = 'event';
+      component.ruleForm.get('type').setValue(ruleType);
       const attributeLabel = component.getAttributeLabel();
       expect(attributeLabel)
         .toBe('event attribute'); // specifically should be lowercase for screen reader

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -205,20 +205,19 @@ describe('ProjectRulesComponent', () => {
     });
 
     it('should not show delete button with one condition', () => {
-      const showDelete = component.showDelete(0);
+      const showDelete = component.showDelete();
       expect(showDelete).toBeFalsy();
     });
 
-    it('should show "and" label with two conditions', () => {
+    it('should show just one "and" label with two conditions', () => {
       component.addCondition();
-      const showAndLabel = component.showAndLabel(0);
-      expect(showAndLabel).toBeTruthy();
+      expect(component.showAndLabel(0)).toBeTruthy();
+      expect(component.showAndLabel(1)).toBeFalsy();
     });
 
-    it('should show delete button with two conditions', () => {
+    it('should show two delete buttons with two conditions', () => {
       component.addCondition();
-      const showDelete = component.showDelete(0);
-      expect(showDelete).toBeTruthy();
+      expect(component.showDelete()).toBeTruthy();
     });
   });
 });

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormArray, FormGroup } from '@angular/forms';
 import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 import * as faker from 'faker';
@@ -198,6 +198,64 @@ describe('ProjectRulesComponent', () => {
       expect(attributeLabel)
         .toBe('event attribute'); // specifically should be lowercase for screen reader
     });
+
+
+    it('converts string to array when switching from equals to member-of', () => {
+      component.ruleForm.get('conditions').setValue([
+        {
+          attribute: 'CHEF_ORGS',
+          operator: 'EQUAL',
+          values: '   one,two,    three   '
+        }
+      ]);
+      const condition = <FormGroup>(<FormArray>component.ruleForm.controls.conditions).controls[0];
+      condition.controls.operator.setValue('MEMBER_OF');
+      component.updateConditionValues(condition);
+      expect(condition.controls.values.value).toEqual(['one', 'two', 'three']);
+    });
+
+    it('converts array to string when switching from member-of to equals', () => {
+      component.ruleForm.get('conditions').setValue([
+        {
+          attribute: 'CHEF_ORGS',
+          operator: 'MEMBER_OF',
+          values: ['one', 'two', 'three']
+        }
+      ]);
+      const condition = <FormGroup>(<FormArray>component.ruleForm.controls.conditions).controls[0];
+      condition.controls.operator.setValue('EQUALS');
+      component.updateConditionValues(condition);
+      expect(condition.controls.values.value).toEqual('one, two, three');
+    });
+
+      it('leaves array unchanged when switching from member-of to member-of', () => {
+      component.ruleForm.get('conditions').setValue([
+        {
+          attribute: 'CHEF_ORGS',
+          operator: 'MEMBER_OF',
+          values: ['one', 'two', 'three']
+        }
+      ]);
+      const condition = <FormGroup>(<FormArray>component.ruleForm.controls.conditions).controls[0];
+      condition.controls.operator.setValue('MEMBER_OF');
+      component.updateConditionValues(condition);
+      expect(condition.controls.values.value).toEqual(['one', 'two', 'three']);
+    });
+
+    it('leaves string unchanged when switching from equals to equals', () => {
+      component.ruleForm.get('conditions').setValue([
+        {
+          attribute: 'CHEF_ORGS',
+          operator: 'EQUAL',
+          values: '   one,two,    three   '
+        }
+      ]);
+      const condition = <FormGroup>(<FormArray>component.ruleForm.controls.conditions).controls[0];
+      condition.controls.operator.setValue('EQUALS');
+      component.updateConditionValues(condition);
+      expect(condition.controls.values.value).toEqual('   one,two,    three   ');
+    });
+
 
     it('should not show "and" label with one condition', () => {
       const showAndLabel = component.showAndLabel(0);

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -3,6 +3,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
+import * as faker from 'faker';
 
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
@@ -114,24 +115,21 @@ describe('ProjectRulesComponent', () => {
       fixture.detectChanges();
     });
 
-    it('the heading should show <Project Name>: Rule', () => {
+    it('with no rule name the heading shows "<Project Name>: Rule"', () => {
       const heading = `${component.project.name}: Rule`;
-      const compHeading = component.getHeading();
-      expect(heading).toBe(compHeading);
+      expect(component.getHeading()).toBe(heading);
     });
 
-    it('the heading should change to <Project Name>: <Rule Name>', () => {
+    it('with a rule name the heading shows "<Project Name>: <Rule Name>"', () => {
       const ruleName = 'My Rule';
       component.ruleForm.get('name').setValue(ruleName);
       const heading = `${component.project.name}: ${ruleName}`;
-      const compHeading = component.getHeading();
-      expect(heading).toBe(compHeading);
+      expect(component.getHeading()).toBe(heading);
     });
 
     it('should have a backroute to project page', () => {
       const backRoute = ['/settings', 'projects', component.project.id];
-      const compBackRoute = component.backRoute();
-      expect(backRoute).toEqual(compBackRoute);
+      expect(component.backRoute()).toEqual(backRoute);
     });
 
     it('the formgroup should have one condition', () => {
@@ -139,28 +137,35 @@ describe('ProjectRulesComponent', () => {
       expect(conditions).toBe(1);
     });
 
-    it('should create a condition', () => {
+    it('upon adding a condition the formgroup includes two conditions', () => {
       component.addCondition();
       const conditions = component.ruleForm.get('conditions').value.length;
       expect(conditions).toBe(2);
     });
 
-    it('should delete a condition', () => {
-      let conditions = component.ruleForm.get('conditions').value.length;
-      expect(conditions).toBe(1);
+    it('upon deleting a condition the condition is removed', () => {
+      component.addCondition();
+      component.addCondition();
+      let conditionCount = component.ruleForm.get('conditions').value.length;
+      expect(conditionCount).toBe(3);
       component.deleteCondition(0);
-      conditions = component.ruleForm.get('conditions').value.length;
-      expect(conditions).toBe(0);
+      conditionCount = component.ruleForm.get('conditions').value.length;
+      expect(conditionCount).toBe(2);
     });
 
     it('should return condition value of string', () => {
-      const conditionValue = component.getConditionValue('adasd');
-      expect(typeof conditionValue === 'string').toBeTruthy();
+      const word = faker.random.word();
+      expect(component.getConditionValue(word)).toBe(word);
     });
 
-    it('should return condition value of array', () => {
-      const conditionValue = component.getConditionValue(['adasd']);
-      expect(typeof conditionValue === 'string').toBeTruthy();
+    it('should return condition value of singleton array', () => {
+      const word = faker.random.word();
+      expect(component.getConditionValue([word])).toBe(word);
+    });
+
+     it('should return condition value of multi-valued array', () => {
+      const wordList = faker.random.words().split(' ');
+      expect(component.getConditionValue(wordList)).toBe(wordList.join(', '));
     });
 
     it('form should be invalid', () => {
@@ -194,7 +199,7 @@ describe('ProjectRulesComponent', () => {
         .toBe('event attribute'); // specifically should be lowercase for screen reader
     });
 
-    it('should not show add label with one condition', () => {
+    it('should not show "and" label with one condition', () => {
       const showAndLabel = component.showAndLabel(0);
       expect(showAndLabel).toBeFalsy();
     });
@@ -204,7 +209,7 @@ describe('ProjectRulesComponent', () => {
       expect(showDelete).toBeFalsy();
     });
 
-    it('should show add label with two conditions', () => {
+    it('should show "and" label with two conditions', () => {
       component.addCondition();
       const showAndLabel = component.showAndLabel(0);
       expect(showAndLabel).toBeTruthy();

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -3,7 +3,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
-import * as faker from 'faker';
 
 import { using } from 'app/testing/spec-helpers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
@@ -152,21 +151,6 @@ describe('ProjectRulesComponent', () => {
       component.deleteCondition(0);
       conditionCount = component.ruleForm.get('conditions').value.length;
       expect(conditionCount).toBe(2);
-    });
-
-    it('should return condition value of string', () => {
-      const word = faker.random.word();
-      expect(component.getConditionValue(word)).toBe(word);
-    });
-
-    it('should return condition value of singleton array', () => {
-      const word = faker.random.word();
-      expect(component.getConditionValue([word])).toBe(word);
-    });
-
-     it('should return condition value of multi-valued array', () => {
-      const wordList = faker.random.words().split(' ');
-      expect(component.getConditionValue(wordList)).toBe(wordList.join(', '));
     });
 
     it('form should be invalid', () => {

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -11,7 +11,7 @@ import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.se
 import { IAMType } from 'app/entities/policies/policy.model';
 import { projectEntityReducer } from 'app/entities/projects/project.reducer';
 import { ProjectRulesComponent } from './project-rules.component';
-import { Rule, Condition, ConditionOperator } from 'app/entities/rules/rule.model';
+import { Rule, Condition, ConditionOperator, RuleType } from 'app/entities/rules/rule.model';
 import { ruleEntityReducer } from 'app/entities/rules/rule.reducer';
 
 describe('ProjectRulesComponent', () => {
@@ -187,14 +187,14 @@ describe('ProjectRulesComponent', () => {
     });
 
     it('should have attribute label with NODE type', () => {
-      component.ruleForm.get('type').setValue('NODE');
+      component.ruleForm.get('type').setValue(<RuleType>'node');
       const attributeLabel = component.getAttributeLabel();
       expect(attributeLabel)
         .toBe('node attribute'); // specifically should be lowercase for screen reader
     });
 
     it('should have attribute label with EVENT type', () => {
-      component.ruleForm.get('type').setValue('EVENT');
+      component.ruleForm.get('type').setValue(<RuleType>'event');
       const attributeLabel = component.getAttributeLabel();
       expect(attributeLabel)
         .toBe('event attribute'); // specifically should be lowercase for screen reader
@@ -222,7 +222,7 @@ describe('ProjectRulesComponent', () => {
         expect(rule.conditions[0]).toEqual(
           <Condition>{
             attribute: uiRule.attribute,
-            operator: operator,
+            operator: uiRule.operator,
             values: expected
           });
       });

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -120,6 +120,13 @@ describe('ProjectRulesComponent', () => {
       expect(component.getHeading()).toBe(heading);
     });
 
+    it('with whitespace for rule name the heading shows "<Project Name>: Rule"', () => {
+      const ruleName = '   ';
+      component.ruleForm.get('name').setValue(ruleName);
+      const heading = `${component.project.name}: Rule`;
+      expect(component.getHeading()).toBe(heading);
+    });
+
     it('with a rule name the heading shows "<Project Name>: <Rule Name>"', () => {
       const ruleName = 'My Rule';
       component.ruleForm.get('name').setValue(ruleName);

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -167,6 +167,7 @@ describe('ProjectRulesComponent', () => {
 
     it('should enable submit when valid', () => {
       component.ruleForm.get('name').setValue('My Rule');
+      component.ruleForm.get('id').setValue('my-rule');
       component.ruleForm.get('type').setValue('NODE');
       const operator: ConditionOperator  = 'EQUALS';
       component.ruleForm.get('conditions').setValue([

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -5,7 +5,6 @@ import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
-import { customMatchers } from 'app/testing/custom-matchers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { IAMType } from 'app/entities/policies/policy.model';
 import { projectEntityReducer } from 'app/entities/projects/project.reducer';
@@ -102,7 +101,6 @@ describe('ProjectRulesComponent', () => {
   }));
 
   beforeEach(() => {
-    jasmine.addMatchers(customMatchers);
     fixture = TestBed.createComponent(ProjectRulesComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -40,13 +40,17 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   public editingRule = false;
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
+  // These constants ensure type safety
+  private equals_op: ConditionOperator = 'EQUALS';
+  private member_of_op: ConditionOperator = 'MEMBER_OF';
+
   public operators = [
     <KVPair>{
-      key: <ConditionOperator>'EQUALS',
+      key: this.equals_op,
       value: 'equals'
     },
     <KVPair>{
-      key: <ConditionOperator>'MEMBER_OF',
+      key: this.member_of_op,
       value: 'member of'
     }
   ];
@@ -204,12 +208,14 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   convertToRule(): Rule {
     const ruleValue = this.ruleForm.value;
     const conditions: Condition[] = [];
+    // This constant ensures type safety
+    const equals_op: ConditionOperator = 'EQUALS';
     ruleValue.conditions.forEach(c => {
       conditions.push(<Condition>{
         attribute: c.attribute,
         operator: c.operator,
           // Convert values string to storage format
-        values: c.operator === <ConditionOperator>'EQUALS'
+        values: c.operator === equals_op
           ? [c.values.trim()]
           : c.values.split(/,\s*/).map(v => v.trim())
       });

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -184,10 +184,6 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     return this.conditions;
   }
 
-  getConditionValue(value: string | string[]): string {
-    return (typeof value === 'string') ? value : value.join(', ');
-  }
-
   createRule() {
     this.store.dispatch(
       new CreateRule({

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -187,6 +187,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   }
 
   createRule() {
+    // TODO: Generate the id!
     this.store.dispatch(
       new CreateRule({
         project_id: this.project.id,
@@ -196,8 +197,6 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
 
   updateRule() {
     const updatedRule = this.convertToRule();
-    updatedRule.id = this.rule.id;
-    updatedRule.project_id = this.rule.project_id;
     this.store.dispatch(new UpdateRule({ rule: updatedRule }));
     this.store.dispatch(new GetRulesForProject({ project_id: this.rule.project_id }));
   }
@@ -216,6 +215,8 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
       });
     });
     return <Rule>{
+      project_id: this.project.id,
+      id: this.rule.id,
       name: ruleValue.name,
       type: ruleValue.type,
       status: 'staged',

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -134,9 +134,10 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
 
   createCondition(attribute = '', operator = '', values = ''): FormGroup {
     return this.fb.group({
+      // Must stay in sync with error checks in project-rules.component.html
       attribute: [attribute, Validators.required],
       operator: [operator, Validators.required],
-      values: [values, Validators.required]
+      values: [values, [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
   }
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -156,9 +156,9 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     return (i + 1) < conditions.length;
   }
 
-  showDelete(i: number): boolean {
+  showDelete(): boolean {
     const conditions = this.ruleForm.get('conditions') as FormArray;
-    return (i + 1) < conditions.length;
+    return conditions.length > 1;
   }
 
   populateConditions() {

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -233,7 +233,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   saveRule() {
     if (this.ruleForm.valid) {
       this.saving = true;
-      this.rule.id ? this.updateRule() : this.createRule();
+      this.rule.id ? this.updateRule() : this.createRule(); // TODO
       const pendingSave = new Subject<boolean>();
       this.store.select(updateStatus).pipe(
         filter(identity),

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -217,7 +217,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
           // Convert values string to storage format
         values: c.operator === equals_op
           ? [c.values.trim()]
-          : c.values.split(/,\s*/).map(v => v.trim())
+          : c.values.split(/,/).map((v: string) => v.trim())
       });
     });
     return <Rule>{

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -124,7 +124,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   }
 
   getHeading() {
-    return `${this.project.name}: ` + (this.ruleForm.value.name || 'Rule');
+    return `${this.project.name}: ` + (this.ruleForm.value.name.trim() || 'Rule');
   }
 
   getAttributeLabel() {

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -37,6 +37,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   public isLoading = true;
   public saving = false;
   public attributes: RuleTypeMappedObject;
+  public editingRule = false;
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
   public operators = [
@@ -91,6 +92,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
         takeUntil(this.isDestroyed),
         map((state) => {
           this.rule = <Rule>Object.assign({}, state);
+          this.editingRule = true;
         })
         ).subscribe();
 
@@ -111,7 +113,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     this.ruleForm = this.fb.group({
       // Must stay in sync with error checks in project-rules.component.html
       name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
-      type: [this.rule.type || '', Validators.required],
+      type: [{ value: this.rule.type || '', disabled: this.editingRule } , Validators.required],
       conditions: this.fb.array(this.populateConditions())
     });
   }

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -175,21 +175,21 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     return this.conditions;
   }
 
-  updateConditionValues(condition): void {
+  updateConditionValues(condition: FormGroup): void {
     if (condition.controls.operator.value === 'MEMBER_OF') {
-      condition.controls.values.value =
+      condition.controls.values.setValue(
         (typeof condition.controls.values.value === 'string')
-          ? [condition.controls.values.value]
-          : condition.controls.values.value.split(',').map((v) => v.trim());
+        ? condition.controls.values.value.split(/,\s*/).map((v: string) => v.trim())
+        : condition.controls.values.value) ;
     } else {
-      condition.controls.values.value =
+      condition.controls.values.setValue(
         (typeof condition.controls.values.value === 'string')
           ? condition.controls.values.value
-          : condition.controls.values.value.join(' ');
+          : condition.controls.values.value.join(', '));
     }
   }
 
-  getConditionValue(value): string {
+  getConditionValue(value: string | string[]): string {
     return (typeof value === 'string') ? value : value.join(', ');
   }
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -10,7 +10,7 @@ import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams } from 'app/route.selectors';
 import { EntityStatus, loading } from 'app/entities/entities';
 import { Regex } from 'app/helpers/auth/regex';
-import { Rule } from 'app/entities/rules/rule.model';
+import { Rule, RuleTypeMappedObject } from 'app/entities/rules/rule.model';
 import {
   GetRule,
   GetRulesForProject,
@@ -37,10 +37,10 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   public ruleId: string;
   public ruleForm: FormGroup;
   public rule: Rule = <Rule>{};
-  public conditions: any[];
+  public conditions: FormGroup[];
   public isLoading = true;
   public saving = false;
-  public attributes: object;
+  public attributes: RuleTypeMappedObject;
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
   constructor(

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -1,13 +1,15 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, FormArray, Validators } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
-import { EntityStatus, loading } from 'app/entities/entities';
 import { Store } from '@ngrx/store';
-import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { routeParams } from 'app/route.selectors';
 import { Subject, combineLatest } from 'rxjs';
 import { map, takeUntil, pluck, filter } from 'rxjs/operators';
 import { identity } from 'lodash/fp';
+
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { routeParams } from 'app/route.selectors';
+import { EntityStatus, loading } from 'app/entities/entities';
+import { Regex } from 'app/helpers/auth/regex';
 import { Rule } from 'app/entities/rules/rule.model';
 import {
   GetRule,
@@ -100,7 +102,8 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.ruleForm = this.fb.group({
-      name: [this.rule.name || '', Validators.required],
+      // Must stay in sync with error checks in project-rules.component.html
+      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       type: [this.rule.type || '', Validators.required],
       conditions: this.fb.array(this.populateConditions())
     });

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -13,7 +13,7 @@ import { IdMapper } from 'app/helpers/auth/id-mapper';
 import { Regex } from 'app/helpers/auth/regex';
 import { EntityStatus, loading } from 'app/entities/entities';
 import {
-  Rule, RuleTypeMappedObject, Condition, ConditionOperator, KVPair
+  Rule, RuleTypeMappedObject, Condition, ConditionOperator
 } from 'app/entities/rules/rule.model';
 import {
   GetRule, GetRulesForProject, CreateRule, UpdateRule
@@ -24,6 +24,11 @@ import {
 import { projectFromRoute } from 'app/entities/projects/project.selectors';
 import { Project } from 'app/entities/projects/project.model';
 import { GetProject } from 'app/entities/projects/project.actions';
+
+interface KVCondition {
+  key: ConditionOperator;
+  value: string;
+}
 
 @Component({
   selector: 'app-project-rules',
@@ -48,17 +53,13 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   // This element assumes 'id' is the only create field that can conflict.
   private conflictErrorEvent = new EventEmitter<boolean>();
 
-  // These constants ensure type safety
-  private equals_op: ConditionOperator = 'EQUALS';
-  private member_of_op: ConditionOperator = 'MEMBER_OF';
-
-  public operators = [
-    <KVPair>{
-      key: this.equals_op,
+  public operators: KVCondition[] = [
+    {
+      key: 'EQUALS',
       value: 'equals'
     },
-    <KVPair>{
-      key: this.member_of_op,
+    {
+      key: 'MEMBER_OF',
       value: 'member of'
     }
   ];


### PR DESCRIPTION
### :nut_and_bolt: Description

This is a follow-on to PR-736, implementing the suggestions/corrections remaining from that PR, plus other issues uncovered.

_Please follow the commits to understand specific changes._

Broadly, this PR covers some architectural changes and some behavioral changes.
The former are covered with my review comments and commit comments; the latter are summarized here:

1. Add an asterisk on name and type indicating required. 🤔 Don't we need to say somewhere `(*) Indicates required fields` ??
2. Tightened spacing per UX design between labels and input boxes.
3. Change the label in the error pop-up to match the `Rule Name` label.
4. Fix the width of the error pop-up to match the `Rule Name` field.
5. Increase spacing per UX design between fields.
6. Add an error pop-up for the `Resource Type` field; this will trigger if you tab your way through the element. 
7. Put that error pop-up immediately beneath the input (instead of beneath the `Resource types cannot be changed...` line). This required moving that line of text outside of the `<chef-form-field>`. Don't know if that will affect a screen reader or not.
8. (no arrow) Adjust the `Rule Name` error pop-up to also appear if only whitespace is typed. (That makes it behave the way every other input field works.)
9. (no arrow) Adjust font sizes/weights of everything except the title and description per UX spec.

![image](https://user-images.githubusercontent.com/6817500/61915481-76849180-aef9-11e9-8642-a04a12d78ea7.png)

1. Add error pop-up for `attribute`. This works independently for each row. Note that always says "Attribute is required" rather than "Event Attribute is required" or "Node Attribute is required". Could add that if desired for consistency. Widths of these pop-ups are a compromise: ideally should be equal to field width, but those elements are too narrow to show the error text. 🤷‍♂ 
2. Add error pop-up for `operator`.
3. Add error pop-up for `value`.
4. Recall in the previous section I mentioned I thought it was desirable to put the error pop-up immediately under the input, not separated by the help line of text, as you see here. Alas, the earlier fix was not viable in this table structure.
5. Displays trash can for all rows--but only when there is more than one row.
6. Adjusted size per UX design spec.

![image](https://user-images.githubusercontent.com/6817500/61916110-0c212080-aefc-11e9-96c1-18fe0dd79c9b.png)


1. Correct enabling control menu: now opens on staged rules.

![image](https://user-images.githubusercontent.com/6817500/61916379-1b549e00-aefd-11e9-85ef-2aea393416cc.png)

1. Disable changing rule type when editing rule.

![image](https://user-images.githubusercontent.com/6817500/61916439-64a4ed80-aefd-11e9-8d3f-25806ee5871b.png)

Still to be done:
Adding the ID as discussed in slack starting here: https://chefio.slack.com/archives/C61F9HHKK/p1564077123212600

### :+1: Definition of Done

Code ready for proper wiring.

### :athletic_shoe: Demo Script / Repro Steps

Rebuild automate-ui.
Go to Settings >> Projects
Create a project.
Create one or more rules for the project with one or more conditions.
Edit a rule.
Add/delete conditions.

_Note that there is no actual storage persistence so you will see some "issues" with data not being saved._

### :chains: Related Resources
https://github.com/chef/automate/pull/736

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
