### PR TITLE
set the background for the page body of different pages

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.html
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.html
@@ -5,7 +5,7 @@
       <chef-subheading>SSH, WinRM, and sudo credentials to remotely access nodes.</chef-subheading>
     </chef-page-header>
 
-    <div class="credentials-list-body">
+    <div class="page-body">
       <chef-toolbar>
         <app-authorized [anyOf]="['/secrets', 'post']">
           <div *ngIf="credentialsList.items.length === 0" class="empty-state">

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.scss
@@ -1,15 +1,11 @@
 @import "~styles/variables";
 
-.credentials-list-body {
-  margin: $content-container-padding;
-}
-
 .empty-state {
   text-align: center;
 
   p {
     font-size: 18px;
     font-weight: 400;
-    margin-top: 70px;
+    margin-top: 42px;
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list.scss
@@ -1,5 +1,10 @@
 @import "~styles/variables";
 
+.page-body {
+  padding-top: 1px;
+  background-color: $page-body-background;
+}
+
 .empty-state {
   text-align: center;
 

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.scss
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.scss
@@ -6,6 +6,11 @@ chef-table {
   }
 }
 
+.page-body {
+  padding-top: 1px;
+  background-color: $page-body-background;
+}
+
 .empty-state {
   text-align: center;
 

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.scss
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.scss
@@ -32,3 +32,8 @@ chef-checkbox {
     padding-bottom: 0;
   }
 }
+
+.page-body {
+  padding-top: 1px;
+  background-color: $page-body-background;
+}

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.scss
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.scss
@@ -141,3 +141,8 @@ app-client-runs-search-filters {
 #download-modal {
   text-align: center;
 }
+
+.page-body {
+  padding-top: 1px;
+  background-color: $page-body-background;
+}

--- a/components/automate-ui/src/app/pages/event-feed/event-feed.component.scss
+++ b/components/automate-ui/src/app/pages/event-feed/event-feed.component.scss
@@ -156,3 +156,8 @@ chef-loading-spinner {
   display: block;
   text-align: center;
 }
+
+.page-body {
+  padding-top: 1px;
+  background-color: $page-body-background;
+}

--- a/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.scss
+++ b/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.scss
@@ -1,3 +1,5 @@
+@import "~styles/variables";
+
 header {
   padding: 1em 0 0 35px;
 }
@@ -21,4 +23,9 @@ chef-td.controls {
 
 chef-card {
   margin-bottom: 35px;
+}
+
+.page-body {
+  padding-top: 1px;
+  background-color: $page-body-background;
 }

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.scss
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.scss
@@ -188,3 +188,8 @@ chef-icon#sort-asc {
     margin-top: 42px;
   }
 }
+
+.page-body {
+  padding-top: 1px;
+  background-color: $page-body-background;
+}

--- a/components/automate-ui/src/app/pages/policy/list/policy-list.component.scss
+++ b/components/automate-ui/src/app/pages/policy/list/policy-list.component.scss
@@ -19,3 +19,9 @@ chef-table {
   }
 
 }
+
+.page-body {
+  padding-top: 1px;
+  background-color: $page-body-background;
+}
+

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.scss
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.scss
@@ -21,3 +21,8 @@ chef-table {
     margin-top: 18px;
   }
 }
+
+.page-body {
+  padding-top: 1px;
+  background-color: $page-body-background;
+}

--- a/components/automate-ui/src/app/pages/roles/list/roles-list.component.scss
+++ b/components/automate-ui/src/app/pages/roles/list/roles-list.component.scss
@@ -1,0 +1,6 @@
+@import "~styles/variables";
+
+.page-body {
+  padding-top: 1px;
+  background-color: $page-body-background;
+}

--- a/components/automate-ui/src/app/pages/team-management/team-management.component.scss
+++ b/components/automate-ui/src/app/pages/team-management/team-management.component.scss
@@ -13,3 +13,8 @@ chef-table {
     justify-content: flex-end;
   }
 }
+
+.page-body {
+  padding-top: 1px;
+  background-color: $page-body-background;
+}

--- a/components/automate-ui/src/app/pages/user-management/user-management.component.scss
+++ b/components/automate-ui/src/app/pages/user-management/user-management.component.scss
@@ -30,3 +30,8 @@ chef-modal {
     text-align: center;
   }
 }
+
+.page-body {
+  padding-top: 1px;
+  background-color: $page-body-background;
+}

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -30,8 +30,6 @@ html, body {
 
 .page-body {
   padding: $content-container-padding;
-  padding-top: 1px;
-  background-color: $page-body-background;
 
   .is-empty {
     border: 1px dashed lighten($chef-dark-grey, 10%);

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -30,6 +30,8 @@ html, body {
 
 .page-body {
   padding: $content-container-padding;
+  padding-top: 1px;
+  background-color: $page-body-background;
 
   .is-empty {
     border: 1px dashed lighten($chef-dark-grey, 10%);

--- a/components/automate-ui/src/styles/_variables.scss
+++ b/components/automate-ui/src/styles/_variables.scss
@@ -54,5 +54,5 @@ $global-radius: 4px;
 $sidebar-right-width: 200px;
 // the padding on the content pane, besides the left sidebar
 $content-container-padding: 35px;
-$page-body-background: #fff;
+$page-body-background: #FFF;
 

--- a/components/automate-ui/src/styles/_variables.scss
+++ b/components/automate-ui/src/styles/_variables.scss
@@ -54,3 +54,5 @@ $global-radius: 4px;
 $sidebar-right-width: 200px;
 // the padding on the content pane, besides the left sidebar
 $content-container-padding: 35px;
+$page-body-background: #fff;
+


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description: 
We are working to align all of the pages in Automate with the new designs that are present on the Applications page. This issue is a small step towards that goal—it involves setting the background colors of page-body to #fff on our list pages that do not have tabs.

- /event-feed
- /client-runs
- /settings/notifications
- /settings/node-integrations
- /settings/node-credentials
- /settings/node-lifecycle
- /settings/users
- /settings/teams
- /settings/tokens
- /settings/policies
- /settings/roles
- /settings/projects

### :chains: Related Resources
https://github.com/chef/automate/issues/1155
### :+1: Definition of Done
I have added some CSS changes for the page body.
### :camera: Screenshots
![Screenshot from 2019-08-07 13-40-22](https://user-images.githubusercontent.com/12297653/62606071-07effc80-b919-11e9-8f48-73fff5d68d59.png)
![Screenshot from 2019-08-07 13-40-29](https://user-images.githubusercontent.com/12297653/62606082-0c1c1a00-b919-11e9-893c-160bb14c67b4.png)
![Screenshot from 2019-08-07 13-40-47](https://user-images.githubusercontent.com/12297653/62606090-10483780-b919-11e9-8434-07e68f931b0d.png)
