### PR TITLE
buildkite: separate changed components/sql files annotations

### DIFF
--- a/scripts/verify_build.sh
+++ b/scripts/verify_build.sh
@@ -45,7 +45,8 @@ else
     buildkite-agent annotate --style "info" "This change rebuilds no components."
 fi
 
-mapfile -t modified_sql_files < <(git diff --name-status "$(./scripts/git_difference_expression.rb)" | awk '/^[RMD][0-9]*.*\.sql/{ print $2 }')
+mapfile -t modified_sql_files < <(git diff --name-status "$(./scripts/git_difference_expression.rb)" |\
+                                    awk '!/datamigration/ && /^[RMD][0-9]*.*\.sql/ { print $2 }')
 if [[ ${#modified_sql_files[@]} -ne 0 ]]; then
     buildkite-agent annotate --context sql-check --style "warning" <<EOF
 This change modifies the following SQL files:

--- a/scripts/verify_build.sh
+++ b/scripts/verify_build.sh
@@ -37,7 +37,7 @@ curl "https://packages.chef.io/manifests/acceptance/automate/latest.json" > resu
 log_section_start "determine changed components"
 mapfile -t changed_components < <(./scripts/changed_components.rb)
 if [[ ${#changed_components[@]} -ne 0 ]]; then
-    buildkite-agent annotate --style "info" << EOF
+    buildkite-agent annotate --style "info" <<EOF
 This change rebuilds the following components:
 $(printf '* %s\n' "${changed_components[@]}")
 EOF
@@ -47,7 +47,7 @@ fi
 
 mapfile -t modified_sql_files < <(git diff --name-status "$(./scripts/git_difference_expression.rb)" | awk '/^[RMD][0-9]*.*\.sql/{ print $2 }')
 if [[ ${#modified_sql_files[@]} -ne 0 ]]; then
-    buildkite-agent annotate --append --style "warning" << EOF
+    buildkite-agent annotate --context sql-check --style "warning" <<EOF
 This change modifies the following SQL files:
 $(printf '* %s\n' "${modified_sql_files[@]}")
 EOF


### PR DESCRIPTION
Before, this would append in an unsatisfying way:

![image](https://user-images.githubusercontent.com/870638/62189551-8bd14400-b36f-11e9-8fd4-a3502df033ec.png)

Now, the two annotations are separate.

Also ignores changes to datamigration files. ✔️ 