### PR TITLE
e2e/cypress: make 03_team_add_users spec work for more users

### DIFF
--- a/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
+++ b/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
@@ -103,15 +103,16 @@ describe('team add users', () => {
     cy.get('chef-tbody chef-tr').contains('chef-tr', usernameForUser)
       .contains(nameForUser);
 
-    // The admin user exists by default
-    cy.get('chef-tbody chef-tr').contains('chef-tr', 'admin')
-      .contains('Local Administrator');
+    // Assert that there's more than two users: the one we created and admin,
+    // that always exists.
+    cy.get('chef-tbody').find('chef-tr').its('length').should('be.gte', 2);
 
     cy.get('#page-footer #right-buttons chef-button ng-container').first().contains('Add User');
   });
 
   it('adds a single user', () => {
-    cy.get('chef-tbody chef-checkbox').first().click();
+    cy.get('chef-tbody').contains('chef-tr', usernameForUser)
+      .find('chef-checkbox').click();
     cy.get('#users-selected').contains('1 user selected');
 
     cy.get('#page-footer #right-buttons chef-button ng-container')


### PR DESCRIPTION
ℹ️ I've run the offending spec against all envs manually now:

- [x] a2-perf-test-single-local-inplace-upgrade-dev.cd.chef.co
- [x] a2-local-fresh-install-dev.cd.chef.co
- [x] a2-iamv2-local-fresh-install-dev.cd.chef.co
- [x] a2-iamv2-local-inplace-upgrade-dev.cd.chef.co
- [x] a2-iamv2p1-local-fresh-install-dev.cd.chef.co
- [x] a2-iamv2p1-local-inplace-upgrade-dev.cd.chef.co