### PR TITLE
fix shadow on chef-side-panel so its only visible when its on-screen

### DIFF
--- a/components/chef-ui-library/src/molecules/chef-side-panel/chef-side-panel.scss
+++ b/components/chef-ui-library/src/molecules/chef-side-panel/chef-side-panel.scss
@@ -6,11 +6,11 @@ chef-side-panel {
   background: var(--chef-lightest-grey);
   width: 450px;
   overflow-x: scroll;
-  box-shadow: 0 0 48px 0 rgba(63, 83, 100 , 0.2);
   transition: right 0.5s ease;
 
   &.is-visible {
     right: 0;
+    box-shadow: 0 0 48px 0 rgba(63, 83, 100 , 0.2);
   }
 
   [label='close'] {


### PR DESCRIPTION
Signed-off-by: susanev <susan.ra.evans@gmail.com>

### :nut_and_bolt: Description: What code changed, and why?
Changed the shadow to only be visible when the side panel is open.

### :chains: Related Resources
fixes #679

### :+1: Definition of Done
No more mysterious shadow on the page when the panel is closed

### :athletic_shoe: How to Build and Test the Change
* `scripts/build_chef_ui_lib && npm run copy-ui-lib` from components/automate-ui
* `build components/automate-ui-devproxy`
* `start_all_services`
* `chef_load_actions 300`
* Navigate to _Dashboards_ > _Event Feed_ and open and close the side panel by using any of the buttons that look like links on the page
    * Filter by _Event Type_: _Environments_ if you are having trouble finding any of the buttons that look like links

### :white_check_mark: Checklist
- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
#### Before
##### Closed (has shadow 😢 )
![before-closed](https://user-images.githubusercontent.com/5489125/62984514-5c4b1e80-bde8-11e9-8a1c-73b16cf3ebe3.png)

#### After
##### Closed (no shadow)
![closed-no-shadow](https://user-images.githubusercontent.com/5489125/62984486-3de52300-bde8-11e9-97f4-2bd2b2fcdcc1.png)

##### Open (shadow)
![open-has-shadow](https://user-images.githubusercontent.com/5489125/62984489-40e01380-bde8-11e9-811b-fb634fde0ae7.png)
