### PR TITLE
lib/cereal: CreateWorkflowSchedule should take a context

### DIFF
--- a/components/applications-service/pkg/server/periodic.go
+++ b/components/applications-service/pkg/server/periodic.go
@@ -75,6 +75,7 @@ func (j *JobScheduler) Setup() error {
 	}
 
 	err = j.createWorkflowIfMissing(
+		context.Background(),
 		DisconnectedServicesScheduleName,
 		DisconnectedServicesJobName,
 		defaultDisconnectedServicesJobParams(),
@@ -95,6 +96,7 @@ func (j *JobScheduler) Setup() error {
 	}
 
 	err = j.createWorkflowIfMissing(
+		context.Background(),
 		DeleteDisconnectedServicesScheduleName,
 		DeleteDisconnectedServicesJobName,
 		defaultDeleteDisconnectedServicesJobParams(),
@@ -122,6 +124,7 @@ func (j *JobScheduler) ResetParams() error {
 }
 
 func (j *JobScheduler) createWorkflowIfMissing(
+	ctx context.Context,
 	scheduleName string,
 	jobName string,
 	jobParams interface{},
@@ -135,6 +138,7 @@ func (j *JobScheduler) createWorkflowIfMissing(
 	})
 
 	err := j.CerealSvc.CreateWorkflowSchedule(
+		ctx,
 		scheduleName,
 		jobName,
 		jobParams,

--- a/components/ingest-service/grpc/grpc.go
+++ b/components/ingest-service/grpc/grpc.go
@@ -165,7 +165,7 @@ func Spawn(opts *serveropts.Opts) error {
 		return err
 	}
 
-	err = server.MigrateJobsSchedule(jobManager, viper.ConfigFileUsed())
+	err = server.MigrateJobsSchedule(context.Background(), jobManager, viper.ConfigFileUsed())
 	if err != nil {
 		logrus.WithError(err).Fatal("could not migrate old job schedules")
 		return err

--- a/components/ingest-service/integration_test/suite_test.go
+++ b/components/ingest-service/integration_test/suite_test.go
@@ -394,7 +394,7 @@ func createServices(s *Suite) error {
 		return errors.Wrap(err, "could not initialize job manager")
 	}
 
-	err = server.MigrateJobsSchedule(jobManager, viper.ConfigFileUsed())
+	err = server.MigrateJobsSchedule(context.Background(), jobManager, viper.ConfigFileUsed())
 	if err != nil {
 		return errors.Wrap(err, "could not migrate old job schedules")
 	}

--- a/components/ingest-service/server/jobs.go
+++ b/components/ingest-service/server/jobs.go
@@ -55,7 +55,7 @@ func InitializeJobManager(c *cereal.Manager, client backend.Client, esSidecarCli
 	return nil
 }
 
-func MigrateJobsSchedule(c *cereal.Manager, oldConfigFile string) error {
+func MigrateJobsSchedule(ctx context.Context, c *cereal.Manager, oldConfigFile string) error {
 	jc, err := config.OldJobConfigFromFile(oldConfigFile)
 	if err != nil {
 		log.WithError(err).Warn("failed to read old job config from disk, defaults will be used")
@@ -81,7 +81,7 @@ func MigrateJobsSchedule(c *cereal.Manager, oldConfigFile string) error {
 			return errors.Wrap(err, "could not create recurrence rule for job configuration")
 		}
 
-		err = c.CreateWorkflowSchedule(scheduleName, name, config.Threshold, config.Running, r)
+		err = c.CreateWorkflowSchedule(ctx, scheduleName, name, config.Threshold, config.Running, r)
 		if err == cereal.ErrWorkflowScheduleExists {
 			log.Infof("Schedule for %s already exists, not migrating", scheduleName)
 		} else if err != nil {

--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -889,6 +889,7 @@ func (m *Manager) Stop() error {
 // rule provided. The first run will happen during when the recurrence is first
 // due from Now.
 func (m *Manager) CreateWorkflowSchedule(
+	ctx context.Context,
 	instanceName string,
 	workflowName string,
 	parameters interface{},
@@ -903,7 +904,7 @@ func (m *Manager) CreateWorkflowSchedule(
 	if err != nil {
 		return err
 	}
-	err = m.backend.CreateWorkflowSchedule(context.TODO(), instanceName, workflowName,
+	err = m.backend.CreateWorkflowSchedule(ctx, instanceName, workflowName,
 		jsonData, enabled, recurRule.String(), nextRunAt)
 	if err == nil {
 		m.workflowScheduler.Trigger()

--- a/lib/cereal/integration/schedule.go
+++ b/lib/cereal/integration/schedule.go
@@ -67,6 +67,7 @@ func (suite *CerealTestSuite) TestSimpleScheduleWorkflow() {
 	suite.Require().NoError(err)
 
 	err = m.CreateWorkflowSchedule(
+		context.Background(),
 		instanceName,
 		workflowName,
 		"testparams",
@@ -119,6 +120,7 @@ func (suite *CerealTestSuite) TestScheduleUpdates() {
 	suite.Require().NoError(err)
 
 	err = m.CreateWorkflowSchedule(
+		context.Background(),
 		instanceName,
 		workflowName,
 		"testparams",
@@ -169,6 +171,7 @@ func (suite *CerealTestSuite) TestCreateExpiredSchedule() {
 	suite.Require().NoError(err)
 
 	err = m.CreateWorkflowSchedule(
+		context.Background(),
 		instanceName,
 		workflowName,
 		"testparams",
@@ -224,6 +227,7 @@ func (suite *CerealTestSuite) TestExpiringSchedule() {
 	suite.Require().NoError(err)
 
 	err = m.CreateWorkflowSchedule(
+		context.Background(),
 		instanceName,
 		workflowName,
 		"testparams",

--- a/lib/datalifecycle/purge/workflow.go
+++ b/lib/datalifecycle/purge/workflow.go
@@ -3,10 +3,11 @@ package purge
 import (
 	"context"
 
-	es "github.com/chef/automate/api/interservice/es_sidecar"
-	"github.com/chef/automate/lib/cereal"
 	"github.com/pkg/errors"
 	"github.com/teambition/rrule-go"
+
+	es "github.com/chef/automate/api/interservice/es_sidecar"
+	"github.com/chef/automate/lib/cereal"
 )
 
 // ConfigureManager registers the purge workflow schedule and job with purge
@@ -42,6 +43,7 @@ func CreateOrUpdatePurgeWorkflow(
 	recurrence *rrule.RRule) error {
 
 	err := man.CreateWorkflowSchedule(
+		ctx,
 		scheduleName,
 		jobName,
 		defaultPolicies,

--- a/tools/cereal-scaffold/main.go
+++ b/tools/cereal-scaffold/main.go
@@ -367,6 +367,7 @@ func runScheduleTest(_ *cobra.Command, args []string) error {
 	}
 
 	err = manager.CreateWorkflowSchedule(
+		context.Background(),
 		scheduleName, "schedule-test", nil, true, recRule)
 	if err != nil {
 		if err == cereal.ErrWorkflowScheduleExists {


### PR DESCRIPTION
This makes it consistent with UpdateWorkflowSchedule and allows the
caller to control any required timeout or cancellation of this create
call.

Signed-off-by: Steven Danna <steve@chef.io>