### PR TITLE
ci: don't commit to master in update_docker_image script

### DIFF
--- a/.expeditor/update_docker_image_version_in_verify_pipeline.sh
+++ b/.expeditor/update_docker_image_version_in_verify_pipeline.sh
@@ -14,6 +14,7 @@ sed -i -r "s|image_sha256: .+|image_sha256: ${EXPEDITOR_SHA256_DIGEST#"sha256:"}
 sed -i -r "s|image_sha256: .+|image_sha256: ${EXPEDITOR_SHA256_DIGEST#"sha256:"}|" .expeditor/verify_private.pipeline.yml
 sed -i -r "s|image_sha256: .+|image_sha256: ${EXPEDITOR_SHA256_DIGEST#"sha256:"}|" .expeditor/nightly.pipeline.yml
 
+git add .expeditor/nightly.pipeline.yml
 git add .expeditor/verify.pipeline.yml
 git add .expeditor/verify_private.pipeline.yml
 
@@ -25,4 +26,5 @@ open_pull_request
 
 # Get back to master and cleanup the leftovers - any changed files left over at the end of this script will get committed to master.
 git checkout -
+git clean -fxd
 git branch -D "$branch"


### PR DESCRIPTION
We failed to `git add` the nightly.pipeline.yml file. As a result,
part of the update this script performs was being committed directly
to master rather than as part of the PR.

Signed-off-by: Steven Danna <steve@chef.io>