### PR TITLE
[e2e] improve cypress tests

### DIFF
--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -32,7 +32,8 @@
             <span class="label">Name <span aria-hidden="true">*</span></span>
             <input chefInput formControlName="name" type="text" [resetOrigin]="saveSuccessful"
               [attr.disabled]="(isChefManaged || isLoading) ? true : null"
-              autocomplete="off">
+              autocomplete="off"
+              data-cy="update-project-name">
           </label>
           <chef-error
             *ngIf="(projectForm.get('name').hasError('required') || projectForm.get('name').hasError('pattern')) && projectForm.get('name').dirty">

--- a/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
@@ -176,7 +176,7 @@ describeIAMV2P1('project management', () => {
     cy.get('[data-cy=details-tab]').click();
     cy.wait('@getProject');
 
-    cy.get('#update-name').find('input').focus().clear()
+    cy.get('[data-cy=update-project-name]').focus().clear()
       .type(updatedProjectName, { delay: typeDelay })
       .should('have.value', updatedProjectName);
     cy.get('app-project-details chef-button').contains('Save').click();
@@ -204,8 +204,7 @@ describeIAMV2P1('project management', () => {
 
     cy.get('app-project-list chef-td').contains(projectID).parent()
       .find('chef-control-menu').as('controlMenu');
-    cy.get('@controlMenu').should('be.visible')
-      .click();
+    cy.get('@controlMenu').click({ force: true });
     cy.get('@controlMenu').find('[data-cy=delete-project]').click({ force: true });
 
     cy.get('app-project-list chef-button').contains('Delete Project').click();


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Did some work to de-flake some Cypress tests I added last week.

This work has been tricky because it's hard to repro failures in buildkite locally. But I've figured out a way to more closely approximate the buildkite run time. 

Open the Cypress app, start running whichever test you're working on, and then immediately open devtools, click on the Network tab, and click Online and change the value to `Slow 3G`.

![image](https://user-images.githubusercontent.com/21015366/63717309-c3ab9a00-c7fc-11e9-9158-6ee1fbd4b2d1.png)

Edit: user_mgmt needs more work so I've moved those commits to a [new branch](https://github.com/chef/automate/compare/bhd/fix-cypress-users)

### :chains: Related Resources

### :+1: Definition of Done
- buildkite passes consistently

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable