### PR TITLE
ci: ignore promotion of x86_64-linux-kernel2 packages

### DIFF
--- a/.expeditor/update-compliance-profiles.sh
+++ b/.expeditor/update-compliance-profiles.sh
@@ -2,6 +2,11 @@
 
 set -eou pipefail
 
+if [[ "$EXPEDITOR_PKG_TARGET" != "x86_64-linux" ]]; then
+    echo "Ignoring $EXPEDITOR_PKG_VERSION/$EXPEDITOR_PKG_RELEASE because its target is '$EXPEDITOR_PKG_TARGET' (expected 'x86_64-linux')"
+    exit 0
+fi
+
 branch="expeditor/bump-compliance-profiles"
 git checkout -b "$branch"
 

--- a/.expeditor/update-inspec-version.sh
+++ b/.expeditor/update-inspec-version.sh
@@ -2,6 +2,11 @@
 
 set -eou pipefail
 
+if [[ "$EXPEDITOR_PKG_TARGET" != "x86_64-linux" ]]; then
+    echo "Ignoring $EXPEDITOR_PKG_VERSION/$EXPEDITOR_PKG_RELEASE because its target is '$EXPEDITOR_PKG_TARGET' (expected 'x86_64-linux')"
+    exit 0
+fi
+
 branch="expeditor/bump-inspec"
 git checkout -b "$branch"
 


### PR DESCRIPTION
Habitat has multiple architecture targets, all of which will be
promoted on release.  We, however, only care about x86_64-linux
packages.

Signed-off-by: Steven Danna <steve@chef.io>