### PR TITLE
Auth input field consistency sweep

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -5,9 +5,7 @@
         <div class="margin">
           <chef-form-field>
             <label>
-              <span class="label">Name
-                <span aria-hidden="true">*</span>
-              </span>
+              <span class="label">Name <span aria-hidden="true">*</span></span>
               <input chefInput formControlName="name" type="text" (keyup)="handleNameInput($event)" id="name-input">
             </label>
             <chef-error *ngIf="(createForm.get('name').hasError('required') || createForm.get('name').hasError('pattern')) && createForm.get('name').dirty">
@@ -19,9 +17,7 @@
         <div *ngIf="modifyID" class="margin">
           <chef-form-field>
             <label>
-              <span class="label">ID
-                <span aria-hidden="true">*</span>
-              </span>
+              <span class="label">ID <span aria-hidden="true">*</span></span>
               <input chefInput formControlName="id" type="text" (keyup)="handleIDInput($event)" id="id-input">
             </label>
             <chef-error *ngIf="createForm?.controls['id'].hasError('maxlength')">

--- a/components/automate-ui/src/app/page-components/create-v1-team-modal/create-v1-team-modal.component.html
+++ b/components/automate-ui/src/app/page-components/create-v1-team-modal/create-v1-team-modal.component.html
@@ -5,9 +5,7 @@
         <div class="margin">
           <chef-form-field>
             <label>
-              <span class="label">Name
-                <span aria-hidden="true">*</span>
-              </span>
+              <span class="label">Name <span aria-hidden="true">*</span></span>
               <input chefInput formControlName="name" type="text" (keyup)="handleNameInput($event)" id="name-input">
             </label>
             <chef-error *ngIf="(createForm.get('name').hasError('required') || createForm.get('name').hasError('pattern')) && createForm.get('name').dirty">
@@ -21,9 +19,7 @@
         <div class="margin">
           <chef-form-field>
             <label>
-              <span class="label">Description
-                <span aria-hidden="true">*</span>
-              </span>
+              <span class="label">Description <span aria-hidden="true">*</span></span>
               <input chefInput formControlName="description" type="text" (keyup)="handleDescriptionInput($event)">
             </label>
             <chef-error *ngIf="createForm?.controls['description'].hasError('maxlength')">

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -23,7 +23,7 @@
               <chef-error *ngIf="duplicateMember">Member expression already in table.</chef-error>
               <chef-error *ngIf="alreadyPolicyMember">Member already in policy.</chef-error>
               <chef-error *ngIf="(expressionForm.get('expression').hasError('required') || expressionForm.get('expression').hasError('pattern')) && expressionForm.get('expression').dirty">
-                Expression is required.
+                Member expression is required.
               </chef-error>
             </chef-form-field>
           </form>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -286,7 +286,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   public validateAndAddExpression(): void {
     this.resetErrors();
 
-    const member = stringToMember(this.expressionForm.value.expression);
+    const member = stringToMember(this.expressionForm.value.expression.trim());
 
     if (member.type === Type.Unknown) {
       this.unparsableMember = true;

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -76,7 +76,7 @@
 
               <chef-form-field class="attribute-field">
                 <label>
-                  <span class="label">{{ getAttributeLabel() }} <span aria-hidden="true">*</span></span>
+                  <span class="label">{{ getAttributeLabel() }}</span>
                   <select ngDefaultControl formControlName="attribute">
                     <option
                       *ngFor="let option of attributes[ruleForm.get('type').value.toLowerCase()]; let i = index"
@@ -91,7 +91,7 @@
 
               <chef-form-field class="attribute-field">
                 <label>
-                  <span class="label">Operator <span aria-hidden="true">*</span></span>
+                  <span class="label">Operator</span>
                   <select ngDefaultControl formControlName="operator">
                     <option *ngFor="let operator of operators"
                       [value]="operator.key"
@@ -105,7 +105,7 @@
 
               <chef-form-field class="attribute-field">
                 <label>
-                  <span class="label">Value <span aria-hidden="true">*</span></span>
+                  <span class="label">Value</span>
                   <chef-input ngDefaultControl
                     formControlName="values"
                     [value]="condition.controls.values.value"

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -76,7 +76,7 @@
 
               <chef-form-field class="attribute-field">
                 <label>
-                  <span class="label">{{ getAttributeLabel() }}</span>
+                  <span class="label">{{ getAttributeLabel() }} <span aria-hidden="true">*</span></span>
                   <select ngDefaultControl formControlName="attribute">
                     <option
                       *ngFor="let option of attributes[ruleForm.get('type').value.toLowerCase()]; let i = index"
@@ -91,7 +91,7 @@
 
               <chef-form-field class="attribute-field">
                 <label>
-                  <span class="label">Operator</span>
+                  <span class="label">Operator <span aria-hidden="true">*</span></span>
                   <select ngDefaultControl formControlName="operator">
                     <option *ngFor="let operator of operators"
                       [value]="operator.key"
@@ -105,7 +105,7 @@
 
               <chef-form-field class="attribute-field">
                 <label>
-                  <span class="label">Value</span>
+                  <span class="label">Value <span aria-hidden="true">*</span></span>
                   <chef-input ngDefaultControl
                     formControlName="values"
                     [value]="condition.controls.values.value"

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -239,7 +239,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     return <Rule>{
       project_id: this.project.id,
       id: ruleValue.id,
-      name: ruleValue.name,
+      name: ruleValue.name.trim(),
       type: ruleValue.type,
       status: 'staged',
       conditions: conditions

--- a/components/automate-ui/src/app/pages/team-management/team-management.component.ts
+++ b/components/automate-ui/src/app/pages/team-management/team-management.component.ts
@@ -111,7 +111,7 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
 
   public createV2Team(): void {
     this.createTeamCommon({
-      id: this.createTeamForm.controls.id.value.trim(),
+      id: this.createTeamForm.controls.id.value,
       name: this.createTeamForm.controls.name.value.trim(),
       projects: [],
       guid: null
@@ -120,7 +120,7 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
 
   public createV1Team(): void {
     this.createTeamCommon({
-      id: this.createV1TeamForm.controls.name.value.trim(),
+      id: this.createV1TeamForm.controls.name.value,
       name: this.createV1TeamForm.controls.description.value.trim(),
       projects: [],
       guid: null

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.html
@@ -25,7 +25,7 @@
             <form [formGroup]="editForm">
               <chef-form-field class="display3">
                 <label>
-                  <span class="label">Full Name</span>
+                  <span class="label">Full Name <span aria-hidden="true">*</span></span>
                   <chef-input ngDefaultControl formControlName="fullName"></chef-input>
                 </label>
                 <chef-error *ngIf="editForm.get('fullName').hasError('required') && editForm.get('fullName').dirty">
@@ -68,7 +68,7 @@
       <form [formGroup]="passwordForm">
         <chef-form-field *ngIf="!isAdminView" class="password">
           <label>
-            <span class="label">Old Password</span>
+            <span class="label">Old Password <span aria-hidden="true">*</span></span>
             <chef-input ngDefaultControl formControlName="oldPassword" type="password"></chef-input>
           </label>
           <chef-error *ngIf="passwordForm.get('oldPassword').hasError('required') && passwordForm.get('oldPassword').dirty">
@@ -80,7 +80,7 @@
         </chef-form-field>
          <chef-form-field class="password">
           <label>
-            <span class="label">New Password</span>
+            <span class="label">New Password <span aria-hidden="true">*</span></span>
             <chef-input ngDefaultControl formControlName="newPassword" type="password"></chef-input>
           </label>
           <chef-error *ngIf="passwordForm.get('newPassword').hasError('required') && passwordForm.get('newPassword').dirty">
@@ -92,7 +92,7 @@
         </chef-form-field>
         <chef-form-field class="password">
           <label>
-            <span class="label">Confirm New Password</span>
+            <span class="label">Confirm New Password <span aria-hidden="true">*</span></span>
             <chef-input ngDefaultControl formControlName="confirmPassword" type="password"></chef-input>
           </label>
           <chef-error *ngIf="passwordForm.get('confirmPassword').hasError('noMatch') && passwordForm.get('confirmPassword').dirty">

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.html
@@ -28,7 +28,7 @@
                   <span class="label">Full Name <span aria-hidden="true">*</span></span>
                   <chef-input ngDefaultControl formControlName="fullName"></chef-input>
                 </label>
-                <chef-error *ngIf="editForm.get('fullName').hasError('required') && editForm.get('fullName').dirty">
+                <chef-error *ngIf="(editForm.get('fullName').hasError('required') || editForm.get('fullName').hasError('pattern')) && editForm.get('fullName').dirty">
                   Full Name is required.
                 </chef-error>
               </chef-form-field>
@@ -83,7 +83,7 @@
             <span class="label">New Password <span aria-hidden="true">*</span></span>
             <chef-input ngDefaultControl formControlName="newPassword" type="password"></chef-input>
           </label>
-          <chef-error *ngIf="passwordForm.get('newPassword').hasError('required') && passwordForm.get('newPassword').dirty">
+          <chef-error *ngIf="(passwordForm.get('newPassword').hasError('required') || passwordForm.get('newPassword').hasError('pattern')) && passwordForm.get('newPassword').dirty">
             Password is required.
           </chef-error>
           <chef-error *ngIf="passwordForm.get('newPassword').hasError('minlength') && passwordForm.get('newPassword').dirty">

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.html
@@ -72,10 +72,10 @@
             <chef-input ngDefaultControl formControlName="oldPassword" type="password"></chef-input>
           </label>
           <chef-error *ngIf="passwordForm.get('oldPassword').hasError('required') && passwordForm.get('oldPassword').dirty">
-            Old password is required.
+            Old Password is required.
           </chef-error>
           <chef-error *ngIf="passwordForm.get('oldPassword').hasError('minlength') && passwordForm.get('oldPassword').dirty">
-            Old password must be at least 8 characters.
+            Old Password must be at least 8 characters.
           </chef-error>
         </chef-form-field>
          <chef-form-field class="password">
@@ -84,10 +84,10 @@
             <chef-input ngDefaultControl formControlName="newPassword" type="password"></chef-input>
           </label>
           <chef-error *ngIf="(passwordForm.get('newPassword').hasError('required') || passwordForm.get('newPassword').hasError('pattern')) && passwordForm.get('newPassword').dirty">
-            Password is required.
+            New Password is required.
           </chef-error>
           <chef-error *ngIf="passwordForm.get('newPassword').hasError('minlength') && passwordForm.get('newPassword').dirty">
-            Password must be at least 8 characters.
+            New Password must be at least 8 characters.
           </chef-error>
         </chef-form-field>
         <chef-form-field class="password">

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.ts
@@ -20,6 +20,7 @@ import {
   allUsers, userStatus, userFromRoute, updateStatus
 } from 'app/entities/users/user.selectors';
 import { User } from 'app/entities/users/user.model';
+import { Regex } from 'app/helpers/auth/regex';
 
 // TODO: deduplicate (copied from user-management.component.ts)
 function matchFieldValidator() {
@@ -128,12 +129,16 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
   }
 
   private createForms(fb: FormBuilder): void {
+    // Must stay in sync with error checks in user-details.component.html
     this.editForm = fb.group({
-      fullName: ['', Validators.required]
+      fullName: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
     this.passwordForm = fb.group({
       oldPassword: ['', [nonAdminValidator(this.isAdminView, 8)]],
-      newPassword: ['', [Validators.required, Validators.minLength(8)]],
+      newPassword: ['',
+        [Validators.required,
+        Validators.pattern(Regex.patterns.NON_BLANK),
+        Validators.minLength(8)]],
       confirmPassword: ['', [Validators.required, matchFieldValidator()]]
     });
   }

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.ts
@@ -178,7 +178,7 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
   }
 
   public updateFullName(): void {
-    const name = this.editForm.get('fullName').value;
+    const name = this.editForm.get('fullName').value.trim();
     this.store.dispatch(
       this.isAdminView ?
         new UpdateUser({ ...this.user, name })

--- a/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
@@ -25,7 +25,7 @@
       <span class="label">Password <span aria-hidden="true">*</span></span>
       <input chefInput formControlName="password" type="password">
     </label>
-    <chef-error *ngIf="createUserForm.get('password').hasError('required') && createUserForm.get('password').dirty">
+    <chef-error *ngIf="createUserForm.get('password').hasError('required') || (createUserForm.get('password').hasError('pattern')) && createUserForm.get('password').dirty">
       Password is required.
     </chef-error>
     <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && createUserForm.get('password').dirty">

--- a/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="createUserForm">
   <chef-form-field>
     <label>
-      <span class="label">User's Full Name</span>
+      <span class="label">User's Full Name <span aria-hidden="true">*</span></span>
       <input chefInput formControlName="fullname" type="text">
     </label>
     <chef-error *ngIf="(createUserForm.get('fullname').hasError('required') || createUserForm.get('fullname').hasError('pattern')) && createUserForm.get('fullname').dirty">
@@ -10,7 +10,7 @@
   </chef-form-field>
   <chef-form-field>
     <label>
-      <span class="label">Username</span>
+      <span class="label">Username <span aria-hidden="true">*</span></span>
       <input chefInput formControlName="username" type="text">
     </label>
     <chef-error *ngIf="createUserForm.get('username').hasError('required') && createUserForm.get('username').dirty">
@@ -22,7 +22,7 @@
   </chef-form-field>
   <chef-form-field>
     <label>
-      <span class="label">Password</span>
+      <span class="label">Password <span aria-hidden="true">*</span></span>
       <input chefInput formControlName="password" type="password">
     </label>
     <chef-error *ngIf="createUserForm.get('password').hasError('required') && createUserForm.get('password').dirty">
@@ -34,7 +34,7 @@
   </chef-form-field>
   <chef-form-field>
     <label>
-      <span class="label">Confirm Password</span>
+      <span class="label">Confirm Password <span aria-hidden="true">*</span></span>
       <input chefInput formControlName="confirmPassword" type="password">
     </label>
     <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && createUserForm.get('confirmPassword').dirty">

--- a/components/automate-ui/src/app/pages/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/pages/user-management/user-management.component.ts
@@ -79,7 +79,10 @@ export class UserManagementComponent implements OnInit, OnDestroy {
       username: ['', [Validators.required, Validators.pattern(USERNAME_PATTERN)]],
       // length validator must be consistent with
       // backend password rules in local-user-service/password/password.go
-      password: ['', [Validators.required, Validators.minLength(8)]],
+      password: ['', [
+        Validators.required,
+        Validators.pattern(Regex.patterns.NON_BLANK),
+        Validators.minLength(8)]],
       confirmPassword: ['', [Validators.required, matchFieldValidator()]]
     });
   }

--- a/components/automate-ui/src/app/pages/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/pages/user-management/user-management.component.ts
@@ -124,7 +124,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     const formValues = this.createUserForm.value;
 
     const userCreateReq = <CreateUserPayload>{
-      name: formValues.fullname,
+      name: formValues.fullname.trim(),
       id: formValues.username,
       password: formValues.password
     };


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Another sweep of consistency checks for auth UI code covering:

- All required fields are marked with an asterisk--and in an `aria-hidden` span.
- All input fields disallow whitespace-only values.
- Extraneous leading/trailing whitespace automatically trimmed.
- Field name in the error pop-up matches the displayed field name exactly.

### :chains: Related Resources
N/A

### :+1: Definition of Done

All auth inputs have identical behavior with respect to the items noted above.

### :athletic_shoe: How to Build and Test the Change

rebuild automate-ui
Navigate through the auth pages to see that any and all input fields behave consistently.
