### PR TITLE
auth-stuff: reduce clutter in pipeline defs

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -490,10 +490,6 @@ steps:
     expeditor:
       executor:
         docker:
-          privileged: true
-          environment:
-            - HAB_STUDIO_SUP=false
-            - HAB_NONINTERACTIVE=true
 
   # TODO(ssd) 2019-03-19: I've added a couple of basic tests here but
   # there are a number of A1 tests we might want to integrate.
@@ -521,7 +517,6 @@ steps:
     expeditor:
       executor:
         docker:
-          privileged: true
           # a1-buildkite has erlang 18 pre-installed
           image: chefes/a1-buildkite
 

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -363,11 +363,11 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  - label: "[static] local-user-service"
+  - label: "[unit] local-user-service"
     command:
       - scripts/install_golang.sh
       - cd components/local-user-service
-      - make static
+      - make static unit
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -375,21 +375,6 @@ steps:
     expeditor:
       executor:
         docker:
-
-  - label: "[unit] local-user-service"
-    command:
-      - hab studio run "source .studiorc && go_component_unit local-user-service"
-    timeout_in_minutes: 10
-    retry:
-      automatic:
-        limit: 1
-    expeditor:
-      executor:
-        docker:
-          privileged: true
-          environment:
-            - HAB_STUDIO_SUP=false
-            - HAB_NONINTERACTIVE=true
 
   - label: "[unit] notifications-client"
     command:
@@ -423,8 +408,6 @@ steps:
             - PORT=4001
             - RULE_STORE_FILE=test_rule_store
 
-  # (@afiune) If this requires the data-store (postgres)
-  # shouldn't this be integration tests? (FWIW we can move it to the studio)
   - label: "[unit] session-service"
     command:
       - scripts/install_golang.sh

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -98,11 +98,9 @@ steps:
 
   - label: "[unit] OPA"
     command:
-      - |
-        hab studio run "source .studiorc &&
-          install_if_missing core/opa opa &&
-          cd /src/components/authz-service/engine/opa/policy &&
-          make static unit"
+      - scripts/install_hab_pkg.sh core/opa
+      - cd components/authz-service/engine/opa/policy
+      - make static unit
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -110,10 +108,6 @@ steps:
     expeditor:
       executor:
         docker:
-          privileged: true
-          environment:
-            - HAB_STUDIO_SUP=false
-            - HAB_NONINTERACTIVE=true
 
   - label: "[unit] authz-service"
     command:

--- a/components/authz-service/engine/opa/policy/Makefile
+++ b/components/authz-service/engine/opa/policy/Makefile
@@ -1,15 +1,8 @@
-.PHONY: opa-cmd
-HAVE_OPA_CMD:=$(shell command -v opa 2>/dev/null)
-opa-cmd:
-ifndef HAVE_OPA_CMD
-	go get -u github.com/open-policy-agent/opa
-endif
-
-static: opa-cmd  # if there's no output, this will not fail; if there is (NR!=0), fail
+static: # if there's no output, this will not fail; if there is (NR!=0), fail
 	opa fmt -d *.rego | awk '{ print } END { if (NR!=0) { print "run make fix-format to fix this"; exit 1 } }'
 
-fix-format: opa-cmd
+fix-format:
 	opa fmt -w *.rego
 
-unit: opa-cmd
+unit:
 	opa test -v .

--- a/components/local-user-service/Makefile
+++ b/components/local-user-service/Makefile
@@ -25,7 +25,6 @@ bin:
 build: ${BINS}
 
 test:
-	@go test -i $(packages)
 	@go test $(packages) -cover
 
 # Regenerate all *.pb.go files

--- a/scripts/install_hab_pkg.sh
+++ b/scripts/install_hab_pkg.sh
@@ -5,5 +5,5 @@ export HAB_NONINTERACTIVE=true
 export HAB_NOCOLORING=true
 export HAB_LICENSE="accept-no-persist"
 
-ident="${1:-ident required}"
+ident="${1?ident required}"
 hab pkg install -b "$ident"

--- a/scripts/install_hab_pkg.sh
+++ b/scripts/install_hab_pkg.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+export HAB_NONINTERACTIVE=true
+export HAB_NOCOLORING=true
+export HAB_LICENSE="accept-no-persist"
+
+ident="${1:-ident required}"
+hab pkg install -b "$ident"


### PR DESCRIPTION
- OPA doesn't need a studio for its tests
- local-user-service doesn't need a studio for its tests, combine static and unit again.
- installing the CLI `opa` in the Makefile is probably not needed
- remove `privileged: true` from some deployment-service steps that don't need them