### PR TITLE
Remove DENY walkthrough examples from IAM v2 Beta documentation

### DIFF
--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -114,8 +114,8 @@ Let's further assume you want user `Bob` as well as anyone on team `gamma` to be
   ],
 ```
 
-Next, you'll specify the permissions themselves, which in IAM v2 are the `statements`, declared as an array.
-Write a statement that **allows** access to the _get_, _list_, and _update_ actions for _users_ and _teams_:
+Next, you'll specify the permissions themselves--which in IAM v2 are the `statements`-- declared as an array.
+We only need a single statement in this case, though, providing access to the _get_, _list_, and _update_ actions for _users_ and _teams_:
 
 ```json
     {

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -115,7 +115,7 @@ Let's further assume you want user `Bob` as well as anyone on team `gamma` to be
 ```
 
 Next, you'll specify the permissions themselves, which in IAM v2 are the `statements`, declared as an array.
-First, write a statement that **allows** access to the _get_, _list_, and _update_ actions for _users_ and _teams_:
+Write a statement that **allows** access to the _get_, _list_, and _update_ actions for _users_ and _teams_:
 
 ```json
     {

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -131,20 +131,6 @@ First, write a statement that **allows** access to the _get_, _list_, and _updat
     },
 ```
 
-Next, write a statement that **denies** access to the _create_ and _delete_ actions:
-
-```json
-    {
-      "effect": "DENY",
-      "actions": [
-        "iam:users:create",
-        "iam:teams:create",
-        "iam:users:delete",
-        "iam:teams:delete"
-      ]
-    }
-```
-
 The complete policy should look like:
 
 ```json
@@ -165,15 +151,6 @@ The complete policy should look like:
         "iam:teams:update",
         "iam:teams:list",
         "iam:teams:get"
-      ]
-    },
-    {
-      "effect": "DENY",
-      "actions": [
-        "iam:users:create",
-        "iam:teams:create",
-        "iam:users:delete",
-        "iam:teams:delete"
       ]
     }
   ]


### PR DESCRIPTION
Signed-off-by: susanev <susan.ra.evans@gmail.com>

### :nut_and_bolt: Description: What code changed, and why?

#### Problem
Users may get into trouble if they use deny in custom policies without considering the global impact.

#### Overview
Since we are not expecting DENY in policies to be a common use case, we would like to change up the IAMv2 walkthrough to not center on a DENY example.

### :+1: Definition of Done
Fixes #1121 

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [x] Docs added/updated?

### :camera: Screenshots, if applicable