### PR TITLE
Add cereal-service to NOPROXY

### DIFF
--- a/components/applications-service/habitat/hooks/run
+++ b/components/applications-service/habitat/hooks/run
@@ -7,6 +7,17 @@ exec 2>&1
 # Call the script to block until user accepts the MLSA via the package's config
 {{pkgPathFor "chef/mlsa"}}/bin/accept {{cfg.mlsa.accept}}
 
+{{~#eachAlive bind.event-service.members as |events|}}
+{{~#if @last}}
+addNoProxy "{{events.sys.ip}}"
+{{~/if}}
+{{~/eachAlive}}
+{{~#eachAlive bind.cereal-service.members as |cereal|}}
+{{~#if @last}}
+addNoProxy "{{cereal.sys.ip}}"
+{{~/if}}
+{{~/eachAlive}}
+
 # Postgres Database Management
 # We do this here because init hooks block the hab supervisor
 DBNAME="{{cfg.storage.database}}"

--- a/components/authz-service/habitat/hooks/run
+++ b/components/authz-service/habitat/hooks/run
@@ -15,7 +15,7 @@ rm -rf {{pkg.svc_static_path}}/{migrations,data-migrations}
 
 {{~#eachAlive bind.cereal-service.members as |cereal-service|}}
 {{~#if @last}}
-addNoProxy {{event-service.sys.ip}}
+addNoProxy {{cereal-service.sys.ip}}
 {{~/if}}
 {{~/eachAlive}}
 

--- a/components/authz-service/habitat/hooks/run
+++ b/components/authz-service/habitat/hooks/run
@@ -13,7 +13,7 @@ pg-helper create-extension "{{cfg.storage.database}}" "uuid-ossp"
 # cleanup old migration files
 rm -rf {{pkg.svc_static_path}}/{migrations,data-migrations}
 
-{{~#eachAlive bind.event-service.members as |event-service|}}
+{{~#eachAlive bind.cereal-service.members as |cereal-service|}}
 {{~#if @last}}
 addNoProxy {{event-service.sys.ip}}
 {{~/if}}

--- a/components/compliance-service/habitat/hooks/run
+++ b/components/compliance-service/habitat/hooks/run
@@ -115,14 +115,14 @@ CONFIG="$CONFIG --event-endpoint {{event.sys.ip}}:{{event.cfg.port}}"
 {{~/eachAlive}}
 
 # get nodemanager binding, used for getting nodes and nodemanager info
- {{~#eachAlive bind.nodemanager-service.members as |manager|}}
- {{~#if @last}}
- addNoProxy {{manager.sys.ip}}
- CONFIG="$CONFIG --manager-host {{manager.sys.ip}} --manager-port {{manager.cfg.port}}"
- {{~/if}}
- {{~/eachAlive}}
+{{~#eachAlive bind.nodemanager-service.members as |manager|}}
+{{~#if @last}}
+addNoProxy {{manager.sys.ip}}
+CONFIG="$CONFIG --manager-host {{manager.sys.ip}} --manager-port {{manager.cfg.port}}"
+{{~/if}}
+{{~/eachAlive}}
 
- # Create the compliance config file
+# Create the compliance config file
 CONFIG="$CONFIG --config {{pkg.svc_data_path}}/.compliance-service.toml"
 
 # Listen to what our gossip protocol whispers
@@ -154,7 +154,6 @@ addNoProxy {{cereal-service.sys.ip}}
 CONFIG="$CONFIG --cereal-endpoint {{cereal-service.sys.ip}}:{{cereal-service.cfg.port}}"
   {{~/if}}
 {{~/eachAlive}}
-
 
 # Postgres
 PG_BACKEND="--postgres-database {{cfg.storage.database}} --migrations-path {{pkg.path}}/migrations"

--- a/components/event-feed-service/habitat/hooks/run
+++ b/components/event-feed-service/habitat/hooks/run
@@ -14,5 +14,9 @@ addNoProxy {{member.sys.ip}}
 {{~/if}}
 {{~/eachAlive}}
 
+{{#eachAlive bind.cereal-service.members as |cereal|}}
+addNoProxy {{cereal.sys.ip}}
+{{~/eachAlive}}
+
 # Start our service
 exec event-feed-service serve --config {{pkg.svc_config_path}}/config.toml

--- a/components/ingest-service/habitat/hooks/run
+++ b/components/ingest-service/habitat/hooks/run
@@ -113,7 +113,6 @@ CONFIG="$CONFIG --cereal-address {{cereal-service.sys.ip}}:{{cereal-service.cfg.
   {{~/if}}
 {{~/eachAlive}}
 
-
 pg-helper ensure-service-database "$DBNAME"
 
 # Start Ingest Service


### PR DESCRIPTION
The nightlies failed because the application-service had not added the
cereal-service to their NOPROXY environment variable. Other services
had also forgotten to do this, but already had the relevant IP added
to NOPROXY because of other binds.

Signed-off-by: Steven Danna <steve@chef.io>