### PR TITLE
prevent to close run history right sidebar

### DIFF
--- a/components/automate-ui/src/app/page-components/date-selector/date-selector.component.html
+++ b/components/automate-ui/src/app/page-components/date-selector/date-selector.component.html
@@ -11,8 +11,8 @@
         </li>
       </ul>
       <div class="button-container">
-        <chef-button primary (click)="apply()">Apply</chef-button>
-        <chef-button tertiary (click)="cancel()">Cancel</chef-button>
+        <chef-button primary (click)="apply($event)">Apply</chef-button>
+        <chef-button tertiary (click)="cancel($event)">Cancel</chef-button>
       </div>
     </div>
   </div>

--- a/components/automate-ui/src/app/page-components/date-selector/date-selector.component.ts
+++ b/components/automate-ui/src/app/page-components/date-selector/date-selector.component.ts
@@ -37,15 +37,17 @@ export class DateSelectorComponent implements OnInit {
     this.inSelection = date;
   }
 
-  apply() {
+  apply(event) {
     this.selectedDate = this.inSelection;
     this.select.emit(this.selectedDate);
     this.dropdownOpen = false;
+    event.stopPropagation();
   }
 
-  cancel() {
+  cancel(event) {
     this.inSelection = this.selectedDate;
     this.dropdownOpen = false;
+    event.stopPropagation();
   }
 }
 


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
Updating the Run History date range closes the right sidebar. to prevent this I have added some code to stop the propagation.

### :chains: Related Resources
https://github.com/chef/automate/issues/1478

### :camera: Screenshots

![MSYS-1100](https://user-images.githubusercontent.com/12297653/64606216-652d1100-d3e3-11e9-9a3b-d79963cadf7a.gif)
