### PR TITLE
Automate-442 Add status filters to compliance node list view Signed-O…

### DIFF
--- a/components/automate-ui/package.json
+++ b/components/automate-ui/package.json
@@ -18,8 +18,7 @@
     "test": "ng test --watch=false --code-coverage --source-map=false --configuration=no_auth",
     "test:watch": "ng test --watch=true --browsers='Chrome' --source-map=true --configuration=no_auth",
     "e2e": "ng e2e",
-    "lint": "npm run lint:ts && npm run lint:html && npm run lint:sass",
-    "lint:ts": "/bin/bash -c 'exec 5>&1; t1=$(ng lint | grep -v \": analyzing \" | grep -v \"select is deprecated\" | tee /dev/fd/5; exit ${PIPESTATUS[0]}); if [ $? -ne 0 ]; then exit 1; else echo $t1 | grep \"is deprecated\" >/dev/null; test $? -ne 0; fi'",
+    "lint": "/bin/bash -c 'exec 5>&1; t1=$(ng lint | grep -v \": analyzing \" | grep -v \"select is deprecated\" | tee /dev/fd/5; exit ${PIPESTATUS[0]}); if [ $? -ne 0 ]; then exit 1; else echo $t1 | grep \"is deprecated\" >/dev/null; test $? -ne 0; fi'",
     "lint:html": "node_modules/htmlhint/bin/htmlhint --config .htmlhintrc src/app/**/*.html",
     "lint:sass": "node node_modules/sass-lint/bin/sass-lint.js -v -q"
   },

--- a/components/automate-ui/package.json
+++ b/components/automate-ui/package.json
@@ -18,7 +18,8 @@
     "test": "ng test --watch=false --code-coverage --source-map=false --configuration=no_auth",
     "test:watch": "ng test --watch=true --browsers='Chrome' --source-map=true --configuration=no_auth",
     "e2e": "ng e2e",
-    "lint": "/bin/bash -c 'exec 5>&1; t1=$(ng lint | grep -v \": analyzing \" | grep -v \"select is deprecated\" | tee /dev/fd/5; exit ${PIPESTATUS[0]}); if [ $? -ne 0 ]; then exit 1; else echo $t1 | grep \"is deprecated\" >/dev/null; test $? -ne 0; fi'",
+    "lint": "npm run lint:ts && npm run lint:html && npm run lint:sass",
+    "lint:ts": "/bin/bash -c 'exec 5>&1; t1=$(ng lint | grep -v \": analyzing \" | grep -v \"select is deprecated\" | tee /dev/fd/5; exit ${PIPESTATUS[0]}); if [ $? -ne 0 ]; then exit 1; else echo $t1 | grep \"is deprecated\" >/dev/null; test $? -ne 0; fi'",
     "lint:html": "node_modules/htmlhint/bin/htmlhint --config .htmlhintrc src/app/**/*.html",
     "lint:sass": "node node_modules/sass-lint/bin/sass-lint.js -v -q"
   },

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
@@ -7,6 +7,36 @@
 </div>
 
 <ng-container *ngIf="!reportData.nodesListEmpty">
+    <chef-phat-radio
+    class="nodes-list-status-filters"
+    [value]="nodeFilterStatus"
+    (change)="filterNodeStatus($event, $event.target.value)">
+    <chef-option class="filter all" value='all'>
+      <span class="filter-label">Total Nodes</span>
+      <span class="filter-total">
+        <chef-icon>storage</chef-icon> {{ reportData.nodesList.total | number}}
+      </span>
+    </chef-option>
+    <chef-option class="filter critical" value='failed'>
+      <span class="filter-label">Failed Nodes</span>
+      <span class="filter-total">
+        <chef-icon>report_problem</chef-icon> {{ reportData.nodesList.statusCount.failed | number}}
+      </span>
+    </chef-option>
+    <chef-option class="filter passed" value='passed'>
+      <span class="filter-label">Passed Nodes</span>
+      <span class="filter-total">
+        <chef-icon>check_circle</chef-icon> {{ reportData.nodesList.statusCount.passed | number}}
+      </span>
+    </chef-option>
+    <chef-option class="filter skipped" value='skipped'>
+      <span class="filter-label">Skipped Nodes</span>
+      <span class="filter-total">
+        <chef-icon>help</chef-icon> {{ reportData.nodesList.statusCount.skipped | number}}
+      </span>
+    </chef-option>
+  </chef-phat-radio>
+  
   <chef-table class="reporting-nodes-table" (sort-toggled)="onNodesListSortToggled($event)">
     <chef-thead>
       <chef-tr>
@@ -49,7 +79,7 @@
       </chef-tr>
     </chef-thead>
     <chef-tbody *ngIf="!reportData.nodesListLoading">
-      <chef-tr *ngFor="let node of reportData.nodesList.items">
+      <chef-tr *ngFor="let node of filteredNodes(reportData.nodesList.items)">
         <chef-td>
           <chef-icon class="status-icon" [ngClass]="node.latest_report.status">
             {{ statusIcon(node.latest_report.status) }}

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
@@ -20,19 +20,19 @@
     <chef-option class="filter critical" value='failed'>
       <span class="filter-label">Failed Nodes</span>
       <span class="filter-total">
-        <chef-icon>report_problem</chef-icon> {{ reportData.nodesList.statusCount.failed | number}}
+        <chef-icon>report_problem</chef-icon> {{ reportData.nodesList.total_failed | number}}
       </span>
     </chef-option>
     <chef-option class="filter passed" value='passed'>
       <span class="filter-label">Passed Nodes</span>
       <span class="filter-total">
-        <chef-icon>check_circle</chef-icon> {{ reportData.nodesList.statusCount.passed | number}}
+        <chef-icon>check_circle</chef-icon> {{ reportData.nodesList.total_passed | number}}
       </span>
     </chef-option>
     <chef-option class="filter skipped" value='skipped'>
       <span class="filter-label">Skipped Nodes</span>
       <span class="filter-total">
-        <chef-icon>help</chef-icon> {{ reportData.nodesList.statusCount.skipped | number}}
+        <chef-icon>help</chef-icon> {{ reportData.nodesList.total_skipped | number}}
       </span>
     </chef-option>
   </chef-phat-radio>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.scss
@@ -1,5 +1,79 @@
 @import "~styles/variables";
 
+.nodes-list-status-filters {
+  display: flex;
+  margin: 35px;
+  align-items: center;
+
+  ::ng-deep .filter {
+    font-size: 14px;
+    height: auto;
+
+    &::before {
+      display: none;
+    }
+
+    .option-content {
+      display: flex;
+      padding: 0;
+      flex-direction: column;
+    }
+
+    .filter-total {
+      display: flex;
+      align-items: center;
+
+      chef-icon {
+        margin: -2px 0.5em 0 0;
+      }
+    }
+
+    &.selected {
+      background: blue;
+
+      .filter-label,
+      .filter-total,
+      .filter-total chef-icon {
+        color: $chef-white;
+      }
+
+      &.all  {
+        background: $chef-primary-bright;
+      }
+
+      &.critical  {
+        background: $chef-critical;
+      }
+
+      &.skipped  {
+        background: $chef-dark-grey;
+      }
+
+      &.passed  {
+        background: $chef-success;
+      }
+    }
+
+    &:not(.selected) {
+      &.all .filter-total  {
+        color: $chef-primary-bright;
+      }
+
+      &.critical .filter-total  {
+        color: $chef-critical;
+      }
+
+      &.skipped .filter-total  {
+        color: $chef-dark-grey;
+      }
+
+      &.passed .filter-total  {
+        color: $chef-success;
+      }
+    }
+  }
+}
+
 .reporting-nodes-table {
   margin: 2em 35px 0;
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.ts
@@ -19,6 +19,7 @@ export class ReportingNodesComponent implements OnInit, OnDestroy {
   layerOneData: any = {};
   layerTwoData: any = {};
   control: any = {};
+  nodeFilterStatus = 'all';
 
   scanResultsPane = 0;
   openControls = {};
@@ -40,6 +41,20 @@ export class ReportingNodesComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
+  }
+
+  filterNodeStatus(_event, status) {
+    this.nodeFilterStatus = status;
+  }
+
+  isNodeStatusSelected(status): boolean {
+    return this.nodeFilterStatus === status;
+  }
+
+  filteredNodes(nodes) {
+    return this.nodeFilterStatus === 'all'
+      ? nodes
+      : nodes.filter((node) => node.latest_report.status === this.nodeFilterStatus);
   }
 
   onNodesListPageChanged(event) {

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { remove, filter } from 'lodash';
+import { remove } from 'lodash';
 import { StatsService } from './stats.service';
 import { TelemetryService } from '../../../../services/telemetry/telemetry.service';
 
@@ -20,11 +20,9 @@ export class ReportDataService {
   nodesList: any = {
     items: [],
     total: 0,
-    statusCount: {
-      failed: 0,
-      passed: 0,
-      skipped: 0
-    }
+    total_failed: 0,
+    total_passed: 0,
+    total_skipped: 0
   };
   nodesListParams: any = {
     perPage: 100,
@@ -69,7 +67,6 @@ export class ReportDataService {
       .subscribe(data => {
         this.nodesListLoading = false;
         this.nodesListEmpty = this.isEmpty(data.items);
-        data.statusCount = this.getStatusCount(data.items);
         this.nodesList = Object.assign({}, this.nodesList, data);
       });
   }
@@ -89,19 +86,6 @@ export class ReportDataService {
       return true;
     }
     return false;
-  }
-
-  getStatusCount(nodes) {
-    return {
-      failed: this.countNodesByStatus(nodes, 'failed'),
-      passed: this.countNodesByStatus(nodes, 'passed'),
-      skipped: this.countNodesByStatus(nodes, 'skipped')
-    };
-  }
-
-  countNodesByStatus(nodes, status) {
-    return filter(nodes, (node) =>
-      node.latest_report.status === status).length;
   }
 
   isAllZeros(data) {

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { remove } from 'lodash';
+import { remove, filter } from 'lodash';
 import { StatsService } from './stats.service';
 import { TelemetryService } from '../../../../services/telemetry/telemetry.service';
 
@@ -19,7 +19,12 @@ export class ReportDataService {
   nodesListEmpty = false;
   nodesList: any = {
     items: [],
-    total: 0
+    total: 0,
+    statusCount: {
+      failed: 0,
+      passed: 0,
+      skipped: 0
+    }
   };
   nodesListParams: any = {
     perPage: 100,
@@ -64,6 +69,7 @@ export class ReportDataService {
       .subscribe(data => {
         this.nodesListLoading = false;
         this.nodesListEmpty = this.isEmpty(data.items);
+        data.statusCount = this.getStatusCount(data.items);
         this.nodesList = Object.assign({}, this.nodesList, data);
       });
   }
@@ -83,6 +89,19 @@ export class ReportDataService {
       return true;
     }
     return false;
+  }
+
+  getStatusCount(nodes) {
+    return {
+      failed: this.countNodesByStatus(nodes, 'failed'),
+      passed: this.countNodesByStatus(nodes, 'passed'),
+      skipped: this.countNodesByStatus(nodes, 'skipped')
+    };
+  }
+
+  countNodesByStatus(nodes, status) {
+    return filter(nodes, (node) =>
+      node.latest_report.status === status).length;
   }
 
   isAllZeros(data) {

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
@@ -38,11 +38,26 @@ describe('StatsService', () => {
 
       const expectedUrl = `${COMPLIANCE_URL}/reporting/nodes/search`;
       const expectedTotal = 20;
+      const expectedTotalFailed = 1;
+      const expectedTotalPassed = 18;
+      const expectedTotalSkipped = 2;
       const expectedItems = [{}, {}];
-      const mockResp = { nodes: expectedItems, total: expectedTotal };
+      const mockResp = {
+        nodes: expectedItems,
+        total: expectedTotal,
+        total_failed: expectedTotalFailed,
+        total_passed: expectedTotalPassed,
+        total_skipped: expectedTotalSkipped,
+      };
 
       service.getNodes(filters, listParams).subscribe(data => {
-        expect(data).toEqual({total: expectedTotal, items: expectedItems});
+        expect(data).toEqual({
+          total: expectedTotal,
+          items: expectedItems,
+          total_failed: expectedTotalFailed,
+          total_passed: expectedTotalPassed,
+          total_skipped: expectedTotalSkipped,
+        });
       });
 
       const req = httpTestingController.expectOne(expectedUrl);

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
@@ -47,7 +47,7 @@ describe('StatsService', () => {
         total: expectedTotal,
         total_failed: expectedTotalFailed,
         total_passed: expectedTotalPassed,
-        total_skipped: expectedTotalSkipped,
+        total_skipped: expectedTotalSkipped
       };
 
       service.getNodes(filters, listParams).subscribe(data => {
@@ -56,7 +56,7 @@ describe('StatsService', () => {
           items: expectedItems,
           total_failed: expectedTotalFailed,
           total_passed: expectedTotalPassed,
-          total_skipped: expectedTotalSkipped,
+          total_skipped: expectedTotalSkipped
         });
       });
 

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -112,7 +112,8 @@ export class StatsService {
     }
 
     return this.httpClient.post<any>(url, body).pipe(
-      map(({ nodes, total }) => ({total, items: nodes})));
+      map(({ nodes, total, total_failed, total_passed, total_skipped }) =>
+        ({total, total_failed, total_passed, total_skipped, items: nodes})));
   }
 
   getProfiles(filters: any[], listParams: any): Observable<any> {


### PR DESCRIPTION
…ff-By: Tara Black <tblack@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
As an Automate User, I would like to filter out the failed/passed/skipped nodes on the compliance node tab so that I may find my failed nodes easier.

### :chains: Related Resources
https://github.com/chef/automate/issues/442

### :+1: Definition of Done
Page: /compliance/reports/nodes

The nodes table will have our standard filter buttons above the nodes table.

Filters:
Total Nodes | Failed Nodes | Passed Nodes | Skipped Nodes

### :athletic_shoe: How to Build and Test the Change
A user can navigate to goes to Compliance > Nodes Tab
User clicks on a status filter
System then filters the data table.

### :camera: Screenshots, if applicable
![Screen Shot 2019-08-04 at 8 54 25 PM](https://user-images.githubusercontent.com/4108100/62433453-16140200-b6fa-11e9-8878-200951fbd399.png)
