### PR TITLE
Automate-1101 Top nav shows on page refresh for page components Sign…

### DIFF
--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -63,9 +63,7 @@ export class UIComponent implements OnInit {
   ngOnInit(): void {
     this.router.events.pipe(
         filter(event => event instanceof ActivationStart)
-    ).subscribe((event: any) => {
-      this.renderNavbar = !event.snapshot.data.hideNavBar;
-    });
+    ).subscribe((event: any) => this.renderNavbar = !event.snapshot.data.hideNavBar);
 
     this.store.dispatch(new GetIamVersion());
   }

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -47,7 +47,7 @@ export class UIComponent implements OnInit {
     private router: Router
   ) {
     this.notifications$ = store.select(notificationState);
-    
+
     // ActivationEnd specifically needs to be here in the constructor to catch early events.
     this.router.events.pipe(
       filter(event => {

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router, ActivationStart, RoutesRecognized } from '@angular/router';
+import { ActivationStart, ActivationEnd, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -44,10 +44,19 @@ export class UIComponent implements OnInit {
 
   constructor(
     private store: Store<NgrxStateAtom>,
-    private router: Router,
-    private route: ActivatedRoute
+    private router: Router
   ) {
     this.notifications$ = store.select(notificationState);
+
+    this.router.events.pipe(
+      filter(event => {
+        return event instanceof ActivationEnd;
+      })
+    ).subscribe((event: any) => {
+      this.renderNavbar = !this.renderNavbar
+        ? false
+        : !event.snapshot.data.hideNavBar;
+    });
   }
 
   ngOnInit(): void {
@@ -56,12 +65,8 @@ export class UIComponent implements OnInit {
           return event instanceof ActivationStart;
         })
     ).subscribe((event: any) => {
-      this.renderNavbar = event.snapshot.data.hideNavBar
-        ? false
-        : true;
+      this.renderNavbar = !event.snapshot.data.hideNavBar;
     });
-
-    this.renderNavbar = this.route.snapshot.data.hideNavBar;
 
     this.store.dispatch(new GetIamVersion());
   }

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -47,7 +47,8 @@ export class UIComponent implements OnInit {
     private router: Router
   ) {
     this.notifications$ = store.select(notificationState);
-
+    
+    // ActivationEnd specifically needs to be here in the constructor to catch early events.
     this.router.events.pipe(
       filter(event => {
         return event instanceof ActivationEnd;

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -61,9 +61,7 @@ export class UIComponent implements OnInit {
 
   ngOnInit(): void {
     this.router.events.pipe(
-        filter(event => {
-          return event instanceof ActivationStart;
-        })
+        filter(event => event instanceof ActivationStart)
     ).subscribe((event: any) => {
       this.renderNavbar = !event.snapshot.data.hideNavBar;
     });

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -53,9 +53,9 @@ export class UIComponent implements OnInit {
         return event instanceof ActivationEnd;
       })
     ).subscribe((event: any) => {
-      this.renderNavbar = !this.renderNavbar
-        ? false
-        : !event.snapshot.data.hideNavBar;
+      this.renderNavbar = typeof event.snapshot.data.hideNavBar !== 'undefined'
+        ? !event.snapshot.data.hideNavBar
+        : this.renderNavbar;
     });
   }
 

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -50,9 +50,7 @@ export class UIComponent implements OnInit {
 
     // ActivationEnd specifically needs to be here in the constructor to catch early events.
     this.router.events.pipe(
-      filter(event => {
-        return event instanceof ActivationEnd;
-      })
+      filter(event => event instanceof ActivationEnd)
     ).subscribe((event: any) => {
       this.renderNavbar = typeof event.snapshot.data.hideNavBar !== 'undefined'
         ? !event.snapshot.data.hideNavBar

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Router, ActivationStart } from '@angular/router';
+import { ActivatedRoute, Router, ActivationStart, RoutesRecognized } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -44,19 +44,24 @@ export class UIComponent implements OnInit {
 
   constructor(
     private store: Store<NgrxStateAtom>,
-    private router: Router
+    private router: Router,
+    private route: ActivatedRoute
   ) {
     this.notifications$ = store.select(notificationState);
   }
 
   ngOnInit(): void {
     this.router.events.pipe(
-        filter(event => event instanceof ActivationStart)
+        filter(event => {
+          return event instanceof ActivationStart;
+        })
     ).subscribe((event: any) => {
       this.renderNavbar = event.snapshot.data.hideNavBar
         ? false
         : true;
     });
+
+    this.renderNavbar = this.route.snapshot.data.hideNavBar;
 
     this.store.dispatch(new GetIamVersion());
   }

--- a/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
+++ b/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
@@ -74,8 +74,6 @@ describe('team add users', () => {
 
     cy.visit(`/settings/teams/${teamUIRouteIdentifier}/add-users`);
     cy.wait(['@getTeam', '@getTeamUsers', '@getUsers']);
-
-    cy.get('app-welcome-modal').invoke('hide');
   });
 
   afterEach(() => {


### PR DESCRIPTION
…ed-Off-By: Tara Black <tblack@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
When on a <chef-page> page if you refresh the top-nav comes back, and it should not.

### :chains: Related Resources
https://github.com/chef/automate/issues/1101

### :+1: Definition of Done
Top nav should not display for page component pages

### :athletic_shoe: How to Build and Test the Change
chef-automate iam upgrade-to-v2 if not already on iam v2.0
navigate to Settings > Policies > any policy detail page > Members tab
use the Add Members button
refresh the page, and notice that the top-nav comes back
