### PR TITLE
Adding ES refreshes to prevent flaky tests

### DIFF
--- a/components/compliance-service/ingest/pipeline/processor/report.go
+++ b/components/compliance-service/ingest/pipeline/processor/report.go
@@ -17,7 +17,7 @@ func ComplianceReport(in <-chan message.Compliance) <-chan message.Compliance {
 	out := make(chan message.Compliance, 100)
 	go func() {
 		for msg := range in {
-			logrus.WithFields(logrus.Fields{"report_id": msg.Report.ReportUuid}).Info("Processing Compliance Report")
+			logrus.WithFields(logrus.Fields{"report_id": msg.Report.ReportUuid}).Debug("Processing Compliance Report")
 			parsedTime, err := time.Parse(time.RFC3339, msg.Report.EndTime)
 			if err != nil {
 				grpcErr := status.Errorf(codes.Internal, "Unable to Parse end_time: %s", err)

--- a/components/compliance-service/ingest/pipeline/processor/summary.go
+++ b/components/compliance-service/ingest/pipeline/processor/summary.go
@@ -79,7 +79,7 @@ func ComplianceSummary(in <-chan message.Compliance) <-chan message.Compliance {
 	out := make(chan message.Compliance, 100)
 	go func() {
 		for msg := range in {
-			logrus.WithFields(logrus.Fields{"report_id": msg.Report.ReportUuid}).Info("Processing Compliance Summary")
+			logrus.WithFields(logrus.Fields{"report_id": msg.Report.ReportUuid}).Debug("Processing Compliance Summary")
 			msg.InspecSummary = &relaxting.ESInSpecSummary{
 				NodeID:           msg.Report.NodeUuid,
 				NodeName:         msg.Report.NodeName,

--- a/components/compliance-service/ingest/pipeline/publisher/compliance.go
+++ b/components/compliance-service/ingest/pipeline/publisher/compliance.go
@@ -75,7 +75,7 @@ func storeCompliance(in <-chan message.Compliance, out chan<- message.Compliance
 func insertInspecSummary(msg message.Compliance, client *ingestic.ESClient) <-chan error {
 	out := make(chan error)
 	go func() {
-		logrus.WithFields(logrus.Fields{"report_id": msg.Report.ReportUuid}).Info("Ingesting inspec_summary")
+		logrus.WithFields(logrus.Fields{"report_id": msg.Report.ReportUuid}).Debug("Ingesting inspec_summary")
 		start := time.Now()
 		err := client.InsertInspecSummary(msg.Ctx, msg.Report.ReportUuid, msg.Shared.EndTime, msg.InspecSummary)
 		if err != nil {
@@ -93,7 +93,7 @@ func insertInspecSummary(msg message.Compliance, client *ingestic.ESClient) <-ch
 func insertInspecReport(msg message.Compliance, client *ingestic.ESClient) <-chan error {
 	out := make(chan error)
 	go func() {
-		logrus.WithFields(logrus.Fields{"report_id": msg.Report.ReportUuid, "node_id": msg.Report.NodeUuid}).Info("Ingesting inspec_report")
+		logrus.WithFields(logrus.Fields{"report_id": msg.Report.ReportUuid, "node_id": msg.Report.NodeUuid}).Debug("Ingesting inspec_report")
 		start := time.Now()
 		err := client.InsertInspecReport(msg.Ctx, msg.Report.ReportUuid, msg.Shared.EndTime, msg.InspecReport)
 		if err != nil {
@@ -114,7 +114,7 @@ func insertInspecProfile(msg message.Compliance, profile *relaxting.ESInspecProf
 		logrus.WithFields(logrus.Fields{
 			"report_id":  msg.Report.ReportUuid,
 			"profile_id": profile.Sha256,
-		}).Info("Ingesting inspec_profile")
+		}).Debug("Ingesting inspec_profile")
 		start := time.Now()
 		profileExists, err := client.ProfileExists(profile.Sha256)
 		if err == nil {

--- a/components/compliance-service/integration_test/reporting_server_list_profiles_test.go
+++ b/components/compliance-service/integration_test/reporting_server_list_profiles_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestListProfiles(t *testing.T) {
+	suite.DeleteAllDocuments()
+
 	es2Backend := relaxting.ES2Backend{ESUrl: elasticsearchUrl}
 	server := reportingServer.New(&es2Backend)
 
@@ -51,6 +53,10 @@ func TestListProfiles(t *testing.T) {
 		return response != nil && len(response.Reports) == n
 	})
 
+	suite.RefreshComplianceSummaryIndex()
+	suite.RefreshComplianceReportIndex()
+	suite.RefreshComplianceProfilesIndex()
+
 	reportsProjects := map[string][]string{
 		"project1": reportIds[1:3],
 		"project2": reportIds[2:5],
@@ -79,7 +85,9 @@ func TestListProfiles(t *testing.T) {
 
 	suite.WaitForESJobToComplete(esJobID)
 
+	suite.RefreshComplianceSummaryIndex()
 	suite.RefreshComplianceReportIndex()
+	suite.RefreshComplianceProfilesIndex()
 
 	profileIds := make([]string, len(reportIds))
 	for i := range reportIds {

--- a/components/compliance-service/integration_test/reporting_server_list_suggestions_test.go
+++ b/components/compliance-service/integration_test/reporting_server_list_suggestions_test.go
@@ -538,6 +538,8 @@ func TestReportingListSuggestionsLargeArrayValues(t *testing.T) {
 }
 
 func TestReportingListSuggestions(t *testing.T) {
+	suite.DeleteAllDocuments()
+
 	reportFileName := "../ingest/examples/compliance-success-tiny-report.json"
 	everythingCtx := contextWithProjects([]string{authzConstants.AllProjectsExternalID})
 
@@ -577,6 +579,9 @@ func TestReportingListSuggestions(t *testing.T) {
 
 		return response != nil && len(response.Reports) == n
 	})
+
+	suite.RefreshComplianceSummaryIndex()
+	suite.RefreshComplianceReportIndex()
 
 	reportsProjects := map[string][]string{
 		"project1": reportIds[1:3],

--- a/components/compliance-service/integration_test/stats_server_read_profiles_test.go
+++ b/components/compliance-service/integration_test/stats_server_read_profiles_test.go
@@ -430,6 +430,11 @@ func setupReadProfiles(t *testing.T) *statsServer.Server {
 
 		return response != nil && len(response.Reports) == n
 	})
+
+	suite.RefreshComplianceSummaryIndex()
+	suite.RefreshComplianceReportIndex()
+	suite.RefreshComplianceProfilesIndex()
+
 	reportsProjects := map[string][]string{
 		"project1": reportIds[1:3],
 		"project2": reportIds[2:5],
@@ -442,8 +447,8 @@ func setupReadProfiles(t *testing.T) *statsServer.Server {
 				{
 					Conditions: []*iam_v2.Condition{
 						{
-							Attribute:   iam_v2.ProjectRuleConditionAttributes_CHEF_ROLE,
-							Values: v,
+							Attribute: iam_v2.ProjectRuleConditionAttributes_CHEF_ROLE,
+							Values:    v,
 						},
 					},
 				},
@@ -454,6 +459,8 @@ func setupReadProfiles(t *testing.T) *statsServer.Server {
 	esJobID, err := suite.ingesticESClient.UpdateReportProjectsTags(everythingCtx, projectRules)
 	assert.Nil(t, err)
 	suite.WaitForESJobToComplete(esJobID)
+	suite.RefreshComplianceSummaryIndex()
 	suite.RefreshComplianceReportIndex()
+	suite.RefreshComplianceProfilesIndex()
 	return statsServer
 }

--- a/components/compliance-service/integration_test/suite_test.go
+++ b/components/compliance-service/integration_test/suite_test.go
@@ -326,6 +326,10 @@ func (s *Suite) RefreshComplianceSummaryIndex() {
 	s.RefreshIndices(complianceSummaryIndex)
 }
 
+func (s *Suite) RefreshComplianceProfilesIndex() {
+	s.RefreshIndices(mappings.ComplianceProfiles.Index)
+}
+
 // RefreshIndices will refresh the provided ES Index or list of Indices
 //
 // Example 1: To refresh a single index, the node-state index


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
These changes prevent the Flaky compliance integration tests. The problem was that when running the project updater on newly created reports, summaries, and profiles the ES documents were not fully created. Add a refresh to the indexes ensures the ES documents are ready for modifications. 

### :chains: Related Resources
#599