### PR TITLE
Move apps e2e hab client to 0.83 stable

### DIFF
--- a/components/applications-service/dev/hab-client/Dockerfile
+++ b/components/applications-service/dev/hab-client/Dockerfile
@@ -13,7 +13,7 @@ RUN useradd -U -M hab
 ENV HAB_LICENSE=accept
 
 RUN curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash && \
-    hab pkg install core/hab-sup/0.83.0-dev -c unstable && \
+    hab pkg install core/hab-sup/0.83.0 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

For the applications view we have a docker-based dev environment we use to test with a real habitat supervisor. Prior to the official release of 0.83.0, we required an RC build from the unstable channel. Now that 0.83.0 is officially released, we want to use that instead.

### :chains: Related Resources

https://discourse.chef.io/t/chef-habitat-0-83-0-released/15670

### :athletic_shoe: How to Build and Test the Change

Follow the instructions in the readme for the hab client dev environment: https://github.com/chef/automate/blob/master/components/applications-service/dev/hab-client/README.md

After running `./run-hab-sup.sh -t YOUR_TOKEN` you should see two services in the applications view UI.

### :white_check_mark: Checklist

- [x] Tests added/updated?
