### PR TITLE
Changing frontend certs correctly renders config before reload

### DIFF
--- a/components/automate-load-balancer/habitat/config/render-certs.sh
+++ b/components/automate-load-balancer/habitat/config/render-certs.sh
@@ -1,0 +1,18 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash
+
+exec 2>&1
+# This file is for openssl to put random bits into when doing key generation.
+export RANDFILE="{{pkg.svc_data_path}}/.rnd"
+touch $RANDFILE
+
+# Hab does not support dynamic templates so we're iterating over our frontend_tls
+# and generating certificate and key files for each server listener in nginx.
+{{#each cfg.frontend_tls as |tls| ~}}
+cert_file="{{../pkg.svc_data_path}}/{{tls.server_name}}.cert"
+key_file="{{../pkg.svc_data_path}}/{{tls.server_name}}.key"
+echo "{{~ tls.cert ~}}" > $cert_file
+echo "{{~ tls.key ~}}" > $key_file
+
+chmod 0600 $cert_file $key_file
+{{/each ~}}
+

--- a/components/automate-load-balancer/habitat/hooks/reload
+++ b/components/automate-load-balancer/habitat/hooks/reload
@@ -1,4 +1,6 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash -ex
 
+source {{pkg.svc_config_path}}/render-certs.sh
+
 PID=$(cat {{pkg.svc_var_path}}/pid)
 kill -HUP "$PID"

--- a/components/automate-load-balancer/habitat/hooks/run
+++ b/components/automate-load-balancer/habitat/hooks/run
@@ -3,19 +3,6 @@
 exec 2>&1
 {{pkgPathFor "chef/mlsa"}}/bin/accept {{cfg.mlsa.accept}}
 
-# This file is for openssl to put random bits into when doing key generation.
-export RANDFILE="{{pkg.svc_data_path}}/.rnd"
-touch $RANDFILE
-
-# Hab does not support dynamic templates so we're iterating over our frontend_tls
-# and generating certificate and key files for each server listener in nginx.
-{{#each cfg.frontend_tls as |tls| ~}}
-cert_file="{{../pkg.svc_data_path}}/{{tls.server_name}}.cert"
-key_file="{{../pkg.svc_data_path}}/{{tls.server_name}}.key"
-echo "{{~ tls.cert ~}}" > $cert_file
-echo "{{~ tls.key ~}}" > $key_file
-
-chmod 0600 $cert_file $key_file
-{{/each ~}}
+source {{pkg.svc_config_path}}/render-certs.sh
 
 exec {{pkgPathFor "core/nginx"}}/bin/nginx -c {{pkg.svc_config_path}}/nginx.conf


### PR DESCRIPTION
We were not rendering the certificates before HUPing nginx. This meant
that any changes to the frontend certificates required the user to
manually restore automate/nginx.
