### PR TITLE
Unify already on IAM version messaging and only migrate if necessary in IAM v1.0

### DIFF
--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -647,7 +647,7 @@ func (s *policyServer) ResetToV1(ctx context.Context,
 		return nil, status.Errorf(codes.Internal, "retrieve migration status: %s", err.Error())
 	}
 	switch ms {
-	case storage.Pristine: // skip
+	case storage.Pristine:
 		return nil, status.Error(codes.AlreadyExists, "already reset")
 	case storage.InProgress:
 		return nil, status.Error(codes.FailedPrecondition, "migration in progress")

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -648,6 +648,7 @@ func (s *policyServer) ResetToV1(ctx context.Context,
 	}
 	switch ms {
 	case storage.Pristine: // skip
+		return nil, status.Error(codes.AlreadyExists, "already reset")
 	case storage.InProgress:
 		return nil, status.Error(codes.FailedPrecondition, "migration in progress")
 	case storage.Successful, storage.SuccessfulBeta1, storage.Failed:

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -2606,7 +2606,7 @@ func TestResetToV1(t *testing.T) {
 	status := ts.status
 
 	cases := map[string]func(*testing.T){
-		"initial migration status eturns AlreadyExists to indicate no-op": func(t *testing.T) {
+		"initial migration status returns AlreadyExists to indicate no-op": func(t *testing.T) {
 			ms, err := status.MigrationStatus(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, storage.Pristine, ms)

--- a/components/automate-cli/cmd/chef-automate/iam.go
+++ b/components/automate-cli/cmd/chef-automate/iam.go
@@ -150,7 +150,7 @@ func init() {
 }
 
 // Note: the indentation is to keep this in line with writer.Body()
-const alreadyMigratedMessage = `You are already using IAM %s.`
+const alreadyMigratedMessage = "You are already on IAM version %s."
 
 type vsn struct {
 	Major policies_common.Version_VersionNumber

--- a/integration/tests/upgrade_reset_iam_v2.sh
+++ b/integration/tests/upgrade_reset_iam_v2.sh
@@ -58,7 +58,7 @@ do_test_deploy() {
     fi
 
     log_info "v2 -> v2 (expect failure)"
-    expect_iam_upgrade_output "You are already using IAM v2." \
+    expect_iam_upgrade_output "You are already on IAM version v2." \
         "$(chef-automate iam upgrade-to-v2 2>&1)" || return 1
 
     log_info "v2 -> v2.1"
@@ -82,6 +82,10 @@ do_test_deploy() {
     log_info "v2 -> v1"
     chef-automate iam reset-to-v1 || return 1
     expect_iam_version "IAM v1.0" || return 1
+
+    log_info "v1 -> v1 (expect failure)"
+    expect_iam_upgrade_output "You are already on IAM version v1." \
+        "$(chef-automate iam reset-to-v1 2>&1)" || return 1
 
     do_test_deploy_default
 }

--- a/integration/tests/upgrade_reset_iam_v2.sh
+++ b/integration/tests/upgrade_reset_iam_v2.sh
@@ -58,7 +58,7 @@ do_test_deploy() {
     fi
 
     log_info "v2 -> v2 (expect failure)"
-    expect_iam_upgrade_output "You have already upgraded to IAM v2." \
+    expect_iam_upgrade_output "You are already using IAM v2." \
         "$(chef-automate iam upgrade-to-v2 2>&1)" || return 1
 
     log_info "v2 -> v2.1"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Updated the messaging output for trying to switch to an IAM version you are already on to be consistent. Also updated the reset to v1 GRPC command to return `AlreadyExists` similar to the upgrade to v2 command and not run the reset migration. 

### :athletic_shoe: How to Build and Test the Change

```
rebuild components/automate-cli
rebuild components/authz-service
```

Upgrade, reset, etc.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable