### PR TITLE
Preventing empty error message suggestions

### DIFF
--- a/components/automate-ui/src/app/entities/client-runs/client-runs.requests.spec.ts
+++ b/components/automate-ui/src/app/entities/client-runs/client-runs.requests.spec.ts
@@ -31,7 +31,7 @@ describe('ClientRunsRequests', () => {
     it('returns all provided values', () => {
       const expectedData: Chicklet[] = [];
       for (let i = 0; i < 50; i++) {
-        expectedData.push({'text': '', 'type': ''});
+        expectedData.push({'text': i.toString(), 'type': 'name'});
       }
       const expectedUrl = `${CONFIG_MGMT_URL}/suggestions?type=name&text=fred`;
       const filters: NodeFilter = <NodeFilter>{};
@@ -50,8 +50,35 @@ describe('ClientRunsRequests', () => {
     it('returns 10 values when 10 are provided', () => {
       const expectedData: Chicklet[] = [];
       for (let i = 0; i < 10; i++) {
-        expectedData.push({'text': i.toString(), 'type': ''});
+        expectedData.push({'text': i.toString(), 'type': 'name'});
       }
+      const expectedUrl = `${CONFIG_MGMT_URL}/suggestions?type=name&text=fred`;
+
+      const filters: NodeFilter = <NodeFilter>{};
+      service.getSuggestions('name', 'fred', filters).subscribe(data => {
+        expect(data.length).toEqual(10);
+        for ( const item of data ) {
+          expect(Number(item.text)).toBeLessThan(10);
+        }
+      });
+
+      const req = httpTestingController.expectOne(expectedUrl);
+
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(expectedData);
+    });
+
+    it('remove empty suggestions', () => {
+      const expectedData: any[] = [];
+      for (let i = 0; i < 10; i++) {
+        expectedData.push({'text': i.toString(), 'type': 'name'});
+      }
+
+      // Add empty suggestions
+      expectedData.push({'type': ''});
+      expectedData.push({'text': '', 'type': 'name'});
+
       const expectedUrl = `${CONFIG_MGMT_URL}/suggestions?type=name&text=fred`;
 
       const filters: NodeFilter = <NodeFilter>{};

--- a/components/automate-ui/src/app/entities/client-runs/client-runs.requests.ts
+++ b/components/automate-ui/src/app/entities/client-runs/client-runs.requests.ts
@@ -20,6 +20,10 @@ const CONFIG_MGMT_URL = environment.config_mgmt_url;
 const INGEST_URL = environment.ingest_url;
 const DEPLOYMENT_URL = environment.deployment_url;
 
+interface RespSuggestion {
+  text: string;
+}
+
 @Injectable()
 export class ClientRunsRequests {
   constructor(
@@ -79,7 +83,7 @@ export class ClientRunsRequests {
       const params = this.formatFilters(filters).set('type', type).set('text', text);
       const url = `${CONFIG_MGMT_URL}/suggestions`;
 
-      return this.httpClient.get<any[]>(url, {params}).pipe(map(
+      return this.httpClient.get<RespSuggestion[]>(url, {params}).pipe(map(
         (suggestions) => suggestions.filter(s => s && s.text && s.text.length !== 0)));
     } else {
       return observableOf([]);

--- a/components/automate-ui/src/app/entities/client-runs/client-runs.requests.ts
+++ b/components/automate-ui/src/app/entities/client-runs/client-runs.requests.ts
@@ -79,7 +79,8 @@ export class ClientRunsRequests {
       const params = this.formatFilters(filters).set('type', type).set('text', text);
       const url = `${CONFIG_MGMT_URL}/suggestions`;
 
-      return this.httpClient.get<Chicklet[]>(url, {params});
+      return this.httpClient.get<any[]>(url, {params}).pipe(map(
+        (suggestions) => suggestions.filter(s => s && s.text && s.text.length !== 0)));
     } else {
       return observableOf([]);
     }

--- a/components/automate-ui/src/app/page-components/search-bar/search-bar.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/search-bar/search-bar.component.spec.ts
@@ -288,7 +288,7 @@ describe('SearchBarComponent', () => {
         });
         fixture.detectChanges();
 
-        expect(component.suggestions.size).toEqual(3);
+        expect(component.suggestions.sort()).toEqual(['1', '2', '3']);
       });
     });
 

--- a/components/automate-ui/src/app/page-components/search-bar/search-bar.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/search-bar/search-bar.component.spec.ts
@@ -288,7 +288,7 @@ describe('SearchBarComponent', () => {
         });
         fixture.detectChanges();
 
-        expect(component.suggestions.sort()).toEqual(['1', '2', '3']);
+        expect(component.suggestions.map(s => s.name).toArray().sort()).toEqual(['1', '2', '3']);
       });
     });
 

--- a/components/automate-ui/src/app/page-components/search-bar/search-bar.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/search-bar/search-bar.component.spec.ts
@@ -279,6 +279,17 @@ describe('SearchBarComponent', () => {
 
         expect(component.suggestionsVisible).toEqual(true);
       });
+
+      it('remove empty string returned suggestions', () => {
+        component.selectedCategoryType = component.categories[0];
+        component.dynamicSuggestions = ['1', '2', '3', '', undefined, null];
+        component.ngOnChanges({
+          dynamicSuggestions: new SimpleChange(null, component.dynamicSuggestions, false)
+        });
+        fixture.detectChanges();
+
+        expect(component.suggestions.size).toEqual(3);
+      });
     });
 
     describe('enter is pressed', () => {

--- a/components/automate-ui/src/app/page-components/search-bar/search-bar.component.ts
+++ b/components/automate-ui/src/app/page-components/search-bar/search-bar.component.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 import { Subject, Observable, of as observableOf } from 'rxjs';
 import { List } from 'immutable';
-import { clamp, compact } from 'lodash';
+import { clamp, compact, isEmpty } from 'lodash';
 import { SearchBarCategoryItem, Chicklet, SuggestionItem } from '../../types/types';
 import {
   debounceTime, switchMap, distinctUntilChanged
@@ -71,8 +71,8 @@ export class SearchBarComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (changes.dynamicSuggestions) {
       this.suggestions = List<SuggestionItem>(
-        compact(changes.dynamicSuggestions.currentValue.filter(
-          (suggestion) => suggestion && suggestion.length !== 0).map((suggestion) => {
+        compact(changes.dynamicSuggestions.currentValue.filter((suggestion) =>
+          !isEmpty(suggestion)).map((suggestion) => {
         return {name: suggestion, title: suggestion};
       })));
 

--- a/components/automate-ui/src/app/page-components/search-bar/search-bar.component.ts
+++ b/components/automate-ui/src/app/page-components/search-bar/search-bar.component.ts
@@ -71,7 +71,8 @@ export class SearchBarComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (changes.dynamicSuggestions) {
       this.suggestions = List<SuggestionItem>(
-        compact(changes.dynamicSuggestions.currentValue.map((suggestion) => {
+        compact(changes.dynamicSuggestions.currentValue.filter(
+          (suggestion) => suggestion && suggestion.length !== 0).map((suggestion) => {
         return {name: suggestion, title: suggestion};
       })));
 

--- a/components/ingest-service/backend/converge.go
+++ b/components/ingest-service/backend/converge.go
@@ -31,7 +31,7 @@ type Node struct {
 	HasDeprecations   bool      `json:"has_deprecations"`
 	DeprecationsCount int       `json:"deprecations_count"`
 	Projects          []string  `json:"projects"`
-	ErrorMessage      string    `json:"error_message"`
+	ErrorMessage      string    `json:"error_message,omitempty"`
 }
 
 // NodeAttribute is the representation of the


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Preventing empty error message suggestions like the one shown below. 
![image](https://user-images.githubusercontent.com/1679247/62980908-b34af680-bddc-11e9-8d30-59aaa9fa7f65.png)
The problem was that the `errorMessage` field was filled with an empty string if there was no error. Therefore the empty string suggestion was correct. The bug was prevented in three places ingestion, request to the API from the UI, and the search bar component. 

### :chains: Related Resources

https://github.com/chef/automate/pull/1211#issuecomment-520996870

### :+1: Definition of Done

The blank suggestion does not appear in the search bar

### :athletic_shoe: How to Build and Test the Change
1. `build components/ingest-service && build components/automate-ui && start_all_services`
1. Add some nodes with empty errors `chef_load_nodes 100`
1. Open https://a2-dev.test/infrastructure/client-runs
1. Type one letter in the search bar for catagory "Error"
1. Ensure the empty suggestion is not displayed.  

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable