### PR TITLE
TypeScript Type Traps

### DIFF
--- a/components/automate-ui/src/app/entities/policies/policy.model.spec.ts
+++ b/components/automate-ui/src/app/entities/policies/policy.model.spec.ts
@@ -4,7 +4,7 @@ describe('policy model', () => {
   describe('stringToMember', () => {
 
     it('All members', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: '*',
         displayName: 'All members',
         displayType: 'All members',
@@ -14,7 +14,7 @@ describe('policy model', () => {
     });
 
     it('All users', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'user:*',
         displayName: 'All users',
         displayType: 'All users',
@@ -24,7 +24,7 @@ describe('policy model', () => {
     });
 
     it('All local users', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'user:local:*',
         displayName: 'All local users',
         displayType: 'All local users',
@@ -34,7 +34,7 @@ describe('policy model', () => {
     });
 
     it('Specific local user', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'user:local:localuser',
         displayName: 'localuser',
         displayType: 'Local user',
@@ -44,7 +44,7 @@ describe('policy model', () => {
     });
 
     it('All LDAP users', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'user:ldap:*',
         displayName: 'All LDAP users',
         displayType: 'All LDAP users',
@@ -54,7 +54,7 @@ describe('policy model', () => {
     });
 
     it('Specific LDAP user', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'user:ldap:ldapuser',
         displayName: 'ldapuser',
         displayType: 'LDAP user',
@@ -64,7 +64,7 @@ describe('policy model', () => {
     });
 
     it('All SAML users', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'user:saml:*',
         displayName: 'All SAML users',
         displayType: 'All SAML users',
@@ -74,7 +74,7 @@ describe('policy model', () => {
     });
 
     it('Specific SAML user', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'user:saml:samluser',
         displayName: 'samluser',
         displayType: 'SAML user',
@@ -84,7 +84,7 @@ describe('policy model', () => {
     });
 
     it('All local teams', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'team:local:*',
         displayName: 'All local teams',
         displayType: 'All local teams',
@@ -94,7 +94,7 @@ describe('policy model', () => {
     });
 
     it('Specific local team', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'team:local:localteam',
         displayName: 'localteam',
         displayType: 'Local team',
@@ -104,7 +104,7 @@ describe('policy model', () => {
     });
 
     it('All LDAP teams', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'team:ldap:*',
         displayName: 'All LDAP teams',
         displayType: 'All LDAP teams',
@@ -114,7 +114,7 @@ describe('policy model', () => {
     });
 
     it('Specific LDAP team', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'team:ldap:ldapteam',
         displayName: 'ldapteam',
         displayType: 'LDAP team',
@@ -124,7 +124,7 @@ describe('policy model', () => {
     });
 
     it('All SAML teams', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'team:saml:*',
         displayName: 'All SAML teams',
         displayType: 'All SAML teams',
@@ -134,7 +134,7 @@ describe('policy model', () => {
     });
 
     it('Specific SAML team', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'team:saml:samlteam',
         displayName: 'samlteam',
         displayType: 'SAML team',
@@ -144,7 +144,7 @@ describe('policy model', () => {
     });
 
     it('All tokens', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'token:*',
         displayName: 'All API tokens',
         displayType: 'All API tokens',
@@ -154,7 +154,7 @@ describe('policy model', () => {
     });
 
     it('Specific token', () => {
-      const expectedMember = <Member>{
+      const expectedMember: Member = {
         name: 'token:tokenname',
         displayName: 'tokenname',
         displayType: 'API token',
@@ -297,7 +297,10 @@ describe('policy model', () => {
 
   describe('policyFromPayload', () => {
     it('removes empty strings from statements', () => {
-      const policy = <Policy>{
+      const policy: Policy = {
+        id: 'any',
+        name: 'any',
+        type: 'CUSTOM',
         members: [],
         statements: [
           {
@@ -313,7 +316,10 @@ describe('policy model', () => {
     });
 
     it('removes empty arrays from statements', () => {
-      const policy = <Policy>{
+      const policy: Policy = {
+        id: 'any',
+        name: 'any',
+        type: 'CUSTOM',
         members: [],
         statements: [
           {

--- a/components/automate-ui/src/app/entities/policies/policy.model.ts
+++ b/components/automate-ui/src/app/entities/policies/policy.model.ts
@@ -65,8 +65,12 @@ export enum Type {
 }
 
 export function stringToMember(memberString: string): Member {
-  const member = <Member>{};
-  member.name = memberString;
+  const member: Member = {
+    name: memberString,
+    type: Type.Unknown,
+    displayName: '',
+    displayType: ''
+  };
   if (memberString.split('').pop() === ':') {
     member.type = Type.Unknown;
     return member;

--- a/components/automate-ui/src/app/entities/teams/team.reducer.spec.ts
+++ b/components/automate-ui/src/app/entities/teams/team.reducer.spec.ts
@@ -292,7 +292,7 @@ describe('teamStatusEntityReducer', () => {
   describe('ADD_USERS', () => {
     const team = genTeam();
     const teamId = team.id;
-    const payload = <TeamUserMgmtPayload>{
+    const payload: TeamUserMgmtPayload = {
       id: teamId,
       user_ids: [
         faker.random.uuid(),
@@ -326,7 +326,7 @@ describe('teamStatusEntityReducer', () => {
           faker.random.uuid(),
           faker.random.uuid()
         ];
-        const payload = <TeamUserMgmtPayload>{
+        const payload: TeamUserMgmtPayload = {
           id: faker.random.uuid(),
           user_ids: userIDArray
         };
@@ -351,7 +351,7 @@ describe('teamStatusEntityReducer', () => {
   describe('REMOVE_USERS', () => {
     const team = genTeam();
     const teamId = team.id;
-    const payload = <TeamUserMgmtPayload>{
+    const payload: TeamUserMgmtPayload = {
       id: teamId,
       user_ids: [
         faker.random.uuid()
@@ -382,7 +382,7 @@ describe('teamStatusEntityReducer', () => {
     ], function (state: TeamEntityState, description: string,
         _initialUserIdLength: number, usersToRemove: string[]) {
       it('removes users from the payload to the state for ' + description, () => {
-        const payload = <TeamUserMgmtPayload>{
+        const payload: TeamUserMgmtPayload = {
           id: faker.random.uuid(),
           user_ids: usersToRemove
         };

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -65,21 +65,21 @@ export class ProjectsFilterDropdownComponent implements OnChanges {
     this.onSelection.emit(this.editableOptions);
   }
 
-  handleArrowUp(event) {
+  handleArrowUp(event: KeyboardEvent) {
     event.preventDefault();
 
-    const element = event.target.previousElementSibling;
+    const element = (event.target as Element).previousElementSibling;
     if (element) {
-      element.focus();
+      (element as HTMLElement).focus();
     }
   }
 
-  handleArrowDown(event) {
+  handleArrowDown(event: KeyboardEvent) {
     event.preventDefault();
 
-    const element = event.target.nextElementSibling;
+    const element = (event.target as Element).nextElementSibling;
     if (element) {
-      element.focus();
+      (element as HTMLElement).focus();
     }
   }
 }

--- a/components/automate-ui/src/app/pages/policy/list/policy-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/list/policy-list.component.spec.ts
@@ -8,7 +8,7 @@ import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { customMatchers } from 'app/testing/custom-matchers';
 import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
 import { GetPoliciesSuccess } from 'app/entities/policies/policy.actions';
-import { IAMMajorVersion, IAMType } from 'app/entities/policies/policy.model';
+import { IAMMajorVersion } from 'app/entities/policies/policy.model';
 import { PolicyListComponent } from './policy-list.component';
 
 describe('PolicyListComponent', () => {
@@ -90,19 +90,19 @@ describe('PolicyListComponent', () => {
         policies: [
           {
             id: 'uuid-1', name: 'Viewer',
-            members: [], statements: [], type: <IAMType>'CHEF_MANAGED'
+            members: [], statements: [], type: 'CHEF_MANAGED'
           },
           {
             id: 'uuid-2', name: 'developer',
-            members: [], statements: [], type: <IAMType>'CUSTOM'
+            members: [], statements: [], type: 'CUSTOM'
           },
           {
             id: 'uuid-5', name: 'Developer',
-            members: [], statements: [], type: <IAMType>'CUSTOM'
+            members: [], statements: [], type: 'CUSTOM'
           },
           {
             id: 'uuid-6', name: 'viewer',
-            members: [], statements: [], type: <IAMType>'CHEF_MANAGED'
+            members: [], statements: [], type: 'CHEF_MANAGED'
           }
         ]
       }));
@@ -120,15 +120,15 @@ describe('PolicyListComponent', () => {
         policies: [
           {
             id: 'uuid-2', name: 'developer',
-            members: [], statements: [], type: <IAMType>'CUSTOM'
+            members: [], statements: [], type: 'CUSTOM'
           },
           {
             id: 'uuid-4', name: 'developer-Manager',
-            members: [], statements: [], type: <IAMType>'CUSTOM'
+            members: [], statements: [], type: 'CUSTOM'
           },
           {
             id: 'uuid-5', name: 'Developer',
-            members: [], statements: [], type: <IAMType>'CUSTOM'
+            members: [], statements: [], type: 'CUSTOM'
           }
         ]
       }));
@@ -145,23 +145,23 @@ describe('PolicyListComponent', () => {
         policies: [
           {
             id: 'uuid-1', name: 'Viewer01',
-            members: [], statements: [], type: <IAMType>'CHEF_MANAGED'
+            members: [], statements: [], type: 'CHEF_MANAGED'
           },
           {
             id: 'uuid-2', name: 'Viewer300',
-            members: [], statements: [], type: <IAMType>'CUSTOM'
+            members: [], statements: [], type: 'CUSTOM'
           },
           {
             id: 'uuid-3', name: 'Viewer3',
-            members: [], statements: [], type: <IAMType>'CUSTOM'
+            members: [], statements: [], type: 'CUSTOM'
           },
           {
             id: 'uuid-4', name: 'Viewer-2', // does not fit in same grouping
-            members: [], statements: [], type: <IAMType>'CUSTOM'
+            members: [], statements: [], type: 'CUSTOM'
           },
           {
             id: 'uuid-6', name: 'viewer',
-            members: [], statements: [], type: <IAMType>'CHEF_MANAGED'
+            members: [], statements: [], type: 'CHEF_MANAGED'
           }
         ]
       }));

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
@@ -10,7 +10,7 @@ import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { customMatchers } from 'app/testing/custom-matchers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { ProjectService } from 'app/entities/projects/project.service';
-import { IAMType, IAMMajorVersion, IAMMinorVersion } from 'app/entities/policies/policy.model';
+import { IAMMajorVersion, IAMMinorVersion } from 'app/entities/policies/policy.model';
 import { GetProjectsSuccess } from 'app/entities/projects/project.actions';
 import { projectEntityReducer } from 'app/entities/projects/project.reducer';
 import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
@@ -95,15 +95,15 @@ describe('ProjectListComponent', () => {
       projects: [
         {
           id: 'uuid-1', name: 'Default',
-          type: <IAMType>'CHEF_MANAGED'
+          type: 'CHEF_MANAGED'
         },
         {
           id: 'uuid-2', name: 'another-project',
-          type: <IAMType>'CUSTOM'
+          type: 'CUSTOM'
         },
         {
           id: 'uuid-5', name: 'zzz-project',
-          type: <IAMType>'CUSTOM'
+          type: 'CUSTOM'
         }
       ]
     }));
@@ -126,15 +126,15 @@ describe('ProjectListComponent', () => {
         projects: [
           {
             id: 'uuid-1', name: 'Default',
-            type: <IAMType>'CHEF_MANAGED'
+            type: 'CHEF_MANAGED'
           },
           {
             id: 'uuid-2', name: 'another-project',
-            type: <IAMType>'CUSTOM'
+            type: 'CUSTOM'
           },
           {
             id: 'uuid-5', name: 'zzz-project',
-            type: <IAMType>'CUSTOM'
+            type: 'CUSTOM'
           }
         ]
       }));
@@ -181,15 +181,15 @@ describe('ProjectListComponent', () => {
         projects: [
           {
             id: 'uuid-1', name: 'Default',
-            type: <IAMType>'CHEF_MANAGED'
+            type: 'CHEF_MANAGED'
           },
           {
             id: 'uuid-2', name: 'another-project',
-            type: <IAMType>'CUSTOM'
+            type: 'CUSTOM'
           },
           {
             id: 'uuid-5', name: 'zzz-project',
-            type: <IAMType>'CUSTOM'
+            type: 'CUSTOM'
           }
         ]
       }));
@@ -206,15 +206,15 @@ describe('ProjectListComponent', () => {
         projects: [
           {
             id: 'uuid-2', name: 'default',
-            type: <IAMType>'CUSTOM'
+            type: 'CUSTOM'
           },
           {
             id: 'uuid-4', name: 'default-resources',
-            type: <IAMType>'CUSTOM'
+            type: 'CUSTOM'
           },
           {
             id: 'uuid-5', name: 'Default',
-            type: <IAMType>'CUSTOM'
+            type: 'CUSTOM'
           }
         ]
       }));
@@ -231,23 +231,23 @@ describe('ProjectListComponent', () => {
         projects: [
           {
             id: 'uuid-1', name: 'Project01',
-            type: <IAMType>'CHEF_MANAGED'
+            type: 'CHEF_MANAGED'
           },
           {
             id: 'uuid-2', name: 'Project300',
-            type: <IAMType>'CUSTOM'
+            type: 'CUSTOM'
           },
           {
             id: 'uuid-3', name: 'Project3',
-            type: <IAMType>'CUSTOM'
+            type: 'CUSTOM'
           },
           {
             id: 'uuid-4', name: 'Project-2',
-            type: <IAMType>'CUSTOM'
+            type: 'CUSTOM'
           },
           {
             id: 'uuid-6', name: 'project',
-            type: <IAMType>'CHEF_MANAGED'
+            type: 'CHEF_MANAGED'
           }
         ]
       }));

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -17,7 +17,7 @@ describe('ProjectRulesComponent', () => {
   let component: ProjectRulesComponent;
   let fixture: ComponentFixture<ProjectRulesComponent>;
 
-  const project = <Project>{
+  const project: Project = {
     id: 'uuid-1',
     name: 'Default',
     type: 'CHEF_MANAGED'

--- a/components/automate-ui/src/app/pages/roles/list/roles-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/roles/list/roles-list.component.spec.ts
@@ -5,7 +5,6 @@ import { MockComponent } from 'ng2-mock-component';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { IAMType } from 'app/entities/policies/policy.model';
 import { GetRolesSuccess } from 'app/entities/roles/role.actions';
 import { roleEntityReducer } from 'app/entities/roles/role.reducer';
 import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
@@ -69,13 +68,13 @@ describe('RolesListComponent', () => {
     it('intermixes capitals and lowercase with lowercase first', () => {
       store.dispatch(new GetRolesSuccess({ roles: [
         { id: 'uuid-1', name: 'Viewer',
-          actions: [], type: <IAMType> 'chef-managed' },
+          actions: [], type: 'CHEF_MANAGED' },
         { id: 'uuid-2', name: 'developer',
-          actions: [], type: <IAMType> 'custom' },
+          actions: [], type:  'CUSTOM' },
         { id: 'uuid-5', name: 'Developer',
-          actions: [], type: <IAMType> 'custom' },
+          actions: [], type:  'CUSTOM' },
         { id: 'uuid-6', name: 'viewer',
-          actions: [], type: <IAMType> 'chef-managed' }
+          actions: [], type:  'CHEF_MANAGED' }
       ]}));
        component.sortedRoles$.subscribe(roles => {
         expect(roles.length).toBe(4);
@@ -89,11 +88,11 @@ describe('RolesListComponent', () => {
     it('sorts by whole string before case', () => {
       store.dispatch(new GetRolesSuccess({ roles: [
         { id: 'uuid-2', name: 'developer',
-          actions: [], type: <IAMType> 'custom' },
+          actions: [], type:  'CUSTOM' },
         { id: 'uuid-4', name: 'developer-Manager',
-          actions: [], type: <IAMType> 'custom' },
+          actions: [], type:  'CUSTOM' },
         { id: 'uuid-5', name: 'Developer',
-          actions: [], type: <IAMType> 'custom' }
+          actions: [], type:  'CUSTOM' }
       ]}));
        component.sortedRoles$.subscribe(roles => {
         expect(roles.length).toBe(3);
@@ -106,15 +105,15 @@ describe('RolesListComponent', () => {
     it('uses natural ordering', () => {
       store.dispatch(new GetRolesSuccess({ roles: [
         { id: 'uuid-1', name: 'Viewer01',
-          actions: [], type: <IAMType> 'chef-managed' },
+          actions: [], type: 'CHEF_MANAGED' },
         { id: 'uuid-2', name: 'Viewer300',
-          actions: [], type: <IAMType> 'custom' },
+          actions: [], type: 'CUSTOM' },
         { id: 'uuid-3', name: 'Viewer3',
-          actions: [], type: <IAMType> 'custom' },
+          actions: [], type: 'CUSTOM' },
         { id: 'uuid-4', name: 'Viewer-2', // does not fit in same grouping
-          actions: [], type: <IAMType> 'custom' },
+          actions: [], type: 'CUSTOM' },
         { id: 'uuid-6', name: 'viewer',
-          actions: [], type: <IAMType> 'chef-managed' }
+          actions: [], type: 'CHEF_MANAGED' }
       ]}));
        component.sortedRoles$.subscribe(roles => {
         expect(roles.length).toBe(5);

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -5,12 +5,12 @@
   <main>
     <chef-breadcrumbs>
       <chef-breadcrumb [link]="['/settings/teams']">Teams</chef-breadcrumb>
-      {{ team?.id }}
+      {{ team.id }}
     </chef-breadcrumbs>
 
     <chef-page-header>
-      <chef-heading *ngIf="isV1">{{ team?.id }}</chef-heading>
-      <chef-heading *ngIf="!isV1">{{ team?.name }}</chef-heading>
+      <chef-heading *ngIf="isV1">{{ team.id }}</chef-heading>
+      <chef-heading *ngIf="!isV1">{{ team.name }}</chef-heading>
       <table>
         <thead>
           <tr class="detail-row">
@@ -20,8 +20,8 @@
         </thead>
         <tbody>
           <tr class="detail-row">
-            <td *ngIf="isV1" class="id-column">{{ team?.name }}</td>
-            <td *ngIf="!isV1" class="id-column">{{ team?.id }}</td>
+            <td *ngIf="isV1" class="id-column">{{ team.name }}</td>
+            <td *ngIf="!isV1" class="id-column">{{ team.id }}</td>
           </tr>
         </tbody>
       </table>
@@ -32,7 +32,7 @@
       </chef-tab-selector>
     </chef-page-header>
     <ng-container *ngIf="tabValue === 'users'">
-      <section class="page-body" *ngIf="team?.id">
+      <section class="page-body" *ngIf="team.id">
         <div id="users-list">
           <div>
             <!-- TODO remove [overridePermissionsCheck]=true once the UI is able to check specific objects
@@ -63,7 +63,7 @@
             </chef-error>
           </chef-form-field>
         </form>
-          <chef-button [disabled]="isLoading || !updateNameForm.valid || updateNameForm.controls['name'].value === team?.name"
+          <chef-button [disabled]="isLoading || !updateNameForm.valid || updateNameForm.controls['name'].value === team.name"
             primary inline (click)="saveNameChange()">
             <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
             <span *ngIf="saving">Saving...</span>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
@@ -87,7 +87,7 @@ describe('TeamDetailsComponent', () => {
     }).compileComponents();
   }));
 
-  const someTeam = <Team>{
+  const someTeam: Team = {
     id: 'some-team',
     name: 'some team',
     guid: 'a-team-uuid-01',
@@ -139,6 +139,50 @@ describe('TeamDetailsComponent', () => {
       component.sortedUsers$.subscribe((users) => {
         expect(users.length).toBe(0);
       });
+    });
+  });
+
+  describe('add users', () => {
+    let store: Store<NgrxStateAtom>;
+
+    const user1: User = {
+      id: 'user1',
+      name: 'user1',
+      membership_id: 'uuid-1'
+    };
+    const user2: User = {
+      id: 'user2',
+      name: 'user2',
+      membership_id: 'uuid-2'
+    };
+    const usersToAdd: HashMapOfUsers = {
+      'user1': user1,
+      'user2': user2
+    };
+
+    beforeEach(() => {
+      store = TestBed.get(Store);
+      store.dispatch(new GetTeamSuccess(someTeam));
+      store.dispatch(new GetUsersSuccess({
+        users: [user1, user2]
+      }));
+    });
+
+    it('successfully adds users', () => {
+      component.teamMembershipView = false;
+      component.toggleUserMembershipView();
+      component.addUsers(usersToAdd);
+
+      expect(component.teamMembershipView).toBe(false);
+      store.dispatch(new GetTeamUsersSuccess({
+        user_ids: [user1.membership_id, user2.membership_id]
+      }));
+
+      for (const user of [user1, user2]) {
+        component.sortedUsers$.subscribe(users => {
+          expect(users).toContain(user);
+        });
+      }
     });
   });
 

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
@@ -7,7 +7,9 @@ import { MockComponent } from 'ng2-mock-component';
 import { StoreModule, Store } from '@ngrx/store';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
+import {
+  policyEntityReducer, PolicyEntityInitialState
+} from 'app/entities/policies/policy.reducer';
 import {
   userEntityReducer,
   UserEntityInitialState
@@ -40,7 +42,8 @@ describe('TeamDetailsComponent', () => {
       navigationId: 0 // what's that zero?
     },
     users: UserEntityInitialState,
-    teams: TeamEntityInitialState
+    teams: TeamEntityInitialState,
+    policies: PolicyEntityInitialState
   };
 
   beforeEach(async(() => {

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
@@ -22,7 +22,7 @@ import {
   GetTeamUsersSuccess
 } from 'app/entities/teams/team.actions';
 import { Team } from 'app/entities/teams/team.model';
-import { TeamDetailsComponent, TeamTabName } from './team-details.component';
+import { TeamDetailsComponent } from './team-details.component';
 
 describe('TeamDetailsComponent', () => {
   let component: TeamDetailsComponent;
@@ -113,15 +113,13 @@ describe('TeamDetailsComponent', () => {
   });
 
   it('show users section when users tab is selected', () => {
-    const tabName: TeamTabName = 'users';
-    component.onSelectedTab({ target: { value: tabName } });
-    expect(component.tabValue).toBe(tabName);
+    component.onSelectedTab({ target: { value: 'users' } });
+    expect(component.tabValue).toBe('users');
   });
 
   it('show details section when details tab is selected', () => {
-    const tabName: TeamTabName = 'details';
-    component.onSelectedTab({ target: { value: tabName } });
-    expect(component.tabValue).toBe(tabName);
+    component.onSelectedTab({ target: { value: 'details' } });
+    expect(component.tabValue).toBe('details');
   });
 
   describe('empty state', () => {
@@ -139,50 +137,6 @@ describe('TeamDetailsComponent', () => {
       component.sortedUsers$.subscribe((users) => {
         expect(users.length).toBe(0);
       });
-    });
-  });
-
-  describe('add users', () => {
-    let store: Store<NgrxStateAtom>;
-
-    const user1: User = {
-      id: 'user1',
-      name: 'user1',
-      membership_id: 'uuid-1'
-    };
-    const user2: User = {
-      id: 'user2',
-      name: 'user2',
-      membership_id: 'uuid-2'
-    };
-    const usersToAdd: HashMapOfUsers = {
-      'user1': user1,
-      'user2': user2
-    };
-
-    beforeEach(() => {
-      store = TestBed.get(Store);
-      store.dispatch(new GetTeamSuccess(someTeam));
-      store.dispatch(new GetUsersSuccess({
-        users: [user1, user2]
-      }));
-    });
-
-    it('successfully adds users', () => {
-      component.teamMembershipView = false;
-      component.toggleUserMembershipView();
-      component.addUsers(usersToAdd);
-
-      expect(component.teamMembershipView).toBe(false);
-      store.dispatch(new GetTeamUsersSuccess({
-        user_ids: [user1.membership_id, user2.membership_id]
-      }));
-
-      for (const user of [user1, user2]) {
-        component.sortedUsers$.subscribe(users => {
-          expect(users).toContain(user);
-        });
-      }
     });
   });
 

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -63,6 +63,12 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     public fb: FormBuilder,
     private router: Router
   ) {
+    this.team = {
+      id: '',
+      name: '',
+      guid: null,
+      projects: []
+    };
     this.updateNameForm = fb.group({
       // Must stay in sync with error checks in team-details.component.html
       name: ['Loading...', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -215,7 +215,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
       });
   }
 
-  onSelectedTab(event): void {
+  onSelectedTab(event: { target: { value: TeamTabName } }): void {
     this.tabValue = event.target.value;
     // Current URL sans any now outdated fragment.
     this.router.navigate([this.url.split('#')[0]], { fragment: event.target.value });

--- a/components/automate-ui/src/app/pages/team-management/team-management.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-management/team-management.component.spec.ts
@@ -171,7 +171,7 @@ describe('TeamManagementComponent', () => {
 
   describe('create v2 team', () => {
     let store: Store<NgrxStateAtom>;
-    const team = <Team>{
+    const team: Team = {
       guid: 'uuid-1',
       id: 'new-team',
       name: 'new team',
@@ -208,7 +208,7 @@ describe('TeamManagementComponent', () => {
 
   describe('delete team', () => {
     let store: Store<NgrxStateAtom>;
-    const deleteTeam = <Team>{
+    const deleteTeam: Team = {
       guid: 'uuid-1',
       id: 'new-team',
       name: 'new team',

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.html
@@ -2,24 +2,24 @@
 <app-profile-sidebar *ngIf="!isAdminView"> </app-profile-sidebar>
 
 <div class="container">
-  <main *ngIf="isAdminView || user?.id">
+  <main *ngIf="isAdminView || user.id">
     <app-delete-object-modal
       [visible]="modalVisible"
       objectNoun="user"
-      [objectName]="user?.name"
+      [objectName]="user.name"
       (close)="closeDeleteConfirmationModal()"
       (deleteClicked)="deleteUser()">
     </app-delete-object-modal>
     <chef-breadcrumbs *ngIf="isAdminView">
       <chef-breadcrumb [link]="['/settings/users']">Users</chef-breadcrumb>
-      {{ user?.name }}
+      {{ user.name }}
     </chef-breadcrumbs>
 
     <chef-page-header>
       <div class="detail-row">
         <div class="name-column">
           <ng-container *ngIf="!editMode">
-            <div class="display3">{{ user?.name }}</div>
+            <div class="display3">{{ user.name }}</div>
           </ng-container>
           <ng-container *ngIf="editMode">
             <form [formGroup]="editForm">
@@ -35,7 +35,7 @@
             </form>
           </ng-container>
           <div class="container-big-header inline-container">
-            <span class="text"> {{ user?.id }}</span>
+            <span class="text"> {{ user.id }}</span>
           </div>
         </div>
         <div class="button-column">

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.spec.ts
@@ -128,11 +128,7 @@ describe('UserDetailsComponent', () => {
       expect(component).toBeTruthy();
     });
 
-    it('has an empty user object', () => {
-      expect(component.user).toEqual({} as User);
-    });
-
-    it('dispatches an action to get its user data', () => {
+   it('dispatches an action to get its user data', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
         new GetUser({ id: user.id }));
     });

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.ts
@@ -75,7 +75,11 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
     // TODO (tc) This needs to be refactored to resemble our other patterns
     // for specific object pages.
     // combineLatest depends on the user object existing already.
-    this.user = <User>{};
+    this.user = {
+      id: '',
+      name: '',
+      membership_id: ''
+    };
 
     this.done$ = <Observable<boolean>>combineLatest(
       store.select(allUsers),


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

On the periphery of some UI work I noticed some type safety anomalies where things that should have been compiler errors (or so I thought) were not flagged as such. Upon refreshing myself on how static typing, type inference, and type assertions actually work in TypeScript I made some surprising discoveries. This PR fixes an assortment of such issues.

They are grouped by commit into several violation categories, so follow the commits!

Here is one startling example: 

After entering an invalid value (`CUSTOMxxx`) for a type, the error is not flagged in VSCode until one **removes** the type assertion:
![image](https://user-images.githubusercontent.com/6817500/62335715-ca572380-b481-11e9-81ac-042bdc56e4c8.png)

### :chains: Related Resources

Alas, these types of potential pitfalls are not going to be noticed by the computer no matter how much linting you do. So I wrote up some slides ("TypeScript Type Traps") to document and explain these for the team's reference moving forward.

---

Please read [TypeScript Type Traps](https://docs.google.com/presentation/d/1ir7P7V0tzO4cd4vCtyUb-a5fHFnBsRYTUoCWLq6xksU/edit?usp=sharing)
![image](https://user-images.githubusercontent.com/6817500/62335918-b5c75b00-b482-11e9-98d3-73a4fbc2f7b4.png)

---

### :+1: Definition of Done

A more type-safe UI codebase.

### :athletic_shoe: How to Build and Test the Change

Rebuild automate-ui

