### PR TITLE
Fix race condition in cypress test by preventing typing in input before team loaded

### DIFF
--- a/components/automate-ui/src/app/components/input/input.directive.scss
+++ b/components/automate-ui/src/app/components/input/input.directive.scss
@@ -31,6 +31,11 @@
     border-color: $chef-primary-bright;
   }
 
+  &[disabled] {
+    background-color: $chef-light-grey;
+    opacity: 0.5;
+  }
+
   .error & {
     border-color: $chef-critical;
     border-radius: $global-radius $global-radius 0 0;

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -111,7 +111,11 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
         this.isLoadingTeam =
           (gStatus !== EntityStatus.loadingSuccess) ||
           (uStatus === EntityStatus.loading);
-        this.updateNameForm.controls['name'].enable();
+        if (this.isLoadingTeam) {
+          this.updateNameForm.controls['name'].disable();
+        } else {
+          this.updateNameForm.controls['name'].enable();
+        }
       })
     ).subscribe();
   }

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -5,7 +5,7 @@ if (Cypress.env('IAM_VERSION') === undefined) {
 const describeIfIAMV2p1 = Cypress.env('IAM_VERSION') === 'v2.1' ? describe : describe.skip;
 
 describeIfIAMV2p1('projects API: applying project', () => {
-  const cypressPrefix = 'cypress-test';
+  const cypressPrefix = 'cypress-projects-api';
   const avengersProject = {
     id: `${cypressPrefix}-project1-${Cypress.moment().format('MMDDYYhhmm')}`,
     name: 'Test Avengers Project'

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -7,12 +7,12 @@ const describeIfIAMV2p1 = Cypress.env('IAM_VERSION') === 'v2.1' ? describe : des
 describeIfIAMV2p1('projects API: applying project', () => {
   const cypressPrefix = 'cypress-test';
   const avengersProject = {
-    id: `${cypressPrefix}-avengers-project-${Cypress.moment().format('MMDDYYhhmm')}`,
+    id: `${cypressPrefix}-project1-${Cypress.moment().format('MMDDYYhhmm')}`,
     name: 'Test Avengers Project'
   };
 
   const xmenProject = {
-    id: `${cypressPrefix}-xmen-project-${Cypress.moment().format('MMDDYYhhmm')}`,
+    id: `${cypressPrefix}-project2-${Cypress.moment().format('MMDDYYhhmm')}`,
     name: 'Test X-men Project'
   };
 

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -5,7 +5,7 @@ if (Cypress.env('IAM_VERSION') === undefined) {
 const describeIfIAMV2p1 = Cypress.env('IAM_VERSION') === 'v2.1' ? describe : describe.skip;
 
 describeIfIAMV2p1('projects API: applying project', () => {
-  const cypressPrefix = 'cypress-projects-api';
+  const cypressPrefix = 'test-projects-api';
   const avengersProject = {
     id: `${cypressPrefix}-project1-${Cypress.moment().format('MMDDYYhhmm')}`,
     name: 'Test Avengers Project'

--- a/e2e/cypress/integration/api/iam/02_policies_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/02_policies_api.spec.ts
@@ -1,7 +1,3 @@
-const cypressPrefix = 'cypress';
-const now = Cypress.moment().format('MMDDYYhhmm');
-const projectID = `${cypressPrefix}-project-${now}`;
-
 // This is to prevent tests from running in wrong
 // CI environments. If local, just always run it.
 let iamVersion = <string><Object>Cypress.env('IAM_VERSION');
@@ -12,6 +8,9 @@ const describeIfIAMV2 = iamVersion.match(/v2/) ? describe : describe.skip;
 
 describeIfIAMV2('policies API', () => {
   let adminToken = '';
+  const cypressPrefix = 'cypress-policies-api';
+  const now = Cypress.moment().format('MMDDYYhhmm');
+  const projectID = `${cypressPrefix}-project-${now}`;
 
   beforeEach(() => {
     cy.adminLogin('/').then(() => {

--- a/e2e/cypress/integration/api/iam/02_policies_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/02_policies_api.spec.ts
@@ -8,7 +8,7 @@ const describeIfIAMV2 = iamVersion.match(/v2/) ? describe : describe.skip;
 
 describeIfIAMV2('policies API', () => {
   let adminToken = '';
-  const cypressPrefix = 'cypress-policies-api';
+  const cypressPrefix = 'test-policies-api';
   const now = Cypress.moment().format('MMDDYYhhmm');
   const projectID = `${cypressPrefix}-project-${now}`;
 

--- a/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
@@ -1,7 +1,7 @@
 describe('team management', () => {
   let adminToken = '';
   const now = Cypress.moment().format('MMDDYYhhmm');
-  const cypressPrefix = 'cypress-team-mgmt';
+  const cypressPrefix = 'test-team-mgmt';
   const teamName = `${cypressPrefix} team ${now}`;
   const customTeamID = `${cypressPrefix}-testing-team-custom-id-${now}`;
   const project1ID = `${cypressPrefix}-project1-${now}`;
@@ -60,6 +60,10 @@ describe('team management', () => {
   afterEach(() => {
     cy.saveStorage();
     cy.cleanupTeamsByDescriptionPrefix(adminToken, cypressPrefix);
+  });
+
+  after(() => {
+    cy.cleanupProjectsByIDPrefix(adminToken, cypressPrefix);
   });
 
   context('no custom initial page state', () => {

--- a/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
@@ -1,7 +1,7 @@
 describe('team management', () => {
   let adminToken = '';
   const now = Cypress.moment().format('MMDDYYhhmm');
-  const cypressPrefix = 'cypress-test';
+  const cypressPrefix = 'cypress-team-mgmt';
   const teamName = `${cypressPrefix} team ${now}`;
   const customTeamID = `${cypressPrefix}-testing-team-custom-id-${now}`;
   const project1ID = `${cypressPrefix}-project1-${now}`;

--- a/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
+++ b/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
@@ -1,6 +1,6 @@
 describe('team add users', () => {
   const now = Cypress.moment().format('MMDDYYhhmm');
-  const cypressPrefix = 'cypress-team-add-users';
+  const cypressPrefix = 'test-add-users';
   const nameForUser = cypressPrefix + ' user ' + now;
   const usernameForUser = 'testing-user-' + now;
   const descriptionForTeam = cypressPrefix + ' team ' + now;

--- a/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
+++ b/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
@@ -1,6 +1,6 @@
 describe('team add users', () => {
   const now = Cypress.moment().format('MMDDYYhhmm');
-  const cypressPrefix = 'cypress-test';
+  const cypressPrefix = 'cypress-team-add-users';
   const nameForUser = cypressPrefix + ' user ' + now;
   const usernameForUser = 'testing-user-' + now;
   const descriptionForTeam = cypressPrefix + ' team ' + now;

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -1,7 +1,7 @@
 describe('team details', () => {
   let adminToken = '';
   const now = Cypress.moment().format('MMDDYYhhmm');
-  const cypressPrefix = 'cypress-team-details';
+  const cypressPrefix = 'test-team-details';
   const teamName = `${cypressPrefix} team ${now}`;
   const teamID = `${cypressPrefix}-testing-team-custom-id-${now}`;
   const project1ID = `${cypressPrefix}-project1-${now}`;
@@ -104,6 +104,10 @@ describe('team details', () => {
 
   afterEach(() => {
     cy.saveStorage();
+  });
+
+  after(() => {
+    cy.cleanupProjectsByIDPrefix(adminToken, cypressPrefix);
   });
 
   it('displays team details for admins team', () => {

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -1,7 +1,7 @@
 describe('team details', () => {
   let adminToken = '';
   const now = Cypress.moment().format('MMDDYYhhmm');
-  const cypressPrefix = 'cypress-test';
+  const cypressPrefix = 'cypress-team-details';
   const teamName = `${cypressPrefix} team ${now}`;
   const teamID = `${cypressPrefix}-testing-team-custom-id-${now}`;
   const project1ID = `${cypressPrefix}-project1-${now}`;

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -1,4 +1,4 @@
-describe('team management', () => {
+describe('team details', () => {
   let adminToken = '';
   const now = Cypress.moment().format('MMDDYYhhmm');
   const cypressPrefix = 'cypress-test';
@@ -140,14 +140,14 @@ describe('team management', () => {
 
       it('cannot access projects dropdown but changing name allows team update submission', () => {
         cy.get('[data-cy=team-details-tab-details]').click();
-        cy.get('[data-cy=team-details-name-input]').should('have.value', teamName);
-        cy.get('[data-cy=team-details-submit-button]').should('have.attr', 'aria-disabled');
 
-        // initial state of dropdown
+        // initial state of page
+        cy.get('[data-cy=team-details-submit-button]').should('have.attr', 'aria-disabled');
         cy.get('app-team-details app-projects-dropdown #projects-selected').contains(unassigned);
         cy.get('app-team-details app-projects-dropdown .dropdown-button').should('be.disabled');
 
-        cy.get('[data-cy=team-details-name-input]').type('updated name');
+        cy.get('[data-cy=team-details-name-input]')
+          .should('have.value', teamName).should('not.be.disabled').type('updated name');
         cy.get('[data-cy=team-details-submit-button]').should('not.have.attr', 'aria-disabled');
       });
     });


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

If you have a team in the store already, it will populate the team save input before the team is fetched via the API. Since we didn't prevent typing in the input before the team was fetched via the API, cypress would find the input, find that the team name was correct (from the store cache), and then type. However, this would happen so fast the team wasn't fetched yet. When the fetch completed, it overwrote the updated team name cypress typed before save was clicked.

I've added functionality to disable the team name input before the team is fetched and while a save is in progress. The cypress tests should now pass since they are asserting that the input is enabled, preventing the race condition.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable

Also added base styling for the chefInput directive when disabled. It looks like this:

![Screen Shot 2019-08-20 at 3 39 07 PM](https://user-images.githubusercontent.com/1899715/63389716-7beec380-c361-11e9-970f-c7c11f04eb6d.png)
