### PR TITLE
Fix task dequeue in cereal service

### DIFF
--- a/components/cereal-service/integration/domain_test.go
+++ b/components/cereal-service/integration/domain_test.go
@@ -238,6 +238,8 @@ func TestDomains(t *testing.T) {
 		domain2Evt, workflowCompleter2, err = grpcBackendDomain2.DequeueWorkflow(ctx, []string{workflowName})
 		require.NoError(t, err)
 		validateInstanceMatches(t, &domain2Evt.Instance, workflowName, instanceName, domain2Params)
+		require.NotNil(t, domain2Evt.TaskResult)
+		require.Equal(t, taskName, domain2Evt.TaskResult.TaskName)
 		require.Equal(t, domain2TaskParams, domain2Evt.TaskResult.Parameters)
 		err = workflowCompleter2.Done(nil)
 		require.NoError(t, err)

--- a/components/cereal-service/pkg/server/server.go
+++ b/components/cereal-service/pkg/server/server.go
@@ -211,6 +211,7 @@ func (s *CerealService) DequeueWorkflow(req cereal.Cereal_DequeueWorkflowServer)
 
 	var taskResult *cereal.TaskResult
 	if evt.TaskResult != nil {
+		_, evt.TaskResult.TaskName = unnamespace(evt.TaskResult.TaskName)
 		taskResult = &cereal.TaskResult{
 			TaskName:   evt.TaskResult.TaskName,
 			Parameters: evt.TaskResult.Parameters,


### PR DESCRIPTION
The domain was not being stripped from the task name