### PR TITLE
ci: temporary fix for bug in single-use buildkite queue

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -546,6 +546,7 @@ steps:
       - sudo scripts/install_grpcurl.sh
       - cd components/compliance-service
       - sudo -E PATH=\$(hab pkg path core/ruby)/bin:\$PATH make test-db
+      - cd ../.. && sudo git clean -fxd
     artifact_paths:
       - /tmp/secrets-service.log
       - /tmp/event-service.log
@@ -572,6 +573,7 @@ steps:
       - sudo scripts/install_grpcurl.sh
       - cd components/compliance-service
       - sudo -E  PATH=\$(hab pkg path core/ruby)/bin:\$PATH make test-integration-scanner
+      - cd ../.. && sudo git clean -fxd
     artifact_paths:
       - /tmp/secrets-service.log
       - /tmp/event-service.log
@@ -598,6 +600,7 @@ steps:
       - sudo scripts/install_grpcurl.sh
       - cd components/compliance-service
       - sudo -E PATH=\$(hab pkg path core/ruby)/bin:\$PATH make test-integration-reporting
+      - cd ../.. && sudo git clean -fxd
     artifact_paths:
       - /tmp/secrets-service.log
       - /tmp/event-service.log
@@ -622,6 +625,7 @@ steps:
       - sudo scripts/install_grpcurl.sh
       - cd components/nodemanager-service
       - sudo -E PATH=\$(hab pkg path core/ruby)/bin:\$PATH make test-integration-db
+      - cd ../.. && sudo git clean -fxd
     artifact_paths:
       - /tmp/compliance.log
       - /tmp/event-service.log
@@ -649,6 +653,7 @@ steps:
       - sudo scripts/install_grpcurl.sh
       - cd components/compliance-service
       - sudo -E PATH=\$(hab pkg path core/ruby)/bin:\$PATH make test-automate-upgrade
+      - cd ../.. && sudo git clean -fxd
     artifact_paths:
       - /tmp/compliance.log
     env:
@@ -675,6 +680,7 @@ steps:
       - sudo scripts/install_grpcurl.sh
       - cd components/compliance-service
       - sudo -E PATH=\$(hab pkg path core/ruby)/bin:\$PATH make test-automate-upgrade
+      - cd ../.. && sudo git clean -fxd
     artifact_paths:
       - /tmp/compliance.log
     env:
@@ -701,6 +707,7 @@ steps:
       - sudo scripts/install_grpcurl.sh
       - cd components/compliance-service
       - sudo -E PATH=\$(hab pkg path core/ruby)/bin:\$PATH make test-automate-upgrade
+      - cd ../.. && sudo git clean -fxd
     artifact_paths:
       - /tmp/compliance.log
     env:
@@ -727,6 +734,7 @@ steps:
       - sudo scripts/install_grpcurl.sh
       - cd components/compliance-service
       - sudo -E PATH=\$(hab pkg path core/ruby)/bin:\$PATH make test-automate-upgrade
+      - cd ../.. && sudo git clean -fxd
     artifact_paths:
       - /tmp/compliance.log
     env:


### PR DESCRIPTION
The single-use buildkite queue currently has a bug in which machines
are being reused. This poses a problem for some of our jobs since they
run and create files as root. Those files cannot later be cleaned up,
failing the build.

This PR adds a `sudo git clean` step to all such jobs in an attempt to
keep the rate of failures down. `sudo git clean` should clean out the
files that we would fail to clean out on a subsequent run.  We'll want
to pair this with a termination of all existing nodes in the single
use queue.

In the long run, we should consider reworking these tests so that they do
not require the single-use queue or sudo.

Signed-off-by: Steven Danna <steve@chef.io>