### PR TITLE
[#1318] proper logout for intercepted 401s

### DIFF
--- a/components/automate-ui/src/app/page-components/profile/profile.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.spec.ts
@@ -149,7 +149,7 @@ describe('ProfileComponent', () => {
 
       const link = element.query(By.css('button.logout'));
       link.triggerEventHandler('click', {});
-      expect(chefSessionService.logout).toHaveBeenCalled();
+      expect(chefSessionService.logout).toHaveBeenCalledWith('/', true);
     });
   });
 

--- a/components/automate-ui/src/app/page-components/profile/profile.component.ts
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.ts
@@ -44,7 +44,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
   }
 
   logout() {
-    this.chefSessionService.logout();
+    this.chefSessionService.logout('/', true /* don't skip signin method selection */);
   }
 
   showWelcomeModal() {

--- a/components/automate-ui/src/app/services/chef-session/chef-session.service.spec.ts
+++ b/components/automate-ui/src/app/services/chef-session/chef-session.service.spec.ts
@@ -143,7 +143,7 @@ describe('ChefSessionService', () => {
 
       it('does not ingest any token, but calls logout', () => {
         service.refreshSessionCallback(event);
-        expect(service.logout).toHaveBeenCalledWith('/some/path', true);
+        expect(service.logout).toHaveBeenCalledWith();
         expect(service.ingestIDToken).not.toHaveBeenCalled();
       });
     });

--- a/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
+++ b/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
@@ -126,7 +126,7 @@ export class ChefSessionService implements CanActivate {
   // available for setSessionOrRedirectToLogin() (part of ChefSession's
   // constructor)
   setSession(uuid, fullname, username, id_token: string, groups: Array<string>): void {
-    this.user = <ChefSessionUser>{
+    this.user = {
       uuid,
       fullname,
       username,
@@ -146,11 +146,14 @@ export class ChefSessionService implements CanActivate {
     return !isNull(localStorage.getItem(sessionKey));
   }
 
-  logout(url: string = '/', refresh: boolean = false): void {
+  // url: UI route to go back to when the (next) signin process has succeeded
+  // noHint: for the sign in, don't try to skip the method selection
+  logout(url?: string, noHint?: boolean): void {
     this.deleteSession();
+    url = url || this.currentPath();
     // note: url will end up url-encoded in this string (magic)
     let signinURL: string;
-    if (refresh && this.user && this.user.id_token) {
+    if (!noHint && this.user && this.user.id_token) {
       signinURL = `/session/new?state=${url}&id_token_hint=${this.user.id_token}`;
     } else {
       signinURL = `/session/new?state=${url}`;
@@ -166,6 +169,9 @@ export class ChefSessionService implements CanActivate {
     }
   }
 
+  // TODO(sr) 2019/08/26: I don't think we should use these global variables.
+  // Instead, we should take the information about the currently-viewed page
+  // from the ngrx store.
   currentPath(): string {
     return window.location.pathname;
   }

--- a/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
+++ b/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
@@ -75,7 +75,7 @@ export class ChefSessionService implements CanActivate {
       if (xhr.status === HTTP_STATUS_OK) {
         this.ingestIDToken(xhr.response.id_token);
       } else if (xhr.status === HTTP_STATUS_UNAUTHORIZED) {
-        this.logout(this.currentPath(), true);
+        this.logout();
       } else {
         // TODO 2017/12/15 (sr): is there anything we could do that's better than
         // this?

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
@@ -43,7 +43,7 @@ describe('HttpClientAuthInterceptor', () => {
       // so our logic shouldn't depend on it.
       httpRequest.flush('response', { status: 401, statusText: 'OK' });
 
-      expect(chefSession.logout).toHaveBeenCalledWith('/', true);
+      expect(chefSession.logout).toHaveBeenCalledWith();
     });
   });
 

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
@@ -43,7 +43,7 @@ describe('HttpClientAuthInterceptor', () => {
       // so our logic shouldn't depend on it.
       httpRequest.flush('response', { status: 401, statusText: 'OK' });
 
-      expect(chefSession.logout).toHaveBeenCalled();
+      expect(chefSession.logout).toHaveBeenCalledWith('/', true);
     });
   });
 

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
@@ -44,12 +44,7 @@ export class HttpClientAuthInterceptor implements HttpInterceptor {
       .handle(request.clone({ headers })).pipe(
         catchError((error: HttpErrorResponse) => {
           if (error.status === 401) {
-            // TODO(sr) When refactoring the session handling in automate-ui and ngrx,
-            // this should be dealt with: right now, if any API request gets a 401,
-            // the user will be signed out. While we attempt to save the user from
-            // having to choose their login method again (that's the `true`), we don't
-            // know on which UI page this has occourred (that's why we pass "/").
-            this.chefSession.logout('/', true);
+            this.chefSession.logout();
           }
           return observableThrowError(error);
         }));

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
@@ -1,9 +1,14 @@
-import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import {
+  HttpEvent,
+  HttpErrorResponse,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest
+} from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { throwError as observableThrowError, Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { get } from 'lodash/fp';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
@@ -29,20 +34,24 @@ export class HttpClientAuthInterceptor implements HttpInterceptor {
     let headers = request.headers.set('Authorization', `Bearer ${this.chefSession.id_token}`);
     const filtered = request.params.get('unfiltered') !== 'true';
     // Uncomment here and after to clone() arg list
-    // after https://github.com/angular/angular/issues/18812 is fixed.
+    // after we've upgraded to angular 7.2+ (for this issue:
+    // https://github.com/angular/angular/issues/18812).
     // const params = request.params.delete('unfiltered');
     if (this.projects && filtered) {
       headers = headers.set('projects', this.projects);
     }
     return next
-      .handle(request.clone({
-        headers
-      })).pipe(
-        catchError((response: HttpEvent<any>) => {
-          if (get('status', response) === 401) {
-            this.chefSession.logout();
+      .handle(request.clone({ headers })).pipe(
+        catchError((error: HttpErrorResponse) => {
+          if (error.status === 401) {
+            // TODO(sr) When refactoring the session handling in automate-ui and ngrx,
+            // this should be dealt with: right now, if any API request gets a 401,
+            // the user will be signed out. While we attempt to save the user from
+            // having to choose their login method again (that's the `true`), we don't
+            // know on which UI page this has occourred (that's why we pass "/").
+            this.chefSession.logout('/', true);
           }
-          return observableThrowError(response);
+          return observableThrowError(error);
         }));
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When a 401 was intercepted by the auth interceptor, and not the periodic call in chef-session, the interceptor would call `logout()` without arguments. This used to have two effects:
1. the user is sent back to `/` (or rather, `/dashboards/event-feed`) after re-signin, regardless of where they were before
2. the user has to select their signin method.

This became apparent most obviously when using IAMv2.1, because it has another peridoc call: checking project rules' apply status. So those calls, when failing, would cause no automatic re-login for SAML users, as desired in #1246.

**Now**, the logic is inverted: If nothing is passed, the signin happens as if it was a re-signin: including the proper state for going back to the page, and skipping signin method selection if possible.

⚠️ The way `chef-session` figures out "which page we're on" is hacky IMHO; it should rather subscribe to something in ngrx store, instead of reading a `window` global. (I might be wrong.)

### :chains: Related Resources

- #1246
- Fixes #1318

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

- `start_all_services`, setup automate-ui in your preferred way
- `chef-automate iam upgrade-to-v2 --beta2.1`
- change the dex config template as outlined in #1246
- sign in locally using SAML, go to https://a2-dev.test/settings
  - you will see nothing, but it's the test to verify we end up on the same page after re-signin
- wait for a minute
- notice that there's a few requests, and a roundtrip through dex and okta, and you'll end up on the same page again

### :white_check_mark: Checklist

- [X] Tests added/updated?
- [ ] Docs added/updated?
