### PR TITLE
ensure ui for compliance suggestions is displaying all 100 results

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/suggestions.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/suggestions.service.spec.ts
@@ -50,17 +50,17 @@ describe('SuggestionsService', () => {
       req.flush(mockResp);
     });
 
-    it('returns maximum of 25 items', () => {
+    it('returns maximum of 100 items', () => {
       const type = 'platform';
       const text = 'win';
       const filters = [];
 
       const expectedUrl = `${COMPLIANCE_URL}/reporting/suggestions`;
-      const expectedSuggestions = Array.from({ length: 50 }).map(i => ({ text: `suggest-${i}` }));
+      const expectedSuggestions = Array.from({ length: 150 }).map(i => ({ text: `suggest-${i}` }));
       const mockResp = { suggestions: expectedSuggestions };
 
       service.getSuggestions(type, text, filters).subscribe(suggestions => {
-        expect(suggestions.length).toEqual(25);
+        expect(suggestions.length).toEqual(100);
       });
 
       const req = httpTestingController.expectOne(expectedUrl);

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/suggestions.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/suggestions.service.ts
@@ -19,6 +19,6 @@ export class SuggestionsService {
     const formatted = this.statsService.formatFilters(filters);
     const body = {type, text, filters: formatted};
     return this.httpClient.post<any>(url, body).pipe(
-      map(({suggestions}) => suggestions.slice(0, 25) || []));
+      map(({suggestions}) => suggestions.slice(0, 100) || []));
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description 
in https://github.com/chef/automate/pull/1065 we did some work to bump the results returned from the compliance api from 10 -> 100, which worked beautifully.
but when testing the change later, i noticed i was only getting 25 results in the ui, despite the api returning 100.
this fixes that!

### :+1: Definition of Done
100 (or as many as available if less than 100) suggestion results returned

### :athletic_shoe: Demo Script / Repro Steps
```
build components/automate-ui
load 100 compliance nodes (or more than 25)
suggest on node name, expect to see more than 25 nodes
```

