### PR TITLE
authz-service: cleanup foreign key error status

### DIFF
--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -170,7 +170,7 @@ func (s *policyServer) CreatePolicy(
 		return nil, status.Errorf(codes.AlreadyExists,
 			"policy with id %q already exists", req.Id)
 	default:
-		if err, ok := err.(*storage_errors.ErrForeignKey); ok {
+		if err, ok := err.(*storage_errors.ForeignKeyError); ok {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		return nil, status.Errorf(codes.Internal,
@@ -277,7 +277,7 @@ func (s *policyServer) UpdatePolicy(
 		case storage_errors.ErrNotFound:
 			return nil, status.Errorf(codes.NotFound, "no policy with ID %q found", req.Id)
 		default:
-			if err, ok := err.(*storage_errors.ErrForeignKey); ok {
+			if err, ok := err.(*storage_errors.ForeignKeyError); ok {
 				return nil, status.Error(codes.InvalidArgument, err.Error())
 			}
 			return nil, err
@@ -415,7 +415,7 @@ func (s *policyServer) CreateRole(
 		return nil, status.Errorf(codes.AlreadyExists, "role with id %q already exists", req.Id)
 	default:
 		switch err.(type) {
-		case *storage_errors.ErrForeignKey:
+		case *storage_errors.ForeignKeyError:
 			return nil, status.Errorf(codes.InvalidArgument, err.Error())
 		}
 		return nil, status.Errorf(codes.Internal, "creating role %q: %s", req.Id, err.Error())

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -416,7 +416,7 @@ func (s *policyServer) CreateRole(
 	default:
 		switch err.(type) {
 		case *storage_errors.ErrForeignKey:
-			return nil, status.Errorf(codes.NotFound, err.Error())
+			return nil, status.Errorf(codes.InvalidArgument, err.Error())
 		}
 		return nil, status.Errorf(codes.Internal, "creating role %q: %s", req.Id, err.Error())
 	}

--- a/components/authz-service/server/v2/project.go
+++ b/components/authz-service/server/v2/project.go
@@ -128,7 +128,7 @@ func (s *ProjectState) CreateProject(ctx context.Context,
 			"max of %d projects allowed while IAM v2 Beta", constants_v2.MaxProjects)
 	default:
 		switch err.(type) {
-		case *storage_errors.ErrForeignKey:
+		case *storage_errors.ForeignKeyError:
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		return nil, status.Errorf(codes.Internal,
@@ -379,7 +379,7 @@ func (s *ProjectState) CreateRule(ctx context.Context, req *api.CreateRuleReq) (
 		return nil, status.Errorf(codes.AlreadyExists, "rule with ID %q already exists", req.Id)
 	default:
 		switch err.(type) {
-		case *storage_errors.ErrForeignKey:
+		case *storage_errors.ForeignKeyError:
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		return nil, status.Errorf(codes.Internal,

--- a/components/authz-service/storage/errors.go
+++ b/components/authz-service/storage/errors.go
@@ -39,37 +39,37 @@ var (
 	ErrChangeTypeForRule = errors.New("cannot change rule type")
 )
 
-// ErrTxCommit occurs when the database attempts to commit a transaction and
+// TxCommitError occurs when the database attempts to commit a transaction and
 // fails.
-type ErrTxCommit struct {
+type TxCommitError struct {
 	underlying error
 }
 
-func NewErrTxCommit(e error) error {
-	return &ErrTxCommit{underlying: e}
+func NewTxCommitError(e error) error {
+	return &TxCommitError{underlying: e}
 }
 
-func (e *ErrTxCommit) Error() string {
+func (e *TxCommitError) Error() string {
 	return "commit db transaction: " + e.underlying.Error()
 }
 
-// ErrMissingField occurs when a required field was not passed.
-type ErrMissingField struct {
+// MissingFieldError occurs when a required field was not passed.
+type MissingFieldError struct {
 	field string
 }
 
 func NewMissingFieldError(f string) error {
-	return &ErrMissingField{field: f}
+	return &MissingFieldError{field: f}
 }
 
-func (e *ErrMissingField) Error() string {
+func (e *MissingFieldError) Error() string {
 	return "must supply policy " + e.field
 }
 
-type ErrForeignKey struct {
+type ForeignKeyError struct {
 	Msg string
 }
 
-func (e *ErrForeignKey) Error() string {
+func (e *ForeignKeyError) Error() string {
 	return e.Msg
 }

--- a/components/authz-service/storage/errors_test.go
+++ b/components/authz-service/storage/errors_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/chef/automate/components/authz-service/storage"
 )
 
-func TestNewErrTxCommit(t *testing.T) {
-	t.Run("ErrTxCommit.Error() does not cause an infinite loop", func(t *testing.T) {
+func TestNewTxCommitError(t *testing.T) {
+	t.Run("TxCommitError.Error() does not cause an infinite loop", func(t *testing.T) {
 		errStr := "this is some transaction error"
 		err := errors.New(errStr)
-		txErr := storage.NewErrTxCommit(err)
+		txErr := storage.NewTxCommitError(err)
 		assert.Equal(t, "commit db transaction: "+errStr, txErr.Error())
 	})
 }

--- a/components/authz-service/storage/postgres/postgres.go
+++ b/components/authz-service/storage/postgres/postgres.go
@@ -76,7 +76,7 @@ func parsePQError(e *pq.Error) error {
 	case "23505": // Unique violation
 		return storage.ErrConflict
 	case "23503": // Foreign key violation
-		return &storage.ErrForeignKey{Msg: e.Message}
+		return &storage.ForeignKeyError{Msg: e.Message}
 	case "P0002": // Not found in plpgsql ("no_data_found")
 		return storage.ErrNotFound
 	case "20000": // Not found

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -94,7 +94,7 @@ func (p *pg) CreatePolicy(ctx context.Context, pol *v2.Policy) (*v2.Policy, erro
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, storage_errors.NewErrTxCommit(err)
+		return nil, storage_errors.NewTxCommitError(err)
 	}
 
 	// Currently, we don't change anything from what is passed in.
@@ -212,7 +212,7 @@ func (p *pg) DeletePolicy(ctx context.Context, id string) error {
 
 	err = tx.Commit()
 	if err != nil {
-		return storage_errors.NewErrTxCommit(err)
+		return storage_errors.NewTxCommitError(err)
 	}
 
 	return nil
@@ -282,7 +282,7 @@ func (p *pg) UpdatePolicy(ctx context.Context, pol *v2.Policy) (*v2.Policy, erro
 	}
 
 	if err := tx.Commit(); err != nil {
-		return nil, storage_errors.NewErrTxCommit(err)
+		return nil, storage_errors.NewTxCommitError(err)
 	}
 
 	// Currently, we don't change anything from what is passed in.
@@ -417,7 +417,7 @@ func (p *pg) ListPolicyMembers(ctx context.Context, id string) ([]v2.Member, err
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, storage_errors.NewErrTxCommit(err)
+		return nil, storage_errors.NewTxCommitError(err)
 	}
 
 	return members, nil
@@ -458,7 +458,7 @@ func (p *pg) AddPolicyMembers(ctx context.Context, id string, members []v2.Membe
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, storage_errors.NewErrTxCommit(err)
+		return nil, storage_errors.NewTxCommitError(err)
 	}
 	return members, nil
 }
@@ -497,7 +497,7 @@ func (p *pg) ReplacePolicyMembers(ctx context.Context, policyID string, members 
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, storage_errors.NewErrTxCommit(err)
+		return nil, storage_errors.NewTxCommitError(err)
 	}
 
 	return members, err
@@ -553,7 +553,7 @@ func (p *pg) RemovePolicyMembers(ctx context.Context,
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, storage_errors.NewErrTxCommit(err)
+		return nil, storage_errors.NewTxCommitError(err)
 	}
 
 	return members, nil
@@ -658,7 +658,7 @@ func (p *pg) CreateRole(ctx context.Context, role *v2.Role) (*v2.Role, error) {
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, storage_errors.NewErrTxCommit(err)
+		return nil, storage_errors.NewTxCommitError(err)
 	}
 
 	return role, nil
@@ -726,7 +726,7 @@ func (p *pg) GetRole(ctx context.Context, id string) (*v2.Role, error) {
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, storage_errors.NewErrTxCommit(err)
+		return nil, storage_errors.NewTxCommitError(err)
 	}
 
 	return &role, nil
@@ -771,7 +771,7 @@ func (p *pg) DeleteRole(ctx context.Context, id string) error {
 
 	err = tx.Commit()
 	if err != nil {
-		return storage_errors.NewErrTxCommit(err)
+		return storage_errors.NewTxCommitError(err)
 	}
 
 	return nil
@@ -836,7 +836,7 @@ func (p *pg) UpdateRole(ctx context.Context, role *v2.Role) (*v2.Role, error) {
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, storage_errors.NewErrTxCommit(err)
+		return nil, storage_errors.NewTxCommitError(err)
 	}
 
 	return role, nil
@@ -887,7 +887,7 @@ func (p *pg) insertRoleWithQuerier(ctx context.Context, role *v2.Role, q Querier
 
 	err = tx.Commit()
 	if err != nil {
-		return storage_errors.NewErrTxCommit(err)
+		return storage_errors.NewTxCommitError(err)
 	}
 
 	return nil
@@ -938,7 +938,7 @@ func (p *pg) CreateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, storage_errors.NewErrTxCommit(err)
+		return nil, storage_errors.NewTxCommitError(err)
 	}
 
 	rule.Status = pgStaged
@@ -985,7 +985,7 @@ func (p *pg) UpdateRule(ctx context.Context, rule *v2.Rule) (*v2.Rule, error) {
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, storage_errors.NewErrTxCommit(err)
+		return nil, storage_errors.NewTxCommitError(err)
 	}
 
 	rule.Status = pgStaged
@@ -1084,7 +1084,7 @@ func (p *pg) DeleteRule(ctx context.Context, id string) error {
 
 	err = tx.Commit()
 	if err != nil {
-		return storage_errors.NewErrTxCommit(err)
+		return storage_errors.NewTxCommitError(err)
 	}
 
 	return nil
@@ -1208,7 +1208,7 @@ func (p *pg) ListRulesForProject(ctx context.Context, projectID string) ([]*v2.R
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, v2.RulesStatusError, storage_errors.NewErrTxCommit(err)
+		return nil, v2.RulesStatusError, storage_errors.NewTxCommitError(err)
 	}
 
 	rulesStatus := v2.Applied
@@ -1318,7 +1318,7 @@ func (p *pg) ApplyStagedRules(ctx context.Context) error {
 
 	err = tx.Commit()
 	if err != nil {
-		return storage_errors.NewErrTxCommit(err)
+		return storage_errors.NewTxCommitError(err)
 	}
 
 	return nil
@@ -1355,7 +1355,7 @@ func (p *pg) CreateProject(ctx context.Context, project *v2.Project) (*v2.Projec
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, storage_errors.NewErrTxCommit(err)
+		return nil, storage_errors.NewTxCommitError(err)
 	}
 
 	// Currently, we don't change anything from what is passed in.
@@ -1541,7 +1541,7 @@ func (p *pg) recordMigrationStatusAndNotifyPG(ctx context.Context, ms string) er
 		return p.processError(err)
 	}
 	if err := tx.Commit(); err != nil {
-		return storage_errors.NewErrTxCommit(err)
+		return storage_errors.NewTxCommitError(err)
 	}
 	return nil
 }

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -879,7 +879,7 @@ func (p *pg) insertRoleWithQuerier(ctx context.Context, role *v2.Role, q Querier
 
 	_, err = q.ExecContext(ctx,
 		`INSERT INTO iam_role_projects (role_id, project_id)
-		SELECT $1, db_id FROM iam_projects WHERE id=ANY($2)`,
+		SELECT $1, project_db_id(p) FROM unnest($2::TEXT[]) as p`,
 		dbID, pq.Array(role.Projects))
 	if err != nil {
 		return p.processError(err)

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -1115,7 +1115,7 @@ func TestCreatePolicy(t *testing.T) {
 			require.Error(t, err)
 			assert.Nil(t, resp)
 
-			_, ok:= err.(*storage_errors.ErrForeignKey)
+			_, ok:= err.(*storage_errors.ForeignKeyError)
 			assert.True(t, ok, "expected foreign key error")
 			assert.Equal(t, "role not found: "+role, err.Error())
 
@@ -1654,7 +1654,7 @@ func TestCreatePolicy(t *testing.T) {
 				resp, err := store.CreatePolicy(ctx, &pol)
 				require.Error(t, err)
 				assert.Nil(t, resp)
-				_, ok := err.(*storage_errors.ErrForeignKey)
+				_, ok := err.(*storage_errors.ForeignKeyError)
 				require.True(t, ok, "expected foreign key error")
 				assert.Equal(t, "project not found: not-real-project", err.Error())
 			})
@@ -1687,7 +1687,7 @@ func TestCreatePolicy(t *testing.T) {
 				resp, err := store.CreatePolicy(ctx, &pol)
 				require.Error(t, err)
 				assert.Nil(t, resp)
-				_, ok := err.(*storage_errors.ErrForeignKey)
+				_, ok := err.(*storage_errors.ForeignKeyError)
 				require.True(t, ok, "expected foreign key error")
 				assert.Equal(t, "project not found: not-real-project", err.Error())
 			})
@@ -3216,7 +3216,7 @@ func TestCreateRule(t *testing.T) {
 			resp, err := store.CreateRule(ctx, &rule)
 			require.Error(t, err)
 			assert.Nil(t, resp)
-			_, ok := err.(*storage_errors.ErrForeignKey)
+			_, ok := err.(*storage_errors.ForeignKeyError)
 			require.True(t, ok, "mismatches expected error type")
 			assert.Equal(t, "project not found: project-not-found", err.Error())
 		},

--- a/components/automate-deployment/pkg/certauthority/certauthority_test.go
+++ b/components/automate-deployment/pkg/certauthority/certauthority_test.go
@@ -186,44 +186,44 @@ func TestValidateCertificateForRequest(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("returns a NotSignedByCA err if the given certificate was not signed by the CA", func(t *testing.T) {
+	t.Run("returns a ErrNotSignedByCA if the given certificate was not signed by the CA", func(t *testing.T) {
 		err := ca.ValidateCertificateForRequest(badCert, goodReq)
-		assert.Equal(t, certauthority.NotSignedByCA, err)
+		assert.Equal(t, certauthority.ErrNotSignedByCA, err)
 	})
 
-	t.Run("returns a CommonNameMismatch err if the given certificate has wrong common name", func(t *testing.T) {
+	t.Run("returns a CommonNameMismatchError if the given certificate has wrong common name", func(t *testing.T) {
 		req := certauthority.NewCertRequest("some-service", expectedIPs, expectedHostnames)
 		err := ca.ValidateCertificateForRequest(goodCert, req)
 		require.Error(t, err)
-		_, ok := err.(*certauthority.CommonNameMismatch)
-		assert.True(t, ok, "error should be a CommonNameMismatch")
+		_, ok := err.(*certauthority.CommonNameMismatchError)
+		assert.True(t, ok, "error should be a CommonNameMismatchError")
 	})
 
-	t.Run("returns a SANIPAddrMismatch err if the given certificate has wrong IP Addr SAN entries", func(t *testing.T) {
+	t.Run("returns a SANIPAddrMismatchError if the given certificate has wrong IP Addr SAN entries", func(t *testing.T) {
 		req := certauthority.NewCertRequest("deployment-service", []net.IP{net.IPv4(172, 0, 2, 2)}, expectedHostnames)
 		err := ca.ValidateCertificateForRequest(goodCert, req)
 		require.Error(t, err)
-		_, ok := err.(*certauthority.SANIPAddrMismatch)
-		assert.True(t, ok, "error should be a SANIPAddrMismatch")
+		_, ok := err.(*certauthority.SANIPAddrMismatchError)
+		assert.True(t, ok, "error should be a SANIPAddrMismatchError")
 	})
 
-	t.Run("returns a SANIPAddrMismatch err if the given certificate has extra IP Addr SAN entries", func(t *testing.T) {
+	t.Run("returns a SANIPAddrMismatchError if the given certificate has extra IP Addr SAN entries", func(t *testing.T) {
 		req := certauthority.NewCertRequest("deployment-service", []net.IP{}, expectedHostnames)
 		err := ca.ValidateCertificateForRequest(goodCert, req)
 		require.Error(t, err)
-		_, ok := err.(*certauthority.SANIPAddrMismatch)
-		assert.True(t, ok, "error should be a SANIPAddrMismatch")
+		_, ok := err.(*certauthority.SANIPAddrMismatchError)
+		assert.True(t, ok, "error should be a SANIPAddrMismatchError")
 	})
 
-	t.Run("returns a SANIPAddrMismatch err if the given certificate has too few IP Addr SAN entries", func(t *testing.T) {
+	t.Run("returns a SANIPAddrMismatchError if the given certificate has too few IP Addr SAN entries", func(t *testing.T) {
 		req := certauthority.NewCertRequest("deployment-service", append(expectedIPs, net.IPv4(172, 0, 2, 2)), expectedHostnames)
 		err := ca.ValidateCertificateForRequest(goodCert, req)
 		require.Error(t, err)
-		_, ok := err.(*certauthority.SANIPAddrMismatch)
-		assert.True(t, ok, "error should be a SANIPAddrMismatch")
+		_, ok := err.(*certauthority.SANIPAddrMismatchError)
+		assert.True(t, ok, "error should be a SANIPAddrMismatchError")
 	})
 
-	t.Run("returns a SANHostnameMismatch err if the given certificate has too few DNSName SAN entries", func(t *testing.T) {
+	t.Run("returns a SANHostnameMismatch if the given certificate has too few DNSName SAN entries", func(t *testing.T) {
 		// NOTE: deployment-service is an implicit DNSName entry
 		req := certauthority.NewCertRequest("deployment-service", expectedIPs, []string{"cool.domain"})
 		err := ca.ValidateCertificateForRequest(goodCert, req)

--- a/components/automate-deployment/pkg/manifest/client/http.go
+++ b/components/automate-deployment/pkg/manifest/client/http.go
@@ -99,7 +99,7 @@ func (c *HTTP) manifestFromURL(ctx context.Context, url string) (*manifest.A2, e
 	case http.StatusOK:
 		// Yay!
 	case http.StatusNotFound:
-		return nil, manifest.NewErrNoSuchManifest(errors.Errorf("%s: %s", url, response.Status))
+		return nil, manifest.NewNoSuchManifestError(errors.Errorf("%s: %s", url, response.Status))
 	default:
 		return nil, errors.Errorf("Unexpected HTTP response from %s: %s", url, response.Status)
 	}

--- a/components/automate-deployment/pkg/manifest/client/http_test.go
+++ b/components/automate-deployment/pkg/manifest/client/http_test.go
@@ -75,6 +75,6 @@ func TestGetManifestReturnNoSuchManifestOn404(t *testing.T) {
 	client := client.NewHTTPClient(client.URLFormat(testFmt))
 	_, err := client.GetManifest(context.Background(), "20180207073355")
 	require.Error(t, err)
-	_, ok := err.(*manifest.ErrNoSuchManifest)
-	require.True(t, ok, "error should be a ErrNoSuchManifest")
+	_, ok := err.(*manifest.NoSuchManifestError)
+	require.True(t, ok, "error should be a NoSuchManifestError")
 }

--- a/components/automate-deployment/pkg/manifest/client/path.go
+++ b/components/automate-deployment/pkg/manifest/client/path.go
@@ -28,7 +28,7 @@ func NewPathClient(path string) *Path {
 func (d *Path) GetCurrentManifest(_ context.Context, channel string) (*manifest.A2, error) {
 	stat, err := os.Stat(d.path)
 	if err != nil {
-		return nil, manifest.NewErrNoSuchManifest(err)
+		return nil, manifest.NewNoSuchManifestError(err)
 	}
 	path := d.path
 
@@ -42,7 +42,7 @@ func (d *Path) GetCurrentManifest(_ context.Context, channel string) (*manifest.
 func (d *Path) GetManifest(_ context.Context, release string) (*manifest.A2, error) {
 	stat, err := os.Stat(d.path)
 	if err != nil {
-		return nil, manifest.NewErrNoSuchManifest(err)
+		return nil, manifest.NewNoSuchManifestError(err)
 	}
 	path := d.path
 
@@ -56,7 +56,7 @@ func (d *Path) GetManifest(_ context.Context, release string) (*manifest.A2, err
 func (d *Path) manifestFromPath(path string) (*manifest.A2, error) {
 	body, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, manifest.NewErrNoSuchManifest(err)
+		return nil, manifest.NewNoSuchManifestError(err)
 	}
 
 	m, err := parser.ManifestFromBytes(body)

--- a/components/automate-deployment/pkg/manifest/client/path_test.go
+++ b/components/automate-deployment/pkg/manifest/client/path_test.go
@@ -56,8 +56,8 @@ func TestDirectoryGetCurrentManifestWhenDoesntExist(t *testing.T) {
 	client := client.NewPathClient(dir)
 	_, err = client.GetCurrentManifest(context.Background(), "current")
 	require.Error(t, err)
-	_, ok := err.(*manifest.ErrNoSuchManifest)
-	require.True(t, ok, "error should be a ErrNoSuchManifest")
+	_, ok := err.(*manifest.NoSuchManifestError)
+	require.True(t, ok, "error should be a NoSuchManifestError")
 }
 
 func TestDirectoryGetCurrentManifestWhenInvalid(t *testing.T) {
@@ -71,8 +71,8 @@ func TestDirectoryGetCurrentManifestWhenInvalid(t *testing.T) {
 	client := client.NewPathClient(dir)
 	_, err = client.GetCurrentManifest(context.Background(), "current")
 	require.Error(t, err)
-	_, ok := err.(*manifest.ErrInvalidSchema)
-	require.True(t, ok, "error should be a ErrInvalidSchema")
+	_, ok := err.(*manifest.InvalidSchemaError)
+	require.True(t, ok, "error should be a InvalidSchemaError")
 }
 
 func TestFileGetCurrentManifestA2(t *testing.T) {
@@ -144,8 +144,8 @@ func TestFileGetCurrentManifestWhenDoesntExist(t *testing.T) {
 	client := client.NewPathClient(filename)
 	_, err = client.GetCurrentManifest(context.Background(), "current")
 	require.Error(t, err)
-	_, ok := err.(*manifest.ErrNoSuchManifest)
-	require.True(t, ok, "error should be a ErrNoSuchManifest")
+	_, ok := err.(*manifest.NoSuchManifestError)
+	require.True(t, ok, "error should be a NoSuchManifestError")
 }
 
 func TestFileGetCurrentManifestWhenInvalid(t *testing.T) {
@@ -159,8 +159,8 @@ func TestFileGetCurrentManifestWhenInvalid(t *testing.T) {
 	err = ioutil.WriteFile(filename, []byte("::::::"), 0700)
 	_, err = client.GetCurrentManifest(context.Background(), "current")
 	require.Error(t, err)
-	_, ok := err.(*manifest.ErrInvalidSchema)
-	require.True(t, ok, "error should be a ErrInvalidSchema")
+	_, ok := err.(*manifest.InvalidSchemaError)
+	require.True(t, ok, "error should be a InvalidSchemaError")
 }
 
 func TestFileGetManifest(t *testing.T) {

--- a/components/automate-deployment/pkg/manifest/errors.go
+++ b/components/automate-deployment/pkg/manifest/errors.go
@@ -2,38 +2,38 @@ package manifest
 
 import "github.com/pkg/errors"
 
-func NewErrInvalidSchema(err error) error {
-	return &ErrInvalidSchema{err}
+func NewInvalidSchemaError(err error) error {
+	return &InvalidSchemaError{err}
 }
 
-type ErrInvalidSchema struct {
+type InvalidSchemaError struct {
 	err error
 }
 
-func (e *ErrInvalidSchema) Error() string {
+func (e *InvalidSchemaError) Error() string {
 	return errors.Wrap(e.err, "unknown schema").Error()
 }
 
-type ErrCannotParse struct {
+type CannotParseError struct {
 	err error
 }
 
-func NewErrCannotParse(err error) error {
-	return &ErrCannotParse{err}
+func NewCannotParseError(err error) error {
+	return &CannotParseError{err}
 }
 
-func (e *ErrCannotParse) Error() string {
+func (e *CannotParseError) Error() string {
 	return errors.Wrap(e.err, "failed to parse manifest").Error()
 }
 
-type ErrNoSuchManifest struct {
+type NoSuchManifestError struct {
 	err error
 }
 
-func NewErrNoSuchManifest(err error) error {
-	return &ErrNoSuchManifest{err}
+func NewNoSuchManifestError(err error) error {
+	return &NoSuchManifestError{err}
 }
 
-func (e *ErrNoSuchManifest) Error() string {
+func (e *NoSuchManifestError) Error() string {
 	return errors.Wrap(e.err, "failed to locate manifest").Error()
 }

--- a/components/automate-deployment/pkg/manifest/parser/parser.go
+++ b/components/automate-deployment/pkg/manifest/parser/parser.go
@@ -39,7 +39,7 @@ func ManifestFromBytes(body []byte) (*manifest.A2, error) {
 	versionedManifest := &versionedManifest{}
 	err := json.Unmarshal(body, versionedManifest)
 	if err != nil {
-		return nil, manifest.NewErrInvalidSchema(err)
+		return nil, manifest.NewInvalidSchemaError(err)
 	}
 
 	ver := versionedManifest.SchemaVersion
@@ -47,7 +47,7 @@ func ManifestFromBytes(body []byte) (*manifest.A2, error) {
 	case "1":
 		return parseV1Manifest(body)
 	default:
-		return nil, manifest.NewErrInvalidSchema(errors.Errorf("schema version unknown: %s", ver))
+		return nil, manifest.NewInvalidSchemaError(errors.Errorf("schema version unknown: %s", ver))
 	}
 }
 
@@ -55,7 +55,7 @@ func parseV1Manifest(body []byte) (*manifest.A2, error) {
 	v1 := &v1Manifest{}
 	err := json.Unmarshal(body, v1)
 	if err != nil {
-		return nil, manifest.NewErrCannotParse(err)
+		return nil, manifest.NewCannotParseError(err)
 	}
 
 	m := &manifest.A2{}
@@ -70,7 +70,7 @@ func parseA2Manifest(body []byte) (*manifest.A2, error) {
 	a2 := &manifest.A2{}
 	err := json.Unmarshal(body, a2)
 	if err != nil {
-		return nil, manifest.NewErrCannotParse(err)
+		return nil, manifest.NewCannotParseError(err)
 	}
 
 	return a2, nil

--- a/components/automate-deployment/pkg/manifest/parser/parser_test.go
+++ b/components/automate-deployment/pkg/manifest/parser/parser_test.go
@@ -104,22 +104,22 @@ func TestManifestFromBytes(t *testing.T) {
 	t.Run("unknown schema", func(t *testing.T) {
 		_, err := parser.ManifestFromBytes([]byte(unknownManifest))
 		require.Error(t, err)
-		_, ok := err.(*manifest.ErrInvalidSchema)
-		require.True(t, ok, "error should be a ErrInvalidSchema")
+		_, ok := err.(*manifest.InvalidSchemaError)
+		require.True(t, ok, "error should be a InvalidSchemaError")
 	})
 
 	t.Run("no schema", func(t *testing.T) {
 		_, err := parser.ManifestFromBytes([]byte(noSchemaManifest))
 		require.Error(t, err)
-		_, ok := err.(*manifest.ErrInvalidSchema)
-		require.True(t, ok, "error should be a ErrInvalidSchema")
+		_, ok := err.(*manifest.InvalidSchemaError)
+		require.True(t, ok, "error should be a InvalidSchemaError")
 	})
 
 	t.Run("malformed JSON", func(t *testing.T) {
 		_, err := parser.ManifestFromBytes([]byte(malformedJSON))
 		require.Error(t, err)
-		_, ok := err.(*manifest.ErrInvalidSchema)
-		require.True(t, ok, "error should be a ErrInvalidSchema")
+		_, ok := err.(*manifest.InvalidSchemaError)
+		require.True(t, ok, "error should be a InvalidSchemaError")
 	})
 
 	t.Run("v1", func(t *testing.T) {

--- a/components/automate-deployment/pkg/server/backup.go
+++ b/components/automate-deployment/pkg/server/backup.go
@@ -145,7 +145,7 @@ func (s *server) RestoreBackup(ctx context.Context, req *api.RestoreBackupReques
 		desiredManifest, err = manifestClient.GetCurrentManifest(ctx, "")
 
 		if err != nil {
-			_, ok := err.(*manifest.ErrCannotParse)
+			_, ok := err.(*manifest.CannotParseError)
 			if ok {
 				return nil, status.Errorf(codes.InvalidArgument, err.Error())
 			}

--- a/components/automate-deployment/pkg/server/server.go
+++ b/components/automate-deployment/pkg/server/server.go
@@ -1797,7 +1797,7 @@ func (s *server) Upgrade(ctx context.Context, req *api.UpgradeRequest) (*api.Upg
 		m, err = s.releaseManifestProvider.RefreshManifest(ctx, channel)
 	}
 
-	_, ok := err.(*manifest.ErrNoSuchManifest)
+	_, ok := err.(*manifest.NoSuchManifestError)
 	if ok {
 		return nil, status.Errorf(codes.NotFound, errors.Wrap(err, "No manifest for the specified version or channel could be found").Error())
 	}

--- a/components/local-user-service/password/password.go
+++ b/components/local-user-service/password/password.go
@@ -12,28 +12,28 @@ type Validator struct {
 	cr   *crunchy.Validator
 }
 
-// ErrEmpty is returned if the validated password is empty or all whitespace.
-type ErrEmpty struct{}
+// EmptyError is returned if the validated password is empty or all whitespace.
+type EmptyError struct{}
 
-func (*ErrEmpty) Error() string { return "password is empty or all whitespace" }
+func (*EmptyError) Error() string { return "password is empty or all whitespace" }
 
-// ErrTooShort is returned if the password is shorter than the required number
+// TooShortError is returned if the password is shorter than the required number
 // of chars.
-type ErrTooShort struct {
+type TooShortError struct {
 	min int
 }
 
-func (e *ErrTooShort) Error() string {
+func (e *TooShortError) Error() string {
 	return fmt.Sprintf("password is too short (must be at least %d characters)", e.min)
 }
 
-// ErrTooFewChars is returned if the password has less than the required number
+// TooFewCharsError is returned if the password has less than the required number
 // of distinct characters.
-type ErrTooFewChars struct {
+type TooFewCharsError struct {
 	min int
 }
 
-func (e *ErrTooFewChars) Error() string {
+func (e *TooFewCharsError) Error() string {
 	return fmt.Sprintf("password does not contain enough distinct characters (minimum %d)", e.min)
 }
 
@@ -69,11 +69,11 @@ func (v *Validator) translateError(err error) error {
 		return nil
 
 	case crunchy.ErrEmpty:
-		return &ErrEmpty{}
+		return &EmptyError{}
 	case crunchy.ErrTooShort:
-		return &ErrTooShort{min: v.opts.MinLength}
+		return &TooShortError{min: v.opts.MinLength}
 	case crunchy.ErrTooFewChars:
-		return &ErrTooFewChars{min: v.opts.MinDiff}
+		return &TooFewCharsError{min: v.opts.MinDiff}
 	default: // includes err == nil
 		return err
 	}


### PR DESCRIPTION
### :nut_and_bolt: Description

✅ Fixes the return status of Create{Policy, Role} requests containing a project/role which do not exist. These will all now return InvalidArgument, which is translated to HTTP 400.

✅ Ensures we follow the naming convention for error constants vs error types.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :athletic_shoe: Demo Script / Repro Steps

- `start_all_services`, `rebuild components/authz-service`
- create project "foo": `chef-automate dev grpcurl authz-service --  -d "$(jq -n '{id: "foo", name: "Foo" }')" chef.automate.domain.authz.v2.Projects.CreateProject`
- create a rule referencing projects "foo" and "bar":
```
[41][default:/src:130]# chef-automate dev grpcurl authz-service --  -d "$(jq -n '{id: "foo2", name: "Foo", projects: ["foo", "bar"], actions: ["svc:type:action"]}')" chef.automate.domain.authz.v2.Policies.CreateRole
ERROR:
  Code: InvalidArgument
  Message: project not found: bar
UnknownError: exit status 1
```
- create a policy referecing those two:
```
[51][default:/src:130]# chef-automate dev grpcurl authz-service -- -d '{"id":"new-id4", "name":"blakepol2", "projects":["foo", "bar"]}' chef.automate.domain.authz.v2.Policies.CreatePolicy
ERROR:
  Code: InvalidArgument
  Message: project not found: bar
UnknownError: exit status 1
```
- create a policy with a statement reference those two:
```
[54][default:/src:113]# echo '{"id":"new-id4", "name":"blakepol2", "projects":["foo"], "statements": [ {"effect": "ALLOW", "actions": [ "iam:*" ], "projects": [ "foo", "bar" ]}] }' | chef-automate dev grpcurl authz-service -- -d @ c
hef.automate.domain.authz.v2.Policies.CreatePolicy
ERROR:
  Code: InvalidArgument
  Message: project not found: bar
UnknownError: exit status 1
```
