### PR TITLE
Fixing the Client Runs page's search bar

### DIFF
--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.scss
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.scss
@@ -29,7 +29,7 @@ chef-page-header {
   }
 }
 
-app-client-runs-search-bar {
+app-search-bar {
   display: inline-block;
   width: calc(100% - 110px);
 }

--- a/components/automate-ui/src/app/pages/event-feed/event-feed.component.scss
+++ b/components/automate-ui/src/app/pages/event-feed/event-feed.component.scss
@@ -39,7 +39,7 @@ chef-page-header {
   }
 }
 
-app-client-runs-search-bar {
+app-search-bar {
   display: inline-block;
   width: 100%;
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The Client Runs page's search bar had the download and share buttons on the next line because the search bar was set at 100%. This was caused by the search bar being rename from app-client-runs-search-bar to app-search-bar. The CSS was not updated with this name. 

### :chains: Related Resources
https://github.com/chef/automate/pull/1106

### :+1: Definition of Done

The download and share buttons are on the same line as the image below. 

### :athletic_shoe: How to Build and Test the Change


### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
![Screen Shot 2019-08-13 at 9 25 17 AM](https://user-images.githubusercontent.com/1679247/62958796-50416b80-bdac-11e9-8bae-2d405818ac0f.png)
