### PR TITLE
Filter sidebar services by filters

### DIFF
--- a/components/applications-service/integration_test/services_test.go
+++ b/components/applications-service/integration_test/services_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/chef/automate/api/external/applications"
 	"github.com/chef/automate/api/external/common/query"
+	"github.com/chef/automate/api/external/habitat"
 )
 
 func TestGetServicesBasic(t *testing.T) {
@@ -426,6 +427,296 @@ func TestGetServicesMultiServiceWithHealthAndServiceGroupIdFilter(t *testing.T) 
 						HealthCheck:  applications.HealthStatus_UNKNOWN,
 						Application:  a, Environment: e, Fqdn: "temp.example.com",
 						Channel: c, UpdateStrategy: none, Site: s,
+					},
+				},
+			}
+		)
+		response, err := suite.ApplicationsServer.GetServices(ctx, request)
+		assert.Nil(t, err)
+		assertServicesEqual(t, expected.GetServices(), response.GetServices())
+	}
+}
+
+func TestGetServicesMultiServiceWithOriginAndServiceGroupIdFilter(t *testing.T) {
+	// Same service group, different origins
+	mockHabServices := []*habitat.HealthCheckEvent{
+		NewHabitatEvent(
+			withSupervisorId("sup2"),
+			withServiceGroup("a.test"),
+			withPackageIdent("core/a/0.1.0/20190101121212"),
+			withHealth("UNKNOWN"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+		),
+		NewHabitatEvent(
+			withSupervisorId("sup3"),
+			withServiceGroup("a.test"),
+			withPackageIdent("chef/a/0.1.0/00000000000000"),
+			withHealth("OK"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+		),
+	}
+	suite.IngestServices(mockHabServices)
+	defer suite.DeleteDataFromStorage()
+
+	// Get the ID from the service group
+	sgList := suite.GetServiceGroups()
+	if assert.Equal(t, 1, len(sgList), "There should be one service_group in the db") {
+
+		var (
+			ctx     = context.Background()
+			sgID    = sgList[0].ID
+			request = &applications.ServicesReq{
+				Filter: []string{
+					"service_group_id:" + sgID,
+					"origin:chef",
+				},
+			}
+			expected = &applications.ServicesRes{
+				Services: []*applications.Service{
+					{
+						SupervisorId:   "sup3",
+						Group:          "a.test",
+						Release:        "chef/a/0.1.0/00000000000000",
+						HealthCheck:    applications.HealthStatus_OK,
+						Application:    "a_app",
+						Environment:    "a_env",
+						UpdateStrategy: none,
+						Site:           s,
+					},
+				},
+			}
+		)
+		response, err := suite.ApplicationsServer.GetServices(ctx, request)
+		assert.Nil(t, err)
+		assertServicesEqual(t, expected.GetServices(), response.GetServices())
+	}
+}
+
+func TestGetServicesMultiServiceWithSiteAndServiceGroupIdFilter(t *testing.T) {
+	// Same service group, different sites
+	mockHabServices := []*habitat.HealthCheckEvent{
+		NewHabitatEvent(
+			withSupervisorId("sup2"),
+			withServiceGroup("a.test"),
+			withPackageIdent("chef/a/0.1.0/20190101121212"),
+			withHealth("UNKNOWN"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+			withSite("chernobyl"),
+		),
+		NewHabitatEvent(
+			withSupervisorId("sup3"),
+			withServiceGroup("a.test"),
+			withPackageIdent("chef/a/0.1.0/00000000000000"),
+			withHealth("OK"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+			withSite("fukushima"),
+		),
+	}
+	suite.IngestServices(mockHabServices)
+	defer suite.DeleteDataFromStorage()
+
+	// Get the ID from the service group
+	sgList := suite.GetServiceGroups()
+	if assert.Equal(t, 1, len(sgList), "There should be one service_group in the db") {
+
+		var (
+			ctx     = context.Background()
+			sgID    = sgList[0].ID
+			request = &applications.ServicesReq{
+				Filter: []string{
+					"service_group_id:" + sgID,
+					"site:fukushima",
+				},
+			}
+			expected = &applications.ServicesRes{
+				Services: []*applications.Service{
+					{
+						SupervisorId:   "sup3",
+						Group:          "a.test",
+						Release:        "chef/a/0.1.0/00000000000000",
+						HealthCheck:    applications.HealthStatus_OK,
+						Application:    "a_app",
+						Environment:    "a_env",
+						UpdateStrategy: none,
+						Site:           "fukushima",
+					},
+				},
+			}
+		)
+		response, err := suite.ApplicationsServer.GetServices(ctx, request)
+		assert.Nil(t, err)
+		assertServicesEqual(t, expected.GetServices(), response.GetServices())
+	}
+}
+
+func TestGetServicesMultiServiceWithChannelAndServiceGroupIdFilter(t *testing.T) {
+	// Same service group, different channels
+	mockHabServices := []*habitat.HealthCheckEvent{
+		NewHabitatEvent(
+			withSupervisorId("sup2"),
+			withServiceGroup("a.test"),
+			withPackageIdent("chef/a/0.1.0/20190101121212"),
+			withHealth("UNKNOWN"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+			withStrategyAtOnce("Q13"),
+		),
+		NewHabitatEvent(
+			withSupervisorId("sup3"),
+			withServiceGroup("a.test"),
+			withPackageIdent("chef/a/0.1.0/00000000000000"),
+			withHealth("OK"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+			withStrategyAtOnce("fox"),
+		),
+	}
+	suite.IngestServices(mockHabServices)
+	defer suite.DeleteDataFromStorage()
+
+	// Get the ID from the service group
+	sgList := suite.GetServiceGroups()
+	if assert.Equal(t, 1, len(sgList), "There should be one service_group in the db") {
+
+		var (
+			ctx     = context.Background()
+			sgID    = sgList[0].ID
+			request = &applications.ServicesReq{
+				Filter: []string{
+					"service_group_id:" + sgID,
+					"channel:fox",
+				},
+			}
+			expected = &applications.ServicesRes{
+				Services: []*applications.Service{
+					{
+						SupervisorId:   "sup3",
+						Group:          "a.test",
+						Release:        "chef/a/0.1.0/00000000000000",
+						HealthCheck:    applications.HealthStatus_OK,
+						Application:    "a_app",
+						Environment:    "a_env",
+						UpdateStrategy: "AT-ONCE",
+						Site:           s,
+						Channel:        "fox",
+					},
+				},
+			}
+		)
+		response, err := suite.ApplicationsServer.GetServices(ctx, request)
+		assert.Nil(t, err)
+		assertServicesEqual(t, expected.GetServices(), response.GetServices())
+	}
+}
+
+func TestGetServicesMultiServiceWithVersionAndServiceGroupIdFilter(t *testing.T) {
+	// Same service group, different versions
+	mockHabServices := []*habitat.HealthCheckEvent{
+		NewHabitatEvent(
+			withSupervisorId("sup2"),
+			withServiceGroup("a.test"),
+			withPackageIdent("chef/a/0.2.2/20190101121212"),
+			withHealth("UNKNOWN"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+		),
+		NewHabitatEvent(
+			withSupervisorId("sup3"),
+			withServiceGroup("a.test"),
+			withPackageIdent("chef/a/0.1.0/00000000000000"),
+			withHealth("OK"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+		),
+	}
+	suite.IngestServices(mockHabServices)
+	defer suite.DeleteDataFromStorage()
+
+	// Get the ID from the service group
+	sgList := suite.GetServiceGroups()
+	if assert.Equal(t, 1, len(sgList), "There should be one service_group in the db") {
+
+		var (
+			ctx     = context.Background()
+			sgID    = sgList[0].ID
+			request = &applications.ServicesReq{
+				Filter: []string{
+					"service_group_id:" + sgID,
+					"version:0.2.2",
+				},
+			}
+			expected = &applications.ServicesRes{
+				Services: []*applications.Service{
+					{
+						SupervisorId:   "sup2",
+						Group:          "a.test",
+						Release:        "chef/a/0.2.2/20190101121212",
+						HealthCheck:    applications.HealthStatus_UNKNOWN,
+						Application:    "a_app",
+						Environment:    "a_env",
+						UpdateStrategy: none,
+						Site:           s,
+					},
+				},
+			}
+		)
+		response, err := suite.ApplicationsServer.GetServices(ctx, request)
+		assert.Nil(t, err)
+		assertServicesEqual(t, expected.GetServices(), response.GetServices())
+	}
+}
+
+func TestGetServicesMultiServiceWithBuildstampAndServiceGroupIdFilter(t *testing.T) {
+	// Same service group, different buildstamps
+	mockHabServices := []*habitat.HealthCheckEvent{
+		NewHabitatEvent(
+			withSupervisorId("sup2"),
+			withServiceGroup("a.test"),
+			withPackageIdent("chef/a/0.1.0/20190101121212"),
+			withHealth("UNKNOWN"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+		),
+		NewHabitatEvent(
+			withSupervisorId("sup3"),
+			withServiceGroup("a.test"),
+			withPackageIdent("chef/a/0.1.0/00000000000000"),
+			withHealth("OK"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+		),
+	}
+	suite.IngestServices(mockHabServices)
+	defer suite.DeleteDataFromStorage()
+
+	// Get the ID from the service group
+	sgList := suite.GetServiceGroups()
+	if assert.Equal(t, 1, len(sgList), "There should be one service_group in the db") {
+
+		var (
+			ctx     = context.Background()
+			sgID    = sgList[0].ID
+			request = &applications.ServicesReq{
+				Filter: []string{
+					"service_group_id:" + sgID,
+					"buildstamp:20190101121212",
+				},
+			}
+			expected = &applications.ServicesRes{
+				Services: []*applications.Service{
+					{
+						SupervisorId:   "sup2",
+						Group:          "a.test",
+						Release:        "chef/a/0.1.0/20190101121212",
+						HealthCheck:    applications.HealthStatus_UNKNOWN,
+						Application:    "a_app",
+						Environment:    "a_env",
+						UpdateStrategy: none,
+						Site:           s,
 					},
 				},
 			}

--- a/components/applications-service/integration_test/services_test.go
+++ b/components/applications-service/integration_test/services_test.go
@@ -726,3 +726,199 @@ func TestGetServicesMultiServiceWithBuildstampAndServiceGroupIdFilter(t *testing
 		assertServicesEqual(t, expected.GetServices(), response.GetServices())
 	}
 }
+
+func TestGetServicesMultiServiceWithEnvironmentAndServiceGroupIdFilter(t *testing.T) {
+	// Same service group
+	mockHabServices := []*habitat.HealthCheckEvent{
+		NewHabitatEvent(
+			withSupervisorId("sup2"),
+			withServiceGroup("a.test"),
+			withPackageIdent("chef/a/0.1.0/20190101121212"),
+			withHealth("UNKNOWN"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+		),
+	}
+	suite.IngestServices(mockHabServices)
+	defer suite.DeleteDataFromStorage()
+
+	// Get the ID from the service group
+	sgList := suite.GetServiceGroups()
+	if assert.Equal(t, 1, len(sgList), "There should be one service_group in the db") {
+
+		var (
+			ctx     = context.Background()
+			sgID    = sgList[0].ID
+			request = &applications.ServicesReq{
+				Filter: []string{
+					"service_group_id:" + sgID,
+					"environment:a_env",
+				},
+			}
+			expected = &applications.ServicesRes{
+				Services: []*applications.Service{
+					{
+						SupervisorId:   "sup2",
+						Group:          "a.test",
+						Release:        "chef/a/0.1.0/20190101121212",
+						HealthCheck:    applications.HealthStatus_UNKNOWN,
+						Application:    "a_app",
+						Environment:    "a_env",
+						UpdateStrategy: none,
+						Site:           s,
+					},
+				},
+			}
+		)
+		response, err := suite.ApplicationsServer.GetServices(ctx, request)
+		assert.Nil(t, err)
+		assertServicesEqual(t, expected.GetServices(), response.GetServices())
+	}
+}
+
+func TestGetServicesMultiServiceWithApplicationAndServiceGroupIdFilter(t *testing.T) {
+	// Same service group
+	mockHabServices := []*habitat.HealthCheckEvent{
+		NewHabitatEvent(
+			withSupervisorId("sup2"),
+			withServiceGroup("a.test"),
+			withPackageIdent("chef/a/0.1.0/20190101121212"),
+			withHealth("UNKNOWN"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+		),
+	}
+	suite.IngestServices(mockHabServices)
+	defer suite.DeleteDataFromStorage()
+
+	// Get the ID from the service group
+	sgList := suite.GetServiceGroups()
+	if assert.Equal(t, 1, len(sgList), "There should be one service_group in the db") {
+
+		var (
+			ctx     = context.Background()
+			sgID    = sgList[0].ID
+			request = &applications.ServicesReq{
+				Filter: []string{
+					"service_group_id:" + sgID,
+					"application:a_app",
+				},
+			}
+			expected = &applications.ServicesRes{
+				Services: []*applications.Service{
+					{
+						SupervisorId:   "sup2",
+						Group:          "a.test",
+						Release:        "chef/a/0.1.0/20190101121212",
+						HealthCheck:    applications.HealthStatus_UNKNOWN,
+						Application:    "a_app",
+						Environment:    "a_env",
+						UpdateStrategy: none,
+						Site:           s,
+					},
+				},
+			}
+		)
+		response, err := suite.ApplicationsServer.GetServices(ctx, request)
+		assert.Nil(t, err)
+		assertServicesEqual(t, expected.GetServices(), response.GetServices())
+	}
+}
+
+func TestGetServicesMultiServiceWithGroupNameAndServiceGroupIdFilter(t *testing.T) {
+	// Same service group
+	mockHabServices := []*habitat.HealthCheckEvent{
+		NewHabitatEvent(
+			withSupervisorId("sup2"),
+			withServiceGroup("a.test"),
+			withPackageIdent("chef/a/0.1.0/20190101121212"),
+			withHealth("UNKNOWN"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+		),
+	}
+	suite.IngestServices(mockHabServices)
+	defer suite.DeleteDataFromStorage()
+
+	// Get the ID from the service group
+	sgList := suite.GetServiceGroups()
+	if assert.Equal(t, 1, len(sgList), "There should be one service_group in the db") {
+
+		var (
+			ctx     = context.Background()
+			sgID    = sgList[0].ID
+			request = &applications.ServicesReq{
+				Filter: []string{
+					"service_group_id:" + sgID,
+					"group:test",
+				},
+			}
+			expected = &applications.ServicesRes{
+				Services: []*applications.Service{
+					{
+						SupervisorId:   "sup2",
+						Group:          "a.test",
+						Release:        "chef/a/0.1.0/20190101121212",
+						HealthCheck:    applications.HealthStatus_UNKNOWN,
+						Application:    "a_app",
+						Environment:    "a_env",
+						UpdateStrategy: none,
+						Site:           s,
+					},
+				},
+			}
+		)
+		response, err := suite.ApplicationsServer.GetServices(ctx, request)
+		assert.Nil(t, err)
+		assertServicesEqual(t, expected.GetServices(), response.GetServices())
+	}
+}
+
+func TestGetServicesMultiServiceWithServiceNameAndServiceGroupIdFilter(t *testing.T) {
+	// Same service group
+	mockHabServices := []*habitat.HealthCheckEvent{
+		NewHabitatEvent(
+			withSupervisorId("sup2"),
+			withServiceGroup("a.test"),
+			withPackageIdent("chef/a/0.1.0/20190101121212"),
+			withHealth("UNKNOWN"),
+			withApplication("a_app"),
+			withEnvironment("a_env"),
+		),
+	}
+	suite.IngestServices(mockHabServices)
+	defer suite.DeleteDataFromStorage()
+
+	// Get the ID from the service group
+	sgList := suite.GetServiceGroups()
+	if assert.Equal(t, 1, len(sgList), "There should be one service_group in the db") {
+
+		var (
+			ctx     = context.Background()
+			sgID    = sgList[0].ID
+			request = &applications.ServicesReq{
+				Filter: []string{
+					"service_group_id:" + sgID,
+					"service:a",
+				},
+			}
+			expected = &applications.ServicesRes{
+				Services: []*applications.Service{
+					{
+						SupervisorId:   "sup2",
+						Group:          "a.test",
+						Release:        "chef/a/0.1.0/20190101121212",
+						HealthCheck:    applications.HealthStatus_UNKNOWN,
+						Application:    "a_app",
+						Environment:    "a_env",
+						UpdateStrategy: none,
+						Site:           s,
+					},
+				},
+			}
+		)
+		response, err := suite.ApplicationsServer.GetServices(ctx, request)
+		assert.Nil(t, err)
+		assertServicesEqual(t, expected.GetServices(), response.GetServices())
+	}
+}

--- a/components/applications-service/pkg/storage/postgres/services.go
+++ b/components/applications-service/pkg/storage/postgres/services.go
@@ -348,6 +348,21 @@ func buildWhereConstraintsFromFilters(filters map[string][]string) (string, erro
 		case "health":
 			WhereConstraints = WhereConstraints + buildORStatementFromValues("health", values)
 
+		case "origin":
+			WhereConstraints = WhereConstraints + buildORStatementFromValues("origin", values)
+
+		case "channel":
+			WhereConstraints = WhereConstraints + buildORStatementFromValues("channel", values)
+
+		case "site":
+			WhereConstraints = WhereConstraints + buildORStatementFromValues("site", values)
+
+		case "version":
+			WhereConstraints = WhereConstraints + buildORStatementFromValues("version", values)
+
+		case "buildstamp":
+			WhereConstraints = WhereConstraints + buildORStatementFromValues("release", values)
+
 		default:
 			return "", errors.Errorf("invalid filter. (%s:%s)", filter, values)
 		}

--- a/components/applications-service/pkg/storage/postgres/services.go
+++ b/components/applications-service/pkg/storage/postgres/services.go
@@ -363,6 +363,18 @@ func buildWhereConstraintsFromFilters(filters map[string][]string) (string, erro
 		case "buildstamp":
 			WhereConstraints = WhereConstraints + buildORStatementFromValues("release", values)
 
+		case "application":
+			WhereConstraints = WhereConstraints + buildORStatementFromValues("application", values)
+
+		case "environment":
+			WhereConstraints = WhereConstraints + buildORStatementFromValues("environment", values)
+
+		case "group":
+			WhereConstraints = WhereConstraints + buildORStatementFromValues("s.service_group_name_suffix", values)
+
+		case "service":
+			WhereConstraints = WhereConstraints + buildORStatementFromValues("name", values)
+
 		default:
 			return "", errors.Errorf("invalid filter. (%s:%s)", filter, values)
 		}


### PR DESCRIPTION
Only support filters that result in partial results for a service group.
origin, channel, site, version and buildstamp

The filters app, env, name, group name would result in different service groups
and therefore in the UI you would not see the service group to access the sidebar

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable