### PR TITLE
deployment-service: stop hard-coding command paths

### DIFF
--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -35,15 +35,6 @@ const (
 	defaultNginxConfPath       = "/hab/svc/automate-load-balancer/config/nginx.conf"
 )
 
-// TODO: Consider having this generated from a config or dynamically
-// in some other way. These are the correct binpaths for
-// enterprise-linux
-var binPaths = map[string]string{
-	"cp":   "/bin/cp",
-	"find": "/bin/find",
-	"tar":  "/bin/tar",
-}
-
 func newGatherLogsCmd() *cobra.Command {
 	gatherLogsCmd := &cobra.Command{
 		Use:   "gather-logs [/path/to/log/bundle.tar.gz]",
@@ -293,7 +284,6 @@ causing a significant increase in disk I/O and inode usage of the filesystem for
 		capturePath,
 		archiveRoot,
 		"chef-automate-local-data-capture",
-		binPaths,
 		time.Now(),
 	)
 
@@ -417,7 +407,6 @@ func runGatherLogsLocalCmd(outfileOverride string, logLines uint64) error {
 		stagingDir,
 		archiveRoot,
 		"chef-automate-local-fallback",
-		binPaths,
 		time.Now(),
 	)
 

--- a/components/automate-deployment/habitat/config/config.toml
+++ b/components/automate-deployment/habitat/config/config.toml
@@ -2,11 +2,6 @@ listen_address = "{{cfg.service.listen_address}}"
 port = {{cfg.service.port}}
 log_level = "{{cfg.log.level}}"
 
-# Gather-Logs
-tar_path       = "{{pkgPathFor "core/tar"}}/bin/tar"
-find_path      = "{{pkgPathFor "core/findutils"}}/bin/find"
-coreutils_path = "{{pkgPathFor "core/coreutils"}}/bin"
-
 {{#if cfg.gather_logs.staging_dir ~}}
 staging_dir = "{{cfg.gather_logs.staging_dir}}"
 {{/if ~}}

--- a/components/automate-deployment/pkg/gatherlogs/copy.go
+++ b/components/automate-deployment/pkg/gatherlogs/copy.go
@@ -8,7 +8,6 @@ import (
 
 // Copy holds the fetching data
 type Copy struct {
-	CpPath   string
 	SrcPath  string
 	DestPath string
 }
@@ -22,7 +21,7 @@ func (c *Copy) execute() error {
 		c.DestPath,
 	)
 
-	out, err := command.CombinedOutput(c.CpPath, copyArgs)
+	out, err := command.CombinedOutput("cp", copyArgs)
 	if err != nil {
 		log.WithFields(
 			log.Fields{

--- a/components/automate-deployment/pkg/gatherlogs/gatherer_test.go
+++ b/components/automate-deployment/pkg/gatherlogs/gatherer_test.go
@@ -18,10 +18,9 @@ func TestNewGatherer(t *testing.T) {
 
 	stagingDir := "/data"
 	tempDir := stagingDir + "/bundle"
-	binPaths := map[string]string{}
 	someTime, _ := time.Parse(time.RFC3339, "2018-02-05T23:20:12Z")
 
-	g := NewGatherer(stagingDir, tempDir, "example.com", binPaths, someTime)
+	g := NewGatherer(stagingDir, tempDir, "example.com", someTime)
 
 	assert.Equal(
 		"/data/bundle",

--- a/components/automate-deployment/pkg/server/config.go
+++ b/components/automate-deployment/pkg/server/config.go
@@ -13,9 +13,6 @@ type Config struct {
 	LogLevel                 string `mapstructure:"log_level"`
 	LogFormat                string `mapstructure:"log_format"`
 	StagingDir               string `mapstructure:"staging_dir"`
-	TarPath                  string `mapstructure:"tar_path"`
-	FindPath                 string `mapstructure:"find_path"`
-	CoreutilsPath            string `mapstructure:"coreutils_path"`
 	ConvergeIntervalSecs     uint32 `mapstructure:"converge_interval_secs"`
 	ConvergeDisableFile      string `mapstructure:"converge_disable_file"`
 	EnsureStatusTimeoutSecs  uint32 `mapstructure:"ensure_status_timeout_secs"`

--- a/components/automate-deployment/pkg/server/gather-logs.go
+++ b/components/automate-deployment/pkg/server/gather-logs.go
@@ -42,21 +42,11 @@ func (s *server) GatherLogs(ctx context.Context, req *api.GatherLogsRequest,
 	// clean up our staging area
 	defer os.RemoveAll(archiveRoot)
 
-	// binPaths defined where we can find the executables required for our log
-	// gathering operations, rather than relying on PATH
-	// TODO: make this s.serverConfig.BinPaths
-	binPaths := map[string]string{
-		"cp":   path.Join(s.serverConfig.CoreutilsPath, "cp"),
-		"find": s.serverConfig.FindPath,
-		"tar":  s.serverConfig.TarPath,
-	}
-
 	// initialize log gathering configuration
 	g := gatherlogs.NewGatherer(
 		stagingDir,
 		archiveRoot,
 		s.deployment.Config.Global.V1.Fqdn.Value,
-		binPaths,
 		time.Now(),
 	)
 	if err = g.CreateBundleDir(); err != nil {


### PR DESCRIPTION
In server mode, Habitat sets our path for us and we trust that path
elsewhere. In local mode, we think it is likely that the user
has tar, cp, and find on their PATH and that this is causing more harm
than good.

Signed-off-by: Steven Danna <steve@chef.io>