### PR TITLE
Force another build

### DIFF
--- a/.expeditor/create-manifest.rb
+++ b/.expeditor/create-manifest.rb
@@ -132,6 +132,9 @@ def get_hab_deps_latest()
   ret
 end
 
+puts "Environment Keys:"
+puts ENV.keys
+
 version = ENV["VERSION"] || DateTime.now.strftime("%Y%m%d%H%M%S")
 filename = ENV["VERSION"] || "manifest"
 


### PR DESCRIPTION
We made a build with incorrect packages due to some eventual consistency
issues with building/uploading a package and then later asking depot for
the latest version

Expeditor has the packages that were built. Printing the environment
keys to see if anything in there can help us.