### PR TITLE
build fix: 45 is clearly better than 48

### DIFF
--- a/components/automate-chef-io/Makefile
+++ b/components/automate-chef-io/Makefile
@@ -4,7 +4,7 @@ SHELL=bash
 SWAGGER_RESULT_FILE=static/api-docs/all-apis.swagger.json
 SWAGGER_DIR=data/docs/api_chef_automate
 SWAGGER_FILES = $(shell find $(SWAGGER_DIR) -name '*.swagger.json')
-EXPECTED_CONFLICTS=48
+EXPECTED_CONFLICTS=45
 
 themes/chef:
 	git clone https://${GITHUB_TOKEN}@github.com/chef/chef-hugo-theme.git themes/chef


### PR DESCRIPTION
The swagger command we use produces conflicts. This number is the
number of allowed conflicts. The number of conflicts has
changed.

This should fix the build, but as this is the second time we've
changed this number without understanding it, we should dig into this.

Signed-off-by: Steven Danna <steve@chef.io>