### PR TITLE
fix node read for nodes with nil target config

### DIFF
--- a/components/compliance-service/api/tests/test_ingest_to_mgr_conn.rb
+++ b/components/compliance-service/api/tests/test_ingest_to_mgr_conn.rb
@@ -26,6 +26,11 @@ describe File.basename(__FILE__) do
     # those nodes should not have been added to the manual node manager, as they were ingested nodes, not manually added nodes
     manually_managed_nodes = MANAGER_GRPC nodes, :list, Nodes::Query.new(filters: [Common::Filter.new(key: "manager_id", values: ["e69dc612-7e67-43f2-9b19-256afd385820"])])
     assert_equal(original_manually_managed_nodes.total, manually_managed_nodes.total)
+
+    # ensure we can read an ingested node
+    nodes_list['nodes'].each { |node|
+      node_read = MANAGER_GRPC nodes, :read, Nodes::Id.new(id: node.id)
+    }
   end
 
   it "nodes have scan data" do

--- a/components/nodemanager-service/api/nodes/server/server.go
+++ b/components/nodemanager-service/api/nodes/server/server.go
@@ -138,6 +138,9 @@ func GetNode(ctx context.Context, in *nodes.Id, db *pgdb.DB, secretsClient secre
 }
 
 func resolveInspecConfigWithSecrets(tc *nodes.TargetConfig, secretsMaps []map[string]string) error {
+	if tc == nil {
+		return nil
+	}
 	secretsArr := make([]*nodes.NodeSecrets, 0)
 
 	for _, secretsMap := range secretsMaps {


### PR DESCRIPTION
### :nut_and_bolt: Description
Part of the node read code in nodemanager service parses the node target config. Ingested nodes (nodes that were not manually added via node integration or node add) do not have a target config, and an oversight in the code resulted in the service exploding when trying to access a field in the nonexistent target config.

### :+1: Definition of Done
Able to read nodes that were only ingested.

### :athletic_shoe: Demo Script / Repro Steps
build components/nodemanager-service
ingest some nodes
read ingested nodes

### :chains: Related Resources
https://github.com/chef/automate/issues/943
