### PR TITLE
[automate-854] Subpage routing for projects

### DIFF
--- a/components/automate-ui/src/app/pages/policy/details/policy-details.component.html
+++ b/components/automate-ui/src/app/pages/policy/details/policy-details.component.html
@@ -24,7 +24,7 @@
       </table>
         <chef-tab-selector (change)="onSelectedTab($event)" [value]="tabValue">
           <chef-option value='definition'>Definition</chef-option>
-          <chef-option value='members' routerLink="./" fragment="members">Members</chef-option>
+          <chef-option value='members'>Members</chef-option>
         </chef-tab-selector>
       </chef-page-header>
     <section class="page-body">

--- a/components/automate-ui/src/app/pages/policy/details/policy-details.component.html
+++ b/components/automate-ui/src/app/pages/policy/details/policy-details.component.html
@@ -22,59 +22,57 @@
           </tr>
         </tbody>
       </table>
-        <chef-tab-selector (change)="onSelectedTab($event)" [value]="tabValue">
-          <chef-option value='definition'>Definition</chef-option>
-          <chef-option value='members'>Members</chef-option>
-        </chef-tab-selector>
-      </chef-page-header>
-    <section class="page-body">
-      <ng-container *ngIf="tabValue === 'definition'">
-        <chef-toolbar>
-          <chef-clipboard value={{policyJSON}} label="Copy Definition" icon=""></chef-clipboard>
-        </chef-toolbar>
-        <section id="json-bg">
-          <chef-snippet [code]="policy | json" lang="json"></chef-snippet>
-        </section>
-      </ng-container>
-      <ng-container *ngIf="tabValue === 'members'">
-        <div *ngIf="(members$ | async)?.length === 0" class="empty-state">
-          <p>Add some members to get started!</p>
+      <chef-tab-selector (change)="onSelectedTab($event)" [value]="tabValue">
+        <chef-option value='definition'>Definition</chef-option>
+        <chef-option value='members'>Members</chef-option>
+      </chef-tab-selector>
+    </chef-page-header>
+    <section class="page-body" *ngIf="tabValue === 'definition'">
+      <chef-toolbar>
+        <chef-clipboard value={{policyJSON}} label="Copy Definition" icon=""></chef-clipboard>
+      </chef-toolbar>
+      <section id="json-bg">
+        <chef-snippet [code]="policy | json" lang="json"></chef-snippet>
+      </section>
+    </section>
+    <section class="page-body" *ngIf="tabValue === 'members'">
+      <div *ngIf="(members$ | async)?.length === 0" class="empty-state">
+        <p>Add some members to get started!</p>
+      </div>
+      <chef-toolbar>
+        <div [ngClass]="(members$ | async)?.length === 0 ? 'empty-state' : ''">
+          <chef-button primary [routerLink]="['/settings', 'policies', policy?.id, 'add-members']">Add Members</chef-button>
         </div>
-        <chef-toolbar>
-          <div [ngClass]="(members$ | async)?.length === 0 ? 'empty-state' : ''">
-            <chef-button primary [routerLink]="['/settings', 'policies', policy?.id, 'add-members']">Add Members</chef-button>
-          </div>
-        </chef-toolbar>
-        <chef-table *ngIf="(members$ | async)?.length > 0">
-          <chef-thead>
-            <chef-tr>
-              <chef-th>ID</chef-th>
-              <chef-th>Type</chef-th>
-              <chef-th></chef-th>
-            </chef-tr>
-          </chef-thead>
-          <chef-tbody>
-            <chef-tr *ngFor="let member of members$ | async">
-              <chef-td>
-                <a *ngIf="memberURLs.hasOwnProperty(member.name)" [routerLink]="memberURLs[member.name]">
-                  {{ member.displayName }}
-                </a>
-                <ng-container *ngIf="!memberURLs.hasOwnProperty(member.name)">
-                  {{ member.displayName }}
-                </ng-container>
-              </chef-td>
-              <chef-td>
-                {{ member.displayType }}
-              </chef-td>
-              <chef-td class="three-dot-entry">
-                <chef-control-menu>
-                  <chef-option (click)="removeMember(member)">Remove Member</chef-option>
-                </chef-control-menu>
-              </chef-td>
-            </chef-tr>
-          </chef-tbody>
-        </chef-table>
-      </ng-container>
+      </chef-toolbar>
+      <chef-table *ngIf="(members$ | async)?.length > 0">
+        <chef-thead>
+          <chef-tr>
+            <chef-th>ID</chef-th>
+            <chef-th>Type</chef-th>
+            <chef-th></chef-th>
+          </chef-tr>
+        </chef-thead>
+        <chef-tbody>
+          <chef-tr *ngFor="let member of members$ | async">
+            <chef-td>
+              <a *ngIf="memberURLs.hasOwnProperty(member.name)" [routerLink]="memberURLs[member.name]">
+                {{ member.displayName }}
+              </a>
+              <ng-container *ngIf="!memberURLs.hasOwnProperty(member.name)">
+                {{ member.displayName }}
+              </ng-container>
+            </chef-td>
+            <chef-td>
+              {{ member.displayType }}
+            </chef-td>
+            <chef-td class="three-dot-entry">
+              <chef-control-menu>
+                <chef-option (click)="removeMember(member)">Remove Member</chef-option>
+              </chef-control-menu>
+            </chef-td>
+          </chef-tr>
+        </chef-tbody>
+      </chef-table>
     </section>
   </main>
 </div>

--- a/components/automate-ui/src/app/pages/policy/details/policy-details.component.ts
+++ b/components/automate-ui/src/app/pages/policy/details/policy-details.component.ts
@@ -31,7 +31,7 @@ export class PolicyDetailsComponent implements OnInit, OnDestroy {
   public policyJSON: string;
   public members$: Observable<Member[]>;
   public tabValue: PolicyTabName = 'definition';
-  public url: string;
+  private url: string;
   // Map of local user and team member IDs to URLs.
   // Will not contain LDAP, SAML, or * members.
   private memberURLs: { [id: string]: string[] } = {};

--- a/components/automate-ui/src/app/pages/policy/details/policy-details.component.ts
+++ b/components/automate-ui/src/app/pages/policy/details/policy-details.component.ts
@@ -111,7 +111,7 @@ export class PolicyDetailsComponent implements OnInit, OnDestroy {
 
   onSelectedTab(event: { target: { value: PolicyTabName } } ): void {
     this.tabValue = event.target.value;
-    // Current URL sans any now outdated fragment.
+    // Drop the previous fragment and add the incoming fragment.
     this.router.navigate([this.url.split('#')[0]], { fragment: event.target.value });
   }
 }

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -25,7 +25,7 @@
         <chef-option value='details'>Details</chef-option>
       </chef-tab-selector>
     </chef-page-header>
-    <section class="page-body" [hidden]="showTab('rules')">
+    <section class="page-body" *ngIf="tabValue === 'details'">
       <form [formGroup]="projectForm">
         <chef-form-field id="update-name">
           <label>
@@ -53,7 +53,7 @@
         </div>
       </form>
     </section>
-    <section class="page-body" [hidden]="showTab('details')">
+    <section class="page-body" *ngIf="tabValue === 'rules'">
       <ng-container *ngIf="showRulesTable()">
         <chef-toolbar>
           <app-authorized [allOf]="['/iam/v2beta/projects', 'post']">

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -20,7 +20,7 @@
           </tr>
         </tbody>
       </table>
-      <chef-tab-selector [value]="selectedTab" (change)="onTabChange($event)">
+      <chef-tab-selector [value]="tabValue" (change)="onSelectedTab($event)">
         <chef-option value='rules'>Ingest Rules</chef-option>
         <chef-option value='details'>Details</chef-option>
       </chef-tab-selector>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -145,11 +145,11 @@ describe('ProjectDetailsComponent', () => {
     });
 
     it('shows/hides sections when based on selection', () => {
-      component.onTabChange({ target: { value: 'details' } });
+      component.onSelectedTab({ target: { value: 'details' } });
       expect(component.showTab('details')).toBeTruthy();
       expect(component.showTab('rules')).toBeFalsy();
 
-      component.onTabChange({ target: { value: 'rules' } });
+      component.onSelectedTab({ target: { value: 'rules' } });
       expect(component.showTab('rules')).toBeTruthy();
       expect(component.showTab('details')).toBeFalsy();
     });
@@ -175,10 +175,10 @@ describe('ProjectDetailsComponent', () => {
     });
 
     it('shows/hides sections when based on selection', () => {
-      component.onTabChange({ target: { value: 'details' } });
+      component.onSelectedTab({ target: { value: 'details' } });
       expect(component.showTab('rules')).toBeFalsy();
       expect(component.showTab('details')).toBeTruthy();
-      component.onTabChange({ target: { value: 'rules' } });
+      component.onSelectedTab({ target: { value: 'rules' } });
       expect(component.showTab('rules')).toBeTruthy();
       expect(component.showTab('details')).toBeFalsy();
     });

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -61,7 +61,7 @@ describe('ProjectDetailsComponent', () => {
           selector: 'chef-toolbar',
           template: '<ng-content></ng-content>'
         }),
-         MockComponent({
+        MockComponent({
           selector: 'app-authorized',
           inputs: ['allOf', 'not'],
           template: '<ng-content></ng-content>'
@@ -73,9 +73,9 @@ describe('ProjectDetailsComponent', () => {
           outputs: ['close', 'deleteClicked']
         }),
         MockComponent({ selector: 'chef-control-menu' }),
-        MockComponent({ selector: 'chef-form-field'}),
-        MockComponent({ selector: 'chef-breadcrumbs'}),
-        MockComponent({ selector: 'chef-error'}),
+        MockComponent({ selector: 'chef-form-field' }),
+        MockComponent({ selector: 'chef-breadcrumbs' }),
+        MockComponent({ selector: 'chef-error' }),
         MockComponent({ selector: 'chef-breadcrumb', inputs: ['link'] }),
         MockComponent({ selector: 'chef-tab-selector', inputs: ['value'] }),
         MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),
@@ -139,19 +139,16 @@ describe('ProjectDetailsComponent', () => {
       component.rules = [];
     });
 
-   it('defaults to showing rules section', () => {
-      expect(component.showTab('rules')).toBeTruthy();
-      expect(component.showTab('details')).toBeFalsy();
+    it('defaults to showing rules section', () => {
+      expect(component.tabValue).toBe('rules');
     });
 
     it('shows/hides sections when based on selection', () => {
       component.onSelectedTab({ target: { value: 'details' } });
-      expect(component.showTab('details')).toBeTruthy();
-      expect(component.showTab('rules')).toBeFalsy();
+      expect(component.tabValue).toBe('details');
 
       component.onSelectedTab({ target: { value: 'rules' } });
-      expect(component.showTab('rules')).toBeTruthy();
-      expect(component.showTab('details')).toBeFalsy();
+      expect(component.tabValue).toBe('rules');
     });
 
     it('does not display rule table', () => {
@@ -170,17 +167,14 @@ describe('ProjectDetailsComponent', () => {
     });
 
     it('defaults to showing rules section', () => {
-      expect(component.showTab('rules')).toBeTruthy();
-      expect(component.showTab('details')).toBeFalsy();
+      expect(component.tabValue).toBe('rules');
     });
 
     it('shows/hides sections when based on selection', () => {
       component.onSelectedTab({ target: { value: 'details' } });
-      expect(component.showTab('rules')).toBeFalsy();
-      expect(component.showTab('details')).toBeTruthy();
+      expect(component.tabValue).toBe('details');
       component.onSelectedTab({ target: { value: 'rules' } });
-      expect(component.showTab('rules')).toBeTruthy();
-      expect(component.showTab('details')).toBeFalsy();
+      expect(component.tabValue).toBe('rules');
     });
 
     it('displays rule table', () => {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -33,8 +33,8 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   public saveSuccessful = false;
   public isChefManaged = false;
   public rules: Rule[] = [];
-  public selectedTab: ProjectTabName = 'rules';
   public ruleToDelete: Rule;
+  public tabValue: ProjectTabName = 'rules';
   public url: string;
   public deleteModalVisible = false;
   public createModalVisible = false;
@@ -59,7 +59,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
         this.url = url;
         const [, fragment] = url.split('#');
         // goes to #rules if (1) explicit #definition, (2) no fragment, or (3) invalid fragment
-        this.selectedTab = (fragment === 'details') ? 'details' : 'rules';
+        this.tabValue = (fragment === 'details') ? 'details' : 'rules';
      });
 
     this.projectForm = this.fb.group({
@@ -110,14 +110,14 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
     this.saveSuccessful = false;
   }
 
-  onTabChange(event: { target: { value: ProjectTabName } }) {
-    this.selectedTab = event.target.value;
+  onSelectedTab(event: { target: { value: ProjectTabName } }) {
+    this.tabValue = event.target.value;
     // Current URL sans any now outdated fragment.
     this.router.navigate([this.url.split('#')[0]], { fragment: event.target.value });
   }
 
   showTab(tabName: ProjectTabName): boolean {
-    return this.selectedTab === tabName;
+    return this.tabValue === tabName;
   }
 
   showFirstRuleMessage(): boolean {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -116,10 +116,6 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
     this.router.navigate([this.url.split('#')[0]], { fragment: event.target.value });
   }
 
-  showTab(tabName: ProjectTabName): boolean {
-    return this.tabValue === tabName;
-  }
-
   showFirstRuleMessage(): boolean {
     return this.rules.length === 0;
   }

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -33,9 +33,9 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   public saveSuccessful = false;
   public isChefManaged = false;
   public rules: Rule[] = [];
-  public ruleToDelete: Rule;
   public tabValue: ProjectTabName = 'rules';
   public url: string;
+  public ruleToDelete: Rule;
   public deleteModalVisible = false;
   public createModalVisible = false;
   public createProjectForm: FormGroup;
@@ -112,7 +112,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
 
   onSelectedTab(event: { target: { value: ProjectTabName } }) {
     this.tabValue = event.target.value;
-    // Current URL sans any now outdated fragment.
+    // Drop the previous fragment and add the incoming fragment.
     this.router.navigate([this.url.split('#')[0]], { fragment: event.target.value });
   }
 

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Subject, combineLatest } from 'rxjs';
 import { filter, map, pluck, takeUntil } from 'rxjs/operators';
 import { identity, some } from 'lodash/fp';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { routeParams } from 'app/route.selectors';
+import { routeParams, routeURL } from 'app/route.selectors';
 import { Regex } from 'app/helpers/auth/regex';
 import { EntityStatus, loading } from 'app/entities/entities';
 import {
@@ -16,9 +17,7 @@ import { Project } from 'app/entities/projects/project.model';
 import { GetProject, UpdateProject } from 'app/entities/projects/project.actions';
 import { GetRulesForProject, DeleteRule } from 'app/entities/rules/rule.actions';
 import { Rule, RuleStatus } from 'app/entities/rules/rule.model';
-import {
-  allRules
-} from 'app/entities/rules/rule.selectors';
+import { allRules } from 'app/entities/rules/rule.selectors';
 
 export type ProjectTabName = 'rules' | 'details';
 
@@ -36,6 +35,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   public rules: Rule[] = [];
   public selectedTab: ProjectTabName = 'rules';
   public ruleToDelete: Rule;
+  public url: string;
   public deleteModalVisible = false;
   public createModalVisible = false;
   public createProjectForm: FormGroup;
@@ -47,10 +47,20 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
 
   constructor(
     private fb: FormBuilder,
-    private store: Store<NgrxStateAtom>
+    private store: Store<NgrxStateAtom>,
+    private router: Router
+
   ) { }
 
   ngOnInit(): void {
+    // Populate our tabValue from the fragment.
+    this.store.select(routeURL).pipe(takeUntil(this.isDestroyed))
+      .subscribe((url: string) => {
+        this.url = url;
+        const [, fragment] = url.split('#');
+        // goes to #rules if (1) explicit #definition, (2) no fragment, or (3) invalid fragment
+        this.selectedTab = (fragment === 'details') ? 'details' : 'rules';
+     });
 
     this.projectForm = this.fb.group({
       // Must stay in sync with error checks in project-details.component.html
@@ -102,6 +112,8 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
 
   onTabChange(event: { target: { value: ProjectTabName } }) {
     this.selectedTab = event.target.value;
+    // Current URL sans any now outdated fragment.
+    this.router.navigate([this.url.split('#')[0]], { fragment: event.target.value });
   }
 
   showTab(tabName: ProjectTabName): boolean {

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -1,5 +1,4 @@
-<app-admin-sidebar>
-</app-admin-sidebar>
+<app-admin-sidebar></app-admin-sidebar>
 
 <div class="container">
   <main>
@@ -44,46 +43,42 @@
         <chef-option value='details'>Details</chef-option>
       </chef-tab-selector>
     </chef-page-header>
-    <ng-container *ngIf="tabValue === 'users'">
-      <section class="page-body" *ngIf="team.id">
-        <div id="users-list">
-          <div>
-            <!-- TODO remove [overridePermissionsCheck]=true once the UI is able to check specific objects
-            since the path to permission on here is /auth/teams/:id/users we'll have to show everything for now. -->
-            <app-user-table
-              [addButtonText]="addButtonText"
-              [removeText]="removeText"
-              [users$]="sortedUsers$"
-              [addButtonEnabled]=true
-              [baseUrl]="'/auth/users/' + team.id"
-              [overridePermissionsCheck]=true
-              (addClicked)="toggleUserMembershipView()"
-              (removeClicked)="removeUser($event)">
-            </app-user-table>
-          </div>
+    <section class="page-body" *ngIf="team.id && (tabValue === 'users')">
+      <div id="users-list">
+        <div>
+          <!-- TODO remove [overridePermissionsCheck]=true once the UI is able to check specific objects
+          since the path to permission on here is /auth/teams/:id/users we'll have to show everything for now. -->
+          <app-user-table
+            [addButtonText]="addButtonText"
+            [removeText]="removeText"
+            [users$]="sortedUsers$"
+            [addButtonEnabled]=true
+            [baseUrl]="'/auth/users/' + team.id"
+            [overridePermissionsCheck]=true
+            (addClicked)="toggleUserMembershipView()"
+            (removeClicked)="removeUser($event)">
+          </app-user-table>
         </div>
-      </section>
-    </ng-container>
-    <ng-container *ngIf="tabValue === 'details'">
-      <section class="page-body">
-        <form [formGroup]="updateNameForm">
-          <chef-form-field>
-            <label>{{ descriptionOrName | titlecase }} <span aria-hidden="true">*</span></label>
-            <input chefInput formControlName="name" type="text" (keyup)="keyPressed()">
-            <chef-error
-              *ngIf="(updateNameForm.get('name').hasError('required') || updateNameForm.get('name').hasError('pattern')) && updateNameForm.get('name').dirty">
-              {{ descriptionOrName | titlecase }} is required.
-            </chef-error>
-          </chef-form-field>
-        </form>
-          <chef-button [disabled]="isLoading || !updateNameForm.valid || updateNameForm.controls['name'].value === team.name"
-            primary inline (click)="saveNameChange()">
-            <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
-            <span *ngIf="saving">Saving...</span>
-            <span *ngIf="!saving">Save</span>
-          </chef-button>
-          <span *ngIf="saveSuccessful" id="save-note">All changes saved.</span>
-      </section>
-    </ng-container>
+      </div>
+    </section>
+    <section class="page-body" *ngIf="tabValue === 'details'">
+      <form [formGroup]="updateNameForm">
+        <chef-form-field>
+          <label>{{ descriptionOrName | titlecase }} <span aria-hidden="true">*</span></label>
+          <input chefInput formControlName="name" type="text" (keyup)="keyPressed()">
+          <chef-error
+            *ngIf="(updateNameForm.get('name').hasError('required') || updateNameForm.get('name').hasError('pattern')) && updateNameForm.get('name').dirty">
+            {{ descriptionOrName | titlecase }} is required.
+          </chef-error>
+        </chef-form-field>
+      </form>
+      <chef-button [disabled]="isLoading || !updateNameForm.valid || updateNameForm.controls['name'].value === team.name"
+        primary inline (click)="saveNameChange()">
+        <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
+        <span *ngIf="saving">Saving...</span>
+        <span *ngIf="!saving">Save</span>
+      </chef-button>
+      <span *ngIf="saveSuccessful" id="save-note">All changes saved.</span>
+    </section>
   </main>
 </div>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -40,8 +40,8 @@
       </table>
 
       <chef-tab-selector (change)="onSelectedTab($event)" [value]="tabValue">
-        <chef-option value='users' routerLink="./" fragment="users">Users</chef-option>
-        <chef-option value='details' routerLink="./" fragment="details">Details</chef-option>
+        <chef-option value='users'>Users</chef-option>
+        <chef-option value='details'>Details</chef-option>
       </chef-tab-selector>
     </chef-page-header>
     <ng-container *ngIf="tabValue === 'users'">

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -234,7 +234,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
 
   onSelectedTab(event: { target: { value: TeamTabName } }): void {
     this.tabValue = event.target.value;
-    // Current URL sans any now outdated fragment.
+    // Drop the previous fragment and add the incoming fragment.
     this.router.navigate([this.url.split('#')[0]], { fragment: event.target.value });
   }
 }

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -48,7 +48,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   public saving = false;
   public saveSuccessful = false;
   public tabValue: TeamTabName = 'users';
-  public url: string;
+  private url: string;
   public teamMembershipView = false;
 
   public team: Team;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This adds a bit of functionality so that when you navigate to different tabs within a project, it is reflected in the URL:

![image](https://user-images.githubusercontent.com/6817500/62668227-f4a45780-b93f-11e9-9a73-0009dc53e4e8.png)

While I was in there, I went through the other auth pages that already handle fragments (team-details and policy-details) and made all 3 use the same names, same structure, and same code patterns. (So the first commit did the task at hand; all the remaining commits did an orderly cleanup.)

There's a lot of whitespace changes, as I did some indentation updates, too. So probably easier to see the changes by following the commits.

### :chains: Related Resources
NA

### :+1: Definition of Done
Selecting a tab updates the URL to show the tab as a fragment.
1. Specifying `#rules` goes to the rules tab.
2. Specifying `#details` goes to the details tab.
3. Specifying no fragment goes to the rules tab (the first tab).
4. Specifying any other fragment (i.e. invalid fragment) goes to the rules tab (the first tab).

### :athletic_shoe: How to Build and Test the Change

rebuild automate-ui
Go to Settings >> Projects.
Add a project if necessary.
Select the project.
Select the tabs.