### PR TITLE
nightlies: Use EC2-based apt mirror, add logging

### DIFF
--- a/components/automate-deployment/a1-migration/Dockerfile
+++ b/components/automate-deployment/a1-migration/Dockerfile
@@ -3,6 +3,8 @@ MAINTAINER Chef Software <ryan@chef.io>
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN sed -i 's/archive.ubuntu.com/us-west-2.ec2.archive.ubuntu.com/' /etc/apt/sources.list
+
 # These lines are copy-pasta from the devchef/chefdk Dockerfile. We can't use
 # that image b/c we need systemd in order to install/upgrade to a2
 RUN apt-get update && apt-get install -y wget curl ssh build-essential && \

--- a/components/automate-deployment/basic-a1/Dockerfile
+++ b/components/automate-deployment/basic-a1/Dockerfile
@@ -3,6 +3,8 @@ MAINTAINER Chef Software <ryan@chef.io>
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN sed -i 's/archive.ubuntu.com/us-west-2.ec2.archive.ubuntu.com/' /etc/apt/sources.list
+
 # These lines are copy-pasta from the devchef/chefdk Dockerfile. We can't use
 # that image b/c we need systemd in order to install/upgrade to a2
 RUN apt-get update && apt-get install -y wget curl ssh build-essential && \

--- a/scripts/nightly_basic_a1.sh
+++ b/scripts/nightly_basic_a1.sh
@@ -32,14 +32,26 @@ if [[ -n "$A1_LICENSE" ]]; then
     echo -e "$A1_LICENSE" | base64 --decode > components/automate-deployment/a1-migration/delivery.license
 fi
 
+log_section_start() {
+    echo "--- [$(date -u)] $*"
+}
+
+log_section_start "Installing automate-cli"
 cd components/automate-deployment
 trap dump_logs EXIT
 curl -O https://packages.chef.io/files/dev/latest/chef-automate-cli/chef-automate_linux_amd64.zip
 unzip -o chef-automate_linux_amd64.zip -d basic-a1
+log_section_start "Building A1 Docker containers"
 make basic-a1-build
+log_section_start "Starting Chef Server"
 make basic-a1-start-chef-server
+log_section_start "Starting Automate 1"
 make basic-a1-up
+log_section_start "Reconfiguring Chef Server"
 make basic-a1-reconfigure-chef-server
+log_section_start "Migrating to Automate 2"
 make basic-a1-migrate
+log_section_start "Running A2 diagnostics"
 make basic-a1-diagnostics
+log_section_start "Running A2 tests"
 make basic-a1-test


### PR DESCRIPTION
The nightlies failed because we hit the 30 minute timeout set in our
buildkite configuration. The logs showed that various apt-get
operations were suddenly taking much longer to download packages:

```
Fetched 65.1 MB in 6min 54s (157 kB/s)
Fetched 26.3 MB in 9min 48s (44.7 kB/s)
```

compared to previous runs:

```
Fetched 65.1 MB in 1min 44s (620 kB/s)
Fetched 26.3 MB in 23s (1108 kB/s)
```

I didn't do an investigating into the cause of the slow-down, but it
seems prudent to use a repository mirror closer to our CI system.

This PR changes our apt-sources list in the docker build step of these
tests to use the us-west-2 repository mirrors.

Further, it adds logging to make it easier to spot which section of
the job is taking a long time.

We should consider uploading these images to dockerhub so we don't
need to build them on every run.

Signed-off-by: Steven Danna <steve@chef.io>