### PR TITLE
Removing code that was moved to ingestion

### DIFF
--- a/components/automate-ui/src/app/services/node-details/node-runs.service.spec.ts
+++ b/components/automate-ui/src/app/services/node-details/node-runs.service.spec.ts
@@ -72,66 +72,6 @@ describe('NodeRunsService', () => {
       req.flush(getNodeRunResponse);
     });
 
-    it('when run\'s error description title gets updated from 412 "Precondition Failed"' +
-      ' to Error Resolving Cookbooks for Run List.', () => {
-      const nodeId = 'fake_id';
-      const runId = 'runId';
-      const endTime = new Date(0);
-      const expectedUrl =
-        `${CONFIG_MGMT_URL}/nodes/${nodeId}/runs/${runId}?end_time=1970-01-01T00:00:00.000Z`;
-
-      const getNodeRunResponse = getRawRun({
-        'class': '',
-        'message': '',
-        'backtrace': [],
-        'description': {
-          'title': '412 "Precondition Failed"'
-        }
-      }, []);
-
-      service.getNodeRun(nodeId, runId, endTime).then(nodeRun => {
-        expect(nodeRun).toBeDefined();
-        expect(nodeRun.error.description.title).toEqual('Error Resolving Cookbooks for Run List.');
-      });
-
-      const req = httpTestingController.expectOne(expectedUrl);
-
-      expect(req.request.method).toEqual('GET');
-
-      req.flush(getNodeRunResponse);
-    });
-
-    it('the run\'s error description title replaces the ' +
-      '":" at the end of the line with a ".". The title is updated from ' +
-      '"Error Resolving Cookbooks for Run List:" to ' +
-      '"Error Resolving Cookbooks for Run List."', () => {
-      const nodeId = 'fake_id';
-      const runId = 'runId';
-      const endTime = new Date(0);
-      const expectedUrl =
-        `${CONFIG_MGMT_URL}/nodes/${nodeId}/runs/${runId}?end_time=1970-01-01T00:00:00.000Z`;
-
-      const getNodeRunResponse = getRawRun({
-        'class': '',
-        'message': '',
-        'backtrace': [],
-        'description': {
-          'title': 'Error Resolving Cookbooks for Run List:'
-        }
-      }, []);
-
-      service.getNodeRun(nodeId, runId, endTime).then(nodeRun => {
-        expect(nodeRun).toBeDefined();
-        expect(nodeRun.error.description.title).toEqual('Error Resolving Cookbooks for Run List.');
-      });
-
-      const req = httpTestingController.expectOne(expectedUrl);
-
-      expect(req.request.method).toEqual('GET');
-
-      req.flush(getNodeRunResponse);
-    });
-
     it('when deprecations are not provided', () => {
       const nodeId = 'fake_id';
       const runId = 'runId';

--- a/components/automate-ui/src/app/services/node-details/node-runs.service.ts
+++ b/components/automate-ui/src/app/services/node-details/node-runs.service.ts
@@ -75,29 +75,7 @@ export class NodeRunsService {
 
     return this.httpClient
       .get<RespNodeRun>(url, options).toPromise()
-      .then((res) => new NodeRun(this.formatError(res)));
-  }
-
-  // This method cleans up an error message comming from chef server.
-  // Because 412 "Precondition Failed" is not user friendly, the message was changed to
-  // "Error Resolving Cookbooks for Run List."
-  //
-  // TODO remove to the backend. This could be moved to the ingest service.
-  private formatError(respNodeRun: RespNodeRun): RespNodeRun {
-    if (this.isNullErrorDescription(respNodeRun)) {
-        // remove confusing colon at end of cookbook depsolve error
-        if ( respNodeRun.error.description.title === '412 "Precondition Failed"' ||
-        respNodeRun.error.description.title === 'Error Resolving Cookbooks for Run List:' ) {
-          respNodeRun.error.description.title = 'Error Resolving Cookbooks for Run List.';
-        }
-    }
-    return respNodeRun;
-  }
-
-  private isNullErrorDescription(respNodeRun: RespNodeRun): boolean {
-    return respNodeRun != null &&
-      respNodeRun.error != null &&
-      respNodeRun.error.description != null;
+      .then((res) => new NodeRun(res));
   }
 
   private buildURLSearchParams(filters: NodeHistoryFilter): HttpParams {


### PR DESCRIPTION
This code was moved to ingest-service's pipeline about 2 years ago. I have always meant to remove it from the UI code. 

Below is a link to where the code moved to in the ingestion pipeline. 
https://github.com/chef/automate/blob/master/components/ingest-service/pipeline/processor/transmogrify_run.go#L107-L112

The PR to move the code to ingestion back on Nov 2017. 
https://github.com/chef/a2/commit/6b6a47187a5634ef8d29b4f6da66bd7f00fb2683#diff-a2c755e72b3d6e6593efd4e5880acdaaR90