### PR TITLE
Automate-1021 Missing max width limits on Client Runs applied filter …

### DIFF
--- a/components/automate-ui/src/app/page-components/search-bar-filter-bar/search-bar-filter-bar.component.html
+++ b/components/automate-ui/src/app/page-components/search-bar-filter-bar/search-bar-filter-bar.component.html
@@ -1,10 +1,18 @@
 <chef-card class="filters-list" *ngIf="filters.length > 0">
   <chef-button secondary (click)="onClearClick()">Clear All</chef-button>
-  <chef-button
-    primary
-    *ngFor="let filter of filters"
-    (click)="onRemoveFilterClick(filter)">
-    <span>{{ filter.type }}: {{ filter.text }}</span>
-    <chef-icon>close</chef-icon>
-  </chef-button>
+  <span *ngFor="let filter of filters; index as i; trackBy: trackBy;">
+    <chef-button
+      primary
+      class="filter"
+      [attr.id]="'filter'+i" 
+      (click)="onRemoveFilterClick(filter)">
+      <span>{{ filter.type }}: {{ filter.text }}</span>
+      <chef-icon>close</chef-icon>
+    </chef-button>
+    <chef-tooltip
+      [attr.for]="'filter'+i"
+      position="top">
+        {{ filter.type }}: {{ filter.text }}
+    </chef-tooltip>
+  </span>
 </chef-card>

--- a/components/automate-ui/src/app/page-components/search-bar-filter-bar/search-bar-filter-bar.component.scss
+++ b/components/automate-ui/src/app/page-components/search-bar-filter-bar/search-bar-filter-bar.component.scss
@@ -3,4 +3,14 @@
 :host ::ng-deep .content {
   padding: 0.5em;
   border: 1px solid $chef-light-grey;
+
+  .filter {
+    max-width: 300px;
+
+    span {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When a filter with long value is applied in the search bar, the filter chip doesn't have a maximum width in place to limit its size. The filter chip will extend to passing the border of its container.

### :chains: Related Resources
https://github.com/chef/automate/issues/1021

### :+1: Definition of Done
When a really long filter is applied, set the limitation of the filter chip to be a set number or dynamic depending on the width of its container; or set a limitation for the characters within the filter chip, and append a ... to indicate hidden content. When hovering over or keyboard focus on the pill, display the full content in a tooltip component.

### :athletic_shoe: How to Build and Test the Change
1. build components/automate-ui && start_all_services && chef_load_nodes
2. Go to https://a2-dev.test/infrastructure/client-runs and inspect

### :camera: Screenshots, if applicable
![Screen Shot 2019-08-11 at 10 19 07 AM](https://user-images.githubusercontent.com/4108100/62835744-843c5580-bc21-11e9-8e8d-f134fcae7261.png)