### PR TITLE
automate-ui/team-details: show name in breadcrumbs

### DIFF
--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -5,7 +5,8 @@
   <main>
     <chef-breadcrumbs>
       <chef-breadcrumb [link]="['/settings/teams']">Teams</chef-breadcrumb>
-      {{ team.id }}
+      <span  *ngIf="isV1">{{ team.id }}</span>
+      <span  *ngIf="!isV1">{{ team.name }}</span>
     </chef-breadcrumbs>
 
     <chef-page-header>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

#### Before (v2)
<img width="322" alt="team-details-with-id" src="https://user-images.githubusercontent.com/870638/62523462-229c7580-b834-11e9-91b6-b38bfb656299.png">

#### After (v1)
![image](https://user-images.githubusercontent.com/870638/62525556-ea973180-b837-11e9-9f90-7770f4489098.png)

#### After (v2)
![image](https://user-images.githubusercontent.com/870638/62525504-d6533480-b837-11e9-913c-548e7e73148b.png)



### :chains: Related Resources

- #794 
  - #1041 

### :+1: Definition of Done

See "After" above.

### :athletic_shoe: How to Build and Test the Change

- `start_all_services`
- `rebuild components/automate-ui-devproxy`
- in another terminal, run `npm run serve:hab` in `components/automate-ui`
- browse to team details, run `chef-automate iam reset-to-v1`, browse to team details again
