### PR TITLE
deps: bump OPA

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -846,7 +846,7 @@
   version = "v6.2.16"
 
 [[projects]]
-  digest = "1:a38c620f603c18e14880033868a91d06959bfea83ad7dac61fec04da81811dbf"
+  digest = "1:2c92a3d315c2605f6cb16ccb05aa14fdf9b375d678badb653cd2e8c54c36d40e"
   name = "github.com/open-policy-agent/opa"
   packages = [
     "ast",
@@ -855,6 +855,7 @@
     "internal/ir",
     "internal/leb128",
     "internal/planner",
+    "internal/version",
     "internal/wasm/constant",
     "internal/wasm/encoding",
     "internal/wasm/instruction",
@@ -868,11 +869,18 @@
     "topdown",
     "topdown/builtins",
     "topdown/copypropagation",
+    "topdown/internal/jwx/buffer",
+    "topdown/internal/jwx/jwa",
+    "topdown/internal/jwx/jwk",
+    "topdown/internal/jwx/jws",
+    "topdown/internal/jwx/jws/sign",
+    "topdown/internal/jwx/jws/verify",
     "types",
     "util",
+    "version",
   ]
   pruneopts = "NUT"
-  revision = "7864d60dd78d748dbce54b569e939f5b0dc07486"
+  revision = "0d70daa545f5a4bf2e6edf3c1b2d635920299bc9"
 
 [[projects]]
   digest = "1:7da29c22bcc5c2ffb308324377dc00b5084650348c2799e573ed226d8cc9faf0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -202,7 +202,7 @@ required = [
 # more easily.)
 [[constraint]]
   name = "github.com/open-policy-agent/opa"
-  revision = "7864d60dd78d748dbce54b569e939f5b0dc07486"
+  revision = "0d70daa545f5a4bf2e6edf3c1b2d635920299bc9"
 
 [[constraint]]
   name = "github.com/chef/toml"

--- a/vendor/github.com/open-policy-agent/opa/ast/builtins.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/builtins.go
@@ -67,8 +67,10 @@ var DefaultBuiltins = [...]*Builtin{
 	ArrayConcat,
 	ArraySlice,
 
-	// Casting
+	// Conversions
 	ToNumber,
+
+	// Casts (DEPRECATED)
 	CastObject,
 	CastNull,
 	CastBoolean,
@@ -123,6 +125,8 @@ var DefaultBuiltins = [...]*Builtin{
 	JWTVerifyES256,
 	JWTVerifyHS256,
 	JWTDecodeVerify,
+	JWTEncodeSignRaw,
+	JWTEncodeSign,
 
 	// Time
 	NowNanos,
@@ -172,6 +176,9 @@ var DefaultBuiltins = [...]*Builtin{
 	// Glob
 	GlobMatch,
 	GlobQuoteMeta,
+
+	// Units
+	UnitsParseBytes,
 }
 
 // BuiltinMap provides a convenient mapping of built-in names to
@@ -522,7 +529,7 @@ var ArraySlice = &Builtin{
 }
 
 /**
- * Casting
+ * Conversions
  */
 
 // ToNumber takes a string, bool, or number value and converts it to a number.
@@ -540,65 +547,6 @@ var ToNumber = &Builtin{
 			),
 		),
 		types.N,
-	),
-}
-
-// CastArray checks the underlying type of the input. If it is array or set, an array
-// containing the values is returned. If it is not an array, an error is thrown.
-var CastArray = &Builtin{
-	Name: "cast_array",
-	Decl: types.NewFunction(
-		types.Args(types.A),
-		types.NewArray(nil, types.A),
-	),
-}
-
-// CastSet checks the underlying type of the input.
-// If it is a set, the set is returned.
-// If it is an array, the array is returned in set form (all duplicates removed)
-// If neither, an error is thrown
-var CastSet = &Builtin{
-	Name: "cast_set",
-	Decl: types.NewFunction(
-		types.Args(types.A),
-		types.NewSet(types.A),
-	),
-}
-
-// CastString returns input if it is a string; if not returns error.
-// For formatting variables, see sprintf
-var CastString = &Builtin{
-	Name: "cast_string",
-	Decl: types.NewFunction(
-		types.Args(types.A),
-		types.S,
-	),
-}
-
-// CastBoolean returns input if it is a boolean; if not returns error.
-var CastBoolean = &Builtin{
-	Name: "cast_boolean",
-	Decl: types.NewFunction(
-		types.Args(types.A),
-		types.B,
-	),
-}
-
-// CastNull returns null if input is null; if not returns error.
-var CastNull = &Builtin{
-	Name: "cast_null",
-	Decl: types.NewFunction(
-		types.Args(types.A),
-		types.NewNull(),
-	),
-}
-
-// CastObject returns the given object if it is null; throws an error otherwise
-var CastObject = &Builtin{
-	Name: "cast_object",
-	Decl: types.NewFunction(
-		types.Args(types.A),
-		types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 	),
 }
 
@@ -634,7 +582,7 @@ var RegexTemplateMatch = &Builtin{
 	),
 }
 
-// RegexSplit splits the input string by the occurences of the given pattern.
+// RegexSplit splits the input string by the occurrences of the given pattern.
 var RegexSplit = &Builtin{
 	Name: "regex.split",
 	Decl: types.NewFunction(
@@ -838,6 +786,18 @@ var Sprintf = &Builtin{
 	),
 }
 
+// UnitsParseBytes converts strings like 10GB, 5K, 4mb, and the like into an
+// integer number of bytes.
+var UnitsParseBytes = &Builtin{
+	Name: "units.parse_bytes",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+		),
+		types.N,
+	),
+}
+
 /**
  * JSON
  */
@@ -1027,6 +987,34 @@ var JWTDecodeVerify = &Builtin{
 			types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 			types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 		}, nil),
+	),
+}
+
+// JWTEncodeSignRaw encodes and optionally sign  a JSON Web Token.
+// Inputs are protected headers, payload, secret
+var JWTEncodeSignRaw = &Builtin{
+	Name: "io.jwt.encode_sign_raw",
+	Decl: types.NewFunction(
+		types.Args(
+			types.S,
+			types.S,
+			types.S,
+		),
+		types.S,
+	),
+}
+
+// JWTEncodeSign encodes and optionally sign  a JSON Web Token.
+// Inputs are protected headers, payload, secret
+var JWTEncodeSign = &Builtin{
+	Name: "io.jwt.encode_sign",
+	Decl: types.NewFunction(
+		types.Args(
+			types.NewObject(nil, types.NewDynamicProperty(types.S, types.A)),
+			types.NewObject(nil, types.NewDynamicProperty(types.S, types.A)),
+			types.NewObject(nil, types.NewDynamicProperty(types.S, types.A)),
+		),
+		types.S,
 	),
 }
 
@@ -1436,6 +1424,65 @@ var NetCIDROverlap = &Builtin{
 			types.S,
 		),
 		types.B,
+	),
+}
+
+// CastArray checks the underlying type of the input. If it is array or set, an array
+// containing the values is returned. If it is not an array, an error is thrown.
+var CastArray = &Builtin{
+	Name: "cast_array",
+	Decl: types.NewFunction(
+		types.Args(types.A),
+		types.NewArray(nil, types.A),
+	),
+}
+
+// CastSet checks the underlying type of the input.
+// If it is a set, the set is returned.
+// If it is an array, the array is returned in set form (all duplicates removed)
+// If neither, an error is thrown
+var CastSet = &Builtin{
+	Name: "cast_set",
+	Decl: types.NewFunction(
+		types.Args(types.A),
+		types.NewSet(types.A),
+	),
+}
+
+// CastString returns input if it is a string; if not returns error.
+// For formatting variables, see sprintf
+var CastString = &Builtin{
+	Name: "cast_string",
+	Decl: types.NewFunction(
+		types.Args(types.A),
+		types.S,
+	),
+}
+
+// CastBoolean returns input if it is a boolean; if not returns error.
+var CastBoolean = &Builtin{
+	Name: "cast_boolean",
+	Decl: types.NewFunction(
+		types.Args(types.A),
+		types.B,
+	),
+}
+
+// CastNull returns null if input is null; if not returns error.
+var CastNull = &Builtin{
+	Name: "cast_null",
+	Decl: types.NewFunction(
+		types.Args(types.A),
+		types.NewNull(),
+	),
+}
+
+// CastObject returns the given object if it is null; throws an error otherwise
+var CastObject = &Builtin{
+	Name: "cast_object",
+	Decl: types.NewFunction(
+		types.Args(types.A),
+		types.NewObject(nil, types.NewDynamicProperty(types.A, types.A)),
 	),
 }
 

--- a/vendor/github.com/open-policy-agent/opa/ast/check.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/check.go
@@ -92,6 +92,7 @@ func (tc *typeChecker) CheckTypes(env *TypeEnv, sorted []util.T) (*TypeEnv, Erro
 	for _, s := range sorted {
 		tc.checkRule(env, s.(*Rule))
 	}
+	tc.errs.Sort()
 	return env, tc.errs
 }
 

--- a/vendor/github.com/open-policy-agent/opa/ast/compare.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/compare.go
@@ -38,16 +38,18 @@ func Compare(a, b interface{}) int {
 
 	if t, ok := a.(*Term); ok {
 		if t == nil {
-			return Compare(nil, b)
+			a = nil
+		} else {
+			a = t.Value
 		}
-		return Compare(t.Value, b)
 	}
 
 	if t, ok := b.(*Term); ok {
 		if t == nil {
-			return Compare(a, nil)
+			b = nil
+		} else {
+			b = t.Value
 		}
-		return Compare(a, t.Value)
 	}
 
 	if a == nil {

--- a/vendor/github.com/open-policy-agent/opa/ast/compile.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/compile.go
@@ -7,6 +7,7 @@ package ast
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/open-policy-agent/opa/metrics"
@@ -77,6 +78,7 @@ type Compiler struct {
 	// TypeEnv holds type information for values inferred by the compiler.
 	TypeEnv *TypeEnv
 
+	localvargen  *localVarGenerator
 	moduleLoader ModuleLoader
 	ruleIndices  *util.HashMap
 	stages       []struct {
@@ -89,6 +91,10 @@ type Compiler struct {
 	pathExists func([]string) (bool, error)
 	after      map[string][]CompilerStageDefinition
 	metrics    metrics.Metrics
+
+	// This is a set of unsafe built-in functions that we are not allowed to
+	// use.
+	unsafeBuiltinsMap map[string]struct{}
 }
 
 // CompilerStage defines the interface for stages in the compiler.
@@ -164,6 +170,13 @@ type QueryCompiler interface {
 	// to Compile will take the QueryContext into account.
 	WithContext(qctx *QueryContext) QueryCompiler
 
+	// WithUnsafeBuiltins sets the built-in functions to treat as unsafe and not
+	// allow inside of queries. By default the query compiler inherits the
+	// compiler's unsafe built-in functions. This function allows callers to
+	// override that set. If an empty (non-nil) map is provided, all built-ins
+	// are allowed.
+	WithUnsafeBuiltins(unsafe map[string]struct{}) QueryCompiler
+
 	// WithStageAfter registers a stage to run during query compilation after
 	// the named stage.
 	WithStageAfter(after string, stage QueryCompilerStageDefinition) QueryCompiler
@@ -198,8 +211,9 @@ func NewCompiler() *Compiler {
 		}, func(x util.T) int {
 			return x.(Ref).Hash()
 		}),
-		maxErrs: CompileErrorLimitDefault,
-		after:   map[string][]CompilerStageDefinition{},
+		maxErrs:           CompileErrorLimitDefault,
+		after:             map[string][]CompilerStageDefinition{},
+		unsafeBuiltinsMap: map[string]struct{}{},
 	}
 
 	c.ModuleTree = NewModuleTree(nil)
@@ -217,6 +231,12 @@ func NewCompiler() *Compiler {
 		// load additional modules. If any stages run before resolution, they
 		// need to be re-run after resolution.
 		{"ResolveRefs", "compile_stage_resolve_refs", c.resolveAllRefs},
+
+		// The local variable generator must be initialized after references are
+		// resolved and the dynamic module loader has run but before subsequent
+		// stages that need to generate variables.
+		{"InitLocalVarGen", "compile_stage_init_local_var_gen", c.initLocalVarGen},
+
 		{"RewriteLocalVars", "compile_stage_rewrite_local_vars", c.rewriteLocalVars},
 		{"RewriteExprTerms", "compile_stage_rewrite_expr_terms", c.rewriteExprTerms},
 		{"SetModuleTree", "compile_stage_set_module_tree", c.setModuleTree},
@@ -232,6 +252,7 @@ func NewCompiler() *Compiler {
 		{"RewriteDynamicTerms", "compile_stage_rewrite_dynamic_terms", c.rewriteDynamicTerms},
 		{"CheckRecursion", "compile_stage_check_recursion", c.checkRecursion},
 		{"CheckTypes", "compile_stage_check_types", c.checkTypes},
+		{"CheckUnsafeBuiltins", "compile_state_check_unsafe_builtins", c.checkUnsafeBuiltins},
 		{"BuildRuleIndices", "compile_stage_rebuild_indices", c.buildRuleIndices},
 	}
 
@@ -267,6 +288,14 @@ func (c *Compiler) WithMetrics(metrics metrics.Metrics) *Compiler {
 	return c
 }
 
+// WithUnsafeBuiltins will add all built-ins in the map to the "blacklist".
+func (c *Compiler) WithUnsafeBuiltins(unsafeBuiltins map[string]struct{}) *Compiler {
+	for name := range unsafeBuiltins {
+		c.unsafeBuiltinsMap[name] = struct{}{}
+	}
+	return c
+}
+
 // QueryCompiler returns a new QueryCompiler object.
 func (c *Compiler) QueryCompiler() QueryCompiler {
 	return newQueryCompiler(c)
@@ -277,11 +306,14 @@ func (c *Compiler) QueryCompiler() QueryCompiler {
 // compiler. If the compilation process fails for any reason, the compiler will
 // contain a slice of errors.
 func (c *Compiler) Compile(modules map[string]*Module) {
+
 	c.Modules = make(map[string]*Module, len(modules))
+
 	for k, v := range modules {
 		c.Modules[k] = v.Copy()
 		c.sorted = append(c.sorted, k)
 	}
+
 	sort.Strings(c.sorted)
 
 	c.compile()
@@ -541,11 +573,15 @@ func (c *Compiler) checkRuleConflicts() {
 		kinds := map[DocKind]struct{}{}
 		defaultRules := 0
 		arities := map[int]struct{}{}
+		declared := false
 
 		for _, rule := range node.Values {
 			r := rule.(*Rule)
 			kinds[r.Head.DocKind()] = struct{}{}
 			arities[len(r.Head.Args)] = struct{}{}
+			if r.Head.Assign {
+				declared = true
+			}
 			if r.Default {
 				defaultRules++
 			}
@@ -553,11 +589,11 @@ func (c *Compiler) checkRuleConflicts() {
 
 		name := Var(node.Key.(String))
 
-		if len(kinds) > 1 || len(arities) > 1 {
+		if declared && len(node.Values) > 1 {
+			c.err(NewError(TypeErr, node.Values[0].(*Rule).Loc(), "rule named %v redeclared at %v", name, node.Values[1].(*Rule).Loc()))
+		} else if len(kinds) > 1 || len(arities) > 1 {
 			c.err(NewError(TypeErr, node.Values[0].(*Rule).Loc(), "conflicting rules named %v found", name))
-		}
-
-		if defaultRules > 1 {
+		} else if defaultRules > 1 {
 			c.err(NewError(TypeErr, node.Values[0].(*Rule).Loc(), "multiple default rules named %s found", name))
 		}
 
@@ -594,15 +630,15 @@ func (c *Compiler) checkSafetyRuleBodies() {
 		WalkRules(m, func(r *Rule) bool {
 			safe := ReservedVars.Copy()
 			safe.Update(r.Head.Args.Vars())
-			r.Body = c.checkBodySafety(safe, m, r.Body, r.Loc())
+			r.Body = c.checkBodySafety(safe, m, r.Body)
 			return false
 		})
 	}
 }
 
-func (c *Compiler) checkBodySafety(safe VarSet, m *Module, b Body, l *Location) Body {
+func (c *Compiler) checkBodySafety(safe VarSet, m *Module, b Body) Body {
 	reordered, unsafe := reorderBodyForSafety(c.GetArity, safe, b)
-	if errs := safetyErrorSlice(l, unsafe); len(errs) > 0 {
+	if errs := safetyErrorSlice(unsafe); len(errs) > 0 {
 		for _, err := range errs {
 			c.err(err)
 		}
@@ -647,6 +683,15 @@ func (c *Compiler) checkTypes() {
 		c.err(err)
 	}
 	c.TypeEnv = env
+}
+
+func (c *Compiler) checkUnsafeBuiltins() {
+	for _, name := range c.sorted {
+		errs := checkUnsafeBuiltins(c.unsafeBuiltinsMap, c.Modules[name])
+		for _, err := range errs {
+			c.err(err)
+		}
+	}
 }
 
 func (c *Compiler) runStage(metricName string, f func()) {
@@ -769,7 +814,7 @@ func (c *Compiler) resolveAllRefs() {
 		}
 
 		for id, module := range parsed {
-			c.Modules[id] = module
+			c.Modules[id] = module.Copy()
 			c.sorted = append(c.sorted, id)
 		}
 
@@ -778,10 +823,14 @@ func (c *Compiler) resolveAllRefs() {
 	}
 }
 
+func (c *Compiler) initLocalVarGen() {
+	c.localvargen = newLocalVarGeneratorForModuleSet(c.sorted, c.Modules)
+}
+
 func (c *Compiler) rewriteComprehensionTerms() {
+	f := newEqualityFactory(c.localvargen)
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-		f := newEqualityFactory(newLocalVarGenerator(mod))
 		rewriteComprehensionTerms(f, mod)
 	}
 }
@@ -789,10 +838,9 @@ func (c *Compiler) rewriteComprehensionTerms() {
 func (c *Compiler) rewriteExprTerms() {
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-		gen := newLocalVarGenerator(mod)
 		WalkRules(mod, func(rule *Rule) bool {
-			rewriteExprTermsInHead(gen, rule)
-			rule.Body = rewriteExprTermsInBody(gen, rule.Body)
+			rewriteExprTermsInHead(c.localvargen, rule)
+			rule.Body = rewriteExprTermsInBody(c.localvargen, rule.Body)
 			return false
 		})
 	}
@@ -812,9 +860,9 @@ func (c *Compiler) rewriteExprTerms() {
 //
 // p[__local0__] { i < 100; __local0__ = {"foo": data.foo[i]} }
 func (c *Compiler) rewriteRefsInHead() {
+	f := newEqualityFactory(c.localvargen)
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-		f := newEqualityFactory(newLocalVarGenerator(mod))
 		WalkRules(mod, func(rule *Rule) bool {
 			if requiresEval(rule.Head.Key) {
 				expr := f.Generate(rule.Head.Key)
@@ -846,9 +894,9 @@ func (c *Compiler) rewriteEquals() {
 }
 
 func (c *Compiler) rewriteDynamicTerms() {
+	f := newEqualityFactory(c.localvargen)
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-		f := newEqualityFactory(newLocalVarGenerator(mod))
 		WalkRules(mod, func(rule *Rule) bool {
 			rule.Body = rewriteDynamics(f, rule.Body)
 			return false
@@ -860,7 +908,7 @@ func (c *Compiler) rewriteLocalVars() {
 
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-		gen := newLocalVarGenerator(mod)
+		gen := c.localvargen
 
 		WalkRules(mod, func(rule *Rule) bool {
 
@@ -963,9 +1011,9 @@ func (c *Compiler) rewriteLocalVars() {
 }
 
 func (c *Compiler) rewriteWithModifiers() {
+	f := newEqualityFactory(c.localvargen)
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-		f := newEqualityFactory(newLocalVarGenerator(mod))
 		t := NewGenericTransformer(func(x interface{}) (interface{}, error) {
 			body, ok := x.(Body)
 			if !ok {
@@ -995,11 +1043,12 @@ func (c *Compiler) setGraph() {
 }
 
 type queryCompiler struct {
-	compiler  *Compiler
-	qctx      *QueryContext
-	typeEnv   *TypeEnv
-	rewritten map[Var]Var
-	after     map[string][]QueryCompilerStageDefinition
+	compiler       *Compiler
+	qctx           *QueryContext
+	typeEnv        *TypeEnv
+	rewritten      map[Var]Var
+	after          map[string][]QueryCompilerStageDefinition
+	unsafeBuiltins map[string]struct{}
 }
 
 func newQueryCompiler(compiler *Compiler) QueryCompiler {
@@ -1018,6 +1067,11 @@ func (qc *queryCompiler) WithContext(qctx *QueryContext) QueryCompiler {
 
 func (qc *queryCompiler) WithStageAfter(after string, stage QueryCompilerStageDefinition) QueryCompiler {
 	qc.after[after] = append(qc.after[after], stage)
+	return qc
+}
+
+func (qc *queryCompiler) WithUnsafeBuiltins(unsafe map[string]struct{}) QueryCompiler {
+	qc.unsafeBuiltins = unsafe
 	return qc
 }
 
@@ -1058,6 +1112,7 @@ func (qc *queryCompiler) Compile(query Body) (Body, error) {
 		{"CheckSafety", "query_compile_stage_check_safety", qc.checkSafety},
 		{"RewriteDynamicTerms", "query_compile_stage_rewrite_dynamic_terms", qc.rewriteDynamicTerms},
 		{"CheckTypes", "query_compile_stage_check_types", qc.checkTypes},
+		{"CheckUnsafeBuiltins", "query_compile_stage_check_unsafe_builtins", qc.checkUnsafeBuiltins},
 	}
 
 	qctx := qc.qctx.Copy()
@@ -1154,7 +1209,7 @@ func (qc *queryCompiler) rewriteLocalVars(_ *QueryContext, body Body) (Body, err
 func (qc *queryCompiler) checkSafety(_ *QueryContext, body Body) (Body, error) {
 	safe := ReservedVars.Copy()
 	reordered, unsafe := reorderBodyForSafety(qc.compiler.GetArity, safe, body)
-	if errs := safetyErrorSlice(body.Loc(), unsafe); len(errs) > 0 {
+	if errs := safetyErrorSlice(unsafe); len(errs) > 0 {
 		return nil, errs
 	}
 	return reordered, nil
@@ -1164,6 +1219,20 @@ func (qc *queryCompiler) checkTypes(qctx *QueryContext, body Body) (Body, error)
 	var errs Errors
 	checker := newTypeChecker()
 	qc.typeEnv, errs = checker.CheckBody(qc.compiler.TypeEnv, body)
+	if len(errs) > 0 {
+		return nil, errs
+	}
+	return body, nil
+}
+
+func (qc *queryCompiler) checkUnsafeBuiltins(qctx *QueryContext, body Body) (Body, error) {
+	var unsafe map[string]struct{}
+	if qc.unsafeBuiltins != nil {
+		unsafe = qc.unsafeBuiltins
+	} else {
+		unsafe = qc.compiler.unsafeBuiltinsMap
+	}
+	errs := checkUnsafeBuiltins(unsafe, body)
 	if len(errs) > 0 {
 		return nil, errs
 	}
@@ -1482,6 +1551,11 @@ type unsafePair struct {
 	Vars VarSet
 }
 
+type unsafeVarLoc struct {
+	Var Var
+	Loc *Location
+}
+
 type unsafeVars map[*Expr]VarSet
 
 func (vs unsafeVars) Add(e *Expr, v Var) {
@@ -1505,12 +1579,31 @@ func (vs unsafeVars) Update(o unsafeVars) {
 	}
 }
 
-func (vs unsafeVars) Vars() VarSet {
-	r := VarSet{}
-	for _, s := range vs {
-		r.Update(s)
+func (vs unsafeVars) Vars() (result []unsafeVarLoc) {
+
+	locs := map[Var]*Location{}
+
+	// If var appears in multiple sets then pick first by location.
+	for expr, vars := range vs {
+		for v := range vars {
+			if locs[v].Compare(expr.Location) > 0 {
+				locs[v] = expr.Location
+			}
+		}
 	}
-	return r
+
+	for v, loc := range locs {
+		result = append(result, unsafeVarLoc{
+			Var: v,
+			Loc: loc,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Loc.Compare(result[j].Loc) < 0
+	})
+
+	return result
 }
 
 func (vs unsafeVars) Slice() (result []unsafePair) {
@@ -1881,35 +1974,35 @@ func (f *equalityFactory) Generate(other *Term) *Expr {
 	return expr
 }
 
-const localVarFmt = "__local%d__"
-
 type localVarGenerator struct {
-	exclude   VarSet
-	generated VarSet
+	exclude VarSet
+	next    int
+}
+
+func newLocalVarGeneratorForModuleSet(sorted []string, modules map[string]*Module) *localVarGenerator {
+	exclude := NewVarSet()
+	vis := &VarVisitor{vars: exclude}
+	for _, key := range sorted {
+		Walk(vis, modules[key])
+	}
+	return &localVarGenerator{exclude: exclude, next: 0}
 }
 
 func newLocalVarGenerator(node interface{}) *localVarGenerator {
 	exclude := NewVarSet()
-	vis := &VarVisitor{
-		vars: exclude,
-	}
+	vis := &VarVisitor{vars: exclude}
 	Walk(vis, node)
-	return &localVarGenerator{exclude, NewVarSet()}
+	return &localVarGenerator{exclude: exclude, next: 0}
 }
 
 func (l *localVarGenerator) Generate() Var {
-	name := Var("")
-	x := 0
-	for len(name) == 0 || l.generated.Contains(name) || l.exclude.Contains(name) {
-		name = Var(fmt.Sprintf(localVarFmt, x))
-		x++
+	for {
+		result := Var("__local" + strconv.Itoa(l.next) + "__")
+		l.next++
+		if !l.exclude.Contains(result) {
+			return result
+		}
 	}
-	l.generated.Add(name)
-	return name
-}
-
-func (l *localVarGenerator) Generated() VarSet {
-	return l.generated
 }
 
 func getGlobals(pkg *Package, rules []Var, imports []*Import) map[Var]Ref {
@@ -2110,30 +2203,30 @@ func resolveRefsInTerm(globals map[Var]Ref, ignore *declaredVarStack, term *Term
 	case *ArrayComprehension:
 		ac := &ArrayComprehension{}
 		ignore.Push(declaredVars(v.Body))
-		defer ignore.Pop()
 		ac.Term = resolveRefsInTerm(globals, ignore, v.Term)
 		ac.Body = resolveRefsInBody(globals, ignore, v.Body)
 		cpy := *term
 		cpy.Value = ac
+		ignore.Pop()
 		return &cpy
 	case *ObjectComprehension:
 		oc := &ObjectComprehension{}
 		ignore.Push(declaredVars(v.Body))
-		defer ignore.Pop()
 		oc.Key = resolveRefsInTerm(globals, ignore, v.Key)
 		oc.Value = resolveRefsInTerm(globals, ignore, v.Value)
 		oc.Body = resolveRefsInBody(globals, ignore, v.Body)
 		cpy := *term
 		cpy.Value = oc
+		ignore.Pop()
 		return &cpy
 	case *SetComprehension:
 		sc := &SetComprehension{}
 		ignore.Push(declaredVars(v.Body))
-		defer ignore.Pop()
 		sc.Term = resolveRefsInTerm(globals, ignore, v.Term)
 		sc.Body = resolveRefsInBody(globals, ignore, v.Body)
 		cpy := *term
 		cpy.Value = sc
+		ignore.Pop()
 		return &cpy
 	default:
 		return term
@@ -2276,62 +2369,57 @@ func rewriteEquals(x interface{}) {
 //
 // foo(data.bar) = 1
 //
-// The rewritten vresion will be:
+// The rewritten version will be:
 //
 // __local0__ = data.bar; foo(__local0__) = 1
 func rewriteDynamics(f *equalityFactory, body Body) Body {
-	cpy := Body{}
+	result := make(Body, 0, len(body))
 	for _, expr := range body {
-		var exprs []*Expr
-		switch expr.Terms.(type) {
-		case []*Term:
-			if expr.IsEquality() {
-				exprs = rewriteDynamicsEqExpr(f, expr)
-			} else {
-				exprs = rewriteDynamicsCallExpr(f, expr)
-			}
-		case *Term:
-			exprs = rewriteDynamicsTermExpr(f, expr)
-		}
-		for _, expr := range exprs {
-			cpy.Append(expr)
+		if expr.IsEquality() {
+			result = rewriteDynamicsEqExpr(f, expr, result)
+		} else if expr.IsCall() {
+			result = rewriteDynamicsCallExpr(f, expr, result)
+		} else {
+			result = rewriteDynamicsTermExpr(f, expr, result)
 		}
 	}
-	return cpy
+	return result
 }
 
-func rewriteDynamicsEqExpr(f *equalityFactory, expr *Expr) []*Expr {
-	var extras []*Expr
+func appendExpr(body Body, expr *Expr) Body {
+	body.Append(expr)
+	return body
+}
+
+func rewriteDynamicsEqExpr(f *equalityFactory, expr *Expr, result Body) Body {
 	if !validEqAssignArgCount(expr) {
-		return append(extras, expr)
+		return appendExpr(result, expr)
 	}
 	terms := expr.Terms.([]*Term)
-	extras, terms[1] = rewriteDynamicsInTerm(expr, f, terms[1], nil)
-	extras, terms[2] = rewriteDynamicsInTerm(expr, f, terms[2], extras)
-	return append(extras, expr)
+	result, terms[1] = rewriteDynamicsInTerm(expr, f, terms[1], result)
+	result, terms[2] = rewriteDynamicsInTerm(expr, f, terms[2], result)
+	return appendExpr(result, expr)
 }
 
-func rewriteDynamicsCallExpr(f *equalityFactory, expr *Expr) []*Expr {
+func rewriteDynamicsCallExpr(f *equalityFactory, expr *Expr, result Body) Body {
 	terms := expr.Terms.([]*Term)
-	var extras []*Expr
 	for i := 1; i < len(terms); i++ {
-		extras, terms[i] = rewriteDynamicsOne(expr, f, terms[i], extras)
+		result, terms[i] = rewriteDynamicsOne(expr, f, terms[i], result)
 	}
-	return append(extras, expr)
+	return appendExpr(result, expr)
 }
 
-func rewriteDynamicsTermExpr(f *equalityFactory, expr *Expr) []*Expr {
+func rewriteDynamicsTermExpr(f *equalityFactory, expr *Expr, result Body) Body {
 	term := expr.Terms.(*Term)
-	var extras []*Expr
-	extras, expr.Terms = rewriteDynamicsInTerm(expr, f, term, nil)
-	return append(extras, expr)
+	result, expr.Terms = rewriteDynamicsInTerm(expr, f, term, result)
+	return appendExpr(result, expr)
 }
 
-func rewriteDynamicsInTerm(original *Expr, f *equalityFactory, term *Term, extras []*Expr) ([]*Expr, *Term) {
+func rewriteDynamicsInTerm(original *Expr, f *equalityFactory, term *Term, result Body) (Body, *Term) {
 	switch v := term.Value.(type) {
 	case Ref:
 		for i := 1; i < len(v); i++ {
-			extras, v[i] = rewriteDynamicsOne(original, f, v[i], extras)
+			result, v[i] = rewriteDynamicsOne(original, f, v[i], result)
 		}
 	case *ArrayComprehension:
 		v.Body = rewriteDynamics(f, v.Body)
@@ -2340,56 +2428,60 @@ func rewriteDynamicsInTerm(original *Expr, f *equalityFactory, term *Term, extra
 	case *ObjectComprehension:
 		v.Body = rewriteDynamics(f, v.Body)
 	default:
-		extras, term = rewriteDynamicsOne(original, f, term, extras)
+		result, term = rewriteDynamicsOne(original, f, term, result)
 	}
-	return extras, term
+	return result, term
 }
 
-func rewriteDynamicsOne(original *Expr, f *equalityFactory, term *Term, extras []*Expr) ([]*Expr, *Term) {
+func rewriteDynamicsOne(original *Expr, f *equalityFactory, term *Term, result Body) (Body, *Term) {
 	switch v := term.Value.(type) {
 	case Ref:
 		for i := 1; i < len(v); i++ {
-			extras, v[i] = rewriteDynamicsOne(original, f, v[i], extras)
+			result, v[i] = rewriteDynamicsOne(original, f, v[i], result)
 		}
 		generated := f.Generate(term)
 		generated.With = original.With
-		extras = append(extras, generated)
-		return extras, extras[len(extras)-1].Operand(0)
+		result.Append(generated)
+		return result, result[len(result)-1].Operand(0)
 	case Array:
 		for i := 0; i < len(v); i++ {
-			extras, v[i] = rewriteDynamicsOne(original, f, v[i], extras)
+			result, v[i] = rewriteDynamicsOne(original, f, v[i], result)
 		}
-		return extras, term
+		return result, term
 	case Object:
-		term.Value, _ = v.Map(func(k, v *Term) (*Term, *Term, error) {
-			extras, k = rewriteDynamicsOne(original, f, k, extras)
-			extras, v = rewriteDynamicsOne(original, f, v, extras)
-			return k, v, nil
-		})
-		return extras, term
+		cpy := NewObject()
+		for _, key := range v.Keys() {
+			value := v.Get(key)
+			result, key = rewriteDynamicsOne(original, f, key, result)
+			result, value = rewriteDynamicsOne(original, f, value, result)
+			cpy.Insert(key, value)
+		}
+		return result, NewTerm(cpy).SetLocation(term.Location)
 	case Set:
-		v, _ = v.Map(func(term *Term) (*Term, error) {
-			extras, term = rewriteDynamicsOne(original, f, term, extras)
-			return term, nil
-		})
-		return extras, NewTerm(v).SetLocation(term.Location)
+		cpy := NewSet()
+		for _, term := range v.Slice() {
+			var rw *Term
+			result, rw = rewriteDynamicsOne(original, f, term, result)
+			cpy.Add(rw)
+		}
+		return result, NewTerm(cpy).SetLocation(term.Location)
 	case *ArrayComprehension:
 		var extra *Expr
 		v.Body, extra = rewriteDynamicsComprehensionBody(original, f, v.Body, term)
-		extras = append(extras, extra)
-		return extras, extras[len(extras)-1].Operand(0)
+		result.Append(extra)
+		return result, result[len(result)-1].Operand(0)
 	case *SetComprehension:
 		var extra *Expr
 		v.Body, extra = rewriteDynamicsComprehensionBody(original, f, v.Body, term)
-		extras = append(extras, extra)
-		return extras, extras[len(extras)-1].Operand(0)
+		result.Append(extra)
+		return result, result[len(result)-1].Operand(0)
 	case *ObjectComprehension:
 		var extra *Expr
 		v.Body, extra = rewriteDynamicsComprehensionBody(original, f, v.Body, term)
-		extras = append(extras, extra)
-		return extras, extras[len(extras)-1].Operand(0)
+		result.Append(extra)
+		return result, result[len(result)-1].Operand(0)
 	}
-	return extras, term
+	return result, term
 }
 
 func rewriteDynamicsComprehensionBody(original *Expr, f *equalityFactory, body Body, term *Term) (Body, *Expr) {
@@ -2962,15 +3054,15 @@ func isDataRef(term *Term) bool {
 	return false
 }
 
-func safetyErrorSlice(l *Location, unsafe unsafeVars) (result Errors) {
+func safetyErrorSlice(unsafe unsafeVars) (result Errors) {
 
 	if len(unsafe) == 0 {
 		return
 	}
 
-	for v := range unsafe.Vars() {
-		if !v.IsGenerated() {
-			result = append(result, NewError(UnsafeVarErr, l, "var %v is unsafe", v))
+	for _, pair := range unsafe.Vars() {
+		if !pair.Var.IsGenerated() {
+			result = append(result, NewError(UnsafeVarErr, pair.Loc, "var %v is unsafe", pair.Var))
 		}
 	}
 
@@ -3003,4 +3095,18 @@ func safetyErrorSlice(l *Location, unsafe unsafeVars) (result Errors) {
 	}
 
 	return
+}
+
+func checkUnsafeBuiltins(unsafeBuiltinsMap map[string]struct{}, node interface{}) Errors {
+	errs := make(Errors, 0)
+	WalkExprs(node, func(x *Expr) bool {
+		if x.IsCall() {
+			operator := x.Operator().String()
+			if _, ok := unsafeBuiltinsMap[operator]; ok {
+				errs = append(errs, NewError(TypeErr, x.Loc(), "unsafe built-in function calls in expression: %v", operator))
+			}
+		}
+		return false
+	})
+	return errs
 }

--- a/vendor/github.com/open-policy-agent/opa/ast/errors.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/errors.go
@@ -6,6 +6,7 @@ package ast
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -29,6 +30,21 @@ func (e Errors) Error() string {
 	}
 
 	return fmt.Sprintf("%d errors occurred:\n%s", len(e), strings.Join(s, "\n"))
+}
+
+// Sort sorts the error slice by location. If the locations are equal then the
+// error message is compared.
+func (e Errors) Sort() {
+	sort.Slice(e, func(i, j int) bool {
+		a := e[i]
+		b := e[j]
+
+		if cmp := a.Location.Compare(b.Location); cmp != 0 {
+			return cmp < 0
+		}
+
+		return a.Error() < b.Error()
+	})
 }
 
 const (
@@ -104,4 +120,14 @@ func NewError(code string, loc *Location, f string, a ...interface{}) *Error {
 		Location: loc,
 		Message:  fmt.Sprintf(f, a...),
 	}
+}
+
+var (
+	errPartialRuleAssignOperator = fmt.Errorf("partial rules must use = operator (not := operator)")
+	errElseAssignOperator        = fmt.Errorf("else keyword cannot be used on rule declared with := operator")
+	errFunctionAssignOperator    = fmt.Errorf("functions must use = operator (not := operator)")
+)
+
+func errTermAssignOperator(x interface{}) error {
+	return fmt.Errorf("cannot assign to %v", TypeName(x))
 }

--- a/vendor/github.com/open-policy-agent/opa/ast/index.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/index.go
@@ -61,91 +61,40 @@ func newBaseDocEqIndex(isVirtual func(Ref) bool) *baseDocEqIndex {
 }
 
 func (i *baseDocEqIndex) Build(rules []*Rule) bool {
-
 	if len(rules) == 0 {
 		return false
 	}
 
 	i.kind = rules[0].Head.DocKind()
-	refs := make(refValueIndex, len(rules))
+	indices := newrefindices(i.isVirtual)
 
-	// freq is map[ref]int where the values represent the frequency of the
-	// ref/key.
-	freq := util.NewHashMap(func(a, b util.T) bool {
-		r1, r2 := a.(Ref), b.(Ref)
-		return r1.Equal(r2)
-	}, func(x util.T) int {
-		return x.(Ref).Hash()
-	})
-
-	// Build refs and freq maps
+	// build indices for each rule.
 	for idx := range rules {
-
 		WalkRules(rules[idx], func(rule *Rule) bool {
-
 			if rule.Default {
-				// Compiler guarantees that only one default will be defined per path.
 				i.defaultRule = rule
 				return false
 			}
-
 			for _, expr := range rule.Body {
-				ref, value, ok := i.getRefAndValue(expr)
-				if ok {
-					refs.Insert(rule, ref, value)
-					count, ok := freq.Get(ref)
-					if !ok {
-						count = 0
-					}
-					count = count.(int) + 1
-					freq.Put(ref, count)
-				}
+				indices.Update(rule, expr)
 			}
-
 			return false
 		})
 	}
 
-	// Sort by frequency
-	type refCountPair struct {
-		ref   Ref
-		count int
-	}
-
-	sorted := make([]refCountPair, 0, freq.Len())
-	freq.Iter(func(k, v util.T) bool {
-		ref, count := k.(Ref), v.(int)
-		sorted = append(sorted, refCountPair{ref, count})
-		return false
-	})
-
-	sort.Slice(sorted, func(i, j int) bool {
-		if sorted[i].count > sorted[j].count {
-			return true
-		}
-		return false
-	})
-
-	// Build trie
+	// build trie out of indices.
 	for idx := range rules {
-
 		var prio int
-
 		WalkRules(rules[idx], func(rule *Rule) bool {
-
 			if rule.Default {
 				return false
 			}
-
 			node := i.root
-
-			if refs := refs[rule]; refs != nil {
-				for _, pair := range sorted {
-					value := refs.Get(pair.ref)
-					node = node.Insert(pair.ref, value)
+			if indices.Indexed(rule) {
+				for _, ref := range indices.Sorted() {
+					node = node.Insert(ref, indices.Value(rule, ref), indices.Mapper(rule, ref))
 				}
 			}
-
 			// Insert rule into trie with (insertion order, priority order)
 			// tuple. Retaining the insertion order allows us to return rules
 			// in the order they were passed to this function.
@@ -190,86 +139,168 @@ func (i *baseDocEqIndex) Lookup(resolver ValueResolver) (*IndexResult, error) {
 	return result, nil
 }
 
-func indexedOperator(expr *Expr) bool {
-	if expr.IsEquality() {
-		return true
-	}
-	if expr.Operator().Compare(Equal.Ref()) == 0 {
-		return true
-	}
-	return false
+type valueMapper func(Value) Value
+
+type refindex struct {
+	Ref    Ref
+	Value  Value
+	Mapper func(Value) Value
 }
 
-func (i *baseDocEqIndex) getRefAndValue(expr *Expr) (Ref, Value, bool) {
-
-	if !indexedOperator(expr) || expr.Negated {
-		return nil, nil, false
-	}
-
-	a, b := expr.Operand(0), expr.Operand(1)
-
-	if ref, value, ok := i.getRefAndValueFromTerms(a, b); ok {
-		return ref, value, true
-	}
-
-	return i.getRefAndValueFromTerms(b, a)
+type refindices struct {
+	isVirtual func(Ref) bool
+	rules     map[*Rule][]*refindex
+	frequency *util.HashMap
+	sorted    []Ref
 }
 
-func (i *baseDocEqIndex) getRefAndValueFromTerms(a, b *Term) (Ref, Value, bool) {
+func newrefindices(isVirtual func(Ref) bool) *refindices {
+	return &refindices{
+		isVirtual: isVirtual,
+		rules:     map[*Rule][]*refindex{},
+		frequency: util.NewHashMap(func(a, b util.T) bool {
+			r1, r2 := a.(Ref), b.(Ref)
+			return r1.Equal(r2)
+		}, func(x util.T) int {
+			return x.(Ref).Hash()
+		}),
+	}
+}
 
-	ref, ok := a.Value.(Ref)
-	if !ok {
-		return nil, nil, false
+// Update attempts to update the refindices for the given expression in the
+// given rule. If the expression cannot be indexed the update does not affect
+// the indices.
+func (i *refindices) Update(rule *Rule, expr *Expr) {
+
+	if expr.Negated {
+		return
 	}
 
-	if !RootDocumentNames.Contains(ref[0]) {
-		return nil, nil, false
-	}
+	op := expr.Operator()
 
-	if i.isVirtual(ref) {
-		return nil, nil, false
-	}
+	if op.Equal(Equality.Ref()) || op.Equal(Equal.Ref()) {
 
-	if ref.IsNested() || !ref.IsGround() {
-		return nil, nil, false
-	}
+		i.updateEq(rule, expr)
 
-	switch b := b.Value.(type) {
-	case Null, Boolean, Number, String, Var:
-		return ref, b, true
-	case Array:
-		stop := false
-		first := true
-		vis := NewGenericVisitor(func(x interface{}) bool {
-			if first {
-				first = false
-				return false
-			}
-			switch x.(type) {
-			// No nested structures or values that require evaluation (other than var).
-			case Array, Object, Set, *ArrayComprehension, *ObjectComprehension, *SetComprehension, Ref:
-				stop = true
-			}
-			return stop
+	} else if op.Equal(GlobMatch.Ref()) {
+
+		i.updateGlobMatch(rule, expr)
+	}
+}
+
+// Sorted returns a sorted list of references that the indices were built from.
+// References that appear more frequently in the indexed rules are ordered
+// before less frequently appearing references.
+func (i *refindices) Sorted() []Ref {
+
+	if i.sorted == nil {
+		counts := make([]int, 0, i.frequency.Len())
+		i.sorted = make([]Ref, 0, i.frequency.Len())
+
+		i.frequency.Iter(func(k, v util.T) bool {
+			counts = append(counts, v.(int))
+			i.sorted = append(i.sorted, k.(Ref))
+			return false
 		})
-		Walk(vis, b)
-		if !stop {
-			return ref, b, true
+
+		sort.Slice(i.sorted, func(i, j int) bool {
+			return counts[i] > counts[j]
+		})
+	}
+
+	return i.sorted
+}
+
+func (i *refindices) Indexed(rule *Rule) bool {
+	return len(i.rules[rule]) > 0
+}
+
+func (i *refindices) Value(rule *Rule, ref Ref) Value {
+	if index := i.index(rule, ref); index != nil {
+		return index.Value
+	}
+	return nil
+}
+
+func (i *refindices) Mapper(rule *Rule, ref Ref) valueMapper {
+	if index := i.index(rule, ref); index != nil {
+		return index.Mapper
+	}
+	return nil
+}
+
+func (i *refindices) updateEq(rule *Rule, expr *Expr) {
+	a, b := expr.Operand(0), expr.Operand(1)
+	if ref, value, ok := eqOperandsToRefAndValue(i.isVirtual, a, b); ok {
+		i.insert(rule, &refindex{
+			Ref:   ref,
+			Value: value,
+		})
+	} else if ref, value, ok := eqOperandsToRefAndValue(i.isVirtual, b, a); ok {
+		i.insert(rule, &refindex{
+			Ref:   ref,
+			Value: value,
+		})
+	}
+}
+
+func (i *refindices) updateGlobMatch(rule *Rule, expr *Expr) {
+
+	delim, ok := globDelimiterToString(expr.Operand(1))
+	if !ok {
+		return
+	}
+
+	if arr := globPatternToArray(expr.Operand(0), delim); arr != nil {
+		// The 3rd operand of glob.match is the value to match. We assume the
+		// 3rd operand was a reference that has been rewritten and bound to a
+		// variable earlier in the query.
+		match := expr.Operand(2)
+		if _, ok := match.Value.(Var); ok {
+			for _, other := range i.rules[rule] {
+				if _, ok := other.Value.(Var); ok && other.Value.Compare(match.Value) == 0 {
+					i.insert(rule, &refindex{
+						Ref:   other.Ref,
+						Value: arr.Value,
+						Mapper: func(v Value) Value {
+							if s, ok := v.(String); ok {
+								return stringSliceToArray(splitStringEscaped(string(s), delim))
+							}
+							return v
+						},
+					})
+				}
+			}
+		}
+	}
+}
+
+func (i *refindices) insert(rule *Rule, index *refindex) {
+
+	count, ok := i.frequency.Get(index.Ref)
+	if !ok {
+		count = 0
+	}
+
+	i.frequency.Put(index.Ref, count.(int)+1)
+
+	for pos, other := range i.rules[rule] {
+		if other.Ref.Equal(index.Ref) {
+			i.rules[rule][pos] = index
+			return
 		}
 	}
 
-	return nil, nil, false
+	i.rules[rule] = append(i.rules[rule], index)
 }
 
-type refValueIndex map[*Rule]*ValueMap
-
-func (m refValueIndex) Insert(rule *Rule, ref Ref, value Value) {
-	vm, ok := m[rule]
-	if !ok {
-		vm = NewValueMap()
-		m[rule] = vm
+func (i *refindices) index(rule *Rule, ref Ref) *refindex {
+	for _, index := range i.rules[rule] {
+		if index.Ref.Equal(ref) {
+			return index
+		}
 	}
-	vm.Put(ref, value)
+	return nil
 }
 
 type trieWalker interface {
@@ -298,6 +329,7 @@ func (tr *trieTraversalResult) Add(node *ruleNode) {
 
 type trieNode struct {
 	ref       Ref
+	mapper    valueMapper
 	next      *trieNode
 	any       *trieNode
 	undefined *trieNode
@@ -335,6 +367,9 @@ func (node *trieNode) String() string {
 	if len(node.rules) > 0 {
 		flags = append(flags, fmt.Sprintf("%d rule(s)", len(node.rules)))
 	}
+	if node.mapper != nil {
+		flags = append(flags, "mapper")
+	}
 	return strings.Join(flags, " ")
 }
 
@@ -371,12 +406,14 @@ func (node *trieNode) Do(walker trieWalker) {
 	}
 }
 
-func (node *trieNode) Insert(ref Ref, value Value) *trieNode {
+func (node *trieNode) Insert(ref Ref, value Value, mapper valueMapper) *trieNode {
 
 	if node.next == nil {
 		node.next = newTrieNodeImpl()
 		node.next.ref = ref
 	}
+
+	node.next.mapper = mapper
 
 	return node.next.insertValue(value)
 }
@@ -474,6 +511,10 @@ func (node *trieNode) traverse(resolver ValueResolver, tr *trieTraversalResult) 
 		node.any.Traverse(resolver, tr)
 	}
 
+	if node.mapper != nil {
+		v = node.mapper(v)
+	}
+
 	return node.traverseValue(resolver, tr, v)
 }
 
@@ -562,4 +603,143 @@ func (p triePrinter) Do(x interface{}) trieWalker {
 	fmt.Fprintf(p.w, "%v%v\n", padding, x)
 	p.depth++
 	return p
+}
+
+func eqOperandsToRefAndValue(isVirtual func(Ref) bool, a, b *Term) (Ref, Value, bool) {
+
+	ref, ok := a.Value.(Ref)
+	if !ok {
+		return nil, nil, false
+	}
+
+	if !RootDocumentNames.Contains(ref[0]) {
+		return nil, nil, false
+	}
+
+	if isVirtual(ref) {
+		return nil, nil, false
+	}
+
+	if ref.IsNested() || !ref.IsGround() {
+		return nil, nil, false
+	}
+
+	switch b := b.Value.(type) {
+	case Null, Boolean, Number, String, Var:
+		return ref, b, true
+	case Array:
+		stop := false
+		first := true
+		vis := NewGenericVisitor(func(x interface{}) bool {
+			if first {
+				first = false
+				return false
+			}
+			switch x.(type) {
+			// No nested structures or values that require evaluation (other than var).
+			case Array, Object, Set, *ArrayComprehension, *ObjectComprehension, *SetComprehension, Ref:
+				stop = true
+			}
+			return stop
+		})
+		Walk(vis, b)
+		if !stop {
+			return ref, b, true
+		}
+	}
+
+	return nil, nil, false
+}
+
+func globDelimiterToString(delim *Term) (string, bool) {
+
+	arr, ok := delim.Value.(Array)
+	if !ok {
+		return "", false
+	}
+
+	var result string
+
+	if len(arr) == 0 {
+		result = "."
+	} else {
+		for _, term := range arr {
+			s, ok := term.Value.(String)
+			if !ok {
+				return "", false
+			}
+			result += string(s)
+		}
+	}
+
+	return result, true
+}
+
+func globPatternToArray(pattern *Term, delim string) *Term {
+
+	s, ok := pattern.Value.(String)
+	if !ok {
+		return nil
+	}
+
+	parts := splitStringEscaped(string(s), delim)
+	result := make(Array, len(parts))
+
+	for i := range parts {
+		if parts[i] == "*" {
+			result[i] = VarTerm("$globwildcard")
+		} else {
+			var escaped bool
+			for _, c := range parts[i] {
+				if c == '\\' {
+					escaped = !escaped
+					continue
+				}
+				if !escaped {
+					switch c {
+					case '[', '?', '{', '*':
+						// TODO(tsandall): super glob and character pattern
+						// matching not supported yet.
+						return nil
+					}
+				}
+				escaped = false
+			}
+			result[i] = StringTerm(parts[i])
+		}
+	}
+
+	return NewTerm(result)
+}
+
+// splits s on characters in delim except if delim characters have been escaped
+// with reverse solidus.
+func splitStringEscaped(s string, delim string) []string {
+
+	var last, curr int
+	var escaped bool
+	var result []string
+
+	for ; curr < len(s); curr++ {
+		if s[curr] == '\\' || escaped {
+			escaped = !escaped
+			continue
+		}
+		if strings.ContainsRune(delim, rune(s[curr])) {
+			result = append(result, s[last:curr])
+			last = curr + 1
+		}
+	}
+
+	result = append(result, s[last:])
+
+	return result
+}
+
+func stringSliceToArray(s []string) (result Array) {
+	result = make(Array, len(s))
+	for i := range s {
+		result[i] = StringTerm(s[i])
+	}
+	return
 }

--- a/vendor/github.com/open-policy-agent/opa/ast/parser.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/parser.go
@@ -267,20 +267,34 @@ var g = &grammar{
 							pos:  position{line: 23, col: 39, offset: 469},
 							name: "_",
 						},
-						&litMatcher{
-							pos:        position{line: 23, col: 41, offset: 471},
-							val:        "=",
-							ignoreCase: false,
+						&labeledExpr{
+							pos:   position{line: 23, col: 41, offset: 471},
+							label: "operator",
+							expr: &choiceExpr{
+								pos: position{line: 23, col: 52, offset: 482},
+								alternatives: []interface{}{
+									&litMatcher{
+										pos:        position{line: 23, col: 52, offset: 482},
+										val:        ":=",
+										ignoreCase: false,
+									},
+									&litMatcher{
+										pos:        position{line: 23, col: 59, offset: 489},
+										val:        "=",
+										ignoreCase: false,
+									},
+								},
+							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 23, col: 45, offset: 475},
+							pos:  position{line: 23, col: 65, offset: 495},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 23, col: 47, offset: 477},
+							pos:   position{line: 23, col: 67, offset: 497},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 23, col: 53, offset: 483},
+								pos:  position{line: 23, col: 73, offset: 503},
 								name: "Term",
 							},
 						},
@@ -290,46 +304,46 @@ var g = &grammar{
 		},
 		{
 			name: "NormalRules",
-			pos:  position{line: 27, col: 1, offset: 553},
+			pos:  position{line: 27, col: 1, offset: 583},
 			expr: &actionExpr{
-				pos: position{line: 27, col: 16, offset: 568},
+				pos: position{line: 27, col: 16, offset: 598},
 				run: (*parser).callonNormalRules1,
 				expr: &seqExpr{
-					pos: position{line: 27, col: 16, offset: 568},
+					pos: position{line: 27, col: 16, offset: 598},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 27, col: 16, offset: 568},
+							pos:   position{line: 27, col: 16, offset: 598},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 27, col: 21, offset: 573},
+								pos:  position{line: 27, col: 21, offset: 603},
 								name: "RuleHead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 27, col: 30, offset: 582},
+							pos:  position{line: 27, col: 30, offset: 612},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 27, col: 32, offset: 584},
+							pos:   position{line: 27, col: 32, offset: 614},
 							label: "rest",
 							expr: &seqExpr{
-								pos: position{line: 27, col: 38, offset: 590},
+								pos: position{line: 27, col: 38, offset: 620},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 27, col: 38, offset: 590},
+										pos:  position{line: 27, col: 38, offset: 620},
 										name: "NonEmptyBraceEnclosedBody",
 									},
 									&zeroOrMoreExpr{
-										pos: position{line: 27, col: 64, offset: 616},
+										pos: position{line: 27, col: 64, offset: 646},
 										expr: &seqExpr{
-											pos: position{line: 27, col: 66, offset: 618},
+											pos: position{line: 27, col: 66, offset: 648},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 27, col: 66, offset: 618},
+													pos:  position{line: 27, col: 66, offset: 648},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 27, col: 68, offset: 620},
+													pos:  position{line: 27, col: 68, offset: 650},
 													name: "RuleExt",
 												},
 											},
@@ -344,57 +358,57 @@ var g = &grammar{
 		},
 		{
 			name: "RuleHead",
-			pos:  position{line: 31, col: 1, offset: 689},
+			pos:  position{line: 31, col: 1, offset: 719},
 			expr: &actionExpr{
-				pos: position{line: 31, col: 13, offset: 701},
+				pos: position{line: 31, col: 13, offset: 731},
 				run: (*parser).callonRuleHead1,
 				expr: &seqExpr{
-					pos: position{line: 31, col: 13, offset: 701},
+					pos: position{line: 31, col: 13, offset: 731},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 31, col: 13, offset: 701},
+							pos:   position{line: 31, col: 13, offset: 731},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 31, col: 18, offset: 706},
+								pos:  position{line: 31, col: 18, offset: 736},
 								name: "Var",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 31, col: 22, offset: 710},
+							pos:   position{line: 31, col: 22, offset: 740},
 							label: "args",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 31, col: 27, offset: 715},
+								pos: position{line: 31, col: 27, offset: 745},
 								expr: &seqExpr{
-									pos: position{line: 31, col: 29, offset: 717},
+									pos: position{line: 31, col: 29, offset: 747},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 29, offset: 717},
+											pos:  position{line: 31, col: 29, offset: 747},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 31, col: 31, offset: 719},
+											pos:        position{line: 31, col: 31, offset: 749},
 											val:        "(",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 35, offset: 723},
+											pos:  position{line: 31, col: 35, offset: 753},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 37, offset: 725},
+											pos:  position{line: 31, col: 37, offset: 755},
 											name: "Args",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 42, offset: 730},
+											pos:  position{line: 31, col: 42, offset: 760},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 31, col: 44, offset: 732},
+											pos:        position{line: 31, col: 44, offset: 762},
 											val:        ")",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 48, offset: 736},
+											pos:  position{line: 31, col: 48, offset: 766},
 											name: "_",
 										},
 									},
@@ -402,41 +416,41 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 31, col: 53, offset: 741},
+							pos:   position{line: 31, col: 53, offset: 771},
 							label: "key",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 31, col: 57, offset: 745},
+								pos: position{line: 31, col: 57, offset: 775},
 								expr: &seqExpr{
-									pos: position{line: 31, col: 59, offset: 747},
+									pos: position{line: 31, col: 59, offset: 777},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 59, offset: 747},
+											pos:  position{line: 31, col: 59, offset: 777},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 31, col: 61, offset: 749},
+											pos:        position{line: 31, col: 61, offset: 779},
 											val:        "[",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 65, offset: 753},
+											pos:  position{line: 31, col: 65, offset: 783},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 67, offset: 755},
+											pos:  position{line: 31, col: 67, offset: 785},
 											name: "ExprTerm",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 76, offset: 764},
+											pos:  position{line: 31, col: 76, offset: 794},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 31, col: 78, offset: 766},
+											pos:        position{line: 31, col: 78, offset: 796},
 											val:        "]",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 82, offset: 770},
+											pos:  position{line: 31, col: 82, offset: 800},
 											name: "_",
 										},
 									},
@@ -444,28 +458,38 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 31, col: 87, offset: 775},
+							pos:   position{line: 31, col: 87, offset: 805},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 31, col: 93, offset: 781},
+								pos: position{line: 31, col: 93, offset: 811},
 								expr: &seqExpr{
-									pos: position{line: 31, col: 95, offset: 783},
+									pos: position{line: 31, col: 95, offset: 813},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 95, offset: 783},
+											pos:  position{line: 31, col: 95, offset: 813},
 											name: "_",
 										},
-										&litMatcher{
-											pos:        position{line: 31, col: 97, offset: 785},
-											val:        "=",
-											ignoreCase: false,
+										&choiceExpr{
+											pos: position{line: 31, col: 99, offset: 817},
+											alternatives: []interface{}{
+												&litMatcher{
+													pos:        position{line: 31, col: 99, offset: 817},
+													val:        ":=",
+													ignoreCase: false,
+												},
+												&litMatcher{
+													pos:        position{line: 31, col: 106, offset: 824},
+													val:        "=",
+													ignoreCase: false,
+												},
+											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 101, offset: 789},
+											pos:  position{line: 31, col: 112, offset: 830},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 103, offset: 791},
+											pos:  position{line: 31, col: 114, offset: 832},
 											name: "ExprTerm",
 										},
 									},
@@ -478,15 +502,15 @@ var g = &grammar{
 		},
 		{
 			name: "Args",
-			pos:  position{line: 35, col: 1, offset: 876},
+			pos:  position{line: 35, col: 1, offset: 917},
 			expr: &actionExpr{
-				pos: position{line: 35, col: 9, offset: 884},
+				pos: position{line: 35, col: 9, offset: 925},
 				run: (*parser).callonArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 35, col: 9, offset: 884},
+					pos:   position{line: 35, col: 9, offset: 925},
 					label: "list",
 					expr: &ruleRefExpr{
-						pos:  position{line: 35, col: 14, offset: 889},
+						pos:  position{line: 35, col: 14, offset: 930},
 						name: "ExprTermList",
 					},
 				},
@@ -494,41 +518,41 @@ var g = &grammar{
 		},
 		{
 			name: "Else",
-			pos:  position{line: 39, col: 1, offset: 933},
+			pos:  position{line: 39, col: 1, offset: 974},
 			expr: &actionExpr{
-				pos: position{line: 39, col: 9, offset: 941},
+				pos: position{line: 39, col: 9, offset: 982},
 				run: (*parser).callonElse1,
 				expr: &seqExpr{
-					pos: position{line: 39, col: 9, offset: 941},
+					pos: position{line: 39, col: 9, offset: 982},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 39, col: 9, offset: 941},
+							pos:        position{line: 39, col: 9, offset: 982},
 							val:        "else",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 39, col: 16, offset: 948},
+							pos:   position{line: 39, col: 16, offset: 989},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 39, col: 22, offset: 954},
+								pos: position{line: 39, col: 22, offset: 995},
 								expr: &seqExpr{
-									pos: position{line: 39, col: 24, offset: 956},
+									pos: position{line: 39, col: 24, offset: 997},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 39, col: 24, offset: 956},
+											pos:  position{line: 39, col: 24, offset: 997},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 39, col: 26, offset: 958},
+											pos:        position{line: 39, col: 26, offset: 999},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 39, col: 30, offset: 962},
+											pos:  position{line: 39, col: 30, offset: 1003},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 39, col: 32, offset: 964},
+											pos:  position{line: 39, col: 32, offset: 1005},
 											name: "Term",
 										},
 									},
@@ -536,17 +560,17 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 39, col: 40, offset: 972},
+							pos:   position{line: 39, col: 40, offset: 1013},
 							label: "body",
 							expr: &seqExpr{
-								pos: position{line: 39, col: 47, offset: 979},
+								pos: position{line: 39, col: 47, offset: 1020},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 39, col: 47, offset: 979},
+										pos:  position{line: 39, col: 47, offset: 1020},
 										name: "_",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 39, col: 49, offset: 981},
+										pos:  position{line: 39, col: 49, offset: 1022},
 										name: "NonEmptyBraceEnclosedBody",
 									},
 								},
@@ -558,15 +582,15 @@ var g = &grammar{
 		},
 		{
 			name: "RuleDup",
-			pos:  position{line: 43, col: 1, offset: 1070},
+			pos:  position{line: 43, col: 1, offset: 1111},
 			expr: &actionExpr{
-				pos: position{line: 43, col: 12, offset: 1081},
+				pos: position{line: 43, col: 12, offset: 1122},
 				run: (*parser).callonRuleDup1,
 				expr: &labeledExpr{
-					pos:   position{line: 43, col: 12, offset: 1081},
+					pos:   position{line: 43, col: 12, offset: 1122},
 					label: "b",
 					expr: &ruleRefExpr{
-						pos:  position{line: 43, col: 14, offset: 1083},
+						pos:  position{line: 43, col: 14, offset: 1124},
 						name: "NonEmptyBraceEnclosedBody",
 					},
 				},
@@ -574,16 +598,16 @@ var g = &grammar{
 		},
 		{
 			name: "RuleExt",
-			pos:  position{line: 47, col: 1, offset: 1179},
+			pos:  position{line: 47, col: 1, offset: 1220},
 			expr: &choiceExpr{
-				pos: position{line: 47, col: 12, offset: 1190},
+				pos: position{line: 47, col: 12, offset: 1231},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 47, col: 12, offset: 1190},
+						pos:  position{line: 47, col: 12, offset: 1231},
 						name: "Else",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 47, col: 19, offset: 1197},
+						pos:  position{line: 47, col: 19, offset: 1238},
 						name: "RuleDup",
 					},
 				},
@@ -591,16 +615,16 @@ var g = &grammar{
 		},
 		{
 			name: "Body",
-			pos:  position{line: 49, col: 1, offset: 1206},
+			pos:  position{line: 49, col: 1, offset: 1247},
 			expr: &choiceExpr{
-				pos: position{line: 49, col: 9, offset: 1214},
+				pos: position{line: 49, col: 9, offset: 1255},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 49, col: 9, offset: 1214},
+						pos:  position{line: 49, col: 9, offset: 1255},
 						name: "NonWhitespaceBody",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 49, col: 29, offset: 1234},
+						pos:  position{line: 49, col: 29, offset: 1275},
 						name: "BraceEnclosedBody",
 					},
 				},
@@ -608,39 +632,39 @@ var g = &grammar{
 		},
 		{
 			name: "NonEmptyBraceEnclosedBody",
-			pos:  position{line: 51, col: 1, offset: 1253},
+			pos:  position{line: 51, col: 1, offset: 1294},
 			expr: &actionExpr{
-				pos: position{line: 51, col: 30, offset: 1282},
+				pos: position{line: 51, col: 30, offset: 1323},
 				run: (*parser).callonNonEmptyBraceEnclosedBody1,
 				expr: &seqExpr{
-					pos: position{line: 51, col: 30, offset: 1282},
+					pos: position{line: 51, col: 30, offset: 1323},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 51, col: 30, offset: 1282},
+							pos:        position{line: 51, col: 30, offset: 1323},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 51, col: 34, offset: 1286},
+							pos:  position{line: 51, col: 34, offset: 1327},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 51, col: 36, offset: 1288},
+							pos:   position{line: 51, col: 36, offset: 1329},
 							label: "val",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 51, col: 40, offset: 1292},
+								pos: position{line: 51, col: 40, offset: 1333},
 								expr: &ruleRefExpr{
-									pos:  position{line: 51, col: 40, offset: 1292},
+									pos:  position{line: 51, col: 40, offset: 1333},
 									name: "WhitespaceBody",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 51, col: 56, offset: 1308},
+							pos:  position{line: 51, col: 56, offset: 1349},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 51, col: 58, offset: 1310},
+							pos:        position{line: 51, col: 58, offset: 1351},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -650,39 +674,39 @@ var g = &grammar{
 		},
 		{
 			name: "BraceEnclosedBody",
-			pos:  position{line: 58, col: 1, offset: 1422},
+			pos:  position{line: 58, col: 1, offset: 1463},
 			expr: &actionExpr{
-				pos: position{line: 58, col: 22, offset: 1443},
+				pos: position{line: 58, col: 22, offset: 1484},
 				run: (*parser).callonBraceEnclosedBody1,
 				expr: &seqExpr{
-					pos: position{line: 58, col: 22, offset: 1443},
+					pos: position{line: 58, col: 22, offset: 1484},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 58, col: 22, offset: 1443},
+							pos:        position{line: 58, col: 22, offset: 1484},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 58, col: 26, offset: 1447},
+							pos:  position{line: 58, col: 26, offset: 1488},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 58, col: 28, offset: 1449},
+							pos:   position{line: 58, col: 28, offset: 1490},
 							label: "val",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 58, col: 32, offset: 1453},
+								pos: position{line: 58, col: 32, offset: 1494},
 								expr: &ruleRefExpr{
-									pos:  position{line: 58, col: 32, offset: 1453},
+									pos:  position{line: 58, col: 32, offset: 1494},
 									name: "WhitespaceBody",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 58, col: 48, offset: 1469},
+							pos:  position{line: 58, col: 48, offset: 1510},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 58, col: 50, offset: 1471},
+							pos:        position{line: 58, col: 50, offset: 1512},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -692,39 +716,39 @@ var g = &grammar{
 		},
 		{
 			name: "WhitespaceBody",
-			pos:  position{line: 62, col: 1, offset: 1538},
+			pos:  position{line: 62, col: 1, offset: 1579},
 			expr: &actionExpr{
-				pos: position{line: 62, col: 19, offset: 1556},
+				pos: position{line: 62, col: 19, offset: 1597},
 				run: (*parser).callonWhitespaceBody1,
 				expr: &seqExpr{
-					pos: position{line: 62, col: 19, offset: 1556},
+					pos: position{line: 62, col: 19, offset: 1597},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 62, col: 19, offset: 1556},
+							pos:   position{line: 62, col: 19, offset: 1597},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 62, col: 24, offset: 1561},
+								pos:  position{line: 62, col: 24, offset: 1602},
 								name: "Literal",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 62, col: 32, offset: 1569},
+							pos:   position{line: 62, col: 32, offset: 1610},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 62, col: 37, offset: 1574},
+								pos: position{line: 62, col: 37, offset: 1615},
 								expr: &seqExpr{
-									pos: position{line: 62, col: 38, offset: 1575},
+									pos: position{line: 62, col: 38, offset: 1616},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 62, col: 38, offset: 1575},
+											pos:  position{line: 62, col: 38, offset: 1616},
 											name: "WhitespaceLiteralSeparator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 62, col: 65, offset: 1602},
+											pos:  position{line: 62, col: 65, offset: 1643},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 62, col: 67, offset: 1604},
+											pos:  position{line: 62, col: 67, offset: 1645},
 											name: "Literal",
 										},
 									},
@@ -737,43 +761,43 @@ var g = &grammar{
 		},
 		{
 			name: "NonWhitespaceBody",
-			pos:  position{line: 66, col: 1, offset: 1654},
+			pos:  position{line: 66, col: 1, offset: 1695},
 			expr: &actionExpr{
-				pos: position{line: 66, col: 22, offset: 1675},
+				pos: position{line: 66, col: 22, offset: 1716},
 				run: (*parser).callonNonWhitespaceBody1,
 				expr: &seqExpr{
-					pos: position{line: 66, col: 22, offset: 1675},
+					pos: position{line: 66, col: 22, offset: 1716},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 66, col: 22, offset: 1675},
+							pos:   position{line: 66, col: 22, offset: 1716},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 66, col: 27, offset: 1680},
+								pos:  position{line: 66, col: 27, offset: 1721},
 								name: "Literal",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 66, col: 35, offset: 1688},
+							pos:   position{line: 66, col: 35, offset: 1729},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 66, col: 40, offset: 1693},
+								pos: position{line: 66, col: 40, offset: 1734},
 								expr: &seqExpr{
-									pos: position{line: 66, col: 42, offset: 1695},
+									pos: position{line: 66, col: 42, offset: 1736},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 66, col: 42, offset: 1695},
+											pos:  position{line: 66, col: 42, offset: 1736},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 66, col: 44, offset: 1697},
+											pos:  position{line: 66, col: 44, offset: 1738},
 											name: "NonWhitespaceLiteralSeparator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 66, col: 74, offset: 1727},
+											pos:  position{line: 66, col: 74, offset: 1768},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 66, col: 76, offset: 1729},
+											pos:  position{line: 66, col: 76, offset: 1770},
 											name: "Literal",
 										},
 									},
@@ -786,14 +810,14 @@ var g = &grammar{
 		},
 		{
 			name: "WhitespaceLiteralSeparator",
-			pos:  position{line: 70, col: 1, offset: 1779},
+			pos:  position{line: 70, col: 1, offset: 1820},
 			expr: &seqExpr{
-				pos: position{line: 70, col: 31, offset: 1809},
+				pos: position{line: 70, col: 31, offset: 1850},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 70, col: 31, offset: 1809},
+						pos: position{line: 70, col: 31, offset: 1850},
 						expr: &charClassMatcher{
-							pos:        position{line: 70, col: 31, offset: 1809},
+							pos:        position{line: 70, col: 31, offset: 1850},
 							val:        "[ \\t]",
 							chars:      []rune{' ', '\t'},
 							ignoreCase: false,
@@ -801,36 +825,36 @@ var g = &grammar{
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 70, col: 39, offset: 1817},
+						pos: position{line: 70, col: 39, offset: 1858},
 						alternatives: []interface{}{
 							&seqExpr{
-								pos: position{line: 70, col: 40, offset: 1818},
+								pos: position{line: 70, col: 40, offset: 1859},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 70, col: 40, offset: 1818},
+										pos:  position{line: 70, col: 40, offset: 1859},
 										name: "NonWhitespaceLiteralSeparator",
 									},
 									&zeroOrOneExpr{
-										pos: position{line: 70, col: 70, offset: 1848},
+										pos: position{line: 70, col: 70, offset: 1889},
 										expr: &ruleRefExpr{
-											pos:  position{line: 70, col: 70, offset: 1848},
+											pos:  position{line: 70, col: 70, offset: 1889},
 											name: "Comment",
 										},
 									},
 								},
 							},
 							&seqExpr{
-								pos: position{line: 70, col: 83, offset: 1861},
+								pos: position{line: 70, col: 83, offset: 1902},
 								exprs: []interface{}{
 									&zeroOrOneExpr{
-										pos: position{line: 70, col: 83, offset: 1861},
+										pos: position{line: 70, col: 83, offset: 1902},
 										expr: &ruleRefExpr{
-											pos:  position{line: 70, col: 83, offset: 1861},
+											pos:  position{line: 70, col: 83, offset: 1902},
 											name: "Comment",
 										},
 									},
 									&charClassMatcher{
-										pos:        position{line: 70, col: 92, offset: 1870},
+										pos:        position{line: 70, col: 92, offset: 1911},
 										val:        "[\\r\\n]",
 										chars:      []rune{'\r', '\n'},
 										ignoreCase: false,
@@ -845,25 +869,25 @@ var g = &grammar{
 		},
 		{
 			name: "NonWhitespaceLiteralSeparator",
-			pos:  position{line: 72, col: 1, offset: 1880},
+			pos:  position{line: 72, col: 1, offset: 1921},
 			expr: &litMatcher{
-				pos:        position{line: 72, col: 34, offset: 1913},
+				pos:        position{line: 72, col: 34, offset: 1954},
 				val:        ";",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 74, col: 1, offset: 1918},
+			pos:  position{line: 74, col: 1, offset: 1959},
 			expr: &choiceExpr{
-				pos: position{line: 74, col: 12, offset: 1929},
+				pos: position{line: 74, col: 12, offset: 1970},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 74, col: 12, offset: 1929},
+						pos:  position{line: 74, col: 12, offset: 1970},
 						name: "TermExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 74, col: 23, offset: 1940},
+						pos:  position{line: 74, col: 23, offset: 1981},
 						name: "SomeDecl",
 					},
 				},
@@ -871,27 +895,27 @@ var g = &grammar{
 		},
 		{
 			name: "SomeDecl",
-			pos:  position{line: 76, col: 1, offset: 1950},
+			pos:  position{line: 76, col: 1, offset: 1991},
 			expr: &actionExpr{
-				pos: position{line: 76, col: 13, offset: 1962},
+				pos: position{line: 76, col: 13, offset: 2003},
 				run: (*parser).callonSomeDecl1,
 				expr: &seqExpr{
-					pos: position{line: 76, col: 13, offset: 1962},
+					pos: position{line: 76, col: 13, offset: 2003},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 76, col: 13, offset: 1962},
+							pos:        position{line: 76, col: 13, offset: 2003},
 							val:        "some",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 76, col: 20, offset: 1969},
+							pos:  position{line: 76, col: 20, offset: 2010},
 							name: "ws",
 						},
 						&labeledExpr{
-							pos:   position{line: 76, col: 23, offset: 1972},
+							pos:   position{line: 76, col: 23, offset: 2013},
 							label: "symbols",
 							expr: &ruleRefExpr{
-								pos:  position{line: 76, col: 31, offset: 1980},
+								pos:  position{line: 76, col: 31, offset: 2021},
 								name: "SomeDeclList",
 							},
 						},
@@ -901,44 +925,44 @@ var g = &grammar{
 		},
 		{
 			name: "SomeDeclList",
-			pos:  position{line: 80, col: 1, offset: 2058},
+			pos:  position{line: 80, col: 1, offset: 2099},
 			expr: &actionExpr{
-				pos: position{line: 80, col: 17, offset: 2074},
+				pos: position{line: 80, col: 17, offset: 2115},
 				run: (*parser).callonSomeDeclList1,
 				expr: &seqExpr{
-					pos: position{line: 80, col: 17, offset: 2074},
+					pos: position{line: 80, col: 17, offset: 2115},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 80, col: 17, offset: 2074},
+							pos:   position{line: 80, col: 17, offset: 2115},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 80, col: 22, offset: 2079},
+								pos:  position{line: 80, col: 22, offset: 2120},
 								name: "Var",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 80, col: 26, offset: 2083},
+							pos:   position{line: 80, col: 26, offset: 2124},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 80, col: 31, offset: 2088},
+								pos: position{line: 80, col: 31, offset: 2129},
 								expr: &seqExpr{
-									pos: position{line: 80, col: 33, offset: 2090},
+									pos: position{line: 80, col: 33, offset: 2131},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 80, col: 33, offset: 2090},
+											pos:  position{line: 80, col: 33, offset: 2131},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 80, col: 35, offset: 2092},
+											pos:        position{line: 80, col: 35, offset: 2133},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 80, col: 39, offset: 2096},
+											pos:  position{line: 80, col: 39, offset: 2137},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 80, col: 41, offset: 2098},
+											pos:  position{line: 80, col: 41, offset: 2139},
 											name: "Var",
 										},
 									},
@@ -951,39 +975,39 @@ var g = &grammar{
 		},
 		{
 			name: "TermExpr",
-			pos:  position{line: 84, col: 1, offset: 2152},
+			pos:  position{line: 84, col: 1, offset: 2193},
 			expr: &actionExpr{
-				pos: position{line: 84, col: 13, offset: 2164},
+				pos: position{line: 84, col: 13, offset: 2205},
 				run: (*parser).callonTermExpr1,
 				expr: &seqExpr{
-					pos: position{line: 84, col: 13, offset: 2164},
+					pos: position{line: 84, col: 13, offset: 2205},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 84, col: 13, offset: 2164},
+							pos:   position{line: 84, col: 13, offset: 2205},
 							label: "negated",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 84, col: 21, offset: 2172},
+								pos: position{line: 84, col: 21, offset: 2213},
 								expr: &ruleRefExpr{
-									pos:  position{line: 84, col: 21, offset: 2172},
+									pos:  position{line: 84, col: 21, offset: 2213},
 									name: "NotKeyword",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 84, col: 33, offset: 2184},
+							pos:   position{line: 84, col: 33, offset: 2225},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 84, col: 39, offset: 2190},
+								pos:  position{line: 84, col: 39, offset: 2231},
 								name: "LiteralExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 84, col: 51, offset: 2202},
+							pos:   position{line: 84, col: 51, offset: 2243},
 							label: "with",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 84, col: 56, offset: 2207},
+								pos: position{line: 84, col: 56, offset: 2248},
 								expr: &ruleRefExpr{
-									pos:  position{line: 84, col: 56, offset: 2207},
+									pos:  position{line: 84, col: 56, offset: 2248},
 									name: "WithKeywordList",
 								},
 							},
@@ -994,43 +1018,43 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralExpr",
-			pos:  position{line: 88, col: 1, offset: 2274},
+			pos:  position{line: 88, col: 1, offset: 2315},
 			expr: &actionExpr{
-				pos: position{line: 88, col: 16, offset: 2289},
+				pos: position{line: 88, col: 16, offset: 2330},
 				run: (*parser).callonLiteralExpr1,
 				expr: &seqExpr{
-					pos: position{line: 88, col: 16, offset: 2289},
+					pos: position{line: 88, col: 16, offset: 2330},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 88, col: 16, offset: 2289},
+							pos:   position{line: 88, col: 16, offset: 2330},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 88, col: 20, offset: 2293},
+								pos:  position{line: 88, col: 20, offset: 2334},
 								name: "ExprTerm",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 88, col: 29, offset: 2302},
+							pos:   position{line: 88, col: 29, offset: 2343},
 							label: "rest",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 88, col: 34, offset: 2307},
+								pos: position{line: 88, col: 34, offset: 2348},
 								expr: &seqExpr{
-									pos: position{line: 88, col: 36, offset: 2309},
+									pos: position{line: 88, col: 36, offset: 2350},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 88, col: 36, offset: 2309},
+											pos:  position{line: 88, col: 36, offset: 2350},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 88, col: 38, offset: 2311},
+											pos:  position{line: 88, col: 38, offset: 2352},
 											name: "LiteralExprOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 88, col: 58, offset: 2331},
+											pos:  position{line: 88, col: 58, offset: 2372},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 88, col: 60, offset: 2333},
+											pos:  position{line: 88, col: 60, offset: 2374},
 											name: "ExprTerm",
 										},
 									},
@@ -1043,23 +1067,23 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralExprOperator",
-			pos:  position{line: 92, col: 1, offset: 2407},
+			pos:  position{line: 92, col: 1, offset: 2448},
 			expr: &actionExpr{
-				pos: position{line: 92, col: 24, offset: 2430},
+				pos: position{line: 92, col: 24, offset: 2471},
 				run: (*parser).callonLiteralExprOperator1,
 				expr: &labeledExpr{
-					pos:   position{line: 92, col: 24, offset: 2430},
+					pos:   position{line: 92, col: 24, offset: 2471},
 					label: "val",
 					expr: &choiceExpr{
-						pos: position{line: 92, col: 30, offset: 2436},
+						pos: position{line: 92, col: 30, offset: 2477},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 92, col: 30, offset: 2436},
+								pos:        position{line: 92, col: 30, offset: 2477},
 								val:        ":=",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 92, col: 37, offset: 2443},
+								pos:        position{line: 92, col: 37, offset: 2484},
 								val:        "=",
 								ignoreCase: false,
 							},
@@ -1070,25 +1094,25 @@ var g = &grammar{
 		},
 		{
 			name: "NotKeyword",
-			pos:  position{line: 96, col: 1, offset: 2511},
+			pos:  position{line: 96, col: 1, offset: 2552},
 			expr: &actionExpr{
-				pos: position{line: 96, col: 15, offset: 2525},
+				pos: position{line: 96, col: 15, offset: 2566},
 				run: (*parser).callonNotKeyword1,
 				expr: &labeledExpr{
-					pos:   position{line: 96, col: 15, offset: 2525},
+					pos:   position{line: 96, col: 15, offset: 2566},
 					label: "val",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 96, col: 19, offset: 2529},
+						pos: position{line: 96, col: 19, offset: 2570},
 						expr: &seqExpr{
-							pos: position{line: 96, col: 20, offset: 2530},
+							pos: position{line: 96, col: 20, offset: 2571},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 96, col: 20, offset: 2530},
+									pos:        position{line: 96, col: 20, offset: 2571},
 									val:        "not",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 96, col: 26, offset: 2536},
+									pos:  position{line: 96, col: 26, offset: 2577},
 									name: "ws",
 								},
 							},
@@ -1099,39 +1123,39 @@ var g = &grammar{
 		},
 		{
 			name: "WithKeywordList",
-			pos:  position{line: 100, col: 1, offset: 2573},
+			pos:  position{line: 100, col: 1, offset: 2614},
 			expr: &actionExpr{
-				pos: position{line: 100, col: 20, offset: 2592},
+				pos: position{line: 100, col: 20, offset: 2633},
 				run: (*parser).callonWithKeywordList1,
 				expr: &seqExpr{
-					pos: position{line: 100, col: 20, offset: 2592},
+					pos: position{line: 100, col: 20, offset: 2633},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 100, col: 20, offset: 2592},
+							pos:  position{line: 100, col: 20, offset: 2633},
 							name: "ws",
 						},
 						&labeledExpr{
-							pos:   position{line: 100, col: 23, offset: 2595},
+							pos:   position{line: 100, col: 23, offset: 2636},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 100, col: 28, offset: 2600},
+								pos:  position{line: 100, col: 28, offset: 2641},
 								name: "WithKeyword",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 100, col: 40, offset: 2612},
+							pos:   position{line: 100, col: 40, offset: 2653},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 100, col: 45, offset: 2617},
+								pos: position{line: 100, col: 45, offset: 2658},
 								expr: &seqExpr{
-									pos: position{line: 100, col: 47, offset: 2619},
+									pos: position{line: 100, col: 47, offset: 2660},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 100, col: 47, offset: 2619},
+											pos:  position{line: 100, col: 47, offset: 2660},
 											name: "ws",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 100, col: 50, offset: 2622},
+											pos:  position{line: 100, col: 50, offset: 2663},
 											name: "WithKeyword",
 										},
 									},
@@ -1144,48 +1168,48 @@ var g = &grammar{
 		},
 		{
 			name: "WithKeyword",
-			pos:  position{line: 104, col: 1, offset: 2685},
+			pos:  position{line: 104, col: 1, offset: 2726},
 			expr: &actionExpr{
-				pos: position{line: 104, col: 16, offset: 2700},
+				pos: position{line: 104, col: 16, offset: 2741},
 				run: (*parser).callonWithKeyword1,
 				expr: &seqExpr{
-					pos: position{line: 104, col: 16, offset: 2700},
+					pos: position{line: 104, col: 16, offset: 2741},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 104, col: 16, offset: 2700},
+							pos:        position{line: 104, col: 16, offset: 2741},
 							val:        "with",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 104, col: 23, offset: 2707},
+							pos:  position{line: 104, col: 23, offset: 2748},
 							name: "ws",
 						},
 						&labeledExpr{
-							pos:   position{line: 104, col: 26, offset: 2710},
+							pos:   position{line: 104, col: 26, offset: 2751},
 							label: "target",
 							expr: &ruleRefExpr{
-								pos:  position{line: 104, col: 33, offset: 2717},
+								pos:  position{line: 104, col: 33, offset: 2758},
 								name: "ExprTerm",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 104, col: 42, offset: 2726},
+							pos:  position{line: 104, col: 42, offset: 2767},
 							name: "ws",
 						},
 						&litMatcher{
-							pos:        position{line: 104, col: 45, offset: 2729},
+							pos:        position{line: 104, col: 45, offset: 2770},
 							val:        "as",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 104, col: 50, offset: 2734},
+							pos:  position{line: 104, col: 50, offset: 2775},
 							name: "ws",
 						},
 						&labeledExpr{
-							pos:   position{line: 104, col: 53, offset: 2737},
+							pos:   position{line: 104, col: 53, offset: 2778},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 104, col: 59, offset: 2743},
+								pos:  position{line: 104, col: 59, offset: 2784},
 								name: "ExprTerm",
 							},
 						},
@@ -1195,43 +1219,43 @@ var g = &grammar{
 		},
 		{
 			name: "ExprTerm",
-			pos:  position{line: 108, col: 1, offset: 2819},
+			pos:  position{line: 108, col: 1, offset: 2860},
 			expr: &actionExpr{
-				pos: position{line: 108, col: 13, offset: 2831},
+				pos: position{line: 108, col: 13, offset: 2872},
 				run: (*parser).callonExprTerm1,
 				expr: &seqExpr{
-					pos: position{line: 108, col: 13, offset: 2831},
+					pos: position{line: 108, col: 13, offset: 2872},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 108, col: 13, offset: 2831},
+							pos:   position{line: 108, col: 13, offset: 2872},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 108, col: 17, offset: 2835},
+								pos:  position{line: 108, col: 17, offset: 2876},
 								name: "RelationExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 108, col: 30, offset: 2848},
+							pos:   position{line: 108, col: 30, offset: 2889},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 108, col: 35, offset: 2853},
+								pos: position{line: 108, col: 35, offset: 2894},
 								expr: &seqExpr{
-									pos: position{line: 108, col: 37, offset: 2855},
+									pos: position{line: 108, col: 37, offset: 2896},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 108, col: 37, offset: 2855},
+											pos:  position{line: 108, col: 37, offset: 2896},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 108, col: 39, offset: 2857},
+											pos:  position{line: 108, col: 39, offset: 2898},
 											name: "RelationOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 108, col: 56, offset: 2874},
+											pos:  position{line: 108, col: 56, offset: 2915},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 108, col: 58, offset: 2876},
+											pos:  position{line: 108, col: 58, offset: 2917},
 											name: "RelationExpr",
 										},
 									},
@@ -1244,47 +1268,47 @@ var g = &grammar{
 		},
 		{
 			name: "ExprTermPairList",
-			pos:  position{line: 112, col: 1, offset: 2952},
+			pos:  position{line: 112, col: 1, offset: 2993},
 			expr: &actionExpr{
-				pos: position{line: 112, col: 21, offset: 2972},
+				pos: position{line: 112, col: 21, offset: 3013},
 				run: (*parser).callonExprTermPairList1,
 				expr: &seqExpr{
-					pos: position{line: 112, col: 21, offset: 2972},
+					pos: position{line: 112, col: 21, offset: 3013},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 112, col: 21, offset: 2972},
+							pos:   position{line: 112, col: 21, offset: 3013},
 							label: "head",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 112, col: 26, offset: 2977},
+								pos: position{line: 112, col: 26, offset: 3018},
 								expr: &ruleRefExpr{
-									pos:  position{line: 112, col: 26, offset: 2977},
+									pos:  position{line: 112, col: 26, offset: 3018},
 									name: "ExprTermPair",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 112, col: 40, offset: 2991},
+							pos:   position{line: 112, col: 40, offset: 3032},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 112, col: 45, offset: 2996},
+								pos: position{line: 112, col: 45, offset: 3037},
 								expr: &seqExpr{
-									pos: position{line: 112, col: 47, offset: 2998},
+									pos: position{line: 112, col: 47, offset: 3039},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 112, col: 47, offset: 2998},
+											pos:  position{line: 112, col: 47, offset: 3039},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 112, col: 49, offset: 3000},
+											pos:        position{line: 112, col: 49, offset: 3041},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 112, col: 53, offset: 3004},
+											pos:  position{line: 112, col: 53, offset: 3045},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 112, col: 55, offset: 3006},
+											pos:  position{line: 112, col: 55, offset: 3047},
 											name: "ExprTermPair",
 										},
 									},
@@ -1292,13 +1316,13 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 112, col: 71, offset: 3022},
+							pos:  position{line: 112, col: 71, offset: 3063},
 							name: "_",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 112, col: 73, offset: 3024},
+							pos: position{line: 112, col: 73, offset: 3065},
 							expr: &litMatcher{
-								pos:        position{line: 112, col: 73, offset: 3024},
+								pos:        position{line: 112, col: 73, offset: 3065},
 								val:        ",",
 								ignoreCase: false,
 							},
@@ -1309,47 +1333,47 @@ var g = &grammar{
 		},
 		{
 			name: "ExprTermList",
-			pos:  position{line: 116, col: 1, offset: 3078},
+			pos:  position{line: 116, col: 1, offset: 3119},
 			expr: &actionExpr{
-				pos: position{line: 116, col: 17, offset: 3094},
+				pos: position{line: 116, col: 17, offset: 3135},
 				run: (*parser).callonExprTermList1,
 				expr: &seqExpr{
-					pos: position{line: 116, col: 17, offset: 3094},
+					pos: position{line: 116, col: 17, offset: 3135},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 116, col: 17, offset: 3094},
+							pos:   position{line: 116, col: 17, offset: 3135},
 							label: "head",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 116, col: 22, offset: 3099},
+								pos: position{line: 116, col: 22, offset: 3140},
 								expr: &ruleRefExpr{
-									pos:  position{line: 116, col: 22, offset: 3099},
+									pos:  position{line: 116, col: 22, offset: 3140},
 									name: "ExprTerm",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 116, col: 32, offset: 3109},
+							pos:   position{line: 116, col: 32, offset: 3150},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 116, col: 37, offset: 3114},
+								pos: position{line: 116, col: 37, offset: 3155},
 								expr: &seqExpr{
-									pos: position{line: 116, col: 39, offset: 3116},
+									pos: position{line: 116, col: 39, offset: 3157},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 116, col: 39, offset: 3116},
+											pos:  position{line: 116, col: 39, offset: 3157},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 116, col: 41, offset: 3118},
+											pos:        position{line: 116, col: 41, offset: 3159},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 116, col: 45, offset: 3122},
+											pos:  position{line: 116, col: 45, offset: 3163},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 116, col: 47, offset: 3124},
+											pos:  position{line: 116, col: 47, offset: 3165},
 											name: "ExprTerm",
 										},
 									},
@@ -1357,13 +1381,13 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 116, col: 59, offset: 3136},
+							pos:  position{line: 116, col: 59, offset: 3177},
 							name: "_",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 116, col: 61, offset: 3138},
+							pos: position{line: 116, col: 61, offset: 3179},
 							expr: &litMatcher{
-								pos:        position{line: 116, col: 61, offset: 3138},
+								pos:        position{line: 116, col: 61, offset: 3179},
 								val:        ",",
 								ignoreCase: false,
 							},
@@ -1374,39 +1398,39 @@ var g = &grammar{
 		},
 		{
 			name: "ExprTermPair",
-			pos:  position{line: 120, col: 1, offset: 3189},
+			pos:  position{line: 120, col: 1, offset: 3230},
 			expr: &actionExpr{
-				pos: position{line: 120, col: 17, offset: 3205},
+				pos: position{line: 120, col: 17, offset: 3246},
 				run: (*parser).callonExprTermPair1,
 				expr: &seqExpr{
-					pos: position{line: 120, col: 17, offset: 3205},
+					pos: position{line: 120, col: 17, offset: 3246},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 120, col: 17, offset: 3205},
+							pos:   position{line: 120, col: 17, offset: 3246},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 120, col: 21, offset: 3209},
+								pos:  position{line: 120, col: 21, offset: 3250},
 								name: "ExprTerm",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 120, col: 30, offset: 3218},
+							pos:  position{line: 120, col: 30, offset: 3259},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 120, col: 32, offset: 3220},
+							pos:        position{line: 120, col: 32, offset: 3261},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 120, col: 36, offset: 3224},
+							pos:  position{line: 120, col: 36, offset: 3265},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 120, col: 38, offset: 3226},
+							pos:   position{line: 120, col: 38, offset: 3267},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 120, col: 44, offset: 3232},
+								pos:  position{line: 120, col: 44, offset: 3273},
 								name: "ExprTerm",
 							},
 						},
@@ -1416,43 +1440,43 @@ var g = &grammar{
 		},
 		{
 			name: "RelationOperator",
-			pos:  position{line: 124, col: 1, offset: 3286},
+			pos:  position{line: 124, col: 1, offset: 3327},
 			expr: &actionExpr{
-				pos: position{line: 124, col: 21, offset: 3306},
+				pos: position{line: 124, col: 21, offset: 3347},
 				run: (*parser).callonRelationOperator1,
 				expr: &labeledExpr{
-					pos:   position{line: 124, col: 21, offset: 3306},
+					pos:   position{line: 124, col: 21, offset: 3347},
 					label: "val",
 					expr: &choiceExpr{
-						pos: position{line: 124, col: 26, offset: 3311},
+						pos: position{line: 124, col: 26, offset: 3352},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 124, col: 26, offset: 3311},
+								pos:        position{line: 124, col: 26, offset: 3352},
 								val:        "==",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 124, col: 33, offset: 3318},
+								pos:        position{line: 124, col: 33, offset: 3359},
 								val:        "!=",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 124, col: 40, offset: 3325},
+								pos:        position{line: 124, col: 40, offset: 3366},
 								val:        "<=",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 124, col: 47, offset: 3332},
+								pos:        position{line: 124, col: 47, offset: 3373},
 								val:        ">=",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 124, col: 54, offset: 3339},
+								pos:        position{line: 124, col: 54, offset: 3380},
 								val:        ">",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 124, col: 60, offset: 3345},
+								pos:        position{line: 124, col: 60, offset: 3386},
 								val:        "<",
 								ignoreCase: false,
 							},
@@ -1463,43 +1487,43 @@ var g = &grammar{
 		},
 		{
 			name: "RelationExpr",
-			pos:  position{line: 128, col: 1, offset: 3412},
+			pos:  position{line: 128, col: 1, offset: 3453},
 			expr: &actionExpr{
-				pos: position{line: 128, col: 17, offset: 3428},
+				pos: position{line: 128, col: 17, offset: 3469},
 				run: (*parser).callonRelationExpr1,
 				expr: &seqExpr{
-					pos: position{line: 128, col: 17, offset: 3428},
+					pos: position{line: 128, col: 17, offset: 3469},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 128, col: 17, offset: 3428},
+							pos:   position{line: 128, col: 17, offset: 3469},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 128, col: 21, offset: 3432},
+								pos:  position{line: 128, col: 21, offset: 3473},
 								name: "BitwiseOrExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 128, col: 35, offset: 3446},
+							pos:   position{line: 128, col: 35, offset: 3487},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 128, col: 40, offset: 3451},
+								pos: position{line: 128, col: 40, offset: 3492},
 								expr: &seqExpr{
-									pos: position{line: 128, col: 42, offset: 3453},
+									pos: position{line: 128, col: 42, offset: 3494},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 128, col: 42, offset: 3453},
+											pos:  position{line: 128, col: 42, offset: 3494},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 128, col: 44, offset: 3455},
+											pos:  position{line: 128, col: 44, offset: 3496},
 											name: "BitwiseOrOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 128, col: 62, offset: 3473},
+											pos:  position{line: 128, col: 62, offset: 3514},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 128, col: 64, offset: 3475},
+											pos:  position{line: 128, col: 64, offset: 3516},
 											name: "BitwiseOrExpr",
 										},
 									},
@@ -1512,15 +1536,15 @@ var g = &grammar{
 		},
 		{
 			name: "BitwiseOrOperator",
-			pos:  position{line: 132, col: 1, offset: 3551},
+			pos:  position{line: 132, col: 1, offset: 3592},
 			expr: &actionExpr{
-				pos: position{line: 132, col: 22, offset: 3572},
+				pos: position{line: 132, col: 22, offset: 3613},
 				run: (*parser).callonBitwiseOrOperator1,
 				expr: &labeledExpr{
-					pos:   position{line: 132, col: 22, offset: 3572},
+					pos:   position{line: 132, col: 22, offset: 3613},
 					label: "val",
 					expr: &litMatcher{
-						pos:        position{line: 132, col: 26, offset: 3576},
+						pos:        position{line: 132, col: 26, offset: 3617},
 						val:        "|",
 						ignoreCase: false,
 					},
@@ -1529,43 +1553,43 @@ var g = &grammar{
 		},
 		{
 			name: "BitwiseOrExpr",
-			pos:  position{line: 136, col: 1, offset: 3642},
+			pos:  position{line: 136, col: 1, offset: 3683},
 			expr: &actionExpr{
-				pos: position{line: 136, col: 18, offset: 3659},
+				pos: position{line: 136, col: 18, offset: 3700},
 				run: (*parser).callonBitwiseOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 136, col: 18, offset: 3659},
+					pos: position{line: 136, col: 18, offset: 3700},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 136, col: 18, offset: 3659},
+							pos:   position{line: 136, col: 18, offset: 3700},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 136, col: 22, offset: 3663},
+								pos:  position{line: 136, col: 22, offset: 3704},
 								name: "BitwiseAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 136, col: 37, offset: 3678},
+							pos:   position{line: 136, col: 37, offset: 3719},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 136, col: 42, offset: 3683},
+								pos: position{line: 136, col: 42, offset: 3724},
 								expr: &seqExpr{
-									pos: position{line: 136, col: 44, offset: 3685},
+									pos: position{line: 136, col: 44, offset: 3726},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 136, col: 44, offset: 3685},
+											pos:  position{line: 136, col: 44, offset: 3726},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 136, col: 46, offset: 3687},
+											pos:  position{line: 136, col: 46, offset: 3728},
 											name: "BitwiseAndOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 136, col: 65, offset: 3706},
+											pos:  position{line: 136, col: 65, offset: 3747},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 136, col: 67, offset: 3708},
+											pos:  position{line: 136, col: 67, offset: 3749},
 											name: "BitwiseAndExpr",
 										},
 									},
@@ -1578,15 +1602,15 @@ var g = &grammar{
 		},
 		{
 			name: "BitwiseAndOperator",
-			pos:  position{line: 140, col: 1, offset: 3785},
+			pos:  position{line: 140, col: 1, offset: 3826},
 			expr: &actionExpr{
-				pos: position{line: 140, col: 23, offset: 3807},
+				pos: position{line: 140, col: 23, offset: 3848},
 				run: (*parser).callonBitwiseAndOperator1,
 				expr: &labeledExpr{
-					pos:   position{line: 140, col: 23, offset: 3807},
+					pos:   position{line: 140, col: 23, offset: 3848},
 					label: "val",
 					expr: &litMatcher{
-						pos:        position{line: 140, col: 27, offset: 3811},
+						pos:        position{line: 140, col: 27, offset: 3852},
 						val:        "&",
 						ignoreCase: false,
 					},
@@ -1595,43 +1619,43 @@ var g = &grammar{
 		},
 		{
 			name: "BitwiseAndExpr",
-			pos:  position{line: 144, col: 1, offset: 3877},
+			pos:  position{line: 144, col: 1, offset: 3918},
 			expr: &actionExpr{
-				pos: position{line: 144, col: 19, offset: 3895},
+				pos: position{line: 144, col: 19, offset: 3936},
 				run: (*parser).callonBitwiseAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 144, col: 19, offset: 3895},
+					pos: position{line: 144, col: 19, offset: 3936},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 144, col: 19, offset: 3895},
+							pos:   position{line: 144, col: 19, offset: 3936},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 144, col: 23, offset: 3899},
+								pos:  position{line: 144, col: 23, offset: 3940},
 								name: "ArithExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 144, col: 33, offset: 3909},
+							pos:   position{line: 144, col: 33, offset: 3950},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 144, col: 38, offset: 3914},
+								pos: position{line: 144, col: 38, offset: 3955},
 								expr: &seqExpr{
-									pos: position{line: 144, col: 40, offset: 3916},
+									pos: position{line: 144, col: 40, offset: 3957},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 144, col: 40, offset: 3916},
+											pos:  position{line: 144, col: 40, offset: 3957},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 144, col: 42, offset: 3918},
+											pos:  position{line: 144, col: 42, offset: 3959},
 											name: "ArithOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 144, col: 56, offset: 3932},
+											pos:  position{line: 144, col: 56, offset: 3973},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 144, col: 58, offset: 3934},
+											pos:  position{line: 144, col: 58, offset: 3975},
 											name: "ArithExpr",
 										},
 									},
@@ -1644,23 +1668,23 @@ var g = &grammar{
 		},
 		{
 			name: "ArithOperator",
-			pos:  position{line: 148, col: 1, offset: 4006},
+			pos:  position{line: 148, col: 1, offset: 4047},
 			expr: &actionExpr{
-				pos: position{line: 148, col: 18, offset: 4023},
+				pos: position{line: 148, col: 18, offset: 4064},
 				run: (*parser).callonArithOperator1,
 				expr: &labeledExpr{
-					pos:   position{line: 148, col: 18, offset: 4023},
+					pos:   position{line: 148, col: 18, offset: 4064},
 					label: "val",
 					expr: &choiceExpr{
-						pos: position{line: 148, col: 23, offset: 4028},
+						pos: position{line: 148, col: 23, offset: 4069},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 148, col: 23, offset: 4028},
+								pos:        position{line: 148, col: 23, offset: 4069},
 								val:        "+",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 148, col: 29, offset: 4034},
+								pos:        position{line: 148, col: 29, offset: 4075},
 								val:        "-",
 								ignoreCase: false,
 							},
@@ -1671,43 +1695,43 @@ var g = &grammar{
 		},
 		{
 			name: "ArithExpr",
-			pos:  position{line: 152, col: 1, offset: 4101},
+			pos:  position{line: 152, col: 1, offset: 4142},
 			expr: &actionExpr{
-				pos: position{line: 152, col: 14, offset: 4114},
+				pos: position{line: 152, col: 14, offset: 4155},
 				run: (*parser).callonArithExpr1,
 				expr: &seqExpr{
-					pos: position{line: 152, col: 14, offset: 4114},
+					pos: position{line: 152, col: 14, offset: 4155},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 152, col: 14, offset: 4114},
+							pos:   position{line: 152, col: 14, offset: 4155},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 152, col: 18, offset: 4118},
+								pos:  position{line: 152, col: 18, offset: 4159},
 								name: "FactorExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 152, col: 29, offset: 4129},
+							pos:   position{line: 152, col: 29, offset: 4170},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 152, col: 34, offset: 4134},
+								pos: position{line: 152, col: 34, offset: 4175},
 								expr: &seqExpr{
-									pos: position{line: 152, col: 36, offset: 4136},
+									pos: position{line: 152, col: 36, offset: 4177},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 152, col: 36, offset: 4136},
+											pos:  position{line: 152, col: 36, offset: 4177},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 152, col: 38, offset: 4138},
+											pos:  position{line: 152, col: 38, offset: 4179},
 											name: "FactorOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 152, col: 53, offset: 4153},
+											pos:  position{line: 152, col: 53, offset: 4194},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 152, col: 55, offset: 4155},
+											pos:  position{line: 152, col: 55, offset: 4196},
 											name: "FactorExpr",
 										},
 									},
@@ -1720,28 +1744,28 @@ var g = &grammar{
 		},
 		{
 			name: "FactorOperator",
-			pos:  position{line: 156, col: 1, offset: 4229},
+			pos:  position{line: 156, col: 1, offset: 4270},
 			expr: &actionExpr{
-				pos: position{line: 156, col: 19, offset: 4247},
+				pos: position{line: 156, col: 19, offset: 4288},
 				run: (*parser).callonFactorOperator1,
 				expr: &labeledExpr{
-					pos:   position{line: 156, col: 19, offset: 4247},
+					pos:   position{line: 156, col: 19, offset: 4288},
 					label: "val",
 					expr: &choiceExpr{
-						pos: position{line: 156, col: 24, offset: 4252},
+						pos: position{line: 156, col: 24, offset: 4293},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 156, col: 24, offset: 4252},
+								pos:        position{line: 156, col: 24, offset: 4293},
 								val:        "*",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 156, col: 30, offset: 4258},
+								pos:        position{line: 156, col: 30, offset: 4299},
 								val:        "/",
 								ignoreCase: false,
 							},
 							&litMatcher{
-								pos:        position{line: 156, col: 36, offset: 4264},
+								pos:        position{line: 156, col: 36, offset: 4305},
 								val:        "%",
 								ignoreCase: false,
 							},
@@ -1752,39 +1776,39 @@ var g = &grammar{
 		},
 		{
 			name: "FactorExpr",
-			pos:  position{line: 160, col: 1, offset: 4330},
+			pos:  position{line: 160, col: 1, offset: 4371},
 			expr: &choiceExpr{
-				pos: position{line: 160, col: 15, offset: 4344},
+				pos: position{line: 160, col: 15, offset: 4385},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 160, col: 15, offset: 4344},
+						pos: position{line: 160, col: 15, offset: 4385},
 						run: (*parser).callonFactorExpr2,
 						expr: &seqExpr{
-							pos: position{line: 160, col: 17, offset: 4346},
+							pos: position{line: 160, col: 17, offset: 4387},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 160, col: 17, offset: 4346},
+									pos:        position{line: 160, col: 17, offset: 4387},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 160, col: 21, offset: 4350},
+									pos:  position{line: 160, col: 21, offset: 4391},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 160, col: 23, offset: 4352},
+									pos:   position{line: 160, col: 23, offset: 4393},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 160, col: 28, offset: 4357},
+										pos:  position{line: 160, col: 28, offset: 4398},
 										name: "ExprTerm",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 160, col: 37, offset: 4366},
+									pos:  position{line: 160, col: 37, offset: 4407},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 160, col: 39, offset: 4368},
+									pos:        position{line: 160, col: 39, offset: 4409},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1792,13 +1816,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 162, col: 5, offset: 4401},
+						pos: position{line: 162, col: 5, offset: 4442},
 						run: (*parser).callonFactorExpr10,
 						expr: &labeledExpr{
-							pos:   position{line: 162, col: 5, offset: 4401},
+							pos:   position{line: 162, col: 5, offset: 4442},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 162, col: 10, offset: 4406},
+								pos:  position{line: 162, col: 10, offset: 4447},
 								name: "Term",
 							},
 						},
@@ -1808,53 +1832,53 @@ var g = &grammar{
 		},
 		{
 			name: "Call",
-			pos:  position{line: 166, col: 1, offset: 4437},
+			pos:  position{line: 166, col: 1, offset: 4478},
 			expr: &actionExpr{
-				pos: position{line: 166, col: 9, offset: 4445},
+				pos: position{line: 166, col: 9, offset: 4486},
 				run: (*parser).callonCall1,
 				expr: &seqExpr{
-					pos: position{line: 166, col: 9, offset: 4445},
+					pos: position{line: 166, col: 9, offset: 4486},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 166, col: 9, offset: 4445},
+							pos:   position{line: 166, col: 9, offset: 4486},
 							label: "operator",
 							expr: &choiceExpr{
-								pos: position{line: 166, col: 19, offset: 4455},
+								pos: position{line: 166, col: 19, offset: 4496},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 166, col: 19, offset: 4455},
+										pos:  position{line: 166, col: 19, offset: 4496},
 										name: "Ref",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 166, col: 25, offset: 4461},
+										pos:  position{line: 166, col: 25, offset: 4502},
 										name: "Var",
 									},
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 166, col: 30, offset: 4466},
+							pos:        position{line: 166, col: 30, offset: 4507},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 166, col: 34, offset: 4470},
+							pos:  position{line: 166, col: 34, offset: 4511},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 166, col: 36, offset: 4472},
+							pos:   position{line: 166, col: 36, offset: 4513},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 166, col: 41, offset: 4477},
+								pos:  position{line: 166, col: 41, offset: 4518},
 								name: "ExprTermList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 166, col: 54, offset: 4490},
+							pos:  position{line: 166, col: 54, offset: 4531},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 166, col: 56, offset: 4492},
+							pos:        position{line: 166, col: 56, offset: 4533},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1864,38 +1888,38 @@ var g = &grammar{
 		},
 		{
 			name: "Term",
-			pos:  position{line: 170, col: 1, offset: 4557},
+			pos:  position{line: 170, col: 1, offset: 4598},
 			expr: &actionExpr{
-				pos: position{line: 170, col: 9, offset: 4565},
+				pos: position{line: 170, col: 9, offset: 4606},
 				run: (*parser).callonTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 170, col: 9, offset: 4565},
+					pos:   position{line: 170, col: 9, offset: 4606},
 					label: "val",
 					expr: &choiceExpr{
-						pos: position{line: 170, col: 15, offset: 4571},
+						pos: position{line: 170, col: 15, offset: 4612},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 170, col: 15, offset: 4571},
+								pos:  position{line: 170, col: 15, offset: 4612},
 								name: "Comprehension",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 170, col: 31, offset: 4587},
+								pos:  position{line: 170, col: 31, offset: 4628},
 								name: "Composite",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 170, col: 43, offset: 4599},
+								pos:  position{line: 170, col: 43, offset: 4640},
 								name: "Scalar",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 170, col: 52, offset: 4608},
+								pos:  position{line: 170, col: 52, offset: 4649},
 								name: "Call",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 170, col: 59, offset: 4615},
+								pos:  position{line: 170, col: 59, offset: 4656},
 								name: "Ref",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 170, col: 65, offset: 4621},
+								pos:  position{line: 170, col: 65, offset: 4662},
 								name: "Var",
 							},
 						},
@@ -1905,39 +1929,39 @@ var g = &grammar{
 		},
 		{
 			name: "TermPair",
-			pos:  position{line: 174, col: 1, offset: 4652},
+			pos:  position{line: 174, col: 1, offset: 4693},
 			expr: &actionExpr{
-				pos: position{line: 174, col: 13, offset: 4664},
+				pos: position{line: 174, col: 13, offset: 4705},
 				run: (*parser).callonTermPair1,
 				expr: &seqExpr{
-					pos: position{line: 174, col: 13, offset: 4664},
+					pos: position{line: 174, col: 13, offset: 4705},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 174, col: 13, offset: 4664},
+							pos:   position{line: 174, col: 13, offset: 4705},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 174, col: 17, offset: 4668},
+								pos:  position{line: 174, col: 17, offset: 4709},
 								name: "Term",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 174, col: 22, offset: 4673},
+							pos:  position{line: 174, col: 22, offset: 4714},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 174, col: 24, offset: 4675},
+							pos:        position{line: 174, col: 24, offset: 4716},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 174, col: 28, offset: 4679},
+							pos:  position{line: 174, col: 28, offset: 4720},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 174, col: 30, offset: 4681},
+							pos:   position{line: 174, col: 30, offset: 4722},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 174, col: 36, offset: 4687},
+								pos:  position{line: 174, col: 36, offset: 4728},
 								name: "Term",
 							},
 						},
@@ -1947,20 +1971,20 @@ var g = &grammar{
 		},
 		{
 			name: "Comprehension",
-			pos:  position{line: 178, col: 1, offset: 4737},
+			pos:  position{line: 178, col: 1, offset: 4778},
 			expr: &choiceExpr{
-				pos: position{line: 178, col: 18, offset: 4754},
+				pos: position{line: 178, col: 18, offset: 4795},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 178, col: 18, offset: 4754},
+						pos:  position{line: 178, col: 18, offset: 4795},
 						name: "ArrayComprehension",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 178, col: 39, offset: 4775},
+						pos:  position{line: 178, col: 39, offset: 4816},
 						name: "ObjectComprehension",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 178, col: 61, offset: 4797},
+						pos:  position{line: 178, col: 61, offset: 4838},
 						name: "SetComprehension",
 					},
 				},
@@ -1968,57 +1992,57 @@ var g = &grammar{
 		},
 		{
 			name: "ArrayComprehension",
-			pos:  position{line: 180, col: 1, offset: 4815},
+			pos:  position{line: 180, col: 1, offset: 4856},
 			expr: &actionExpr{
-				pos: position{line: 180, col: 23, offset: 4837},
+				pos: position{line: 180, col: 23, offset: 4878},
 				run: (*parser).callonArrayComprehension1,
 				expr: &seqExpr{
-					pos: position{line: 180, col: 23, offset: 4837},
+					pos: position{line: 180, col: 23, offset: 4878},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 180, col: 23, offset: 4837},
+							pos:        position{line: 180, col: 23, offset: 4878},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 180, col: 27, offset: 4841},
+							pos:  position{line: 180, col: 27, offset: 4882},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 180, col: 29, offset: 4843},
+							pos:   position{line: 180, col: 29, offset: 4884},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 180, col: 34, offset: 4848},
+								pos:  position{line: 180, col: 34, offset: 4889},
 								name: "Term",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 180, col: 39, offset: 4853},
+							pos:  position{line: 180, col: 39, offset: 4894},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 180, col: 41, offset: 4855},
+							pos:        position{line: 180, col: 41, offset: 4896},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 180, col: 45, offset: 4859},
+							pos:  position{line: 180, col: 45, offset: 4900},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 180, col: 47, offset: 4861},
+							pos:   position{line: 180, col: 47, offset: 4902},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 180, col: 52, offset: 4866},
+								pos:  position{line: 180, col: 52, offset: 4907},
 								name: "WhitespaceBody",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 180, col: 67, offset: 4881},
+							pos:  position{line: 180, col: 67, offset: 4922},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 180, col: 69, offset: 4883},
+							pos:        position{line: 180, col: 69, offset: 4924},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -2028,57 +2052,57 @@ var g = &grammar{
 		},
 		{
 			name: "ObjectComprehension",
-			pos:  position{line: 184, col: 1, offset: 4958},
+			pos:  position{line: 184, col: 1, offset: 4999},
 			expr: &actionExpr{
-				pos: position{line: 184, col: 24, offset: 4981},
+				pos: position{line: 184, col: 24, offset: 5022},
 				run: (*parser).callonObjectComprehension1,
 				expr: &seqExpr{
-					pos: position{line: 184, col: 24, offset: 4981},
+					pos: position{line: 184, col: 24, offset: 5022},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 184, col: 24, offset: 4981},
+							pos:        position{line: 184, col: 24, offset: 5022},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 28, offset: 4985},
+							pos:  position{line: 184, col: 28, offset: 5026},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 184, col: 30, offset: 4987},
+							pos:   position{line: 184, col: 30, offset: 5028},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 184, col: 35, offset: 4992},
+								pos:  position{line: 184, col: 35, offset: 5033},
 								name: "TermPair",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 45, offset: 5002},
+							pos:  position{line: 184, col: 45, offset: 5043},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 184, col: 47, offset: 5004},
+							pos:        position{line: 184, col: 47, offset: 5045},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 51, offset: 5008},
+							pos:  position{line: 184, col: 51, offset: 5049},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 184, col: 53, offset: 5010},
+							pos:   position{line: 184, col: 53, offset: 5051},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 184, col: 58, offset: 5015},
+								pos:  position{line: 184, col: 58, offset: 5056},
 								name: "WhitespaceBody",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 73, offset: 5030},
+							pos:  position{line: 184, col: 73, offset: 5071},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 184, col: 75, offset: 5032},
+							pos:        position{line: 184, col: 75, offset: 5073},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -2088,57 +2112,57 @@ var g = &grammar{
 		},
 		{
 			name: "SetComprehension",
-			pos:  position{line: 188, col: 1, offset: 5108},
+			pos:  position{line: 188, col: 1, offset: 5149},
 			expr: &actionExpr{
-				pos: position{line: 188, col: 21, offset: 5128},
+				pos: position{line: 188, col: 21, offset: 5169},
 				run: (*parser).callonSetComprehension1,
 				expr: &seqExpr{
-					pos: position{line: 188, col: 21, offset: 5128},
+					pos: position{line: 188, col: 21, offset: 5169},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 188, col: 21, offset: 5128},
+							pos:        position{line: 188, col: 21, offset: 5169},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 188, col: 25, offset: 5132},
+							pos:  position{line: 188, col: 25, offset: 5173},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 188, col: 27, offset: 5134},
+							pos:   position{line: 188, col: 27, offset: 5175},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 188, col: 32, offset: 5139},
+								pos:  position{line: 188, col: 32, offset: 5180},
 								name: "Term",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 188, col: 37, offset: 5144},
+							pos:  position{line: 188, col: 37, offset: 5185},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 188, col: 39, offset: 5146},
+							pos:        position{line: 188, col: 39, offset: 5187},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 188, col: 43, offset: 5150},
+							pos:  position{line: 188, col: 43, offset: 5191},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 188, col: 45, offset: 5152},
+							pos:   position{line: 188, col: 45, offset: 5193},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 188, col: 50, offset: 5157},
+								pos:  position{line: 188, col: 50, offset: 5198},
 								name: "WhitespaceBody",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 188, col: 65, offset: 5172},
+							pos:  position{line: 188, col: 65, offset: 5213},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 188, col: 67, offset: 5174},
+							pos:        position{line: 188, col: 67, offset: 5215},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -2148,20 +2172,20 @@ var g = &grammar{
 		},
 		{
 			name: "Composite",
-			pos:  position{line: 192, col: 1, offset: 5247},
+			pos:  position{line: 192, col: 1, offset: 5288},
 			expr: &choiceExpr{
-				pos: position{line: 192, col: 14, offset: 5260},
+				pos: position{line: 192, col: 14, offset: 5301},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 192, col: 14, offset: 5260},
+						pos:  position{line: 192, col: 14, offset: 5301},
 						name: "Object",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 192, col: 23, offset: 5269},
+						pos:  position{line: 192, col: 23, offset: 5310},
 						name: "Array",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 192, col: 31, offset: 5277},
+						pos:  position{line: 192, col: 31, offset: 5318},
 						name: "Set",
 					},
 				},
@@ -2169,24 +2193,24 @@ var g = &grammar{
 		},
 		{
 			name: "Scalar",
-			pos:  position{line: 194, col: 1, offset: 5282},
+			pos:  position{line: 194, col: 1, offset: 5323},
 			expr: &choiceExpr{
-				pos: position{line: 194, col: 11, offset: 5292},
+				pos: position{line: 194, col: 11, offset: 5333},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 194, col: 11, offset: 5292},
+						pos:  position{line: 194, col: 11, offset: 5333},
 						name: "Number",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 194, col: 20, offset: 5301},
+						pos:  position{line: 194, col: 20, offset: 5342},
 						name: "String",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 194, col: 29, offset: 5310},
+						pos:  position{line: 194, col: 29, offset: 5351},
 						name: "Bool",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 194, col: 36, offset: 5317},
+						pos:  position{line: 194, col: 36, offset: 5358},
 						name: "Null",
 					},
 				},
@@ -2194,36 +2218,36 @@ var g = &grammar{
 		},
 		{
 			name: "Object",
-			pos:  position{line: 196, col: 1, offset: 5323},
+			pos:  position{line: 196, col: 1, offset: 5364},
 			expr: &actionExpr{
-				pos: position{line: 196, col: 11, offset: 5333},
+				pos: position{line: 196, col: 11, offset: 5374},
 				run: (*parser).callonObject1,
 				expr: &seqExpr{
-					pos: position{line: 196, col: 11, offset: 5333},
+					pos: position{line: 196, col: 11, offset: 5374},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 196, col: 11, offset: 5333},
+							pos:        position{line: 196, col: 11, offset: 5374},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 196, col: 15, offset: 5337},
+							pos:  position{line: 196, col: 15, offset: 5378},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 196, col: 17, offset: 5339},
+							pos:   position{line: 196, col: 17, offset: 5380},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 196, col: 22, offset: 5344},
+								pos:  position{line: 196, col: 22, offset: 5385},
 								name: "ExprTermPairList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 196, col: 39, offset: 5361},
+							pos:  position{line: 196, col: 39, offset: 5402},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 196, col: 41, offset: 5363},
+							pos:        position{line: 196, col: 41, offset: 5404},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -2233,36 +2257,36 @@ var g = &grammar{
 		},
 		{
 			name: "Array",
-			pos:  position{line: 200, col: 1, offset: 5420},
+			pos:  position{line: 200, col: 1, offset: 5461},
 			expr: &actionExpr{
-				pos: position{line: 200, col: 10, offset: 5429},
+				pos: position{line: 200, col: 10, offset: 5470},
 				run: (*parser).callonArray1,
 				expr: &seqExpr{
-					pos: position{line: 200, col: 10, offset: 5429},
+					pos: position{line: 200, col: 10, offset: 5470},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 200, col: 10, offset: 5429},
+							pos:        position{line: 200, col: 10, offset: 5470},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 200, col: 14, offset: 5433},
+							pos:  position{line: 200, col: 14, offset: 5474},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 200, col: 16, offset: 5435},
+							pos:   position{line: 200, col: 16, offset: 5476},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 200, col: 21, offset: 5440},
+								pos:  position{line: 200, col: 21, offset: 5481},
 								name: "ExprTermList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 200, col: 34, offset: 5453},
+							pos:  position{line: 200, col: 34, offset: 5494},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 200, col: 36, offset: 5455},
+							pos:        position{line: 200, col: 36, offset: 5496},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -2272,16 +2296,16 @@ var g = &grammar{
 		},
 		{
 			name: "Set",
-			pos:  position{line: 204, col: 1, offset: 5511},
+			pos:  position{line: 204, col: 1, offset: 5552},
 			expr: &choiceExpr{
-				pos: position{line: 204, col: 8, offset: 5518},
+				pos: position{line: 204, col: 8, offset: 5559},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 204, col: 8, offset: 5518},
+						pos:  position{line: 204, col: 8, offset: 5559},
 						name: "SetEmpty",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 204, col: 19, offset: 5529},
+						pos:  position{line: 204, col: 19, offset: 5570},
 						name: "SetNonEmpty",
 					},
 				},
@@ -2289,24 +2313,24 @@ var g = &grammar{
 		},
 		{
 			name: "SetEmpty",
-			pos:  position{line: 206, col: 1, offset: 5542},
+			pos:  position{line: 206, col: 1, offset: 5583},
 			expr: &actionExpr{
-				pos: position{line: 206, col: 13, offset: 5554},
+				pos: position{line: 206, col: 13, offset: 5595},
 				run: (*parser).callonSetEmpty1,
 				expr: &seqExpr{
-					pos: position{line: 206, col: 13, offset: 5554},
+					pos: position{line: 206, col: 13, offset: 5595},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 206, col: 13, offset: 5554},
+							pos:        position{line: 206, col: 13, offset: 5595},
 							val:        "set(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 206, col: 20, offset: 5561},
+							pos:  position{line: 206, col: 20, offset: 5602},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 206, col: 22, offset: 5563},
+							pos:        position{line: 206, col: 22, offset: 5604},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -2316,36 +2340,36 @@ var g = &grammar{
 		},
 		{
 			name: "SetNonEmpty",
-			pos:  position{line: 211, col: 1, offset: 5640},
+			pos:  position{line: 211, col: 1, offset: 5681},
 			expr: &actionExpr{
-				pos: position{line: 211, col: 16, offset: 5655},
+				pos: position{line: 211, col: 16, offset: 5696},
 				run: (*parser).callonSetNonEmpty1,
 				expr: &seqExpr{
-					pos: position{line: 211, col: 16, offset: 5655},
+					pos: position{line: 211, col: 16, offset: 5696},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 211, col: 16, offset: 5655},
+							pos:        position{line: 211, col: 16, offset: 5696},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 211, col: 20, offset: 5659},
+							pos:  position{line: 211, col: 20, offset: 5700},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 211, col: 22, offset: 5661},
+							pos:   position{line: 211, col: 22, offset: 5702},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 211, col: 27, offset: 5666},
+								pos:  position{line: 211, col: 27, offset: 5707},
 								name: "ExprTermList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 211, col: 40, offset: 5679},
+							pos:  position{line: 211, col: 40, offset: 5720},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 211, col: 42, offset: 5681},
+							pos:        position{line: 211, col: 42, offset: 5722},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -2355,28 +2379,28 @@ var g = &grammar{
 		},
 		{
 			name: "Ref",
-			pos:  position{line: 215, col: 1, offset: 5735},
+			pos:  position{line: 215, col: 1, offset: 5776},
 			expr: &actionExpr{
-				pos: position{line: 215, col: 8, offset: 5742},
+				pos: position{line: 215, col: 8, offset: 5783},
 				run: (*parser).callonRef1,
 				expr: &seqExpr{
-					pos: position{line: 215, col: 8, offset: 5742},
+					pos: position{line: 215, col: 8, offset: 5783},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 215, col: 8, offset: 5742},
+							pos:   position{line: 215, col: 8, offset: 5783},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 215, col: 13, offset: 5747},
+								pos:  position{line: 215, col: 13, offset: 5788},
 								name: "Var",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 215, col: 17, offset: 5751},
+							pos:   position{line: 215, col: 17, offset: 5792},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 215, col: 22, offset: 5756},
+								pos: position{line: 215, col: 22, offset: 5797},
 								expr: &ruleRefExpr{
-									pos:  position{line: 215, col: 22, offset: 5756},
+									pos:  position{line: 215, col: 22, offset: 5797},
 									name: "RefOperand",
 								},
 							},
@@ -2387,16 +2411,16 @@ var g = &grammar{
 		},
 		{
 			name: "RefOperand",
-			pos:  position{line: 219, col: 1, offset: 5824},
+			pos:  position{line: 219, col: 1, offset: 5865},
 			expr: &choiceExpr{
-				pos: position{line: 219, col: 15, offset: 5838},
+				pos: position{line: 219, col: 15, offset: 5879},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 219, col: 15, offset: 5838},
+						pos:  position{line: 219, col: 15, offset: 5879},
 						name: "RefOperandDot",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 219, col: 31, offset: 5854},
+						pos:  position{line: 219, col: 31, offset: 5895},
 						name: "RefOperandCanonical",
 					},
 				},
@@ -2404,23 +2428,23 @@ var g = &grammar{
 		},
 		{
 			name: "RefOperandDot",
-			pos:  position{line: 221, col: 1, offset: 5875},
+			pos:  position{line: 221, col: 1, offset: 5916},
 			expr: &actionExpr{
-				pos: position{line: 221, col: 18, offset: 5892},
+				pos: position{line: 221, col: 18, offset: 5933},
 				run: (*parser).callonRefOperandDot1,
 				expr: &seqExpr{
-					pos: position{line: 221, col: 18, offset: 5892},
+					pos: position{line: 221, col: 18, offset: 5933},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 221, col: 18, offset: 5892},
+							pos:        position{line: 221, col: 18, offset: 5933},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 221, col: 22, offset: 5896},
+							pos:   position{line: 221, col: 22, offset: 5937},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 221, col: 26, offset: 5900},
+								pos:  position{line: 221, col: 26, offset: 5941},
 								name: "Var",
 							},
 						},
@@ -2430,28 +2454,28 @@ var g = &grammar{
 		},
 		{
 			name: "RefOperandCanonical",
-			pos:  position{line: 225, col: 1, offset: 5963},
+			pos:  position{line: 225, col: 1, offset: 6004},
 			expr: &actionExpr{
-				pos: position{line: 225, col: 24, offset: 5986},
+				pos: position{line: 225, col: 24, offset: 6027},
 				run: (*parser).callonRefOperandCanonical1,
 				expr: &seqExpr{
-					pos: position{line: 225, col: 24, offset: 5986},
+					pos: position{line: 225, col: 24, offset: 6027},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 225, col: 24, offset: 5986},
+							pos:        position{line: 225, col: 24, offset: 6027},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 225, col: 28, offset: 5990},
+							pos:   position{line: 225, col: 28, offset: 6031},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 225, col: 32, offset: 5994},
+								pos:  position{line: 225, col: 32, offset: 6035},
 								name: "ExprTerm",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 225, col: 41, offset: 6003},
+							pos:        position{line: 225, col: 41, offset: 6044},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -2461,15 +2485,15 @@ var g = &grammar{
 		},
 		{
 			name: "Var",
-			pos:  position{line: 229, col: 1, offset: 6032},
+			pos:  position{line: 229, col: 1, offset: 6073},
 			expr: &actionExpr{
-				pos: position{line: 229, col: 8, offset: 6039},
+				pos: position{line: 229, col: 8, offset: 6080},
 				run: (*parser).callonVar1,
 				expr: &labeledExpr{
-					pos:   position{line: 229, col: 8, offset: 6039},
+					pos:   position{line: 229, col: 8, offset: 6080},
 					label: "val",
 					expr: &ruleRefExpr{
-						pos:  position{line: 229, col: 12, offset: 6043},
+						pos:  position{line: 229, col: 12, offset: 6084},
 						name: "VarChecked",
 					},
 				},
@@ -2477,20 +2501,20 @@ var g = &grammar{
 		},
 		{
 			name: "VarChecked",
-			pos:  position{line: 233, col: 1, offset: 6098},
+			pos:  position{line: 233, col: 1, offset: 6139},
 			expr: &seqExpr{
-				pos: position{line: 233, col: 15, offset: 6112},
+				pos: position{line: 233, col: 15, offset: 6153},
 				exprs: []interface{}{
 					&labeledExpr{
-						pos:   position{line: 233, col: 15, offset: 6112},
+						pos:   position{line: 233, col: 15, offset: 6153},
 						label: "val",
 						expr: &ruleRefExpr{
-							pos:  position{line: 233, col: 19, offset: 6116},
+							pos:  position{line: 233, col: 19, offset: 6157},
 							name: "VarUnchecked",
 						},
 					},
 					&notCodeExpr{
-						pos: position{line: 233, col: 32, offset: 6129},
+						pos: position{line: 233, col: 32, offset: 6170},
 						run: (*parser).callonVarChecked4,
 					},
 				},
@@ -2498,31 +2522,22 @@ var g = &grammar{
 		},
 		{
 			name: "VarUnchecked",
-			pos:  position{line: 237, col: 1, offset: 6194},
+			pos:  position{line: 237, col: 1, offset: 6235},
 			expr: &actionExpr{
-				pos: position{line: 237, col: 17, offset: 6210},
+				pos: position{line: 237, col: 17, offset: 6251},
 				run: (*parser).callonVarUnchecked1,
 				expr: &seqExpr{
-					pos: position{line: 237, col: 17, offset: 6210},
+					pos: position{line: 237, col: 17, offset: 6251},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 237, col: 17, offset: 6210},
-							name: "AsciiLetter",
+							pos:  position{line: 237, col: 17, offset: 6251},
+							name: "VarStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 237, col: 29, offset: 6222},
-							expr: &choiceExpr{
-								pos: position{line: 237, col: 30, offset: 6223},
-								alternatives: []interface{}{
-									&ruleRefExpr{
-										pos:  position{line: 237, col: 30, offset: 6223},
-										name: "AsciiLetter",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 237, col: 44, offset: 6237},
-										name: "DecimalDigit",
-									},
-								},
+							pos: position{line: 237, col: 26, offset: 6260},
+							expr: &ruleRefExpr{
+								pos:  position{line: 237, col: 26, offset: 6260},
+								name: "VarChar",
 							},
 						},
 					},
@@ -2531,30 +2546,30 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 241, col: 1, offset: 6304},
+			pos:  position{line: 241, col: 1, offset: 6321},
 			expr: &actionExpr{
-				pos: position{line: 241, col: 11, offset: 6314},
+				pos: position{line: 241, col: 11, offset: 6331},
 				run: (*parser).callonNumber1,
 				expr: &seqExpr{
-					pos: position{line: 241, col: 11, offset: 6314},
+					pos: position{line: 241, col: 11, offset: 6331},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 241, col: 11, offset: 6314},
+							pos: position{line: 241, col: 11, offset: 6331},
 							expr: &litMatcher{
-								pos:        position{line: 241, col: 11, offset: 6314},
+								pos:        position{line: 241, col: 11, offset: 6331},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 241, col: 18, offset: 6321},
+							pos: position{line: 241, col: 18, offset: 6338},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 241, col: 18, offset: 6321},
+									pos:  position{line: 241, col: 18, offset: 6338},
 									name: "Float",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 241, col: 26, offset: 6329},
+									pos:  position{line: 241, col: 26, offset: 6346},
 									name: "Integer",
 								},
 							},
@@ -2565,16 +2580,16 @@ var g = &grammar{
 		},
 		{
 			name: "Float",
-			pos:  position{line: 245, col: 1, offset: 6394},
+			pos:  position{line: 245, col: 1, offset: 6411},
 			expr: &choiceExpr{
-				pos: position{line: 245, col: 10, offset: 6403},
+				pos: position{line: 245, col: 10, offset: 6420},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 245, col: 10, offset: 6403},
+						pos:  position{line: 245, col: 10, offset: 6420},
 						name: "ExponentFloat",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 245, col: 26, offset: 6419},
+						pos:  position{line: 245, col: 26, offset: 6436},
 						name: "PointFloat",
 					},
 				},
@@ -2582,25 +2597,25 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentFloat",
-			pos:  position{line: 247, col: 1, offset: 6431},
+			pos:  position{line: 247, col: 1, offset: 6448},
 			expr: &seqExpr{
-				pos: position{line: 247, col: 18, offset: 6448},
+				pos: position{line: 247, col: 18, offset: 6465},
 				exprs: []interface{}{
 					&choiceExpr{
-						pos: position{line: 247, col: 20, offset: 6450},
+						pos: position{line: 247, col: 20, offset: 6467},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 247, col: 20, offset: 6450},
+								pos:  position{line: 247, col: 20, offset: 6467},
 								name: "PointFloat",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 247, col: 33, offset: 6463},
+								pos:  position{line: 247, col: 33, offset: 6480},
 								name: "Integer",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 247, col: 43, offset: 6473},
+						pos:  position{line: 247, col: 43, offset: 6490},
 						name: "Exponent",
 					},
 				},
@@ -2608,19 +2623,19 @@ var g = &grammar{
 		},
 		{
 			name: "PointFloat",
-			pos:  position{line: 249, col: 1, offset: 6483},
+			pos:  position{line: 249, col: 1, offset: 6500},
 			expr: &seqExpr{
-				pos: position{line: 249, col: 15, offset: 6497},
+				pos: position{line: 249, col: 15, offset: 6514},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 249, col: 15, offset: 6497},
+						pos: position{line: 249, col: 15, offset: 6514},
 						expr: &ruleRefExpr{
-							pos:  position{line: 249, col: 15, offset: 6497},
+							pos:  position{line: 249, col: 15, offset: 6514},
 							name: "Integer",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 249, col: 24, offset: 6506},
+						pos:  position{line: 249, col: 24, offset: 6523},
 						name: "Fraction",
 					},
 				},
@@ -2628,19 +2643,19 @@ var g = &grammar{
 		},
 		{
 			name: "Fraction",
-			pos:  position{line: 251, col: 1, offset: 6516},
+			pos:  position{line: 251, col: 1, offset: 6533},
 			expr: &seqExpr{
-				pos: position{line: 251, col: 13, offset: 6528},
+				pos: position{line: 251, col: 13, offset: 6545},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 251, col: 13, offset: 6528},
+						pos:        position{line: 251, col: 13, offset: 6545},
 						val:        ".",
 						ignoreCase: false,
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 251, col: 17, offset: 6532},
+						pos: position{line: 251, col: 17, offset: 6549},
 						expr: &ruleRefExpr{
-							pos:  position{line: 251, col: 17, offset: 6532},
+							pos:  position{line: 251, col: 17, offset: 6549},
 							name: "DecimalDigit",
 						},
 					},
@@ -2649,19 +2664,19 @@ var g = &grammar{
 		},
 		{
 			name: "Exponent",
-			pos:  position{line: 253, col: 1, offset: 6547},
+			pos:  position{line: 253, col: 1, offset: 6564},
 			expr: &seqExpr{
-				pos: position{line: 253, col: 13, offset: 6559},
+				pos: position{line: 253, col: 13, offset: 6576},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 253, col: 13, offset: 6559},
+						pos:        position{line: 253, col: 13, offset: 6576},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 253, col: 18, offset: 6564},
+						pos: position{line: 253, col: 18, offset: 6581},
 						expr: &charClassMatcher{
-							pos:        position{line: 253, col: 18, offset: 6564},
+							pos:        position{line: 253, col: 18, offset: 6581},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -2669,9 +2684,9 @@ var g = &grammar{
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 253, col: 24, offset: 6570},
+						pos: position{line: 253, col: 24, offset: 6587},
 						expr: &ruleRefExpr{
-							pos:  position{line: 253, col: 24, offset: 6570},
+							pos:  position{line: 253, col: 24, offset: 6587},
 							name: "DecimalDigit",
 						},
 					},
@@ -2680,26 +2695,26 @@ var g = &grammar{
 		},
 		{
 			name: "Integer",
-			pos:  position{line: 255, col: 1, offset: 6585},
+			pos:  position{line: 255, col: 1, offset: 6602},
 			expr: &choiceExpr{
-				pos: position{line: 255, col: 12, offset: 6596},
+				pos: position{line: 255, col: 12, offset: 6613},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 255, col: 12, offset: 6596},
+						pos:        position{line: 255, col: 12, offset: 6613},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 255, col: 20, offset: 6604},
+						pos: position{line: 255, col: 20, offset: 6621},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 255, col: 20, offset: 6604},
+								pos:  position{line: 255, col: 20, offset: 6621},
 								name: "NonZeroDecimalDigit",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 255, col: 40, offset: 6624},
+								pos: position{line: 255, col: 40, offset: 6641},
 								expr: &ruleRefExpr{
-									pos:  position{line: 255, col: 40, offset: 6624},
+									pos:  position{line: 255, col: 40, offset: 6641},
 									name: "DecimalDigit",
 								},
 							},
@@ -2710,16 +2725,16 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 257, col: 1, offset: 6641},
+			pos:  position{line: 257, col: 1, offset: 6658},
 			expr: &choiceExpr{
-				pos: position{line: 257, col: 11, offset: 6651},
+				pos: position{line: 257, col: 11, offset: 6668},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 257, col: 11, offset: 6651},
+						pos:  position{line: 257, col: 11, offset: 6668},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 257, col: 26, offset: 6666},
+						pos:  position{line: 257, col: 26, offset: 6683},
 						name: "RawString",
 					},
 				},
@@ -2727,30 +2742,30 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 259, col: 1, offset: 6677},
+			pos:  position{line: 259, col: 1, offset: 6694},
 			expr: &choiceExpr{
-				pos: position{line: 259, col: 17, offset: 6693},
+				pos: position{line: 259, col: 17, offset: 6710},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 259, col: 17, offset: 6693},
+						pos: position{line: 259, col: 17, offset: 6710},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 259, col: 17, offset: 6693},
+							pos: position{line: 259, col: 17, offset: 6710},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 259, col: 17, offset: 6693},
+									pos:        position{line: 259, col: 17, offset: 6710},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 259, col: 21, offset: 6697},
+									pos: position{line: 259, col: 21, offset: 6714},
 									expr: &ruleRefExpr{
-										pos:  position{line: 259, col: 21, offset: 6697},
+										pos:  position{line: 259, col: 21, offset: 6714},
 										name: "Char",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 259, col: 27, offset: 6703},
+									pos:        position{line: 259, col: 27, offset: 6720},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -2758,27 +2773,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 261, col: 5, offset: 6763},
+						pos: position{line: 261, col: 5, offset: 6780},
 						run: (*parser).callonQuotedString8,
 						expr: &seqExpr{
-							pos: position{line: 261, col: 5, offset: 6763},
+							pos: position{line: 261, col: 5, offset: 6780},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 261, col: 5, offset: 6763},
+									pos:        position{line: 261, col: 5, offset: 6780},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 261, col: 9, offset: 6767},
+									pos: position{line: 261, col: 9, offset: 6784},
 									expr: &ruleRefExpr{
-										pos:  position{line: 261, col: 9, offset: 6767},
+										pos:  position{line: 261, col: 9, offset: 6784},
 										name: "Char",
 									},
 								},
 								&notExpr{
-									pos: position{line: 261, col: 15, offset: 6773},
+									pos: position{line: 261, col: 15, offset: 6790},
 									expr: &litMatcher{
-										pos:        position{line: 261, col: 16, offset: 6774},
+										pos:        position{line: 261, col: 16, offset: 6791},
 										val:        "\"",
 										ignoreCase: false,
 									},
@@ -2791,22 +2806,22 @@ var g = &grammar{
 		},
 		{
 			name: "RawString",
-			pos:  position{line: 265, col: 1, offset: 6854},
+			pos:  position{line: 265, col: 1, offset: 6871},
 			expr: &actionExpr{
-				pos: position{line: 265, col: 14, offset: 6867},
+				pos: position{line: 265, col: 14, offset: 6884},
 				run: (*parser).callonRawString1,
 				expr: &seqExpr{
-					pos: position{line: 265, col: 14, offset: 6867},
+					pos: position{line: 265, col: 14, offset: 6884},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 265, col: 14, offset: 6867},
+							pos:        position{line: 265, col: 14, offset: 6884},
 							val:        "`",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 265, col: 18, offset: 6871},
+							pos: position{line: 265, col: 18, offset: 6888},
 							expr: &charClassMatcher{
-								pos:        position{line: 265, col: 18, offset: 6871},
+								pos:        position{line: 265, col: 18, offset: 6888},
 								val:        "[^`]",
 								chars:      []rune{'`'},
 								ignoreCase: false,
@@ -2814,7 +2829,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 265, col: 24, offset: 6877},
+							pos:        position{line: 265, col: 24, offset: 6894},
 							val:        "`",
 							ignoreCase: false,
 						},
@@ -2824,25 +2839,37 @@ var g = &grammar{
 		},
 		{
 			name: "Bool",
-			pos:  position{line: 269, col: 1, offset: 6939},
+			pos:  position{line: 269, col: 1, offset: 6956},
 			expr: &actionExpr{
-				pos: position{line: 269, col: 9, offset: 6947},
+				pos: position{line: 269, col: 9, offset: 6964},
 				run: (*parser).callonBool1,
-				expr: &labeledExpr{
-					pos:   position{line: 269, col: 9, offset: 6947},
-					label: "val",
-					expr: &choiceExpr{
-						pos: position{line: 269, col: 14, offset: 6952},
-						alternatives: []interface{}{
-							&litMatcher{
-								pos:        position{line: 269, col: 14, offset: 6952},
-								val:        "true",
-								ignoreCase: false,
+				expr: &seqExpr{
+					pos: position{line: 269, col: 9, offset: 6964},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 269, col: 9, offset: 6964},
+							label: "val",
+							expr: &choiceExpr{
+								pos: position{line: 269, col: 14, offset: 6969},
+								alternatives: []interface{}{
+									&litMatcher{
+										pos:        position{line: 269, col: 14, offset: 6969},
+										val:        "true",
+										ignoreCase: false,
+									},
+									&litMatcher{
+										pos:        position{line: 269, col: 23, offset: 6978},
+										val:        "false",
+										ignoreCase: false,
+									},
+								},
 							},
-							&litMatcher{
-								pos:        position{line: 269, col: 23, offset: 6961},
-								val:        "false",
-								ignoreCase: false,
+						},
+						&notExpr{
+							pos: position{line: 269, col: 32, offset: 6987},
+							expr: &ruleRefExpr{
+								pos:  position{line: 269, col: 33, offset: 6988},
+								name: "VarChar",
 							},
 						},
 					},
@@ -2851,22 +2878,59 @@ var g = &grammar{
 		},
 		{
 			name: "Null",
-			pos:  position{line: 273, col: 1, offset: 7023},
+			pos:  position{line: 273, col: 1, offset: 7049},
 			expr: &actionExpr{
-				pos: position{line: 273, col: 9, offset: 7031},
+				pos: position{line: 273, col: 9, offset: 7057},
 				run: (*parser).callonNull1,
-				expr: &litMatcher{
-					pos:        position{line: 273, col: 9, offset: 7031},
-					val:        "null",
-					ignoreCase: false,
+				expr: &seqExpr{
+					pos: position{line: 273, col: 9, offset: 7057},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 273, col: 9, offset: 7057},
+							val:        "null",
+							ignoreCase: false,
+						},
+						&notExpr{
+							pos: position{line: 273, col: 16, offset: 7064},
+							expr: &ruleRefExpr{
+								pos:  position{line: 273, col: 17, offset: 7065},
+								name: "VarChar",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "VarStart",
+			pos:  position{line: 277, col: 1, offset: 7118},
+			expr: &ruleRefExpr{
+				pos:  position{line: 277, col: 13, offset: 7130},
+				name: "AsciiLetter",
+			},
+		},
+		{
+			name: "VarChar",
+			pos:  position{line: 279, col: 1, offset: 7143},
+			expr: &choiceExpr{
+				pos: position{line: 279, col: 12, offset: 7154},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 279, col: 12, offset: 7154},
+						name: "AsciiLetter",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 279, col: 26, offset: 7168},
+						name: "DecimalDigit",
+					},
 				},
 			},
 		},
 		{
 			name: "AsciiLetter",
-			pos:  position{line: 277, col: 1, offset: 7083},
+			pos:  position{line: 281, col: 1, offset: 7182},
 			expr: &charClassMatcher{
-				pos:        position{line: 277, col: 16, offset: 7098},
+				pos:        position{line: 281, col: 16, offset: 7197},
 				val:        "[A-Za-z_]",
 				chars:      []rune{'_'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -2876,35 +2940,35 @@ var g = &grammar{
 		},
 		{
 			name: "Char",
-			pos:  position{line: 279, col: 1, offset: 7109},
+			pos:  position{line: 283, col: 1, offset: 7208},
 			expr: &choiceExpr{
-				pos: position{line: 279, col: 9, offset: 7117},
+				pos: position{line: 283, col: 9, offset: 7216},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 279, col: 11, offset: 7119},
+						pos: position{line: 283, col: 11, offset: 7218},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 279, col: 11, offset: 7119},
+								pos: position{line: 283, col: 11, offset: 7218},
 								expr: &ruleRefExpr{
-									pos:  position{line: 279, col: 12, offset: 7120},
+									pos:  position{line: 283, col: 12, offset: 7219},
 									name: "EscapedChar",
 								},
 							},
 							&anyMatcher{
-								line: 279, col: 24, offset: 7132,
+								line: 283, col: 24, offset: 7231,
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 279, col: 32, offset: 7140},
+						pos: position{line: 283, col: 32, offset: 7239},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 279, col: 32, offset: 7140},
+								pos:        position{line: 283, col: 32, offset: 7239},
 								val:        "\\",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 279, col: 37, offset: 7145},
+								pos:  position{line: 283, col: 37, offset: 7244},
 								name: "EscapeSequence",
 							},
 						},
@@ -2914,9 +2978,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 281, col: 1, offset: 7163},
+			pos:  position{line: 285, col: 1, offset: 7262},
 			expr: &charClassMatcher{
-				pos:        position{line: 281, col: 16, offset: 7178},
+				pos:        position{line: 285, col: 16, offset: 7277},
 				val:        "[\\x00-\\x1f\"\\\\]",
 				chars:      []rune{'"', '\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -2926,16 +2990,16 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 283, col: 1, offset: 7194},
+			pos:  position{line: 287, col: 1, offset: 7293},
 			expr: &choiceExpr{
-				pos: position{line: 283, col: 19, offset: 7212},
+				pos: position{line: 287, col: 19, offset: 7311},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 283, col: 19, offset: 7212},
+						pos:  position{line: 287, col: 19, offset: 7311},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 283, col: 38, offset: 7231},
+						pos:  position{line: 287, col: 38, offset: 7330},
 						name: "UnicodeEscape",
 					},
 				},
@@ -2943,9 +3007,9 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 285, col: 1, offset: 7246},
+			pos:  position{line: 289, col: 1, offset: 7345},
 			expr: &charClassMatcher{
-				pos:        position{line: 285, col: 21, offset: 7266},
+				pos:        position{line: 289, col: 21, offset: 7365},
 				val:        "[ \" \\\\ / b f n r t ]",
 				chars:      []rune{' ', '"', ' ', '\\', ' ', '/', ' ', 'b', ' ', 'f', ' ', 'n', ' ', 'r', ' ', 't', ' '},
 				ignoreCase: false,
@@ -2954,29 +3018,29 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 287, col: 1, offset: 7288},
+			pos:  position{line: 291, col: 1, offset: 7387},
 			expr: &seqExpr{
-				pos: position{line: 287, col: 18, offset: 7305},
+				pos: position{line: 291, col: 18, offset: 7404},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 287, col: 18, offset: 7305},
+						pos:        position{line: 291, col: 18, offset: 7404},
 						val:        "u",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 287, col: 22, offset: 7309},
+						pos:  position{line: 291, col: 22, offset: 7408},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 287, col: 31, offset: 7318},
+						pos:  position{line: 291, col: 31, offset: 7417},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 287, col: 40, offset: 7327},
+						pos:  position{line: 291, col: 40, offset: 7426},
 						name: "HexDigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 287, col: 49, offset: 7336},
+						pos:  position{line: 291, col: 49, offset: 7435},
 						name: "HexDigit",
 					},
 				},
@@ -2984,9 +3048,9 @@ var g = &grammar{
 		},
 		{
 			name: "DecimalDigit",
-			pos:  position{line: 289, col: 1, offset: 7346},
+			pos:  position{line: 293, col: 1, offset: 7445},
 			expr: &charClassMatcher{
-				pos:        position{line: 289, col: 17, offset: 7362},
+				pos:        position{line: 293, col: 17, offset: 7461},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -2995,9 +3059,9 @@ var g = &grammar{
 		},
 		{
 			name: "NonZeroDecimalDigit",
-			pos:  position{line: 291, col: 1, offset: 7369},
+			pos:  position{line: 295, col: 1, offset: 7468},
 			expr: &charClassMatcher{
-				pos:        position{line: 291, col: 24, offset: 7392},
+				pos:        position{line: 295, col: 24, offset: 7491},
 				val:        "[1-9]",
 				ranges:     []rune{'1', '9'},
 				ignoreCase: false,
@@ -3006,9 +3070,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 293, col: 1, offset: 7399},
+			pos:  position{line: 297, col: 1, offset: 7498},
 			expr: &charClassMatcher{
-				pos:        position{line: 293, col: 13, offset: 7411},
+				pos:        position{line: 297, col: 13, offset: 7510},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -3018,11 +3082,11 @@ var g = &grammar{
 		{
 			name:        "ws",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 295, col: 1, offset: 7424},
+			pos:         position{line: 299, col: 1, offset: 7523},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 295, col: 20, offset: 7443},
+				pos: position{line: 299, col: 20, offset: 7542},
 				expr: &charClassMatcher{
-					pos:        position{line: 295, col: 20, offset: 7443},
+					pos:        position{line: 299, col: 20, offset: 7542},
 					val:        "[ \\t\\r\\n]",
 					chars:      []rune{' ', '\t', '\r', '\n'},
 					ignoreCase: false,
@@ -3033,21 +3097,21 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 297, col: 1, offset: 7455},
+			pos:         position{line: 301, col: 1, offset: 7554},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 297, col: 19, offset: 7473},
+				pos: position{line: 301, col: 19, offset: 7572},
 				expr: &choiceExpr{
-					pos: position{line: 297, col: 21, offset: 7475},
+					pos: position{line: 301, col: 21, offset: 7574},
 					alternatives: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 297, col: 21, offset: 7475},
+							pos:        position{line: 301, col: 21, offset: 7574},
 							val:        "[ \\t\\r\\n]",
 							chars:      []rune{' ', '\t', '\r', '\n'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 297, col: 33, offset: 7487},
+							pos:  position{line: 301, col: 33, offset: 7586},
 							name: "Comment",
 						},
 					},
@@ -3056,17 +3120,17 @@ var g = &grammar{
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 299, col: 1, offset: 7499},
+			pos:  position{line: 303, col: 1, offset: 7598},
 			expr: &actionExpr{
-				pos: position{line: 299, col: 12, offset: 7510},
+				pos: position{line: 303, col: 12, offset: 7609},
 				run: (*parser).callonComment1,
 				expr: &seqExpr{
-					pos: position{line: 299, col: 12, offset: 7510},
+					pos: position{line: 303, col: 12, offset: 7609},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 299, col: 12, offset: 7510},
+							pos: position{line: 303, col: 12, offset: 7609},
 							expr: &charClassMatcher{
-								pos:        position{line: 299, col: 12, offset: 7510},
+								pos:        position{line: 303, col: 12, offset: 7609},
 								val:        "[ \\t]",
 								chars:      []rune{' ', '\t'},
 								ignoreCase: false,
@@ -3074,17 +3138,17 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 299, col: 19, offset: 7517},
+							pos:        position{line: 303, col: 19, offset: 7616},
 							val:        "#",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 299, col: 23, offset: 7521},
+							pos:   position{line: 303, col: 23, offset: 7620},
 							label: "text",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 299, col: 28, offset: 7526},
+								pos: position{line: 303, col: 28, offset: 7625},
 								expr: &charClassMatcher{
-									pos:        position{line: 299, col: 28, offset: 7526},
+									pos:        position{line: 303, col: 28, offset: 7625},
 									val:        "[^\\r\\n]",
 									chars:      []rune{'\r', '\n'},
 									ignoreCase: false,
@@ -3098,11 +3162,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 303, col: 1, offset: 7573},
+			pos:  position{line: 307, col: 1, offset: 7672},
 			expr: &notExpr{
-				pos: position{line: 303, col: 8, offset: 7580},
+				pos: position{line: 307, col: 8, offset: 7679},
 				expr: &anyMatcher{
-					line: 303, col: 9, offset: 7581,
+					line: 307, col: 9, offset: 7680,
 				},
 			},
 		},
@@ -3149,14 +3213,14 @@ func (p *parser) callonImport1() (interface{}, error) {
 	return p.cur.onImport1(stack["path"], stack["alias"])
 }
 
-func (c *current) onDefaultRules1(name, value interface{}) (interface{}, error) {
-	return makeDefaultRule(currentLocation(c), name, value)
+func (c *current) onDefaultRules1(name, operator, value interface{}) (interface{}, error) {
+	return makeDefaultRule(currentLocation(c), name, operator, value)
 }
 
 func (p *parser) callonDefaultRules1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onDefaultRules1(stack["name"], stack["value"])
+	return p.cur.onDefaultRules1(stack["name"], stack["operator"], stack["value"])
 }
 
 func (c *current) onNormalRules1(head, rest interface{}) (interface{}, error) {

--- a/vendor/github.com/open-policy-agent/opa/ast/parser_internal.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/parser_internal.go
@@ -100,7 +100,11 @@ func makeImport(loc *Location, path, alias interface{}) (interface{}, error) {
 	return imp, nil
 }
 
-func makeDefaultRule(loc *Location, name, value interface{}) (interface{}, error) {
+func makeDefaultRule(loc *Location, name, operator, value interface{}) (interface{}, error) {
+
+	if string(operator.([]uint8)) == Assign.Infix {
+		return nil, fmt.Errorf("default rules must use = operator (not := operator)")
+	}
 
 	term := value.(*Term)
 	var err error
@@ -166,6 +170,10 @@ func makeRule(loc *Location, head, rest interface{}) (interface{}, error) {
 		next := elem.([]interface{})
 		re := next[1].(ruleExt)
 
+		if rules[0].Head.Assign {
+			return nil, errElseAssignOperator
+		}
+
 		if re.term == nil {
 			if ordered {
 				return nil, fmt.Errorf("expected 'else' keyword")
@@ -222,6 +230,17 @@ func makeRuleHead(loc *Location, name, args, key, value interface{}) (interface{
 
 	if value != nil {
 		valueSlice := value.([]interface{})
+		operator := string(valueSlice[1].([]uint8))
+
+		if operator == Assign.Infix {
+			if head.Key != nil {
+				return nil, errPartialRuleAssignOperator
+			} else if len(head.Args) > 0 {
+				return nil, errFunctionAssignOperator
+			}
+			head.Assign = true
+		}
+
 		// Head definition above describes the "value" slice. We care about the "Term" element.
 		head.Value = valueSlice[len(valueSlice)-1].(*Term)
 	}

--- a/vendor/github.com/open-policy-agent/opa/ast/visit.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/visit.go
@@ -12,7 +12,7 @@ type Visitor interface {
 	Visit(v interface{}) (w Visitor)
 }
 
-// BeforeAndAfterVisitor wraps Visitor to provie hooks for being called before
+// BeforeAndAfterVisitor wraps Visitor to provide hooks for being called before
 // and after the AST has been visited.
 type BeforeAndAfterVisitor interface {
 	Visitor
@@ -23,18 +23,22 @@ type BeforeAndAfterVisitor interface {
 // Walk iterates the AST by calling the Visit function on the Visitor
 // v for x before recursing.
 func Walk(v Visitor, x interface{}) {
-	wrapped, ok := v.(BeforeAndAfterVisitor)
-	if !ok {
-		wrapped = noopBeforeAndAfterVisitor{v}
+	if bav, ok := v.(BeforeAndAfterVisitor); !ok {
+		walk(v, x)
+	} else {
+		bav.Before(x)
+		defer bav.After(x)
+		walk(bav, x)
 	}
-	WalkBeforeAndAfter(wrapped, x)
 }
 
 // WalkBeforeAndAfter iterates the AST by calling the Visit function on the
 // Visitor v for x before recursing.
 func WalkBeforeAndAfter(v BeforeAndAfterVisitor, x interface{}) {
-	v.Before(x)
-	defer v.After(x)
+	Walk(v, x)
+}
+
+func walk(v Visitor, x interface{}) {
 	w := v.Visit(x)
 	if w == nil {
 		return
@@ -222,7 +226,12 @@ func WalkBodies(x interface{}, f func(Body) bool) {
 func WalkRules(x interface{}, f func(*Rule) bool) {
 	vis := &GenericVisitor{func(x interface{}) bool {
 		if r, ok := x.(*Rule); ok {
-			return f(r)
+			stop := f(r)
+			// NOTE(tsandall): since rules cannot be embedded inside of queries
+			// we can stop early if there is no else block.
+			if stop || r.Else == nil {
+				return true
+			}
 		}
 		return false
 	}}
@@ -364,10 +373,3 @@ func (vis *VarVisitor) Visit(v interface{}) Visitor {
 	}
 	return vis
 }
-
-type noopBeforeAndAfterVisitor struct {
-	Visitor
-}
-
-func (noopBeforeAndAfterVisitor) Before(interface{}) {}
-func (noopBeforeAndAfterVisitor) After(interface{})  {}

--- a/vendor/github.com/open-policy-agent/opa/docs/website/scripts/live-blocks/static/icons/LICENSE
+++ b/vendor/github.com/open-policy-agent/opa/docs/website/scripts/live-blocks/static/icons/LICENSE
@@ -1,0 +1,204 @@
+The icons in this folder are provided by Google under the Apache 2.0 license (https://github.com/google/material-design-icons), a copy of which is included below:
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/open-policy-agent/opa/internal/planner/planner.go
+++ b/vendor/github.com/open-policy-agent/opa/internal/planner/planner.go
@@ -117,7 +117,7 @@ func (p *Planner) planRules(trieNode *functrieValue) error {
 
 	rules := trieNode.Rules
 
-	// Create function definiton for rules.
+	// Create function definition for rules.
 	fn := &ir.Func{
 		Name:   rules[0].Path().String(),
 		Params: []ir.Local{p.newLocal()},

--- a/vendor/github.com/open-policy-agent/opa/internal/version/version.go
+++ b/vendor/github.com/open-policy-agent/opa/internal/version/version.go
@@ -1,0 +1,40 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package version implements helper functions for the stored version.
+package version
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/version"
+)
+
+var versionPath = storage.MustParsePath("/system/version")
+
+// Write the build version information into storage. This makes the
+// version information available to the REPL and the HTTP server.
+func Write(ctx context.Context, store storage.Store, txn storage.Transaction) error {
+
+	if err := storage.MakeDir(ctx, store, txn, versionPath); err != nil {
+		return err
+	}
+
+	if err := store.Write(ctx, txn, storage.AddOp, versionPath, map[string]interface{}{
+		"version":         version.Version,
+		"build_commit":    version.Vcs,
+		"build_timestamp": version.Timestamp,
+		"build_hostname":  version.Hostname,
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UserAgent defines the current OPA instances User-Agent default header value.
+var UserAgent = fmt.Sprintf("Open Policy Agent/%s (%s, %s)", version.Version, runtime.GOOS, runtime.GOARCH)

--- a/vendor/github.com/open-policy-agent/opa/metrics/metrics.go
+++ b/vendor/github.com/open-policy-agent/opa/metrics/metrics.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	go_metrics "github.com/rcrowley/go-metrics"
@@ -27,9 +29,15 @@ const (
 	RegoInputParse    = "rego_input_parse"
 )
 
+// Info contains attributes describing the underlying metrics provider.
+type Info struct {
+	Name string `json:"name"` // name is a unique human-readable identifier for the provider.
+}
+
 // Metrics defines the interface for a collection of performance metrics in the
 // policy engine.
 type Metrics interface {
+	Info() Info
 	Timer(name string) Timer
 	Histogram(name string) Histogram
 	Counter(name string) Counter
@@ -39,6 +47,7 @@ type Metrics interface {
 }
 
 type metrics struct {
+	mtx        sync.Mutex
 	timers     map[string]Timer
 	histograms map[string]Histogram
 	counters   map[string]Counter
@@ -54,6 +63,12 @@ func New() Metrics {
 type metric struct {
 	Key   string
 	Value interface{}
+}
+
+func (m *metrics) Info() Info {
+	return Info{
+		Name: "<built-in>",
+	}
 }
 
 func (m *metrics) String() string {
@@ -85,6 +100,8 @@ func (m *metrics) MarshalJSON() ([]byte, error) {
 }
 
 func (m *metrics) Timer(name string) Timer {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	t, ok := m.timers[name]
 	if !ok {
 		t = &timer{}
@@ -94,6 +111,8 @@ func (m *metrics) Timer(name string) Timer {
 }
 
 func (m *metrics) Histogram(name string) Histogram {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	h, ok := m.histograms[name]
 	if !ok {
 		h = newHistogram()
@@ -103,9 +122,11 @@ func (m *metrics) Histogram(name string) Histogram {
 }
 
 func (m *metrics) Counter(name string) Counter {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	c, ok := m.counters[name]
 	if !ok {
-		zero := counter(0)
+		zero := counter{}
 		c = &zero
 		m.counters[name] = c
 	}
@@ -113,6 +134,8 @@ func (m *metrics) Counter(name string) Counter {
 }
 
 func (m *metrics) All() map[string]interface{} {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	result := map[string]interface{}{}
 	for name, timer := range m.timers {
 		result[m.formatKey(name, timer)] = timer.Value()
@@ -127,6 +150,8 @@ func (m *metrics) All() map[string]interface{} {
 }
 
 func (m *metrics) Clear() {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	m.timers = map[string]Timer{}
 	m.histograms = map[string]Histogram{}
 	m.counters = map[string]Counter{}
@@ -155,25 +180,32 @@ type Timer interface {
 }
 
 type timer struct {
+	mtx   sync.Mutex
 	start time.Time
 	value int64
 }
 
 func (t *timer) Start() {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
 	t.start = time.Now()
 }
 
 func (t *timer) Stop() int64 {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
 	delta := time.Now().Sub(t.start).Nanoseconds()
 	t.value += delta
 	return delta
 }
 
-func (t timer) Value() interface{} {
+func (t *timer) Value() interface{} {
 	return t.Int64()
 }
 
-func (t timer) Int64() int64 {
+func (t *timer) Int64() int64 {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
 	return t.value
 }
 
@@ -184,7 +216,7 @@ type Histogram interface {
 }
 
 type histogram struct {
-	hist go_metrics.Histogram
+	hist go_metrics.Histogram // is thread-safe because of the underlying ExpDecaySample
 }
 
 func newHistogram() Histogram {
@@ -233,12 +265,14 @@ type Counter interface {
 	Incr()
 }
 
-type counter uint64
+type counter struct {
+	c uint64
+}
 
 func (c *counter) Incr() {
-	*c++
+	atomic.AddUint64(&c.c, 1)
 }
 
 func (c *counter) Value() interface{} {
-	return uint64(*c)
+	return atomic.LoadUint64(&c.c)
 }

--- a/vendor/github.com/open-policy-agent/opa/storage/inmem/txn.go
+++ b/vendor/github.com/open-policy-agent/opa/storage/inmem/txn.go
@@ -32,9 +32,11 @@ import (
 type transaction struct {
 	xid      uint64
 	write    bool
+	stale    bool
 	db       *store
 	updates  *list.List
 	policies map[string]policyUpdate
+	context  *storage.Context
 }
 
 type policyUpdate struct {
@@ -42,13 +44,14 @@ type policyUpdate struct {
 	remove bool
 }
 
-func newTransaction(xid uint64, write bool, db *store) *transaction {
+func newTransaction(xid uint64, write bool, context *storage.Context, db *store) *transaction {
 	return &transaction{
 		xid:      xid,
 		write:    write,
 		db:       db,
 		policies: map[string]policyUpdate{},
 		updates:  list.New(),
+		context:  context,
 	}
 }
 
@@ -139,6 +142,7 @@ func (txn *transaction) updateRoot(op storage.PatchOp, value interface{}) error 
 }
 
 func (txn *transaction) Commit() (result storage.TriggerEvent) {
+	result.Context = txn.context
 	for curr := txn.updates.Front(); curr != nil; curr = curr.Next() {
 		action := curr.Value.(*update)
 		updated := action.Apply(txn.db.data)

--- a/vendor/github.com/open-policy-agent/opa/storage/interface.go
+++ b/vendor/github.com/open-policy-agent/opa/storage/interface.go
@@ -44,6 +44,34 @@ type TransactionParams struct {
 
 	// Write indicates if this transaction will perform any write operations.
 	Write bool
+
+	// Context contains key/value pairs passed to triggers.
+	Context *Context
+}
+
+// Context is a simple container for key/value pairs.
+type Context struct {
+	values map[interface{}]interface{}
+}
+
+// NewContext returns a new context object.
+func NewContext() *Context {
+	return &Context{
+		values: map[interface{}]interface{}{},
+	}
+}
+
+// Get returns the key value in the context.
+func (ctx *Context) Get(key interface{}) interface{} {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.values[key]
+}
+
+// Put adds a key/value pair to the context.
+func (ctx *Context) Put(key, value interface{}) {
+	ctx.values[key] = value
 }
 
 // WriteParams specifies the TransactionParams for a write transaction.
@@ -117,8 +145,9 @@ type DataEvent struct {
 
 // TriggerEvent describes the changes that caused the trigger to be invoked.
 type TriggerEvent struct {
-	Policy []PolicyEvent
-	Data   []DataEvent
+	Policy  []PolicyEvent
+	Data    []DataEvent
+	Context *Context
 }
 
 // IsZero returns true if the TriggerEvent indicates no changes occurred. This

--- a/vendor/github.com/open-policy-agent/opa/storage/path.go
+++ b/vendor/github.com/open-policy-agent/opa/storage/path.go
@@ -57,6 +57,8 @@ func NewPathForRef(ref ast.Ref) (path Path, err error) {
 		return Path{}, nil
 	}
 
+	path = make(Path, 0, len(ref)-1)
+
 	for _, term := range ref[1:] {
 		switch v := term.Value.(type) {
 		case ast.String:

--- a/vendor/github.com/open-policy-agent/opa/topdown/bindings.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/bindings.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/util"
 )
 
 type undo struct {
@@ -38,30 +37,12 @@ var sentinel = newBindings(math.MaxUint64, nil)
 
 type bindings struct {
 	id     uint64
-	values *util.HashMap
+	values bindingsArrayHashmap
 	instr  *Instrumentation
 }
 
 func newBindings(id uint64, instr *Instrumentation) *bindings {
-
-	eq := func(a, b util.T) bool {
-		v1, ok1 := a.(*ast.Term)
-		if ok1 {
-			v2 := b.(*ast.Term)
-			return v1.Equal(v2)
-		}
-		uv1 := a.(*value)
-		uv2 := b.(*value)
-		return uv1.equal(uv2)
-	}
-
-	hash := func(x util.T) int {
-		v := x.(*ast.Term)
-		return v.Hash()
-	}
-
-	values := util.NewHashMap(eq, hash)
-
+	values := newBindingsArrayHashmap()
 	return &bindings{id, values, instr}
 }
 
@@ -69,12 +50,11 @@ func (u *bindings) Iter(caller *bindings, iter func(*ast.Term, *ast.Term) error)
 
 	var err error
 
-	u.values.Iter(func(k, v util.T) bool {
+	u.values.Iter(func(k *ast.Term, v value) bool {
 		if err != nil {
 			return true
 		}
-		term := k.(*ast.Term)
-		err = iter(term, u.PlugNamespaced(term, caller))
+		err = iter(k, u.PlugNamespaced(k, caller))
 
 		return false
 	})
@@ -96,8 +76,11 @@ func (u *bindings) Plug(a *ast.Term) *ast.Term {
 func (u *bindings) PlugNamespaced(a *ast.Term, caller *bindings) *ast.Term {
 	if u != nil {
 		u.instr.startTimer(evalOpPlug)
-		defer u.instr.stopTimer(evalOpPlug)
+		t := u.plugNamespaced(a, caller)
+		u.instr.stopTimer(evalOpPlug)
+		return t
 	}
+
 	return u.plugNamespaced(a, caller)
 }
 
@@ -181,11 +164,7 @@ func (u *bindings) get(v *ast.Term) (value, bool) {
 	if u == nil {
 		return value{}, false
 	}
-	r, ok := u.values.Get(v)
-	if !ok {
-		return value{}, false
-	}
-	return r.(value), true
+	return u.values.Get(v)
 }
 
 func (u *bindings) String() string {
@@ -193,7 +172,7 @@ func (u *bindings) String() string {
 		return "()"
 	}
 	var buf []string
-	u.values.Iter(func(a, b util.T) bool {
+	u.values.Iter(func(a *ast.Term, b value) bool {
 		buf = append(buf, fmt.Sprintf("%v: %v", a, b))
 		return false
 	})
@@ -305,4 +284,113 @@ func (vis namespacingVisitor) namespaceTerm(a *ast.Term) *ast.Term {
 		return &cpy
 	}
 	return a
+}
+
+const maxLinearScan = 16
+
+// bindingsArrayHashMap uses an array with linear scan instead of a hash map for smaller # of entries. Hash maps start to show off their performance advantage only after 16 keys.
+type bindingsArrayHashmap struct {
+	n int // Entries in the array.
+	a *[maxLinearScan]bindingArrayKeyValue
+	m map[ast.Var]bindingArrayKeyValue
+}
+
+type bindingArrayKeyValue struct {
+	key   *ast.Term
+	value value
+}
+
+func newBindingsArrayHashmap() bindingsArrayHashmap {
+	return bindingsArrayHashmap{}
+}
+
+func (b *bindingsArrayHashmap) Put(key *ast.Term, value value) {
+	if b.m == nil {
+		if b.a == nil {
+			b.a = new([maxLinearScan]bindingArrayKeyValue)
+		} else if i := b.find(key); i >= 0 {
+			(*b.a)[i].value = value
+			return
+		}
+
+		if b.n < maxLinearScan {
+			(*b.a)[b.n] = bindingArrayKeyValue{key, value}
+			b.n++
+			return
+		}
+
+		// Array is full, revert to using the hash map instead.
+
+		b.m = make(map[ast.Var]bindingArrayKeyValue, maxLinearScan+1)
+		for _, kv := range *b.a {
+			b.m[kv.key.Value.(ast.Var)] = bindingArrayKeyValue{kv.key, kv.value}
+		}
+		b.m[key.Value.(ast.Var)] = bindingArrayKeyValue{key, value}
+
+		b.n = 0
+		return
+	}
+
+	b.m[key.Value.(ast.Var)] = bindingArrayKeyValue{key, value}
+}
+
+func (b *bindingsArrayHashmap) Get(key *ast.Term) (value, bool) {
+	if b.m == nil {
+		if i := b.find(key); i >= 0 {
+			return (*b.a)[i].value, true
+		}
+
+		return value{}, false
+	}
+
+	v, ok := b.m[key.Value.(ast.Var)]
+	if ok {
+		return v.value, true
+	}
+
+	return value{}, false
+}
+
+func (b *bindingsArrayHashmap) Delete(key *ast.Term) {
+	if b.m == nil {
+		if i := b.find(key); i >= 0 {
+			n := b.n - 1
+			if i < n {
+				(*b.a)[i] = (*b.a)[n]
+			}
+
+			b.n = n
+		}
+		return
+	}
+
+	delete(b.m, key.Value.(ast.Var))
+}
+
+func (b *bindingsArrayHashmap) Iter(f func(k *ast.Term, v value) bool) {
+	if b.m == nil {
+		for i := 0; i < b.n; i++ {
+			if f((*b.a)[i].key, (*b.a)[i].value) {
+				return
+			}
+		}
+		return
+	}
+
+	for _, v := range b.m {
+		if f(v.key, v.value) {
+			return
+		}
+	}
+}
+
+func (b *bindingsArrayHashmap) find(key *ast.Term) int {
+	v := key.Value.(ast.Var)
+	for i := 0; i < b.n; i++ {
+		if (*b.a)[i].key.Value.(ast.Var) == v {
+			return i
+		}
+	}
+
+	return -1
 }

--- a/vendor/github.com/open-policy-agent/opa/topdown/builtins.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/builtins.go
@@ -66,7 +66,7 @@ type (
 	// BuiltinFunc defines an interface for implementing built-in functions.
 	// The built-in function is called with the plugged operands from the call
 	// (including the output operands.) The implementation should evaluate the
-	// operands and invoke the iteraror for each successful/defined output
+	// operands and invoke the iterator for each successful/defined output
 	// value.
 	BuiltinFunc func(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error
 )

--- a/vendor/github.com/open-policy-agent/opa/topdown/casts.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/casts.go
@@ -32,6 +32,7 @@ func builtinToNumber(a ast.Value) (ast.Value, error) {
 	return nil, builtins.NewOperandTypeErr(1, a, "null", "boolean", "number", "string")
 }
 
+// Deprecated in v0.13.0.
 func builtinToArray(a ast.Value) (ast.Value, error) {
 	switch val := a.(type) {
 	case ast.Array:
@@ -49,6 +50,7 @@ func builtinToArray(a ast.Value) (ast.Value, error) {
 	}
 }
 
+// Deprecated in v0.13.0.
 func builtinToSet(a ast.Value) (ast.Value, error) {
 	switch val := a.(type) {
 	case ast.Array:
@@ -60,6 +62,7 @@ func builtinToSet(a ast.Value) (ast.Value, error) {
 	}
 }
 
+// Deprecated in v0.13.0.
 func builtinToString(a ast.Value) (ast.Value, error) {
 	switch val := a.(type) {
 	case ast.String:
@@ -69,6 +72,7 @@ func builtinToString(a ast.Value) (ast.Value, error) {
 	}
 }
 
+// Deprecated in v0.13.0.
 func builtinToBoolean(a ast.Value) (ast.Value, error) {
 	switch val := a.(type) {
 	case ast.Boolean:
@@ -78,6 +82,7 @@ func builtinToBoolean(a ast.Value) (ast.Value, error) {
 	}
 }
 
+// Deprecated in v0.13.0.
 func builtinToNull(a ast.Value) (ast.Value, error) {
 	switch val := a.(type) {
 	case ast.Null:
@@ -87,6 +92,7 @@ func builtinToNull(a ast.Value) (ast.Value, error) {
 	}
 }
 
+// Deprecated in v0.13.0.
 func builtinToObject(a ast.Value) (ast.Value, error) {
 	switch val := a.(type) {
 	case ast.Object:

--- a/vendor/github.com/open-policy-agent/opa/topdown/http.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/http.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"github.com/open-policy-agent/opa/internal/version"
 	"io"
 	"io/ioutil"
 	"strconv"
@@ -268,6 +269,10 @@ func executeHTTPRequest(bctx BuiltinContext, obj ast.Object) (ast.Value, error) 
 	if len(customHeaders) != 0 {
 		if ok, err := addHeaders(req, customHeaders); !ok {
 			return nil, err
+		}
+		// Don't overwrite or append to one that was set in the custom headers
+		if _, hasUA := customHeaders["User-Agent"]; !hasUA {
+			req.Header.Add("User-Agent", version.UserAgent)
 		}
 	}
 

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/LICENSE
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 lestrrat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/buffer/buffer.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/buffer/buffer.go
@@ -1,0 +1,113 @@
+// Package buffer provides a very thin wrapper around []byte buffer called
+// `Buffer`, to provide functionalities that are often used within the jwx
+// related packages
+package buffer
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// Buffer wraps `[]byte` and provides functions that are often used in
+// the jwx related packages. One notable difference is that while
+// encoding/json marshalls `[]byte` using base64.StdEncoding, this
+// module uses base64.RawURLEncoding as mandated by the spec
+type Buffer []byte
+
+// FromUint creates a `Buffer` from an unsigned int
+func FromUint(v uint64) Buffer {
+	data := make([]byte, 8)
+	binary.BigEndian.PutUint64(data, v)
+
+	i := 0
+	for ; i < len(data); i++ {
+		if data[i] != 0x0 {
+			break
+		}
+	}
+	return Buffer(data[i:])
+}
+
+// FromBase64 constructs a new Buffer from a base64 encoded data
+func FromBase64(v []byte) (Buffer, error) {
+	b := Buffer{}
+	if err := b.Base64Decode(v); err != nil {
+		return Buffer(nil), errors.Wrap(err, "failed to decode from base64")
+	}
+
+	return b, nil
+}
+
+// FromNData constructs a new Buffer from a "n:data" format
+// (I made that name up)
+func FromNData(v []byte) (Buffer, error) {
+	size := binary.BigEndian.Uint32(v)
+	buf := make([]byte, int(size))
+	copy(buf, v[4:4+size])
+	return Buffer(buf), nil
+}
+
+// Bytes returns the raw bytes that comprises the Buffer
+func (b Buffer) Bytes() []byte {
+	return []byte(b)
+}
+
+// NData returns Datalen || Data, where Datalen is a 32 bit counter for
+// the length of the following data, and Data is the octets that comprise
+// the buffer data
+func (b Buffer) NData() []byte {
+	buf := make([]byte, 4+b.Len())
+	binary.BigEndian.PutUint32(buf, uint32(b.Len()))
+
+	copy(buf[4:], b.Bytes())
+	return buf
+}
+
+// Len returns the number of bytes that the Buffer holds
+func (b Buffer) Len() int {
+	return len(b)
+}
+
+// Base64Encode encodes the contents of the Buffer using base64.RawURLEncoding
+func (b Buffer) Base64Encode() ([]byte, error) {
+	enc := base64.RawURLEncoding
+	out := make([]byte, enc.EncodedLen(len(b)))
+	enc.Encode(out, b)
+	return out, nil
+}
+
+// Base64Decode decodes the contents of the Buffer using base64.RawURLEncoding
+func (b *Buffer) Base64Decode(v []byte) error {
+	enc := base64.RawURLEncoding
+	out := make([]byte, enc.DecodedLen(len(v)))
+	n, err := enc.Decode(out, v)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode from base64")
+	}
+	out = out[:n]
+	*b = Buffer(out)
+	return nil
+}
+
+// MarshalJSON marshals the buffer into JSON format after encoding the buffer
+// with base64.RawURLEncoding
+func (b Buffer) MarshalJSON() ([]byte, error) {
+	v, err := b.Base64Encode()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to encode to base64")
+	}
+	return json.Marshal(string(v))
+}
+
+// UnmarshalJSON unmarshals from a JSON string into a Buffer, after decoding it
+// with base64.RawURLEncoding
+func (b *Buffer) UnmarshalJSON(data []byte) error {
+	var x string
+	if err := json.Unmarshal(data, &x); err != nil {
+		return errors.Wrap(err, "failed to unmarshal JSON")
+	}
+	return b.Base64Decode([]byte(x))
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwa/elliptic.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwa/elliptic.go
@@ -1,0 +1,11 @@
+package jwa
+
+// EllipticCurveAlgorithm represents the algorithms used for EC keys
+type EllipticCurveAlgorithm string
+
+// Supported values for EllipticCurveAlgorithm
+const (
+	P256 EllipticCurveAlgorithm = "P-256"
+	P384 EllipticCurveAlgorithm = "P-384"
+	P521 EllipticCurveAlgorithm = "P-521"
+)

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwa/key_type.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwa/key_type.go
@@ -1,0 +1,66 @@
+package jwa
+
+import (
+	"github.com/pkg/errors"
+	"strconv"
+)
+
+// KeyType represents the key type ("kty") that are supported
+type KeyType string
+
+var keyTypeAlg = map[string]struct{}{"EC": {}, "oct": {}, "RSA": {}}
+
+// Supported values for KeyType
+const (
+	EC             KeyType = "EC"  // Elliptic Curve
+	InvalidKeyType KeyType = ""    // Invalid KeyType
+	OctetSeq       KeyType = "oct" // Octet sequence (used to represent symmetric keys)
+	RSA            KeyType = "RSA" // RSA
+)
+
+// Accept is used when conversion from values given by
+// outside sources (such as JSON payloads) is required
+func (keyType *KeyType) Accept(value interface{}) error {
+	var tmp KeyType
+	switch x := value.(type) {
+	case string:
+		tmp = KeyType(x)
+	case KeyType:
+		tmp = x
+	default:
+		return errors.Errorf(`invalid type for jwa.KeyType: %T`, value)
+	}
+	_, ok := keyTypeAlg[tmp.String()]
+	if !ok {
+		return errors.Errorf("Unknown Key Type algorithm")
+	}
+
+	*keyType = tmp
+	return nil
+}
+
+// String returns the string representation of a KeyType
+func (keyType KeyType) String() string {
+	return string(keyType)
+}
+
+// UnmarshalJSON unmarshals and checks data as KeyType Algorithm
+func (keyType *KeyType) UnmarshalJSON(data []byte) error {
+	var quote byte = '"'
+	var quoted string
+	if data[0] == quote {
+		var err error
+		quoted, err = strconv.Unquote(string(data))
+		if err != nil {
+			return errors.Wrap(err, "Failed to process signature algorithm")
+		}
+	} else {
+		quoted = string(data)
+	}
+	_, ok := keyTypeAlg[quoted]
+	if !ok {
+		return errors.Errorf("Unknown signature algorithm")
+	}
+	*keyType = KeyType(quoted)
+	return nil
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwa/parameters.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwa/parameters.go
@@ -1,0 +1,28 @@
+package jwa
+
+import (
+	"crypto/elliptic"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/buffer"
+)
+
+// EllipticCurve provides a indirect type to standard elliptic curve such that we can
+// use it for unmarshal
+type EllipticCurve struct {
+	elliptic.Curve
+}
+
+// AlgorithmParameters provides a single structure suitable to unmarshaling any JWK
+type AlgorithmParameters struct {
+	N   buffer.Buffer          `json:"n,omitempty"`
+	E   buffer.Buffer          `json:"e,omitempty"`
+	D   buffer.Buffer          `json:"d,omitempty"`
+	P   buffer.Buffer          `json:"p,omitempty"`
+	Q   buffer.Buffer          `json:"q,omitempty"`
+	Dp  buffer.Buffer          `json:"dp,omitempty"`
+	Dq  buffer.Buffer          `json:"dq,omitempty"`
+	Qi  buffer.Buffer          `json:"qi,omitempty"`
+	Crv EllipticCurveAlgorithm `json:"crv,omitempty"`
+	X   buffer.Buffer          `json:"x,omitempty"`
+	Y   buffer.Buffer          `json:"y,omitempty"`
+	K   buffer.Buffer          `json:"k,omitempty"`
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwa/signature.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwa/signature.go
@@ -1,0 +1,75 @@
+package jwa
+
+import (
+	"github.com/pkg/errors"
+	"strconv"
+)
+
+// SignatureAlgorithm represents the various signature algorithms as described in https://tools.ietf.org/html/rfc7518#section-3.1
+type SignatureAlgorithm string
+
+var signatureAlg = map[string]struct{}{"ES256": {}, "ES384": {}, "ES512": {}, "HS256": {}, "HS384": {}, "HS512": {}, "PS256": {}, "PS384": {}, "PS512": {}, "RS256": {}, "RS384": {}, "RS512": {}, "none": {}}
+
+// Supported values for SignatureAlgorithm
+const (
+	ES256       SignatureAlgorithm = "ES256" // ECDSA using P-256 and SHA-256
+	ES384       SignatureAlgorithm = "ES384" // ECDSA using P-384 and SHA-384
+	ES512       SignatureAlgorithm = "ES512" // ECDSA using P-521 and SHA-512
+	HS256       SignatureAlgorithm = "HS256" // HMAC using SHA-256
+	HS384       SignatureAlgorithm = "HS384" // HMAC using SHA-384
+	HS512       SignatureAlgorithm = "HS512" // HMAC using SHA-512
+	NoSignature SignatureAlgorithm = "none"
+	PS256       SignatureAlgorithm = "PS256" // RSASSA-PSS using SHA256 and MGF1-SHA256
+	PS384       SignatureAlgorithm = "PS384" // RSASSA-PSS using SHA384 and MGF1-SHA384
+	PS512       SignatureAlgorithm = "PS512" // RSASSA-PSS using SHA512 and MGF1-SHA512
+	RS256       SignatureAlgorithm = "RS256" // RSASSA-PKCS-v1.5 using SHA-256
+	RS384       SignatureAlgorithm = "RS384" // RSASSA-PKCS-v1.5 using SHA-384
+	RS512       SignatureAlgorithm = "RS512" // RSASSA-PKCS-v1.5 using SHA-512
+	NoValue     SignatureAlgorithm = ""      // No value is different from none
+)
+
+// Accept is used when conversion from values given by
+// outside sources (such as JSON payloads) is required
+func (signature *SignatureAlgorithm) Accept(value interface{}) error {
+	var tmp SignatureAlgorithm
+	switch x := value.(type) {
+	case string:
+		tmp = SignatureAlgorithm(x)
+	case SignatureAlgorithm:
+		tmp = x
+	default:
+		return errors.Errorf(`invalid type for jwa.SignatureAlgorithm: %T`, value)
+	}
+	_, ok := signatureAlg[tmp.String()]
+	if !ok {
+		return errors.Errorf("Unknown signature algorithm")
+	}
+	*signature = tmp
+	return nil
+}
+
+// String returns the string representation of a SignatureAlgorithm
+func (signature SignatureAlgorithm) String() string {
+	return string(signature)
+}
+
+// UnmarshalJSON unmarshals and checks data as Signature Algorithm
+func (signature *SignatureAlgorithm) UnmarshalJSON(data []byte) error {
+	var quote byte = '"'
+	var quoted string
+	if data[0] == quote {
+		var err error
+		quoted, err = strconv.Unquote(string(data))
+		if err != nil {
+			return errors.Wrap(err, "Failed to process signature algorithm")
+		}
+	} else {
+		quoted = string(data)
+	}
+	_, ok := signatureAlg[quoted]
+	if !ok {
+		return errors.Errorf("Unknown signature algorithm")
+	}
+	*signature = SignatureAlgorithm(quoted)
+	return nil
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/ecdsa.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/ecdsa.go
@@ -1,0 +1,119 @@
+package jwk
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"math/big"
+
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+	"github.com/pkg/errors"
+)
+
+func newECDSAPublicKey(key *ecdsa.PublicKey) (*ECDSAPublicKey, error) {
+
+	var hdr StandardHeaders
+	err := hdr.Set(KeyTypeKey, jwa.EC)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to set Key Type")
+	}
+
+	return &ECDSAPublicKey{
+		StandardHeaders: &hdr,
+		key:             key,
+	}, nil
+}
+
+func newECDSAPrivateKey(key *ecdsa.PrivateKey) (*ECDSAPrivateKey, error) {
+
+	var hdr StandardHeaders
+	err := hdr.Set(KeyTypeKey, jwa.EC)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to set Key Type")
+	}
+
+	return &ECDSAPrivateKey{
+		StandardHeaders: &hdr,
+		key:             key,
+	}, nil
+}
+
+// Materialize returns the EC-DSA public key represented by this JWK
+func (k ECDSAPublicKey) Materialize() (interface{}, error) {
+	return k.key, nil
+}
+
+// Materialize returns the EC-DSA private key represented by this JWK
+func (k ECDSAPrivateKey) Materialize() (interface{}, error) {
+	return k.key, nil
+}
+
+// GenerateKey creates a ECDSAPublicKey from JWK format
+func (k *ECDSAPublicKey) GenerateKey(keyJSON *RawKeyJSON) error {
+
+	var x, y big.Int
+
+	if keyJSON.X == nil || keyJSON.Y == nil || keyJSON.Crv == "" {
+		return errors.Errorf("Missing mandatory key parameters X, Y or Crv")
+	}
+
+	x.SetBytes(keyJSON.X.Bytes())
+	y.SetBytes(keyJSON.Y.Bytes())
+
+	var curve elliptic.Curve
+	switch keyJSON.Crv {
+	case jwa.P256:
+		curve = elliptic.P256()
+	case jwa.P384:
+		curve = elliptic.P384()
+	case jwa.P521:
+		curve = elliptic.P521()
+	default:
+		return errors.Errorf(`invalid curve name %s`, keyJSON.Crv)
+	}
+
+	*k = ECDSAPublicKey{
+		StandardHeaders: &keyJSON.StandardHeaders,
+		key: &ecdsa.PublicKey{
+			Curve: curve,
+			X:     &x,
+			Y:     &y,
+		},
+	}
+	return nil
+}
+
+// GenerateKey creates a ECDSAPrivateKey from JWK format
+func (k *ECDSAPrivateKey) GenerateKey(keyJSON *RawKeyJSON) error {
+
+	if keyJSON.D == nil {
+		return errors.Errorf("Missing mandatory key parameter D")
+	}
+	eCDSAPublicKey := &ECDSAPublicKey{}
+	err := eCDSAPublicKey.GenerateKey(keyJSON)
+	if err != nil {
+		return errors.Wrap(err, `failed to generate public key`)
+	}
+	dBytes := keyJSON.D.Bytes()
+	// The length of this octet string MUST be ceiling(log-base-2(n)/8)
+	// octets (where n is the order of the curve). This is because the private
+	// key d must be in the interval [1, n-1] so the bitlength of d should be
+	// no larger than the bitlength of n-1. The easiest way to find the octet
+	// length is to take bitlength(n-1), add 7 to force a carry, and shift this
+	// bit sequence right by 3, which is essentially dividing by 8 and adding
+	// 1 if there is any remainder. Thus, the private key value d should be
+	// output to (bitlength(n-1)+7)>>3 octets.
+	n := eCDSAPublicKey.key.Params().N
+	octetLength := (new(big.Int).Sub(n, big.NewInt(1)).BitLen() + 7) >> 3
+	if octetLength-len(dBytes) != 0 {
+		return errors.Errorf("Failed to generate private key. Incorrect D value")
+	}
+	privateKey := &ecdsa.PrivateKey{
+		PublicKey: *eCDSAPublicKey.key,
+		D:         (&big.Int{}).SetBytes(keyJSON.D.Bytes()),
+	}
+
+	k.key = privateKey
+	k.StandardHeaders = &keyJSON.StandardHeaders
+
+	return nil
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/headers.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/headers.go
@@ -1,0 +1,177 @@
+package jwk
+
+import (
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+	"github.com/pkg/errors"
+)
+
+// Convenience constants for common JWK parameters
+const (
+	AlgorithmKey     = "alg"
+	KeyIDKey         = "kid"
+	KeyOpsKey        = "key_ops"
+	KeyTypeKey       = "kty"
+	KeyUsageKey      = "use"
+	PrivateParamsKey = "privateParams"
+)
+
+// Headers provides a common interface to all future possible headers
+type Headers interface {
+	Get(string) (interface{}, bool)
+	Set(string, interface{}) error
+	Walk(func(string, interface{}) error) error
+	GetAlgorithm() jwa.SignatureAlgorithm
+	GetKeyID() string
+	GetKeyOps() KeyOperationList
+	GetKeyType() jwa.KeyType
+	GetKeyUsage() string
+	GetPrivateParams() map[string]interface{}
+}
+
+// StandardHeaders stores the common JWK parameters
+type StandardHeaders struct {
+	Algorithm     *jwa.SignatureAlgorithm `json:"alg,omitempty"`           // https://tools.ietf.org/html/rfc7517#section-4.4
+	KeyID         string                  `json:"kid,omitempty"`           // https://tools.ietf.org/html/rfc7515#section-4.1.4
+	KeyOps        KeyOperationList        `json:"key_ops,omitempty"`       // https://tools.ietf.org/html/rfc7517#section-4.3
+	KeyType       jwa.KeyType             `json:"kty,omitempty"`           // https://tools.ietf.org/html/rfc7517#section-4.1
+	KeyUsage      string                  `json:"use,omitempty"`           // https://tools.ietf.org/html/rfc7517#section-4.2
+	PrivateParams map[string]interface{}  `json:"privateParams,omitempty"` // https://tools.ietf.org/html/rfc7515#section-4.1.4
+}
+
+// GetAlgorithm is a convenience function to retrieve the corresponding value stored in the StandardHeaders
+func (h *StandardHeaders) GetAlgorithm() jwa.SignatureAlgorithm {
+	if v := h.Algorithm; v != nil {
+		return *v
+	}
+	return jwa.NoValue
+}
+
+// GetKeyID is a convenience function to retrieve the corresponding value stored in the StandardHeaders
+func (h *StandardHeaders) GetKeyID() string {
+	return h.KeyID
+}
+
+// GetKeyOps is a convenience function to retrieve the corresponding value stored in the StandardHeaders
+func (h *StandardHeaders) GetKeyOps() KeyOperationList {
+	return h.KeyOps
+}
+
+// GetKeyType is a convenience function to retrieve the corresponding value stored in the StandardHeaders
+func (h *StandardHeaders) GetKeyType() jwa.KeyType {
+	return h.KeyType
+}
+
+// GetKeyUsage is a convenience function to retrieve the corresponding value stored in the StandardHeaders
+func (h *StandardHeaders) GetKeyUsage() string {
+	return h.KeyUsage
+}
+
+// GetPrivateParams is a convenience function to retrieve the corresponding value stored in the StandardHeaders
+func (h *StandardHeaders) GetPrivateParams() map[string]interface{} {
+	return h.PrivateParams
+}
+
+// Get is a general getter function for JWK StandardHeaders structure
+func (h *StandardHeaders) Get(name string) (interface{}, bool) {
+	switch name {
+	case AlgorithmKey:
+		alg := h.GetAlgorithm()
+		if alg != jwa.NoValue {
+			return alg, true
+		}
+		return nil, false
+	case KeyIDKey:
+		v := h.KeyID
+		if v == "" {
+			return nil, false
+		}
+		return v, true
+	case KeyOpsKey:
+		v := h.KeyOps
+		if v == nil {
+			return nil, false
+		}
+		return v, true
+	case KeyTypeKey:
+		v := h.KeyType
+		if v == jwa.InvalidKeyType {
+			return nil, false
+		}
+		return v, true
+	case KeyUsageKey:
+		v := h.KeyUsage
+		if v == "" {
+			return nil, false
+		}
+		return v, true
+	case PrivateParamsKey:
+		v := h.PrivateParams
+		if len(v) == 0 {
+			return nil, false
+		}
+		return v, true
+	default:
+		return nil, false
+	}
+}
+
+// Set is a general getter function for JWK StandardHeaders structure
+func (h *StandardHeaders) Set(name string, value interface{}) error {
+	switch name {
+	case AlgorithmKey:
+		var acceptor jwa.SignatureAlgorithm
+		if err := acceptor.Accept(value); err != nil {
+			return errors.Wrapf(err, `invalid value for %s key`, AlgorithmKey)
+		}
+		h.Algorithm = &acceptor
+		return nil
+	case KeyIDKey:
+		if v, ok := value.(string); ok {
+			h.KeyID = v
+			return nil
+		}
+		return errors.Errorf("invalid value for %s key: %T", KeyIDKey, value)
+	case KeyOpsKey:
+		if err := h.KeyOps.Accept(value); err != nil {
+			return errors.Wrapf(err, "invalid value for %s key", KeyOpsKey)
+		}
+		return nil
+	case KeyTypeKey:
+		if err := h.KeyType.Accept(value); err != nil {
+			return errors.Wrapf(err, "invalid value for %s key", KeyTypeKey)
+		}
+		return nil
+	case KeyUsageKey:
+		if v, ok := value.(string); ok {
+			h.KeyUsage = v
+			return nil
+		}
+		return errors.Errorf("invalid value for %s key: %T", KeyUsageKey, value)
+	case PrivateParamsKey:
+		if v, ok := value.(map[string]interface{}); ok {
+			h.PrivateParams = v
+			return nil
+		}
+		return errors.Errorf("invalid value for %s key: %T", PrivateParamsKey, value)
+	default:
+		return errors.Errorf(`invalid key: %s`, name)
+	}
+}
+
+// Walk iterates over all JWK standard headers fields while applying a function to its value.
+func (h StandardHeaders) Walk(f func(string, interface{}) error) error {
+	for _, key := range []string{AlgorithmKey, KeyIDKey, KeyOpsKey, KeyTypeKey, KeyUsageKey, PrivateParamsKey} {
+		if v, ok := h.Get(key); ok {
+			if err := f(key, v); err != nil {
+				return errors.Wrapf(err, `walk function returned error for %s`, key)
+			}
+		}
+	}
+
+	for k, v := range h.PrivateParams {
+		if err := f(k, v); err != nil {
+			return errors.Wrapf(err, `walk function returned error for %s`, k)
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/interface.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/interface.go
@@ -1,0 +1,69 @@
+package jwk
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+)
+
+// Set is a convenience struct to allow generating and parsing
+// JWK sets as opposed to single JWKs
+type Set struct {
+	Keys []Key `json:"keys"`
+}
+
+// Key defines the minimal interface for each of the
+// key types. Their use and implementation differ significantly
+// between each key types, so you should use type assertions
+// to perform more specific tasks with each key
+type Key interface {
+	Headers
+
+	// Materialize creates the corresponding key. For example,
+	// RSA types would create *rsa.PublicKey or *rsa.PrivateKey,
+	// EC types would create *ecdsa.PublicKey or *ecdsa.PrivateKey,
+	// and OctetSeq types create a []byte key.
+	Materialize() (interface{}, error)
+	GenerateKey(*RawKeyJSON) error
+}
+
+// RawKeyJSON is generic type that represents any kind JWK
+type RawKeyJSON struct {
+	StandardHeaders
+	jwa.AlgorithmParameters
+}
+
+// RawKeySetJSON is generic type that represents a JWK Set
+type RawKeySetJSON struct {
+	Keys []RawKeyJSON `json:"keys"`
+}
+
+// RSAPublicKey is a type of JWK generated from RSA public keys
+type RSAPublicKey struct {
+	*StandardHeaders
+	key *rsa.PublicKey
+}
+
+// RSAPrivateKey is a type of JWK generated from RSA private keys
+type RSAPrivateKey struct {
+	*StandardHeaders
+	key *rsa.PrivateKey
+}
+
+// SymmetricKey is a type of JWK generated from symmetric keys
+type SymmetricKey struct {
+	*StandardHeaders
+	key []byte
+}
+
+// ECDSAPublicKey is a type of JWK generated from ECDSA public keys
+type ECDSAPublicKey struct {
+	*StandardHeaders
+	key *ecdsa.PublicKey
+}
+
+// ECDSAPrivateKey is a type of JWK generated from ECDH-ES private keys
+type ECDSAPrivateKey struct {
+	*StandardHeaders
+	key *ecdsa.PrivateKey
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/jwk.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/jwk.go
@@ -1,0 +1,149 @@
+// Package jwk implements JWK as described in https://tools.ietf.org/html/rfc7517
+package jwk
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"encoding/json"
+
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+	"github.com/pkg/errors"
+)
+
+// GetPublicKey returns the public key based on the private key type.
+// For rsa key types *rsa.PublicKey is returned; for ecdsa key types *ecdsa.PublicKey;
+// for byte slice (raw) keys, the key itself is returned. If the corresponding
+// public key cannot be deduced, an error is returned
+func GetPublicKey(key interface{}) (interface{}, error) {
+	if key == nil {
+		return nil, errors.New(`jwk.New requires a non-nil key`)
+	}
+
+	switch v := key.(type) {
+	// Mental note: although Public() is defined in both types,
+	// you can not coalesce the clauses for rsa.PrivateKey and
+	// ecdsa.PrivateKey, as then `v` becomes interface{}
+	// b/c the compiler cannot deduce the exact type.
+	case *rsa.PrivateKey:
+		return v.Public(), nil
+	case *ecdsa.PrivateKey:
+		return v.Public(), nil
+	case []byte:
+		return v, nil
+	default:
+		return nil, errors.Errorf(`invalid key type %T`, key)
+	}
+}
+
+// GetKeyTypeFromKey creates a jwk.Key from the given key.
+func GetKeyTypeFromKey(key interface{}) jwa.KeyType {
+
+	switch key.(type) {
+	case *rsa.PrivateKey, *rsa.PublicKey:
+		return jwa.RSA
+	case *ecdsa.PrivateKey, *ecdsa.PublicKey:
+		return jwa.EC
+	case []byte:
+		return jwa.OctetSeq
+	default:
+		return jwa.InvalidKeyType
+	}
+}
+
+// New creates a jwk.Key from the given key.
+func New(key interface{}) (Key, error) {
+	if key == nil {
+		return nil, errors.New(`jwk.New requires a non-nil key`)
+	}
+
+	switch v := key.(type) {
+	case *rsa.PrivateKey:
+		return newRSAPrivateKey(v)
+	case *rsa.PublicKey:
+		return newRSAPublicKey(v)
+	case *ecdsa.PrivateKey:
+		return newECDSAPrivateKey(v)
+	case *ecdsa.PublicKey:
+		return newECDSAPublicKey(v)
+	case []byte:
+		return newSymmetricKey(v)
+	default:
+		return nil, errors.Errorf(`invalid key type %T`, key)
+	}
+}
+
+func parse(jwkSrc string) (*Set, error) {
+
+	var jwkKeySet Set
+	var jwkKey Key
+	rawKeySetJSON := &RawKeySetJSON{}
+	err := json.Unmarshal([]byte(jwkSrc), rawKeySetJSON)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to unmarshal JWK Set")
+	}
+	if len(rawKeySetJSON.Keys) == 0 {
+
+		// It might be a single key
+		rawKeyJSON := &RawKeyJSON{}
+		err := json.Unmarshal([]byte(jwkSrc), rawKeyJSON)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to unmarshal JWK")
+		}
+		jwkKey, err = rawKeyJSON.GenerateKey()
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to generate key")
+		}
+		// Add to set
+		jwkKeySet.Keys = append(jwkKeySet.Keys, jwkKey)
+	} else {
+		for i := range rawKeySetJSON.Keys {
+			rawKeyJSON := rawKeySetJSON.Keys[i]
+			jwkKey, err = rawKeyJSON.GenerateKey()
+			if err != nil {
+				return nil, errors.Wrap(err, "Failed to generate key: %s")
+			}
+			jwkKeySet.Keys = append(jwkKeySet.Keys, jwkKey)
+		}
+	}
+	return &jwkKeySet, nil
+}
+
+// ParseBytes parses JWK from the incoming byte buffer.
+func ParseBytes(buf []byte) (*Set, error) {
+	return parse(string(buf[:]))
+}
+
+// ParseString parses JWK from the incoming string.
+func ParseString(s string) (*Set, error) {
+	return parse(s)
+}
+
+// GenerateKey creates an internal representation of a key from a raw JWK JSON
+func (r *RawKeyJSON) GenerateKey() (Key, error) {
+
+	var key Key
+
+	switch r.KeyType {
+	case jwa.RSA:
+		if r.D != nil {
+			key = &RSAPrivateKey{}
+		} else {
+			key = &RSAPublicKey{}
+		}
+	case jwa.EC:
+		if r.D != nil {
+			key = &ECDSAPrivateKey{}
+		} else {
+			key = &ECDSAPublicKey{}
+		}
+	case jwa.OctetSeq:
+		key = &SymmetricKey{}
+	default:
+		return nil, errors.Errorf(`Unrecognized key type`)
+	}
+	err := key.GenerateKey(r)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to generate key from JWK")
+	}
+	return key, nil
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/key_ops.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/key_ops.go
@@ -1,0 +1,67 @@
+package jwk
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+)
+
+// KeyUsageType is used to denote what this key should be used for
+type KeyUsageType string
+
+const (
+	// ForSignature is the value used in the headers to indicate that
+	// this key should be used for signatures
+	ForSignature KeyUsageType = "sig"
+	// ForEncryption is the value used in the headers to indicate that
+	// this key should be used for encryptiong
+	ForEncryption KeyUsageType = "enc"
+)
+
+// KeyOperation is used to denote the allowed operations for a Key
+type KeyOperation string
+
+// KeyOperationList represents an slice of KeyOperation
+type KeyOperationList []KeyOperation
+
+var keyOps = map[string]struct{}{"sign": {}, "verify": {}, "encrypt": {}, "decrypt": {}, "wrapKey": {}, "unwrapKey": {}, "deriveKey": {}, "deriveBits": {}}
+
+// KeyOperation constants
+const (
+	KeyOpSign       KeyOperation = "sign"       // (compute digital signature or MAC)
+	KeyOpVerify                  = "verify"     // (verify digital signature or MAC)
+	KeyOpEncrypt                 = "encrypt"    // (encrypt content)
+	KeyOpDecrypt                 = "decrypt"    // (decrypt content and validate decryption, if applicable)
+	KeyOpWrapKey                 = "wrapKey"    // (encrypt key)
+	KeyOpUnwrapKey               = "unwrapKey"  // (decrypt key and validate decryption, if applicable)
+	KeyOpDeriveKey               = "deriveKey"  // (derive key)
+	KeyOpDeriveBits              = "deriveBits" // (derive bits not to be used as a key)
+)
+
+// Accept determines if Key Operation is valid
+func (keyOperationList *KeyOperationList) Accept(v interface{}) error {
+	switch x := v.(type) {
+	case KeyOperationList:
+		*keyOperationList = x
+		return nil
+	default:
+		return errors.Errorf(`invalid value %T`, v)
+	}
+}
+
+// UnmarshalJSON unmarshals and checks data as KeyType Algorithm
+func (keyOperationList *KeyOperationList) UnmarshalJSON(data []byte) error {
+	var tempKeyOperationList []string
+	err := json.Unmarshal(data, &tempKeyOperationList)
+	if err != nil {
+		return fmt.Errorf("invalid key operation")
+	}
+	for _, value := range tempKeyOperationList {
+		_, ok := keyOps[value]
+		if !ok {
+			return fmt.Errorf("unknown key operation")
+		}
+		*keyOperationList = append(*keyOperationList, KeyOperation(value))
+	}
+	return nil
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/rsa.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/rsa.go
@@ -1,0 +1,102 @@
+package jwk
+
+import (
+	"crypto/rsa"
+	"math/big"
+
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+	"github.com/pkg/errors"
+)
+
+func newRSAPublicKey(key *rsa.PublicKey) (*RSAPublicKey, error) {
+
+	var hdr StandardHeaders
+	err := hdr.Set(KeyTypeKey, jwa.RSA)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to set Key Type")
+	}
+	return &RSAPublicKey{
+		StandardHeaders: &hdr,
+		key:             key,
+	}, nil
+}
+
+func newRSAPrivateKey(key *rsa.PrivateKey) (*RSAPrivateKey, error) {
+
+	var hdr StandardHeaders
+	err := hdr.Set(KeyTypeKey, jwa.RSA)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to set Key Type")
+	}
+	return &RSAPrivateKey{
+		StandardHeaders: &hdr,
+		key:             key,
+	}, nil
+}
+
+// Materialize returns the standard RSA Public Key representation stored in the internal representation
+func (k *RSAPublicKey) Materialize() (interface{}, error) {
+	if k.key == nil {
+		return nil, errors.New(`key has no rsa.PublicKey associated with it`)
+	}
+	return k.key, nil
+}
+
+// Materialize returns the standard RSA Private Key representation stored in the internal representation
+func (k *RSAPrivateKey) Materialize() (interface{}, error) {
+	if k.key == nil {
+		return nil, errors.New(`key has no rsa.PrivateKey associated with it`)
+	}
+	return k.key, nil
+}
+
+// GenerateKey creates a RSAPublicKey from a RawKeyJSON
+func (k *RSAPublicKey) GenerateKey(keyJSON *RawKeyJSON) error {
+
+	if keyJSON.N == nil || keyJSON.E == nil {
+		return errors.Errorf("Missing mandatory key parameters N or E")
+	}
+	rsaPublicKey := &rsa.PublicKey{
+		N: (&big.Int{}).SetBytes(keyJSON.N.Bytes()),
+		E: int((&big.Int{}).SetBytes(keyJSON.E.Bytes()).Int64()),
+	}
+	k.key = rsaPublicKey
+	k.StandardHeaders = &keyJSON.StandardHeaders
+	return nil
+}
+
+// GenerateKey creates a RSAPublicKey from a RawKeyJSON
+func (k *RSAPrivateKey) GenerateKey(keyJSON *RawKeyJSON) error {
+
+	rsaPublicKey := &RSAPublicKey{}
+	err := rsaPublicKey.GenerateKey(keyJSON)
+	if err != nil {
+		return errors.Wrap(err, "failed to generate public key")
+	}
+
+	if keyJSON.D == nil || keyJSON.P == nil || keyJSON.Q == nil {
+		return errors.Errorf("Missing mandatory key parameters D, P or Q")
+	}
+	privateKey := &rsa.PrivateKey{
+		PublicKey: *rsaPublicKey.key,
+		D:         (&big.Int{}).SetBytes(keyJSON.D.Bytes()),
+		Primes: []*big.Int{
+			(&big.Int{}).SetBytes(keyJSON.P.Bytes()),
+			(&big.Int{}).SetBytes(keyJSON.Q.Bytes()),
+		},
+	}
+
+	if keyJSON.Dp.Len() > 0 {
+		privateKey.Precomputed.Dp = (&big.Int{}).SetBytes(keyJSON.Dp.Bytes())
+	}
+	if keyJSON.Dq.Len() > 0 {
+		privateKey.Precomputed.Dq = (&big.Int{}).SetBytes(keyJSON.Dq.Bytes())
+	}
+	if keyJSON.Qi.Len() > 0 {
+		privateKey.Precomputed.Qinv = (&big.Int{}).SetBytes(keyJSON.Qi.Bytes())
+	}
+
+	k.key = privateKey
+	k.StandardHeaders = &keyJSON.StandardHeaders
+	return nil
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/symmetric.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jwk/symmetric.go
@@ -1,0 +1,40 @@
+package jwk
+
+import (
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+	"github.com/pkg/errors"
+)
+
+func newSymmetricKey(key []byte) (*SymmetricKey, error) {
+	var hdr StandardHeaders
+
+	err := hdr.Set(KeyTypeKey, jwa.OctetSeq)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to set Key Type")
+	}
+	return &SymmetricKey{
+		StandardHeaders: &hdr,
+		key:             key,
+	}, nil
+}
+
+// Materialize returns the octets for this symmetric key.
+// Since this is a symmetric key, this just calls Octets
+func (s SymmetricKey) Materialize() (interface{}, error) {
+	return s.Octets(), nil
+}
+
+// Octets returns the octets in the key
+func (s SymmetricKey) Octets() []byte {
+	return s.key
+}
+
+// GenerateKey creates a Symmetric key from a RawKeyJSON
+func (s *SymmetricKey) GenerateKey(keyJSON *RawKeyJSON) error {
+
+	*s = SymmetricKey{
+		StandardHeaders: &keyJSON.StandardHeaders,
+		key:             keyJSON.K,
+	}
+	return nil
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/headers.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/headers.go
@@ -1,0 +1,153 @@
+package jws
+
+import (
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+	"github.com/pkg/errors"
+)
+
+// Constants for JWS Common parameters
+const (
+	AlgorithmKey     = "alg"
+	ContentTypeKey   = "cty"
+	CriticalKey      = "crit"
+	JWKKey           = "jwk"
+	JWKSetURLKey     = "jku"
+	KeyIDKey         = "kid"
+	PrivateParamsKey = "privateParams"
+	TypeKey          = "typ"
+)
+
+// Headers provides a common interface for common header parameters
+type Headers interface {
+	Get(string) (interface{}, bool)
+	Set(string, interface{}) error
+	GetAlgorithm() jwa.SignatureAlgorithm
+}
+
+// StandardHeaders contains JWS common parameters.
+type StandardHeaders struct {
+	Algorithm     jwa.SignatureAlgorithm `json:"alg,omitempty"`           // https://tools.ietf.org/html/rfc7515#section-4.1.1
+	ContentType   string                 `json:"cty,omitempty"`           // https://tools.ietf.org/html/rfc7515#section-4.1.10
+	Critical      []string               `json:"crit,omitempty"`          // https://tools.ietf.org/html/rfc7515#section-4.1.11
+	JWK           string                 `json:"jwk,omitempty"`           // https://tools.ietf.org/html/rfc7515#section-4.1.3
+	JWKSetURL     string                 `json:"jku,omitempty"`           // https://tools.ietf.org/html/rfc7515#section-4.1.2
+	KeyID         string                 `json:"kid,omitempty"`           // https://tools.ietf.org/html/rfc7515#section-4.1.4
+	PrivateParams map[string]interface{} `json:"privateParams,omitempty"` // https://tools.ietf.org/html/rfc7515#section-4.1.9
+	Type          string                 `json:"typ,omitempty"`           // https://tools.ietf.org/html/rfc7515#section-4.1.9
+}
+
+// GetAlgorithm returns algorithm
+func (h *StandardHeaders) GetAlgorithm() jwa.SignatureAlgorithm {
+	return h.Algorithm
+}
+
+// Get is a general getter function for StandardHeaders structure
+func (h *StandardHeaders) Get(name string) (interface{}, bool) {
+	switch name {
+	case AlgorithmKey:
+		v := h.Algorithm
+		if v == "" {
+			return nil, false
+		}
+		return v, true
+	case ContentTypeKey:
+		v := h.ContentType
+		if v == "" {
+			return nil, false
+		}
+		return v, true
+	case CriticalKey:
+		v := h.Critical
+		if len(v) == 0 {
+			return nil, false
+		}
+		return v, true
+	case JWKKey:
+		v := h.JWK
+		if v == "" {
+			return nil, false
+		}
+		return v, true
+	case JWKSetURLKey:
+		v := h.JWKSetURL
+		if v == "" {
+			return nil, false
+		}
+		return v, true
+	case KeyIDKey:
+		v := h.KeyID
+		if v == "" {
+			return nil, false
+		}
+		return v, true
+	case PrivateParamsKey:
+		v := h.PrivateParams
+		if len(v) == 0 {
+			return nil, false
+		}
+		return v, true
+	case TypeKey:
+		v := h.Type
+		if v == "" {
+			return nil, false
+		}
+		return v, true
+	default:
+		return nil, false
+	}
+}
+
+// Set is a general setter function for StandardHeaders structure
+func (h *StandardHeaders) Set(name string, value interface{}) error {
+	switch name {
+	case AlgorithmKey:
+		if err := h.Algorithm.Accept(value); err != nil {
+			return errors.Wrapf(err, `invalid value for %s key`, AlgorithmKey)
+		}
+		return nil
+	case ContentTypeKey:
+		if v, ok := value.(string); ok {
+			h.ContentType = v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, ContentTypeKey, value)
+	case CriticalKey:
+		if v, ok := value.([]string); ok {
+			h.Critical = v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, CriticalKey, value)
+	case JWKKey:
+		if v, ok := value.(string); ok {
+			h.JWK = v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, JWKKey, value)
+	case JWKSetURLKey:
+		if v, ok := value.(string); ok {
+			h.JWKSetURL = v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, JWKSetURLKey, value)
+	case KeyIDKey:
+		if v, ok := value.(string); ok {
+			h.KeyID = v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, KeyIDKey, value)
+	case PrivateParamsKey:
+		if v, ok := value.(map[string]interface{}); ok {
+			h.PrivateParams = v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, PrivateParamsKey, value)
+	case TypeKey:
+		if v, ok := value.(string); ok {
+			h.Type = v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, TypeKey, value)
+	default:
+		return errors.Errorf(`invalid key: %s`, name)
+	}
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/interface.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/interface.go
@@ -1,0 +1,22 @@
+package jws
+
+// Message represents a full JWS encoded message. Flattened serialization
+// is not supported as a struct, but rather it's represented as a
+// Message struct with only one `Signature` element.
+//
+// Do not expect to use the Message object to verify or construct a
+// signed payloads with. You should only use this when you want to actually
+// want to programmatically view the contents for the full JWS Payload.
+//
+// To sign and verify, use the appropriate `SignWithOption()` nad `Verify()` functions
+type Message struct {
+	Payload    []byte       `json:"payload"`
+	Signatures []*Signature `json:"signatures,omitempty"`
+}
+
+// Signature represents the headers and signature of a JWS message
+type Signature struct {
+	Headers   Headers `json:"header,omitempty"`    // Unprotected Headers
+	Protected Headers `json:"Protected,omitempty"` // Protected Headers
+	Signature []byte  `json:"signature,omitempty"` // GetSignature
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/jws.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/jws.go
@@ -1,0 +1,209 @@
+// Package jws implements the digital Signature on JSON based data
+// structures as described in https://tools.ietf.org/html/rfc7515
+//
+// If you do not care about the details, the only things that you
+// would need to use are the following functions:
+//
+//     jws.SignWithOption(Payload, algorithm, key)
+//     jws.Verify(encodedjws, algorithm, key)
+//
+// To sign, simply use `jws.SignWithOption`. `Payload` is a []byte buffer that
+// contains whatever data you want to sign. `alg` is one of the
+// jwa.SignatureAlgorithm constants from package jwa. For RSA and
+// ECDSA family of algorithms, you will need to prepare a private key.
+// For HMAC family, you just need a []byte value. The `jws.SignWithOption`
+// function will return the encoded JWS message on success.
+//
+// To verify, use `jws.Verify`. It will parse the `encodedjws` buffer
+// and verify the result using `algorithm` and `key`. Upon successful
+// verification, the original Payload is returned, so you can work on it.
+package jws
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwk"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jws/sign"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jws/verify"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// SignLiteral generates a Signature for the given Payload and Headers, and serializes
+// it in compact serialization format. In this format you may NOT use
+// multiple signers.
+//
+func SignLiteral(payload []byte, alg jwa.SignatureAlgorithm, key interface{}, hdrBuf []byte) ([]byte, error) {
+	encodedHdr := base64.RawURLEncoding.EncodeToString(hdrBuf)
+	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
+	signingInput := strings.Join(
+		[]string{
+			encodedHdr,
+			encodedPayload,
+		}, ".",
+	)
+	signer, err := sign.New(alg)
+	if err != nil {
+		return nil, errors.Wrap(err, `failed to create signer`)
+	}
+	signature, err := signer.Sign([]byte(signingInput), key)
+	if err != nil {
+		return nil, errors.Wrap(err, `failed to sign Payload`)
+	}
+	encodedSignature := base64.RawURLEncoding.EncodeToString(signature)
+	compactSerialization := strings.Join(
+		[]string{
+			signingInput,
+			encodedSignature,
+		}, ".",
+	)
+	return []byte(compactSerialization), nil
+}
+
+// SignWithOption generates a Signature for the given Payload, and serializes
+// it in compact serialization format. In this format you may NOT use
+// multiple signers.
+//
+// If you would like to pass custom Headers, use the WithHeaders option.
+func SignWithOption(payload []byte, alg jwa.SignatureAlgorithm, key interface{}) ([]byte, error) {
+	var headers Headers = &StandardHeaders{}
+
+	err := headers.Set(AlgorithmKey, alg)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to set alg value")
+	}
+
+	hdrBuf, err := json.Marshal(headers)
+	if err != nil {
+		return nil, errors.Wrap(err, `failed to marshal Headers`)
+	}
+	return SignLiteral(payload, alg, key, hdrBuf)
+}
+
+// Verify checks if the given JWS message is verifiable using `alg` and `key`.
+// If the verification is successful, `err` is nil, and the content of the
+// Payload that was signed is returned. If you need more fine-grained
+// control of the verification process, manually call `Parse`, generate a
+// verifier, and call `Verify` on the parsed JWS message object.
+func Verify(buf []byte, alg jwa.SignatureAlgorithm, key interface{}) (ret []byte, err error) {
+
+	verifier, err := verify.New(alg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create verifier")
+	}
+
+	buf = bytes.TrimSpace(buf)
+	if len(buf) == 0 {
+		return nil, errors.New(`attempt to verify empty buffer`)
+	}
+
+	parts, err := SplitCompact(string(buf[:]))
+	if err != nil {
+		return nil, errors.Wrap(err, `failed extract from compact serialization format`)
+	}
+
+	signingInput := strings.Join(
+		[]string{
+			parts[0],
+			parts[1],
+		}, ".",
+	)
+
+	decodedSignature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to decode signature")
+	}
+	if err := verifier.Verify([]byte(signingInput), decodedSignature, key); err != nil {
+		return nil, errors.Wrap(err, "Failed to verify message")
+	}
+
+	if decodedPayload, err := base64.RawURLEncoding.DecodeString(parts[1]); err == nil {
+		return decodedPayload, nil
+	}
+	return nil, errors.Wrap(err, "Failed to decode Payload")
+}
+
+// VerifyWithJWK verifies the JWS message using the specified JWK
+func VerifyWithJWK(buf []byte, key jwk.Key) (payload []byte, err error) {
+
+	keyVal, err := key.Materialize()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to materialize key")
+	}
+	return Verify(buf, key.GetAlgorithm(), keyVal)
+}
+
+// VerifyWithJWKSet verifies the JWS message using JWK key set.
+// By default it will only pick up keys that have the "use" key
+// set to either "sig" or "enc", but you can override it by
+// providing a keyaccept function.
+func VerifyWithJWKSet(buf []byte, keyset *jwk.Set) (payload []byte, err error) {
+
+	for _, key := range keyset.Keys {
+		payload, err := VerifyWithJWK(buf, key)
+		if err == nil {
+			return payload, nil
+		}
+	}
+	return nil, errors.New("failed to verify with any of the keys")
+}
+
+// ParseByte parses a JWS value serialized via compact serialization and provided as []byte.
+func ParseByte(jwsCompact []byte) (m *Message, err error) {
+	return parseCompact(string(jwsCompact[:]))
+}
+
+// ParseString parses a JWS value serialized via compact serialization and provided as string.
+func ParseString(s string) (*Message, error) {
+	return parseCompact(s)
+}
+
+// SplitCompact splits a JWT and returns its three parts
+// separately: Protected Headers, Payload and Signature.
+func SplitCompact(jwsCompact string) ([]string, error) {
+
+	parts := strings.Split(jwsCompact, ".")
+	if len(parts) < 3 {
+		return nil, errors.New("Failed to split compact serialization")
+	}
+	return parts, nil
+}
+
+// parseCompact parses a JWS value serialized via compact serialization.
+func parseCompact(str string) (m *Message, err error) {
+
+	var decodedHeader, decodedPayload, decodedSignature []byte
+	parts, err := SplitCompact(str)
+	if err != nil {
+		return nil, errors.Wrap(err, `invalid compact serialization format`)
+	}
+
+	if decodedHeader, err = base64.RawURLEncoding.DecodeString(parts[0]); err != nil {
+		return nil, errors.Wrap(err, `failed to decode Headers`)
+	}
+	var hdr StandardHeaders
+	if err := json.Unmarshal(decodedHeader, &hdr); err != nil {
+		return nil, errors.Wrap(err, `failed to parse JOSE Headers`)
+	}
+
+	if decodedPayload, err = base64.RawURLEncoding.DecodeString(parts[1]); err != nil {
+		return nil, errors.Wrap(err, `failed to decode Payload`)
+	}
+
+	if len(parts) > 2 {
+		if decodedSignature, err = base64.RawURLEncoding.DecodeString(parts[2]); err != nil {
+			return nil, errors.Wrap(err, `failed to decode Signature`)
+		}
+	}
+
+	var msg Message
+	msg.Payload = decodedPayload
+	msg.Signatures = append(msg.Signatures, &Signature{
+		Protected: &hdr,
+		Signature: decodedSignature,
+	})
+	return &msg, nil
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/message.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/message.go
@@ -1,0 +1,26 @@
+package jws
+
+// PublicHeaders returns the public headers in a JWS
+func (s Signature) PublicHeaders() Headers {
+	return s.Headers
+}
+
+// ProtectedHeaders returns the protected headers in a JWS
+func (s Signature) ProtectedHeaders() Headers {
+	return s.Protected
+}
+
+// GetSignature returns the signature in a JWS
+func (s Signature) GetSignature() []byte {
+	return s.Signature
+}
+
+// GetPayload returns the payload in a JWS
+func (m Message) GetPayload() []byte {
+	return m.Payload
+}
+
+// GetSignatures returns the all signatures in a JWS
+func (m Message) GetSignatures() []*Signature {
+	return m.Signatures
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/sign/ecdsa.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/sign/ecdsa.go
@@ -1,0 +1,83 @@
+package sign
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+
+	"github.com/pkg/errors"
+)
+
+var ecdsaSignFuncs = map[jwa.SignatureAlgorithm]ecdsaSignFunc{}
+
+func init() {
+	algs := map[jwa.SignatureAlgorithm]crypto.Hash{
+		jwa.ES256: crypto.SHA256,
+		jwa.ES384: crypto.SHA384,
+		jwa.ES512: crypto.SHA512,
+	}
+
+	for alg, h := range algs {
+		ecdsaSignFuncs[alg] = makeECDSASignFunc(h)
+	}
+}
+
+func makeECDSASignFunc(hash crypto.Hash) ecdsaSignFunc {
+	return ecdsaSignFunc(func(payload []byte, key *ecdsa.PrivateKey) ([]byte, error) {
+		curveBits := key.Curve.Params().BitSize
+		keyBytes := curveBits / 8
+		// Curve bits do not need to be a multiple of 8.
+		if curveBits%8 > 0 {
+			keyBytes++
+		}
+		h := hash.New()
+		h.Write(payload)
+		r, s, err := ecdsa.Sign(rand.Reader, key, h.Sum(nil))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to sign payload using ecdsa")
+		}
+
+		rBytes := r.Bytes()
+		rBytesPadded := make([]byte, keyBytes)
+		copy(rBytesPadded[keyBytes-len(rBytes):], rBytes)
+
+		sBytes := s.Bytes()
+		sBytesPadded := make([]byte, keyBytes)
+		copy(sBytesPadded[keyBytes-len(sBytes):], sBytes)
+
+		out := append(rBytesPadded, sBytesPadded...)
+		return out, nil
+	})
+}
+
+func newECDSA(alg jwa.SignatureAlgorithm) (*ECDSASigner, error) {
+	signfn, ok := ecdsaSignFuncs[alg]
+	if !ok {
+		return nil, errors.Errorf(`unsupported algorithm while trying to create ECDSA signer: %s`, alg)
+	}
+
+	return &ECDSASigner{
+		alg:  alg,
+		sign: signfn,
+	}, nil
+}
+
+// Algorithm returns the signer algorithm
+func (s ECDSASigner) Algorithm() jwa.SignatureAlgorithm {
+	return s.alg
+}
+
+// Sign signs payload with a ECDSA private key
+func (s ECDSASigner) Sign(payload []byte, key interface{}) ([]byte, error) {
+	if key == nil {
+		return nil, errors.New(`missing private key while signing payload`)
+	}
+
+	privateKey, ok := key.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, errors.Errorf(`invalid key type %T. *ecdsa.PrivateKey is required`, key)
+	}
+
+	return s.sign(payload, privateKey)
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/sign/hmac.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/sign/hmac.go
@@ -1,0 +1,65 @@
+package sign
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha512"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+	"hash"
+
+	"github.com/pkg/errors"
+)
+
+var hmacSignFuncs = map[jwa.SignatureAlgorithm]hmacSignFunc{}
+
+func init() {
+	algs := map[jwa.SignatureAlgorithm]func() hash.Hash{
+		jwa.HS256: sha256.New,
+		jwa.HS384: sha512.New384,
+		jwa.HS512: sha512.New,
+	}
+
+	for alg, h := range algs {
+		hmacSignFuncs[alg] = makeHMACSignFunc(h)
+
+	}
+}
+
+func newHMAC(alg jwa.SignatureAlgorithm) (*HMACSigner, error) {
+	signer, ok := hmacSignFuncs[alg]
+	if !ok {
+		return nil, errors.Errorf(`unsupported algorithm while trying to create HMAC signer: %s`, alg)
+	}
+
+	return &HMACSigner{
+		alg:  alg,
+		sign: signer,
+	}, nil
+}
+
+func makeHMACSignFunc(hfunc func() hash.Hash) hmacSignFunc {
+	return hmacSignFunc(func(payload []byte, key []byte) ([]byte, error) {
+		h := hmac.New(hfunc, key)
+		h.Write(payload)
+		return h.Sum(nil), nil
+	})
+}
+
+// Algorithm returns the signer algorithm
+func (s HMACSigner) Algorithm() jwa.SignatureAlgorithm {
+	return s.alg
+}
+
+// Sign signs payload with a Symmetric  key
+func (s HMACSigner) Sign(payload []byte, key interface{}) ([]byte, error) {
+	hmackey, ok := key.([]byte)
+	if !ok {
+		return nil, errors.Errorf(`invalid key type %T. []byte is required`, key)
+	}
+
+	if len(hmackey) == 0 {
+		return nil, errors.New(`missing key while signing payload`)
+	}
+
+	return s.sign(payload, hmackey)
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/sign/interface.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/sign/interface.go
@@ -1,0 +1,44 @@
+package sign
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+)
+
+// Signer provides a common interface for supported alg signing methods
+type Signer interface {
+	// Sign creates a signature for the given `payload`.
+	// `key` is the key used for signing the payload, and is usually
+	// the private key type associated with the signature method. For example,
+	// for `jwa.RSXXX` and `jwa.PSXXX` types, you need to pass the
+	// `*"crypto/rsa".PrivateKey` type.
+	// Check the documentation for each signer for details
+	Sign(payload []byte, key interface{}) ([]byte, error)
+
+	Algorithm() jwa.SignatureAlgorithm
+}
+
+type rsaSignFunc func([]byte, *rsa.PrivateKey) ([]byte, error)
+
+// RSASigner uses crypto/rsa to sign the payloads.
+type RSASigner struct {
+	alg  jwa.SignatureAlgorithm
+	sign rsaSignFunc
+}
+
+type ecdsaSignFunc func([]byte, *ecdsa.PrivateKey) ([]byte, error)
+
+// ECDSASigner uses crypto/ecdsa to sign the payloads.
+type ECDSASigner struct {
+	alg  jwa.SignatureAlgorithm
+	sign ecdsaSignFunc
+}
+
+type hmacSignFunc func([]byte, []byte) ([]byte, error)
+
+// HMACSigner uses crypto/hmac to sign the payloads.
+type HMACSigner struct {
+	alg  jwa.SignatureAlgorithm
+	sign hmacSignFunc
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/sign/rsa.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/sign/rsa.go
@@ -1,0 +1,96 @@
+package sign
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+
+	"github.com/pkg/errors"
+)
+
+var rsaSignFuncs = map[jwa.SignatureAlgorithm]rsaSignFunc{}
+
+func init() {
+	algs := map[jwa.SignatureAlgorithm]struct {
+		Hash     crypto.Hash
+		SignFunc func(crypto.Hash) rsaSignFunc
+	}{
+		jwa.RS256: {
+			Hash:     crypto.SHA256,
+			SignFunc: makeSignPKCS1v15,
+		},
+		jwa.RS384: {
+			Hash:     crypto.SHA384,
+			SignFunc: makeSignPKCS1v15,
+		},
+		jwa.RS512: {
+			Hash:     crypto.SHA512,
+			SignFunc: makeSignPKCS1v15,
+		},
+		jwa.PS256: {
+			Hash:     crypto.SHA256,
+			SignFunc: makeSignPSS,
+		},
+		jwa.PS384: {
+			Hash:     crypto.SHA384,
+			SignFunc: makeSignPSS,
+		},
+		jwa.PS512: {
+			Hash:     crypto.SHA512,
+			SignFunc: makeSignPSS,
+		},
+	}
+
+	for alg, item := range algs {
+		rsaSignFuncs[alg] = item.SignFunc(item.Hash)
+	}
+}
+
+func makeSignPKCS1v15(hash crypto.Hash) rsaSignFunc {
+	return rsaSignFunc(func(payload []byte, key *rsa.PrivateKey) ([]byte, error) {
+		h := hash.New()
+		h.Write(payload)
+		return rsa.SignPKCS1v15(rand.Reader, key, hash, h.Sum(nil))
+	})
+}
+
+func makeSignPSS(hash crypto.Hash) rsaSignFunc {
+	return rsaSignFunc(func(payload []byte, key *rsa.PrivateKey) ([]byte, error) {
+		h := hash.New()
+		h.Write(payload)
+		return rsa.SignPSS(rand.Reader, key, hash, h.Sum(nil), &rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthAuto,
+		})
+	})
+}
+
+func newRSA(alg jwa.SignatureAlgorithm) (*RSASigner, error) {
+	signfn, ok := rsaSignFuncs[alg]
+	if !ok {
+		return nil, errors.Errorf(`unsupported algorithm while trying to create RSA signer: %s`, alg)
+	}
+	return &RSASigner{
+		alg:  alg,
+		sign: signfn,
+	}, nil
+}
+
+// Algorithm returns the signer algorithm
+func (s RSASigner) Algorithm() jwa.SignatureAlgorithm {
+	return s.alg
+}
+
+// Sign creates a signature using crypto/rsa. key must be a non-nil instance of
+// `*"crypto/rsa".PrivateKey`.
+func (s RSASigner) Sign(payload []byte, key interface{}) ([]byte, error) {
+	if key == nil {
+		return nil, errors.New(`missing private key while signing payload`)
+	}
+	rsakey, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.Errorf(`invalid key type %T. *rsa.PrivateKey is required`, key)
+	}
+
+	return s.sign(payload, rsakey)
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/sign/sign.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/sign/sign.go
@@ -1,0 +1,20 @@
+package sign
+
+import (
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+	"github.com/pkg/errors"
+)
+
+// New creates a signer that signs payloads using the given signature algorithm.
+func New(alg jwa.SignatureAlgorithm) (Signer, error) {
+	switch alg {
+	case jwa.RS256, jwa.RS384, jwa.RS512, jwa.PS256, jwa.PS384, jwa.PS512:
+		return newRSA(alg)
+	case jwa.ES256, jwa.ES384, jwa.ES512:
+		return newECDSA(alg)
+	case jwa.HS256, jwa.HS384, jwa.HS512:
+		return newHMAC(alg)
+	default:
+		return nil, errors.Errorf(`unsupported signature algorithm %s`, alg)
+	}
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/verify/ecdsa.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/verify/ecdsa.go
@@ -1,0 +1,66 @@
+package verify
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"math/big"
+
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+	"github.com/pkg/errors"
+)
+
+var ecdsaVerifyFuncs = map[jwa.SignatureAlgorithm]ecdsaVerifyFunc{}
+
+func init() {
+	algs := map[jwa.SignatureAlgorithm]crypto.Hash{
+		jwa.ES256: crypto.SHA256,
+		jwa.ES384: crypto.SHA384,
+		jwa.ES512: crypto.SHA512,
+	}
+
+	for alg, h := range algs {
+		ecdsaVerifyFuncs[alg] = makeECDSAVerifyFunc(h)
+	}
+}
+
+func makeECDSAVerifyFunc(hash crypto.Hash) ecdsaVerifyFunc {
+	return ecdsaVerifyFunc(func(payload []byte, signature []byte, key *ecdsa.PublicKey) error {
+
+		r, s := &big.Int{}, &big.Int{}
+		n := len(signature) / 2
+		r.SetBytes(signature[:n])
+		s.SetBytes(signature[n:])
+
+		h := hash.New()
+		h.Write(payload)
+
+		if !ecdsa.Verify(key, h.Sum(nil), r, s) {
+			return errors.New(`failed to verify signature using ecdsa`)
+		}
+		return nil
+	})
+}
+
+func newECDSA(alg jwa.SignatureAlgorithm) (*ECDSAVerifier, error) {
+	verifyfn, ok := ecdsaVerifyFuncs[alg]
+	if !ok {
+		return nil, errors.Errorf(`unsupported algorithm while trying to create ECDSA verifier: %s`, alg)
+	}
+
+	return &ECDSAVerifier{
+		verify: verifyfn,
+	}, nil
+}
+
+// Verify checks whether the signature for a given input and key is correct
+func (v ECDSAVerifier) Verify(payload []byte, signature []byte, key interface{}) error {
+	if key == nil {
+		return errors.New(`missing public key while verifying payload`)
+	}
+	ecdsakey, ok := key.(*ecdsa.PublicKey)
+	if !ok {
+		return errors.Errorf(`invalid key type %T. *ecdsa.PublicKey is required`, key)
+	}
+
+	return v.verify(payload, signature, ecdsakey)
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/verify/hmac.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/verify/hmac.go
@@ -1,0 +1,31 @@
+package verify
+
+import (
+	"crypto/hmac"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jws/sign"
+	"github.com/pkg/errors"
+)
+
+func newHMAC(alg jwa.SignatureAlgorithm) (*HMACVerifier, error) {
+
+	s, err := sign.New(alg)
+	if err != nil {
+		return nil, errors.Wrap(err, `failed to generate HMAC signer`)
+	}
+	return &HMACVerifier{signer: s}, nil
+}
+
+// Verify checks whether the signature for a given input and key is correct
+func (v HMACVerifier) Verify(signingInput, signature []byte, key interface{}) (err error) {
+
+	expected, err := v.signer.Sign(signingInput, key)
+	if err != nil {
+		return errors.Wrap(err, `failed to generated signature`)
+	}
+
+	if !hmac.Equal(signature, expected) {
+		return errors.New(`failed to match hmac signature`)
+	}
+	return nil
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/verify/interface.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/verify/interface.go
@@ -1,0 +1,38 @@
+package verify
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jws/sign"
+)
+
+// Verifier provides a common interface for supported alg verification methods
+type Verifier interface {
+	// Verify checks whether the payload and signature are valid for
+	// the given key.
+	// `key` is the key used for verifying the payload, and is usually
+	// the public key associated with the signature method. For example,
+	// for `jwa.RSXXX` and `jwa.PSXXX` types, you need to pass the
+	// `*"crypto/rsa".PublicKey` type.
+	// Check the documentation for each verifier for details
+	Verify(payload []byte, signature []byte, key interface{}) error
+}
+
+type rsaVerifyFunc func([]byte, []byte, *rsa.PublicKey) error
+
+// RSAVerifier implements the Verifier interface
+type RSAVerifier struct {
+	verify rsaVerifyFunc
+}
+
+type ecdsaVerifyFunc func([]byte, []byte, *ecdsa.PublicKey) error
+
+// ECDSAVerifier implements the Verifier interface
+type ECDSAVerifier struct {
+	verify ecdsaVerifyFunc
+}
+
+// HMACVerifier implements the Verifier interface
+type HMACVerifier struct {
+	signer sign.Signer
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/verify/rsa.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/verify/rsa.go
@@ -1,0 +1,87 @@
+package verify
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+
+	"github.com/pkg/errors"
+)
+
+var rsaVerifyFuncs = map[jwa.SignatureAlgorithm]rsaVerifyFunc{}
+
+func init() {
+	algs := map[jwa.SignatureAlgorithm]struct {
+		Hash       crypto.Hash
+		VerifyFunc func(crypto.Hash) rsaVerifyFunc
+	}{
+		jwa.RS256: {
+			Hash:       crypto.SHA256,
+			VerifyFunc: makeVerifyPKCS1v15,
+		},
+		jwa.RS384: {
+			Hash:       crypto.SHA384,
+			VerifyFunc: makeVerifyPKCS1v15,
+		},
+		jwa.RS512: {
+			Hash:       crypto.SHA512,
+			VerifyFunc: makeVerifyPKCS1v15,
+		},
+		jwa.PS256: {
+			Hash:       crypto.SHA256,
+			VerifyFunc: makeVerifyPSS,
+		},
+		jwa.PS384: {
+			Hash:       crypto.SHA384,
+			VerifyFunc: makeVerifyPSS,
+		},
+		jwa.PS512: {
+			Hash:       crypto.SHA512,
+			VerifyFunc: makeVerifyPSS,
+		},
+	}
+
+	for alg, item := range algs {
+		rsaVerifyFuncs[alg] = item.VerifyFunc(item.Hash)
+	}
+}
+
+func makeVerifyPKCS1v15(hash crypto.Hash) rsaVerifyFunc {
+	return rsaVerifyFunc(func(payload, signature []byte, key *rsa.PublicKey) error {
+		h := hash.New()
+		h.Write(payload)
+		return rsa.VerifyPKCS1v15(key, hash, h.Sum(nil), signature)
+	})
+}
+
+func makeVerifyPSS(hash crypto.Hash) rsaVerifyFunc {
+	return rsaVerifyFunc(func(payload, signature []byte, key *rsa.PublicKey) error {
+		h := hash.New()
+		h.Write(payload)
+		return rsa.VerifyPSS(key, hash, h.Sum(nil), signature, nil)
+	})
+}
+
+func newRSA(alg jwa.SignatureAlgorithm) (*RSAVerifier, error) {
+	verifyfn, ok := rsaVerifyFuncs[alg]
+	if !ok {
+		return nil, errors.Errorf(`unsupported algorithm while trying to create RSA verifier: %s`, alg)
+	}
+
+	return &RSAVerifier{
+		verify: verifyfn,
+	}, nil
+}
+
+// Verify checks if a JWS is valid.
+func (v RSAVerifier) Verify(payload, signature []byte, key interface{}) error {
+	if key == nil {
+		return errors.New(`missing public key while verifying payload`)
+	}
+	rsaKey, ok := key.(*rsa.PublicKey)
+	if !ok {
+		return errors.Errorf(`invalid key type %T. *rsa.PublicKey is required`, key)
+	}
+
+	return v.verify(payload, signature, rsaKey)
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/verify/verify.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/internal/jwx/jws/verify/verify.go
@@ -1,0 +1,21 @@
+package verify
+
+import (
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwa"
+	"github.com/pkg/errors"
+)
+
+// New creates a new JWS verifier using the specified algorithm
+// and the public key
+func New(alg jwa.SignatureAlgorithm) (Verifier, error) {
+	switch alg {
+	case jwa.RS256, jwa.RS384, jwa.RS512, jwa.PS256, jwa.PS384, jwa.PS512:
+		return newRSA(alg)
+	case jwa.ES256, jwa.ES384, jwa.ES512:
+		return newECDSA(alg)
+	case jwa.HS256, jwa.HS384, jwa.HS512:
+		return newHMAC(alg)
+	default:
+		return nil, errors.Errorf(`unsupported signature algorithm: %s`, alg)
+	}
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/parse_bytes.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/parse_bytes.go
@@ -1,0 +1,155 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/topdown/builtins"
+)
+
+type multiplier int
+
+const (
+	none multiplier = 1
+	kb              = 1000
+	ki              = 1024
+	mb              = kb * 1000
+	mi              = ki * 1024
+	gb              = mb * 1000
+	gi              = mi * 1024
+	tb              = gb * 1000
+	ti              = gi * 1024
+)
+
+// The rune values for 0..9 as well as the period symbol (for parsing floats)
+var numRunes = []rune("0123456789.")
+
+func parseNumBytesError(msg string) error {
+	return fmt.Errorf("%s error: %s", ast.UnitsParseBytes.Name, msg)
+}
+
+func errUnitNotRecognized(unit string) error {
+	return parseNumBytesError(fmt.Sprintf("byte unit %s not recognized", unit))
+}
+
+var (
+	errNoAmount       = parseNumBytesError("no byte amount provided")
+	errIntConv        = parseNumBytesError("could not parse byte amount to integer")
+	errIncludesSpaces = parseNumBytesError("spaces not allowed in resource strings")
+)
+
+func builtinNumBytes(a ast.Value) (ast.Value, error) {
+	var m multiplier
+
+	raw, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	s := formatString(raw)
+
+	if strings.Contains(s, " ") {
+		return nil, errIncludesSpaces
+	}
+
+	numStr, unitStr := extractNumAndUnit(s)
+
+	if numStr == "" {
+		return nil, errNoAmount
+	}
+
+	switch unitStr {
+	case "":
+		m = none
+	case "kb":
+		m = kb
+	case "kib":
+		m = ki
+	case "mb":
+		m = mb
+	case "mib":
+		m = mi
+	case "gb":
+		m = gb
+	case "gib":
+		m = gi
+	case "tb":
+		m = tb
+	case "tib":
+		m = ti
+	default:
+		return nil, errUnitNotRecognized(unitStr)
+	}
+
+	num, err := strconv.Atoi(numStr)
+	if err != nil {
+		return nil, errIntConv
+	}
+
+	total := num * int(m)
+
+	return builtins.IntToNumber(big.NewInt(int64(total))), nil
+}
+
+// Makes the string lower case and removes spaces and quotation marks
+func formatString(s ast.String) string {
+	str := string(s)
+	lower := strings.ToLower(str)
+	return strings.Replace(lower, "\"", "", -1)
+}
+
+// Splits the string into a number string à la "10" or "10.2" and a unit string à la "gb" or "MiB" or "foo". Either
+// can be an empty string (error handling is provided elsewhere).
+func extractNumAndUnit(s string) (string, string) {
+	isNum := func(r rune) (isNum bool) {
+		for _, nr := range numRunes {
+			if nr == r {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	// Returns the index of the first rune that's not a number (or 0 if there are only numbers)
+	getFirstNonNumIdx := func(s string) int {
+		for idx, r := range s {
+			if !isNum(r) {
+				return idx
+			}
+		}
+
+		return 0
+	}
+
+	firstRuneIsNum := func(s string) bool {
+		return isNum(rune(s[0]))
+	}
+
+	firstNonNumIdx := getFirstNonNumIdx(s)
+
+	// The string contains only a number
+	numOnly := firstNonNumIdx == 0 && firstRuneIsNum(s)
+
+	// The string contains only a unit
+	unitOnly := firstNonNumIdx == 0 && !firstRuneIsNum(s)
+
+	if numOnly {
+		return s, ""
+	} else if unitOnly {
+		return "", s
+	} else {
+		return s[0:firstNonNumIdx], s[firstNonNumIdx:]
+	}
+}
+
+func init() {
+	RegisterFunctionalBuiltin1(ast.UnitsParseBytes.Name, builtinNumBytes)
+}

--- a/vendor/github.com/open-policy-agent/opa/topdown/query.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/query.go
@@ -250,8 +250,7 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		runtime:      q.runtime,
 	}
 	q.startTimer(metrics.RegoQueryEval)
-	defer q.stopTimer(metrics.RegoQueryEval)
-	return e.Run(func(e *eval) error {
+	err := e.Run(func(e *eval) error {
 		qr := QueryResult{}
 		e.bindings.Iter(nil, func(k, v *ast.Term) error {
 			qr[k.Value.(ast.Var)] = v
@@ -259,6 +258,8 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		})
 		return iter(qr)
 	})
+	q.stopTimer(metrics.RegoQueryEval)
+	return err
 }
 
 func (q *Query) startTimer(name string) {

--- a/vendor/github.com/open-policy-agent/opa/topdown/save.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/save.go
@@ -41,8 +41,9 @@ func (ss *saveSet) Pop() {
 func (ss *saveSet) Contains(t *ast.Term, b *bindings) bool {
 	if ss != nil {
 		ss.instr.startTimer(partialOpSaveSetContains)
-		defer ss.instr.stopTimer(partialOpSaveSetContains)
-		return ss.contains(t, b)
+		ret := ss.contains(t, b)
+		ss.instr.stopTimer(partialOpSaveSetContains)
+		return ret
 	}
 	return false
 }
@@ -62,8 +63,9 @@ func (ss *saveSet) contains(t *ast.Term, b *bindings) bool {
 func (ss *saveSet) ContainsRecursive(t *ast.Term, b *bindings) bool {
 	if ss != nil {
 		ss.instr.startTimer(partialOpSaveSetContainsRec)
-		defer ss.instr.stopTimer(partialOpSaveSetContainsRec)
-		return ss.containsrec(t, b)
+		ret := ss.containsrec(t, b)
+		ss.instr.stopTimer(partialOpSaveSetContainsRec)
+		return ret
 	}
 	return false
 }

--- a/vendor/github.com/open-policy-agent/opa/topdown/tokens.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/tokens.go
@@ -12,6 +12,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"math/big"
@@ -23,6 +24,8 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/topdown/builtins"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jwk"
+	"github.com/open-policy-agent/opa/topdown/internal/jwx/jws"
 )
 
 var (
@@ -635,7 +638,70 @@ func (header *tokenHeader) valid() bool {
 	return true
 }
 
-// The full verifier/decoder
+func commonBuiltinJWTEncodeSign(inputHeaders, jwsPayload, jwkSrc string) (v ast.Value, err error) {
+
+	keys, err := jwk.ParseString(jwkSrc)
+	if err != nil {
+		return nil, err
+	}
+	key, err := keys.Keys[0].Materialize()
+	if err != nil {
+		return nil, err
+	}
+	if jwk.GetKeyTypeFromKey(key) != keys.Keys[0].GetKeyType() {
+		return nil, fmt.Errorf("JWK derived key type and keyType parameter do not match")
+	}
+
+	standardHeaders := &jws.StandardHeaders{}
+	jwsHeaders := []byte(inputHeaders)
+	err = json.Unmarshal(jwsHeaders, standardHeaders)
+	if err != nil {
+		return nil, err
+	}
+	alg := standardHeaders.GetAlgorithm()
+
+	if (standardHeaders.Type == "" || standardHeaders.Type == "JWT") && !json.Valid([]byte(jwsPayload)) {
+		return nil, fmt.Errorf("type is JWT but payload is not JSON")
+	}
+
+	// process payload and sign
+	var jwsCompact []byte
+	jwsCompact, err = jws.SignLiteral([]byte(jwsPayload), alg, key, jwsHeaders)
+	if err != nil {
+		return nil, err
+	}
+	return ast.String(jwsCompact[:]), nil
+
+}
+
+func builtinJWTEncodeSign(a ast.Value, b ast.Value, c ast.Value) (v ast.Value, err error) {
+
+	jwkSrc := c.String()
+
+	inputHeaders := a.String()
+
+	jwsPayload := b.String()
+
+	return commonBuiltinJWTEncodeSign(inputHeaders, jwsPayload, jwkSrc)
+
+}
+
+func builtinJWTEncodeSignRaw(a ast.Value, b ast.Value, c ast.Value) (v ast.Value, err error) {
+
+	jwkSrc, err := builtins.StringOperand(c, 1)
+	if err != nil {
+		return nil, err
+	}
+	inputHeaders, err := builtins.StringOperand(a, 1)
+	if err != nil {
+		return nil, err
+	}
+	jwsPayload, err := builtins.StringOperand(b, 1)
+	if err != nil {
+		return nil, err
+	}
+	return commonBuiltinJWTEncodeSign(string(inputHeaders), string(jwsPayload), string(jwkSrc))
+}
 
 // Implements full JWT decoding, validation and verification.
 func builtinJWTDecodeVerify(a ast.Value, b ast.Value) (v ast.Value, err error) {
@@ -855,4 +921,6 @@ func init() {
 	RegisterFunctionalBuiltin2(ast.JWTVerifyES256.Name, builtinJWTVerifyES256)
 	RegisterFunctionalBuiltin2(ast.JWTVerifyHS256.Name, builtinJWTVerifyHS256)
 	RegisterFunctionalBuiltin2(ast.JWTDecodeVerify.Name, builtinJWTDecodeVerify)
+	RegisterFunctionalBuiltin3(ast.JWTEncodeSignRaw.Name, builtinJWTEncodeSignRaw)
+	RegisterFunctionalBuiltin3(ast.JWTEncodeSign.Name, builtinJWTEncodeSign)
 }

--- a/vendor/github.com/open-policy-agent/opa/util/backoff.go
+++ b/vendor/github.com/open-policy-agent/opa/util/backoff.go
@@ -9,13 +9,13 @@ import (
 	"time"
 )
 
-// DefaultBackoff returns a delay with an expontential backoff based on the
+// DefaultBackoff returns a delay with an exponential backoff based on the
 // number of retries.
 func DefaultBackoff(base, max float64, retries int) time.Duration {
 	return Backoff(base, max, .2, 1.6, retries)
 }
 
-// Backoff returns a delay with an expontential backoff based on the number of
+// Backoff returns a delay with an exponential backoff based on the number of
 // retries. Same algorithm used in gRPC.
 func Backoff(base, max, jitter, factor float64, retries int) time.Duration {
 	if retries == 0 {

--- a/vendor/github.com/open-policy-agent/opa/util/close.go
+++ b/vendor/github.com/open-policy-agent/opa/util/close.go
@@ -1,6 +1,6 @@
 // Copyright 2018 The OPA Authors.  All rights reserved.
 // Use of this source code is governed by an Apache2
-// license that can be found in the LICENSE file.p
+// license that can be found in the LICENSE file.
 
 package util
 
@@ -14,7 +14,7 @@ import (
 // ensure that the connection is freed. If the body is not read and closed, a
 // leak can occur.
 func Close(resp *http.Response) {
-	if resp != nil {
+	if resp != nil && resp.Body != nil {
 		if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
 			return
 		}

--- a/vendor/github.com/open-policy-agent/opa/version/version.go
+++ b/vendor/github.com/open-policy-agent/opa/version/version.go
@@ -1,0 +1,15 @@
+// Copyright 2016 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package version contains version information that is set at build time.
+package version
+
+// Version information that is displayed by the "version" command and used to
+// identify the version of running instances of OPA.
+var (
+	Version   = ""
+	Vcs       = ""
+	Timestamp = ""
+	Hostname  = ""
+)


### PR DESCRIPTION
Some very recent performance improvements in OPA's innards have an
effect on what we do, as well:

    name                                                                                              old time/op    new time/op    delta
    InitPartialResultV2/default_policies-8                                                               123ms ± 6%      48ms ± 4%  -61.15%  (p=0.000 n=10+10)
    InitPartialResultV2/IsAuthorized(allow)_with_the_result_of_BenchmarkInitPartialResultV2-8            294µs ± 3%     183µs ± 4%  -37.66%  (p=0.000 n=10+10)
    InitPartialResultV2/IsAuthorized(deny)_with_the_result_of_BenchmarkInitPartialResultV2-8             305µs ± 7%     185µs ± 5%  -39.45%  (p=0.000 n=10+10)
    InitPartialResultV2/IsAuthorized(default_deny)_with_the_result_of_BenchmarkInitPartialResultV2-8     297µs ± 5%     192µs ± 9%  -35.48%  (p=0.000 n=10+10)

    name                                                                                              old alloc/op   new alloc/op   delta
    InitPartialResultV2/default_policies-8                                                              23.5MB ± 0%    13.3MB ± 0%  -43.31%  (p=0.000 n=9+10)
    InitPartialResultV2/IsAuthorized(allow)_with_the_result_of_BenchmarkInitPartialResultV2-8           98.0kB ± 0%    79.0kB ± 0%  -19.38%  (p=0.000 n=9+10)
    InitPartialResultV2/IsAuthorized(deny)_with_the_result_of_BenchmarkInitPartialResultV2-8            95.6kB ± 0%    77.5kB ± 0%  -18.88%  (p=0.000 n=10+10)
    InitPartialResultV2/IsAuthorized(default_deny)_with_the_result_of_BenchmarkInitPartialResultV2-8    95.6kB ± 0%    77.5kB ± 0%  -18.89%  (p=0.000 n=10+10)

    name                                                                                              old allocs/op  new allocs/op  delta
    InitPartialResultV2/default_policies-8                                                                906k ± 0%      343k ± 0%  -62.16%  (p=0.000 n=10+10)
    InitPartialResultV2/IsAuthorized(allow)_with_the_result_of_BenchmarkInitPartialResultV2-8            2.49k ± 0%     1.28k ± 0%  -48.53%  (p=0.000 n=10+10)
    InitPartialResultV2/IsAuthorized(deny)_with_the_result_of_BenchmarkInitPartialResultV2-8             2.41k ± 0%     1.24k ± 0%  -48.44%  (p=0.000 n=10+10)
    InitPartialResultV2/IsAuthorized(default_deny)_with_the_result_of_BenchmarkInitPartialResultV2-8     2.41k ± 0%     1.24k ± 0%  -48.44%  (p=0.000 n=10+10)

So, let's pull this in.

---------------

For the curious, [these are the commits](https://github.com/open-policy-agent/opa/compare/7864d60dd78d748dbce54b569e939f5b0dc07486...0d70daa545f5a4bf2e6edf3c1b2d635920299bc9), where it's @koponen-styra's [recent commits focused on performance](https://github.com/open-policy-agent/opa/commits?author=koponen-styra) that brought this about 🎉 