### PR TITLE
ci: try verify_build in docker for better isolation

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -54,19 +54,18 @@ steps:
     command:
       - scripts/verify_build.sh
     timeout_in_minutes: 45
-    env:
-      ALLOW_LOCAL_PACKAGES: true
-      HAB_STUDIO_SUP: false
-      HAB_NONINTERACTIVE: true
     expeditor:
       secrets:
         HAB_STUDIO_SECRET_GITHUB_TOKEN:
           account: github/chef-ci
           field: token
       executor:
-        linux:
+        docker:
           privileged: true
-
+          environment:
+            - ALLOW_LOCAL_PACKAGES=true
+            - HAB_STUDIO_SUP=false
+            - HAB_NONINTERACTIVE=true
 
   - label: "[unit] license-control-service"
     command:

--- a/scripts/verify_build.sh
+++ b/scripts/verify_build.sh
@@ -63,7 +63,7 @@ done
 if [[ "$build_commands" != "" ]]; then
     # We override HAB_CACHE_KEY_PATH to ensure we only see the key we
     # generated in this build
-    HAB_DOCKER_OPTS="--tty" HAB_ORIGIN="" HAB_CACHE_KEY_PATH=$RESOLVED_RESULTS_DIR DO_CHECK=true hab studio -D run "source .studiorc; set -e; $build_commands"
+    HAB_ORIGIN=chef HAB_CACHE_KEY_PATH=$RESOLVED_RESULTS_DIR DO_CHECK=true hab studio run "source .studiorc; set -e; $build_commands"
 fi
 
 # Generate a local A2 manifest. This manifest represents the total


### PR DESCRIPTION
Right now we use the linux executor. We've had semi-regular problems
with the linux executor not giving us the isolation we require during
builds.

Most recently, we've hit a problem where we see artifacts from other
builds in our results folder. We have not fully investigated this
problem. However, our suspicion is that what we are seeing is that
canceled builds are not tearing down the hab-studio, leading to the
builds in those studios continuing to run, and later writing into a
results folder now in use by another build.

We have this suspicion because we've seen this before (private repo,
sorry):

chef/a2@d481491

there we added the --tty flag to influence how signals would interact
with the build.

We could continue down that road. Instead, this PR moves us to the
docker executor as a way to avoid some of these problems. When using
the docker executor, buildkite itself will destroy our entire docker
container when the build is canceled. Our hope is this is a bit more
reliable.

This is not without risks since the docker-based studios (which we are
currently using) and chroot-based studio (which we'll be moving to)
have many differences that we might not have accounted for here.

Signed-off-by: Steven Danna <steve@chef.io>