### PR TITLE
Ensure license-control-database is included in backup spec

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -714,6 +714,10 @@ steps:
       - integration/run_test integration/tests/backup.sh
     timeout_in_minutes: 20
     expeditor:
+      secrets:
+        A2_LICENSE:
+          path: secret/a2/license
+          field: license
       executor:
         linux:
           privileged: true

--- a/components/automate-deployment/pkg/backup/spec.go
+++ b/components/automate-deployment/pkg/backup/spec.go
@@ -256,6 +256,12 @@ func DefaultSpecs(serviceNames []string) []Spec {
 		{
 			Name:          "license-control-service",
 			WriteMetadata: true,
+			SyncDbsV2: []DatabaseDumpOperationV2{
+				{
+					Name: "chef_license_control_service",
+					User: "license-control",
+				},
+			},
 			SyncPaths: []PathCopyOperation{
 				{
 					Name:    "data",

--- a/integration/tests/backup.sh
+++ b/integration/tests/backup.sh
@@ -5,6 +5,12 @@ test_name="backup"
 test_backup_restore=true
 test_diagnostics_filters="~iam-v2"
 
+do_deploy() {
+    do_deploy_default
+    log_info "applying dev license"
+    chef-automate license apply "$A2_LICENSE"
+}
+
 do_restore() {
     test_metadata_sha256_mismatch_fails || return 1
     test_missing_checksums_file_fails || return 1


### PR DESCRIPTION
Signed-off-by: Steven Danna <steve@chef.io>