### PR TITLE
Compliance API suggestion for control tags

### DIFF
--- a/components/compliance-service/api/reporting/server/server.go
+++ b/components/compliance-service/api/reporting/server/server.go
@@ -139,7 +139,7 @@ func (srv *Server) ListSuggestions(ctx context.Context, in *reporting.Suggestion
 	if err != nil {
 		return nil, errorutils.FormatErrorMsg(err, "")
 	}
-	suggestionsList, err := srv.es.GetSuggestions(in.Type, formattedFilters, in.Text, in.Size)
+	suggestionsList, err := srv.es.GetSuggestions(ctx, in.Type, formattedFilters, in.Text, in.Size)
 	if err != nil {
 		return nil, errorutils.FormatErrorMsg(err, "")
 	}

--- a/components/compliance-service/api/tests/02_nodes_spec.rb
+++ b/components/compliance-service/api/tests/02_nodes_spec.rb
@@ -1437,7 +1437,7 @@ describe File.basename(__FILE__) do
 
     resp = GRPC reporting, :list_nodes, Reporting::Query.new(filters: [
       Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
-      Reporting::ListFilter.new(type: 'control_tag:scop?', values: ['ap?che'])
+      Reporting::ListFilter.new(type: 'control_tag:scope', values: ['ap?che'])
     ], sort: 'name')
     assert_equal(['centos-beta', 'windows(1)-zeta-apache(s)-skipped'],
                  resp['nodes'].map {|x| x['name']},

--- a/components/compliance-service/api/tests/07_suggestions_control_tags_spec.rb
+++ b/components/compliance-service/api/tests/07_suggestions_control_tags_spec.rb
@@ -1,0 +1,136 @@
+##### GRPC SETUP #####
+require 'api/reporting/reporting_pb'
+require 'api/reporting/reporting_services_pb'
+
+describe File.basename(__FILE__) do
+  Reporting = Chef::Automate::Domain::Compliance::Api::Reporting unless defined?(Reporting)
+
+  def reporting
+    Reporting::ReportingService;
+  end
+
+  it "errors" do
+    assert_grpc_error("'control_tag' filter is required for 'control_tag_value' suggestions", 2) do
+      GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+        type: 'control_tag_value',
+        filters: []
+      )
+    end
+  end
+
+  it "works" do
+    # suggest control tag keys
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+      type: 'control_tag_key',
+      text: 'scope',
+      filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z'])
+      ],
+      size: 10
+    )
+    expected = [
+      "scope",
+      "scoop",
+      "Scoops"
+    ]
+    assert_suggestions_text(expected, actual_data)
+
+    # suggest control tag keys
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+      type: 'control_tag_key',
+      text: 'scope',
+      filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z'])
+      ],
+      size: 2
+    )
+    expected = [
+      "scope",
+      "scoop"
+    ]
+    assert_suggestions_text(expected, actual_data)
+
+    # suggest control tag keys
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+      type: 'control_tag_key',
+      text: 'Scoo',
+      filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z'])
+      ],
+      size: 100
+    )
+    expected = [
+      "scoop",
+      "Scoops",
+      "scope"
+    ]
+    assert_suggestions_text(expected, actual_data)
+
+    # suggest control tag keys without text given
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+      type: 'control_tag_key',
+      filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z'])
+      ],
+      size: 100
+    )
+    expected = [ "cci", "gtitle", "satisfies", "scoop", "Scoops", "scope", "stig_id", "tag1", "web" ]
+    assert_suggestions_text(expected, actual_data)
+
+    # suggest control tag values with a tag key filter without text
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+      type: 'control_tag_value',
+      filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'control_tag:scope', values: []),
+      ],
+      size: 100
+    )
+    expected = [ "Apache", "apalache", "NginX" ]
+    assert_suggestions_text(expected, actual_data)
+
+    # suggest control tag values with tag key filter without text
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+      type: 'control_tag_value',
+      filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'control_tag:satisfies', values: []),
+      ],
+      size: 5
+    )
+    expected = [ "apache-1", "apache-2", "NGX-1", "NGX-2", "SRG-00006" ]
+    assert_suggestions_text(expected, actual_data)
+
+    # suggest control tag values with a tag key filter without text
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+      type: 'control_tag_value',
+      text: 'apaCH',
+      filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'control_tag:scope', values: []),
+      ]
+    )
+    expected = [ "Apache", "apalache" ]
+    assert_suggestions_text(expected, actual_data)
+
+    # suggest control tag values with a missing tag key filter
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+      type: 'control_tag_value',
+      text: 'apaCH',
+      filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'control_tag:missing', values: []),
+      ]
+    )
+    expected = []
+    assert_suggestions_text(expected, actual_data)
+  end
+end

--- a/components/compliance-service/api/tests/07_suggestions_control_tags_spec.rb
+++ b/components/compliance-service/api/tests/07_suggestions_control_tags_spec.rb
@@ -9,7 +9,7 @@ describe File.basename(__FILE__) do
     Reporting::ReportingService;
   end
 
-  it "errors" do
+  it "errors without control_tag filter" do
     assert_grpc_error("'control_tag' filter is required for 'control_tag_value' suggestions", 2) do
       GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
         type: 'control_tag_value',
@@ -18,8 +18,7 @@ describe File.basename(__FILE__) do
     end
   end
 
-  it "works" do
-    # suggest control tag keys
+  it "suggests control tag keys matching 'scope'" do
     actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
       type: 'control_tag_key',
       text: 'scope',
@@ -35,8 +34,9 @@ describe File.basename(__FILE__) do
       "Scoops"
     ]
     assert_suggestions_text(expected, actual_data)
+  end
 
-    # suggest control tag keys
+  it "suggests control tag keys with a size of 2" do
     actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
       type: 'control_tag_key',
       text: 'scope',
@@ -51,8 +51,9 @@ describe File.basename(__FILE__) do
       "scoop"
     ]
     assert_suggestions_text(expected, actual_data)
+  end
 
-    # suggest control tag keys
+  it "suggests control tag keys matching 'Scoo'" do
     actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
       type: 'control_tag_key',
       text: 'Scoo',
@@ -68,7 +69,9 @@ describe File.basename(__FILE__) do
       "scope"
     ]
     assert_suggestions_text(expected, actual_data)
+  end
 
+  it "suggests control tag keys without text" do
     # suggest control tag keys without text given
     actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
       type: 'control_tag_key',
@@ -80,7 +83,23 @@ describe File.basename(__FILE__) do
     )
     expected = [ "cci", "gtitle", "satisfies", "scoop", "Scoops", "scope", "stig_id", "tag1", "web" ]
     assert_suggestions_text(expected, actual_data)
+  end
 
+  it "suggests control tag keys with platform filter" do
+    # suggest control tag keys without text given
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+      type: 'control_tag_key',
+      filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'platform', values: ['centos', 'windows'])
+      ]
+    )
+    expected = ["satisfies", "scoop", "Scoops", "scope", "web"]
+    assert_suggestions_text(expected, actual_data)
+  end
+
+  it "suggests control tag values without text" do
     # suggest control tag values with a tag key filter without text
     actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
       type: 'control_tag_value',
@@ -93,7 +112,9 @@ describe File.basename(__FILE__) do
     )
     expected = [ "Apache", "apalache", "NginX" ]
     assert_suggestions_text(expected, actual_data)
+  end
 
+  it "suggests control tag values without text and size of 5" do
     # suggest control tag values with tag key filter without text
     actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
       type: 'control_tag_value',
@@ -106,7 +127,9 @@ describe File.basename(__FILE__) do
     )
     expected = [ "apache-1", "apache-2", "NGX-1", "NGX-2", "SRG-00006" ]
     assert_suggestions_text(expected, actual_data)
+  end
 
+  it "suggests control tag values matching apaCH" do
     # suggest control tag values with a tag key filter without text
     actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
       type: 'control_tag_value',
@@ -119,7 +142,9 @@ describe File.basename(__FILE__) do
     )
     expected = [ "Apache", "apalache" ]
     assert_suggestions_text(expected, actual_data)
+  end
 
+  it "suggests control tag values with missing key" do
     # suggest control tag values with a missing tag key filter
     actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
       type: 'control_tag_value',

--- a/components/compliance-service/api/tests/07_suggestions_control_tags_spec.rb
+++ b/components/compliance-service/api/tests/07_suggestions_control_tags_spec.rb
@@ -10,7 +10,7 @@ describe File.basename(__FILE__) do
   end
 
   it "errors without control_tag filter" do
-    assert_grpc_error("'control_tag' filter is required for 'control_tag_value' suggestions", 2) do
+    assert_grpc_error("rpc error: code = InvalidArgument desc = 'control_tag' filter is required for 'control_tag_value' suggestions", 2) do
       GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
         type: 'control_tag_value',
         filters: []
@@ -126,6 +126,20 @@ describe File.basename(__FILE__) do
       size: 5
     )
     expected = [ "apache-1", "apache-2", "NGX-1", "NGX-2", "SRG-00006" ]
+    assert_suggestions_text(expected, actual_data)
+  end
+
+  it "suggests control tag values without text and control_tag full filter" do
+    # suggest control tag values with tag key filter without text
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+      type: 'control_tag_value',
+      filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'control_tag:satisfies', values: ['NGX-1', 'SRG-00006']),
+      ]
+    )
+    expected = [ "NGX-1", "NGX-2", "SRG-00006", "SRG-00007" ]
     assert_suggestions_text(expected, actual_data)
   end
 

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -625,14 +625,12 @@ func (backend ES2Backend) getControlTagsSuggestions(ctx context.Context, client 
 		}
 	}
 
-	suggs := make([]*reportingapi.Suggestion, len(scoredTagSuggs))
-	i := 0
+	suggs := make([]*reportingapi.Suggestion, 0, len(scoredTagSuggs))
 	for mSugg, mScore := range scoredTagSuggs {
-		suggs[i] = &reportingapi.Suggestion{
+		suggs = append(suggs, &reportingapi.Suggestion{
 			Text:  mSugg,
 			Score: *mScore,
-		}
-		i++
+		})
 	}
 
 	return suggs, nil

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -493,6 +493,8 @@ func (backend ES2Backend) getControlSuggestions(ctx context.Context, client *ela
 										suggs = append(suggs, &oneSugg)
 										addedControls[c.ID] = true
 									}
+								} else {
+									logrus.Errorf("Invalid control (%+v) found in report %s", c, hit2.Id)
 								}
 							}
 						}
@@ -590,11 +592,13 @@ func (backend ES2Backend) getControlTagsSuggestions(ctx context.Context, client 
 					}
 					var c ControlSourceTags
 					err := json.Unmarshal(*hit2.Source, &c)
-					if err == nil && c.ID != "" {
+					if err == nil && len(c.StringTags) > 0 {
 						foundControlTags = append(foundControlTags, ControlTagsScore{
 							float32(*hit2.Score),
 							c.StringTags,
 						})
+					} else {
+						logrus.Errorf("Invalid control (%+v) found in report %s", c, hit2.Id)
 					}
 				}
 			}

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -594,7 +594,7 @@ func (backend ES2Backend) getControlTagsSuggestions(ctx context.Context, client 
 	})
 
 	// Map the found tag suggestions to remove duplications
-	scoredTagSuggs := make(map[string]*float32)
+	scoredTagSuggs := make(map[string]float32)
 	for _, item := range foundControlTags {
 		matches := make([]string, 0)
 		// If the suggestion is for control tag key, we need to find the one that
@@ -619,8 +619,8 @@ func (backend ES2Backend) getControlTagsSuggestions(ctx context.Context, client 
 		bestMatch := findBestArrayMatch(text, matches)
 		for _, match := range bestMatch {
 			bestMatchScore := item.Score
-			if scoredTagSuggs[match] == nil || *scoredTagSuggs[match] < item.Score {
-				scoredTagSuggs[match] = &bestMatchScore
+			if scoredTagSuggs[match] < item.Score {
+				scoredTagSuggs[match] = bestMatchScore
 			}
 		}
 	}
@@ -629,7 +629,7 @@ func (backend ES2Backend) getControlTagsSuggestions(ctx context.Context, client 
 	for mSugg, mScore := range scoredTagSuggs {
 		suggs = append(suggs, &reportingapi.Suggestion{
 			Text:  mSugg,
-			Score: *mScore,
+			Score: mScore,
 		})
 	}
 

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -24,8 +24,7 @@ func (backend ES2Backend) GetSuggestions(ctx context.Context, typeParam string, 
 	client, err := backend.ES2Client()
 	size := int(size32)
 	if err != nil {
-		logrus.Error("Cannot connect to ElasticSearch")
-		return nil, err
+		return nil, errors.Wrap(err, "GetSuggestions cannot connect to ElasticSearch")
 	}
 
 	var SUGGESTIONS_TYPES = map[string]string{
@@ -191,8 +190,7 @@ func (backend ES2Backend) getAggSuggestions(ctx context.Context, client *elastic
 		Do(ctx)
 
 	if err != nil {
-		logrus.Error("getAggSuggestions search failed")
-		return nil, err
+		return nil, errors.Wrap(err, "getAggSuggestions search failed")
 	}
 
 	LogQueryPartMin(esIndex, searchResult, "getAggSuggestions - searchResult")
@@ -268,8 +266,7 @@ func (backend ES2Backend) getArrayAggSuggestions(ctx context.Context, client *el
 		Do(ctx)
 
 	if err != nil {
-		logrus.Error("getArrayAggSuggestions search failed")
-		return nil, err
+		return nil, errors.Wrap(err, "getArrayAggSuggestions search failed")
 	}
 
 	LogQueryPartMin(esIndex, searchResult, "getArrayAggSuggestions - searchResult")
@@ -357,8 +354,7 @@ func (backend ES2Backend) getProfileSuggestions(ctx context.Context, client *ela
 		Do(ctx)
 
 	if err != nil {
-		logrus.Error("getProfileSuggestions search failed")
-		return nil, err
+		return nil, errors.Wrap(err, "getProfileSuggestions search failed")
 	}
 
 	logrus.Debugf("Search query took %d milliseconds\n", searchResult.TookInMillis)
@@ -454,8 +450,7 @@ func (backend ES2Backend) getControlSuggestions(ctx context.Context, client *ela
 		Do(ctx)
 
 	if err != nil {
-		logrus.Error("getControlSuggestions search failed")
-		return nil, err
+		return nil, errors.Wrap(err, "getControlSuggestions search failed")
 	}
 
 	logrus.Debugf("Search query took %d milliseconds\n", searchResult.TookInMillis)
@@ -485,7 +480,7 @@ func (backend ES2Backend) getControlSuggestions(ctx context.Context, client *ela
 										addedControls[c.ID] = true
 									}
 								} else {
-									logrus.Errorf("Invalid control (%+v) found in report %s", c, hit2.Id)
+									logrus.Errorf("getControlSuggestions: Invalid control (%+v) found in report %s", c, hit2.Id)
 								}
 							}
 						}
@@ -551,8 +546,7 @@ func (backend ES2Backend) getControlTagsSuggestions(ctx context.Context, client 
 		Do(ctx)
 
 	if err != nil {
-		logrus.Error("getControlTagsSuggestions search failed")
-		return nil, err
+		return nil, errors.Wrap(err, "getControlTagsSuggestions search failed")
 	}
 
 	logrus.Debugf("Search query took %d milliseconds\n", searchResult.TookInMillis)
@@ -589,7 +583,7 @@ func (backend ES2Backend) getControlTagsSuggestions(ctx context.Context, client 
 							c.StringTags,
 						})
 					} else {
-						logrus.Errorf("Invalid control (%+v) found in report %s", c, hit2.Id)
+						logrus.Errorf("getControlTagsSuggestions: Invalid control (%+v) found in report %s", c, hit2.Id)
 					}
 				}
 			}

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -575,21 +575,24 @@ func (backend ES2Backend) getControlTagsSuggestions(client *elastic.Client, type
 	foundControlTags := make([]ControlTagsScore, 0)
 	if searchResult != nil {
 		for _, hit := range searchResult.Hits.Hits {
-			if hit != nil {
-				for _, inner_hit := range hit.InnerHits {
-					if inner_hit != nil {
-						for _, hit2 := range inner_hit.Hits.Hits {
-							var c ControlSourceTags
-							if hit2.Source != nil {
-								err := json.Unmarshal(*hit2.Source, &c)
-								if err == nil && c.ID != "" {
-									foundControlTags = append(foundControlTags, ControlTagsScore{
-										float32(*hit2.Score),
-										c.StringTags,
-									})
-								}
-							}
-						}
+			if hit == nil {
+				continue
+			}
+			for _, inner_hit := range hit.InnerHits {
+				if inner_hit == nil {
+					continue
+				}
+				for _, hit2 := range inner_hit.Hits.Hits {
+					if hit2.Source == nil {
+						continue
+					}
+					var c ControlSourceTags
+					err := json.Unmarshal(*hit2.Source, &c)
+					if err == nil && c.ID != "" {
+						foundControlTags = append(foundControlTags, ControlTagsScore{
+							float32(*hit2.Score),
+							c.StringTags,
+						})
 					}
 				}
 			}

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -12,9 +12,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/schollz/closestmatch"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/status"
 
 	reportingapi "github.com/chef/automate/components/compliance-service/api/reporting"
 	"github.com/chef/automate/lib/errorutils"
+	"google.golang.org/grpc/codes"
 )
 
 // GetSuggestions - Report #12
@@ -504,7 +506,7 @@ func (backend ES2Backend) getControlSuggestions(client *elastic.Client, typePara
 
 func (backend ES2Backend) getControlTagsSuggestions(client *elastic.Client, typeParam string, target string, text string, controlTagFilterKey string, size int, filters map[string][]string, useSummaryIndex bool) ([]*reportingapi.Suggestion, error) {
 	if typeParam == "control_tag_value" && controlTagFilterKey == "" {
-		return nil, errors.New("'control_tag' filter is required for 'control_tag_value' suggestions")
+		return nil, status.Error(codes.InvalidArgument, "'control_tag' filter is required for 'control_tag_value' suggestions")
 	}
 	esIndex, err := GetEsIndex(filters, useSummaryIndex, true)
 	if err != nil {

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -194,10 +194,6 @@ func (backend ES2Backend) getAggSuggestions(ctx context.Context, client *elastic
 		logrus.Error("getAggSuggestions search failed")
 		return nil, err
 	}
-	// Sample search sent to ElasticSearch for a node_name suggestion
-	//{
-	//	"aggregations": {
-	//		"myagg": {
 
 	LogQueryPartMin(esIndex, searchResult, "getAggSuggestions - searchResult")
 	logrus.Debugf("Search query took %d milliseconds\n", searchResult.TookInMillis)
@@ -359,11 +355,6 @@ func (backend ES2Backend) getProfileSuggestions(ctx context.Context, client *ela
 			"hits.hits.inner_hits.profiles.hits.hits._source.version",
 			"hits.hits.inner_hits.profiles.hits.hits._score").
 		Do(ctx)
-
-	//// Sample search sent to ElasticSearch when suggesting controls:
-	//{
-	//	"_source": false,
-	//...
 
 	if err != nil {
 		logrus.Error("getProfileSuggestions search failed")
@@ -630,7 +621,7 @@ func (backend ES2Backend) getControlTagsSuggestions(ctx context.Context, client 
 			}
 		}
 
-		// Find the best engram match from the array of texts
+		// Find the best engram match from the array of matches
 		bestMatch := findBestArrayMatch(text, matches)
 		for _, match := range bestMatch {
 			bestMatchScore := item.Score
@@ -640,12 +631,14 @@ func (backend ES2Backend) getControlTagsSuggestions(ctx context.Context, client 
 		}
 	}
 
-	suggs := make([]*reportingapi.Suggestion, 0)
+	suggs := make([]*reportingapi.Suggestion, len(scoredTagSuggs))
+	i := 0
 	for mSugg, mScore := range scoredTagSuggs {
-		suggs = append(suggs, &reportingapi.Suggestion{
+		suggs[i] = &reportingapi.Suggestion{
 			Text:  mSugg,
 			Score: *mScore,
-		})
+		}
+		i++
 	}
 
 	return suggs, nil

--- a/components/compliance-service/test_data/audit_reports/2018-02-09_debian(2)-zeta-linux(f)-apache(p)-failed.json
+++ b/components/compliance-service/test_data/audit_reports/2018-02-09_debian(2)-zeta-linux(f)-apache(p)-failed.json
@@ -111,7 +111,7 @@
           "refs": [],
           "tags": {
             "web": null,
-            "scope": "OS",
+            "scope": "apalache",
             "gtitle": "TitleVal",
             "satisfies": [
               "SRG-00006",

--- a/components/compliance-service/test_data/audit_reports/2018-03-04_centos(3)-beta-nginx(p)-apache(s)-fake(s)-passed.json
+++ b/components/compliance-service/test_data/audit_reports/2018-03-04_centos(3)-beta-nginx(p)-apache(s)-fake(s)-passed.json
@@ -190,7 +190,7 @@
         },
         {
           "id": "apache-01",
-          "code": "control 'apache-01' do\n  impact 1.0\n  title 'Apache should be running'\n  desc 'Apache should be running.'\n  describe service(apache.service) do\n    it { should be_installed }\n    it { should be_running }\n  end\nend\n",
+          "code": "control 'apache-01' do\n  impact 1.0\n  title 'Apache should be running'\n  desc 'Apache should be running.'\n  describe service(apache.service) do\n    it { should be_installed }\n    it { should be_running }\n  end\n  tag 'scoop': 'icecream'\nend\n",
           "desc": "Apache should be running.",
           "impact": 1,
           "title": "Apache should be running",
@@ -199,7 +199,9 @@
             "line": 29
           },
           "refs": [],
-          "tags": {},
+          "tags": {
+            "scoop": "icecream"
+          },
           "results": [
             {
               "status": "skipped",
@@ -211,7 +213,7 @@
         },
         {
           "id": "apache-02",
-          "code": "control 'apache-02' do\n  impact 1.0\n  title 'Apache should be enabled'\n  desc 'Configure apache service to be automatically started at boot time'\n  only_if { os[:family] != 'ubuntu' && os[:release] != '16.04' } || only_if { os[:family] != 'debian' && os[:release] != '8' }\n  describe service(apache.service) do\n    it { should be_enabled }\n  end\nend\n",
+          "code": "control 'apache-02' do\n  impact 1.0\n  title 'Apache should be enabled'\n  desc 'Configure apache service to be automatically started at boot time'\n  only_if { os[:family] != 'ubuntu' && os[:release] != '16.04' } || only_if { os[:family] != 'debian' && os[:release] != '8' }\n  describe service(apache.service) do\n    it { should be_enabled }\n  end\n  tag 'Scoops': 'icey gelato'\nend\n",
           "desc": "Configure apache service to be automatically started at boot time",
           "impact": 1,
           "title": "Apache should be enabled",
@@ -220,7 +222,9 @@
             "line": 39
           },
           "refs": [],
-          "tags": {},
+          "tags": {
+            "Scoops": "ices gelato"
+          },
           "results": [
             {
               "status": "skipped",
@@ -232,7 +236,7 @@
         },
         {
           "id": "apache-04",
-          "code": "control 'apache-04' do\n  impact 1.0\n  title 'Check Apache config folder owner, group and permissions.'\n  desc 'The Apache config folder should owned and grouped by root, be writable, readable and executable by owner. It should be readable, executable by group and not readable, not writeable by others.'\n  describe file(apache.conf_dir) do\n    it { should be_owned_by 'root' }\n    it { should be_grouped_into 'root' }\n    it { should be_readable.by('owner') }\n    it { should be_writable.by('owner') }\n    it { should be_executable.by('owner') }\n    it { should be_readable.by('group') }\n    it { should_not be_writable.by('group') }\n    it { should be_executable.by('group') }\n    it { should_not be_readable.by('others') }\n    it { should_not be_writable.by('others') }\n    it { should be_executable.by('others') }\n  end\nend\n",
+          "code": "control 'apache-04' do\n  impact 1.0\n  title 'Check Apache config folder owner, group and permissions.'\n  desc 'The Apache config folder should owned and grouped by root, be writable, readable and executable by owner. It should be readable, executable by group and not readable, not writeable by others.'\n  describe file(apache.conf_dir) do\n    it { should be_owned_by 'root' }\n    it { should be_grouped_into 'root' }\n    it { should be_readable.by('owner') }\n    it { should be_writable.by('owner') }\n    it { should be_executable.by('owner') }\n    it { should be_readable.by('group') }\n    it { should_not be_writable.by('group') }\n    it { should be_executable.by('group') }\n    it { should_not be_readable.by('others') }\n    it { should_not be_writable.by('others') }\n    it { should be_executable.by('others') }\n  end\n  tag 'scoop': 'hot icetea'\nend\n",
           "desc": "The Apache config folder should owned and grouped by root, be writable, readable and executable by owner. It should be readable, executable by group and not readable, not writeable by others.",
           "impact": 1,
           "title": "Check Apache config folder owner, group and permissions.",
@@ -241,7 +245,9 @@
             "line": 58
           },
           "refs": [],
-          "tags": {},
+          "tags": {
+            "scoop": "italian gelato"
+          },
           "results": [
             {
               "status": "skipped",


### PR DESCRIPTION
This PR introduces `control_tag_key` and `control_tag_value` compliance API suggestions.

Because of the level of nesting control tags are at, the suggestions happen in two steps:

1. `engram` ElasticSearch query returns a list with all controls that match the text. We get all tags from these controls with a score we can't associate to a particular tag.

2. Tags are then aggregated to reduce duplicates and sorted by score. The `closestmatch` go lib is used to further `engram` search the aggregated tag key or values.

For `control_tag_value` suggestions a `control_tag` filter is required. This will be used to figure out the control tag key for which to do the value suggestions. Example from the tests in this PR:

```
    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
      type: 'control_tag_value',
      filters: [
        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
        Reporting::ListFilter.new(type: 'control_tag:satisfies', values: []),
      ]
    )
```