### PR TITLE
Removing the browser's built-in autocomplete feature

### DIFF
--- a/components/automate-ui/src/app/page-components/client-runs-search-bar/client-runs-search-bar.component.html
+++ b/components/automate-ui/src/app/page-components/client-runs-search-bar/client-runs-search-bar.component.html
@@ -16,7 +16,8 @@
           [value]="inputText"
           type="text"
           class="suggester-input"
-          placeholder="{{ get_filter_text() }}">
+          placeholder="{{ get_filter_text() }}"
+          autocomplete="off">
     <ng-content select=".suggester-input-buttons"></ng-content>
     <div *ngIf="numberOfFilters > 0" class="search-suffix">
       <chef-button class="filter-btn" secondary (click)="handleFiltersClick()">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
@@ -13,7 +13,8 @@
     (click)="handleFocus($event)"
     (focus)="handleFocus($event)"
     (change)="onKeyChange($event)"
-    (keyup)="handleInput($event.key, keyInput.value)" />
+    (keyup)="handleInput($event.key, keyInput.value)"
+    autocomplete="off"/>
   <div *ngIf="suggestionsVisible && !selectedType" class="input-dropdown categories">
     <ul>
       <li *ngIf="filterTypes.length === 0" class="no-category-items">
@@ -40,7 +41,8 @@
     (input)="onValInputAndFocus($event)"
     (focus)="onValInputAndFocus($event)"
     [value]="inputText"
-    (keyup)="handleInput($event.key, valInput.value)"/>
+    (keyup)="handleInput($event.key, valInput.value)"
+    autocomplete="off"/>
   <div *ngIf="suggestionsVisible && selectedType" class="input-dropdown suggestions">
     <ul>
       <li *ngIf="inputText !== '' && isLoadingSuggestions" class="suggestion-status">


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The browser has a built-in autocomplete feature that displays over the Automate suggestions. This fix removes the browser built-in autocomplete feature. 

Thank you @scottopherson for pointing out the fix for this. 
https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion

### :chains: Related Resources

### :+1: Definition of Done

The browser's built-in auto-complete feature is not displayed. 

### :athletic_shoe: How to Build and Test the Change
1. `start_all_services`
1. Open https://a2-dev.test/client-runs and click in the search bar. There should be built-in auto-complete suggestion showing up like the image below
1. `build components/automate-ui`
1. Refresh https://a2-dev.test/client-runs and the suggestion should not appear. 

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
![Screen Shot 2019-07-26 at 3 52 22 PM](https://user-images.githubusercontent.com/1679247/61985298-73eb7000-afbd-11e9-835d-a2414fdf31f3.png)