### PR TITLE
Delete now-unused normalized tables for applications

### DIFF
--- a/components/applications-service/pkg/storage/postgres/schema/sql/13_delete_normalized_tables.up.sql
+++ b/components/applications-service/pkg/storage/postgres/schema/sql/13_delete_normalized_tables.up.sql
@@ -1,0 +1,4 @@
+DROP TABLE service;
+DROP TABLE service_group;
+DROP TABLE supervisor;
+DROP TABLE deployment;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Deletes the old tables from the applications database. These are now unused by the application.

### :chains: Related Resources

#1233 

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

Most complete version:
1. remove everything from `results/`
2. `start_all_services` in the studio
3. `applications_populate_database`
4. See your services in the UI
5. See the old tables are in the UI: `chef-automate dev psql chef_applications_service` then run `\d` in the interactive Postgres client.
6. `build components/applications-service` and wait for it to get deployed
7. Your services from step 3/4 are still in the UI
8. `chef-automate dev psql chef_applications_service` then run `\d` in the interactive Postgres client. The old tables are gone.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?
