### PR TITLE
added changes for sort the platform with name and release version

### DIFF
--- a/components/compliance-service/api/reporting/server/server.go
+++ b/components/compliance-service/api/reporting/server/server.go
@@ -305,11 +305,16 @@ func csvExport(stream reporting.ReportingService_ExportServer) exportHandler {
 
 // ListNodes returns a list of nodes based on query
 func (srv *Server) ListNodes(ctx context.Context, in *reporting.Query) (*reporting.Nodes, error) {
+	formattedFilters := formatFilters(in.Filters)
+	var platform_sort_field = "platform.name.lower"
+	if len(formattedFilters["platform"]) == 1 {
+		platform_sort_field = "platform.release.lower"
+	}
 	var nodes reporting.Nodes
 	var SORT_FIELDS = map[string]string{
 		"name":                                   "node_name.lower",
 		"environment":                            "environment.lower",
-		"platform":                               "platform.name.lower",
+		"platform":                               platform_sort_field,
 		"status":                                 "status",
 		"latest_report.status":                   "status",
 		"latest_report.end_time":                 "end_time",
@@ -321,7 +326,7 @@ func (srv *Server) ListNodes(ctx context.Context, in *reporting.Query) (*reporti
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	formattedFilters := formatFilters(in.Filters)
+	
 	formattedFilters, err = filterByProjects(ctx, formattedFilters)
 	if err != nil {
 		return nil, errorutils.FormatErrorMsg(err, "")

--- a/components/compliance-service/api/reporting/server/server.go
+++ b/components/compliance-service/api/reporting/server/server.go
@@ -306,15 +306,15 @@ func csvExport(stream reporting.ReportingService_ExportServer) exportHandler {
 // ListNodes returns a list of nodes based on query
 func (srv *Server) ListNodes(ctx context.Context, in *reporting.Query) (*reporting.Nodes, error) {
 	formattedFilters := formatFilters(in.Filters)
-	var platform_sort_field = "platform.name.lower"
-	if len(formattedFilters["platform"]) == 1 {
-		platform_sort_field = "platform.release.lower"
-	}
+	// var platform_sort_field = "platform.name.lower"
+	// if len(formattedFilters["platform"]) == 1 {
+	// 	platform_sort_field = "platform.release.lower"
+	// }
 	var nodes reporting.Nodes
 	var SORT_FIELDS = map[string]string{
 		"name":                                   "node_name.lower",
 		"environment":                            "environment.lower",
-		"platform":                               platform_sort_field,
+		"platform":                               "platform.full",
 		"status":                                 "status",
 		"latest_report.status":                   "status",
 		"latest_report.end_time":                 "end_time",

--- a/components/compliance-service/api/reporting/server/server.go
+++ b/components/compliance-service/api/reporting/server/server.go
@@ -306,10 +306,6 @@ func csvExport(stream reporting.ReportingService_ExportServer) exportHandler {
 // ListNodes returns a list of nodes based on query
 func (srv *Server) ListNodes(ctx context.Context, in *reporting.Query) (*reporting.Nodes, error) {
 	formattedFilters := formatFilters(in.Filters)
-	// var platform_sort_field = "platform.name.lower"
-	// if len(formattedFilters["platform"]) == 1 {
-	// 	platform_sort_field = "platform.release.lower"
-	// }
 	var nodes reporting.Nodes
 	var SORT_FIELDS = map[string]string{
 		"name":                                   "node_name.lower",

--- a/components/compliance-service/api/reporting/server/server.go
+++ b/components/compliance-service/api/reporting/server/server.go
@@ -326,7 +326,6 @@ func (srv *Server) ListNodes(ctx context.Context, in *reporting.Query) (*reporti
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	
 	formattedFilters, err = filterByProjects(ctx, formattedFilters)
 	if err != nil {
 		return nil, errorutils.FormatErrorMsg(err, "")

--- a/components/compliance-service/reporting/relaxting/nodes.go
+++ b/components/compliance-service/reporting/relaxting/nodes.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/golang/protobuf/ptypes"
 
@@ -177,30 +175,11 @@ func (backend *ES2Backend) GetNodes(from int32, size int32, filters map[string][
 		if err != nil {
 			return nil, emptyTotals, errors.Wrapf(err, "%s error retrieving node count totals: ", myName)
 		}
-		// sort nodes by the platform name and release
-		if sortField == "platform.name.lower" {
-			sortNodes(nodes, sortField, sortAsc)
-		}
 		return nodes, TotalNodeCounts{Total: int32(searchResult.TotalHits()), Passed: nodeSummary.Compliant, Failed: nodeSummary.Noncompliant, Skipped: nodeSummary.Skipped}, nil
 	}
 
 	logrus.Debugf("%s Found no nodes\n", myName)
 	return nodes, emptyTotals, nil
-}
-
-func sortNodes(nodes []*reportingapi.Node, sortField string, sortAsc bool) {
-	sort.Slice(nodes, func(i, j int) bool {
-		if sortAsc {
-			if strings.Compare(nodes[i].Platform.Name, nodes[j].Platform.Name) == 0 {
-				return nodes[i].Platform.Release < nodes[j].Platform.Release
-			}
-			return nodes[i].Platform.Name < nodes[j].Platform.Name
-		}
-		if strings.Compare(nodes[i].Platform.Name, nodes[j].Platform.Name) == 0 {
-			return nodes[i].Platform.Release > nodes[j].Platform.Release
-		}
-		return nodes[i].Platform.Name > nodes[j].Platform.Name
-	})
 }
 
 func convertToRSControlSummary(summ reporting.NodeControlSummary) *reportingapi.ControlSummary {


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description: 
When trying to sort by the platform in the compliance section, the release numbers of any platform do not get properly parsed/sorted

**Expected Results**: Sorting by a platform column will sort correctly
### :chains: Related Resources
https://github.com/chef/automate/issues/752
### :+1: Definition of Done
I have added one sorting function which can help to sort the platform with name and release version.
please find the attached video link below
https://chef.zoom.us/recording/share/WTWPt3eJlLCcjQXsqaX-Zg-WSgN39E0lvjcHDVL5COewIumekTziMw?startTime=1565259570000