### PR TITLE
lib/cereal: jitter the task poller wakeup

### DIFF
--- a/lib/cereal/cereal_test.go
+++ b/lib/cereal/cereal_test.go
@@ -7,6 +7,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestJitterDownIntervalProvider(t *testing.T) {
+	base := 10 * time.Second
+	jitter := 1 * time.Second
+	provider := newJitterDownIntervalProvider(base, jitter)
+
+	t.Run("it doesn't return a value less than interval - jitter", func(t *testing.T) {
+		for i := 0; i < 1000; i++ {
+			n := provider.Next()
+			assert.True(t, n > 9*time.Second, "returned interval is above min")
+		}
+	})
+	// This test is kinda silly
+	t.Run("it rarely returns a value equal to the base", func(t *testing.T) {
+		sameCount := 0
+		for i := 0; i < 1000; i++ {
+			n := provider.Next()
+			if n == base {
+				sameCount++
+			}
+		}
+		assert.True(t, sameCount < 3, "returned interval was the same as the base an unusual number of times")
+	})
+}
+
 func TestWaywardWorkflowList(t *testing.T) {
 	waywardWorkflowTimeout = 10 * time.Millisecond
 	t.Run("filter returns the entire list if there are no wayward workflows", func(t *testing.T) {

--- a/lib/cereal/integration/delayed_task.go
+++ b/lib/cereal/integration/delayed_task.go
@@ -47,6 +47,7 @@ func (suite *CerealTestSuite) TestDelayedTask() {
 			},
 		),
 		WithManagerOpts(
+			cereal.WithTaskPollInterval(2*time.Second),
 			cereal.WithOnWorkflowCompleteCallback(func(*backend.WorkflowEvent) {
 				wgTask.Done()
 			}),


### PR DESCRIPTION
This is one of a couple of changes to reduce the churn in database
connections used by cereal. By default, the Go sql library only keeps
2 idle connections. Thus, when we have a burst of task poller
activity, we start and subsequently close many new connections,
causing log spam from automate-pg-gateway.
    
One thing we can and will do is bump the number of idle connections.
    
This PR, however, reduces the "thundering hurd" of task pollers, by
introducing a small jitter into their wakeup time.

Signed-off-by: Steven Danna <steve@chef.io>