### PR TITLE
Enable control_tag filtering for compliance API calls

### DIFF
--- a/components/compliance-service/api/tests/03_reports_spec.rb
+++ b/components/compliance-service/api/tests/03_reports_spec.rb
@@ -54,6 +54,22 @@ describe File.basename(__FILE__) do
         }.to_json
     assert_equal_json_sorted(expected_json, actual_data.to_json)
 
+    # Get report ids from a date range if they contain at least one control tagged 'web'
+    actual_data = GRPC reporting, :list_report_ids, Reporting::Query.new(filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T00:00:00Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-04-01T00:00:00Z']),
+        Reporting::ListFilter.new(type: 'control_tag:web', values: []),
+    ])
+    expected_json =
+        {
+            "ids" => ["44024b50-2e0d-42fa-a57c-dddddddddddd",
+                      "bb93e1b2-36d6-439e-ac70-cccccccccc04",
+                      "3ca95021-84c1-43a6-a2e7-wwwwwwwwwwww",
+                      "bb93e1b2-36d6-439e-ac70-cccccccccc09"
+            ]
+        }.to_json
+    assert_equal_json_sorted(expected_json, actual_data.to_json)
+
     # Get all until march 4th up to and including beginning of day
     actual_data = GRPC reporting, :list_report_ids, Reporting::Query.new(filters: [
         Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T00:00:00Z'])
@@ -410,6 +426,55 @@ describe File.basename(__FILE__) do
             }
         ],
         "total" => 1
+    }.to_json
+    assert_equal_json_sorted(expected_json, actual_data.to_json)
+
+    # Get reports based on control tag filter
+    actual_data = GRPC reporting, :list_reports, Reporting::Query.new(filters: [
+      Reporting::ListFilter.new(type: 'control_tag:scope', values: ['NGI*'])
+    ])
+    expected_json = {
+        "reports" => [
+          {
+              "id" => "bb93e1b2-36d6-439e-ac70-cccccccccc04",
+              "nodeId" => "9b9f4e51-b049-4b10-9555-10578916e149",
+              "nodeName" => "centos-beta",
+              "endTime" => "2018-03-04T09:18:41Z",
+              "status" => "passed",
+              "controls" => {
+                  "total" => 18,
+                  "passed" => {
+                      "total" => 3
+                  },
+                  "skipped" => {
+                      "total" => 15
+                  },
+                  "failed" => {}
+              }
+          },
+          {
+            "endTime" => "2018-03-04T09:18:43Z",
+            "id" => "bb93e1b2-36d6-439e-ac70-cccccccccc09",
+            "nodeId" => "9b9f4e51-b049-4b10-9555-10578916e222",
+            "nodeName" => "RedHat(2)-beta-nginx(f)-apache(s)-failed",
+            "status" => "failed",
+            "controls" => {
+              "failed" => {
+                "critical" => 1,
+                "major" => 1,
+                "total" => 2
+              },
+              "passed" => {
+                "total" => 1
+              },
+              "skipped" => {
+                "total" => 15
+              },
+              "total" => 18
+            }
+          }
+        ],
+        "total" => 2
     }.to_json
     assert_equal_json_sorted(expected_json, actual_data.to_json)
 

--- a/components/compliance-service/api/tests/04_stats_spec.rb
+++ b/components/compliance-service/api/tests/04_stats_spec.rb
@@ -22,7 +22,7 @@ if !ENV['NO_STATS_TESTS']
       end
 
       ##### Success tests #####
-      # Failure by platform
+      # Failures by platform
       actual_data = GRPC stats, :read_failures, Stats::Query.new(filters: [
         Stats::ListFilter.new(type: "types", values: ["platform"]),
         Stats::ListFilter.new(type: 'end_time', values: ['2018-02-09T23:59:59Z'])
@@ -125,6 +125,27 @@ if !ENV['NO_STATS_TESTS']
       }
       assert_equal_json_content(expected_data, actual_data)
 
+      # Get both failures by environment and platform with control tag filter
+      actual_data = GRPC stats, :read_failures, Stats::Query.new(filters: [
+        Stats::ListFilter.new(type: "types", values: ["environment", "platform"]),
+        Stats::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
+        Stats::ListFilter.new(type: 'control_tag:web', values: [])
+      ])
+      expected_data = {
+        "platforms" => [
+          {
+            "name" => "redhat",
+            "failures" => 1
+          }
+        ],
+        "environments" => [
+          {
+            "name"=>"DevSec Prod beta",
+            "failures" => 1
+          }
+        ]
+      }
+      assert_equal_json_content(expected_data, actual_data)
 
       # todo - this one is in the deep test: 04_deep_stats_spec.rb::test3::line:57
       # Get failures by profile

--- a/components/compliance-service/api/tests/05_stats_summary_spec.rb
+++ b/components/compliance-service/api/tests/05_stats_summary_spec.rb
@@ -72,6 +72,23 @@ if !ENV['NO_STATS_SUMMARY_TESTS']
       }.to_json
       assert_equal(expected_data, actual_data.to_json)
 
+      # Filter by control tag
+      actual_data = GRPC stats, :read_summary, Stats::Query.new(filters: [
+        Stats::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
+        Stats::ListFilter.new(type: 'control_tag:scope', values: ['nginx', 'Apache'])
+      ])
+      expected_data = {
+        "reportSummary" => {
+          "status" => "failed",
+          "stats" => {
+            "nodes" => 3,
+            "platforms" => 3,
+            "environments" => 2,
+            "profiles" => 3
+          }
+        }
+      }.to_json
+      assert_equal(expected_data, actual_data.to_json)
 
       # Filter by job_id
       actual_data = GRPC stats, :read_summary, Stats::Query.new(filters: [

--- a/components/compliance-service/api/tests/06_stats_trend_spec.rb
+++ b/components/compliance-service/api/tests/06_stats_trend_spec.rb
@@ -101,7 +101,6 @@ if !ENV['NO_STATS_TREND_TESTS']
               Stats::ListFilter.new(type: "environment", values: ['DevSec Prod Zeta'])
           ]
       )
-      #Bunching the data up as shown below, helps in it's readability. See how the numbers pop out at you?
       expected_data = {
           "trends" => [
               {"reportTime" => "2018-02-08T23:59:59Z"},
@@ -120,6 +119,52 @@ if !ENV['NO_STATS_TREND_TESTS']
           ]
       }.to_json
       assert_equal(expected_data, actual_data.to_json)
+
+
+      # The whole range. For nodes
+      # Filter: control tag with key 'web'
+      # should have zeroes on the bookends, some numbers on 2/9, 3/4 and zeroes in between.
+      actual_data = GRPC stats, :read_trend, Stats::Query.new(
+          type: "nodes",
+          interval: 86400,
+          filters: [
+              Stats::ListFilter.new(type: "start_time", values: ['2018-02-09T00:00:00Z']),
+              Stats::ListFilter.new(type: "end_time", values: ["2018-03-05T#{END_OF_DAY}"]),
+              Stats::ListFilter.new(type: 'control_tag:web', values: [])
+          ]
+      )
+      #Bunching the data up as shown below, helps in it's readability. See how the numbers pop out at you?
+      expected_data = {
+        "trends":[
+          {"reportTime":"2018-02-09T23:59:59Z", "failed":1},
+          {"reportTime":"2018-02-10T23:59:59Z"},
+          {"reportTime":"2018-02-11T23:59:59Z"},
+          {"reportTime":"2018-02-12T23:59:59Z"},
+          {"reportTime":"2018-02-13T23:59:59Z"},
+          {"reportTime":"2018-02-14T23:59:59Z"},
+          {"reportTime":"2018-02-15T23:59:59Z"},
+          {"reportTime":"2018-02-16T23:59:59Z"},
+          {"reportTime":"2018-02-17T23:59:59Z"},
+          {"reportTime":"2018-02-18T23:59:59Z"},
+          {"reportTime":"2018-02-19T23:59:59Z"},
+          {"reportTime":"2018-02-20T23:59:59Z"},
+          {"reportTime":"2018-02-21T23:59:59Z"},
+          {"reportTime":"2018-02-22T23:59:59Z"},
+          {"reportTime":"2018-02-23T23:59:59Z"},
+          {"reportTime":"2018-02-24T23:59:59Z"},
+          {"reportTime":"2018-02-25T23:59:59Z"},
+          {"reportTime":"2018-02-26T23:59:59Z"},
+          {"reportTime":"2018-02-27T23:59:59Z"},
+          {"reportTime":"2018-02-28T23:59:59Z"},
+          {"reportTime":"2018-03-01T23:59:59Z"},
+          {"reportTime":"2018-03-02T23:59:59Z"},
+          {"reportTime":"2018-03-03T23:59:59Z"},
+          {"reportTime":"2018-03-04T23:59:59Z", "passed":1, "failed":1, "skipped":1},
+          {"reportTime":"2018-03-05T23:59:59Z"}
+        ]
+      }.to_json
+      assert_equal(expected_data, actual_data.to_json)
+
 
       # The whole range. for controls
       # Filter: environment="DevSec Prod Zeta"

--- a/components/compliance-service/api/tests/07_suggestions_w_filters_spec.rb
+++ b/components/compliance-service/api/tests/07_suggestions_w_filters_spec.rb
@@ -150,6 +150,17 @@ describe File.basename(__FILE__) do
     )
     assert_suggestions_text(["DevSec Prod Alpha", "DevSec Prod beta", "DevSec Prod Zeta"], actual_data)
 
+    # suggest nodes, when we have control_tag and time filters
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+      type: 'node',
+      text: 'Beta',
+      filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-28T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'control_tag:scope', values: ['nginx'])
+      ]
+    )
+    assert_suggestions_text(["RedHat(2)-beta-nginx(f)-apache(s)-failed", "centos-beta"], actual_data)
 
     # suggest roles with valid filters
     actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(

--- a/components/compliance-service/api/tests/08_search_profiles_spec.rb
+++ b/components/compliance-service/api/tests/08_search_profiles_spec.rb
@@ -248,6 +248,42 @@ describe File.basename(__FILE__) do
     }.to_json
     assert_equal(expected_data, actual_data.to_json)
 
+    # Get profiles used in reports where control tags scope:apache or scope:nginx are used
+    actual_data = GRPC reporting, :list_profiles, Reporting::Query.new(filters: [
+        Reporting::ListFilter.new(type: 'control_tag:scope', values: ['apache', 'nginx']),
+        Reporting::ListFilter.new(type: "end_time", values: ["2018-03-04T#{END_OF_DAY}"])
+    ])
+    expected_data = {
+        "profiles" => [
+            {
+                "name" => "fake-baseline",
+                "title" => "A fake one",
+                "id" => "41a02797bfea15592ba2748d55929d8d1f9da205816ef18d3bb2ebe4c5ce18a9",
+                "version" => "2.0.1",
+                "status" => "skipped"
+            },
+            {
+                "name" => "apache-baseline",
+                "title" => "DevSec Apache Baseline",
+                "id" => "41a02784bfea15592ba2748d55927d8d1f9da205816ef18d3bb2ebe4c5ce18a9",
+                "version" => "2.0.1",
+                "status" => "skipped"
+            },
+            {
+                "name" => "nginx-baseline",
+                "title" => "DevSec Nginx Baseline",
+                "id" => "09adcbb3b9b3233d5de63cd98a5ba3e155b3aaeb66b5abed379f5fb1ff143988",
+                "version" => "2.1.0",
+                "status" => "failed"
+            }
+        ],
+        "counts" => {
+            "total" => 3,
+            "failed" => 1,
+            "skipped" => 2
+        }
+    }.to_json
+    assert_equal(expected_data, actual_data.to_json)
 
     # Filter by job_id which exists on this date
     actual_data = GRPC reporting, :list_profiles, Reporting::Query.new(filters: [

--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -657,6 +657,15 @@ func (backend ES2Backend) getFiltersQuery(filters map[string][]string, latestOnl
 		boolQuery = boolQuery.Must(termQuery)
 	}
 
+	// Going through all filters to find the ones prefixed with 'control_tag', e.g. 'control_tag:nist'
+	for filterType, _ := range filters {
+		if strings.HasPrefix(filterType, "control_tag") {
+			_, tagKey := leftSplit(filterType, ":")
+			termQuery := backend.newNestedTermQueryFromControlTagsFilter(tagKey, filters[filterType])
+			boolQuery = boolQuery.Must(termQuery)
+		}
+	}
+
 	return boolQuery
 }
 
@@ -711,17 +720,17 @@ func (backend ES2Backend) newTermQueryFromFilter(ESField string,
 }
 
 func (backend ES2Backend) newNestedTermQueryFromFilter(ESField string, ESFieldPath string,
-	filters []string) *elastic.BoolQuery {
+	filterValues []string) *elastic.BoolQuery {
 	refinedValues := make([]string, 0, 0)
 	filterQuery := elastic.NewBoolQuery()
 
-	for _, value := range filters {
-		if containsWildcardChar(value) {
-			wildQuery := elastic.NewWildcardQuery(ESField, value)
+	for _, filterValue := range filterValues {
+		if containsWildcardChar(filterValue) {
+			wildQuery := elastic.NewWildcardQuery(ESField, filterValue)
 			nestedQuery := elastic.NewNestedQuery(ESFieldPath, wildQuery)
 			filterQuery = filterQuery.Should(nestedQuery)
 		} else {
-			refinedValues = append(refinedValues, value)
+			refinedValues = append(refinedValues, filterValue)
 		}
 	}
 	if len(refinedValues) > 0 {
@@ -731,6 +740,48 @@ func (backend ES2Backend) newNestedTermQueryFromFilter(ESField string, ESFieldPa
 	}
 
 	return filterQuery
+}
+
+// Returns an ElasticSearch nested query to filter reports by control tags
+func (backend ES2Backend) newNestedTermQueryFromControlTagsFilter(tagKey string, tagValues []string) *elastic.NestedQuery {
+	refinedValues := make([]string, 0, 0)
+	ESFieldPath := "profiles.controls.string_tags"
+	ESFieldTagKey := "profiles.controls.string_tags.key.lower"
+	ESFieldTagValues := "profiles.controls.string_tags.values.lower"
+
+	// Add ElasticSearch query filter for the control tag key
+	tagKey = strings.ToLower(tagKey)
+	boolQuery := elastic.NewBoolQuery()
+	if containsWildcardChar(tagKey) {
+		boolQuery.Must(elastic.NewWildcardQuery(ESFieldTagKey, tagKey))
+	} else {
+		boolQuery.Must(elastic.NewTermsQuery(ESFieldTagKey, tagKey))
+	}
+
+	// Add ElasticSearch query filters for the control tag value(s)
+	insideBoolQuery := elastic.NewBoolQuery()
+	insideBool := false
+	for _, tagValue := range tagValues {
+		tagValue = strings.ToLower(tagValue)
+		if containsWildcardChar(tagValue) {
+			insideBoolQuery.Should(elastic.NewWildcardQuery(ESFieldTagValues, tagValue))
+			insideBool = true
+		} else {
+			refinedValues = append(refinedValues, tagValue)
+		}
+	}
+	// Here we handle control tag value(s) without wildcard characters
+	if len(refinedValues) > 0 {
+		termQuery := elastic.NewTermsQuery(ESFieldTagValues, stringArrayToInterfaceArray(refinedValues)...)
+		insideBoolQuery.Should(termQuery)
+		insideBool = true
+	}
+	if insideBool {
+		boolQuery.Must(insideBoolQuery)
+	}
+
+	nestedQuery := elastic.NewNestedQuery(ESFieldPath, boolQuery)
+	return nestedQuery
 }
 
 func containsWildcardChar(value string) bool {

--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -126,36 +126,6 @@ func (backend ES2Backend) getNodeReportIdsFromTimeseries(esIndex string,
 		}
 	}
 
-	//When filtering by controls, we are reducing the array of report ids based on
-	// another query on inspec_report documents where we have control ids
-	if len(filters["control"]) > 0 {
-		esIndex, err := GetEsIndex(filters, false, false)
-		if err != nil {
-			return nil, errors.Wrap(err, "getNodeReportIdsFromTimeseries unable to GetEsIndex")
-		}
-		filteredReportIds, err := backend.filterIdsByControl(esIndex, MapValues(nodeReport), filters["control"])
-		if err != nil {
-			return []string{}, errors.Wrap(err, "getNodeReportIdsFromTimeseries unable to filter ids by "+
-				"control")
-		}
-		logrus.Debugf("getNodeReportIdsFromTimeseries control filtering, len(nodeReport)=%d, "+
-			"len(filteredNodeIds)=%d\n", len(nodeReport), len(filteredReportIds))
-
-		//flipping map[nodeid][reportid] to map[reportid][nodeid] for quicker lookups, to avoid an expensive O(n^2)
-		// Contains(filteredReportIds, reportId) call
-		reportNode := make(map[string]string, len(nodeReport))
-		for nodeID, reportID := range nodeReport {
-			reportNode[reportID] = nodeID
-		}
-
-		// filtering out the nodes for which the report id is no longer in filteredReportIds
-		filteredNodeReport := make(map[string]string, len(filteredReportIds))
-		for _, reportID := range filteredReportIds {
-			filteredNodeReport[reportNode[reportID]] = reportID
-		}
-		nodeReport = filteredNodeReport
-	}
-
 	reportIds := MapValues(nodeReport)
 
 	logrus.Debugf("getNodeReportIdsFromTimeseries returning %d report ids in %d milliseconds\n",

--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -629,7 +629,7 @@ func (backend ES2Backend) getFiltersQuery(filters map[string][]string, latestOnl
 
 	// Going through all filters to find the ones prefixed with 'control_tag', e.g. 'control_tag:nist'
 	for filterType := range filters {
-		if strings.HasPrefix(filterType, "control_tag") {
+		if strings.HasPrefix(filterType, "control_tag:") {
 			_, tagKey := leftSplit(filterType, ":")
 			termQuery := backend.newNestedTermQueryFromControlTagsFilter(tagKey, filters[filterType])
 			boolQuery = boolQuery.Must(termQuery)

--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -658,7 +658,7 @@ func (backend ES2Backend) getFiltersQuery(filters map[string][]string, latestOnl
 	}
 
 	// Going through all filters to find the ones prefixed with 'control_tag', e.g. 'control_tag:nist'
-	for filterType, _ := range filters {
+	for filterType := range filters {
 		if strings.HasPrefix(filterType, "control_tag") {
 			_, tagKey := leftSplit(filterType, ":")
 			termQuery := backend.newNestedTermQueryFromControlTagsFilter(tagKey, filters[filterType])

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -69,7 +69,7 @@ func (backend ES2Backend) GetSuggestions(typeParam string, filters map[string][]
 		useSummaryIndex = false
 	} else {
 		// Going through all filters to find the ones prefixed with 'control_tag', e.g. 'control_tag:nist'
-		for filterType, _ := range filters {
+		for filterType := range filters {
 			if strings.HasPrefix(filterType, "control_tag") {
 				useSummaryIndex = false
 				break

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -70,7 +70,7 @@ func (backend ES2Backend) GetSuggestions(typeParam string, filters map[string][]
 	} else {
 		// Going through all filters to find the ones prefixed with 'control_tag', e.g. 'control_tag:nist'
 		for filterType := range filters {
-			if strings.HasPrefix(filterType, "control_tag") {
+			if strings.HasPrefix(filterType, "control_tag:") {
 				useSummaryIndex = false
 				break
 			}
@@ -226,10 +226,6 @@ func (backend ES2Backend) getAggSuggestions(client *elastic.Client, typeParam st
 }
 
 func (backend ES2Backend) getArrayAggSuggestions(client *elastic.Client, typeParam string, target string, text string, size int, filters map[string][]string, useSummaryIndex bool) ([]*reportingapi.Suggestion, error) {
-	//here, we base our decision on which index set (det or summary) to use for querying suggestions
-	// the reason this is necessary is in the where a control has already been added to the query and therefore
-	// the query needs to dive down to the control depth.. requiring the detailed indices.
-	// in other words, only use summary here if there are no controls in the filter
 	esIndex, err := GetEsIndex(filters, useSummaryIndex, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "getArrayAggSuggestions unable to get index dates")

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -60,15 +60,32 @@ func (backend ES2Backend) GetSuggestions(typeParam string, filters map[string][]
 		filters[typeParam] = []string{}
 	}
 
+	//here, we base our decision on which index set (det or summary) to use for querying suggestions
+	// the reason this is necessary is in the where a control has already been added to the query and therefore
+	// the query needs to dive down to the control depth.. requiring the detailed indices.
+	// in other words, only use summary here if there are no 'control' or 'control_tag' filters
+	useSummaryIndex := true
+	if len(filters["control"]) > 0 {
+		useSummaryIndex = false
+	} else {
+		// Going through all filters to find the ones prefixed with 'control_tag', e.g. 'control_tag:nist'
+		for filterType, _ := range filters {
+			if strings.HasPrefix(filterType, "control_tag") {
+				useSummaryIndex = false
+				break
+			}
+		}
+	}
+
 	suggs := make([]*reportingapi.Suggestion, 0)
 	if typeParam == "profile" {
-		suggs, err = backend.getProfileSuggestions(client, typeParam, target, text, size, filters)
+		suggs, err = backend.getProfileSuggestions(client, typeParam, target, text, size, filters, useSummaryIndex)
 	} else if typeParam == "control" {
 		suggs, err = backend.getControlSuggestions(client, typeParam, target, text, size, filters)
 	} else if suggestionFieldArray(typeParam) {
-		suggs, err = backend.getArrayAggSuggestions(client, typeParam, target, text, size, filters)
+		suggs, err = backend.getArrayAggSuggestions(client, typeParam, target, text, size, filters, useSummaryIndex)
 	} else {
-		suggs, err = backend.getAggSuggestions(client, typeParam, target, text, size, filters)
+		suggs, err = backend.getAggSuggestions(client, typeParam, target, text, size, filters, useSummaryIndex)
 	}
 
 	if err != nil {
@@ -105,12 +122,8 @@ func suggestionFieldArray(field string) bool {
 	}
 }
 
-func (backend ES2Backend) getAggSuggestions(client *elastic.Client, typeParam string, target string, text string, size int, filters map[string][]string) ([]*reportingapi.Suggestion, error) {
-	//here, we base our decision on which index set (det or summary) to use for querying suggestions
-	// the reason this is necessary is in the where a control has already been added to the query and therefore
-	// the query needs to dive down to the control depth.. requiring the detailed indices.
-	// in other words, only use summary here if there are no controls in the filter
-	esIndex, err := GetEsIndex(filters, len(filters["control"]) == 0, true)
+func (backend ES2Backend) getAggSuggestions(client *elastic.Client, typeParam string, target string, text string, size int, filters map[string][]string, useSummaryIndex bool) ([]*reportingapi.Suggestion, error) {
+	esIndex, err := GetEsIndex(filters, useSummaryIndex, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "getAggSuggestions unable to get index dates")
 	}
@@ -212,12 +225,12 @@ func (backend ES2Backend) getAggSuggestions(client *elastic.Client, typeParam st
 	return suggs, nil
 }
 
-func (backend ES2Backend) getArrayAggSuggestions(client *elastic.Client, typeParam string, target string, text string, size int, filters map[string][]string) ([]*reportingapi.Suggestion, error) {
+func (backend ES2Backend) getArrayAggSuggestions(client *elastic.Client, typeParam string, target string, text string, size int, filters map[string][]string, useSummaryIndex bool) ([]*reportingapi.Suggestion, error) {
 	//here, we base our decision on which index set (det or summary) to use for querying suggestions
 	// the reason this is necessary is in the where a control has already been added to the query and therefore
 	// the query needs to dive down to the control depth.. requiring the detailed indices.
 	// in other words, only use summary here if there are no controls in the filter
-	esIndex, err := GetEsIndex(filters, len(filters["control"]) == 0, true)
+	esIndex, err := GetEsIndex(filters, useSummaryIndex, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "getArrayAggSuggestions unable to get index dates")
 	}
@@ -294,10 +307,10 @@ func (backend ES2Backend) getArrayAggSuggestions(client *elastic.Client, typePar
 	return finalSuggs, nil
 }
 
-func (backend ES2Backend) getProfileSuggestions(client *elastic.Client, typeParam string, target string, text string, size int, filters map[string][]string) ([]*reportingapi.Suggestion, error) {
+func (backend ES2Backend) getProfileSuggestions(client *elastic.Client, typeParam string, target string, text string, size int, filters map[string][]string, useSummaryIndex bool) ([]*reportingapi.Suggestion, error) {
 	//the reason we may use summary index here is because we always throw away the current profile filter when
 	// getting a suggestion for profile.. if we didn't then we'd only ever see the filter that's in our filter!
-	esIndex, err := GetEsIndex(filters, len(filters["control"]) == 0, true)
+	esIndex, err := GetEsIndex(filters, useSummaryIndex, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "getProfileSuggestions unable to get index dates")
 	}

--- a/components/compliance-service/reporting/relaxting/util.go
+++ b/components/compliance-service/reporting/relaxting/util.go
@@ -96,8 +96,18 @@ func Remove(arr *[]string, i int) {
 	*arr = s
 }
 
+// Splits a string by its rightmost delimiter
 func rightSplit(stringToSplit string, delimiter string) (string, string) {
 	n := strings.LastIndex(stringToSplit, delimiter)
+	if n >= 0 {
+		return stringToSplit[0:n], stringToSplit[n+1:]
+	}
+	return stringToSplit, ""
+}
+
+// Splits a string by its leftmost delimiter
+func leftSplit(stringToSplit string, delimiter string) (string, string) {
+	n := strings.Index(stringToSplit, delimiter)
 	if n >= 0 {
 		return stringToSplit[0:n], stringToSplit[n+1:]
 	}

--- a/components/compliance-service/reporting/relaxting/util_test.go
+++ b/components/compliance-service/reporting/relaxting/util_test.go
@@ -53,6 +53,16 @@ func TestRightSplit(t *testing.T) {
 	assert.Equal(t, "ng", right)
 }
 
+func TestLeftSplit(t *testing.T) {
+	left, right := leftSplit("something", "|")
+	assert.Equal(t, "something", left)
+	assert.Equal(t, "", right)
+
+	left, right = leftSplit("some|thi|ng", "|")
+	assert.Equal(t, "some", left)
+	assert.Equal(t, "thi|ng", right)
+}
+
 func TestRemove(t *testing.T) {
 	arr := []string{"item1", "item2"}
 	Remove(&arr, 1)

--- a/components/compliance-service/test_data/audit_reports/2018-02-09_debian(2)-zeta-linux(f)-apache(p)-failed.json
+++ b/components/compliance-service/test_data/audit_reports/2018-02-09_debian(2)-zeta-linux(f)-apache(p)-failed.json
@@ -86,7 +86,7 @@
       "controls": [
         {
           "id": "os-01",
-          "code": "control 'os-01' do\n  impact 1.0\n  title 'Trusted hosts login'\n  desc \"Rhosts/hosts.equiv files are a weak implemenation of authentication. Disabling the .rhosts and hosts.equiv support helps to prevent users from subverting the system's normal access control mechanisms of the system.\"\n  describe command('find / -name \\'.rhosts\\'') do\n    its('stdout') { should be_empty }\n  end\n  describe command('find / -name \\'hosts.equiv\\' ') do\n    its('stdout') { should be_empty }\n  end\nend\n",
+          "code": "control 'os-01' do\n  impact 1.0\n  title 'Trusted hosts login'\n  desc \"Rhosts/hosts.equiv files are a weak implemenation of authentication. Disabling the .rhosts and hosts.equiv support helps to prevent users from subverting the system's normal access control mechanisms of the system.\"\n  describe command('find / -name \\'.rhosts\\'') do\n    its('stdout') { should be_empty }\n  end\n  describe command('find / -name \\'hosts.equiv\\' ') do\n    its('stdout') { should be_empty }\n  end\n  tag 'web'\n  tag 'scope': 'OS'\n  tag 'gtitle': 'TitleVal'\n  tag 'satisfies': ['SRG-00006', 'SRG-00007']\n  tag 'stig_id': 'RHEL-07-010050'\n  tag 'cci': ['CCI-000048']\n  tag 'hashhash': { \"bad.one\": [6] }\n  tag 'documentable': false\n  tag 'our_criticality': 8\nend\n  ",
           "desc": "Rhosts/hosts.equiv files are a weak implemenation of authentication. Disabling the .rhosts and hosts.equiv support helps to prevent users from subverting the system's normal access control mechanisms of the system.",
           "descriptions": [
             {
@@ -110,20 +110,20 @@
           },
           "refs": [],
           "tags": {
-            "firewall": null,
-            "gtitle": "SRG-OS-000023-GPOS-00006",
+            "web": null,
+            "scope": "OS",
+            "gtitle": "TitleVal",
             "satisfies": [
-              "SRG-OS-000023-GPOS-00006",
-              "SRG-OS-000024-GPOS-00007"
+              "SRG-00006",
+              "SRG-00007"
             ],
             "stig_id": "RHEL-07-010050",
-            "cci": [
-              "CCI-000048"
-            ],
+            "cci": ["CCI-000048"],
             "hashhash": {
               "bad.one": [6]
             },
-            "documentable": false
+            "documentable": false,
+            "our_criticality": 8
           },
           "results": [
             {
@@ -140,7 +140,7 @@
         },
         {
           "id": "os-02",
-          "code": "control 'os-02' do\n  impact 1.0\n  title 'Check owner and permissions for /etc/shadow'\n  desc 'Check periodically the owner and permissions for /etc/shadow'\n  describe file('/etc/shadow') do\n    it { should exist }\n    it { should be_file }\n    it { should be_owned_by 'root' }\n    its('group') { should eq 'root' }\n    it { should_not be_executable }\n    it { should be_writable.by('owner') }\n    it { should be_readable.by('owner') }\n    it { should_not be_readable.by('group') }\n    it { should_not be_readable.by('other') }\n  end\nend\n",
+          "code": "control 'os-02' do\n  impact 1.0\n  title 'Check owner and permissions for /etc/shadow'\n  desc 'Check periodically the owner and permissions for /etc/shadow'\n  describe file('/etc/shadow') do\n    it { should exist }\n    it { should be_file }\n    it { should be_owned_by 'root' }\n    its('group') { should eq 'root' }\n    it { should_not be_executable }\n    it { should be_writable.by('owner') }\n    it { should be_readable.by('owner') }\n    it { should_not be_readable.by('group') }\n    it { should_not be_readable.by('other') }\n  end\n  tag 'tag1': 'value1'\nend\n",
           "desc": "Check periodically the owner and permissions for /etc/shadow",
           "impact": 1,
           "title": "Check owner and permissions for /etc/shadow",

--- a/components/compliance-service/test_data/audit_reports/2018-03-04_centos(3)-beta-nginx(p)-apache(s)-fake(s)-passed.json
+++ b/components/compliance-service/test_data/audit_reports/2018-03-04_centos(3)-beta-nginx(p)-apache(s)-fake(s)-passed.json
@@ -67,8 +67,11 @@
           "desc": "The NGINX worker processes should run as non-privileged user. In case of compromise of the process, an attacker has full access to the system.",
           "impact": 1,
           "refs": [],
-          "tags": {},
-          "code": "control 'nginx-01' do\n  impact 1.0\n  title 'Running worker process as non-privileged user'\n  desc 'The NGINX worker processes should run as non-privileged user. In case of compromise of the process, an attacker has full access to the system.'\n  describe user(nginx_lib.valid_users) do\n    it { should exist }\n  end\n  describe parse_config_file(nginx_conf, options) do\n    its('user') { should eq nginx_lib.valid_users }\n  end\n\n  describe parse_config_file(nginx_conf, options) do\n    its('group') { should_not eq 'root' }\n  end\nend\n",
+          "tags": {
+            "web": null,
+            "scope": "NginX"
+          },
+          "code": "control 'nginx-01' do\n  impact 1.0\n  title 'Running worker process as non-privileged user'\n  desc 'The NGINX worker processes should run as non-privileged user. In case of compromise of the process, an attacker has full access to the system.'\n  describe user(nginx_lib.valid_users) do\n    it { should exist }\n  end\n  describe parse_config_file(nginx_conf, options) do\n    its('user') { should eq nginx_lib.valid_users }\n  end\n\n  describe parse_config_file(nginx_conf, options) do\n    its('group') { should_not eq 'root' }\n  end\n  tag 'web'\n  tag 'scope': 'NginX'\nend\n",
           "source_location": {
             "line": 99,
             "ref": "nginx-baseline-master/controls/nginx_spec.rb"
@@ -163,7 +166,7 @@
       "controls": [
         {
           "id": "apache-03",
-          "code": "control 'apache-03' do\n  title 'Apache should start max. 1 root-task'\n  desc 'The Apache service in its own non-privileged account. If the web server process runs with administrative privileges, an attack who obtains control over the apache process may control the entire system.'\n  total_tasks = command(\"ps aux | grep #{apache.service} | grep -v grep | grep root | wc -l | tr -d [:space:]\").stdout.to_i\n  describe total_tasks do\n    it { should eq 1 }\n  end\nend\n",
+          "code": "control 'apache-03' do\n  title 'Apache should start max. 1 root-task'\n  desc 'The Apache service in its own non-privileged account. If the web server process runs with administrative privileges, an attack who obtains control over the apache process may control the entire system.'\n  total_tasks = command(\"ps aux | grep #{apache.service} | grep -v grep | grep root | wc -l | tr -d [:space:]\").stdout.to_i\n  describe total_tasks do\n    it { should eq 1 }\n  end\n  tag 'web'\n  tag 'scope': 'Apache'\nend\n",
           "desc": "The Apache service in its own non-privileged account. If the web server process runs with administrative privileges, an attack who obtains control over the apache process may control the entire system.",
           "impact": 0.5,
           "title": "Apache should start max. 1 root-task",
@@ -172,7 +175,10 @@
             "line": 49
           },
           "refs": [],
-          "tags": {},
+          "tags": {
+            "web": null,
+            "scope": "Apache"
+          },
           "results": [
             {
               "status": "skipped",

--- a/components/compliance-service/test_data/audit_reports/2018-03-04_redhat(2)-beta-nginx(f)-apache(s)-failed.json
+++ b/components/compliance-service/test_data/audit_reports/2018-03-04_redhat(2)-beta-nginx(f)-apache(s)-failed.json
@@ -67,8 +67,12 @@
           "desc": "The NGINX worker processes should run as non-privileged user. In case of compromise of the process, an attacker has full access to the system.",
           "impact": 1,
           "refs": [],
-          "tags": {},
-          "code": "control 'nginx-01' do\n  impact 1.0\n  title 'Running worker process as non-privileged user'\n  desc 'The NGINX worker processes should run as non-privileged user. In case of compromise of the process, an attacker has full access to the system.'\n  describe user(nginx_lib.valid_users) do\n    it { should exist }\n  end\n  describe parse_config_file(nginx_conf, options) do\n    its('user') { should eq nginx_lib.valid_users }\n  end\n\n  describe parse_config_file(nginx_conf, options) do\n    its('group') { should_not eq 'root' }\n  end\nend\n",
+          "tags": {
+            "web": null,
+            "scope": "NginX",
+            "satisfies": ["NGX-1", "NGX-2"]
+          },
+          "code": "control 'nginx-01' do\n  impact 1.0\n  title 'Running worker process as non-privileged user'\n  desc 'The NGINX worker processes should run as non-privileged user. In case of compromise of the process, an attacker has full access to the system.'\n  describe user(nginx_lib.valid_users) do\n    it { should exist }\n  end\n  describe parse_config_file(nginx_conf, options) do\n    its('user') { should eq nginx_lib.valid_users }\n  end\n\n  describe parse_config_file(nginx_conf, options) do\n    its('group') { should_not eq 'root' }\n  end\n  tag 'web'\n  tag 'scope': 'NginX'\n  tag 'satisfies': ['NGX-1', 'NGX-2']\nend\n",
           "source_location": {
             "line": 99,
             "ref": "nginx-baseline-master/controls/nginx_spec.rb"

--- a/components/compliance-service/test_data/audit_reports/2018-03-04_windows(1)-zeta-apache(s)-skipped.json
+++ b/components/compliance-service/test_data/audit_reports/2018-03-04_windows(1)-zeta-apache(s)-skipped.json
@@ -32,7 +32,7 @@
       "controls": [
         {
           "id": "apache-03",
-          "code": "control 'apache-03' do\n  title 'Apache should start max. 1 root-task'\n  desc 'The Apache service in its own non-privileged account. If the web server process runs with administrative privileges, an attack who obtains control over the apache process may control the entire system.'\n  total_tasks = command(\"ps aux | grep #{apache.service} | grep -v grep | grep root | wc -l | tr -d [:space:]\").stdout.to_i\n  describe total_tasks do\n    it { should eq 1 }\n  end\nend\n",
+          "code": "control 'apache-03' do\n  title 'Apache should start max. 1 root-task'\n  desc 'The Apache service in its own non-privileged account. If the web server process runs with administrative privileges, an attack who obtains control over the apache process may control the entire system.'\n  total_tasks = command(\"ps aux | grep #{apache.service} | grep -v grep | grep root | wc -l | tr -d [:space:]\").stdout.to_i\n  describe total_tasks do\n    it { should eq 1 }\n  end\n  tag 'web'\n  tag 'scope': 'Apache'\n  tag 'satisfies': ['apache-1', 'apache-2']\nend\n",
           "desc": "The Apache service in its own non-privileged account. If the web server process runs with administrative privileges, an attack who obtains control over the apache process may control the entire system.",
           "impact": 0.5,
           "title": "Apache should start max. 1 root-task",
@@ -41,7 +41,11 @@
             "line": 49
           },
           "refs": [],
-          "tags": {},
+          "tags": {
+            "web": null,
+            "scope": "Apache",
+            "satisfies": ["apache-1", "apache-2"]
+          },
           "results": [
             {
               "status": "skipped",


### PR DESCRIPTION
This PR enables `control_tag` filters for the compliance APIs.
I updated test data as well to support integration testing of this new filter.

This is an example where we filter for compliance reports that have at least one control with tagged `scope:nginx` or `scope:apache`, case insensitive:

```
Reporting::ListFilter.new(type: 'control_tag:scope', values: ['nginx', 'apache'])
```

