### PR TITLE
Add domain support to cereal service

### DIFF
--- a/components/cereal-service/integration/domain_test.go
+++ b/components/cereal-service/integration/domain_test.go
@@ -1,0 +1,263 @@
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"google.golang.org/grpc/codes"
+
+	"google.golang.org/grpc/status"
+
+	grpccereal "github.com/chef/automate/api/interservice/cereal"
+	"github.com/chef/automate/components/cereal-service/pkg/server"
+	"github.com/chef/automate/lib/cereal"
+	"github.com/chef/automate/lib/cereal/backend"
+	libgrpc "github.com/chef/automate/lib/cereal/grpc"
+	"github.com/chef/automate/lib/cereal/postgres"
+	"github.com/chef/automate/lib/grpc/grpctest"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestDomains(t *testing.T) {
+	ctx := context.Background()
+	logrus.SetLevel(logrus.DebugLevel)
+	require.NoError(t, runResetDB())
+	pgBackend := postgres.NewPostgresBackend(testDBURL(), postgres.WithTaskPingInterval(3*time.Second))
+	require.NoError(t, pgBackend.Init())
+
+	grpcServer := grpc.NewServer()
+	svc := server.NewCerealService(ctx, pgBackend)
+	grpccereal.RegisterCerealServer(grpcServer, svc)
+	g := grpctest.NewServer(grpcServer)
+	cereal.MaxWakeupInterval = 2 * time.Second
+
+	defer g.Close()
+
+	conn, err := grpc.Dial(g.URL, grpc.WithInsecure(), grpc.WithMaxMsgSize(64*1024*1024))
+	if err != nil {
+		panic(err)
+	}
+
+	t.Run("RPCs fail if domain is missing", func(t *testing.T) {
+		workflowName := "mytestworkflow"
+		instanceName := "mytestinstance"
+		taskName := "mytaskname"
+		grpcBackend := libgrpc.NewGrpcBackendFromConn("", conn)
+		rpcs := []struct {
+			Name string
+			Call func() error
+		}{
+			{
+				Name: "EnqueueWorkflow",
+				Call: func() error {
+					return grpcBackend.EnqueueWorkflow(ctx, &backend.WorkflowInstance{
+						WorkflowName: workflowName,
+						InstanceName: instanceName,
+					})
+				},
+			},
+			{
+				Name: "DequeueWorkflow",
+				Call: func() error {
+					_, completer, err := grpcBackend.DequeueWorkflow(ctx, []string{workflowName})
+					if err != nil {
+						return err
+					}
+					completer.Close()
+					return nil
+				},
+			},
+			{
+				Name: "CancelWorkflow",
+				Call: func() error {
+					return grpcBackend.CancelWorkflow(ctx, instanceName, workflowName)
+				},
+			},
+			{
+				Name: "DequeueTask",
+				Call: func() error {
+					_, completer, err := grpcBackend.DequeueTask(ctx, taskName)
+					if err != nil {
+						return err
+					}
+					completer.Fail("should not happen")
+					return nil
+				},
+			},
+			{
+				Name: "CreateWorkflowSchedule",
+				Call: func() error {
+					return grpcBackend.CreateWorkflowSchedule(ctx, instanceName,
+						workflowName, nil, false, "FREQ=HOURLY;INTERVAL=1", time.Now())
+				},
+			},
+			{
+				Name: "ListWorkflowSchedules",
+				Call: func() error {
+					_, err := grpcBackend.ListWorkflowSchedules(ctx)
+					return err
+				},
+			},
+			{
+				Name: "GetWorkflowScheduleByName",
+				Call: func() error {
+					_, err := grpcBackend.GetWorkflowScheduleByName(ctx, instanceName, workflowName)
+					return err
+				},
+			},
+			{
+				Name: "UpdateWorkflowScheduleByName",
+				Call: func() error {
+					err := grpcBackend.UpdateWorkflowScheduleByName(ctx, instanceName, workflowName, backend.WorkflowScheduleUpdateOpts{})
+					return err
+				},
+			},
+			{
+				Name: "GetWorkflowInstanceByName",
+				Call: func() error {
+					_, err := grpcBackend.GetWorkflowInstanceByName(ctx, instanceName, workflowName)
+					return err
+				},
+			},
+			{
+				Name: "ListWorkflowInstances",
+				Call: func() error {
+					_, err := grpcBackend.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{})
+					return err
+				},
+			},
+		}
+		for _, rpc := range rpcs {
+			t.Run(rpc.Name, func(t *testing.T) {
+				err := rpc.Call()
+				require.Error(t, err)
+				s, ok := status.FromError(err)
+				require.True(t, ok, "did not get a grpc status")
+				require.Equal(t, codes.InvalidArgument, s.Code())
+				assert.Contains(t, s.Err().Error(), "must specify domain")
+			})
+		}
+	})
+
+	t.Run("Workflow Domain Usage", func(t *testing.T) {
+		workflowName := "mytestworkflow"
+		instanceName := "mytestinstance"
+		taskName := "mytaskname"
+		grpcBackendDomain1 := libgrpc.NewGrpcBackendFromConn("domain1", conn)
+		grpcBackendDomain2 := libgrpc.NewGrpcBackendFromConn("domain2", conn)
+		domain1Params := []byte("domain1workflow")
+		domain2Params := []byte("domain2workflow")
+		domain1TaskParams := []byte("domain1task")
+		domain2TaskParams := []byte("domain2task")
+
+		// Enqueue workflow with same name in different domains
+		err := grpcBackendDomain1.EnqueueWorkflow(ctx, &backend.WorkflowInstance{
+			WorkflowName: workflowName,
+			InstanceName: instanceName,
+			Parameters:   domain1Params,
+		})
+		require.NoError(t, err)
+
+		domain2Instances, err := grpcBackendDomain2.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{})
+		require.NoError(t, err)
+		require.Len(t, domain2Instances, 0)
+
+		err = grpcBackendDomain2.EnqueueWorkflow(ctx, &backend.WorkflowInstance{
+			WorkflowName: workflowName,
+			InstanceName: instanceName,
+			Parameters:   domain2Params,
+		})
+		require.NoError(t, err)
+
+		domain1Instances, err := grpcBackendDomain1.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{})
+		require.NoError(t, err)
+		require.Len(t, domain1Instances, 1)
+		validateInstanceMatches(t, domain1Instances[0], workflowName, instanceName, domain1Params)
+
+		domain2Instances, err = grpcBackendDomain2.ListWorkflowInstances(ctx, backend.ListWorkflowOpts{})
+		require.NoError(t, err)
+		require.Len(t, domain2Instances, 1)
+		validateInstanceMatches(t, domain2Instances[0], workflowName, instanceName, domain2Params)
+
+		domain2Instance, err := grpcBackendDomain2.GetWorkflowInstanceByName(ctx, instanceName, workflowName)
+		require.NoError(t, err)
+		validateInstanceMatches(t, domain2Instance, workflowName, instanceName, domain2Params)
+
+		// Dequeue workflows and enqueue tasks
+		domain2Evt, workflowCompleter2, err := grpcBackendDomain2.DequeueWorkflow(ctx, []string{workflowName})
+		require.NoError(t, err)
+		validateInstanceMatches(t, &domain2Evt.Instance, workflowName, instanceName, domain2Params)
+		err = workflowCompleter2.EnqueueTask(&backend.Task{
+			Name:       taskName,
+			Parameters: domain2TaskParams,
+		}, backend.TaskEnqueueOpts{})
+		require.NoError(t, err)
+		err = workflowCompleter2.Continue(nil)
+		require.NoError(t, err)
+		_, _, err = grpcBackendDomain2.DequeueWorkflow(ctx, []string{workflowName})
+		require.Equal(t, cereal.ErrNoWorkflowInstances, err)
+
+		domain1Evt, workflowCompleter1, err := grpcBackendDomain1.DequeueWorkflow(ctx, []string{workflowName})
+		require.NoError(t, err)
+		validateInstanceMatches(t, &domain1Evt.Instance, workflowName, instanceName, domain1Params)
+		err = workflowCompleter1.EnqueueTask(&backend.Task{
+			Name:       taskName,
+			Parameters: domain1TaskParams,
+		}, backend.TaskEnqueueOpts{})
+		require.NoError(t, err)
+		err = workflowCompleter1.Continue(nil)
+		require.NoError(t, err)
+		_, _, err = grpcBackendDomain1.DequeueWorkflow(ctx, []string{workflowName})
+		require.Equal(t, cereal.ErrNoWorkflowInstances, err)
+
+		// Dequeue Tasks
+		task1, taskCompleter1, err := grpcBackendDomain1.DequeueTask(ctx, taskName)
+		require.NoError(t, err)
+		validateTaskMatches(t, task1, taskName, domain1TaskParams)
+		taskCompleter1.Succeed(nil)
+		_, _, err = grpcBackendDomain1.DequeueTask(ctx, taskName)
+		require.Equal(t, cereal.ErrNoTasks, err)
+
+		task2, taskCompleter2, err := grpcBackendDomain2.DequeueTask(ctx, taskName)
+		require.NoError(t, err)
+		validateTaskMatches(t, task2, taskName, domain2TaskParams)
+		taskCompleter2.Succeed(nil)
+		_, _, err = grpcBackendDomain2.DequeueTask(ctx, taskName)
+		require.Equal(t, cereal.ErrNoTasks, err)
+
+		// Finish workflows
+		domain2Evt, workflowCompleter2, err = grpcBackendDomain2.DequeueWorkflow(ctx, []string{workflowName})
+		require.NoError(t, err)
+		validateInstanceMatches(t, &domain2Evt.Instance, workflowName, instanceName, domain2Params)
+		require.Equal(t, domain2TaskParams, domain2Evt.TaskResult.Parameters)
+		err = workflowCompleter2.Done(nil)
+		require.NoError(t, err)
+
+		domain1Evt, workflowCompleter1, err = grpcBackendDomain1.DequeueWorkflow(ctx, []string{workflowName})
+		require.NoError(t, err)
+		validateInstanceMatches(t, &domain1Evt.Instance, workflowName, instanceName, domain1Params)
+		require.Equal(t, domain1TaskParams, domain1Evt.TaskResult.Parameters)
+		err = workflowCompleter1.Done(nil)
+		require.NoError(t, err)
+	})
+}
+
+func validateInstanceMatches(t *testing.T, instance *backend.WorkflowInstance, workflowName string, instanceName string, params []byte) {
+	t.Helper()
+	require.Equal(t, workflowName, instance.WorkflowName)
+	require.Equal(t, instanceName, instance.InstanceName)
+	require.Equal(t, params, instance.Parameters)
+}
+
+func validateTaskMatches(t *testing.T, task *backend.Task, taskName string, taskParams []byte) {
+	t.Helper()
+	require.Equal(t, taskName, task.Name)
+	require.Equal(t, taskParams, task.Parameters)
+}

--- a/components/cereal-service/integration/integration_test.go
+++ b/components/cereal-service/integration/integration_test.go
@@ -80,6 +80,7 @@ func TestGrpcPostgres(t *testing.T) {
 	svc := server.NewCerealService(ctx, pgBackend)
 	grpccereal.RegisterCerealServer(grpcServer, svc)
 	g := grpctest.NewServer(grpcServer)
+	defer g.Close()
 	cereal.MaxWakeupInterval = 2 * time.Second
 
 	defer g.Close()

--- a/components/cereal-service/integration/integration_test.go
+++ b/components/cereal-service/integration/integration_test.go
@@ -88,7 +88,7 @@ func TestGrpcPostgres(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	grpcBackend := libgrpc.NewGrpcBackendFromConn(conn)
+	grpcBackend := libgrpc.NewGrpcBackendFromConn("test", conn)
 	s := cerealintegration.NewSuiteForBackend(ctx, t, grpcBackend)
 	suite.Run(t, s)
 	require.NoError(t, grpcBackend.Close())

--- a/components/cereal-service/pkg/server/server.go
+++ b/components/cereal-service/pkg/server/server.go
@@ -199,7 +199,7 @@ func (s *CerealService) DequeueWorkflow(req cereal.Cereal_DequeueWorkflowServer)
 	domain, workflowName := unnamespace(evt.Instance.WorkflowName)
 	evt.Instance.WorkflowName = workflowName
 	logctx = logctx.WithFields(logrus.Fields{
-		"domain-recv":     domain,
+		"domain_recv":     domain,
 		"workflow_name":   evt.Instance.WorkflowName,
 		"instance_name":   evt.Instance.InstanceName,
 		"workflow_status": evt.Instance.Status,

--- a/components/cereal-service/pkg/server/server.go
+++ b/components/cereal-service/pkg/server/server.go
@@ -506,6 +506,7 @@ func (s *CerealService) ListWorkflowSchedules(req *cereal.ListWorkflowSchedulesR
 	logctx := logrus.WithFields(logrus.Fields{
 		"id":     generateRequestID(),
 		"method": "ListWorkflowSchedules",
+		"domain": req.Domain,
 	})
 
 	if err := validateDomain(req.Domain); err != nil {
@@ -557,7 +558,7 @@ func (s *CerealService) GetWorkflowScheduleByName(ctx context.Context, req *cere
 		return nil, err
 	}
 	logctx.Info("getting workflow schedule")
-	schedule, err := s.backend.GetWorkflowScheduleByName(ctx, req.InstanceName, req.WorkflowName)
+	schedule, err := s.backend.GetWorkflowScheduleByName(ctx, req.InstanceName, namespace(req.Domain, req.WorkflowName))
 	if err != nil {
 		logctx.WithError(err).Error("failed to get workflow schedule")
 		if err == libcereal.ErrWorkflowScheduleNotFound {

--- a/components/cereal-service/pkg/server/server.go
+++ b/components/cereal-service/pkg/server/server.go
@@ -3,7 +3,8 @@ package server
 import (
 	"context"
 	"errors"
-	"path"
+	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 )
 
 var errInvalidMsg = errors.New("invalid msg")
+var domainRegex = regexp.MustCompile("^[a-zA-Z0-9]+$")
 
 type CerealService struct {
 	workflowScheduler *libcereal.WorkflowScheduler
@@ -49,7 +51,7 @@ func generateRequestID() string {
 }
 
 func namespace(domain string, name string) string {
-	return path.Join(domain, name)
+	return fmt.Sprintf("%s/%s", domain, name)
 }
 
 func unnamespace(domainAndName string) (domain string, name string) {
@@ -62,9 +64,11 @@ func unnamespace(domainAndName string) (domain string, name string) {
 }
 
 func validateDomain(domain string) error {
-	if domain == "" {
+
+	if !domainRegex.MatchString(domain) {
 		return status.Error(codes.InvalidArgument, "must specify domain")
 	}
+
 	return nil
 }
 

--- a/components/cereal-service/pkg/server/server_test.go
+++ b/components/cereal-service/pkg/server/server_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNamespace(t *testing.T) {
+	examples := []struct {
+		Domain string
+		Name   string
+	}{
+		{
+			Domain: "foo",
+			Name:   "bar",
+		},
+		{
+			Domain: "foo",
+			Name:   "bar/baz",
+		},
+		{
+			Domain: "foo",
+			Name:   "/bar/baz",
+		},
+		{
+			Domain: "foo",
+			Name:   "/bar/baz/quux",
+		},
+	}
+
+	for _, example := range examples {
+		namespaced := namespace(example.Domain, example.Name)
+		t.Run(namespaced, func(t *testing.T) {
+			domain, name := unnamespace(namespaced)
+			assert.Equal(t, example.Domain, domain)
+			assert.Equal(t, example.Name, name)
+		})
+	}
+}
+
+func TestValidateDomain(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		err := validateDomain("valid")
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid if empty", func(t *testing.T) {
+		err := validateDomain("")
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid if contains spaces", func(t *testing.T) {
+		err := validateDomain(" notvalid")
+		assert.Error(t, err)
+
+		err = validateDomain("notvalid ")
+		assert.Error(t, err)
+
+		err = validateDomain("not valid")
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid if contains /", func(t *testing.T) {
+		err := validateDomain("not/valid")
+		assert.Error(t, err)
+	})
+}

--- a/lib/cereal/grpc/grpc.go
+++ b/lib/cereal/grpc/grpc.go
@@ -52,9 +52,8 @@ func (g *GrpcBackend) EnqueueWorkflow(ctx context.Context, workflow *backend.Wor
 			if s.Code() == codes.FailedPrecondition {
 				return cereal.ErrWorkflowInstanceExists
 			}
-		} else {
-			return err
 		}
+		return err
 	}
 	return nil
 }
@@ -530,7 +529,9 @@ func (g *GrpcBackend) GetWorkflowInstanceByName(ctx context.Context, instanceNam
 }
 
 func (g *GrpcBackend) ListWorkflowInstances(ctx context.Context, opts backend.ListWorkflowOpts) ([]*backend.WorkflowInstance, error) {
-	req := grpccereal.ListWorkflowInstancesRequest{}
+	req := grpccereal.ListWorkflowInstancesRequest{
+		Domain: g.domain,
+	}
 	if opts.WorkflowName != nil {
 		req.WorkflowName = &wrappers.StringValue{
 			Value: *opts.WorkflowName,

--- a/lib/cereal/grpc/grpc.go
+++ b/lib/cereal/grpc/grpc.go
@@ -25,21 +25,25 @@ import (
 var _ backend.Driver = &GrpcBackend{}
 
 type GrpcBackend struct {
+	domain string
 	client grpccereal.CerealClient
 }
 
-func NewGrpcBackend(client grpccereal.CerealClient) *GrpcBackend {
+func NewGrpcBackend(domain string, client grpccereal.CerealClient) *GrpcBackend {
 	return &GrpcBackend{
+		domain: domain,
 		client: client,
 	}
 }
-func NewGrpcBackendFromConn(conn *grpc.ClientConn) *GrpcBackend {
+func NewGrpcBackendFromConn(domain string, conn *grpc.ClientConn) *GrpcBackend {
 	return &GrpcBackend{
+		domain: domain,
 		client: grpccereal.NewCerealClient(conn),
 	}
 }
 func (g *GrpcBackend) EnqueueWorkflow(ctx context.Context, workflow *backend.WorkflowInstance) error {
 	if _, err := g.client.EnqueueWorkflow(ctx, &grpccereal.EnqueueWorkflowRequest{
+		Domain:       g.domain,
 		InstanceName: workflow.InstanceName,
 		WorkflowName: workflow.WorkflowName,
 		Parameters:   workflow.Parameters,
@@ -152,6 +156,7 @@ func (g *GrpcBackend) DequeueWorkflow(ctx context.Context, workflowNames []strin
 	if err := s.Send(&grpccereal.DequeueWorkflowRequest{
 		Cmd: &grpccereal.DequeueWorkflowRequest_Dequeue_{
 			Dequeue: &grpccereal.DequeueWorkflowRequest_Dequeue{
+				Domain:        g.domain,
 				WorkflowNames: workflowNames,
 			},
 		},
@@ -216,6 +221,7 @@ func grpcWorkflowInstanceToBackend(grpcInstance *grpccereal.WorkflowInstance) ba
 
 func (g *GrpcBackend) CancelWorkflow(ctx context.Context, instanceName string, workflowName string) error {
 	_, err := g.client.CancelWorkflow(ctx, &grpccereal.CancelWorkflowRequest{
+		Domain:       g.domain,
 		InstanceName: instanceName,
 		WorkflowName: workflowName,
 	})
@@ -288,6 +294,7 @@ func (g *GrpcBackend) DequeueTask(ctx context.Context, taskName string) (*backen
 	if err := s.Send(&grpccereal.DequeueTaskRequest{
 		Cmd: &grpccereal.DequeueTaskRequest_Dequeue_{
 			Dequeue: &grpccereal.DequeueTaskRequest_Dequeue{
+				Domain:   g.domain,
 				TaskName: taskName,
 			},
 		},
@@ -342,6 +349,7 @@ func (g *GrpcBackend) CreateWorkflowSchedule(ctx context.Context, instanceName s
 		return err
 	}
 	_, err = g.client.CreateWorkflowSchedule(ctx, &grpccereal.CreateWorkflowScheduleRequest{
+		Domain:       g.domain,
 		InstanceName: instanceName,
 		WorkflowName: workflowName,
 		Parameters:   parameters,
@@ -364,7 +372,9 @@ func (g *GrpcBackend) ListWorkflowSchedules(ctx context.Context) ([]*backend.Sch
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	s, err := g.client.ListWorkflowSchedules(ctx, &grpccereal.ListWorkflowSchedulesRequest{})
+	s, err := g.client.ListWorkflowSchedules(ctx, &grpccereal.ListWorkflowSchedulesRequest{
+		Domain: g.domain,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -390,6 +400,7 @@ func (g *GrpcBackend) ListWorkflowSchedules(ctx context.Context) ([]*backend.Sch
 
 func (g *GrpcBackend) GetWorkflowScheduleByName(ctx context.Context, instanceName string, workflowName string) (*backend.Schedule, error) {
 	resp, err := g.client.GetWorkflowScheduleByName(ctx, &grpccereal.GetWorkflowScheduleByNameRequest{
+		Domain:       g.domain,
 		InstanceName: instanceName,
 		WorkflowName: workflowName,
 	})
@@ -455,6 +466,7 @@ func grpcSchedToBackend(grpcSched *grpccereal.Schedule) *backend.Schedule {
 
 func (g *GrpcBackend) UpdateWorkflowScheduleByName(ctx context.Context, instanceName string, workflowName string, opts backend.WorkflowScheduleUpdateOpts) error {
 	req := grpccereal.UpdateWorkflowScheduleByNameRequest{
+		Domain:       g.domain,
 		InstanceName: instanceName,
 		WorkflowName: workflowName,
 	}
@@ -497,6 +509,7 @@ func (g *GrpcBackend) UpdateWorkflowScheduleByName(ctx context.Context, instance
 
 func (g *GrpcBackend) GetWorkflowInstanceByName(ctx context.Context, instanceName string, workflowName string) (*backend.WorkflowInstance, error) {
 	resp, err := g.client.GetWorkflowInstanceByName(ctx, &grpccereal.GetWorkflowInstanceByNameRequest{
+		Domain:       g.domain,
 		InstanceName: instanceName,
 		WorkflowName: workflowName,
 	})

--- a/tools/cereal-scaffold/main.go
+++ b/tools/cereal-scaffold/main.go
@@ -302,7 +302,7 @@ func getBackend(dbName string) backend.Driver {
 		if err != nil {
 			panic(err)
 		}
-		grpcBackend := grpccereal.NewGrpcBackendFromConn(conn)
+		grpcBackend := grpccereal.NewGrpcBackendFromConn("test", conn)
 		return grpcBackend
 	}
 	return postgres.NewPostgresBackend(defaultConnURIForDatabase(dbName))


### PR DESCRIPTION
Using the grpc backend now requires specifying a domain to namespace workflows and tasks