### PR TITLE
Automate-1113 Fix colors on unkown status message Signed-Off-By: Tara…

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.scss
@@ -132,6 +132,10 @@ chef-subheading {
 
   .unknown .summary-toggle {
     background: $chef-grey;
+
+    p, chef-icon {
+      color: $chef-primary-dark;
+    }
   }
 
   .summary-body {


### PR DESCRIPTION
… Black <tblack@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Currently, on the Compliance > Reports page when the status is unknown we display an inaccessible (by color) message. To fix this please change the text and icons from #fff to chef-primary-dark. This change should apply only to the unknown status and not effect the other status messages.

### :chains: Related Resources
https://github.com/chef/automate/issues/1113

### :athletic_shoe: How to Build and Test the Change
1. build components/automate-ui && start_all_services
2. Go to https://a2-dev.test/compliance/reports/overview
3. Have an unknown status :)

### :camera: Screenshots, if applicable
![Screen Shot 2019-08-09 at 6 22 50 PM](https://user-images.githubusercontent.com/4108100/62814230-30bcf100-bad5-11e9-9208-485d4dfb8f18.png)
