### PR TITLE
Remove polling on projects page due to flicker

### DIFF
--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, OnInit, OnDestroy } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { interval as observableInterval,  Observable, Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { map, takeUntil, filter } from 'rxjs/operators';
 import { identity } from 'lodash/fp';
 
@@ -43,7 +43,6 @@ export class ProjectListComponent implements OnInit, OnDestroy {
   public applyRulesButtonText$: Observable<string>;
   public ApplyRulesStatusState = ApplyRulesStatusState;
 
-  private POLLING_INTERVAL_IN_SECONDS = 10;
   private isDestroyed = new Subject<boolean>();
 
   constructor(
@@ -85,16 +84,8 @@ export class ProjectListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    // Get status now; periodic checks are already being done globally so no need to poll further
     this.projects.getApplyRulesStatus();
-
-    // Get projects status now and periodically while on this page
     this.store.dispatch(new GetProjects());
-    observableInterval(1000 * this.POLLING_INTERVAL_IN_SECONDS).pipe(
-      takeUntil(this.isDestroyed))
-      .subscribe(() => {
-        this.store.dispatch(new GetProjects());
-      });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Due to flicker, remove polling on projects list page.

### :chains: Related Resources

### :+1: Definition of Done
No flicker

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui.
Set to IAM v2.1.
Go to Settings > Projects
