### PR TITLE
Prevent introspect_projects call unless IAM V2p1 or greater

### DIFF
--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
+import { Store } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { interval as observableInterval, of as observableOf, Observable } from 'rxjs';
-import { catchError, mergeMap, map, tap } from 'rxjs/operators';
+import { catchError, mergeMap, map, tap, withLatestFrom, filter } from 'rxjs/operators';
 
+import { atLeastV2p1 } from 'app/entities/policies/policy.selectors';
 import { Project } from 'app/entities/projects/project.model';
 import { ProjectsFilterOption, ProjectsFilterOptionTuple } from './projects-filter.reducer';
 import { ProjectsFilterService } from './projects-filter.service';
@@ -21,6 +24,7 @@ import {
 export class ProjectsFilterEffects {
   constructor(
     private actions$: Actions,
+    private store: Store<NgrxStateAtom>,
     private projectsFilter: ProjectsFilterService,
     private requests: ProjectsFilterRequests
   ) { }
@@ -28,8 +32,10 @@ export class ProjectsFilterEffects {
   private POLLING_INTERVAL_IN_SECONDS = 120; // 2 minutes
 
   @Effect()
-  latestOptions$ = observableInterval(1000 * this.POLLING_INTERVAL_IN_SECONDS)
-    .pipe(mergeMap(this.loadOptionsAction$()));
+  latestOptions$ = observableInterval(1000 * this.POLLING_INTERVAL_IN_SECONDS).pipe(
+    withLatestFrom(this.store.select(atLeastV2p1)),
+    filter(([_, projectsEnabled]) => projectsEnabled),
+    mergeMap(this.loadOptionsAction$()));
 
   @Effect()
   loadOptions$ = this.actions$.pipe(


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

There is a periodic `introspect_projects` call to populate the global projects filter--irrespective of the IAM version. This should only be happening for IAM V2p1. This PR adds a guard function based on IAM version to accomplish that.

### :chains: Related Resources
NA

### :+1: Definition of Done
No `introspect_projects` calls on V1 or V2.

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui.
Login.
Try each IAM version successively:
```
# chef-automate iam reset-to-v1
# chef-automate iam upgrade-to-v2
# chef-automate iam upgrade-to-v2 --beta2.1
```

Open dev tools >> network in your browser and notice that the introspect project calls only occur when on v2p1.

### :camera: Screenshots, if applicable

![image](https://user-images.githubusercontent.com/6817500/64314330-85804a00-cf63-11e9-9d2b-aafb42f9978f.png)
