### PR TITLE
Re-enable non-flaky cypress tests in verify_private

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -465,7 +465,7 @@ steps:
 
   - label: ":cypress: IAMv1"
     command:
-      - integration/run_test integration/tests/cypress_e2e.sh
+      - IAM=v1.0 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
     expeditor:
       secrets: &cypress_secrets

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -412,7 +412,7 @@ steps:
   # end-to-end testing. These tests all test full deployments of
   # Automate in different configurations.
   #
-  - label: ":cypress: IAMv1"
+  - label: ":cypress: (flaky included) IAMv1"
     command:
       - IAM=v1.0 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
@@ -431,19 +431,64 @@ steps:
         CYPRESS_AUTOMATE_ACCEPTANCE_TARGET_KEY:
           path: secret/a2/testing/target_key
           field: data
-        # Note: this isn't currently used for pre-merge tests
-        # CYPRESS_RECORD_KEY:
-        #   path: secret/a2/cypress
-        #   field: record_key
+      executor:
+        linux:
+          privileged: true
+          environment:
+            - CYPRESS_RUN_FLAKY=true
+
+  - label: ":cypress: (flaky included) IAMv2"
+    command:
+      - IAM=v2.0 integration/run_test integration/tests/cypress_e2e.sh
+    timeout_in_minutes: 20
+    soft_fail: true
+    expeditor:
+      secrets: *cypress_secrets
+      executor:
+        linux:
+          privileged: true
+          environment:
+            - CYPRESS_RUN_FLAKY=true
+
+  - label: ":cypress: (flaky included) IAMv2.1"
+    command:
+      - IAM=v2.1 integration/run_test integration/tests/cypress_e2e.sh
+    timeout_in_minutes: 20
+    soft_fail: true
+    expeditor:
+      secrets: *cypress_secrets
+      executor:
+        linux:
+          privileged: true
+          environment:
+            - CYPRESS_RUN_FLAKY=true
+
+  - label: ":cypress: IAMv1"
+    command:
+      - integration/run_test integration/tests/cypress_e2e.sh
+    timeout_in_minutes: 20
+    expeditor:
+      secrets: &cypress_secrets
+        A2_LICENSE:
+          path: secret/a2/license
+          field: license
+        CYPRESS_AUTOMATE_ACCEPTANCE_TARGET_HOST:
+          path: secret/a2/testing/target_host
+          field: data
+        CYPRESS_AUTOMATE_ACCEPTANCE_TARGET_USER:
+          path: secret/a2/testing/target_user
+          field: data
+        CYPRESS_AUTOMATE_ACCEPTANCE_TARGET_KEY:
+          path: secret/a2/testing/target_key
+          field: data
       executor:
         linux:
           privileged: true
 
   - label: ":cypress: IAMv2"
     command:
-      - IAM=v2.0 integration/run_test integration/tests/cypress_e2e.sh
+      - IAM=v2 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
-    soft_fail: true
     expeditor:
       secrets: *cypress_secrets
       executor:
@@ -454,7 +499,6 @@ steps:
     command:
       - IAM=v2.1 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
-    soft_fail: true
     expeditor:
       secrets: *cypress_secrets
       executor:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -95,6 +95,16 @@ Possible values are `"v1.0"`, `"v2.0"`, and `"v2.1"`.
 
 Your dev environment's IAM version MUST match the value of CYPRESS_IAM_VERSION for the tests to pass locally.
 
+### Running Flaky Tests
+
+There are some known flaky tests we are trying to debug. By default, they do not run. If you wish to run them:
+
+```
+CYPRESS_RUN_FLAKY=true npm run cypress:run
+```
+
+The tests are marked as flaky by the `itFlaky` descriptor instead of the `it` descriptor.
+
 ## Running Cypress pipeline tests
 
 As part of our [deploy

--- a/e2e/cypress/integration/constants.ts
+++ b/e2e/cypress/integration/constants.ts
@@ -1,5 +1,5 @@
 export const iamVersion: string = Cypress.env('IAM_VERSION') || 'v2.0';
 export const describeIfIAMV2 = iamVersion.match(/v2/) ? describe : describe.skip;
 export const describeIfIAMV2p1 = iamVersion === 'v2.1' ? describe : describe.skip;
-export const runFlaky = <boolean><Object>Cypress.env('RUN_FLAKY') || false;
+export const runFlaky: boolean = Cypress.env('RUN_FLAKY') || false;
 export const itFlaky = runFlaky ? it : it.skip;

--- a/e2e/cypress/integration/constants.ts
+++ b/e2e/cypress/integration/constants.ts
@@ -1,3 +1,5 @@
 export const iamVersion: string = Cypress.env('IAM_VERSION') || 'v2.0';
 export const describeIfIAMV2 = iamVersion.match(/v2/) ? describe : describe.skip;
 export const describeIfIAMV2p1 = iamVersion === 'v2.1' ? describe : describe.skip;
+export const runFlaky = <boolean><Object>Cypress.env('RUN_FLAKY') || false;
+export const itFlaky = runFlaky ? it : it.skip;

--- a/e2e/cypress/integration/ui/compliance/01_ssh_scan_job.spec.ts
+++ b/e2e/cypress/integration/ui/compliance/01_ssh_scan_job.spec.ts
@@ -1,4 +1,5 @@
 import { Base64 } from 'js-base64';
+import { itFlaky } from '../../constants';
 
 describe('create a manual node ssh scan job and cleanup after', () => {
   before(() => {
@@ -17,7 +18,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
   const jobName = 'job ' + nowTime;
   const decoded = Base64.decode(Cypress.env('AUTOMATE_ACCEPTANCE_TARGET_KEY'));
 
-  it('can create a credential with a username and key', () => {
+  itFlaky('can create a credential with a username and key', () => {
     // we save the route that will be called when we navigate to the page
     // in order to be able to wait for it later
     cy.route('POST', '/api/v0/secrets/search').as('getSecrets');
@@ -51,7 +52,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     cy.contains(credName).should('exist');
   });
 
-  it('can create a node and attach a credential', () => {
+  itFlaky('can create a node and attach a credential', () => {
     // navigate to node create page:
     // click on scan jobs
     cy.get('.nav-link').contains('Compliance').click();
@@ -96,7 +97,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
       cy.contains(nodePrefix).should('exist');
   });
 
-  it('can install a profile', () => {
+  itFlaky('can install a profile', () => {
     // we save the route that will be called when we navigate to the page
     // in order to be able to wait for it later
     cy.route('POST', '/api/v0/compliance/profiles/search').as('getProfiles');
@@ -122,7 +123,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     cy.contains('CIS Amazon Linux 2 Benchmark Level 1').should('exist');
   });
 
-  it('can create a scan job with a reccurence schedule', () => {
+  itFlaky('can create a scan job with a reccurence schedule', () => {
     // navigate to scan create page
     // click on scan jobs
     cy.get('.nav-link').contains('Compliance').click();
@@ -172,7 +173,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     cy.url().should('include', '/scans');
   });
 
-  it('can delete the created credential', () => {
+  itFlaky('can delete the created credential', () => {
     // we save the route that will be called when we navigate to the page
     // in order to be able to wait for it later
     cy.route('POST', '/api/v0/secrets/search').as('getSecrets');
@@ -192,7 +193,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     });
   });
 
-  it('can delete the created node', () => {
+  itFlaky('can delete the created node', () => {
     // navigate to node create page:
     // click on scan jobs
     cy.get('.nav-link').contains('Compliance').click();
@@ -215,7 +216,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     cy.contains(nodePrefix).parent().find('chef-button[label="delete"]').click();
   });
 
-  it('can delete the created profile', () => {
+  itFlaky('can delete the created profile', () => {
     // navigate to asset store
     cy.get('.nav-link').contains('Compliance').click();
     cy.get('chef-sidebar-entry').contains('Profiles').click({ force: true });
@@ -233,7 +234,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     });
   });
 
-  it('can delete the created scan job', () => {
+  itFlaky('can delete the created scan job', () => {
     // save the route for the delete request so that we can ensure the
     // response is returned
     cy.route('DELETE', '/api/v0/compliance/scanner/jobs/id/**').as('deleteScanJob');

--- a/e2e/cypress/integration/ui/compliance/01_ssh_scan_job.spec.ts
+++ b/e2e/cypress/integration/ui/compliance/01_ssh_scan_job.spec.ts
@@ -18,7 +18,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
   const jobName = 'job ' + nowTime;
   const decoded = Base64.decode(Cypress.env('AUTOMATE_ACCEPTANCE_TARGET_KEY'));
 
-  itFlaky('can create a credential with a username and key', () => {
+  it('can create a credential with a username and key', () => {
     // we save the route that will be called when we navigate to the page
     // in order to be able to wait for it later
     cy.route('POST', '/api/v0/secrets/search').as('getSecrets');
@@ -52,7 +52,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     cy.contains(credName).should('exist');
   });
 
-  itFlaky('can create a node and attach a credential', () => {
+  it('can create a node and attach a credential', () => {
     // navigate to node create page:
     // click on scan jobs
     cy.get('.nav-link').contains('Compliance').click();

--- a/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
@@ -1,3 +1,5 @@
+import { itFlaky } from '../../constants';
+
 describe('user management', () => {
   before(() => {
     cy.adminLogin('/settings/users').then(() => {
@@ -52,7 +54,7 @@ describe('user management', () => {
     cy.get('app-user-table chef-td').contains(name).should('exist');
   });
 
-  it('can view and edit user details', () => {
+  itFlaky('can view and edit user details', () => {
     cy.route('GET', `**/users/${username}`).as('getUser');
     cy.route('PUT', `**/users/${username}`).as('updateUser');
 
@@ -88,7 +90,8 @@ describe('user management', () => {
     cy.get('chef-notification.info').should('be.visible');
   });
 
-  it('can delete user', () => {
+  // this test isn't flaky but depends on the flaky one
+  itFlaky('can delete user', () => {
     cy.route('GET', '**/users').as('getUsers');
     cy.route('DELETE', `**/users/${username}`).as('deleteUser');
 

--- a/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
@@ -91,7 +91,7 @@ describe('team management', () => {
     });
 
     describeIfIAMV2('team create modal (IAM v2.x)', () => {
-      it('can create a team with a default ID', () => {
+      itFlaky('can create a team with a default ID', () => {
         cy.get('[data-cy=team-create-button]').contains('Create Team').click();
         cy.get('app-team-management chef-modal').should('exist');
 
@@ -106,7 +106,7 @@ describe('team management', () => {
         cy.contains(generatedTeamID).should('exist');
       });
 
-      it('can create a team with a custom ID', () => {
+      itFlaky('can create a team with a custom ID', () => {
         cy.get('[data-cy=team-create-button]').contains('Create Team').click();
         cy.get('app-team-management chef-modal').should('exist');
 

--- a/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
@@ -134,7 +134,7 @@ describe('team management', () => {
         cy.applyProjectsFilter([unassigned]);
       });
 
-      it('can create a team with no projects (unassigned) ' +
+      itFlaky('can create a team with no projects (unassigned) ' +
       'and cannot access projects dropdown', () => {
         cy.get('[data-cy=team-create-button]').contains('Create Team').click();
         cy.get('app-team-management chef-modal').should('exist');
@@ -207,7 +207,7 @@ describe('team management', () => {
         cy.contains(projectSummary).should('exist');
       });
 
-      it('can create a team with one project selected', () => {
+      itFlaky('can create a team with one project selected', () => {
         cy.get('[data-cy=team-create-button]').contains('Create Team').click();
         cy.get('app-team-management chef-modal').should('exist');
         cy.get('[data-cy=create-name]').type(teamName);
@@ -241,7 +241,7 @@ describe('team management', () => {
         cy.contains(project2ID).should('exist');
       });
 
-      it('can create a team with no projects selected (unassigned)', () => {
+      itFlaky('can create a team with no projects selected (unassigned)', () => {
         cy.get('[data-cy=team-create-button]').contains('Create Team').click();
         cy.get('app-team-management chef-modal').should('exist');
         cy.get('[data-cy=create-name]').type(teamName);

--- a/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
@@ -1,4 +1,4 @@
-import { describeIfIAMV2, describeIfIAMV2p1 } from '../../constants';
+import { describeIfIAMV2, describeIfIAMV2p1, itFlaky } from '../../constants';
 
 describe('team management', () => {
   let adminToken = '';
@@ -172,7 +172,7 @@ describe('team management', () => {
         cy.cleanupTeamsByDescriptionPrefix(adminToken, cypressPrefix);
       });
 
-      it('can create a team with multiple projects', () => {
+      itFlaky('can create a team with multiple projects', () => {
         const projectSummary = '2 projects';
         cy.get('[data-cy=team-create-button]').contains('Create Team').click();
         cy.get('app-team-management chef-modal').should('exist');

--- a/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
+++ b/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
@@ -148,7 +148,7 @@ describe('team add users', () => {
     cy.get('chef-tbody chef-td a').contains('Local Administrator');
 
     // navigate back to add users and see empty page and message
-    cy.get('chef-toolbar chef-button').contains('Add Users').click();
+    cy.get('chef-toolbar chef-button').contains('Add User').click();
     cy.url().should('eq',
     `${Cypress.config().baseUrl}/settings/teams/${teamUIRouteIdentifier}/add-users`);
     cy.get('chef-table').should('not.exist');

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -1,4 +1,4 @@
-import { describeIfIAMV2p1, iamVersion } from '../../constants';
+import { describeIfIAMV2p1, iamVersion, itFlaky } from '../../constants';
 
 describe('team details', () => {
   let adminToken = '';
@@ -184,7 +184,7 @@ describe('team details', () => {
           cy.applyProjectsFilter([unassigned, project1Name, project2Name]);
         });
 
-        it('both are contained in the projects dropdown and the team project is selected,' +
+        itFlaky('both are contained in the projects dropdown and the team project is selected,' +
               'and both can be added or removed', () => {
           const projectSummary = '2 projects';
 

--- a/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
@@ -24,6 +24,8 @@ describeIfIAMV2p1('project management', () => {
       const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
       adminToken = admin.id_token;
       cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['projects']);
+        // Set the projects filter to all projects
+        cy.applyProjectsFilter([]);
     });
   });
 
@@ -79,7 +81,8 @@ describeIfIAMV2p1('project management', () => {
     cy.url().should('include', `/settings/projects/${projectID}`);
   });
 
-  it('can create a rule for the new project', () => {
+  // something is occasionally resetting the projects filter to (unassigned)
+  itFlaky('can create a rule for the new project', () => {
     cy.get('app-project-details app-authorized button').contains('Create Rule').click();
 
     cy.url().should('include', `/settings/projects/${projectID}/rules`);
@@ -119,7 +122,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details chef-td').contains(ruleID);
   });
 
-  it('displays a list of rules for a project', () => {
+  itFlaky('displays a list of rules for a project', () => {
     ['Name', 'ID', 'Resource Type', 'Conditions', 'Edits'].forEach((header) => {
       cy.get('app-project-details chef-th').contains(header);
     });
@@ -131,7 +134,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details chef-td').contains('Edits pending');
   });
 
-  it('can update a project rule', () => {
+  itFlaky('can update a project rule', () => {
     const updatedRuleName = `updated ${ruleName}`;
     cy.get('app-project-details a').contains(ruleName).click();
 
@@ -168,7 +171,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details chef-td').contains('2 conditions');
   });
 
-  it('can update a project name', () => {
+  itFlaky('can update a project name', () => {
     const updatedProjectName = `updated ${projectName}`;
     cy.route('GET', `/apis/iam/v2beta/projects/${projectID}`).as('getProject');
 
@@ -183,7 +186,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details h1.page-title').contains(updatedProjectName);
   });
 
-  it('can delete a project rule', () => {
+  itFlaky('can delete a project rule', () => {
     cy.get('[data-cy=rules-tab]').click();
 
     cy.get('app-project-details chef-td').contains(ruleID).parent()

--- a/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
@@ -79,7 +79,7 @@ describeIfIAMV2p1('project management', () => {
     cy.url().should('include', `/settings/projects/${projectID}`);
   });
 
-  itFlaky('can create a rule for the new project', () => {
+  it('can create a rule for the new project', () => {
     cy.get('app-project-details app-authorized button').contains('Create Rule').click();
 
     cy.url().should('include', `/settings/projects/${projectID}/rules`);
@@ -119,7 +119,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details chef-td').contains(ruleID);
   });
 
-  itFlaky('displays a list of rules for a project', () => {
+  it('displays a list of rules for a project', () => {
     ['Name', 'ID', 'Resource Type', 'Conditions', 'Edits'].forEach((header) => {
       cy.get('app-project-details chef-th').contains(header);
     });
@@ -131,7 +131,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details chef-td').contains('Edits pending');
   });
 
-  itFlaky('can update a project rule', () => {
+  it('can update a project rule', () => {
     const updatedRuleName = `updated ${ruleName}`;
     cy.get('app-project-details a').contains(ruleName).click();
 
@@ -168,7 +168,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details chef-td').contains('2 conditions');
   });
 
-  itFlaky('can update a project name', () => {
+  it('can update a project name', () => {
     const updatedProjectName = `updated ${projectName}`;
     cy.route('GET', `/apis/iam/v2beta/projects/${projectID}`).as('getProject');
 
@@ -183,7 +183,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details h1.page-title').contains(updatedProjectName);
   });
 
-  itFlaky('can delete a project rule', () => {
+  it('can delete a project rule', () => {
     cy.get('[data-cy=rules-tab]').click();
 
     cy.get('app-project-details chef-td').contains(ruleID).parent()
@@ -200,6 +200,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details chef-tbody').should('not.exist');
   });
 
+  // sometimes the deleted successfully notification isn't showing up
   itFlaky('can delete a project', () => {
     cy.get('.breadcrumb').click();
 
@@ -229,7 +230,10 @@ describeIfIAMV2p1('project management', () => {
     });
   });
 
-  it('can create a project with a custom ID', () => {
+  // these tests are currently interdependent so mark as flaky until the above isn't
+  itFlaky('can create a project with a custom ID', () => {
+    cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['projects']);
+
     cy.get('[data-cy=create-project]').contains('Create Project').click();
     cy.get('app-project-list chef-modal').should('have.class', 'visible');
 

--- a/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
@@ -1,4 +1,4 @@
-import { describeIfIAMV2p1 } from '../../constants';
+import { describeIfIAMV2p1, itFlaky } from '../../constants';
 interface Project {
   id: string;
   name: string;
@@ -79,7 +79,7 @@ describeIfIAMV2p1('project management', () => {
     cy.url().should('include', `/settings/projects/${projectID}`);
   });
 
-  it('can create a rule for the new project', () => {
+  itFlaky('can create a rule for the new project', () => {
     cy.get('app-project-details app-authorized button').contains('Create Rule').click();
 
     cy.url().should('include', `/settings/projects/${projectID}/rules`);
@@ -119,7 +119,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details chef-td').contains(ruleID);
   });
 
-  it('displays a list of rules for a project', () => {
+  itFlaky('displays a list of rules for a project', () => {
     ['Name', 'ID', 'Resource Type', 'Conditions', 'Edits'].forEach((header) => {
       cy.get('app-project-details chef-th').contains(header);
     });
@@ -131,7 +131,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details chef-td').contains('Edits pending');
   });
 
-  it('can update a project rule', () => {
+  itFlaky('can update a project rule', () => {
     const updatedRuleName = `updated ${ruleName}`;
     cy.get('app-project-details a').contains(ruleName).click();
 
@@ -168,7 +168,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details chef-td').contains('2 conditions');
   });
 
-  it('can update a project name', () => {
+  itFlaky('can update a project name', () => {
     const updatedProjectName = `updated ${projectName}`;
     cy.route('GET', `/apis/iam/v2beta/projects/${projectID}`).as('getProject');
 
@@ -183,7 +183,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details h1.page-title').contains(updatedProjectName);
   });
 
-  it('can delete a project rule', () => {
+  itFlaky('can delete a project rule', () => {
     cy.get('[data-cy=rules-tab]').click();
 
     cy.get('app-project-details chef-td').contains(ruleID).parent()
@@ -200,7 +200,7 @@ describeIfIAMV2p1('project management', () => {
     cy.get('app-project-details chef-tbody').should('not.exist');
   });
 
-  it('can delete a project', () => {
+  itFlaky('can delete a project', () => {
     cy.get('.breadcrumb').click();
 
     cy.get('app-project-list chef-td').contains(projectID).parent()


### PR DESCRIPTION
# :nut_and_bolt: Description: What code changed, and why?

Added a conditional itFlaky that will only run tests if CYPRESS_RUN_FLAKY=true is passed when running the cypress tests. Added a set of cypress tasks to run in verify_private that will run the flaky tests in soft_fail mode, while the non-flaky tests are no longer soft_fail.

Will enable in deploy after we are successful in verify_private for a bit.

### :athletic_shoe: How to Build and Test the Change

```
cd e2e
CYPRESS_RUN_FLAKY=true npm run cypress:open
npm run cypress:open
```

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?
