### PR TITLE
session-service: send the user to dex with their connector selected already

### DIFF
--- a/components/automate-ui/src/app/services/chef-session/chef-session.service.spec.ts
+++ b/components/automate-ui/src/app/services/chef-session/chef-session.service.spec.ts
@@ -143,7 +143,7 @@ describe('ChefSessionService', () => {
 
       it('does not ingest any token, but calls logout', () => {
         service.refreshSessionCallback(event);
-        expect(service.logout).toHaveBeenCalledWith('/some/path');
+        expect(service.logout).toHaveBeenCalledWith('/some/path', true);
         expect(service.ingestIDToken).not.toHaveBeenCalled();
       });
     });

--- a/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
+++ b/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
@@ -75,7 +75,7 @@ export class ChefSessionService implements CanActivate {
       if (xhr.status === HTTP_STATUS_OK) {
         this.ingestIDToken(xhr.response.id_token);
       } else if (xhr.status === HTTP_STATUS_UNAUTHORIZED) {
-        this.logout(this.currentPath());
+        this.logout(this.currentPath(), true);
       } else {
         // TODO 2017/12/15 (sr): is there anything we could do that's better than
         // this?
@@ -105,7 +105,7 @@ export class ChefSessionService implements CanActivate {
   // canActivate determines if any of the routes (except signin) can be activated
   canActivate(_route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
     if (!this.hasSession()) {
-      this.logout(state.url);
+      this.logout(state.url, true);
       return false;
     }
     return true;
@@ -146,11 +146,11 @@ export class ChefSessionService implements CanActivate {
     return !isNull(localStorage.getItem(sessionKey));
   }
 
-  logout(url = '/'): void {
+  logout(url: string = '/', refresh: boolean = false): void {
     this.deleteSession();
     // note: url will end up url-encoded in this string (magic)
     let signinURL: string;
-    if (this.user && this.user.id_token) {
+    if (refresh && this.user && this.user.id_token) {
       signinURL = `/session/new?state=${url}&id_token_hint=${this.user.id_token}`;
     } else {
       signinURL = `/session/new?state=${url}`;

--- a/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
+++ b/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
@@ -149,7 +149,14 @@ export class ChefSessionService implements CanActivate {
   logout(url = '/'): void {
     this.deleteSession();
     // note: url will end up url-encoded in this string (magic)
-    window.location.href = `/session/new?state=${url}`;
+    let signinURL: string;
+    if (this.user && this.user.id_token) {
+      signinURL = `/session/new?state=${url}&id_token_hint=${this.user.id_token}`;
+    } else {
+      signinURL = `/session/new?state=${url}`;
+    }
+
+    window.location.href = signinURL;
   }
 
   storeTelemetryPreference(isOptedIn: boolean): void {

--- a/components/session-service/oidc/oidc.go
+++ b/components/session-service/oidc/oidc.go
@@ -80,7 +80,7 @@ func New(cfg Config, retrySec int, certs *certs.ServiceCerts, l OIDCLogger) (Cli
 	}
 
 	verifier := provider.Verifier(&oidc.Config{
-		// we want to allow for expired tokens => they'll  just trigger a refresh
+		// we want to allow for expired tokens => they'll just trigger a refresh
 		// anyways.
 		SkipExpiryCheck:   true,
 		SkipClientIDCheck: true, // we don't care

--- a/components/session-service/server/server.go
+++ b/components/session-service/server/server.go
@@ -595,7 +595,12 @@ func (s *Server) newHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.log.Debugf("stored relayState %s", relayState)
-	authCodeURL := s.client.AuthCodeURL(relayState)
+
+	opts := []oauth2.AuthCodeOption{}
+	if connectorID := s.connectorIDFromRequest(r); connectorID != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("connector_id", connectorID))
+	}
+	authCodeURL := s.client.AuthCodeURL(relayState, opts...)
 
 	if err := sess.PutBool(w, aliveKey, true); err != nil {
 		s.log.Errorf("couldn't put aliveness state into session: %s", err)
@@ -604,6 +609,32 @@ func (s *Server) newHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, authCodeURL, http.StatusSeeOther)
+}
+
+func (s *Server) connectorIDFromRequest(r *http.Request) string {
+	token := r.FormValue("id_token_hint")
+	if token == "" { // ignore errors, we just use this as a hint
+		s.log.Error("no id_token_hint")
+		return ""
+	}
+	// Note(sr): The way the verifier is set up, this allows for expired tokens --
+	// so, this wouldn't fail unless we're given something that is not a JWT at all.
+	idToken, err := s.client.Verify(r.Context(), token)
+	if err != nil {
+		s.log.Errorf("failed to verify id_token_hint: %v", err)
+		return ""
+	}
+	var claims struct {
+		Federated struct {
+			ConnectorID string `json:"connector_id"`
+		} `json:"federated_claims"`
+	}
+	err = idToken.Claims(&claims)
+	if err != nil {
+		s.log.Errorf("failed to read claims from id_token_hint: %v", err)
+		return ""
+	}
+	return claims.Federated.ConnectorID
 }
 
 func httpError(w http.ResponseWriter, code int) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When a user's session cannot be refreshed anymore, they'll be sent to the _Sign In_ page. There, they'll have to select a method to use for Sign In, although we know what they had used before.

With this change, we'll make use of that knowledge, and send them to the right method immediately.

❕*Note*: The `Back` link is a bit wonky: It'll send them back to Automate, but they'll lack an ID token, so they'll be sent back to dex, but since there's no ID token, they'll see the selection. So, it **works**, but in a very odd way. Unfortunately, a proper fix is a bit more involved.

❕ *Note*: For SAML, there's no back button. So, to abort, and get back to the selection once you've used SAML, you'll need to browse to Automate again **manually**.

☑️ Depends on #1243 to get in first, this needs dex v2.18.0. ✔️ 

☑️ *TODO*
- [x] *Verify signout* for SAML and non-SAML: if you're signing out, you should be sent back to the sign in method chooser .

### :chains: Related Resources

None.

### :+1: Definition of Done

A user that's logged out no longer needs to select their login method. But if they want to, they can.

### :athletic_shoe: How to Build and Test the Change

- `rebuild components/session-service`
- get the UI to be rebuilt (devproxy etc, or `rebuild components/automate-ui`
- login as a local user
- kill all sessions: `chef-automate dev psql chef_session_service -- -c 'delete from sessions'`
- wait for a minute, see that you're sent to the username/password form directly

#### SAML

To see how this behaves with SAML, `rebuild components/automate-dex` after changing the hardcoded token expiry for using SAML like this:
```diff
diff --git a/components/automate-dex/habitat/templates/config.yml b/components/automate-dex/habitat/templates/config.yml
index f29edd636..4e1510ee0 100644
--- a/components/automate-dex/habitat/templates/config.yml
+++ b/components/automate-dex/habitat/templates/config.yml
@@ -227,7 +227,7 @@ expiry:
   signingKeys: {{cfg.expiry.signing_keys}}
   {{- if cfg.connectors.saml}}
   # SAML is being used, so we cannot tweak ID token expiry
-  idTokens: 24h
+  idTokens: 1m
   {{- else}}
   idTokens: {{cfg.expiry.id_tokens}}
   {{- end}}
```
Then login via SAML and wait for a minute. You'll see a series of flickers while your browser goes to Okta, finds the session still intact, and redirects you to Automate.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?
