### PR TITLE
authz-service/sql: make helper methods strict

### DIFF
--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -415,10 +415,11 @@ func (s *policyServer) CreateRole(
 	case nil: // continue
 	case storage_errors.ErrConflict:
 		return nil, status.Errorf(codes.AlreadyExists, "role with id %q already exists", req.Id)
-	case storage_errors.ErrForeignKey:
-		return nil, status.Errorf(codes.NotFound, "could not create role with projects %s as "+
-			"some projects were not found", req.Projects)
 	default:
+		switch err.(type) {
+		case *storage_errors.ErrForeignKey:
+			return nil, status.Errorf(codes.NotFound, err.Error())
+		}
 		return nil, status.Errorf(codes.Internal, "creating role %q: %s", req.Id, err.Error())
 	}
 

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -164,16 +164,15 @@ func (s *policyServer) CreatePolicy(
 	}
 
 	returnPol, err := s.store.CreatePolicy(ctx, &pol)
-
-	if err, ok := err.(*storage_errors.ErrRoleMustExistForStatement); ok {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
 	switch err {
 	case nil: // continue
 	case storage_errors.ErrConflict:
 		return nil, status.Errorf(codes.AlreadyExists,
 			"policy with id %q already exists", req.Id)
 	default:
+		if err, ok := err.(*storage_errors.ErrForeignKey); ok {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 		return nil, status.Errorf(codes.Internal,
 			"creating policy %q: %s", req.Id, err.Error())
 	}
@@ -271,19 +270,18 @@ func (s *policyServer) UpdatePolicy(
 	}
 
 	polInternal, err := s.store.UpdatePolicy(ctx, &storagePolicy)
-
-	if err, ok := err.(*storage_errors.ErrRoleMustExistForStatement); ok {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-
 	if err != nil {
 		switch err {
 		case storage_errors.ErrConflict:
 			return nil, status.Errorf(codes.AlreadyExists, "policy with name %q already exists", req.Name)
 		case storage_errors.ErrNotFound:
 			return nil, status.Errorf(codes.NotFound, "no policy with ID %q found", req.Id)
+		default:
+			if err, ok := err.(*storage_errors.ErrForeignKey); ok {
+				return nil, status.Error(codes.InvalidArgument, err.Error())
+			}
+			return nil, err
 		}
-		return nil, err
 	}
 
 	return policyFromInternal(polInternal)

--- a/components/authz-service/storage/errors.go
+++ b/components/authz-service/storage/errors.go
@@ -22,9 +22,6 @@ var (
 	// ErrGenerateUUID occurs when a UUID could not be generated for a new object.
 	ErrGenerateUUID = errors.New("could not generate UUID")
 
-	// ErrForeignKey occurs, among other times, when attempting to insert a foreign key whose referent does not exist
-	ErrForeignKey = errors.New("foreign key violation")
-
 	// ErrMaxProjectsExceeded indicates that a new project cannot be created
 	// since the max allowed are already created.
 	ErrMaxProjectsExceeded = errors.New("max projects allowed")
@@ -81,4 +78,12 @@ func NewMissingFieldError(f string) error {
 
 func (e *ErrMissingField) Error() string {
 	return "must supply policy " + e.field
+}
+
+type ErrForeignKey struct {
+	Msg string
+}
+
+func (e *ErrForeignKey) Error() string {
+	return e.Msg
 }

--- a/components/authz-service/storage/errors.go
+++ b/components/authz-service/storage/errors.go
@@ -39,20 +39,6 @@ var (
 	ErrChangeTypeForRule = errors.New("cannot change rule type")
 )
 
-// ErrRoleMustExistForStatement indicates that the user attempted to insert a role that
-// does not exist into a new or updated policy statement
-type ErrRoleMustExistForStatement struct {
-	pgErrMessage string
-}
-
-func NewErrRoleMustExistForStatement(pgErrMessage string) error {
-	return &ErrRoleMustExistForStatement{pgErrMessage: pgErrMessage}
-}
-
-func (e *ErrRoleMustExistForStatement) Error() string {
-	return e.pgErrMessage
-}
-
 // ErrTxCommit occurs when the database attempts to commit a transaction and
 // fails.
 type ErrTxCommit struct {

--- a/components/authz-service/storage/errors_test.go
+++ b/components/authz-service/storage/errors_test.go
@@ -17,11 +17,3 @@ func TestNewErrTxCommit(t *testing.T) {
 		assert.Equal(t, "commit db transaction: "+errStr, txErr.Error())
 	})
 }
-
-func TestNewErrRoleMustExistForStatement(t *testing.T) {
-	t.Run("ErrTxCommit.Error() does not cause an infinite loop", func(t *testing.T) {
-		pgErrStr := "role must exist to be inserted into a policy statement, missing role with ID: missing"
-		err := storage.NewErrRoleMustExistForStatement(pgErrStr)
-		assert.Equal(t, pgErrStr, err.Error())
-	})
-}

--- a/components/authz-service/storage/postgres/datamigration/sql/01_v2_data_migrations.up.sql
+++ b/components/authz-service/storage/postgres/datamigration/sql/01_v2_data_migrations.up.sql
@@ -9,12 +9,6 @@ UPDATE iam_members
         name = 'team:local:operators';
 
 UPDATE iam_statements
-    SET
-        role_id = role_db_id('editor')
-    WHERE
-        role_id = role_db_id('operator');
-
-UPDATE iam_statements
     SET resources = array_replace(resources, 'team:local:operator', 'team:local:editor');
 
 UPDATE iam_roles

--- a/components/authz-service/storage/postgres/datamigration/sql/02_v2_rename_all_actions.up.sql
+++ b/components/authz-service/storage/postgres/datamigration/sql/02_v2_rename_all_actions.up.sql
@@ -1,11 +1,5 @@
 BEGIN;
 
-UPDATE iam_statements
-    SET
-        role_id = role_db_id('owner')
-    WHERE
-        role_id = role_db_id('all-actions');
-
 UPDATE iam_roles
     SET
         id = 'owner',

--- a/components/authz-service/storage/postgres/migration/sql/63_make_db_id_lookup_functions_strict.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/63_make_db_id_lookup_functions_strict.up.sql
@@ -32,5 +32,23 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION role_db_id (
+    _id iam_roles.id % TYPE,
+    OUT _db_id iam_roles.db_id % TYPE
+)
+    RETURNS iam_roles.db_id % TYPE
+    AS $$
+BEGIN
+    SELECT
+        db_id INTO _db_id
+    FROM
+        iam_roles
+    WHERE
+        id = _id;
+    IF NOT FOUND THEN
+        RAISE foreign_key_violation USING MESSAGE='role not found: ' || _id;
+    END IF;
+END;
+$$
+LANGUAGE plpgsql;
 COMMIT;
-

--- a/components/authz-service/storage/postgres/migration/sql/63_make_db_id_lookup_functions_strict.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/63_make_db_id_lookup_functions_strict.up.sql
@@ -1,5 +1,4 @@
 BEGIN;
-
 -- lookup by name, the UUID column can go away
 CREATE OR REPLACE FUNCTION member_db_id (
     _name iam_members.name % TYPE,
@@ -17,6 +16,21 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
-
+CREATE OR REPLACE FUNCTION policy_db_id (
+    _id iam_policies.id % TYPE,
+    OUT _db_id iam_policies.db_id % TYPE
+)
+    RETURNS iam_policies.db_id % TYPE
+    AS $$
+BEGIN
+    SELECT
+        db_id INTO STRICT _db_id
+    FROM
+        iam_policies
+    WHERE
+        id = _id;
+END;
+$$
+LANGUAGE plpgsql;
 COMMIT;
 

--- a/components/authz-service/storage/postgres/migration/sql/63_make_db_id_lookup_functions_strict.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/63_make_db_id_lookup_functions_strict.up.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+-- lookup by name, the UUID column can go away
+CREATE OR REPLACE FUNCTION member_db_id (
+    _name iam_members.name % TYPE,
+    OUT _db_id iam_members.db_id % TYPE
+)
+    RETURNS iam_members.db_id % TYPE
+    AS $$
+BEGIN
+    SELECT
+        db_id INTO STRICT _db_id
+    FROM
+        iam_members
+    WHERE
+        name = _name;
+END;
+$$
+LANGUAGE plpgsql;
+
+COMMIT;
+

--- a/components/authz-service/storage/postgres/migration/sql/63_make_db_id_lookup_functions_strict.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/63_make_db_id_lookup_functions_strict.up.sql
@@ -1,5 +1,8 @@
 BEGIN;
+
 -- lookup by name, the UUID column can go away
+-- Note: no need to raise a custom exception here, either, as we're only
+-- calling this function internally after having upsert'ed the members.
 CREATE OR REPLACE FUNCTION member_db_id (
     _name iam_members.name % TYPE,
     OUT _db_id iam_members.db_id % TYPE
@@ -16,6 +19,11 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
+
+-- Note: we don't raise any customized exceptions here, since this is
+-- never called using user-provided inputs. It's only called internally
+-- when linking the statements to their policies; and when deleting a
+-- policy's members.
 CREATE OR REPLACE FUNCTION policy_db_id (
     _id iam_policies.id % TYPE,
     OUT _db_id iam_policies.db_id % TYPE
@@ -32,6 +40,7 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION role_db_id (
     _id iam_roles.id % TYPE,
     OUT _db_id iam_roles.db_id % TYPE
@@ -46,9 +55,32 @@ BEGIN
     WHERE
         id = _id;
     IF NOT FOUND THEN
-        RAISE foreign_key_violation USING MESSAGE='role not found: ' || _id;
+        RAISE foreign_key_violation
+        USING MESSAGE = 'role not found: ' || _id;
     END IF;
 END;
 $$
 LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION project_db_id (
+    _id iam_projects.id % TYPE,
+    OUT _db_id iam_projects.db_id % TYPE
+)
+    RETURNS iam_projects.db_id % TYPE
+    AS $$
+BEGIN
+    SELECT
+        db_id INTO _db_id
+    FROM
+        iam_projects
+    WHERE
+        id = _id;
+    IF NOT FOUND THEN
+        RAISE foreign_key_violation
+        USING MESSAGE = 'project not found: ' || _id;
+    END IF;
+END;
+$$
+LANGUAGE plpgsql;
+
 COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -62,3 +62,4 @@
 - [`60_use_db_id_as_primary_key_in_iam_statement_projects.up.sql`](60_use_db_id_as_primary_key_in_iam_statement_projects.up.sql)
 - [`61_use_role_db_id_in_iam_statements.up.sql`](61_use_role_db_id_in_iam_statements.up.sql)
 - [`62_add_not_null_constraints.up.sql`](62_add_not_null_constraints.up.sql)
+- [`63_make_db_id_lookup_functions_strict.up.sql`](63_make_db_id_lookup_functions_strict.up.sql)

--- a/components/authz-service/storage/postgres/postgres.go
+++ b/components/authz-service/storage/postgres/postgres.go
@@ -69,14 +69,14 @@ func ProcessError(err error) error {
 }
 
 // parsePQError is able to parse pq specific errors into storage interface errors.
-func parsePQError(err *pq.Error) error {
-	switch err.Code {
+func parsePQError(e *pq.Error) error {
+	switch e.Code {
 	case "DRPPC": // Custom code: attempt to delete a non-deletable policy defined in migration 02
 		return storage.ErrCannotDelete
 	case "23505": // Unique violation
 		return storage.ErrConflict
 	case "23503": // Foreign key violation
-		return storage.ErrForeignKey
+		return &storage.ErrForeignKey{Msg: e.Message}
 	case "P0002": // Not found in plpgsql ("no_data_found")
 		return storage.ErrNotFound
 	case "20000": // Not found
@@ -88,7 +88,7 @@ func parsePQError(err *pq.Error) error {
 	case "RLTYP": // Custom code: attempt to update a rule's type that is immutable
 		return storage.ErrChangeTypeForRule
 	case "RDNES": // Custom code: attempt to create a policy statement with a role that does not exist
-		return storage.NewErrRoleMustExistForStatement(err.Message)
+		return storage.NewErrRoleMustExistForStatement(e.Message)
 	}
 
 	return storage.ErrDatabase

--- a/components/authz-service/storage/postgres/postgres.go
+++ b/components/authz-service/storage/postgres/postgres.go
@@ -87,8 +87,6 @@ func parsePQError(e *pq.Error) error {
 		return storage.ErrMarkedForDeletion
 	case "RLTYP": // Custom code: attempt to update a rule's type that is immutable
 		return storage.ErrChangeTypeForRule
-	case "RDNES": // Custom code: attempt to create a policy statement with a role that does not exist
-		return storage.NewErrRoleMustExistForStatement(e.Message)
 	}
 
 	return storage.ErrDatabase

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -337,13 +337,7 @@ func (p *pg) insertPolicyStatementsWithQuerier(ctx context.Context,
 			pq.Array(s.Resources), s.Role, pq.Array(s.Projects),
 		)
 		if err != nil {
-			err = p.processError(err)
-			switch err {
-			case storage_errors.ErrForeignKey: // occurs when a project in the statement does not exist
-				return errors.Errorf("not allowed: one or more of the projects %s does not exist", s.Projects)
-			default:
-				return err
-			}
+			return p.processError(err)
 		}
 	}
 
@@ -367,13 +361,7 @@ func (p *pg) associatePolicyWithProjects(ctx context.Context,
 			`INSERT INTO iam_policy_projects (policy_id, project_id) VALUES (policy_db_id($1), project_db_id($2))`,
 			&policyID, &project)
 		if err != nil {
-			err = p.processError(err)
-			switch err {
-			case storage_errors.ErrForeignKey: // occurs when a project in the policy does not exist
-				return errors.Errorf("not allowed: one or more of the projects %s does not exist", inProjects)
-			default:
-				return err
-			}
+			return p.processError(err)
 		}
 	}
 
@@ -454,13 +442,7 @@ func (p *pg) AddPolicyMembers(ctx context.Context, id string, members []v2.Membe
 	for _, member := range members {
 		err := p.insertOrReusePolicyMemberWithQuerier(ctx, id, member, tx)
 		if err != nil {
-			err = p.processError(err)
-			switch err {
-			case storage_errors.ErrForeignKey: // occurs when id not found for policy
-				return nil, storage_errors.ErrNotFound
-			default:
-				return nil, err
-			}
+			return nil, p.processError(err)
 		}
 	}
 
@@ -499,13 +481,7 @@ func (p *pg) ReplacePolicyMembers(ctx context.Context, policyID string, members 
 
 	err = p.replacePolicyMembersWithQuerier(ctx, policyID, members, tx)
 	if err != nil {
-		err = p.processError(err)
-		switch err {
-		case storage_errors.ErrForeignKey: // occurs when id not found for policy
-			return nil, storage_errors.ErrNotFound
-		default:
-			return nil, err
-		}
+		return nil, p.processError(err)
 	}
 
 	// fetch fresh data so returned data will reflect that any pre-existing members re-use existing IDs
@@ -555,8 +531,6 @@ func (p *pg) RemovePolicyMembers(ctx context.Context,
 			err = p.processError(err)
 			switch err {
 			case storage_errors.ErrNotFound: // continue
-			case storage_errors.ErrForeignKey:
-				return nil, storage_errors.ErrNotFound
 			default:
 				return nil, err
 			}
@@ -613,7 +587,7 @@ func (p *pg) insertOrReusePolicyMemberWithQuerier(ctx context.Context, policyID 
 	// not deleting any of the rows, but reusing them per name string.
 
 	_, err := q.ExecContext(ctx,
-		 `INSERT INTO iam_members (id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING;`,
+		`INSERT INTO iam_members (id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING;`,
 		member.ID, member.Name)
 	if err != nil {
 		return errors.Wrapf(err, "failed to upsert member %s (id %s)", member.Name, member.ID)

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -937,7 +937,6 @@ func TestDeletePolicy(t *testing.T) {
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1`, sID1))
 			// Members get left in the table for now.
 			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_members WHERE id=$1`, member.ID))
-			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_policy_members WHERE policy_id=policy_db_id($1)`, polID1))
 			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_policies`))
 			assertCount(t, 2, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE policy_id=policy_db_id($1)`, polID0))
 		},
@@ -1458,8 +1457,6 @@ func TestCreatePolicy(t *testing.T) {
 			assertEmpty(t,
 				db.QueryRow(`SELECT count(*) FROM iam_policies WHERE id=$1 AND name=$2 AND type=$3`,
 					polID, name, typeVal.String()))
-			// and it doesn't have any statements...
-			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE policy_id=policy_db_id($1)`, failedPolID))
 			// however, the original statement is still there
 			assertOne(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1 AND resources=$2 AND actions=$3 AND effect=$4 AND policy_id=policy_db_id($5)`,
 				sID, pq.Array(resources), pq.Array(actions), "allow", polID))

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -3,7 +3,6 @@ package postgres_test
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -1116,10 +1115,9 @@ func TestCreatePolicy(t *testing.T) {
 			require.Error(t, err)
 			assert.Nil(t, resp)
 
-			_, wasCorrectError := err.(*storage_errors.ErrRoleMustExistForStatement)
+			_, wasCorrectError := err.(*storage_errors.ErrForeignKey)
 			assert.True(t, wasCorrectError)
-			assert.Equal(t,
-				fmt.Sprintf("role must exist to be inserted into a policy statement, missing role with ID: %s", role), err.Error())
+			assert.Equal(t, "role not found: "+role, err.Error())
 
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_policies WHERE id=$1`, polID))
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE id=$1`, sID))


### PR DESCRIPTION
### :nut_and_bolt: Description

The helper methods are strict now. There's no customer impact besides a bit of warm, fuzzy feeling for our developers knowing their database contents are consistent.

Also refactored some of the error handling, using the foreign key exception to signal missing roles or projects in policy creations etc.

### :athletic_shoe: Demo Script / Repro Steps

See tests pass.

### :chains: Related Resources

- #832 
