### PR TITLE
Cypress: restore user management tests

### DIFF
--- a/e2e/cypress/integration/ui/compliance/01_ssh_scan_job.spec.ts
+++ b/e2e/cypress/integration/ui/compliance/01_ssh_scan_job.spec.ts
@@ -2,7 +2,7 @@ import { Base64 } from 'js-base64';
 
 describe('create a manual node ssh scan job and cleanup after', () => {
   before(() => {
-    cy.adminLogin('/');
+    cy.adminLogin('/settings');
   });
   beforeEach(() => {
     // cypress clears local storage between tests
@@ -18,10 +18,6 @@ describe('create a manual node ssh scan job and cleanup after', () => {
   const decoded = Base64.decode(Cypress.env('AUTOMATE_ACCEPTANCE_TARGET_KEY'));
 
   it('can create a credential with a username and key', () => {
-    // navigate to credentials create page:
-    // click on settings
-    cy.get('.nav-link').contains('Settings').click();
-
     // we save the route that will be called when we navigate to the page
     // in order to be able to wait for it later
     cy.route('POST', '/api/v0/secrets/search').as('getSecrets');
@@ -41,8 +37,9 @@ describe('create a manual node ssh scan job and cleanup after', () => {
       cy.get('form input[formcontrolname="name"]').first().type(credName);
       cy.get('form input[formcontrolname="username"]').first()
         .type(Cypress.env('AUTOMATE_ACCEPTANCE_TARGET_USER'));
-      cy.get('form textarea[formcontrolname="key"]')
-        .type(decoded);
+
+      // we save some time by setting this long string as the value rather than typing it out
+      cy.get('form textarea[formcontrolname="key"]').clear().invoke('val', decoded).trigger('input')
 
       // we save the route that will be called when we navigate to the page
       // in order to be able to wait for it later

--- a/e2e/cypress/integration/ui/compliance/01_ssh_scan_job.spec.ts
+++ b/e2e/cypress/integration/ui/compliance/01_ssh_scan_job.spec.ts
@@ -2,7 +2,7 @@ import { Base64 } from 'js-base64';
 
 describe('create a manual node ssh scan job and cleanup after', () => {
   before(() => {
-    cy.adminLogin('/settings');
+    cy.adminLogin('/settings/node-credentials');
   });
   beforeEach(() => {
     // cypress clears local storage between tests
@@ -22,52 +22,42 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     // in order to be able to wait for it later
     cy.route('POST', '/api/v0/secrets/search').as('getSecrets');
 
-    // click on node credentials in sidebar
-    cy.get('chef-sidebar-entry').contains('Node Credentials').click();
+    // click on add credential button to open create form
+    cy.contains('Add Credential').click();
+    cy.url().should('include', '/settings/node-credentials/add');
+
+    // fill in name for credential, username, and key
+    cy.get('form input[formcontrolname="name"]').first().type(credName);
+    cy.get('form input[formcontrolname="username"]').first()
+      .type(Cypress.env('AUTOMATE_ACCEPTANCE_TARGET_USER'));
+
+    // we save some time by setting this long string as the value rather than typing it out
+    cy.get('form textarea[formcontrolname="key"]').clear().invoke('val', decoded).trigger('input');
+
+    // we save the route that will be called when we navigate to the page
+    // in order to be able to wait for it later
+    cy.route('POST', '/api/v0/secrets').as('createSecret');
+
+    // save the credential
+    cy.contains('Save').click();
+
     cy.url().should('include', '/settings/node-credentials');
 
     // wait for data to return
+    cy.wait('@createSecret');
     cy.wait('@getSecrets');
 
-    // click on add credential button to open create form
-    cy.contains('Add Credential').click().then(() => {
-      cy.url().should('include', '/settings/node-credentials/add');
-
-      // fill in name for credential, username, and key
-      cy.get('form input[formcontrolname="name"]').first().type(credName);
-      cy.get('form input[formcontrolname="username"]').first()
-        .type(Cypress.env('AUTOMATE_ACCEPTANCE_TARGET_USER'));
-
-      // we save some time by setting this long string as the value rather than typing it out
-      cy.get('form textarea[formcontrolname="key"]').clear().invoke('val', decoded).trigger('input')
-
-      // we save the route that will be called when we navigate to the page
-      // in order to be able to wait for it later
-      cy.route('POST', '/api/v0/secrets').as('createSecret');
-
-      // save the credential
-      cy.contains('Save').click().then(() => {
-
-        cy.url().should('include', '/settings/node-credentials');
-
-        // wait for data to return
-        cy.wait('@createSecret');
-        cy.wait('@getSecrets');
-
-        // assert table has credential
-        cy.contains(credName).should('exist');
-      });
-    });
+    // assert table has credential
+    cy.contains(credName).should('exist');
   });
 
   it('can create a node and attach a credential', () => {
     // navigate to node create page:
     // click on scan jobs
     cy.get('.nav-link').contains('Compliance').click();
-    cy.url().should('include', '/compliance/reports/overview');
 
-    // click into scan jobs
-    cy.get('chef-sidebar-entry').contains('Scan Jobs').click();
+    // add force to avoid waiting on the whole page to load
+    cy.get('chef-sidebar-entry').contains('Scan Jobs').click({ force: true });
     cy.url().should('include', '/compliance/scan-jobs/jobs');
 
     // we save the route that will be called when we navigate to the page
@@ -75,40 +65,34 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     cy.route('POST', '/api/v0/nodes/search').as('getNodes');
 
     // click on nodes tab
-    cy.get('.nav-tab').contains('Nodes added').click().then(() => {
+    cy.get('.nav-tab').contains('Nodes added').click();
+    cy.url().should('include', '/compliance/scan-jobs/nodes');
+
+    // click on add node button to open create form
+    cy.contains('Add Nodes').parent().invoke('show').click();
+    cy.url().should('include', '/compliance/scan-jobs/nodes/add');
+
+    // fill in hostname and select a credential for the node
+    cy.get('form input[formcontrolname="hosts"]')
+      .type(Cypress.env('AUTOMATE_ACCEPTANCE_TARGET_HOST'));
+    // add a prefix to ensure the node is at top of list
+    cy.get('form input[formcontrolname="customPrefix"]').type(nodePrefix);
+    cy.get('form select[formcontrolname="secrets"]').select(credName);
+
+    // we save the route that will be called when we navigate to the page
+    // in order to be able to wait for it later
+    cy.route('POST', '/api/v0/nodes/bulk-create').as('createNode');
+
+    // save the node
+    cy.get('chef-button').contains('Add 1 Node(s)').click();
+
       cy.url().should('include', '/compliance/scan-jobs/nodes');
 
       // wait for data to return
-      cy.wait('@getNodes');
+      cy.wait('@createNode');
 
-      // click on add node button to open create form
-      cy.contains('Add Nodes').parent().invoke('show').click().then(() => {
-        cy.url().should('include', '/compliance/scan-jobs/nodes/add');
-
-        // fill in hostname and select a credential for the node
-        cy.get('form input[formcontrolname="hosts"]')
-          .type(Cypress.env('AUTOMATE_ACCEPTANCE_TARGET_HOST'));
-        // add a prefix to ensure the node is at top of list
-        cy.get('form input[formcontrolname="customPrefix"]').type(nodePrefix);
-        cy.get('form select[formcontrolname="secrets"]').select(credName);
-
-        // we save the route that will be called when we navigate to the page
-        // in order to be able to wait for it later
-        cy.route('POST', '/api/v0/nodes/bulk-create').as('createNode');
-
-        // save the node
-        cy.get('chef-button').contains('Add 1 Node(s)').click().then(() => {
-
-          cy.url().should('include', '/compliance/scan-jobs/nodes');
-
-          // wait for data to return
-          cy.wait('@createNode');
-
-          // assert table has node
-          cy.contains(nodePrefix).should('exist');
-        });
-      });
-    });
+      // assert table has node
+      cy.contains(nodePrefix).should('exist');
   });
 
   it('can install a profile', () => {
@@ -118,7 +102,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
 
     // navigate to asset store
     cy.get('.nav-link').contains('Compliance').click();
-    cy.get('chef-sidebar-entry').contains('Profiles').click();
+    cy.get('chef-sidebar-entry').contains('Profiles').click({ force: true });
     cy.url().should('include', '/compliance/compliance-profiles');
 
     // wait for data to return
@@ -130,21 +114,18 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     cy.wait(5000);
 
     // click on market profiles tab
-    cy.get('chef-option[value="available"]').click().then(() => {
-      cy.contains('CIS Amazon Linux 2 Benchmark Level 1').parent().parent().as('row');
-      cy.get('@row').contains('Get').parent().invoke('show').parent().invoke('show').click()
-        .then(() => {
-          // assert table has profile
-          cy.contains('CIS Amazon Linux 2 Benchmark Level 1').should('exist');
-        });
-    });
+    cy.get('chef-option[value="available"]').click();
+    cy.contains('CIS Amazon Linux 2 Benchmark Level 1').parent().parent().as('row');
+    cy.get('@row').contains('Get').parent().invoke('show').parent().invoke('show').click();
+    // assert table has profile
+    cy.contains('CIS Amazon Linux 2 Benchmark Level 1').should('exist');
   });
 
   it('can create a scan job with a reccurence schedule', () => {
-    // navigate to scan create page:
+    // navigate to scan create page
     // click on scan jobs
     cy.get('.nav-link').contains('Compliance').click();
-    cy.get('chef-sidebar-entry').contains('Scan Jobs').click();
+    cy.get('chef-sidebar-entry').contains('Scan Jobs').click({ force: true });
     cy.url().should('include', '/compliance/scan-jobs/jobs');
 
     // we save the route that will be called when we navigate to the next page
@@ -152,61 +133,51 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     cy.route('POST', '/api/v0/compliance/profiles/search').as('getProfiles');
 
     // open scan create form
-    cy.contains('Create new job').click().then(() => {
-      cy.url().should('include', '/jobs/add');
+    cy.contains('Create new job').click();
+    cy.url().should('include', '/jobs/add');
 
-      // select nodes
-      cy.get('chef-job-nodes-form .manager-header').contains('Automate').as('manager-row');
-      cy.get('@manager-row').parent().parent().find('input[type="checkbox"]').check();
+    // select nodes
+    cy.get('chef-job-nodes-form .manager-header').contains('Automate').as('manager-row');
+    cy.get('@manager-row').parent().parent().find('input[type="checkbox"]').check();
 
-      // click next
-      cy.contains('Next').click().then(() => {
-        // wait for data to return
-        cy.wait('@getProfiles');
+    // click next
+    cy.contains('Next').click();
+    // wait for data to return
+    cy.wait('@getProfiles');
 
-        // select profiles
-        cy.get('chef-job-profiles-form').find('[data-cy=select-all-profiles]').check().then(() => {
-          // click next
-          cy.contains('Next').click().then(() => {
+    // select profiles
+    cy.get('chef-job-profiles-form').find('[data-cy=select-all-profiles]').check();
+    // click next
+    cy.contains('Next').click();
 
-            // give the scan job a name
-            cy.get('form input[formcontrolname="name"]').type('a ' + jobName);
+    // give the scan job a name
+    cy.get('form input[formcontrolname="name"]').type('a ' + jobName);
 
-            // expand the recurrence schedule and schedule job to repeat every 1 day
-            cy.get('chef-job-schedule-form input[type="checkbox"]').check();
-            cy.get('.schedule-body input[type="checkbox"]').check();
-            cy.get('fieldset[formgroupname="repeat"]').get('select').last().select('Days');
+    // expand the recurrence schedule and schedule job to repeat every 1 day
+    cy.get('chef-job-schedule-form input[type="checkbox"]').check();
+    cy.get('.schedule-body input[type="checkbox"]').check();
+    cy.get('fieldset[formgroupname="repeat"]').get('select').last().select('Days');
 
-            // click save
-            cy.contains('Save').click().then(() => {
-              cy.url().should('include', '/compliance/scan-jobs/jobs');
+    // click save
+    cy.contains('Save').click();
+    cy.url().should('include', '/compliance/scan-jobs/jobs');
 
-              // assert table has scan job
-              cy.contains(jobName).should('exist');
+    // assert table has scan job
+    cy.contains(jobName).should('exist');
 
-              // click into the scan job to view runs page
-              cy.contains(jobName)
-                .click().then(() => {
-                  cy.url().should('include', '/scans');
-                });
-            });
-          });
-        });
-      });
-    });
+    // click into the scan job to view runs page
+    cy.contains(jobName).click();
+    cy.url().should('include', '/scans');
   });
 
   it('can delete the created credential', () => {
-    // navigate to credentials create page:
-    // click on settings
-    cy.get('.nav-link').contains('Settings').click();
-
     // we save the route that will be called when we navigate to the page
     // in order to be able to wait for it later
     cy.route('POST', '/api/v0/secrets/search').as('getSecrets');
 
-    // click on node credentials in sidebar
-    cy.get('chef-sidebar-entry').contains('Node Credentials').click();
+    // click on settings, then node credentials in sidebar
+    cy.get('.nav-link').contains('Settings').click();
+    cy.get('chef-sidebar-entry').contains('Node Credentials').click({ force: true });
     cy.url().should('include', '/settings/node-credentials');
 
     // wait for data to return
@@ -218,6 +189,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
       cy.get('@row-menu').find('[data-cy=delete]').click({force: true});
     });
   });
+
   it('can delete the created node', () => {
     // navigate to node create page:
     // click on scan jobs
@@ -230,30 +202,26 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     cy.route('POST', '/api/v0/nodes/search').as('getNodes');
 
     // click on nodes tab
-    cy.get('.nav-tab').contains('Nodes added').click().then(() => {
-      cy.url().should('include', '/compliance/scan-jobs/nodes');
+    cy.get('.nav-tab').contains('Nodes added').click();
+    cy.url().should('include', '/compliance/scan-jobs/nodes');
 
-      // wait for data to return
-      cy.wait('@getNodes');
+    // wait for data to return
+    cy.wait('@getNodes');
 
-      // delete the node
-      cy.contains(nodePrefix)
-        .parent().find('chef-button[label="delete"]').click();
-    });
+    // delete the node
+    cy.contains(nodePrefix).parent().find('chef-button[label="delete"]').click();
   });
+
   it('can delete the created profile', () => {
     // navigate to asset store
     cy.get('.nav-link').contains('Compliance').click();
-    cy.get('chef-sidebar-entry').contains('Profiles').click();
+    cy.get('chef-sidebar-entry').contains('Profiles').click({ force: true });
     cy.url().should('include', '/compliance/compliance-profiles');
 
     // delete profile
-    cy.contains('CIS Amazon Linux 2 Benchmark Level 1')
-      .click().then(() => {
-        cy.get('chef-page-header').find('#uninstall-btn').click().then(() => {
-          cy.get('chef-modal').find('chef-button').contains('Delete').click();
-        });
-      });
+    cy.contains('CIS Amazon Linux 2 Benchmark Level 1').click();
+    cy.get('chef-page-header').find('#uninstall-btn').click();
+    cy.get('chef-modal').find('chef-button').contains('Delete').click();
 
     // ensure that the profile is deleted
     cy.url().should('include', '/compliance/compliance-profiles');
@@ -261,6 +229,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
       expect($b).not.to.contain('CIS Amazon Linux 2 Benchmark Level 1');
     });
   });
+
   it('can delete the created scan job', () => {
     // save the route for the delete request so that we can ensure the
     // response is returned
@@ -274,9 +243,8 @@ describe('create a manual node ssh scan job and cleanup after', () => {
 
     // delete scan job
     cy.contains(jobName)
-      .parent().parent().find('chef-button[label="delete"]').click().then(() => {
+      .parent().parent().find('chef-button[label="delete"]').click();
         cy.get('chef-modal').find('chef-button').contains('Delete').click();
-      });
 
     // wait for the delete to finish:
 

--- a/e2e/cypress/integration/ui/compliance/01_ssh_scan_job.spec.ts
+++ b/e2e/cypress/integration/ui/compliance/01_ssh_scan_job.spec.ts
@@ -55,6 +55,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     // navigate to node create page:
     // click on scan jobs
     cy.get('.nav-link').contains('Compliance').click();
+    cy.url().should('include', '/compliance/reports/overview');
 
     // add force to avoid waiting on the whole page to load
     cy.get('chef-sidebar-entry').contains('Scan Jobs').click({ force: true });
@@ -125,6 +126,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     // navigate to scan create page
     // click on scan jobs
     cy.get('.nav-link').contains('Compliance').click();
+    cy.url().should('include', '/compliance/reports/overview');
     cy.get('chef-sidebar-entry').contains('Scan Jobs').click({ force: true });
     cy.url().should('include', '/compliance/scan-jobs/jobs');
 
@@ -194,7 +196,8 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     // navigate to node create page:
     // click on scan jobs
     cy.get('.nav-link').contains('Compliance').click();
-    cy.get('chef-sidebar-entry').contains('Scan Jobs').click();
+    cy.url().should('include', '/compliance/reports/overview');
+    cy.get('chef-sidebar-entry').contains('Scan Jobs').click({ force: true });
     cy.url().should('include', '/compliance/scan-jobs/jobs');
 
     // we save the route that will be called when we navigate to the page
@@ -238,7 +241,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     // navigate to scan create page:
     // click on scan jobs
     cy.get('.nav-link').contains('Compliance').click();
-    cy.get('chef-sidebar-entry').contains('Scan Jobs').click();
+    cy.get('chef-sidebar-entry').contains('Scan Jobs').click({ force: true });
     cy.url().should('include', '/compliance/scan-jobs/jobs');
 
     // delete scan job

--- a/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
@@ -16,7 +16,6 @@ describe('user management', () => {
   });
 
   const now = Cypress.moment().format('MMDDYYhhmm');
-  const typeDelay = 50;
   const name = `cypress test user ${now}`;
   const username = `testing${now}`;
   const password = 'testing!';
@@ -28,20 +27,13 @@ describe('user management', () => {
     cy.get('app-user-table chef-button').contains('Create User').click();
     cy.get('app-user-management chef-modal').should('exist');
 
-    // adding a delay to more closely approximate an average human's type speed (200 char/min)
-    // the `should` will wait until the actual input value matches the expected value
-    // ref: https://github.com/cypress-io/cypress/issues/534
-    cy.get('[formcontrolname=fullname]')
-      .type(name, { delay: typeDelay }).should('have.value', name);
+    cy.get('[formcontrolname=fullname]').type(name).should('have.value', name);
 
-    cy.get('[formcontrolname=username]')
-      .type(username, { delay: typeDelay }).should('have.value', username);
+    cy.get('[formcontrolname=username]').type(username).should('have.value', username);
 
-    cy.get('[formcontrolname=password]')
-      .type(password, { delay: typeDelay }).should('have.value', password);
+    cy.get('[formcontrolname=password]').type(password).should('have.value', password);
 
-    cy.get('[formcontrolname=confirmPassword]')
-      .type(password, { delay: typeDelay }).should('have.value', password);
+    cy.get('[formcontrolname=confirmPassword]').type(password).should('have.value', password);
 
     // save new user
     cy.get('[data-cy=save-user]').click();
@@ -65,16 +57,16 @@ describe('user management', () => {
 
     cy.get('app-user-details chef-button.edit-button').click();
     cy.get('[formcontrolname=fullName]').find('input')
-      .clear().type(updated_name, { delay: typeDelay }).should('have.value', updated_name);
+      .clear().type(updated_name).should('have.value', updated_name);
 
     cy.get('app-user-details chef-button.save-button').click();
     cy.wait('@updateUser');
     cy.contains(updated_name).should('exist');
 
     cy.get('[formcontrolname=newPassword]').find('input')
-      .type(updated_password, { delay: typeDelay }).should('have.value', updated_password);
+      .type(updated_password).should('have.value', updated_password);
     cy.get('[formcontrolname=confirmPassword]').find('input')
-      .type(updated_password, { delay: typeDelay }).should('have.value', updated_password);
+      .type(updated_password).should('have.value', updated_password);
     cy.get('app-user-details chef-button').contains('Update Password').click({ force: true} );
 
     // success alert displays

--- a/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
@@ -16,6 +16,7 @@ describe('user management', () => {
   });
 
   const now = Cypress.moment().format('MMDDYYhhmm');
+  const typeDelay = 50;
   const name = `cypress test user ${now}`;
   const username = `testing${now}`;
   const password = 'testing!';
@@ -31,24 +32,24 @@ describe('user management', () => {
     // the `should` will wait until the actual input value matches the expected value
     // ref: https://github.com/cypress-io/cypress/issues/534
     cy.get('[formcontrolname=fullname]')
-      .type(name, { delay: 50 }).should('have.value', name);
+      .type(name, { delay: typeDelay }).should('have.value', name);
 
     cy.get('[formcontrolname=username]')
-      .type(username, { delay: 50 }).should('have.value', username);
+      .type(username, { delay: typeDelay }).should('have.value', username);
 
     cy.get('[formcontrolname=password]')
-      .type(password, { delay: 50 }).should('have.value', password);
+      .type(password, { delay: typeDelay }).should('have.value', password);
 
     cy.get('[formcontrolname=confirmPassword]')
-      .type(password, { delay: 50 }).should('have.value', password);
+      .type(password, { delay: typeDelay }).should('have.value', password);
 
     // save new user
     cy.get('[data-cy=save-user]').click();
     cy.get('app-user-management chef-modal').should('not.be.visible');
     cy.get('chef-notification.info').should('be.visible');
 
-    cy.get('chef-td').contains(username).should('exist');
-    cy.get('chef-td').contains(name).should('exist');
+    cy.get('app-user-table chef-td').contains(username).should('exist');
+    cy.get('app-user-table chef-td').contains(name).should('exist');
   });
 
   it('can view and edit user details', () => {
@@ -57,47 +58,46 @@ describe('user management', () => {
     const updated_name = `${name} updated`;
     const updated_password = 'testing?';
     cy.contains(name).click();
-    cy.get('app-user-details').should('exist');
-    cy.get('div.name-column').contains(name).should('exist');
-    cy.get('span').contains(username).should('exist');
-    cy.get('chef-form-field').contains('New Password').should('exist');
-    cy.get('chef-form-field').contains('Confirm New Password').should('exist');
+    cy.get('app-user-details div.name-column').contains(name).should('exist');
+    cy.get('app-user-details span').contains(username).should('exist');
+    cy.get('app-user-details chef-form-field').contains('New Password').should('exist');
+    cy.get('app-user-details chef-form-field').contains('Confirm New Password').should('exist');
 
-    cy.get('chef-button.edit-button').click();
+    cy.get('app-user-details chef-button.edit-button').click();
     cy.get('[formcontrolname=fullName]').find('input')
-      .clear().type(updated_name, { delay: 50 }).should('have.value', updated_name);
+      .clear().type(updated_name, { delay: typeDelay }).should('have.value', updated_name);
 
-    cy.get('chef-button.save-button').click();
+    cy.get('app-user-details chef-button.save-button').click();
     cy.wait('@updateUser');
     cy.contains(updated_name).should('exist');
 
     cy.get('[formcontrolname=newPassword]').find('input')
-      .type(updated_password, { delay: 50 }).should('have.value', updated_password);
+      .type(updated_password, { delay: typeDelay }).should('have.value', updated_password);
     cy.get('[formcontrolname=confirmPassword]').find('input')
-      .type(updated_password, { delay: 50 }).should('have.value', updated_password);
-    cy.get('chef-button').contains('Update Password').click({ force: true} );
+      .type(updated_password, { delay: typeDelay }).should('have.value', updated_password);
+    cy.get('app-user-details chef-button').contains('Update Password').click({ force: true} );
 
     // success alert displays
     cy.get('chef-notification.info').should('be.visible');
 
     // back to user list page
-    cy.get('.breadcrumb').contains('Users').click();
+    cy.get('app-user-details .breadcrumb').contains('Users').click();
   });
 
   it('can delete user', () => {
     cy.route('DELETE', '**/users/**').as('deleteUser');
 
-      cy.get('chef-td').contains(name).parent().parent()
+    cy.get('app-user-table chef-td').contains(name).parent().parent()
         .find('chef-control-menu').as('controlMenu');
-      // we throw in a should so cypress waits until introspection allows menu to be shown
-      cy.get('@controlMenu').should('be.visible')
-        .click();
-      cy.get('@controlMenu').find('[data-cy=delete]').click({ force: true });
+    // we throw in a should so cypress waits until introspection allows menu to be shown
+    cy.get('@controlMenu').should('be.visible')
+      .click();
+    cy.get('@controlMenu').find('[data-cy=delete]').click({ force: true });
 
-      // confirm in modal
-      cy.get('chef-button').contains('Delete User').click();
+    // confirm in modal
+    cy.get('app-user-management chef-button').contains('Delete User').click();
 
-      cy.wait('@deleteUser');
-      cy.get('chef-tbody chef-td').contains(username).should('not.exist');
+    cy.wait('@deleteUser');
+    cy.get('app-user-management chef-tbody chef-td').contains(username).should('not.exist');
   });
 });

--- a/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
@@ -16,8 +16,8 @@ describe('user management', () => {
   });
 
   const now = Cypress.moment().format('MMDDYYhhmm');
-  const name = 'cypress test user ' + now;
-  const username = 'testing' + now;
+  const name = `cypress test user ${now}`;
+  const username = `testing${now}`;
 
   it('can create a user', () => {
     cy.get('app-user-table').should('exist');
@@ -36,71 +36,61 @@ describe('user management', () => {
       .type('chefautomate');
 
     cy.get('[formcontrolname=confirmPassword]')
-      .type('chefautomate').then(() => {
-        // save new user
-        cy.get('[data-cy=save-user]').click().then(() => {
-          // confirm modal closed
-          cy.get('app-user-management chef-modal').should('not.be.visible');
-          // success alert displays
-          cy.get('chef-notification.info').should('be.visible');
-          // confirm new user row added
-          cy.contains(username).should('exist');
-          cy.contains(name).should('exist');
-        });
-      });
+      .type('chefautomate');
+
+    // save new user
+    cy.get('[data-cy=save-user]').click();
+    cy.get('app-user-management chef-modal').should('not.be.visible');
+    cy.get('chef-notification.info').should('be.visible');
+
+    cy.get('chef-td').contains(username).should('exist');
+    cy.get('chef-td').contains(name).should('exist');
   });
 
-  // it("can view and edit a user's details", () => {
-  //   let updated_name = name + 'update'
-  //   let updated_password = 'chefautomate1'
-  //   cy.contains(name).click().then(() => {
-  //     cy.get('app-user-details').should('exist')
-  //     cy.get('div.name-column').contains(name).should('exist')
-  //     cy.get('span').contains(username).should('exist')
-  //     cy.get('chef-form-field').contains('New Password').should('exist')
-  //     cy.get('chef-form-field').contains('Confirm New Password').should('exist')
+  it('can view and edit user details', () => {
+    cy.route('PUT', '**/users/**').as('updateUser');
 
-  //     cy.get('chef-button.edit-button').click().then(() => {
-  //       cy.get('[formcontrolname=fullName]').find('input').type(updated_name)
+    const updated_name = `${name} updated`;
+    const updated_password = 'chefautomate1';
+    cy.contains(name).click();
+    cy.get('app-user-details').should('exist');
+    cy.get('div.name-column').contains(name).should('exist');
+    cy.get('span').contains(username).should('exist');
+    cy.get('chef-form-field').contains('New Password').should('exist');
+    cy.get('chef-form-field').contains('Confirm New Password').should('exist');
 
-  //       cy.get('chef-button.save-button').click(() => {
-  //         cy.get('div.name-column').contains(updated_name).should('exist')
-  //       })
-  //     })
+    cy.get('chef-button.edit-button').click();
+    cy.get('[formcontrolname=fullName]').find('input').clear().type(updated_name, { delay: 5 });
 
-  //     cy.get('[formcontrolname=newPassword]').find('input').type(updated_password).then(() => {
-  //       cy.get('[formcontrolname=confirmPassword]').find('input').type(updated_password)
-  //         .then(() => {
-  //         cy.get('chef-button').contains('Update Password').click().then(() => {
-  //           // success alert displays
-  //           cy.get('chef-notification.info').should('be.visible')
+    cy.get('chef-button.save-button').click();
+    cy.wait('@updateUser');
+    cy.contains(updated_name).should('exist');
 
-  //           // back to user list page
-  //           cy.get('.breadcrumb').contains('Users').click()
-  //         })
-  //       })
-  //     })
-  //   })
-  // })
+    // adding a delay mimics a real user's typing
+    cy.get('[formcontrolname=newPassword]').find('input').type(updated_password, { delay: 5 });
+    cy.get('[formcontrolname=confirmPassword]').find('input').type(updated_password, { delay: 5 });
+    cy.get('chef-button').contains('Update Password').click({ force: true} );
 
-  // it("can delete user", () => {
-  //   // find the created user row
-  //   cy.get('chef-tbody chef-tr').contains(name).parent().parent()
-  //     .find('chef-control-menu').as('control-menu')
+    // success alert displays
+    cy.get('chef-notification.info').should('be.visible');
 
-  //   cy.get('@control-menu').click().then(() => {
+    // back to user list page
+    cy.get('.breadcrumb').contains('Users').click();
+  });
 
-  //     // force:true disables waiting for actionability
-  // tslint:disable-next-line:max-line-length
-  //     // https://docs.cypress.io/guides/core-concepts/interacting-with-elements.html#Actionability
-  //     // in this case, the delete button is hidden under the control menu so we decrease
-  //     // test flakiness by having less stringent checks before clicking
-  //     cy.get('@control-menu').find('[data-cy=delete]').click({ force: true }).then(() => {
-  //       // confirm user delete
-  //       cy.get('chef-button').contains('Delete User').click().then(() => {
-  //         cy.get('chef-tbody chef-td').contains(username).should('not.exist')
-  //       })
-  //     })
-  //   })
-  // })
+  it('can delete user', () => {
+    cy.route('DELETE', '**/users/**').as('deleteUser');
+
+    cy.get('chef-tbody chef-tr').contains(name).parent().parent()
+      .find('chef-control-menu').as('controlMenu');
+
+    cy.get('@controlMenu').click().then(($menu) => {
+      $menu.find('[data-cy=delete]').click();
+      // confirm in modal
+      cy.get('chef-button').contains('Delete User').click();
+
+      cy.wait('@deleteUser');
+      cy.get('chef-tbody chef-td').contains(username).should('not.exist');
+    });
+  });
 });

--- a/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
@@ -27,16 +27,16 @@ describe('user management', () => {
     cy.get('app-user-management chef-modal').should('exist');
 
     cy.get('[formcontrolname=fullname]')
-      .type(name);
+      .focus().type(name);
 
     cy.get('[formcontrolname=username]')
-      .type(username);
+      .focus().type(username);
 
     cy.get('[formcontrolname=password]')
-      .type('chefautomate');
+      .focus().type('chefautomate');
 
     cy.get('[formcontrolname=confirmPassword]')
-      .type('chefautomate');
+      .focus().type('chefautomate');
 
     // save new user
     cy.get('[data-cy=save-user]').click();
@@ -60,15 +60,17 @@ describe('user management', () => {
     cy.get('chef-form-field').contains('Confirm New Password').should('exist');
 
     cy.get('chef-button.edit-button').click();
-    cy.get('[formcontrolname=fullName]').find('input').clear().type(updated_name, { delay: 5 });
+    cy.get('[formcontrolname=fullName]').find('input')
+      .clear().focus().type(updated_name);
 
     cy.get('chef-button.save-button').click();
     cy.wait('@updateUser');
     cy.contains(updated_name).should('exist');
 
-    // adding a delay mimics a real user's typing
-    cy.get('[formcontrolname=newPassword]').find('input').type(updated_password, { delay: 5 });
-    cy.get('[formcontrolname=confirmPassword]').find('input').type(updated_password, { delay: 5 });
+    cy.get('[formcontrolname=newPassword]').find('input')
+      .focus().type(updated_password);
+    cy.get('[formcontrolname=confirmPassword]').find('input')
+      .focus().type(updated_password);
     cy.get('chef-button').contains('Update Password').click({ force: true} );
 
     // success alert displays

--- a/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
@@ -16,6 +16,7 @@ describe('user management', () => {
   });
 
   const now = Cypress.moment().format('MMDDYYhhmm');
+  const typeDelay = 50;
   const name = `cypress test user ${now}`;
   const username = `testing${now}`;
   const password = 'testing!';
@@ -27,13 +28,20 @@ describe('user management', () => {
     cy.get('app-user-table chef-button').contains('Create User').click();
     cy.get('app-user-management chef-modal').should('exist');
 
-    cy.get('[formcontrolname=fullname]').type(name).should('have.value', name);
+    // we increase the default delay to mimic the average human's typing speed
+    // only need this for input values upon which later test assertions depend
+    // ref: https://github.com/cypress-io/cypress/issues/534
+    cy.get('[formcontrolname=fullname]').focus()
+      .type(name, { delay: typeDelay }).should('have.value', name);
 
-    cy.get('[formcontrolname=username]').type(username).should('have.value', username);
+    cy.get('[formcontrolname=username]').focus()
+      .type(username, { delay: typeDelay }).should('have.value', username);
 
-    cy.get('[formcontrolname=password]').type(password).should('have.value', password);
+    cy.get('[formcontrolname=password]').focus()
+      .type(password, { delay: typeDelay }).should('have.value', password);
 
-    cy.get('[formcontrolname=confirmPassword]').type(password).should('have.value', password);
+    cy.get('[formcontrolname=confirmPassword]')
+      .type(password, { delay: typeDelay }).should('have.value', password);
 
     // save new user
     cy.get('[data-cy=save-user]').click();
@@ -64,9 +72,9 @@ describe('user management', () => {
     cy.contains(updated_name).should('exist');
 
     cy.get('[formcontrolname=newPassword]').find('input')
-      .type(updated_password).should('have.value', updated_password);
+      .type(updated_password, { delay: typeDelay }).should('have.value', updated_password);
     cy.get('[formcontrolname=confirmPassword]').find('input')
-      .type(updated_password).should('have.value', updated_password);
+      .type(updated_password, { delay: typeDelay }).should('have.value', updated_password);
     cy.get('app-user-details chef-button').contains('Update Password').click({ force: true} );
 
     // success alert displays
@@ -79,7 +87,7 @@ describe('user management', () => {
   it('can delete user', () => {
     cy.route('DELETE', '**/users/**').as('deleteUser');
 
-    cy.get('app-user-table chef-td').contains(name).parent().parent()
+    cy.get('app-user-table chef-td').contains(username).parent()
         .find('chef-control-menu').as('controlMenu');
     // we throw in a should so cypress waits until introspection allows menu to be shown
     cy.get('@controlMenu').should('be.visible')


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

We had the user management tests commented out because they were flaky. I made a few tweaks and wanted to see if they'll be more stable now.

Edit: local runs are stable but pipeline runs still need some debugging

### :chains: Related Resources
-  https://github.com/chef/automate/issues/959

### :+1: Definition of Done
- buildkite tests pass reliably (gonna retry them a few times)

### :athletic_shoe: How to Build and Test the Change
- see buildkite
- [run locally](https://github.com/chef/automate/blob/master/e2e/README.md#running-cypress-locally)

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [x] Docs added/updated?

### :camera: Screenshots, if applicable