### PR TITLE
scaffolding: Always add sys.ip to NOPROXY

### DIFF
--- a/lib/scaffolding/shared.sh
+++ b/lib/scaffolding/shared.sh
@@ -46,6 +46,8 @@ export A2_SVC_PATH="{{pkg.svc_path}}"
 
 . ${pkg_prefix}/libexec/shell/*.sh
 
+addNoProxy "{{sys.ip}"
+
 chmod 0600 {{pkg.svc_config_path}}/service.crt
 chmod 0600 {{pkg.svc_config_path}}/service.key
 chmod 0600 {{pkg.svc_config_path}}/root_ca.crt


### PR DESCRIPTION
As can be seen in #1413 and similar previous fixes, we almost always
forget to call the addNoProxy function when adding a new bind.

At the moment, the ceremony around this is completely unnecessary
since we know that we are running all relevant components on the local
machine.  However, the current approach of each bind separately was
put in place when we thought that different services might be living
on different machines.

Adding sys.ip to NORPOXY in the scaffolding will mean that any service
using the scaffoldings can likely omit adding `addNoProxy` lines for
every service bind.

Signed-off-by: Steven Danna <steve@chef.io>