### PR TITLE
Give s3 backup test the right permissions

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -627,6 +627,8 @@ steps:
       - integration/run_test integration/tests/backup_s3.sh
     timeout_in_minutes: 20
     expeditor:
+      accounts:
+        - aws/chef-cd
       executor:
         linux:
           single-use: true


### PR DESCRIPTION
This test breaks every time releng rebuilds the queue. We think adding
this will prevent the breakage in the future.
