### PR TITLE
session-service: update and fix stuff

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,7 +50,7 @@
   version = "v1.2.2"
 
 [[projects]]
-  digest = "1:9bb971cde0707689d979882ca7e4e7fb9dc0ad22407eba2d6edfff50b30c3e8a"
+  digest = "1:9017953e03588c23a22baf05ecd0574a86b17adb6b81a3cafa889bb9ec38c03e"
   name = "github.com/alexedwards/scs"
   packages = [
     ".",
@@ -59,8 +59,8 @@
     "stores/pgstore",
   ]
   pruneopts = "NUT"
-  revision = "dbad6751cfac0714e079d0ef9a8bc1d14d52de21"
-  version = "v1.1.0"
+  revision = "cfcbf41460ffe695c7d52159fbff3393c646c8f0"
+  version = "v1.4.1"
 
 [[projects]]
   digest = "1:9752dad5e89cd779096bf2477a4ded16bea7ac62de453c8d6b4bf841d51a8512"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -257,6 +257,11 @@ required = [
   name = "github.com/nats-io/go-nats-streaming"
   branch = "master"
 
+# session-service
+[[constraint]]
+  name = "github.com/alexedwards/scs"
+  version = "1.4.1"
+
 # for testing
 [[constraint]]
   name = "github.com/leanovate/gopter"

--- a/components/session-service/server/server_test.go
+++ b/components/session-service/server/server_test.go
@@ -86,13 +86,13 @@ func TestNewHandler(t *testing.T) {
 			}
 			require.NotEmpty(t, sessionID, "there is a session ID cookie")
 			data, exists, err := ms.Find(sessionID)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.True(t, exists, "there is a stored session")
 			var cookie struct {
 				Data map[string]interface{} `json:"data"`
 			}
 			err = json.Unmarshal(data, &cookie)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, 3, len(cookie.Data), "expecting 3 keys in cookie data")
 
 			aliveStateInCookieData(t, cookie.Data)
@@ -138,13 +138,13 @@ func TestNewHandler(t *testing.T) {
 			assert.NotEqual(t, sessionID, sessionID2, "session ID has changed")
 
 			data, exists, err := ms.Find(sessionID2)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.True(t, exists, "there is a stored session")
 			var cookie struct {
 				Data map[string]interface{} `json:"data"`
 			}
 			err = json.Unmarshal(data, &cookie)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, 5, len(cookie.Data), "expecting 5 keys in cookie data")
 
 			// find relay states
@@ -194,7 +194,7 @@ func TestNewHandler(t *testing.T) {
 				Data map[string]interface{} `json:"data"`
 			}
 			err = json.Unmarshal(data, &cookie)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, 4, len(cookie.Data), "expecting 4 keys in cookie data")
 			ru, ok := cookie.Data["redirect_uri"]
 			require.True(t, ok)
@@ -317,8 +317,8 @@ func TestRefreshHandler(t *testing.T) {
 			s.setTestToken(t2, nil)
 
 			sessionData := struct {
-				RT string `json:"refresh_token"` // should equal refreshTokenKey const
-				Alive bool `json:"alive"`
+				RT    string `json:"refresh_token"` // should equal refreshTokenKey const
+				Alive bool   `json:"alive"`
 			}{RT: refreshToken, Alive: true}
 			if err := addSessionDataToStore(ms, sessionID, sessionData, nil); err != nil {
 				t.Fatal(err)
@@ -378,8 +378,8 @@ func TestRefreshHandler(t *testing.T) {
 			s.setTestToken(nil, errors.New("token exchange failed"))
 
 			sessionData := struct {
-				RT string `json:"refresh_token"` // should equal refreshTokenKey const
-				Alive bool `json:"alive"`
+				RT    string `json:"refresh_token"` // should equal refreshTokenKey const
+				Alive bool   `json:"alive"`
 			}{RT: refreshToken, Alive: true}
 			if err := addSessionDataToStore(ms, sessionID, sessionData, nil); err != nil {
 				t.Fatal(err)
@@ -475,14 +475,14 @@ func TestCallbackHandler(t *testing.T) {
 
 			// relay_state was removed from session data
 			data, exists, err := ms.Find(newSessionID)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.True(t, exists, "there is a stored session")
 
 			var cookie struct {
 				Data map[string]interface{} `json:"data"`
 			}
 			err = json.Unmarshal(data, &cookie)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			// check that there's no relay state whatsoever
 			rs := 0
@@ -600,14 +600,14 @@ func TestCallbackHandler(t *testing.T) {
 
 			// relay_state was removed from session data
 			data, exists, err := ms.Find(newSessionID)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.True(t, exists, "there is a stored session")
 
 			var cookie struct {
 				Data map[string]interface{} `json:"data"`
 			}
 			err = json.Unmarshal(data, &cookie)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			// check that there's exactly one state pair left
 			assert.Equal(t, 3, len(cookie.Data)) // refresh_token + the other state pair

--- a/vendor/github.com/alexedwards/scs/options.go
+++ b/vendor/github.com/alexedwards/scs/options.go
@@ -17,4 +17,5 @@ type options struct {
 	path        string
 	persist     bool
 	secure      bool
+	sameSite    string
 }

--- a/vendor/github.com/alexedwards/scs/stores/memstore/memstore.go
+++ b/vendor/github.com/alexedwards/scs/stores/memstore/memstore.go
@@ -25,7 +25,7 @@ var errTypeAssertionFailed = errors.New("type assertion failed: could not conver
 // MemStore represents the currently configured session session store. It is essentially
 // a wrapper around a go-cache instance (see https://github.com/patrickmn/go-cache).
 type MemStore struct {
-	*cache.Cache
+	cache *cache.Cache
 }
 
 // New returns a new MemStore instance.
@@ -42,7 +42,7 @@ func New(cleanupInterval time.Duration) *MemStore {
 // Find returns the data for a given session token from the MemStore instance. If the session
 // token is not found or is expired, the returned exists flag will be set to false.
 func (m *MemStore) Find(token string) (b []byte, exists bool, err error) {
-	v, exists := m.Cache.Get(token)
+	v, exists := m.cache.Get(token)
 	if exists == false {
 		return nil, exists, nil
 	}
@@ -58,12 +58,12 @@ func (m *MemStore) Find(token string) (b []byte, exists bool, err error) {
 // Save adds a session token and data to the MemStore instance with the given expiry time.
 // If the session token already exists then the data and expiry time are updated.
 func (m *MemStore) Save(token string, b []byte, expiry time.Time) error {
-	m.Cache.Set(token, b, expiry.Sub(time.Now()))
+	m.cache.Set(token, b, expiry.Sub(time.Now()))
 	return nil
 }
 
 // Delete removes a session token and corresponding data from the MemStore instance.
 func (m *MemStore) Delete(token string) error {
-	m.Cache.Delete(token)
+	m.cache.Delete(token)
 	return nil
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When the code->token exchange in session-service's callback handler does not return a refresh_token, and there was a refresh_token stored with the session before, it is now removed instead of left untouched.

### :chains: Related Resources

- #1352 made this apparent

### :+1: Definition of Done

The above doesn't happen anymore. When playing with #1352, you now never see the local user signin screen.

### :athletic_shoe: How to Build and Test the Change

See #1352, let it refresh for a while.

### :white_check_mark: Checklist

- [X] Tests added/updated?
- [ ] Docs added/updated?
