### PR TITLE
Update unknown URL to reroute to event feed page

### DIFF
--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -305,14 +305,14 @@ const routes: Routes = [
     pathMatch: 'prefix',
     redirectTo: 'settings/node-credentials'
   },
-  { // ued by projects-filter.service.ts
+  { // used by projects-filter.service.ts
     path: 'reload',
     children: []
   },
   // END Deprecated routes.
   { // everything unknown goes to client runs
     path: '**',
-    redirectTo: 'infrastructure/client-runs'
+    redirectTo: 'dashboards/event-feed'
   }
 ];
 

--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -310,7 +310,7 @@ const routes: Routes = [
     children: []
   },
   // END Deprecated routes.
-  { // everything unknown goes to client runs
+  {
     path: '**',
     redirectTo: 'dashboards/event-feed'
   }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
If a user types in the wrong URL they will be rerouted to the event feed page instead of the client runs page. 

### :athletic_shoe: How to Build and Test the Change

1. `build components/automate-ui && start_all_services`
1. Type in an incorrect URL like "https://a2-dev.test/incorrect"
1. Ensure the event feed page opens. 