### PR TITLE
Clean up IAM v2.1 version checking in UI

### DIFF
--- a/components/automate-ui/src/app/components/settings-sidebar/settings-sidebar.component.html
+++ b/components/automate-ui/src/app/components/settings-sidebar/settings-sidebar.component.html
@@ -27,15 +27,15 @@
     </app-authorized>
 
     <div *ngIf="(iamMajorVersion$ | async) !== 'v1'">
-      <div class="group" *ngIf="policies.visible || roles.visible || (projects.visible && (iamMinorVersion$ | async) === 'v1')">Access Management</div>
+      <div class="group" *ngIf="policies.visible || roles.visible || (projects && projects.visible)">Access Management</div>
       <app-authorized #policies [allOf]="['/iam/v2beta/policies', 'get']">
         <chef-sidebar-entry route="/settings/policies" icon="security">Policies</chef-sidebar-entry>
       </app-authorized>
       <app-authorized #roles [allOf]="['/iam/v2beta/roles', 'get']">
         <chef-sidebar-entry route="/settings/roles" icon="assignment_ind">Roles</chef-sidebar-entry>
       </app-authorized>
-      <app-authorized #projects [allOf]="['/iam/v2beta/projects', 'get']">
-        <chef-sidebar-entry *ngIf="(iamMinorVersion$ | async) === 'v1'" route="/settings/projects" icon="work">Projects</chef-sidebar-entry>
+      <app-authorized #projects [allOf]="['/iam/v2beta/projects', 'get']" *ngIf="projectsEnabled$ | async">
+        <chef-sidebar-entry route="/settings/projects" icon="work">Projects</chef-sidebar-entry>
       </app-authorized>
     </div>
   </div>

--- a/components/automate-ui/src/app/components/settings-sidebar/settings-sidebar.component.ts
+++ b/components/automate-ui/src/app/components/settings-sidebar/settings-sidebar.component.ts
@@ -3,7 +3,11 @@ import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { iamMajorVersion, iamMinorVersion } from 'app/entities/policies/policy.selectors';
+import {
+  iamMajorVersion,
+  iamMinorVersion,
+  atLeastV2p1
+} from 'app/entities/policies/policy.selectors';
 import { GetIamVersion } from 'app/entities/policies/policy.actions';
 import { IAMMajorVersion, IAMMinorVersion } from 'app/entities/policies/policy.model';
 
@@ -16,12 +20,14 @@ import { IAMMajorVersion, IAMMinorVersion } from 'app/entities/policies/policy.m
 export class SettingsSidebarComponent implements OnInit {
   public iamMajorVersion$: Observable<IAMMajorVersion>;
   public iamMinorVersion$: Observable<IAMMinorVersion>;
+  public projectsEnabled$: Observable<boolean>;
 
   constructor(
     private store: Store<NgrxStateAtom>
     ) {
     this.iamMajorVersion$ = store.select(iamMajorVersion);
     this.iamMinorVersion$ = store.select(iamMinorVersion);
+    this.projectsEnabled$ = store.select(atLeastV2p1);
   }
 
   ngOnInit() {

--- a/components/automate-ui/src/app/entities/projects/project.effects.ts
+++ b/components/automate-ui/src/app/entities/projects/project.effects.ts
@@ -9,7 +9,7 @@ import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { HttpStatus } from 'app/types/types';
 import { CreateNotification } from 'app/entities/notifications/notification.actions';
 import { Type } from 'app/entities/notifications/notification.model';
-import { iamMajorVersion, iamMinorVersion } from 'app/entities/policies/policy.selectors';
+import { atLeastV2p1 } from 'app/entities/policies/policy.selectors';
 import { ProjectRequests } from './project.requests';
 
 import {
@@ -201,21 +201,19 @@ export class ProjectEffects {
 
   @Effect()
   getActiveApplyRulesStatus$ = observableInterval(1000 * ACTIVE_RULE_STATUS_INTERVAL).pipe(
-    withLatestFrom(this.store.select(iamMajorVersion)),
-    withLatestFrom(this.store.select(iamMinorVersion)),
+    withLatestFrom(this.store.select(atLeastV2p1)),
     withLatestFrom(this.store.select(applyRulesStatus)),
-    filter(([[[_, major], minor], { state }]) =>
-      major === 'v2' && minor === 'v1' && state === ApplyRulesStatusState.Running
+    filter(([[_, projectsEnabled], { state }]) =>
+      projectsEnabled && state === ApplyRulesStatusState.Running
     ),
     switchMap(this.getRulesStatus$()));
 
   @Effect()
   getDormantApplyRulesStatus$ = observableInterval(1000 * DORMANT_RULE_STATUS_INTERVAL).pipe(
-    withLatestFrom(this.store.select(iamMajorVersion)),
-    withLatestFrom(this.store.select(iamMinorVersion)),
+    withLatestFrom(this.store.select(atLeastV2p1)),
     withLatestFrom(this.store.select(applyRulesStatus)),
-    filter(([[[_, major], minor], { state }]) =>
-      major === 'v2' && minor === 'v1' && state === ApplyRulesStatusState.NotRunning
+    filter(([[_, projectsEnabled], { state }]) =>
+      projectsEnabled && state === ApplyRulesStatusState.NotRunning
     ),
     switchMap(this.getRulesStatus$()));
 

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -28,9 +28,7 @@
       </div>
     </div>
     <div class="right-nav" role="menubar">
-      <app-projects-filter
-        *ngIf="(iamMajorVersion$ | async) === 'v2' && (iamMinorVersion$ | async) === 'v1'">
-      </app-projects-filter>
+      <app-projects-filter *ngIf="projectsEnabled$ | async"></app-projects-filter>
       <app-profile></app-profile>
     </div>
   </nav>

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.spec.ts
@@ -10,7 +10,6 @@ import {
   PolicyEntityInitialState,
   policyEntityReducer
 } from 'app/entities/policies/policy.reducer';
-import { IAMMajorVersion, IAMMinorVersion } from 'app/entities/policies/policy.model';
 
 describe('NavbarComponent', () => {
   let component: NavbarComponent;
@@ -73,8 +72,7 @@ describe('NavbarComponent', () => {
 
   describe('when IAM v2.1 is enabled', () => {
     beforeEach(() => {
-      component.iamMajorVersion$ = observableOf(<IAMMajorVersion>'v2');
-      component.iamMinorVersion$ = observableOf(<IAMMinorVersion>'v1');
+      component.projectsEnabled$ = observableOf(true);
       fixture.detectChanges();
     });
 

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.ts
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.ts
@@ -3,8 +3,7 @@ import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { iamMinorVersion, iamMajorVersion } from 'app/entities/policies/policy.selectors';
-import { IAMMinorVersion, IAMMajorVersion } from 'app/entities/policies/policy.model';
+import { atLeastV2p1 } from 'app/entities/policies/policy.selectors';
 
 @Component({
   selector: 'app-navbar',
@@ -14,8 +13,7 @@ import { IAMMinorVersion, IAMMajorVersion } from 'app/entities/policies/policy.m
 
 export class NavbarComponent implements OnInit {
   public applicationsFeatureFlagOn: boolean;
-  public iamMajorVersion$: Observable<IAMMajorVersion>;
-  public iamMinorVersion$: Observable<IAMMinorVersion>;
+  public projectsEnabled$: Observable<boolean>;
 
   constructor(
     private featureFlagsService: FeatureFlagsService,
@@ -28,7 +26,6 @@ export class NavbarComponent implements OnInit {
 
   ngOnInit() {
     this.applicationsFeatureFlagOn = this.featureFlagsService.getFeatureStatus('applications');
-    this.iamMajorVersion$ = this.store.select(iamMajorVersion);
-    this.iamMinorVersion$ = this.store.select(iamMinorVersion);
+    this.projectsEnabled$ = this.store.select(atLeastV2p1);
   }
 }

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
@@ -14,7 +14,7 @@
       [conflictErrorEvent]="conflictErrorEvent"
       objectNoun="token"
       [createForm]="createTokenForm"
-      [showProjectsDropdown]="!isMajorV1 && isMinorV1"
+      [showProjectsDropdown]="projectsEnabled$ | async"
       [assignableProjects]="dropdownProjects"
       (close)="closeCreateModal()"
       (createClicked)="createToken()">
@@ -46,7 +46,7 @@
             <chef-tr>
               <chef-th>Name</chef-th>
               <chef-th *ngIf="(iamMajorVersion$ | async) !== 'v1'">ID</chef-th>
-              <chef-th *ngIf="!isMajorV1 && isMinorV1">Projects</chef-th>
+              <chef-th *ngIf="projectsEnabled$ | async">Projects</chef-th>
               <chef-th>Created Date</chef-th>
               <chef-th>Status</chef-th>
               <chef-th class="controls"></chef-th>
@@ -58,7 +58,7 @@
                 <a [routerLink]="['/settings/tokens', token.id]">{{ token.name }}</a>
               </chef-td>
               <chef-td *ngIf="(iamMajorVersion$ | async) !== 'v1'">{{ token.id }}</chef-td>
-              <chef-td *ngIf="!isMajorV1 && isMinorV1" class="projects-column">
+              <chef-td *ngIf="projectsEnabled$ | async" class="projects-column">
                 <span *ngIf="token.projects.length === 0">{{ unassigned }}</span>
                 <span *ngIf="token.projects.length === 1">{{ token.projects[0] }}</span>
                 <span *ngIf="token.projects.length > 1">{{ token.projects.length }} projects</span>

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.html
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.html
@@ -9,11 +9,11 @@
         Projects group resources together. Max of {{ MAX_PROJECTS }} projects allowed.
       </chef-subheading>
     </chef-page-header>
-    <section *ngIf="(iamMajorVersion$ | async) === 'v1' || (iamMinorVersion$ | async) === 'v0'" class="page-body">
-      Currently, you are using IAM {{ iamMajorVersion$ | async }}. Projects are only available when using IAM v2.1.
+    <section *ngIf="!(projectsEnabled$ | async)" class="page-body">
+      Projects are only available when using IAM v2.1 or higher.
     </section>
 
-    <section *ngIf="(iamMinorVersion$ | async) === 'v1'" class="page-body">
+    <section *ngIf="projectsEnabled$ | async" class="page-body">
       <ng-container *ngIf="(sortedProjects$ | async)?.length > 0">
         <chef-toolbar>
           <app-authorized [allOf]="['/iam/v2beta/projects', 'post']">

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.html
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.html
@@ -10,7 +10,7 @@
       </chef-subheading>
     </chef-page-header>
     <section *ngIf="!(projectsEnabled$ | async)" class="page-body">
-      Projects are only available when using IAM v2.1 or higher.
+      Currently, you are using IAM {{ iamMajorVersion$ | async }}. Projects are only available with IAM v2.1 or higher.
     </section>
 
     <section *ngIf="projectsEnabled$ | async" class="page-body">

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
@@ -9,7 +9,6 @@ import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { customMatchers } from 'app/testing/custom-matchers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { IAMMajorVersion, IAMMinorVersion } from 'app/entities/policies/policy.model';
 import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
 import { ProjectService } from 'app/entities/projects/project.service';
 import {
@@ -118,8 +117,7 @@ describe('ProjectListComponent', () => {
     element = fixture.debugElement.nativeElement;
     store = TestBed.get(Store);
 
-    component.iamMajorVersion$ = observableOf(<IAMMajorVersion>'v2');
-    component.iamMinorVersion$ = observableOf(<IAMMinorVersion>'v1');
+    component.projectsEnabled$ = observableOf(true);
     fixture.detectChanges();
   });
 
@@ -145,22 +143,13 @@ describe('ProjectListComponent', () => {
       });
     });
 
-    it('does not display project data for v2.0', () => {
-      component.iamMajorVersion$ = observableOf(<IAMMajorVersion>'v2');
-      component.iamMinorVersion$ = observableOf(<IAMMinorVersion>'v0');
+    it('does not display project data for less than v2.1', () => {
+      component.projectsEnabled$ = observableOf(false);
       store.dispatch(new GetProjectsSuccess({ projects: projectList }));
       expect(element).not.toContainPath('chef-table');
     });
 
-    it('does not display project data for v1', () => {
-      component.iamMajorVersion$ = observableOf(<IAMMajorVersion>'v1');
-      component.iamMinorVersion$ = observableOf(<IAMMinorVersion>'v0');
-      store.dispatch(new GetProjectsSuccess({ projects: projectList }));
-      fixture.detectChanges();
-      expect(element).not.toContainPath('chef-table');
-    });
-
-    describe('sortedProject$', () => {
+     describe('sortedProject$', () => {
     it('intermixes capitals and lowercase with lowercase first', () => {
       store.dispatch(new GetProjectsSuccess({
         projects: [

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -9,8 +9,7 @@ import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Regex } from 'app/helpers/auth/regex';
 import { HttpStatus } from 'app/types/types';
 import { loading, EntityStatus } from 'app/entities/entities';
-import { iamMajorVersion, iamMinorVersion } from 'app/entities/policies/policy.selectors';
-import { IAMMajorVersion, IAMMinorVersion } from 'app/entities/policies/policy.model';
+import { atLeastV2p1 } from 'app/entities/policies/policy.selectors';
 import { ProjectService } from 'app/entities/projects/project.service';
 import {
   allProjects, getAllStatus, createStatus, createError
@@ -29,8 +28,7 @@ import { LoadOptions } from 'app/services/projects-filter/projects-filter.action
 export class ProjectListComponent implements OnInit, OnDestroy {
   public MAX_PROJECTS = 6;
   public loading$: Observable<boolean>;
-  public iamMajorVersion$: Observable<IAMMajorVersion>;
-  public iamMinorVersion$: Observable<IAMMinorVersion>;
+  public projectsEnabled$: Observable<boolean>;
   public sortedProjects$: Observable<Project[]>;
   public projectToDelete: Project;
   public deleteModalVisible = false;
@@ -76,8 +74,7 @@ export class ProjectListComponent implements OnInit, OnDestroy {
         }
       )));
 
-    this.iamMajorVersion$ = store.select(iamMajorVersion);
-    this.iamMinorVersion$ = store.select(iamMinorVersion);
+    this.projectsEnabled$ = store.select(atLeastV2p1);
 
     this.applyRulesButtonText$ = this.projects.applyRulesStatus$.pipe(
       map(({ state, percentageComplete }: ApplyRulesStatus) => {

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -10,6 +10,8 @@ import { Regex } from 'app/helpers/auth/regex';
 import { HttpStatus } from 'app/types/types';
 import { loading, EntityStatus } from 'app/entities/entities';
 import { atLeastV2p1 } from 'app/entities/policies/policy.selectors';
+import { iamMajorVersion } from 'app/entities/policies/policy.selectors';
+import { IAMMajorVersion } from 'app/entities/policies/policy.model';
 import { ProjectService } from 'app/entities/projects/project.service';
 import {
   allProjects, getAllStatus, createStatus, createError
@@ -28,6 +30,7 @@ import { LoadOptions } from 'app/services/projects-filter/projects-filter.action
 export class ProjectListComponent implements OnInit, OnDestroy {
   public MAX_PROJECTS = 6;
   public loading$: Observable<boolean>;
+  public iamMajorVersion$: Observable<IAMMajorVersion>;
   public projectsEnabled$: Observable<boolean>;
   public sortedProjects$: Observable<Project[]>;
   public projectToDelete: Project;
@@ -74,6 +77,7 @@ export class ProjectListComponent implements OnInit, OnDestroy {
         }
       )));
 
+    this.iamMajorVersion$ = store.select(iamMajorVersion);
     this.projectsEnabled$ = store.select(atLeastV2p1);
 
     this.applyRulesButtonText$ = this.projects.applyRulesStatus$.pipe(

--- a/components/automate-ui/src/app/pages/team-add-users/team-add-users.component.ts
+++ b/components/automate-ui/src/app/pages/team-add-users/team-add-users.component.ts
@@ -40,7 +40,7 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
   public team: Team;
   public users: User[] = [];
   private mapOfUsersToFilter: HashMapOfUsers = {};
-  private isV1 = true;
+  private isMajorV1 = true;
   private isDestroyed = new Subject<boolean>();
   public addingUsers = false;
   private usersToAdd: { [id: string]: User } = {};
@@ -58,9 +58,9 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.isDestroyed))
       .subscribe((version) => {
         if (version === null) { return; }
-        this.isV1 = version === 'v1';
+        this.isMajorV1 = version === 'v1';
 
-        if (this.isV1) {
+        if (this.isMajorV1) {
           this.store.select(v1TeamFromRoute)
             .pipe(filter(identity), takeUntil(this.isDestroyed))
             .subscribe(this.getUsersForTeam.bind(this));
@@ -226,6 +226,6 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
   }
 
   private get teamId(): string {
-    return this.isV1 ? this.team.guid : this.team.id;
+    return this.isMajorV1 ? this.team.guid : this.team.id;
   }
 }

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -76,7 +76,6 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   public addButtonText = 'Add User';
   public removeText = 'Remove User';
 
-  public atLeastV2p1$: Observable<boolean>;
   public projectsEnabled: boolean;
   public projects: ProjectCheckedMap = {};
   public unassigned = ProjectConstants.UNASSIGNED_PROJECT_ID;
@@ -117,8 +116,6 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.atLeastV2p1$ = this.store.select(atLeastV2p1);
-
     this.store.select(routeURL).pipe(takeUntil(this.isDestroyed))
       .subscribe((url: string) => {
         this.url = url;

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -13,11 +13,7 @@ import { User } from 'app/entities/users/user.model';
 import { Regex } from 'app/helpers/auth/regex';
 import { allUsers, userStatus } from 'app/entities/users/user.selectors';
 import { GetUsers } from 'app/entities/users/user.actions';
-import {
-  iamMajorVersion,
-  iamMinorVersion,
-  atLeastV2p1
-} from 'app/entities/policies/policy.selectors';
+import { iamMajorVersion, atLeastV2p1 } from 'app/entities/policies/policy.selectors';
 import {
   v1TeamFromRoute,
   v2TeamFromRoute,
@@ -68,7 +64,6 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
 
   public team: Team;
   public isMajorV1 = true;
-  public isMinorV1 = false;
 
   public users: User[] = [];
   private isDestroyed = new Subject<boolean>();
@@ -122,12 +117,6 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
         const [, fragment] = url.split('#');
         // goes to #users if (1) explicit #users, (2) no fragment, or (3) invalid fragment
         this.tabValue = (fragment === 'details') ? 'details' : 'users';
-      });
-
-    this.store.select(iamMinorVersion)
-      .pipe(takeUntil(this.isDestroyed))
-      .subscribe((minor) => {
-        this.isMinorV1 = minor === 'v1';
       });
 
     combineLatest([

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -3,7 +3,7 @@ import { FormBuilder, FormGroup, FormControl, Validators } from '@angular/forms'
 import { Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 import { isEmpty, identity, keyBy, at, xor } from 'lodash/fp';
-import { combineLatest, Observable, Subject } from 'rxjs';
+import { combineLatest, Subject } from 'rxjs';
 import { filter, map, pluck, takeUntil } from 'rxjs/operators';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';

--- a/components/automate-ui/src/app/pages/team-management/team-management.component.html
+++ b/components/automate-ui/src/app/pages/team-management/team-management.component.html
@@ -23,7 +23,7 @@
       [conflictErrorEvent]="conflictErrorEvent"
       objectNoun="team"
       [createForm]="createTeamForm"
-      [showProjectsDropdown]="!isMajorV1 && isMinorV1"
+      [showProjectsDropdown]="projectsEnabled$ | async"
       [assignableProjects]="dropdownProjects"
       (close)="closeCreateModal()"
       (createClicked)="createV2Team()">
@@ -57,7 +57,7 @@
                     <span *ngIf="isMajorV1">Description</span>
                     <span *ngIf="!isMajorV1">ID</span>
                   </chef-th>
-                  <chef-th *ngIf="!isMajorV1 && isMinorV1" class="projects-column">
+                  <chef-th *ngIf="projectsEnabled$ | async" class="projects-column">
                     <span>Projects</span>
                   </chef-th>
                   <chef-th class="button-column"></chef-th>
@@ -74,7 +74,7 @@
                     <span *ngIf="isMajorV1">{{ team.name }}</span>
                     <span *ngIf="!isMajorV1">{{ team.id }}</span>
                   </chef-td>
-                  <chef-td *ngIf="!isMajorV1 && isMinorV1" class="projects-column">
+                  <chef-td *ngIf="projectsEnabled$ | async" class="projects-column">
                     <span *ngIf="team.projects.length === 0">{{ unassigned }}</span>
                     <span *ngIf="team.projects.length === 1">{{ team.projects[0] }}</span>
                     <span *ngIf="team.projects.length > 1">{{ team.projects.length }} projects</span>

--- a/components/automate-ui/src/app/pages/team-management/team-management.component.spec.ts
+++ b/components/automate-ui/src/app/pages/team-management/team-management.component.spec.ts
@@ -4,12 +4,11 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MockComponent } from 'ng2-mock-component';
 import { StoreModule, Store } from '@ngrx/store';
-import { of as observableOf } from 'rxjs';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { HttpStatus } from 'app/types/types';
 import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
-import { IAMMajorVersion } from 'app/entities/policies/policy.model';
+import { projectsFilterReducer } from 'app/services/projects-filter/projects-filter.reducer';
 import { teamEntityReducer } from 'app/entities/teams/team.reducer';
 import { Team } from 'app/entities/teams/team.model';
 import {
@@ -18,7 +17,6 @@ import {
   CreateTeamFailure,
   DeleteTeamSuccess
 } from 'app/entities/teams/team.actions';
-import { projectsFilterReducer } from 'app/services/projects-filter/projects-filter.reducer';
 import { TeamManagementComponent } from './team-management.component';
 
 describe('TeamManagementComponent', () => {
@@ -101,7 +99,7 @@ describe('TeamManagementComponent', () => {
 
     beforeEach(() => {
       store = TestBed.get(Store);
-      component.iamMajorVersion$ = observableOf(<IAMMajorVersion>'v1');
+      component.isMajorV1 = true;
     });
 
     it('openCreateModal on v1 opens v1 modal', () => {
@@ -179,7 +177,6 @@ describe('TeamManagementComponent', () => {
     beforeEach(() => {
       store = TestBed.get(Store);
       component.isMajorV1 = false;
-      fixture.detectChanges();
     });
 
     it('openCreateModal on v2 opens v2 modal', () => {

--- a/components/automate-ui/src/app/pages/team-management/team-management.component.ts
+++ b/components/automate-ui/src/app/pages/team-management/team-management.component.ts
@@ -7,11 +7,7 @@ import { identity } from 'lodash/fp';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { loading, EntityStatus } from 'app/entities/entities';
-import {
-  iamMajorVersion,
-  iamMinorVersion,
-  atLeastV2p1
-} from 'app/entities/policies/policy.selectors';
+import { iamMajorVersion, atLeastV2p1 } from 'app/entities/policies/policy.selectors';
 import {
   createError,
   createStatus,
@@ -43,7 +39,6 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
   public conflictErrorEvent = new EventEmitter<boolean>();
   public projectsEnabled$: Observable<boolean>;
   public isMajorV1 = true;
-  public isMinorV1 = false;
   public dropdownProjects: Project[] = [];
   public unassigned = ProjectConstants.UNASSIGNED_PROJECT_ID;
 
@@ -94,12 +89,6 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.isDestroyed))
       .subscribe((majorVersion) => {
         this.isMajorV1 = majorVersion === 'v1';
-      });
-
-    this.store.select(iamMinorVersion)
-      .pipe(takeUntil(this.isDestroyed))
-      .subscribe((minorVersion) => {
-        this.isMinorV1 = minorVersion === 'v1';
       });
 
     this.store.select(assignableProjects)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This is a cleanup of IAM version selectors in the UI.
A couple recent PRs introduced the new `atLeastV2p1` ngrx/store selector.
Rather than bloat those PRs with unrelated cleanup, though, made all the
rest of it into this separate PR.

1. Uses the new atLeastV2p1 selector in place of the individual
major/minor selectors, bringing the version determination to a
single point of truth, yielding simpler code.
2. Perhaps more importantly, abstracts the notion of "projects enabled"
to all consumers, so that they do not need to care about the specifics of the major and minor versions.
This allows for future version bumps to be much cleaner and simpler.

Now the code has clear distinction between projects
and things that are v1 vs. v2 (e.g. roles, aspects of teams, etc.).

### :chains: Related Resources

### :+1: Definition of Done

Code looks a little cleaner; no visible changes.

### :athletic_shoe: How to Build and Test the Change

Rebuild automate-ui