### PR TITLE
Open PR for updated swagger files instead of committing directly to master

### DIFF
--- a/.expeditor/generate-automate-api-docs.sh
+++ b/.expeditor/generate-automate-api-docs.sh
@@ -5,6 +5,18 @@ set -eou pipefail
 mkdir -p /go/src/github.com/chef
 ln -s /workspace /go/src/github.com/chef/automate
 
+branch="expeditor/generate-automate-api-docs"
+git checkout -b "$branch"
+
 pushd /go/src/github.com/chef/automate/components/automate-chef-io
   make sync_swagger_files
 popd
+
+git add components/automate-chef-io/data/docs/api_chef_automate
+
+git commit --message "Sync swagger files for Automate docs." --message "This pull request was triggered automatically via Expeditor." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
+
+open_pull_request
+
+git checkout -
+git branch -D "$branch"


### PR DESCRIPTION
Followup to #1376.

Since building the automate-chef-io package can (and often does) fail when swagger files are updated, changed swagger files should end up in a PR instead of getting merged directly to master.