### PR TITLE
ci: use <details> for files causing rebuilds

### DIFF
--- a/scripts/changed_components.rb
+++ b/scripts/changed_components.rb
@@ -74,8 +74,9 @@ hab_deps.tsort.each do |p|
 end
 
 changed_package_files.each do |p, files|
-  STDERR.puts "- #{p}"
+  STDERR.puts "<details><summary>#{p}</summary>\n\n"
   files.each do |file|
     STDERR.puts "  - #{file}"
   end
+  STDERR.puts "</details>"
 end


### PR DESCRIPTION
In #1226, we've added outputting why components are rebuild. It output can easily go out of hand. An example for this is #1237, where we see a few screenfuls of this:

![image](https://user-images.githubusercontent.com/870638/63002743-e4780500-be76-11e9-8d20-cffeab76ff97.png)

With the change introduced here, these will be collapsed. What you'll see now is
![image](https://user-images.githubusercontent.com/870638/63002785-007ba680-be77-11e9-8df5-6bedeb524115.png)

...and when you're wondering why, say, `automate-cli` is going to be rebuilt, you can open the details thingy:

![image](https://user-images.githubusercontent.com/870638/63002834-23a65600-be77-11e9-9a77-531facd15317.png)
