### PR TITLE
bugfix: correct navigation path for run history items

### DIFF
--- a/components/automate-ui/src/app/pages/node-details/node-details.component.html
+++ b/components/automate-ui/src/app/pages/node-details/node-details.component.html
@@ -4,7 +4,7 @@
     <div class="node-details-container">
       <div class="run-container">
         <chef-breadcrumbs>
-          <chef-breadcrumb [link]="['/client-runs']">Client runs</chef-breadcrumb>
+          <chef-breadcrumb [link]="['/infrastructure/client-runs']">Client runs</chef-breadcrumb>
           Node {{nodeRun.nodeName}}
         </chef-breadcrumbs>
 

--- a/components/automate-ui/src/app/pages/node-details/node-details.component.ts
+++ b/components/automate-ui/src/app/pages/node-details/node-details.component.ts
@@ -73,7 +73,7 @@ export class NodeDetailsComponent implements OnInit, OnDestroy {
   updateRunId(newRun: RunInfo): void {
     this.router.navigate(
       [
-        'client-runs', this.nodeId, 'runs', newRun.runId, {end_time: newRun.endTime}
+        'infrastructure/client-runs', this.nodeId, 'runs', newRun.runId, {end_time: newRun.endTime}
       ]
     );
   }

--- a/components/automate-ui/src/app/services/node-details/node-details-resolver.service.spec.ts
+++ b/components/automate-ui/src/app/services/node-details/node-details-resolver.service.spec.ts
@@ -62,7 +62,7 @@ describe('NodeDetailsResolverService', () => {
       spyOn(router, 'navigate');
 
       service.resolve(route, null).then((_nodeRun: NodeRun) => {
-        expect(router.navigate).toHaveBeenCalledWith(['/client-runs/fake-node-id/missing-runs']);
+        expect(router.navigate).toHaveBeenCalledWith(['/infrastructure/client-runs/fake-node-id/missing-runs']);
         done();
       });
 
@@ -78,7 +78,7 @@ describe('NodeDetailsResolverService', () => {
       spyOn(router, 'navigate');
 
       service.resolve(route, null).then((_nodeRun: NodeRun) => {
-        expect(router.navigate).toHaveBeenCalledWith(['/client-runs']);
+        expect(router.navigate).toHaveBeenCalledWith(['/infrastructure/client-runs']);
         done();
       });
     });
@@ -94,7 +94,7 @@ describe('NodeDetailsResolverService', () => {
       spyOn(route.paramMap, 'get').and.callFake(() => 'fake-node-id');
 
       service.resolve(route, null).then((_nodeRun: NodeRun) => {
-        expect(router.navigate).toHaveBeenCalledWith(['/client-runs/fake-node-id/missing-runs']);
+        expect(router.navigate).toHaveBeenCalledWith(['/infrastructure/client-runs/fake-node-id/missing-runs']);
         done();
       });
     });

--- a/components/automate-ui/src/app/services/node-details/node-details-resolver.service.spec.ts
+++ b/components/automate-ui/src/app/services/node-details/node-details-resolver.service.spec.ts
@@ -62,7 +62,8 @@ describe('NodeDetailsResolverService', () => {
       spyOn(router, 'navigate');
 
       service.resolve(route, null).then((_nodeRun: NodeRun) => {
-        expect(router.navigate).toHaveBeenCalledWith(['/infrastructure/client-runs/fake-node-id/missing-runs']);
+        expect(router.navigate)
+          .toHaveBeenCalledWith(['/infrastructure/client-runs/fake-node-id/missing-runs']);
         done();
       });
 
@@ -94,7 +95,8 @@ describe('NodeDetailsResolverService', () => {
       spyOn(route.paramMap, 'get').and.callFake(() => 'fake-node-id');
 
       service.resolve(route, null).then((_nodeRun: NodeRun) => {
-        expect(router.navigate).toHaveBeenCalledWith(['/infrastructure/client-runs/fake-node-id/missing-runs']);
+        expect(router.navigate)
+          .toHaveBeenCalledWith(['/infrastructure/client-runs/fake-node-id/missing-runs']);
         done();
       });
     });

--- a/components/automate-ui/src/app/services/node-details/node-details-resolver.service.ts
+++ b/components/automate-ui/src/app/services/node-details/node-details-resolver.service.ts
@@ -19,18 +19,18 @@ export class NodeDetailsResolverService implements Resolve<NodeRun> {
         if (nodeRun) {
           return nodeRun;
         } else {
-          // if the node run was not found we assume this node has not runs.
+          // if the node run was not found we assume this node has no runs.
           // Go to node missing runs page
-          this.router.navigate(['/client-runs/' + nodeId + '/missing-runs']);
+          this.router.navigate(['/infrastructure/client-runs/' + nodeId + '/missing-runs']);
           return null;
         }
       }).catch(e => {
         // if the node run was not found we assume this node has no runs.
         // Go to node missing runs page
         if (JSON.stringify(e).indexOf('404') > 0) {
-          this.router.navigate(['/client-runs/' + nodeId + '/missing-runs']);
+          this.router.navigate(['/infrastructure/client-runs/' + nodeId + '/missing-runs']);
         } else {
-          this.router.navigate(['/client-runs']);
+          this.router.navigate(['/infrastructure/client-runs']);
         }
 
         return null;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
We got a report in success slack of a bug: "Looks like seeing run history is broken in Automate. (I can see run history, but clicking on the specific run takes you back to the main "Infrastructure" (formerly client-runs) page."
Upon investigation, I noticed we missed a navigation rename when going from client-runs to infrastructure/client-runs.
This corrects that.

### :chains: Related Resources
N/A

### :+1: Definition of Done
Selecting a past item in the run history for a node correctly loads the node details page with that run's information.

### :athletic_shoe: How to Build and Test the Change
chef_load_nodes at least 2 times
rebuild the ui
select an item in the run history, expect to see that run loaded on the node details page

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
<img width="1414" alt="Screen Shot 2019-08-19 at 13 14 45" src="https://user-images.githubusercontent.com/10341541/63292865-e4677300-c283-11e9-84f4-e30f88a5f2df.png">
<img width="1409" alt="Screen Shot 2019-08-19 at 13 14 54" src="https://user-images.githubusercontent.com/10341541/63292866-e5000980-c283-11e9-9b80-3b2c095e3440.png">
