### PR TITLE
lib/cereal: Use in-process notifications to avoid delays

### DIFF
--- a/components/cereal-service/Makefile
+++ b/components/cereal-service/Makefile
@@ -1,5 +1,4 @@
 PACKAGE_PATH = github.com/chef/automate/components/cereal-service
-BINS = ${PACKAGE_PATH}/cmd/cereal-service
 
 GIT_SHA = $(shell git rev-parse HEAD)
 BUILD_TIME ?= $(shell date -u '+%Y%m%d%H%M%S')
@@ -7,7 +6,8 @@ VERSION = ${BUILD_TIME}
 GO_LDFLAGS = --ldflags "-X ${LIBRARY_PATH}/version.Version=${BUILD_TIME} -X ${LIBRARY_PATH}/version.GitSHA=${GIT_SHA} -X ${LIBRARY_PATH}/version.BuildTime=${BUILD_TIME}"
 GOPATH = $(shell go env GOPATH)
 
-build: ${BINS}
+build:
+	go build ./cmd/cereal-service
 
 include ../../Makefile.common_go
 

--- a/components/cereal-service/pkg/server/server.go
+++ b/components/cereal-service/pkg/server/server.go
@@ -35,7 +35,7 @@ func NewCerealService(ctx context.Context, b backend.Driver) *CerealService {
 	}
 
 	if v, ok := b.(backend.SchedulerDriver); ok {
-		cs.workflowScheduler = libcereal.NewWorkflowScheduler(v)
+		cs.workflowScheduler = libcereal.NewWorkflowScheduler(v, func() {})
 		go cs.workflowScheduler.Run(ctx)
 	}
 

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -605,8 +605,8 @@ func (r *registeredExecutor) startTaskWorker(ctx context.Context, b backend.Driv
 		return
 	}
 
+	r.wg.Add(1)
 	go func() {
-		r.wg.Add(1)
 		startedNext := false
 		for {
 			t, taskCompleter, err := b.DequeueTask(ctx, r.name)
@@ -883,8 +883,8 @@ func (m *Manager) WakeupTaskPollersByRequests(taskRequests []enqueueTaskRequest)
 func (m *Manager) startTaskPollers(ctx context.Context) error {
 	for _, exec := range m.taskExecutors {
 		e := exec
+		m.wg.Add(1)
 		go func() {
-			m.wg.Add(1)
 			e.StartPoller(ctx, m.backend, m.taskPollInterval, m.WakeupWorkflowExecutor)
 			m.wg.Done()
 		}()

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -1029,7 +1029,6 @@ func (m *Manager) processWorkflow(ctx context.Context, workflowNames []string) b
 				return true
 			}
 		}
-		m.WakeupTaskPollersByRequests(decision.tasks)
 		s.End("enqueue_task")
 		s.Begin("continue")
 		jsonPayload, err := jsonify(decision.payload)
@@ -1044,6 +1043,7 @@ func (m *Manager) processWorkflow(ctx context.Context, workflowNames []string) b
 			if err != nil {
 				logrus.WithError(err).Error("failed to continue workflow")
 			}
+			m.WakeupTaskPollersByRequests(decision.tasks)
 		}
 		s.End("continue")
 	}

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -909,7 +909,6 @@ func (m *Manager) runWorkflowExecutor(ctx context.Context) {
 	m.wg.Add(1)
 LOOP:
 	for {
-
 		select {
 		case <-ctx.Done():
 			logrus.Info("exiting workflow executor")

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -464,18 +464,18 @@ func NewManager(b backend.Driver, opts ...ManagerOpt) (*Manager, error) {
 	}
 
 	workflowWakeupChan := make(chan struct{}, 5) // 5 is arbitrary
-	var workflowScheduler *WorkflowScheduler
-	if v, ok := b.(backend.SchedulerDriver); ok {
-		workflowScheduler = NewWorkflowScheduler(v, workflowWakeupChan)
-	}
 	m := &Manager{
-		backend:            b,
-		waywardWorkflows:   make(waywardWorkflowList),
-		workflowExecutors:  make(map[string]WorkflowExecutor),
-		taskExecutors:      make(map[string]*registeredExecutor),
-		workflowScheduler:  workflowScheduler,
+		backend:           b,
+		waywardWorkflows:  make(waywardWorkflowList),
+		workflowExecutors: make(map[string]WorkflowExecutor),
+		taskExecutors:     make(map[string]*registeredExecutor),
+
 		taskPollInterval:   defaultTaskPollInterval,
 		workflowWakeupChan: workflowWakeupChan,
+	}
+
+	if v, ok := b.(backend.SchedulerDriver); ok {
+		m.workflowScheduler = NewWorkflowScheduler(v, m.WakeupWorkflowExecutor)
 	}
 
 	for _, o := range opts {

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -871,7 +871,7 @@ func (m *Manager) WakeupTaskPollerByTaskName(taskName string) {
 	}
 }
 
-func (m *Manager) WakeupTaskPollersByRequests(taskRequests []enqueueTaskRequest) {
+func (m *Manager) wakeupTaskPollersByRequests(taskRequests []enqueueTaskRequest) {
 	uniqueTaskNames := []string{}
 	markMap := make(map[string]struct{})
 	for _, tr := range taskRequests {
@@ -1043,7 +1043,7 @@ func (m *Manager) processWorkflow(ctx context.Context, workflowNames []string) b
 			if err != nil {
 				logrus.WithError(err).Error("failed to continue workflow")
 			}
-			m.WakeupTaskPollersByRequests(decision.tasks)
+			m.wakeupTaskPollersByRequests(decision.tasks)
 		}
 		s.End("continue")
 	}

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -508,9 +508,9 @@ type TaskExecutorOpts struct {
 //
 // Tasks are polled for based on
 //
-// - a time-based internval, and
-// - an in-process notifications that is triggered when we think there
-// might be a task.
+// - a time-based interval, and
+// - in-process notifications that are sent when we think there
+// might be a task available.
 //
 // When either of these tiggers occur, we spawn a new goroutine (the
 // "task worker") provided that we are under the maximum configured
@@ -545,7 +545,7 @@ func (r *registeredExecutor) DecActiveWorkers() {
 }
 
 // IncActiveWorkers increments the active worker count if another
-// worker is allowed. It returns true if the count was incremened and
+// worker is allowed. It returns true if the count was incremented and
 // false otherwise. The caller should not start a worker if false is
 // returned.
 func (r *registeredExecutor) IncActiveWorkers() bool {
@@ -562,7 +562,7 @@ func (r *registeredExecutor) IncActiveWorkers() bool {
 
 // WakeupPoller will wake up the poller for this
 // registeredExecutor. This is called when a workflow executor
-// enqueue's tasks.
+// enqueues tasks.
 func (r *registeredExecutor) WakeupPoller() {
 	select {
 	case r.wakeupChan <- struct{}{}:
@@ -572,7 +572,7 @@ func (r *registeredExecutor) WakeupPoller() {
 
 // StartPoller runs until the given context is cancelled, starting a
 // TaskWorker every interval (or sooner if we've been notified of a
-// change)
+// change).
 func (r *registeredExecutor) StartPoller(ctx context.Context, b backend.Driver, taskPollInterval time.Duration, workflowWakeupFun func()) {
 	logctx := logrus.WithField("task_name", r.name)
 	logctx.Infof("Starting task poller")
@@ -591,7 +591,7 @@ func (r *registeredExecutor) StartPoller(ctx context.Context, b backend.Driver, 
 	}
 }
 
-// startTaskPoller starts a goroutine that will dequeue new tasks and
+// startTaskWorker starts a goroutine that will dequeue new tasks and
 // execute them, exiting when no tasks are available in the queue. If
 // the task poller initially finds a job, it will also start the next
 // task worker.

--- a/lib/cereal/workflow_scheduler.go
+++ b/lib/cereal/workflow_scheduler.go
@@ -21,14 +21,14 @@ var (
 )
 
 type WorkflowScheduler struct {
-	backend            backend.SchedulerDriver
-	workflowWakeupChan chan struct{}
+	backend           backend.SchedulerDriver
+	workflowWakeupFun func()
 }
 
-func NewWorkflowScheduler(b backend.SchedulerDriver, c chan struct{}) *WorkflowScheduler {
+func NewWorkflowScheduler(b backend.SchedulerDriver, w func()) *WorkflowScheduler {
 	return &WorkflowScheduler{
-		backend:            b,
-		workflowWakeupChan: c,
+		backend:           b,
+		workflowWakeupFun: w,
 	}
 }
 
@@ -130,10 +130,6 @@ func (w *WorkflowScheduler) scheduleWorkflow(ctx context.Context) (time.Duration
 		return sleepTime, errors.Wrap(err, "could not update scheduled workflow record")
 	}
 
-	select {
-	case w.workflowWakeupChan <- struct{}{}:
-	default:
-	}
-
+	w.workflowWakeupFun()
 	return sleepTime, nil
 }


### PR DESCRIPTION
This change allows us to wake up relevant go-routines in the local
process when certain events happens:

- When we enqueue tasks, we wake up the task polling goroutine
- When we finish a task, we wake up the workflow polling goroutine

For each registered task executor we have a "Poller" which wakes up at an interval
or on notification and starts a task worker.  An additional worker will be spawned as 
long as there is more work to do.  When the worker finds that there is no more work to
do it exits.

Note to reviewers: We probably want to think about this worker management strategy.
We could make it more responsive by growing the queue

Signed-off-by: Steven Danna <steve@chef.io>