### PR TITLE
deps: bump dex 2.18.0 -> 2.19.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -227,7 +227,7 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:746dcdabe712f3f748a35d4aba1208bb17212d525b34cb04cc1fdb9c9d6d012c"
+  digest = "1:894f28af0aba942ac18880562ff31742d343cc8d04015d7bf96c1401546936e1"
   name = "github.com/dexidp/dex"
   packages = [
     "api",
@@ -252,8 +252,8 @@
     "version",
   ]
   pruneopts = "NUT"
-  revision = "aeb2861a40b50b283d3dcd964a421be7780b43b7"
-  version = "v2.18.0"
+  revision = "179cce36efda5343404194ebc292bfbc0dc183c3"
+  version = "v2.19.0"
 
 [[projects]]
   digest = "1:7a6852b35eb5bbc184561443762d225116ae630c26a7c4d90546619f1e7d2ad2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -81,7 +81,7 @@ required = [
 
 [[constraint]]
   name = "github.com/dexidp/dex"
-  version = "2.18.0"
+  version = "2.19.0"
 
 [[constraint]]
   name = "github.com/coreos/go-oidc"

--- a/components/automate-dex/habitat/plan.sh
+++ b/components/automate-dex/habitat/plan.sh
@@ -16,7 +16,7 @@ pkg_binds=(
   [pg-sidecar-service]="port"
 )
 pkg_deps=(
-  core/dex/2.18.0
+  core/dex/2.19.0
   chef/mlsa
   ${local_platform_tools_origin:-chef}/automate-platform-tools
   core/bash

--- a/integration/helpers/ssl_filters.jq
+++ b/integration/helpers/ssl_filters.jq
@@ -32,12 +32,6 @@ map(select(
          (.id != "security_headers" or .port != "10161") and
          (.id != "security_headers" or .port != "10200") and
 
-         # TODO Submit PR to dexip/dex to improve ciphersuite defaults
-         (.id != "cipherlist_AVERAGE" or (.port != "10116" and .port != "10117")) and
-         (.id != "cipherlist_3DES_IDEA" or (.port != "10116" and .port != "10117")) and
-         (.id != "SWEET32" or (.port != "10116" and .port != "10117")) and
-         (.id != "LUCKY13" or (.port != "10116" and .port != "10117")) and
-
          # automate-cs erlang-services
          # TODO: erlang services use common prime
          (.id != "LOGJAM-common_primes" or (.port != "10201" and .port != "10202" and .port != "10203")) and

--- a/vendor/github.com/dexidp/dex/server/api.go
+++ b/vendor/github.com/dexidp/dex/server/api.go
@@ -1,14 +1,11 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"golang.org/x/crypto/bcrypt"
-
-	// go-grpc doesn't use the standard library's context.
-	// https://github.com/grpc/grpc-go/issues/711
-	"golang.org/x/net/context"
 
 	"github.com/dexidp/dex/api"
 	"github.com/dexidp/dex/pkg/log"

--- a/vendor/github.com/dexidp/dex/server/handlers.go
+++ b/vendor/github.com/dexidp/dex/server/handlers.go
@@ -373,7 +373,7 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 		identity, ok, err := passwordConnector.Login(r.Context(), scopes, username, password)
 		if err != nil {
 			s.logger.Errorf("Failed to login user: %v", err)
-			s.renderError(w, http.StatusInternalServerError, "Login error.")
+			s.renderError(w, http.StatusInternalServerError, fmt.Sprintf("Login error: %v", err))
 			return
 		}
 		if !ok {


### PR DESCRIPTION
👉 Release notes are here: https://github.com/dexidp/dex/releases/tag/v2.19.0

ℹ️ We're interested in @stevendanna 's ciphersuite changes. (Note: these don't reflect in the vendored sources -- we're only vendoring parts of dex for some tests; the changes are pulled in via the updated `core/dex` habitat package.)

Fixes #1379.