### PR TITLE
Add "unrecognized" update strategy to applications service backend

### DIFF
--- a/components/applications-service/cmd/applications-publisher/main.go
+++ b/components/applications-service/cmd/applications-publisher/main.go
@@ -114,7 +114,7 @@ func main() {
 	flag.StringVar(&version, "version", "0.1.0", "The version of a package")
 	flag.StringVar(&release, "release", t.Format("20060102150405"), "The release of a package")
 	flag.StringVar(&channel, "channel", "", "The habitat channel name that the service is subscribed to")
-	flag.StringVar(&strategy, "strategy", "at-once", "The habitat update strategy for the service. [ at-once | rolling ]")
+	flag.StringVar(&strategy, "strategy", "at-once", "The habitat update strategy for the service. [ at-once | rolling | unrecognized ]")
 	flag.IntVar(&health, "health", 0, "The health check code of a service")
 	flag.BoolVar(&uniqID, "uniq-client-id", false, "Generate a unique client-id to connect to server")
 	flag.BoolVar(&infiniteLoop, "infinite-stream", false, "Publish message every second infinitely")
@@ -142,8 +142,19 @@ func main() {
 				Strategy: habitat.UpdateStrategy_Rolling,
 				Channel:  channel,
 			}
+		case "unrecognized":
+			event.ServiceMetadata.UpdateConfig = &habitat.UpdateConfig{
+				// "unrecognized" isn't a real update strategy, it's the Automate term
+				// for an update strategy that isn't a recognized enum member in the
+				// version of automate that's running. This would happen if a new
+				// update strategy is added to habitat but automate doesn't have the
+				// updated protobuf definition. To send this kind of message across the
+				// wire requires some shenanigans:
+				Strategy: habitat.UpdateStrategy(int32(2)),
+				Channel:  channel,
+			}
 		default:
-			fmt.Println("Unknown update strategy, choose between 'at-once' and 'rolling'.")
+			fmt.Println("Unknown update strategy, choose between 'at-once', 'rolling', or 'unrecognized'.")
 			os.Exit(1)
 		}
 	}

--- a/components/applications-service/pkg/storage/client.go
+++ b/components/applications-service/pkg/storage/client.go
@@ -53,16 +53,22 @@ const (
 	NoneStrategy UpdateStrategy = iota
 	AtOnceStrategy
 	RollingStrategy
+	UnrecognizedStrategy
 )
+
+// Set as a const to share with the tests
+const updateStrategyUnrecognizedName = "UNRECOGNIZED"
 
 func (x UpdateStrategy) String() string {
 	switch x {
+	case NoneStrategy:
+		return "NONE"
 	case AtOnceStrategy:
 		return "AT-ONCE"
 	case RollingStrategy:
 		return "ROLLING"
 	default:
-		return "NONE"
+		return updateStrategyUnrecognizedName
 	}
 }
 
@@ -73,7 +79,7 @@ func HabitatUpdateStrategyToStorageFormat(strategy habitat.UpdateStrategy) Updat
 	case habitat.UpdateStrategy_Rolling:
 		return RollingStrategy
 	default:
-		return NoneStrategy
+		return UnrecognizedStrategy
 	}
 }
 

--- a/components/applications-service/pkg/storage/client_test.go
+++ b/components/applications-service/pkg/storage/client_test.go
@@ -1,0 +1,57 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/chef/automate/api/external/habitat"
+)
+
+// TestUpdateStrategiesInSyncBetweenAutomateAndHabitat verifies that the code
+// in this package is up-to-date with the update strategies described by the
+// habitat protobuf file.
+func TestUpdateStrategiesInSyncBetweenAutomateAndHabitat(t *testing.T) {
+	// At the time of writing, habitat defines:
+	//
+	//   UpdateStrategy_AtOnce UpdateStrategy = 0
+	//   UpdateStrategy_Rolling UpdateStrategy = 1
+	//
+	// If a new one is added, then we need to update our corresponding UpdateStrategy constants
+
+	// The highest integer-value update strategy that Automate code knows about
+	// should exist in the map that the protobuf code generator made:
+	maxHabUpdateStrategyInt := int32(1)
+	_, isKnown := habitat.UpdateStrategy_name[maxHabUpdateStrategyInt]
+	assert.True(t, isKnown)
+
+	for i := int32(0); i <= maxHabUpdateStrategyInt; i++ {
+		habStrategy := habitat.UpdateStrategy(i)
+		storageFormattedStrategy := HabitatUpdateStrategyToStorageFormat(habStrategy)
+		assert.NotEqual(t, updateStrategyUnrecognizedName, storageFormattedStrategy.String())
+	}
+
+	// Check the next 10 integer values, they should not be known to the hab
+	// protobuf code. We check several in case some values got reserved.
+	for i := int32(1); i <= 10; i++ {
+		index := maxHabUpdateStrategyInt + i
+		val, isKnown := habitat.UpdateStrategy_name[index]
+		assert.False(t, isKnown, "expected to not find value %q for update strategy index %d", val, index)
+	}
+}
+
+func TestUpdateStrategiesHaveAStringDefined(t *testing.T) {
+	// ensure all update strategies have an entry in the case statement for the String() method
+	for i := 0; i < int(UnrecognizedStrategy); i++ {
+		str := UpdateStrategy(i).String()
+		assert.NotEqual(t, updateStrategyUnrecognizedName, str)
+	}
+}
+
+func TestUpdateStrategyFromTheFutureIsUNRECOGNIZED(t *testing.T) {
+	nextHabUpdateStrategyInt := int32(2)
+	nextHabUpdateStrategy := habitat.UpdateStrategy(nextHabUpdateStrategyInt)
+
+	storageFormattedStrategy := HabitatUpdateStrategyToStorageFormat(nextHabUpdateStrategy)
+	assert.Equal(t, updateStrategyUnrecognizedName, storageFormattedStrategy.String())
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Add "UNRECOGNIZED" update strategy to account for some upgrade scenarios

This change accounts for the case where:
1. A new update strategy is added to the habitat supervisor
2. A user upgrades habitat and uses this update strategy
3. But does not upgrade Automate

In this case, Automate will not be able to infer the proper name of the update strategy because the names of the update strategies are hard coded in Automate, and even if we did not hardcode them in the Automate codebase, we would need to infer them from the compiled protocol buffer code, which means that in either case a new version of the applications service needs to be built and upgraded-to before habitat messages referencing the new update strategy can be properly understood.

Should these conditions occur, we want to label the update strategy "UNRECOGNIZED" instead of incorrectly coercing to one of the strategies we do know about.

### :chains: Related Resources

https://github.com/chef/automate/issues/902

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

Build applications service and start all services. A health check message with an unrecognized update strategy can be sent with: `applications_publish_supervisor_message --strategy unrecognized --channel stable`

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [x] Docs added/updated?
