### PR TITLE
Filter packages and release based on search parameters

### DIFF
--- a/components/applications-service/pkg/storage/postgres/service_groups.go
+++ b/components/applications-service/pkg/storage/postgres/service_groups.go
@@ -248,9 +248,9 @@ func formatFilters(filters map[string][]string) (string, string, string, bool, e
 		case "origin", "ORIGIN":
 			selectQuery, err := queryFromFieldFilter("s.origin", values, first)
 			whereQuery = whereQuery + selectQuery
-			q, err := queryFromFieldFilter("s_for_releases.origin", values, false)
+			q, err1 := queryFromFieldFilter("s_for_releases.origin", values, false)
 			packageWhereQuery = packageWhereQuery + q
-			if err != nil {
+			if err != nil || err1 != nil {
 				return "", "", "", false, err
 			}
 		case "service", "SERVICE":
@@ -274,9 +274,9 @@ func formatFilters(filters map[string][]string) (string, string, string, bool, e
 		case "version", "VERSION":
 			selectQuery, err := queryFromFieldFilter("s.version", values, first)
 			whereQuery = whereQuery + selectQuery
-			q, err := queryFromFieldFilter("s_for_releases.version", values, false)
+			q, err1 := queryFromFieldFilter("s_for_releases.version", values, false)
 			packageWhereQuery = packageWhereQuery + q
-			if err != nil {
+			if err != nil || err1 != nil {
 				return "", "", "", false, err
 			}
 		case "buildstamp", "BUILDSTAMP":


### PR DESCRIPTION
Previously when searching on something that would narrow origin or version
and result in a partially filtered service group the packages and releases
were not filtered correctly. This adds a filter to the array agg subquery
in order to properly partially filter
Signed-off-by: kmacgugan <kmacgugan@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable