### PR TITLE
Add support for filtering service groups by app, env and name

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -582,6 +582,7 @@ paths = [
   "components/automate-gateway/api/authz/*",
   "components/automate-gateway/authz/policy_v2/*",
   "components/automate-grpc/*",
+  "components/secrets-service/*",
   "lib/db/*",
   "lib/grpc/*",
   "lib/io/*",

--- a/components/applications-service/integration_test/ingestion_test.go
+++ b/components/applications-service/integration_test/ingestion_test.go
@@ -644,9 +644,13 @@ func TestIngestDenySupervisorMemberIDUpdates(t *testing.T) {
 
 	// we expect to have two services
 	if assert.Equal(t, 2, len(svcList)) {
-		assert.Equal(t, "4f1un3", svcList[0].SupMemberID,
+		svcIdList := make([]string, 2)
+		for i, svc := range svcList {
+			svcIdList[i] = svc.SupMemberID
+		}
+		assert.Contains(t, svcIdList, "4f1un3",
 			"the service supervisor_id is not the expected one")
-		assert.Equal(t, "foo", svcList[1].SupMemberID,
+		assert.Contains(t, svcIdList, "foo",
 			"the service supervisor_id is not the expected one")
 	}
 }

--- a/components/applications-service/integration_test/service_groups_filters_test.go
+++ b/components/applications-service/integration_test/service_groups_filters_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/chef/automate/api/external/applications"
+	"github.com/chef/automate/api/external/habitat"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -188,4 +189,192 @@ func TestServiceGroupsFilterWrongType(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), expectedErr)
 	}
+}
+
+func TestServiceGroupsFilterEnvironment(t *testing.T) {
+	var (
+		ctx     = context.Background()
+		request = &applications.ServiceGroupsReq{
+			Filter: []string{"environment:a_env"},
+		}
+		expected = &applications.ServiceGroups{
+			ServiceGroups: []*applications.ServiceGroup{
+				{
+					Name:             "a.default",
+					Package:          "core/a",
+					Release:          "0.1.0/20190101121212",
+					Status:           applications.HealthStatus_UNKNOWN,
+					HealthPercentage: 0,
+					Application:      "a_app",
+					Environment:      "a_env",
+					ServicesHealthCounts: &applications.HealthCounts{
+						Total:   1,
+						Unknown: 1,
+					},
+				},
+			},
+		}
+		mockHabServicesMatrix = habServicesABCD()
+	)
+
+	suite.IngestServices(mockHabServicesMatrix)
+	defer suite.DeleteDataFromStorage()
+
+	response, err := suite.ApplicationsServer.GetServiceGroups(ctx, request)
+	assert.Nil(t, err)
+	assertServiceGroupsEqual(t, expected, response)
+}
+
+func TestServiceGroupsFilterApp(t *testing.T) {
+	var (
+		ctx     = context.Background()
+		request = &applications.ServiceGroupsReq{
+			Filter: []string{"application:a_app"},
+		}
+		expected = &applications.ServiceGroups{
+			ServiceGroups: []*applications.ServiceGroup{
+				{
+					Name:             "a.default",
+					Package:          "core/a",
+					Release:          "0.1.0/20190101121212",
+					Status:           applications.HealthStatus_UNKNOWN,
+					HealthPercentage: 0,
+					Application:      "a_app",
+					Environment:      "a_env",
+					ServicesHealthCounts: &applications.HealthCounts{
+						Total:   1,
+						Unknown: 1,
+					},
+				},
+			},
+		}
+		mockHabServicesMatrix = habServicesABCD()
+	)
+
+	suite.IngestServices(mockHabServicesMatrix)
+	defer suite.DeleteDataFromStorage()
+
+	response, err := suite.ApplicationsServer.GetServiceGroups(ctx, request)
+	assert.Nil(t, err)
+	assertServiceGroupsEqual(t, expected, response)
+}
+
+func TestServiceGroupsMultiServiceFilterAppEnv(t *testing.T) {
+	var (
+		ctx     = context.Background()
+		request = &applications.ServiceGroupsReq{
+			Filter: []string{"application:a_app", "environment:a_env"},
+		}
+		expected = &applications.ServiceGroups{
+			ServiceGroups: []*applications.ServiceGroup{
+				{
+					Name:             "a.default",
+					Package:          "core/a",
+					Release:          "0.1.0/20190101121212",
+					Status:           applications.HealthStatus_UNKNOWN,
+					HealthPercentage: 0,
+					Application:      "a_app",
+					Environment:      "a_env",
+					ServicesHealthCounts: &applications.HealthCounts{
+						Total:   1,
+						Unknown: 1,
+					},
+				},
+			},
+		}
+		mockHabServicesMatrix = habServicesABCD()
+	)
+
+	suite.IngestServices(mockHabServicesMatrix)
+	defer suite.DeleteDataFromStorage()
+
+	response, err := suite.ApplicationsServer.GetServiceGroups(ctx, request)
+	assert.Nil(t, err)
+	assertServiceGroupsEqual(t, expected, response)
+}
+
+func TestServiceGroupsFilterAppEnvStatus(t *testing.T) {
+	var (
+		ctx     = context.Background()
+		request = &applications.ServiceGroupsReq{
+			Filter: []string{"application:a_app", "environment:a_env", "status:UNKNOWN"},
+		}
+		expected = &applications.ServiceGroups{
+			ServiceGroups: []*applications.ServiceGroup{
+				{
+					Name:             "a.default",
+					Package:          "core/a",
+					Release:          "0.1.0/20190101121212",
+					Status:           applications.HealthStatus_UNKNOWN,
+					HealthPercentage: 0,
+					Application:      "a_app",
+					Environment:      "a_env",
+					ServicesHealthCounts: &applications.HealthCounts{
+						Total:   1,
+						Unknown: 1,
+					},
+				},
+			},
+		}
+		mockHabServicesMatrix = habServicesABCD()
+	)
+
+	suite.IngestServices(mockHabServicesMatrix)
+	defer suite.DeleteDataFromStorage()
+
+	response, err := suite.ApplicationsServer.GetServiceGroups(ctx, request)
+	assert.Nil(t, err)
+	assertServiceGroupsEqual(t, expected, response)
+}
+
+func TestServiceGroupsFilterServiceGroupName(t *testing.T) {
+	var (
+		ctx     = context.Background()
+		request = &applications.ServiceGroupsReq{
+			Filter: []string{"group:default"},
+		}
+		expected = &applications.ServiceGroups{
+			ServiceGroups: []*applications.ServiceGroup{
+				{
+					Name:             "a.default",
+					Package:          "core/a",
+					Release:          "0.1.0/20190101121212",
+					Status:           applications.HealthStatus_UNKNOWN,
+					HealthPercentage: 0,
+					Application:      "a_app",
+					Environment:      "a_env",
+					ServicesHealthCounts: &applications.HealthCounts{
+						Total:   1,
+						Unknown: 1,
+					},
+				},
+			},
+		}
+		//2 services in different service groups
+		mockHabServices = []*habitat.HealthCheckEvent{
+			NewHabitatEvent(
+				withSupervisorId("sup2"),
+				withServiceGroup("a.default"),
+				withPackageIdent("core/a/0.1.0/20190101121212"),
+				withHealth("UNKNOWN"),
+				withApplication("a_app"),
+				withEnvironment("a_env"),
+			),
+			NewHabitatEvent(
+				withSupervisorId("sup3"),
+				withServiceGroup("a.test"),
+				withPackageIdent("core/b/0.1.0/20190101121212"),
+				withHealth("OK"),
+				withApplication("a_app"),
+				withEnvironment("a_env"),
+			),
+		}
+	)
+
+	suite.IngestServices(mockHabServices)
+	defer suite.DeleteDataFromStorage()
+
+	response, err := suite.ApplicationsServer.GetServiceGroups(ctx, request)
+	assert.Nil(t, err)
+	assertServiceGroupsEqual(t, expected, response)
 }

--- a/components/applications-service/integration_test/service_groups_filters_test.go
+++ b/components/applications-service/integration_test/service_groups_filters_test.go
@@ -442,5 +442,17 @@ func TestServiceGroupsFilterServiceGroupNameDouble(t *testing.T) {
 
 	response, err := suite.ApplicationsServer.GetServiceGroups(ctx, request)
 	assert.Nil(t, err)
-	assertServiceGroupsEqual(t, expected, response)
+
+	//Should return both service groups
+	if assert.Equal(t, 2, len(response.GetServiceGroups())) {
+		svcList := response.GetServiceGroups()
+		svcIdList := make([]string, 2)
+		for i, svc := range svcList {
+			svcIdList[i] = svc.Name
+		}
+		assert.Contains(t, svcIdList, expected.GetServiceGroups()[0].Name,
+			"the service group name is not the expected one")
+		assert.Contains(t, svcIdList, expected.GetServiceGroups()[1].Name,
+			"the service group name is not the expected one")
+	}
 }

--- a/components/applications-service/pkg/storage/postgres/db.go
+++ b/components/applications-service/pkg/storage/postgres/db.go
@@ -130,6 +130,7 @@ func (s *supervisor) NeedUpdate() bool {
 type serviceGroup struct {
 	ID           int32     `db:"id"`
 	Name         string    `db:"name"`
+	NameSuffix   string    `db:"name_suffix"`
 	DeploymentID int32     `db:"deployment_id"`
 	CreatedAt    time.Time `db:"-"`
 	UpdatedAt    time.Time `db:"-"`

--- a/components/applications-service/pkg/storage/postgres/hab_event.go
+++ b/components/applications-service/pkg/storage/postgres/hab_event.go
@@ -425,6 +425,7 @@ func (db *Postgres) insertNewService(
 		if !exist {
 			svcGroup := &serviceGroup{
 				Name:         svcMetadata.GetServiceGroup(),
+				NameSuffix:   trimSuffix(svcMetadata.GetServiceGroup()),
 				DeploymentID: did,
 			}
 			if err := tx.Insert(svcGroup); err != nil {
@@ -479,4 +480,9 @@ func (db *Postgres) insertNewService(
 		return nil
 	})
 
+}
+
+func trimSuffix(name string) string {
+	parts := strings.Split(name, ".")
+	return parts[1]
 }

--- a/components/applications-service/pkg/storage/postgres/hab_event.go
+++ b/components/applications-service/pkg/storage/postgres/hab_event.go
@@ -257,10 +257,7 @@ func (db *Postgres) updateServiceAndRelations(
 			}
 
 			// 2) the service group doesn't exist
-			svcGroup := &serviceGroup{
-				Name:         svcMetadata.GetServiceGroup(),
-				DeploymentID: did,
-			}
+			svcGroup := bakeServiceGroup(svcMetadata.GetServiceGroup(), did)
 			if err := tx.Insert(svcGroup); err != nil {
 				return errors.Wrap(err, "Unable to insert service_group")
 			}
@@ -301,6 +298,15 @@ func (db *Postgres) updateServiceAndRelations(
 
 		return nil
 	})
+}
+
+// constructs service group
+func bakeServiceGroup(name string, did int32) *serviceGroup {
+	return &serviceGroup{
+		Name:         name,
+		NameSuffix:   trimSuffix(name),
+		DeploymentID: did,
+	}
 }
 
 // updates the provided supervisor from a HealthCheck event
@@ -423,11 +429,7 @@ func (db *Postgres) insertNewService(
 		// 2) Service Group
 		gid, exist := db.getServiceGroupID(svcMetadata.GetServiceGroup(), did)
 		if !exist {
-			svcGroup := &serviceGroup{
-				Name:         svcMetadata.GetServiceGroup(),
-				NameSuffix:   trimSuffix(svcMetadata.GetServiceGroup()),
-				DeploymentID: did,
-			}
+			svcGroup := bakeServiceGroup(svcMetadata.GetServiceGroup(), did)
 			if err := tx.Insert(svcGroup); err != nil {
 				return errors.Wrap(err, "Unable to insert service_group")
 			}

--- a/components/applications-service/pkg/storage/postgres/schema/sql/09_add_service_group_view_columns.up.sql
+++ b/components/applications-service/pkg/storage/postgres/schema/sql/09_add_service_group_view_columns.up.sql
@@ -1,0 +1,40 @@
+-- Add service group name suffix column, for easier search by service group name
+-- The suffix is everything after the '.', (eg: for nginx.default the suffix is default)
+ALTER TABLE service_group ADD COLUMN name_suffix TEXT NOT NULL DEFAULT '';
+
+UPDATE service_group
+SET name_suffix = substring(name FROM '\.(.*)');
+
+-- View won't accept new columns, so we must kill the view.
+DROP VIEW service_group_health;
+
+--Add service group name suffix to view so we can search by it.
+CREATE OR REPLACE VIEW service_group_health AS
+SELECT *
+       ,(CASE WHEN health_critical > 0 THEN '1_CRITICAL'
+              WHEN health_unknown  > 0 THEN '2_UNKNOWN'
+              WHEN health_warning  > 0 THEN '3_WARNING'
+              ELSE '4_OK' END ) as health
+  FROM (SELECT  sg.id
+               ,sg.deployment_id
+               ,sg.name as name
+               ,COUNT(s.health) FILTER (WHERE s.health = 'OK') AS health_ok
+               ,COUNT(s.health) FILTER (WHERE s.health = 'CRITICAL') AS health_critical
+               ,COUNT(s.health) FILTER (WHERE s.health = 'WARNING') AS health_warning
+               ,COUNT(s.health) FILTER (WHERE s.health = 'UNKNOWN') AS health_unknown
+               ,COUNT(s.health) AS health_total
+               ,round((COUNT(s.health) FILTER (WHERE s.health = 'OK')
+                     / COUNT(s.health)::float) * 100) as percent_ok
+               ,(SELECT array_agg(DISTINCT CONCAT (s.package_ident))
+                   FROM service AS s
+                  WHERE s.group_id = sg.id) AS releases
+               ,d.app_name as app_name
+               ,d.environment as environment
+               ,sg.name_suffix as name_suffix
+        FROM service_group AS sg
+        JOIN service AS s
+             ON s.group_id = sg.id
+        JOIN deployment as d
+             ON sg.deployment_id = d.id
+       GROUP BY sg.id, sg.deployment_id, sg.name, d.app_name, d.environment, sg.name_suffix
+       ) AS service_groups_health_calculation;

--- a/components/applications-service/pkg/storage/postgres/service_groups.go
+++ b/components/applications-service/pkg/storage/postgres/service_groups.go
@@ -51,46 +51,31 @@ const (
 FROM service_group_health AS service_group_health_counts
 `
 
-	selectServiceGroupHealthWithPageSort = `
+	selectServiceGroupHealth = `
 SELECT * FROM service_group_health AS service_group_health
- ORDER BY %s
- LIMIT $1
-OFFSET $2
 `
 	selectServiceGroupHealthFilterCRITICAL = `
-SELECT * FROM service_group_health AS service_group_health
- WHERE health_critical > 0
- ORDER BY %s
- LIMIT $1
-OFFSET $2
+   health_critical > 0
 `
 	selectServiceGroupHealthFilterUNKNOWN = `
-SELECT * FROM service_group_health AS service_group_health
- WHERE health_unknown  > 0
+   health_unknown  > 0
    AND health_critical = 0
- ORDER BY %s
- LIMIT $1
-OFFSET $2
 `
 	selectServiceGroupHealthFilterWARNING = `
-SELECT * FROM service_group_health AS service_group_health
- WHERE health_warning  > 0
+   health_warning  > 0
    AND health_critical = 0
    AND health_unknown  = 0
- ORDER BY %s
- LIMIT $1
-OFFSET $2
 `
 	selectServiceGroupHealthFilterOK = `
-SELECT * FROM service_group_health AS service_group_health
- WHERE health_ok > 0
+   health_ok > 0
    AND health_critical = 0
    AND health_warning  = 0
    AND health_unknown  = 0
- ORDER BY %s
- LIMIT $1
-OFFSET $2
-`
+ `
+	paginationSorting = `
+  ORDER BY %s
+  LIMIT $1
+  OFFSET $2`
 
 	selectServiceGroupsTotalCount = `
 SELECT count(*)
@@ -117,6 +102,8 @@ type serviceGroupHealth struct {
 	PercentOk      int32          `db:"percent_ok"`
 	Application    string         `db:"app_name"`
 	Environment    string         `db:"environment"`
+	//We are not returning this just using it for filters
+	NameSuffix string `db:"name_suffix"`
 
 	// These fields are not mapped to any database field,
 	// they are here just to help us internally
@@ -134,10 +121,10 @@ func (db *Postgres) GetServiceGroups(
 	page = page - 1
 	offset := pageSize * page
 	var (
-		sgHealth    []*serviceGroupHealth
-		selectQuery string = selectServiceGroupHealthWithPageSort
-		sortOrder   string
-		err         error
+		sgHealth        []*serviceGroupHealth
+		selectMainQuery string = selectServiceGroupHealth
+		sortOrder       string
+		err             error
 	)
 
 	if sortAsc {
@@ -146,27 +133,55 @@ func (db *Postgres) GetServiceGroups(
 		sortOrder = "DESC"
 	}
 
+	first := true
+	whereQuery := ``
 	for filter, values := range filters {
 		if len(values) == 0 {
 			continue
+		} else if first {
+			whereQuery = ` WHERE `
+			first = false
+		} else { // not first, add on an AND
+			whereQuery = whereQuery + ` AND `
 		}
 
 		switch filter {
 		case "status", "STATUS":
 			// @afiune What if the user specify more than one Status Filter?
 			// status=["ok", "critical"]
-			selectQuery, err = queryFromStatusFilter(values[0])
+			selectQuery, err := queryFromStatusFilter(values[0])
+			whereQuery = whereQuery + selectQuery
 			if err != nil {
 				return nil, err
 			}
 
+		case "environment", "ENVIRONMENT":
+			selectQuery, err := queryFromFieldFilter("environment", values)
+			whereQuery = whereQuery + selectQuery
+			if err != nil {
+				return nil, err
+			}
+		case "application", "APPLICATION":
+			selectQuery, err := queryFromFieldFilter("app_name", values)
+			whereQuery = whereQuery + selectQuery
+			if err != nil {
+				return nil, err
+			}
+		case "group", "GROUP":
+			selectQuery, err := queryFromFieldFilter("name_suffix", values)
+			whereQuery = whereQuery + selectQuery
+			if err != nil {
+				return nil, err
+			}
 		default:
 			return nil, errors.Errorf("invalid filter. (%s:%s)", filter, values)
 		}
 	}
 
+	selectAllPartsQuery := selectMainQuery + whereQuery + paginationSorting
+
 	// Formatting our Query with sort field and sort order
-	formattedQuery := fmt.Sprintf(selectQuery, formatSortFields(sortField, sortOrder))
+	formattedQuery := fmt.Sprintf(selectAllPartsQuery, formatSortFields(sortField, sortOrder))
 
 	_, err = db.DbMap.Select(&sgHealth, formattedQuery, pageSize, offset)
 	if err != nil {
@@ -335,6 +350,14 @@ func queryFromStatusFilter(text string) (string, error) {
 	default:
 		return "", errors.Errorf("invalid status filter '%s'", text)
 	}
+}
+
+func queryFromFieldFilter(field string, envs []string) (string, error) {
+	formattedVals := strings.Join(envs[:], "','")
+	formattedVals = "'" + formattedVals + "'"
+	fmt.Println(formattedVals)
+	query := ` ` + field + ` in (` + formattedVals + `)`
+	return query, nil
 }
 
 // formatSortFields returns a customized ORDER BY statement from the provided sort field,


### PR DESCRIPTION
To avoid a query with substring we added a new column for name suffix to service group.
Technically the name suffix is actually the name of the service group, and the alternative
would be to compose the service.service_group name upon query.

App, Env and service group name all result in complete service group returns
this allows us to continue to use the view for these filters.

### :nut_and_bolt: Description

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :+1: Definition of Done

### :athletic_shoe: Demo Script / Repro Steps

### :chains: Related Resources

### :white_check_mark: Checklist

- [ ] Necessary tests added/updated?
- [ ] Necessary docs added/updated?
- [ ] Code actually executed?
- [ ] Vetting performed (unit tests, lint, etc.)?
