### PR TITLE
lib/cereal: Don't log max worker warning if max is 1

### DIFF
--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -749,9 +749,11 @@ func (r *registeredExecutor) StartPoller(ctx context.Context, d backend.TaskDequ
 func (r *registeredExecutor) startTaskWorker(ctx context.Context, d backend.TaskDequeuer, workflowWakeupFun func()) {
 	logctx := logrus.WithField("task_name", r.name)
 	if !r.IncActiveWorkers() {
-		logctx.WithFields(logrus.Fields{
-			"max_workers": r.maxWorkers,
-		}).Warn("Maximum task workers already started")
+		if r.maxWorkers > 1 {
+			logctx.WithFields(logrus.Fields{
+				"max_workers": r.maxWorkers,
+			}).Warn("Maximum task workers already started")
+		}
 		return
 	}
 


### PR DESCRIPTION
We register a number of task executors with a single worker. In this
case, we always hit this warning, which makes it less useful.

Signed-off-by: Steven Danna <steve@chef.io>