### PR TITLE
Dan/fix incorrect service grouping

### DIFF
--- a/components/applications-service/integration_test/ingestion_test.go
+++ b/components/applications-service/integration_test/ingestion_test.go
@@ -7,7 +7,6 @@ package integration_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -677,98 +676,333 @@ func TestIngestConcurrencySafe(t *testing.T) {
 }
 
 func TestNewSgAndDeploymentUpdate(t *testing.T) {
-	defer suite.DeleteDataFromStorage()
-	suite.Ingester.ResetStats()
+	setupData := func(t *testing.T) {
+		eventsProcessed := suite.Ingester.EventsProcessed()
+		event1 := NewHabitatEvent(
+			withSupervisorId("1"),
+			withPackageIdent("core/db/0.1.0/20200101121212"),
+			withServiceGroup("db.default"),
+		)
+		bytes1, err := proto.Marshal(event1)
+		require.NoError(t, err)
+		suite.Ingester.IngestMessage(bytes1)
+		eventsProcessed++
 
-	eventsProcessed := suite.Ingester.EventsProcessed()
-	event1 := NewHabitatEvent(
-		withSupervisorId("1"),
-		withPackageIdent("core/db/0.1.0/20200101121212"),
-		withServiceGroup("db.default"),
-	)
-	bytes1, err := proto.Marshal(event1)
-	require.NoError(t, err)
-	suite.Ingester.IngestMessage(bytes1)
-	eventsProcessed++
-
-	event2 := NewHabitatEvent(
-		withSupervisorId("2"),
-		withPackageIdent("core/db/0.1.0/20200101121212"),
-		withServiceGroup("db.default"),
-	)
-	bytes2, err := proto.Marshal(event2)
-	require.NoError(t, err)
-	suite.Ingester.IngestMessage(bytes2)
-	eventsProcessed++
-	suite.WaitForEventsToProcess(eventsProcessed)
-
-	// TODO: replace printf with test to assert we have 2 services w/ 2 supervisors in 1 service group in 1 deployment
-	fmt.Println("start results-----------------------------")
-	stats, err := suite.ApplicationsServer.GetServicesStats(context.Background(), &applications.ServicesStatsReq{})
-	require.NoError(t, err)
-	fmt.Printf("%+v\n", stats)
-	svcList, err := suite.StorageClient.GetServices("name", true, 1, 5, nil)
-	require.NoError(t, err)
-	for _, svc := range svcList {
-		fmt.Printf("%+v\n", svc)
+		event2 := NewHabitatEvent(
+			withSupervisorId("2"),
+			withPackageIdent("core/db/0.1.0/20200101121212"),
+			withServiceGroup("db.default"),
+		)
+		bytes2, err := proto.Marshal(event2)
+		require.NoError(t, err)
+		suite.Ingester.IngestMessage(bytes2)
+		eventsProcessed++
+		suite.WaitForEventsToProcess(eventsProcessed)
 	}
-	fmt.Println("end results-----------------------------")
 
-	// event3 changes the app_name and environment of the service from event 2
-	event3 := NewHabitatEvent(
-		withSupervisorId("2"),
-		withPackageIdent("core/db/0.1.0/20200101121212"),
-		withServiceGroup("db.default"),
-		withApplication("newApp"),
-		withEnvironment("newEnv"),
-	)
-	bytes3, err := proto.Marshal(event3)
-	require.NoError(t, err)
-	suite.Ingester.IngestMessage(bytes3)
-	eventsProcessed++
-	suite.WaitForEventsToProcess(eventsProcessed)
-
-	// TODO: replace printf with test to assert we have 2 services w/ 2 supervisors in 2 service groups in 2 deployments
-	fmt.Println("start results-----------------------------")
-	stats, err = suite.ApplicationsServer.GetServicesStats(context.Background(), &applications.ServicesStatsReq{})
-	require.NoError(t, err)
-	fmt.Printf("%+v\n", stats)
-	svcList, err = suite.StorageClient.GetServices("name", true, 1, 5, nil)
-	require.NoError(t, err)
-	for _, svc := range svcList {
-		fmt.Printf("%+v\n", svc)
-	}
-	fmt.Println("end results-----------------------------")
-
-	// event3 changes the app_name and environment of the service from event 1
-	event4 := NewHabitatEvent(
-		withSupervisorId("1"),
-		withPackageIdent("core/db/0.1.0/20200101121212"),
-		withServiceGroup("db.default"),
-		withApplication("newApp"),
-		withEnvironment("newEnv"),
-	)
-	bytes4, err := proto.Marshal(event4)
-	require.NoError(t, err)
-	suite.Ingester.IngestMessage(bytes4)
-	eventsProcessed++
-	suite.WaitForEventsToProcess(eventsProcessed)
-
-	// TODO: replace printf with test to assert we have 2 services w/ 2 supervisors in 1 service groups in 1 deployments
-	fmt.Println("start results-----------------------------")
-	stats, err = suite.ApplicationsServer.GetServicesStats(context.Background(), &applications.ServicesStatsReq{})
-	require.NoError(t, err)
-	fmt.Printf("%+v\n", stats)
-	svcList, err = suite.StorageClient.GetServices("name", true, 1, 5, nil)
-	require.NoError(t, err)
-	for _, svc := range svcList {
-		fmt.Printf("%+v\n", svc)
-	}
-	fmt.Println("end results-----------------------------")
 	// TODO: test matrix:
-	// 1) move service to a new deployment and service group that didn't exist before
-	// 2) move service to an existing deployment but new service group
-	// 3) move service to an existing deployment and service group
-	// 4) (for completeness) nothing changes when deployment and sg stay the same
-	// 5) when last service is removed from sg or deployment, they are deleted
+	t.Run("nothing changes when deployment and sg stay the same", func(t *testing.T) {
+		defer suite.DeleteDataFromStorage()
+		suite.Ingester.ResetStats()
+		setupData(t)
+		eventsProcessed := suite.Ingester.EventsProcessed()
+
+		// service stays in same service group and deployment
+		update1 := NewHabitatEvent(
+			withSupervisorId("1"),
+			withPackageIdent("core/db/0.1.0/20200101121212"),
+			withServiceGroup("db.default"),
+		)
+		updateBytes, err := proto.Marshal(update1)
+		require.NoError(t, err)
+		suite.Ingester.IngestMessage(updateBytes)
+		eventsProcessed++
+		suite.WaitForEventsToProcess(eventsProcessed)
+
+		stats, err := suite.ApplicationsServer.GetServicesStats(context.Background(), &applications.ServicesStatsReq{})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), stats.TotalServiceGroups)
+		assert.Equal(t, int32(1), stats.TotalDeployments)
+		assert.Equal(t, int32(2), stats.TotalSupervisors)
+		assert.Equal(t, int32(2), stats.TotalServices)
+
+		svcList, err := suite.StorageClient.GetServices("name", true, 1, 5, nil)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(svcList))
+		for _, svc := range svcList {
+			assert.Equal(t, "db.default", svc.Group)
+			assert.Equal(t, "app", svc.Application)
+			assert.Equal(t, "test-env", svc.Environment)
+		}
+	})
+	t.Run("move service to a new deployment and service group that didn't exist before", func(t *testing.T) {
+		defer suite.DeleteDataFromStorage()
+		setupData(t)
+		suite.Ingester.ResetStats()
+		eventsProcessed := suite.Ingester.EventsProcessed()
+
+		// update1 changes the app_name and environment of the service from event 2
+		update1 := NewHabitatEvent(
+			withSupervisorId("2"),
+			withPackageIdent("core/db/0.1.0/20200101121212"),
+			withServiceGroup("db.newGroup"),
+			withApplication("newApp"),
+			withEnvironment("newEnv"),
+		)
+		update1Bytes, err := proto.Marshal(update1)
+		require.NoError(t, err)
+		suite.Ingester.IngestMessage(update1Bytes)
+		eventsProcessed++
+		suite.WaitForEventsToProcess(eventsProcessed)
+
+		stats, err := suite.ApplicationsServer.GetServicesStats(context.Background(), &applications.ServicesStatsReq{})
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), stats.TotalServiceGroups)
+		assert.Equal(t, int32(2), stats.TotalDeployments)
+		assert.Equal(t, int32(2), stats.TotalSupervisors)
+		assert.Equal(t, int32(2), stats.TotalServices)
+		svcs, err := suite.StorageClient.GetServices("name", true, 1, 5, nil)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(svcs))
+
+		for _, svc := range svcs {
+			if svc.SupMemberID != "1" {
+				continue
+			}
+			// first service should be unchanged
+			assert.Equal(t, "db.default", svc.Group)
+			assert.Equal(t, "app", svc.Application)
+			assert.Equal(t, "test-env", svc.Environment)
+		}
+
+		for _, svc := range svcs {
+			if svc.SupMemberID != "2" {
+				continue
+			}
+			// second service should be changed
+			assert.Equal(t, "db.newGroup", svc.Group)
+			assert.Equal(t, "newApp", svc.Application)
+			assert.Equal(t, "newEnv", svc.Environment)
+		}
+
+	})
+	t.Run("move service to an existing deployment but new service group", func(t *testing.T) {
+		defer suite.DeleteDataFromStorage()
+		suite.Ingester.ResetStats()
+		setupData(t)
+		eventsProcessed := suite.Ingester.EventsProcessed()
+
+		// Event 3 creates the deployment for newApp+newEnv, but is a different
+		// service so the service group should not be used for service 2 when we update it later
+		event3 := NewHabitatEvent(
+			withSupervisorId("3"),
+			withPackageIdent("core/otherpkg/0.1.0/20200101121212"),
+			withServiceGroup("otherpkg.default"),
+			withApplication("newApp"),
+			withEnvironment("newEnv"),
+		)
+		bytes3, err := proto.Marshal(event3)
+		require.NoError(t, err)
+		suite.Ingester.IngestMessage(bytes3)
+		eventsProcessed++
+		suite.WaitForEventsToProcess(eventsProcessed)
+
+		// update1 changes the app_name and environment of the service from event 2
+		// there should be a new service group row in the database, it will have
+		// the same name "db.default" but have a different deployment_id
+		update1 := NewHabitatEvent(
+			withSupervisorId("2"),
+			withPackageIdent("core/db/0.1.0/20200101121212"),
+			withApplication("newApp"),
+			withEnvironment("newEnv"),
+			withServiceGroup("db.default"),
+		)
+		update1Bytes, err := proto.Marshal(update1)
+		require.NoError(t, err)
+		suite.Ingester.IngestMessage(update1Bytes)
+		eventsProcessed++
+		suite.WaitForEventsToProcess(eventsProcessed)
+
+		stats, err := suite.ApplicationsServer.GetServicesStats(context.Background(), &applications.ServicesStatsReq{})
+		require.NoError(t, err)
+		assert.Equal(t, int32(3), stats.TotalServiceGroups)
+		assert.Equal(t, int32(2), stats.TotalDeployments)
+		assert.Equal(t, int32(3), stats.TotalSupervisors)
+		assert.Equal(t, int32(3), stats.TotalServices)
+		svcs, err := suite.StorageClient.GetServices("name", true, 1, 5, nil)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(svcs))
+
+		for _, svc := range svcs {
+			if svc.SupMemberID != "1" {
+				continue
+			}
+			// first service should be unchanged
+			assert.Equal(t, "db.default", svc.Group)
+			assert.Equal(t, "app", svc.Application)
+			assert.Equal(t, "test-env", svc.Environment)
+		}
+
+		for _, svc := range svcs {
+			if svc.SupMemberID != "2" {
+				continue
+			}
+			// second service should be changed
+			assert.Equal(t, "db.default", svc.Group)
+			assert.Equal(t, "newApp", svc.Application)
+			assert.Equal(t, "newEnv", svc.Environment)
+		}
+
+		for _, svc := range svcs {
+			if svc.SupMemberID != "3" {
+				continue
+			}
+			// third service shouldn't be changed
+			assert.Equal(t, "otherpkg.default", svc.Group)
+			assert.Equal(t, "newApp", svc.Application)
+			assert.Equal(t, "newEnv", svc.Environment)
+		}
+	})
+	t.Run("move service to an existing deployment and service group", func(t *testing.T) {
+		defer suite.DeleteDataFromStorage()
+		suite.Ingester.ResetStats()
+		setupData(t)
+		eventsProcessed := suite.Ingester.EventsProcessed()
+
+		// Event 3 creates the deployment for newApp+newEnv and service group db.newGroup
+		event3 := NewHabitatEvent(
+			withSupervisorId("3"),
+			withPackageIdent("core/db/0.1.0/20200101121212"),
+			withApplication("newApp"),
+			withEnvironment("newEnv"),
+			withServiceGroup("db.newGroup"),
+		)
+		bytes3, err := proto.Marshal(event3)
+		require.NoError(t, err)
+		suite.Ingester.IngestMessage(bytes3)
+		eventsProcessed++
+		suite.WaitForEventsToProcess(eventsProcessed)
+
+		// update1 changes the app_name and environment of the service from event 2
+		update1 := NewHabitatEvent(
+			withSupervisorId("2"),
+			withPackageIdent("core/db/0.1.0/20200101121212"),
+			withApplication("newApp"),
+			withEnvironment("newEnv"),
+			withServiceGroup("db.newGroup"),
+		)
+		update1Bytes, err := proto.Marshal(update1)
+		require.NoError(t, err)
+		suite.Ingester.IngestMessage(update1Bytes)
+		eventsProcessed++
+		suite.WaitForEventsToProcess(eventsProcessed)
+
+		stats, err := suite.ApplicationsServer.GetServicesStats(context.Background(), &applications.ServicesStatsReq{})
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), stats.TotalServiceGroups)
+		assert.Equal(t, int32(2), stats.TotalDeployments)
+		assert.Equal(t, int32(3), stats.TotalSupervisors)
+		assert.Equal(t, int32(3), stats.TotalServices)
+		svcs, err := suite.StorageClient.GetServices("name", true, 1, 5, nil)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(svcs))
+
+		for _, svc := range svcs {
+			if svc.SupMemberID != "1" {
+				continue
+			}
+			// first service should be unchanged
+			assert.Equal(t, "db.default", svc.Group)
+			assert.Equal(t, "app", svc.Application)
+			assert.Equal(t, "test-env", svc.Environment)
+		}
+
+		for _, svc := range svcs {
+			if svc.SupMemberID != "2" {
+				continue
+			}
+			// second service should be changed
+			assert.Equal(t, "db.newGroup", svc.Group)
+			assert.Equal(t, "newApp", svc.Application)
+			assert.Equal(t, "newEnv", svc.Environment)
+		}
+
+		for _, svc := range svcs {
+			if svc.SupMemberID != "3" {
+				continue
+			}
+			// third service shouldn't be changed
+			assert.Equal(t, "db.newGroup", svc.Group)
+			assert.Equal(t, "newApp", svc.Application)
+			assert.Equal(t, "newEnv", svc.Environment)
+		}
+	})
+	t.Run("empty service groups and deployments are cleaned up", func(t *testing.T) {
+		defer suite.DeleteDataFromStorage()
+		suite.Ingester.ResetStats()
+		setupData(t)
+		eventsProcessed := suite.Ingester.EventsProcessed()
+
+		// update1 changes the app_name and environment of the service from event 2
+		// there should be a new service group row in the database, it will have
+		// the same name "db.default" but have a different deployment_id
+		update1 := NewHabitatEvent(
+			withSupervisorId("2"),
+			withPackageIdent("core/db/0.1.0/20200101121212"),
+			withApplication("newApp"),
+			withEnvironment("newEnv"),
+			withServiceGroup("db.newGroup"),
+		)
+		update1Bytes, err := proto.Marshal(update1)
+		require.NoError(t, err)
+		suite.Ingester.IngestMessage(update1Bytes)
+		eventsProcessed++
+		suite.WaitForEventsToProcess(eventsProcessed)
+
+		// update2 changes the app_name and environment of the service from event 1
+		update2 := NewHabitatEvent(
+			withSupervisorId("1"),
+			withPackageIdent("core/db/0.1.0/20200101121212"),
+			withApplication("newApp"),
+			withEnvironment("newEnv"),
+			withServiceGroup("db.newGroup"),
+		)
+		update2Bytes, err := proto.Marshal(update2)
+		require.NoError(t, err)
+		suite.Ingester.IngestMessage(update2Bytes)
+		eventsProcessed++
+		suite.WaitForEventsToProcess(eventsProcessed)
+
+		stats, err := suite.ApplicationsServer.GetServicesStats(context.Background(), &applications.ServicesStatsReq{})
+		require.NoError(t, err)
+		// the old service groups and deployments should be deleted, leaving just one of each
+		assert.Equal(t, int32(1), stats.TotalServiceGroups)
+		assert.Equal(t, int32(1), stats.TotalDeployments)
+		assert.Equal(t, int32(2), stats.TotalSupervisors)
+		assert.Equal(t, int32(2), stats.TotalServices)
+		svcs, err := suite.StorageClient.GetServices("name", true, 1, 5, nil)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(svcs))
+
+		for _, svc := range svcs {
+			if svc.SupMemberID != "1" {
+				continue
+			}
+			// first service was changed
+			assert.Equal(t, "db.newGroup", svc.Group)
+			assert.Equal(t, "newApp", svc.Application)
+			assert.Equal(t, "newEnv", svc.Environment)
+		}
+
+		for _, svc := range svcs {
+			if svc.SupMemberID != "2" {
+				continue
+			}
+			// second service should be changed
+			assert.Equal(t, "db.newGroup", svc.Group)
+			assert.Equal(t, "newApp", svc.Application)
+			assert.Equal(t, "newEnv", svc.Environment)
+		}
+	})
+
 }

--- a/components/applications-service/integration_test/ingestion_test.go
+++ b/components/applications-service/integration_test/ingestion_test.go
@@ -700,7 +700,6 @@ func TestNewSgAndDeploymentUpdate(t *testing.T) {
 		suite.WaitForEventsToProcess(eventsProcessed)
 	}
 
-	// TODO: test matrix:
 	t.Run("nothing changes when deployment and sg stay the same", func(t *testing.T) {
 		defer suite.DeleteDataFromStorage()
 		suite.Ingester.ResetStats()
@@ -943,9 +942,7 @@ func TestNewSgAndDeploymentUpdate(t *testing.T) {
 		setupData(t)
 		eventsProcessed := suite.Ingester.EventsProcessed()
 
-		// update1 changes the app_name and environment of the service from event 2
-		// there should be a new service group row in the database, it will have
-		// the same name "db.default" but have a different deployment_id
+		// update1 changes the app_name, environment, and service group of the service from event 2
 		update1 := NewHabitatEvent(
 			withSupervisorId("2"),
 			withPackageIdent("core/db/0.1.0/20200101121212"),
@@ -959,7 +956,7 @@ func TestNewSgAndDeploymentUpdate(t *testing.T) {
 		eventsProcessed++
 		suite.WaitForEventsToProcess(eventsProcessed)
 
-		// update2 changes the app_name and environment of the service from event 1
+		// update2 changes the app_name, environment, and service group of the service from event 1
 		update2 := NewHabitatEvent(
 			withSupervisorId("1"),
 			withPackageIdent("core/db/0.1.0/20200101121212"),

--- a/components/applications-service/integration_test/service_groups_sorting_test.go
+++ b/components/applications-service/integration_test/service_groups_sorting_test.go
@@ -218,11 +218,13 @@ func TestGetServiceGroupsSortedPercent(t *testing.T) {
 	response, err := suite.ApplicationsServer.GetServiceGroups(ctx, request)
 	assert.Nil(t, err)
 
-	if assert.Equal(t, 4, len(response.ServiceGroups)) {
+	if assert.Equal(t, 6, len(response.ServiceGroups)) {
 		assert.Equal(t, int32(100), response.ServiceGroups[0].HealthPercentage)
-		assert.Equal(t, int32(50), response.ServiceGroups[1].HealthPercentage)
-		assert.Equal(t, int32(25), response.ServiceGroups[2].HealthPercentage)
+		assert.Equal(t, int32(100), response.ServiceGroups[1].HealthPercentage)
+		assert.Equal(t, int32(33), response.ServiceGroups[2].HealthPercentage)
 		assert.Equal(t, int32(0), response.ServiceGroups[3].HealthPercentage)
+		assert.Equal(t, int32(0), response.ServiceGroups[4].HealthPercentage)
+		assert.Equal(t, int32(0), response.ServiceGroups[5].HealthPercentage)
 	}
 }
 
@@ -266,11 +268,13 @@ func TestGetServiceGroupsSortedPercentAsc(t *testing.T) {
 	response, err := suite.ApplicationsServer.GetServiceGroups(ctx, request)
 	assert.Nil(t, err)
 
-	if assert.Equal(t, 4, len(response.ServiceGroups)) {
+	if assert.Equal(t, 6, len(response.ServiceGroups)) {
 		assert.Equal(t, int32(0), response.ServiceGroups[0].HealthPercentage)
-		assert.Equal(t, int32(25), response.ServiceGroups[1].HealthPercentage)
-		assert.Equal(t, int32(50), response.ServiceGroups[2].HealthPercentage)
-		assert.Equal(t, int32(100), response.ServiceGroups[3].HealthPercentage)
+		assert.Equal(t, int32(0), response.ServiceGroups[1].HealthPercentage)
+		assert.Equal(t, int32(0), response.ServiceGroups[2].HealthPercentage)
+		assert.Equal(t, int32(33), response.ServiceGroups[3].HealthPercentage)
+		assert.Equal(t, int32(100), response.ServiceGroups[4].HealthPercentage)
+		assert.Equal(t, int32(100), response.ServiceGroups[5].HealthPercentage)
 	}
 }
 

--- a/components/applications-service/pkg/storage/postgres/db.go
+++ b/components/applications-service/pkg/storage/postgres/db.go
@@ -87,10 +87,6 @@ func (db *Postgres) initDB() error {
 	return nil
 }
 
-type dbTable interface {
-	NeedUpdate() bool
-}
-
 // service struct is the representation of the service table inside the db
 type service struct {
 	ID                  int32     `db:"id"`
@@ -111,13 +107,6 @@ type service struct {
 	HealthUpdatedAt     time.Time `db:"health_updated_at"`
 	CreatedAt           time.Time `db:"-"`
 	UpdatedAt           time.Time `db:"-"`
-
-	// (internal) use it to know if the service needs an update or not
-	needUpdate bool `db:"-"`
-}
-
-func (svc *service) NeedUpdate() bool {
-	return svc.needUpdate
 }
 
 // supervisor struct is the representation of the supervisor table inside the db
@@ -144,13 +133,6 @@ type serviceGroup struct {
 	DeploymentID int32     `db:"deployment_id"`
 	CreatedAt    time.Time `db:"-"`
 	UpdatedAt    time.Time `db:"-"`
-
-	// (internal) use it to know if the service-group needs an update or not
-	needUpdate bool `db:"-"`
-}
-
-func (sg *serviceGroup) NeedUpdate() bool {
-	return sg.needUpdate
 }
 
 // deployment struct is the representation of the deployment table inside the db
@@ -160,11 +142,4 @@ type deployment struct {
 	Environment string    `db:"environment"`
 	CreatedAt   time.Time `db:"-"`
 	UpdatedAt   time.Time `db:"-"`
-
-	// (internal) use it to know if the deployment needs an update or not
-	needUpdate bool `db:"-"`
-}
-
-func (d *deployment) NeedUpdate() bool {
-	return d.needUpdate
 }

--- a/components/applications-service/pkg/storage/postgres/hab_event.go
+++ b/components/applications-service/pkg/storage/postgres/hab_event.go
@@ -395,7 +395,16 @@ func (db *Postgres) insertNewService(
 		}
 
 		// 2) Service Group
-		gid, exist := db.getServiceGroupID(svcMetadata.GetServiceGroup())
+		// FIXME that's your problem right there :P
+		// we need to find service group by name and deployment id (done)
+		// TODO after this:
+		// * undo the view changes, retest to make sure all that still works
+		// * regression test
+		// * see how it behaves when running with existing bad data
+		// * does updateService work? (seems to, but be more systematic)
+		// 		* when deployment is not changed
+		//    * when deployment is changed
+		gid, exist := db.getServiceGroupID(svcMetadata.GetServiceGroup(), did)
 		if !exist {
 			svcGroup := &serviceGroup{
 				Name:         svcMetadata.GetServiceGroup(),

--- a/components/applications-service/pkg/storage/postgres/hab_event.go
+++ b/components/applications-service/pkg/storage/postgres/hab_event.go
@@ -353,7 +353,6 @@ func (db *Postgres) updateService(
 		svc.HealthUpdatedAt = time.Now()
 		svc.PreviousHealth = svc.Health
 		svc.Health = health
-		svc.needUpdate = true
 	}
 
 	// Update Package Identifier
@@ -362,7 +361,6 @@ func (db *Postgres) updateService(
 		svc.Version = pkgIdent.Version
 		svc.Release = pkgIdent.Release
 		svc.FullPkgIdent = pkgIdent.FullPackageIdent()
-		svc.needUpdate = true
 	}
 
 	// Update Channel
@@ -375,7 +373,6 @@ func (db *Postgres) updateService(
 	// update always the timestamp of the last event received so that the database
 	// has a record of when the last message was received for a service
 	svc.LastEventOccurredAt = convertOrCreateGoTime(eventMetadata.GetOccurredAt())
-	svc.needUpdate = true
 }
 
 // update the service channel & update strategy from the provided habitat update config
@@ -383,24 +380,20 @@ func updateServiceStrategyAndChannel(svc *service, updateConfig *habitat.UpdateC
 	if updateConfig == nil {
 		if svc.Channel != "" {
 			svc.Channel = ""
-			svc.needUpdate = true
 		}
 
 		if svc.UpdateStrategy != storage.NoneStrategy.String() {
 			svc.UpdateStrategy = storage.NoneStrategy.String()
-			svc.needUpdate = true
 		}
 	} else {
 		channel := updateConfig.GetChannel()
 		if svc.Channel != channel {
 			svc.Channel = channel
-			svc.needUpdate = true
 		}
 
 		strategy := storage.HabitatUpdateStrategyToStorageFormat(updateConfig.GetStrategy())
 		if svc.UpdateStrategy != strategy.String() {
 			svc.UpdateStrategy = strategy.String()
-			svc.needUpdate = true
 		}
 	}
 }

--- a/components/applications-service/pkg/storage/postgres/hab_event.go
+++ b/components/applications-service/pkg/storage/postgres/hab_event.go
@@ -266,6 +266,7 @@ func (db *Postgres) updateTables(
 					AppName:     eventMetadata.GetApplication(),
 					Environment: eventMetadata.GetEnvironment(),
 				}
+				log.Infof("creating deployment %+v", deploy)
 				if err := tx.Insert(deploy); err != nil {
 					return errors.Wrap(err, "Unable to insert deployment")
 				}
@@ -277,6 +278,7 @@ func (db *Postgres) updateTables(
 				Name:         svcMetadata.GetServiceGroup(),
 				DeploymentID: did,
 			}
+			log.Infof("creating svc group %+v", svcGroup)
 			if err := tx.Insert(svcGroup); err != nil {
 				return errors.Wrap(err, "Unable to insert service_group")
 			}

--- a/components/applications-service/pkg/storage/postgres/service_groups.go
+++ b/components/applications-service/pkg/storage/postgres/service_groups.go
@@ -378,11 +378,13 @@ func (db *Postgres) getServiceGroup(id int32) (*serviceGroup, error) {
 
 	return &sg, nil
 }
-func (db *Postgres) getServiceGroupID(name string) (int32, bool) {
+
+func (db *Postgres) getServiceGroupID(name string, deploymentID int32) (int32, bool) {
 	var gid int32
 	err := db.SelectOne(&gid,
-		"SELECT id FROM service_group WHERE name = $1",
+		"SELECT id FROM service_group WHERE name = $1 AND deployment_id = $2",
 		name,
+		deploymentID,
 	)
 	if err != nil {
 		return gid, false


### PR DESCRIPTION
### :nut_and_bolt: Description

A customer reported that services are not assigned to the correct groups when they have different application settings. I was able to reproduce pretty easily by running:

```
applications_publish_supervisor_message --application ONE --sup-id 1111
applications_publish_supervisor_message --application TWO --sup-id 2222
applications_publish_supervisor_message --application THREE --sup-id 3333
```

On insert of a new service, the problem was that we were only looking at service groups based on their name, whereas we needed to be checking both the name and deployment id to get the correct row back.

After applying a fix for that problem, I investigated how the system would behave if the user has existing data that is incorrect due to this insertion bug. We recently added some code to modify the application and environment names if they change, but I've discovered that it was subtly incorrect: the existing code updates the deployment and/or service group values to match what was given in the latest health check message, but this changes the app name/environment/service group name for all services associated with the deployment/service group. I've therefore changed the logic so that when a health check message indicates that a service should belong to a different service group/deployment than what is currently in the database, we create a new deployment/service group, if necessary, then move the service over to the correct deployment and service group. I have confirmed that if there is incorrect data in the database resulting from the #1000 bug, it will be repaired as new health checks come in and the update logic gets applied.

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

To repro bug #1000, run this in the studio with the packages from the dev channel:

```
applications_publish_supervisor_message --application ONE --sup-id 1111
applications_publish_supervisor_message --application TWO --sup-id 2222
applications_publish_supervisor_message --application THREE --sup-id 3333
```

In the UI you will see all 3 services in one row in the UI which indicates they are all in the same application.

To repro the fix, build applications service and wait for it to get deployed. Then re-run the `applications_publish_supervisor_message` step from above and you should see 3 service groups in the UI.

### :chains: Related Resources

#1000 

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?