### PR TITLE
authz-service/sql: drop iam_statements' id column

### DIFF
--- a/components/authz-service/server/v2/migration_internal_test.go
+++ b/components/authz-service/server/v2/migration_internal_test.go
@@ -2412,23 +2412,15 @@ func hasName(name string) checkFunc {
 }
 
 func hasStatements(expected ...storage_v2.Statement) checkFunc {
-	return func(t *testing.T, pol *storage_v2.Policy) {
-		statementsSansIDs := make([]storage_v2.Statement, len(pol.Statements))
-		for i, statement := range pol.Statements {
-			st := statement
-			// We don't know statement IDs, so we reset the ones we get back;
-			// making it easier to compare the expected and actual set below in ElementsMatch.
-			st.ID = uuid.UUID{}
-
-			// expected statement in test case does not initialize projects slice
-			// so we initialize it here
-			if expected[i].Projects == nil {
-				expected[i].Projects = []string{}
-			}
-
-			statementsSansIDs[i] = st
+	// expected statement in test case does not initialize projects slice
+	// so we initialize it here
+	for i := range expected {
+		if expected[i].Projects == nil {
+			expected[i].Projects = []string{}
 		}
-		assert.ElementsMatch(t, expected, statementsSansIDs)
+	}
+	return func(t *testing.T, pol *storage_v2.Policy) {
+		assert.ElementsMatch(t, expected, pol.Statements)
 	}
 }
 

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -155,10 +155,6 @@ func (s *policyServer) CreatePolicy(
 		req.Projects)
 
 	if err != nil {
-		if errors.Cause(err) == storage_errors.ErrGenerateUUID {
-			return nil, status.Errorf(codes.Internal,
-				"error generating UUID for policy database entry %q: %s", req.Id, err.Error())
-		}
 		return nil, status.Errorf(codes.InvalidArgument,
 			"error parsing policy %q: %s", req.Id, err.Error())
 	}

--- a/components/authz-service/server/v2/policy_refresher.go
+++ b/components/authz-service/server/v2/policy_refresher.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -211,7 +212,7 @@ func (refresher *policyRefresher) getPolicyMap(ctx context.Context) (map[string]
 	for _, p := range policies {
 
 		statements := make(map[string]interface{})
-		for _, st := range p.Statements {
+		for i, st := range p.Statements {
 			stmt := map[string]interface{}{
 				"effect":   st.Effect.String(),
 				"projects": st.Projects,
@@ -226,7 +227,7 @@ func (refresher *policyRefresher) getPolicyMap(ctx context.Context) (map[string]
 			if len(st.Resources) != 0 {
 				stmt["resources"] = st.Resources
 			}
-			statements[st.ID.String()] = stmt
+			statements[strconv.Itoa(i)] = stmt
 		}
 
 		members := make([]string, len(p.Members))

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -3256,7 +3256,6 @@ func genPolicy(t *testing.T, id string, p *prng.Prng) storage.Policy {
 		}
 
 		statements[i] = storage.Statement{
-			ID:        genUUID(t),
 			Actions:   actions,
 			Resources: resources,
 			Role:      faker.Lorem().Word(),

--- a/components/authz-service/server/v2/system.go
+++ b/components/authz-service/server/v2/system.go
@@ -3,21 +3,6 @@ package v2
 import (
 	constants "github.com/chef/automate/components/authz-service/constants/v2"
 	storage "github.com/chef/automate/components/authz-service/storage/v2"
-	uuid "github.com/chef/automate/lib/uuid4"
-)
-
-const (
-	universalAccessStatementID        = "9edf285c-fc96-4363-a0b9-59e5b46f2a76"
-	ingestProviderStatementID         = "f777e560-663f-45b0-93a5-f955843be34c"
-	systemIntrospectionStatementID    = "4cc6e7cd-5e32-43e5-af04-d32b15796590"
-	systemPolicyVersionStatementID    = "173a18a6-c102-4e45-a0d0-dfec68c2eee5"
-	systemVersionStatementID          = "d7ed1d1f-1f6a-4055-a07e-23430c267e42"
-	systemLicenseStatementID          = "e5e1da2d-bbda-4211-adf5-c83e13f1891a"
-	systemLocalUsersStatementID       = "e9faa7a9-d458-4009-8192-edee6024b5d9"
-	systemLocalUsersDeleteStatementID = "55754dbe-8aec-4346-aadb-90116bc0d867"
-	chefManagedPoliciesStatementID    = "2b5a3f1d-9d25-46f3-b1dd-8f46c7d323a3"
-	chefManagedRolesStatementID       = "0d516454-7a0c-4922-86f9-8b93d035e869"
-	chefManagedProjectsStatementID    = "d49181d1-37b7-459d-8935-f11a9fa6b9e1"
 )
 
 // SystemPolicies returns a list of system policies that should always exist by default.
@@ -34,7 +19,6 @@ func SystemPolicies() []*storage.Policy {
 			},
 		},
 		Statements: []storage.Statement{{
-			ID:        uuid.Must(uuid.FromString(universalAccessStatementID)),
 			Effect:    storage.Allow,
 			Actions:   []string{"*"},
 			Resources: []string{"*"},
@@ -53,28 +37,24 @@ func SystemPolicies() []*storage.Policy {
 		},
 		Statements: []storage.Statement{
 			{
-				ID:        uuid.Must(uuid.FromString(systemIntrospectionStatementID)),
 				Effect:    storage.Allow,
 				Actions:   []string{"iam:introspect:*"},
 				Resources: []string{"iam:introspect"},
 				Projects:  []string{constants.AllProjectsID},
 			},
 			{
-				ID:        uuid.Must(uuid.FromString(systemVersionStatementID)),
 				Effect:    storage.Allow,
 				Actions:   []string{"system:serviceVersion:get", "system:serviceVersion:list"},
 				Resources: []string{"system:service:version"},
 				Projects:  []string{constants.AllProjectsID},
 			},
 			{
-				ID:        uuid.Must(uuid.FromString(systemLicenseStatementID)),
 				Effect:    storage.Allow,
 				Actions:   []string{"system:license:get"},
 				Resources: []string{"system:status"},
 				Projects:  []string{constants.AllProjectsID},
 			},
 			{
-				ID:        uuid.Must(uuid.FromString(systemPolicyVersionStatementID)),
 				Effect:    storage.Allow,
 				Actions:   []string{"iam:policies:get"},
 				Resources: []string{"iam:policyVersion"},
@@ -94,14 +74,12 @@ func SystemPolicies() []*storage.Policy {
 		},
 		Statements: []storage.Statement{
 			{
-				ID:        uuid.Must(uuid.FromString(systemLocalUsersStatementID)),
 				Effect:    storage.Allow,
 				Actions:   []string{"iam:users:get", "iam:users:list", "iam:users:update", "iam:usersSelf:update"},
 				Resources: []string{"iam:users:${a2:username}", "iam:usersSelf:${a2:username}"},
 				Projects:  []string{constants.AllProjectsID},
 			},
 			{
-				ID:        uuid.Must(uuid.FromString(systemLocalUsersDeleteStatementID)),
 				Effect:    storage.Deny,
 				Actions:   []string{"iam:users:delete"},
 				Resources: []string{"iam:users:${a2:username}"},
@@ -124,7 +102,6 @@ func SystemPolicies() []*storage.Policy {
 		},
 		Statements: []storage.Statement{
 			{
-				ID:        uuid.Must(uuid.FromString(ingestProviderStatementID)),
 				Effect:    storage.Allow,
 				Actions:   []string{"infra:ingest:*", "compliance:profiles:get", "compliance:profiles:list"},
 				Resources: []string{"*"},
@@ -144,7 +121,6 @@ func SystemPolicies() []*storage.Policy {
 		},
 		Statements: []storage.Statement{
 			{
-				ID:      uuid.Must(uuid.FromString(chefManagedPoliciesStatementID)),
 				Effect:  storage.Deny,
 				Actions: []string{"iam:policies:update", "iam:policies:delete"},
 				Resources: []string{
@@ -156,7 +132,6 @@ func SystemPolicies() []*storage.Policy {
 				Projects: []string{constants.AllProjectsID},
 			},
 			{
-				ID:      uuid.Must(uuid.FromString(chefManagedRolesStatementID)),
 				Effect:  storage.Deny,
 				Actions: []string{"iam:roles:update", "iam:roles:delete"},
 				Resources: []string{
@@ -170,7 +145,6 @@ func SystemPolicies() []*storage.Policy {
 				Projects: []string{constants.AllProjectsID},
 			},
 			{
-				ID:      uuid.Must(uuid.FromString(chefManagedProjectsStatementID)),
 				Effect:  storage.Deny,
 				Actions: []string{"iam:projects:update", "iam:projects:delete"},
 				Resources: []string{

--- a/components/authz-service/storage/errors.go
+++ b/components/authz-service/storage/errors.go
@@ -19,9 +19,6 @@ var (
 	// ErrDatabase results from unexpected database errors.
 	ErrDatabase = errors.New("database internal")
 
-	// ErrGenerateUUID occurs when a UUID could not be generated for a new object.
-	ErrGenerateUUID = errors.New("could not generate UUID")
-
 	// ErrMaxProjectsExceeded indicates that a new project cannot be created
 	// since the max allowed are already created.
 	ErrMaxProjectsExceeded = errors.New("max projects allowed")

--- a/components/authz-service/storage/postgres/migration/sql/66_iam_statements_drop_id_column.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/66_iam_statements_drop_id_column.up.sql
@@ -1,0 +1,167 @@
+BEGIN;
+
+ALTER TABLE iam_statements DROP COLUMN id;
+
+-- we change the types, so we'll first remove the old one
+DROP FUNCTION insert_iam_statement_into_policy(TEXT, UUID, iam_effect, TEXT[], TEXT[], TEXT, TEXT[]);
+DROP FUNCTION statement_db_id(UUID);
+
+CREATE OR REPLACE FUNCTION
+    insert_iam_statement_into_policy(_policy_id TEXT, _statement_effect iam_effect, _statement_actions TEXT[],
+    _statement_resources TEXT[], _statement_role TEXT, _statement_projects TEXT[])
+RETURNS void AS $$
+DECLARE
+  statement_db_id INTEGER;
+BEGIN
+    -- if NULL or an empty string was passed for the role, we shouldn't try to insert a role.
+    IF _statement_role IS NULL OR _statement_role=''
+    THEN
+        INSERT INTO iam_statements (policy_id, effect, actions, resources)
+        VALUES (policy_db_id(_policy_id), _statement_effect, _statement_actions, _statement_resources)
+        RETURNING db_id INTO statement_db_id;
+    ELSE
+        INSERT INTO iam_statements (policy_id, effect, actions, resources, role_id)
+        VALUES (policy_db_id(_policy_id), _statement_effect, _statement_actions, _statement_resources, role_db_id(_statement_role))
+        RETURNING db_id INTO statement_db_id;
+    END IF;
+    INSERT INTO iam_statement_projects (statement_id, project_id)
+      SELECT statement_db_id, project_db_id(p_id)
+      FROM UNNEST(_statement_projects) projects(p_id)
+    ON CONFLICT DO NOTHING;
+    RETURN;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- removed stmt.id
+CREATE OR REPLACE FUNCTION query_policy (_policy_id TEXT, _projects_filter TEXT[])
+    RETURNS json
+    AS $$
+    WITH temp AS (
+        SELECT
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type,
+            -- get policy's statements using temporary table
+            ( WITH statement_rows AS (
+                    SELECT
+                        stmt.db_id,
+                        stmt.effect,
+                        stmt.actions,
+                        stmt.resources,
+                        (
+                          SELECT COALESCE((SELECT id FROM iam_roles WHERE db_id=stmt.role_id), '') AS role
+                        ),
+                        (
+                            SELECT
+                                COALESCE(json_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL),
+                                    '[]')
+                                FROM iam_statement_projects AS stmt_projs
+                            LEFT JOIN iam_projects AS proj
+                            ON stmt_projs.statement_id = stmt.db_id
+                            WHERE stmt_projs.project_id = proj.db_id
+                        ) AS projects
+                    FROM iam_statements stmt
+                    JOIN iam_policies ON stmt.policy_id = pol.db_id
+                GROUP BY
+                    stmt.db_id,
+                    stmt.effect,
+                    stmt.actions,
+                    stmt.resources,
+                    stmt.role_id)
+            SELECT
+                array_agg(statement_rows)
+            FROM statement_rows) AS statements,
+            -- get policy members
+            (
+            SELECT
+                array_agg(mem)
+            FROM iam_policy_members AS pol_mems
+            LEFT JOIN iam_members AS mem ON pol_mems.member_id = mem.db_id WHERE pol_mems.policy_id = pol.db_id) AS members,
+            -- get projects
+            (
+            SELECT
+                array_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL)
+            FROM iam_policy_projects AS pol_projs
+            LEFT JOIN iam_projects AS proj
+            ON pol_projs.project_id = proj.db_id
+            WHERE pol_projs.policy_id = pol.db_id
+        ) AS projects
+    FROM iam_policies AS pol
+    WHERE pol.id = _policy_id
+        GROUP BY
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type
+)
+SELECT
+    json_build_object('id', temp.id, 'name', temp.name, 'type', temp.type, 'statements', COALESCE(temp.statements, '{}'), 'members', COALESCE(temp.members, '{}'), 'projects', COALESCE(temp.projects, '{}')) AS POLICY
+FROM
+    temp
+WHERE
+    projects_match (temp.projects::TEXT[], _projects_filter);
+$$
+LANGUAGE sql;
+
+-- removed stmt.id
+CREATE OR REPLACE FUNCTION query_policies (_projects_filter TEXT[])
+    RETURNS SETOF json
+    AS $$
+    WITH temp AS (
+        SELECT
+            pol.db_id,
+            pol.id,
+            pol.name,
+            pol.type,
+            ( WITH statement_rows AS (
+                    SELECT
+                        stmt.db_id,
+                        stmt.effect,
+                        stmt.actions,
+                        stmt.resources,
+                        (
+                          SELECT COALESCE((SELECT id FROM iam_roles WHERE db_id=stmt.role_id), '') AS role
+                        ),
+                        (
+                            SELECT
+                                COALESCE(json_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL),
+                                    '[]')
+                                FROM iam_statement_projects AS stmt_projs
+                            LEFT JOIN iam_projects AS proj ON stmt_projs.statement_id = stmt.db_id WHERE stmt_projs.project_id = proj.db_id) AS projects FROM iam_statements stmt
+                    JOIN iam_policies ON stmt.policy_id = pol.db_id
+                GROUP BY
+                    stmt.db_id,
+                    stmt.effect,
+                    stmt.actions,
+                    stmt.resources,
+                    stmt.role_id
+)
+            SELECT array_agg(statement_rows) FROM statement_rows) AS statements,
+            ( SELECT
+                array_agg(mem)
+              FROM iam_policy_members AS pol_mems
+              LEFT JOIN iam_members AS mem ON pol_mems.member_id = mem.db_id WHERE pol_mems.policy_id = pol.db_id
+            ) AS members,
+    ( SELECT
+        array_agg(proj.id) FILTER (WHERE proj.id IS NOT NULL)
+        FROM iam_policy_projects AS pol_projs
+        LEFT JOIN iam_projects AS proj ON pol_projs.project_id = proj.db_id WHERE pol_projs.policy_id = pol.db_id
+    ) AS projects FROM iam_policies AS pol
+GROUP BY
+    pol.db_id,
+    pol.id,
+    pol.name,
+    pol.type
+)
+SELECT
+    json_build_object('id', temp.id, 'name', temp.name, 'type', temp.type, 'statements', COALESCE(temp.statements, '{}'), 'members', COALESCE(temp.members, '{}'), 'projects', COALESCE(temp.projects, '{}')) AS POLICY
+FROM
+    temp
+WHERE
+    projects_match (temp.projects::TEXT[], _projects_filter);
+$$
+LANGUAGE sql;
+
+COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -65,3 +65,4 @@
 - [`63_make_db_id_lookup_functions_strict.up.sql`](63_make_db_id_lookup_functions_strict.up.sql)
 - [`64_drop_uuid_of_iam_members.up.sql`](64_drop_uuid_of_iam_members.up.sql)
 - [`65_iam_projects_drop_projects_column.up.sql`](65_iam_projects_drop_projects_column.up.sql)
+- [`66_iam_statements_drop_id_column.up.sql`](66_iam_statements_drop_id_column.up.sql)

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -332,8 +332,8 @@ func (p *pg) insertPolicyStatementsWithQuerier(ctx context.Context,
 	q Querier) error {
 	for _, s := range inputStatements {
 		_, err := q.ExecContext(ctx,
-			`SELECT insert_iam_statement_into_policy($1, $2, $3, $4, $5, $6, $7);`,
-			policyID, s.ID, s.Effect.String(), pq.Array(s.Actions),
+			`SELECT insert_iam_statement_into_policy($1, $2, $3, $4, $5, $6);`,
+			policyID, s.Effect.String(), pq.Array(s.Actions),
 			pq.Array(s.Resources), s.Role, pq.Array(s.Projects),
 		)
 		if err != nil {
@@ -754,7 +754,7 @@ func (p *pg) DeleteRole(ctx context.Context, id string) error {
 		return storage_errors.ErrNotFound
 	}
 
-	res, err := tx.ExecContext(ctx, `DELETE FROM iam_roles WHERE id=$1;`, id)
+	res, err := tx.ExecContext(ctx, "DELETE FROM iam_roles WHERE id=$1", id)
 	if err != nil {
 		return p.processError(err)
 	}

--- a/components/authz-service/storage/v2/statement.go
+++ b/components/authz-service/storage/v2/statement.go
@@ -1,25 +1,20 @@
 package v2
 
 import (
-	"github.com/pkg/errors"
-
-	storage_errors "github.com/chef/automate/components/authz-service/storage"
-	uuid "github.com/chef/automate/lib/uuid4"
+	"errors"
 )
 
 // Statement must have at least a role OR a non-empty actions list
 type Statement struct {
-	ID        uuid.UUID `json:"id"`
-	Actions   []string  `json:"actions"`
-	Resources []string  `json:"resources"`
-	Role      string    `json:"role"`
-	Projects  []string  `json:"projects"`
-	Effect    Effect    `json:"effect"`
+	Actions   []string `json:"actions"`
+	Resources []string `json:"resources"`
+	Role      string   `json:"role"`
+	Projects  []string `json:"projects"`
+	Effect    Effect   `json:"effect"`
 }
 
 // NewStatement is a factory for creating a Statement storage object that also does
 // validation around what a valid statement is in terms of our storage layer.
-// It also generates a new ID for our statement.
 func NewStatement(effect Effect, role string, projects, resources, actions []string) (Statement, error) {
 	if actions == nil {
 		actions = []string{}
@@ -33,17 +28,11 @@ func NewStatement(effect Effect, role string, projects, resources, actions []str
 			errors.New("unsupported statement variant: you must pass a role, a non-empty array of actions, or both")
 	}
 
-	id, err := uuid.New()
-	if err != nil {
-		return Statement{}, storage_errors.ErrGenerateUUID
-	}
-
 	return Statement{
 		Effect:    effect,
 		Role:      role,
 		Projects:  projects,
 		Actions:   actions,
 		Resources: resources,
-		ID:        id,
 	}, nil
 }


### PR DESCRIPTION
## :nut_and_bolt: Description: What code changed, and why?

When moving from `id` to `db_id` for all auth database entities, `id` became superfluous. This PR cleans that up.

Also, please see individual commits for:
✅ Made some often-repeated queries in `postgres_test.go` constants.
✅ ~Made a `storage.Statement`'s `Role` field `sql.NullString` instead of treating `""` as unset~ _some other day..._

### :chains: Related Resources

#832 

### :+1: Definition of Done

Test pass

### :athletic_shoe: How to Build and Test the Change

`start_all_services`, `rebuild components/authz-service`, create some policies. But really, our tests should have us well covered here 😄 

### :white_check_mark: Checklist

- [X] Tests added/updated?
- [ ] ~Docs added/updated?~ Internal change, no user-visible changes.

### :camera: Screenshots, if applicable