### PR TITLE
tools: Add danger-delete-ds-certs for emergency cert regen

### DIFF
--- a/tools/danger-delete-ds-certs/main.go
+++ b/tools/danger-delete-ds-certs/main.go
@@ -34,7 +34,7 @@ Do not run this tool when deployment-service is running.
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(*cobra.Command, []string) {
 			if opts.Debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}

--- a/tools/danger-delete-ds-certs/main.go
+++ b/tools/danger-delete-ds-certs/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/chef/automate/components/automate-deployment/pkg/deployment"
+	"github.com/chef/automate/components/automate-deployment/pkg/habpkg"
+	"github.com/chef/automate/components/automate-deployment/pkg/persistence/boltdb"
+)
+
+const DBFile = "/hab/svc/deployment-service/data/bolt.db"
+
+var opts = struct {
+	Debug bool
+}{}
+
+func main() {
+	cmd := &cobra.Command{
+		Use:   "danger-delete-ds-certs",
+		Short: "DANGER -- Removes certificates from a deployment-service database. Only run this tool if directed to by Chef Support",
+		Long: `
+!!! DANGER DANGER DANGER !!!
+
+This tool modifies the deployment-service's bolt database.
+
+Only run this tool if explicitly told to by Chef Support.
+Do not run this tool when deployment-service is running.
+
+!!! DANGER DANGER DANGER !!!
+`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if opts.Debug {
+				logrus.SetLevel(logrus.DebugLevel)
+			}
+		},
+		RunE: run,
+	}
+
+	cmd.PersistentFlags().BoolVarP(
+		&opts.Debug,
+		"debug",
+		"d",
+		false,
+		"Enabled debug output")
+
+	err := cmd.Execute()
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+}
+
+func run(*cobra.Command, []string) error {
+	logrus.Infof("Attempting to remove service certificates from %s", DBFile)
+	database, err := bolt.Open(DBFile, 0600, nil)
+	if err != nil {
+		return errors.Wrap(err, "could not open database")
+	}
+	defer database.Close()
+
+	deploymentStore := boltdb.NewDeploymentStore(database)
+	_, version, err := deploymentStore.TryRead()
+	if err != nil {
+		return errors.Wrap(err, "could not read deployment database")
+	}
+
+	logrus.Debugf("database is at version %s", version.Name())
+	if _, isLatest := version.(boltdb.CurrentVersion); !isLatest {
+		return errors.Wrap(err, "database is not at most recent version, cannot modifiy")
+	}
+
+	err = deploymentStore.Initialize()
+	if err != nil {
+		return errors.Wrap(err, "could not initialize database")
+	}
+
+	_, err = deploymentStore.UpdateDeployment(func(d *deployment.Deployment) error {
+		for _, s := range d.ExpectedServices {
+			if s.SSLKey != "" || s.SSLCert != "" {
+				logrus.Infof("Found certificate data for %s", habpkg.ShortIdent(s))
+				s.SSLKey = ""
+				s.SSLCert = ""
+			} else {
+				logrus.Infof("No certificate data for %s", habpkg.ShortIdent(s))
+			}
+		}
+		return nil
+	})
+	return err
+}


### PR DESCRIPTION
### :nut_and_bolt: Description

As outlined in

https://discourse.chef.io/t/important-chef-automate-2-internal-certificate-expiration/15624

users may soon be approaching the expiration date of their internal
certificates. For those on most recent versions, the
deployment-service will attempt to regenerate the certificates
automatically, and the chef-automate tool provides tooling to do this
manually.

However, for users on older versions this is not the case.

For versions 20181020020209 or higher, the following alternate
strategy should work:

    rm /hab/svc/deployment-service/data/*.crt  /hab/svc/deployment-service/data/*.key /hab/svc/deployment-service/data/*.crl
    hab svc status
    # get chef/deployment-service pid
    kill "$DEPLOYMENT_SERVICE_PID"

For versions older than 20181020020209, this will not work. Rather,
the tooling added in this PR will be required:

    # Not that if the services are alraedy failing, many of these hab
    # commands may take several seconds:
    #
    # Get the deployment-service ident
    DS_IDENT=$(hab svc status | awk '/chef\/deployment-service/ { print $1}')
    # Unload the deployment-service
    # Ident here is an example, it should come from the command above.
    hab svc unload "$DS_IDENT"
    # Wait for deployment-service to actually stop
    ps auxww | grep deployment-service
    # Delete the existing certificates from disk
    rm /hab/svc/deployment-service/data/*.crt  /hab/svc/deployment-service/data/*.key /hab/svc/deployment-service/data/*.crl
    # Run our custom tool, support should have given this to you
    ./danger-delete-ds-certs --debug
    # Reload deployment-service
    hab svc load "$DS_IDENT"
    # Wait for services to come up
    chef-autoamte status
    # Remove this tool and never user it again
    rm ./danger-delete-ds-certs

Signed-off-by: Steven Danna <steve@chef.io>