### PR TITLE
Client Runs page, detecting bad page selection

### DIFF
--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.spec.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.spec.ts
@@ -10,6 +10,7 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { Router } from '@angular/router';
 import { UpdateNodeFilters } from '../../entities/client-runs/client-runs.actions';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
+import { EntityStatus } from '../../entities/entities';
 
 class MockTelemetryService {
   track() { }
@@ -76,6 +77,70 @@ describe('ClientRunsComponent', () => {
         (type1, type2) => (type1 < type2 ? -1 : 1));
 
       expect(expectedTypeText).toEqual(typeText, 'Filter Types are not sorted');
+    });
+  });
+
+  describe('isNotFirstPage', () => {
+    it('No page parameter', () => {
+      expect(component.isNotFirstPage([])).toBeFalsy();
+    });
+
+    it('has page parameter', () => {
+      expect(component.isNotFirstPage([{type: 'page', text: '2'}])).toBeTruthy();
+    });
+  });
+
+  describe('isCurrentPageEmpty', () => {
+    const node =     {
+        id: '56343c09-e968-43b3-b896-edd7cca03fbd',
+        name: 'A-non-architecto',
+        fqdn: 'A-non-architecto.bergnaum.co',
+        checkin: null,
+        uptime_seconds: 17112079,
+        environment: 'test',
+        platform: 'solaris',
+        policy_group: '',
+        organization: '',
+        source_fqdn: '',
+        status: 'failure',
+        latestRunId: '22efcb97-ae0d-4ece-b284-51bc73b2c6cc',
+        hasRuns: true,
+        lastCcrReceived: new Date(),
+        deprecationsCount: 0,
+        chefVersion: '12.6.0'
+      };
+
+    it('no nodes, loaded successfully', () => {
+      expect(component.isCurrentPageEmpty([], EntityStatus.loadingSuccess)).toBeTruthy();
+    });
+
+    it('no nodes, load failure', () => {
+      expect(component.isCurrentPageEmpty([], EntityStatus.loadingFailure)).toBeFalsy();
+    });
+
+    it('no nodes, loading', () => {
+      expect(component.isCurrentPageEmpty([], EntityStatus.loading)).toBeFalsy();
+    });
+
+    it('no nodes, not loaded', () => {
+      expect(component.isCurrentPageEmpty([], EntityStatus.notLoaded)).toBeFalsy();
+    });
+
+    it('some nodes, loaded successfully', () => {
+
+      expect(component.isCurrentPageEmpty([node], EntityStatus.loadingSuccess)).toBeFalsy();
+    });
+
+    it('some nodes, load failure', () => {
+      expect(component.isCurrentPageEmpty([node], EntityStatus.loadingFailure)).toBeFalsy();
+    });
+
+    it('some nodes, loading', () => {
+      expect(component.isCurrentPageEmpty([node], EntityStatus.loading)).toBeFalsy();
+    });
+
+    it('some nodes, not loaded', () => {
+      expect(component.isCurrentPageEmpty([node], EntityStatus.notLoaded)).toBeFalsy();
     });
   });
 

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -580,7 +580,7 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
 
   // If there is a page parameter in the URL the first page is not selected.
   isNotFirstPage(allUrlParameters: Chicklet[]): boolean {
-    return allUrlParameters.findIndex((parm: Chicklet) => parm.type === 'page') >= 0;
+    return allUrlParameters.some((parm: Chicklet) => parm.type === 'page');
   }
 
   private getSelectedPageNumber(allUrlParameters: Chicklet[]): number {

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -331,6 +331,26 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
 
     this.loadedStatus$ = this.store.select(clientRunsLoading);
 
+
+    // When zero nodes are loaded successfully and we are not on the 1 page
+    // automatically change to the first page.
+    combineLatest([
+      this.nodes$, this.loadedStatus$, allUrlParameters$])
+      .pipe(
+        map(([nodes, loadedStatus, allUrlParameters]:
+          [Node[], EntityStatus, Chicklet[]]) =>
+            this.isCurrentPageEmpty(nodes, loadedStatus) &&
+            this.isNotFirstPage(allUrlParameters)
+        )).subscribe((noNodesLoadedWithPageSet: boolean) => {
+          if ( noNodesLoadedWithPageSet ) {
+            const queryParams = {...this.route.snapshot.queryParams};
+
+            // removing the URL page parameter the nodes are moved back to the first page
+            delete queryParams['page'];
+            this.router.navigate([], {queryParams});
+          }
+        });
+
       // We want to report total nodes to telemetry, but only when there are no
     // filters. This way we can see how many nodes a customer has connected to
     // automate in total.
@@ -356,7 +376,6 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
       }
     ], []);
   }
-
 
   hideNotification() {
     this.notificationVisible = false;
@@ -553,6 +572,15 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
     };
 
     this.store.dispatch(new UpdateNodeFilters({filters: nodeFilters}));
+  }
+
+  isCurrentPageEmpty(nodes: Node[], loadedStatus: EntityStatus): boolean {
+    return loadedStatus === EntityStatus.loadingSuccess && nodes.length === 0;
+  }
+
+  // If there is a page parameter in the URL the first page is not selected.
+  isNotFirstPage(allUrlParameters: Chicklet[]): boolean {
+    return allUrlParameters.findIndex((parm: Chicklet) => parm.type === 'page') >= 0;
   }
 
   private getSelectedPageNumber(allUrlParameters: Chicklet[]): number {

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -580,7 +580,7 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
 
   // If there is a page parameter in the URL the first page is not selected.
   isNotFirstPage(allUrlParameters: Chicklet[]): boolean {
-    return allUrlParameters.some((parm: Chicklet) => parm.type === 'page');
+    return allUrlParameters.some((parameter: Chicklet) => parameter.type === 'page');
   }
 
   private getSelectedPageNumber(allUrlParameters: Chicklet[]): number {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This change allows the client runs page to revert back to the first page of nodes if the page selected does not have nodes. 

This problem was found with the IAM v2 global project filtering feature. When the project filter is updated it refreshes the page. Say the user is on page 2 with 100 nodes per page. If the user updates the project filter to have only 50 nodes then page 2 would be empty. Since the page 2 selection is in the URL after the refresh the user would be left with zero nodes. 

### :chains: Related Resources
#1341 
### :+1: Definition of Done

The repro steps in issue #1341 are resolved. 

### :athletic_shoe: How to Build and Test the Change
1. Build the changed code and start Automate: `build components/automate-ui && start_all_services`
1. Turn on IAM v2: `chef-automate iam upgrade-to-v2 --beta2.1`
1. Add some nodes to full at least two pages `chef_load_nodes 120`
1. Find the environment of one of less than 100 nodes. I found this from the search bar. 
1. Create and apply a project with the rule of the environment found above. 
1. Go to the client runs page https://a2-dev.test/infrastructure/client-runs.
1. Go to the second page of nodes. 
1. Apply the newly created project filter. 
1. Ensure that the client runs page goes back to the first page. 

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
![project_filter_client_runs](https://user-images.githubusercontent.com/1679247/64655153-33ff1180-d3e0-11e9-9915-9588c17f0d2d.gif)
