### PR TITLE
Updating client runs missing run date left sidebar

### DIFF
--- a/components/automate-ui/src/app/pages/node-noruns-details/node-noruns-details.component.html
+++ b/components/automate-ui/src/app/pages/node-noruns-details/node-noruns-details.component.html
@@ -1,6 +1,4 @@
-<app-server-org-filter-sidebar>
-    <chef-sidebar-entry route="/client-runs" icon="storage">Node State</chef-sidebar-entry>
-</app-server-org-filter-sidebar>
+<app-client-runs-sidebar></app-client-runs-sidebar>
 
 <div class="container">
     <main>

--- a/components/automate-ui/src/app/pages/node-noruns-details/node-noruns-details.component.html
+++ b/components/automate-ui/src/app/pages/node-noruns-details/node-noruns-details.component.html
@@ -5,16 +5,21 @@
         <div class="node-noruns-details-container">
           <chef-breadcrumbs>
             <chef-breadcrumb [link]="['/client-runs']">Client runs</chef-breadcrumb>
-            Node {{ nodeId }}
+            Node {{ node.name }}
           </chef-breadcrumbs>
 
             <div class="run-container">
                 <chef-page-header>
-                    <chef-heading>Node {{nodeId }}</chef-heading>
+                    <chef-heading>Node {{node.name }}</chef-heading>
                     <chef-alert type="error">
                         There is no client run data available for this node.
                     </chef-alert>
                     <dl class="metadata">
+                        <dt class="heading">
+                            Node ID
+                        </dt>
+                        <dd class="content">{{node.id}}</dd>
+
                         <dt class="heading">
                             Uptime
                         </dt>

--- a/components/automate-ui/src/app/pages/node-noruns-details/node-noruns-details.component.scss
+++ b/components/automate-ui/src/app/pages/node-noruns-details/node-noruns-details.component.scss
@@ -1,14 +1,12 @@
 @import "~styles/variables";
 
 chef-page-header {
-  padding-bottom: 50px;
+  padding-bottom: 0px;
 }
 
 .metadata {
   margin-top: 10px;
   padding: 30px 10px 30px;
-  box-shadow: 0 0 20px rgba($gray-light, .20);
-  border-radius: $global-radius;
   width: 100%;
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The missing-runs page needs the left sidebar updated like the other Client Runs pages.

### :chains: Related Resources

#1361

### :+1: Definition of Done
The left sidebar on the Client runs missing runs page should match the client runs page (look like below).

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui && start_all_services`
1. Add some nodes with chef_load_nodes 10
1. Go to the Client Runs page https://a2-dev.test/infrastructure/client-runs.
1. Select a node.
1. In the URL change the UUID after 'run' to anything. For example https://a2-dev.test/infrastructure/client-runs/d92fbcb5-9ccf-3fed-997f-1f77c2e988b3/runs/incorrect_id
1. Ensure the left sidebar is correct. 

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
Below is the correct left sidebar
![Screen Shot 2019-09-09 at 11 51 55 AM](https://user-images.githubusercontent.com/1679247/64558210-400fa400-d2f8-11e9-9a7f-c61929b43c51.png)