### PR TITLE
Force rebuild of components using Go net/http

### DIFF
--- a/components/applications-service/pkg/server/server.go
+++ b/components/applications-service/pkg/server/server.go
@@ -6,7 +6,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
+	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/chef/automate/api/external/applications"
 	ver_api "github.com/chef/automate/api/external/common/version"
@@ -18,11 +22,6 @@ import (
 	"github.com/chef/automate/lib/stringutils"
 	"github.com/chef/automate/lib/timef"
 	"github.com/chef/automate/lib/version"
-
-	"github.com/golang/protobuf/ptypes"
-	timestamp "github.com/golang/protobuf/ptypes/timestamp"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // ApplicationsServer is the interface to this component.

--- a/components/automate-gateway/handler/license.go
+++ b/components/automate-gateway/handler/license.go
@@ -99,7 +99,7 @@ func (t *LicenseServer) RequestLicense(ctx context.Context,
 
 	deploymentID, err := t.getDeploymentID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, "couldn't identify the requesting a2 installation")
+		return nil, status.Error(codes.Internal, "couldn't identify the requesting Automate installation")
 	}
 
 	l, err := t.requestLicense(ctx, req, deploymentID, chefAutomateVersion)

--- a/components/session-service/server/server.go
+++ b/components/session-service/server/server.go
@@ -29,20 +29,6 @@ import (
 	"github.com/chef/automate/lib/tls/certs"
 )
 
-// This determines how often the PG backend will cleanup expired session
-// records. It does not affect session expiration; only records that have
-// already expired are dropped.
-// Note 2017/12/07 (sr): 12hrs here is completely arbitrary.
-const dbCleanupInterval = 12 * time.Hour
-
-// This duration drives the refresh process: if the token expires within the
-// next minute, we'll refresh. This is a first guess and might need tweaking.
-const remainingDuration = time.Minute
-
-// servingStatus is our -- currently hardcoded -- /health endpoint response.
-// It mimics the grpc.health.v1 response we return in GRPC services.
-const servingStatus = "SERVING"
-
 // BldrClient holds the config for the bldr oauth2 client.
 type BldrClient struct {
 	SignInURL    *url.URL
@@ -70,6 +56,20 @@ const (
 	clientStateKeyPrefix     = "client_state_" // coming from the browser, passed back on success
 	numRelayStateRandomBytes = 10
 	redirectURIKey           = "redirect_uri"
+
+	// This determines how often the PG backend will cleanup expired session
+	// records. It does not affect session expiration; only records that have
+	// already expired are dropped.
+	// Note 2017/12/07 (sr): 12hrs here is completely arbitrary.
+	dbCleanupInterval = 12 * time.Hour
+
+	// This duration drives the refresh process: if the token expires within the
+	// next minute, we'll refresh. This is a first guess and might need tweaking.
+	remainingDuration = time.Minute
+
+	// servingStatus is our -- currently hardcoded -- /health endpoint response.
+	// It mimics the grpc.health.v1 response we return in GRPC services.
+	servingStatus = "SERVING"
 )
 
 // New returns a new instance of the server

--- a/components/trial-license-service/pkg/license/license.go
+++ b/components/trial-license-service/pkg/license/license.go
@@ -18,9 +18,11 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 )
 
-const trialLicenseType = "trial"
-const licenseVersion = "1"
-const customerIDVersion = "2"
+const (
+	trialLicenseType  = "trial"
+	licenseVersion    = "1"
+	customerIDVersion = "2"
+)
 
 // ServerError is returned when the license-generation-server returns an error
 // code in the 5xx range


### PR DESCRIPTION
A new version of Go was recently released that addresses multiple CVEs
in their implementation of HTTP2. This PR makes minor changes to force
a rebuild of the following components:

- applications-service
- automate-gateway
- session-service
- trial-license-service

to ensure that they are rebuilt with the most recent go version.

Signed-off-by: Steven Danna <steve@chef.io>