### PR TITLE
Remove retry for applications-service

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -135,9 +135,6 @@ steps:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh && start_deployment_service && chef-automate dev deploy-some chef/applications-service --with-deps && applications_integration"
     timeout_in_minutes: 20
-    retry:
-      automatic:
-        limit: 1
     expeditor:
       executor:
         docker:


### PR DESCRIPTION
This will remove the retry for applications-service integration test when they fail. 

Signed-off-by: kmacgugan <kmacgugan@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable