### PR TITLE
Add single task workflow pattern

### DIFF
--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -300,6 +300,9 @@ type immutableWorkflowInstanceImpl struct {
 }
 
 func (w *immutableWorkflowInstanceImpl) GetPayload(obj interface{}) error {
+	if w.instance.Err != nil {
+		return w.instance.Err
+	}
 	if w.instance.Payload != nil && len(w.instance.Payload) > 0 {
 		return json.Unmarshal(w.instance.Payload, obj)
 	}
@@ -316,6 +319,9 @@ func (w *immutableWorkflowInstanceImpl) GetParameters(obj interface{}) error {
 func (w *immutableWorkflowInstanceImpl) GetResult(obj interface{}) error {
 	if w.IsRunning() {
 		return ErrWorkflowNotComplete
+	}
+	if w.instance.Err != nil {
+		return w.instance.Err
 	}
 	if w.instance.Result != nil && len(w.instance.Result) > 0 {
 		return json.Unmarshal(w.instance.Result, obj)

--- a/lib/cereal/integration/pattern_single_task_workflow.go
+++ b/lib/cereal/integration/pattern_single_task_workflow.go
@@ -1,0 +1,238 @@
+package integration
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/chef/automate/lib/cereal/patterns"
+	"github.com/pkg/errors"
+
+	"github.com/chef/automate/lib/cereal"
+)
+
+func (suite *CerealTestSuite) TestPatternSingleTaskWorkflowSuccess() {
+	taskName := randName("single_task")
+	workflowName := randName("single_task_workflow")
+	instanceName := randName("instance")
+	type TaskResult struct {
+		Value string
+	}
+	type TaskParameters struct {
+		Value string
+	}
+	tp := TaskParameters{Value: "value"}
+	tr := TaskResult{Value: "value"}
+
+	wgTask := sync.WaitGroup{}
+	wgTask.Add(1)
+
+	m := suite.newManager(
+		WithTaskExecutorF(
+			taskName,
+			func(ctx context.Context, task cereal.Task) (interface{}, error) {
+				defer wgTask.Done()
+				params := TaskParameters{}
+				if err := task.GetParameters(&params); err != nil {
+					return nil, err
+				}
+				return TaskResult{Value: params.Value}, nil
+			}),
+		WithWorkflowExecutor(
+			workflowName,
+			patterns.NewSingleTaskWorkflowExecutor(taskName, false),
+		),
+	)
+	defer m.Stop()
+	err := m.EnqueueWorkflow(context.Background(), workflowName, instanceName, tp)
+	suite.Require().NoError(err, "Failed to enqueue workflow")
+	wgTask.Wait()
+	time.Sleep(20 * time.Millisecond)
+
+	instance, err := m.GetWorkflowInstanceByName(context.Background(), instanceName, workflowName)
+	suite.Require().NoError(err)
+	params := TaskParameters{}
+	result := TaskResult{}
+	suite.Require().False(instance.IsRunning())
+	err = instance.GetParameters(&params)
+	suite.Require().NoError(err)
+	err = instance.GetResult(&result)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(tp, params)
+	suite.Assert().Equal(tr, result)
+
+	err = m.Stop()
+	suite.NoError(err)
+}
+
+func (suite *CerealTestSuite) TestPatternSingleTaskWorkflowFail() {
+	taskName := randName("single_task")
+	workflowName := randName("single_task_workflow")
+	instanceName := randName("instance")
+	type TaskResult struct {
+		Value string
+	}
+	type TaskParameters struct {
+		Value string
+	}
+	tp := TaskParameters{Value: "value"}
+	errMsg := "i have failed"
+
+	wgTask := sync.WaitGroup{}
+	wgTask.Add(1)
+
+	m := suite.newManager(
+		WithTaskExecutorF(
+			taskName,
+			func(ctx context.Context, task cereal.Task) (interface{}, error) {
+				defer wgTask.Done()
+				return nil, errors.New(errMsg)
+			}),
+		WithWorkflowExecutor(
+			workflowName,
+			patterns.NewSingleTaskWorkflowExecutor(taskName, false),
+		),
+	)
+	defer m.Stop()
+	err := m.EnqueueWorkflow(context.Background(), workflowName, instanceName, tp)
+	suite.Require().NoError(err, "Failed to enqueue workflow")
+	wgTask.Wait()
+	time.Sleep(20 * time.Millisecond)
+
+	instance, err := m.GetWorkflowInstanceByName(context.Background(), instanceName, workflowName)
+	suite.Require().NoError(err)
+
+	result := TaskResult{}
+	suite.Require().False(instance.IsRunning())
+	suite.Require().Error(instance.Err())
+	err = instance.GetResult(&result)
+	suite.Require().Error(err)
+	suite.Require().Equal(errMsg, err.Error())
+
+	err = m.Stop()
+	suite.NoError(err)
+}
+
+func (suite *CerealTestSuite) TestPatternSingleTaskWorkflowCancelWhenNotAllowed() {
+	taskName := randName("single_task")
+	workflowName := randName("single_task_workflow")
+	instanceName := randName("instance")
+	type TaskResult struct {
+		Value string
+	}
+	type TaskParameters struct {
+		Value string
+	}
+	tp := TaskParameters{Value: "value"}
+	tr := TaskResult{Value: "value"}
+
+	wgTaskStart := sync.WaitGroup{}
+	wgTaskStart.Add(1)
+	wgTaskEnd := sync.WaitGroup{}
+	wgTaskEnd.Add(1)
+
+	m := suite.newManager(
+		WithTaskExecutorF(
+			taskName,
+			func(ctx context.Context, task cereal.Task) (interface{}, error) {
+				defer wgTaskEnd.Done()
+				wgTaskStart.Done()
+				params := TaskParameters{}
+				if err := task.GetParameters(&params); err != nil {
+					return nil, err
+				}
+				select {
+				case <-time.After(15 * time.Second):
+					return TaskResult{Value: params.Value}, nil
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}),
+		WithWorkflowExecutor(
+			workflowName,
+			patterns.NewSingleTaskWorkflowExecutor(taskName, false),
+		),
+	)
+	defer m.Stop()
+	err := m.EnqueueWorkflow(context.Background(), workflowName, instanceName, tp)
+	suite.Require().NoError(err, "Failed to enqueue workflow")
+	wgTaskStart.Wait()
+	err = m.CancelWorkflow(context.Background(), workflowName, instanceName)
+	suite.Require().NoError(err)
+	wgTaskEnd.Wait()
+	time.Sleep(20 * time.Millisecond)
+
+	instance, err := m.GetWorkflowInstanceByName(context.Background(), instanceName, workflowName)
+	suite.Require().NoError(err)
+	params := TaskParameters{}
+	result := TaskResult{}
+	suite.Require().False(instance.IsRunning())
+	err = instance.GetParameters(&params)
+	suite.Require().NoError(err)
+	err = instance.GetResult(&result)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(tp, params)
+	suite.Assert().Equal(tr, result)
+
+	err = m.Stop()
+	suite.NoError(err)
+}
+
+func (suite *CerealTestSuite) TestPatternSingleTaskWorkflowCancelWhenAllowed() {
+	taskName := randName("single_task")
+	workflowName := randName("single_task_workflow")
+	instanceName := randName("instance")
+	type TaskResult struct {
+		Value string
+	}
+	type TaskParameters struct {
+		Value string
+	}
+	tp := TaskParameters{Value: "value"}
+
+	wgTaskStart := sync.WaitGroup{}
+	wgTaskStart.Add(1)
+	wgTaskEnd := sync.WaitGroup{}
+	wgTaskEnd.Add(1)
+
+	m := suite.newManager(
+		WithTaskExecutorF(
+			taskName,
+			func(ctx context.Context, task cereal.Task) (interface{}, error) {
+				defer wgTaskEnd.Done()
+				wgTaskStart.Done()
+				params := TaskParameters{}
+				if err := task.GetParameters(&params); err != nil {
+					return nil, err
+				}
+				<-ctx.Done()
+				// return value is forever lost
+				return nil, ctx.Err()
+			}),
+		WithWorkflowExecutor(
+			workflowName,
+			patterns.NewSingleTaskWorkflowExecutor(taskName, true),
+		),
+	)
+	defer m.Stop()
+	err := m.EnqueueWorkflow(context.Background(), workflowName, instanceName, tp)
+	suite.Require().NoError(err, "Failed to enqueue workflow")
+	wgTaskStart.Wait()
+	err = m.CancelWorkflow(context.Background(), workflowName, instanceName)
+	suite.Require().NoError(err)
+	wgTaskEnd.Wait()
+	time.Sleep(20 * time.Millisecond)
+
+	instance, err := m.GetWorkflowInstanceByName(context.Background(), instanceName, workflowName)
+	suite.Require().NoError(err)
+	result := TaskResult{}
+	suite.Require().False(instance.IsRunning())
+	suite.Require().Error(instance.Err())
+	err = instance.GetResult(&result)
+	suite.Require().Equal(context.Canceled.Error(), err.Error())
+
+	err = m.Stop()
+	suite.NoError(err)
+}

--- a/lib/cereal/integration/pattern_single_task_workflow.go
+++ b/lib/cereal/integration/pattern_single_task_workflow.go
@@ -5,10 +5,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/chef/automate/lib/cereal/patterns"
 	"github.com/pkg/errors"
 
 	"github.com/chef/automate/lib/cereal"
+	"github.com/chef/automate/lib/cereal/patterns"
 )
 
 func (suite *CerealTestSuite) TestPatternSingleTaskWorkflowSuccess() {
@@ -43,7 +43,7 @@ func (suite *CerealTestSuite) TestPatternSingleTaskWorkflowSuccess() {
 			patterns.NewSingleTaskWorkflowExecutor(taskName, false),
 		),
 	)
-	defer m.Stop()
+	defer m.Stop() // nolint: errcheck
 	err := m.EnqueueWorkflow(context.Background(), workflowName, instanceName, tp)
 	suite.Require().NoError(err, "Failed to enqueue workflow")
 	wgTask.Wait()
@@ -94,7 +94,7 @@ func (suite *CerealTestSuite) TestPatternSingleTaskWorkflowFail() {
 			patterns.NewSingleTaskWorkflowExecutor(taskName, false),
 		),
 	)
-	defer m.Stop()
+	defer m.Stop() // nolint: errcheck
 	err := m.EnqueueWorkflow(context.Background(), workflowName, instanceName, tp)
 	suite.Require().NoError(err, "Failed to enqueue workflow")
 	wgTask.Wait()
@@ -154,7 +154,7 @@ func (suite *CerealTestSuite) TestPatternSingleTaskWorkflowCancelWhenNotAllowed(
 			patterns.NewSingleTaskWorkflowExecutor(taskName, false),
 		),
 	)
-	defer m.Stop()
+	defer m.Stop() // nolint: errcheck
 	err := m.EnqueueWorkflow(context.Background(), workflowName, instanceName, tp)
 	suite.Require().NoError(err, "Failed to enqueue workflow")
 	wgTaskStart.Wait()
@@ -216,7 +216,7 @@ func (suite *CerealTestSuite) TestPatternSingleTaskWorkflowCancelWhenAllowed() {
 			patterns.NewSingleTaskWorkflowExecutor(taskName, true),
 		),
 	)
-	defer m.Stop()
+	defer m.Stop() // nolint: errcheck
 	err := m.EnqueueWorkflow(context.Background(), workflowName, instanceName, tp)
 	suite.Require().NoError(err, "Failed to enqueue workflow")
 	wgTaskStart.Wait()

--- a/lib/cereal/patterns/singletaskworkflow.go
+++ b/lib/cereal/patterns/singletaskworkflow.go
@@ -1,0 +1,53 @@
+package patterns
+
+import (
+	"encoding/json"
+
+	"github.com/chef/automate/lib/cereal"
+	"github.com/sirupsen/logrus"
+)
+
+type SingleTaskWorkflowExecutor struct {
+	taskName    string
+	allowCancel bool
+}
+
+func NewSingleTaskWorkflowExecutor(taskName string, allowCancel bool) *SingleTaskWorkflowExecutor {
+	return &SingleTaskWorkflowExecutor{
+		taskName:    taskName,
+		allowCancel: allowCancel,
+	}
+}
+
+func (s *SingleTaskWorkflowExecutor) OnStart(w cereal.WorkflowInstance, ev cereal.StartEvent) cereal.Decision {
+	var params json.RawMessage
+	err := w.GetParameters(&params)
+	if err != nil {
+		logrus.WithError(err).Error("failed to get parameters")
+		w.Complete()
+	}
+
+	if err := w.EnqueueTask(s.taskName, params); err != nil {
+		return w.Fail(err)
+	}
+	return w.Continue(nil)
+}
+
+func (s *SingleTaskWorkflowExecutor) OnTaskComplete(w cereal.WorkflowInstance, ev cereal.TaskCompleteEvent) cereal.Decision {
+	var result json.RawMessage
+	if err := ev.Result.Err(); err != nil {
+		return w.Fail(err)
+	}
+	if err := ev.Result.Get(&result); err != nil {
+		return w.Fail(err)
+	}
+	return w.Complete(cereal.WithResult(result))
+}
+
+func (s *SingleTaskWorkflowExecutor) OnCancel(w cereal.WorkflowInstance, ev cereal.CancelEvent) cereal.Decision {
+	if s.allowCancel {
+		return w.Complete()
+	} else {
+		return w.Continue(nil)
+	}
+}

--- a/lib/cereal/patterns/singletaskworkflow.go
+++ b/lib/cereal/patterns/singletaskworkflow.go
@@ -1,6 +1,7 @@
 package patterns
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/chef/automate/lib/cereal"
@@ -46,7 +47,7 @@ func (s *SingleTaskWorkflowExecutor) OnTaskComplete(w cereal.WorkflowInstance, e
 
 func (s *SingleTaskWorkflowExecutor) OnCancel(w cereal.WorkflowInstance, ev cereal.CancelEvent) cereal.Decision {
 	if s.allowCancel {
-		return w.Complete()
+		return w.Fail(context.Canceled)
 	} else {
 		return w.Continue(nil)
 	}

--- a/lib/cereal/patterns/singletaskworkflow.go
+++ b/lib/cereal/patterns/singletaskworkflow.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/chef/automate/lib/cereal"
 	"github.com/sirupsen/logrus"
+
+	"github.com/chef/automate/lib/cereal"
 )
 
+// A SingleTaskWorkflowExecutor handles running a workflow composed of
+// a single task. The workflow enqueues the task and startup. The
+// workflow fails if the task fails.
 type SingleTaskWorkflowExecutor struct {
 	taskName    string
 	allowCancel bool

--- a/lib/cereal/patterns/singletaskworkflow.go
+++ b/lib/cereal/patterns/singletaskworkflow.go
@@ -25,7 +25,7 @@ func (s *SingleTaskWorkflowExecutor) OnStart(w cereal.WorkflowInstance, ev cerea
 	err := w.GetParameters(&params)
 	if err != nil {
 		logrus.WithError(err).Error("failed to get parameters")
-		w.Complete()
+		return w.Fail(err)
 	}
 
 	if err := w.EnqueueTask(s.taskName, params); err != nil {


### PR DESCRIPTION
This workflow executor makes it so you don't have to write a workflow executor if your workflow just needs to run 1 task. You can decide if you want to ignore cancel.