### PR TITLE
WIP: Adding mapping fields for project filters

### DIFF
--- a/components/authz-service/server/v2/project_update_manager.go
+++ b/components/authz-service/server/v2/project_update_manager.go
@@ -137,7 +137,7 @@ func (manager *ProjectUpdateManager) ProcessFailEvent(eventMessage *automate_eve
 				return stage, errors.New("Producer ID was not provided in status message")
 			}
 			fromProducer := eventMessage.Producer.ID
-			projectUpdateID, err := getProjectUpdateID(eventMessage)
+			projectUpdateID, err := project_update_tags.GetProjectUpdateID(eventMessage)
 			if err != nil {
 				return stage, err
 			}
@@ -182,7 +182,7 @@ func (manager *ProjectUpdateManager) ProcessStatusEvent(
 				return stage, errors.New("Producer was not provided in status message")
 			}
 			fromProducer := eventMessage.Producer.ID
-			projectUpdateID, err := getProjectUpdateID(eventMessage)
+			projectUpdateID, err := project_update_tags.GetProjectUpdateID(eventMessage)
 			if err != nil {
 				return stage, err
 			}
@@ -469,18 +469,6 @@ func createEventUUID() string {
 	}
 
 	return uuid.String()
-}
-
-// Get the Project Update ID out of the event Data fields
-func getProjectUpdateID(event *automate_event.EventMsg) (string, error) {
-	fieldName := project_update_tags.ProjectUpdateIDTag
-	if event.Data != nil && event.Data.Fields != nil && event.Data.Fields[fieldName] != nil &&
-		event.Data.Fields[fieldName].GetStringValue() != "" {
-		return event.Data.Fields[fieldName].GetStringValue(), nil
-	}
-
-	return "", fmt.Errorf("Event message sent without a %s field eventID: %q",
-		fieldName, event.EventID)
 }
 
 func getFailureMessage(event *automate_event.EventMsg) string {

--- a/components/compliance-service/api/jobs/server/server.go
+++ b/components/compliance-service/api/jobs/server/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/golang/protobuf/ptypes"
 	pb "github.com/golang/protobuf/ptypes/empty"
+	_struct "github.com/golang/protobuf/ptypes/struct"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	rrule "github.com/teambition/rrule-go"
@@ -281,10 +282,11 @@ func (srv *Server) fireEvent(eventType string, in *jobs.Job, id *jobs.Id, user s
 
 func (srv *Server) newEventMsg(eventType string, in *jobs.Job, id *jobs.Id, user string) *automate_event.EventMsg {
 	var (
-		verbVal string
-		tagsVal []string
-		nameVal string
-		userVal string
+		verbVal              string
+		tagsVal              []string
+		nameVal              string
+		userVal              string
+		ProjectFilterableTag = "project_filterable"
 	)
 
 	if len(user) == 0 {
@@ -340,6 +342,15 @@ func (srv *Server) newEventMsg(eventType string, in *jobs.Job, id *jobs.Id, user
 			ID:          "",
 			ObjectType:  "Not Applicable",
 			DisplayName: "Not Applicable",
+		},
+		Data: &_struct.Struct{
+			Fields: map[string]*_struct.Value{
+				ProjectFilterableTag: {
+					Kind: &_struct.Value_BoolValue{
+						BoolValue: false,
+					},
+				},
+			},
 		},
 	}
 }

--- a/components/compliance-service/api/profiles/server/pgserver.go
+++ b/components/compliance-service/api/profiles/server/pgserver.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/golang/protobuf/ptypes"
 	pb "github.com/golang/protobuf/ptypes/empty"
+	_struct "github.com/golang/protobuf/ptypes/struct"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -340,10 +341,11 @@ func (srv *PGProfileServer) fireEvent(eventType string, owner string, name strin
 
 func (srv *PGProfileServer) newEventMsg(eventType string, owner string, name string, version string) *automate_event.EventMsg {
 	var (
-		verbVal string
-		tagsVal []string
-		nameVal = name + " version " + version
-		userVal = owner
+		verbVal              string
+		tagsVal              []string
+		nameVal              = name + " version " + version
+		userVal              = owner
+		ProjectFilterableTag = "project_filterable"
 	)
 
 	switch eventType {
@@ -385,6 +387,15 @@ func (srv *PGProfileServer) newEventMsg(eventType string, owner string, name str
 			ID:          "",
 			ObjectType:  "Not Applicable",
 			DisplayName: "Not Applicable",
+		},
+		Data: &_struct.Struct{
+			Fields: map[string]*_struct.Value{
+				ProjectFilterableTag: {
+					Kind: &_struct.Value_BoolValue{
+						BoolValue: false,
+					},
+				},
+			},
 		},
 	}
 }

--- a/components/compliance-service/ingest/server/compliance.go
+++ b/components/compliance-service/ingest/server/compliance.go
@@ -67,7 +67,7 @@ func (srv *ComplianceIngestServer) HandleEvent(ctx context.Context, req *automat
 
 	response := &automate_event.EventResponse{}
 	if req.Type.Name == event.ProjectRulesUpdate {
-		projectUpdateID, err := getProjectUpdateID(req)
+		projectUpdateID, err := project_update_lib.GetProjectUpdateID(req)
 		if err != nil {
 			logrus.Errorf("Project Rule Update sent without a ProjectUpdateID eventID %q",
 				req.EventID)
@@ -76,7 +76,7 @@ func (srv *ComplianceIngestServer) HandleEvent(ctx context.Context, req *automat
 
 		srv.updateManager.Start(projectUpdateID)
 	} else if req.Type.Name == event.ProjectRulesCancelUpdate {
-		projectUpdateID, err := getProjectUpdateID(req)
+		projectUpdateID, err := project_update_lib.GetProjectUpdateID(req)
 		if err != nil {
 			logrus.Errorf("Project Rule Update Cancel sent without a ProjectUpdateID. eventID %q",
 				req.EventID)
@@ -101,15 +101,6 @@ func (srv *ComplianceIngestServer) ProjectUpdateStatus(ctx context.Context,
 		PercentageComplete:    srv.updateManager.PercentageComplete(),
 		EstimatedTimeComplete: time,
 	}, nil
-}
-
-func getProjectUpdateID(event *automate_event.EventMsg) (string, error) {
-	if event.Data != nil && event.Data.Fields != nil && event.Data.Fields["ProjectUpdateID"] != nil &&
-		event.Data.Fields["ProjectUpdateID"].GetStringValue() != "" {
-		return event.Data.Fields["ProjectUpdateID"].GetStringValue(), nil
-	}
-
-	return "", fmt.Errorf("Project Rule Update sent without a ProjectUpdateID eventID: %q", event.EventID)
 }
 
 func (s *ComplianceIngestServer) ProcessComplianceReport(ctx context.Context, in *compliance.Report) (*gp.Empty, error) {

--- a/components/event-feed-service/pkg/config/config_mgmt.go
+++ b/components/event-feed-service/pkg/config/config_mgmt.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"io/ioutil"
+	"os"
+
+	toml "github.com/pelletier/go-toml"
+	log "github.com/sirupsen/logrus"
+
+	project_update_lib "github.com/chef/automate/lib/authz"
+	base_config "github.com/chef/automate/lib/config"
+)
+
+func defaultConfig() aggregateConfig {
+	return aggregateConfig{
+		ProjectUpdateConfig: project_update_lib.ProjectUpdateConfig{
+			State: project_update_lib.NotRunningState,
+		},
+	}
+}
+
+// Manager - configuration manager for the service
+type Manager struct {
+	baseConfigManager *base_config.Manager
+}
+
+// Config - stores the configuration for the service
+type aggregateConfig struct {
+	ProjectUpdateConfig project_update_lib.ProjectUpdateConfig `toml:"project_update_config"`
+}
+
+// NewManager - create a new config. There should only be one config for the service.
+func NewManager(configFile string) (*Manager, error) {
+	storedConfig, err := readConfigFromFile(configFile, defaultConfig())
+	if err != nil {
+		return &Manager{}, err
+	}
+
+	// Testing Updating
+	baseManager := base_config.NewManager(configFile, storedConfig)
+	err = baseManager.UpdateConfig(func(config interface{}) (interface{}, error) {
+		return storedConfig, nil
+	})
+	if err != nil {
+		return &Manager{}, err
+	}
+
+	return &Manager{
+		baseConfigManager: baseManager,
+	}, err
+}
+
+// Close - close channels
+func (manager *Manager) Close() {
+	manager.baseConfigManager.Close()
+}
+
+// GetProjectUpdateConfig - get the project update config data
+func (manager *Manager) GetProjectUpdateConfig() project_update_lib.ProjectUpdateConfig {
+	return manager.getConfig().ProjectUpdateConfig
+}
+
+// UpdateProjectUpdateConfig - update the project update config
+func (manager *Manager) UpdateProjectUpdateConfig(projectUpdateConfig project_update_lib.ProjectUpdateConfig) error {
+	return manager.updateConfig(func(config aggregateConfig) (aggregateConfig, error) {
+		config.ProjectUpdateConfig = projectUpdateConfig
+		return config, nil
+	})
+}
+
+func (manager *Manager) updateConfig(updateFunc func(aggregateConfig) (aggregateConfig, error)) error {
+	return manager.baseConfigManager.UpdateConfig(func(config interface{}) (interface{}, error) {
+		return updateFunc(config.(aggregateConfig))
+	})
+}
+
+func (manager *Manager) getConfig() aggregateConfig {
+	aggregateConfig, ok := manager.baseConfigManager.Config.(aggregateConfig)
+	if !ok {
+		log.Error("baseConfigManager.Config is not of type 'aggregateConfig'")
+		os.Exit(1)
+	}
+
+	return aggregateConfig
+}
+
+func readConfigFromFile(configFile string, defaultConfig aggregateConfig) (interface{}, error) {
+	config := defaultConfig
+
+	tomlData, err := ioutil.ReadFile(configFile)
+	if os.IsNotExist(err) {
+		// config file does not exists use the default config
+		return config, nil
+	} else if err != nil {
+		log.WithFields(log.Fields{
+			"config_file": configFile,
+		}).WithError(err).Error("Unable to read config file")
+
+		return defaultConfig, err
+	}
+
+	err = toml.Unmarshal(tomlData, &config)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"config_file": configFile,
+		}).WithError(err).Error("Unable to load manager configuration")
+
+		// Could not load data from config file using the default config.
+		return defaultConfig, nil
+	}
+
+	return config, nil
+}

--- a/components/event-feed-service/pkg/grpc/grpc.go
+++ b/components/event-feed-service/pkg/grpc/grpc.go
@@ -85,7 +85,13 @@ func newGRPCServer(connFactory *secureconn.Factory, c *config.EventFeed,
 	feedStore persistence.FeedStore, esSidecarConn *grpc.ClientConn) *grpc.Server {
 	grpcServer := connFactory.NewServer()
 
-	eventFeedServer := server.New(feedStore)
+	configManager, err := config.NewManager(viper.ConfigFileUsed())
+	if err != nil {
+		return err
+	}
+	defer configManager.Close()
+
+	eventFeedServer := server.New(feedStore, configManager)
 
 	event_feed.RegisterEventFeedServiceServer(grpcServer, eventFeedServer)
 

--- a/components/event-feed-service/pkg/persistence/feed-elastic.go
+++ b/components/event-feed-service/pkg/persistence/feed-elastic.go
@@ -192,9 +192,9 @@ func (efs ElasticFeedStore) GetFeed(query *util.FeedQuery) ([]*util.FeedEntry, i
 			entries = append(entries, entry)
 		}
 		return entries, searchResult.Hits.TotalHits, nil
-	} else {
-		return entries, 0, nil
 	}
+
+	return entries, 0, nil
 }
 
 func (efs ElasticFeedStore) GetFeedSummary(q *util.FeedSummaryQuery) (map[string]int64, error) {

--- a/components/event-feed-service/pkg/persistence/mappings.go
+++ b/components/event-feed-service/pkg/persistence/mappings.go
@@ -90,6 +90,19 @@ var feedProps = `
 		"target_object_type":{
 				"type":"text"
 		},
+		"organization_name": {
+			"type": "keyword"
+		},
+		"chef_server_fqdn": {
+			"type": "keyword"
+		},
+		"projects": {
+			"type": "keyword"
+		},
+		"project_filterable": {
+			"type": "boolean",
+			"null_value": true
+		},
 		"created":{
 				"type":"date",
 				"format":"strict_date_optional_time||epoch_millis"

--- a/components/event-feed-service/pkg/persistence/store.go
+++ b/components/event-feed-service/pkg/persistence/store.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	iam_v2 "github.com/chef/automate/api/interservice/authz/v2"
 	"github.com/chef/automate/components/event-feed-service/pkg/util"
 	project_update_lib "github.com/chef/automate/lib/authz"
 	olivere "github.com/olivere/elastic"
@@ -12,13 +13,17 @@ type FeedStore interface {
 	DeleteIndex(ctx context.Context, index string) error
 	// @param (context, jobID)
 	JobStatus(context.Context, string) (project_update_lib.JobStatus, error)
+	// @param (context, projectUpdateID)
+	JobCancel(context.Context, string) error
+	// @param (context, project_rules)
+	UpdateProjectTags(context.Context, map[string]*iam_v2.ProjectRules) ([]string, error)
 	// @param (context, indexName)
 	DoesIndexExists(context.Context, string) (bool, error)
 	// @param (context, previousIndex)
 	ReindexFeedsToLatest(context.Context, string) (string, error)
 	// @param (context)
 	InitializeStore(context.Context) error
-	CreateFeedEntry(entry *util.FeedEntry) (bool, error)
+	CreateFeedEntry(entry *util.FeedEntry) error
 	GetFeed(query *util.FeedQuery) ([]*util.FeedEntry, int64, error)
 	GetFeedSummary(query *util.FeedSummaryQuery) (map[string]int64, error)
 	GetActionLine(filters []string, startDate string, endDate string, timezone string, interval int, action string) (*util.ActionLine, error)

--- a/components/event-feed-service/pkg/server/feed.go
+++ b/components/event-feed-service/pkg/server/feed.go
@@ -98,12 +98,12 @@ func (f *Feeds) GetActionLine(filters []string, startDate string, endDate string
 
 // Going forward, we'll need to maintain a map of event types to feed type(s). Since the
 // only events we support currently map to the "event" feed type, we're hard-coding the feed type below.
-func (f *Feeds) HandleEvent(req *api.EventMsg) (*api.EventResponse, error) {
+func (f *Feeds) CreateFeedEntry(req *api.EventMsg) error {
 	logrus.Debug("automate-feed is handling your event...")
 
 	publishedAt, err := ptypes.Timestamp(req.Published)
 	if err != nil {
-		return nil, errors.GrpcErrorFromErr(codes.InvalidArgument, err)
+		return errors.GrpcErrorFromErr(codes.InvalidArgument, err)
 	}
 
 	// translate event message into feed entry
@@ -134,18 +134,15 @@ func (f *Feeds) HandleEvent(req *api.EventMsg) (*api.EventResponse, error) {
 		Projects:           getProjects(req),
 	}
 
-	success, err := f.store.CreateFeedEntry(&feedEntry)
-	logrus.Debugf("Event was successfully handled: %t", success)
-	res := api.EventResponse{Success: success}
-
+	err = f.store.CreateFeedEntry(&feedEntry)
 	if err != nil {
 		logrus.Warn("Event was not handled... error creating feed entry")
-		return &res, err
+		return err
 	}
 
 	logrus.Debug("automate-feed has finished handling your event...")
 
-	return &res, nil
+	return nil
 }
 
 func getOrganizationName(event *automate_event.EventMsg) string {

--- a/components/event-feed-service/pkg/util/util.go
+++ b/components/event-feed-service/pkg/util/util.go
@@ -112,6 +112,10 @@ type FeedEntry struct {
 	TargetName         string    `json:"target_name"`
 	TargetObjectType   string    `json:"target_object_type"`
 	Created            time.Time `json:"created"`
+	OrganizationName   string    `json:"organization_name"`
+	ChefServerFQDN     string    `json:"chef_server_fqdn"`
+	Projects           []string  `json:"projects"`
+	ProjectFilterable  bool      `json:"project_filterable"`
 }
 
 func (f *FeedEntry) ToJSON() ([]byte, error) {

--- a/components/ingest-service/backend/elastic/actions.go
+++ b/components/ingest-service/backend/elastic/actions.go
@@ -12,6 +12,7 @@ import (
 	iam_v2 "github.com/chef/automate/api/interservice/authz/v2"
 	"github.com/chef/automate/components/ingest-service/backend"
 	"github.com/chef/automate/components/ingest-service/backend/elastic/mappings"
+	project_update_lib "github.com/chef/automate/lib/authz"
 	"github.com/olivere/elastic"
 )
 
@@ -80,7 +81,8 @@ func (es *Backend) UpdateActionProjectTags(ctx context.Context,
 	startTaskResult, err := elastic.NewUpdateByQueryService(es.client).
 		Index(index).
 		Type(mappings.Actions.Type).
-		Script(elastic.NewScript(script).Params(convertProjectTaggingRulesToEsParams(projectTaggingRules))).
+		Script(elastic.NewScript(script).Params(
+			project_update_lib.ConvertProjectTaggingRulesToEsParams(projectTaggingRules))).
 		WaitForCompletion(false).
 		ProceedOnVersionConflict().
 		DoAsync(ctx)

--- a/components/ingest-service/server/automate_event_handler.go
+++ b/components/ingest-service/server/automate_event_handler.go
@@ -69,7 +69,7 @@ func (s *AutomateEventHandlerServer) HandleEvent(ctx context.Context,
 			}
 		}
 	} else if req.Type.Name == server.ProjectRulesUpdate {
-		projectUpdateID, err := getProjectUpdateID(req)
+		projectUpdateID, err := project_update_lib.GetProjectUpdateID(req)
 		if err != nil {
 			logrus.Errorf("Project Rule Update sent without a ProjectUpdateID eventID %q",
 				req.EventID)
@@ -78,7 +78,7 @@ func (s *AutomateEventHandlerServer) HandleEvent(ctx context.Context,
 
 		s.updateManager.Start(projectUpdateID)
 	} else if req.Type.Name == server.ProjectRulesCancelUpdate {
-		projectUpdateID, err := getProjectUpdateID(req)
+		projectUpdateID, err := project_update_lib.GetProjectUpdateID(req)
 		if err != nil {
 			logrus.Errorf("Project Rule Update Cancel sent without a ProjectUpdateID. eventID %q",
 				req.EventID)
@@ -98,19 +98,8 @@ func (s *AutomateEventHandlerServer) ProjectUpdateStatus(ctx context.Context,
 		time = &tspb.Timestamp{}
 	}
 	return &ingest_api.ProjectUpdateStatusResp{
-		State:                  s.updateManager.State(),
-		PercentageComplete:     float32(s.updateManager.PercentageComplete()),
+		State:                 s.updateManager.State(),
+		PercentageComplete:    float32(s.updateManager.PercentageComplete()),
 		EstimatedTimeComplete: time,
 	}, nil
-}
-
-func getProjectUpdateID(event *automate_event.EventMsg) (string, error) {
-	if event.Data != nil && event.Data.Fields != nil &&
-		event.Data.Fields["ProjectUpdateID"] != nil &&
-		event.Data.Fields["ProjectUpdateID"].GetStringValue() != "" {
-		return event.Data.Fields["ProjectUpdateID"].GetStringValue(), nil
-	}
-
-	return "", fmt.Errorf("Project Rule Update sent without a ProjectUpdateID eventID: %q",
-		event.EventID)
 }

--- a/lib/authz/project_rules.go
+++ b/lib/authz/project_rules.go
@@ -1,5 +1,11 @@
 package authz
 
+import (
+	"fmt"
+	iam_v2 "github.com/chef/automate/api/interservice/authz/v2"
+	automate_event "github.com/chef/automate/api/interservice/event"
+)
+
 const (
 	// ProjectUpdateIDTag - The tag used to designate the project update job
 	ProjectUpdateIDTag = "ProjectUpdateID"
@@ -30,4 +36,74 @@ func FindSlowestJobStatus(jobStatuses []JobStatus) JobStatus {
 	}
 
 	return combinedJobStatus
+}
+
+// GetProjectUpdateID - get the project update ID from the event message
+func GetProjectUpdateID(event *automate_event.EventMsg) (string, error) {
+	if event.Data != nil && event.Data.Fields != nil &&
+		event.Data.Fields["ProjectUpdateID"] != nil &&
+		event.Data.Fields["ProjectUpdateID"].GetStringValue() != "" {
+		return event.Data.Fields["ProjectUpdateID"].GetStringValue(), nil
+	}
+
+	return "", fmt.Errorf("Event Msg does not have a ProjectUpdateID eventID: %q",
+		event.EventID)
+}
+
+func ConvertProjectTaggingRulesToEsParams(projectTaggingRules map[string]*iam_v2.ProjectRules) map[string]interface{} {
+	esProjectCollection := make([]map[string]interface{}, len(projectTaggingRules))
+	projectIndex := 0
+	for projectName, projectRules := range projectTaggingRules {
+		esRuleCollection := make([]map[string]interface{}, len(projectRules.Rules))
+		for ruleIndex, rule := range projectRules.Rules {
+			esConditionCollection := make([]map[string]interface{}, len(rule.Conditions))
+
+			for conditionIndex, condition := range rule.Conditions {
+				chefServers := []string{}
+				organizations := []string{}
+				environments := []string{}
+				roles := []string{}
+				chefTags := []string{}
+				policyGroups := []string{}
+				policyNames := []string{}
+				switch condition.Attribute {
+				case iam_v2.ProjectRuleConditionAttributes_CHEF_SERVERS:
+					chefServers = condition.Values
+				case iam_v2.ProjectRuleConditionAttributes_CHEF_ORGS:
+					organizations = condition.Values
+				case iam_v2.ProjectRuleConditionAttributes_CHEF_ENVIRONMENTS:
+					environments = condition.Values
+				case iam_v2.ProjectRuleConditionAttributes_ROLES:
+					roles = condition.Values
+				case iam_v2.ProjectRuleConditionAttributes_CHEF_TAGS:
+					chefTags = condition.Values
+				case iam_v2.ProjectRuleConditionAttributes_POLICY_GROUP:
+					policyGroups = condition.Values
+				case iam_v2.ProjectRuleConditionAttributes_POLICY_NAME:
+					policyNames = condition.Values
+				}
+				esConditionCollection[conditionIndex] = map[string]interface{}{
+					"chefServers":   chefServers,
+					"organizations": organizations,
+					"environments":  environments,
+					"roles":         roles,
+					"chefTags":      chefTags,
+					"policyGroups":  policyGroups,
+					"policyNames":   policyNames,
+				}
+
+			}
+			esRuleCollection[ruleIndex] = map[string]interface{}{
+				"conditions": esConditionCollection,
+			}
+		}
+
+		esProjectCollection[projectIndex] = map[string]interface{}{
+			"name":  projectName,
+			"rules": esRuleCollection,
+		}
+		projectIndex++
+	}
+
+	return map[string]interface{}{"projects": esProjectCollection}
 }

--- a/lib/event/ids.go
+++ b/lib/event/ids.go
@@ -3,4 +3,5 @@ package event
 const (
 	InfraClientRunsProducerID        = "infraClientRuns"
 	ComplianceInspecReportProducerID = "complianceInspecReport"
+	EventFeedProducerID              = "eventFeedEntry"
 )


### PR DESCRIPTION
### 📋 TODO
- [ ] Talk with Jay about his work with refactoring the project updater before moving forward with this. 
- [ ] Add authz-service bin to event feed
- [ ] Add event service bind to event feed
- [ ] Add config manager
- [ ] Add project updater
- [ ] Add project tag filtering to requests
- [ ] Tests!!!!

### :nut_and_bolt: Description: What code changed, and why?
Adding IAMv2 project filtering to the event feed service


### :chains: Related Resources
#444 

### :+1: Definition of Done
* The event feed items have project tags. 
* The event feed is added to the authz project update. 
* Request for event feeds items are filtered by projects

### :athletic_shoe: How to Build and Test the Change
1. `build components/event-feed-service && start_all_services`
1. Send a few example project filterable events with orgs, chef servers and project tags.
1. Send request for events with different project tags
1. Trigger a project tag update. 
1. Ensure the project tags updated correctly

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable