### PR TITLE
ci: shellcheck rendered hooks

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -770,3 +770,12 @@ steps:
         linux:
           single-use: true
           privileged: true
+
+  - label: "shellcheck hooks"
+    command:
+      - integration/run_test integration/tests/shellcheck_rendered_hooks.sh
+    timeout_in_minutes: 20
+    expeditor:
+      executor:
+        linux:
+          privileged: true

--- a/components/automate-deployment/habitat/hooks/reload
+++ b/components/automate-deployment/habitat/hooks/reload
@@ -2,4 +2,4 @@
 
 PID=$(cat {{pkg.svc_pid_file}})
 echo "Sending SIGHUP to deployment-service (PID=$PID)"
-kill -HUP $PID
+kill -HUP "$PID"

--- a/components/automate-dex/habitat/hooks/health-check
+++ b/components/automate-dex/habitat/hooks/health-check
@@ -11,6 +11,6 @@ res=$?
 # we translate everything != 0 to exit code 2 ("critical")
 if test "$res" != "0"; then
    echo "health check curl command returned exit code ${res}:"
-   echo $output
+   echo "$output"
    exit 2
 fi

--- a/components/automate-gateway/habitat/hooks/health-check
+++ b/components/automate-gateway/habitat/hooks/health-check
@@ -2,8 +2,10 @@
 
 # For now we will just use curl and ensure that we have GRPC Error code 16
 # that means that Auth is blocking the requests
-url="https://{{sys.ip}}:{{cfg.service.port}}"
-health=$(curl --insecure --max-time 2 --noproxy {{sys.ip}} ${url}/gateway/health 2>/dev/null)
+health=$(curl --cacert {{pkg.svc_config_path}}/root_ca.crt \
+  --max-time 2 \
+  --noproxy {{sys.ip}} \
+  "https://{{sys.ip}}:{{cfg.service.port}}/gateway/health" 2>/dev/null)
 status=$(echo "$health" | jq -r '.code // .status')
 
 # Inspect the health of the automate-gateway service

--- a/components/automate-gateway/habitat/hooks/health-check
+++ b/components/automate-gateway/habitat/hooks/health-check
@@ -1,15 +1,5 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
-rc=0
-
-opts="-cert {{pkg.svc_config_path}}/service.crt"
-opts="${opts} -key {{pkg.svc_config_path}}/service.key"
-opts="${opts} {{sys.ip}}:{{cfg.service.port}}"
-
-# This is the right GRPC call but to make it we need a Bearer token.
-# It would be good to make simple endpoints like this one to not ask for auth
-#health=$(grpcurl -insecure ${opts} chef.automate.api.Gateway.GetHealth)
-#
 # For now we will just use curl and ensure that we have GRPC Error code 16
 # that means that Auth is blocking the requests
 url="https://{{sys.ip}}:{{cfg.service.port}}"
@@ -22,7 +12,6 @@ status=$(echo "$health" | jq -r '.code // .status')
 # {
 #   "status": "ok"
 # }
-#status=$(echo $health | jq .status -r)
 case $status in
   "16")
     # Workaround until we find a way to hit GRPC calls or endpoints with NO auth

--- a/components/automate-gateway/habitat/hooks/health-check
+++ b/components/automate-gateway/habitat/hooks/health-check
@@ -14,7 +14,7 @@ opts="${opts} {{sys.ip}}:{{cfg.service.port}}"
 # that means that Auth is blocking the requests
 url="https://{{sys.ip}}:{{cfg.service.port}}"
 health=$(curl --insecure --max-time 2 --noproxy {{sys.ip}} ${url}/gateway/health 2>/dev/null)
-status=$(echo $health | jq -r '.code // .status')
+status=$(echo "$health" | jq -r '.code // .status')
 
 # Inspect the health of the automate-gateway service
 #

--- a/components/automate-load-balancer/habitat/hooks/reload
+++ b/components/automate-load-balancer/habitat/hooks/reload
@@ -1,4 +1,4 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash -ex
 
 PID=$(cat {{pkg.svc_var_path}}/pid)
-kill -HUP $PID
+kill -HUP "$PID"

--- a/components/automate-ui/habitat/hooks/health-check
+++ b/components/automate-ui/habitat/hooks/health-check
@@ -1,15 +1,12 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
-output=$(curl --fail --head --cacert {{pkg.svc_config_path}}/root_ca.crt \
+if ! output=$(curl --fail --head \
+  --cacert {{pkg.svc_config_path}}/root_ca.crt \
   --noproxy automate-ui \
   --resolve automate-ui:{{cfg.service.port}}:{{sys.ip}} \
   --max-time 2 \
-  https://automate-ui:{{cfg.service.port}} 2>&1)
-
-if [[ "$?" != "0" ]]; then
-  echo "health check curl command returned exit code ${res}:"
-  echo $output
+  https://automate-ui:{{cfg.service.port}} 2>&1); then
+  echo "health check curl command returned exit code $?:"
+  echo "$output"
   exit 2
 fi
-
-exit 0

--- a/components/backup-gateway/habitat/hooks/run
+++ b/components/backup-gateway/habitat/hooks/run
@@ -26,8 +26,10 @@ ln -fs "{{pkg.svc_config_path}}/custom_s3.crt" "{{pkg.svc_var_path}}/config/cert
 secrets-helper generate backup-gateway.access_key 64 --if-not-exists
 secrets-helper generate backup-gateway.secret_key 64 --if-not-exists
 
-export MINIO_ACCESS_KEY="$(secrets-helper show backup-gateway.access_key)"
-export MINIO_SECRET_KEY="$(secrets-helper show backup-gateway.secret_key)"
+MINIO_ACCESS_KEY="$(secrets-helper show backup-gateway.access_key)"
+export MINIO_ACCESS_KEY
+MINIO_SECRET_KEY="$(secrets-helper show backup-gateway.secret_key)"
+export MINIO_SECRET_KEY
 export MINIO_BROWSER=off
 export SSL_CERT_FILE={{pkgPathFor "core/cacerts"}}/ssl/cert.pem
 export SSL_CERT_DIR={{pkgPathFor "core/cacerts"}}/ssl/certs

--- a/components/compliance-service/habitat/hooks/health-check
+++ b/components/compliance-service/habitat/hooks/health-check
@@ -1,5 +1,5 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
-
+{{!--
 # The protocol for hab's health_check is to exit with a status of: 0 for
 # success, 1 for warning, 2 for error, and 3 for unknown.
 # https://www.habitat.sh/docs/reference/#health_check
@@ -11,20 +11,25 @@
 # That will return an HTTP status code of 200 for success and warning, 503 for
 # critical, and 500 for unknown:
 # https://github.com/habitat-sh/habitat/pull/4873
-# shellcheck disable=SC2140
-
-rc=3
-
-opts="-cert {{pkg.svc_config_path}}/service.crt"
-opts="${opts} -key {{pkg.svc_config_path}}/service.key"
-opts="${opts} {{sys.ip}}:{{cfg.service.port}}"
 
 # A successful response looks like:
-# { "name": "compliance", "version": "1.11.1", "sha": "223c3690b", "built": "2018-04-14_00:47:47", api": "compliance" }
-response=$({{pkgPathFor "core/grpcurl"}}/bin/grpcurl -max-time 2 -insecure ${opts} chef.automate.domain.compliance.api.version.VersionService.Version 2>&1)
+# { "name": "compliance",
+#   "version": "1.11.1",
+#   "sha": "223c3690b",
+#   "built": "2018-04-14_00:47:47",
+#   "api": "compliance"
+# }
+--}}
 
-parse_result=$(echo $response | {{pkgPathFor "core/jq-static"}}/bin/jq .name -r 2>&1)
+response=$(grpcurl -max-time 2 -insecure \
+  -cert {{pkg.svc_config_path}}/service.crt \
+  -key {{pkg.svc_config_path}}/service.key \
+  {{sys.ip}}:{{cfg.service.port}} \
+  chef.automate.domain.compliance.api.version.VersionService.Version 2>&1)
 
+parse_result=$(echo "$response" | jq -r .name)
+
+rc=3
 case $parse_result in
   "compliance")
     rc=0 ;;

--- a/components/compliance-service/habitat/hooks/health-check
+++ b/components/compliance-service/habitat/hooks/health-check
@@ -21,7 +21,8 @@
 # }
 --}}
 
-response=$(grpcurl -max-time 2 -insecure \
+response=$(grpcurl -max-time 2 \
+  -cacert {{pkg.svc_config_path}}/root_ca.crt \
   -cert {{pkg.svc_config_path}}/service.crt \
   -key {{pkg.svc_config_path}}/service.key \
   {{sys.ip}}:{{cfg.service.port}} \

--- a/components/compliance-service/habitat/hooks/run
+++ b/components/compliance-service/habitat/hooks/run
@@ -155,4 +155,5 @@ export HOME="{{pkg.svc_data_path}}"
 CONFIG="$CONFIG --inspec-tmp-dir {{pkg.svc_var_path}}/tmp"
 
 # Start our service
+# shellcheck disable=SC2086
 exec compliance-service run ${CONFIG} ${ES_BACKEND} ${PG_BACKEND}

--- a/components/compliance-service/habitat/plan.sh
+++ b/components/compliance-service/habitat/plan.sh
@@ -8,7 +8,6 @@ pkg_upstream_url="http://github.com/chef/automate/components/compliance-service"
 pkg_build_deps=(
   core/curl
   core/gcc
-  core/jq-static
   core/tar
 )
 pkg_bin_dirs=(bin)

--- a/components/config-mgmt-service/habitat/hooks/health-check
+++ b/components/config-mgmt-service/habitat/hooks/health-check
@@ -1,7 +1,7 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
 health=$(grpcurl -max-time 2 \
-  -insecure \
+  -cacert {{pkg.svc_config_path}}/root_ca.crt \
   -cert {{pkg.svc_config_path}}/service.crt \
   -key {{pkg.svc_config_path}}/service.key \
   {{sys.ip}}:{{cfg.service.port}} \

--- a/components/config-mgmt-service/habitat/hooks/health-check
+++ b/components/config-mgmt-service/habitat/hooks/health-check
@@ -1,12 +1,11 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
-rc=0
-
-opts="-cert {{pkg.svc_config_path}}/service.crt"
-opts="${opts} -key {{pkg.svc_config_path}}/service.key"
-opts="${opts} {{sys.ip}}:{{cfg.service.port}}"
-
-health=$(grpcurl -max-time 2 -insecure ${opts} chef.automate.domain.cfgmgmt.service.CfgMgmt.GetHealth)
+health=$(grpcurl -max-time 2 \
+  -insecure \
+  -cert {{pkg.svc_config_path}}/service.crt \
+  -key {{pkg.svc_config_path}}/service.key \
+  {{sys.ip}}:{{cfg.service.port}} \
+  chef.automate.domain.cfgmgmt.service.CfgMgmt.GetHealth)
 
 # Inspect the health of the config-mgmt-service
 #
@@ -14,7 +13,7 @@ health=$(grpcurl -max-time 2 -insecure ${opts} chef.automate.domain.cfgmgmt.serv
 # {
 #   "status": "ok"
 # }
-status=$(echo $health | jq .status -r)
+status=$(echo "$health" | jq -r .status)
 case $status in
   "ok")
     rc=0 ;;

--- a/components/ingest-service/habitat/hooks/health-check
+++ b/components/ingest-service/habitat/hooks/health-check
@@ -1,7 +1,7 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
 health=$(grpcurl -max-time 2 \
-  -insecure \
+  -cacert {{pkg.svc_config_path}}/root_ca.crt \
   -cert {{pkg.svc_config_path}}/service.crt \
   -key {{pkg.svc_config_path}}/service.key \
   {{sys.ip}}:{{cfg.service.port}} \

--- a/components/ingest-service/habitat/hooks/health-check
+++ b/components/ingest-service/habitat/hooks/health-check
@@ -1,12 +1,11 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
-rc=0
-
-opts="-cert {{pkg.svc_config_path}}/service.crt"
-opts="${opts} -key {{pkg.svc_config_path}}/service.key"
-opts="${opts} {{sys.ip}}:{{cfg.service.port}}"
-
-health=$(grpcurl -max-time 2 -insecure ${opts} chef.automate.domain.ingest.IngestStatus.GetHealth)
+health=$(grpcurl -max-time 2 \
+  -insecure \
+  -cert {{pkg.svc_config_path}}/service.crt \
+  -key {{pkg.svc_config_path}}/service.key \
+  {{sys.ip}}:{{cfg.service.port}} \
+  chef.automate.domain.ingest.IngestStatus.GetHealth)
 
 # Inspect the health of the ingest service
 #
@@ -14,7 +13,7 @@ health=$(grpcurl -max-time 2 -insecure ${opts} chef.automate.domain.ingest.Inges
 # {
 #   "status": "ok"
 # }
-status=$(echo $health | jq .status -r)
+status=$(echo "$health" | jq -r .status)
 case $status in
   "ok")
     rc=0 ;;

--- a/components/ingest-service/habitat/hooks/run
+++ b/components/ingest-service/habitat/hooks/run
@@ -108,4 +108,5 @@ CONFIG="$CONFIG --nodemanager-address {{manager.sys.ip}}:{{manager.cfg.port}}"
 pg-helper ensure-service-database "$DBNAME"
 
 # Start Ingest Service
+# shellcheck disable=SC2086
 exec ingest-service serve $CONFIG $BACKEND

--- a/components/nodemanager-service/habitat/hooks/run
+++ b/components/nodemanager-service/habitat/hooks/run
@@ -63,4 +63,5 @@ PG_BACKEND="--postgres-database {{cfg.storage.database}} --migrations-path {{pkg
 export HOME="{{pkg.svc_data_path}}"
 
 # Start our service
+# shellcheck disable=SC2086
 exec nodemanager-service run ${CONFIG} ${PG_BACKEND}

--- a/components/session-service/habitat/hooks/health-check
+++ b/components/session-service/habitat/hooks/health-check
@@ -1,17 +1,14 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
 # query /health handler
-output=$(curl --fail --cacert {{pkg.svc_config_path}}/root_ca.crt \
+# potential curl exit codes are various, see https://ec.haxx.se/usingcurl-returns.html
+# we translate everything != 0 to exit code 2 ("critical")
+if ! output=$(curl --fail --cacert {{pkg.svc_config_path}}/root_ca.crt \
   --resolve session-service:{{cfg.service.port}}:{{sys.ip}} \
   --noproxy session-service \
   --max-time 2 \
-  https://session-service:{{cfg.service.port}}/health 2>&1)
-res=$?
-
-# potential curl exit codes are various, see https://ec.haxx.se/usingcurl-returns.html
-# we translate everything != 0 to exit code 2 ("critical")
-if test "$res" != "0"; then
-   echo "health check curl command returned exit code ${res}:"
-   echo $output
+  https://session-service:{{cfg.service.port}}/health 2>&1); then
+  echo "health check curl command returned exit code $?:"
+   echo "$output"
    exit 2
 fi

--- a/integration/tests/shellcheck_rendered_hooks.sh
+++ b/integration/tests/shellcheck_rendered_hooks.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#shellcheck disable=SC2034
+test_name="shellcheck hooks"
+test_deploy_inspec_profiles=()
+test_skip_diagnostics=true
+
+do_setup() {
+    do_setup_default
+
+    # We are defaulting to a umask of 077 to test
+    # installations on systems that are super locked down.
+    # Briefly override that strict default so we can install
+    # packages that non-root users can use (like the hab user
+    # for health checks or this script).
+    local previous_umask
+    previous_umask=$(umask)
+    umask 022
+
+    hab pkg install -b core/shellcheck
+
+    umask "$previous_umask"
+}
+
+do_test_deploy() {
+    shellcheck -s bash -x /hab/svc/*/hooks/*
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

We have a bunch of bash scripts that are not shellchecked at the moment, because they're habitat templates. This PR introduces shellcheck into that, by shellchecking **the rendered hook scripts**. Naturally, they fail validation, so the findings don't break the build, but are merely reported and ignored.

At some later time, we can remove the `|| return 0` -- when the issues have been resolved.

👉 [These are the current findings](https://buildkite.com/chef/chef-automate-master-verify-private/builds/4052#d9d4e702-f302-49da-94f5-3f87df8e08b1/484)