### PR TITLE
gather-logs: adding journalctl hab-sup unit for HA backend nodes

### DIFF
--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -435,11 +435,10 @@ func runGatherLogsLocalCmd(outfileOverride string, logLines uint64) error {
 	g.AddCommand("hab_sup_status", "hab", "sup", "status")
 	if logLines > 0 {
 		logLinesStr := strconv.FormatUint(logLines, 10)
-		g.AddCommand("journalctl_chef-automate", "journalctl", "--utc", "-u", "chef-automate", "-n", logLinesStr)
+		g.AddCommand("journalctl_chef-automate", "journalctl", "--utc", "-u", "chef-automate", "-u", "hab-sup", "-n", logLinesStr)
 	} else {
-		g.AddCommand("journalctl_chef-automate", "journalctl", "--utc", "-u", "chef-automate")
+		g.AddCommand("journalctl_chef-automate", "journalctl", "--utc", "-u", "chef-automate", "-u", "hab-sup")
 	}
-	g.AddCommand("journalctl_chef-automate", "journalctl", "--utc", "-u", "chef-automate")
 
 	// hab version info
 	g.AddCommand("hab_version", "hab", "--version")


### PR DESCRIPTION
Signed-off-by: Jeremy J. Miller <jm@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
For consistency with Chef Automate Frontends, the [Automate Cluster](https://github.com/chef/a2-ha-backend) uses `chef-automate gather-logs` in local fallback mode to capture logs for Support bundles on the backend nodes. This PR simply adds the `hab-sup` systemd unit to the command used to capture journalctl output. `journalctl` accepts multiple `-u|--unit` arguments without problem. With `-u hab-sup` we can also capture the systemd logs for the backend Habitat services running under the `hab-sup` unit. 

The new modified command works seamlessly on front or backend nodes.

Additionally, this PR fixes a small bug, removing the following line that appears to be a duplicate:
`g.AddCommand("journalctl_chef-automate", "journalctl", "--utc", "-u", "chef-automate")`

I verified that in local fallback mode, the above line was overwriting the previous `AddCommand` entry and therefore never honoring the value of `--log-lines` even when the user specified it on the cli.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable