### PR TITLE
deps: bump go-grpc (1.23.0) and protobuf (1.3.2)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -417,7 +417,7 @@
   revision = "837231f7bb377b365da147e5ff6c031b12f0dfaa"
 
 [[projects]]
-  digest = "1:328e72b35acbe8bd8ca553e075d33461fb71e02ccc5ddb31d2b3c33e2d008e5b"
+  digest = "1:6b3d0f402c88b60e78bca3ee8332a79f02e6964d2b4a44092620f1448e16cbb6"
   name = "github.com/golang/protobuf"
   packages = [
     "descriptor",
@@ -438,8 +438,8 @@
     "ptypes/wrappers",
   ]
   pruneopts = "NUT"
-  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
-  version = "v1.3.1"
+  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
+  version = "v1.3.2"
 
 [[projects]]
   digest = "1:39f0aa89737a0f37df361fba39858b685d00caff4bdcd4363f768075fbedbb15"
@@ -1360,7 +1360,7 @@
   revision = "67d6565462c5a0d99b88193d59fefa10ca7e3010"
 
 [[projects]]
-  digest = "1:72979c5a2c853cb42434d7082e70496014a1449872bdc4b25ef2a215bc6c8ef6"
+  digest = "1:53c6cedea8e03c74798be20889807a872935554abbe1bfd7617dfee004417f51"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -1404,8 +1404,8 @@
     "test/bufconn",
   ]
   pruneopts = "NUT"
-  revision = "1d89a3c832915b2314551c1d2a506874d62e53f7"
-  version = "v1.22.0"
+  revision = "6eaf6f47437a6b4e2153a190160ef39a92c7eceb"
+  version = "v1.23.0"
 
 [[projects]]
   digest = "1:aea6e9483c167cc6fdf1274c442558c5dda8fd3373372be04d98c79100868da1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@ required = [
 
 [[override]]
   name = "github.com/golang/protobuf"
-  version = "1.3.1"
+  version = "1.3.2"
 
 # "github.com/grpc-ecosystem/go-grpc-middleware" depends on logrus@^1.0.3
 [[override]]
@@ -77,7 +77,7 @@ required = [
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "1.22.0"
+  version = "1.23.0"
 
 [[constraint]]
   name = "github.com/dexidp/dex"

--- a/api/external/applications/applications.pb.go
+++ b/api/external/applications/applications.pb.go
@@ -14,6 +14,8 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1197,6 +1199,35 @@ type ApplicationsServiceServer interface {
 	GetDisconnectedServices(context.Context, *DisconnectedServicesReq) (*ServicesRes, error)
 	DeleteDisconnectedServices(context.Context, *DisconnectedServicesReq) (*ServicesRes, error)
 	GetVersion(context.Context, *version.VersionInfoRequest) (*version.VersionInfo, error)
+}
+
+// UnimplementedApplicationsServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedApplicationsServiceServer struct {
+}
+
+func (*UnimplementedApplicationsServiceServer) GetServiceGroups(ctx context.Context, req *ServiceGroupsReq) (*ServiceGroups, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetServiceGroups not implemented")
+}
+func (*UnimplementedApplicationsServiceServer) GetServiceGroupsHealthCounts(ctx context.Context, req *ServiceGroupsHealthCountsReq) (*HealthCounts, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetServiceGroupsHealthCounts not implemented")
+}
+func (*UnimplementedApplicationsServiceServer) GetServices(ctx context.Context, req *ServicesReq) (*ServicesRes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetServices not implemented")
+}
+func (*UnimplementedApplicationsServiceServer) GetServicesBySG(ctx context.Context, req *ServicesBySGReq) (*ServicesBySGRes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetServicesBySG not implemented")
+}
+func (*UnimplementedApplicationsServiceServer) GetServicesStats(ctx context.Context, req *ServicesStatsReq) (*ServicesStatsRes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetServicesStats not implemented")
+}
+func (*UnimplementedApplicationsServiceServer) GetDisconnectedServices(ctx context.Context, req *DisconnectedServicesReq) (*ServicesRes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetDisconnectedServices not implemented")
+}
+func (*UnimplementedApplicationsServiceServer) DeleteDisconnectedServices(ctx context.Context, req *DisconnectedServicesReq) (*ServicesRes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteDisconnectedServices not implemented")
+}
+func (*UnimplementedApplicationsServiceServer) GetVersion(ctx context.Context, req *version.VersionInfoRequest) (*version.VersionInfo, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
 }
 
 func RegisterApplicationsServiceServer(s *grpc.Server, srv ApplicationsServiceServer) {

--- a/api/external/cfgmgmt/cfgmgmt.pb.go
+++ b/api/external/cfgmgmt/cfgmgmt.pb.go
@@ -16,6 +16,8 @@ import (
 	_struct "github.com/golang/protobuf/ptypes/struct"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -237,6 +239,44 @@ type ConfigMgmtServer interface {
 	GetAttributes(context.Context, *request.Node) (*response.NodeAttribute, error)
 	GetVersion(context.Context, *version.VersionInfoRequest) (*version.VersionInfo, error)
 	GetPolicyCookbooks(context.Context, *request.PolicyRevision) (*response.PolicyCookbooks, error)
+}
+
+// UnimplementedConfigMgmtServer can be embedded to have forward compatible implementations.
+type UnimplementedConfigMgmtServer struct {
+}
+
+func (*UnimplementedConfigMgmtServer) GetNodes(ctx context.Context, req *request.Nodes) (*_struct.ListValue, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetNodes not implemented")
+}
+func (*UnimplementedConfigMgmtServer) GetRuns(ctx context.Context, req *request.Runs) (*_struct.ListValue, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetRuns not implemented")
+}
+func (*UnimplementedConfigMgmtServer) GetNodesCounts(ctx context.Context, req *request.NodesCounts) (*response.NodesCounts, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetNodesCounts not implemented")
+}
+func (*UnimplementedConfigMgmtServer) GetRunsCounts(ctx context.Context, req *request.RunsCounts) (*response.RunsCounts, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetRunsCounts not implemented")
+}
+func (*UnimplementedConfigMgmtServer) GetNodeRun(ctx context.Context, req *request.NodeRun) (*response.Run, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetNodeRun not implemented")
+}
+func (*UnimplementedConfigMgmtServer) GetSuggestions(ctx context.Context, req *query.Suggestion) (*_struct.ListValue, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetSuggestions not implemented")
+}
+func (*UnimplementedConfigMgmtServer) GetOrganizations(ctx context.Context, req *request.Organizations) (*_struct.ListValue, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetOrganizations not implemented")
+}
+func (*UnimplementedConfigMgmtServer) GetSourceFqdns(ctx context.Context, req *request.SourceFqdns) (*_struct.ListValue, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetSourceFqdns not implemented")
+}
+func (*UnimplementedConfigMgmtServer) GetAttributes(ctx context.Context, req *request.Node) (*response.NodeAttribute, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetAttributes not implemented")
+}
+func (*UnimplementedConfigMgmtServer) GetVersion(ctx context.Context, req *version.VersionInfoRequest) (*version.VersionInfo, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
+}
+func (*UnimplementedConfigMgmtServer) GetPolicyCookbooks(ctx context.Context, req *request.PolicyRevision) (*response.PolicyCookbooks, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetPolicyCookbooks not implemented")
 }
 
 func RegisterConfigMgmtServer(s *grpc.Server, srv ConfigMgmtServer) {

--- a/api/external/ingest/chef.pb.go
+++ b/api/external/ingest/chef.pb.go
@@ -14,6 +14,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -169,6 +171,29 @@ type ChefIngesterServer interface {
 	ProcessMultipleNodeDeletes(context.Context, *request.MultipleNodeDeleteRequest) (*response.ProcessMultipleNodeDeleteResponse, error)
 	ProcessLivenessPing(context.Context, *request.Liveness) (*response.ProcessLivenessResponse, error)
 	GetVersion(context.Context, *version.VersionInfoRequest) (*version.VersionInfo, error)
+}
+
+// UnimplementedChefIngesterServer can be embedded to have forward compatible implementations.
+type UnimplementedChefIngesterServer struct {
+}
+
+func (*UnimplementedChefIngesterServer) ProcessChefRun(ctx context.Context, req *request.Run) (*response.ProcessChefRunResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProcessChefRun not implemented")
+}
+func (*UnimplementedChefIngesterServer) ProcessChefAction(ctx context.Context, req *request.Action) (*response.ProcessChefActionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProcessChefAction not implemented")
+}
+func (*UnimplementedChefIngesterServer) ProcessNodeDelete(ctx context.Context, req *request.Delete) (*response.ProcessNodeDeleteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProcessNodeDelete not implemented")
+}
+func (*UnimplementedChefIngesterServer) ProcessMultipleNodeDeletes(ctx context.Context, req *request.MultipleNodeDeleteRequest) (*response.ProcessMultipleNodeDeleteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProcessMultipleNodeDeletes not implemented")
+}
+func (*UnimplementedChefIngesterServer) ProcessLivenessPing(ctx context.Context, req *request.Liveness) (*response.ProcessLivenessResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProcessLivenessPing not implemented")
+}
+func (*UnimplementedChefIngesterServer) GetVersion(ctx context.Context, req *version.VersionInfoRequest) (*version.VersionInfo, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
 }
 
 func RegisterChefIngesterServer(s *grpc.Server, srv ChefIngesterServer) {

--- a/api/external/ingest/job_scheduler.pb.go
+++ b/api/external/ingest/job_scheduler.pb.go
@@ -13,6 +13,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -136,6 +138,23 @@ type JobSchedulerServer interface {
 	ConfigureNodesMissingScheduler(context.Context, *request.SchedulerConfig) (*response.ConfigureNodesMissingScheduler, error)
 	ConfigureDeleteNodesScheduler(context.Context, *request.SchedulerConfig) (*response.ConfigureDeleteNodesScheduler, error)
 	ConfigureMissingNodesForDeletionScheduler(context.Context, *request.SchedulerConfig) (*response.ConfigureMissingNodesForDeletionScheduler, error)
+}
+
+// UnimplementedJobSchedulerServer can be embedded to have forward compatible implementations.
+type UnimplementedJobSchedulerServer struct {
+}
+
+func (*UnimplementedJobSchedulerServer) GetStatusJobScheduler(ctx context.Context, req *request.GetStatusJobScheduler) (*response.JobSchedulerStatus, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetStatusJobScheduler not implemented")
+}
+func (*UnimplementedJobSchedulerServer) ConfigureNodesMissingScheduler(ctx context.Context, req *request.SchedulerConfig) (*response.ConfigureNodesMissingScheduler, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConfigureNodesMissingScheduler not implemented")
+}
+func (*UnimplementedJobSchedulerServer) ConfigureDeleteNodesScheduler(ctx context.Context, req *request.SchedulerConfig) (*response.ConfigureDeleteNodesScheduler, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConfigureDeleteNodesScheduler not implemented")
+}
+func (*UnimplementedJobSchedulerServer) ConfigureMissingNodesForDeletionScheduler(ctx context.Context, req *request.SchedulerConfig) (*response.ConfigureMissingNodesForDeletionScheduler, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConfigureMissingNodesForDeletionScheduler not implemented")
 }
 
 func RegisterJobSchedulerServer(s *grpc.Server, srv JobSchedulerServer) {

--- a/api/external/secrets/secrets.pb.go
+++ b/api/external/secrets/secrets.pb.go
@@ -12,6 +12,8 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -599,6 +601,26 @@ type SecretsServiceServer interface {
 	Update(context.Context, *Secret) (*UpdateResponse, error)
 	Delete(context.Context, *Id) (*DeleteResponse, error)
 	List(context.Context, *Query) (*Secrets, error)
+}
+
+// UnimplementedSecretsServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedSecretsServiceServer struct {
+}
+
+func (*UnimplementedSecretsServiceServer) Create(ctx context.Context, req *Secret) (*Id, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Create not implemented")
+}
+func (*UnimplementedSecretsServiceServer) Read(ctx context.Context, req *Id) (*Secret, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Read not implemented")
+}
+func (*UnimplementedSecretsServiceServer) Update(ctx context.Context, req *Secret) (*UpdateResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Update not implemented")
+}
+func (*UnimplementedSecretsServiceServer) Delete(ctx context.Context, req *Id) (*DeleteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Delete not implemented")
+}
+func (*UnimplementedSecretsServiceServer) List(ctx context.Context, req *Query) (*Secrets, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method List not implemented")
 }
 
 func RegisterSecretsServiceServer(s *grpc.Server, srv SecretsServiceServer) {

--- a/api/interservice/authn/authenticate.pb.go
+++ b/api/interservice/authn/authenticate.pb.go
@@ -9,6 +9,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -181,6 +183,14 @@ type AuthenticationServer interface {
 	// request, or the tokens are wrong, the AuthenticationService will return the
 	// corresponding error code, with details in the message.
 	Authenticate(context.Context, *AuthenticateRequest) (*AuthenticateResponse, error)
+}
+
+// UnimplementedAuthenticationServer can be embedded to have forward compatible implementations.
+type UnimplementedAuthenticationServer struct {
+}
+
+func (*UnimplementedAuthenticationServer) Authenticate(ctx context.Context, req *AuthenticateRequest) (*AuthenticateResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Authenticate not implemented")
 }
 
 func RegisterAuthenticationServer(s *grpc.Server, srv AuthenticationServer) {

--- a/api/interservice/authn/tokens.pb.go
+++ b/api/interservice/authn/tokens.pb.go
@@ -10,6 +10,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -675,6 +677,29 @@ type TokensMgmtServer interface {
 	UpdateToken(context.Context, *UpdateTokenReq) (*Token, error)
 	GetToken(context.Context, *GetTokenReq) (*Token, error)
 	DeleteToken(context.Context, *DeleteTokenReq) (*DeleteTokenResp, error)
+}
+
+// UnimplementedTokensMgmtServer can be embedded to have forward compatible implementations.
+type UnimplementedTokensMgmtServer struct {
+}
+
+func (*UnimplementedTokensMgmtServer) GetTokens(ctx context.Context, req *GetTokensReq) (*Tokens, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTokens not implemented")
+}
+func (*UnimplementedTokensMgmtServer) CreateToken(ctx context.Context, req *CreateTokenReq) (*Token, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateToken not implemented")
+}
+func (*UnimplementedTokensMgmtServer) CreateTokenWithValue(ctx context.Context, req *CreateTokenWithValueReq) (*Token, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateTokenWithValue not implemented")
+}
+func (*UnimplementedTokensMgmtServer) UpdateToken(ctx context.Context, req *UpdateTokenReq) (*Token, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateToken not implemented")
+}
+func (*UnimplementedTokensMgmtServer) GetToken(ctx context.Context, req *GetTokenReq) (*Token, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetToken not implemented")
+}
+func (*UnimplementedTokensMgmtServer) DeleteToken(ctx context.Context, req *DeleteTokenReq) (*DeleteTokenResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteToken not implemented")
 }
 
 func RegisterTokensMgmtServer(s *grpc.Server, srv TokensMgmtServer) {

--- a/api/interservice/authz/authz.pb.go
+++ b/api/interservice/authz/authz.pb.go
@@ -11,6 +11,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -882,6 +884,32 @@ type AuthorizationServer interface {
 	ListPolicies(context.Context, *ListPoliciesReq) (*ListPoliciesResp, error)
 	DeletePolicy(context.Context, *DeletePolicyReq) (*DeletePolicyResp, error)
 	PurgeSubjectFromPolicies(context.Context, *PurgeSubjectFromPoliciesReq) (*PurgeSubjectFromPoliciesResp, error)
+}
+
+// UnimplementedAuthorizationServer can be embedded to have forward compatible implementations.
+type UnimplementedAuthorizationServer struct {
+}
+
+func (*UnimplementedAuthorizationServer) GetVersion(ctx context.Context, req *version.VersionInfoRequest) (*version.VersionInfo, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
+}
+func (*UnimplementedAuthorizationServer) IsAuthorized(ctx context.Context, req *IsAuthorizedReq) (*IsAuthorizedResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method IsAuthorized not implemented")
+}
+func (*UnimplementedAuthorizationServer) FilterAuthorizedPairs(ctx context.Context, req *FilterAuthorizedPairsReq) (*FilterAuthorizedPairsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method FilterAuthorizedPairs not implemented")
+}
+func (*UnimplementedAuthorizationServer) CreatePolicy(ctx context.Context, req *CreatePolicyReq) (*CreatePolicyResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreatePolicy not implemented")
+}
+func (*UnimplementedAuthorizationServer) ListPolicies(ctx context.Context, req *ListPoliciesReq) (*ListPoliciesResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListPolicies not implemented")
+}
+func (*UnimplementedAuthorizationServer) DeletePolicy(ctx context.Context, req *DeletePolicyReq) (*DeletePolicyResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeletePolicy not implemented")
+}
+func (*UnimplementedAuthorizationServer) PurgeSubjectFromPolicies(ctx context.Context, req *PurgeSubjectFromPoliciesReq) (*PurgeSubjectFromPoliciesResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PurgeSubjectFromPolicies not implemented")
 }
 
 func RegisterAuthorizationServer(s *grpc.Server, srv AuthorizationServer) {

--- a/api/interservice/authz/common/subject_purge.pb.go
+++ b/api/interservice/authz/common/subject_purge.pb.go
@@ -9,6 +9,8 @@ import (
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -250,6 +252,14 @@ func (c *subjectPurgeClient) PurgeSubjectFromPolicies(ctx context.Context, in *P
 // SubjectPurgeServer is the server API for SubjectPurge service.
 type SubjectPurgeServer interface {
 	PurgeSubjectFromPolicies(context.Context, *PurgeSubjectFromPoliciesReq) (*PurgeSubjectFromPoliciesResp, error)
+}
+
+// UnimplementedSubjectPurgeServer can be embedded to have forward compatible implementations.
+type UnimplementedSubjectPurgeServer struct {
+}
+
+func (*UnimplementedSubjectPurgeServer) PurgeSubjectFromPolicies(ctx context.Context, req *PurgeSubjectFromPoliciesReq) (*PurgeSubjectFromPoliciesResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PurgeSubjectFromPolicies not implemented")
 }
 
 func RegisterSubjectPurgeServer(s *grpc.Server, srv SubjectPurgeServer) {

--- a/api/interservice/authz/v2/authz.pb.go
+++ b/api/interservice/authz/v2/authz.pb.go
@@ -9,6 +9,8 @@ import (
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -564,6 +566,23 @@ type AuthorizationServer interface {
 	FilterAuthorizedPairs(context.Context, *FilterAuthorizedPairsReq) (*FilterAuthorizedPairsResp, error)
 	FilterAuthorizedProjects(context.Context, *FilterAuthorizedProjectsReq) (*FilterAuthorizedProjectsResp, error)
 	ProjectsAuthorized(context.Context, *ProjectsAuthorizedReq) (*ProjectsAuthorizedResp, error)
+}
+
+// UnimplementedAuthorizationServer can be embedded to have forward compatible implementations.
+type UnimplementedAuthorizationServer struct {
+}
+
+func (*UnimplementedAuthorizationServer) IsAuthorized(ctx context.Context, req *IsAuthorizedReq) (*IsAuthorizedResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method IsAuthorized not implemented")
+}
+func (*UnimplementedAuthorizationServer) FilterAuthorizedPairs(ctx context.Context, req *FilterAuthorizedPairsReq) (*FilterAuthorizedPairsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method FilterAuthorizedPairs not implemented")
+}
+func (*UnimplementedAuthorizationServer) FilterAuthorizedProjects(ctx context.Context, req *FilterAuthorizedProjectsReq) (*FilterAuthorizedProjectsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method FilterAuthorizedProjects not implemented")
+}
+func (*UnimplementedAuthorizationServer) ProjectsAuthorized(ctx context.Context, req *ProjectsAuthorizedReq) (*ProjectsAuthorizedResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProjectsAuthorized not implemented")
 }
 
 func RegisterAuthorizationServer(s *grpc.Server, srv AuthorizationServer) {

--- a/api/interservice/authz/v2/policy.pb.go
+++ b/api/interservice/authz/v2/policy.pb.go
@@ -9,6 +9,8 @@ import (
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -2009,6 +2011,65 @@ type PoliciesServer interface {
 	RemovePolicyMembers(context.Context, *RemovePolicyMembersReq) (*RemovePolicyMembersResp, error)
 	AddPolicyMembers(context.Context, *AddPolicyMembersReq) (*AddPolicyMembersResp, error)
 	PurgeSubjectFromPolicies(context.Context, *PurgeSubjectFromPoliciesReq) (*PurgeSubjectFromPoliciesResp, error)
+}
+
+// UnimplementedPoliciesServer can be embedded to have forward compatible implementations.
+type UnimplementedPoliciesServer struct {
+}
+
+func (*UnimplementedPoliciesServer) ReplacePolicyMembers(ctx context.Context, req *ReplacePolicyMembersReq) (*ReplacePolicyMembersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReplacePolicyMembers not implemented")
+}
+func (*UnimplementedPoliciesServer) CreatePolicy(ctx context.Context, req *CreatePolicyReq) (*Policy, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreatePolicy not implemented")
+}
+func (*UnimplementedPoliciesServer) DeletePolicy(ctx context.Context, req *DeletePolicyReq) (*DeletePolicyResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeletePolicy not implemented")
+}
+func (*UnimplementedPoliciesServer) ListPolicies(ctx context.Context, req *ListPoliciesReq) (*ListPoliciesResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListPolicies not implemented")
+}
+func (*UnimplementedPoliciesServer) GetPolicy(ctx context.Context, req *GetPolicyReq) (*Policy, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetPolicy not implemented")
+}
+func (*UnimplementedPoliciesServer) UpdatePolicy(ctx context.Context, req *UpdatePolicyReq) (*Policy, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdatePolicy not implemented")
+}
+func (*UnimplementedPoliciesServer) MigrateToV2(ctx context.Context, req *MigrateToV2Req) (*MigrateToV2Resp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method MigrateToV2 not implemented")
+}
+func (*UnimplementedPoliciesServer) GetPolicyVersion(ctx context.Context, req *GetPolicyVersionReq) (*GetPolicyVersionResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetPolicyVersion not implemented")
+}
+func (*UnimplementedPoliciesServer) ResetToV1(ctx context.Context, req *ResetToV1Req) (*ResetToV1Resp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ResetToV1 not implemented")
+}
+func (*UnimplementedPoliciesServer) CreateRole(ctx context.Context, req *CreateRoleReq) (*Role, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateRole not implemented")
+}
+func (*UnimplementedPoliciesServer) ListRoles(ctx context.Context, req *ListRolesReq) (*ListRolesResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListRoles not implemented")
+}
+func (*UnimplementedPoliciesServer) GetRole(ctx context.Context, req *GetRoleReq) (*Role, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetRole not implemented")
+}
+func (*UnimplementedPoliciesServer) DeleteRole(ctx context.Context, req *DeleteRoleReq) (*DeleteRoleResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteRole not implemented")
+}
+func (*UnimplementedPoliciesServer) UpdateRole(ctx context.Context, req *UpdateRoleReq) (*Role, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateRole not implemented")
+}
+func (*UnimplementedPoliciesServer) ListPolicyMembers(ctx context.Context, req *ListPolicyMembersReq) (*ListPolicyMembersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListPolicyMembers not implemented")
+}
+func (*UnimplementedPoliciesServer) RemovePolicyMembers(ctx context.Context, req *RemovePolicyMembersReq) (*RemovePolicyMembersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RemovePolicyMembers not implemented")
+}
+func (*UnimplementedPoliciesServer) AddPolicyMembers(ctx context.Context, req *AddPolicyMembersReq) (*AddPolicyMembersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddPolicyMembers not implemented")
+}
+func (*UnimplementedPoliciesServer) PurgeSubjectFromPolicies(ctx context.Context, req *PurgeSubjectFromPoliciesReq) (*PurgeSubjectFromPoliciesResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PurgeSubjectFromPolicies not implemented")
 }
 
 func RegisterPoliciesServer(s *grpc.Server, srv PoliciesServer) {

--- a/api/interservice/authz/v2/project.pb.go
+++ b/api/interservice/authz/v2/project.pb.go
@@ -11,6 +11,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1943,6 +1945,62 @@ type ProjectsServer interface {
 	ListRulesForProject(context.Context, *ListRulesForProjectReq) (*ListRulesForProjectResp, error)
 	DeleteRule(context.Context, *DeleteRuleReq) (*DeleteRuleResp, error)
 	ListRulesForAllProjects(context.Context, *ListRulesForAllProjectsReq) (*ListRulesForAllProjectsResp, error)
+}
+
+// UnimplementedProjectsServer can be embedded to have forward compatible implementations.
+type UnimplementedProjectsServer struct {
+}
+
+func (*UnimplementedProjectsServer) UpdateProject(ctx context.Context, req *UpdateProjectReq) (*UpdateProjectResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateProject not implemented")
+}
+func (*UnimplementedProjectsServer) CreateProject(ctx context.Context, req *CreateProjectReq) (*CreateProjectResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateProject not implemented")
+}
+func (*UnimplementedProjectsServer) GetProject(ctx context.Context, req *GetProjectReq) (*GetProjectResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetProject not implemented")
+}
+func (*UnimplementedProjectsServer) DeleteProject(ctx context.Context, req *DeleteProjectReq) (*DeleteProjectResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteProject not implemented")
+}
+func (*UnimplementedProjectsServer) ListProjects(ctx context.Context, req *ListProjectsReq) (*ListProjectsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListProjects not implemented")
+}
+func (*UnimplementedProjectsServer) ListProjectsForIntrospection(ctx context.Context, req *ListProjectsReq) (*ListProjectsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListProjectsForIntrospection not implemented")
+}
+func (*UnimplementedProjectsServer) HandleEvent(ctx context.Context, req *event.EventMsg) (*event.EventResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method HandleEvent not implemented")
+}
+func (*UnimplementedProjectsServer) ApplyRulesStart(ctx context.Context, req *ApplyRulesStartReq) (*ApplyRulesStartResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ApplyRulesStart not implemented")
+}
+func (*UnimplementedProjectsServer) ApplyRulesCancel(ctx context.Context, req *ApplyRulesCancelReq) (*ApplyRulesCancelResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ApplyRulesCancel not implemented")
+}
+func (*UnimplementedProjectsServer) ApplyRulesStatus(ctx context.Context, req *ApplyRulesStatusReq) (*ApplyRulesStatusResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ApplyRulesStatus not implemented")
+}
+func (*UnimplementedProjectsServer) CreateRule(ctx context.Context, req *CreateRuleReq) (*CreateRuleResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateRule not implemented")
+}
+func (*UnimplementedProjectsServer) UpdateRule(ctx context.Context, req *UpdateRuleReq) (*UpdateRuleResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateRule not implemented")
+}
+func (*UnimplementedProjectsServer) GetRule(ctx context.Context, req *GetRuleReq) (*GetRuleResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetRule not implemented")
+}
+func (*UnimplementedProjectsServer) ListRules(ctx context.Context, req *ListRulesReq) (*ListRulesResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListRules not implemented")
+}
+func (*UnimplementedProjectsServer) ListRulesForProject(ctx context.Context, req *ListRulesForProjectReq) (*ListRulesForProjectResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListRulesForProject not implemented")
+}
+func (*UnimplementedProjectsServer) DeleteRule(ctx context.Context, req *DeleteRuleReq) (*DeleteRuleResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteRule not implemented")
+}
+func (*UnimplementedProjectsServer) ListRulesForAllProjects(ctx context.Context, req *ListRulesForAllProjectsReq) (*ListRulesForAllProjectsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListRulesForAllProjects not implemented")
 }
 
 func RegisterProjectsServer(s *grpc.Server, srv ProjectsServer) {

--- a/api/interservice/cereal/cereal.pb.go
+++ b/api/interservice/cereal/cereal.pb.go
@@ -10,6 +10,8 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -2413,6 +2415,41 @@ type CerealServer interface {
 	UpdateWorkflowScheduleByName(context.Context, *UpdateWorkflowScheduleByNameRequest) (*UpdateWorkflowScheduleByNameResponse, error)
 	GetWorkflowInstanceByName(context.Context, *GetWorkflowInstanceByNameRequest) (*GetWorkflowInstanceByNameResponse, error)
 	ListWorkflowInstances(*ListWorkflowInstancesRequest, Cereal_ListWorkflowInstancesServer) error
+}
+
+// UnimplementedCerealServer can be embedded to have forward compatible implementations.
+type UnimplementedCerealServer struct {
+}
+
+func (*UnimplementedCerealServer) EnqueueWorkflow(ctx context.Context, req *EnqueueWorkflowRequest) (*EnqueueWorkflowResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method EnqueueWorkflow not implemented")
+}
+func (*UnimplementedCerealServer) DequeueWorkflow(srv Cereal_DequeueWorkflowServer) error {
+	return status.Errorf(codes.Unimplemented, "method DequeueWorkflow not implemented")
+}
+func (*UnimplementedCerealServer) CancelWorkflow(ctx context.Context, req *CancelWorkflowRequest) (*CancelWorkflowResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CancelWorkflow not implemented")
+}
+func (*UnimplementedCerealServer) DequeueTask(srv Cereal_DequeueTaskServer) error {
+	return status.Errorf(codes.Unimplemented, "method DequeueTask not implemented")
+}
+func (*UnimplementedCerealServer) CreateWorkflowSchedule(ctx context.Context, req *CreateWorkflowScheduleRequest) (*CreateWorkflowScheduleResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateWorkflowSchedule not implemented")
+}
+func (*UnimplementedCerealServer) ListWorkflowSchedules(req *ListWorkflowSchedulesRequest, srv Cereal_ListWorkflowSchedulesServer) error {
+	return status.Errorf(codes.Unimplemented, "method ListWorkflowSchedules not implemented")
+}
+func (*UnimplementedCerealServer) GetWorkflowScheduleByName(ctx context.Context, req *GetWorkflowScheduleByNameRequest) (*GetWorkflowScheduleByNameResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetWorkflowScheduleByName not implemented")
+}
+func (*UnimplementedCerealServer) UpdateWorkflowScheduleByName(ctx context.Context, req *UpdateWorkflowScheduleByNameRequest) (*UpdateWorkflowScheduleByNameResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateWorkflowScheduleByName not implemented")
+}
+func (*UnimplementedCerealServer) GetWorkflowInstanceByName(ctx context.Context, req *GetWorkflowInstanceByNameRequest) (*GetWorkflowInstanceByNameResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetWorkflowInstanceByName not implemented")
+}
+func (*UnimplementedCerealServer) ListWorkflowInstances(req *ListWorkflowInstancesRequest, srv Cereal_ListWorkflowInstancesServer) error {
+	return status.Errorf(codes.Unimplemented, "method ListWorkflowInstances not implemented")
 }
 
 func RegisterCerealServer(s *grpc.Server, srv CerealServer) {

--- a/api/interservice/cfgmgmt/service/cfgmgmt.pb.go
+++ b/api/interservice/cfgmgmt/service/cfgmgmt.pb.go
@@ -11,6 +11,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_struct "github.com/golang/protobuf/ptypes/struct"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -320,6 +322,65 @@ type CfgMgmtServer interface {
 	GetEventStringBuckets(context.Context, *request.EventStrings) (*response.EventStrings, error)
 	GetInventoryNodes(context.Context, *request.InventoryNodes) (*response.InventoryNodes, error)
 	NodeExport(*request.NodeExport, CfgMgmt_NodeExportServer) error
+}
+
+// UnimplementedCfgMgmtServer can be embedded to have forward compatible implementations.
+type UnimplementedCfgMgmtServer struct {
+}
+
+func (*UnimplementedCfgMgmtServer) GetVersion(ctx context.Context, req *request.VersionInfo) (*response.VersionInfo, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetHealth(ctx context.Context, req *request.Health) (*response.Health, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetHealth not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetNodesCounts(ctx context.Context, req *request.NodesCounts) (*response.NodesCounts, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetNodesCounts not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetRunsCounts(ctx context.Context, req *request.RunsCounts) (*response.RunsCounts, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetRunsCounts not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetNodeRun(ctx context.Context, req *request.NodeRun) (*response.Run, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetNodeRun not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetNodes(ctx context.Context, req *request.Nodes) (*_struct.ListValue, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetNodes not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetRuns(ctx context.Context, req *request.Runs) (*_struct.ListValue, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetRuns not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetSuggestions(ctx context.Context, req *request.Suggestion) (*_struct.ListValue, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetSuggestions not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetOrganizations(ctx context.Context, req *request.Organizations) (*_struct.ListValue, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetOrganizations not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetSourceFqdns(ctx context.Context, req *request.SourceFQDNS) (*_struct.ListValue, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetSourceFqdns not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetAttributes(ctx context.Context, req *request.Node) (*response.NodeAttribute, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetAttributes not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetPolicyCookbooks(ctx context.Context, req *request.PolicyRevision) (*response.PolicyCookbooks, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetPolicyCookbooks not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetEventFeed(ctx context.Context, req *request.EventFilter) (*response.Events, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetEventFeed not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetEventTypeCounts(ctx context.Context, req *request.EventCountsFilter) (*response.EventCounts, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetEventTypeCounts not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetEventTaskCounts(ctx context.Context, req *request.EventCountsFilter) (*response.EventCounts, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetEventTaskCounts not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetEventStringBuckets(ctx context.Context, req *request.EventStrings) (*response.EventStrings, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetEventStringBuckets not implemented")
+}
+func (*UnimplementedCfgMgmtServer) GetInventoryNodes(ctx context.Context, req *request.InventoryNodes) (*response.InventoryNodes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetInventoryNodes not implemented")
+}
+func (*UnimplementedCfgMgmtServer) NodeExport(req *request.NodeExport, srv CfgMgmt_NodeExportServer) error {
+	return status.Errorf(codes.Unimplemented, "method NodeExport not implemented")
 }
 
 func RegisterCfgMgmtServer(s *grpc.Server, srv CfgMgmtServer) {

--- a/api/interservice/data_lifecycle/manageable.pb.go
+++ b/api/interservice/data_lifecycle/manageable.pb.go
@@ -8,6 +8,8 @@ import (
 	fmt "fmt"
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -261,6 +263,14 @@ type DataLifecycleManageableServer interface {
 	// We could make this streaming and return how much is
 	// finished
 	Purge(context.Context, *PurgeRequest) (*PurgeResponse, error)
+}
+
+// UnimplementedDataLifecycleManageableServer can be embedded to have forward compatible implementations.
+type UnimplementedDataLifecycleManageableServer struct {
+}
+
+func (*UnimplementedDataLifecycleManageableServer) Purge(ctx context.Context, req *PurgeRequest) (*PurgeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Purge not implemented")
 }
 
 func RegisterDataLifecycleManageableServer(s *grpc.Server, srv DataLifecycleManageableServer) {

--- a/api/interservice/data_lifecycle/server.pb.go
+++ b/api/interservice/data_lifecycle/server.pb.go
@@ -8,6 +8,8 @@ import (
 	fmt "fmt"
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -270,6 +272,17 @@ type DataLifecycleServer interface {
 	// Health checks and metadata
 	Version(context.Context, *VersionRequest) (*VersionResponse, error)
 	TriggerPurge(context.Context, *TriggerPurgeRequest) (*TriggerPurgeResponse, error)
+}
+
+// UnimplementedDataLifecycleServer can be embedded to have forward compatible implementations.
+type UnimplementedDataLifecycleServer struct {
+}
+
+func (*UnimplementedDataLifecycleServer) Version(ctx context.Context, req *VersionRequest) (*VersionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Version not implemented")
+}
+func (*UnimplementedDataLifecycleServer) TriggerPurge(ctx context.Context, req *TriggerPurgeRequest) (*TriggerPurgeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method TriggerPurge not implemented")
 }
 
 func RegisterDataLifecycleServer(s *grpc.Server, srv DataLifecycleServer) {

--- a/api/interservice/deployment/automate_deployment.pb.go
+++ b/api/interservice/deployment/automate_deployment.pb.go
@@ -10,6 +10,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -6012,6 +6014,146 @@ type DeploymentServer interface {
 	Usage(context.Context, *UsageRequest) (*UsageResponse, error)
 	GetCLIExecutable(*GetCLIExecutableRequest, Deployment_GetCLIExecutableServer) error
 	BootstrapBundle(*BootstrapBundleRequest, Deployment_BootstrapBundleServer) error
+}
+
+// UnimplementedDeploymentServer can be embedded to have forward compatible implementations.
+type UnimplementedDeploymentServer struct {
+}
+
+func (*UnimplementedDeploymentServer) Deploy(ctx context.Context, req *DeployRequest) (*DeployResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Deploy not implemented")
+}
+func (*UnimplementedDeploymentServer) DeployDataServices(ctx context.Context, req *DeployRequest) (*DeployResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeployDataServices not implemented")
+}
+func (*UnimplementedDeploymentServer) DeploySome(ctx context.Context, req *DeployRequest) (*DeployResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeploySome not implemented")
+}
+func (*UnimplementedDeploymentServer) DeployStatus(req *DeployStatusRequest, srv Deployment_DeployStatusServer) error {
+	return status.Errorf(codes.Unimplemented, "method DeployStatus not implemented")
+}
+func (*UnimplementedDeploymentServer) Preload(ctx context.Context, req *DeployRequest) (*DeployResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Preload not implemented")
+}
+func (*UnimplementedDeploymentServer) RemoveSome(ctx context.Context, req *RemoveRequest) (*RemoveResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RemoveSome not implemented")
+}
+func (*UnimplementedDeploymentServer) StartNonDataServices(ctx context.Context, req *DeployRequest) (*DeployResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StartNonDataServices not implemented")
+}
+func (*UnimplementedDeploymentServer) NewDeployment(ctx context.Context, req *NewDeploymentRequest) (*DeploymentID, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method NewDeployment not implemented")
+}
+func (*UnimplementedDeploymentServer) ConfigureDeployment(ctx context.Context, req *ConfigureDeploymentRequest) (*ConfigureDeploymentResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConfigureDeployment not implemented")
+}
+func (*UnimplementedDeploymentServer) Ping(ctx context.Context, req *PingRequest) (*PingResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Ping not implemented")
+}
+func (*UnimplementedDeploymentServer) Status(ctx context.Context, req *StatusRequest) (*StatusResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Status not implemented")
+}
+func (*UnimplementedDeploymentServer) ServiceVersions(ctx context.Context, req *ServiceVersionsRequest) (*ServiceVersionsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ServiceVersions not implemented")
+}
+func (*UnimplementedDeploymentServer) LicenseStatus(ctx context.Context, req *LicenseStatusRequest) (*LicenseStatusResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method LicenseStatus not implemented")
+}
+func (*UnimplementedDeploymentServer) LicenseApply(ctx context.Context, req *LicenseApplyRequest) (*LicenseApplyResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method LicenseApply not implemented")
+}
+func (*UnimplementedDeploymentServer) Stop(ctx context.Context, req *StopRequest) (*StopResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Stop not implemented")
+}
+func (*UnimplementedDeploymentServer) SystemLogs(req *SystemLogsRequest, srv Deployment_SystemLogsServer) error {
+	return status.Errorf(codes.Unimplemented, "method SystemLogs not implemented")
+}
+func (*UnimplementedDeploymentServer) GatherLogs(ctx context.Context, req *GatherLogsRequest) (*GatherLogsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GatherLogs not implemented")
+}
+func (*UnimplementedDeploymentServer) GatherLogsDownload(req *GatherLogsDownloadRequest, srv Deployment_GatherLogsDownloadServer) error {
+	return status.Errorf(codes.Unimplemented, "method GatherLogsDownload not implemented")
+}
+func (*UnimplementedDeploymentServer) StopConverge(ctx context.Context, req *StopConvergeRequest) (*StopConvergeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StopConverge not implemented")
+}
+func (*UnimplementedDeploymentServer) StartConverge(ctx context.Context, req *StartConvergeRequest) (*StartConvergeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StartConverge not implemented")
+}
+func (*UnimplementedDeploymentServer) UpgradeStatus(ctx context.Context, req *UpgradeStatusRequest) (*UpgradeStatusResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpgradeStatus not implemented")
+}
+func (*UnimplementedDeploymentServer) RestartServices(ctx context.Context, req *RestartServicesRequest) (*RestartServicesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RestartServices not implemented")
+}
+func (*UnimplementedDeploymentServer) GetAutomateConfig(ctx context.Context, req *GetAutomateConfigRequest) (*GetAutomateConfigResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetAutomateConfig not implemented")
+}
+func (*UnimplementedDeploymentServer) PatchAutomateConfig(ctx context.Context, req *PatchAutomateConfigRequest) (*PatchAutomateConfigResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PatchAutomateConfig not implemented")
+}
+func (*UnimplementedDeploymentServer) SetAutomateConfig(ctx context.Context, req *SetAutomateConfigRequest) (*SetAutomateConfigResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetAutomateConfig not implemented")
+}
+func (*UnimplementedDeploymentServer) DumpDB(req *DumpDBRequest, srv Deployment_DumpDBServer) error {
+	return status.Errorf(codes.Unimplemented, "method DumpDB not implemented")
+}
+func (*UnimplementedDeploymentServer) ManifestVersion(ctx context.Context, req *ManifestVersionRequest) (*ManifestVersionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ManifestVersion not implemented")
+}
+func (*UnimplementedDeploymentServer) CreateBackup(ctx context.Context, req *CreateBackupRequest) (*CreateBackupResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateBackup not implemented")
+}
+func (*UnimplementedDeploymentServer) ListBackups(ctx context.Context, req *ListBackupsRequest) (*ListBackupsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListBackups not implemented")
+}
+func (*UnimplementedDeploymentServer) ShowBackup(ctx context.Context, req *ShowBackupRequest) (*ShowBackupResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ShowBackup not implemented")
+}
+func (*UnimplementedDeploymentServer) DeleteBackups(ctx context.Context, req *DeleteBackupsRequest) (*DeleteBackupsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteBackups not implemented")
+}
+func (*UnimplementedDeploymentServer) RestoreBackup(ctx context.Context, req *RestoreBackupRequest) (*RestoreBackupResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RestoreBackup not implemented")
+}
+func (*UnimplementedDeploymentServer) BackupStatus(ctx context.Context, req *BackupStatusRequest) (*BackupStatusResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BackupStatus not implemented")
+}
+func (*UnimplementedDeploymentServer) CancelBackup(ctx context.Context, req *CancelBackupRequest) (*CancelBackupResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CancelBackup not implemented")
+}
+func (*UnimplementedDeploymentServer) Upgrade(ctx context.Context, req *UpgradeRequest) (*UpgradeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Upgrade not implemented")
+}
+func (*UnimplementedDeploymentServer) SetLogLevel(ctx context.Context, req *SetLogLevelRequest) (*SetLogLevelResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetLogLevel not implemented")
+}
+func (*UnimplementedDeploymentServer) GenerateAdminToken(ctx context.Context, req *GenerateAdminTokenRequest) (*GenerateAdminTokenResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GenerateAdminToken not implemented")
+}
+func (*UnimplementedDeploymentServer) DeployID(ctx context.Context, req *DeployIDRequest) (*DeployIDResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeployID not implemented")
+}
+func (*UnimplementedDeploymentServer) CurrentReleaseManifest(ctx context.Context, req *CurrentReleaseManifestRequest) (*ReleaseManifest, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CurrentReleaseManifest not implemented")
+}
+func (*UnimplementedDeploymentServer) A1UpgradeStatus(req *A1UpgradeStatusRequest, srv Deployment_A1UpgradeStatusServer) error {
+	return status.Errorf(codes.Unimplemented, "method A1UpgradeStatus not implemented")
+}
+func (*UnimplementedDeploymentServer) NodeInventory(ctx context.Context, req *NodeInventoryRequest) (*NodeInventoryResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method NodeInventory not implemented")
+}
+func (*UnimplementedDeploymentServer) InfrastructureNodeDelete(ctx context.Context, req *InfrastructureNodeDeleteRequest) (*InfrastructureNodeDeleteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method InfrastructureNodeDelete not implemented")
+}
+func (*UnimplementedDeploymentServer) Usage(ctx context.Context, req *UsageRequest) (*UsageResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Usage not implemented")
+}
+func (*UnimplementedDeploymentServer) GetCLIExecutable(req *GetCLIExecutableRequest, srv Deployment_GetCLIExecutableServer) error {
+	return status.Errorf(codes.Unimplemented, "method GetCLIExecutable not implemented")
+}
+func (*UnimplementedDeploymentServer) BootstrapBundle(req *BootstrapBundleRequest, srv Deployment_BootstrapBundleServer) error {
+	return status.Errorf(codes.Unimplemented, "method BootstrapBundle not implemented")
 }
 
 func RegisterDeploymentServer(s *grpc.Server, srv DeploymentServer) {

--- a/api/interservice/deployment/certificate_authority.pb.go
+++ b/api/interservice/deployment/certificate_authority.pb.go
@@ -8,6 +8,8 @@ import (
 	fmt "fmt"
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -231,6 +233,17 @@ func (c *certificateAuthorityClient) RegenerateRoot(ctx context.Context, in *Reg
 type CertificateAuthorityServer interface {
 	GetRootCert(context.Context, *RootCertRequest) (*RootCertResponse, error)
 	RegenerateRoot(context.Context, *RegenerateRootRequest) (*RegenerateRootResponse, error)
+}
+
+// UnimplementedCertificateAuthorityServer can be embedded to have forward compatible implementations.
+type UnimplementedCertificateAuthorityServer struct {
+}
+
+func (*UnimplementedCertificateAuthorityServer) GetRootCert(ctx context.Context, req *RootCertRequest) (*RootCertResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetRootCert not implemented")
+}
+func (*UnimplementedCertificateAuthorityServer) RegenerateRoot(ctx context.Context, req *RegenerateRootRequest) (*RegenerateRootResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RegenerateRoot not implemented")
 }
 
 func RegisterCertificateAuthorityServer(s *grpc.Server, srv CertificateAuthorityServer) {

--- a/api/interservice/es_sidecar/service.pb.go
+++ b/api/interservice/es_sidecar/service.pb.go
@@ -9,6 +9,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	empty "github.com/golang/protobuf/ptypes/empty"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1171,6 +1173,44 @@ type EsSidecarServer interface {
 	RestoreSnapshotStatus(context.Context, *RestoreSnapshotStatusRequest) (*RestoreSnapshotStatusResponse, error)
 	DeleteSnapshot(context.Context, *DeleteSnapshotRequest) (*DeleteSnapshotResponse, error)
 	Version(context.Context, *empty.Empty) (*VersionResponse, error)
+}
+
+// UnimplementedEsSidecarServer can be embedded to have forward compatible implementations.
+type UnimplementedEsSidecarServer struct {
+}
+
+func (*UnimplementedEsSidecarServer) PurgeTimeSeriesIndicesByAge(ctx context.Context, req *PurgeRequest) (*PurgeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PurgeTimeSeriesIndicesByAge not implemented")
+}
+func (*UnimplementedEsSidecarServer) PurgeDocumentsFromIndexByAge(ctx context.Context, req *PurgeRequest) (*PurgeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PurgeDocumentsFromIndexByAge not implemented")
+}
+func (*UnimplementedEsSidecarServer) CreateRepository(ctx context.Context, req *CreateRepositoryRequest) (*CreateRepositoryResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateRepository not implemented")
+}
+func (*UnimplementedEsSidecarServer) ConvergeRepositorySettings(ctx context.Context, req *ConvergeRepositorySettingsRequest) (*ConvergeRepositorySettingsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConvergeRepositorySettings not implemented")
+}
+func (*UnimplementedEsSidecarServer) RemoveRepository(ctx context.Context, req *RemoveRepositoryRequest) (*RemoveRepositoryResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RemoveRepository not implemented")
+}
+func (*UnimplementedEsSidecarServer) CreateSnapshot(ctx context.Context, req *CreateSnapshotRequest) (*CreateSnapshotResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateSnapshot not implemented")
+}
+func (*UnimplementedEsSidecarServer) CreateSnapshotStatus(ctx context.Context, req *CreateSnapshotStatusRequest) (*CreateSnapshotStatusResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateSnapshotStatus not implemented")
+}
+func (*UnimplementedEsSidecarServer) RestoreSnapshot(ctx context.Context, req *RestoreSnapshotRequest) (*RestoreSnapshotResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RestoreSnapshot not implemented")
+}
+func (*UnimplementedEsSidecarServer) RestoreSnapshotStatus(ctx context.Context, req *RestoreSnapshotStatusRequest) (*RestoreSnapshotStatusResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RestoreSnapshotStatus not implemented")
+}
+func (*UnimplementedEsSidecarServer) DeleteSnapshot(ctx context.Context, req *DeleteSnapshotRequest) (*DeleteSnapshotResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteSnapshot not implemented")
+}
+func (*UnimplementedEsSidecarServer) Version(ctx context.Context, req *empty.Empty) (*VersionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Version not implemented")
 }
 
 func RegisterEsSidecarServer(s *grpc.Server, srv EsSidecarServer) {

--- a/api/interservice/event/event.pb.go
+++ b/api/interservice/event/event.pb.go
@@ -10,6 +10,8 @@ import (
 	_struct "github.com/golang/protobuf/ptypes/struct"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -836,6 +838,23 @@ type EventServiceServer interface {
 	Subscribe(context.Context, *SubscribeRequest) (*SubscribeResponse, error)
 	Start(context.Context, *StartRequest) (*StartResponse, error)
 	Stop(context.Context, *StopRequest) (*StopResponse, error)
+}
+
+// UnimplementedEventServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedEventServiceServer struct {
+}
+
+func (*UnimplementedEventServiceServer) Publish(ctx context.Context, req *PublishRequest) (*PublishResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Publish not implemented")
+}
+func (*UnimplementedEventServiceServer) Subscribe(ctx context.Context, req *SubscribeRequest) (*SubscribeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Subscribe not implemented")
+}
+func (*UnimplementedEventServiceServer) Start(ctx context.Context, req *StartRequest) (*StartResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Start not implemented")
+}
+func (*UnimplementedEventServiceServer) Stop(ctx context.Context, req *StopRequest) (*StopResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Stop not implemented")
 }
 
 func RegisterEventServiceServer(s *grpc.Server, srv EventServiceServer) {

--- a/api/interservice/event_feed/event_feed.pb.go
+++ b/api/interservice/event_feed/event_feed.pb.go
@@ -10,6 +10,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1074,6 +1076,23 @@ type EventFeedServiceServer interface {
 	GetFeedSummary(context.Context, *FeedSummaryRequest) (*FeedSummaryResponse, error)
 	GetFeedTimeline(context.Context, *FeedTimelineRequest) (*FeedTimelineResponse, error)
 	HandleEvent(context.Context, *event.EventMsg) (*event.EventResponse, error)
+}
+
+// UnimplementedEventFeedServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedEventFeedServiceServer struct {
+}
+
+func (*UnimplementedEventFeedServiceServer) GetFeed(ctx context.Context, req *FeedRequest) (*FeedResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetFeed not implemented")
+}
+func (*UnimplementedEventFeedServiceServer) GetFeedSummary(ctx context.Context, req *FeedSummaryRequest) (*FeedSummaryResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetFeedSummary not implemented")
+}
+func (*UnimplementedEventFeedServiceServer) GetFeedTimeline(ctx context.Context, req *FeedTimelineRequest) (*FeedTimelineResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetFeedTimeline not implemented")
+}
+func (*UnimplementedEventFeedServiceServer) HandleEvent(ctx context.Context, req *event.EventMsg) (*event.EventResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method HandleEvent not implemented")
 }
 
 func RegisterEventFeedServiceServer(s *grpc.Server, srv EventFeedServiceServer) {

--- a/api/interservice/ingest/automate_event.pb.go
+++ b/api/interservice/ingest/automate_event.pb.go
@@ -10,6 +10,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -190,6 +192,17 @@ func (c *eventHandlerClient) ProjectUpdateStatus(ctx context.Context, in *Projec
 type EventHandlerServer interface {
 	HandleEvent(context.Context, *event.EventMsg) (*event.EventResponse, error)
 	ProjectUpdateStatus(context.Context, *ProjectUpdateStatusReq) (*ProjectUpdateStatusResp, error)
+}
+
+// UnimplementedEventHandlerServer can be embedded to have forward compatible implementations.
+type UnimplementedEventHandlerServer struct {
+}
+
+func (*UnimplementedEventHandlerServer) HandleEvent(ctx context.Context, req *event.EventMsg) (*event.EventResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method HandleEvent not implemented")
+}
+func (*UnimplementedEventHandlerServer) ProjectUpdateStatus(ctx context.Context, req *ProjectUpdateStatusReq) (*ProjectUpdateStatusResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProjectUpdateStatus not implemented")
 }
 
 func RegisterEventHandlerServer(s *grpc.Server, srv EventHandlerServer) {

--- a/api/interservice/ingest/chef.pb.go
+++ b/api/interservice/ingest/chef.pb.go
@@ -11,6 +11,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -260,6 +262,29 @@ type ChefIngesterServer interface {
 	ProcessMultipleNodeDeletes(context.Context, *request.MultipleNodeDeleteRequest) (*response.ProcessMultipleNodeDeleteResponse, error)
 	ProcessNodeDelete(context.Context, *request.Delete) (*response.ProcessNodeDeleteResponse, error)
 	GetVersion(context.Context, *VersionRequest) (*Version, error)
+}
+
+// UnimplementedChefIngesterServer can be embedded to have forward compatible implementations.
+type UnimplementedChefIngesterServer struct {
+}
+
+func (*UnimplementedChefIngesterServer) ProcessChefRun(ctx context.Context, req *request.Run) (*response.ProcessChefRunResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProcessChefRun not implemented")
+}
+func (*UnimplementedChefIngesterServer) ProcessChefAction(ctx context.Context, req *request.Action) (*response.ProcessChefActionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProcessChefAction not implemented")
+}
+func (*UnimplementedChefIngesterServer) ProcessLivenessPing(ctx context.Context, req *request.Liveness) (*response.ProcessLivenessResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProcessLivenessPing not implemented")
+}
+func (*UnimplementedChefIngesterServer) ProcessMultipleNodeDeletes(ctx context.Context, req *request.MultipleNodeDeleteRequest) (*response.ProcessMultipleNodeDeleteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProcessMultipleNodeDeletes not implemented")
+}
+func (*UnimplementedChefIngesterServer) ProcessNodeDelete(ctx context.Context, req *request.Delete) (*response.ProcessNodeDeleteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProcessNodeDelete not implemented")
+}
+func (*UnimplementedChefIngesterServer) GetVersion(ctx context.Context, req *VersionRequest) (*Version, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
 }
 
 func RegisterChefIngesterServer(s *grpc.Server, srv ChefIngesterServer) {

--- a/api/interservice/ingest/job_scheduler.pb.go
+++ b/api/interservice/ingest/job_scheduler.pb.go
@@ -9,6 +9,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1322,6 +1324,50 @@ type JobSchedulerServer interface {
 	ConfigureMissingNodesForDeletionScheduler(context.Context, *JobSettings) (*ConfigureMissingNodesForDeletionSchedulerResponse, error)
 	StartMissingNodesForDeletionScheduler(context.Context, *StartMissingNodesForDeletionSchedulerRequest) (*StartMissingNodesForDeletionSchedulerResponse, error)
 	StopMissingNodesForDeletionScheduler(context.Context, *StopMissingNodesForDeletionSchedulerRequest) (*StopMissingNodesForDeletionSchedulerResponse, error)
+}
+
+// UnimplementedJobSchedulerServer can be embedded to have forward compatible implementations.
+type UnimplementedJobSchedulerServer struct {
+}
+
+func (*UnimplementedJobSchedulerServer) GetStatusJobScheduler(ctx context.Context, req *JobSchedulerStatusRequest) (*JobSchedulerStatus, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetStatusJobScheduler not implemented")
+}
+func (*UnimplementedJobSchedulerServer) MarkNodesMissing(ctx context.Context, req *MarkNodesMissingRequest) (*MarkNodesMissingResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method MarkNodesMissing not implemented")
+}
+func (*UnimplementedJobSchedulerServer) ConfigureNodesMissingScheduler(ctx context.Context, req *JobSettings) (*ConfigureNodesMissingSchedulerResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConfigureNodesMissingScheduler not implemented")
+}
+func (*UnimplementedJobSchedulerServer) StartNodesMissingScheduler(ctx context.Context, req *StartNodesMissingSchedulerRequest) (*StartNodesMissingSchedulerResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StartNodesMissingScheduler not implemented")
+}
+func (*UnimplementedJobSchedulerServer) StopNodesMissingScheduler(ctx context.Context, req *StopNodesMissingSchedulerRequest) (*StopNodesMissingSchedulerResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StopNodesMissingScheduler not implemented")
+}
+func (*UnimplementedJobSchedulerServer) DeleteMarkedNodes(ctx context.Context, req *DeleteMarkedNodesRequest) (*DeleteMarkedNodesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteMarkedNodes not implemented")
+}
+func (*UnimplementedJobSchedulerServer) StartDeleteNodesScheduler(ctx context.Context, req *StartDeleteNodesSchedulerRequest) (*StartDeleteNodesSchedulerResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StartDeleteNodesScheduler not implemented")
+}
+func (*UnimplementedJobSchedulerServer) StopDeleteNodesScheduler(ctx context.Context, req *StopDeleteNodesSchedulerRequest) (*StopDeleteNodesSchedulerResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StopDeleteNodesScheduler not implemented")
+}
+func (*UnimplementedJobSchedulerServer) ConfigureDeleteNodesScheduler(ctx context.Context, req *JobSettings) (*ConfigureDeleteNodesSchedulerResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConfigureDeleteNodesScheduler not implemented")
+}
+func (*UnimplementedJobSchedulerServer) MarkMissingNodesForDeletion(ctx context.Context, req *MarkMissingNodesForDeletionRequest) (*MarkMissingNodesForDeletionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method MarkMissingNodesForDeletion not implemented")
+}
+func (*UnimplementedJobSchedulerServer) ConfigureMissingNodesForDeletionScheduler(ctx context.Context, req *JobSettings) (*ConfigureMissingNodesForDeletionSchedulerResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConfigureMissingNodesForDeletionScheduler not implemented")
+}
+func (*UnimplementedJobSchedulerServer) StartMissingNodesForDeletionScheduler(ctx context.Context, req *StartMissingNodesForDeletionSchedulerRequest) (*StartMissingNodesForDeletionSchedulerResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StartMissingNodesForDeletionScheduler not implemented")
+}
+func (*UnimplementedJobSchedulerServer) StopMissingNodesForDeletionScheduler(ctx context.Context, req *StopMissingNodesForDeletionSchedulerRequest) (*StopMissingNodesForDeletionSchedulerResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StopMissingNodesForDeletionScheduler not implemented")
 }
 
 func RegisterJobSchedulerServer(s *grpc.Server, srv JobSchedulerServer) {

--- a/api/interservice/ingest/status.pb.go
+++ b/api/interservice/ingest/status.pb.go
@@ -9,6 +9,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -427,6 +429,20 @@ type IngestStatusServer interface {
 	GetMetrics(context.Context, *MetricsRequest) (*Metrics, error)
 	GetHealth(context.Context, *HealthRequest) (*Health, error)
 	GetMigrationStatus(context.Context, *MigrationStatusRequest) (*MigrationStatus, error)
+}
+
+// UnimplementedIngestStatusServer can be embedded to have forward compatible implementations.
+type UnimplementedIngestStatusServer struct {
+}
+
+func (*UnimplementedIngestStatusServer) GetMetrics(ctx context.Context, req *MetricsRequest) (*Metrics, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetMetrics not implemented")
+}
+func (*UnimplementedIngestStatusServer) GetHealth(ctx context.Context, req *HealthRequest) (*Health, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetHealth not implemented")
+}
+func (*UnimplementedIngestStatusServer) GetMigrationStatus(ctx context.Context, req *MigrationStatusRequest) (*MigrationStatus, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetMigrationStatus not implemented")
 }
 
 func RegisterIngestStatusServer(s *grpc.Server, srv IngestStatusServer) {

--- a/api/interservice/license_control/license-control.pb.go
+++ b/api/interservice/license_control/license-control.pb.go
@@ -10,6 +10,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -779,6 +781,26 @@ type LicenseControlServer interface {
 	Status(context.Context, *StatusRequest) (*StatusResponse, error)
 	Update(context.Context, *UpdateRequest) (*UpdateResponse, error)
 	Telemetry(context.Context, *TelemetryRequest) (*TelemetryResponse, error)
+}
+
+// UnimplementedLicenseControlServer can be embedded to have forward compatible implementations.
+type UnimplementedLicenseControlServer struct {
+}
+
+func (*UnimplementedLicenseControlServer) License(ctx context.Context, req *LicenseRequest) (*LicenseResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method License not implemented")
+}
+func (*UnimplementedLicenseControlServer) Policy(ctx context.Context, req *PolicyRequest) (*PolicyResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Policy not implemented")
+}
+func (*UnimplementedLicenseControlServer) Status(ctx context.Context, req *StatusRequest) (*StatusResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Status not implemented")
+}
+func (*UnimplementedLicenseControlServer) Update(ctx context.Context, req *UpdateRequest) (*UpdateResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Update not implemented")
+}
+func (*UnimplementedLicenseControlServer) Telemetry(ctx context.Context, req *TelemetryRequest) (*TelemetryResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Telemetry not implemented")
 }
 
 func RegisterLicenseControlServer(s *grpc.Server, srv LicenseControlServer) {

--- a/api/interservice/local_user/users.pb.go
+++ b/api/interservice/local_user/users.pb.go
@@ -10,6 +10,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -588,6 +590,29 @@ type UsersMgmtServer interface {
 	DeleteUser(context.Context, *Email) (*DeleteUserResp, error)
 	UpdateUser(context.Context, *UpdateUserReq) (*User, error)
 	UpdateSelf(context.Context, *UpdateSelfReq) (*User, error)
+}
+
+// UnimplementedUsersMgmtServer can be embedded to have forward compatible implementations.
+type UnimplementedUsersMgmtServer struct {
+}
+
+func (*UnimplementedUsersMgmtServer) GetUsers(ctx context.Context, req *GetUsersReq) (*Users, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetUsers not implemented")
+}
+func (*UnimplementedUsersMgmtServer) GetUser(ctx context.Context, req *Email) (*User, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetUser not implemented")
+}
+func (*UnimplementedUsersMgmtServer) CreateUser(ctx context.Context, req *CreateUserReq) (*User, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateUser not implemented")
+}
+func (*UnimplementedUsersMgmtServer) DeleteUser(ctx context.Context, req *Email) (*DeleteUserResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteUser not implemented")
+}
+func (*UnimplementedUsersMgmtServer) UpdateUser(ctx context.Context, req *UpdateUserReq) (*User, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateUser not implemented")
+}
+func (*UnimplementedUsersMgmtServer) UpdateSelf(ctx context.Context, req *UpdateSelfReq) (*User, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateSelf not implemented")
 }
 
 func RegisterUsersMgmtServer(s *grpc.Server, srv UsersMgmtServer) {

--- a/api/interservice/pg_sidecar/service.pb.go
+++ b/api/interservice/pg_sidecar/service.pb.go
@@ -8,6 +8,8 @@ import (
 	fmt "fmt"
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1145,6 +1147,35 @@ type PGSidecarServer interface {
 	SetPublicSchemaRole(context.Context, *SetPublicSchemaRoleReq) (*SetPublicSchemaRoleRes, error)
 	AlterRole(context.Context, *AlterRoleReq) (*AlterRoleRes, error)
 	DropTables(context.Context, *DropTablesReq) (*DropTablesRes, error)
+}
+
+// UnimplementedPGSidecarServer can be embedded to have forward compatible implementations.
+type UnimplementedPGSidecarServer struct {
+}
+
+func (*UnimplementedPGSidecarServer) MigrateTables(ctx context.Context, req *MigrateTablesReq) (*MigrateTablesRes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method MigrateTables not implemented")
+}
+func (*UnimplementedPGSidecarServer) RenameDB(ctx context.Context, req *RenameDBReq) (*RenameDBRes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RenameDB not implemented")
+}
+func (*UnimplementedPGSidecarServer) CreateDB(ctx context.Context, req *CreateDBReq) (*CreateDBRes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateDB not implemented")
+}
+func (*UnimplementedPGSidecarServer) CreateExtension(ctx context.Context, req *CreateExtensionReq) (*CreateExtensionRes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateExtension not implemented")
+}
+func (*UnimplementedPGSidecarServer) DeploySqitch(ctx context.Context, req *DeploySqitchReq) (*DeploySqitchRes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeploySqitch not implemented")
+}
+func (*UnimplementedPGSidecarServer) SetPublicSchemaRole(ctx context.Context, req *SetPublicSchemaRoleReq) (*SetPublicSchemaRoleRes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetPublicSchemaRole not implemented")
+}
+func (*UnimplementedPGSidecarServer) AlterRole(ctx context.Context, req *AlterRoleReq) (*AlterRoleRes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AlterRole not implemented")
+}
+func (*UnimplementedPGSidecarServer) DropTables(ctx context.Context, req *DropTablesReq) (*DropTablesRes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DropTables not implemented")
 }
 
 func RegisterPGSidecarServer(s *grpc.Server, srv PGSidecarServer) {

--- a/api/interservice/teams/v1/teams.pb.go
+++ b/api/interservice/teams/v1/teams.pb.go
@@ -10,6 +10,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1213,6 +1215,47 @@ type TeamsV1Server interface {
 	// to use the V2 service.
 	PurgeUserMembership(context.Context, *PurgeUserMembershipReq) (*PurgeUserMembershipResp, error)
 	GetTeamByName(context.Context, *GetTeamByNameReq) (*GetTeamByNameResp, error)
+}
+
+// UnimplementedTeamsV1Server can be embedded to have forward compatible implementations.
+type UnimplementedTeamsV1Server struct {
+}
+
+func (*UnimplementedTeamsV1Server) GetVersion(ctx context.Context, req *version.VersionInfoRequest) (*version.VersionInfo, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
+}
+func (*UnimplementedTeamsV1Server) CreateTeam(ctx context.Context, req *CreateTeamReq) (*CreateTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateTeam not implemented")
+}
+func (*UnimplementedTeamsV1Server) UpdateTeam(ctx context.Context, req *UpdateTeamReq) (*UpdateTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateTeam not implemented")
+}
+func (*UnimplementedTeamsV1Server) DeleteTeam(ctx context.Context, req *DeleteTeamReq) (*DeleteTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteTeam not implemented")
+}
+func (*UnimplementedTeamsV1Server) GetTeams(ctx context.Context, req *GetTeamsReq) (*GetTeamsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTeams not implemented")
+}
+func (*UnimplementedTeamsV1Server) GetTeam(ctx context.Context, req *GetTeamReq) (*GetTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTeam not implemented")
+}
+func (*UnimplementedTeamsV1Server) AddUsers(ctx context.Context, req *AddUsersReq) (*AddUsersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddUsers not implemented")
+}
+func (*UnimplementedTeamsV1Server) RemoveUsers(ctx context.Context, req *RemoveUsersReq) (*RemoveUsersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RemoveUsers not implemented")
+}
+func (*UnimplementedTeamsV1Server) GetTeamsForUser(ctx context.Context, req *GetTeamsForUserReq) (*GetTeamsForUserResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTeamsForUser not implemented")
+}
+func (*UnimplementedTeamsV1Server) GetUsers(ctx context.Context, req *GetUsersReq) (*GetUsersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetUsers not implemented")
+}
+func (*UnimplementedTeamsV1Server) PurgeUserMembership(ctx context.Context, req *PurgeUserMembershipReq) (*PurgeUserMembershipResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PurgeUserMembership not implemented")
+}
+func (*UnimplementedTeamsV1Server) GetTeamByName(ctx context.Context, req *GetTeamByNameReq) (*GetTeamByNameResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTeamByName not implemented")
 }
 
 func RegisterTeamsV1Server(s *grpc.Server, srv TeamsV1Server) {

--- a/api/interservice/teams/v2/teams.pb.go
+++ b/api/interservice/teams/v2/teams.pb.go
@@ -10,6 +10,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1111,6 +1113,41 @@ type TeamsV2Server interface {
 	GetTeamsForMember(context.Context, *GetTeamsForMemberReq) (*GetTeamsForMemberResp, error)
 	GetTeamMembership(context.Context, *GetTeamMembershipReq) (*GetTeamMembershipResp, error)
 	UpgradeToV2(context.Context, *UpgradeToV2Req) (*UpgradeToV2Resp, error)
+}
+
+// UnimplementedTeamsV2Server can be embedded to have forward compatible implementations.
+type UnimplementedTeamsV2Server struct {
+}
+
+func (*UnimplementedTeamsV2Server) GetTeam(ctx context.Context, req *GetTeamReq) (*GetTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTeam not implemented")
+}
+func (*UnimplementedTeamsV2Server) ListTeams(ctx context.Context, req *ListTeamsReq) (*ListTeamsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListTeams not implemented")
+}
+func (*UnimplementedTeamsV2Server) CreateTeam(ctx context.Context, req *CreateTeamReq) (*CreateTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateTeam not implemented")
+}
+func (*UnimplementedTeamsV2Server) UpdateTeam(ctx context.Context, req *UpdateTeamReq) (*UpdateTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateTeam not implemented")
+}
+func (*UnimplementedTeamsV2Server) DeleteTeam(ctx context.Context, req *DeleteTeamReq) (*DeleteTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteTeam not implemented")
+}
+func (*UnimplementedTeamsV2Server) AddTeamMembers(ctx context.Context, req *AddTeamMembersReq) (*AddTeamMembersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddTeamMembers not implemented")
+}
+func (*UnimplementedTeamsV2Server) RemoveTeamMembers(ctx context.Context, req *RemoveTeamMembersReq) (*RemoveTeamMembersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RemoveTeamMembers not implemented")
+}
+func (*UnimplementedTeamsV2Server) GetTeamsForMember(ctx context.Context, req *GetTeamsForMemberReq) (*GetTeamsForMemberResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTeamsForMember not implemented")
+}
+func (*UnimplementedTeamsV2Server) GetTeamMembership(ctx context.Context, req *GetTeamMembershipReq) (*GetTeamMembershipResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTeamMembership not implemented")
+}
+func (*UnimplementedTeamsV2Server) UpgradeToV2(ctx context.Context, req *UpgradeToV2Req) (*UpgradeToV2Resp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpgradeToV2 not implemented")
 }
 
 func RegisterTeamsV2Server(s *grpc.Server, srv TeamsV2Server) {

--- a/components/automate-gateway/api/auth/teams/teams.pb.go
+++ b/components/automate-gateway/api/auth/teams/teams.pb.go
@@ -14,6 +14,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -220,6 +222,41 @@ type TeamsServer interface {
 	AddUsers(context.Context, *request.AddUsersReq) (*response.AddUsersResp, error)
 	RemoveUsers(context.Context, *request.RemoveUsersReq) (*response.RemoveUsersResp, error)
 	GetTeamsForUser(context.Context, *request.GetTeamsForUserReq) (*response.GetTeamsForUserResp, error)
+}
+
+// UnimplementedTeamsServer can be embedded to have forward compatible implementations.
+type UnimplementedTeamsServer struct {
+}
+
+func (*UnimplementedTeamsServer) GetVersion(ctx context.Context, req *version.VersionInfoRequest) (*version.VersionInfo, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
+}
+func (*UnimplementedTeamsServer) GetTeams(ctx context.Context, req *request.GetTeamsReq) (*response.Teams, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTeams not implemented")
+}
+func (*UnimplementedTeamsServer) GetTeam(ctx context.Context, req *request.GetTeamReq) (*response.GetTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTeam not implemented")
+}
+func (*UnimplementedTeamsServer) CreateTeam(ctx context.Context, req *request.CreateTeamReq) (*response.CreateTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateTeam not implemented")
+}
+func (*UnimplementedTeamsServer) UpdateTeam(ctx context.Context, req *request.UpdateTeamReq) (*response.UpdateTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateTeam not implemented")
+}
+func (*UnimplementedTeamsServer) DeleteTeam(ctx context.Context, req *request.DeleteTeamReq) (*response.DeleteTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteTeam not implemented")
+}
+func (*UnimplementedTeamsServer) GetUsers(ctx context.Context, req *request.GetUsersReq) (*response.GetUsersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetUsers not implemented")
+}
+func (*UnimplementedTeamsServer) AddUsers(ctx context.Context, req *request.AddUsersReq) (*response.AddUsersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddUsers not implemented")
+}
+func (*UnimplementedTeamsServer) RemoveUsers(ctx context.Context, req *request.RemoveUsersReq) (*response.RemoveUsersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RemoveUsers not implemented")
+}
+func (*UnimplementedTeamsServer) GetTeamsForUser(ctx context.Context, req *request.GetTeamsForUserReq) (*response.GetTeamsForUserResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTeamsForUser not implemented")
 }
 
 func RegisterTeamsServer(s *grpc.Server, srv TeamsServer) {

--- a/components/automate-gateway/api/auth/tokens/tokens.pb.go
+++ b/components/automate-gateway/api/auth/tokens/tokens.pb.go
@@ -13,6 +13,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -145,6 +147,26 @@ type TokensMgmtServer interface {
 	UpdateToken(context.Context, *request.UpdateToken) (*response.Token, error)
 	GetToken(context.Context, *request.Uuid) (*response.Token, error)
 	DeleteToken(context.Context, *request.Uuid) (*response.DeleteTokenResp, error)
+}
+
+// UnimplementedTokensMgmtServer can be embedded to have forward compatible implementations.
+type UnimplementedTokensMgmtServer struct {
+}
+
+func (*UnimplementedTokensMgmtServer) GetTokens(ctx context.Context, req *request.GetTokensReq) (*response.Tokens, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTokens not implemented")
+}
+func (*UnimplementedTokensMgmtServer) CreateToken(ctx context.Context, req *request.CreateToken) (*response.Token, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateToken not implemented")
+}
+func (*UnimplementedTokensMgmtServer) UpdateToken(ctx context.Context, req *request.UpdateToken) (*response.Token, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateToken not implemented")
+}
+func (*UnimplementedTokensMgmtServer) GetToken(ctx context.Context, req *request.Uuid) (*response.Token, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetToken not implemented")
+}
+func (*UnimplementedTokensMgmtServer) DeleteToken(ctx context.Context, req *request.Uuid) (*response.DeleteTokenResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteToken not implemented")
 }
 
 func RegisterTokensMgmtServer(s *grpc.Server, srv TokensMgmtServer) {

--- a/components/automate-gateway/api/auth/users/users.pb.go
+++ b/components/automate-gateway/api/auth/users/users.pb.go
@@ -13,6 +13,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -189,6 +191,35 @@ type UsersMgmtServer interface {
 	// deprecated API
 	GetUser(context.Context, *request.Email) (*response.User, error)
 	DeleteUser(context.Context, *request.Email) (*response.DeleteUserResp, error)
+}
+
+// UnimplementedUsersMgmtServer can be embedded to have forward compatible implementations.
+type UnimplementedUsersMgmtServer struct {
+}
+
+func (*UnimplementedUsersMgmtServer) GetUsers(ctx context.Context, req *request.GetUsersReq) (*response.Users, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetUsers not implemented")
+}
+func (*UnimplementedUsersMgmtServer) GetUserByUsername(ctx context.Context, req *request.Username) (*response.User, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetUserByUsername not implemented")
+}
+func (*UnimplementedUsersMgmtServer) CreateUser(ctx context.Context, req *request.CreateUser) (*response.User, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateUser not implemented")
+}
+func (*UnimplementedUsersMgmtServer) DeleteUserByUsername(ctx context.Context, req *request.Username) (*response.DeleteUserResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteUserByUsername not implemented")
+}
+func (*UnimplementedUsersMgmtServer) UpdateUser(ctx context.Context, req *request.UpdateUser) (*response.User, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateUser not implemented")
+}
+func (*UnimplementedUsersMgmtServer) UpdateSelf(ctx context.Context, req *request.UpdateSelf) (*response.User, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateSelf not implemented")
+}
+func (*UnimplementedUsersMgmtServer) GetUser(ctx context.Context, req *request.Email) (*response.User, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetUser not implemented")
+}
+func (*UnimplementedUsersMgmtServer) DeleteUser(ctx context.Context, req *request.Email) (*response.DeleteUserResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteUser not implemented")
 }
 
 func RegisterUsersMgmtServer(s *grpc.Server, srv UsersMgmtServer) {

--- a/components/automate-gateway/api/authz/authz.pb.go
+++ b/components/automate-gateway/api/authz/authz.pb.go
@@ -14,6 +14,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -181,6 +183,32 @@ type AuthorizationServer interface {
 	IntrospectAll(context.Context, *request.IntrospectAllReq) (*response.IntrospectResp, error)
 	IntrospectSome(context.Context, *request.IntrospectSomeReq) (*response.IntrospectResp, error)
 	Introspect(context.Context, *request.IntrospectReq) (*response.IntrospectResp, error)
+}
+
+// UnimplementedAuthorizationServer can be embedded to have forward compatible implementations.
+type UnimplementedAuthorizationServer struct {
+}
+
+func (*UnimplementedAuthorizationServer) GetVersion(ctx context.Context, req *version.VersionInfoRequest) (*version.VersionInfo, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
+}
+func (*UnimplementedAuthorizationServer) CreatePolicy(ctx context.Context, req *request.CreatePolicyReq) (*response.CreatePolicyResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreatePolicy not implemented")
+}
+func (*UnimplementedAuthorizationServer) ListPolicies(ctx context.Context, req *request.ListPoliciesReq) (*response.ListPoliciesResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListPolicies not implemented")
+}
+func (*UnimplementedAuthorizationServer) DeletePolicy(ctx context.Context, req *request.DeletePolicyReq) (*response.DeletePolicyResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeletePolicy not implemented")
+}
+func (*UnimplementedAuthorizationServer) IntrospectAll(ctx context.Context, req *request.IntrospectAllReq) (*response.IntrospectResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method IntrospectAll not implemented")
+}
+func (*UnimplementedAuthorizationServer) IntrospectSome(ctx context.Context, req *request.IntrospectSomeReq) (*response.IntrospectResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method IntrospectSome not implemented")
+}
+func (*UnimplementedAuthorizationServer) Introspect(ctx context.Context, req *request.IntrospectReq) (*response.IntrospectResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Introspect not implemented")
 }
 
 func RegisterAuthorizationServer(s *grpc.Server, srv AuthorizationServer) {

--- a/components/automate-gateway/api/compliance/profiles/profiles.pb.go
+++ b/components/automate-gateway/api/compliance/profiles/profiles.pb.go
@@ -12,6 +12,8 @@ import (
 	empty "github.com/golang/protobuf/ptypes/empty"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1773,6 +1775,29 @@ type ProfilesServiceServer interface {
 	ReadTar(*ProfileDetails, ProfilesService_ReadTarServer) error
 	Delete(context.Context, *ProfileDetails) (*empty.Empty, error)
 	List(context.Context, *Query) (*Profiles, error)
+}
+
+// UnimplementedProfilesServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedProfilesServiceServer struct {
+}
+
+func (*UnimplementedProfilesServiceServer) Create(srv ProfilesService_CreateServer) error {
+	return status.Errorf(codes.Unimplemented, "method Create not implemented")
+}
+func (*UnimplementedProfilesServiceServer) Read(ctx context.Context, req *ProfileDetails) (*Profile, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Read not implemented")
+}
+func (*UnimplementedProfilesServiceServer) ReadFromMarket(ctx context.Context, req *ProfileDetails) (*Profile, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadFromMarket not implemented")
+}
+func (*UnimplementedProfilesServiceServer) ReadTar(req *ProfileDetails, srv ProfilesService_ReadTarServer) error {
+	return status.Errorf(codes.Unimplemented, "method ReadTar not implemented")
+}
+func (*UnimplementedProfilesServiceServer) Delete(ctx context.Context, req *ProfileDetails) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Delete not implemented")
+}
+func (*UnimplementedProfilesServiceServer) List(ctx context.Context, req *Query) (*Profiles, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method List not implemented")
 }
 
 func RegisterProfilesServiceServer(s *grpc.Server, srv ProfilesServiceServer) {

--- a/components/automate-gateway/api/compliance/reporting/reporting.pb.go
+++ b/components/automate-gateway/api/compliance/reporting/reporting.pb.go
@@ -14,6 +14,8 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -2648,6 +2650,41 @@ type ReportingServiceServer interface {
 	ListNodes(context.Context, *Query) (*Nodes, error)
 	GetVersion(context.Context, *empty.Empty) (*version.VersionInfo, error)
 	LicenseUsageNodes(context.Context, *TimeQuery) (*Reports, error)
+}
+
+// UnimplementedReportingServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedReportingServiceServer struct {
+}
+
+func (*UnimplementedReportingServiceServer) ListReports(ctx context.Context, req *Query) (*Reports, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListReports not implemented")
+}
+func (*UnimplementedReportingServiceServer) ListReportIds(ctx context.Context, req *Query) (*ReportIds, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListReportIds not implemented")
+}
+func (*UnimplementedReportingServiceServer) ReadReport(ctx context.Context, req *Query) (*Report, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadReport not implemented")
+}
+func (*UnimplementedReportingServiceServer) ListSuggestions(ctx context.Context, req *SuggestionRequest) (*Suggestions, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListSuggestions not implemented")
+}
+func (*UnimplementedReportingServiceServer) ListProfiles(ctx context.Context, req *Query) (*ProfileMins, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListProfiles not implemented")
+}
+func (*UnimplementedReportingServiceServer) Export(req *Query, srv ReportingService_ExportServer) error {
+	return status.Errorf(codes.Unimplemented, "method Export not implemented")
+}
+func (*UnimplementedReportingServiceServer) ReadNode(ctx context.Context, req *Id) (*Node, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadNode not implemented")
+}
+func (*UnimplementedReportingServiceServer) ListNodes(ctx context.Context, req *Query) (*Nodes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListNodes not implemented")
+}
+func (*UnimplementedReportingServiceServer) GetVersion(ctx context.Context, req *empty.Empty) (*version.VersionInfo, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
+}
+func (*UnimplementedReportingServiceServer) LicenseUsageNodes(ctx context.Context, req *TimeQuery) (*Reports, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method LicenseUsageNodes not implemented")
 }
 
 func RegisterReportingServiceServer(s *grpc.Server, srv ReportingServiceServer) {

--- a/components/automate-gateway/api/compliance/reporting/stats/stats.pb.go
+++ b/components/automate-gateway/api/compliance/reporting/stats/stats.pb.go
@@ -12,6 +12,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1510,6 +1512,23 @@ type StatsServiceServer interface {
 	// should cover /profiles, profiles/:profile-id/summary, profiles/:profile-id/controls
 	ReadProfiles(context.Context, *Query) (*Profile, error)
 	ReadFailures(context.Context, *Query) (*Failures, error)
+}
+
+// UnimplementedStatsServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedStatsServiceServer struct {
+}
+
+func (*UnimplementedStatsServiceServer) ReadSummary(ctx context.Context, req *Query) (*Summary, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadSummary not implemented")
+}
+func (*UnimplementedStatsServiceServer) ReadTrend(ctx context.Context, req *Query) (*Trends, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadTrend not implemented")
+}
+func (*UnimplementedStatsServiceServer) ReadProfiles(ctx context.Context, req *Query) (*Profile, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadProfiles not implemented")
+}
+func (*UnimplementedStatsServiceServer) ReadFailures(ctx context.Context, req *Query) (*Failures, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadFailures not implemented")
 }
 
 func RegisterStatsServiceServer(s *grpc.Server, srv StatsServiceServer) {

--- a/components/automate-gateway/api/compliance/scanner/jobs/jobs.pb.go
+++ b/components/automate-gateway/api/compliance/scanner/jobs/jobs.pb.go
@@ -14,6 +14,8 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -759,6 +761,29 @@ type JobsServiceServer interface {
 	Delete(context.Context, *Id) (*empty.Empty, error)
 	List(context.Context, *Query) (*Jobs, error)
 	Rerun(context.Context, *Id) (*RerunResponse, error)
+}
+
+// UnimplementedJobsServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedJobsServiceServer struct {
+}
+
+func (*UnimplementedJobsServiceServer) Create(ctx context.Context, req *Job) (*Id, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Create not implemented")
+}
+func (*UnimplementedJobsServiceServer) Read(ctx context.Context, req *Id) (*Job, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Read not implemented")
+}
+func (*UnimplementedJobsServiceServer) Update(ctx context.Context, req *Job) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Update not implemented")
+}
+func (*UnimplementedJobsServiceServer) Delete(ctx context.Context, req *Id) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Delete not implemented")
+}
+func (*UnimplementedJobsServiceServer) List(ctx context.Context, req *Query) (*Jobs, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method List not implemented")
+}
+func (*UnimplementedJobsServiceServer) Rerun(ctx context.Context, req *Id) (*RerunResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Rerun not implemented")
 }
 
 func RegisterJobsServiceServer(s *grpc.Server, srv JobsServiceServer) {

--- a/components/automate-gateway/api/deployment/deployment.pb.go
+++ b/components/automate-gateway/api/deployment/deployment.pb.go
@@ -12,6 +12,8 @@ import (
 	empty "github.com/golang/protobuf/ptypes/empty"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -293,6 +295,17 @@ func (c *deploymentClient) ServiceVersions(ctx context.Context, in *ServiceVersi
 type DeploymentServer interface {
 	GetVersion(context.Context, *empty.Empty) (*Version, error)
 	ServiceVersions(context.Context, *ServiceVersionsRequest) (*ServiceVersionsResponse, error)
+}
+
+// UnimplementedDeploymentServer can be embedded to have forward compatible implementations.
+type UnimplementedDeploymentServer struct {
+}
+
+func (*UnimplementedDeploymentServer) GetVersion(ctx context.Context, req *empty.Empty) (*Version, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
+}
+func (*UnimplementedDeploymentServer) ServiceVersions(ctx context.Context, req *ServiceVersionsRequest) (*ServiceVersionsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ServiceVersions not implemented")
 }
 
 func RegisterDeploymentServer(s *grpc.Server, srv DeploymentServer) {

--- a/components/automate-gateway/api/event_feed/event_feed.pb.go
+++ b/components/automate-gateway/api/event_feed/event_feed.pb.go
@@ -13,6 +13,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -131,6 +133,23 @@ type EventFeedServer interface {
 	GetEventTypeCounts(context.Context, *request.EventCountsFilter) (*response.EventCounts, error)
 	GetEventTaskCounts(context.Context, *request.EventCountsFilter) (*response.EventCounts, error)
 	GetEventStringBuckets(context.Context, *request.EventStrings) (*response.EventStrings, error)
+}
+
+// UnimplementedEventFeedServer can be embedded to have forward compatible implementations.
+type UnimplementedEventFeedServer struct {
+}
+
+func (*UnimplementedEventFeedServer) GetEventFeed(ctx context.Context, req *request.EventFilter) (*response.Events, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetEventFeed not implemented")
+}
+func (*UnimplementedEventFeedServer) GetEventTypeCounts(ctx context.Context, req *request.EventCountsFilter) (*response.EventCounts, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetEventTypeCounts not implemented")
+}
+func (*UnimplementedEventFeedServer) GetEventTaskCounts(ctx context.Context, req *request.EventCountsFilter) (*response.EventCounts, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetEventTaskCounts not implemented")
+}
+func (*UnimplementedEventFeedServer) GetEventStringBuckets(ctx context.Context, req *request.EventStrings) (*response.EventStrings, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetEventStringBuckets not implemented")
 }
 
 func RegisterEventFeedServer(s *grpc.Server, srv EventFeedServer) {

--- a/components/automate-gateway/api/gateway/gateway.pb.go
+++ b/components/automate-gateway/api/gateway/gateway.pb.go
@@ -12,6 +12,8 @@ import (
 	empty "github.com/golang/protobuf/ptypes/empty"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -231,6 +233,17 @@ func (c *gatewayClient) GetHealth(ctx context.Context, in *empty.Empty, opts ...
 type GatewayServer interface {
 	GetVersion(context.Context, *empty.Empty) (*Version, error)
 	GetHealth(context.Context, *empty.Empty) (*Health, error)
+}
+
+// UnimplementedGatewayServer can be embedded to have forward compatible implementations.
+type UnimplementedGatewayServer struct {
+}
+
+func (*UnimplementedGatewayServer) GetVersion(ctx context.Context, req *empty.Empty) (*Version, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
+}
+func (*UnimplementedGatewayServer) GetHealth(ctx context.Context, req *empty.Empty) (*Health, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetHealth not implemented")
 }
 
 func RegisterGatewayServer(s *grpc.Server, srv GatewayServer) {

--- a/components/automate-gateway/api/iam/v2beta/policy.pb.go
+++ b/components/automate-gateway/api/iam/v2beta/policy.pb.go
@@ -13,6 +13,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -399,6 +401,80 @@ type PoliciesServer interface {
 	UpgradeToV2(context.Context, *request.UpgradeToV2Req) (*response.UpgradeToV2Resp, error)
 	ResetToV1(context.Context, *request.ResetToV1Req) (*response.ResetToV1Resp, error)
 	IntrospectAllProjects(context.Context, *request.ListProjectsReq) (*response.ListProjectsResp, error)
+}
+
+// UnimplementedPoliciesServer can be embedded to have forward compatible implementations.
+type UnimplementedPoliciesServer struct {
+}
+
+func (*UnimplementedPoliciesServer) CreatePolicy(ctx context.Context, req *request.CreatePolicyReq) (*response.CreatePolicyResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreatePolicy not implemented")
+}
+func (*UnimplementedPoliciesServer) GetPolicy(ctx context.Context, req *request.GetPolicyReq) (*response.GetPolicyResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetPolicy not implemented")
+}
+func (*UnimplementedPoliciesServer) ListPolicies(ctx context.Context, req *request.ListPoliciesReq) (*response.ListPoliciesResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListPolicies not implemented")
+}
+func (*UnimplementedPoliciesServer) DeletePolicy(ctx context.Context, req *request.DeletePolicyReq) (*response.DeletePolicyResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeletePolicy not implemented")
+}
+func (*UnimplementedPoliciesServer) UpdatePolicy(ctx context.Context, req *request.UpdatePolicyReq) (*response.UpdatePolicyResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdatePolicy not implemented")
+}
+func (*UnimplementedPoliciesServer) GetPolicyVersion(ctx context.Context, req *request.GetPolicyVersionReq) (*response.GetPolicyVersionResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetPolicyVersion not implemented")
+}
+func (*UnimplementedPoliciesServer) ListPolicyMembers(ctx context.Context, req *request.ListPolicyMembersReq) (*response.ListPolicyMembersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListPolicyMembers not implemented")
+}
+func (*UnimplementedPoliciesServer) ReplacePolicyMembers(ctx context.Context, req *request.ReplacePolicyMembersReq) (*response.ReplacePolicyMembersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReplacePolicyMembers not implemented")
+}
+func (*UnimplementedPoliciesServer) RemovePolicyMembers(ctx context.Context, req *request.RemovePolicyMembersReq) (*response.RemovePolicyMembersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RemovePolicyMembers not implemented")
+}
+func (*UnimplementedPoliciesServer) AddPolicyMembers(ctx context.Context, req *request.AddPolicyMembersReq) (*response.AddPolicyMembersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddPolicyMembers not implemented")
+}
+func (*UnimplementedPoliciesServer) CreateRole(ctx context.Context, req *request.CreateRoleReq) (*response.CreateRoleResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateRole not implemented")
+}
+func (*UnimplementedPoliciesServer) ListRoles(ctx context.Context, req *request.ListRolesReq) (*response.ListRolesResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListRoles not implemented")
+}
+func (*UnimplementedPoliciesServer) GetRole(ctx context.Context, req *request.GetRoleReq) (*response.GetRoleResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetRole not implemented")
+}
+func (*UnimplementedPoliciesServer) DeleteRole(ctx context.Context, req *request.DeleteRoleReq) (*response.DeleteRoleResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteRole not implemented")
+}
+func (*UnimplementedPoliciesServer) UpdateRole(ctx context.Context, req *request.UpdateRoleReq) (*response.UpdateRoleResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateRole not implemented")
+}
+func (*UnimplementedPoliciesServer) CreateProject(ctx context.Context, req *request.CreateProjectReq) (*response.CreateProjectResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateProject not implemented")
+}
+func (*UnimplementedPoliciesServer) UpdateProject(ctx context.Context, req *request.UpdateProjectReq) (*response.UpdateProjectResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateProject not implemented")
+}
+func (*UnimplementedPoliciesServer) GetProject(ctx context.Context, req *request.GetProjectReq) (*response.GetProjectResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetProject not implemented")
+}
+func (*UnimplementedPoliciesServer) ListProjects(ctx context.Context, req *request.ListProjectsReq) (*response.ListProjectsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListProjects not implemented")
+}
+func (*UnimplementedPoliciesServer) DeleteProject(ctx context.Context, req *request.DeleteProjectReq) (*response.DeleteProjectResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteProject not implemented")
+}
+func (*UnimplementedPoliciesServer) UpgradeToV2(ctx context.Context, req *request.UpgradeToV2Req) (*response.UpgradeToV2Resp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpgradeToV2 not implemented")
+}
+func (*UnimplementedPoliciesServer) ResetToV1(ctx context.Context, req *request.ResetToV1Req) (*response.ResetToV1Resp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ResetToV1 not implemented")
+}
+func (*UnimplementedPoliciesServer) IntrospectAllProjects(ctx context.Context, req *request.ListProjectsReq) (*response.ListProjectsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method IntrospectAllProjects not implemented")
 }
 
 func RegisterPoliciesServer(s *grpc.Server, srv PoliciesServer) {

--- a/components/automate-gateway/api/iam/v2beta/rules.pb.go
+++ b/components/automate-gateway/api/iam/v2beta/rules.pb.go
@@ -13,6 +13,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -188,6 +190,35 @@ type RulesServer interface {
 	ApplyRulesStart(context.Context, *request.ApplyRulesStartReq) (*response.ApplyRulesStartResp, error)
 	ApplyRulesCancel(context.Context, *request.ApplyRulesCancelReq) (*response.ApplyRulesCancelResp, error)
 	ApplyRulesStatus(context.Context, *request.ApplyRulesStatusReq) (*response.ApplyRulesStatusResp, error)
+}
+
+// UnimplementedRulesServer can be embedded to have forward compatible implementations.
+type UnimplementedRulesServer struct {
+}
+
+func (*UnimplementedRulesServer) CreateRule(ctx context.Context, req *request.CreateRuleReq) (*response.CreateRuleResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateRule not implemented")
+}
+func (*UnimplementedRulesServer) UpdateRule(ctx context.Context, req *request.UpdateRuleReq) (*response.UpdateRuleResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateRule not implemented")
+}
+func (*UnimplementedRulesServer) GetRule(ctx context.Context, req *request.GetRuleReq) (*response.GetRuleResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetRule not implemented")
+}
+func (*UnimplementedRulesServer) ListRulesForProject(ctx context.Context, req *request.ListRulesForProjectReq) (*response.ListRulesForProjectResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListRulesForProject not implemented")
+}
+func (*UnimplementedRulesServer) DeleteRule(ctx context.Context, req *request.DeleteRuleReq) (*response.DeleteRuleResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteRule not implemented")
+}
+func (*UnimplementedRulesServer) ApplyRulesStart(ctx context.Context, req *request.ApplyRulesStartReq) (*response.ApplyRulesStartResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ApplyRulesStart not implemented")
+}
+func (*UnimplementedRulesServer) ApplyRulesCancel(ctx context.Context, req *request.ApplyRulesCancelReq) (*response.ApplyRulesCancelResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ApplyRulesCancel not implemented")
+}
+func (*UnimplementedRulesServer) ApplyRulesStatus(ctx context.Context, req *request.ApplyRulesStatusReq) (*response.ApplyRulesStatusResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ApplyRulesStatus not implemented")
 }
 
 func RegisterRulesServer(s *grpc.Server, srv RulesServer) {

--- a/components/automate-gateway/api/iam/v2beta/teams.pb.go
+++ b/components/automate-gateway/api/iam/v2beta/teams.pb.go
@@ -13,6 +13,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -220,6 +222,41 @@ type TeamsServer interface {
 	// Expose on GRPC API only so we don't expose this to the enduser.
 	// Just want to be able to trigger this via automate-cli.
 	ApplyV2DataMigrations(context.Context, *request.ApplyV2DataMigrationsReq) (*response.ApplyV2DataMigrationsResp, error)
+}
+
+// UnimplementedTeamsServer can be embedded to have forward compatible implementations.
+type UnimplementedTeamsServer struct {
+}
+
+func (*UnimplementedTeamsServer) ListTeams(ctx context.Context, req *request.ListTeamsReq) (*response.ListTeamsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListTeams not implemented")
+}
+func (*UnimplementedTeamsServer) GetTeam(ctx context.Context, req *request.GetTeamReq) (*response.GetTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTeam not implemented")
+}
+func (*UnimplementedTeamsServer) CreateTeam(ctx context.Context, req *request.CreateTeamReq) (*response.CreateTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateTeam not implemented")
+}
+func (*UnimplementedTeamsServer) UpdateTeam(ctx context.Context, req *request.UpdateTeamReq) (*response.UpdateTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateTeam not implemented")
+}
+func (*UnimplementedTeamsServer) DeleteTeam(ctx context.Context, req *request.DeleteTeamReq) (*response.DeleteTeamResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteTeam not implemented")
+}
+func (*UnimplementedTeamsServer) GetTeamMembership(ctx context.Context, req *request.GetTeamMembershipReq) (*response.GetTeamMembershipResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTeamMembership not implemented")
+}
+func (*UnimplementedTeamsServer) AddTeamMembers(ctx context.Context, req *request.AddTeamMembersReq) (*response.AddTeamMembersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddTeamMembers not implemented")
+}
+func (*UnimplementedTeamsServer) RemoveTeamMembers(ctx context.Context, req *request.RemoveTeamMembersReq) (*response.RemoveTeamMembersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RemoveTeamMembers not implemented")
+}
+func (*UnimplementedTeamsServer) GetTeamsForMember(ctx context.Context, req *request.GetTeamsForMemberReq) (*response.GetTeamsForMemberResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTeamsForMember not implemented")
+}
+func (*UnimplementedTeamsServer) ApplyV2DataMigrations(ctx context.Context, req *request.ApplyV2DataMigrationsReq) (*response.ApplyV2DataMigrationsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ApplyV2DataMigrations not implemented")
 }
 
 func RegisterTeamsServer(s *grpc.Server, srv TeamsServer) {

--- a/components/automate-gateway/api/iam/v2beta/tokens.pb.go
+++ b/components/automate-gateway/api/iam/v2beta/tokens.pb.go
@@ -13,6 +13,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -145,6 +147,26 @@ type TokensServer interface {
 	UpdateToken(context.Context, *request.UpdateTokenReq) (*response.UpdateTokenResp, error)
 	DeleteToken(context.Context, *request.DeleteTokenReq) (*response.DeleteTokenResp, error)
 	ListTokens(context.Context, *request.ListTokensReq) (*response.ListTokensResp, error)
+}
+
+// UnimplementedTokensServer can be embedded to have forward compatible implementations.
+type UnimplementedTokensServer struct {
+}
+
+func (*UnimplementedTokensServer) CreateToken(ctx context.Context, req *request.CreateTokenReq) (*response.CreateTokenResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateToken not implemented")
+}
+func (*UnimplementedTokensServer) GetToken(ctx context.Context, req *request.GetTokenReq) (*response.GetTokenResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetToken not implemented")
+}
+func (*UnimplementedTokensServer) UpdateToken(ctx context.Context, req *request.UpdateTokenReq) (*response.UpdateTokenResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateToken not implemented")
+}
+func (*UnimplementedTokensServer) DeleteToken(ctx context.Context, req *request.DeleteTokenReq) (*response.DeleteTokenResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteToken not implemented")
+}
+func (*UnimplementedTokensServer) ListTokens(ctx context.Context, req *request.ListTokensReq) (*response.ListTokensResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListTokens not implemented")
 }
 
 func RegisterTokensServer(s *grpc.Server, srv TokensServer) {

--- a/components/automate-gateway/api/iam/v2beta/users.pb.go
+++ b/components/automate-gateway/api/iam/v2beta/users.pb.go
@@ -13,6 +13,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -159,6 +161,29 @@ type UsersServer interface {
 	DeleteUser(context.Context, *request.DeleteUserReq) (*response.DeleteUserResp, error)
 	UpdateUser(context.Context, *request.UpdateUserReq) (*response.UpdateUserResp, error)
 	UpdateSelf(context.Context, *request.UpdateSelfReq) (*response.UpdateSelfResp, error)
+}
+
+// UnimplementedUsersServer can be embedded to have forward compatible implementations.
+type UnimplementedUsersServer struct {
+}
+
+func (*UnimplementedUsersServer) CreateUser(ctx context.Context, req *request.CreateUserReq) (*response.CreateUserResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateUser not implemented")
+}
+func (*UnimplementedUsersServer) ListUsers(ctx context.Context, req *request.ListUsersReq) (*response.ListUsersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListUsers not implemented")
+}
+func (*UnimplementedUsersServer) GetUser(ctx context.Context, req *request.GetUserReq) (*response.GetUserResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetUser not implemented")
+}
+func (*UnimplementedUsersServer) DeleteUser(ctx context.Context, req *request.DeleteUserReq) (*response.DeleteUserResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteUser not implemented")
+}
+func (*UnimplementedUsersServer) UpdateUser(ctx context.Context, req *request.UpdateUserReq) (*response.UpdateUserResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateUser not implemented")
+}
+func (*UnimplementedUsersServer) UpdateSelf(ctx context.Context, req *request.UpdateSelfReq) (*response.UpdateSelfResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateSelf not implemented")
 }
 
 func RegisterUsersServer(s *grpc.Server, srv UsersServer) {

--- a/components/automate-gateway/api/legacy/legacy.pb.go
+++ b/components/automate-gateway/api/legacy/legacy.pb.go
@@ -12,6 +12,8 @@ import (
 	empty "github.com/golang/protobuf/ptypes/empty"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -145,6 +147,14 @@ type LegacyDataCollectorServer interface {
 	// Since this is for legacy-support only, we don't bother much about having
 	// google.protobuf.Empty as argument.
 	Status(context.Context, *empty.Empty) (*StatusResponse, error)
+}
+
+// UnimplementedLegacyDataCollectorServer can be embedded to have forward compatible implementations.
+type UnimplementedLegacyDataCollectorServer struct {
+}
+
+func (*UnimplementedLegacyDataCollectorServer) Status(ctx context.Context, req *empty.Empty) (*StatusResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Status not implemented")
 }
 
 func RegisterLegacyDataCollectorServer(s *grpc.Server, srv LegacyDataCollectorServer) {

--- a/components/automate-gateway/api/license/license.pb.go
+++ b/components/automate-gateway/api/license/license.pb.go
@@ -12,6 +12,8 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -475,6 +477,20 @@ type LicenseServer interface {
 	ApplyLicense(context.Context, *ApplyLicenseReq) (*ApplyLicenseResp, error)
 	GetStatus(context.Context, *GetStatusReq) (*GetStatusResp, error)
 	RequestLicense(context.Context, *RequestLicenseReq) (*RequestLicenseResp, error)
+}
+
+// UnimplementedLicenseServer can be embedded to have forward compatible implementations.
+type UnimplementedLicenseServer struct {
+}
+
+func (*UnimplementedLicenseServer) ApplyLicense(ctx context.Context, req *ApplyLicenseReq) (*ApplyLicenseResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ApplyLicense not implemented")
+}
+func (*UnimplementedLicenseServer) GetStatus(ctx context.Context, req *GetStatusReq) (*GetStatusResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetStatus not implemented")
+}
+func (*UnimplementedLicenseServer) RequestLicense(ctx context.Context, req *RequestLicenseReq) (*RequestLicenseResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RequestLicense not implemented")
 }
 
 func RegisterLicenseServer(s *grpc.Server, srv LicenseServer) {

--- a/components/automate-gateway/api/nodes/manager/manager.pb.go
+++ b/components/automate-gateway/api/nodes/manager/manager.pb.go
@@ -14,6 +14,8 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -879,6 +881,44 @@ type NodeManagerServiceServer interface {
 	SearchNodeFields(context.Context, *FieldQuery) (*Fields, error)
 	SearchNodes(context.Context, *NodeQuery) (*Nodes, error)
 	Connect(context.Context, *Id) (*ConnectResponse, error)
+}
+
+// UnimplementedNodeManagerServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedNodeManagerServiceServer struct {
+}
+
+func (*UnimplementedNodeManagerServiceServer) Create(ctx context.Context, req *NodeManager) (*Ids, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Create not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) Read(ctx context.Context, req *Id) (*NodeManager, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Read not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) Update(ctx context.Context, req *NodeManager) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Update not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) Delete(ctx context.Context, req *Id) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Delete not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) DeleteWithNodes(ctx context.Context, req *Id) (*Ids, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteWithNodes not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) DeleteWithNodeStateStopped(ctx context.Context, req *Id) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteWithNodeStateStopped not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) DeleteWithNodeStateTerminated(ctx context.Context, req *Id) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteWithNodeStateTerminated not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) List(ctx context.Context, req *Query) (*NodeManagers, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method List not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) SearchNodeFields(ctx context.Context, req *FieldQuery) (*Fields, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SearchNodeFields not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) SearchNodes(ctx context.Context, req *NodeQuery) (*Nodes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SearchNodes not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) Connect(ctx context.Context, req *Id) (*ConnectResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Connect not implemented")
 }
 
 func RegisterNodeManagerServiceServer(s *grpc.Server, srv NodeManagerServiceServer) {

--- a/components/automate-gateway/api/nodes/nodes.pb.go
+++ b/components/automate-gateway/api/nodes/nodes.pb.go
@@ -14,6 +14,8 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1091,6 +1093,38 @@ type NodesServiceServer interface {
 	Rerun(context.Context, *Id) (*RerunResponse, error)
 	BulkDelete(context.Context, *Query) (*BulkDeleteResponse, error)
 	BulkCreate(context.Context, *Nodes) (*Ids, error)
+}
+
+// UnimplementedNodesServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedNodesServiceServer struct {
+}
+
+func (*UnimplementedNodesServiceServer) Create(ctx context.Context, req *Node) (*Id, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Create not implemented")
+}
+func (*UnimplementedNodesServiceServer) Read(ctx context.Context, req *Id) (*Node, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Read not implemented")
+}
+func (*UnimplementedNodesServiceServer) Update(ctx context.Context, req *Node) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Update not implemented")
+}
+func (*UnimplementedNodesServiceServer) Delete(ctx context.Context, req *Id) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Delete not implemented")
+}
+func (*UnimplementedNodesServiceServer) BulkDeleteById(ctx context.Context, req *Ids) (*BulkDeleteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BulkDeleteById not implemented")
+}
+func (*UnimplementedNodesServiceServer) List(ctx context.Context, req *Query) (*Nodes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method List not implemented")
+}
+func (*UnimplementedNodesServiceServer) Rerun(ctx context.Context, req *Id) (*RerunResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Rerun not implemented")
+}
+func (*UnimplementedNodesServiceServer) BulkDelete(ctx context.Context, req *Query) (*BulkDeleteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BulkDelete not implemented")
+}
+func (*UnimplementedNodesServiceServer) BulkCreate(ctx context.Context, req *Nodes) (*Ids, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BulkCreate not implemented")
 }
 
 func RegisterNodesServiceServer(s *grpc.Server, srv NodesServiceServer) {

--- a/components/automate-gateway/api/notifications/notifications.pb.go
+++ b/components/automate-gateway/api/notifications/notifications.pb.go
@@ -11,6 +11,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1213,6 +1215,32 @@ type NotificationsServer interface {
 	ListRules(context.Context, *RuleListRequest) (*RuleListResponse, error)
 	ValidateWebhook(context.Context, *URLValidationRequest) (*URLValidationResponse, error)
 	Version(context.Context, *VersionRequest) (*VersionResponse, error)
+}
+
+// UnimplementedNotificationsServer can be embedded to have forward compatible implementations.
+type UnimplementedNotificationsServer struct {
+}
+
+func (*UnimplementedNotificationsServer) AddRule(ctx context.Context, req *RuleAddRequest) (*RuleAddResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddRule not implemented")
+}
+func (*UnimplementedNotificationsServer) DeleteRule(ctx context.Context, req *RuleIdentifier) (*RuleDeleteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteRule not implemented")
+}
+func (*UnimplementedNotificationsServer) UpdateRule(ctx context.Context, req *RuleUpdateRequest) (*RuleUpdateResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateRule not implemented")
+}
+func (*UnimplementedNotificationsServer) GetRule(ctx context.Context, req *RuleIdentifier) (*RuleGetResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetRule not implemented")
+}
+func (*UnimplementedNotificationsServer) ListRules(ctx context.Context, req *RuleListRequest) (*RuleListResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListRules not implemented")
+}
+func (*UnimplementedNotificationsServer) ValidateWebhook(ctx context.Context, req *URLValidationRequest) (*URLValidationResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ValidateWebhook not implemented")
+}
+func (*UnimplementedNotificationsServer) Version(ctx context.Context, req *VersionRequest) (*VersionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Version not implemented")
 }
 
 func RegisterNotificationsServer(s *grpc.Server, srv NotificationsServer) {

--- a/components/automate-gateway/api/telemetry/telemetry.pb.go
+++ b/components/automate-gateway/api/telemetry/telemetry.pb.go
@@ -11,6 +11,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -228,6 +230,14 @@ func (c *telemetryClient) GetTelemetryConfiguration(ctx context.Context, in *Tel
 // TelemetryServer is the server API for Telemetry service.
 type TelemetryServer interface {
 	GetTelemetryConfiguration(context.Context, *TelemetryRequest) (*TelemetryResponse, error)
+}
+
+// UnimplementedTelemetryServer can be embedded to have forward compatible implementations.
+type UnimplementedTelemetryServer struct {
+}
+
+func (*UnimplementedTelemetryServer) GetTelemetryConfiguration(ctx context.Context, req *TelemetryRequest) (*TelemetryResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTelemetryConfiguration not implemented")
 }
 
 func RegisterTelemetryServer(s *grpc.Server, srv TelemetryServer) {

--- a/components/compliance-service/api/jobs/jobs.pb.go
+++ b/components/compliance-service/api/jobs/jobs.pb.go
@@ -12,6 +12,8 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -897,6 +899,35 @@ type JobsServiceServer interface {
 	Rerun(context.Context, *Id) (*RerunResponse, error)
 	ListInitiatedScans(context.Context, *TimeQuery) (*Ids, error)
 	GetJobResultByNodeId(context.Context, *GetJobResultByNodeIdRequest) (*ResultsRow, error)
+}
+
+// UnimplementedJobsServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedJobsServiceServer struct {
+}
+
+func (*UnimplementedJobsServiceServer) Create(ctx context.Context, req *Job) (*Id, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Create not implemented")
+}
+func (*UnimplementedJobsServiceServer) Read(ctx context.Context, req *Id) (*Job, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Read not implemented")
+}
+func (*UnimplementedJobsServiceServer) Update(ctx context.Context, req *Job) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Update not implemented")
+}
+func (*UnimplementedJobsServiceServer) Delete(ctx context.Context, req *Id) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Delete not implemented")
+}
+func (*UnimplementedJobsServiceServer) List(ctx context.Context, req *Query) (*Jobs, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method List not implemented")
+}
+func (*UnimplementedJobsServiceServer) Rerun(ctx context.Context, req *Id) (*RerunResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Rerun not implemented")
+}
+func (*UnimplementedJobsServiceServer) ListInitiatedScans(ctx context.Context, req *TimeQuery) (*Ids, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListInitiatedScans not implemented")
+}
+func (*UnimplementedJobsServiceServer) GetJobResultByNodeId(ctx context.Context, req *GetJobResultByNodeIdRequest) (*ResultsRow, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetJobResultByNodeId not implemented")
 }
 
 func RegisterJobsServiceServer(s *grpc.Server, srv JobsServiceServer) {

--- a/components/compliance-service/api/profiles/profiles.pb.go
+++ b/components/compliance-service/api/profiles/profiles.pb.go
@@ -10,6 +10,8 @@ import (
 	empty "github.com/golang/protobuf/ptypes/empty"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1747,6 +1749,26 @@ type ProfilesServiceServer interface {
 	List(context.Context, *Query) (*Profiles, error)
 }
 
+// UnimplementedProfilesServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedProfilesServiceServer struct {
+}
+
+func (*UnimplementedProfilesServiceServer) Create(srv ProfilesService_CreateServer) error {
+	return status.Errorf(codes.Unimplemented, "method Create not implemented")
+}
+func (*UnimplementedProfilesServiceServer) Read(ctx context.Context, req *ProfileDetails) (*Profile, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Read not implemented")
+}
+func (*UnimplementedProfilesServiceServer) ReadTar(req *ProfileDetails, srv ProfilesService_ReadTarServer) error {
+	return status.Errorf(codes.Unimplemented, "method ReadTar not implemented")
+}
+func (*UnimplementedProfilesServiceServer) Delete(ctx context.Context, req *ProfileDetails) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Delete not implemented")
+}
+func (*UnimplementedProfilesServiceServer) List(ctx context.Context, req *Query) (*Profiles, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method List not implemented")
+}
+
 func RegisterProfilesServiceServer(s *grpc.Server, srv ProfilesServiceServer) {
 	s.RegisterService(&_ProfilesService_serviceDesc, srv)
 }
@@ -1922,6 +1944,17 @@ func (c *profilesAdminServiceClient) MigrateDiskProfiles(ctx context.Context, in
 type ProfilesAdminServiceServer interface {
 	RebuildElasticCache(context.Context, *empty.Empty) (*empty.Empty, error)
 	MigrateDiskProfiles(context.Context, *empty.Empty) (*empty.Empty, error)
+}
+
+// UnimplementedProfilesAdminServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedProfilesAdminServiceServer struct {
+}
+
+func (*UnimplementedProfilesAdminServiceServer) RebuildElasticCache(ctx context.Context, req *empty.Empty) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RebuildElasticCache not implemented")
+}
+func (*UnimplementedProfilesAdminServiceServer) MigrateDiskProfiles(ctx context.Context, req *empty.Empty) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method MigrateDiskProfiles not implemented")
 }
 
 func RegisterProfilesAdminServiceServer(s *grpc.Server, srv ProfilesAdminServiceServer) {

--- a/components/compliance-service/api/reporting/reporting.pb.go
+++ b/components/compliance-service/api/reporting/reporting.pb.go
@@ -10,6 +10,8 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -2538,6 +2540,35 @@ type ReportingServiceServer interface {
 	Export(*Query, ReportingService_ExportServer) error
 	ReadNode(context.Context, *Id) (*Node, error)
 	ListNodes(context.Context, *Query) (*Nodes, error)
+}
+
+// UnimplementedReportingServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedReportingServiceServer struct {
+}
+
+func (*UnimplementedReportingServiceServer) ListReports(ctx context.Context, req *Query) (*Reports, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListReports not implemented")
+}
+func (*UnimplementedReportingServiceServer) ListReportIds(ctx context.Context, req *Query) (*ReportIds, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListReportIds not implemented")
+}
+func (*UnimplementedReportingServiceServer) ReadReport(ctx context.Context, req *Query) (*Report, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadReport not implemented")
+}
+func (*UnimplementedReportingServiceServer) ListSuggestions(ctx context.Context, req *SuggestionRequest) (*Suggestions, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListSuggestions not implemented")
+}
+func (*UnimplementedReportingServiceServer) ListProfiles(ctx context.Context, req *Query) (*ProfileMins, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListProfiles not implemented")
+}
+func (*UnimplementedReportingServiceServer) Export(req *Query, srv ReportingService_ExportServer) error {
+	return status.Errorf(codes.Unimplemented, "method Export not implemented")
+}
+func (*UnimplementedReportingServiceServer) ReadNode(ctx context.Context, req *Id) (*Node, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadNode not implemented")
+}
+func (*UnimplementedReportingServiceServer) ListNodes(ctx context.Context, req *Query) (*Nodes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListNodes not implemented")
 }
 
 func RegisterReportingServiceServer(s *grpc.Server, srv ReportingServiceServer) {

--- a/components/compliance-service/api/stats/stats.pb.go
+++ b/components/compliance-service/api/stats/stats.pb.go
@@ -10,6 +10,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1458,6 +1460,23 @@ type StatsServiceServer interface {
 	ReadTrend(context.Context, *Query) (*Trends, error)
 	ReadProfiles(context.Context, *Query) (*Profile, error)
 	ReadFailures(context.Context, *Query) (*Failures, error)
+}
+
+// UnimplementedStatsServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedStatsServiceServer struct {
+}
+
+func (*UnimplementedStatsServiceServer) ReadSummary(ctx context.Context, req *Query) (*Summary, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadSummary not implemented")
+}
+func (*UnimplementedStatsServiceServer) ReadTrend(ctx context.Context, req *Query) (*Trends, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadTrend not implemented")
+}
+func (*UnimplementedStatsServiceServer) ReadProfiles(ctx context.Context, req *Query) (*Profile, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadProfiles not implemented")
+}
+func (*UnimplementedStatsServiceServer) ReadFailures(ctx context.Context, req *Query) (*Failures, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadFailures not implemented")
 }
 
 func RegisterStatsServiceServer(s *grpc.Server, srv StatsServiceServer) {

--- a/components/compliance-service/api/status/status.pb.go
+++ b/components/compliance-service/api/status/status.pb.go
@@ -10,6 +10,8 @@ import (
 	empty "github.com/golang/protobuf/ptypes/empty"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -253,6 +255,14 @@ func (c *complianceStatusClient) GetMigrationStatus(ctx context.Context, in *emp
 // ComplianceStatusServer is the server API for ComplianceStatus service.
 type ComplianceStatusServer interface {
 	GetMigrationStatus(context.Context, *empty.Empty) (*MigrationStatus, error)
+}
+
+// UnimplementedComplianceStatusServer can be embedded to have forward compatible implementations.
+type UnimplementedComplianceStatusServer struct {
+}
+
+func (*UnimplementedComplianceStatusServer) GetMigrationStatus(ctx context.Context, req *empty.Empty) (*MigrationStatus, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetMigrationStatus not implemented")
 }
 
 func RegisterComplianceStatusServer(s *grpc.Server, srv ComplianceStatusServer) {

--- a/components/compliance-service/api/version/version.pb.go
+++ b/components/compliance-service/api/version/version.pb.go
@@ -10,6 +10,8 @@ import (
 	empty "github.com/golang/protobuf/ptypes/empty"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -159,6 +161,14 @@ func (c *versionServiceClient) Version(ctx context.Context, in *empty.Empty, opt
 // VersionServiceServer is the server API for VersionService service.
 type VersionServiceServer interface {
 	Version(context.Context, *empty.Empty) (*VersionInfo, error)
+}
+
+// UnimplementedVersionServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedVersionServiceServer struct {
+}
+
+func (*UnimplementedVersionServiceServer) Version(ctx context.Context, req *empty.Empty) (*VersionInfo, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Version not implemented")
 }
 
 func RegisterVersionServiceServer(s *grpc.Server, srv VersionServiceServer) {

--- a/components/compliance-service/ingest/ingest/compliance.pb.go
+++ b/components/compliance-service/ingest/ingest/compliance.pb.go
@@ -13,6 +13,8 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -211,6 +213,20 @@ type ComplianceIngesterServer interface {
 	ProcessComplianceReport(context.Context, *compliance.Report) (*empty.Empty, error)
 	HandleEvent(context.Context, *event.EventMsg) (*event.EventResponse, error)
 	ProjectUpdateStatus(context.Context, *ProjectUpdateStatusReq) (*ProjectUpdateStatusResp, error)
+}
+
+// UnimplementedComplianceIngesterServer can be embedded to have forward compatible implementations.
+type UnimplementedComplianceIngesterServer struct {
+}
+
+func (*UnimplementedComplianceIngesterServer) ProcessComplianceReport(ctx context.Context, req *compliance.Report) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProcessComplianceReport not implemented")
+}
+func (*UnimplementedComplianceIngesterServer) HandleEvent(ctx context.Context, req *event.EventMsg) (*event.EventResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method HandleEvent not implemented")
+}
+func (*UnimplementedComplianceIngesterServer) ProjectUpdateStatus(ctx context.Context, req *ProjectUpdateStatusReq) (*ProjectUpdateStatusResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProjectUpdateStatus not implemented")
 }
 
 func RegisterComplianceIngesterServer(s *grpc.Server, srv ComplianceIngesterServer) {

--- a/components/nodemanager-service/api/manager/manager.pb.go
+++ b/components/nodemanager-service/api/manager/manager.pb.go
@@ -13,6 +13,8 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1407,6 +1409,59 @@ type NodeManagerServiceServer interface {
 	ChangeNodeState(context.Context, *NodeState) (*ChangeNodeStateResponse, error)
 	GetNodeWithSecrets(context.Context, *Id) (*nodes.Node, error)
 	SearchManagerNodes(context.Context, *NodeQuery) (*ManagerNodes, error)
+}
+
+// UnimplementedNodeManagerServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedNodeManagerServiceServer struct {
+}
+
+func (*UnimplementedNodeManagerServiceServer) Create(ctx context.Context, req *NodeManager) (*Ids, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Create not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) Read(ctx context.Context, req *Id) (*NodeManager, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Read not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) Update(ctx context.Context, req *NodeManager) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Update not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) Delete(ctx context.Context, req *Id) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Delete not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) DeleteWithNodes(ctx context.Context, req *Id) (*Ids, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteWithNodes not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) DeleteWithNodeStateStopped(ctx context.Context, req *Id) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteWithNodeStateStopped not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) DeleteWithNodeStateTerminated(ctx context.Context, req *Id) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteWithNodeStateTerminated not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) List(ctx context.Context, req *Query) (*NodeManagers, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method List not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) Connect(ctx context.Context, req *NodeManager) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Connect not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) ConnectManager(ctx context.Context, req *Id) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConnectManager not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) SearchNodeFields(ctx context.Context, req *FieldQuery) (*Fields, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SearchNodeFields not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) SearchNodes(ctx context.Context, req *NodeQuery) (*Nodes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SearchNodes not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) ProcessNode(ctx context.Context, req *NodeMetadata) (*ProcessNodeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProcessNode not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) ChangeNodeState(ctx context.Context, req *NodeState) (*ChangeNodeStateResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ChangeNodeState not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) GetNodeWithSecrets(ctx context.Context, req *Id) (*nodes.Node, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetNodeWithSecrets not implemented")
+}
+func (*UnimplementedNodeManagerServiceServer) SearchManagerNodes(ctx context.Context, req *NodeQuery) (*ManagerNodes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SearchManagerNodes not implemented")
 }
 
 func RegisterNodeManagerServiceServer(s *grpc.Server, srv NodeManagerServiceServer) {

--- a/components/nodemanager-service/api/nodes/nodes.pb.go
+++ b/components/nodemanager-service/api/nodes/nodes.pb.go
@@ -12,6 +12,8 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1470,6 +1472,41 @@ type NodesServiceServer interface {
 	UpdateNodeDetectInfo(context.Context, *NodeDetectJobInfo) (*empty.Empty, error)
 	UpdateNodeConnectionError(context.Context, *NodeError) (*empty.Empty, error)
 	BulkDeleteById(context.Context, *Ids) (*BulkDeleteResponse, error)
+}
+
+// UnimplementedNodesServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedNodesServiceServer struct {
+}
+
+func (*UnimplementedNodesServiceServer) Create(ctx context.Context, req *Node) (*Id, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Create not implemented")
+}
+func (*UnimplementedNodesServiceServer) Read(ctx context.Context, req *Id) (*Node, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Read not implemented")
+}
+func (*UnimplementedNodesServiceServer) Update(ctx context.Context, req *Node) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Update not implemented")
+}
+func (*UnimplementedNodesServiceServer) Delete(ctx context.Context, req *Id) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Delete not implemented")
+}
+func (*UnimplementedNodesServiceServer) List(ctx context.Context, req *Query) (*Nodes, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method List not implemented")
+}
+func (*UnimplementedNodesServiceServer) BulkDelete(ctx context.Context, req *Query) (*BulkDeleteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BulkDelete not implemented")
+}
+func (*UnimplementedNodesServiceServer) BulkCreate(ctx context.Context, req *Nodes) (*Ids, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BulkCreate not implemented")
+}
+func (*UnimplementedNodesServiceServer) UpdateNodeDetectInfo(ctx context.Context, req *NodeDetectJobInfo) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateNodeDetectInfo not implemented")
+}
+func (*UnimplementedNodesServiceServer) UpdateNodeConnectionError(ctx context.Context, req *NodeError) (*empty.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateNodeConnectionError not implemented")
+}
+func (*UnimplementedNodesServiceServer) BulkDeleteById(ctx context.Context, req *Ids) (*BulkDeleteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BulkDeleteById not implemented")
 }
 
 func RegisterNodesServiceServer(s *grpc.Server, srv NodesServiceServer) {

--- a/lib/grpc/debug/debug_api/debug.pb.go
+++ b/lib/grpc/debug/debug_api/debug.pb.go
@@ -11,6 +11,8 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	duration "github.com/golang/protobuf/ptypes/duration"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -521,6 +523,23 @@ type DebugServer interface {
 	Profile(*ProfileRequest, Debug_ProfileServer) error
 	SetLogLevel(context.Context, *SetLogLevelRequest) (*SetLogLevelResponse, error)
 	GetVersion(context.Context, *VersionRequest) (*VersionResponse, error)
+}
+
+// UnimplementedDebugServer can be embedded to have forward compatible implementations.
+type UnimplementedDebugServer struct {
+}
+
+func (*UnimplementedDebugServer) Trace(req *TraceRequest, srv Debug_TraceServer) error {
+	return status.Errorf(codes.Unimplemented, "method Trace not implemented")
+}
+func (*UnimplementedDebugServer) Profile(req *ProfileRequest, srv Debug_ProfileServer) error {
+	return status.Errorf(codes.Unimplemented, "method Profile not implemented")
+}
+func (*UnimplementedDebugServer) SetLogLevel(ctx context.Context, req *SetLogLevelRequest) (*SetLogLevelResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetLogLevel not implemented")
+}
+func (*UnimplementedDebugServer) GetVersion(ctx context.Context, req *VersionRequest) (*VersionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
 }
 
 func RegisterDebugServer(s *grpc.Server, srv DebugServer) {

--- a/vendor/github.com/golang/protobuf/jsonpb/jsonpb.go
+++ b/vendor/github.com/golang/protobuf/jsonpb/jsonpb.go
@@ -57,6 +57,7 @@ import (
 )
 
 const secondInNanos = int64(time.Second / time.Nanosecond)
+const maxSecondsInDuration = 315576000000
 
 // Marshaler is a configurable object for converting between
 // protocol buffer objects and a JSON representation for them.
@@ -182,7 +183,12 @@ func (m *Marshaler) marshalObject(out *errWriter, v proto.Message, indent, typeU
 				return fmt.Errorf("failed to marshal type URL %q to JSON: %v", typeURL, err)
 			}
 			js["@type"] = (*json.RawMessage)(&turl)
-			if b, err = json.Marshal(js); err != nil {
+			if m.Indent != "" {
+				b, err = json.MarshalIndent(js, indent, m.Indent)
+			} else {
+				b, err = json.Marshal(js)
+			}
+			if err != nil {
 				return err
 			}
 		}
@@ -206,19 +212,26 @@ func (m *Marshaler) marshalObject(out *errWriter, v proto.Message, indent, typeU
 			// Any is a bit more involved.
 			return m.marshalAny(out, v, indent)
 		case "Duration":
-			// "Generated output always contains 0, 3, 6, or 9 fractional digits,
-			//  depending on required precision."
 			s, ns := s.Field(0).Int(), s.Field(1).Int()
+			if s < -maxSecondsInDuration || s > maxSecondsInDuration {
+				return fmt.Errorf("seconds out of range %v", s)
+			}
 			if ns <= -secondInNanos || ns >= secondInNanos {
 				return fmt.Errorf("ns out of range (%v, %v)", -secondInNanos, secondInNanos)
 			}
 			if (s > 0 && ns < 0) || (s < 0 && ns > 0) {
 				return errors.New("signs of seconds and nanos do not match")
 			}
-			if s < 0 {
+			// Generated output always contains 0, 3, 6, or 9 fractional digits,
+			// depending on required precision, followed by the suffix "s".
+			f := "%d.%09d"
+			if ns < 0 {
 				ns = -ns
+				if s == 0 {
+					f = "-%d.%09d"
+				}
 			}
-			x := fmt.Sprintf("%d.%09d", s, ns)
+			x := fmt.Sprintf(f, s, ns)
 			x = strings.TrimSuffix(x, "000")
 			x = strings.TrimSuffix(x, "000")
 			x = strings.TrimSuffix(x, ".000")

--- a/vendor/github.com/golang/protobuf/proto/properties.go
+++ b/vendor/github.com/golang/protobuf/proto/properties.go
@@ -38,7 +38,6 @@ package proto
 import (
 	"fmt"
 	"log"
-	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -194,7 +193,7 @@ func (p *Properties) Parse(s string) {
 	// "bytes,49,opt,name=foo,def=hello!"
 	fields := strings.Split(s, ",") // breaks def=, but handled below.
 	if len(fields) < 2 {
-		fmt.Fprintf(os.Stderr, "proto: tag has too few fields: %q\n", s)
+		log.Printf("proto: tag has too few fields: %q", s)
 		return
 	}
 
@@ -214,7 +213,7 @@ func (p *Properties) Parse(s string) {
 		p.WireType = WireBytes
 		// no numeric converter for non-numeric types
 	default:
-		fmt.Fprintf(os.Stderr, "proto: tag has unknown wire type: %q\n", s)
+		log.Printf("proto: tag has unknown wire type: %q", s)
 		return
 	}
 

--- a/vendor/github.com/golang/protobuf/protoc-gen-go/grpc/grpc.go
+++ b/vendor/github.com/golang/protobuf/protoc-gen-go/grpc/grpc.go
@@ -54,6 +54,8 @@ const generatedCodeVersion = 4
 const (
 	contextPkgPath = "context"
 	grpcPkgPath    = "google.golang.org/grpc"
+	codePkgPath    = "google.golang.org/grpc/codes"
+	statusPkgPath  = "google.golang.org/grpc/status"
 )
 
 func init() {
@@ -216,6 +218,12 @@ func (g *grpc) generateService(file *generator.FileDescriptor, service *pb.Servi
 	g.P("}")
 	g.P()
 
+	// Server Unimplemented struct for forward compatability.
+	if deprecated {
+		g.P(deprecationComment)
+	}
+	g.generateUnimplementedServer(servName, service)
+
 	// Server registration.
 	if deprecated {
 		g.P(deprecationComment)
@@ -267,6 +275,35 @@ func (g *grpc) generateService(file *generator.FileDescriptor, service *pb.Servi
 	g.P("Metadata: \"", file.GetName(), "\",")
 	g.P("}")
 	g.P()
+}
+
+// generateUnimplementedServer creates the unimplemented server struct
+func (g *grpc) generateUnimplementedServer(servName string, service *pb.ServiceDescriptorProto) {
+	serverType := servName + "Server"
+	g.P("// Unimplemented", serverType, " can be embedded to have forward compatible implementations.")
+	g.P("type Unimplemented", serverType, " struct {")
+	g.P("}")
+	g.P()
+	// Unimplemented<service_name>Server's concrete methods
+	for _, method := range service.Method {
+		g.generateServerMethodConcrete(servName, method)
+	}
+	g.P()
+}
+
+// generateServerMethodConcrete returns unimplemented methods which ensure forward compatibility
+func (g *grpc) generateServerMethodConcrete(servName string, method *pb.MethodDescriptorProto) {
+	header := g.generateServerSignatureWithParamNames(servName, method)
+	g.P("func (*Unimplemented", servName, "Server) ", header, " {")
+	var nilArg string
+	if !method.GetServerStreaming() && !method.GetClientStreaming() {
+		nilArg = "nil, "
+	}
+	methName := generator.CamelCase(method.GetName())
+	statusPkg := string(g.gen.AddImport(statusPkgPath))
+	codePkg := string(g.gen.AddImport(codePkgPath))
+	g.P("return ", nilArg, statusPkg, `.Errorf(`, codePkg, `.Unimplemented, "method `, methName, ` not implemented")`)
+	g.P("}")
 }
 
 // generateClientSignature returns the client-side signature for a method.
@@ -366,6 +403,30 @@ func (g *grpc) generateClientMethod(servName, fullServName, serviceDescVar strin
 		g.P("}")
 		g.P()
 	}
+}
+
+// generateServerSignatureWithParamNames returns the server-side signature for a method with parameter names.
+func (g *grpc) generateServerSignatureWithParamNames(servName string, method *pb.MethodDescriptorProto) string {
+	origMethName := method.GetName()
+	methName := generator.CamelCase(origMethName)
+	if reservedClientName[methName] {
+		methName += "_"
+	}
+
+	var reqArgs []string
+	ret := "error"
+	if !method.GetServerStreaming() && !method.GetClientStreaming() {
+		reqArgs = append(reqArgs, "ctx "+contextPkg+".Context")
+		ret = "(*" + g.typeName(method.GetOutputType()) + ", error)"
+	}
+	if !method.GetClientStreaming() {
+		reqArgs = append(reqArgs, "req *"+g.typeName(method.GetInputType()))
+	}
+	if method.GetServerStreaming() || method.GetClientStreaming() {
+		reqArgs = append(reqArgs, "srv "+servName+"_"+generator.CamelCase(origMethName)+"Server")
+	}
+
+	return methName + "(" + strings.Join(reqArgs, ", ") + ") " + ret
 }
 
 // generateServerSignature returns the server-side signature for a method.

--- a/vendor/google.golang.org/grpc/balancer.go
+++ b/vendor/google.golang.org/grpc/balancer.go
@@ -43,7 +43,7 @@ type Address struct {
 
 // BalancerConfig specifies the configurations for Balancer.
 //
-// Deprecated: please use package balancer.
+// Deprecated: please use package balancer.  May be removed in a future 1.x release.
 type BalancerConfig struct {
 	// DialCreds is the transport credential the Balancer implementation can
 	// use to dial to a remote load balancer server. The Balancer implementations
@@ -57,7 +57,7 @@ type BalancerConfig struct {
 
 // BalancerGetOptions configures a Get call.
 //
-// Deprecated: please use package balancer.
+// Deprecated: please use package balancer.  May be removed in a future 1.x release.
 type BalancerGetOptions struct {
 	// BlockingWait specifies whether Get should block when there is no
 	// connected address.
@@ -66,7 +66,7 @@ type BalancerGetOptions struct {
 
 // Balancer chooses network addresses for RPCs.
 //
-// Deprecated: please use package balancer.
+// Deprecated: please use package balancer.  May be removed in a future 1.x release.
 type Balancer interface {
 	// Start does the initialization work to bootstrap a Balancer. For example,
 	// this function may start the name resolution and watch the updates. It will
@@ -120,7 +120,7 @@ type Balancer interface {
 // RoundRobin returns a Balancer that selects addresses round-robin. It uses r to watch
 // the name resolution updates and updates the addresses available correspondingly.
 //
-// Deprecated: please use package balancer/roundrobin.
+// Deprecated: please use package balancer/roundrobin. May be removed in a future 1.x release.
 func RoundRobin(r naming.Resolver) Balancer {
 	return &roundRobin{r: r}
 }

--- a/vendor/google.golang.org/grpc/balancer/base/balancer.go
+++ b/vendor/google.golang.org/grpc/balancer/base/balancer.go
@@ -73,7 +73,9 @@ func (b *baseBalancer) HandleResolvedAddrs(addrs []resolver.Address, err error) 
 func (b *baseBalancer) UpdateClientConnState(s balancer.ClientConnState) {
 	// TODO: handle s.ResolverState.Err (log if not nil) once implemented.
 	// TODO: handle s.ResolverState.ServiceConfig?
-	grpclog.Infoln("base.baseBalancer: got new ClientConn state: ", s)
+	if grpclog.V(2) {
+		grpclog.Infoln("base.baseBalancer: got new ClientConn state: ", s)
+	}
 	// addrsSet is the set converted from addrs, it's used for quick lookup of an address.
 	addrsSet := make(map[resolver.Address]struct{})
 	for _, a := range s.ResolverState.Addresses {
@@ -127,10 +129,14 @@ func (b *baseBalancer) HandleSubConnStateChange(sc balancer.SubConn, s connectiv
 
 func (b *baseBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
 	s := state.ConnectivityState
-	grpclog.Infof("base.baseBalancer: handle SubConn state change: %p, %v", sc, s)
+	if grpclog.V(2) {
+		grpclog.Infof("base.baseBalancer: handle SubConn state change: %p, %v", sc, s)
+	}
 	oldS, ok := b.scStates[sc]
 	if !ok {
-		grpclog.Infof("base.baseBalancer: got state changes for an unknown SubConn: %p, %v", sc, s)
+		if grpclog.V(2) {
+			grpclog.Infof("base.baseBalancer: got state changes for an unknown SubConn: %p, %v", sc, s)
+		}
 		return
 	}
 	b.scStates[sc] = s

--- a/vendor/google.golang.org/grpc/balancer_conn_wrappers.go
+++ b/vendor/google.golang.org/grpc/balancer_conn_wrappers.go
@@ -183,7 +183,7 @@ func (ccb *ccBalancerWrapper) handleSubConnStateChange(sc balancer.SubConn, s co
 func (ccb *ccBalancerWrapper) updateClientConnState(ccs *balancer.ClientConnState) {
 	if ccb.cc.curBalancerName != grpclbName {
 		// Filter any grpclb addresses since we don't have the grpclb balancer.
-		s := ccs.ResolverState
+		s := &ccs.ResolverState
 		for i := 0; i < len(s.Addresses); {
 			if s.Addresses[i].Type == resolver.GRPCLB {
 				copy(s.Addresses[i:], s.Addresses[i+1:])

--- a/vendor/google.golang.org/grpc/clientconn.go
+++ b/vendor/google.golang.org/grpc/clientconn.go
@@ -38,7 +38,6 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/backoff"
 	"google.golang.org/grpc/internal/channelz"
-	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/keepalive"
@@ -1061,8 +1060,8 @@ func (ac *addrConn) resetTransport() {
 
 		ac.mu.Lock()
 		if ac.state == connectivity.Shutdown {
-			newTr.Close()
 			ac.mu.Unlock()
+			newTr.Close()
 			return
 		}
 		ac.curAddr = addr
@@ -1077,20 +1076,16 @@ func (ac *addrConn) resetTransport() {
 		// we restart from the top of the addr list.
 		<-reconnect.Done()
 		hcancel()
-
-		// Need to reconnect after a READY, the addrConn enters
-		// TRANSIENT_FAILURE.
+		// restart connecting - the top of the loop will set state to
+		// CONNECTING.  This is against the current connectivity semantics doc,
+		// however it allows for graceful behavior for RPCs not yet dispatched
+		// - unfortunate timing would otherwise lead to the RPC failing even
+		// though the TRANSIENT_FAILURE state (called for by the doc) would be
+		// instantaneous.
 		//
-		// This will set addrConn to TRANSIENT_FAILURE for a very short period
-		// of time, and turns CONNECTING. It seems reasonable to skip this, but
-		// READY-CONNECTING is not a valid transition.
-		ac.mu.Lock()
-		if ac.state == connectivity.Shutdown {
-			ac.mu.Unlock()
-			return
-		}
-		ac.updateConnectivityState(connectivity.TransientFailure)
-		ac.mu.Unlock()
+		// Ideally we should transition to Idle here and block until there is
+		// RPC activity that leads to the balancer requesting a reconnect of
+		// the associated SubConn.
 	}
 }
 
@@ -1147,14 +1142,35 @@ func (ac *addrConn) createTransport(addr resolver.Address, copts transport.Conne
 		Authority: ac.cc.authority,
 	}
 
+	once := sync.Once{}
 	onGoAway := func(r transport.GoAwayReason) {
 		ac.mu.Lock()
 		ac.adjustParams(r)
+		once.Do(func() {
+			if ac.state == connectivity.Ready {
+				// Prevent this SubConn from being used for new RPCs by setting its
+				// state to Connecting.
+				//
+				// TODO: this should be Idle when grpc-go properly supports it.
+				ac.updateConnectivityState(connectivity.Connecting)
+			}
+		})
 		ac.mu.Unlock()
 		reconnect.Fire()
 	}
 
 	onClose := func() {
+		ac.mu.Lock()
+		once.Do(func() {
+			if ac.state == connectivity.Ready {
+				// Prevent this SubConn from being used for new RPCs by setting its
+				// state to Connecting.
+				//
+				// TODO: this should be Idle when grpc-go properly supports it.
+				ac.updateConnectivityState(connectivity.Connecting)
+			}
+		})
+		ac.mu.Unlock()
 		close(onCloseCalled)
 		reconnect.Fire()
 	}
@@ -1176,20 +1192,18 @@ func (ac *addrConn) createTransport(addr resolver.Address, copts transport.Conne
 		return nil, nil, err
 	}
 
-	if ac.dopts.reqHandshake == envconfig.RequireHandshakeOn {
-		select {
-		case <-time.After(connectDeadline.Sub(time.Now())):
-			// We didn't get the preface in time.
-			newTr.Close()
-			grpclog.Warningf("grpc: addrConn.createTransport failed to connect to %v: didn't receive server preface in time. Reconnecting...", addr)
-			return nil, nil, errors.New("timed out waiting for server handshake")
-		case <-prefaceReceived:
-			// We got the preface - huzzah! things are good.
-		case <-onCloseCalled:
-			// The transport has already closed - noop.
-			return nil, nil, errors.New("connection closed")
-			// TODO(deklerk) this should bail on ac.ctx.Done(). Add a test and fix.
-		}
+	select {
+	case <-time.After(connectDeadline.Sub(time.Now())):
+		// We didn't get the preface in time.
+		newTr.Close()
+		grpclog.Warningf("grpc: addrConn.createTransport failed to connect to %v: didn't receive server preface in time. Reconnecting...", addr)
+		return nil, nil, errors.New("timed out waiting for server handshake")
+	case <-prefaceReceived:
+		// We got the preface - huzzah! things are good.
+	case <-onCloseCalled:
+		// The transport has already closed - noop.
+		return nil, nil, errors.New("connection closed")
+		// TODO(deklerk) this should bail on ac.ctx.Done(). Add a test and fix.
 	}
 	return newTr, reconnect, nil
 }

--- a/vendor/google.golang.org/grpc/dialoptions.go
+++ b/vendor/google.golang.org/grpc/dialoptions.go
@@ -60,7 +60,6 @@ type dialOptions struct {
 	balancerBuilder balancer.Builder
 	// This is to support grpclb.
 	resolverBuilder             resolver.Builder
-	reqHandshake                envconfig.RequireHandshakeSetting
 	channelzParentID            int64
 	disableServiceConfig        bool
 	disableRetry                bool
@@ -98,17 +97,6 @@ func newFuncDialOption(f func(*dialOptions)) *funcDialOption {
 	return &funcDialOption{
 		f: f,
 	}
-}
-
-// WithWaitForHandshake blocks until the initial settings frame is received from
-// the server before assigning RPCs to the connection.
-//
-// Deprecated: this is the default behavior, and this option will be removed
-// after the 1.18 release.
-func WithWaitForHandshake() DialOption {
-	return newFuncDialOption(func(o *dialOptions) {
-		o.reqHandshake = envconfig.RequireHandshakeOn
-	})
 }
 
 // WithWriteBufferSize determines how much data can be batched before doing a
@@ -156,7 +144,8 @@ func WithInitialConnWindowSize(s int32) DialOption {
 // WithMaxMsgSize returns a DialOption which sets the maximum message size the
 // client can receive.
 //
-// Deprecated: use WithDefaultCallOptions(MaxCallRecvMsgSize(s)) instead.
+// Deprecated: use WithDefaultCallOptions(MaxCallRecvMsgSize(s)) instead.  Will
+// be supported throughout 1.x.
 func WithMaxMsgSize(s int) DialOption {
 	return WithDefaultCallOptions(MaxCallRecvMsgSize(s))
 }
@@ -172,7 +161,8 @@ func WithDefaultCallOptions(cos ...CallOption) DialOption {
 // WithCodec returns a DialOption which sets a codec for message marshaling and
 // unmarshaling.
 //
-// Deprecated: use WithDefaultCallOptions(ForceCodec(_)) instead.
+// Deprecated: use WithDefaultCallOptions(ForceCodec(_)) instead.  Will be
+// supported throughout 1.x.
 func WithCodec(c Codec) DialOption {
 	return WithDefaultCallOptions(CallCustomCodec(c))
 }
@@ -181,7 +171,7 @@ func WithCodec(c Codec) DialOption {
 // message compression. It has lower priority than the compressor set by the
 // UseCompressor CallOption.
 //
-// Deprecated: use UseCompressor instead.
+// Deprecated: use UseCompressor instead.  Will be supported throughout 1.x.
 func WithCompressor(cp Compressor) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.cp = cp
@@ -196,7 +186,8 @@ func WithCompressor(cp Compressor) DialOption {
 // message.  If no compressor is registered for the encoding, an Unimplemented
 // status error will be returned.
 //
-// Deprecated: use encoding.RegisterCompressor instead.
+// Deprecated: use encoding.RegisterCompressor instead.  Will be supported
+// throughout 1.x.
 func WithDecompressor(dc Decompressor) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.dc = dc
@@ -207,7 +198,7 @@ func WithDecompressor(dc Decompressor) DialOption {
 // Name resolver will be ignored if this DialOption is specified.
 //
 // Deprecated: use the new balancer APIs in balancer package and
-// WithBalancerName.
+// WithBalancerName.  Will be removed in a future 1.x release.
 func WithBalancer(b Balancer) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.balancerBuilder = &balancerWrapperBuilder{
@@ -223,7 +214,8 @@ func WithBalancer(b Balancer) DialOption {
 // The balancer cannot be overridden by balancer option specified by service
 // config.
 //
-// This is an EXPERIMENTAL API.
+// Deprecated: use WithDefaultServiceConfig and WithDisableServiceConfig
+// instead.  Will be removed in a future 1.x release.
 func WithBalancerName(balancerName string) DialOption {
 	builder := balancer.Get(balancerName)
 	if builder == nil {
@@ -244,9 +236,10 @@ func withResolverBuilder(b resolver.Builder) DialOption {
 // WithServiceConfig returns a DialOption which has a channel to read the
 // service configuration.
 //
-// Deprecated: service config should be received through name resolver, as
-// specified here.
-// https://github.com/grpc/grpc/blob/master/doc/service_config.md
+// Deprecated: service config should be received through name resolver or via
+// WithDefaultServiceConfig, as specified at
+// https://github.com/grpc/grpc/blob/master/doc/service_config.md.  Will be
+// removed in a future 1.x release.
 func WithServiceConfig(c <-chan ServiceConfig) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.scChan = c
@@ -329,7 +322,8 @@ func WithCredentialsBundle(b credentials.Bundle) DialOption {
 // WithTimeout returns a DialOption that configures a timeout for dialing a
 // ClientConn initially. This is valid if and only if WithBlock() is present.
 //
-// Deprecated: use DialContext and context.WithTimeout instead.
+// Deprecated: use DialContext and context.WithTimeout instead.  Will be
+// supported throughout 1.x.
 func WithTimeout(d time.Duration) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.timeout = d
@@ -356,7 +350,8 @@ func init() {
 // is returned by f, gRPC checks the error's Temporary() method to decide if it
 // should try to reconnect to the network address.
 //
-// Deprecated: use WithContextDialer instead
+// Deprecated: use WithContextDialer instead.  Will be supported throughout
+// 1.x.
 func WithDialer(f func(string, time.Duration) (net.Conn, error)) DialOption {
 	return WithContextDialer(
 		func(ctx context.Context, addr string) (net.Conn, error) {
@@ -480,8 +475,10 @@ func WithDisableServiceConfig() DialOption {
 
 // WithDefaultServiceConfig returns a DialOption that configures the default
 // service config, which will be used in cases where:
-// 1. WithDisableServiceConfig is called.
-// 2. Resolver does not return service config or if the resolver gets and invalid config.
+//
+// 1. WithDisableServiceConfig is also used.
+// 2. Resolver does not return a service config or if the resolver returns an
+//    invalid service config.
 //
 // This API is EXPERIMENTAL.
 func WithDefaultServiceConfig(s string) DialOption {
@@ -537,7 +534,6 @@ func withHealthCheckFunc(f internal.HealthChecker) DialOption {
 func defaultDialOptions() dialOptions {
 	return dialOptions{
 		disableRetry:    !envconfig.Retry,
-		reqHandshake:    envconfig.RequireHandshake,
 		healthCheckFunc: internal.HealthCheckFunc,
 		copts: transport.ConnectOptions{
 			WriteBufferSize: defaultWriteBufSize,

--- a/vendor/google.golang.org/grpc/internal/envconfig/envconfig.go
+++ b/vendor/google.golang.org/grpc/internal/envconfig/envconfig.go
@@ -25,40 +25,11 @@ import (
 )
 
 const (
-	prefix              = "GRPC_GO_"
-	retryStr            = prefix + "RETRY"
-	requireHandshakeStr = prefix + "REQUIRE_HANDSHAKE"
-)
-
-// RequireHandshakeSetting describes the settings for handshaking.
-type RequireHandshakeSetting int
-
-const (
-	// RequireHandshakeOn indicates to wait for handshake before considering a
-	// connection ready/successful.
-	RequireHandshakeOn RequireHandshakeSetting = iota
-	// RequireHandshakeOff indicates to not wait for handshake before
-	// considering a connection ready/successful.
-	RequireHandshakeOff
+	prefix   = "GRPC_GO_"
+	retryStr = prefix + "RETRY"
 )
 
 var (
 	// Retry is set if retry is explicitly enabled via "GRPC_GO_RETRY=on".
 	Retry = strings.EqualFold(os.Getenv(retryStr), "on")
-	// RequireHandshake is set based upon the GRPC_GO_REQUIRE_HANDSHAKE
-	// environment variable.
-	//
-	// Will be removed after the 1.18 release.
-	RequireHandshake = RequireHandshakeOn
 )
-
-func init() {
-	switch strings.ToLower(os.Getenv(requireHandshakeStr)) {
-	case "on":
-		fallthrough
-	default:
-		RequireHandshake = RequireHandshakeOn
-	case "off":
-		RequireHandshake = RequireHandshakeOff
-	}
-}

--- a/vendor/google.golang.org/grpc/internal/transport/controlbuf.go
+++ b/vendor/google.golang.org/grpc/internal/transport/controlbuf.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
+	"sync/atomic"
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
@@ -84,11 +85,23 @@ func (il *itemList) isEmpty() bool {
 // the control buffer of transport. They represent different aspects of
 // control tasks, e.g., flow control, settings, streaming resetting, etc.
 
+// maxQueuedTransportResponseFrames is the most queued "transport response"
+// frames we will buffer before preventing new reads from occurring on the
+// transport.  These are control frames sent in response to client requests,
+// such as RST_STREAM due to bad headers or settings acks.
+const maxQueuedTransportResponseFrames = 50
+
+type cbItem interface {
+	isTransportResponseFrame() bool
+}
+
 // registerStream is used to register an incoming stream with loopy writer.
 type registerStream struct {
 	streamID uint32
 	wq       *writeQuota
 }
+
+func (*registerStream) isTransportResponseFrame() bool { return false }
 
 // headerFrame is also used to register stream on the client-side.
 type headerFrame struct {
@@ -102,12 +115,18 @@ type headerFrame struct {
 	onOrphaned func(error)    // Valid on client-side
 }
 
+func (h *headerFrame) isTransportResponseFrame() bool {
+	return h.cleanup != nil && h.cleanup.rst // Results in a RST_STREAM
+}
+
 type cleanupStream struct {
 	streamID uint32
 	rst      bool
 	rstCode  http2.ErrCode
 	onWrite  func()
 }
+
+func (c *cleanupStream) isTransportResponseFrame() bool { return c.rst } // Results in a RST_STREAM
 
 type dataFrame struct {
 	streamID  uint32
@@ -119,26 +138,40 @@ type dataFrame struct {
 	onEachWrite func()
 }
 
+func (*dataFrame) isTransportResponseFrame() bool { return false }
+
 type incomingWindowUpdate struct {
 	streamID  uint32
 	increment uint32
 }
+
+func (*incomingWindowUpdate) isTransportResponseFrame() bool { return false }
 
 type outgoingWindowUpdate struct {
 	streamID  uint32
 	increment uint32
 }
 
+func (*outgoingWindowUpdate) isTransportResponseFrame() bool {
+	return false // window updates are throttled by thresholds
+}
+
 type incomingSettings struct {
 	ss []http2.Setting
 }
+
+func (*incomingSettings) isTransportResponseFrame() bool { return true } // Results in a settings ACK
 
 type outgoingSettings struct {
 	ss []http2.Setting
 }
 
+func (*outgoingSettings) isTransportResponseFrame() bool { return false }
+
 type incomingGoAway struct {
 }
+
+func (*incomingGoAway) isTransportResponseFrame() bool { return false }
 
 type goAway struct {
 	code      http2.ErrCode
@@ -147,14 +180,20 @@ type goAway struct {
 	closeConn bool
 }
 
+func (*goAway) isTransportResponseFrame() bool { return false }
+
 type ping struct {
 	ack  bool
 	data [8]byte
 }
 
+func (*ping) isTransportResponseFrame() bool { return true }
+
 type outFlowControlSizeRequest struct {
 	resp chan uint32
 }
+
+func (*outFlowControlSizeRequest) isTransportResponseFrame() bool { return false }
 
 type outStreamState int
 
@@ -238,6 +277,14 @@ type controlBuffer struct {
 	consumerWaiting bool
 	list            *itemList
 	err             error
+
+	// transportResponseFrames counts the number of queued items that represent
+	// the response of an action initiated by the peer.  trfChan is created
+	// when transportResponseFrames >= maxQueuedTransportResponseFrames and is
+	// closed and nilled when transportResponseFrames drops below the
+	// threshold.  Both fields are protected by mu.
+	transportResponseFrames int
+	trfChan                 atomic.Value // *chan struct{}
 }
 
 func newControlBuffer(done <-chan struct{}) *controlBuffer {
@@ -248,12 +295,24 @@ func newControlBuffer(done <-chan struct{}) *controlBuffer {
 	}
 }
 
-func (c *controlBuffer) put(it interface{}) error {
+// throttle blocks if there are too many incomingSettings/cleanupStreams in the
+// controlbuf.
+func (c *controlBuffer) throttle() {
+	ch, _ := c.trfChan.Load().(*chan struct{})
+	if ch != nil {
+		select {
+		case <-*ch:
+		case <-c.done:
+		}
+	}
+}
+
+func (c *controlBuffer) put(it cbItem) error {
 	_, err := c.executeAndPut(nil, it)
 	return err
 }
 
-func (c *controlBuffer) executeAndPut(f func(it interface{}) bool, it interface{}) (bool, error) {
+func (c *controlBuffer) executeAndPut(f func(it interface{}) bool, it cbItem) (bool, error) {
 	var wakeUp bool
 	c.mu.Lock()
 	if c.err != nil {
@@ -271,6 +330,15 @@ func (c *controlBuffer) executeAndPut(f func(it interface{}) bool, it interface{
 		c.consumerWaiting = false
 	}
 	c.list.enqueue(it)
+	if it.isTransportResponseFrame() {
+		c.transportResponseFrames++
+		if c.transportResponseFrames == maxQueuedTransportResponseFrames {
+			// We are adding the frame that puts us over the threshold; create
+			// a throttling channel.
+			ch := make(chan struct{})
+			c.trfChan.Store(&ch)
+		}
+	}
 	c.mu.Unlock()
 	if wakeUp {
 		select {
@@ -304,7 +372,17 @@ func (c *controlBuffer) get(block bool) (interface{}, error) {
 			return nil, c.err
 		}
 		if !c.list.isEmpty() {
-			h := c.list.dequeue()
+			h := c.list.dequeue().(cbItem)
+			if h.isTransportResponseFrame() {
+				if c.transportResponseFrames == maxQueuedTransportResponseFrames {
+					// We are removing the frame that put us over the
+					// threshold; close and clear the throttling channel.
+					ch := c.trfChan.Load().(*chan struct{})
+					close(*ch)
+					c.trfChan.Store((*chan struct{})(nil))
+				}
+				c.transportResponseFrames--
+			}
 			c.mu.Unlock()
 			return h, nil
 		}

--- a/vendor/google.golang.org/grpc/internal/transport/flowcontrol.go
+++ b/vendor/google.golang.org/grpc/internal/transport/flowcontrol.go
@@ -149,6 +149,7 @@ func (f *inFlow) maybeAdjust(n uint32) uint32 {
 		n = uint32(math.MaxInt32)
 	}
 	f.mu.Lock()
+	defer f.mu.Unlock()
 	// estSenderQuota is the receiver's view of the maximum number of bytes the sender
 	// can send without a window update.
 	estSenderQuota := int32(f.limit - (f.pendingData + f.pendingUpdate))
@@ -169,10 +170,8 @@ func (f *inFlow) maybeAdjust(n uint32) uint32 {
 			// is padded; We will fallback on the current available window(at least a 1/4th of the limit).
 			f.delta = n
 		}
-		f.mu.Unlock()
 		return f.delta
 	}
-	f.mu.Unlock()
 	return 0
 }
 

--- a/vendor/google.golang.org/grpc/internal/transport/http2_client.go
+++ b/vendor/google.golang.org/grpc/internal/transport/http2_client.go
@@ -493,6 +493,9 @@ func (t *http2Client) createAudience(callHdr *CallHdr) string {
 }
 
 func (t *http2Client) getTrAuthData(ctx context.Context, audience string) (map[string]string, error) {
+	if len(t.perRPCCreds) == 0 {
+		return nil, nil
+	}
 	authData := map[string]string{}
 	for _, c := range t.perRPCCreds {
 		data, err := c.GetRequestMetadata(ctx, audience)
@@ -513,7 +516,7 @@ func (t *http2Client) getTrAuthData(ctx context.Context, audience string) (map[s
 }
 
 func (t *http2Client) getCallAuthData(ctx context.Context, audience string, callHdr *CallHdr) (map[string]string, error) {
-	callAuthData := map[string]string{}
+	var callAuthData map[string]string
 	// Check if credentials.PerRPCCredentials were provided via call options.
 	// Note: if these credentials are provided both via dial options and call
 	// options, then both sets of credentials will be applied.
@@ -525,6 +528,7 @@ func (t *http2Client) getCallAuthData(ctx context.Context, audience string, call
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "transport: %v", err)
 		}
+		callAuthData = make(map[string]string, len(data))
 		for k, v := range data {
 			// Capital header names are illegal in HTTP/2
 			k = strings.ToLower(k)
@@ -556,7 +560,6 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 		if atomic.CompareAndSwapUint32(&s.headerChanClosed, 0, 1) {
 			close(s.headerChan)
 		}
-
 	}
 	hdr := &headerFrame{
 		hf:        headerFields,
@@ -769,6 +772,9 @@ func (t *http2Client) Close() error {
 		t.mu.Unlock()
 		return nil
 	}
+	// Call t.onClose before setting the state to closing to prevent the client
+	// from attempting to create new streams ASAP.
+	t.onClose()
 	t.state = closing
 	streams := t.activeStreams
 	t.activeStreams = nil
@@ -789,7 +795,6 @@ func (t *http2Client) Close() error {
 		}
 		t.statsHandler.HandleConn(t.ctx, connEnd)
 	}
-	t.onClose()
 	return err
 }
 
@@ -978,9 +983,9 @@ func (t *http2Client) handleRSTStream(f *http2.RSTStreamFrame) {
 		statusCode = codes.Unknown
 	}
 	if statusCode == codes.Canceled {
-		// Our deadline was already exceeded, and that was likely the cause of
-		// this cancelation.  Alter the status code accordingly.
-		if d, ok := s.ctx.Deadline(); ok && d.After(time.Now()) {
+		if d, ok := s.ctx.Deadline(); ok && !d.After(time.Now()) {
+			// Our deadline was already exceeded, and that was likely the cause
+			// of this cancelation.  Alter the status code accordingly.
 			statusCode = codes.DeadlineExceeded
 		}
 	}
@@ -1085,11 +1090,12 @@ func (t *http2Client) handleGoAway(f *http2.GoAwayFrame) {
 	default:
 		t.setGoAwayReason(f)
 		close(t.goAway)
-		t.state = draining
 		t.controlBuf.put(&incomingGoAway{})
-
-		// This has to be a new goroutine because we're still using the current goroutine to read in the transport.
+		// Notify the clientconn about the GOAWAY before we set the state to
+		// draining, to allow the client to stop attempting to create streams
+		// before disallowing new streams on this connection.
 		t.onGoAway(t.goAwayReason)
+		t.state = draining
 	}
 	// All streams with IDs greater than the GoAwayId
 	// and smaller than the previous GoAway ID should be killed.
@@ -1239,6 +1245,7 @@ func (t *http2Client) reader() {
 
 	// loop to keep reading incoming messages on this transport.
 	for {
+		t.controlBuf.throttle()
 		frame, err := t.framer.fr.ReadFrame()
 		if t.keepaliveEnabled {
 			atomic.CompareAndSwapUint32(&t.activity, 0, 1)
@@ -1326,6 +1333,7 @@ func (t *http2Client) keepalive() {
 					timer.Reset(t.kp.Time)
 					continue
 				}
+				infof("transport: closing client transport due to idleness.")
 				t.Close()
 				return
 			case <-t.ctx.Done():

--- a/vendor/google.golang.org/grpc/internal/transport/http2_server.go
+++ b/vendor/google.golang.org/grpc/internal/transport/http2_server.go
@@ -436,6 +436,7 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 func (t *http2Server) HandleStreams(handle func(*Stream), traceCtx func(context.Context, string) context.Context) {
 	defer close(t.readerDone)
 	for {
+		t.controlBuf.throttle()
 		frame, err := t.framer.fr.ReadFrame()
 		atomic.StoreUint32(&t.activity, 1)
 		if err != nil {
@@ -766,6 +767,10 @@ func (t *http2Server) WriteHeader(s *Stream, md metadata.MD) error {
 	return nil
 }
 
+func (t *http2Server) setResetPingStrikes() {
+	atomic.StoreUint32(&t.resetPingStrikes, 1)
+}
+
 func (t *http2Server) writeHeaderLocked(s *Stream) error {
 	// TODO(mmukhi): Benchmark if the performance gets better if count the metadata and other header fields
 	// first and create a slice of that exact size.
@@ -780,9 +785,7 @@ func (t *http2Server) writeHeaderLocked(s *Stream) error {
 		streamID:  s.id,
 		hf:        headerFields,
 		endStream: false,
-		onWrite: func() {
-			atomic.StoreUint32(&t.resetPingStrikes, 1)
-		},
+		onWrite:   t.setResetPingStrikes,
 	})
 	if !success {
 		if err != nil {
@@ -842,9 +845,7 @@ func (t *http2Server) WriteStatus(s *Stream, st *status.Status) error {
 		streamID:  s.id,
 		hf:        headerFields,
 		endStream: true,
-		onWrite: func() {
-			atomic.StoreUint32(&t.resetPingStrikes, 1)
-		},
+		onWrite:   t.setResetPingStrikes,
 	}
 	s.hdrMu.Unlock()
 	success, err := t.controlBuf.execute(t.checkForHeaderListSize, trailingHeader)
@@ -896,12 +897,10 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 	hdr = append(hdr, data[:emptyLen]...)
 	data = data[emptyLen:]
 	df := &dataFrame{
-		streamID: s.id,
-		h:        hdr,
-		d:        data,
-		onEachWrite: func() {
-			atomic.StoreUint32(&t.resetPingStrikes, 1)
-		},
+		streamID:    s.id,
+		h:           hdr,
+		d:           data,
+		onEachWrite: t.setResetPingStrikes,
 	}
 	if err := s.wq.get(int32(len(hdr) + len(data))); err != nil {
 		select {
@@ -967,6 +966,7 @@ func (t *http2Server) keepalive() {
 			select {
 			case <-maxAge.C:
 				// Close the connection after grace period.
+				infof("transport: closing server transport due to maximum connection age.")
 				t.Close()
 				// Resetting the timer so that the clean-up doesn't deadlock.
 				maxAge.Reset(infinity)
@@ -980,6 +980,7 @@ func (t *http2Server) keepalive() {
 				continue
 			}
 			if pingSent {
+				infof("transport: closing server transport due to idleness.")
 				t.Close()
 				// Resetting the timer so that the clean-up doesn't deadlock.
 				keepalive.Reset(infinity)

--- a/vendor/google.golang.org/grpc/pickfirst.go
+++ b/vendor/google.golang.org/grpc/pickfirst.go
@@ -51,14 +51,18 @@ type pickfirstBalancer struct {
 
 func (b *pickfirstBalancer) HandleResolvedAddrs(addrs []resolver.Address, err error) {
 	if err != nil {
-		grpclog.Infof("pickfirstBalancer: HandleResolvedAddrs called with error %v", err)
+		if grpclog.V(2) {
+			grpclog.Infof("pickfirstBalancer: HandleResolvedAddrs called with error %v", err)
+		}
 		return
 	}
 	if b.sc == nil {
 		b.sc, err = b.cc.NewSubConn(addrs, balancer.NewSubConnOptions{})
 		if err != nil {
 			//TODO(yuxuanli): why not change the cc state to Idle?
-			grpclog.Errorf("pickfirstBalancer: failed to NewSubConn: %v", err)
+			if grpclog.V(2) {
+				grpclog.Errorf("pickfirstBalancer: failed to NewSubConn: %v", err)
+			}
 			return
 		}
 		b.cc.UpdateBalancerState(connectivity.Idle, &picker{sc: b.sc})
@@ -70,9 +74,13 @@ func (b *pickfirstBalancer) HandleResolvedAddrs(addrs []resolver.Address, err er
 }
 
 func (b *pickfirstBalancer) HandleSubConnStateChange(sc balancer.SubConn, s connectivity.State) {
-	grpclog.Infof("pickfirstBalancer: HandleSubConnStateChange: %p, %v", sc, s)
+	if grpclog.V(2) {
+		grpclog.Infof("pickfirstBalancer: HandleSubConnStateChange: %p, %v", sc, s)
+	}
 	if b.sc != sc {
-		grpclog.Infof("pickfirstBalancer: ignored state change because sc is not recognized")
+		if grpclog.V(2) {
+			grpclog.Infof("pickfirstBalancer: ignored state change because sc is not recognized")
+		}
 		return
 	}
 	if s == connectivity.Shutdown {

--- a/vendor/google.golang.org/grpc/server.go
+++ b/vendor/google.golang.org/grpc/server.go
@@ -42,6 +42,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/binarylog"
 	"google.golang.org/grpc/internal/channelz"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
@@ -55,6 +56,8 @@ const (
 	defaultServerMaxReceiveMessageSize = 1024 * 1024 * 4
 	defaultServerMaxSendMessageSize    = math.MaxInt32
 )
+
+var statusOK = status.New(codes.OK, "")
 
 type methodHandler func(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor UnaryServerInterceptor) (interface{}, error)
 
@@ -97,10 +100,8 @@ type Server struct {
 	m      map[string]*service // service name -> service info
 	events trace.EventLog
 
-	quit               chan struct{}
-	done               chan struct{}
-	quitOnce           sync.Once
-	doneOnce           sync.Once
+	quit               *grpcsync.Event
+	done               *grpcsync.Event
 	channelzRemoveOnce sync.Once
 	serveWG            sync.WaitGroup // counts active Serve goroutines for GracefulStop
 
@@ -388,8 +389,8 @@ func NewServer(opt ...ServerOption) *Server {
 		opts:   opts,
 		conns:  make(map[transport.ServerTransport]bool),
 		m:      make(map[string]*service),
-		quit:   make(chan struct{}),
-		done:   make(chan struct{}),
+		quit:   grpcsync.NewEvent(),
+		done:   grpcsync.NewEvent(),
 		czData: new(channelzData),
 	}
 	s.cv = sync.NewCond(&s.mu)
@@ -556,11 +557,9 @@ func (s *Server) Serve(lis net.Listener) error {
 	s.serveWG.Add(1)
 	defer func() {
 		s.serveWG.Done()
-		select {
-		// Stop or GracefulStop called; block until done and return nil.
-		case <-s.quit:
-			<-s.done
-		default:
+		if s.quit.HasFired() {
+			// Stop or GracefulStop called; block until done and return nil.
+			<-s.done.Done()
 		}
 	}()
 
@@ -603,7 +602,7 @@ func (s *Server) Serve(lis net.Listener) error {
 				timer := time.NewTimer(tempDelay)
 				select {
 				case <-timer.C:
-				case <-s.quit:
+				case <-s.quit.Done():
 					timer.Stop()
 					return nil
 				}
@@ -613,10 +612,8 @@ func (s *Server) Serve(lis net.Listener) error {
 			s.printf("done serving; Accept = %v", err)
 			s.mu.Unlock()
 
-			select {
-			case <-s.quit:
+			if s.quit.HasFired() {
 				return nil
-			default:
 			}
 			return err
 		}
@@ -637,6 +634,10 @@ func (s *Server) Serve(lis net.Listener) error {
 // handleRawConn forks a goroutine to handle a just-accepted connection that
 // has not had any I/O performed on it yet.
 func (s *Server) handleRawConn(rawConn net.Conn) {
+	if s.quit.HasFired() {
+		rawConn.Close()
+		return
+	}
 	rawConn.SetDeadline(time.Now().Add(s.opts.connectionTimeout))
 	conn, authInfo, err := s.useTransportAuthenticator(rawConn)
 	if err != nil {
@@ -652,14 +653,6 @@ func (s *Server) handleRawConn(rawConn net.Conn) {
 		rawConn.SetDeadline(time.Time{})
 		return
 	}
-
-	s.mu.Lock()
-	if s.conns == nil {
-		s.mu.Unlock()
-		conn.Close()
-		return
-	}
-	s.mu.Unlock()
 
 	// Finish handshaking (HTTP2)
 	st := s.newHTTP2Transport(conn, authInfo)
@@ -768,6 +761,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // traceInfo returns a traceInfo and associates it with stream, if tracing is enabled.
 // If tracing is not enabled, it returns nil.
 func (s *Server) traceInfo(st transport.ServerTransport, stream *transport.Stream) (trInfo *traceInfo) {
+	if !EnableTracing {
+		return nil
+	}
 	tr, ok := trace.FromContext(stream.Context())
 	if !ok {
 		return nil
@@ -978,10 +974,11 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 		}
 		if sh != nil {
 			sh.HandleRPC(stream.Context(), &stats.InPayload{
-				RecvTime: time.Now(),
-				Payload:  v,
-				Data:     d,
-				Length:   len(d),
+				RecvTime:   time.Now(),
+				Payload:    v,
+				WireLength: payInfo.wireLength,
+				Data:       d,
+				Length:     len(d),
 			})
 		}
 		if binlog != nil {
@@ -1077,7 +1074,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 	// TODO: Should we be logging if writing status failed here, like above?
 	// Should the logging be in WriteStatus?  Should we ignore the WriteStatus
 	// error or allow the stats handler to see it?
-	err = t.WriteStatus(stream, status.New(codes.OK, ""))
+	err = t.WriteStatus(stream, statusOK)
 	if binlog != nil {
 		binlog.Log(&binarylog.ServerTrailer{
 			Trailer: stream.Trailer(),
@@ -1235,7 +1232,7 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 		ss.trInfo.tr.LazyLog(stringer("OK"), false)
 		ss.mu.Unlock()
 	}
-	err = t.WriteStatus(ss.s, status.New(codes.OK, ""))
+	err = t.WriteStatus(ss.s, statusOK)
 	if ss.binlog != nil {
 		ss.binlog.Log(&binarylog.ServerTrailer{
 			Trailer: ss.s.Trailer(),
@@ -1352,15 +1349,11 @@ func ServerTransportStreamFromContext(ctx context.Context) ServerTransportStream
 // pending RPCs on the client side will get notified by connection
 // errors.
 func (s *Server) Stop() {
-	s.quitOnce.Do(func() {
-		close(s.quit)
-	})
+	s.quit.Fire()
 
 	defer func() {
 		s.serveWG.Wait()
-		s.doneOnce.Do(func() {
-			close(s.done)
-		})
+		s.done.Fire()
 	}()
 
 	s.channelzRemoveOnce.Do(func() {
@@ -1397,15 +1390,8 @@ func (s *Server) Stop() {
 // accepting new connections and RPCs and blocks until all the pending RPCs are
 // finished.
 func (s *Server) GracefulStop() {
-	s.quitOnce.Do(func() {
-		close(s.quit)
-	})
-
-	defer func() {
-		s.doneOnce.Do(func() {
-			close(s.done)
-		})
-	}()
+	s.quit.Fire()
+	defer s.done.Fire()
 
 	s.channelzRemoveOnce.Do(func() {
 		if channelz.IsOn() {

--- a/vendor/google.golang.org/grpc/status/status.go
+++ b/vendor/google.golang.org/grpc/status/status.go
@@ -58,6 +58,17 @@ func (se *statusError) GRPCStatus() *Status {
 	return &Status{s: (*spb.Status)(se)}
 }
 
+// Is implements future error.Is functionality.
+// A statusError is equivalent if the code and message are identical.
+func (se *statusError) Is(target error) bool {
+	tse, ok := target.(*statusError)
+	if !ok {
+		return false
+	}
+
+	return proto.Equal((*spb.Status)(se), (*spb.Status)(tse))
+}
+
 // Status represents an RPC status code, message, and details.  It is immutable
 // and should be created with New, Newf, or FromProto.
 type Status struct {
@@ -132,7 +143,7 @@ func FromProto(s *spb.Status) *Status {
 // Status is returned with codes.Unknown and the original error message.
 func FromError(err error) (s *Status, ok bool) {
 	if err == nil {
-		return &Status{s: &spb.Status{Code: int32(codes.OK)}}, true
+		return nil, true
 	}
 	if se, ok := err.(interface {
 		GRPCStatus() *Status
@@ -206,7 +217,7 @@ func Code(err error) codes.Code {
 func FromContextError(err error) *Status {
 	switch err {
 	case nil:
-		return New(codes.OK, "")
+		return nil
 	case context.DeadlineExceeded:
 		return New(codes.DeadlineExceeded, err.Error())
 	case context.Canceled:

--- a/vendor/google.golang.org/grpc/stream.go
+++ b/vendor/google.golang.org/grpc/stream.go
@@ -327,13 +327,23 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 	return cs, nil
 }
 
-func (cs *clientStream) newAttemptLocked(sh stats.Handler, trInfo *traceInfo) error {
-	cs.attempt = &csAttempt{
+// newAttemptLocked creates a new attempt with a transport.
+// If it succeeds, then it replaces clientStream's attempt with this new attempt.
+func (cs *clientStream) newAttemptLocked(sh stats.Handler, trInfo *traceInfo) (retErr error) {
+	newAttempt := &csAttempt{
 		cs:           cs,
 		dc:           cs.cc.dopts.dc,
 		statsHandler: sh,
 		trInfo:       trInfo,
 	}
+	defer func() {
+		if retErr != nil {
+			// This attempt is not set in the clientStream, so it's finish won't
+			// be called. Call it here for stats and trace in case they are not
+			// nil.
+			newAttempt.finish(retErr)
+		}
+	}()
 
 	if err := cs.ctx.Err(); err != nil {
 		return toRPCErr(err)
@@ -345,8 +355,9 @@ func (cs *clientStream) newAttemptLocked(sh stats.Handler, trInfo *traceInfo) er
 	if trInfo != nil {
 		trInfo.firstLine.SetRemoteAddr(t.RemoteAddr())
 	}
-	cs.attempt.t = t
-	cs.attempt.done = done
+	newAttempt.t = t
+	newAttempt.done = done
+	cs.attempt = newAttempt
 	return nil
 }
 
@@ -395,11 +406,18 @@ type clientStream struct {
 	serverHeaderBinlogged bool
 
 	mu                      sync.Mutex
-	firstAttempt            bool       // if true, transparent retry is valid
-	numRetries              int        // exclusive of transparent retry attempt(s)
-	numRetriesSincePushback int        // retries since pushback; to reset backoff
-	finished                bool       // TODO: replace with atomic cmpxchg or sync.Once?
-	attempt                 *csAttempt // the active client stream attempt
+	firstAttempt            bool // if true, transparent retry is valid
+	numRetries              int  // exclusive of transparent retry attempt(s)
+	numRetriesSincePushback int  // retries since pushback; to reset backoff
+	finished                bool // TODO: replace with atomic cmpxchg or sync.Once?
+	// attempt is the active client stream attempt.
+	// The only place where it is written is the newAttemptLocked method and this method never writes nil.
+	// So, attempt can be nil only inside newClientStream function when clientStream is first created.
+	// One of the first things done after clientStream's creation, is to call newAttemptLocked which either
+	// assigns a non nil value to the attempt or returns an error. If an error is returned from newAttemptLocked,
+	// then newClientStream calls finish on the clientStream and returns. So, finish method is the only
+	// place where we need to check if the attempt is nil.
+	attempt *csAttempt
 	// TODO(hedging): hedging will have multiple attempts simultaneously.
 	committed  bool                       // active attempt committed for retry?
 	buffer     []func(a *csAttempt) error // operations to replay on retry
@@ -457,8 +475,8 @@ func (cs *clientStream) shouldRetry(err error) error {
 	if cs.attempt.s != nil {
 		<-cs.attempt.s.Done()
 	}
-	if cs.firstAttempt && !cs.callInfo.failFast && (cs.attempt.s == nil || cs.attempt.s.Unprocessed()) {
-		// First attempt, wait-for-ready, stream unprocessed: transparently retry.
+	if cs.firstAttempt && (cs.attempt.s == nil || cs.attempt.s.Unprocessed()) {
+		// First attempt, stream unprocessed: transparently retry.
 		cs.firstAttempt = false
 		return nil
 	}
@@ -805,11 +823,11 @@ func (cs *clientStream) finish(err error) {
 	}
 	if cs.attempt != nil {
 		cs.attempt.finish(err)
-	}
-	// after functions all rely upon having a stream.
-	if cs.attempt.s != nil {
-		for _, o := range cs.opts {
-			o.after(cs.callInfo)
+		// after functions all rely upon having a stream.
+		if cs.attempt.s != nil {
+			for _, o := range cs.opts {
+				o.after(cs.callInfo)
+			}
 		}
 	}
 	cs.cancel()

--- a/vendor/google.golang.org/grpc/version.go
+++ b/vendor/google.golang.org/grpc/version.go
@@ -19,4 +19,4 @@
 package grpc
 
 // Version is the current grpc version.
-const Version = "1.22.0"
+const Version = "1.23.0"


### PR DESCRIPTION
### Release notes

- [go-grpc 1.23.0](https://github.com/grpc/grpc-go/releases/tag/v1.23.0)
  - much stuff! a bunch of HTTP2-related fixes -- we don't _expose_ go-grpc's listener, but we use it interally all over the place
  - there's `*satus.Is` now: https://github.com/grpc/grpc-go/pull/2868 -- we could make some use of that, I suppose.
  - a bunch of perf improvements, always welcome :smile:
- [protobuf 1.3.2](https://github.com/golang/protobuf/releases/tag/v1.3.2)
  - small fry, but nice stuff: https://github.com/golang/protobuf/pull/785 adds an Unimplemented method to each server, allowing old servers to be used when there's proto changes.