### PR TITLE
Streamline projects on team details page

### DIFF
--- a/components/automate-ui/src/app/entities/policies/policy.requests.ts
+++ b/components/automate-ui/src/app/entities/policies/policy.requests.ts
@@ -3,12 +3,12 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 import { environment as env } from 'environments/environment';
-import { Policy } from './policy.model';
+import { Policy, IAMMajorVersion, IAMMinorVersion } from './policy.model';
 
 export interface IamVersionResponse {
   version: {
-    major: 'V1' | 'V2';
-    minor: 'V0' | 'V1';
+    major: IAMMajorVersion;
+    minor: IAMMinorVersion;
   };
 }
 

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -78,9 +78,8 @@
           (onProjectChecked)="onProjectChecked($event)"
           [disabled]="dropdownDisabled()">
         </app-projects-dropdown>
-        <chef-loading-spinner  size="30" *ngIf="teamProjectsLeftToFetch.length !== 0"></chef-loading-spinner>
       </div>
-      <chef-button [disabled]="isLoadingTeam || teamProjectsLeftToFetch.length !== 0 || !updateNameForm.valid || (!updateNameForm.dirty && noProjectsUpdated())"
+      <chef-button [disabled]="isLoadingTeam || !updateNameForm.valid || (!updateNameForm.dirty && noProjectsUpdated())"
         primary inline (click)="saveTeam()" data-cy="team-details-submit-button">
         <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
         <span *ngIf="saving">Saving...</span>

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
@@ -24,8 +24,6 @@ import {
   projectEntityReducer,
   ProjectEntityInitialState
 } from 'app/entities/projects/project.reducer';
-import { GetProjects, GetProjectsSuccess } from 'app/entities/projects/project.actions';
-import { Project } from 'app/entities/projects/project.model';
 import {
   userEntityReducer,
   UserEntityInitialState
@@ -179,7 +177,6 @@ describe('TeamDetailsComponent', () => {
       const version: IamVersionResponse = { version: { major: major, minor: 'v0' } };
       store.dispatch(new GetIamVersionSuccess(version));
 
-      expect(store.dispatch).toHaveBeenCalledWith(new GetProjects());
       expect(store.dispatch).toHaveBeenCalledWith(new GetUsers());
       expect(store.dispatch).toHaveBeenCalledWith(new GetTeamUsers({ id: targetId }));
     });
@@ -197,7 +194,7 @@ describe('TeamDetailsComponent', () => {
       expect(component.projects[p.value]).toBeTruthy();
       expect(component.projects[p.value].checked).toEqual(false);
     });
-    // But team's projects are still empty at this point!
+    // But team's projects are still empty at this point
     expect(component.team.projects.length).toEqual(0);
   });
 
@@ -218,23 +215,6 @@ describe('TeamDetailsComponent', () => {
     ];
     store.dispatch(new LoadOptionsSuccess({ fetched: projectOptionList, restored: [] }));
 
-    // That initializes the list for the team projects dropdown, all unchecked
-    expect(Object.keys(component.projects))
-      .toEqual(jasmine.arrayWithExactContents(projectOptionList.map(p => p.value)));
-    Object.keys(component.projects).forEach(id => {
-      expect(component.projects[id].checked).toEqual(false);
-    });
-
-    // Team details initiates GetProjects to fetch a hydrated list of projects
-    const projectList = [
-      genProject('a-proj'),
-      genProject('b-proj'),
-      genProject('c-proj'),
-      genProject('d-proj')
-    ];
-    store.dispatch(new GetProjectsSuccess({ projects: projectList }));
-
-    // And that is used to set checked true for any projects that the team already includes
     projectOptionList.forEach(p => {
       expect(component.projects[p.value].checked).toEqual(teamProjects.includes(p.value));
     });
@@ -341,15 +321,5 @@ describe('TeamDetailsComponent', () => {
       value: value ? value : label
     };
   }
-
-function genProject(id: string): Project {
-  return {
-    id,
-    status: 'NO_RULES', // unused
-    name: id, // unused
-    type: 'CUSTOM' // unused
-  };
-}
-
 
 });

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
@@ -182,22 +182,6 @@ describe('TeamDetailsComponent', () => {
     });
   });
 
-  it('initializes dropdown with all assignable projects, each unchecked', () => {
-    const projectOptionList = [
-      genProjectOption('a-proj'),
-      genProjectOption('b-proj'),
-      genProjectOption('c-proj'),
-      genProjectOption('d-proj')
-    ];
-    store.dispatch(new LoadOptionsSuccess({ fetched: projectOptionList, restored: [] }));
-    projectOptionList.forEach(p => {
-      expect(component.projects[p.value]).toBeTruthy();
-      expect(component.projects[p.value].checked).toEqual(false);
-    });
-    // But team's projects are still empty at this point
-    expect(component.team.projects.length).toEqual(0);
-  });
-
   it('initializes dropdown with those included on the team checked', () => {
     const teamProjects = ['b-proj', 'd-proj'];
     const team: Team = { id: targetId, guid: 'any', name: 'any', projects: teamProjects };

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
@@ -7,43 +7,54 @@ import { MockComponent } from 'ng2-mock-component';
 import { StoreModule, Store } from '@ngrx/store';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { using } from 'app/testing/spec-helpers';
+import {
+  projectsFilterReducer,
+  projectsFilterInitialState,
+  ProjectsFilterOption
+} from 'app/services/projects-filter/projects-filter.reducer';
+import { LoadOptionsSuccess } from 'app/services/projects-filter/projects-filter.actions';
 import {
   policyEntityReducer, PolicyEntityInitialState
 } from 'app/entities/policies/policy.reducer';
+import { GetIamVersionSuccess } from 'app/entities/policies/policy.actions';
+import { IamVersionResponse } from 'app/entities/policies/policy.requests';
+import { IAMMajorVersion } from 'app/entities/policies/policy.model';
+import {
+  projectEntityReducer,
+  ProjectEntityInitialState
+} from 'app/entities/projects/project.reducer';
+import { GetProjects, GetProjectsSuccess } from 'app/entities/projects/project.actions';
+import { Project } from 'app/entities/projects/project.model';
 import {
   userEntityReducer,
   UserEntityInitialState
 } from 'app/entities/users/user.reducer';
-import { GetUsersSuccess } from 'app/entities/users/user.actions';
+import { GetUsersSuccess, GetUsers } from 'app/entities/users/user.actions';
 import {
   teamEntityReducer,
   TeamEntityInitialState
 } from 'app/entities/teams/team.reducer';
 import {
   GetTeamSuccess,
-  GetTeamUsersSuccess
+  GetTeamUsersSuccess,
+  GetTeamUsers
 } from 'app/entities/teams/team.actions';
 import { Team } from 'app/entities/teams/team.model';
 import { TeamDetailsComponent } from './team-details.component';
-import {
-  projectsFilterReducer,
-  projectsFilterInitialState
-} from 'app/services/projects-filter/projects-filter.reducer';
-import {
-  projectEntityReducer,
-  ProjectEntityInitialState
-} from 'app/entities/projects/project.reducer';
 
 describe('TeamDetailsComponent', () => {
   let component: TeamDetailsComponent;
   let fixture: ComponentFixture<TeamDetailsComponent>;
   let router: Router;
+  let store: Store<NgrxStateAtom>;
 
+  const targetId = 'a-team-uuid-01';
   const initialState = {
     router: {
       state: {
-        url: '/settings/teams/a-team-uuid-01',
-        params: { id: 'a-team-uuid-01' },
+        url: `/settings/teams/${targetId}`,
+        params: { id: targetId },
         queryParams: {},
         fragment: ''
       },
@@ -106,15 +117,16 @@ describe('TeamDetailsComponent', () => {
   }));
 
   const someTeam: Team = {
-    id: 'some-team',
+    id: targetId,
     name: 'some team',
-    guid: 'a-team-uuid-01',
+    guid: targetId,
     projects: []
   };
 
   beforeEach(() => {
     router = TestBed.get(Router);
     spyOn(router, 'navigate').and.stub();
+    store = TestBed.get(Store);
 
     fixture = TestBed.createComponent(TeamDetailsComponent);
     component = fixture.componentInstance;
@@ -141,9 +153,7 @@ describe('TeamDetailsComponent', () => {
   });
 
   describe('empty state', () => {
-    let store: Store<NgrxStateAtom>;
     beforeEach(() => {
-      store = TestBed.get(Store);
       store.dispatch(new GetTeamSuccess(someTeam));
       store.dispatch(new GetTeamUsersSuccess({
         user_ids: []
@@ -158,11 +168,79 @@ describe('TeamDetailsComponent', () => {
     });
   });
 
-  describe('sortedUsers$', () => {
-    let store: Store<NgrxStateAtom>;
-    beforeEach(() => {
-      store = TestBed.get(Store);
+  using([
+    [targetId, 'other', 'V2'],
+    ['other', targetId, 'V1']
+  ], function (id: string, guid: string, major: IAMMajorVersion) {
+    it(`initializes with fetching data for ${major} team users and projects`, () => {
+      spyOn(store, 'dispatch').and.callThrough();
+      const team: Team = { id, guid, name: 'any', projects: [] };
+      store.dispatch(new GetTeamSuccess(team));
+      const version: IamVersionResponse = { version: { major: major, minor: 'v0' } };
+      store.dispatch(new GetIamVersionSuccess(version));
+
+      expect(store.dispatch).toHaveBeenCalledWith(new GetProjects());
+      expect(store.dispatch).toHaveBeenCalledWith(new GetUsers());
+      expect(store.dispatch).toHaveBeenCalledWith(new GetTeamUsers({ id: targetId }));
     });
+  });
+
+  it('initializes dropdown with all assignable projects, each unchecked', () => {
+    const projectOptionList = [
+      genProjectOption('a-proj'),
+      genProjectOption('b-proj'),
+      genProjectOption('c-proj'),
+      genProjectOption('d-proj')
+    ];
+    store.dispatch(new LoadOptionsSuccess({ fetched: projectOptionList, restored: [] }));
+    projectOptionList.forEach(p => {
+      expect(component.projects[p.value]).toBeTruthy();
+      expect(component.projects[p.value].checked).toEqual(false);
+    });
+    // But team's projects are still empty at this point!
+    expect(component.team.projects.length).toEqual(0);
+  });
+
+  it('initializes dropdown with those included on the team checked', () => {
+    const teamProjects = ['b-proj', 'd-proj'];
+    const team: Team = { id: targetId, guid: 'any', name: 'any', projects: teamProjects };
+    store.dispatch(new GetTeamSuccess(team));
+
+    const version: IamVersionResponse = { version: { major: 'v2', minor: 'v1' } };
+    store.dispatch(new GetIamVersionSuccess(version));
+
+    // populate the global project filter (the source for assignable projects)
+    const projectOptionList = [
+      genProjectOption('a-proj'),
+      genProjectOption('b-proj'),
+      genProjectOption('c-proj'),
+      genProjectOption('d-proj')
+    ];
+    store.dispatch(new LoadOptionsSuccess({ fetched: projectOptionList, restored: [] }));
+
+    // That initializes the list for the team projects dropdown, all unchecked
+    expect(Object.keys(component.projects))
+      .toEqual(jasmine.arrayWithExactContents(projectOptionList.map(p => p.value)));
+    Object.keys(component.projects).forEach(id => {
+      expect(component.projects[id].checked).toEqual(false);
+    });
+
+    // Team details initiates GetProjects to fetch a hydrated list of projects
+    const projectList = [
+      genProject('a-proj'),
+      genProject('b-proj'),
+      genProject('c-proj'),
+      genProject('d-proj')
+    ];
+    store.dispatch(new GetProjectsSuccess({ projects: projectList }));
+
+    // And that is used to set checked true for any projects that the team already includes
+    projectOptionList.forEach(p => {
+      expect(component.projects[p.value].checked).toEqual(teamProjects.includes(p.value));
+    });
+   });
+
+  describe('sortedUsers$', () => {
 
     it('intermixes capitals and lowercase with lowercase first', () => {
       store.dispatch(new GetTeamUsersSuccess({ user_ids: ['user-id-1', 'user-id-2'] }));
@@ -254,5 +332,24 @@ describe('TeamDetailsComponent', () => {
       });
     });
   });
-});
 
+  function genProjectOption(
+    label: string, checked?: boolean, value?: string): ProjectsFilterOption {
+    return <ProjectsFilterOption>{
+      label: label,
+      checked: checked === undefined ? false : checked,
+      value: value ? value : label
+    };
+  }
+
+function genProject(id: string): Project {
+  return {
+    id,
+    status: 'NO_RULES', // unused
+    name: id, // unused
+    type: 'CUSTOM' // unused
+  };
+}
+
+
+});

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.spec.ts
@@ -10,10 +10,8 @@ import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { using } from 'app/testing/spec-helpers';
 import {
   projectsFilterReducer,
-  projectsFilterInitialState,
-  ProjectsFilterOption
+  projectsFilterInitialState
 } from 'app/services/projects-filter/projects-filter.reducer';
-import { LoadOptionsSuccess } from 'app/services/projects-filter/projects-filter.actions';
 import {
   policyEntityReducer, PolicyEntityInitialState
 } from 'app/entities/policies/policy.reducer';
@@ -24,6 +22,8 @@ import {
   projectEntityReducer,
   ProjectEntityInitialState
 } from 'app/entities/projects/project.reducer';
+import { Project } from 'app/entities/projects/project.model';
+import { GetProjectsSuccess, GetProjects } from 'app/entities/projects/project.actions';
 import {
   userEntityReducer,
   UserEntityInitialState
@@ -179,6 +179,7 @@ describe('TeamDetailsComponent', () => {
 
       expect(store.dispatch).toHaveBeenCalledWith(new GetUsers());
       expect(store.dispatch).toHaveBeenCalledWith(new GetTeamUsers({ id: targetId }));
+      expect(store.dispatch).toHaveBeenCalledWith(new GetProjects());
     });
   });
 
@@ -190,17 +191,16 @@ describe('TeamDetailsComponent', () => {
     const version: IamVersionResponse = { version: { major: 'v2', minor: 'v1' } };
     store.dispatch(new GetIamVersionSuccess(version));
 
-    // populate the global project filter (the source for assignable projects)
-    const projectOptionList = [
-      genProjectOption('a-proj'),
-      genProjectOption('b-proj'),
-      genProjectOption('c-proj'),
-      genProjectOption('d-proj')
+    const projectList = [
+      genProject('a-proj'),
+      genProject('b-proj'),
+      genProject('c-proj'),
+      genProject('d-proj')
     ];
-    store.dispatch(new LoadOptionsSuccess({ fetched: projectOptionList, restored: [] }));
+    store.dispatch(new GetProjectsSuccess({ projects: projectList }));
 
-    projectOptionList.forEach(p => {
-      expect(component.projects[p.value].checked).toEqual(teamProjects.includes(p.value));
+    projectList.forEach(p => {
+      expect(component.projects[p.id].checked).toEqual(teamProjects.includes(p.id));
     });
    });
 
@@ -297,13 +297,12 @@ describe('TeamDetailsComponent', () => {
     });
   });
 
-  function genProjectOption(
-    label: string, checked?: boolean, value?: string): ProjectsFilterOption {
-    return <ProjectsFilterOption>{
-      label: label,
-      checked: checked === undefined ? false : checked,
-      value: value ? value : label
+  function genProject(id: string): Project {
+    return {
+      id,
+      status: 'NO_RULES', // unused
+      name: id, // unused
+      type: 'CUSTOM' // unused
     };
   }
-
 });

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
@@ -6,8 +6,7 @@ import {
   ProjectsFilterState,
   projectsFilterInitialState,
   projectsFilterReducer,
-  ProjectsFilterOption,
-  ProjectsFilterOptionTuple
+  ProjectsFilterOption
 } from './projects-filter.reducer';
 import { LoadOptions, LoadOptionsSuccess } from './projects-filter.actions';
 
@@ -114,7 +113,7 @@ describe('projectsFilterReducer', () => {
 
       it('returns no values when no fetched values and no restored values', () => {
         const action = new LoadOptionsSuccess(
-          <ProjectsFilterOptionTuple>{
+          {
             fetched: [],
             restored: []
           });
@@ -126,7 +125,7 @@ describe('projectsFilterReducer', () => {
 
       it('returns no values when restored values but no fetched values', () => {
         const action = new LoadOptionsSuccess(
-          <ProjectsFilterOptionTuple>{
+          {
             fetched: [],
             restored: [
               genProject('a-proj', false),
@@ -142,7 +141,7 @@ describe('projectsFilterReducer', () => {
 
       it('returns all fetched values when no restored values', () => {
         const action = new LoadOptionsSuccess(
-          <ProjectsFilterOptionTuple>{
+          {
             fetched: [
               genProject('zz-proj'),
               genProject('c-proj', true),
@@ -150,7 +149,7 @@ describe('projectsFilterReducer', () => {
               genProject('a-proj', true),
               genProject('b-proj')
             ],
-            restored: {}
+            restored: []
           });
 
         const { options } = projectsFilterReducer(initialState, action);
@@ -166,7 +165,7 @@ describe('projectsFilterReducer', () => {
 
       it('includes all fetched options even if not in restored', () => {
         const action = new LoadOptionsSuccess(
-          <ProjectsFilterOptionTuple>{
+          {
             fetched: [
               genProject('a-proj'),
               genProject('b-proj'),
@@ -185,7 +184,7 @@ describe('projectsFilterReducer', () => {
 
       it('skips restored options that are not included in fetched', () => {
         const action = new LoadOptionsSuccess(
-          <ProjectsFilterOptionTuple>{
+          {
             fetched: [
               genProject('a-proj'),
               genProject('b-proj')
@@ -204,7 +203,7 @@ describe('projectsFilterReducer', () => {
 
       it('uses stored checked values when present', () => {
         const action = new LoadOptionsSuccess(
-          <ProjectsFilterOptionTuple>{
+          {
             fetched: [
               genProject('a-proj', true),
               genProject('b-proj'),
@@ -693,13 +692,13 @@ describe('projectsFilterReducer', () => {
     // Then generate the fetched list as the same thing with checked false for all projects.
     if (projects.filter(p => p.checked === true)) {
       return new LoadOptionsSuccess(
-        <ProjectsFilterOptionTuple>{
+        {
           fetched: projects.map(p => Object.assign({}, p, { checked: false })),
           restored: projects
         });
     }
     // Otherwise, we don't care about the restored list.
     return new LoadOptionsSuccess(
-      <ProjectsFilterOptionTuple>{ fetched: projects, restored: {} });
+      { fetched: projects, restored: [] });
   }
 });


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Initially I started to replace the sequence of GetProject (singular) calls
with just one GetProjects (plural) call, to reduce overhead and simplify the code.
Part way through that, though, I realized we do not even need GetProjects;
we already have enough project details from the global projects filter.

So this streamlines the team details code based on the above,
and adds some tests to show it is working.

![image](https://user-images.githubusercontent.com/6817500/63658297-4cbfc400-c75e-11e9-92dc-3e98c1cb5068.png)


Also addresses one UX issue:
If someone else deleted a project but the user has not refreshed the browser
lately, the global projects filter will still update periodically, but opening
team details looks like this, and the spinner remains indefinitely. Those projects are reporting errors because they are not amongst those in the current list (see above image).

![image](https://user-images.githubusercontent.com/6817500/63658252-f783b280-c75d-11e9-8f1b-5b49b202fccc.png)

Now, those deleted projects are automatically pruned from the team upon opening the details page.

### :chains: Related Resources

PR - #1260 Update projects for a team

### :+1: Definition of Done

Everything still works, but faster.

### :athletic_shoe: How to Build and Test the Change

Rebuild automate-ui
Go to Settings >> Teams >> <team> >> Details
Observe that the projects dropdown correctly populates and retains memory
of the projects belonging to the team.
