### PR TITLE
Ensure ui-lib builds include font assets

### DIFF
--- a/components/chef-ui-library/stencil.config.ts
+++ b/components/chef-ui-library/stencil.config.ts
@@ -12,9 +12,10 @@ export const config: Config = {
     { type: 'dist' }
   ],
   globalStyle: 'src/global/chef.scss',
-  copy:[
+  copy: [
     { src: 'global/variables.css', dest: 'styles/variables.example.css' },
     { src: 'global/ui-lib-styles.css', dest: 'styles/ui-lib-styles.css' },
+    { src: 'assets', dest: 'assets' },
     { src: '../node_modules/material-design-icons/iconfont',
       dest: 'assets/fonts/material-icons' },
     { src: 'sandbox.html', dest: 'sandbox.html' }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

It seems the latest versions of Stencil compiler no longer copy the entire `assets` directory by default. This was causing the `muli` fonts to be excluded from the ui-lib build output and thus unavailable to the browser.

![Screen Shot 2019-08-01 at 4 57 31 PM](https://user-images.githubusercontent.com/479121/62334868-9f230300-b486-11e9-9628-54cd2352abff.png)

Only [svg and js files](https://github.com/ionic-team/stencil/blob/ee28dc04678a54e1862c5905c87b30218535f888/src/compiler/config/validate-outputs-dist.ts#L70-L71) are now copied by default (weird default?). This commit ensures everything in `assets` is copied.

### :chains: Related Resources

https://github.com/chef/automate/pull/1053

### :+1: Definition of Done

`dist/collection` in chef-ui-library build contains `assets` directory identical to `src/assets`.

### :athletic_shoe: How to Build and Test the Change

- `cd chef-ui-library`
- `npm run build`
- see that `dist/collection/assets` matches `src/assets`

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable