### PR TITLE
compliance-service: prealloc linter

### DIFF
--- a/components/compliance-service/Makefile
+++ b/components/compliance-service/Makefile
@@ -1,8 +1,5 @@
-# lll: ignore long lines
-# unparam: unused parameters
 # nakedret: naked returns in long functions
-# prealloc: slices that could be preallocated
-LINTERARGS=-v -D lll -D unparam -D nakedret -D prealloc --deadline 1m ./...
+LINTERARGS=-v -D nakedret ./...
 # govet in 1.16 is very confused by some of the code in this component
 include ../../Makefile.common_go
 

--- a/components/compliance-service/api/profiles/conversion/conversion.go
+++ b/components/compliance-service/api/profiles/conversion/conversion.go
@@ -22,7 +22,7 @@ func ConvertToPSProfile(profile inspec.Profile, namespace string) (profiles.Prof
 	convertedProfile.Sha256 = profile.Sha256
 	convertedProfile.Owner = namespace
 
-	var convertedSupports []*profiles.Support
+	convertedSupports := make([]*profiles.Support, 0, len(profile.Supports))
 	for _, support := range profile.Supports {
 		family := support["os-family"]
 		if len(family) == 0 {
@@ -72,7 +72,7 @@ func ConvertToPSProfile(profile inspec.Profile, namespace string) (profiles.Prof
 		convertedProfile.Attributes = convertedAttributes
 	}
 
-	var convertedControls []*profiles.Control
+	convertedControls := make([]*profiles.Control, 0, len(profile.Controls))
 	for _, control := range profile.Controls {
 		convertedControl := profiles.Control{
 			Id:     control.ID,
@@ -112,7 +112,7 @@ func ConvertToPSProfile(profile inspec.Profile, namespace string) (profiles.Prof
 			convertedControl.Refs = convertedRefs
 		}
 
-		var convertedResults []*profiles.Result
+		convertedResults := make([]*profiles.Result, 0, len(control.Results))
 		for _, result := range control.Results {
 			convertedResult := profiles.Result{
 				Status:      result.Status,

--- a/components/compliance-service/dao/pgdb/filtering.go
+++ b/components/compliance-service/dao/pgdb/filtering.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/chef/automate/components/compliance-service/api/common"
-	"github.com/chef/automate/components/compliance-service/utils"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"github.com/chef/automate/components/compliance-service/api/common"
+	"github.com/chef/automate/components/compliance-service/utils"
 )
 
 func mergeFilters(mergeableFilters []*common.Filter) ([]common.Filter, error) {
@@ -50,7 +51,7 @@ func buildWhereFilter(mergeableFilters []*common.Filter, tableAbbrev string, fil
 		return "", errors.Wrap(err, "buildWhereFilter error")
 	}
 
-	var conditions []string
+	conditions := make([]string, 0, len(filters))
 	for _, filter := range filters {
 		var newCondition string
 		var err error

--- a/components/compliance-service/dao/pgdb/profiles.go
+++ b/components/compliance-service/dao/pgdb/profiles.go
@@ -64,7 +64,7 @@ func (trans *DBTrans) addProfiles(profiles []string) ([]string, error) {
 		delete(profilesToInsert, p.URL)
 	}
 
-	var profilesToBeInserted []interface{}
+	profilesToBeInserted := make([]interface{}, 0, len(profilesToInsert))
 	//iterate over what's left in the map.  this is what needs to be inserted into profiles table.
 	for k := range profilesToInsert {
 		namespace, name, err := parseNamespaceAndNameFromUrl(k)

--- a/components/compliance-service/reporting/relaxting/profiles.go
+++ b/components/compliance-service/reporting/relaxting/profiles.go
@@ -87,7 +87,8 @@ func (esprofile *ESInspecProfile) parseInspecProfile(profile inspec.Profile) err
 	esprofile.Dependencies = convertRSProfileDependenciesToInspecDependencies(profile.Dependencies)
 	esprofile.Sha256 = profile.Sha256
 	// no need for Status and SkipMessage here as it's not static metadata of the profile
-	var groups []inspec.Group
+
+	groups := make([]inspec.Group, 0, len(profile.Groups))
 	for _, group := range profile.Groups {
 		eGroup := inspec.Group{
 			ID:       group.Id,
@@ -98,7 +99,7 @@ func (esprofile *ESInspecProfile) parseInspecProfile(profile inspec.Profile) err
 	}
 	esprofile.Groups = groups
 
-	esprofile.Attributes = make([]ESInspecAttribute, 0)
+	esprofile.Attributes = make([]ESInspecAttribute, 0, len(profile.Attributes))
 	for _, attribute := range profile.Attributes {
 		esAttribute := ESInspecAttribute{
 			Name: attribute.Name,
@@ -115,8 +116,7 @@ func (esprofile *ESInspecProfile) parseInspecProfile(profile inspec.Profile) err
 		esprofile.Attributes = append(esprofile.Attributes, esAttribute)
 	}
 
-	esprofile.Controls = make([]ESInspecControl, 0)
-
+	esprofile.Controls = make([]ESInspecControl, 0, len(profile.Controls))
 	// we need to marshal refs and tags for each control
 	for _, control := range profile.Controls {
 		esControl := ESInspecControl{
@@ -126,7 +126,8 @@ func (esprofile *ESInspecProfile) parseInspecProfile(profile inspec.Profile) err
 			ID:     control.ID,
 			Title:  control.Title,
 		}
-		var results []reportingapi.Result
+
+		results := make([]reportingapi.Result, 0, len(control.Results))
 		for _, res := range control.Results {
 			eRes := reportingapi.Result{
 				Status:      res.Status,
@@ -179,7 +180,8 @@ func (esprofile *ESInspecProfile) convertToInspecProfile() (reportingapi.Profile
 	inspecProfile.Sha256 = esprofile.Sha256
 	inspecProfile.Status = esprofile.Status
 	inspecProfile.SkipMessage = esprofile.SkipMessage
-	var groups []*reportingapi.Group
+
+	groups := make([]*reportingapi.Group, 0, len(esprofile.Groups))
 	for _, group := range esprofile.Groups {
 		eGroup := reportingapi.Group{
 			Id:       group.ID,
@@ -193,7 +195,7 @@ func (esprofile *ESInspecProfile) convertToInspecProfile() (reportingapi.Profile
 	inspecProfile.Groups = groups
 
 	// we need to unmarshal attributes
-	inspecProfile.Attributes = make([]*reportingapi.Attribute, 0)
+	inspecProfile.Attributes = make([]*reportingapi.Attribute, 0, len(esprofile.Attributes))
 	for _, esAttribute := range esprofile.Attributes {
 		attribute := reportingapi.Attribute{
 			Name: esAttribute.Name,
@@ -214,7 +216,7 @@ func (esprofile *ESInspecProfile) convertToInspecProfile() (reportingapi.Profile
 	}
 
 	// we need to unmarshal refs and tags for each control
-	inspecProfile.Controls = make([]*reportingapi.Control, 0)
+	inspecProfile.Controls = make([]*reportingapi.Control, 0, len(esprofile.Controls))
 	for _, esControl := range esprofile.Controls {
 		control := reportingapi.Control{
 			Code:   esControl.Code,
@@ -223,7 +225,7 @@ func (esprofile *ESInspecProfile) convertToInspecProfile() (reportingapi.Profile
 			Id:     esControl.ID,
 			Title:  esControl.Title,
 		}
-		var results []*reportingapi.Result
+		results := make([]*reportingapi.Result, 0, len(esControl.Results))
 		for _, res := range esControl.Results {
 			eRes := reportingapi.Result{
 				Status:      res.Status,


### PR DESCRIPTION
This fixes all the prealloc violations and simplifies our LINTERARGS
based on changes to the main linter configuration.

The only remaining differences in compliance-service from the standard
configuration is the nakedret violations. Fixing those looks _mostly_
straightforward but there are a few with some subtle behavior so it is
probably best done as its own PR.

Signed-off-by: Steven Danna <steve@chef.io>