### PR TITLE
Print docker inspect after build

### DIFF
--- a/scripts/verify_build.sh
+++ b/scripts/verify_build.sh
@@ -94,3 +94,6 @@ sudo chmod a+r results/*.pub
 # jobs.
 tar cvzf results.tar.gz results/
 buildkite-agent artifact upload results.tar.gz
+
+log_section_start "docker inspect"
+docker inspect $(docker ps -aq)


### PR DESCRIPTION
We think containers are not being correctly isolated which is causing
builds to fail
