### PR TITLE
[AUTH-1256] Enforce project assignment permissions for policy create and update on IAM v2.1

### DIFF
--- a/components/authz-service/projectassignment/errors.go
+++ b/components/authz-service/projectassignment/errors.go
@@ -4,17 +4,17 @@ import (
 	"fmt"
 )
 
-// ProjectsMissingErr occurs when some of the projects in the project diff
+// ProjectsMissingError occurs when some of the projects in the project diff
 // did not exist.
-type ProjectsMissingErr struct {
+type ProjectsMissingError struct {
 	projectsMissing []string
 }
 
-func NewProjectsMissingError(projectsMissing []string) error {
-	return &ProjectsMissingErr{projectsMissing: projectsMissing}
+func NewProjectsMissingErroror(projectsMissing []string) error {
+	return &ProjectsMissingError{projectsMissing: projectsMissing}
 }
 
-func (e *ProjectsMissingErr) Error() string {
+func (e *ProjectsMissingError) Error() string {
 	var errorStr string
 	if len(e.projectsMissing) > 1 {
 		errorStr = fmt.Sprintf("You cannot modify projects for this object because these projects did not exist: %q", e.projectsMissing)

--- a/components/authz-service/projectassignment/project_assignment.go
+++ b/components/authz-service/projectassignment/project_assignment.go
@@ -6,7 +6,7 @@ import (
 	"github.com/chef/automate/components/authz-service/engine"
 )
 
-func ErrIfProjectAssignmentUnauthorized(ctx context.Context, authorizer engine.V2Authorizer, subjects, projectIDs []string) error {
+func EnsureProjectAssignmentAuthorized(ctx context.Context, authorizer engine.V2Authorizer, subjects, projectIDs []string) error {
 	engineResp, err := authorizer.V2ProjectsAuthorized(ctx,
 		engine.Subjects(subjects),
 		engine.Action("iam:projects:assign"),

--- a/components/authz-service/server/v2/authz.go
+++ b/components/authz-service/server/v2/authz.go
@@ -208,15 +208,15 @@ func (s *authzServer) ValidateProjectAssignment(
 		return nil, errors.New("must be on v2.1 to assign projects")
 	}
 
-	err := s.store.ErrIfMissingProjects(ctx, req.ProjectIds)
+	err := s.store.EnsureNoProjectsMissing(ctx, req.ProjectIds)
 	if err != nil {
-		if _, ok := err.(*projectassignment.ProjectsMissingErr); ok {
+		if _, ok := err.(*projectassignment.ProjectsMissingError); ok {
 			return nil, status.Error(codes.NotFound, err.Error())
 		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	err = projectassignment.ErrIfProjectAssignmentUnauthorized(ctx, s.engine, req.Subjects, req.ProjectIds)
+	err = projectassignment.EnsureProjectAssignmentAuthorized(ctx, s.engine, req.Subjects, req.ProjectIds)
 	if err != nil {
 		if _, ok := err.(*projectassignment.ProjectsUnauthorizedForAssignmentErr); ok {
 			return nil, status.Error(codes.PermissionDenied, err.Error())

--- a/components/authz-service/server/v2/migration.go
+++ b/components/authz-service/server/v2/migration.go
@@ -64,7 +64,7 @@ func (s *policyServer) migrateV1Policies(ctx context.Context) ([]error, error) {
 		if storagePol == nil {
 			continue // nothing to create
 		}
-		_, err = s.store.CreatePolicy(ctx, storagePol)
+		_, err = s.store.CreatePolicy(ctx, storagePol, false)
 		switch err {
 		case nil, storage_errors.ErrConflict: // ignore, continue
 		default:

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -162,7 +162,7 @@ func (s *policyServer) CreatePolicy(
 			"policy with id %q already exists", req.Id)
 	default:
 		switch err.(type) {
-		case *projectassignment.ProjectsMissingErr:
+		case *projectassignment.ProjectsMissingError:
 			return nil, status.Error(codes.NotFound, err.Error())
 		case *projectassignment.ProjectsUnauthorizedForAssignmentErr:
 			return nil, status.Errorf(codes.PermissionDenied, err.Error())
@@ -275,7 +275,7 @@ func (s *policyServer) UpdatePolicy(
 			return nil, status.Errorf(codes.NotFound, "no policy with ID %q found", req.Id)
 		default:
 			switch err.(type) {
-			case *projectassignment.ProjectsMissingErr:
+			case *projectassignment.ProjectsMissingError:
 				return nil, status.Errorf(codes.NotFound, err.Error())
 			case *projectassignment.ProjectsUnauthorizedForAssignmentErr:
 				return nil, status.Errorf(codes.PermissionDenied, err.Error())
@@ -422,7 +422,7 @@ func (s *policyServer) CreateRole(
 		switch err.(type) {
 		case *storage_errors.ForeignKeyError:
 			return nil, status.Errorf(codes.InvalidArgument, err.Error())
-		case *projectassignment.ProjectsMissingErr:
+		case *projectassignment.ProjectsMissingError:
 			return nil, status.Errorf(codes.NotFound, err.Error())
 		case *projectassignment.ProjectsUnauthorizedForAssignmentErr:
 			return nil, status.Errorf(codes.PermissionDenied, err.Error())
@@ -511,7 +511,7 @@ func (s *policyServer) UpdateRole(
 		return nil, status.Errorf(codes.NotFound, "no role with ID %q found", req.Id)
 	default:
 		switch err.(type) {
-		case *projectassignment.ProjectsMissingErr:
+		case *projectassignment.ProjectsMissingError:
 			return nil, status.Errorf(codes.NotFound, err.Error())
 		case *projectassignment.ProjectsUnauthorizedForAssignmentErr:
 			return nil, status.Errorf(codes.PermissionDenied, err.Error())

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -163,7 +163,7 @@ func (s *policyServer) CreatePolicy(
 	default:
 		switch err.(type) {
 		case *projectassignment.ProjectsMissingErr:
-			return nil, status.Errorf(codes.NotFound, err.Error())
+			return nil, status.Error(codes.NotFound, err.Error())
 		case *projectassignment.ProjectsUnauthorizedForAssignmentErr:
 			return nil, status.Errorf(codes.PermissionDenied, err.Error())
 		case *storage_errors.ForeignKeyError:

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -154,18 +154,24 @@ func (s *policyServer) CreatePolicy(
 			"error parsing policy %q: %s", req.Id, err.Error())
 	}
 
-	returnPol, err := s.store.CreatePolicy(ctx, &pol)
+	returnPol, err := s.store.CreatePolicy(ctx, &pol, s.isBeta2p1())
 	switch err {
 	case nil: // continue
 	case storage_errors.ErrConflict:
 		return nil, status.Errorf(codes.AlreadyExists,
 			"policy with id %q already exists", req.Id)
 	default:
-		if err, ok := err.(*storage_errors.ForeignKeyError); ok {
+		switch err.(type) {
+		case *projectassignment.ProjectsMissingErr:
+			return nil, status.Errorf(codes.NotFound, err.Error())
+		case *projectassignment.ProjectsUnauthorizedForAssignmentErr:
+			return nil, status.Errorf(codes.PermissionDenied, err.Error())
+		case *storage_errors.ForeignKeyError:
 			return nil, status.Error(codes.InvalidArgument, err.Error())
+		default:
+			return nil, status.Errorf(codes.Internal,
+				"creating policy %q: %s", req.Id, err.Error())
 		}
-		return nil, status.Errorf(codes.Internal,
-			"creating policy %q: %s", req.Id, err.Error())
 	}
 
 	return policyFromInternal(returnPol)
@@ -260,7 +266,7 @@ func (s *policyServer) UpdatePolicy(
 		return nil, status.Errorf(codes.InvalidArgument, "parse policy with ID %q: %s", req.Id, err.Error())
 	}
 
-	polInternal, err := s.store.UpdatePolicy(ctx, &storagePolicy)
+	polInternal, err := s.store.UpdatePolicy(ctx, &storagePolicy, s.isBeta2p1())
 	if err != nil {
 		switch err {
 		case storage_errors.ErrConflict:
@@ -268,10 +274,17 @@ func (s *policyServer) UpdatePolicy(
 		case storage_errors.ErrNotFound:
 			return nil, status.Errorf(codes.NotFound, "no policy with ID %q found", req.Id)
 		default:
-			if err, ok := err.(*storage_errors.ForeignKeyError); ok {
+			switch err.(type) {
+			case *projectassignment.ProjectsMissingErr:
+				return nil, status.Errorf(codes.NotFound, err.Error())
+			case *projectassignment.ProjectsUnauthorizedForAssignmentErr:
+				return nil, status.Errorf(codes.PermissionDenied, err.Error())
+			case *storage_errors.ForeignKeyError:
 				return nil, status.Error(codes.InvalidArgument, err.Error())
+			default:
+				return nil, status.Errorf(codes.Internal,
+					"updating policy %q: %s", req.Id, err.Error())
 			}
-			return nil, err
 		}
 	}
 
@@ -553,7 +566,7 @@ func (s *policyServer) MigrateToV2(ctx context.Context,
 	}
 
 	for _, pol := range defaultPolicies {
-		if _, err := s.store.CreatePolicy(ctx, &pol); err != nil {
+		if _, err := s.store.CreatePolicy(ctx, &pol, false); err != nil {
 			return nil, status.Errorf(codes.Internal, "reset to default policies: %s", err.Error())
 		}
 	}

--- a/components/authz-service/storage/v2/memstore/memstore.go
+++ b/components/authz-service/storage/v2/memstore/memstore.go
@@ -372,7 +372,7 @@ func (*State) FetchAppliedRulesByProjectIDs(ctx context.Context) (map[string][]*
 	return nil, nil
 }
 
-func (*State) ErrIfMissingProjects(ctx context.Context, projectIDs []string) error {
+func (*State) EnsureNoProjectsMissing(ctx context.Context, projectIDs []string) error {
 	return nil
 }
 

--- a/components/authz-service/storage/v2/memstore/memstore.go
+++ b/components/authz-service/storage/v2/memstore/memstore.go
@@ -41,7 +41,7 @@ func (s *State) bumpPolicyVersion() {
 	s.changeManager.notifyChange()
 }
 
-func (s *State) CreatePolicy(_ context.Context, inputPol *storage.Policy) (*storage.Policy, error) {
+func (s *State) CreatePolicy(_ context.Context, inputPol *storage.Policy, checkProjects bool) (*storage.Policy, error) {
 	for _, item := range s.policies.Items() {
 		if pol, ok := item.Object.(*storage.Policy); ok &&
 			(pol.ID == inputPol.ID) {
@@ -147,7 +147,7 @@ func (s *State) AddPolicyMembers(
 	return pol.Members, nil
 }
 
-func (s *State) UpdatePolicy(_ context.Context, p *storage.Policy) (*storage.Policy, error) {
+func (s *State) UpdatePolicy(_ context.Context, p *storage.Policy, checkProjects bool) (*storage.Policy, error) {
 	item, exists := s.policies.Get(p.ID)
 	if !exists {
 		return nil, storage_errors.ErrNotFound

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -69,7 +69,7 @@ type Querier interface {
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 // CreatePolicy stores a new policy and its statements in postgres and returns the final policy.
-func (p *pg) CreatePolicy(ctx context.Context, pol *v2.Policy) (*v2.Policy, error) {
+func (p *pg) CreatePolicy(ctx context.Context, pol *v2.Policy, checkProjects bool) (*v2.Policy, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -83,6 +83,21 @@ func (p *pg) CreatePolicy(ctx context.Context, pol *v2.Policy) (*v2.Policy, erro
 	tx, err := p.db.BeginTx(ctx, nil /* use driver default */)
 	if err != nil {
 		return nil, p.processError(err)
+	}
+
+	if checkProjects {
+		err = p.errIfMissingProjectsWithQuerier(ctx, tx, pol.Projects)
+		if err != nil {
+			return nil, p.processError(err)
+		}
+
+		err = projectassignment.ErrIfProjectAssignmentUnauthorized(ctx,
+			p.engine,
+			auth_context.FromContext(auth_context.FromIncomingMetadata(ctx)).Subjects,
+			pol.Projects)
+		if err != nil {
+			return nil, p.processError(err)
+		}
 	}
 
 	err = p.insertPolicyWithQuerier(ctx, pol, tx)
@@ -187,7 +202,7 @@ func (p *pg) ListPolicies(ctx context.Context) ([]*v2.Policy, error) {
 }
 
 func (p *pg) GetPolicy(ctx context.Context, id string) (*v2.Policy, error) {
-	pol, err := p.queryPolicy(ctx, id, p.db)
+	pol, err := p.queryPolicy(ctx, id, p.db, false)
 	if err != nil {
 		return nil, p.processError(err)
 	}
@@ -205,7 +220,7 @@ func (p *pg) DeletePolicy(ctx context.Context, id string) error {
 	}
 
 	// Project filtering handled in here
-	_, err = p.queryPolicy(ctx, id, tx)
+	_, err = p.queryPolicy(ctx, id, tx, false)
 	if err != nil {
 		return p.processError(err)
 	}
@@ -231,7 +246,7 @@ func (p *pg) DeletePolicy(ctx context.Context, id string) error {
 	return nil
 }
 
-func (p *pg) UpdatePolicy(ctx context.Context, pol *v2.Policy) (*v2.Policy, error) {
+func (p *pg) UpdatePolicy(ctx context.Context, pol *v2.Policy, checkProjects bool) (*v2.Policy, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -241,9 +256,30 @@ func (p *pg) UpdatePolicy(ctx context.Context, pol *v2.Policy) (*v2.Policy, erro
 	}
 
 	// Project filtering handled in here. We'll return a 404 right away if we can't find
-	// the policy via ID as filtered by projects.
-	if _, err = p.queryPolicy(ctx, pol.ID, tx); err != nil {
+	// the policy via ID as filtered by projects. Also selects for update if in v2.1 mode
+	// so we can check project assignment permissions without them being changed under us.
+	oldPolicy, err := p.queryPolicy(ctx, pol.ID, tx, checkProjects)
+	if err != nil {
 		return nil, p.processError(err)
+	}
+
+	if checkProjects {
+		projectDiff := projectassignment.CalculateProjectDiff(oldPolicy.Projects, pol.Projects)
+
+		if len(projectDiff) != 0 {
+			err = p.errIfMissingProjectsWithQuerier(ctx, tx, projectDiff)
+			if err != nil {
+				return nil, p.processError(err)
+			}
+
+			err = projectassignment.ErrIfProjectAssignmentUnauthorized(ctx,
+				p.engine,
+				auth_context.FromContext(auth_context.FromIncomingMetadata(ctx)).Subjects,
+				projectDiff)
+			if err != nil {
+				return nil, p.processError(err)
+			}
+		}
 	}
 
 	// Since we are forcing users to update the entire policy, we should delete
@@ -388,18 +424,23 @@ func (p *pg) notifyPolicyChange(ctx context.Context, q Querier) error {
 	return err
 }
 
-// queryPolicy returns a policy based on id or an error.
-func (p *pg) queryPolicy(ctx context.Context, id string, q Querier) (*v2.Policy, error) {
+// queryPolicy returns a policy based on id or an error. Can optionally lock for updates.
+func (p *pg) queryPolicy(ctx context.Context, id string, q Querier, selectForUpdate bool) (*v2.Policy, error) {
 	projectsFilter, err := projectsListFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	var pol v2.Policy
-	if err := q.QueryRowContext(ctx, "SELECT query_policy($1, $2)", id, pq.Array(projectsFilter)).
+	query := "SELECT query_policy($1, $2)"
+	if selectForUpdate {
+		query = "SELECT query_policy($1, $2) FOR UPDATE"
+	}
+	if err := q.QueryRowContext(ctx, query, id, pq.Array(projectsFilter)).
 		Scan(&pol); err != nil {
 		return nil, err
 	}
+
 	return &pol, nil
 }
 
@@ -418,7 +459,7 @@ func (p *pg) ListPolicyMembers(ctx context.Context, id string) ([]v2.Member, err
 
 	// Project filtering handled in here. We'll return a 404 here right away if
 	// we can't find the policy via ID as filtered by projects.
-	_, err = p.queryPolicy(ctx, id, tx)
+	_, err = p.queryPolicy(ctx, id, tx, false)
 	if err != nil {
 		return nil, p.processError(err)
 	}
@@ -447,7 +488,7 @@ func (p *pg) AddPolicyMembers(ctx context.Context, id string, members []v2.Membe
 
 	// Project filtering handled in here. We'll return a 404 right away if we can't find
 	// the policy via ID as filtered by projects.
-	_, err = p.queryPolicy(ctx, id, tx)
+	_, err = p.queryPolicy(ctx, id, tx, false)
 	if err != nil {
 		return nil, p.processError(err)
 	}
@@ -487,7 +528,7 @@ func (p *pg) ReplacePolicyMembers(ctx context.Context, policyID string, members 
 
 	// Project filtering handled in here. We'll return a 404 right away if we can't find
 	// the policy via ID as filtered by projects.
-	_, err = p.queryPolicy(ctx, policyID, tx)
+	_, err = p.queryPolicy(ctx, policyID, tx, false)
 	if err != nil {
 		return nil, p.processError(err)
 	}
@@ -531,7 +572,7 @@ func (p *pg) RemovePolicyMembers(ctx context.Context,
 
 	// Project filtering handled in here. We'll return a 404 right away if we can't find
 	// the policy via ID as filtered by projects.
-	_, err = p.queryPolicy(ctx, policyID, tx)
+	_, err = p.queryPolicy(ctx, policyID, tx, false)
 	if err != nil {
 		return nil, p.processError(err)
 	}

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -256,7 +256,7 @@ func (p *pg) UpdatePolicy(ctx context.Context, pol *v2.Policy, checkProjects boo
 	}
 
 	// Project filtering handled in here. We'll return a 404 right away if we can't find
-	// the policy via ID as filtered by projects. Also selects for update if in v2.1 mode
+	// the policy via ID as filtered by projects. Also locks relevant rows if in v2.1 mode
 	// so we can check project assignment permissions without them being changed under us.
 	oldPolicy, err := p.queryPolicy(ctx, pol.ID, tx, checkProjects)
 	if err != nil {

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -1054,7 +1054,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -1076,7 +1076,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -1106,13 +1106,47 @@ func TestCreatePolicy(t *testing.T) {
 				Statements: []storage.Statement{statement},
 			}
 
-			resp, err := store.CreatePolicy(ctx, &pol)
+			resp, err := store.CreatePolicy(ctx, &pol, false)
 			require.Error(t, err)
 			assert.Nil(t, resp)
 
 			_, ok := err.(*storage_errors.ForeignKeyError)
 			assert.True(t, ok, "expected foreign key error")
 			assert.Equal(t, "role not found: "+role, err.Error())
+
+			assertEmpty(t, db.QueryRow(policyWithID, polID))
+			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_statements`))
+			assertEmpty(t, db.QueryRow(policyMembersByPolicyID, polID))
+			assertEmpty(t, db.QueryRow(membersCount))
+		},
+		"policy that contains a non-existent project returns ProjectsMissingErr": func(t *testing.T) {
+			polID := genSimpleID(t, prngSeed)
+			name, typeVal := "toBeCreated", storage.Custom
+
+			resources, actions := []string{"iam:users"}, []string{"iam:users:create", "iam:users:delete"}
+			member := genMember(t, "user:local:albertine")
+			statement := storage.Statement{
+				Effect:    storage.Deny,
+				Resources: resources,
+				Actions:   actions,
+			}
+
+			pol := storage.Policy{
+				ID:         polID,
+				Name:       name,
+				Members:    []storage.Member{member},
+				Type:       typeVal,
+				Statements: []storage.Statement{statement},
+				Projects:   []string{"notfound"},
+			}
+
+			assertNoPolicyChange(t, store, func() {
+				resp, err := store.CreatePolicy(ctx, &pol, true)
+				assert.Error(t, err)
+				_, correctError := err.(*projectassignment.ProjectsMissingErr)
+				assert.True(t, correctError)
+				assert.Empty(t, resp)
+			})
 
 			assertEmpty(t, db.QueryRow(policyWithID, polID))
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_statements`))
@@ -1140,7 +1174,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -1177,7 +1211,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -1214,7 +1248,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -1247,7 +1281,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -1283,7 +1317,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -1315,7 +1349,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -1350,7 +1384,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.NotNil(t, resp)
 			})
@@ -1381,7 +1415,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -1423,7 +1457,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -1468,7 +1502,7 @@ func TestCreatePolicy(t *testing.T) {
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_statement_projects WHERE project_id=project_db_id($1)`, projID))
 
 			assertNoPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.Error(t, err)
 				assert.Nil(t, resp)
 			})
@@ -1486,7 +1520,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -1513,7 +1547,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -1542,7 +1576,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -1570,7 +1604,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertNoPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.Error(t, err)
 				assert.Nil(t, resp)
 				_, ok := err.(*storage_errors.ForeignKeyError)
@@ -1601,7 +1635,7 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			assertNoPolicyChange(t, store, func() {
-				resp, err := store.CreatePolicy(ctx, &pol)
+				resp, err := store.CreatePolicy(ctx, &pol, false)
 				require.Error(t, err)
 				assert.Nil(t, resp)
 				_, ok := err.(*storage_errors.ForeignKeyError)
@@ -2497,7 +2531,7 @@ func TestUpdatePolicy(t *testing.T) {
 				Members: []storage.Member{member},
 			}
 			assertNoPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				assert.Error(t, err)
 				assert.Equal(t, storage_errors.ErrNotFound, err)
 				assert.Nil(t, resp)
@@ -2520,7 +2554,7 @@ func TestUpdatePolicy(t *testing.T) {
 				Members: []storage.Member{member},
 			}
 			assertNoPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				assert.Error(t, err)
 				assert.Equal(t, storage_errors.ErrNotFound, err)
 				assert.Nil(t, resp)
@@ -2541,7 +2575,7 @@ func TestUpdatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -2550,6 +2584,33 @@ func TestUpdatePolicy(t *testing.T) {
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_statements WHERE policy_id=policy_db_id($1)`, polID))
 			assertOne(t, db.QueryRow(policyMembersByPolicyID, polID))
 			assertOne(t, db.QueryRow(membersCount))
+		},
+		"policy that updates the project diff to contain a nonexisting project returns ProjectsMissingErr": func(t *testing.T) {
+			ctx := context.Background()
+			initPolName := "testpolicy"
+			polID := insertTestPolicy(t, db, initPolName)
+			insertTestPolicyMember(t, db, polID, "user:local:albertine")
+
+			newPolName, typeVal := "new-name", storage.Custom
+			member := genMember(t, "user:local:albertine")
+			pol := storage.Policy{
+				ID:       polID,
+				Name:     newPolName,
+				Type:     typeVal,
+				Members:  []storage.Member{member},
+				Projects: []string{"notfound"},
+			}
+
+			assertNoPolicyChange(t, store, func() {
+				resp, err := store.UpdatePolicy(ctx, &pol, true)
+				assert.Error(t, err)
+				assert.Empty(t, resp)
+				_, correctError := err.(*projectassignment.ProjectsMissingErr)
+				assert.True(t, correctError)
+			})
+
+			assertOne(t, db.QueryRow(policyFull, polID, initPolName, typeVal.String()))
+			assertEmpty(t, db.QueryRow(policyFull, polID, newPolName, typeVal.String()))
 		},
 		"policy with no statements, changing the type": func(t *testing.T) {
 			ctx := context.Background()
@@ -2567,7 +2628,7 @@ func TestUpdatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -2604,7 +2665,7 @@ func TestUpdatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -2643,7 +2704,7 @@ func TestUpdatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -2689,7 +2750,7 @@ func TestUpdatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -2734,7 +2795,7 @@ func TestUpdatePolicy(t *testing.T) {
 			assertEmpty(t, db.QueryRow(`SELECT count(*) FROM iam_statement_projects WHERE project_id=project_db_id($1)`, projID))
 
 			assertNoPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.Error(t, err)
 				assert.Nil(t, resp)
 			})
@@ -2765,7 +2826,7 @@ func TestUpdatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.ElementsMatch(t, []string{projID}, resp.Projects)
 			})
@@ -2793,7 +2854,7 @@ func TestUpdatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.ElementsMatch(t, expProjs, resp.Projects)
 			})
@@ -2827,7 +2888,7 @@ func TestUpdatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, expProjs, resp.Projects)
 			})
@@ -2860,7 +2921,7 @@ func TestUpdatePolicy(t *testing.T) {
 
 			expProjs := []string{projID2}
 			assertPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.ElementsMatch(t, expProjs, resp.Projects)
 			})
@@ -2893,7 +2954,7 @@ func TestUpdatePolicy(t *testing.T) {
 			}
 
 			assertPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, expProjs, resp.Projects)
 			})
@@ -2923,7 +2984,7 @@ func TestUpdatePolicy(t *testing.T) {
 			}
 
 			assertNoPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				assert.Error(t, err)
 				assert.Nil(t, resp)
 			})
@@ -2950,7 +3011,7 @@ func TestUpdatePolicy(t *testing.T) {
 			}
 			ctx = insertProjectsIntoContext(ctx, []string{projID1})
 			assertPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -2972,7 +3033,7 @@ func TestUpdatePolicy(t *testing.T) {
 			}
 			ctx = insertProjectsIntoContext(ctx, []string{v2.AllProjectsExternalID})
 			assertPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -2992,7 +3053,7 @@ func TestUpdatePolicy(t *testing.T) {
 			projID1 := "team-rocket"
 			ctx = insertProjectsIntoContext(ctx, []string{projID1, v2.UnassignedProjectID})
 			assertPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				require.NoError(t, err)
 				assert.Equal(t, &pol, resp)
 			})
@@ -3017,7 +3078,7 @@ func TestUpdatePolicy(t *testing.T) {
 			}
 			ctx = insertProjectsIntoContext(ctx, []string{projID2, v2.UnassignedProjectID})
 			assertNoPolicyChange(t, store, func() {
-				resp, err := store.UpdatePolicy(ctx, &pol)
+				resp, err := store.UpdatePolicy(ctx, &pol, false)
 				assert.Nil(t, resp)
 				assert.Equal(t, storage_errors.ErrNotFound, err)
 			})

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -1119,7 +1119,7 @@ func TestCreatePolicy(t *testing.T) {
 			assertEmpty(t, db.QueryRow(policyMembersByPolicyID, polID))
 			assertEmpty(t, db.QueryRow(membersCount))
 		},
-		"policy that contains a non-existent project returns ProjectsMissingErr": func(t *testing.T) {
+		"policy that contains a non-existent project returns ProjectsMissingError": func(t *testing.T) {
 			polID := genSimpleID(t, prngSeed)
 			name, typeVal := "toBeCreated", storage.Custom
 
@@ -1143,7 +1143,7 @@ func TestCreatePolicy(t *testing.T) {
 			assertNoPolicyChange(t, store, func() {
 				resp, err := store.CreatePolicy(ctx, &pol, true)
 				assert.Error(t, err)
-				_, correctError := err.(*projectassignment.ProjectsMissingErr)
+				_, correctError := err.(*projectassignment.ProjectsMissingError)
 				assert.True(t, correctError)
 				assert.Empty(t, resp)
 			})
@@ -2585,7 +2585,7 @@ func TestUpdatePolicy(t *testing.T) {
 			assertOne(t, db.QueryRow(policyMembersByPolicyID, polID))
 			assertOne(t, db.QueryRow(membersCount))
 		},
-		"policy that updates the project diff to contain a nonexisting project returns ProjectsMissingErr": func(t *testing.T) {
+		"policy that updates the project diff to contain a nonexisting project returns ProjectsMissingError": func(t *testing.T) {
 			ctx := context.Background()
 			initPolName := "testpolicy"
 			polID := insertTestPolicy(t, db, initPolName)
@@ -2605,7 +2605,7 @@ func TestUpdatePolicy(t *testing.T) {
 				resp, err := store.UpdatePolicy(ctx, &pol, true)
 				assert.Error(t, err)
 				assert.Empty(t, resp)
-				_, correctError := err.(*projectassignment.ProjectsMissingErr)
+				_, correctError := err.(*projectassignment.ProjectsMissingError)
 				assert.True(t, correctError)
 			})
 
@@ -6518,7 +6518,7 @@ func TestPurgeSubjectFromPolicies(t *testing.T) {
 	}
 }
 
-func TestErrIfMissingProjects(t *testing.T) {
+func TestEnsureNoProjectsMissing(t *testing.T) {
 	store, db, _, _, _ := testhelpers.SetupTestDB(t)
 	defer db.CloseDB(t)
 	defer store.Close()
@@ -6528,24 +6528,24 @@ func TestErrIfMissingProjects(t *testing.T) {
 		desc string
 		f    func(*testing.T)
 	}{
-		{"when there are no projects, returns ProjectsMissingErr", func(t *testing.T) {
-			err := store.ErrIfMissingProjects(ctx, []string{"missing"})
+		{"when there are no projects, returns ProjectsMissingError", func(t *testing.T) {
+			err := store.EnsureNoProjectsMissing(ctx, []string{"missing"})
 			assert.Error(t, err)
-			_, correctError := err.(*projectassignment.ProjectsMissingErr)
+			_, correctError := err.(*projectassignment.ProjectsMissingError)
 			assert.True(t, correctError)
 		}},
-		{"when some projects don't exist, returns ProjectsMissingErr", func(t *testing.T) {
+		{"when some projects don't exist, returns ProjectsMissingError", func(t *testing.T) {
 			insertTestProject(t, db, "proj0", "test project 0", storage.Custom)
 			insertTestProject(t, db, "proj1", "test project 1", storage.Custom)
-			err := store.ErrIfMissingProjects(ctx, []string{"proj0", "missing"})
+			err := store.EnsureNoProjectsMissing(ctx, []string{"proj0", "missing"})
 			assert.Error(t, err)
-			_, correctError := err.(*projectassignment.ProjectsMissingErr)
+			_, correctError := err.(*projectassignment.ProjectsMissingError)
 			assert.True(t, correctError)
 		}},
 		{"when all projects exist, return snil", func(t *testing.T) {
 			insertTestProject(t, db, "proj0", "test project 0", storage.Custom)
 			insertTestProject(t, db, "proj1", "test project 1", storage.Custom)
-			err := store.ErrIfMissingProjects(ctx, []string{"proj0", "proj1"})
+			err := store.EnsureNoProjectsMissing(ctx, []string{"proj0", "proj1"})
 			assert.NoError(t, err)
 		}},
 	}

--- a/components/authz-service/storage/v2/storage.go
+++ b/components/authz-service/storage/v2/storage.go
@@ -66,7 +66,7 @@ type projectStorage interface {
 	GetProject(context.Context, string) (*Project, error)
 	DeleteProject(context.Context, string) error
 	ListProjects(context.Context) ([]*Project, error)
-	ErrIfMissingProjects(context.Context, []string) error
+	EnsureNoProjectsMissing(context.Context, []string) error
 }
 
 type ruleStorage interface {

--- a/components/authz-service/storage/v2/storage.go
+++ b/components/authz-service/storage/v2/storage.go
@@ -36,10 +36,10 @@ type policyStorage interface {
 	ReplacePolicyMembers(context.Context, string, []Member) ([]Member, error)
 	RemovePolicyMembers(context.Context, string, []Member) ([]Member, error)
 	DeletePolicy(context.Context, string) error
-	CreatePolicy(context.Context, *Policy) (*Policy, error)
+	CreatePolicy(context.Context, *Policy, bool) (*Policy, error)
 	ListPolicies(context.Context) ([]*Policy, error)
 	GetPolicy(context.Context, string) (*Policy, error)
-	UpdatePolicy(context.Context, *Policy) (*Policy, error)
+	UpdatePolicy(context.Context, *Policy, bool) (*Policy, error)
 	ListPolicyMembers(context.Context, string) ([]Member, error)
 	AddPolicyMembers(context.Context, string, []Member) ([]Member, error)
 	ApplyV2DataMigrations(context.Context) error

--- a/e2e/cypress/integration/api/iam/02_policies_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/02_policies_api.spec.ts
@@ -10,33 +10,48 @@ describeIfIAMV2('policies API', () => {
   let adminToken = '';
   const cypressPrefix = 'test-policies-api';
   const now = Cypress.moment().format('MMDDYYhhmm');
-  const projectID = `${cypressPrefix}-project-${now}`;
+  const project1 = {
+      id: `${cypressPrefix}-project1-${now}`,
+      name: 'Test Project 1'
+  };
+  const project2 = {
+      id: `${cypressPrefix}-project2-${now}`,
+      name: 'Test Project 2'
+  };
+  const describeIfIAMV2p1 = Cypress.env('IAM_VERSION') === 'v2.1' ? describe : describe.skip;
 
-  beforeEach(() => {
+  before(() => {
     cy.adminLogin('/').then(() => {
       const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
       adminToken = admin.id_token;
       cy.cleanupPoliciesByIDPrefix(adminToken, cypressPrefix);
       cy.cleanupProjectsByIDPrefix(adminToken, cypressPrefix);
 
-      cy.request({
-        auth: { bearer: adminToken },
-        method: 'POST',
-        url: '/apis/iam/v2beta/projects',
-        body: {
-          id: projectID,
-          name: `${cypressPrefix} project ${now}`
-        }
-      });
+      for (const project of [project1, project2]) {
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/projects',
+            body: project
+        });
+      }
     });
   });
 
-  afterEach(() => {
+  after(() => {
     cy.cleanupPoliciesByIDPrefix(adminToken, cypressPrefix);
     cy.cleanupProjectsByIDPrefix(adminToken, cypressPrefix);
   });
 
   describe('POST /apis/iam/v2beta/policies', () => {
+    beforeEach(() => {
+      cy.cleanupPoliciesByIDPrefix(adminToken, cypressPrefix);
+    });
+
+    afterEach(() => {
+      cy.cleanupPoliciesByIDPrefix(adminToken, cypressPrefix);
+    });
+
     it('returns 400 when there are no statements',  () => {
       cy.request({
         auth: { bearer: adminToken },
@@ -47,7 +62,7 @@ describeIfIAMV2('policies API', () => {
           id: `${cypressPrefix}-policy-${now}`,
           name: `${cypressPrefix} policy ${now}`,
           members: ['team:local:test'],
-          projects: [projectID]
+          projects: [project1.id]
         }
       }).then((response) => {
        expect(response.status).to.equal(400);
@@ -56,6 +71,14 @@ describeIfIAMV2('policies API', () => {
   });
 
   describe('PUT /apis/iam/v2beta/policies', () => {
+    beforeEach(() => {
+      cy.cleanupPoliciesByIDPrefix(adminToken, cypressPrefix);
+    });
+
+    afterEach(() => {
+      cy.cleanupPoliciesByIDPrefix(adminToken, cypressPrefix);
+    });
+
     const policyID = `${cypressPrefix}-policy-${now}`;
     beforeEach(() => {
       cy.request({
@@ -70,10 +93,10 @@ describeIfIAMV2('policies API', () => {
             {
               effect: 'ALLOW',
               actions: ['test:svc:someaction', 'test:svc:otheraction'],
-              projects: [projectID]
+              projects: [project1.id]
             }
           ],
-          projects: [projectID]
+          projects: [project1.id]
         }
       });
     });
@@ -87,11 +110,359 @@ describeIfIAMV2('policies API', () => {
         body: {
           name: `${cypressPrefix} policy ${now}`,
           members: ['team:local:test'],
-          projects: [projectID]
+          projects: [project1.id]
         }
       }).then((response) => {
        expect(response.status).to.equal(400);
       });
     });
   });
+
+  describeIfIAMV2p1('project assignment enforcement', () => {
+    let nonAdminToken = '';
+    const nonAdminTokenID = `${cypressPrefix}-nonadmin-token-${now}`;
+    const statementProjects = [project1.id];
+    const policyID = `${cypressPrefix}-policy-${now}`;
+
+    before(() => {
+      cy.request({
+        auth: { bearer: adminToken },
+        method: 'POST',
+        url: '/apis/iam/v2beta/tokens',
+        body: {
+            active: true,
+            id: nonAdminTokenID,
+            name: 'Nonadmin Token'
+        }
+      }).then((response) => {
+          nonAdminToken = response.body.token.value;
+      });
+
+      cy.request({
+        auth: { bearer: adminToken },
+        method: 'POST',
+        url: '/apis/iam/v2beta/policies',
+        body: {
+            name: 'token-access',
+            id: `${cypressPrefix}-token-access-policy-${now}`,
+            members: [ `token:${nonAdminTokenID}` ],
+            statements: [
+              {
+                effect: 'ALLOW',
+                actions: [ 'iam:policies:*' ],
+                projects: [ '*' ]
+              },
+              {
+                effect: 'ALLOW',
+                actions: [ 'iam:projects:assign' ],
+                projects: [ project1.id ]
+              }
+            ],
+            projects: []
+        }
+      });
+    });
+
+    after(() => {
+      cy.cleanupProjectsByIDPrefix(adminToken, cypressPrefix);
+      cy.cleanupPoliciesByIDPrefix(adminToken, cypressPrefix);
+      cy.cleanupTokensByIDPrefix(adminToken, cypressPrefix);
+    });
+
+    beforeEach(() => {
+      cy.request({
+        auth: { bearer: adminToken },
+        method: 'DELETE',
+        url: `/apis/iam/v2beta/policies/${policyID}`,
+        failOnStatusCode: false
+      });
+    });
+
+    afterEach(() => {
+      cy.request({
+        auth: { bearer: adminToken },
+        method: 'DELETE',
+        url: `/apis/iam/v2beta/policies/${policyID}`,
+        failOnStatusCode: false
+      });
+    });
+
+    describe('POST /apis/iam/v2beta/policies', () => {
+      it('admin can create a new policy with no projects', () => {
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            body: policyWithProjects(policyID, [], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(0);
+        });
+      });
+
+      it('admin can create a new policy with multiple projects', () => {
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            body: policyWithProjects(policyID, [project1.id, project2.id], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(2);
+        });
+      });
+
+      it('admin gets a 404 when it attempts to create ' +
+         'a policy with a project that does not exist', () => {
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            failOnStatusCode: false,
+            body: policyWithProjects(policyID,
+              [project1.id, project2.id, 'notfound'], statementProjects)
+        }).then((response) => {
+            expect(response.status).to.equal(404);
+        });
+      });
+
+      it('non-admin with project1 assignment access can create a new policy ' +
+      'with no projects', () => {
+        cy.request({
+            headers: { 'api-token': nonAdminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            body: policyWithProjects(policyID, [], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(0);
+        });
+      });
+
+      it('non-admin with project1 assignment access can create ' +
+      'a new policy with project1', () => {
+        cy.request({
+            headers: { 'api-token': nonAdminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            body: policyWithProjects(policyID, [project1.id], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(1);
+        });
+      });
+
+      it('non-admin with project1 assignment access gets a 404 when it attempts to create ' +
+      'a policy with a project that does not exist', () => {
+        cy.request({
+            headers: { 'api-token': nonAdminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            failOnStatusCode: false,
+            body: policyWithProjects(policyID,
+              [project1.id, project2.id, 'notfound'], statementProjects)
+        }).then((response) => {
+            expect(response.status).to.equal(404);
+        });
+      });
+
+      it('non-admin with project1 assignment access cannot create ' +
+      'a new policy with other projects (403)', () => {
+        cy.request({
+            headers: { 'api-token': nonAdminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            failOnStatusCode: false,
+            body: policyWithProjects(policyID, [project1.id, project2.id], statementProjects)
+        }).then((response) => {
+            expect(response.status).to.equal(403);
+        });
+      });
+    });
+
+    describe('PUT /apis/iam/v2beta/policies', () => {
+      it('admin can update a policy with no projects to have projects', () => {
+        console.log(policyWithProjects(policyID, [], statementProjects));
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            body: policyWithProjects(policyID, [], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(0);
+        });
+
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'PUT',
+            url: `/apis/iam/v2beta/policies/${policyID}`,
+            body: policyWithProjects(policyID, [project1.id, project2.id], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(2);
+        });
+      });
+
+      it('admin can update a policy with projects to have no projects', () => {
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            body: policyWithProjects(policyID, [project1.id, project2.id], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(2);
+        });
+
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'PUT',
+            url: `/apis/iam/v2beta/policies/${policyID}`,
+            body: policyWithProjects(policyID, [], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(0);
+        });
+      });
+
+      it('admin cannot update a policy to have projects that do not exist', () => {
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            body: policyWithProjects(policyID, [], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(0);
+        });
+
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'PUT',
+            url: `/apis/iam/v2beta/policies/${policyID}`,
+            failOnStatusCode: false,
+            body: policyWithProjects(policyID, [project1.id, 'notfound'], statementProjects)
+        }).then((response) => {
+            expect(response.status).to.equal(404);
+        });
+      });
+
+      it('non-admin with project1 assignment access can update ' +
+      'a policy with no projects to have project1', () => {
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            body: policyWithProjects(policyID, [], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(0);
+        });
+
+        cy.request({
+            headers: { 'api-token': nonAdminToken },
+            method: 'PUT',
+            url: `/apis/iam/v2beta/policies/${policyID}`,
+            body: policyWithProjects(policyID, [project1.id], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(1);
+        });
+      });
+
+      it('non-admin with project1 assignment access can update ' +
+      'a policy to remove project1', () => {
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            body: policyWithProjects(policyID, [project1.id], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(1);
+        });
+
+        cy.request({
+            headers: { 'api-token': nonAdminToken },
+            method: 'PUT',
+            url: `/apis/iam/v2beta/policies/${policyID}`,
+            body: policyWithProjects(policyID, [], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(0);
+        });
+      });
+
+      it('non-admin with project1 assignment access gets a 404 ' +
+      'when updating a policy to have non-existent policies', () => {
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            body: policyWithProjects(policyID, [], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(0);
+        });
+
+        cy.request({
+            headers: { 'api-token': nonAdminToken },
+            method: 'PUT',
+            url: `/apis/iam/v2beta/policies/${policyID}`,
+            failOnStatusCode: false,
+            body: policyWithProjects(policyID, [project1.id, 'notfound'], statementProjects)
+        }).then((response) => {
+            expect(response.status).to.equal(404);
+        });
+      });
+
+      it('non-admin with project1 assignment access cannot update ' +
+      'a policy with no projects to have other projects', () => {
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            body: policyWithProjects(policyID, [], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(0);
+        });
+
+        cy.request({
+            headers: { 'api-token': nonAdminToken },
+            method: 'PUT',
+            url: `/apis/iam/v2beta/policies/${policyID}`,
+            failOnStatusCode: false,
+            body: policyWithProjects(policyID, [project1.id, project2.id], statementProjects)
+        }).then((response) => {
+            expect(response.status).to.equal(403);
+        });
+      });
+
+      it('non-admin with project1 assignment access cannot update ' +
+      'a policy to remove other projects', () => {
+        cy.request({
+            auth: { bearer: adminToken },
+            method: 'POST',
+            url: '/apis/iam/v2beta/policies',
+            body: policyWithProjects(policyID, [project1.id, project2.id], statementProjects)
+        }).then((response) => {
+            expect(response.body.policy.projects).to.have.length(2);
+        });
+
+        cy.request({
+            headers: { 'api-token': nonAdminToken },
+            method: 'PUT',
+            url: `/apis/iam/v2beta/policies/${policyID}`,
+            failOnStatusCode: false,
+            body: policyWithProjects(policyID, [project1.id], statementProjects)
+        }).then((response) => {
+            expect(response.status).to.equal(403);
+        });
+      });
+    });
+  });
 });
+
+function policyWithProjects(id: string, projects: string[], statementProjects: string[]): any {
+
+  return {
+    id: id,
+    name: 'fun name',
+    members: ['team:local:test'],
+    statements: [
+      {
+        effect: 'ALLOW',
+        actions: ['test:svc:someaction', 'test:svc:otheraction'],
+        projects: statementProjects
+      }
+    ],
+    projects: projects
+  };
+}

--- a/e2e/cypress/integration/api/iam/03_roles_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/03_roles_api.spec.ts
@@ -53,8 +53,6 @@ describe('roles API', () => {
                 }
             }).then((response) => {
                 nonAdminToken = response.body.token.value;
-                console.log('wat');
-                console.log(nonAdminToken);
             });
 
             cy.request({


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Follow up to https://github.com/chef/automate/pull/1340, which implemented the framework and enforcement for role creation and update.

### :athletic_shoe: How to Build and Test the Change

Setup admin token and some projects:

```
start_all_services
rebuild components/authz-service
chef-automate iam upgrade-to-v2 --beta2.1
export ADMINTOK=`chef-automate iam token create admin --admin`
curl -H "api-token: $ADMINTOK" -XPOST -d '{"name":"project1", "id":"project1"}' https://a2-dev.test/apis/iam/v2beta/projects --insecure
curl -H "api-token: $ADMINTOK" -XPOST -d '{"name":"project2", "id":"project2"}' https://a2-dev.test/apis/iam/v2beta/projects --insecure
```

Make a non-admin token and grant it access to a single project:

```
export PLEBTOK=`chef-automate iam token create plebtoken`
```

setup-policy.json:

```
{
  "name": "token-access-project-1",
  "id": "token-access-project-1",
  "members": [
    "token:plebtoken"
  ],
  "statements": [
    {
      "effect": "ALLOW",
      "actions": [
        "*"
      ],
      "projects": [
        "project1"
      ]
    }
  ],
  "projects": []
}
```

Grant PLEBTOKEN universal access to everything in project1 (including assignment):

```
curl -H "api-token: $ADMINTOK" -XPOST -d @setup-policy.json https://a2-dev.test/apis/iam/v2beta/policies --insecure
```

Admin token can create policies with any project:

```
cat policy.json
{
  ...
  "projects": ["project1", "project2"]
}
curl -H "api-token: $ADMINTOK" -XPOST -d @policy.json https://a2-dev.test/apis/iam/v2beta/policies --insecure
```

Unless it doesn't exist:

```
cat policy.json
{
  ...
  "projects": ["project1", "project2", "notfound"]
}
curl -H "api-token: $ADMINTOK" -XPOST -d @policy.json https://a2-dev.test/apis/iam/v2beta/policies --insecure
{"error":"You cannot modify a project for this object because this project did not exist: [\"notfound\"]","message":"You cannot modify a project for this object because this project did not exist: [\"notfound\"]","code":5,"details":[]}
```

But the token that only has access to project1 can only create tokens with project1 (403):

```
cat policy.json
{
  ...
  "projects": ["project1", "project2"]
}
curl -H "api-token: $PLEBTOK" -XPOST -d @policy.json https://a2-dev.test/apis/iam/v2beta/policies --insecure
{"error":"You cannot modify a project for this object because you are missing iam:projects:assign on this project: [\"project2\"]","message":"You cannot modify a project for this object because you are missing iam:projects:assign on this project: [\"project2\"]","code":7,"details":[]}
```

For update, it only gets a 403 if it actually changes projects it doesn't have access too:

```
curl -H "api-token: $ADMINTOK" https://a2-dev.test/apis/iam/v2beta/policies/id --insecure
...
    "projects": [
      "project1",
      "project2"
    ]
}

# attempt to remove project2 (no access)
{
  ...
  "projects": ["project1"]
}
curl -H "api-token: $PLEBTOK" -XPUT -d @policy.json https://a2-dev.test/apis/iam/v2beta/policies --insecure
{
  "error": "You cannot modify a project for this object because you are missing iam:projects:assign on this project: [\"project2\"]",
  "message": "You cannot modify a project for this object because you are missing iam:projects:assign on this project: [\"project2\"]",
  "code": 7,
  "details": []
}

# but can remove project1
{
  ...
  "projects": ["project2"]
}
curl -H "api-token: $PLEBTOK" -XPUT -d @tyler-local/policy.json https://a2-dev.test/apis/iam/v2beta/policies/id --insecure | jq
...
    "projects": [
      "project2"
    ]
}
```

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?
