### PR TITLE
Suppress password error upon open

### DIFF
--- a/components/automate-ui/src/app/helpers/auth/validator.ts
+++ b/components/automate-ui/src/app/helpers/auth/validator.ts
@@ -1,0 +1,35 @@
+import { FormControl, FormGroup } from '@angular/forms';
+
+// Custom validators for use on Angular Forms.
+export class ChefValidators {
+
+  // Typical use of matchFieldValidator is confirming a doubly-entered password
+  public static matchFieldValidator(otherField: string) {
+    return (control: FormControl): { [key: string]: any } => {
+      if (!control.root || !(<FormGroup>control.root).controls) {
+        return null;
+      }
+      const valid = control.value === (<FormGroup>control.root).controls[otherField].value;
+      return valid ? null : {
+        'noMatch': { value: control }
+      };
+    };
+  }
+
+  // Validates length but only for non-admin users; admins are exempt from the check.
+  public static nonAdminLengthValidator(isAdminView: boolean, minLength: number) {
+    return (control: FormControl): { [key: string]: any } => {
+      // Don't error if we are in admin view.
+      if (isAdminView) {
+        return null;
+      }
+      if (!control.value) {
+        return { 'required': { value: control } };
+      }
+      if (control.value.length < minLength) {
+        return { 'minlength': { value: control } };
+      }
+      return null;
+    };
+  }
+}

--- a/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
@@ -25,7 +25,7 @@
       <span class="label">Password <span aria-hidden="true">*</span></span>
       <input chefInput formControlName="password" type="password">
     </label>
-    <chef-error *ngIf="createUserForm.get('password').hasError('required') || (createUserForm.get('password').hasError('pattern')) && createUserForm.get('password').dirty">
+    <chef-error *ngIf="(createUserForm.get('password').hasError('required') || createUserForm.get('password').hasError('pattern')) && createUserForm.get('password').dirty">
       Password is required.
     </chef-error>
     <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && createUserForm.get('password').dirty">

--- a/components/automate-ui/src/app/pages/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/pages/user-management/user-management.component.ts
@@ -6,23 +6,13 @@ import { takeUntil, map } from 'rxjs/operators';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Regex } from 'app/helpers/auth/regex';
+import { ChefValidators } from 'app/helpers/auth/validator';
 import { EntityStatus, loading } from 'app/entities/entities';
 import { allUsers, userStatus } from 'app/entities/users/user.selectors';
 import {
   CreateUser, DeleteUser, GetUsers, CreateUserPayload
 } from 'app/entities/users/user.actions';
 import { User } from 'app/entities/users/user.model';
-
-function matchFieldValidator() {
-    return (control): { [key: string]: any } => {
-      if (!control.root || !control.root.controls) {
-        return null;
-      }
-      const valid = control.value === control.root.controls.password.value;
-      return valid ? null : { 'noMatch': { value: control }
-    };
-  };
-}
 
 // pattern for valid usernames
 const USERNAME_PATTERN = '[0-9A-Za-z_@.+-]+';
@@ -83,7 +73,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
         Validators.required,
         Validators.pattern(Regex.patterns.NON_BLANK),
         Validators.minLength(8)]],
-      confirmPassword: ['', [Validators.required, matchFieldValidator()]]
+      confirmPassword: ['', [Validators.required, ChefValidators.matchFieldValidator('password')]]
     });
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Recent code changes inadvertently made the error-pop up for the auth password field when creating a user open immediately upon the form opening:

![image](https://user-images.githubusercontent.com/6817500/62655553-19d0a000-b917-11e9-91fe-99195e3d3a7d.png)

This PR fixes that.

Also did a quick drive-by to DRY up some validator code.

### :+1: Definition of Done

Opening the form does not show that pop-up error.

### :athletic_shoe: How to Build and Test the Change

Rebuild automate-ui.
Go to Settings >> Users >> Create User.