### PR TITLE
Increase event-gateway test timeout

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -378,7 +378,7 @@ steps:
     command:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh && start_deployment_service && chef-automate dev deployinate && event_gateway_integration"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 15
     expeditor:
       executor:
         docker:


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When deploys run a bit slower in Ci this can fail. In a non-scientific
sampling, the last 3 runs of this test suite I've looked at have taken 6.5
minutes, 10 minutes (barely passed before timeout would have kicked in), and
10.5 minutes (failed by timeout).
