### PR TITLE
Apply ui-lib polyfills for older browsers

### DIFF
--- a/components/automate-ui/src/main.ts
+++ b/components/automate-ui/src/main.ts
@@ -1,7 +1,7 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
-import { defineCustomElements } from './assets/chef-ui-library/loader';
+import { applyPolyfills, defineCustomElements } from './assets/chef-ui-library/loader';
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
@@ -12,4 +12,6 @@ if (environment.production) {
 
 platformBrowserDynamic().bootstrapModule(AppModule, { preserveWhitespaces: true });
 
-defineCustomElements(window);
+applyPolyfills().then(() => {
+  defineCustomElements(window);
+});


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Sometime during 1.0-alpha it appears Stencil changed some of their upstream polyfills and how they're loaded. `applyPolyfills` is now required to be called before `defineCustomElements` if you want to support IE11, Edge, and other browsers without full custom element support.

https://github.com/ionic-team/stencil/commit/881c49bb9f2c812341890d3605664405ec455265
https://github.com/ionic-team/stencil-site/commit/6a4d8a5383867a3392e16c3719a685e2b18f1591

**Before - Firefox 60esr**
<img width="875" alt="Screen Shot 2019-08-12 at 9 43 31 PM" src="https://user-images.githubusercontent.com/479121/62914375-581df300-bd4d-11e9-84a6-12e0dc593635.png">

**After - Firefox 60esr**
<img width="875" alt="Screen Shot 2019-08-12 at 9 47 01 PM" src="https://user-images.githubusercontent.com/479121/62914379-5bb17a00-bd4d-11e9-958c-66cd8a1107ed.png">

