### PR TITLE
teams-service: cut down "create team" error strings

### DIFF
--- a/components/teams-service/server/v1/server.go
+++ b/components/teams-service/server/v1/server.go
@@ -60,10 +60,7 @@ func (s *Server) CreateTeam(ctx context.Context, req *teams.CreateTeamReq) (*tea
 	var err error
 	if team, err = s.service.Storage.StoreTeam(ctx, req.Name, req.Description); err != nil {
 		if err == storage.ErrConflict {
-			return nil, status.Errorf(
-				codes.AlreadyExists,
-				"unable to create team: a team with name %q already exists.",
-				req.Name)
+			return nil, status.Errorf(codes.AlreadyExists, "team with name %q already exists", req.Name)
 		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/components/teams-service/server/v1/server.go
+++ b/components/teams-service/server/v1/server.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -126,9 +125,7 @@ func (s *Server) DeleteTeam(ctx context.Context, req *teams.DeleteTeamReq) (*tea
 	})
 	if err != nil {
 		s.service.Logger.Warnf("failed to purge subjects on team delete: %s", err.Error())
-		return nil, status.Error(codes.Internal,
-			fmt.Sprintf("the team named %s with id %s was successfully deleted but its "+
-				"subject could not be purged from the policies: %s", team.Name, team.ID, err.Error()))
+		return nil, status.Errorf(codes.Internal, "failed to purge team %q from policies: %s", team.ID, err.Error())
 	}
 
 	return &teams.DeleteTeamResp{

--- a/components/teams-service/server/v2/server.go
+++ b/components/teams-service/server/v2/server.go
@@ -64,10 +64,7 @@ func (s *Server) CreateTeam(ctx context.Context,
 	var err error
 	if team, err = s.service.Storage.StoreTeamWithProjects(ctx, req.Id, req.Name, req.Projects); err != nil {
 		if err == storage.ErrConflict {
-			return nil, status.Errorf(
-				codes.AlreadyExists,
-				"unable to create team: a team with id %q already exists.",
-				req.Id)
+			return nil, status.Errorf(codes.AlreadyExists, "team with ID %q already exists", req.Id)
 		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -96,7 +93,7 @@ func (s *Server) DeleteTeam(ctx context.Context, req *teams.DeleteTeamReq) (*tea
 	if err != nil {
 		s.service.Logger.Warnf("failed to purge subjects on team delete: %s", err.Error())
 		return nil, status.Error(codes.Internal,
-			fmt.Sprintf("the team named %q with id %q was successfully deleted but its "+
+			fmt.Sprintf("the team named %q with ID %q was successfully deleted but its "+
 				"subject could not be purged from the policies: %s", team.Name, req.Id, err.Error()))
 	}
 
@@ -127,7 +124,7 @@ func (s *Server) AddTeamMembers(ctx context.Context,
 	req *teams.AddTeamMembersReq) (*teams.AddTeamMembersResp, error) {
 
 	if len(req.UserIds) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "missing user ids")
+		return nil, status.Error(codes.InvalidArgument, "missing user IDs")
 	}
 	// TODO (tc): The storage interface is still using V1 verbiage, so
 	// name is really the ID in V2 terms. We'll refactor at GA when V1 is removed.

--- a/components/teams-service/server/v2/server.go
+++ b/components/teams-service/server/v2/server.go
@@ -2,7 +2,6 @@ package v2
 
 import (
 	"context"
-	"fmt"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -92,9 +91,7 @@ func (s *Server) DeleteTeam(ctx context.Context, req *teams.DeleteTeamReq) (*tea
 	})
 	if err != nil {
 		s.service.Logger.Warnf("failed to purge subjects on team delete: %s", err.Error())
-		return nil, status.Error(codes.Internal,
-			fmt.Sprintf("the team named %q with ID %q was successfully deleted but its "+
-				"subject could not be purged from the policies: %s", team.Name, req.Id, err.Error()))
+		return nil, status.Errorf(codes.Internal, "failed to purge team %q from policies: %s", req.Id, err.Error())
 	}
 
 	return &teams.DeleteTeamResp{


### PR DESCRIPTION
There' some decent guidance here: https://github.com/golang/go/wiki/Errors

Error strings should

- start with lowercase
- be specific: if create fails, don't say that create failed
- not end with a period

...because they might be wrapped, as it happens in this case: When this error
bubbles up in the UI, it'll say

> Could not create team: unable to create team: a team with name "..." already exists..