### PR TITLE
Update rules-check permission

### DIFF
--- a/components/authz-service/server/v2/system.go
+++ b/components/authz-service/server/v2/system.go
@@ -60,6 +60,12 @@ func SystemPolicies() []*storage.Policy {
 				Resources: []string{"iam:policyVersion"},
 				Projects:  []string{constants.AllProjectsID},
 			},
+			{
+				Effect:    storage.Allow,
+				Actions:   []string{"iam:rules:status"},
+				Resources: []string{"iam:rules"},
+				Projects:  []string{constants.AllProjectsID},
+			},
 		},
 	}
 


### PR DESCRIPTION
_Note: I marked this as "do-not-merge" only because I think it is useful for folks to review PR-1158 before this PR gets merged._

### :nut_and_bolt: Description: What code changed, and why?

All users should be able to check the appply-rules status:
on the projects list page they should be able to see
the percentage complete on the button if its in progress.

(Soon that will be converted to a global progress message at the bottom of all pages.)

### :chains: Related Resources

PR - #1158 (Check apply rules only in IAM v2.1)

### :+1: Definition of Done

Requests to check rules status should be fired periodically:

![image](https://user-images.githubusercontent.com/6817500/62436825-b6b3f300-b6f5-11e9-873a-53d8c3d3ed7e.png)

### :athletic_shoe: How to Build and Test the Change

1. Rebuild components/authz-service
2. Create a new user.
3. Login as that user.
4. Open Dev Tools >> Network and observe that calls to check the apply-rules status are occurring--and succeeding!

Different scenarios you can check--assuming PR-1158 has not yet merged--and assuming you are running v2.1:
1. Without this PR and without PR-1158, you will see `apply-rules` calls occurring but failing with a `403`.
2. With just this PR added, those calls will now succeed.
3. With just PR-1158, those calls will not be made at all.
4. With both PRs, the calls will again be made and they will succeed.

Also, if you run different IAM versions, then PR-1158 will dictate that `apply-rules` calls will not be made for anyone if you are not on v2.1.

(Note that you run both this PR and PR-1158 together easily because one is Go and the other is TypeScript. So on this branch rebuild authz-service first, then switch to the PR-1158 branch (sr/issue-1129/no-GET-apply-rules-unless-iam-v2) and rebuild automate-ui.)