### PR TITLE
change the color of left nav headings

### DIFF
--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.scss
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.scss
@@ -112,7 +112,7 @@
         padding-left: 14px;
         text-transform: uppercase;
         font-size: 12px;
-        color: #6f7878;
+        color: #6F7878;
       }
     }
   }

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.scss
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.scss
@@ -112,6 +112,7 @@
         padding-left: 14px;
         text-transform: uppercase;
         font-size: 12px;
+        color: #6f7878;
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description: 
The headings in the left nav on Dashboards, Infrastructure, and Compliance are the wrong colors. All of the headings in the left-nav bar should be #6f7878. See Applications or Settings for the correct styles in the left-nav.

### :chains: Related Resources
fixes https://github.com/chef/automate/issues/688

### :+1: Definition of Done
I have added css for this to change the color.

### :camera: Screenshots
![Screenshot from 2019-08-19 17-45-48](https://user-images.githubusercontent.com/12297653/63265547-7c2c8780-c2ab-11e9-8a9c-6194dc97ce8c.png)