### PR TITLE
Run compliance reindex calls async

### DIFF
--- a/components/compliance-service/reporting/relaxting/migrations_from_a1.go
+++ b/components/compliance-service/reporting/relaxting/migrations_from_a1.go
@@ -28,16 +28,16 @@ func (migratable A1ElasticSearchIndices) migrateProfiles() error {
 	defer util.TimeTrack(time.Now(), myName)
 
 	src := a1IndexPrefix + "profiles"
-	reindexResp, _, err := migratable.backend.reindex(src, CompProfilesIndex, a1ProfilesMigrationScript, "inspec_profile")
+	indexExists, err := migratable.backend.reindex(src, CompProfilesIndex, a1ProfilesMigrationScript, "inspec_profile")
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("%s unable to reindex %s", src, myName))
 	}
 
-	if reindexResp == nil {
+	if !indexExists {
 		//there must not have been an alias to named compliance-profiles
 		//so let's see if there is an index named compliance-profiles-2 and if so reindex that
 		src := a1IndexPrefix + "profiles-2"
-		_, _, err = migratable.backend.reindex(src, CompProfilesIndex, a1ProfilesMigrationScript, "inspec_profile")
+		_, err = migratable.backend.reindex(src, CompProfilesIndex, a1ProfilesMigrationScript, "inspec_profile")
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("%s unable to reindex %s", src, myName))
 		}

--- a/components/compliance-service/reporting/relaxting/migrations_from_a2_v1.go
+++ b/components/compliance-service/reporting/relaxting/migrations_from_a2_v1.go
@@ -27,7 +27,7 @@ func (migratable A2V1ElasticSearchIndices) migrateProfiles() error {
 	defer util.TimeTrack(time.Now(), myName)
 
 	src := a2V1IndexPrefix + "profiles"
-	_, _, err := migratable.backend.reindex(src, CompProfilesIndex, noScript, "doc")
+	_, err := migratable.backend.reindex(src, CompProfilesIndex, noScript, "doc")
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("%s unable to reindex %s", src, myName))
 	}

--- a/components/compliance-service/reporting/relaxting/migrations_from_a2_v2.go
+++ b/components/compliance-service/reporting/relaxting/migrations_from_a2_v2.go
@@ -49,7 +49,7 @@ func (migratable A2V2ElasticSearchIndices) migrateProfiles() error {
 	defer util.TimeTrack(time.Now(), myName)
 
 	src := a2V2IndexPrefix + "profiles"
-	_, _, err := migratable.backend.reindex(src, CompProfilesIndex, noScript, "_doc")
+	_, err := migratable.backend.reindex(src, CompProfilesIndex, noScript, "_doc")
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("%s unable to reindex %s", src, myName))
 	}

--- a/components/compliance-service/reporting/relaxting/migrations_from_a2_v3.go
+++ b/components/compliance-service/reporting/relaxting/migrations_from_a2_v3.go
@@ -33,14 +33,14 @@ func (migratable A2V3ElasticSearchIndices) migrateTimeSeries(dateToMigrate time.
 
 	src := fmt.Sprintf("%ss-%s", a2V3IndexPrefix, dateToMigrateAsString)
 	dest := fmt.Sprintf("%s%s", CompDailySumIndexPrefix, dateToMigrateAsString)
-	_, _, err := migratable.backend.reindex(src, dest, noScript, "_doc")
+	_, err := migratable.backend.reindex(src, dest, noScript, "_doc")
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("%s unable to reindex %s", src, myName))
 	}
 
 	src = fmt.Sprintf("%sr-%s", a2V3IndexPrefix, dateToMigrateAsString)
 	dest = fmt.Sprintf("%s%s", CompDailyRepIndexPrefix, dateToMigrateAsString)
-	_, _, err = migratable.backend.reindex(src, dest, noScript, "_doc")
+	_, err = migratable.backend.reindex(src, dest, noScript, "_doc")
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("%s unable to reindex %s", src, myName))
 	}

--- a/components/compliance-service/reporting/relaxting/util.go
+++ b/components/compliance-service/reporting/relaxting/util.go
@@ -73,6 +73,22 @@ func (backend *ES2Backend) ES2Client() (*elastic.Client, error) {
 	return esClient, err
 }
 
+func (backend *ES2Backend) ReindexStatus(ctx context.Context, taskID string) (bool, error) {
+	tasksGetTaskResponse, err := elastic.NewTasksGetTaskService(esClient).
+		TaskId(taskID).
+		WaitForCompletion(false).
+		Do(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if tasksGetTaskResponse.Task == nil {
+		return false, fmt.Errorf("ReindexStatus: task %s not found", taskID)
+	}
+
+	return tasksGetTaskResponse.Completed, nil
+}
+
 // Removes element with index i from array arr
 func Remove(arr *[]string, i int) {
 	if len(*arr) <= i {


### PR DESCRIPTION
Switched to async ElasticSearch reindex calls to avoid gateway timeouts on long running reindexes.