### PR TITLE
 lib/cereal: bump default polling interval to 10 seconds

### DIFF
--- a/lib/cereal/backend/backend.go
+++ b/lib/cereal/backend/backend.go
@@ -30,6 +30,14 @@ type SchedulerDriver interface {
 	GetNextScheduledWorkflow(ctx context.Context) (*Schedule, error)
 }
 
+// IntervalSuggester is an interface that backends can optionally
+// implement to suggest a default TaskPollInterval and
+// WorkflowPollInterval to the rest of the cereal library.
+type IntervalSuggester interface {
+	DefaultTaskPollInterval() time.Duration
+	DefaultWorkflowPollInterval() time.Duration
+}
+
 type ListWorkflowOpts struct {
 	WorkflowName *string
 	InstanceName *string

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -248,7 +248,7 @@ func (w *workflowInstanceImpl) EnqueueTask(taskName string, parameters interface
 
 func (w *workflowInstanceImpl) Complete(opts ...CompleteOpts) Decision {
 	if len(w.tasks) > 0 {
-		logrus.Errorf("cannot call EnqueueTask and Complete in same workflow step! failing workflow")
+		logrus.Error("Cannot call EnqueueTask and Complete in same workflow step! failing workflow")
 		return Decision{failed: true, err: errors.New("EnqueueTask and Complete called in same workflow step")}
 	}
 
@@ -655,13 +655,13 @@ func (r *registeredExecutor) runTask(ctx context.Context, t *backend.Task, taskC
 	if err != nil {
 		err := taskCompleter.Fail(err.Error())
 		if err != nil {
-			logctx.WithError(err).Error("failed to mark task as failed")
+			logctx.WithError(err).Error("Failed to mark task as failed")
 			return err
 		}
 	} else {
 		jsonResults, err := jsonify(result)
 		if err != nil {
-			logctx.WithError(err).Error("could not convert returned results to JSON")
+			logctx.WithError(err).Error("Could not convert returned results to JSON")
 			if err := taskCompleter.Fail(err.Error()); err != nil {
 				logctx.WithError(err).Error("Failed to fail task completer")
 				return err
@@ -669,7 +669,7 @@ func (r *registeredExecutor) runTask(ctx context.Context, t *backend.Task, taskC
 		}
 		err = taskCompleter.Succeed(jsonResults)
 		if err != nil {
-			logctx.WithError(err).Error("failed to mark task as successful")
+			logctx.WithError(err).Error("Failed to mark task as successful")
 			return err
 		}
 	}
@@ -718,9 +718,9 @@ func (m *Manager) Stop() error {
 		m.cancel()
 	}
 
-	logrus.Info("waiting for goroutines to stop")
+	logrus.Info("Waiting for goroutines to stop")
 	m.wg.Wait()
-	logrus.Info("goroutines stopped")
+	logrus.Info("Goroutines stopped")
 
 	var err error
 	if m.backend != nil {
@@ -911,7 +911,7 @@ LOOP:
 	for {
 		select {
 		case <-ctx.Done():
-			logrus.Info("exiting workflow executor")
+			logrus.Info("Exiting workflow executor")
 			break LOOP
 		case <-m.workflowWakeupChan:
 			if !timer.Stop() {
@@ -938,7 +938,7 @@ func (m *Manager) processWorkflow(ctx context.Context, workflowNames []string) b
 	wevt, completer, err := m.backend.DequeueWorkflow(ctx, workflowsToProcess)
 	if err != nil {
 		if err != ErrNoWorkflowInstances {
-			logrus.WithError(err).Error("failed to dequeue workflow!")
+			logrus.WithError(err).Error("Failed to dequeue workflow!")
 		}
 		return true
 	}
@@ -998,7 +998,7 @@ func (m *Manager) processWorkflow(ctx context.Context, workflowNames []string) b
 
 		err = completer.Fail(decision.err)
 		if err != nil {
-			logctx.WithError(err).Error("failed to complete workflow")
+			logctx.WithError(err).Error("Failed to complete workflow")
 		}
 
 		s.End("failed")
@@ -1011,13 +1011,13 @@ func (m *Manager) processWorkflow(ctx context.Context, workflowNames []string) b
 		}
 		jsonResult, err := jsonify(decision.result)
 		if err != nil {
-			logctx.WithError(err).Error("failed to jsonify workflow result")
+			logctx.WithError(err).Error("Failed to jsonify workflow result")
 			jsonResult = nil
 		}
 
 		err = completer.Done(jsonResult)
 		if err != nil {
-			logctx.WithError(err).Error("failed to complete workflow")
+			logctx.WithError(err).Error("Failed to complete workflow")
 		}
 		s.End("complete")
 	} else if decision.continuing {
@@ -1025,7 +1025,7 @@ func (m *Manager) processWorkflow(ctx context.Context, workflowNames []string) b
 		for _, t := range decision.tasks {
 			err := completer.EnqueueTask(&t.backendTask, t.opts)
 			if err != nil {
-				logrus.WithError(err).Error("failed to enqueue task!")
+				logrus.WithError(err).Error("Failed to enqueue task!")
 				return true
 			}
 		}
@@ -1033,15 +1033,15 @@ func (m *Manager) processWorkflow(ctx context.Context, workflowNames []string) b
 		s.Begin("continue")
 		jsonPayload, err := jsonify(decision.payload)
 		if err != nil {
-			logrus.WithError(err).Error("could not marshal payload to JSON, failing workflow")
+			logrus.WithError(err).Error("Could not marshal payload to JSON, failing workflow")
 			err := completer.Fail(err)
 			if err != nil {
-				logrus.WithError(err).Error("failed to fail workflow after JSON marshal failure")
+				logrus.WithError(err).Error("Failed to fail workflow after JSON marshal failure")
 			}
 		} else {
 			err := completer.Continue(jsonPayload)
 			if err != nil {
-				logrus.WithError(err).Error("failed to continue workflow")
+				logrus.WithError(err).Error("Failed to continue workflow")
 			}
 			m.wakeupTaskPollersByRequests(decision.tasks)
 		}
@@ -1073,7 +1073,7 @@ type statsInfo struct {
 func (s *statsInfo) Begin(label string) {
 	_, ok := s.start[label]
 	if ok {
-		logrus.Warn("statsInfo.Begin on currently running label, ignoring")
+		logrus.Warn("Called statsInfo.Begin on currently running label, ignoring")
 		return
 	}
 
@@ -1083,7 +1083,7 @@ func (s *statsInfo) Begin(label string) {
 func (s *statsInfo) End(label string) {
 	start, ok := s.start[label]
 	if !ok {
-		logrus.Warn("statsInfo.End on label with no start, ignoring")
+		logrus.Warn("Called statsInfo.End on label with no start, ignoring")
 		return
 	}
 

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -31,8 +31,8 @@ var (
 )
 
 const (
-	defaultTaskPollInterval     = 2 * time.Second
-	defaultWorkflowPollInterval = 2 * time.Second
+	defaultTaskPollInterval     = 10 * time.Second
+	defaultWorkflowPollInterval = 10 * time.Second
 )
 
 // Schedule represents a recurring workflow.

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -575,7 +575,7 @@ func (r *registeredExecutor) WakeupPoller() {
 // change).
 func (r *registeredExecutor) StartPoller(ctx context.Context, b backend.Driver, taskPollInterval time.Duration, workflowWakeupFun func()) {
 	logctx := logrus.WithField("task_name", r.name)
-	logctx.Infof("Starting task poller")
+	logctx.Info("Starting task poller")
 	timer := time.NewTimer(taskPollInterval)
 	for {
 		select {

--- a/lib/cereal/grpc/grpc.go
+++ b/lib/cereal/grpc/grpc.go
@@ -37,6 +37,15 @@ func NewGrpcBackendFromConn(domain string, conn *grpc.ClientConn) *GrpcBackend {
 		client: grpccereal.NewCerealClient(conn),
 	}
 }
+
+func (g *GrpcBackend) DefaultTaskPollInterval() time.Duration {
+	return 10 * time.Second
+}
+
+func (g *GrpcBackend) DefaultWorkflowPollInterval() time.Duration {
+	return 2 * time.Second
+}
+
 func (g *GrpcBackend) EnqueueWorkflow(ctx context.Context, workflow *backend.WorkflowInstance) error {
 	if _, err := g.client.EnqueueWorkflow(ctx, &grpccereal.EnqueueWorkflowRequest{
 		Domain:       g.domain,

--- a/lib/cereal/grpc/grpc.go
+++ b/lib/cereal/grpc/grpc.go
@@ -6,19 +6,15 @@ import (
 	"io"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/wrappers"
-
 	"github.com/golang/protobuf/ptypes"
-
-	"github.com/chef/automate/lib/cereal"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/sirupsen/logrus"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-
 	"google.golang.org/grpc/status"
 
 	grpccereal "github.com/chef/automate/api/interservice/cereal"
+	"github.com/chef/automate/lib/cereal"
 	"github.com/chef/automate/lib/cereal/backend"
 )
 
@@ -95,7 +91,7 @@ func (c *workflowCompleter) Continue(payload []byte) error {
 		return err
 	}
 	if err := c.s.CloseSend(); err != nil {
-		logrus.WithError(err).Error("failed to continue workflow")
+		logrus.WithError(err).Error("Failed to continue workflow")
 		return err
 	}
 	_, _ = c.s.Recv()
@@ -115,7 +111,7 @@ func (c *workflowCompleter) Fail(errMsg error) error {
 		return err
 	}
 	if err := c.s.CloseSend(); err != nil {
-		logrus.WithError(err).Error("failed to fail workflow")
+		logrus.WithError(err).Error("Failed to fail workflow")
 		return err
 	}
 	_, _ = c.s.Recv()
@@ -135,7 +131,7 @@ func (c *workflowCompleter) Done(result []byte) error {
 		return err
 	}
 	if err := c.s.CloseSend(); err != nil {
-		logrus.WithError(err).Error("failed to complete workflow")
+		logrus.WithError(err).Error("Failed to complete workflow")
 		return err
 	}
 	_, _ = c.s.Recv()
@@ -353,13 +349,13 @@ func (g *GrpcBackend) DequeueTask(ctx context.Context, taskName string) (*backen
 		for {
 			msg, err := s.Recv()
 			if err != nil {
-				logrus.WithError(err).Debug("received error: canceling task context")
+				logrus.WithError(err).Debug("Received error: canceling task context")
 				cancel()
 				doneChan <- err
 				return
 			}
 			if c := msg.GetCancel(); c != nil {
-				logrus.Debug("received cancel: canceling task context")
+				logrus.Debug("Received cancel: canceling task context")
 				cancel()
 				doneChan <- errors.New("canceled")
 				return
@@ -447,7 +443,7 @@ func (g *GrpcBackend) GetWorkflowScheduleByName(ctx context.Context, instanceNam
 		return nil, err
 	}
 	if resp.Schedule == nil {
-		logrus.Error("missing schedule")
+		logrus.Error("Missing schedule")
 		return nil, cereal.ErrWorkflowScheduleNotFound
 	}
 	return grpcSchedToBackend(resp.Schedule), nil
@@ -464,7 +460,7 @@ func grpcSchedToBackend(grpcSched *grpccereal.Schedule) *backend.Schedule {
 	if grpcSched.NextDueAt != nil {
 		ts, err := ptypes.Timestamp(grpcSched.NextDueAt)
 		if err != nil {
-			logrus.WithError(err).Warn("could not decode NextDueAt timestamp")
+			logrus.WithError(err).Warn("Could not decode NextDueAt timestamp")
 		}
 		schedule.NextDueAt = ts
 	}
@@ -472,7 +468,7 @@ func grpcSchedToBackend(grpcSched *grpccereal.Schedule) *backend.Schedule {
 	if grpcSched.LastEnqueuedAt != nil {
 		ts, err := ptypes.Timestamp(grpcSched.LastEnqueuedAt)
 		if err != nil {
-			logrus.WithError(err).Warn("could not decode LastEnqueuedAt timestamp")
+			logrus.WithError(err).Warn("Could not decode LastEnqueuedAt timestamp")
 		} else {
 			schedule.LastEnqueuedAt = ts
 		}
@@ -481,7 +477,7 @@ func grpcSchedToBackend(grpcSched *grpccereal.Schedule) *backend.Schedule {
 	if grpcSched.LastStart != nil {
 		ts, err := ptypes.Timestamp(grpcSched.LastStart)
 		if err != nil {
-			logrus.WithError(err).Warn("could not decode LastStart timestamp")
+			logrus.WithError(err).Warn("Could not decode LastStart timestamp")
 		} else {
 			schedule.LastStart = &ts
 		}
@@ -490,7 +486,7 @@ func grpcSchedToBackend(grpcSched *grpccereal.Schedule) *backend.Schedule {
 	if grpcSched.LastEnd != nil {
 		ts, err := ptypes.Timestamp(grpcSched.LastEnd)
 		if err != nil {
-			logrus.WithError(err).Warn("could not decode LastEnd timestamp")
+			logrus.WithError(err).Warn("Could not decode LastEnd timestamp")
 		} else {
 			schedule.LastEnd = &ts
 		}
@@ -556,7 +552,7 @@ func (g *GrpcBackend) GetWorkflowInstanceByName(ctx context.Context, instanceNam
 		return nil, err
 	}
 	if resp.WorkflowInstance == nil {
-		logrus.Error("missing workflow instance")
+		logrus.Error("Missing workflow instance")
 		return nil, cereal.ErrWorkflowInstanceNotFound
 	}
 	backendInstance := grpcWorkflowInstanceToBackend(resp.WorkflowInstance)
@@ -600,7 +596,7 @@ func (g *GrpcBackend) ListWorkflowInstances(ctx context.Context, opts backend.Li
 			return nil, err
 		}
 		if instance.WorkflowInstance == nil {
-			logrus.Error("received nil workflow instance")
+			logrus.Error("Received nil workflow instance")
 		}
 		backendInstance := grpcWorkflowInstanceToBackend(instance.WorkflowInstance)
 		instances = append(instances, &backendInstance)

--- a/lib/cereal/integration/abandon_workflow.go
+++ b/lib/cereal/integration/abandon_workflow.go
@@ -7,8 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/chef/automate/lib/cereal"
 	"github.com/sirupsen/logrus"
+
+	"github.com/chef/automate/lib/cereal"
 )
 
 func (suite *CerealTestSuite) TestCompleteWorkflowWithPendingWorkflowEvents() {
@@ -50,7 +51,7 @@ func (suite *CerealTestSuite) TestCompleteWorkflowWithPendingWorkflowEvents() {
 	suite.Require().NoError(err, "Failed to enqueue workflow")
 	wgTask.Wait()
 	time.Sleep(2 * time.Second) // Sleep a little to make sure task complete doesn't get called multiple times
-	logrus.Info("calling stop")
+	logrus.Info("Calling stop")
 	err = m.Stop()
 	suite.NoError(err)
 }

--- a/lib/cereal/integration/cancel_workflow.go
+++ b/lib/cereal/integration/cancel_workflow.go
@@ -59,7 +59,7 @@ func (suite *CerealTestSuite) TestCancelWorkflow() {
 	suite.Require().NoError(err, "Failed to enqueue workflow")
 	wgWorkflowStart.Wait()
 	wgTaskStart.Wait()
-	logrus.Debug("canceling workflow")
+	logrus.Debug("Canceling workflow")
 	err = m.CancelWorkflow(context.Background(), workflowName, instanceName)
 	suite.Require().NoError(err, "Failed to cancel workflow")
 	wgTaskDone.Wait()

--- a/lib/cereal/postgres/postgres.go
+++ b/lib/cereal/postgres/postgres.go
@@ -51,7 +51,7 @@ WITH res AS (
 )
 -- Select the workflow instance data, giving priority to that coming
 -- from the cereal_workflow_instances table
-SELECT COALESCE(a.id, res.id) id, 
+SELECT COALESCE(a.id, res.id) id,
        COALESCE(a.status, 'completed') status,
        COALESCE(a.instance_name, res.instance_name) instance_name,
 	   COALESCE(a.workflow_name, res.workflow_name) workflow_name,
@@ -73,9 +73,9 @@ WHERE
 	-- or passing in NULL. If a value is given for a column, we make sure the value matches either
 	-- of the cereal_workflow_instances table or the cereal_workflow_results table. Passing in NULL
 	-- for the value reduces down into saying the value in the column matches the value in the column.
-	(a.workflow_name = COALESCE($1, a.workflow_name) OR 
+	(a.workflow_name = COALESCE($1, a.workflow_name) OR
 	res.workflow_name = COALESCE($1, res.workflow_name)) AND
-	(a.instance_name = COALESCE($2, a.instance_name) OR 
+	(a.instance_name = COALESCE($2, a.instance_name) OR
 	res.instance_name = COALESCE($2, res.instance_name)) AND
 	-- We'll select the row if is_running is now specified
 	(($3::boolean IS NULL) OR
@@ -287,9 +287,9 @@ func (pg *PostgresBackend) Init() error {
 func (pg *PostgresBackend) Close() error {
 	if pg.db != nil {
 		pg.cleaner.Stop()
-		logrus.Debug("closing cereal database")
+		logrus.Debug("Closing cereal database")
 		err := pg.db.Close()
-		logrus.WithError(err).Debug("closed cereal database")
+		logrus.WithError(err).Debug("Closed cereal database")
 		return err
 	}
 	return nil
@@ -407,7 +407,7 @@ func (pg *PostgresBackend) GetDueScheduledWorkflow(ctx context.Context) (*backen
 		if err == sql.ErrNoRows {
 			err := tx.Commit()
 			if err != nil {
-				logrus.WithError(err).Warn("failed to commit transaction in GetDueScheduledWorkflows")
+				logrus.WithError(err).Warn("Failed to commit transaction in GetDueScheduledWorkflows")
 			}
 			cancel()
 			return nil, nil, cereal.ErrNoDueWorkflows
@@ -682,7 +682,7 @@ func (pg *PostgresBackend) DequeueWorkflow(ctx context.Context, workflowNames []
 		"event_type":    event.Type,
 	})
 
-	logctx.Debug("dequeued workflow")
+	logctx.Debug("Dequeued workflow")
 
 	if event.Instance.Status == backend.WorkflowInstanceStatusStarting && event.Type == backend.WorkflowCancel {
 		defer cancel()
@@ -801,7 +801,7 @@ func (pg *PostgresBackend) DequeueTask(ctx context.Context, taskName string) (*b
 	tid, task, err := pg.dequeueTask(tx, taskName)
 	if err != nil {
 		if errR := tx.Rollback(); errR != nil {
-			logrus.WithError(errR).Warn("failed to rollback dequeue transaction")
+			logrus.WithError(errR).Warn("Failed to rollback dequeue transaction")
 		}
 		cancel()
 		return nil, nil, err
@@ -845,7 +845,7 @@ func (taskc *PostgresTaskCompleter) Fail(errMsg string) error {
 
 	if err != nil {
 		if isErrTaskLost(err) {
-			logrus.WithField("task_id", taskc.tid).Warn("task not updated")
+			logrus.WithField("task_id", taskc.tid).Warn("Task not updated")
 			return cereal.ErrTaskLost
 		}
 		return errors.Wrapf(err, "failed to mark task %d as failed", taskc.tid)
@@ -870,7 +870,7 @@ func (taskc *PostgresTaskCompleter) Succeed(results []byte) error {
 
 	if err != nil {
 		if isErrTaskLost(err) {
-			logrus.WithField("task_id", taskc.tid).Warn("task not updated")
+			logrus.WithField("task_id", taskc.tid).Warn("Task not updated")
 			return cereal.ErrTaskLost
 		}
 		return errors.Wrapf(err, "failed to mark task %d as successful", taskc.tid)

--- a/lib/cereal/postgres/task_cleaner.go
+++ b/lib/cereal/postgres/task_cleaner.go
@@ -57,26 +57,26 @@ func (w *taskCleaner) Start(ctx context.Context) {
 	w.stop = cancel
 
 	go func() {
-		logrus.Debug("starting task cleaner")
+		logrus.Debug("Starting task cleaner")
 	OUTER:
 		for {
 			select {
 			case <-ctx.Done():
 				break OUTER
 			case <-time.After(w.checkInterval):
-				logrus.Debug("checking for dead tasks")
+				logrus.Debug("Checking for dead tasks")
 				if err := w.expireDeadTasks(ctx, int64(math.Ceil(w.taskTimeout.Seconds()))); err != nil {
-					logrus.WithError(err).Error("failed to run periodic dead-task cleaner")
+					logrus.WithError(err).Error("Failed to run periodic dead-task cleaner")
 				}
 
-				logrus.Debug("cleaning workflow results table")
+				logrus.Debug("Cleaning workflow results table")
 				if err := w.cleanResultsTable(ctx); err != nil {
-					logrus.WithError(err).Error("failed to run periodic workflow-results cleaner")
+					logrus.WithError(err).Error("Failed to run periodic workflow-results cleaner")
 				}
 			}
 		}
 		w.wgStop.Done()
-		logrus.Debug("exiting task cleaner")
+		logrus.Debug("Exiting task cleaner")
 	}()
 }
 
@@ -94,7 +94,7 @@ func (w *taskCleaner) expireDeadTasks(ctx context.Context, expireOlderThanSecond
 
 	defer func() {
 		if err := rows.Close(); err != nil {
-			logrus.WithError(err).Error("failed to close db rows")
+			logrus.WithError(err).Error("Failed to close db rows")
 		}
 	}()
 
@@ -134,7 +134,7 @@ func (w *taskCleaner) cleanResultsTable(ctx context.Context) error {
 	}
 
 	if !locked {
-		logrus.Debug("failed to acquired advisory lock for cleanup task, returning")
+		logrus.Debug("Failed to acquired advisory lock for cleanup task, returning")
 		return tx.Commit()
 	}
 

--- a/lib/cereal/postgres/task_cleaner.go
+++ b/lib/cereal/postgres/task_cleaner.go
@@ -109,7 +109,7 @@ func (w *taskCleaner) expireDeadTasks(ctx context.Context, expireOlderThanSecond
 			logrus.Fields{
 				"tid":                tid,
 				"workflowInstanceID": workflowInstanceID,
-			}).Warnf("Expired task")
+			}).Warn("Expired task")
 	}
 	return rows.Err()
 }

--- a/lib/cereal/postgres/task_pinger.go
+++ b/lib/cereal/postgres/task_pinger.go
@@ -51,9 +51,10 @@ func (w *taskPinger) Start(ctx context.Context, onTaskLost func()) {
 		logctx := logrus.WithFields(logrus.Fields{
 			"taskID": w.taskID,
 		})
+		logctx.Debug("Starting taskPinger")
 	OUTER:
 		for {
-			logctx.Debug("pinging task")
+
 			select {
 			case <-ctx.Done():
 				break OUTER
@@ -66,8 +67,7 @@ func (w *taskPinger) Start(ctx context.Context, onTaskLost func()) {
 			}
 		}
 		w.wgStop.Done()
-		logctx.Debug("done pinging")
-
+		logctx.Debug("Exiting taskPinger")
 	}()
 }
 
@@ -75,10 +75,10 @@ func (w *taskPinger) ping(ctx context.Context) (shouldExit bool, err error) {
 	logctx := logrus.WithFields(logrus.Fields{
 		"taskID": w.taskID,
 	})
-	logctx.Debug("checkin for task")
+	logctx.Debug("Pinging task")
 	_, err = w.db.ExecContext(ctx, "SELECT cereal_ping_task($1)", w.taskID)
 	if err != nil {
-		logctx.WithError(err).Error("failed to update task check-in time")
+		logctx.WithError(err).Error("Failed to ping task")
 		if isErrTaskLost(err) {
 			return true, nil
 		}

--- a/lib/cereal/workflow_scheduler.go
+++ b/lib/cereal/workflow_scheduler.go
@@ -43,7 +43,7 @@ func (w *WorkflowScheduler) Run(ctx context.Context) {
 		case <-time.After(nextSleep):
 			nextSleep, err = w.scheduleWorkflows(ctx)
 			if err != nil {
-				logrus.WithError(err).Error("failed to schedule workflows")
+				logrus.WithError(err).Error("Failed to schedule workflows")
 			}
 			logrus.Debugf("Recurring workflow scheduler sleep for %fs", nextSleep.Seconds())
 		}
@@ -76,7 +76,7 @@ func (w *WorkflowScheduler) scheduleWorkflow(ctx context.Context) (time.Duration
 				if err2 == ErrNoScheduledWorkflows {
 					return MaxWakeupInterval, err
 				}
-				logrus.WithError(err2).Error("failed to determine next scheduled workflow")
+				logrus.WithError(err2).Error("Failed to determine next scheduled workflow")
 				return MaxWakeupInterval, err
 			}
 			logrus.Debugf("Woke up %fs early for task", time.Until(s.NextDueAt).Seconds())
@@ -92,7 +92,7 @@ func (w *WorkflowScheduler) scheduleWorkflow(ctx context.Context) (time.Duration
 
 	recurrence, err := rrule.StrToRRule(s.Recurrence)
 	if err != nil {
-		logrus.WithError(err).Error("scheduled workflow has invalid recurrence rule, attempting to disable it")
+		logrus.WithError(err).Error("Scheduled workflow has invalid recurrence rule, attempting to disable it")
 		err2 := completer.DisableSchedule(s)
 		if err2 != nil {
 			return MaxWakeupInterval, errors.Wrap(err2, "failed to disable workflow with invalid recurrence rule")
@@ -107,7 +107,7 @@ func (w *WorkflowScheduler) scheduleWorkflow(ctx context.Context) (time.Duration
 	nowUTC := time.Now().UTC()
 	nextDueAt := recurrence.After(nowUTC, true).UTC()
 	if nextDueAt.IsZero() {
-		logrus.Infof("recurrence rule for scheduled workflow %q ends after this run", s.InstanceName)
+		logrus.Infof("Recurrence rule for scheduled workflow %q ends after this run", s.InstanceName)
 		s.Enabled = false
 	}
 


### PR DESCRIPTION
Now that we have in-process notifications, we think we can push the
default time-based polling interval a bit higher to cut down on
unnecessary database queries.

While I was here, I did some minor cleanups on our logging.

Signed-off-by: Steven Danna <steve@chef.io>