### PR TITLE
ci: always git-clean when we expect expeditor to open PRs

### DIFF
--- a/.expeditor/generate-automate-api-docs.sh
+++ b/.expeditor/generate-automate-api-docs.sh
@@ -19,5 +19,5 @@ git commit --message "Sync swagger files for Automate docs." --message "This pul
 open_pull_request
 
 git checkout -
-gi clean -fxd
+git clean -fxd
 git branch -D "$branch"

--- a/.expeditor/generate-automate-api-docs.sh
+++ b/.expeditor/generate-automate-api-docs.sh
@@ -19,4 +19,5 @@ git commit --message "Sync swagger files for Automate docs." --message "This pul
 open_pull_request
 
 git checkout -
+gi clean -fxd
 git branch -D "$branch"

--- a/.expeditor/update-compliance-profiles.sh
+++ b/.expeditor/update-compliance-profiles.sh
@@ -28,4 +28,5 @@ git commit --message "Bump automate-compliance-profiles"  --message "This pull r
 open_pull_request
 
 git checkout -
+git clean -fxd
 git branch -D "$branch"

--- a/.expeditor/update-inspec-version.sh
+++ b/.expeditor/update-inspec-version.sh
@@ -31,4 +31,5 @@ git commit --message "Bump inspec to $EXPEDITOR_PKG_VERSION/$EXPEDITOR_PKG_RELEA
 open_pull_request
 
 git checkout -
+git clean -fxd
 git branch -D "$branch"

--- a/.expeditor/update_chef_server.sh
+++ b/.expeditor/update_chef_server.sh
@@ -71,5 +71,6 @@ if [[ "$NO_GIT" != "true" ]]; then
     # left over at the end of this script will get committed to
     # master.
     git checkout -
+    git clean -fxd
     git branch -D "$branch"
 fi

--- a/.expeditor/update_habitat.sh
+++ b/.expeditor/update_habitat.sh
@@ -39,5 +39,6 @@ if [[ "$NO_GIT" != "true" ]]; then
 
     # Get back to master and cleanup the leftovers - any changed files left over at the end of this script will get committed to master.
     git checkout -
+    git clean -fxd
     git branch -D "$branch"
 fi


### PR DESCRIPTION
Expeditor by default commits any modified files directly to
master. We currently prefer that expeditor open PRs so that we can
evaluate whether the verify tests have passed and whether we want to
make the given change.

Here, we run `git clean -fxd` to avoid anything getting unexpectedly
committed to master.

Signed-off-by: Steven Danna <steve@chef.io>