### PR TITLE
Add API to list workflow instances

### DIFF
--- a/lib/cereal/backend/backend.go
+++ b/lib/cereal/backend/backend.go
@@ -20,9 +20,16 @@ type Driver interface {
 	UpdateWorkflowScheduleByName(ctx context.Context, instanceName string, workflowName string, opts WorkflowScheduleUpdateOpts) error
 
 	GetWorkflowInstanceByName(ctx context.Context, instanceName string, workflowName string) (*WorkflowInstance, error)
+	ListWorkflowInstances(ctx context.Context, opts ListWorkflowOpts) ([]*WorkflowInstance, error)
 
 	Init() error
 	Close() error
+}
+
+type ListWorkflowOpts struct {
+	WorkflowName *string
+	InstanceName *string
+	IsRunning    *bool
 }
 
 type WorkflowInstanceStatus string

--- a/lib/cereal/postgres/postgres.go
+++ b/lib/cereal/postgres/postgres.go
@@ -29,28 +29,61 @@ const (
 	failWorkflowQuery     = `SELECT cereal_fail_workflow($1, $2)`
 	continueWorkflowQuery = `SELECT cereal_continue_workflow($1, $2, $3, $4, $5)`
 
+	// listWorkflowInstanceQuery is quite a tricky query. It's intent is to select
+	// one run of each workflow instance. This means it has to consult the actively
+	// running workflow instances from the cereal_workflow_instances table, and the
+	// completed workflow results from cereal_workflow_results.
+	// Parameters:
+	// $1 : workflow_name OR NULL: only workflow_names of the given value will match.
+	//                             all will match on NULL
+	// $2 : instance_name OR NULL: only instance_names of the given value will match.
+	//                             all will match on NULL
+	// $3 : is_running OR NULL: if true, only running instances will match. if false,
+	//                          only completed instances will match. if NULL, all will
+	//                          match.
 	listWorkflowInstancesQuery = `
+-- Find at most one of each (instance_name, workflow_name) from results,
+-- picking at the most recent result if multiple exist
 WITH res AS (
 	SELECT DISTINCT ON (instance_name, workflow_name) *
     FROM cereal_workflow_results
 	ORDER BY instance_name, workflow_name, end_at DESC
 )
+-- Select the workflow instance data, giving priority to that coming
+-- from the cereal_workflow_instances table
 SELECT COALESCE(a.id, res.id) id, 
        COALESCE(a.status, 'completed') status,
        COALESCE(a.instance_name, res.instance_name) instance_name,
 	   COALESCE(a.workflow_name, res.workflow_name) workflow_name,
 	   COALESCE(a.parameters, res.parameters) parameters,
 	   a.payload payload,
+	   -- The result, and error only in the cereal_workflow_results table.
+	   -- This means that these could potentially be garbage if the previous
+	   -- data (id, status, etc) came from the cereal_workflow_instances.
+	   -- This means we need to clean this up after the query
 	   res.result result,
 	   res.error error
+-- We do a full outer join on the two tables on (workflow_name, instance_name).
+-- This gives us 1 row for every distinct (workflow_name, instance_name) pair.
 FROM cereal_workflow_instances a
 FULL OUTER JOIN res ON a.workflow_name = res.workflow_name AND a.instance_name = res.instance_name
 WHERE
+	-- NOTE: The WHERE clause is processed after the join.
+	-- The pattern below allows us to either specify a contraint by giving a value for the column,
+	-- or passing in NULL. If a value is given for a column, we make sure the value matches either
+	-- of the cereal_workflow_instances table or the cereal_workflow_results table. Passing in NULL
+	-- for the value reduces down into saying the value in the column matches the value in the column.
 	(a.workflow_name = COALESCE($1, a.workflow_name) OR 
 	res.workflow_name = COALESCE($1, res.workflow_name)) AND
 	(a.instance_name = COALESCE($2, a.instance_name) OR 
 	res.instance_name = COALESCE($2, res.instance_name)) AND
-	(($3::boolean IS NULL) OR ($3::boolean IS NOT NULL AND $3::boolean AND a.status IS NOT NULL) OR ($3::boolean IS NOT NULL AND NOT $3::boolean AND a.status IS NULL));
+	-- We'll select the row if is_running is now specified
+	(($3::boolean IS NULL) OR
+	-- If is_running is true, there must be a status in the cereal_workflow_instances
+	-- table.
+	 ($3::boolean IS NOT NULL AND $3::boolean AND a.status IS NOT NULL) OR
+	-- If is_running is false, there must not be a status
+	 ($3::boolean IS NOT NULL AND NOT $3::boolean AND a.status IS NULL));
 	`
 	listScheduledWorkflowsQuery = `
 WITH res AS (

--- a/lib/cereal/postgres/postgres_test.go
+++ b/lib/cereal/postgres/postgres_test.go
@@ -1086,6 +1086,260 @@ func TestWorkflowCancellationBeforeStart(t *testing.T) {
 	assertNoPendingWork(t, b1)
 }
 
+func TestListWorkflowInstancesEmpty(t *testing.T) {
+	err := runResetDB()
+	require.NoError(t, err)
+	b1 := NewPostgresBackend(testDBURL())
+	err = b1.Init()
+	require.NoError(t, err)
+	defer b1.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	instances, err := b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{})
+	require.NoError(t, err)
+	assert.Len(t, instances, 0)
+}
+
+func TestListWorkflowInstancesMultipleInstances(t *testing.T) {
+	workflowName := "workflow_name"
+	err := runResetDB()
+	require.NoError(t, err)
+	b1 := NewPostgresBackend(testDBURL())
+	err = b1.Init()
+	require.NoError(t, err)
+	defer b1.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	instance1Name := "instance1"
+	instance1Parameters := []byte("instance1Parameters")
+	err = b1.EnqueueWorkflow(ctx, &backend.WorkflowInstance{
+		InstanceName: instance1Name,
+		WorkflowName: workflowName,
+		Parameters:   instance1Parameters,
+	})
+	require.NoError(t, err)
+	instance2Name := "instance2"
+	instance2Parameters := []byte("instance2Parameters")
+	err = b1.EnqueueWorkflow(ctx, &backend.WorkflowInstance{
+		InstanceName: instance2Name,
+		WorkflowName: workflowName,
+		Parameters:   instance2Parameters,
+	})
+	require.NoError(t, err)
+
+	err = b1.EnqueueWorkflow(ctx, &backend.WorkflowInstance{
+		InstanceName: instance1Name,
+		WorkflowName: "someotherworkflow",
+		Parameters:   nil,
+	})
+	require.NoError(t, err)
+
+	instances, err := b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{})
+	require.NoError(t, err)
+	assert.Len(t, instances, 3)
+
+	for _, instance := range instances {
+		assert.Equal(t, backend.WorkflowInstanceStatusStarting, instance.Status)
+		assert.True(t, instance.IsRunning)
+		if instance.WorkflowName == workflowName {
+			if instance.InstanceName == instance1Name {
+				assert.Equal(t, instance1Parameters, instance.Parameters)
+			} else {
+				assert.Equal(t, instance2Parameters, instance.Parameters)
+			}
+		}
+	}
+
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		WorkflowName: &workflowName,
+	})
+	require.NoError(t, err)
+	assert.Len(t, instances, 2)
+
+	for _, instance := range instances {
+		assert.Equal(t, backend.WorkflowInstanceStatusStarting, instance.Status)
+		assert.True(t, instance.IsRunning)
+		if instance.InstanceName == instance1Name {
+			assert.Equal(t, instance1Parameters, instance.Parameters)
+		} else {
+			assert.Equal(t, instance2Parameters, instance.Parameters)
+		}
+	}
+
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		WorkflowName: &workflowName,
+		InstanceName: &instance1Name,
+	})
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+	assert.Equal(t, backend.WorkflowInstanceStatusStarting, instances[0].Status)
+	assert.True(t, instances[0].IsRunning)
+	assert.Equal(t, instance1Parameters, instances[0].Parameters)
+
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		WorkflowName: &workflowName,
+		InstanceName: &instance2Name,
+	})
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+	assert.Equal(t, backend.WorkflowInstanceStatusStarting, instances[0].Status)
+	assert.True(t, instances[0].IsRunning)
+	assert.Equal(t, instance2Parameters, instances[0].Parameters)
+
+	isRunning := true
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		WorkflowName: &workflowName,
+		IsRunning:    &isRunning,
+	})
+	require.NoError(t, err)
+	assert.Len(t, instances, 2)
+
+	for _, instance := range instances {
+		assert.Equal(t, backend.WorkflowInstanceStatusStarting, instance.Status)
+		assert.True(t, instance.IsRunning)
+		if instance.InstanceName == instance1Name {
+			assert.Equal(t, instance1Parameters, instance.Parameters)
+		} else {
+			assert.Equal(t, instance2Parameters, instance.Parameters)
+		}
+	}
+
+	isRunning = false
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		WorkflowName: &workflowName,
+		IsRunning:    &isRunning,
+	})
+	require.NoError(t, err)
+	assert.Len(t, instances, 0)
+
+	w1, completer, err := b1.DequeueWorkflow(ctx, []string{workflowName})
+	err = completer.Done([]byte("result"))
+	require.NoError(t, err)
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		WorkflowName: &workflowName,
+		IsRunning:    &isRunning,
+	})
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+	assert.Equal(t, backend.WorkflowInstanceStatusCompleted, instances[0].Status)
+	assert.Equal(t, w1.Instance.WorkflowName, instances[0].WorkflowName)
+	assert.Equal(t, w1.Instance.InstanceName, instances[0].InstanceName)
+	assert.Equal(t, w1.Instance.Parameters, instances[0].Parameters)
+	assert.Equal(t, []byte("result"), instances[0].Result)
+
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		WorkflowName: &workflowName,
+		InstanceName: &w1.Instance.InstanceName,
+	})
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+	assert.Equal(t, backend.WorkflowInstanceStatusCompleted, instances[0].Status)
+	assert.Equal(t, w1.Instance.WorkflowName, instances[0].WorkflowName)
+	assert.Equal(t, w1.Instance.InstanceName, instances[0].InstanceName)
+	assert.Equal(t, w1.Instance.Parameters, instances[0].Parameters)
+	assert.Nil(t, instances[0].Payload)
+	assert.Equal(t, []byte("result"), instances[0].Result)
+
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		WorkflowName: &workflowName,
+	})
+	require.NoError(t, err)
+	require.Len(t, instances, 2)
+
+	isRunning = false
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		IsRunning: &isRunning,
+	})
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+
+	isRunning = true
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		IsRunning: &isRunning,
+	})
+	require.NoError(t, err)
+	require.Len(t, instances, 2)
+
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{})
+	require.NoError(t, err)
+	require.Len(t, instances, 3)
+
+	w2, completer, err := b1.DequeueWorkflow(ctx, []string{workflowName})
+	require.NoError(t, err)
+	err = completer.Fail(errors.New("fail"))
+	require.NoError(t, err)
+
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		WorkflowName: &workflowName,
+		InstanceName: &w2.Instance.InstanceName,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+	assert.Equal(t, backend.WorkflowInstanceStatusCompleted, instances[0].Status)
+	assert.Equal(t, w2.Instance.WorkflowName, instances[0].WorkflowName)
+	assert.Equal(t, w2.Instance.InstanceName, instances[0].InstanceName)
+	assert.Equal(t, w2.Instance.Parameters, instances[0].Parameters)
+	assert.Nil(t, instances[0].Result)
+	assert.Nil(t, instances[0].Payload)
+	assert.Equal(t, "fail", instances[0].Err.Error())
+
+	isRunning = false
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		IsRunning: &isRunning,
+	})
+	require.NoError(t, err)
+	require.Len(t, instances, 2)
+
+	isRunning = true
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		IsRunning: &isRunning,
+	})
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+
+	instance1Parameters = []byte("instance1Parameters-new")
+	err = b1.EnqueueWorkflow(ctx, &backend.WorkflowInstance{
+		InstanceName: instance1Name,
+		WorkflowName: workflowName,
+		Parameters:   instance1Parameters,
+	})
+	require.NoError(t, err)
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		WorkflowName: &workflowName,
+		InstanceName: &instance1Name,
+	})
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+	assert.Equal(t, backend.WorkflowInstanceStatusStarting, instances[0].Status)
+	assert.True(t, instances[0].IsRunning)
+	assert.Equal(t, instance1Parameters, instances[0].Parameters)
+	assert.Nil(t, instances[0].Result)
+	assert.Nil(t, instances[0].Err)
+
+	err = b1.EnqueueWorkflow(ctx, &backend.WorkflowInstance{
+		InstanceName: instance2Name,
+		WorkflowName: workflowName,
+		Parameters:   instance2Parameters,
+	})
+	require.NoError(t, err)
+	instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
+		WorkflowName: &workflowName,
+		InstanceName: &instance2Name,
+	})
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+	assert.Equal(t, backend.WorkflowInstanceStatusStarting, instances[0].Status)
+	assert.True(t, instances[0].IsRunning)
+	assert.Equal(t, instance2Parameters, instances[0].Parameters)
+	assert.Nil(t, instances[0].Result)
+	assert.Nil(t, instances[0].Err)
+}
+
 func assertNoPendingWork(t *testing.T, b *PostgresBackend) {
 	t.Helper()
 

--- a/lib/cereal/postgres/sql_schema.go
+++ b/lib/cereal/postgres/sql_schema.go
@@ -369,4 +369,10 @@ $$;
 COMMIT;
 `,
 	},
+	{
+		desc: "completed workflow instance status",
+		upSQL: `
+ALTER TYPE cereal_workflow_instance_status ADD VALUE 'completed';
+`,
+	},
 }

--- a/tools/cereal-scaffold/main.go
+++ b/tools/cereal-scaffold/main.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -464,6 +462,17 @@ func runListInstances(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	spew.Dump(instances)
+	for _, instance := range instances {
+		fmt.Printf("%13s: %s\n", "Workflow Name", instance.WorkflowName)
+		fmt.Printf("%13s: %s\n", "Instance Name", instance.InstanceName)
+		fmt.Printf("%13s: %s\n", "Status", string(instance.Status))
+		fmt.Printf("%13s: %v\n", "Is Running", instance.IsRunning)
+		fmt.Printf("%13s: %s\n", "Parameters", string(instance.Parameters))
+		fmt.Printf("%13s: %s\n", "Payload", string(instance.Payload))
+		fmt.Printf("%13s: %s\n", "Result", string(instance.Result))
+		fmt.Printf("%13s: %v\n", "Err", instance.Err)
+		fmt.Println("-----------------------------------")
+	}
+
 	return nil
 }


### PR DESCRIPTION
Added an API to the cereal backend to list workflow instances.

```golang
type Driver interface {
  ListWorkflowInstances(ctx context.Context, opts ListWorkflowOpts) ([]*WorkflowInstance, error)
}

type ListWorkflowOpts struct {
  WorkflowName *string
  InstanceName *string
  IsRunning    *bool
}
```

It allows finding a workflow instance by (workflow name, instance name),
or allows listing all workflows, or all workflows of a certain workflow
name, or all running/not running workflows.

Example usages:

```golang
// List all workflow instances
instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{})

// List all completed workflow instances
isRunning = false
instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
    IsRunning: &isRunning,
})

// List all running workflow instances
isRunning = true
instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
    IsRunning: &isRunning,
})

// List all workflow instances of type workflowName
instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
    WorkflowName: &workflowName,
})

// List all workflow instances of type workflowName that are currently
// running
instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
    WorkflowName: &workflowName,
    IsRunning:    &isRunning,
})

// Find the workflow instance (workflowName, instanceName)
instances, err = b1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{
    WorkflowName: &workflowName,
    InstanceName: &instanceName
})

```