### PR TITLE
Fix race condition in the grpc cereal backend

### DIFF
--- a/components/cereal-service/integration/domain_test.go
+++ b/components/cereal-service/integration/domain_test.go
@@ -221,14 +221,16 @@ func TestDomains(t *testing.T) {
 		task1, taskCompleter1, err := grpcBackendDomain1.DequeueTask(ctx, taskName)
 		require.NoError(t, err)
 		validateTaskMatches(t, task1, taskName, domain1TaskParams)
-		taskCompleter1.Succeed(nil)
+		err = taskCompleter1.Succeed(nil)
+		require.NoError(t, err)
 		_, _, err = grpcBackendDomain1.DequeueTask(ctx, taskName)
 		require.Equal(t, cereal.ErrNoTasks, err)
 
 		task2, taskCompleter2, err := grpcBackendDomain2.DequeueTask(ctx, taskName)
 		require.NoError(t, err)
 		validateTaskMatches(t, task2, taskName, domain2TaskParams)
-		taskCompleter2.Succeed(nil)
+		err = taskCompleter2.Succeed(nil)
+		require.NoError(t, err)
 		_, _, err = grpcBackendDomain2.DequeueTask(ctx, taskName)
 		require.Equal(t, cereal.ErrNoTasks, err)
 

--- a/components/cereal-service/pkg/server/server.go
+++ b/components/cereal-service/pkg/server/server.go
@@ -464,6 +464,7 @@ func (s *CerealService) DequeueTask(req cereal.Cereal_DequeueTaskServer) error {
 			return err
 		}
 	} else {
+		logctx.Error("invalid message")
 		return errInvalidMsg
 	}
 

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -536,7 +536,9 @@ func (m *Manager) Stop() error {
 		m.cancel()
 	}
 
+	logrus.Info("waiting for goroutines to stop")
 	m.wg.Wait()
+	logrus.Info("goroutines stopped")
 
 	var err error
 	if m.backend != nil {

--- a/lib/cereal/integration/abandon_workflow.go
+++ b/lib/cereal/integration/abandon_workflow.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/chef/automate/lib/cereal"
+	"github.com/sirupsen/logrus"
 )
 
 func (suite *CerealTestSuite) TestCompleteWorkflowWithPendingWorkflowEvents() {
@@ -49,6 +50,7 @@ func (suite *CerealTestSuite) TestCompleteWorkflowWithPendingWorkflowEvents() {
 	suite.Require().NoError(err, "Failed to enqueue workflow")
 	wgTask.Wait()
 	time.Sleep(2 * time.Second) // Sleep a little to make sure task complete doesn't get called multiple times
+	logrus.Info("calling stop")
 	err = m.Stop()
 	suite.NoError(err)
 }


### PR DESCRIPTION
Task completion wasn't waiting around for the server to confirm that it
processed the task completion messages. This was causing the tests to
fail as they assumed that once the backend function returns (without
error), the data has been persisted.
