### PR TITLE
[issue 1185] autocomplete="off" and dirty check in id input

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -6,7 +6,7 @@
           <chef-form-field>
             <label>
               <span class="label">Name <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="name" type="text" (keyup)="handleNameInput($event)" id="name-input" data-cy="create-name">
+              <input chefInput formControlName="name" type="text" (keyup)="handleNameInput($event)" id="name-input" data-cy="create-name" autocomplete="off">
             </label>
             <chef-error *ngIf="(createForm.get('name').hasError('required') || createForm.get('name').hasError('pattern')) && createForm.get('name').dirty">
               Name is required.
@@ -18,7 +18,7 @@
           <chef-form-field>
             <label>
               <span class="label">ID <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="id" type="text" (keyup)="handleIDInput($event)" id="id-input" data-cy="create-id">
+              <input chefInput formControlName="id" type="text" (keyup)="handleIDInput($event)" id="id-input" data-cy="create-id" autocomplete="off"/>
             </label>
             <chef-error *ngIf="createForm?.controls['id'].hasError('maxlength')">
               ID must be 64 characters or less.

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -20,13 +20,13 @@
               <span class="label">ID <span aria-hidden="true">*</span></span>
               <input chefInput formControlName="id" type="text" (keyup)="handleIDInput($event)" id="id-input" data-cy="create-id" autocomplete="off"/>
             </label>
-            <chef-error *ngIf="createForm?.controls['id'].hasError('maxlength')">
+            <chef-error *ngIf="createForm.get('id').hasError('maxlength') && createForm.get('id').dirty">
               ID must be 64 characters or less.
             </chef-error>
-            <chef-error *ngIf="createForm?.controls['id'].hasError('required')">
+            <chef-error *ngIf="createForm.get('id').hasError('required') && createForm.get('id').dirty">
               ID is required.
             </chef-error>
-            <chef-error *ngIf="createForm?.controls['id'].hasError('pattern')">
+            <chef-error *ngIf="createForm.get('id').hasError('pattern') && createForm.get('id').dirty">
               Only lowercase letters, numbers, hyphens, and underscores are allowed.
             </chef-error>
             <chef-error *ngIf="conflictError">

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -30,7 +30,7 @@
               Only lowercase letters, numbers, hyphens, and underscores are allowed.
             </chef-error>
             <chef-error *ngIf="conflictError">
-              IDs must be unique--{{objectNoun}} with ID "{{createForm?.controls['id'].value}}" already exists.
+              {{ objectNoun | titlecase }} ID "{{createForm.get('id').value}}" already exists.
             </chef-error>
           </chef-form-field>
           <span class="detail">{{ objectNoun | titlecase }} IDs are unique, permanent, and cannot be changed later.</span>

--- a/components/automate-ui/src/app/page-components/create-v1-team-modal/create-v1-team-modal.component.html
+++ b/components/automate-ui/src/app/page-components/create-v1-team-modal/create-v1-team-modal.component.html
@@ -6,7 +6,7 @@
           <chef-form-field>
             <label>
               <span class="label">Name <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="name" type="text" (keyup)="handleNameInput($event)" id="name-input">
+              <input chefInput formControlName="name" type="text" (keyup)="handleNameInput($event)" id="name-input" autocomplete="off"/>
             </label>
             <chef-error *ngIf="(createForm.get('name').hasError('required') || createForm.get('name').hasError('pattern')) && createForm.get('name').dirty">
               Name is required.
@@ -20,7 +20,7 @@
           <chef-form-field>
             <label>
               <span class="label">Description <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="description" type="text" (keyup)="handleDescriptionInput($event)">
+              <input chefInput formControlName="description" type="text" (keyup)="handleDescriptionInput($event)" autocomplete="off"/>
             </label>
             <chef-error *ngIf="createForm?.controls['description'].hasError('maxlength')">
               Description must be 64 characters or less.

--- a/components/automate-ui/src/app/page-components/create-v1-team-modal/create-v1-team-modal.component.html
+++ b/components/automate-ui/src/app/page-components/create-v1-team-modal/create-v1-team-modal.component.html
@@ -12,7 +12,7 @@
               Name is required.
             </chef-error>
             <chef-error *ngIf="conflictError">
-              Name must be unique-- Team with name "{{createForm?.controls['name'].value}}" already exists.
+              Team name "{{createForm.get('name').value}}" already exists.
             </chef-error>
           </chef-form-field>
         </div>

--- a/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.html
+++ b/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.html
@@ -32,7 +32,7 @@
       <form [formGroup]="updateForm">
         <chef-form-field>
           <label>Name <span aria-hidden="true">*</span></label>
-          <input chefInput formControlName="name" type="text" (keyup)="handleChange()">
+          <input chefInput formControlName="name" type="text" (keyup)="handleChange()" autocomplete="off"/>
           <chef-error *ngIf="(nameCtrl.hasError('required') || nameCtrl.hasError('pattern')) && nameCtrl.dirty">
             Name is required.
           </chef-error>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -18,7 +18,7 @@
           <form [formGroup]="expressionForm">
             <chef-form-field>
               <label>Member expression *</label>
-              <input chefInput formControlName="expression" type="text" (keyup)="resetErrors()" >
+              <input chefInput formControlName="expression" type="text" (keyup)="resetErrors()" autocomplete="off">
               <chef-error *ngIf="unparsableMember">Invalid member expression.</chef-error>
               <chef-error *ngIf="duplicateMember">Member expression already in table.</chef-error>
               <chef-error *ngIf="alreadyPolicyMember">Member already in policy.</chef-error>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -32,7 +32,7 @@
             <span class="label">Name <span aria-hidden="true">*</span></span>
             <input chefInput formControlName="name" type="text"
               [attr.disabled]="(isChefManaged || isLoading) ? true : null"
-              (keyup)="keyPressed()">
+              (keyup)="keyPressed()" autocomplete="off">
           </label>
           <chef-error
             *ngIf="(projectForm.get('name').hasError('required') || projectForm.get('name').hasError('pattern')) && projectForm.get('name').dirty">

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -27,13 +27,13 @@
               <span class="label">Rule ID <span aria-hidden="true">*</span> </span>
               <chef-input ngDefaultControl formControlName="id" (keyup)="handleIDInput($event)"></chef-input>
             </label>
-            <chef-error *ngIf="ruleForm.controls['id'].hasError('maxlength')">
+            <chef-error *ngIf="ruleForm.get('id').hasError('maxlength') && ruleForm.get('id').dirty">
               Rule ID must be 64 characters or less.
             </chef-error>
-            <chef-error *ngIf="ruleForm.controls['id'].hasError('required')">
+            <chef-error *ngIf="ruleForm.get('id').hasError('required') && ruleForm.get('id').dirty">
               Rule ID is required.
             </chef-error>
-            <chef-error *ngIf="ruleForm.controls['id'].hasError('pattern')">
+            <chef-error *ngIf="ruleForm.get('id').hasError('pattern') && ruleForm.get('id').dirty">
               Only lowercase letters, numbers, hyphens, and underscores are allowed.
             </chef-error>
             <chef-error *ngIf="conflictError">

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -109,8 +109,7 @@
                   <chef-input ngDefaultControl
                     formControlName="values"
                     [value]="condition.controls.values.value"
-                    (keyup)="handleConditionChange()"
-                  ></chef-input>
+                    (keyup)="handleConditionChange()"></chef-input>
                 </label>
                 <chef-error
                   *ngIf="(ruleForm.get('conditions').controls[i].get('values').hasError('required') || ruleForm.get('conditions').controls[i].get('values').hasError('pattern')) && ruleForm.get('conditions').controls[i].get('values').dirty"

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -65,7 +65,7 @@
       <form [formGroup]="updateNameForm">
         <chef-form-field>
           <label>{{ descriptionOrName | titlecase }} <span aria-hidden="true">*</span></label>
-          <input chefInput formControlName="name" type="text" (keyup)="keyPressed()">
+          <input chefInput formControlName="name" type="text" (keyup)="keyPressed()" autocomplete="off">
           <chef-error
             *ngIf="(updateNameForm.get('name').hasError('required') || updateNameForm.get('name').hasError('pattern')) && updateNameForm.get('name').dirty">
             {{ descriptionOrName | titlecase }} is required.

--- a/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/pages/user-management/user-form/user-form.component.html
@@ -2,7 +2,7 @@
   <chef-form-field>
     <label>
       <span class="label">User's Full Name <span aria-hidden="true">*</span></span>
-      <input chefInput formControlName="fullname" type="text">
+      <input chefInput formControlName="fullname" type="text" autocomplete="off"/>
     </label>
     <chef-error *ngIf="(createUserForm.get('fullname').hasError('required') || createUserForm.get('fullname').hasError('pattern')) && createUserForm.get('fullname').dirty">
       User's Full Name is required.
@@ -11,7 +11,7 @@
   <chef-form-field>
     <label>
       <span class="label">Username <span aria-hidden="true">*</span></span>
-      <input chefInput formControlName="username" type="text">
+      <input chefInput formControlName="username" type="text" autocomplete="off"/>
     </label>
     <chef-error *ngIf="createUserForm.get('username').hasError('required') && createUserForm.get('username').dirty">
       Username is required.
@@ -23,7 +23,7 @@
   <chef-form-field>
     <label>
       <span class="label">Password <span aria-hidden="true">*</span></span>
-      <input chefInput formControlName="password" type="password">
+      <input chefInput formControlName="password" type="password"/>
     </label>
     <chef-error *ngIf="(createUserForm.get('password').hasError('required') || createUserForm.get('password').hasError('pattern')) && createUserForm.get('password').dirty">
       Password is required.
@@ -35,7 +35,7 @@
   <chef-form-field>
     <label>
       <span class="label">Confirm Password <span aria-hidden="true">*</span></span>
-      <input chefInput formControlName="confirmPassword" type="password">
+      <input chefInput formControlName="confirmPassword" type="password"/>
     </label>
     <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && createUserForm.get('confirmPassword').dirty">
       Passwords must match.

--- a/components/chef-ui-library/src/atoms/chef-input/chef-input.tsx
+++ b/components/chef-ui-library/src/atoms/chef-input/chef-input.tsx
@@ -25,6 +25,9 @@ import { Component, Host, Listen, Prop, State, h } from '@stencil/core';
  * <chef-input type='key-value' placeholder='Enter value...'></chef-input>
  *
  * @example
+ * <chef-input placeholder='Enter value...' autocomplete="on"></chef-input>
+ *
+ * @example
  * <chef-input type='key-value' value='foobar:bizbang' placeholder='Enter value...'></chef-input>
  */
 @Component({
@@ -52,6 +55,11 @@ export class ChefInput {
    * Indicate input as disabled
    */
   @Prop({ reflectToAttr: true }) disabled = false;
+
+  /**
+   * Enable or disable autocomplete for input (defaults to "off").
+   */
+  @Prop() autocomplete = 'off';
 
   @State() focused = false;
 
@@ -96,9 +104,9 @@ export class ChefInput {
         value={ this.value }
         placeholder={ this.placeholder }
         onChange={ this.handleChange.bind(this) }
-        disabled={this.disabled}
-        aria-disabled={this.disabled}
-        autocomplete="off"/>
+        disabled={ this.disabled }
+        aria-disabled={ this.disabled }
+        autocomplete={ this.autocomplete }/>
     );
   }
 

--- a/components/chef-ui-library/src/atoms/chef-input/chef-input.tsx
+++ b/components/chef-ui-library/src/atoms/chef-input/chef-input.tsx
@@ -10,6 +10,8 @@ import { Component, Host, Listen, Prop, State, h } from '@stencil/core';
  * provided is `key-value`. The key/value can be provided via the value
  * attribute as a ':' delimited string, 'key:value'.
  *
+ * The underlying <input> element has autocomplete set to "off".
+ *
  * @example
  * <chef-input placeholder='Enter value...'></chef-input>
  *
@@ -95,7 +97,8 @@ export class ChefInput {
         placeholder={ this.placeholder }
         onChange={ this.handleChange.bind(this) }
         disabled={this.disabled}
-        aria-disabled={this.disabled}></input>
+        aria-disabled={this.disabled}
+        autocomplete="off"/>
     );
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

1. set `autocomplete="off"` on some more inputs
2. ensure that clicking "edit ID" before having entered a name doesn't make the error pop up

(See the linked issue for details.)

#### ➕ wrapped into this PR

![image](https://user-images.githubusercontent.com/870638/62699428-c9714500-b9df-11e9-8248-82487bdfca4e.png)
![image](https://user-images.githubusercontent.com/870638/62699570-22d97400-b9e0-11e9-81d8-abc0689e2d3d.png)

☝️ Fixed the uniqueness error messages, as discussed with @susanev in slack.

### :chains: Related Resources

- #1185
- a little overlap with #1156, but not too much

### :+1: Definition of Done

NA

### :athletic_shoe: How to Build and Test the Change

💁‍♂ See #1185's repro steps please.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?
