### PR TITLE
Instrument chef-form-field to watch its input

### DIFF
--- a/components/automate-ui/src/app/components/form-field/form-field.component.spec.ts
+++ b/components/automate-ui/src/app/components/form-field/form-field.component.spec.ts
@@ -1,6 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FormFieldComponent } from './form-field.component';
+import { FormControl } from '@angular/forms';
+import { Component } from '@angular/core';
 
 describe('FormFieldComponent', () => {
   let component: FormFieldComponent;
@@ -22,4 +24,124 @@ describe('FormFieldComponent', () => {
   it('should be created', () => {
     expect(component).toBeTruthy();
   });
+});
+
+@Component({
+  template: '<chef-form-field></chef-form-field>'
+})
+class TestEmptyHostComponent {
+  myWatch: string;
+  myControl: FormControl;
+}
+describe('FormFieldComponent without watched control', () => {
+  let component: TestEmptyHostComponent;
+  let fixture: ComponentFixture<TestEmptyHostComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [FormFieldComponent, TestEmptyHostComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestEmptyHostComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('can create chef-form-field without a watched control', () => {
+    expect(component).toBeTruthy();
+  });
+});
+
+@Component({
+  template: '<chef-form-field [watch]="myControl.value" [control]="myControl"></chef-form-field>'
+})
+class TestHostComponent {
+  myWatch: string;
+  myControl: FormControl;
+}
+
+describe('FormFieldComponent with watched control', () => {
+  let component: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [FormFieldComponent, TestHostComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    component.myControl = new FormControl();
+    spyOn(component.myControl, 'markAsPristine');
+  });
+
+  it('can create chef-form-field with a watched control', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('setting watched form control to first value marks it pristine', () => {
+    expect(component.myControl.markAsPristine).toHaveBeenCalledTimes(0);
+    component.myControl.setValue('foo');
+    fixture.detectChanges();
+    expect(component.myControl.markAsPristine).toHaveBeenCalledTimes(1);
+  });
+
+   it('setting watched form control to different value does not mark it pristine', () => {
+    component.myControl.setValue('foo');
+    fixture.detectChanges();
+    expect(component.myControl.markAsPristine).toHaveBeenCalledTimes(1);
+
+    component.myControl.setValue('bar');
+    fixture.detectChanges();
+    // not called again, thus dirty
+    expect(component.myControl.markAsPristine).toHaveBeenCalledTimes(1);
+  });
+
+    it('setting watched form control to original value marks it pristine again', () => {
+    component.myControl.setValue('foo');
+    fixture.detectChanges();
+    expect(component.myControl.markAsPristine).toHaveBeenCalledTimes(1);
+
+    component.myControl.setValue('bar');
+    fixture.detectChanges();
+    expect(component.myControl.markAsPristine).toHaveBeenCalledTimes(1);
+
+    component.myControl.setValue('foo');
+    fixture.detectChanges();
+    expect(component.myControl.markAsPristine).toHaveBeenCalledTimes(2);
+  });
+
+  it('setting watched form control to empty does not mark it pristine', () => {
+    component.myControl.setValue('foo');
+    fixture.detectChanges();
+    expect(component.myControl.markAsPristine).toHaveBeenCalledTimes(1);
+
+    component.myControl.setValue('bar');
+    fixture.detectChanges();
+    expect(component.myControl.markAsPristine).toHaveBeenCalledTimes(1);
+
+    component.myControl.setValue('');
+    fixture.detectChanges();
+    expect(component.myControl.markAsPristine).toHaveBeenCalledTimes(1);
+  });
+
+  it('setting watched form control to non-empty after empty does not mark it pristine', () => {
+    component.myControl.setValue('foo');
+    fixture.detectChanges();
+    expect(component.myControl.markAsPristine).toHaveBeenCalledTimes(1);
+
+    component.myControl.setValue('');
+    fixture.detectChanges();
+    expect(component.myControl.markAsPristine).toHaveBeenCalledTimes(1);
+
+    component.myControl.setValue('non-empty');
+    fixture.detectChanges();
+    expect(component.myControl.markAsPristine).toHaveBeenCalledTimes(1);
+  });
+
 });

--- a/components/automate-ui/src/app/components/form-field/form-field.component.ts
+++ b/components/automate-ui/src/app/components/form-field/form-field.component.ts
@@ -3,8 +3,13 @@ import { Component,
          QueryList,
          AfterContentInit,
          ChangeDetectionStrategy,
-         ChangeDetectorRef
+         ChangeDetectorRef,
+         Input,
+         OnChanges,
+         SimpleChanges,
+         SimpleChange
        } from '@angular/core';
+import { FormControl } from '@angular/forms';
 import { ErrorDirective } from '../error/error.directive';
 
 @Component({
@@ -15,8 +20,30 @@ import { ErrorDirective } from '../error/error.directive';
               '../input/input.directive.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class FormFieldComponent implements AfterContentInit {
+export class FormFieldComponent implements AfterContentInit, OnChanges {
   @ContentChildren(ErrorDirective) errorChildren: QueryList<ErrorDirective>;
+
+  // A FormFieldComponent can optionally track whether an input field (FormControl)
+  // being edited is the same as, or different from, the field's initial value.
+  // That is, it knows whether the user has made a change or not,
+  // and marks the pristine/dirty state accordingly, so that information may be used
+  // in the parent form to e.g., disable the `Save` button, per our UX guidelines.
+  // Example:
+  // <form [formGroup]="updateForm">
+  //   <chef-form-field
+  //       [watch]="updateForm.controls.name.value"
+  //       [control]="updateForm.controls.name">
+  //     <label>Name <span aria-hidden="true">*</span></label>
+  //     <chef-input formControlName="name" type="text"></chef-input>
+  //   </chef-form-field>
+  // </form>
+  // <chef-button primary [disabled]="!updateForm.valid || !updateForm.dirty">
+  //
+  // You need to supply these two parameters:
+  @Input() watch: string; //  dynamic value to watch
+  @Input() control: FormControl; // control to set back to pristine when needed
+
+  private originalValue = '';
 
   constructor(public changeDetectorRef: ChangeDetectorRef) {}
 
@@ -28,4 +55,13 @@ export class FormFieldComponent implements AfterContentInit {
     });
   }
 
+  ngOnChanges(changes: SimpleChanges): void {
+    const change: SimpleChange = changes.watch;
+    if (!change.previousValue && change.currentValue && !this.originalValue) {
+      this.originalValue = change.currentValue;
+    }
+    if (change.currentValue && (change.currentValue === this.originalValue)) {
+      this.control.markAsPristine();
+    }
+  }
 }

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -27,7 +27,7 @@
     </chef-page-header>
     <section class="page-body" [hidden]="showTab('rules')">
       <form [formGroup]="projectForm">
-        <chef-form-field id="update-name">
+        <chef-form-field id="update-name" [watch]="projectForm.controls.name.value" [control]="projectForm.controls.name">
           <label>
             <span class="label">Name <span aria-hidden="true">*</span></span>
             <input chefInput formControlName="name" type="text"
@@ -43,7 +43,7 @@
           Name changes are not allowed for the default project.
         </span>
         <div id="button-bar" *ngIf="!isChefManaged">
-          <chef-button [disabled]="isLoading || !projectForm.valid || projectForm.controls['name'].value === project?.name"
+          <chef-button [disabled]="isLoading || !projectForm.valid || !projectForm.dirty"
             primary inline (click)="saveProject()">
             <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
             <span *ngIf="saving">Saving...</span>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -73,7 +73,7 @@ describe('ProjectDetailsComponent', () => {
           outputs: ['close', 'deleteClicked']
         }),
         MockComponent({ selector: 'chef-control-menu' }),
-        MockComponent({ selector: 'chef-form-field'}),
+        MockComponent({ selector: 'chef-form-field', inputs: ['watch', 'control']}),
         MockComponent({ selector: 'chef-breadcrumbs'}),
         MockComponent({ selector: 'chef-error'}),
         MockComponent({ selector: 'chef-breadcrumb', inputs: ['link'] }),

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -61,7 +61,7 @@
     <ng-container *ngIf="tabValue === 'details'">
       <section class="page-body">
         <form [formGroup]="updateNameForm">
-          <chef-form-field>
+          <chef-form-field [watch]="updateNameForm.controls.name.value" [control]="updateNameForm.controls.name">
             <label>{{ descriptionOrName | titlecase }} <span aria-hidden="true">*</span></label>
             <input chefInput formControlName="name" type="text" (keyup)="keyPressed()">
             <chef-error
@@ -70,7 +70,7 @@
             </chef-error>
           </chef-form-field>
         </form>
-          <chef-button [disabled]="isLoading || !updateNameForm.valid || updateNameForm.controls['name'].value === team?.name"
+          <chef-button [disabled]="isLoading || !updateNameForm.valid || !updateNameForm.dirty"
             primary inline (click)="saveNameChange()">
             <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
             <span *ngIf="saving">Saving...</span>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
@@ -63,7 +63,7 @@ describe('TeamDetailsComponent', () => {
         MockComponent({ selector: 'chef-breadcrumbs' }),
         MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),
         MockComponent({ selector: 'chef-error' }),
-        MockComponent({ selector: 'chef-form-field' }),
+        MockComponent({ selector: 'chef-form-field', inputs: ['watch', 'control']}),
         MockComponent({ selector: 'chef-input' }),
         MockComponent({ selector: 'chef-page-header' }),
         MockComponent({ selector: 'chef-option' }),

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -65,7 +65,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   ) {
     this.updateNameForm = fb.group({
       // Must stay in sync with error checks in team-details.component.html
-      name: ['Loading...', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
+      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
 
     combineLatest(


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Rather than having to manually instrument every input to watch for
its value being edited so that it matches its original value, this bakes that into the component. Here's the details embedded in the code itself:
```
 // A FormFieldComponent can optionally track whether an input field (FormControl)
  // being edited is the same as, or different from, the field's initial value.
  // That is, it knows whether the user has made a change or not,
  // and marks the pristine/dirty state accordingly, so that information may be used
  // in the parent form to e.g., disable the `Save` button, per our UX guidelines.
  // Example:
  // <form [formGroup]="updateForm">
  //   <chef-form-field
  //       [watch]="updateForm.controls.name.value"
  //       [control]="updateForm.controls.name">
  //     <label>Name <span aria-hidden="true">*</span></label>
  //     <chef-input formControlName="name" type="text"></chef-input>
  //   </chef-form-field>
  // </form>
  // <chef-button primary [disabled]="!updateForm.valid || !updateForm.dirty">
  //
  // You need to supply these two parameters:
  @Input() watch: string; //  dynamic value to watch
  @Input() control: FormControl; // control to set back to pristine when needed
```

Note that this functionality is optional. 
Any existing `<chef-form-field>` elements will function exactly as they did before.

### :chains: Related Resources

NA

### :+1: Definition of Done

The new functionality is wired into editing:
- a project name (Settings >> Projects >> `<project>` >> Details) 
- a team name (Settings >> Teams >> `<project>` >> Details) 

### :athletic_shoe: How to Build and Test the Change

Rebuild automate-ui.
Edit a project or team name as indicated above.
Edit the value.
➡️ Observe `Save` becomes enabled.
Restore the original value.
➡️ Observe `Save` becomes disable.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [x] Docs added/updated?

### :camera: Screenshots, if applicable