### PR TITLE
Accept Habitat Healthchecks via "Plain" NATS Messaging

### DIFF
--- a/components/applications-service/cmd/applications-publisher/main.go
+++ b/components/applications-service/cmd/applications-publisher/main.go
@@ -162,7 +162,7 @@ func main() {
 	if internalNats {
 		client = nats.New(
 			fmt.Sprintf("nats://0.0.0.0:%s", port),
-			"event-service", clientID, "", "habitat",
+			"event-service", clientID, "",
 			certs.TLSConfig{
 				CertPath:       "/hab/svc/applications-service/config/service.crt",
 				KeyPath:        "/hab/svc/applications-service/config/service.key",

--- a/components/applications-service/pkg/ingester/v1/ingest.go
+++ b/components/applications-service/pkg/ingester/v1/ingest.go
@@ -89,8 +89,7 @@ func (i *Ingester) Run() {
 			err := proto.Unmarshal(eventBytes, &habMsg)
 			if err != nil {
 				log.WithFields(log.Fields{
-					"data":    string(eventBytes),
-					"subject": i.natsClient.Subject(),
+					"data": string(eventBytes),
 				}).Error("Unknown message, dropping")
 				continue
 			}

--- a/components/applications-service/pkg/nats/nats.go
+++ b/components/applications-service/pkg/nats/nats.go
@@ -18,8 +18,8 @@ import (
 const (
 	connectionRetries                      = 5
 	deprecatedNATSStreamHealthCheckChannel = "habitat"
-	// natsMessagingHealthcheckSubject        = "habitat.event.healthcheck"
-	// natsMessagingQueueGroup                = "automate"
+	natsMessagingHealthcheckSubject        = "habitat.event.healthcheck"
+	natsMessagingQueueGroup                = "automate"
 )
 
 // The subject is the topic this subscriber will be listening to,

--- a/components/applications-service/pkg/nats/nats.go
+++ b/components/applications-service/pkg/nats/nats.go
@@ -19,6 +19,7 @@ const (
 	connectionRetries                      = 5
 	deprecatedNATSStreamHealthCheckChannel = "habitat"
 	natsMessagingHealthcheckSubject        = "habitat.event.healthcheck"
+	natsMessagingSubscribeGroup            = "habitat.event.>"
 	natsMessagingQueueGroup                = "automate"
 )
 

--- a/components/applications-service/pkg/nats/publisher.go
+++ b/components/applications-service/pkg/nats/publisher.go
@@ -24,7 +24,7 @@ func (nc *NatsClient) PublishHabEvent(msg *habitat.HealthCheckEvent) error {
 	if err != nil {
 		return err
 	}
-	return nc.conn.Publish(nc.subject, b)
+	return nc.streamConn.Publish(nc.subject, b)
 }
 
 // PublishBytes publishes an array of bytes to the NATS server
@@ -40,5 +40,5 @@ func (nc *NatsClient) PublishBytes(b []byte) error {
 		"message": string(b),
 	}).Info("Publishing message")
 
-	return nc.conn.Publish(nc.subject, b)
+	return nc.streamConn.Publish(nc.subject, b)
 }

--- a/components/applications-service/pkg/nats/publisher.go
+++ b/components/applications-service/pkg/nats/publisher.go
@@ -24,7 +24,7 @@ func (nc *NatsClient) PublishHabEvent(msg *habitat.HealthCheckEvent) error {
 	if err != nil {
 		return err
 	}
-	return nc.streamConn.Publish(nc.subject, b)
+	return nc.streamConn.Publish(deprecatedNATSStreamHealthCheckChannel, b)
 }
 
 // PublishBytes publishes an array of bytes to the NATS server
@@ -40,5 +40,5 @@ func (nc *NatsClient) PublishBytes(b []byte) error {
 		"message": string(b),
 	}).Info("Publishing message")
 
-	return nc.streamConn.Publish(nc.subject, b)
+	return nc.streamConn.Publish(deprecatedNATSStreamHealthCheckChannel, b)
 }

--- a/components/applications-service/pkg/nats/publisher.go
+++ b/components/applications-service/pkg/nats/publisher.go
@@ -24,7 +24,7 @@ func (nc *NatsClient) PublishHabEvent(msg *habitat.HealthCheckEvent) error {
 	if err != nil {
 		return err
 	}
-	return nc.streamConn.Publish(deprecatedNATSStreamHealthCheckChannel, b)
+	return nc.msgConn.Publish(natsMessagingHealthcheckSubject, b)
 }
 
 // PublishBytes publishes an array of bytes to the NATS server
@@ -40,5 +40,5 @@ func (nc *NatsClient) PublishBytes(b []byte) error {
 		"message": string(b),
 	}).Info("Publishing message")
 
-	return nc.streamConn.Publish(deprecatedNATSStreamHealthCheckChannel, b)
+	return nc.msgConn.Publish(natsMessagingHealthcheckSubject, b)
 }

--- a/components/applications-service/pkg/nats/subscriber.go
+++ b/components/applications-service/pkg/nats/subscriber.go
@@ -1,7 +1,7 @@
 package nats
 
 import (
-	//natsc "github.com/nats-io/go-nats"
+	natsc "github.com/nats-io/go-nats"
 	stan "github.com/nats-io/go-nats-streaming"
 	log "github.com/sirupsen/logrus"
 )
@@ -29,11 +29,17 @@ func (nc *NatsClient) Subscribe(eventsCh chan<- []byte) error {
 		eventsCh <- msg.Data
 	}, stan.DurableName(nc.durableID))
 
-	// if err != nil {
-	// 	return err
-	// }
-	// _, err = nc.msgConn.QueueSubscribe(natsMessagingHealthcheckSubject, natsMessagingQueueGroup, func(msg *natsc.Msg) {
-	// })
+	if err != nil {
+		return err
+	}
+	_, err = nc.msgConn.QueueSubscribe(natsMessagingHealthcheckSubject, natsMessagingQueueGroup, func(msg *natsc.Msg) {
+		log.WithFields(log.Fields{
+			"protocol":        "nats messaging",
+			"message_data":    string(msg.Data),
+			"message_subject": msg.Subject,
+		}).Debug("Message received")
+		eventsCh <- msg.Data
+	})
 
 	return err
 

--- a/components/applications-service/pkg/nats/subscriber.go
+++ b/components/applications-service/pkg/nats/subscriber.go
@@ -14,7 +14,7 @@ func (nc *NatsClient) Subscribe(eventsCh chan<- []byte) (stan.Subscription, erro
 	}).Info("Subscribing to subject")
 
 	// Subscribe with durable name
-	return nc.conn.Subscribe(nc.subject, func(msg *stan.Msg) {
+	return nc.streamConn.Subscribe(nc.subject, func(msg *stan.Msg) {
 
 		log.WithFields(log.Fields{
 			"protocol":          "nats",

--- a/components/applications-service/pkg/nats/subscriber.go
+++ b/components/applications-service/pkg/nats/subscriber.go
@@ -1,23 +1,25 @@
 package nats
 
 import (
+	//natsc "github.com/nats-io/go-nats"
 	stan "github.com/nats-io/go-nats-streaming"
 	log "github.com/sirupsen/logrus"
 )
 
-func (nc *NatsClient) Subscribe(eventsCh chan<- []byte) (stan.Subscription, error) {
+func (nc *NatsClient) Subscribe(eventsCh chan<- []byte) error {
 
 	log.WithFields(log.Fields{
-		"subject":    nc.subject,
+		"subject":    deprecatedNATSStreamHealthCheckChannel,
 		"durable_id": nc.durableID,
 		"client_id":  nc.clientID,
 	}).Info("Subscribing to subject")
 
 	// Subscribe with durable name
-	return nc.streamConn.Subscribe(nc.subject, func(msg *stan.Msg) {
+	_, err := nc.streamConn.Subscribe(deprecatedNATSStreamHealthCheckChannel, func(msg *stan.Msg) {
 
 		log.WithFields(log.Fields{
-			"protocol":          "nats",
+			"protocol":          "nats streaming",
+			"channel":           deprecatedNATSStreamHealthCheckChannel,
 			"message_data":      string(msg.Data),
 			"message_timestamp": msg.Timestamp,
 			"message_subject":   msg.Subject,
@@ -26,4 +28,13 @@ func (nc *NatsClient) Subscribe(eventsCh chan<- []byte) (stan.Subscription, erro
 
 		eventsCh <- msg.Data
 	}, stan.DurableName(nc.durableID))
+
+	// if err != nil {
+	// 	return err
+	// }
+	// _, err = nc.msgConn.QueueSubscribe(natsMessagingHealthcheckSubject, natsMessagingQueueGroup, func(msg *natsc.Msg) {
+	// })
+
+	return err
+
 }

--- a/components/applications-service/pkg/nats/subscriber.go
+++ b/components/applications-service/pkg/nats/subscriber.go
@@ -32,7 +32,7 @@ func (nc *NatsClient) Subscribe(eventsCh chan<- []byte) error {
 	if err != nil {
 		return err
 	}
-	_, err = nc.msgConn.QueueSubscribe(natsMessagingHealthcheckSubject, natsMessagingQueueGroup, func(msg *natsc.Msg) {
+	_, err = nc.msgConn.QueueSubscribe(natsMessagingSubscribeGroup, natsMessagingQueueGroup, func(msg *natsc.Msg) {
 		log.WithFields(log.Fields{
 			"protocol":        "nats messaging",
 			"message_data":    string(msg.Data),

--- a/components/event-gateway/pkg/nats/authenticator.go
+++ b/components/event-gateway/pkg/nats/authenticator.go
@@ -185,6 +185,7 @@ func habNatsUser() *natsd.User {
 					"_STAN.discover.event-service.*",
 					"_STAN.pub.*.habitat",
 					"_STAN.close.*",
+					"habitat.event.*",
 				},
 			},
 			Subscribe: &natsd.SubjectPermission{


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This enables Automate to receive health check events from habitat via "plain" NATS messaging instead of NATS-streaming (though nats-streaming continues to work; this patch makes automate subscribe to messages from both systems).

Messages sent via "plain" NATS messaging are not persisted in transit, so this change increases the possibility that messages will be lost, for example when the event service restarts. While not ideal, this is considered acceptable because the behavior of the overall system is generally convergent: habitat is sending a complete picture of the state of a service as understood by Automate with each health check message, which is sent by default every 30s. Automate does not keep a historical record of service states. Therefore, once Automate's ingestion system becomes available after a service interruption, it should recover a full picture of the state of all services within 30s.

In the future if we introduce new features that need more reliable delivery, we will reintroduce nats-streaming or use some other means to achieve more reliable delivery.

 There are two reasons we are making this change:
1. There is currently not a library available for rust that supports nats-streaming and also works correctly with TLS in all the configurations we need to support (such as self-signed certs). Supporting TLS is more important than reliable delivery of health check messages.
2. Past performance testing showed reason to suspect that persistence of in-transit messages reduced system throughput. For health check messages, which are currently the only message type and likely to be the vast majority of events in the future, we believe improved throughput will be worth the reduced delivery reliability.

### :chains: Related Resources

https://github.com/chef/automate/issues/1124

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

Since we are just changing the internals of the messaging protocol and the data generators have been updated, the change can only really be observed via debug logs.

Start all services in the studio, then build applications-service and event-gateway. Patch the config with the following to enable debug logging for applications service:

```toml
[applications]
  [applications.v1]
    [applications.v1.sys]
      [applications.v1.sys.log]
        level = "debug"
```

Run the following to publish a message via the front-end event-gateway:
```sh
install_if_missing "$(app_service_origin)/applications-service" applications-publisher;
t=$(get_api_token)
applications-publisher --auth-token $t
```

Use `sl` to tail the log. You should see a log message like this:

```
[2019-07-30T22:41:32+00:00] applications-service.default(O): time="2019-07-30T22:41:32Z" level=debug msg="Message received" message_data="\n0\n\n1234567890\x1a\v\b\x9c\x8f\x83\xea\x05\x10\xc4\xd2\xf9$\"\x04demo*\x04demo:\tlocalhost\x120\n\x1fcore/redis/0.1.0/20190730224132\x1a\rredis.default" message_subject=habitat.event.healthcheck protocol="nats messaging"
```

The `protocol="nats messaging"` means the message was sent via "plain" NATS instead of NATS-streaming.

