### PR TITLE
only include add nodes button on node integ. detail page for automate mgr

### DIFF
--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.html
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.html
@@ -35,7 +35,8 @@
 
     <div class="page-body">
       <chef-toolbar>
-        <chef-button primary
+        <chef-button *ngIf="isAutomateManager(managerDetail.manager.type)"
+          primary
           routerLink="/compliance/scanner/nodes/add">
           Add Nodes
         </chef-button>

--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.ts
@@ -57,6 +57,10 @@ export class IntegrationsDetailComponent {
     return includes(this.selectedNodes, id);
   }
 
+  isAutomateManager(type: string) {
+    return type === 'automate';
+  }
+
   hasSelectedNodes() {
     return this.selectedNodes.length > 0;
   }


### PR DESCRIPTION
### :nut_and_bolt: Description
As noted in https://github.com/chef/automate/issues/735, the Add Nodes button only belongs on the Automate manager details page, as the functionality that button directs to is for adding nodes to the automate node manager.

### :+1: Definition of Done
no add nodes button on automate manager details page

### :athletic_shoe: Demo Script / Repro Steps
build ui
add an aws, azure. or gcp integration
view details pages for new manager page and automate manager page
only see add nodes button on automate manager page

### :chains: Related Resources
https://github.com/chef/automate/issues/735

