### PR TITLE
Updating Elasticsearch reindexes to async

### DIFF
--- a/components/ingest-service/backend/elastic/migration.go
+++ b/components/ingest-service/backend/elastic/migration.go
@@ -122,7 +122,6 @@ func (es *Backend) ReindexInsightstoActions(ctx context.Context,
 			"cookbook", "role", "node", "group", "organization", "user")
 
 	startTaskResult, err := es.client.Reindex().
-		WaitForCompletion(true).
 		Source(reindexSource).
 		DestinationIndexAndType(actionsIndexName, "actions").
 		Script(esScript).
@@ -179,7 +178,6 @@ func (es *Backend) ReindexInsightstoConvergeHistory(ctx context.Context, insight
 		Query(boolQuery)
 
 	startTaskResult, err := es.client.Reindex().
-		WaitForCompletion(true).
 		Source(reindexSource).
 		DestinationIndexAndType(convergeHistoryIndexName, "converge").
 		Script(esScript).
@@ -239,7 +237,6 @@ func (es *Backend) ReindexNodeStateA1(ctx context.Context, a1NodeStateIndexName 
 	`
 	esScript := elastic.NewScript(script).Lang("painless")
 	startTaskResult, err := es.client.Reindex().
-		WaitForCompletion(true).
 		SourceIndex(a1NodeStateIndexName).
 		DestinationIndex(mappings.NodeState.Index).
 		Script(esScript).


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
All Elasticsearch reindexes should be done with async. This change is needed because all elasticsearch requests go through the automate-es-gateway which adds a 60-second timeout. 

### :chains: Related Resources
#557

### :+1: Definition of Done
The ingest-service does not have any reindexes that are not using the DoAsync function. 