### PR TITLE
a1upgrade: fix more references to chef-server-ctl

### DIFF
--- a/components/automate-deployment/pkg/client/deployer.go
+++ b/components/automate-deployment/pkg/client/deployer.go
@@ -1451,7 +1451,7 @@ func (d *deployer) writeA1ComplianceSecret() {
 func (d *deployer) cancelUpgradeInstructions() string {
 	restartCmd := "automate-ctl start"
 	if d.mergedCfg.GetDeployment().GetV1().GetSvc().GetEnableChefServer().GetValue() {
-		restartCmd += "\nchef-server-ctl start"
+		restartCmd = fmt.Sprintf("%s\n%s start", restartCmd, a1upgrade.A1ChefServerCtlPath)
 	}
 	return fmt.Sprintf(cancelUpgradeInstructionsFmt, restartCmd)
 }


### PR DESCRIPTION
The a1upgrade also calls chef-server-ctl show-secret which needs to
come from the old chef-server-ctl.

An alternative would be to ensure we don't do the binlinking at the
wrong time.

Signed-off-by: Steven Danna <steve@chef.io>