### PR TITLE
Add cypress prefix to projects and clean them up before and after the projects API tests

### DIFF
--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -1,41 +1,3 @@
-const avengersProject = {
-  id: `avengers-project-${Cypress.moment().format('MMDDYYhhmm')}`,
-  name: 'Test Avengers Project'
-};
-
-const xmenProject = {
-  id: `xmen-project-${Cypress.moment().format('MMDDYYhhmm')}`,
-  name: 'Test X-men Project'
-};
-
-const avengersRule = {
-  id: 'avengers-rule-1',
-  name: 'first rule of avengers project',
-  type: 'NODE',
-  project_id: avengersProject.id,
-  conditions: [
-    {
-      attribute: 'CHEF_ORGANIZATION',
-      operator: 'EQUALS',
-      values: ['avengers']
-    }
-  ]
-};
-
-const xmenRule = {
-  id: 'xmen-rule-1',
-  name: 'first rule of xmen project',
-  type: 'NODE',
-  project_id: xmenProject.id,
-  conditions: [
-    {
-      attribute: 'CHEF_ORGANIZATION',
-      operator: 'EQUALS',
-      values: ['xmen']
-    }
-  ]
-};
-
 if (Cypress.env('IAM_VERSION') === undefined) {
   // assume local env is on IAM v2.0 since that's the default setting
   Cypress.env('IAM_VERSION', 'v2.0');
@@ -43,115 +5,156 @@ if (Cypress.env('IAM_VERSION') === undefined) {
 const describeIfIAMV2p1 = Cypress.env('IAM_VERSION') === 'v2.1' ? describe : describe.skip;
 
 describeIfIAMV2p1('projects API: applying project', () => {
+  const cypressPrefix = 'cypress-test';
+  const avengersProject = {
+    id: `${cypressPrefix}-avengers-project-${Cypress.moment().format('MMDDYYhhmm')}`,
+    name: 'Test Avengers Project'
+  };
+
+  const xmenProject = {
+    id: `${cypressPrefix}-xmen-project-${Cypress.moment().format('MMDDYYhhmm')}`,
+    name: 'Test X-men Project'
+  };
+
+  const avengersRule = {
+    id: 'avengers-rule-1',
+    name: 'first rule of avengers project',
+    type: 'NODE',
+    project_id: avengersProject.id,
+    conditions: [
+      {
+        attribute: 'CHEF_ORGANIZATION',
+        operator: 'EQUALS',
+        values: ['avengers']
+      }
+    ]
+  };
+
+  const xmenRule = {
+    id: 'xmen-rule-1',
+    name: 'first rule of xmen project',
+    type: 'NODE',
+    project_id: xmenProject.id,
+    conditions: [
+      {
+        attribute: 'CHEF_ORGANIZATION',
+        operator: 'EQUALS',
+        values: ['xmen']
+      }
+    ]
+  };
+  let adminIdToken = '';
+
   before(() => {
     cy.adminLogin('/').then(() => {
-      const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
+      adminIdToken = JSON.parse(<string>localStorage.getItem('chef-automate-user')).id_token;
 
-    // Cypress recommends state cleanup in the before block to ensure
-    // it gets run every time:
-    // tslint:disable-next-line:max-line-length
-    // https://docs.cypress.io/guides/references/best-practices.html#Using-after-or-afterEach-hooks
-    cleanupTestProjects(admin.id_token);
+      // Cypress recommends state cleanup in the before block to ensure
+      // it gets run every time:
+      // tslint:disable-next-line:max-line-length
+      // https://docs.cypress.io/guides/references/best-practices.html#Using-after-or-afterEach-hooks
+      cleanupTestProjects(adminIdToken);
+      cy.cleanupProjectsByIDPrefix(adminIdToken, cypressPrefix);
 
-    cy.request({
-      auth: { bearer: admin.id_token },
-      method: 'POST',
-      url: 'api/v0/ingest/events/chef/node-multiple-deletes',
-      body: {
-        node_ids: [
-          'f6a5c33f-bef5-433b-815e-a8f6e69e6b1b',
-          '82760210-4686-497e-b039-efca78dee64b',
-          '9c139ad0-89a5-44bc-942c-d7f248b155ba',
-          '6453a764-2415-4934-8cee-2a008834a74a'
-        ]
-      },
-      failOnStatusCode: false
-    });
-
-    // use our Admin user's ID token to generate an admin-level API token
-    // for use in the tests as Cypress.env('adminTokenValue')
-    cy.generateAdminToken(admin.id_token);
-
-    // create projects or confirm they already exist
-    for (const project of [avengersProject, xmenProject]) {
       cy.request({
-        auth: { bearer: admin.id_token },
+        auth: { bearer: adminIdToken },
         method: 'POST',
-        url: '/apis/iam/v2beta/projects',
-        failOnStatusCode: false,
-        body: project
-      }).then((response) => {
-        expect([200, 409]).to.include(response.status);
+        url: 'api/v0/ingest/events/chef/node-multiple-deletes',
+        body: {
+          node_ids: [
+            'f6a5c33f-bef5-433b-815e-a8f6e69e6b1b',
+            '82760210-4686-497e-b039-efca78dee64b',
+            '9c139ad0-89a5-44bc-942c-d7f248b155ba',
+            '6453a764-2415-4934-8cee-2a008834a74a'
+          ]
+        },
+        failOnStatusCode: false
       });
-    }
 
-    let totalNodes = 0;
-    cy.request({
-      auth: { bearer: admin.id_token },
-      headers: {
-        projects: '(unassigned)'
-      },
-      method: 'GET',
-      url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
-    }).then((response) => {
-      totalNodes = response.body.length;
-    });
+      // use our Admin user's ID token to generate an admin-level API token
+      // for use in the tests as Cypress.env('adminTokenValue')
+      cy.generateAdminToken(adminIdToken);
 
-    cy.fixture('converge/avengers1.json').then(node1 => {
-      cy.fixture('converge/avengers2.json').then(node2 => {
-        cy.fixture('converge/xmen1.json').then(node3 => {
-          cy.fixture('converge/xmen2.json').then(node4 => {
-            for (const node of [node1, node2, node3, node4]) {
-              cy.request({
-                auth: { bearer: admin.id_token },
-                method: 'POST',
-                url: '/data-collector/v0',
-                body: node
-              });
-            }
+      for (const project of [avengersProject, xmenProject]) {
+        cy.request({
+          auth: { bearer: adminIdToken },
+          method: 'POST',
+          url: '/apis/iam/v2beta/projects',
+          body: project
+        });
+      }
+
+      let totalNodes = 0;
+      cy.request({
+        auth: { bearer: adminIdToken},
+        headers: {
+          projects: '(unassigned)'
+        },
+        method: 'GET',
+        url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+      }).then((response) => {
+        totalNodes = response.body.length;
+      });
+
+      cy.fixture('converge/avengers1.json').then(node1 => {
+        cy.fixture('converge/avengers2.json').then(node2 => {
+          cy.fixture('converge/xmen1.json').then(node3 => {
+            cy.fixture('converge/xmen2.json').then(node4 => {
+              for (const node of [node1, node2, node3, node4]) {
+                cy.request({
+                  auth: { bearer: adminIdToken },
+                  method: 'POST',
+                  url: '/data-collector/v0',
+                  body: node
+                });
+              }
+            });
           });
         });
       });
-    });
-    // There's no waiting involved, it's sending request after request.
-    const maxRetries = 200;
-    waitForNodes(admin.id_token, totalNodes, maxRetries);
+      // There's no waiting involved, it's sending request after request.
+      const maxRetries = 200;
+      waitForNodes(adminIdToken, totalNodes, maxRetries);
 
-    // confirm nodes are unassigned
-    cy.request({
-      auth: { bearer: admin.id_token },
-      headers: {
-        projects: '(unassigned)'
-      },
-      method: 'GET',
-      url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
-    }).then((response) => {
-      expect(response.body).to.have.length(totalNodes + 4);
-    });
+      // confirm nodes are unassigned
+      cy.request({
+        auth: { bearer: adminIdToken },
+        headers: {
+          projects: '(unassigned)'
+        },
+        method: 'GET',
+        url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+      }).then((response) => {
+        expect(response.body).to.have.length(totalNodes + 4);
+      });
 
-    cy.request({
-      auth: { bearer: admin.id_token },
-      headers: {
-        projects: avengersProject.id
-      },
-      method: 'GET',
-      url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
-    }).then((response) => {
-      expect(response.body).to.have.length(0);
-    });
+      cy.request({
+        auth: { bearer: adminIdToken },
+        headers: {
+          projects: avengersProject.id
+        },
+        method: 'GET',
+        url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+      }).then((response) => {
+        expect(response.body).to.have.length(0);
+      });
 
-    cy.request({
-      auth: { bearer: admin.id_token },
-      headers: {
-        projects: xmenProject.id
-      },
-      method: 'GET',
-      url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
-    }).then((response) => {
-      expect(response.body).to.have.length(0);
+      cy.request({
+        auth: { bearer: adminIdToken },
+        headers: {
+          projects: xmenProject.id
+        },
+        method: 'GET',
+        url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
+      }).then((response) => {
+        expect(response.body).to.have.length(0);
+      });
     });
   });
-});
+
+  after(() => {
+    cy.cleanupProjectsByIDPrefix(adminIdToken, cypressPrefix);
+  });
 
   it('new rules get applied to nodes', () => {
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This should help make them less flaky since you can only have 6 projects in a single environment at any time. Also prevented the project variables from being global in scope by moving them into the describe block and fixed the tabbing in before.
