### PR TITLE
Add default line-height to input fields

### DIFF
--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -159,3 +159,7 @@ html.no-smil {
 chef-loading-spinner[fixed] {
   top: $navigation-height;
 }
+
+input {
+  line-height: normal;
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Inputs in Automate have a line-height that is causing the descenders of the type to be cut off by a few pixels.

### :chains: Related Resources
https://app.zenhub.com/workspaces/ui-team-5cba23a3b14fdc05970c8f87/issues/chef/automate/1104

### :athletic_shoe: How to Build and Test the Change
Navigate to a form input
Type in the letter g or something else with a descender and notice that you can't see the full-complete letter

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [x ] Docs added/updated?

### :camera: Screenshots, if applicable
![Screen Shot 2019-09-09 at 1 11 50 PM](https://user-images.githubusercontent.com/4108100/64555694-7dc5fa00-d303-11e9-930a-f139eebaa9c2.png)
