### PR TITLE
Not returning an error when the Task info is nil

### DIFF
--- a/components/compliance-service/reporting/relaxting/util.go
+++ b/components/compliance-service/reporting/relaxting/util.go
@@ -82,10 +82,6 @@ func (backend *ES2Backend) ReindexStatus(ctx context.Context, taskID string) (bo
 		return false, err
 	}
 
-	if tasksGetTaskResponse.Task == nil {
-		return false, fmt.Errorf("ReindexStatus: task %s not found", taskID)
-	}
-
 	return tasksGetTaskResponse.Completed, nil
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Some Elasticsearch instances do not return task info in the response when checking if a task is complete. This is not an error when this happens. 

Initial PR https://github.com/chef/automate/pull/1175/files