### PR TITLE
[release notes] update release note template

### DIFF
--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -18,10 +18,6 @@ pushd ./automate.wiki
 
   # Reset "Pending Release Notes" wiki page
   cat >./Pending-Release-Notes.md <<EOH
-## Upgrade Impact
-
-ICYMI: If you are upgrading from a version prior to 20190410001346, please read our [Important Compliance Outage Announcement](https://discourse.chef.io/t/important-compliance-outage-information-on-automate-2-april-15th-upgrade/14909).
-
 ## New Features
 -
 


### PR DESCRIPTION
remove the **Upgrade Impact** section from the release notes template.
the impactful upgrade was from April and does not need to be called
out weekly in release notes.

Signed-off-by: Stephen Delano <stephen@chef.io>