### PR TITLE
create-manifest.rb: print all available environment variables

### DIFF
--- a/.expeditor/create-manifest.rb
+++ b/.expeditor/create-manifest.rb
@@ -140,6 +140,10 @@ puts "HAB_ORIGIN=#{ENV["HAB_ORIGIN"]}"
 puts "VERSION=#{ENV["VERSION"]}"
 puts "EXPEDITOR_PKG_IDENTS=#{ENV["EXPEDITOR_PKG_IDENTS"]}"
 puts "-------------------------------"
+puts "Environment Variable Keys"
+puts "-------------------------------"
+puts "#{ENV.keys}"
+puts "-------------------------------"
 
 version = ENV["VERSION"] || DateTime.now.strftime("%Y%m%d%H%M%S")
 filename = ENV["VERSION"] || "manifest"

--- a/components/ingest-service/grpc/grpc.go
+++ b/components/ingest-service/grpc/grpc.go
@@ -189,7 +189,7 @@ func Spawn(opts *serveropts.Opts) error {
 	// Data Lifecycle Interface
 	esSidecarConn, err := opts.ConnFactory.Dial("es-sidecar-service", opts.EsSidecarAddress)
 	if err != nil {
-		// This should never happend
+		// This should never happen
 		log.WithError(err).Error("Failed to create ES Sidecar connection")
 		return err
 	}


### PR DESCRIPTION
Also, fix the spelling in a brave comment in ingest-service.

Signed-off-by: Steven Danna <steve@chef.io>