### PR TITLE
[#1272] refresh global project filter when a new project is created

### DIFF
--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -20,6 +20,7 @@ import { GetProjects, CreateProject, DeleteProject  } from 'app/entities/project
 import { Project } from 'app/entities/projects/project.model';
 import { ApplyRulesStatus, ApplyRulesStatusState } from 'app/entities/projects/project.reducer';
 import { ProjectStatus } from 'app/entities/rules/rule.model';
+import { LoadOptions } from 'app/services/projects-filter/projects-filter.actions';
 
 @Component({
   selector: 'app-project-list',
@@ -165,6 +166,9 @@ export class ProjectListComponent implements OnInit, OnDestroy {
           pendingCreate.complete();
           this.creatingProject = false;
           if (state === EntityStatus.loadingSuccess) {
+            // This is issued periodically from projects-filter.effects.ts; we do it now
+            // so the user doesn't have to wait.
+            this.store.dispatch(new LoadOptions());
             this.closeCreateModal();
             this.router.navigate(['/settings', 'projects', project.id]);
           }

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -105,11 +105,9 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       takeUntil(this.isDestroyed),
       // do not update this cache while an update is in progress
       filter(() => !this.applyRulesInProgress)
-    )
-      .subscribe((projectList: Project[]) => {
-        this.statusCache = {};
-        projectList.forEach(p => this.statusCache[p.id] = p.status);
-      });
+    ).subscribe((projectList: Project[]) => {
+      this.statusCache = projectList.reduce((m, p) => m[p.id] = p.status, {});
+    });
 
     this.createProjectForm = fb.group({
       // Must stay in sync with error checks in create-object-modal.component.html
@@ -182,8 +180,7 @@ export class ProjectListComponent implements OnInit, OnDestroy {
                 pendingCreateError.complete();
                 if (error.status === HttpStatus.CONFLICT) {
                   this.conflictErrorEvent.emit(true);
-                // Close the modal on any error other than conflict and display in banner.
-                } else {
+                } else { // Close the modal on any error other than conflict and display in banner.
                   this.closeCreateModal();
                 }
             });

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -106,7 +106,7 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       // do not update this cache while an update is in progress
       filter(() => !this.applyRulesInProgress)
     ).subscribe((projectList: Project[]) => {
-      this.statusCache = projectList.reduce((m, p) => m[p.id] = p.status, {});
+      this.statusCache = projectList.reduce((m, p) => ({ ...m, [p.id]: p.status }), {});
     });
 
     this.createProjectForm = fb.group({

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
@@ -8,7 +8,7 @@ import { catchError, mergeMap, map, tap, withLatestFrom, filter } from 'rxjs/ope
 
 import { atLeastV2p1 } from 'app/entities/policies/policy.selectors';
 import { Project } from 'app/entities/projects/project.model';
-import { ProjectsFilterOption, ProjectsFilterOptionTuple } from './projects-filter.reducer';
+import { ProjectsFilterOption } from './projects-filter.reducer';
 import { ProjectsFilterService } from './projects-filter.service';
 import { ProjectsFilterRequests, AuthorizedProjectsResponse } from './projects-filter.requests';
 import {
@@ -53,9 +53,9 @@ export class ProjectsFilterEffects {
       map((fetched: AuthorizedProjectsResponse) => {
         const converted = this.convertResponse(fetched.projects);
         const restored = this.projectsFilter.restoreOptions() || [];
-        return new LoadOptionsSuccess(<ProjectsFilterOptionTuple>{
+        return new LoadOptionsSuccess({
           fetched: converted,
-          restored: restored
+          restored
         });
       }),
       catchError((error: HttpErrorResponse) => observableOf(new LoadOptionsFailure(error))));
@@ -63,12 +63,12 @@ export class ProjectsFilterEffects {
 
   private convertResponse(authorizedProjects: Project[]): ProjectsFilterOption[] {
     return authorizedProjects.map(
-      project => <ProjectsFilterOption>{
+      project => ({
         label: project.name,
         value: project.id,
-        type:  project.type,
+        type: project.type,
         checked: false
-      });
+      }));
   }
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The top-right project filter dropdown **should** display a newly created project immediately.

### :chains: Related Resources
- #1272 

### :athletic_shoe: How to Build and Test the Change

- start stuff, with the UI rebuilt or using devproxy, upgrade to v2.1beta.
- create a project:

TODO


### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?
