### PR TITLE
Use full path to chef-server-ctl during migration

### DIFF
--- a/components/automate-deployment/pkg/a1upgrade/a1commands.go
+++ b/components/automate-deployment/pkg/a1upgrade/a1commands.go
@@ -123,7 +123,7 @@ func SystemCtlIsEnabledChefServer() bool {
 // ChefServerCtlStop stops all Chef Server services via
 // chef-server-ctl.
 func ChefServerCtlStop() error {
-	return defaultCommandExecutor.Run("chef-server-ctl",
+	return defaultCommandExecutor.Run("/opt/opscode/bin/chef-server-ctl",
 		command.Args("stop"),
 		command.Timeout(automateCtlTimeout))
 }
@@ -131,7 +131,7 @@ func ChefServerCtlStop() error {
 // ChefServerCtlStopService stops the given service using
 // chef-server-ctl.
 func ChefServerCtlStopService(svcName string) error {
-	return defaultCommandExecutor.Run("chef-server-ctl",
+	return defaultCommandExecutor.Run("/opt/opscode/bin/chef-server-ctl",
 		command.Args("stop", svcName),
 		command.Timeout(automateCtlTimeout))
 }

--- a/integration/tests/a1migration.sh
+++ b/integration/tests/a1migration.sh
@@ -20,6 +20,12 @@ do_build() {
 }
 
 do_deploy() {
+    # We read chef-server-ctl directly from /opt/opscode/bin because automate
+    # has its own chef-server-ctl that can overwrite the original. This happens
+    # when bin and usr/bin are the same directory and thus migrations will fail.
+    mkdir -p /opt/opscode/bin/
+    cp "$A2_ROOT_DIR/components/automate-deployment/bin/linux/chef-server-ctl" /opt/opscode/bin/
+
     #shellcheck disable=SC2154
     chef-automate migrate-from-v1 "$test_config_path" \
         --hartifacts "$test_hartifacts_path" \


### PR DESCRIPTION
A1 migration will fail for people with /bin linked to /usr/bin
because we binlink chef-server-ctl into /bin before the migration is
complete. This prevents us from calling the correct chef-server-ctl.
I hope this commit fixes that
