### PR TITLE
Automate-1042 Client Runs search bar: filter suggestions content over…

### DIFF
--- a/components/automate-ui/src/app/page-components/search-bar/search-bar.component.scss
+++ b/components/automate-ui/src/app/page-components/search-bar/search-bar.component.scss
@@ -98,6 +98,8 @@
     border-bottom: 1px solid lightGrey;
 
     &.list-item {
+      overflow-wrap: break-word;
+      
       &.selected {
         color: $white;
         cursor: pointer;

--- a/components/automate-ui/src/app/page-components/search-bar/search-bar.component.scss
+++ b/components/automate-ui/src/app/page-components/search-bar/search-bar.component.scss
@@ -99,7 +99,7 @@
 
     &.list-item {
       overflow-wrap: break-word;
-      
+
       &.selected {
         color: $white;
         cursor: pointer;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When a filter with long value appears in the search bar suggestions, the text flows over the edge of its container.

### :chains: Related Resources
https://github.com/chef/automate/issues/1042

### :+1: Definition of Done
Either increase the size of the suggestions container or wrap the text to a new line.
Set a limitation of the text being displayed, could be 260 characters max.

### :athletic_shoe: How to Build and Test the Change
1. build components/automate-ui && start_all_services && chef_load_nodes
2. Go to https://a2-dev.test/infrastructure/client-runs and inspect

### :camera: Screenshots, if applicable
![Screen Shot 2019-08-11 at 11 27 25 AM](https://user-images.githubusercontent.com/4108100/62836650-08470b00-bc2b-11e9-9628-928dbb4a5880.png)
