### PR TITLE
[lib/cereal] Avoid spurious connection closes

### DIFF
--- a/components/cereal-service/integration/integration_test.go
+++ b/components/cereal-service/integration/integration_test.go
@@ -9,21 +9,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
-	"github.com/chef/automate/components/cereal-service/pkg/server"
-	"github.com/chef/automate/lib/cereal"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
 
 	grpccereal "github.com/chef/automate/api/interservice/cereal"
+	"github.com/chef/automate/components/cereal-service/pkg/server"
+	"github.com/chef/automate/lib/cereal"
 	libgrpc "github.com/chef/automate/lib/cereal/grpc"
 	cerealintegration "github.com/chef/automate/lib/cereal/integration"
 	"github.com/chef/automate/lib/cereal/postgres"
 	"github.com/chef/automate/lib/grpc/grpctest"
 	"github.com/chef/automate/lib/platform/pg"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -86,11 +85,12 @@ func TestGrpcPostgres(t *testing.T) {
 	defer g.Close()
 
 	conn, err := grpc.Dial(g.URL, grpc.WithInsecure(), grpc.WithMaxMsgSize(64*1024*1024))
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
+
 	grpcBackend := libgrpc.NewGrpcBackendFromConn("test", conn)
 	s := cerealintegration.NewSuiteForBackend(ctx, t, grpcBackend)
 	suite.Run(t, s)
+
 	require.NoError(t, grpcBackend.Close())
+	require.NoError(t, pgBackend.Close())
 }

--- a/lib/cereal/postgres/postgres.go
+++ b/lib/cereal/postgres/postgres.go
@@ -404,10 +404,15 @@ func (pg *PostgresBackend) GetDueScheduledWorkflow(ctx context.Context) (*backen
 	)
 
 	if err != nil {
-		cancel()
 		if err == sql.ErrNoRows {
+			err := tx.Commit()
+			if err != nil {
+				logrus.WithError(err).Warn("failed to commit transaction in GetDueScheduledWorkflows")
+			}
+			cancel()
 			return nil, nil, cereal.ErrNoDueWorkflows
 		}
+		cancel()
 		return nil, nil, errors.Wrap(err, "error fetching due workflows")
 	}
 


### PR DESCRIPTION
Calling cancel() on an uncommitted/rolledback transactions results in
the underlying connection also being closed.

This happens in the common case of the workflow scheduler when there
are no scheduled workflows to run. To avoid log messages for
automate-pg-gateway about the connection close, we explicitly commit
the transaction to avoid it.

Signed-off-by: Steven Danna <steve@chef.io>