### PR TITLE
ci: avoid hab progress bars in terraform output

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
+++ b/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
@@ -3,6 +3,8 @@ set -e
 # NOTE: This is a terraform template. The ${upgrade} and ${channel}
 # variables will be replaced with strings at rendering time.  Those
 # are not shell variables.
+export HAB_NONINTERACTIVE="true"
+export HAB_NOCOLORING="true"
 
 automate_deployed() {
     [[ -f /hab/user/deployment-service/config/user.toml ]]


### PR DESCRIPTION
These logs are hard to read, this helps a little.

Signed-off-by: Steven Danna <steve@chef.io>