### PR TITLE
deps: bump grpc-gateway: 1.9.4 -> 1.9.5

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -481,7 +481,7 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:622ee79f2c74e6f03e4dfdbcb3fd7b82869f0a3e2ffe52f96f285dd3cb256bdf"
+  digest = "1:20fdee92b940d438a4b38d7e5eae5e25e390e9480ee6ae756fc6f015b382a345"
   name = "github.com/grpc-ecosystem/grpc-gateway"
   packages = [
     "codegenerator",
@@ -498,8 +498,8 @@
     "utilities",
   ]
   pruneopts = "T"
-  revision = "bebc7374a79e1105d786ef3468b474e47d652511"
-  version = "v1.9.4"
+  revision = "ad529a448ba494a88058f9e5be0988713174ac86"
+  version = "v1.9.5"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,7 +71,7 @@ required = [
 
 [[constraint]]
   name = "github.com/grpc-ecosystem/grpc-gateway"
-  version = "1.9.4"
+  version = "1.9.5"
 
 [[constraint]]
   name = "github.com/olivere/elastic"

--- a/vendor/github.com/grpc-ecosystem/grpc-gateway/CHANGELOG.md
+++ b/vendor/github.com/grpc-ecosystem/grpc-gateway/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [v1.9.5](https://github.com/grpc-ecosystem/grpc-gateway/tree/v1.9.5) (2019-07-22)
+[Full Changelog](https://github.com/grpc-ecosystem/grpc-gateway/compare/v1.9.4...v1.9.5)
+
+**Fixed bugs:**
+
+- Non-standard use of 412 HTTP Status Code [\#972](https://github.com/grpc-ecosystem/grpc-gateway/issues/972)
+
+**Closed issues:**
+
+- why response use enum's name [\#970](https://github.com/grpc-ecosystem/grpc-gateway/issues/970)
+
+**Merged pull requests:**
+
+- Fix HTTP Status Code returned for a `Failed Precondition` error [\#974](https://github.com/grpc-ecosystem/grpc-gateway/pull/974) ([cjcormack](https://github.com/cjcormack))
+- Examples fix: Support preflight of auth libraries in js [\#973](https://github.com/grpc-ecosystem/grpc-gateway/pull/973) ([GhiaC](https://github.com/GhiaC))
+
 ## [v1.9.4](https://github.com/grpc-ecosystem/grpc-gateway/tree/v1.9.4) (2019-07-09)
 [Full Changelog](https://github.com/grpc-ecosystem/grpc-gateway/compare/v1.9.3...v1.9.4)
 
@@ -10,6 +26,7 @@
 
 **Merged pull requests:**
 
+- Generate changelog for 1.9.4 [\#969](https://github.com/grpc-ecosystem/grpc-gateway/pull/969) ([johanbrandhorst](https://github.com/johanbrandhorst))
 - Fix query.go to avoid invalid protobuf assumptions [\#967](https://github.com/grpc-ecosystem/grpc-gateway/pull/967) ([dsnet](https://github.com/dsnet))
 - doc\(readme\): fix typo [\#965](https://github.com/grpc-ecosystem/grpc-gateway/pull/965) ([franxois](https://github.com/franxois))
 - Added comments to base\_path to explain behavior [\#919](https://github.com/grpc-ecosystem/grpc-gateway/pull/919) ([nu11ptr](https://github.com/nu11ptr))

--- a/vendor/github.com/grpc-ecosystem/grpc-gateway/Makefile
+++ b/vendor/github.com/grpc-ecosystem/grpc-gateway/Makefile
@@ -194,7 +194,7 @@ changelog:
 				--compare-link \
 				--github-site=https://github.com \
 				--unreleased-label "**Next release**" \
-				--future-release=v1.9.4
+				--future-release=v1.9.5
 lint:
 	golint --set_exit_status ./runtime
 	golint --set_exit_status ./utilities/...

--- a/vendor/github.com/grpc-ecosystem/grpc-gateway/examples/gateway/handlers.go
+++ b/vendor/github.com/grpc-ecosystem/grpc-gateway/examples/gateway/handlers.go
@@ -46,7 +46,7 @@ func allowCORS(h http.Handler) http.Handler {
 // CORS from any origin using the methods "GET", "HEAD", "POST", "PUT", "DELETE"
 // We insist, don't do this without consideration in production systems.
 func preflightHandler(w http.ResponseWriter, r *http.Request) {
-	headers := []string{"Content-Type", "Accept"}
+	headers := []string{"Content-Type", "Accept", "Authorization"}
 	w.Header().Set("Access-Control-Allow-Headers", strings.Join(headers, ","))
 	methods := []string{"GET", "HEAD", "POST", "PUT", "DELETE"}
 	w.Header().Set("Access-Control-Allow-Methods", strings.Join(methods, ","))

--- a/vendor/github.com/grpc-ecosystem/grpc-gateway/runtime/errors.go
+++ b/vendor/github.com/grpc-ecosystem/grpc-gateway/runtime/errors.go
@@ -37,7 +37,8 @@ func HTTPStatusFromCode(code codes.Code) int {
 	case codes.ResourceExhausted:
 		return http.StatusTooManyRequests
 	case codes.FailedPrecondition:
-		return http.StatusPreconditionFailed
+		// Note, this deliberately doesn't translate to the similarly named '412 Precondition Failed' HTTP response status.
+		return http.StatusBadRequest
 	case codes.Aborted:
 		return http.StatusConflict
 	case codes.OutOfRange:


### PR DESCRIPTION
⚠️ This time, we've got to expect trouble: the GRPC status
`FailedPreconditon` is now -- correctly, as it seems -- translated to HTTP
status `400 Bad Request`.

I think we might rely on this being translated to `412 Precondition
Failed` in a few places, at least from grepping around.