### PR TITLE
ci: move back to docker-based studio, now with labels

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -54,18 +54,19 @@ steps:
     command:
       - scripts/verify_build.sh
     timeout_in_minutes: 45
+    env:
+      ALLOW_LOCAL_PACKAGES: true
+      HAB_STUDIO_SUP: false
+      HAB_NONINTERACTIVE: true
     expeditor:
       secrets:
         HAB_STUDIO_SECRET_GITHUB_TOKEN:
           account: github/chef-ci
           field: token
       executor:
-        docker:
+        linux:
           privileged: true
-          environment:
-            - ALLOW_LOCAL_PACKAGES=true
-            - HAB_STUDIO_SUP=false
-            - HAB_NONINTERACTIVE=true
+
 
   - label: "[unit] license-control-service"
     command:

--- a/scripts/verify_build.sh
+++ b/scripts/verify_build.sh
@@ -63,7 +63,8 @@ done
 if [[ "$build_commands" != "" ]]; then
     # We override HAB_CACHE_KEY_PATH to ensure we only see the key we
     # generated in this build
-    HAB_ORIGIN=chef HAB_CACHE_KEY_PATH=$RESOLVED_RESULTS_DIR DO_CHECK=true hab studio run "source .studiorc; set -e; $build_commands"
+    export HAB_DOCKER_OPTS="--label buildkitejob=$BUILDKITE_JOB_ID"
+    HAB_ORIGIN=chef HAB_CACHE_KEY_PATH=$RESOLVED_RESULTS_DIR DO_CHECK=true hab studio run -D "source .studiorc; set -e; $build_commands"
 fi
 
 # Generate a local A2 manifest. This manifest represents the total


### PR DESCRIPTION
This moves us back to the linux executor with a docker based studio.
We are moving back because of

https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/127

which is still present in the build that we have.

Signed-off-by: Steven Danna <steve@chef.io>
