### PR TITLE
lib/cereal limit number of concurrent TaskDequeue calls

### DIFF
--- a/lib/cereal/backend/backend.go
+++ b/lib/cereal/backend/backend.go
@@ -6,11 +6,11 @@ import (
 )
 
 type Driver interface {
+	TaskDequeuer
+
 	EnqueueWorkflow(ctx context.Context, workflow *WorkflowInstance) error
 	DequeueWorkflow(ctx context.Context, workflowNames []string) (*WorkflowEvent, WorkflowCompleter, error)
 	CancelWorkflow(ctx context.Context, instanceName string, workflowName string) error
-
-	DequeueTask(ctx context.Context, taskName string) (*Task, TaskCompleter, error)
 
 	CreateWorkflowSchedule(ctx context.Context, instanceName string, workflowName string, parameters []byte, enabled bool, recurrence string, nextRunAt time.Time) error
 	ListWorkflowSchedules(ctx context.Context) ([]*Schedule, error)
@@ -23,6 +23,10 @@ type Driver interface {
 
 	Init() error
 	Close() error
+}
+
+type TaskDequeuer interface {
+	DequeueTask(ctx context.Context, taskName string) (*Task, TaskCompleter, error)
 }
 
 type SchedulerDriver interface {

--- a/lib/cereal/postgres/postgres.go
+++ b/lib/cereal/postgres/postgres.go
@@ -840,6 +840,7 @@ func (pg *PostgresBackend) DequeueTask(ctx context.Context, taskName string) (*b
 
 	return task, taskc, nil
 }
+
 func (taskc *PostgresTaskCompleter) Context() context.Context {
 	return taskc.ctx
 }

--- a/lib/cereal/task_dequeue_pool.go
+++ b/lib/cereal/task_dequeue_pool.go
@@ -1,0 +1,128 @@
+package cereal
+
+import (
+	"context"
+	"sync"
+
+	"github.com/chef/automate/lib/cereal/backend"
+)
+
+// taskDequeuePool is a pool of workers calling DequeueTask on the
+// given TaskDequeuer. The purpose of the pool is to limit concurrent
+// dequeue operations being send to the backend.
+type taskDequeuePool struct {
+	size     int
+	dequeuer backend.TaskDequeuer
+
+	reqChan chan taskDequeueReq
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	wgStart sync.WaitGroup
+}
+
+type taskDequeueReq struct {
+	name     string
+	ctx      context.Context
+	respChan chan taskDequeueResp
+}
+
+type taskDequeueResp struct {
+	err       error
+	task      *backend.Task
+	completer backend.TaskCompleter
+}
+
+func newTaskDequeuePool(size int, dequeuer backend.TaskDequeuer) *taskDequeuePool {
+	p := &taskDequeuePool{
+		size:     size,
+		dequeuer: dequeuer,
+		reqChan:  make(chan taskDequeueReq),
+	}
+	p.wgStart.Add(1)
+	return p
+}
+
+func (d *taskDequeuePool) Start(ctx context.Context) {
+	d.wgStart.Done() // panic if start is called twice
+
+	ctx, cancel := context.WithCancel(ctx)
+	d.ctx = ctx
+	d.cancel = cancel
+
+	d.wg.Add(d.size)
+	for i := 0; i < d.size; i++ {
+		go d.worker(d.ctx)
+	}
+}
+
+func (d *taskDequeuePool) Stop() {
+	if d.cancel != nil {
+		d.cancel()
+	}
+	d.wg.Wait()
+}
+
+func (d *taskDequeuePool) DequeueTask(ctx context.Context, taskName string) (*backend.Task, backend.TaskCompleter, error) {
+	respChan := make(chan taskDequeueResp)
+	req := taskDequeueReq{
+		name:     taskName,
+		ctx:      ctx,
+		respChan: respChan,
+	}
+	select {
+	case d.reqChan <- req:
+		// TODO(ssd) 2019-08-23: We don't wait on the context
+		// here. We depend on the worker to respect the
+		// context we sent in the dequeueReq.
+		//
+		// If we were to select on the context here, the
+		// worker could dequeued the task and try to send it
+		// to us after we've exited. This would be bad because
+		// then nothing would stop the taskPinger in the pg
+		// case, or close the grpc connection in the GRPC
+		// case.
+		//
+		// At the moment, this wouldn't be a big deal since if
+		// those contexts get cancelled it likely means the
+		// entire service is shutting down. But, let's avoid
+		// it anyway.
+		//
+		// We could alternatively avoid it by adding an
+		// Abandon() on the task completer. Then if we were to
+		// exit here early, we could have a goroutine that ate
+		// the last respond and called Abandon() on it.
+		resp := <-respChan
+		return resp.task, resp.completer, resp.err
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	}
+}
+
+func (d *taskDequeuePool) worker(ctx context.Context) {
+	for {
+		select {
+		case req := <-d.reqChan:
+			// NOTE(ssd) 2019-08-23: In-flight dequeues
+			// currently cause Stop() to block until they
+			// are complete, because the context used here
+			// is from the client, not the worker. We
+			// could create a combined context from the
+			// worker and the client contexts, but then we
+			// would either need to leak the resources
+			// related to that context or somehow untangle
+			// the TaskCompleter which will stop pinging
+			// if the context we pass here is ever
+			// cancelled.
+			t, taskCompleter, err := d.dequeuer.DequeueTask(req.ctx, req.name)
+			req.respChan <- taskDequeueResp{
+				task:      t,
+				completer: taskCompleter,
+				err:       err,
+			}
+		case <-d.ctx.Done():
+			d.wg.Done()
+			return
+		}
+	}
+}

--- a/lib/cereal/task_dequeue_pool_test.go
+++ b/lib/cereal/task_dequeue_pool_test.go
@@ -1,0 +1,118 @@
+package cereal
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/chef/automate/lib/cereal/backend"
+)
+
+var errTestDequeueNoTasks = errors.New("no tasks in test dequeuer")
+
+type sleepyDequeuer struct {
+	maxMS int
+}
+
+func (s *sleepyDequeuer) DequeueTask(ctx context.Context, name string) (*backend.Task, backend.TaskCompleter, error) {
+	if s.maxMS > 0 {
+		time.Sleep(time.Duration(rand.Intn(s.maxMS)) * time.Millisecond)
+	}
+	return nil, nil, errTestDequeueNoTasks
+}
+
+type checkedMaxDequeuer struct {
+	max   int
+	t     *testing.T
+	inner backend.TaskDequeuer
+
+	active int
+	mu     sync.Mutex
+}
+
+func (w *checkedMaxDequeuer) DequeueTask(ctx context.Context, name string) (*backend.Task, backend.TaskCompleter, error) {
+	w.checkWorkerLimit()
+	defer w.done()
+
+	return w.inner.DequeueTask(ctx, name)
+}
+
+func (w *checkedMaxDequeuer) checkWorkerLimit() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.active++
+	if w.active > w.max {
+		w.t.Errorf("worker count went over expected max of %d", w.max)
+	}
+}
+
+func (w *checkedMaxDequeuer) done() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.active--
+}
+
+func TestDequeuePoolCanDequeue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	d := &checkedMaxDequeuer{
+		t:     t,
+		max:   2,
+		inner: &sleepyDequeuer{},
+	}
+	pool := newTaskDequeuePool(2, d)
+	pool.Start(ctx)
+	defer pool.Stop()
+
+	_, _, err := pool.DequeueTask(ctx, "some task")
+	assert.Equal(t, errTestDequeueNoTasks, err)
+}
+
+func TestDequeuePoolLimitsWorkers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	defer cancel()
+	d := &checkedMaxDequeuer{
+		t:     t,
+		max:   2,
+		inner: &sleepyDequeuer{maxMS: 5},
+	}
+	wg := &sync.WaitGroup{}
+	pool := newTaskDequeuePool(2, d)
+	pool.Start(ctx)
+	defer pool.Stop()
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			_, _, _ = pool.DequeueTask(ctx, "some task")
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestDequeuePoolWaitingRequestsRespectContexts(t *testing.T) {
+	tCtx, tCancel := context.WithCancel(context.Background())
+	defer tCancel()
+
+	d := &checkedMaxDequeuer{
+		t:     t,
+		max:   2,
+		inner: &sleepyDequeuer{},
+	}
+
+	pool := newTaskDequeuePool(0, d) // no worker, job should time out
+	pool.Start(tCtx)
+	defer pool.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	_, _, err := pool.DequeueTask(ctx, "some task")
+	assert.Equal(t, context.DeadlineExceeded, err)
+}


### PR DESCRIPTION
For each registered task, we call TaskDequeue every
TaskPoolInterval. For a service with a large number of task executors,
this can cause a large number TaskDequeue calls to be made to the
backend.

Similarly, even with 1 TaskExecutor configured for 10 workers, if
those workers are processing a large number of tasks, each worker will
call TaskDequeue. This may not be the most efficient way to use a
given backend.

This changes adds a small pool that can be used to limit the
concurrency of TaskDequeue calls.

Signed-off-by: Steven Danna <steve@chef.io>