### PR TITLE
pg-sidecar-service: minor error handling fixes, new build

### DIFF
--- a/components/pg-sidecar-service/cmd/pg-sidecar-service/commands/serve.go
+++ b/components/pg-sidecar-service/cmd/pg-sidecar-service/commands/serve.go
@@ -2,9 +2,9 @@ package commands
 
 import (
 	"context"
-	"os"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -29,7 +29,7 @@ var serveCmd = &cobra.Command{
 		*/
 
 		if err = server.StartGRPC(context.Background(), conf); err != nil {
-			os.Exit(1)
+			logrus.Fatal(err)
 		}
 	},
 }

--- a/components/pg-sidecar-service/cmd/pg-sidecar-service/commands/serve.go
+++ b/components/pg-sidecar-service/cmd/pg-sidecar-service/commands/serve.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -29,7 +28,7 @@ var serveCmd = &cobra.Command{
 		*/
 
 		if err = server.StartGRPC(context.Background(), conf); err != nil {
-			logrus.Fatal(err)
+			log.Fatal(err)
 		}
 	},
 }


### PR DESCRIPTION
This fixes some uses of logrus.Fatal inside a function that returns an
error to its caller.

But, this also has the side-effect of rebuilding the package. We
haven't shipped pg-sidecar-service in a while. Because of the bug
fixed in #1111 we think that many installations likely have a small
problem where not all of pg-sidecar-service's dependencies are
installed. Shipping a new version will fix since the update
dependencies will get installed on upgrade.

Signed-off-by: Steven Danna <steve@chef.io>