### PR TITLE
Add `FormControlDirective ` to track original value of form controls

### DIFF
--- a/components/automate-ui/src/app/components/chef-components.module.ts
+++ b/components/automate-ui/src/app/components/chef-components.module.ts
@@ -14,6 +14,7 @@ import { CalendarComponent } from './calendar/calendar.component';
 import { CreateObjectModalComponent } from './create-object-modal/create-object-modal.component';
 import { DeleteObjectModalComponent } from './delete-object-modal/delete-object-modal.component';
 import { ErrorDirective } from './error/error.directive';
+import { FormControlDirective } from './form-control/form-control.directive';
 import { FormFieldComponent } from './form-field/form-field.component';
 import {
   GuitarStringComponent
@@ -77,6 +78,7 @@ import { TabsComponent } from './tabs/tabs.component';
 
     // Directives
     ErrorDirective,
+    FormControlDirective,
     InputDirective
   ],
   declarations: [
@@ -88,6 +90,7 @@ import { TabsComponent } from './tabs/tabs.component';
     CreateObjectModalComponent,
     DeleteObjectModalComponent,
     ErrorDirective,
+    FormControlDirective,
     FormFieldComponent,
     GuitarStringComponent,
     GuitarStringCollectionComponent,

--- a/components/automate-ui/src/app/components/form-control/form-control.directive.spec.ts
+++ b/components/automate-ui/src/app/components/form-control/form-control.directive.spec.ts
@@ -1,0 +1,142 @@
+import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Component, DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { using } from 'app/testing/spec-helpers';
+import { FormControlDirective } from './form-control.directive';
+
+const originalValue = 'originalValue';
+const newValue = 'newValue';
+
+@Component({
+  template: '<input [formControl]="control" />'
+})
+class InputFormControlHostComponent {
+  control: FormControl = new FormControl(originalValue);
+}
+
+@Component({
+  template: `
+    <form [formGroup]="form">
+      <input formControlName="control" />
+    </form>
+  `
+})
+class InputFormControlNameHostComponent {
+  form: FormGroup = new FormGroup({
+    control: new FormControl(originalValue)
+  });
+}
+
+@Component({
+  template: `
+    <select [formControl]="control">
+      <option value="${originalValue}">${originalValue}</option>
+      <option value="${newValue}">${newValue}</option>
+    </select>
+  `
+})
+class SelectFormControlHostComponent {
+  control: FormControl = new FormControl(originalValue);
+}
+
+@Component({
+  template: `
+    <form [formGroup]="form">
+      <select formControlName="control">
+        <option value="${originalValue}">${originalValue}</option>
+        <option value="${newValue}">${newValue}</option>
+      </select>
+    </form>
+  `
+})
+class SelectFormControlNameHostComponent {
+  form: FormGroup = new FormGroup({
+    control: new FormControl(originalValue)
+  });
+}
+
+type TestHostComponents =
+  | InputFormControlHostComponent
+  | InputFormControlNameHostComponent
+  | SelectFormControlHostComponent
+  | SelectFormControlNameHostComponent;
+
+const scenarios = [
+  [InputFormControlHostComponent,      'input',                   'input' ],
+  [InputFormControlNameHostComponent,  'input[formcontrolname]',  'input' ],
+  [SelectFormControlHostComponent,     'select',                  'change'],
+  [SelectFormControlNameHostComponent, 'select[formcontrolname]', 'change']
+];
+
+using(scenarios, (host, selector, eventName) => {
+  describe(`FormControlDirective using '${host.name}'`, () => {
+    let fixture: ComponentFixture<TestHostComponents>;
+    let input: DebugElement;
+    let inputEl: HTMLInputElement | HTMLSelectElement;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          ReactiveFormsModule
+        ],
+        declarations: [
+          host,
+          FormControlDirective
+        ]
+      })
+      .compileComponents();
+    }));
+
+    beforeEach(fakeAsync(() => {
+      fixture = TestBed.createComponent(host);
+      input = fixture.debugElement.query(By.css(selector));
+      inputEl = input.nativeElement;
+      fixture.detectChanges();
+      tick();
+    }));
+
+    describe('when initialized', () => {
+      it('is marked as pristine', () => {
+        expect(inputEl.value).toEqual(originalValue);
+        expect(inputEl.classList.contains('ng-dirty')).toEqual(false);
+        expect(inputEl.classList.contains('ng-pristine')).toEqual(true);
+      });
+    });
+
+    describe('when value changes from original value', () => {
+      it('is marked as dirty', fakeAsync(() => {
+        inputEl.value = newValue;
+        inputEl.dispatchEvent(new Event(eventName));
+        fixture.detectChanges();
+        tick();
+
+        expect(inputEl.value).toEqual(newValue);
+        expect(inputEl.classList.contains('ng-dirty')).toEqual(true);
+        expect(inputEl.classList.contains('ng-pristine')).toEqual(false);
+      }));
+    });
+
+    describe('when value changes to original value', () => {
+      it('is marked as pristine', fakeAsync(() => {
+        inputEl.value = newValue;
+        inputEl.dispatchEvent(new Event(eventName));
+        fixture.detectChanges();
+        tick();
+
+        expect(inputEl.value).toEqual(newValue);
+        expect(inputEl.classList.contains('ng-dirty')).toEqual(true);
+        expect(inputEl.classList.contains('ng-pristine')).toEqual(false);
+
+        inputEl.value = originalValue;
+        inputEl.dispatchEvent(new Event(eventName));
+        fixture.detectChanges();
+        tick();
+
+        expect(inputEl.value).toEqual(originalValue);
+        expect(inputEl.classList.contains('ng-dirty')).toEqual(false);
+        expect(inputEl.classList.contains('ng-pristine')).toEqual(true);
+      }));
+    });
+  });
+});

--- a/components/automate-ui/src/app/components/form-control/form-control.directive.ts
+++ b/components/automate-ui/src/app/components/form-control/form-control.directive.ts
@@ -1,0 +1,36 @@
+import { Directive, OnDestroy, OnInit } from '@angular/core';
+import { NgControl } from '@angular/forms';
+import { Subject } from 'rxjs';
+import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
+
+@Directive({
+  selector: '[formControl],[formControlName]'
+})
+export class FormControlDirective implements OnInit, OnDestroy {
+
+  constructor(private control: NgControl) {}
+
+  private originalValue: any;
+
+  private isDestroyed$: Subject<boolean> = new Subject<boolean>();
+
+  ngOnInit() {
+    this.originalValue = this.control.value;
+
+    this.control.valueChanges
+      .pipe(
+        takeUntil(this.isDestroyed$),
+        distinctUntilChanged()
+      )
+      .subscribe(newValue => {
+        if (newValue === this.originalValue) {
+          this.control.reset(this.originalValue);
+        }
+      });
+  }
+
+  ngOnDestroy() {
+    this.isDestroyed$.next(true);
+    this.isDestroyed$.complete();
+  }
+}

--- a/components/automate-ui/tslint.json
+++ b/components/automate-ui/tslint.json
@@ -144,12 +144,7 @@
       "check-type",
       "check-type-operator"
     ],
-    "directive-selector": [
-      true,
-      ["attribute", "element"],
-      ["app", "chef"],
-      ["camelCase", "kebab-case"]
-    ],
+    "directive-selector": false,
     "component-selector": [
       true,
       ["element", "attribute"],


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Adds a `FormControlDirective` that matches any form inputs utilizing
`[formControl]` or `[formControlName]` bindings. This directive keeps a reference to the control's initial value and ensures that a dirty control is marked as pristine if/whenever the value changes back to its initial value.

<img src="https://user-images.githubusercontent.com/479121/62528777-a174bc80-b7fa-11e9-8e0c-585198346ba5.gif" width="288" />

### :chains: Related Resources

https://github.com/chef/automate/pull/1115

### :+1: Definition of Done

Form controls are marked as pristine whenever its value is equal to its initial value.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?