### PR TITLE
Fix race condition in disabled status of team details projects dropdown

### DIFF
--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -323,6 +323,8 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   }
 
   dropdownDisabled(): boolean {
-    return Object.values(this.projects).length === 0 || this.teamProjectsLeftToFetch.length !== 0;
+    return Object.values(this.projects).length === 0 ||
+      this.teamProjectsLeftToFetch.length !== 0 ||
+      this.saving;
   }
 }

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -145,8 +145,7 @@ describe('team management', () => {
 
         // initial state of dropdown
         cy.get('app-team-details app-projects-dropdown #projects-selected').contains(unassigned);
-        cy.get('app-team-details app-projects-dropdown .dropdown-button')
-          .should('have.attr', 'disabled');
+        cy.get('app-team-details app-projects-dropdown .dropdown-button').should('be.disabled');
 
         cy.get('[data-cy=team-details-name-input]').type('updated name');
         cy.get('[data-cy=team-details-submit-button]').should('not.have.attr', 'aria-disabled');
@@ -201,7 +200,7 @@ describe('team management', () => {
           cy.get('app-team-details app-projects-dropdown #projects-selected')
             .contains(`${project1Name.substring(0, dropdownNameUntilEllipsisLen)}...`);
           cy.get('app-team-details app-projects-dropdown .dropdown-button')
-            .should('not.have.attr', 'disabled');
+            .should('not.be.disabled');
 
           // open projects dropdown
           cy.get('app-team-details app-projects-dropdown .dropdown-button').click();
@@ -219,7 +218,8 @@ describe('team management', () => {
           cy.get('[data-cy=team-details-submit-button]').click();
 
           // de-select project1 and project2
-          cy.get('app-team-details app-projects-dropdown .dropdown-button').click();
+          cy.get('app-team-details app-projects-dropdown .dropdown-button')
+            .should('not.be.disabled').click();
           cy.get(`app-team-details app-projects-dropdown chef-checkbox[title="${project1Name}"]`)
             .should('have.attr', 'aria-checked', 'true').find('chef-icon').click();
           cy.get(`app-team-details app-projects-dropdown chef-checkbox[title="${project2Name}"]`)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The dropdown was not becoming properly disabled when saves were in progress, resulting in a race condition that made the tests flaky. Also hardened the cypress tests by adding 'is.not.disabled' assertion so that cypress will actually wait for the dropdown to not be disabled before sending the click event.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?
