### PR TITLE
Make cypress soft_fail everywhere in our pipeline

### DIFF
--- a/.expeditor/deploy.pipeline.yml
+++ b/.expeditor/deploy.pipeline.yml
@@ -28,6 +28,7 @@ steps:
 
   - label: ":cypress:"
     command: .expeditor/buildkite/cypress.sh
+    soft_fail: true
     retry:
       automatic:
         limit: 1

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -416,6 +416,7 @@ steps:
     command:
       - integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
+    soft_fail: true
     expeditor:
       secrets: &cypress_secrets
         A2_LICENSE:
@@ -442,6 +443,7 @@ steps:
     command:
       - IAM=v2 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
+    soft_fail: true
     expeditor:
       secrets: *cypress_secrets
       executor:
@@ -452,6 +454,7 @@ steps:
     command:
       - IAM=v2.1 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
+    soft_fail: true
     expeditor:
       secrets: *cypress_secrets
       executor:

--- a/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
@@ -52,7 +52,7 @@ describe('user management', () => {
     cy.get('app-user-table chef-td').contains(name).should('exist');
   });
 
-  it.skip('can view and edit user details', () => {
+  it('can view and edit user details', () => {
     cy.route('GET', `**/users/${username}`).as('getUser');
     cy.route('PUT', `**/users/${username}`).as('updateUser');
 
@@ -88,7 +88,7 @@ describe('user management', () => {
     cy.get('chef-notification.info').should('be.visible');
   });
 
-  it.skip('can delete user', () => {
+  it('can delete user', () => {
     cy.route('GET', '**/users').as('getUsers');
     cy.route('DELETE', `**/users/${username}`).as('deleteUser');
 

--- a/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
@@ -184,14 +184,7 @@ describe('team management', () => {
         cy.cleanupTeamsByDescriptionPrefix(adminToken, cypressPrefix);
       });
 
-      // FIXME (sr): Failed in deploy/dev with
-      //   CypressError: Timed out retrying: cy.click() failed because this element is not visible:
-      //     <button type="button">Create ...</button>
-      //   This element '<button>' is not visible because it has an effective width and height of:
-      //     '0 x 0' pixels.
-      // I didn't want to blindly add {force: true}, since if this sometimes passes, something
-      // else might be going on -- and we should try to understand that...
-      it.skip('can create a team with multiple projects', () => {
+      it('can create a team with multiple projects', () => {
         const projectSummary = '2 projects';
         cy.get('[data-cy=team-create-button]').contains('Create Team').click();
         cy.get('app-team-management chef-modal').should('exist');
@@ -227,8 +220,7 @@ describe('team management', () => {
         cy.go('back');
       });
 
-      // FIXME (sr): see above
-      it.skip('can create a team with one project selected', () => {
+      it('can create a team with one project selected', () => {
         cy.get('[data-cy=team-create-button]').contains('Create Team').click();
         cy.get('app-team-management chef-modal').should('exist');
         cy.get('[data-cy=create-name]').type(teamName);
@@ -263,8 +255,7 @@ describe('team management', () => {
         cy.go('back');
       });
 
-      // FIXME (sr): see above
-      it.skip('can create a team with no projects selected (unassigned)', () => {
+      it('can create a team with no projects selected (unassigned)', () => {
         cy.get('[data-cy=team-create-button]').contains('Create Team').click();
         cy.get('app-team-management chef-modal').should('exist');
         cy.get('[data-cy=create-name]').type(teamName);

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -142,8 +142,7 @@ describe('team details', () => {
         cy.applyProjectsFilter([unassigned]);
       });
 
-      // TODO this test has proven flaky, further investigation needed
-      it.skip('cannot access projects dropdown but can still update name', () => {
+      it('cannot access projects dropdown but can still update name', () => {
         cy.get('[data-cy=team-details-tab-details]').click();
 
         // initial state of page

--- a/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
@@ -184,11 +184,7 @@ describeIAMV2P1('project management', () => {
     cy.get('app-project-details h1.page-title').contains(updatedProjectName);
   });
 
-  // FIXME (sr): Failed in deploy/dev with
-  //   CypressError: Timed out retrying: Expected to find element:
-  //     'app-project-details chef-tbody chef-td', but never found it.
-  // So, skipping now, to be fixed.
-  it.skip('can delete a project rule', () => {
+  it('can delete a project rule', () => {
     cy.get('[data-cy=rules-tab]').click();
 
     cy.get('app-project-details chef-td').contains(ruleID).parent()


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Also un-skipped all the tests. Our cypress usage isn't quite ready yet but we want the tests to keep running in all environments so we can start to understand failure patterns, etc. The auth team is going to be on the lookout for these failures but if you aren't directly working on cypress you should be able to ignore failures for now.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?
