### PR TITLE
bump suggestions results in compliance from 10 to 100

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -53,8 +53,8 @@ export class ReportingComponent implements OnInit, OnDestroy {
     {
       'name': 'environment',
       'title': 'Environment',
-      'description': 'Add the name to filter this report to a specific environment',
-      'placeholder': 'Name'
+      'description': 'Add the environment name to filter this report to a specific environment',
+      'placeholder': 'Environment'
     },
     {
       'name': 'inspec_version',
@@ -64,10 +64,9 @@ export class ReportingComponent implements OnInit, OnDestroy {
     },
     {
       'name': 'node',
-      'title': 'Node',
-      'description':
-        'Add the name, ID, or hostname to filter this report against a specific node',
-      'placeholder': 'Name, ID, or hostname'
+      'title': 'Node Name',
+      'description': 'Add the node name to filter this report against a specific node',
+      'placeholder': 'Node Name'
     },
     {
       'name': 'organization',

--- a/components/compliance-service/api/reporting/server/server.go
+++ b/components/compliance-service/api/reporting/server/server.go
@@ -128,7 +128,7 @@ func (srv *Server) ReadReport(ctx context.Context, in *reporting.Query) (*report
 func (srv *Server) ListSuggestions(ctx context.Context, in *reporting.SuggestionRequest) (*reporting.Suggestions, error) {
 	var suggestions reporting.Suggestions
 	if in.Size == 0 {
-		in.Size = 10
+		in.Size = 100
 	}
 	if in.Type == "" {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Parameter 'type' not specified"))

--- a/components/compliance-service/api/tests/07_suggestions_spec.rb
+++ b/components/compliance-service/api/tests/07_suggestions_spec.rb
@@ -29,7 +29,7 @@ describe File.basename(__FILE__) do
 
     # suggest environment, lower case text with space
     actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
-      type: 'environment', text: 'devsec zeT'
+      type: 'environment', text: 'devsec zeT', size: 10
     )
     assert_suggestions_text(["DevSec Prod Zeta", "DevSec Prod Alpha", "DevSec Prod beta"], actual_data)
 
@@ -104,7 +104,7 @@ describe File.basename(__FILE__) do
 
     # suggest all controls
     actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
-      type: 'control'
+      type: 'control', size: 10
     )
     expected = ["Check Apache config file owner, group and permissions.--apache-05--",
       "Disable Apache’s follows Symbolic Links for directories in alias.conf--apache-11--",

--- a/components/compliance-service/api/tests/07_suggestions_w_filters_spec.rb
+++ b/components/compliance-service/api/tests/07_suggestions_w_filters_spec.rb
@@ -16,7 +16,8 @@ describe File.basename(__FILE__) do
       filters: [
         Reporting::ListFilter.new(type: 'start_time', values: ['2018-01-01T23:59:59Z']),
         Reporting::ListFilter.new(type: 'end_time', values: ['2018-07-01T23:59:59Z'])
-      ]
+      ],
+      size: 10
     )
     expected = [
       "Check Apache config file owner, group and permissions.--apache-05--",
@@ -39,7 +40,8 @@ describe File.basename(__FILE__) do
       filters: [
         Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
         Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-01T23:59:59Z'])
-      ]
+      ],
+      size: 10
     )
     expected = [
       "Disable neighbor solicitations to send out per address--sysctl-27--",


### PR DESCRIPTION
### :nut_and_bolt: Description
also modified the field for node name from 'Node' to
to 'Node Name' for parity with client runs and clarity!

### :+1: Definition of Done
- compliance suggestions returns 100 results
- node -> node name

### :athletic_shoe: Demo Script / Repro Steps
```
build components/compliance-service
build components/automate-ui
chef_load_compliance_scans (more than 10 nodes)
use search bar to search for nodes by name, ensure it says "Node Name", ensure more than 10 results are returned
```

### :chains: Related Resources
https://github.com/chef/automate/issues/737

### :white_check_mark: Checklist

- [x] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [x] Code actually executed?
- [x] Vetting performed (unit tests, lint, etc.)?
