### PR TITLE
add telemetry for node integration type and scan job payload

### DIFF
--- a/components/automate-ui/src/app/entities/jobs/job.requests.ts
+++ b/components/automate-ui/src/app/entities/jobs/job.requests.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 
 import { environment as env } from '../../../environments/environment';
 import { Job } from './job.model';
+import { TelemetryService } from '../../services/telemetry/telemetry.service';
 
 export interface JobsResponse {
   jobs: Job[];
@@ -23,7 +24,7 @@ export interface JobUpdateResponse {
 @Injectable()
 export class JobRequests {
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private telemetryService: TelemetryService) {}
 
   public fetchJobs(params): Observable<JobsResponse> {
     return this.http.post<JobsResponse>(`${env.compliance_url}/scanner/jobs/search`, params);
@@ -34,6 +35,7 @@ export class JobRequests {
   }
 
   public jobCreate(params): Observable<JobCreateResponse> {
+    this.telemetryService.track('scanJobCreation', { params });
     return this.http.post<JobCreateResponse>(`${env.compliance_url}/scanner/jobs`, params);
   }
 

--- a/components/automate-ui/src/app/entities/managers/manager.requests.ts
+++ b/components/automate-ui/src/app/entities/managers/manager.requests.ts
@@ -11,6 +11,7 @@ import {
   ManagerSearchNodesPayload,
   ManagerSearchFieldsPayload
 } from './manager.actions';
+import { TelemetryService } from '../../services/telemetry/telemetry.service';
 
 export interface ManagersSearchResponse {
   managers: Manager[];
@@ -34,7 +35,7 @@ export interface ManagerSearchFieldsResponse {
 @Injectable()
 export class ManagerRequests {
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private telemetryService: TelemetryService) { }
 
   public search(payload: ManagersSearchPayload): Observable<ManagersSearchResponse> {
     const url = `${env.nodemgrs_url}/search`;
@@ -79,6 +80,8 @@ export class ManagerRequests {
   }
 
   public create(managerData) {
+    const managerType = managerData['type'];
+    this.telemetryService.track('nodeManagerType', { managerType });
     return this.http.post<Manager>(`${env.nodemgrs_url}`, mapKeys(snakeCase, managerData));
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description
Just adding a couple telemetry calls to track:
- node integration type
- scan job creation data

### :+1: Definition of Done
telemetry calls for the two above mentioned items

### :athletic_shoe: Demo Script / Repro Steps
build components/automate-ui
create node integration, see telemetry call in dev tools
create scan job, see telemetry call in dev tools
