### PR TITLE
Fix dep warning.

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -105,10 +105,6 @@ required = [
 
 [[constraint]]
   branch = "master"
-  name = "golang.org/x/net"
-
-[[constraint]]
-  branch = "master"
   name = "go.uber.org/zap"
 
 [[constraint]]


### PR DESCRIPTION
Before:
```
Petes-MBP:automate pete$ dep ensure -v
Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:

  ✗  golang.org/x/net

However, these projects are not direct dependencies of the current project:
they are not imported in any .go files, nor are they in the 'required' list in
Gopkg.toml. Dep only applies [[constraint]] rules to direct dependencies, so
these rules will have no effect.

Either import/require packages from these projects so that they become direct
dependencies, or convert each [[constraint]] to an [[override]] to enforce rules
on these projects, if they happen to be transitive dependencies.

Petes-MBP:automate pete$
```

After:
```
Petes-MBP:automate pete$ dep ensure -v
Petes-MBP:automate pete$
```