### PR TITLE
ci: use expeditor environment to get package idents

### DIFF
--- a/.expeditor/create-manifest.rb
+++ b/.expeditor/create-manifest.rb
@@ -56,7 +56,9 @@ class PackageQuerier
     def get_latest(_channel, origin, name)
       ret = get_latest_from_disk(origin, origin, name)
       if ret == nil
-        return get_latest_from_disk(@fallback_origin, origin, name)
+        get_latest_from_disk(@fallback_origin, origin, name)
+      else
+        ret
       end
     end
 

--- a/.expeditor/create-manifest.rb
+++ b/.expeditor/create-manifest.rb
@@ -5,7 +5,7 @@
 # package from one of the following sources:
 #
 # - A set of pins maintained in this file
-# - (optionally) Environement variables set by expeditor
+# - (optionally) Environment variables set by expeditor
 # - The Habitat Depot's dev channel
 # - (optionally) Local files on disk
 #

--- a/.expeditor/create-manifest.rb
+++ b/.expeditor/create-manifest.rb
@@ -203,17 +203,21 @@ local_package_directory = "results"
 
 use_environment_idents=(ENV["EXPEDITOR_NAME"].to_s != "")
 version = ENV["VERSION"] || DateTime.now.strftime("%Y%m%d%H%M%S")
-filename = ENV["VERSION"] || "manifest"
+filename = if ENV["VERSION"]
+             "#{ENV["VERSION"]}.json"
+           else
+             "manifest.json"
+           end
 
 puts "Creating release manifest for Automate"
 puts "--------------------------------------"
 puts "Configuration:"
-puts "     use_local_packages=#{use_local_packages}"
-puts " use_environment_idents=#{use_environment_idents}"
-puts "   local_package_origin=#{local_package_origin}"
-puts "local_package_directory=#{local_package_directory}"
-puts "               filename=#{filename}"
-puts "                filenme=#{filename}"
+puts "  use_local_packages=#{use_local_packages}"
+puts "  use_environment_idents=#{use_environment_idents}"
+puts "  local_package_origin=#{local_package_origin}"
+puts "  local_package_directory=#{local_package_directory}"
+puts "  filename=#{filename}"
+puts "  version=#{version}"
 puts "-------------------------------"
 
 package_queriers = [PackageQuerier::PinQuerier.new(pins)]
@@ -305,4 +309,4 @@ manifest["packages"].uniq!
 manifest["packages"].sort!
 
 
-File.open("#{filename}.json", "w") { |file| file.write(JSON.pretty_generate(manifest)) }
+File.open("#{filename}", "w") { |file| file.write(JSON.pretty_generate(manifest)) }

--- a/.expeditor/create-manifest.rb
+++ b/.expeditor/create-manifest.rb
@@ -8,8 +8,6 @@ require 'json'
 require 'openssl'
 require 'open3'
 
-BLDR_API_HOST="bldr.habitat.sh"
-BLDR_API_USER_AGENT="Chef Expeditor"
 
 # Packages that are present in products.meta but we wish to
 # exclude from the manifest (probably because they are not yet published to the
@@ -19,13 +17,140 @@ BLDR_API_USER_AGENT="Chef Expeditor"
 # we fail to get expected package data from the hab depot.
 SKIP_PACKAGES = []
 
+class PackageQuerier
+  class ChainQuerier
+    def initialize(queriers=[])
+      @queriers=queriers
+    end
 
-# When true, ALLOW_LOCAL_PACKAGES creates the manifest using locally
-# created hartifacts if it can not otherwise find the package uploaded
-# to the depot.
-ALLOW_LOCAL_PACKAGES=(ENV["ALLOW_LOCAL_PACKAGES"] == "true")
-LOCAL_PACKAGE_PATH="results/"
-LOCAL_PACKAGE_ORIGIN=ENV["HAB_ORIGIN"] || "chef"
+    def get_latest(channel, origin, name)
+      @queriers.each do |q|
+        ret = q.get_latest(channel, origin, name)
+        if ret != nil
+          return ret
+        end
+      end
+    end
+  end
+
+  class PinQuerier
+    def initialize(pins={})
+      @pins = pins
+    end
+
+    def get_latest(_channel, _origin, name)
+      ident = @pins[name]
+      if ident != nil
+        ident["source"] = "pin"
+      end
+      ident
+    end
+  end
+
+  class DiskQuerier
+    def initialize(dir, origin)
+      @dir=dir
+      @fallback_origin=origin
+    end
+
+    def get_latest(_channel, origin, name)
+      ret = get_latest_from_disk(origin, origin, name)
+      if ret == nil
+        return get_latest_from_disk(@fallback_origin, origin, name)
+      end
+    end
+
+    def get_latest_from_disk(lookup_origin, desired_origin, name)
+      # We are just going to depend on glob ordering here rather than
+      # explicitly sorting
+      candidates = Dir.glob("#{@dir}/#{lookup_origin}-#{name}-*.hart")
+      if candidates.length > 0
+        ident_from_package(desired_origin, name, lookup_origin, candidates.first)
+      else
+        nil
+      end
+    end
+
+    def ident_from_package(desired_origin, desired_name, found_origin, package_path)
+      ident = {}
+      ident["source"] = "local file #{package_path}"
+      ident["origin"] = desired_origin
+      ident["name"] = desired_name
+
+      hart_name = File.basename(package_path)
+      if match_data = /^#{found_origin}-#{desired_name}-(.*)-(\d{14})-x86_64-linux.hart$/.match(hart_name)
+        ident["version"] = match_data[1]
+        ident["release"] = match_data[2]
+        ident
+      else
+        raise "Could not parse ident from filename #{hart_name}"
+      end
+    end
+  end
+
+  class ExpeditorEnvQuerier
+    def initialize
+      @idents=collect_package_idents_from_env
+    end
+
+    def get_latest(_channel, origin, name)
+      @idents["#{origin}/#{name}"]
+    end
+
+    def collect_package_idents_from_env
+      idents = {}
+      ENV.keys.each do |key|
+        if key.start_with?("EXPEDITOR_PKG_IDENTS_")
+          ident=ENV[key]
+          origin, name, version, release = ident.split("/")
+          idents["#{origin}/#{name}"] = {
+            "origin" => origin,
+            "name" => name,
+            "version" => version,
+            "release" => release,
+            "source" => "expeditor environment"
+          }
+        end
+      end
+      idents
+    end
+  end
+
+  class DepotQuerier
+    BLDR_API_HOST="bldr.habitat.sh"
+    BLDR_API_USER_AGENT="Chef Expeditor"
+
+    def initialize(host=BLDR_API_HOST)
+      @host=host
+    end
+
+    def get_latest(channel, origin, name)
+      http = Net::HTTP.new(@host, 443)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      req = Net::HTTP::Get.new("/v1/depot/channels/#{origin}/#{channel}/pkgs/#{name}/latest", {'User-Agent' => BLDR_API_USER_AGENT})
+      response = http.request(req)
+      case response
+      when Net::HTTPNotFound
+        return nil
+      else
+        latest_release = JSON.parse(response.body)
+        ident = latest_release["ident"]
+        ident["source"] = "Habitat Depot"
+        ident
+      end
+    end
+  end
+end
+
+def get_hab_deps_latest(package_querier)
+  ret = {}
+  ["hab", "hab-sup", "hab-launcher"].each do |name|
+    d = package_querier.get_latest("stable", "core", name)
+    ret[name] = "#{d["origin"]}/#{d["name"]}/#{d["version"]}/#{d["release"]}"
+  end
+  ret
+end
 
 def channel_for_origin(origin)
   case origin
@@ -36,117 +161,75 @@ def channel_for_origin(origin)
   end
 end
 
-def get_latest(channel, origin, name)
-  # -- FIXME: PINNED DATABASES - sdelano 2018/07/19 --
-  #
-  # We currently believe it's unsafe to upgrade the database packages in an existing
-  # A2 installation because of unconfigurable shutdown behavior for Habitat services.
-  # Until we have a new supervisor that can safely stop PostgreSQL and ElasticSearch,
-  # we need to avoid upgrading the databases and risking potential data corruption and
-  # stale service state.
-  #
-  # This will pin the services that we package and start with the deployment service,
-  # while still allowing the clients of these databases to upgrade their client
-  # libraries if any fixes are shipped there.
-  pinned_databases = {
-    "automate-postgresql"    => {"version" => "9.6.11", "release" => "20190409151101"},
-    "automate-elasticsearch" => {"version" => "6.2.2", "release" => "20190123133819"}
-  }
+def log_added_ident(ident)
+  puts "  Adding package #{ident["origin"]}/#{ident["name"]}/#{ident["version"]}/#{ident["release"]} from #{ident["source"]}"
+end
 
-  # IF YOU UPDATE THESE PINS YOU MUST ALSO UPDATE THE core/hab PIN IN components/automate-deployment/habitat/plan.sh
-  #
-  pinned_hab_components = {
+
+# -- FIXME: PINNED DATABASES - sdelano 2018/07/19 --
+#
+# We currently believe it's unsafe to upgrade the database packages in an existing
+# A2 installation because of unconfigurable shutdown behavior for Habitat services.
+# Until we have a new supervisor that can safely stop PostgreSQL and ElasticSearch,
+# we need to avoid upgrading the databases and risking potential data corruption and
+# stale service state.
+#
+# This will pin the services that we package and start with the deployment service,
+# while still allowing the clients of these databases to upgrade their client
+# libraries if any fixes are shipped there.
+pinned_databases = {
+  "automate-postgresql"    => {"origin" => "chef", "name" => "automate-postgresql",    "version" => "9.6.11", "release" => "20190409151101"},
+  "automate-elasticsearch" => {"origin" => "chef", "name" => "automate-elasticsearch", "version" => "6.2.2",  "release" => "20190123133819"}
+}
+
+# IF YOU UPDATE THESE PINS YOU MUST ALSO UPDATE THE core/hab PIN IN
+# components/automate-deployment/habitat/plan.sh
+#
+pinned_hab_components = {
     "hab"          => { "origin" => "core", "name" => "hab",          "version" => "0.69.0", "release" => "20181127182011"},
     "hab-sup"      => { "origin" => "core", "name" => "hab-sup",      "version" => "0.69.0", "release" => "20181127183841"},
     "hab-launcher" => { "origin" => "core", "name" => "hab-launcher", "version" => "9106",   "release" => "20181126205526"}
-  }
+}
 
-  if pinned_databases.keys.include?(name)
-    return pinned_databases[name]
-  end
-
-  if pinned_hab_components.include?(name)
-    return pinned_hab_components[name]
-  end
-
-  http = Net::HTTP.new(BLDR_API_HOST, 443)
-  http.use_ssl = true
-  http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-  req = Net::HTTP::Get.new("/v1/depot/channels/#{origin}/#{channel}/pkgs/#{name}/latest", {'User-Agent' => BLDR_API_USER_AGENT})
-  response = http.request(req)
-  case response
-  when Net::HTTPNotFound
-    if ALLOW_LOCAL_PACKAGES
-      puts "  Could not find '#{origin}/#{name}' in Habitat Depot, searching local packages in '#{LOCAL_PACKAGE_PATH}'"
-      get_local_package(origin, name)
-    else
-      raise "Could not find package '#{origin}/#{name}' in channel '#{channel}'.  Has this package been built and uploaded to the Habitat Depot?"
-    end
-  else
-    latest_release = JSON.parse(response.body)
-    latest_release["ident"]
-  end
-end
-
-def get_local_package(origin, name)
-  # We are just going to depend on glob ordering here rather than explicitly sorting
-  candidates_real_origin = Dir.glob("#{LOCAL_PACKAGE_PATH}/#{origin}-#{name}-*.hart")
-  if candidates_real_origin.length > 0
-    puts "  Using #{candidates_real_origin.first}"
-    return ident_from_package(origin, name, origin, candidates_real_origin.first)
-  else
-    puts "  No candidates for #{origin}/#{name}, trying '#{LOCAL_PACKAGE_ORIGIN}/#{name}'"
-  end
-
-  candidates_override_origin= Dir.glob("#{LOCAL_PACKAGE_PATH}/#{LOCAL_PACKAGE_ORIGIN}-#{name}-*.hart")
-  if candidates_override_origin.length > 0
-    puts "  Using #{candidates_override_origin.first}"
-    return ident_from_package(origin, name, LOCAL_PACKAGE_ORIGIN, candidates_override_origin.first)
-  end
-
-  raise "Could not find package '#{name} in '#{LOCAL_PACKAGE_PATH}'"
-end
+pins = pinned_databases.merge(pinned_hab_components)
 
 
-def ident_from_package(desired_origin, desired_name, found_origin, package_path)
-  ident = {}
-  ident["origin"] = desired_origin
-  ident["name"] = desired_name
+# When true, ALLOW_LOCAL_PACKAGES creates the manifest using locally
+# created hartifacts if it can not otherwise find the package uploaded
+# to the depot.
+use_local_packages=(ENV["ALLOW_LOCAL_PACKAGES"] == "true")
+local_package_origin = ENV["HAB_ORIGIN"] || "chef"
+local_package_directory = "results"
 
-  hart_name = File.basename(package_path)
-  if match_data = /^#{found_origin}-#{desired_name}-(.*)-(\d{14})-x86_64-linux.hart$/.match(hart_name)
-    ident["version"] = match_data[1]
-    ident["release"] = match_data[2]
-    ident
-  else
-    raise "Could not parse ident from filename #{hart_name}"
-  end
-end
-
-def get_hab_deps_latest()
-  ret = {}
-  ["hab", "hab-sup", "hab-launcher"].each do |name|
-    d = get_latest("stable", "core", name)
-    ret[name] = "#{d["origin"]}/#{d["name"]}/#{d["version"]}/#{d["release"]}"
-  end
-  ret
-end
-
-puts "Creating release manifest for Automate"
-puts "Important Environment Variables"
-puts "-------------------------------"
-puts "ALLOW_LOCAL_PACKAGES=#{ENV["ALLOW_LOCAL_PACKAGES"]}"
-puts "HAB_ORIGIN=#{ENV["HAB_ORIGIN"]}"
-puts "VERSION=#{ENV["VERSION"]}"
-puts "EXPEDITOR_PKG_IDENTS=#{ENV["EXPEDITOR_PKG_IDENTS"]}"
-puts "-------------------------------"
-puts "Environment Variable Keys"
-puts "-------------------------------"
-puts "#{ENV.keys}"
-puts "-------------------------------"
-
+use_environment_idents=(ENV["EXPEDITOR_NAME"].to_s != "")
 version = ENV["VERSION"] || DateTime.now.strftime("%Y%m%d%H%M%S")
 filename = ENV["VERSION"] || "manifest"
+
+puts "Creating release manifest for Automate"
+puts "--------------------------------------"
+puts "Configuration:"
+puts "     use_local_packages=#{use_local_packages}"
+puts " use_environment_idents=#{use_environment_idents}"
+puts "   local_package_origin=#{local_package_origin}"
+puts "local_package_directory=#{local_package_directory}"
+puts "               filename=#{filename}"
+puts "                filenme=#{filename}"
+puts "-------------------------------"
+
+package_queriers = [PackageQuerier::PinQuerier.new(pins)]
+if use_environment_idents
+  package_queriers << PackageQuerier::ExpeditorEnvQuerier.new
+end
+package_queriers << PackageQuerier::DepotQuerier.new
+# NOTE(ssd) 2019-08-30: This comes after DepotQuerier, becuase we only
+# really need to look at local packages in the case of adding a new
+# service that hasn't been uploaded to the depot. For other newly
+# built packages, we depend on the deployment-service's override
+# origin.
+if use_local_packages
+  package_queriers << PackageQuerier::DiskQuerier.new(local_package_directory, local_package_origin)
+end
+package_querier = PackageQuerier::ChainQuerier.new(package_queriers)
 
 manifest = {}
 
@@ -157,8 +240,7 @@ manifest["schema_version"] = "1"
 manifest["build"] = version
 
 # Grab the version of various Habitat components from the deployment-service
-
-hab_deps = get_hab_deps_latest
+hab_deps = get_hab_deps_latest(package_querier)
 manifest["hab"] = []
 manifest["hab"] << hab_deps["hab"]
 manifest["hab"] << hab_deps["hab-sup"]
@@ -187,12 +269,12 @@ products_meta["packages"].each do |pkg_path|
   pkg_origin = package_ident[0]
   pkg_name = package_ident[1]
 
-  latest_release = get_latest(channel_for_origin(pkg_origin), pkg_origin, pkg_name)
+  latest_release = package_querier.get_latest(channel_for_origin(pkg_origin), pkg_origin, pkg_name)
 
   pkg_version = latest_release["version"]
   pkg_release = latest_release["release"]
 
-  puts "  Adding package #{pkg_origin}/#{pkg_name}/#{pkg_version}/#{pkg_release}"
+  log_added_ident(latest_release)
   manifest["packages"] << "#{pkg_origin}/#{pkg_name}/#{pkg_version}/#{pkg_release}"
 end
 
@@ -210,12 +292,11 @@ end
   pkg_origin = package_ident[0]
   pkg_name = package_ident[1]
 
-  latest_release = get_latest(channel_for_origin(pkg_origin), pkg_origin, pkg_name)
+  latest_release = package_querier.get_latest(channel_for_origin(pkg_origin), pkg_origin, pkg_name)
 
   pkg_version = latest_release["version"]
   pkg_release = latest_release["release"]
-
-  puts "  Adding package #{pkg_origin}/#{pkg_name}/#{pkg_version}/#{pkg_release}"
+  log_added_ident(latest_release)
   manifest["packages"] << "#{pkg_origin}/#{pkg_name}/#{pkg_version}/#{pkg_release}"
 end
 

--- a/.expeditor/create-manifest.rb
+++ b/.expeditor/create-manifest.rb
@@ -1,21 +1,21 @@
 #!/usr/bin/env ruby
-
-# By default, this script creates a manifest.json file that contains all the packages in the dev channel
-
+#
+# This script creates the Chef Automate release manifest. For each
+# package in products.meta, we lookup the most recent version of the
+# package from one of the following sources:
+#
+# - A set of pins maintained in this file
+# - (optionally) Environement variables set by expeditor
+# - The Habitat Depot's dev channel
+# - (optionally) Local files on disk
+#
+# See the comment starting with CONFIGURATION for more details.
 require 'date'
 require 'net/http'
 require 'json'
 require 'openssl'
 require 'open3'
 require 'logger'
-
-# Packages that are present in products.meta but we wish to
-# exclude from the manifest (probably because they are not yet published to the
-# depot).
-#
-# We make this list explicit so that we can make manifest generation fail when
-# we fail to get expected package data from the hab depot.
-SKIP_PACKAGES = []
 
 class PackageQuerier
   class Ident
@@ -41,7 +41,7 @@ class PackageQuerier
     end
 
     def ==(other)
-      other != nil && ident == other.ident
+      !other.nil? && ident == other.ident
     end
   end
 
@@ -53,10 +53,24 @@ class PackageQuerier
     def get_latest(channel, origin, name)
       @queriers.each do |q|
         ret = q.get_latest(channel, origin, name)
-        if ret != nil
+        if !ret.nil?
           return ret
         end
       end
+    end
+  end
+
+  class MustExistQuerier
+    def initialize(inner)
+      @inner = inner
+    end
+
+    def get_latest(channel, origin, name)
+      ret = @inner.get_latest(channel, origin, name)
+      if ret.nil?
+        raise "Could not find #{origin}/#{name} (channel: #{channel}) in any of the available sources!"
+      end
+      ret
     end
   end
 
@@ -69,7 +83,7 @@ class PackageQuerier
 
     def get_latest(channel, origin, name)
       ret = @main.get_latest(channel, origin, name)
-      if ret != nil
+      if !ret.nil?
         compare_result = @compare.get_latest(channel, origin, name)
         if compare_result != ret
           @logger.warn("Found mismatch between sources:")
@@ -89,7 +103,7 @@ class PackageQuerier
 
     def get_latest(_channel, _origin, name)
       ident = @pins[name]
-      if ident != nil
+      if !ident.nil?
         ident["source"] = "pin"
         Ident.new(ident)
       else
@@ -106,7 +120,7 @@ class PackageQuerier
 
     def get_latest(_channel, origin, name)
       ret = get_latest_from_disk(origin, origin, name)
-      if ret == nil
+      if ret.nil?
         get_latest_from_disk(@fallback_origin, origin, name)
       else
         ret
@@ -197,69 +211,147 @@ class PackageQuerier
   end
 end
 
-def get_hab_deps_latest(package_querier)
-  ret = {}
-  ["hab", "hab-sup", "hab-launcher"].each do |name|
-    d = package_querier.get_latest("stable", "core", name)
-    ret[name] = d.ident
+class ManifestGenerator
+  def generate(package_querier, products_meta_file, version, skip_packages, log)
+    manifest = {}
+    # The version of the manifest schema. WARNING: DO NOT CHANGE: Because
+    # of an implementation mistake in deployment-service, changing this
+    # version is impossible without major feature work in
+    # deployment-service to manage the upgrade.
+    manifest["schema_version"] = "1"
+    manifest["hab_build"] = local_hab_version
+    manifest["build"] = version
+    manifest["hab"] = []
+    manifest["hab"] << package_querier.get_latest("stable", "core", "hab")
+    manifest["hab"] << package_querier.get_latest("stable", "core", "hab-sup")
+    manifest["hab"] << package_querier.get_latest("stable", "core", "hab-launcher")
+    manifest["git_sha"] = git_sha
+    manifest["packages"] = []
+
+    products_meta = parse_products_meta_file(products_meta_file)
+    products_meta["packages"].each do |pkg_path|
+      next if skip_packages.include?(pkg_path)
+      package_ident = pkg_path.split("/")
+      pkg_origin = package_ident[0]
+      pkg_name = package_ident[1]
+
+      latest_release = package_querier.get_latest(channel_for_origin(pkg_origin), pkg_origin, pkg_name)
+      log.info "Adding package #{latest_release.pretty}"
+      manifest["packages"] << latest_release.ident
+    end
+
+    products_meta["deleted_packages"].each do |pkg|
+      log.info "Adding last stable release of deleted package #{pkg}"
+      manifest["packages"] << "#{pkg}"
+    end
+
+    # Add extra packages to manifest that deployment-service doesn't need to manage
+    # but we still want versioned with each release.
+    %w{
+       chef/automate-chef-io
+    }.each do |extra_package|
+      package_ident = extra_package.split("/")
+      pkg_origin = package_ident[0]
+      pkg_name = package_ident[1]
+
+      latest_release = package_querier.get_latest(channel_for_origin(pkg_origin), pkg_origin, pkg_name)
+      log.info "Adding package #{latest_release.pretty}"
+      manifest["packages"] << latest_release.ident
+    end
+
+    manifest["packages"].uniq!
+    # Sort the packages for easier diff-ing
+    manifest["packages"].sort!
+    manifest
   end
-  ret
-end
 
-def channel_for_origin(origin)
-  case origin
-  when "chef"
-    "dev"
-  else
-    "stable"
+  def channel_for_origin(origin)
+    case origin
+    when "chef"
+      "dev"
+    else
+      "stable"
+    end
+  end
+
+  def local_hab_version
+    # Grab the version of hab in the build environment. Comes out in the
+    # form of 'hab 0.54.0/20180221020527'
+    hab_version = /(\d+\.\d+\.\d+\/\d{14})/.match(`hab --version`.strip)[0]
+    "core/hab/#{hab_version}"
+  end
+
+  def git_sha
+    out, err, status = Open3.capture3("git show-ref HEAD --hash")
+    raise "Failed to get git_sha: exitcode=#{status.exitstatus} stderr=#{err}" if status.exitstatus != 0
+    out.strip
+  end
+
+  def parse_products_meta_file(path)
+    File.open(path) do |f|
+      JSON.parse(f.read)
+    end
   end
 end
 
-def log_added_ident(log, ident)
-  log.info "Adding package #{ident.pretty}"
-end
-
-# -- FIXME: PINNED DATABASES - sdelano 2018/07/19 --
-#
-# We currently believe it's unsafe to upgrade the database packages in an existing
-# A2 installation because of unconfigurable shutdown behavior for Habitat services.
-# Until we have a new supervisor that can safely stop PostgreSQL and ElasticSearch,
-# we need to avoid upgrading the databases and risking potential data corruption and
-# stale service state.
-#
-# This will pin the services that we package and start with the deployment service,
-# while still allowing the clients of these databases to upgrade their client
-# libraries if any fixes are shipped there.
-pinned_databases = {
+pins = {
+  # -- FIXME: PINNED DATABASES - sdelano 2018/07/19 --
+  #
+  # We currently believe it's unsafe to upgrade the database packages in an existing
+  # A2 installation because of unconfigurable shutdown behavior for Habitat services.
+  # Until we have a new supervisor that can safely stop PostgreSQL and ElasticSearch,
+  # we need to avoid upgrading the databases and risking potential data corruption and
+  # stale service state.
+  #
+  # This will pin the services that we package and start with the deployment service,
+  # while still allowing the clients of these databases to upgrade their client
+  # libraries if any fixes are shipped there.
   "automate-postgresql"    => {"origin" => "chef", "name" => "automate-postgresql",    "version" => "9.6.11", "release" => "20190409151101"},
-  "automate-elasticsearch" => {"origin" => "chef", "name" => "automate-elasticsearch", "version" => "6.2.2",  "release" => "20190123133819"}
+  "automate-elasticsearch" => {"origin" => "chef", "name" => "automate-elasticsearch", "version" => "6.2.2",  "release" => "20190123133819"},
+
+  # IF YOU UPDATE THESE PINS YOU MUST ALSO UPDATE THE core/hab PIN IN
+  # components/automate-deployment/habitat/plan.sh
+  #
+  # WARNING: These pins are managed by .expeditor/update_habitat.sh.
+  "hab"          => { "origin" => "core", "name" => "hab",          "version" => "0.69.0", "release" => "20181127182011"},
+  "hab-sup"      => { "origin" => "core", "name" => "hab-sup",      "version" => "0.69.0", "release" => "20181127183841"},
+  "hab-launcher" => { "origin" => "core", "name" => "hab-launcher", "version" => "9106",   "release" => "20181126205526"}
 }
 
-# IF YOU UPDATE THESE PINS YOU MUST ALSO UPDATE THE core/hab PIN IN
-# components/automate-deployment/habitat/plan.sh
+# CONFIGURATION
 #
-pinned_hab_components = {
-    "hab"          => { "origin" => "core", "name" => "hab",          "version" => "0.69.0", "release" => "20181127182011"},
-    "hab-sup"      => { "origin" => "core", "name" => "hab-sup",      "version" => "0.69.0", "release" => "20181127183841"},
-    "hab-launcher" => { "origin" => "core", "name" => "hab-launcher", "version" => "9106",   "release" => "20181126205526"}
-}
-
-pins = pinned_databases.merge(pinned_hab_components)
-
-# When true, ALLOW_LOCAL_PACKAGES creates the manifest using locally
+# When true, allow_local_packages creates the manifest using locally
 # created hartifacts if it can not otherwise find the package uploaded
 # to the depot.
-use_local_packages=(ENV["ALLOW_LOCAL_PACKAGES"] == "true")
+allow_local_packages=(ENV["ALLOW_LOCAL_PACKAGES"] == "true")
+# An additional origin that we will accept locally built packages
+# from. Similar to override-origin in deployment-service.
 local_package_origin = ENV["HAB_ORIGIN"] || "chef"
+# The directory that we will look for local packages in.
 local_package_directory = "results"
-
+# Whether or not we should lookup package idents using the
+# EXPEDITOR_PKG_IDENT_ environment variables. Enabled only if it
+# appears we are running as an Expeditor job.
 use_environment_idents=(ENV["EXPEDITOR_NAME"].to_s != "")
+# The top level version of Chef Automate
 version = ENV["VERSION"] || DateTime.now.strftime("%Y%m%d%H%M%S")
+# The output filename
 filename = if ENV["VERSION"]
              "#{ENV["VERSION"]}.json"
            else
              "manifest.json"
            end
+# Packages that are present in products.meta but we wish to exclude
+# from the manifest (probably because they are not yet published to
+# the depot).
+#
+# We make this list explicit so that we can make manifest generation
+# fail when we fail to get expected package data from the hab depot.
+#
+# TODO(ssd) 2019-08-30: Do we actually need this anymore? Newly
+# created packages should be handled by ALLOW_LOCAL_PACKAGES.
+skip_packages = []
+
 
 log = Logger.new(STDOUT)
 log.formatter = proc do |severity, datetime, progname, msg|
@@ -268,12 +360,13 @@ end
 log.info "Creating release manifest for Automate"
 log.info "--------------------------------------"
 log.info "Configuration:"
-log.info "  use_local_packages=#{use_local_packages}"
+log.info "  allow_local_packages=#{allow_local_packages}"
 log.info "  use_environment_idents=#{use_environment_idents}"
 log.info "  local_package_origin=#{local_package_origin}"
 log.info "  local_package_directory=#{local_package_directory}"
 log.info "  filename=#{filename}"
 log.info "  version=#{version}"
+log.info "  skip_packages=#{skip_packages}"
 log.info "-------------------------------"
 
 package_queriers = [PackageQuerier::PinQuerier.new(pins)]
@@ -281,81 +374,10 @@ if use_environment_idents
   package_queriers << PackageQuerier::LoggedComparisonQuerier.new(PackageQuerier::ExpeditorEnvQuerier.new, PackageQuerier::DepotQuerier.new, log)
 end
 package_queriers << PackageQuerier::DepotQuerier.new
-# NOTE(ssd) 2019-08-30: This comes after DepotQuerier, becuase we only
-# really need to look at local packages in the case of adding a new
-# service that hasn't been uploaded to the depot. For other newly
-# built packages, we depend on the deployment-service's override
-# origin.
-if use_local_packages
+if allow_local_packages
   package_queriers << PackageQuerier::DiskQuerier.new(local_package_directory, local_package_origin)
 end
-package_querier = PackageQuerier::ChainQuerier.new(package_queriers)
+package_querier = PackageQuerier::MustExistQuerier.new(PackageQuerier::ChainQuerier.new(package_queriers))
 
-manifest = {}
-
-# The version of the manifest schema - might need to be bumped in the future
-manifest["schema_version"] = "1"
-
-# The version of the manifest - the "engineering" version
-manifest["build"] = version
-
-# Grab the version of various Habitat components from the deployment-service
-hab_deps = get_hab_deps_latest(package_querier)
-manifest["hab"] = []
-manifest["hab"] << hab_deps["hab"]
-manifest["hab"] << hab_deps["hab-sup"]
-manifest["hab"] << hab_deps["hab-launcher"]
-
-
-# Grab the version of hab in the build environment. Comes out in the
-# form of 'hab 0.54.0/20180221020527'
-hab_version = /(\d+\.\d+\.\d+\/\d{14})/.match(`hab --version`.strip)[0]
-manifest["hab_build"] = "core/hab/#{hab_version}"
-
-# Grab the git SHA
-out, err, status = Open3.capture3("git show-ref HEAD --hash")
-raise "Failed to get git_sha: exitcode=#{status.exitstatus} stderr=#{err}" if status.exitstatus != 0
-manifest["git_sha"] = out.strip
-
-products_meta = File.open("products.meta") do |f|
-  JSON.parse(f.read)
-end
-
-manifest["packages"] = []
-products_meta["packages"].each do |pkg_path|
-  next if SKIP_PACKAGES.include?(pkg_path)
-
-  package_ident = pkg_path.split("/")
-  pkg_origin = package_ident[0]
-  pkg_name = package_ident[1]
-
-  latest_release = package_querier.get_latest(channel_for_origin(pkg_origin), pkg_origin, pkg_name)
-  log_added_ident(log, latest_release)
-  manifest["packages"] << latest_release.ident
-end
-
-products_meta["deleted_packages"].each do |pkg|
-  log.info "Adding last stable release of deleted package #{pkg}"
-  manifest["packages"] << "#{pkg}"
-end
-
-# Add extra packages to manifest that deployment-service doesn't need to manage
-# but we still want versioned with each release.
-%w{
-  chef/automate-chef-io
-}.each do |extra_package|
-  package_ident = extra_package.split("/")
-  pkg_origin = package_ident[0]
-  pkg_name = package_ident[1]
-
-  latest_release = package_querier.get_latest(channel_for_origin(pkg_origin), pkg_origin, pkg_name)
-  log_added_ident(log, latest_release)
-  manifest["packages"] << latest_release.ident
-end
-
-manifest["packages"].uniq!
-# Sort the packages for easier diff-ing
-manifest["packages"].sort!
-
-
+manifest = ManifestGenerator.new.generate(package_querier, "products.meta", version, skip_packages, log)
 File.open("#{filename}", "w") { |file| file.write(JSON.pretty_generate(manifest)) }

--- a/.expeditor/create-manifest.rb
+++ b/.expeditor/create-manifest.rb
@@ -85,7 +85,9 @@ class PackageQuerier
       ret = @main.get_latest(channel, origin, name)
       if !ret.nil?
         compare_result = @compare.get_latest(channel, origin, name)
-        if compare_result != ret
+        if compare_result.nil?
+          @logger.warn("#{origin}/#{name} not found in secondary source #{@compare}")
+        elsif compare_result != ret
           @logger.warn("Found mismatch between sources:")
           @logger.warn("   #{ret.pretty}")
           @logger.warn("   #{compare_result.pretty}")


### PR DESCRIPTION
In expeditor, we have access to the exact package identifiers that
were included in the build group.  We can use these identifiers to
avoid eventual consistency issues we've seen with the Habitat Depot.

We are currently unsure on the exact cause of the inconsistent manifest
creation.  While we think it is the result of caching in the Depot API,
we have been unable to confirm this.

To facilitate hunting it down, I've also added logging for cases where the expeditor
environment doesn't match what is found in the depot:

```
2019-08-30 11:18:37 +0100 WARN: Found mismatch between sources:
2019-08-30 11:18:37 +0100 WARN:    chef/automate-gateway/0.1.0/20190829202630 from expeditor environment
2019-08-30 11:18:37 +0100 WARN:    chef/automate-gateway/0.1.0/20190829202631 from Habitat Depot
2019-08-30 11:18:37 +0100 WARN: Using chef/automate-gateway/0.1.0/20190829202630
```

This script was growing rather large, so I've broken it up a bit:

- Added a number of `PackageQuerier` classes each of which knows how to
  look up packages from a single source.  The MustExistQuerier is maybe a
  bridge too far, but oh well, I think the rest are fine.

- Added a `ManifestGenerator` class just to provide a line between "setup" logic and
  generation logic since there were a LOT of state variables in the main script.

- Added a logger so that we get timestamps in the logs

- Add some more log statements so we can see what configuration was used to generate
  a given manifest from looking at the logs.
Signed-off-by: Steven Danna <steve@chef.io>