### PR TITLE
Correct action filter on getUserFailure effect

### DIFF
--- a/components/automate-ui/src/app/entities/users/user.effects.ts
+++ b/components/automate-ui/src/app/entities/users/user.effects.ts
@@ -77,7 +77,7 @@ export class UserEffects {
 
   @Effect()
   getUserFailure$ = this.actions$.pipe(
-    ofType(UserActionTypes.GET),
+    ofType(UserActionTypes.GET_FAILURE),
     map(({ payload: { error } }: GetUserFailure) => {
       const msg = error.error;
       return new CreateNotification({


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Found that, after a browser refresh, the first time you go into user details generated a run time error:

![image](https://user-images.githubusercontent.com/6817500/62743140-22e46e80-b9f6-11e9-8e2d-aa94c7ee8a24.png)


### :chains: Related Resources
N/A

### :+1: Definition of Done
Browser error be gone!

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui.
Navigate to Settings > Users.
Refresh browser.
Select any user to get to the user details.
Observe no run-time error on the JavaScript console.
