### PR TITLE
cleanup: remove member id column

### DIFF
--- a/components/authz-service/server/v2/system.go
+++ b/components/authz-service/server/v2/system.go
@@ -8,15 +8,9 @@ import (
 
 const (
 	universalAccessStatementID        = "9edf285c-fc96-4363-a0b9-59e5b46f2a76"
-	universalAccessMemberID           = "f04ed84e-37da-4d62-808b-cbf81d2da666"
-	ingestNginxMemberID               = "f00f256a-53c9-4311-8f8a-1dda7402ca9f"
-	ingestErchefMemberID              = "f777e560-663f-45b0-93a5-f955843be34c"
 	ingestProviderStatementID         = "f777e560-663f-45b0-93a5-f955843be34c"
-	systemMemberID                    = "123e3a47-4ebd-4162-a836-e2955c5b5034"
-	systemLocalUsersMemberID          = "eedcb506-4aa0-4fc4-9800-ea2859b7ffb2"
 	systemIntrospectionStatementID    = "4cc6e7cd-5e32-43e5-af04-d32b15796590"
 	systemPolicyVersionStatementID    = "173a18a6-c102-4e45-a0d0-dfec68c2eee5"
-	allMembersID                      = "ea130a63-6b97-41c9-84c4-b7d074d869ef"
 	systemVersionStatementID          = "d7ed1d1f-1f6a-4055-a07e-23430c267e42"
 	systemLicenseStatementID          = "e5e1da2d-bbda-4211-adf5-c83e13f1891a"
 	systemLocalUsersStatementID       = "e9faa7a9-d458-4009-8192-edee6024b5d9"
@@ -36,7 +30,6 @@ func SystemPolicies() []*storage.Policy {
 		Name: "deployment-service universal access",
 		Members: []storage.Member{
 			{
-				ID:   uuid.Must(uuid.FromString(universalAccessMemberID)),
 				Name: "tls:service:deployment-service:*",
 			},
 		},
@@ -55,7 +48,6 @@ func SystemPolicies() []*storage.Policy {
 		Name: "System",
 		Members: []storage.Member{
 			{
-				ID:   uuid.Must(uuid.FromString(systemMemberID)),
 				Name: "*",
 			},
 		},
@@ -97,7 +89,6 @@ func SystemPolicies() []*storage.Policy {
 		Name: "System Local Users",
 		Members: []storage.Member{
 			{
-				ID:   uuid.Must(uuid.FromString(systemLocalUsersMemberID)),
 				Name: "user:local:*",
 			},
 		},
@@ -125,11 +116,9 @@ func SystemPolicies() []*storage.Policy {
 		Name: "System Ingest Providers",
 		Members: []storage.Member{
 			{
-				ID:   uuid.Must(uuid.FromString(ingestNginxMemberID)),
 				Name: "tls:service:automate-cs-nginx:*",
 			},
 			{
-				ID:   uuid.Must(uuid.FromString(ingestErchefMemberID)),
 				Name: "tls:service:automate-cs-oc-erchef:*",
 			},
 		},
@@ -150,7 +139,6 @@ func SystemPolicies() []*storage.Policy {
 		Name: "System policy to protect Chef-managed entities",
 		Members: []storage.Member{
 			{
-				ID:   uuid.Must(uuid.FromString(allMembersID)),
 				Name: "*",
 			},
 		},

--- a/components/authz-service/storage/postgres/migration/sql/64_drop_uuid_of_iam_members.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/64_drop_uuid_of_iam_members.up.sql
@@ -1,0 +1,141 @@
+BEGIN;
+
+ALTER TABLE iam_members DROP COLUMN id;
+
+CREATE OR REPLACE FUNCTION query_policy (_policy_id TEXT, _projects_filter TEXT[])
+    RETURNS json
+    AS $$
+    WITH temp AS (
+        SELECT
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type,
+            -- get policy's statements using temporary table
+            ( WITH statement_rows AS (
+                    SELECT
+                        stmt.db_id,
+                        stmt.id,
+                        stmt.effect,
+                        stmt.actions,
+                        stmt.resources,
+                        (
+                          SELECT COALESCE((SELECT id FROM iam_roles WHERE db_id=stmt.role_id), '') AS role
+                        ),
+                        (
+                            SELECT
+                                COALESCE(json_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL),
+                                    '[]')
+                                FROM iam_statement_projects AS stmt_projs
+                            LEFT OUTER JOIN iam_projects AS proj
+                            ON stmt_projs.statement_id = stmt.db_id
+                            WHERE stmt_projs.project_id = proj.db_id
+                        ) AS projects
+                    FROM iam_statements stmt
+                    INNER JOIN iam_policies ON stmt.policy_id = pol.db_id
+                GROUP BY
+                    stmt.db_id,
+                    stmt.id,
+                    stmt.effect,
+                    stmt.actions,
+                    stmt.resources,
+                    stmt.role_id)
+            SELECT
+                array_agg(statement_rows) FILTER (WHERE statement_rows.id IS NOT NULL)
+            FROM statement_rows) AS statements,
+            -- get policy members
+            (
+            SELECT
+                array_agg(mem)
+            FROM iam_policy_members AS pol_mems
+        LEFT OUTER JOIN iam_members AS mem ON pol_mems.member_id = mem.db_id WHERE pol_mems.policy_id = pol.db_id) AS members,
+            -- get projects
+            (
+            SELECT
+                array_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL)
+            FROM iam_policy_projects AS pol_projs
+            LEFT OUTER JOIN iam_projects AS proj
+            ON pol_projs.project_id = proj.db_id
+            WHERE pol_projs.policy_id = pol.db_id
+        ) AS projects
+    FROM iam_policies AS pol
+    WHERE pol.id = _policy_id
+        GROUP BY
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type
+)
+SELECT
+    json_build_object('id', temp.id, 'name', temp.name, 'type', temp.type, 'statements', COALESCE(temp.statements, '{}'), 'members', COALESCE(temp.members, '{}'), 'projects', COALESCE(temp.projects, '{}')) AS POLICY
+FROM
+    temp
+WHERE
+    projects_match (temp.projects::TEXT[], _projects_filter);
+$$
+LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION query_policies (_projects_filter TEXT[])
+    RETURNS SETOF json
+    AS $$
+    WITH temp AS (
+        SELECT
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type,
+            ( WITH statement_rows AS (
+                    SELECT
+                        stmt.db_id,
+                        stmt.id,
+                        stmt.effect,
+                        stmt.actions,
+                        stmt.resources,
+                        (
+                          SELECT COALESCE((SELECT id FROM iam_roles WHERE db_id=stmt.role_id), '') AS role
+                        ),
+                        (
+                            SELECT
+                                COALESCE(json_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL),
+                                    '[]')
+                                FROM iam_statement_projects AS stmt_projs
+                            LEFT OUTER JOIN iam_projects AS proj ON stmt_projs.statement_id = stmt.db_id WHERE stmt_projs.project_id = proj.db_id) AS projects FROM iam_statements stmt
+                    INNER JOIN iam_policies ON stmt.policy_id = pol.db_id
+                GROUP BY
+                    stmt.db_id,
+                    stmt.id,
+                    stmt.effect,
+                    stmt.actions,
+                    stmt.resources,
+                    stmt.role_id
+)
+            SELECT
+                array_agg(statement_rows) FILTER (WHERE statement_rows.id IS NOT NULL)
+                FROM statement_rows) AS statements,
+            (
+            SELECT
+                array_agg(mem)
+                FROM iam_policy_members AS pol_mems
+            LEFT OUTER JOIN iam_members AS mem ON pol_mems.member_id = mem.db_id WHERE pol_mems.policy_id = pol.db_id) AS members,
+    (
+    SELECT
+        array_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL)
+        FROM iam_policy_projects AS pol_projs
+        LEFT OUTER JOIN iam_projects AS proj ON pol_projs.project_id = proj.db_id WHERE pol_projs.policy_id = pol.db_id) AS projects FROM iam_policies AS pol
+GROUP BY
+    pol.db_id,
+    pol.id,
+    pol.name,
+    pol.type
+)
+SELECT
+    json_build_object('id', temp.id, 'name', temp.name, 'type', temp.type, 'statements', COALESCE(temp.statements, '{}'), 'members', COALESCE(temp.members, '{}'), 'projects', COALESCE(temp.projects, '{}')) AS POLICY
+FROM
+    temp
+WHERE
+    projects_match (temp.projects::TEXT[], _projects_filter);
+$$
+LANGUAGE sql;
+
+
+COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -63,3 +63,4 @@
 - [`61_use_role_db_id_in_iam_statements.up.sql`](61_use_role_db_id_in_iam_statements.up.sql)
 - [`62_add_not_null_constraints.up.sql`](62_add_not_null_constraints.up.sql)
 - [`63_make_db_id_lookup_functions_strict.up.sql`](63_make_db_id_lookup_functions_strict.up.sql)
+- [`64_drop_uuid_of_iam_members.up.sql`](64_drop_uuid_of_iam_members.up.sql)

--- a/components/authz-service/storage/v2/member.go
+++ b/components/authz-service/storage/v2/member.go
@@ -2,15 +2,11 @@ package v2
 
 import (
 	"github.com/pkg/errors"
-
-	storage_errors "github.com/chef/automate/components/authz-service/storage"
-	uuid "github.com/chef/automate/lib/uuid4"
 )
 
 // Member represents a member that can be added / removed from a policy.
 type Member struct {
-	ID   uuid.UUID `json:"id"`
-	Name string    `json:"name"`
+	Name string `json:"name"`
 }
 
 // NewMember is a factory for creating a Member storage object.
@@ -20,13 +16,7 @@ func NewMember(name string) (Member, error) {
 			errors.New("member cannot have an empty name")
 	}
 
-	id, err := uuid.New()
-	if err != nil {
-		return Member{}, storage_errors.ErrGenerateUUID
-	}
-
 	return Member{
-		ID:   id,
 		Name: name,
 	}, nil
 }


### PR DESCRIPTION
### :nut_and_bolt: Description

~Branched off of #1055, use [this view to review](https://github.com/chef/automate/compare/385d0b9fb7852bfaa3aab78ef55b76f8c3571483...sr/cleanup/remove-member-id-column), please.~ ✔️ other PR merged, this one rebased

Since members are now referenced by their `db_id`, we no longer need a UUID for a member. Their names are unique as well. This change drops that column, and deals with the fallout.

### :athletic_shoe: Demo Script / Repro Steps

See tests pass.

### :chains: Related Resources

- #832 
  - #1055
