### PR TITLE
Remove non async reindexes

### DIFF
--- a/components/automate-deployment/pkg/a1stub/server.go
+++ b/components/automate-deployment/pkg/a1stub/server.go
@@ -325,6 +325,8 @@ func setupEsAPIServer() *http.Server {
 		mux.HandleFunc(path, handleEsIndicesStatsStore)
 	}
 
+	mux.HandleFunc("/elasticsearch/_tasks/", handleEsTaskStatus)
+
 	mux.HandleFunc("/", debug404Handler)
 
 	esAPIServer = &http.Server{
@@ -504,6 +506,11 @@ func handleEsSnapshotStatus(w http.ResponseWriter, r *http.Request) {
 func handleEsIndicesSettings(w http.ResponseWriter, r *http.Request) {
 	thPrintf("sending indicesSettingsJSON\n")
 	fmt.Fprint(w, indicesSettingsJSON())
+}
+
+func handleEsTaskStatus(w http.ResponseWriter, r *http.Request) {
+	thPrintf("sending task complete\n")
+	fmt.Fprint(w, `{"completed": true}`)
 }
 
 func handleEsIndexCreate(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
All Elasticsearch reindexes should be done with async. This change is needed because all elasticsearch requests go through the automate-es-gateway which adds a 60-second timeout.

### :chains: Related Resources

https://github.com/chef/automate/pull/1177