### PR TITLE
Reset for initial inputs

### DIFF
--- a/components/automate-ui/e2e/admin.e2e-spec.ts
+++ b/components/automate-ui/e2e/admin.e2e-spec.ts
@@ -1527,7 +1527,7 @@ describe('Admin pages', () => {
           const heading = $('chef-heading');
           expect(heading.getText()).toBe('My Project Changed');
           expect(projectSaveButton.getAttribute('disabled')).toBe('true');
-          expect($('app-project-details section #button-bar #save-note').getText())
+          expect($('app-project-details section #button-bar #saved-note').getText())
             .toBe('All changes saved.');
 
           // Type once more
@@ -1535,7 +1535,7 @@ describe('Admin pages', () => {
           expect(projectSaveButton.getAttribute('disabled')).toBeNull();
 
           // Removed save note
-          expect($('app-project-details section #button-bar #save-note').isPresent()).toBeFalsy();
+          expect($('app-project-details section #button-bar #saved-note').isPresent()).toBeFalsy();
         });
       });
     });

--- a/components/automate-ui/src/app/components/form-control/form-control.directive.ts
+++ b/components/automate-ui/src/app/components/form-control/form-control.directive.ts
@@ -3,10 +3,59 @@ import { NgControl } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
+// Getting the most from an Angular form
+// *************************************
+// Out of the box, this directive automatically provides "memory" to your form
+// controls (typically <chef-input>, <chef-radio>, and <chef-select> elements)
+// when a focussed control is being edited.
+// Should the user change the value back to its original value,
+// the control is reset to a pristine state.
+// You can make use of that fact by, e.g., disabling your Save button,
+// since the field has no new value to be saved:
+//      <chef-button [disabled]="!yourForm.dirty || ..."
+//
+// If, upon a successful operation, the user is taken elsewhere
+// (e.g. the modal closes, or the page navigates to a summary, etc.)
+// nothing further is required.
+// If, however, the form (or modal) remains open, you typically want
+// to have the "pristine state" of the control be updated
+// to the newly processed value. Here's how to make that happen:
+//
+// 1. Add the `resetOrigin` property to each control in your form,
+//    assigning them all the same flag value, in this case `saveSuccessful`:
+//    <input formControlName="name" type="text" [resetOrigin]="saveSuccessful" />
+//
+// 2. In your function that processes the form, set that flag to false
+//    and then change it to true once your operation is confirmed successful.
+//    That is all you need to complete the "memory" of the form control.
+//
+// 3. Hearkening back to providing the `[disabled]` functionality on the Save button
+//    above, though, you need one more thing.
+//    Once you have confirmed the operation successful,
+//    you also need to mark the form pristine so that `dirty` check will
+//    initialize your Save button to disabled, which is typically desired
+//    immediately following the Save.
+//
+// Implementing (2) and (3) would look something like this:
+//
+//  saveStuff(): void {
+//    this.saveSuccessful = false;
+//    // ...perform the save and get a status back...
+//    this.saveSuccessful = (state === EntityStatus.loadingSuccess);
+//    if (this.saveSuccessful) {
+//      this.myForm.markAsPristine();
+//    }
+
 @Directive({
   selector: '[formControl],[formControlName]'
 })
 export class FormControlDirective implements OnInit, OnDestroy, OnChanges {
+
+  // Whenever you set this to true it resets the origin to the current value of the control.
+  // Typically it should be initialized to false.
+  // When you process a form (e.g. doing a "save" operation) start by setting this to false.
+  // When the save is complete--and successful--then set it to true,
+  // signalling that the new, present value should now be considered the base for comparison.
   @Input() resetOrigin = false;
 
   constructor(private control: NgControl) {}

--- a/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.html
+++ b/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.html
@@ -46,7 +46,7 @@
         </chef-form-field>
       </form>
       <div id="save">
-        <chef-button primary [disabled]="!updateForm.valid || !updateForm.dirty || saveInProgress" (click)="saveChange()">
+        <chef-button primary [disabled]="!updateForm.valid || !updateForm.dirty || saveInProgress" (click)="saveToken()">
           <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
           <span *ngIf="saveInProgress">Saving...</span>
           <span *ngIf="!saveInProgress">Save</span>

--- a/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.html
+++ b/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.html
@@ -32,7 +32,7 @@
       <form [formGroup]="updateForm">
         <chef-form-field>
           <label>Name <span aria-hidden="true">*</span></label>
-          <input chefInput formControlName="name" type="text" (keyup)="handleChange()" autocomplete="off"/>
+          <input chefInput formControlName="name" type="text" autocomplete="off"/>
           <chef-error *ngIf="(nameCtrl.hasError('required') || nameCtrl.hasError('pattern')) && nameCtrl.dirty">
             Name is required.
           </chef-error>

--- a/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.html
+++ b/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.html
@@ -32,14 +32,14 @@
       <form [formGroup]="updateForm">
         <chef-form-field>
           <label>Name <span aria-hidden="true">*</span></label>
-          <input chefInput formControlName="name" type="text" autocomplete="off"/>
+          <input chefInput formControlName="name" type="text" [resetOrigin]="saveSuccessful" autocomplete="off"/>
           <chef-error *ngIf="(nameCtrl.hasError('required') || nameCtrl.hasError('pattern')) && nameCtrl.dirty">
             Name is required.
           </chef-error>
         </chef-form-field>
         <chef-form-field>
           <label>Status <span aria-hidden="true">*</span></label>
-          <chef-radio ngDefaultControl formControlName="status">
+          <chef-radio ngDefaultControl formControlName="status" [resetOrigin]="saveSuccessful">
             <chef-option value="active">Active</chef-option>
             <chef-option value="inactive">Inactive</chef-option>
           </chef-radio>
@@ -51,7 +51,7 @@
           <span *ngIf="saveInProgress">Saving...</span>
           <span *ngIf="!saveInProgress">Save</span>
         </chef-button>
-        <span id="saved-note" *ngIf="!firstLoad && !updateForm.dirty">All changes saved.</span>
+        <span id="saved-note" *ngIf="saveSuccessful && !updateForm.dirty">All changes saved.</span>
       </div>
     </section>
   </main>

--- a/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.ts
@@ -69,12 +69,6 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
     this.isDestroyed.complete();
   }
 
-  public handleChange(): void {
-    if (this.nameCtrl.value === this.token.name) {
-      this.nameCtrl.markAsPristine();
-    }
-  }
-
   public saveChange(): void {
     this.firstLoad = false;
     this.saveInProgress = true;

--- a/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.ts
@@ -8,7 +8,7 @@ import { filter, pluck, takeUntil } from 'rxjs/operators';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams } from 'app/route.selectors';
 import { Regex } from 'app/helpers/auth/regex';
-import { loading } from 'app/entities/entities';
+import { loading, EntityStatus } from 'app/entities/entities';
 import { GetToken, UpdateToken } from 'app/entities/api-tokens/api-token.actions';
 import { apiTokenFromRoute, updateStatus } from 'app/entities/api-tokens/api-token.selectors';
 import { ApiToken } from 'app/entities/api-tokens/api-token.model';
@@ -28,7 +28,7 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
   public updateForm: FormGroup;
   public saveInProgress = false;
-  public firstLoad = true;
+  public saveSuccessful = false;
 
   constructor(
     private store: Store<NgrxStateAtom>,
@@ -70,11 +70,10 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
   }
 
   public saveChange(): void {
-    this.firstLoad = false;
+    this.saveSuccessful = false;
     this.saveInProgress = true;
     const name: string = this.updateForm.controls.name.value.trim();
     const active = <TokenStatus>this.updateForm.controls.status.value === 'active';
-    const status: TokenStatus = active ? 'active' : 'inactive';
     const token: ApiToken = { ...this.token, name, active };
     this.store.dispatch(new UpdateToken({ token }));
 
@@ -88,7 +87,10 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
           pendingSave.next(true);
           pendingSave.complete();
           this.saveInProgress = false;
-          this.updateForm.reset({ name, status });
+          this.saveSuccessful = (state === EntityStatus.loadingSuccess);
+          if (this.saveSuccessful) {
+            this.updateForm.markAsPristine();
+          }
         }
       });
   }

--- a/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.ts
@@ -64,7 +64,7 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
       });
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
   }

--- a/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/pages/api-token/details/api-token-details.component.ts
@@ -69,7 +69,7 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
     this.isDestroyed.complete();
   }
 
-  public saveChange(): void {
+  public saveToken(): void {
     this.saveSuccessful = false;
     this.saveInProgress = true;
     const name: string = this.updateForm.controls.name.value.trim();

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -43,7 +43,7 @@
           Name changes are not allowed for the default project.
         </span>
         <div id="button-bar" *ngIf="!isChefManaged">
-          <chef-button [disabled]="isLoading || !projectForm.valid || projectForm.controls['name'].value === project?.name"
+          <chef-button [disabled]="isLoading || !projectForm.valid || !projectForm.dirty"
             primary inline (click)="saveProject()">
             <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
             <span *ngIf="saving">Saving...</span>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -30,9 +30,9 @@
         <chef-form-field id="update-name">
           <label>
             <span class="label">Name <span aria-hidden="true">*</span></span>
-            <input chefInput formControlName="name" type="text"
+            <input chefInput formControlName="name" type="text" [resetOrigin]="saveSuccessful"
               [attr.disabled]="(isChefManaged || isLoading) ? true : null"
-              (keyup)="keyPressed()" autocomplete="off">
+              autocomplete="off">
           </label>
           <chef-error
             *ngIf="(projectForm.get('name').hasError('required') || projectForm.get('name').hasError('pattern')) && projectForm.get('name').dirty">

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -49,7 +49,7 @@
             <span *ngIf="saving">Saving...</span>
             <span *ngIf="!saving">Save</span>
           </chef-button>
-          <span *ngIf="saveSuccessful" id="save-note">All changes saved.</span>
+          <span id="saved-note" *ngIf="saveSuccessful && !projectForm.dirty">All changes saved.</span>
         </div>
       </form>
     </section>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.scss
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.scss
@@ -48,7 +48,7 @@ form {
   #button-bar {
     margin-top: 15px;
 
-    span#save-note {
+    span#saved-note {
       display: inline-block;
       margin-top: 5px;
       font-size: 12px;

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -92,6 +92,7 @@ describe('ProjectDetailsComponent', () => {
         MockComponent({ selector: 'chef-th' }),
         MockComponent({ selector: 'chef-td' }),
         MockComponent({ selector: 'ng-container', inputs: ['hidden'] }),
+        MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
         ProjectDetailsComponent
       ],
       imports: [

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -106,10 +106,6 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
     this.isDestroyed.complete();
   }
 
-  keyPressed() {
-    this.saveSuccessful = false;
-  }
-
   onSelectedTab(event: { target: { value: ProjectTabName } }) {
     this.tabValue = event.target.value;
     // Drop the previous fragment and add the incoming fragment.
@@ -173,6 +169,9 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
           pendingSave.complete();
           this.saving = false;
           this.saveSuccessful = (state === EntityStatus.loadingSuccess);
+          if (this.saveSuccessful) {
+            this.projectForm.markAsPristine();
+          }
         }
       });
   }

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -101,7 +101,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
       });
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
   }
@@ -151,7 +151,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
     return some([statusPropertyName, ruleStatus], this.rules);
   }
 
-  saveProject() {
+  saveProject(): void {
     this.saveSuccessful = false;
     this.saving = true;
     this.store.dispatch(new UpdateProject({

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -77,7 +77,7 @@
               <chef-form-field class="attribute-field">
                 <label>
                   <span class="label">{{ getAttributeLabel() }}</span>
-                  <select ngDefaultControl formControlName="attribute" (change)="handleConditionChange()">
+                  <select ngDefaultControl formControlName="attribute">
                     <option
                       *ngFor="let option of attributes[ruleForm.get('type').value.toLowerCase()]; let i = index"
                       [value]="option.key"
@@ -92,7 +92,7 @@
               <chef-form-field class="attribute-field">
                 <label>
                   <span class="label">Operator</span>
-                  <select ngDefaultControl formControlName="operator" (change)="handleConditionChange()">
+                  <select ngDefaultControl formControlName="operator">
                     <option *ngFor="let operator of operators"
                       [value]="operator.key"
                     >{{ operator.value }}</option>
@@ -106,10 +106,7 @@
               <chef-form-field class="attribute-field">
                 <label>
                   <span class="label">Value</span>
-                  <chef-input ngDefaultControl
-                    formControlName="values"
-                    [value]="condition.controls.values.value"
-                    (keyup)="handleConditionChange()"></chef-input>
+                  <chef-input ngDefaultControl formControlName="values" [value]="condition.controls.values.value"></chef-input>
                 </label>
                 <chef-error
                   *ngIf="(ruleForm.get('conditions').controls[i].get('values').hasError('required') || ruleForm.get('conditions').controls[i].get('values').hasError('pattern')) && ruleForm.get('conditions').controls[i].get('values').dirty"

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -301,10 +301,6 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
       this.ruleForm.controls.id.setValue(
         IdMapper.transform(this.ruleForm.controls.name.value.trim()));
     }
-
-    if (this.editingRule) {
-      this.ruleForm.markAsDirty();
-    }
   }
 
   handleIDInput(event: KeyboardEvent): void {
@@ -312,14 +308,6 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
       return;
     }
     this.conflictError = false;
-  }
-
-  handleConditionChange(): void {
-    if (this.editingRule) {
-      // changes on the condition forms do not bubble up to the ruleForm
-      // so we explicitly set it to dirty here
-      this.ruleForm.markAsDirty();
-    }
   }
 
   private isNavigationKey(event: KeyboardEvent): boolean {

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -150,18 +150,18 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     }
   }
 
-  get getConditions() { return this.ruleForm.get('conditions'); }
-
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
   }
 
-  getHeading() {
+  get getConditions() { return this.ruleForm.get('conditions'); }
+
+  getHeading(): string {
     return `${this.project.name}: ` + (this.ruleForm.value.name.trim() || 'Rule');
   }
 
-  getAttributeLabel() {
+  getAttributeLabel(): string {
     // Important for this to be all lower case for screen readers!
     // (All uppercase is typically read as an acronym.)
     return `${this.ruleForm.get('type').value.toLowerCase()} attribute`;
@@ -171,11 +171,11 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     return ['/settings', 'projects', this.project.id];
   }
 
-  closePage() {
+  closePage(): void {
     this.router.navigate(this.backRoute());
   }
 
-  createCondition(attribute = '', operator = '', values = ''): FormGroup {
+  private createCondition(attribute = '', operator = '', values = ''): FormGroup {
     return this.fb.group({
       // Must stay in sync with error checks in project-rules.component.html
       attribute: [attribute, Validators.required],
@@ -189,7 +189,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     conditions.push(this.createCondition());
   }
 
-  deleteCondition(index: number) {
+  deleteCondition(index: number): void {
     const conditions = this.ruleForm.get('conditions') as FormArray;
     conditions.removeAt(index);
   }
@@ -204,7 +204,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     return conditions.length > 1;
   }
 
-  populateConditions() {
+  private populateConditions(): FormGroup[] {
     this.conditions = [];
 
     if (this.rule.conditions && this.rule.conditions.length !== 0) {
@@ -220,14 +220,14 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     return this.conditions;
   }
 
-  createRule() {
+  private createRule(): void {
     this.store.dispatch(
       new CreateRule({
         rule: this.convertToRule()
       }));
   }
 
-  updateRule() {
+  private updateRule(): void {
     const updatedRule = this.convertToRule();
     this.store.dispatch(new UpdateRule({ rule: updatedRule }));
     this.store.dispatch(new GetRulesForProject({ project_id: this.rule.project_id }));
@@ -258,10 +258,10 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   }
 
   // TODO: Leveraged much from ID section of create-object-modal... make a shared component...?
-  saveRule() {
+  saveRule(): void {
     if (this.ruleForm.valid) {
       this.saving = true;
-      this.rule.id ? this.updateRule() : this.createRule(); // TODO
+      this.rule.id ? this.updateRule() : this.createRule();
       const selector = this.rule.id ? updateStatus : createStatus;
       const pendingSave = new Subject<boolean>();
       this.store.select(selector).pipe(

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -81,7 +81,7 @@
         <chef-loading-spinner  size="30" *ngIf="teamProjectsLeftToFetch.length !== 0"></chef-loading-spinner>
       </div>
       <chef-button [disabled]="isLoadingTeam || teamProjectsLeftToFetch.length !== 0 || !updateNameForm.valid || (!updateNameForm.dirty && noProjectsUpdated())"
-        primary inline (click)="updateTeam()" data-cy="team-details-submit-button">
+        primary inline (click)="saveTeam()" data-cy="team-details-submit-button">
         <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
         <span *ngIf="saving">Saving...</span>
         <span *ngIf="!saving">Save</span>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -80,7 +80,7 @@
         </app-projects-dropdown>
         <chef-loading-spinner  size="30" *ngIf="teamProjectsLeftToFetch.length !== 0"></chef-loading-spinner>
       </div>
-      <chef-button [disabled]="isLoadingTeam || teamProjectsLeftToFetch.length !== 0 || !updateNameForm.valid || (updateNameForm.controls['name'].value === team.name && noProjectsUpdated())"
+      <chef-button [disabled]="isLoadingTeam || teamProjectsLeftToFetch.length !== 0 || !updateNameForm.valid || (!updateNameForm.dirty && noProjectsUpdated())"
         primary inline (click)="updateTeam()" data-cy="team-details-submit-button">
         <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
         <span *ngIf="saving">Saving...</span>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -86,7 +86,7 @@
         <span *ngIf="saving">Saving...</span>
         <span *ngIf="!saving">Save</span>
       </chef-button>
-      <span *ngIf="saveSuccessful" id="save-note">All changes saved.</span>
+      <span *ngIf="saveSuccessful" id="saved-note">All changes saved.</span>
     </section>
   </main>
 </div>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -65,7 +65,7 @@
       <form [formGroup]="updateNameForm">
         <chef-form-field>
           <label>{{ descriptionOrName | titlecase }} <span aria-hidden="true">*</span></label>
-          <input chefInput formControlName="name" type="text" (keyup)="keyPressed()" autocomplete="off" data-cy="team-details-name-input">
+          <input chefInput formControlName="name" type="text" [resetOrigin]="saveSuccessful" autocomplete="off" data-cy="team-details-name-input">
           <chef-error
             *ngIf="(updateNameForm.get('name').hasError('required') || updateNameForm.get('name').hasError('pattern')) && updateNameForm.get('name').dirty">
             {{ descriptionOrName | titlecase }} is required.
@@ -86,7 +86,7 @@
         <span *ngIf="saving">Saving...</span>
         <span *ngIf="!saving">Save</span>
       </chef-button>
-      <span *ngIf="saveSuccessful" id="saved-note">All changes saved.</span>
+      <span id="saved-note" *ngIf="saveSuccessful && !updateNameForm.dirty">All changes saved.</span>
     </section>
   </main>
 </div>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.scss
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.scss
@@ -43,7 +43,7 @@ chef-page-header {
 }
 
 section {
-  span#save-note {
+  span#saved-note {
     display: inline-block;
     margin-top: 5px;
     font-size: 12px;

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
@@ -71,6 +71,7 @@ describe('TeamDetailsComponent', () => {
         }),
         MockComponent({ selector: 'app-user-team-membership-table',
           inputs: ['usersToFilter', 'users$', 'removeText', 'addButtonText'] }),
+        MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
         MockComponent({ selector: 'chef-breadcrumb', inputs: ['link'] }),
         MockComponent({ selector: 'chef-breadcrumbs' }),
         MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -249,7 +249,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
       })).subscribe();
  }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
   }

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -276,10 +276,6 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     }));
   }
 
-  public keyPressed() {
-    this.saveSuccessful = false;
-  }
-
   public updateTeam(): void {
     this.saveSuccessful = false;
     this.saving = true;
@@ -302,6 +298,9 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
           pendingSave.complete();
           this.saving = false;
           this.saveSuccessful = (state === EntityStatus.loadingSuccess);
+          if (this.saveSuccessful) {
+            this.updateNameForm.markAsPristine();
+          }
         }
       });
   }

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -276,7 +276,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     }));
   }
 
-  public updateTeam(): void {
+  public saveTeam(): void {
     this.saveSuccessful = false;
     this.saving = true;
     const name: string = this.updateNameForm.controls.name.value.trim();

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.html
@@ -50,7 +50,7 @@
             </chef-button>
           </ng-container>
           <ng-container *ngIf="editMode">
-            <chef-button primary class="save-button" [disabled]="!editForm.valid || !editForm.dirty" (click)="updateFullName()">
+            <chef-button primary class="save-button" [disabled]="!editForm.valid || !editForm.dirty" (click)="saveFullName()">
               <span>Save</span>
             </chef-button>
             <chef-button tertiary (click)="setEditMode(false)">Cancel</chef-button>
@@ -99,7 +99,7 @@
             Passwords must match.
           </chef-error>
         </chef-form-field>
-        <chef-button [disabled]="!passwordForm.valid" class="update-password-button" primary (click)="updatePassword()">
+        <chef-button [disabled]="!passwordForm.valid" class="update-password-button" primary (click)="savePassword()">
           <span>Update Password</span>
         </chef-button>
       </form>

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.html
@@ -50,7 +50,7 @@
             </chef-button>
           </ng-container>
           <ng-container *ngIf="editMode">
-            <chef-button primary class="save-button" (click)="updateFullName()">
+            <chef-button primary class="save-button" [disabled]="!editForm.valid || !editForm.dirty" (click)="updateFullName()">
               <span>Save</span>
             </chef-button>
             <chef-button tertiary (click)="setEditMode(false)">Cancel</chef-button>

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.ts
@@ -125,6 +125,7 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
   }
 
   private resetForms(): void {
+    this.editForm.reset();
     this.editMode = false;
     this.passwordForm.reset();
   }

--- a/components/automate-ui/src/app/pages/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/pages/user-details/user-details.component.ts
@@ -129,20 +129,20 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
     this.passwordForm.reset();
   }
 
-  public updatePassword(): void {
+  public savePassword(): void {
     if (this.isAdminView) {
-      this.updatePasswordForUser();
+      this.savePasswordForUser();
     } else {
-      this.updatePasswordForSelf();
+      this.savePasswordForSelf();
     }
   }
 
-  private updatePasswordForUser(): void {
+  private savePasswordForUser(): void {
     const password = this.passwordForm.get('newPassword').value;
     this.store.dispatch(new UpdateUser({ ...this.user, password }));
   }
 
-  private updatePasswordForSelf(): void {
+  private savePasswordForSelf(): void {
     const password = this.passwordForm.get('newPassword').value;
     const previous_password = this.passwordForm.get('oldPassword').value;
     this.store.dispatch(new UpdateSelf({
@@ -154,7 +154,7 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
     }));
   }
 
-  public updateFullName(): void {
+  public saveFullName(): void {
     const name = this.editForm.get('fullName').value.trim();
     this.store.dispatch(
       this.isAdminView ?


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This PR uses the new functionality embued to `FormControls` to remember their original values and reset themselves to pristine when appropriate.
With that, we can strip out the various ways we have done that manually.
The table shows the state of things auth prior to this PR. Each of the items below needed a bit of tweaking, making them cleaner. 

| Resource | Where to find it | Method |
| --- | --- | --- |
| user name | users >> [user] > edit > name | not checked! |
| team name | teams >> [team] > details > name | manual equality check |
| token name | [token] > details > name | dirty check fueled by manual keyup handler |
| token status | [token] > details > status | not checked! |
| project name | projects >> [project] > details > name | manual equality check |
| rule name | projects >> [project] > rules > [rule] > name | dirty check fueled by manual keyup handler |
| rule conditions | projects >> [project] > rules > [rule] > conditions | dirty check fueled by manual keyup handler |

~~Remaining work to do:~~
- [x] Re-initialize a `FormControl` upon pressing `Save`, so it has a new "original" value. 🤔 

2019.08.17 Finished this last bit (upon pressing `Save`). Note that it has been applied to just tokens, projects, and teams. It is not applicable to users and roles because those forms immediately close upon save.

### :chains: Related Resources

PR - #1171 Add FormControlDirective

### :+1: Definition of Done

All the above resources now know when they have been modified. When the user edits a given value so that it is back to its original, then the `Save` button becomes disabled because there are no changes to save. Furthermore, upon selecting `Save` the newly saved value becomes the new basis for determining edited-or-not.

### :athletic_shoe: How to Build and Test the Change

rebuild automate-ui.
Navigate to any of the items detailed above.
Edit the value.
➡️ Observe `Save` becomes enabled.
Restore the original value.
➡️ Observe `Save` becomes disable.
For token, project, or team, go ahead and select `Save`. The form remains open, but the field's origin value is reset to the newly saved value.
Now edit the value again.
➡️ Observe `Save` becomes enabled/disabled based on the newly saved value.

In (a) we just arrived: no edits, Save disabled.
In (b) both the name and status have been edited, so Save is enabled.
In (c), both name and status have been edited back to their original values, so Save again becomes disabled.

![image](https://user-images.githubusercontent.com/6817500/62827297-22c4aa00-bb81-11e9-9ff8-40e69d40af04.png)
