### PR TITLE
diagnostics: fix errant error message and functions names

### DIFF
--- a/components/automate-cli/pkg/diagnostics/integration/license.go
+++ b/components/automate-cli/pkg/diagnostics/integration/license.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -12,10 +11,6 @@ import (
 )
 
 type licenseSave struct {
-	LicenseID string `json:"license_id"`
-}
-
-type licenseStatusResp struct {
 	LicenseID string `json:"license_id"`
 }
 
@@ -51,7 +46,9 @@ func CreateLicenseDiagnostic() diagnostics.Diagnostic {
 }
 
 func getLicenseID(tstCtx diagnostics.TestContext) (string, error) {
-	reqPath := fmt.Sprintf("/api/v0/license/status")
+	// We use the telemetry/config API endpoint since it is
+	// available on more versions of Automate.
+	reqPath := "/api/v0/telemetry/config"
 	resp, err := tstCtx.DoLBRequest(reqPath)
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to GET %s", reqPath)
@@ -65,7 +62,9 @@ func getLicenseID(tstCtx diagnostics.TestContext) (string, error) {
 		return "", errors.Errorf("Failed to GET %s with status code %d", reqPath, resp.StatusCode)
 	}
 
-	respUnmarshalled := licenseStatusResp{}
+	respUnmarshalled := struct {
+		LicenseID string `json:"license_id"`
+	}{}
 	err = json.NewDecoder(resp.Body).Decode(&respUnmarshalled)
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to decode GET %s", reqPath)

--- a/components/automate-cli/pkg/diagnostics/integration/license.go
+++ b/components/automate-cli/pkg/diagnostics/integration/license.go
@@ -15,24 +15,24 @@ type licenseSave struct {
 	LicenseID string `json:"license_id"`
 }
 
-type telemetryConfigResp struct {
+type licenseStatusResp struct {
 	LicenseID string `json:"license_id"`
 }
 
-// CreateLicenseDiagnostic create the diagnostic struct for the license service
-// It will disabled telemetry. It verifies that telemetry is disabled, along with
-// a license is present
+// CreateLicenseDiagnostic returns a diagnostic test that tests the
+// license status API endpoint. It does not add a new license but
+// rather only verifies that the applied license hasn't changed.
 func CreateLicenseDiagnostic() diagnostics.Diagnostic {
 	return diagnostics.Diagnostic{
 		Name: "license",
 		Generate: func(tstCtx diagnostics.TestContext) error {
-			currentConfig, err := telemetryConfig(tstCtx)
+			licenseID, err := getLicenseID(tstCtx)
 			if err != nil {
-				return errors.Wrap(err, "Could not get current telemetry config")
+				return errors.Wrap(err, "Could not get current license ID")
 			}
 
 			tstCtx.SetValue("license", licenseSave{
-				LicenseID: currentConfig.LicenseID,
+				LicenseID: licenseID,
 			})
 			return nil
 		},
@@ -42,28 +42,19 @@ func CreateLicenseDiagnostic() diagnostics.Diagnostic {
 			err := tstCtx.GetValue("license", &loaded)
 			require.NoError(tstCtx, err, "Generated context was not found")
 
-			resp, err := telemetryConfig(tstCtx)
+			licenseID, err := getLicenseID(tstCtx)
 			require.NoError(tstCtx, err)
-			assert.Equal(tstCtx, loaded.LicenseID, resp.LicenseID, "Unexpected license id")
+			assert.Equal(tstCtx, loaded.LicenseID, licenseID, "Unexpected license id")
 		},
-
-		Cleanup: func(tstCtx diagnostics.TestContext) error {
-			loaded := licenseSave{}
-			err := tstCtx.GetValue("license", &loaded)
-			if err != nil {
-				return errors.Wrap(err, "Generated context was not found")
-			}
-
-			return err
-		},
+		Cleanup: func(diagnostics.TestContext) error { return nil },
 	}
 }
 
-func telemetryConfig(tstCtx diagnostics.TestContext) (*telemetryConfigResp, error) {
-	reqPath := fmt.Sprintf("/api/v0/telemetry/config")
+func getLicenseID(tstCtx diagnostics.TestContext) (string, error) {
+	reqPath := fmt.Sprintf("/api/v0/license/status")
 	resp, err := tstCtx.DoLBRequest(reqPath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to GET %s", reqPath)
+		return "", errors.Wrapf(err, "Failed to GET %s", reqPath)
 	}
 
 	defer func() {
@@ -71,15 +62,15 @@ func telemetryConfig(tstCtx diagnostics.TestContext) (*telemetryConfigResp, erro
 	}()
 
 	if resp.StatusCode != 200 {
-		return nil, errors.Errorf("Failed to GET %s with status code %d", reqPath, resp.StatusCode)
+		return "", errors.Errorf("Failed to GET %s with status code %d", reqPath, resp.StatusCode)
 	}
 
-	respUnmarshalled := telemetryConfigResp{}
+	respUnmarshalled := licenseStatusResp{}
 	err = json.NewDecoder(resp.Body).Decode(&respUnmarshalled)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to decode GET %s", reqPath)
+		return "", errors.Wrapf(err, "Failed to decode GET %s", reqPath)
 	}
-	return &respUnmarshalled, nil
+	return respUnmarshalled.LicenseID, nil
 }
 
 func init() {


### PR DESCRIPTION
This appeared to be testing the OptOut configuration but really tests
whether the license ID has changed. I've updated the comments,
function name, and API endpoint used to be a bit more honest.

Signed-off-by: Steven Danna <steve@chef.io>