### PR TITLE
Update e2e cypress deps to address security warnings

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -2183,9 +2183,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.4.0.tgz",
-      "integrity": "sha512-vUE+sK3l23fhs5qTN3dKpveyP0fGr37VmK3FSYaTEjbqC/qh4DbA1Ych/3bLStUpHP4rpE5KAx7i1s/tpdD9vQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.4.1.tgz",
+      "integrity": "sha512-1HBS7t9XXzkt6QHbwfirWYty8vzxNMawGj1yI+Fu6C3/VZJ8UtUngMW6layqwYZzLTZV8tiDpdCNBypn78V4Dg==",
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
         "@cypress/xvfb": "1.2.4",
@@ -2202,12 +2202,11 @@
         "extract-zip": "1.6.7",
         "fs-extra": "5.0.0",
         "getos": "3.1.1",
-        "glob": "7.1.3",
         "is-ci": "1.2.1",
         "is-installed-globally": "0.1.0",
         "lazy-ass": "1.6.0",
         "listr": "0.12.0",
-        "lodash": "4.17.11",
+        "lodash": "4.17.15",
         "log-symbols": "2.2.0",
         "minimist": "1.2.0",
         "moment": "2.24.0",
@@ -4100,9 +4099,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.once": {
       "version": "4.1.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "cypress": "^3.4.0"
+    "cypress": "^3.4.1"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^4.1.0",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Updates cypress to latest minor version to resolve `npm audit` warnings.

**Before**
```
$ npm audit

found 163 high severity vulnerabilities in 6065 scanned packages
```

**After**
```
$ npm audit

found 0 vulnerabilities in 6065 scanned packages
```

### :+1: Definition of Done

There are no `npm audit` warnings within `/e2e` directory.