### PR TITLE
Remove unnecessary copies from pkg.path

### DIFF
--- a/components/applications-service/habitat/config/config.toml
+++ b/components/applications-service/habitat/config/config.toml
@@ -20,7 +20,7 @@ cluster_id = "{{events.cfg.cluster_id}}"
 
 [postgres]
 database = "{{cfg.storage.database}}"
-schema_path = "{{pkg.svc_static_path}}/schema"
+schema_path = "{{pkg.path}}/schema"
 
 [tls]
 cert_path = "{{pkg.svc_config_path}}/service.crt"

--- a/components/applications-service/habitat/hooks/run
+++ b/components/applications-service/habitat/hooks/run
@@ -1,5 +1,7 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
+set -e
+
 exec 2>&1
 
 # Call the script to block until user accepts the MLSA via the package's config
@@ -12,9 +14,6 @@ DBNAME="{{cfg.storage.database}}"
 pg-helper ensure-service-database "$DBNAME"
 pg-helper create-extension "$DBNAME" "pgcrypto"
 pg-helper fix-permissions "$DBNAME"
-
-# Copy schema sql files
-cp -r "{{pkg.path}}/schema" "{{pkg.svc_static_path}}/."
 
 # Start our service
 exec applications-service serve --config {{pkg.svc_config_path}}/config.toml

--- a/components/applications-service/habitat/hooks/run
+++ b/components/applications-service/habitat/hooks/run
@@ -15,5 +15,8 @@ pg-helper ensure-service-database "$DBNAME"
 pg-helper create-extension "$DBNAME" "pgcrypto"
 pg-helper fix-permissions "$DBNAME"
 
+# cleanup old migration files
+rm -rf "{{pkg.svc_static_path}}/schema"
+
 # Start our service
 exec applications-service serve --config {{pkg.svc_config_path}}/config.toml

--- a/components/authz-service/habitat/config/config.yml
+++ b/components/authz-service/habitat/config/config.yml
@@ -9,8 +9,8 @@ tls:
   root_ca_path: {{pkg.svc_config_path}}/root_ca.crt
 
 database: {{cfg.storage.database}}
-migrations-path: {{ pkg.svc_static_path }}/migrations
-data-migrations-path: {{ pkg.svc_static_path }}/data-migrations
+migrations-path: {{pkg.path}}/migrations
+data-migrations-path: {{pkg.path}}/data-migrations
 
 {{~#eachAlive bind.event-service.members as |event-service|}}
   {{~#if @last}}

--- a/components/authz-service/habitat/hooks/run
+++ b/components/authz-service/habitat/hooks/run
@@ -10,18 +10,6 @@ pg-helper ensure-service-database "{{cfg.storage.database}}"
 pg-helper create-extension "{{cfg.storage.database}}" "pgcrypto"
 pg-helper create-extension "{{cfg.storage.database}}" "uuid-ossp"
 
-# Note: We only want the current hart's contents there. Nothing else.
-# When we had merged two PRs both featuring a migration number 45, we
-# ended up with two 45_*.up.sql files in pkg.svc_static_path.
-# Fixing the file names resolved the issue for fresh installs, but our
-# inplace upgrades still failed -- the old, two, 45 files are still
-# present. To solve that, and not ever be hit by this `cp -r` bug again,
-# we'll ensure that svc_static_path never contains any old cruft by
-# clearing it out first:
-rm -rf {{pkg.svc_static_path}}/{migrations,data-migrations}
-cp -r {{pkg.path}}/migrations {{pkg.svc_static_path}}
-cp -r {{pkg.path}}/data-migrations {{pkg.svc_static_path}}
-
 {{~#eachAlive bind.event-service.members as |event-service|}}
 {{~#if @last}}
 addNoProxy {{event-service.sys.ip}}

--- a/components/authz-service/habitat/hooks/run
+++ b/components/authz-service/habitat/hooks/run
@@ -10,6 +10,9 @@ pg-helper ensure-service-database "{{cfg.storage.database}}"
 pg-helper create-extension "{{cfg.storage.database}}" "pgcrypto"
 pg-helper create-extension "{{cfg.storage.database}}" "uuid-ossp"
 
+# cleanup old migration files
+rm -rf {{pkg.svc_static_path}}/{migrations,data-migrations}
+
 {{~#eachAlive bind.event-service.members as |event-service|}}
 {{~#if @last}}
 addNoProxy {{event-service.sys.ip}}

--- a/components/automate-dex/habitat/config/config.json
+++ b/components/automate-dex/habitat/config/config.json
@@ -2,6 +2,7 @@
 "service": {{ toJson cfg.service }},
 "storage": {{ toJson cfg.storage }},
 "grpc": {{ toJson cfg.grpc }},
+"frontend_dir": "{{pkg.path}}/web",
 {{ ~#if cfg.log }}
 "log": {{ toJson cfg.log }},
 {{ ~/if }}

--- a/components/automate-dex/habitat/hooks/run
+++ b/components/automate-dex/habitat/hooks/run
@@ -14,4 +14,7 @@ render-template config.yml {{pkg.svc_var_path}}/etc/config.yml --conf {{pkg.svc_
 pg-helper ensure-service-database "{{cfg.storage.database}}"
 pg-helper create-extension "{{cfg.storage.database}}" "pgcrypto"
 
+# cleanup static path
+rm -rf "{{pkg.svc_static_path}}/web"
+
 exec dex serve {{pkg.svc_var_path}}/etc/config.yml

--- a/components/automate-dex/habitat/hooks/run
+++ b/components/automate-dex/habitat/hooks/run
@@ -12,9 +12,6 @@ mkdir -p {{pkg.svc_var_path}}/etc
 render-template config.yml {{pkg.svc_var_path}}/etc/config.yml --conf {{pkg.svc_config_path}}/config.json
 
 pg-helper ensure-service-database "{{cfg.storage.database}}"
-
 pg-helper create-extension "{{cfg.storage.database}}" "pgcrypto"
-
-cp -r {{pkg.path}}/web {{pkg.svc_static_path}}
 
 exec dex serve {{pkg.svc_var_path}}/etc/config.yml

--- a/components/automate-dex/habitat/templates/config.yml
+++ b/components/automate-dex/habitat/templates/config.yml
@@ -45,7 +45,7 @@ grpc:
   tlsKey: {{svc_key_path}}
   tlsClientCA: {{svc_root_ca_path}}
 frontend:
-  dir: {{svc_static_path}}/web
+  dir: {{cfg.frontend_dir}}
   issuer: Chef Automate
   theme: chef
 logger:

--- a/components/compliance-service/habitat/hooks/run
+++ b/components/compliance-service/habitat/hooks/run
@@ -22,12 +22,6 @@ pg-helper fix-permissions "$DBNAME"
 
 mkdir -p "{{pkg.svc_data_path}}/profiles"
 
-# remove the stale dir that was created by a lack of trailing slash on the next command!
-rm -rf "{{pkg.svc_static_path}}/migrations"
-
-# trailing slash is important here!!! (to make cp not create extra subdirs and mess up the pg migrations)
-cp -r {{pkg.path}}/migrations/* {{pkg.svc_static_path}}/
-
 {{!--
 # we use bash to test for the existence of the automate-compliance-profiles path
 # because the handlebars combo of `#if pkgPathFor "chef/automate-compliance-profiles"`
@@ -151,7 +145,7 @@ ES_BACKEND="--es-url http://127.0.0.1:{{member.cfg.http-port}}"
 {{~/eachAlive}}
 
 # Postgres
-PG_BACKEND="--postgres-database {{cfg.storage.database}} --migrations-path {{pkg.svc_static_path}}"
+PG_BACKEND="--postgres-database {{cfg.storage.database}} --migrations-path {{pkg.path}}/migrations"
 
 export HOME="{{pkg.svc_data_path}}"
 

--- a/components/compliance-service/habitat/hooks/run
+++ b/components/compliance-service/habitat/hooks/run
@@ -22,6 +22,9 @@ pg-helper fix-permissions "$DBNAME"
 
 mkdir -p "{{pkg.svc_data_path}}/profiles"
 
+# cleanup old migration files
+rm -rf "{{pkg.svc_static_path}}/migrations" {{pkg.svc_static_path}}/*.sql
+
 {{!--
 # we use bash to test for the existence of the automate-compliance-profiles path
 # because the handlebars combo of `#if pkgPathFor "chef/automate-compliance-profiles"`

--- a/components/nodemanager-service/habitat/hooks/run
+++ b/components/nodemanager-service/habitat/hooks/run
@@ -16,6 +16,9 @@ trigger_migrations
 
 pg-helper ensure-service-database "$DBNAME" || exit 1
 
+# cleanup old migration files
+rm -rf {{pkg.svc_static_path}}/*.sql
+
 # Setting coming from our default.toml
 CONFIG="--log-level {{cfg.log.level}}"
 CONFIG="$CONFIG --port {{cfg.service.port}}"

--- a/components/nodemanager-service/habitat/hooks/run
+++ b/components/nodemanager-service/habitat/hooks/run
@@ -16,9 +16,6 @@ trigger_migrations
 
 pg-helper ensure-service-database "$DBNAME" || exit 1
 
-# Copy the migrations files
-cp -r {{pkg.path}}/migrations/* {{pkg.svc_static_path}}/
-
 # Setting coming from our default.toml
 CONFIG="--log-level {{cfg.log.level}}"
 CONFIG="$CONFIG --port {{cfg.service.port}}"
@@ -58,7 +55,7 @@ CONFIG="$CONFIG --event-endpoint {{event.sys.ip}}:{{event.cfg.port}}"
 {{~/eachAlive}}
 
 # Postgres
-PG_BACKEND="--postgres-database {{cfg.storage.database}} --migrations-path {{pkg.svc_static_path}}"
+PG_BACKEND="--postgres-database {{cfg.storage.database}} --migrations-path {{pkg.path}}/migrations"
 
 export HOME="{{pkg.svc_data_path}}"
 

--- a/components/secrets-service/habitat/config/config.toml
+++ b/components/secrets-service/habitat/config/config.toml
@@ -21,7 +21,7 @@ log_level = "{{cfg.log.level}}"
 
 [postgres]
 database = "{{cfg.storage.database}}"
-migrations_path = "{{pkg.svc_static_path}}"
+migrations_path = "{{pkg.path}}/migrations"
 
 [tls]
 cert_path = "{{pkg.svc_config_path}}/service.crt"

--- a/components/secrets-service/habitat/hooks/run
+++ b/components/secrets-service/habitat/hooks/run
@@ -16,9 +16,6 @@ trigger_migrations
 
 pg-helper ensure-service-database "$DBNAME" || exit 1
 
-# Copy the migrations files
-cp -r {{pkg.path}}/migrations/* {{pkg.svc_static_path}}/
-
 secrets-service init "{{pkg.svc_data_path}}/secrets_key" || exit 1
 
 # Start our service

--- a/components/secrets-service/habitat/hooks/run
+++ b/components/secrets-service/habitat/hooks/run
@@ -16,6 +16,9 @@ trigger_migrations
 
 pg-helper ensure-service-database "$DBNAME" || exit 1
 
+# cleanup old migration files
+rm -rf {{pkg.svc_static_path}}/*.sql
+
 secrets-service init "{{pkg.svc_data_path}}/secrets_key" || exit 1
 
 # Start our service

--- a/components/session-service/habitat/config/config.yml
+++ b/components/session-service/habitat/config/config.yml
@@ -17,7 +17,7 @@ bldr-client-secret: {{ cfg.service.bldr_client_secret }}
 log-level: {{ cfg.logger.level }}
 log-format: {{ cfg.logger.format }}
 database: {{ cfg.storage.database }}
-migrations-path: {{ pkg.svc_static_path }}/migrations
+migrations-path: {{ pkg.path }}/migrations
 
 tls:
   cert_path: {{pkg.svc_config_path}}/service.crt

--- a/components/session-service/habitat/hooks/run
+++ b/components/session-service/habitat/hooks/run
@@ -9,4 +9,7 @@ pg-helper ensure-service-database "{{cfg.storage.database}}"
 
 pg-helper create-extension "{{cfg.storage.database}}" "pgcrypto"
 
+# cleanup old migration files
+rm -rf {{pkg.svc_static_path}}/migrations
+
 exec session-service {{pkg.svc_config_path}}/config.yml

--- a/components/session-service/habitat/hooks/run
+++ b/components/session-service/habitat/hooks/run
@@ -9,6 +9,4 @@ pg-helper ensure-service-database "{{cfg.storage.database}}"
 
 pg-helper create-extension "{{cfg.storage.database}}" "pgcrypto"
 
-cp -r {{pkg.path}}/migrations {{pkg.svc_static_path}}
-
 exec session-service {{pkg.svc_config_path}}/config.yml

--- a/components/teams-service/habitat/config/config.yml
+++ b/components/teams-service/habitat/config/config.yml
@@ -9,8 +9,8 @@ tls:
   root_ca_path: {{pkg.svc_config_path}}/root_ca.crt
 
 database: {{ cfg.storage.database }}
-migrations-path: {{ pkg.svc_static_path }}/migrations
-data-migrations-path: {{ pkg.svc_static_path }}/data-migrations
+migrations-path: {{ pkg.path }}/migrations
+data-migrations-path: {{ pkg.path }}/data-migrations
 
 {{~#eachAlive bind.authz-service.members as |authz-service|}}
 {{~#if @last}}

--- a/components/teams-service/habitat/hooks/run
+++ b/components/teams-service/habitat/hooks/run
@@ -16,10 +16,6 @@ pg-helper ensure-service-database "{{cfg.storage.database}}"
 
 echo "Creating extension"
 pg-helper create-extension "{{cfg.storage.database}}" "pgcrypto"
-
 pg-helper create-extension "{{cfg.storage.database}}" "uuid-ossp"
-
-cp -r {{pkg.path}}/migrations {{pkg.svc_static_path}}
-cp -r {{pkg.path}}/data-migrations {{pkg.svc_static_path}}
 
 exec teams-service {{pkg.svc_config_path}}/config.yml

--- a/components/teams-service/habitat/hooks/run
+++ b/components/teams-service/habitat/hooks/run
@@ -18,4 +18,7 @@ echo "Creating extension"
 pg-helper create-extension "{{cfg.storage.database}}" "pgcrypto"
 pg-helper create-extension "{{cfg.storage.database}}" "uuid-ossp"
 
+# cleanup old migration files
+rm -rf {{pkg.svc_static_path}}/{migrations,data-migrations}
+
 exec teams-service {{pkg.svc_config_path}}/config.yml


### PR DESCRIPTION
These services were copying files that are only used for reading out
of package path and into the service's static path. No one I talked to
had a reason for why we were doing this.

We think maybe one of the following let us here:

1) permissions problems on files. We now test with a restrictive
default umask and it is unclear to me what permissions problem we
could have hit that the `cp` would have avoided.

2) Following a "rule of thumb" that the service should only depend on
files in `/hab/svc/SERVICE-NAME`. While I think this is a good rule
of thumb, for static data (this data could have been compiled into the
binary), I don't see the harm in reading it directly from the package
path.

Removing the copy comes with the advantage of removing another step
from service startup that could fail.

There is still calls to `cp` in our run scripts, but they are in
services that I'm not inclined to touch at the moment:

    components/automate-cs-nginx/habitat/hooks/run
    15:cp {{cfg.required_recipe.path}} {{pkg.svc_var_path}}/required_recipe

    components/automate-cs-oc-erchef/habitat/hooks/run
    56:cp {{pkg.svc_config_path}}/dark_launch_features.json {{pkg.svc_data_path}}

    components/automate-workflow-server/habitat/hooks/run
    26:  cp -a {{pkg.path}}/{{cfg.ssh_git.git_repo_template}} {{pkg.svc_files_path}}/

Signed-off-by: Steven Danna <steve@chef.io>