### PR TITLE
ingest-service: make tests pass before 4PM UTC

### DIFF
--- a/components/ingest-service/integration_test/purge_test.go
+++ b/components/ingest-service/integration_test/purge_test.go
@@ -1,15 +1,15 @@
 package integration_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
-	"context"
+	"github.com/stretchr/testify/require"
+	"github.com/teambition/rrule-go"
 
 	"github.com/chef/automate/api/interservice/data_lifecycle"
 	iBackend "github.com/chef/automate/components/ingest-service/backend"
-	"github.com/stretchr/testify/require"
-	"github.com/teambition/rrule-go"
 )
 
 // TestPurge tests the Purge server
@@ -147,13 +147,13 @@ func TestPurge(t *testing.T) {
 				RemoteHostname:   "chef-server.org",
 				OrganizationName: "org1",
 				Projects:         []string{"org1"},
-				RecordedAt:       time.Now().Add(time.Hour * -8),
+				RecordedAt:       time.Now(), // always today's index
 			},
 			iBackend.InternalChefAction{
 				RemoteHostname:   "chef-server.org",
 				OrganizationName: "org2",
 				Projects:         []string{"org2"},
-				RecordedAt:       time.Now().Add(time.Hour * -16),
+				RecordedAt:       time.Now().Add(time.Hour * -24), // always yesterday's index
 			},
 			iBackend.InternalChefAction{
 				RemoteHostname:   "chef-server.org",
@@ -205,6 +205,6 @@ func TestPurge(t *testing.T) {
 		waitForModificationsToApply()
 		actualActions, err = suite.GetActions(5)
 		require.NoError(t, err)
-		require.Equal(t, 2, len(actualActions), "wrong number of actions retrieved")
+		require.Equal(t, 1, len(actualActions), "wrong number of actions retrieved")
 	})
 }


### PR DESCRIPTION
The es-sidecar-service's purge API purges based on entire indexes. A
side-effect of this is that a request with OlderThanDays = 1, will
delete any document in the previous day's index. This includes many
documents that are less than a day old.

In the case of this test, we were injecting 4 events and expecting 2
of them to be deleted because only 2 of the RecordedAt timestamps were
less than 24 hours old. However, the two documents we expected not to
be deleted were 8 and 16 hours in the past.  In both cases, for large
portions of the day, these will be in yesterday's index instead of
today's index and thus they will get deleted.

This fixes the test by ensuring that we only expect actions that are
definitely in today's index to still exist.

These tests would have started working again at 4PM UTC.

One might argue that we should change the es-sidecar-service's API
instead of changing this test. I can be convinced.

Signed-off-by: Steven Danna <steve@chef.io>