### PR TITLE
[es-sidecar-service] Remove dependency on config-mgmt-service

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -512,7 +512,6 @@ paths = [
   "components/automate-gateway/api/authz/*",
   "components/automate-gateway/authz/policy_v2/*",
   "components/automate-grpc/*",
-  "components/config-mgmt-service/*",
   "lib/grpc/*",
   "lib/io/*",
   "lib/tls/*",

--- a/components/es-sidecar-service/pkg/server/purge.go
+++ b/components/es-sidecar-service/pkg/server/purge.go
@@ -6,9 +6,9 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	api "github.com/chef/automate/api/interservice/es_sidecar"
-	"github.com/chef/automate/components/config-mgmt-service/errors"
 	"github.com/chef/automate/components/es-sidecar-service/pkg/elastic"
 	"github.com/chef/automate/lib/version"
 )
@@ -27,7 +27,7 @@ func (server *EsSidecarServer) PurgeTimeSeriesIndicesByAge(ctx context.Context, 
 		return &api.PurgeResponse{
 			Success: false,
 			Message: errStr,
-		}, errors.GrpcError(codes.Internal, errStr)
+		}, status.Error(codes.Internal, errStr)
 	}
 
 	return &api.PurgeResponse{
@@ -63,10 +63,10 @@ func (server *EsSidecarServer) PurgeDocumentsFromIndexByAge(ctx context.Context,
 				Success:  false,
 				Message:  errStr,
 				Failures: failures,
-			}, errors.GrpcError(codes.Internal, errStr)
+			}, status.Error(codes.Internal, errStr)
 		}
 	}
-	return nil, errors.GrpcError(codes.Internal, err.Error())
+	return nil, status.Error(codes.Internal, err.Error())
 }
 
 // Version returns the Version of the ES Sidecar Service


### PR DESCRIPTION
This was only being used for a thin wrapper function that didn't
look like it was providing much value.

Signed-off-by: Steven Danna <steve@chef.io>