### PR TITLE
[automate-809] Update projects for a team

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -46,9 +46,9 @@
         </div>
         <div *ngIf="showProjectsDropdown">
           <app-projects-dropdown
-            [projects]="assignableProjects"
-            (onSelection)="projectsDropdownAction($event)"
-            [disabled]="assignableProjects.length === 0">
+            [projects]="projects"
+            (onProjectChecked)="onProjectChecked($event)"
+            [disabled]="dropdownDisabled()">
           </app-projects-dropdown>
         </div>
         <div id="button-bar">

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
@@ -19,7 +19,8 @@ describe('CreateObjectModalComponent', () => {
         MockComponent({ selector: 'chef-error' }),
         MockComponent({ selector: 'chef-toolbar' }),
         MockComponent({ selector: 'chef-modal', inputs: ['visible'] }),
-        MockComponent({ selector: 'app-projects-dropdown', inputs: ['projects', 'disabled'] })
+        MockComponent({ selector: 'app-projects-dropdown',
+          inputs: ['projects', 'disabled'], outputs: ['onProjectChecked'] })
       ],
      imports: [
         ReactiveFormsModule

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -7,7 +7,8 @@ import { hasIn } from 'lodash/fp';
 import { IdMapper } from 'app/helpers/auth/id-mapper';
 import { Project } from 'app/entities/projects/project.model';
 import {
-  ProjectChecked
+  ProjectChecked,
+  ProjectCheckedMap
 } from 'app/components/projects-dropdown/projects-dropdown.component';
 
 @Component({
@@ -27,7 +28,7 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
   @Output() close = new EventEmitter();
   @Output() createClicked = new EventEmitter<Project[]>();
 
-  public projects: { [id: string]: ProjectChecked } = {};
+  public projects: ProjectCheckedMap = {};
 
   // Whether the edit ID form is open or not.
   public modifyID = false;
@@ -45,13 +46,14 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
     // if a new list of projects to populate dropdown with is passed in we update the dropdown
     const checked = false;
     if (hasIn('assignableProjects.currentValue', changes)) {
+      this.projects = {};
       changes.assignableProjects.currentValue.forEach((proj: Project) =>
         this.projects[proj.id] = { ...proj, checked });
     }
   }
 
   onProjectChecked(project: ProjectChecked): void {
-    this.projects[project.id] = project;
+    this.projects[project.id].checked = project.checked;
   }
 
   dropdownDisabled(): boolean {

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -41,7 +41,7 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
     });
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges): void {
     // if a new list of projects to populate dropdown with is passed in we update the dropdown
     const checked = false;
     if (hasIn('assignableProjects.currentValue', changes)) {

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -45,7 +45,7 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
     // if a new list of projects to populate dropdown with is passed in we update the dropdown
     const checked = false;
     if (hasIn('assignableProjects.currentValue', changes)) {
-      changes.assignableProjects.currentValue.forEach(proj =>
+      changes.assignableProjects.currentValue.forEach((proj: Project) =>
         this.projects[proj.id] = { ...proj, checked });
     }
   }

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
+
 import { IdMapper } from 'app/helpers/auth/id-mapper';
 import { Project } from 'app/entities/projects/project.model';
 
@@ -61,7 +62,7 @@ export class CreateObjectModalComponent implements OnInit {
     return event.key === 'Shift' || event.key === 'Tab';
   }
 
-  projectsDropdownAction(projects) {
+  projectsDropdownAction(projects: Project[]): void {
     this.projectsSelected = projects;
   }
 }

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -7,7 +7,7 @@ import { hasIn } from 'lodash/fp';
 import { IdMapper } from 'app/helpers/auth/id-mapper';
 import { Project } from 'app/entities/projects/project.model';
 import {
-  ProjectChecked, projectCheckedFromProject
+  ProjectChecked
 } from 'app/components/projects-dropdown/projects-dropdown.component';
 
 @Component({
@@ -43,9 +43,10 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     // if a new list of projects to populate dropdown with is passed in we update the dropdown
+    const checked = false;
     if (hasIn('assignableProjects.currentValue', changes)) {
       changes.assignableProjects.currentValue.forEach(proj =>
-        this.projects[proj.id] = projectCheckedFromProject(proj, false));
+        this.projects[proj.id] = { ...proj, checked });
     }
   }
 

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
@@ -15,16 +15,14 @@
   <chef-click-outside (clickOutside)="closeDropdown()">
     <chef-dropdown [attr.visible]="active">
       <chef-checkbox
-        *ngFor="let project of projects; index as i"
-        [checked]="projectSelected(project)"
-        (change)="updateProjects($event.detail, i)"
+        *ngFor="let project of projectsArray();"
+        [checked]="project.checked"
+        [attr.title]="project.name"
+        (change)="projectChecked($event.detail, project)"
         (keydown.enter)="closeColumnDropdown()"
         (keydown.esc)="closeColumnDropdown()"
         (keydown.arrowup)="moveFocus($event)"
         (keydown.arrowdown)="moveFocus($event)">{{ project['name'] }}</chef-checkbox>
-      <div class="error" *ngIf="showError">
-        At least one item must be selected.
-      </div>
     </chef-dropdown>
   </chef-click-outside>
 </div>

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
@@ -16,7 +16,7 @@
     <chef-dropdown [attr.visible]="active">
       <chef-checkbox
         *ngFor="let project of projects; index as i"
-        [checked]="project.enabled"
+        [checked]="projectSelected(project)"
         (change)="updateProjects($event.detail, i)"
         (keydown.enter)="closeColumnDropdown()"
         (keydown.esc)="closeColumnDropdown()"

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
@@ -15,7 +15,7 @@
   <chef-click-outside (clickOutside)="closeDropdown()">
     <chef-dropdown [attr.visible]="active">
       <chef-checkbox
-        *ngFor="let project of projectsArray();"
+        *ngFor="let project of projectsArray()"
         [checked]="project.checked"
         [attr.title]="project.name"
         (change)="projectChecked($event.detail, project)"

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
@@ -1,5 +1,5 @@
 <label>
-  Projects <span *ngIf="required">*</span>
+  Projects
 </label>
 <div class="dropdown-wrap">
   <button class="dropdown-button"

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
@@ -4,7 +4,6 @@
   display: block;
 }
 
-// NOTE (delete before merge): review if this is still correct with susan.
 // todo: update dropdown to have min-width of 250px and increase in width based on length of project name
 .dropdown-wrap {
   position: relative;

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -6,6 +6,9 @@ import { ProjectConstants, Project } from 'app/entities/projects/project.model';
 
 const { UNASSIGNED_PROJECT_ID } = ProjectConstants;
 
+// Extend the project model with the checked field.
+// This represents whether the project's checkbox is unchecked or not
+// in this component's UI
 export interface ProjectChecked extends Project {
   checked: boolean;
 }
@@ -28,8 +31,6 @@ export class ProjectsDropdownComponent implements OnChanges {
 
   active = false;
   label = UNASSIGNED_PROJECT_ID;
-
-  constructor() { }
 
   projectsArray(): ProjectChecked[] {
     return Object.values(this.projects);

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -1,7 +1,6 @@
 import {
   Component, EventEmitter, Input, Output, OnChanges
 } from '@angular/core';
-//import { orderBy, hasIn } from 'lodash/fp';
 
 import { ProjectConstants, Project } from 'app/entities/projects/project.model';
 

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -1,94 +1,68 @@
 import {
-  Component, EventEmitter, Input, Output
+  Component, EventEmitter, Input, Output, OnChanges
 } from '@angular/core';
+//import { orderBy, hasIn } from 'lodash/fp';
 
 import { ProjectConstants, Project } from 'app/entities/projects/project.model';
 
 const { UNASSIGNED_PROJECT_ID } = ProjectConstants;
+
+export interface ProjectChecked extends Project {
+  checked: boolean;
+}
+
+export function projectCheckedFromProject(project: Project, checked: boolean): ProjectChecked {
+  const projectChecked = <ProjectChecked>project;
+  projectChecked.checked = checked;
+  return projectChecked;
+}
 
 @Component({
   selector: 'app-projects-dropdown',
   templateUrl: './projects-dropdown.component.html',
   styleUrls: ['./projects-dropdown.component.scss']
 })
-export class ProjectsDropdownComponent {
-
-  // The array of projects that you pass into the component.
-  @Input() projects: Array<Project> = [];
-
-  // Setting required to true means the dropdown will show an error if a user tries to close the
-  // dropdown but hasn't selected any projects.
-  @Input() required = false;
+export class ProjectsDropdownComponent implements OnChanges {
+  // The map of ProjectChecked by id. Any checked changes propogated via
+  // onProjectChecked. Updates should be applied to parent component state.
+  @Input() projects: { [id: string]: ProjectChecked } = {};
 
   // Setting disabled to true means the dropdown will be unusable and will have a grey background
   @Input() disabled = false;
 
-  // Emits the array of projects to the parent component
-  @Output() onSelection = new EventEmitter<Array<Project>>();
+  // Emits a project that changed as a result of a check or uncheck.
+  @Output() onProjectChecked = new EventEmitter<ProjectChecked>();
 
   active = false;
-  showError = false;
   label = UNASSIGNED_PROJECT_ID;
-
-  // Map of projects currently selected
-  selectedProjects: { [id: string]: Project } = {};
 
   constructor() { }
 
-  // If you want to mark some projects as pre-selected, use @ViewChild.
-  // See team-details.component.ts for an example.
-  public updateSelectedProjects(project: Project, enabled: boolean): void {
-    console.log('update');
-    console.log(project);
-    console.log(enabled);
-    console.log(this.selectedProjects);
-    if (enabled) {
-      this.selectedProjects[project.id] = project;
-    } else {
-      delete this.selectedProjects[project.id];
-    }
-    this.updateLabel();
+  projectsArray(): ProjectChecked[] {
+    return Object.values(this.projects) ? Object.values(this.projects) : [];
   }
 
-  projectSelected(project: Project): boolean {
-    return this.selectedProjects[project.id] !== undefined;
+  ngOnChanges() {
+    this.updateLabel();
   }
 
   toggleDropdown(event: MouseEvent): void {
     event.stopPropagation();
     if (this.disabled) { return; }
 
-    if (this.active) {
-      this.closeDropdown();
-    } else {
-      this.active = true;
-    }
+    this.active = !this.active;
+  }
+
+  projectChecked(checked: boolean, project: ProjectChecked): void {
+    project.checked = checked;
+    this.updateLabel();
+    this.onProjectChecked.emit(project);
   }
 
   closeDropdown(): void {
-    const isValidSelection = this.validateSelection(this.required);
-
-    if (!isValidSelection) {
-      this.showError = true;
-      return;
-    } else {
-      this.showError = false;
-    }
-
     if (this.active) {
-      const result = <Project[]>Object.values(this.selectedProjects);
-      const resultProjects = result.map(p => <Project>{
-        id: p.id,
-        name: p.name,
-        type: p.type
-      });
-      this.onSelection.emit(resultProjects);
       this.active = false;
     }
-  }
-
-  updateProjects(checked: boolean, index: number): void {
-    this.updateSelectedProjects(this.projects[index], checked);
   }
 
   moveFocus(event: KeyboardEvent): void {
@@ -109,11 +83,11 @@ export class ProjectsDropdownComponent {
     }
   }
 
-  private updateLabel(): void {
-    const selectedLen = Object.keys(this.selectedProjects).length;
-    switch (selectedLen) {
+  updateLabel(): void {
+    const checkedProjects = this.projectsArray().filter(p => p.checked);
+    switch (checkedProjects.length) {
       case 1: {
-        const onlyProject = <Project>Object.values(this.selectedProjects)[0];
+        const onlyProject = checkedProjects[0];
         this.label = onlyProject.name;
         break;
       }
@@ -122,13 +96,9 @@ export class ProjectsDropdownComponent {
         break;
       }
       default: {
-        this.label = `${selectedLen} projects`;
+        this.label = `${checkedProjects.length} projects`;
         break;
       }
     }
-  }
-
-  private validateSelection(isRequired): boolean {
-    return !isRequired || (isRequired && Object.keys(this.selectedProjects).length > 0);
   }
 }

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -13,6 +13,10 @@ export interface ProjectChecked extends Project {
   checked: boolean;
 }
 
+export interface ProjectCheckedMap {
+  [id: string]: ProjectChecked;
+}
+
 @Component({
   selector: 'app-projects-dropdown',
   templateUrl: './projects-dropdown.component.html',
@@ -21,7 +25,7 @@ export interface ProjectChecked extends Project {
 export class ProjectsDropdownComponent implements OnChanges {
   // The map of ProjectChecked by id. Any checked changes propagated via
   // onProjectChecked. Updates should be applied to parent component state.
-  @Input() projects: { [id: string]: ProjectChecked } = {};
+  @Input() projects: ProjectCheckedMap = {};
 
   // Setting disabled to true means the dropdown will be unusable and will have a grey background
   @Input() disabled = false;
@@ -77,7 +81,7 @@ export class ProjectsDropdownComponent implements OnChanges {
     }
   }
 
-  updateLabel(): void {
+  private updateLabel(): void {
     const checkedProjects = this.projectsArray().filter(p => p.checked);
     switch (checkedProjects.length) {
       case 1: {

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -10,12 +10,6 @@ export interface ProjectChecked extends Project {
   checked: boolean;
 }
 
-export function projectCheckedFromProject(project: Project, checked: boolean): ProjectChecked {
-  const projectChecked = <ProjectChecked>project;
-  projectChecked.checked = checked;
-  return projectChecked;
-}
-
 @Component({
   selector: 'app-projects-dropdown',
   templateUrl: './projects-dropdown.component.html',
@@ -38,7 +32,7 @@ export class ProjectsDropdownComponent implements OnChanges {
   constructor() { }
 
   projectsArray(): ProjectChecked[] {
-    return Object.values(this.projects) ? Object.values(this.projects) : [];
+    return Object.values(this.projects);
   }
 
   ngOnChanges() {

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -35,7 +35,7 @@ export class ProjectsDropdownComponent implements OnChanges {
     return Object.values(this.projects);
   }
 
-  ngOnChanges() {
+  ngOnChanges(): void {
     this.updateLabel();
   }
 

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -16,7 +16,7 @@ export interface ProjectChecked extends Project {
   styleUrls: ['./projects-dropdown.component.scss']
 })
 export class ProjectsDropdownComponent implements OnChanges {
-  // The map of ProjectChecked by id. Any checked changes propogated via
+  // The map of ProjectChecked by id. Any checked changes propagated via
   // onProjectChecked. Updates should be applied to parent component state.
   @Input() projects: { [id: string]: ProjectChecked } = {};
 

--- a/components/automate-ui/src/app/entities/projects/project.model.ts
+++ b/components/automate-ui/src/app/entities/projects/project.model.ts
@@ -1,3 +1,5 @@
+import { orderBy } from 'lodash/fp';
+
 import { IAMType } from '../policies/policy.model';
 import { ProjectStatus } from '../rules/rule.model';
 
@@ -6,6 +8,10 @@ export interface Project {
   name: string;
   type: IAMType;
   status: ProjectStatus;
+}
+
+export function sortProjectsByName(projects: Array<Project>): Array<Project> {
+  return orderBy(['name'], ['asc'], projects);
 }
 
 export class ProjectConstants {

--- a/components/automate-ui/src/app/entities/teams/team.reducer.ts
+++ b/components/automate-ui/src/app/entities/teams/team.reducer.ts
@@ -80,7 +80,7 @@ export function teamEntityReducer(state: TeamEntityState = TeamEntityInitialStat
       return set(
         'getStatus',
         EntityStatus.loadingSuccess,
-        teamEntityAdapter.addOne(action.payload, state)
+        teamEntityAdapter.upsertOne(action.payload, state)
       ) as TeamEntityState;
     }
 

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -1,5 +1,5 @@
 <button class="dropdown-label"
-  data-cy="projects-filter-button"
+  id="projects-filter-button"
   aria-label="Projects filter"
   [attr.title]="selectionLabel"
   [disabled]="!dropdownCaretVisible"
@@ -13,7 +13,7 @@
   <chef-icon *ngIf="dropdownCaretVisible" aria-hidden>keyboard_arrow_down</chef-icon>
 </button>
 <chef-click-outside omit="dropdown-label" (clickOutside)="handleEscape()">
-  <chef-dropdown class="dropdown" data-cy="projects-filter-dropdown" [attr.visible]="dropdownActive" (keydown.esc)="handleEscape()">
+  <chef-dropdown class="dropdown" id="projects-filter-dropdown" [attr.visible]="dropdownActive" (keydown.esc)="handleEscape()">
     <div class="dropdown-body">
       <span class="optgroup-label">Projects</span>
       <chef-checkbox
@@ -24,7 +24,7 @@
         (keydown.arrowup)="handleArrowUp($event)"
         (keydown.arrowdown)="handleArrowDown($event)">{{ option.label }}</chef-checkbox>
       <div class="dropdown-footer">
-        <chef-button primary [attr.disabled]="!optionsEdited" (click)="handleApplyClick()" data-cy="projects-filter-apply-changes">Apply Changes</chef-button>
+        <chef-button primary [attr.disabled]="!optionsEdited" (click)="handleApplyClick()" id="projects-filter-apply-changes">Apply Changes</chef-button>
       </div>
     </div>
   </chef-dropdown>

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -24,7 +24,7 @@
         (keydown.arrowup)="handleArrowUp($event)"
         (keydown.arrowdown)="handleArrowDown($event)">{{ option.label }}</chef-checkbox>
       <div class="dropdown-footer">
-        <chef-button primary [attr.disabled]="!optionsEdited" (click)="handleApplyClick()">Apply Changes</chef-button>
+        <chef-button primary [attr.disabled]="!optionsEdited" (click)="handleApplyClick()" data-cy="projects-filter-apply-changes">Apply Changes</chef-button>
       </div>
     </div>
   </chef-dropdown>

--- a/components/automate-ui/src/app/pages/component-library/demos/demo-projects-dropdown/demo-projects-dropdown.component.html
+++ b/components/automate-ui/src/app/pages/component-library/demos/demo-projects-dropdown/demo-projects-dropdown.component.html
@@ -4,12 +4,12 @@
 
     <app-projects-dropdown
       [projects]="dropdownProjects"
-      (onSelection)="projectsDropdownAction($event)">
+      (onProjectChecked)="onProjectChecked($event)">
     </app-projects-dropdown>
     <app-projects-dropdown
       [disabled]="true"
       [projects]="dropdownProjects"
-      (onSelection)="projectsDropdownAction($event)">
+      (onProjectChecked)="onProjectChecked($event)">
     </app-projects-dropdown>
   </app-cl-section>
 
@@ -18,7 +18,7 @@
 
     <pre>&lt;app-projects-dropdown
   [projects]="arrayOfProjects"
-  (onSelection)="someFunction($event.detail)"&gt;
+  (onProjectChecked)="someFunction($event)"&gt;
 &lt;/app-projects-dropdown&gt;
 </pre>
   </app-cl-code-section>
@@ -38,30 +38,36 @@ import {{'{'}} Component {{'}'}} from '@angular/core';
 export class DemoProjectsDropdownComponent {{'{'}}
   dropdownProjects = [{{'{'}}
     'name': 'Project 1',
-    'id': 'project-1'
+    'id': 'project-1',
+    'checked': false
   {{'}'}}, {{'{'}}
     'name': 'Project 2',
-    'id': 'project-2'
+    'id': 'project-2',
+    'checked': false
   {{'}'}}, {{'{'}}
     'name': 'Project 3',
-    'id': 'project-3'
+    'id': 'project-3',
+    'checked': false
   {{'}'}}, {{'{'}}
     'name': 'Project 4',
-    'id': 'project-4'
+    'id': 'project-4',
+    'checked': false
   {{'}'}}, {{'{'}}
     'name': 'Project 5',
-    'id': 'project-5'
+    'id': 'project-5',
+    'checked': false
   {{'}'}}, {{'{'}}
     'name':
     `Project 6 Has A Really Ridiculously Long Name and It should Stay on the same line
     Stay on the same line`,
-    'id': 'project-6'
+    'id': 'project-6',
+    'checked': false
 {{'}'}}];
 
 
-  projectsDropdownAction(projects) {{'{'}}
-    console.log('projects:');
-    console.log(projects);
+  onProjectChecked(project) {{'{'}}
+    console.log('this project was checked or unchecked:');
+    console.log(project);
   {{'}'}}
 {{'}'}}
       </pre>
@@ -72,20 +78,18 @@ export class DemoProjectsDropdownComponent {{'{'}}
     <h3>API</h3>
 
     <app-cl-api>
-      <api-prop name="projects" type="Array" required>
-        Array of projects to be passed to the dropdown
+      <api-prop name="projects" type="[id: string]: ProjectChecked" required>
+        The map of ProjectChecked by id. Any checked changes propogated via
+        onProjectChecked. Updates should be applied to parent component state.
       </api-prop>
 
-      <api-prop name="onSelection" type="Function(Array): void" required>
-        Emits the array of projects that has been selected
+      <api-prop name="onProjectChecked" type="Function(ProjectChecked): void" required>
+        Emits an updated project that has been checked or unchecked. Keep projects input
+        up to date in parent.
       </api-prop>
 
       <api-prop name="disabled" type="Boolean" default="false">
         Specify whether the dropdown should be disabled.
-      </api-prop>
-
-      <api-prop name="required" type="Boolean" default="false">
-        Specify whether the dropdown is a required element to fill out.
       </api-prop>
     </app-cl-api>
   </app-cl-section>

--- a/components/automate-ui/src/app/pages/component-library/demos/demo-projects-dropdown/demo-projects-dropdown.component.html
+++ b/components/automate-ui/src/app/pages/component-library/demos/demo-projects-dropdown/demo-projects-dropdown.component.html
@@ -79,7 +79,7 @@ export class DemoProjectsDropdownComponent {{'{'}}
 
     <app-cl-api>
       <api-prop name="projects" type="[id: string]: ProjectChecked" required>
-        The map of ProjectChecked by id. Any checked changes propogated via
+        The map of ProjectChecked by id. Any checked changes propagated via
         onProjectChecked. Updates should be applied to parent component state.
       </api-prop>
 

--- a/components/automate-ui/src/app/pages/component-library/demos/demo-projects-dropdown/demo-projects-dropdown.component.html
+++ b/components/automate-ui/src/app/pages/component-library/demos/demo-projects-dropdown/demo-projects-dropdown.component.html
@@ -78,7 +78,7 @@ export class DemoProjectsDropdownComponent {{'{'}}
     <h3>API</h3>
 
     <app-cl-api>
-      <api-prop name="projects" type="[id: string]: ProjectChecked" required>
+      <api-prop name="projects" type="ProjectCheckedMap" required>
         The map of ProjectChecked by id. Any checked changes propagated via
         onProjectChecked. Updates should be applied to parent component state.
       </api-prop>

--- a/components/automate-ui/src/app/pages/component-library/demos/demo-projects-dropdown/demo-projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/pages/component-library/demos/demo-projects-dropdown/demo-projects-dropdown.component.ts
@@ -8,29 +8,35 @@ import { Component } from '@angular/core';
 export class DemoProjectsDropdownComponent {
   dropdownProjects = [{
     'name': 'Project 1',
-    'id': 'project-1'
+    'id': 'project-1',
+    'checked': false
   }, {
     'name': 'Project 2',
-    'id': 'project-2'
+    'id': 'project-2',
+    'checked': false
   }, {
     'name': 'Project 3',
-    'id': 'project-3'
+    'id': 'project-3',
+    'checked': false
   }, {
     'name': 'Project 4',
-    'id': 'project-4'
+    'id': 'project-4',
+    'checked': false
   }, {
     'name': 'Project 5',
-    'id': 'project-5'
+    'id': 'project-5',
+    'checked': false
   }, {
     'name':
     `Project 6 Has A Really Ridiculously Long Name and It should Stay on the same line
     Stay on the same line`,
-    'id': 'project-6'
+    'id': 'project-6',
+    'checked': false
   }];
 
 
-  projectsDropdownAction(projects) {
-    console.log('projects:');
-    console.log(projects);
+  onProjectChecked(project) {
+    console.log('this project was checked or unchecked:');
+    console.log(project);
   }
 }

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -4,8 +4,8 @@
   <main>
     <chef-breadcrumbs>
       <chef-breadcrumb [link]="['/settings/teams']">Teams</chef-breadcrumb>
-      <span  *ngIf="isMajorV1">{{ team.id }}</span>
-      <span  *ngIf="!isMajorV1">{{ team.name }}</span>
+      <span *ngIf="isMajorV1">{{ team.id }}</span>
+      <span *ngIf="!isMajorV1">{{ team.name }}</span>
     </chef-breadcrumbs>
 
     <chef-page-header>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -74,9 +74,9 @@
       </form>
       <div id='projects-container' *ngIf="!isMajorV1 && isMinorV1">
         <app-projects-dropdown
-          [projects]="dropdownProjects"
-          (onSelection)="projectsDropdownAction($event)"
-          [disabled]="dropdownProjects.length === 0 || teamProjectsLeftToFetch.length !== 0">
+          [projects]="projects"
+          (onProjectChecked)="onProjectChecked($event)"
+          [disabled]="dropdownDisabled()">
         </app-projects-dropdown>
         <chef-loading-spinner  size="30" *ngIf="teamProjectsLeftToFetch.length !== 0"></chef-loading-spinner>
       </div>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -72,8 +72,16 @@
           </chef-error>
         </chef-form-field>
       </form>
-      <chef-button [disabled]="isLoading || !updateNameForm.valid || updateNameForm.controls['name'].value === team.name"
-        primary inline (click)="saveNameChange()">
+      <div id='projects-container' *ngIf="!isMajorV1 && isMinorV1">
+        <app-projects-dropdown
+          [projects]="dropdownProjects"
+          (onSelection)="projectsDropdownAction($event)"
+          [disabled]="dropdownProjects.length === 0 || teamProjectsLeftToFetch.length !== 0">
+        </app-projects-dropdown>
+        <chef-loading-spinner  size="30" *ngIf="teamProjectsLeftToFetch.length !== 0"></chef-loading-spinner>
+      </div>
+      <chef-button [disabled]="isLoadingTeam || teamProjectsLeftToFetch.length !== 0 || !updateNameForm.valid || (updateNameForm.controls['name'].value === team.name && noProjectsUpdated())"
+        primary inline (click)="updateTeam()">
         <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
         <span *ngIf="saving">Saving...</span>
         <span *ngIf="!saving">Save</span>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -40,7 +40,7 @@
 
       <chef-tab-selector (change)="onSelectedTab($event)" [value]="tabValue">
         <chef-option value='users'>Users</chef-option>
-        <chef-option value='details'>Details</chef-option>
+        <chef-option value='details' data-cy="team-details-tab-details">Details</chef-option>
       </chef-tab-selector>
     </chef-page-header>
     <section class="page-body" *ngIf="team.id && (tabValue === 'users')">
@@ -65,7 +65,7 @@
       <form [formGroup]="updateNameForm">
         <chef-form-field>
           <label>{{ descriptionOrName | titlecase }} <span aria-hidden="true">*</span></label>
-          <input chefInput formControlName="name" type="text" (keyup)="keyPressed()" autocomplete="off">
+          <input chefInput formControlName="name" type="text" (keyup)="keyPressed()" autocomplete="off" data-cy="team-details-name-input">
           <chef-error
             *ngIf="(updateNameForm.get('name').hasError('required') || updateNameForm.get('name').hasError('pattern')) && updateNameForm.get('name').dirty">
             {{ descriptionOrName | titlecase }} is required.
@@ -81,7 +81,7 @@
         <chef-loading-spinner  size="30" *ngIf="teamProjectsLeftToFetch.length !== 0"></chef-loading-spinner>
       </div>
       <chef-button [disabled]="isLoadingTeam || teamProjectsLeftToFetch.length !== 0 || !updateNameForm.valid || (updateNameForm.controls['name'].value === team.name && noProjectsUpdated())"
-        primary inline (click)="updateTeam()">
+        primary inline (click)="updateTeam()" data-cy="team-details-submit-button">
         <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
         <span *ngIf="saving">Saving...</span>
         <span *ngIf="!saving">Save</span>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.scss
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.scss
@@ -50,7 +50,20 @@ section {
   }
 
   chef-form-field {
-    width: 240px;
+    width: 310px;
+  }
+
+  #projects-container {
+    display: flex;
+
+    chef-loading-spinner {
+      margin-top: 40px;
+      margin-left: 10px;
+    }
+
+    app-projects-dropdown {
+      width: 310px;
+    }
   }
 
   chef-button {

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.scss
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.scss
@@ -49,6 +49,10 @@ section {
     font-size: 12px;
   }
 
+  #projects-container {
+    margin-bottom: 26px;
+  }
+
   chef-form-field {
     width: 310px;
   }

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.scss
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.scss
@@ -49,16 +49,13 @@ section {
     font-size: 12px;
   }
 
-  #projects-container {
-    margin-bottom: 26px;
-  }
-
   chef-form-field {
     width: 310px;
   }
 
   #projects-container {
     display: flex;
+    margin-bottom: 38px;
 
     chef-loading-spinner {
       margin-top: 40px;

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
@@ -25,9 +25,13 @@ import {
 } from 'app/entities/teams/team.actions';
 import { Team } from 'app/entities/teams/team.model';
 import { TeamDetailsComponent } from './team-details.component';
-import { projectsFilterReducer } from 'app/services/projects-filter/projects-filter.reducer';
 import {
-  projectEntityReducer
+  projectsFilterReducer,
+  projectsFilterInitialState
+} from 'app/services/projects-filter/projects-filter.reducer';
+import {
+  projectEntityReducer,
+  ProjectEntityInitialState
 } from 'app/entities/projects/project.reducer';
 
 describe('TeamDetailsComponent', () => {
@@ -47,7 +51,9 @@ describe('TeamDetailsComponent', () => {
     },
     users: UserEntityInitialState,
     teams: TeamEntityInitialState,
-    policies: PolicyEntityInitialState
+    policies: PolicyEntityInitialState,
+    projects: ProjectEntityInitialState,
+    projectsFilter: projectsFilterInitialState
   };
 
   beforeEach(async(() => {

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
@@ -25,6 +25,10 @@ import {
 } from 'app/entities/teams/team.actions';
 import { Team } from 'app/entities/teams/team.model';
 import { TeamDetailsComponent } from './team-details.component';
+import { projectsFilterReducer } from 'app/services/projects-filter/projects-filter.reducer';
+import {
+  projectEntityReducer
+} from 'app/entities/projects/project.reducer';
 
 describe('TeamDetailsComponent', () => {
   let component: TeamDetailsComponent;
@@ -72,6 +76,8 @@ describe('TeamDetailsComponent', () => {
         MockComponent({ selector: 'chef-heading' }),
         MockComponent({ selector: 'chef-subheading' }),
         MockComponent({ selector: 'chef-loading-spinner' }),
+        MockComponent({ selector: 'app-projects-dropdown',
+          inputs: ['projects', 'disabled'], outputs: ['onProjectChecked'] }),
         MockComponent({ selector: 'chef-tab-selector',
           inputs: ['value', 'routerLink', 'fragment']
         }),
@@ -84,7 +90,9 @@ describe('TeamDetailsComponent', () => {
           router: routerReducer,
           teams: teamEntityReducer,
           users: userEntityReducer,
-          policies: policyEntityReducer
+          policies: policyEntityReducer,
+          projects: projectEntityReducer,
+          projectsFilter: projectsFilterReducer
         }, { initialState })
       ]
     }).compileComponents();

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -305,7 +305,6 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   noProjectsUpdated(): boolean {
     return xor(this.team.projects,
       Object.values(this.projects).filter(p => p.checked).map(p => p.id)).length === 0;
-
   }
 
   dropdownDisabled(): boolean {

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -134,7 +134,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     this.store.select(assignableProjects)
       .subscribe((assignable: ProjectsFilterOption[]) => {
         assignable.forEach(({ value: id, label: name, type: stringType }) => {
-          const type = <IAMType>stringType;
+          const type: IAMType = stringType;
           const proj: Project = { id, name, type};
           // we don't want to override values that we fetched
           // that were part of the team already

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -219,7 +219,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     combineLatest([
       this.store.select(getProjectStatus),
       this.store.select(projectEntities)])
-      .pipe(filter(([status, _]) => status === EntityStatus.loadingSuccess),
+      .pipe(filter(([status, _]: [EntityStatus, ProjectMap]) => status === EntityStatus.loadingSuccess),
         map(([_, projectMap]) => {
           const projectsFound: { [id: string]: boolean } = {};
           this.teamProjectsLeftToFetch.forEach(pID => {

--- a/components/automate-ui/src/app/pages/team-management/team-management.component.ts
+++ b/components/automate-ui/src/app/pages/team-management/team-management.component.ts
@@ -21,7 +21,7 @@ import { Regex } from 'app/helpers/auth/regex';
 import { HttpStatus } from 'app/types/types';
 import { assignableProjects } from 'app/services/projects-filter/projects-filter.selectors';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
-import { Project, ProjectConstants, sortProjectsByName } from 'app/entities/projects/project.model';
+import { Project, ProjectConstants } from 'app/entities/projects/project.model';
 
 @Component({
   selector: 'app-team-management',
@@ -106,13 +106,13 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
 
     this.store.select(assignableProjects)
       .subscribe((assignable: ProjectsFilterOption[]) => {
-        this.dropdownProjects = sortProjectsByName(assignable.map(p => {
+        this.dropdownProjects = assignable.map(p => {
           return <Project>{
             id: p.value,
             name: p.label,
             type: p.type
           };
-        }));
+        });
       });
   }
 

--- a/components/automate-ui/src/app/pages/team-management/team-management.component.ts
+++ b/components/automate-ui/src/app/pages/team-management/team-management.component.ts
@@ -21,7 +21,7 @@ import { Regex } from 'app/helpers/auth/regex';
 import { HttpStatus } from 'app/types/types';
 import { assignableProjects } from 'app/services/projects-filter/projects-filter.selectors';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
-import { Project, ProjectConstants } from 'app/entities/projects/project.model';
+import { Project, ProjectConstants, sortProjectsByName } from 'app/entities/projects/project.model';
 
 @Component({
   selector: 'app-team-management',
@@ -106,13 +106,13 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
 
     this.store.select(assignableProjects)
       .subscribe((assignable: ProjectsFilterOption[]) => {
-        this.dropdownProjects = assignable.map(p => {
+        this.dropdownProjects = sortProjectsByName(assignable.map(p => {
           return <Project>{
             id: p.value,
             name: p.label,
             type: p.type
           };
-        });
+        }));
       });
   }
 

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -43,11 +43,14 @@ export class ProjectsFilterService {
     // This is a dummy URL but it must exist in the routing module.
     const reloadUrl = '/reload';
 
+    console.log('before');
     // The router only routes if the route changes.
     // This first switches to somewhere-that-is-not-here
     // then back to here, so the router will do its thing.
+    console.log(currentUrl);
     this.router.navigateByUrl(reloadUrl, { skipLocationChange: true })
       .then(() => this.router.navigateByUrl(currentUrl, { skipLocationChange: true }));
+    console.log('after');
   }
 
   restoreOptions(): ProjectsFilterOption[] {

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -43,14 +43,11 @@ export class ProjectsFilterService {
     // This is a dummy URL but it must exist in the routing module.
     const reloadUrl = '/reload';
 
-    console.log('before');
     // The router only routes if the route changes.
     // This first switches to somewhere-that-is-not-here
     // then back to here, so the router will do its thing.
-    console.log(currentUrl);
     this.router.navigateByUrl(reloadUrl, { skipLocationChange: true })
       .then(() => this.router.navigateByUrl(currentUrl, { skipLocationChange: true }));
-    console.log('after');
   }
 
   restoreOptions(): ProjectsFilterOption[] {

--- a/e2e/cypress/index.d.ts
+++ b/e2e/cypress/index.d.ts
@@ -6,6 +6,7 @@ declare namespace Cypress {
     logout(): Cypress.Chainable<Object>
     saveStorage(): void
     restoreStorage(): void
+    applyProjectsFilter(projectsToFilterOn: string[]): void
     generateAdminToken(idToken: string): void
     cleanupPoliciesByIDPrefix(idToken: string, idPrefix: string): void
     cleanupProjectsByIDPrefix(idToken: string, idPrefix: string): void

--- a/e2e/cypress/integration/ui/common/02_global_filter.spec.ts
+++ b/e2e/cypress/integration/ui/common/02_global_filter.spec.ts
@@ -37,13 +37,13 @@ describe('global projects filter', () => {
         // Cypress.ObjectLike can't be casted to a string directly,
         // so must convert to Object type (common to all JS objects) first
         if (<string><Object>obj === 'v1') {
-          cy.get('[data-cy=projects-filter-button]').click();
+          cy.get('#projects-filter-button').click();
 
           const allowedProjects = [proj1.name, proj2.name, proj3.name, '(unassigned)'];
           // we don't check that projects in dropdown match *exactly* as
           // we can't control creation of other projects in the test env
           allowedProjects.forEach(project => {
-            cy.get('[data-cy=projects-filter-dropdown]').contains(project);
+            cy.get('#projects-filter-dropdown').contains(project);
           });
         }
       });

--- a/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
@@ -130,8 +130,6 @@ describe('team management', () => {
   });
 
   describeProjectsEnabled('team create modal with projects (IAM v2.1 only)', () => {
-    const unusedProject = 'cypress-unused';
-    const STORE_OPTIONS_KEY = 'projectsFilter.options';
     const dropdownNameUntilEllipsisLen = 25;
 
     context('when only the unassigned project is selected', () => {

--- a/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
@@ -149,10 +149,10 @@ describe('team management', () => {
         cy.get('[data-cy=id-label]').contains(generatedTeamID);
 
         // initial state of dropdown
-        cy.get('app-projects-dropdown #projects-selected').contains(unassigned);
-
-        // TODO (tc) why doesn't this work?
-        // cy.get('app-projects-dropdown .dropdown-button').should('have.attr', 'disabled', true);
+        cy.get('app-team-management app-projects-dropdown #projects-selected')
+          .contains(unassigned);
+        cy.get('app-team-management app-projects-dropdown .dropdown-button')
+          .should('have.attr', 'disabled');
 
         // save team
         cy.get('[data-cy=save-button]').click();
@@ -188,21 +188,23 @@ describe('team management', () => {
         cy.get('[data-cy=id-label]').contains(generatedTeamID);
 
         // initial state of dropdown
-        cy.get('app-projects-dropdown #projects-selected').contains(unassigned);
-        cy.get('app-projects-dropdown .dropdown-button').should('not.have.attr', 'disabled');
+        cy.get('app-team-management app-projects-dropdown #projects-selected').contains(unassigned);
+        cy.get('app-team-management app-projects-dropdown .dropdown-button')
+          .should('not.have.attr', 'disabled');
 
         // open projects dropdown
-        cy.get('app-projects-dropdown .dropdown-button').click();
+        cy.get('app-team-management app-projects-dropdown .dropdown-button').click();
 
         // dropdown contains both custom projects, click them both
-        cy.get('app-projects-dropdown chef-dropdown')
-          .children('chef-checkbox').contains(project1Name).click();
-        cy.get('app-projects-dropdown chef-dropdown')
-          .children('chef-checkbox').contains(project2Name).click();
+        cy.get(`app-team-management app-projects-dropdown chef-checkbox[title="${project1Name}"]`)
+          .should('have.attr', 'aria-checked', 'false').click();
+        cy.get(`app-team-management app-projects-dropdown chef-checkbox[title="${project2Name}"]`)
+          .should('have.attr', 'aria-checked', 'false').click();
 
         // close projects dropdown
-        cy.get('app-projects-dropdown .dropdown-button').click();
-        cy.get('app-projects-dropdown #projects-selected').contains(projectSummary);
+        cy.get('app-team-management app-projects-dropdown .dropdown-button').click();
+        cy.get('app-team-management app-projects-dropdown #projects-selected')
+          .contains(projectSummary);
 
         // save team
         cy.get('[data-cy=save-button]').click();
@@ -221,21 +223,22 @@ describe('team management', () => {
         cy.get('[data-cy=id-label]').contains(generatedTeamID);
 
         // initial state of dropdown
-        cy.get('app-projects-dropdown #projects-selected').contains(unassigned);
-        cy.get('app-projects-dropdown .dropdown-button').should('not.have.attr', 'disabled');
+        cy.get('app-team-management app-projects-dropdown #projects-selected').contains(unassigned);
+        cy.get('app-team-management app-projects-dropdown .dropdown-button')
+          .should('not.have.attr', 'disabled');
 
         // open projects dropdown
-        cy.get('app-projects-dropdown .dropdown-button').click();
+        cy.get('app-team-management app-projects-dropdown .dropdown-button').click();
 
         // dropdown contains both custom projects, click one
-        cy.get('app-projects-dropdown chef-dropdown')
-          .children('chef-checkbox').contains(project1Name);
-        cy.get('app-projects-dropdown chef-dropdown')
-          .children('chef-checkbox').contains(project2Name).click();
+        cy.get(`app-team-management app-projects-dropdown chef-checkbox[title="${project1Name}"]`)
+          .should('have.attr', 'aria-checked', 'false');
+        cy.get(`app-team-management app-projects-dropdown chef-checkbox[title="${project2Name}"]`)
+          .should('have.attr', 'aria-checked', 'false').click();
 
         // close projects dropdown
-        cy.get('app-projects-dropdown .dropdown-button').click();
-        cy.get('app-projects-dropdown #projects-selected')
+        cy.get('app-team-management app-projects-dropdown .dropdown-button').click();
+        cy.get('app-team-management app-projects-dropdown #projects-selected')
           .contains(`${project2Name.substring(0, dropdownNameUntilEllipsisLen)}...`);
 
         // save team
@@ -255,17 +258,18 @@ describe('team management', () => {
         cy.get('[data-cy=id-label]').contains(generatedTeamID);
 
         // initial state of dropdown
-        cy.get('app-projects-dropdown #projects-selected').contains(unassigned);
-        cy.get('app-projects-dropdown .dropdown-button').should('not.have.attr', 'disabled');
+        cy.get('app-team-management app-projects-dropdown #projects-selected').contains(unassigned);
+        cy.get('app-team-management app-projects-dropdown .dropdown-button')
+          .should('not.have.attr', 'disabled');
 
         // open projects dropdown
-        cy.get('app-projects-dropdown .dropdown-button').click();
+        cy.get('app-team-management app-projects-dropdown .dropdown-button').click();
 
         // dropdown contains both custom projects, none clicked
-        cy.get('app-projects-dropdown chef-dropdown')
-          .children('chef-checkbox').contains(project1Name);
-        cy.get('app-projects-dropdown chef-dropdown')
-          .children('chef-checkbox').contains(project2Name);
+        cy.get(`app-team-management app-projects-dropdown chef-checkbox[title="${project1Name}"]`)
+          .should('have.attr', 'aria-checked', 'false');
+        cy.get(`app-team-management app-projects-dropdown chef-checkbox[title="${project2Name}"]`)
+          .should('have.attr', 'aria-checked', 'false');
 
         // close projects dropdown
         cy.get('app-projects-dropdown .dropdown-button').click();
@@ -273,7 +277,7 @@ describe('team management', () => {
 
         // save team
         cy.get('[data-cy=save-button]').click();
-        cy.get('app-team-management chef-modal').should('not.be.visible');
+        cy.get('app-team-management app-team-management chef-modal').should('not.be.visible');
         cy.get('chef-notification.info').should('be.visible');
         cy.contains(teamName).should('exist');
         cy.contains(generatedTeamID).should('exist');

--- a/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
@@ -53,6 +53,10 @@ describe('team management', () => {
     cy.restoreStorage();
   });
 
+  beforeEach(() => {
+    cy.restoreStorage();
+  });
+
   afterEach(() => {
     cy.saveStorage();
     cy.cleanupTeamsByDescriptionPrefix(adminToken, cypressPrefix);

--- a/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
+++ b/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
@@ -1,6 +1,6 @@
 describe('team add users', () => {
   const now = Cypress.moment().format('MMDDYYhhmm');
-  const cypressPrefix = 'cypress test';
+  const cypressPrefix = 'cypress-test';
   const nameForUser = cypressPrefix + ' user ' + now;
   const usernameForUser = 'testing-user-' + now;
   const descriptionForTeam = cypressPrefix + ' team ' + now;

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -107,10 +107,16 @@ describe('team management', () => {
   });
 
   it('displays team details for admins team', () => {
+    let title = '';
+    if (iamVersion.match(/v2/)) {
+      title = teamName;
+    } else {
+      title = teamID;
+    }
     cy.get('chef-breadcrumbs').contains('Teams');
-    cy.get('chef-breadcrumbs').contains(teamName);
+    cy.get('chef-breadcrumbs').contains(title);
 
-    cy.get('.page-title').contains(teamName);
+    cy.get('.page-title').contains(title);
     cy.contains('Add User');
   });
 

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -96,27 +96,33 @@ describe('team management', () => {
         cy.get('app-welcome-modal').invoke('hide');
       });
     });
+  });
 
+  beforeEach(() => {
     cy.restoreStorage();
   });
 
-  // it('displays team details for admins team', () => {
-  //   cy.get('chef-breadcrumbs').contains('Teams');
-  //   cy.get('chef-breadcrumbs').contains(teamName);
+  afterEach(() => {
+    cy.saveStorage();
+  });
 
-  //   cy.get('.page-title').contains(teamName);
-  //   cy.contains('Add User');
-  // });
+  it('displays team details for admins team', () => {
+    cy.get('chef-breadcrumbs').contains('Teams');
+    cy.get('chef-breadcrumbs').contains(teamName);
 
-  // context('when the team has users', () => {
-  //   it('displays team users', () => {
-  //     cy.get('chef-option').contains('Users');
-  //     cy.get('app-user-table chef-th').contains('Name');
-  //     cy.get('app-user-table chef-th').contains('Username');
-  //     cy.get('app-user-table chef-td').contains(usernameForUser);
-  //     cy.get('app-user-table chef-td').contains(nameForUser);
-  //   });
-  // });
+    cy.get('.page-title').contains(teamName);
+    cy.contains('Add User');
+  });
+
+  context('when the team has users', () => {
+    it('displays team users', () => {
+      cy.get('chef-option').contains('Users');
+      cy.get('app-user-table chef-th').contains('Name');
+      cy.get('app-user-table chef-th').contains('Username');
+      cy.get('app-user-table chef-td').contains(usernameForUser);
+      cy.get('app-user-table chef-td').contains(nameForUser);
+    });
+  });
 
   describeProjectsEnabled('update team projects (IAM v2.1 only)', () => {
     const dropdownNameUntilEllipsisLen = 25;
@@ -126,18 +132,18 @@ describe('team management', () => {
         cy.applyProjectsFilter([unassigned]);
       });
 
-      // it('cannot access projects dropdown but changing name allows team update submission', () => {
-      //   cy.get('[data-cy=team-details-tab-details]').click();
-      //   cy.get('[data-cy=team-details-name-input]').should('have.value', teamName);
-      //   cy.get('[data-cy=team-details-submit-button]').should('have.attr', 'aria-disabled');
+      it('cannot access projects dropdown but changing name allows team update submission', () => {
+        cy.get('[data-cy=team-details-tab-details]').click();
+        cy.get('[data-cy=team-details-name-input]').should('have.value', teamName);
+        cy.get('[data-cy=team-details-submit-button]').should('have.attr', 'aria-disabled');
 
-      //   // initial state of dropdown
-      //   cy.get('app-team-details app-projects-dropdown #projects-selected').contains(unassigned);
-      //   cy.get('app-projects-dropdown .dropdown-button').should('have.attr', 'disabled');
+        // initial state of dropdown
+        cy.get('app-team-details app-projects-dropdown #projects-selected').contains(unassigned);
+        cy.get('app-projects-dropdown .dropdown-button').should('have.attr', 'disabled');
 
-      //   cy.get('[data-cy=team-details-name-input]').type('updated name');
-      //   cy.get('[data-cy=team-details-submit-button]').should('not.have.attr', 'aria-disabled');
-      // });
+        cy.get('[data-cy=team-details-name-input]').type('updated name');
+        cy.get('[data-cy=team-details-submit-button]').should('not.have.attr', 'aria-disabled');
+      });
     });
 
     context('when the team contains a project', () => {
@@ -169,17 +175,11 @@ describe('team management', () => {
 
       context('when the project filter contains team project and other project', () => {
         beforeEach(() => {
-          cy.route('GET', `/apis/iam/v2beta/projects/${project1ID}`).as('getProjectForTeam');
-
           // TODO (tc): Note that as stands, if you ever update a team to only contain projects
           // not in the project filter -- including (unassigned) -- you'll get an error on save
           // since the project filter is applied to the request to re-fetch the team. Known issue
           // we are going to address in future work.
           cy.applyProjectsFilter([unassigned, project1Name, project2Name]);
-
-          // Wait for the project contained in the team to be fetched. This is necessary
-          // since the element will load before this request does so cypress won't wait.
-          cy.wait('@getProjectForTeam');
         });
 
         it('both are contained in the projects dropdown and the team project is selected,' +

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -169,11 +169,15 @@ describe('team management', () => {
 
       context('when the project filter contains team project and other project', () => {
         beforeEach(() => {
+          cy.route('GET', `/apis/iam/v2beta/projects/${project1ID}`).as('getProjectForTeam');
           // TODO (tc): Note that as stands, if you ever update a team to only contain projects
           // not in the project filter -- including (unassigned) -- you'll get an error on save
           // since the project filter is applied to the request to re-fetch the team. Known issue
           // we are going to address in future work.
           cy.applyProjectsFilter([unassigned, project1Name, project2Name]);
+
+          // Wait for the project contained in the team to 
+          cy.wait('@getProjectForTeam');
         });
 
         it('both are contained in the projects dropdown and the team project is selected,' +
@@ -185,7 +189,8 @@ describe('team management', () => {
           cy.get('[data-cy=team-details-submit-button]').should('have.attr', 'aria-disabled');
 
           // initial state of dropdown
-          cy.get('app-team-details app-projects-dropdown #projects-selected').contains(project1ID);
+          cy.get('app-team-details app-projects-dropdown #projects-selected')
+            .contains(`${project1Name.substring(0, dropdownNameUntilEllipsisLen)}...`);
           cy.get('app-team-details app-projects-dropdown .dropdown-button')
             .should('not.have.attr', 'disabled');
 

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -1,0 +1,120 @@
+describe('team management', () => {
+  let adminToken = '';
+  const now = Cypress.moment().format('MMDDYYhhmm');
+  const cypressPrefix = 'cypress-test';
+  const teamName = `${cypressPrefix} team ${now}`;
+  const teamID = `${cypressPrefix}-testing-team-custom-id-${now}`;
+  const project1ID = `${cypressPrefix}-project1-${now}`;
+  const project1Name = `${cypressPrefix} project1 ${now}`;
+  const project2ID = `${cypressPrefix}-project2-${now}`;
+  const project2Name = `${cypressPrefix} project2 ${now}`;
+  const unassigned = '(unassigned)';
+  let teamUIRouteIdentifier = '';
+  const nameForUser = cypressPrefix + ' user ' + now;
+  const usernameForUser = cypressPrefix + 'testing-user-' + now;
+  let userMembershipID = '';
+
+  let iamVersion = <string><Object>Cypress.env('IAM_VERSION');
+  // assume 2.0 if not in CI. if you wish something different start cypress with
+  // IAM_VERSION set to what you are testing.
+  if (iamVersion === undefined) {
+    iamVersion = 'v2.0';
+  }
+
+  const describeIAMV2 = iamVersion.match(/v2/) ? describe : describe.skip;
+  const describeProjectsEnabled = iamVersion === 'v2.1' ? describe : describe.skip;
+
+  before(() => {
+    cy.adminLogin('/').then(() => {
+      const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
+      adminToken = admin.id_token;
+
+      cy.cleanupUsersByNamePrefix(adminToken, cypressPrefix);
+      cy.cleanupProjectsByIDPrefix(adminToken, cypressPrefix);
+      cy.cleanupTeamsByDescriptionPrefix(adminToken, cypressPrefix);
+
+      cy.request({
+        auth: { bearer: adminToken },
+        method: 'POST',
+        url: '/api/v0/auth/users',
+        body: {
+          username: usernameForUser,
+          name: nameForUser,
+          password: 'chefautomate'
+        }
+      }).then((resp) => {
+        userMembershipID = resp.body.id;
+      });
+
+      cy.request({
+        auth: { bearer: adminToken },
+        method: 'POST',
+        url: '/apis/iam/v2beta/projects',
+        body: {
+          id: project1ID,
+          name: project1Name
+        }
+      });
+
+      cy.request({
+        auth: { bearer: adminToken },
+        method: 'POST',
+        url: '/apis/iam/v2beta/projects',
+        body: {
+          id: project2ID,
+          name: project2Name
+        }
+      });
+
+      cy.request({
+        auth: { bearer: adminToken },
+        method: 'POST',
+        url: '/api/v0/auth/teams',
+        body: {
+          name: teamID,
+          description: teamName
+        }
+      }).then((resp) => {
+        const guid = resp.body.team.id;
+
+        if (iamVersion.match(/v2/)) {
+          teamUIRouteIdentifier = teamID;
+        } else {
+          teamUIRouteIdentifier = guid;
+        }
+
+        cy.request({
+          auth: { bearer: adminToken },
+          method: 'POST',
+          url: `/apis/iam/v2beta/teams/${teamID}/users:add`,
+          body: {
+            user_ids: [userMembershipID]
+          }
+        });
+
+        cy.visit(`/settings/teams/${teamUIRouteIdentifier}`);
+        cy.get('app-welcome-modal').invoke('hide');
+      });
+    });
+
+    cy.restoreStorage();
+  });
+
+  it('displays team details for admins team', () => {
+    cy.get('chef-breadcrumbs').contains('Teams');
+    cy.get('chef-breadcrumbs').contains(teamName);
+
+    cy.get('.page-title').contains(teamName);
+    cy.contains('Add User');
+  });
+
+  context('when the team has users', () => {
+    it('displays team users', () => {
+      cy.get('chef-option').contains('Users');
+      cy.get('app-user-table chef-th').contains('Name');
+      cy.get('app-user-table chef-th').contains('Username');
+      cy.get('app-user-table chef-td').contains(usernameForUser);
+      cy.get('app-user-table chef-td').contains(nameForUser);
+    });
+  });
+});

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -139,7 +139,8 @@ describe('team management', () => {
 
         // initial state of dropdown
         cy.get('app-team-details app-projects-dropdown #projects-selected').contains(unassigned);
-        cy.get('app-projects-dropdown .dropdown-button').should('have.attr', 'disabled');
+        cy.get('app-team-details app-projects-dropdown .dropdown-button')
+          .should('have.attr', 'disabled');
 
         cy.get('[data-cy=team-details-name-input]').type('updated name');
         cy.get('[data-cy=team-details-submit-button]').should('not.have.attr', 'aria-disabled');
@@ -200,9 +201,9 @@ describe('team management', () => {
           cy.get('app-team-details app-projects-dropdown .dropdown-button').click();
 
           // dropdown contains both custom projects, one selected already, click the other
-          cy.get(`app-projects-dropdown chef-checkbox[title="${project1Name}"]`)
+          cy.get(`app-team-details app-projects-dropdown chef-checkbox[title="${project1Name}"]`)
             .should('have.attr', 'aria-checked', 'true');
-          cy.get(`app-projects-dropdown chef-checkbox[title="${project2Name}"]`)
+          cy.get(`app-team-details app-projects-dropdown chef-checkbox[title="${project2Name}"]`)
             .should('have.attr', 'aria-checked', 'false').find('chef-icon').click();
           cy.get('app-team-details app-projects-dropdown .dropdown-button').click();
 
@@ -213,9 +214,9 @@ describe('team management', () => {
 
           // de-select project1 and project2
           cy.get('app-team-details app-projects-dropdown .dropdown-button').click();
-          cy.get(`app-projects-dropdown chef-checkbox[title="${project1Name}"]`)
+          cy.get(`app-team-details app-projects-dropdown chef-checkbox[title="${project1Name}"]`)
             .should('have.attr', 'aria-checked', 'true').find('chef-icon').click();
-          cy.get(`app-projects-dropdown chef-checkbox[title="${project2Name}"]`)
+          cy.get(`app-team-details app-projects-dropdown chef-checkbox[title="${project2Name}"]`)
             .should('have.attr', 'aria-checked', 'true').find('chef-icon').click();
           cy.get('app-team-details app-projects-dropdown .dropdown-button').click();
 

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -126,17 +126,100 @@ describe('team management', () => {
         cy.applyProjectsFilter([unassigned]);
       });
 
-      it('cannot access projects dropdown but changing name allows team update submission', () => {
-        cy.get('[data-cy=team-details-tab-details]').click();
-        cy.get('[data-cy=team-details-name-input]').should('have.value', teamName);
-        cy.get('[data-cy=team-details-submit-button]').should('have.attr', 'aria-disabled');
+      // it('cannot access projects dropdown but changing name allows team update submission', () => {
+      //   cy.get('[data-cy=team-details-tab-details]').click();
+      //   cy.get('[data-cy=team-details-name-input]').should('have.value', teamName);
+      //   cy.get('[data-cy=team-details-submit-button]').should('have.attr', 'aria-disabled');
 
-        // initial state of dropdown
-        cy.get('app-team-details app-projects-dropdown #projects-selected').contains(unassigned);
-        cy.get('app-projects-dropdown .dropdown-button').should('have.attr', 'disabled');
+      //   // initial state of dropdown
+      //   cy.get('app-team-details app-projects-dropdown #projects-selected').contains(unassigned);
+      //   cy.get('app-projects-dropdown .dropdown-button').should('have.attr', 'disabled');
 
-        cy.get('[data-cy=team-details-name-input]').type('updated name');
-        cy.get('[data-cy=team-details-submit-button]').should('not.have.attr', 'aria-disabled');
+      //   cy.get('[data-cy=team-details-name-input]').type('updated name');
+      //   cy.get('[data-cy=team-details-submit-button]').should('not.have.attr', 'aria-disabled');
+      // });
+    });
+
+    context('when the team contains a project', () => {
+      beforeEach(() => {
+        cy.request({
+          auth: { bearer: adminToken },
+          method: 'PUT',
+          url: `/apis/iam/v2beta/teams/${teamUIRouteIdentifier}`,
+          body: {
+            name: teamName,
+            projects: [project1ID]
+          }
+        });
+        cy.reload(true);
+        cy.get('app-welcome-modal').invoke('hide');
+      });
+
+      afterEach(() => {
+        cy.request({
+          auth: { bearer: adminToken },
+          method: 'PUT',
+          url: `/apis/iam/v2beta/teams/${teamUIRouteIdentifier}`,
+          body: {
+            name: teamName,
+            projects: []
+          }
+        });
+      });
+
+      context('when the project filter contains team project and other project', () => {
+        beforeEach(() => {
+          // TODO (tc): Note that as stands, if you ever update a team to only contain projects
+          // not in the project filter -- including (unassigned) -- you'll get an error on save
+          // since the project filter is applied to the request to re-fetch the team. Known issue
+          // we are going to address in future work.
+          cy.applyProjectsFilter([unassigned, project1Name, project2Name]);
+        });
+
+        it('both are contained in the projects dropdown and the team project is selected,' +
+              'and both can be added or removed', () => {
+          const projectSummary = '2 projects';
+
+          cy.get('[data-cy=team-details-tab-details]').click();
+          cy.get('[data-cy=team-details-name-input]').should('have.value', teamName);
+          cy.get('[data-cy=team-details-submit-button]').should('have.attr', 'aria-disabled');
+
+          // initial state of dropdown
+          cy.get('app-team-details app-projects-dropdown #projects-selected').contains(project1ID);
+          cy.get('app-team-details app-projects-dropdown .dropdown-button')
+            .should('not.have.attr', 'disabled');
+
+          // open projects dropdown
+          cy.get('app-team-details app-projects-dropdown .dropdown-button').click();
+
+          // dropdown contains both custom projects, one selected already, click the other
+          cy.get('app-projects-dropdown chef-dropdown')
+            .children('chef-checkbox').contains(project1Name)
+            .should('have.attr', 'aria-checked', 'true');
+          cy.get('app-projects-dropdown chef-dropdown')
+            .children('chef-checkbox').contains(project2Name)
+            .should('not.have.attr', 'aria-checked', 'true').click();
+
+          // save
+          cy.get('app-team-details app-projects-dropdown #projects-selected')
+            .contains(projectSummary);
+          cy.get('[data-cy=team-details-submit-button]')
+            .should('not.have.attr', 'aria-disabled').click();
+
+          // de-select project1 and project2
+          cy.get('app-projects-dropdown chef-dropdown')
+          .children('chef-checkbox').contains(project1Name)
+            .should('have.attr', 'aria-checked', 'true').click();
+          cy.get('app-projects-dropdown chef-dropdown')
+            .children('chef-checkbox').contains(project2Name)
+            .should('have.attr', 'aria-checked', 'true').click();
+
+          // save
+          cy.get('app-team-details app-projects-dropdown #projects-selected')
+            .contains(unassigned);
+          cy.get('[data-cy=team-details-submit-button]')
+            .should('not.have.attr', 'aria-disabled').click();
+        });
       });
     });
   });

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -100,21 +100,44 @@ describe('team management', () => {
     cy.restoreStorage();
   });
 
-  it('displays team details for admins team', () => {
-    cy.get('chef-breadcrumbs').contains('Teams');
-    cy.get('chef-breadcrumbs').contains(teamName);
+  // it('displays team details for admins team', () => {
+  //   cy.get('chef-breadcrumbs').contains('Teams');
+  //   cy.get('chef-breadcrumbs').contains(teamName);
 
-    cy.get('.page-title').contains(teamName);
-    cy.contains('Add User');
-  });
+  //   cy.get('.page-title').contains(teamName);
+  //   cy.contains('Add User');
+  // });
 
-  context('when the team has users', () => {
-    it('displays team users', () => {
-      cy.get('chef-option').contains('Users');
-      cy.get('app-user-table chef-th').contains('Name');
-      cy.get('app-user-table chef-th').contains('Username');
-      cy.get('app-user-table chef-td').contains(usernameForUser);
-      cy.get('app-user-table chef-td').contains(nameForUser);
+  // context('when the team has users', () => {
+  //   it('displays team users', () => {
+  //     cy.get('chef-option').contains('Users');
+  //     cy.get('app-user-table chef-th').contains('Name');
+  //     cy.get('app-user-table chef-th').contains('Username');
+  //     cy.get('app-user-table chef-td').contains(usernameForUser);
+  //     cy.get('app-user-table chef-td').contains(nameForUser);
+  //   });
+  // });
+
+  describeProjectsEnabled('update team projects (IAM v2.1 only)', () => {
+    const dropdownNameUntilEllipsisLen = 25;
+
+    context('when only the unassigned project is selected', () => {
+      beforeEach(() => {
+        cy.applyProjectsFilter([unassigned]);
+      });
+
+      it('cannot access projects dropdown but changing name allows team update submission', () => {
+        cy.get('[data-cy=team-details-tab-details]').click();
+        cy.get('[data-cy=team-details-name-input]').should('have.value', teamName);
+        cy.get('[data-cy=team-details-submit-button]').should('have.attr', 'aria-disabled');
+
+        // initial state of dropdown
+        cy.get('app-team-details app-projects-dropdown #projects-selected').contains(unassigned);
+        cy.get('app-projects-dropdown .dropdown-button').should('have.attr', 'disabled');
+
+        cy.get('[data-cy=team-details-name-input]').type('updated name');
+        cy.get('[data-cy=team-details-submit-button]').should('not.have.attr', 'aria-disabled');
+      });
     });
   });
 });

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -31,26 +31,30 @@ Cypress.Commands.add('logout', () => {
 // check any projects by NAME (not id) passed -- if any -- and apply any changes.
 // if there are no resulting changes to apply, it will simply click out of the filter.
 Cypress.Commands.add('applyProjectsFilter', (projectsToFilterOn: string[]) => {
-  cy.get('[data-cy=projects-filter-button]').click();
-  cy.get('[data-cy=projects-filter-dropdown]').find('chef-checkbox').each(child => {
+  cy.get('app-projects-filter button#projects-filter-button').click();
+  cy.get('app-projects-filter chef-dropdown#projects-filter-dropdown')
+    .find('chef-checkbox').each(child => {
     // deselect every checkbox
-    if (child.attr('aria-checked')) {
+    console.log('wat');
+    console.log(child);
+    console.log(child.attr('aria-checked') === 'true');
+    if (child.attr('aria-checked') === 'true') {
       child.click();
     }
   });
+
   // check all desired checkboxes
   projectsToFilterOn.forEach(proj =>
-    cy.get('[data-cy=projects-filter-dropdown]').contains(proj).parent().click());
-  const applyButton = Cypress.$('[data-cy=projects-filter-apply-changes]');
-  if (applyButton.is('[disabled]')) {
+    cy.get(`chef-checkbox[title="${proj}"]`).find('chef-icon').click());
+
+  if (projectsToFilterOn.length === 0) {
     // no changes to apply, close projects filter
-    cy.get('[data-cy=projects-filter-button]').click();
+    cy.get('app-projects-filter button#projects-filter-button').click();
   } else {
     // apply projects filter
-    applyButton.click();
+    cy.get('app-projects-filter chef-button#projects-filter-apply-changes').click();
   }
 });
-
 
 interface MemoryMap {
   [key: string]: any;

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -27,6 +27,31 @@ Cypress.Commands.add('logout', () => {
   return cy.url().should('include', '/dex/auth');
 });
 
+// applyProjectsFilter will deselect any selected projects from the filter,
+// check any projects by NAME (not id) passed -- if any -- and apply any changes.
+// if there are no resulting changes to apply, it will simply click out of the filter.
+Cypress.Commands.add('applyProjectsFilter', (projectsToFilterOn: string[]) => {
+  cy.get('[data-cy=projects-filter-button]').click();
+  cy.get('[data-cy=projects-filter-dropdown]').find('chef-checkbox').each(child => {
+    // deselect every checkbox
+    if (child.attr('aria-checked')) {
+      child.click();
+    }
+  });
+  // check all desired checkboxes
+  projectsToFilterOn.forEach(proj =>
+    cy.get('[data-cy=projects-filter-dropdown]').contains(proj).parent().click());
+  const applyButton = Cypress.$('[data-cy=projects-filter-apply-changes]');
+  if (applyButton.is('[disabled]')) {
+    // no changes to apply, close projects filter
+    cy.get('[data-cy=projects-filter-button]').click();
+  } else {
+    // apply projects filter
+    applyButton.click();
+  }
+});
+
+
 interface MemoryMap {
   [key: string]: any;
 }

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -42,7 +42,7 @@ Cypress.Commands.add('applyProjectsFilter', (projectsToFilterOn: string[]) => {
 
   // check all desired checkboxes
   projectsToFilterOn.forEach(proj =>
-    cy.get(`chef-checkbox[title="${proj}"]`).find('chef-icon').click());
+    cy.get(`app-projects-filter chef-checkbox[title="${proj}"]`).find('chef-icon').click());
 
   if (projectsToFilterOn.length === 0) {
     // no changes to apply, close projects filter

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -35,9 +35,6 @@ Cypress.Commands.add('applyProjectsFilter', (projectsToFilterOn: string[]) => {
   cy.get('app-projects-filter chef-dropdown#projects-filter-dropdown')
     .find('chef-checkbox').each(child => {
     // deselect every checkbox
-    console.log('wat');
-    console.log(child);
-    console.log(child.attr('aria-checked') === 'true');
     if (child.attr('aria-checked') === 'true') {
       child.click();
     }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Added project update to teams. In the dropdown, all projects a team is a member of will start out pre-checked and any additional projects in the project filter will also be avaliable.

Simplified the state that was contained in the projects-dropdown and updated the object-create-modal to reflect those changes.

Cleaned up the cypress tests.

### :athletic_shoe: How to Build and Test the Change

Start the UI in the standard way, create some projects from the UI, create a team, modify its projects.

### Resources
- https://github.com/chef/automate/issues/809
- [Zeplin Designs](https://app.zeplin.io/project/5ba808703eb54372d860c737?seid=5ca78c9bfe244b013f56f0f6)

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable

<img width="1435" alt="Screen Shot 2019-08-15 at 2 42 10 PM" src="https://user-images.githubusercontent.com/1899715/63128883-f76c0180-bf6a-11e9-840d-01c8fb04ad71.png">

<img width="1439" alt="Screen Shot 2019-08-15 at 2 42 19 PM" src="https://user-images.githubusercontent.com/1899715/63128889-fc30b580-bf6a-11e9-86a9-128a4cf9c369.png">

