### PR TITLE
Use correct format strings for 24h instead of 12h

### DIFF
--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -33,7 +33,7 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   //
   // TODO @afiune we should move this to a common place where other
   // components can usee this time format
-  readonly RFC2822 = 'ddd, DD MMM YYYY, hh:mm:ss [UTC]';
+  readonly RFC2822 = 'ddd, DD MMM YYYY, HH:mm:ss [UTC]';
 
   public services$: Observable<Service[]>;
   public servicesStatus$: Observable<EntityStatus>;


### PR DESCRIPTION
### :nut_and_bolt: Description

I found an unrelated bug when investigating https://github.com/chef/automate/issues/972

We used the 12 hour format `h` in our time wizard time format when it should have been 24 hour `H`. So anything that happened in the afternoon/evening UTC time would show up with the wrong time.

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

Wait until 13:00 or later UTC. `start_all_services` in the studio, then run `applications_populate_database`. Navigate to the applications page, then hover over the text that's like `Since the service was loaded, 45 minutes 47 seconds ago`, and you will see it says the wrong hour. In my case, it should have said `21` for the hour but it said `09` (because `21 - 12 == 9`). 

Then build automate-ui, wait a bit for it to load and refresh the page, it will say the correct time.

### :chains: Related Resources

https://momentjs.com/docs/#/displaying/

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?