### PR TITLE
Automate 1531, 1296 Pass filters

### DIFF
--- a/components/automate-ui/src/app/entities/service-groups/service-groups.effects.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.effects.ts
@@ -67,9 +67,9 @@ export class ServiceGroupsEffects {
       withLatestFrom(this.store.select(serviceGroupsFilters)),
       switchMap(([_action, filters]: [any, ServiceGroupsFilters]) => {
         return this.requests.fetchServiceGroupHealth(filters).pipe(
-        map((payload: ServiceGroupsHealthSummary) => new GetServiceGroupsCountsSuccess(payload)),
-        catchError((error: HttpErrorResponse) => of(new GetServiceGroupsCountsFailure(error)))
-      );
+          map((payload: ServiceGroupsHealthSummary) => new GetServiceGroupsCountsSuccess(payload)),
+          catchError((error: HttpErrorResponse) => of(new GetServiceGroupsCountsFailure(error)))
+        );
       }));
 
   @Effect()

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.effects.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.effects.ts
@@ -64,9 +64,9 @@ export class ServiceGroupsEffects {
   @Effect()
   getServiceGroupsCounts$ = this.actions$.pipe(
       ofType(ServiceGroupsActionTypes.GET_SERVICE_GROUPS_COUNTS),
-      withLatestFrom(this.store),
-      switchMap(([_action]) => {
-        return this.requests.fetchServiceGroupHealth().pipe(
+      withLatestFrom(this.store.select(serviceGroupsFilters)),
+      switchMap(([_action, filters]: [any, ServiceGroupsFilters]) => {
+        return this.requests.fetchServiceGroupHealth(filters).pipe(
         map((payload: ServiceGroupsHealthSummary) => new GetServiceGroupsCountsSuccess(payload)),
         catchError((error: HttpErrorResponse) => of(new GetServiceGroupsCountsFailure(error)))
       );

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
@@ -79,6 +79,7 @@ export interface GroupServicesFilters {
   health?: string;
   page?: number;
   pageSize?: number;
+  searchBar?: Array<Chicklet>;
 }
 
 export interface GroupServicesPayload {

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.requests.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.requests.ts
@@ -81,21 +81,32 @@ export class ServiceGroupsRequests {
         params = params.append('pagination.page', filters.page.toString());
         params = params.append('pagination.size', filters.pageSize.toString());
       }
+      if (filters.searchBar) {
+        params = reduce((param, pill) => {
+          const filterParam = `${encodeURIComponent(pill.type)}:${encodeURIComponent(pill.text)}`;
+          return param.append('filter', filterParam);
+        }, params, filters.searchBar);
+      }
     }
 
     return params;
   }
 
-  public fetchServiceGroupHealth(): Observable<ServiceGroupsHealthSummary> {
-    const url = `${APPLICATIONS_URL}/service_groups_health_counts`;
+  public fetchServiceGroupHealth(filters: ServiceGroupsFilters):
+    Observable<ServiceGroupsHealthSummary> {
+      const url = `${APPLICATIONS_URL}/service_groups_health_counts`;
+      const params = this.formatFilters(filters);
 
-    return this.httpClient.get<ServiceGroupsHealthSummary>(url);
+      return this.httpClient.get<ServiceGroupsHealthSummary>(url, {params});
   }
 
   public getSuggestions(
     fieldName: string,
     queryFragment: string,
     filters: ServiceGroupsFilters): Observable<any[]> {
+      // This api requires different filter names for group and service, should it?
+      fieldName = fieldName === 'group' ? 'group_name' : fieldName;
+      fieldName = fieldName === 'service' ? 'service_name' : fieldName;
       const params = this.formatFilters(filters)
         .set('field_name', fieldName)
         .set('query_fragment', queryFragment);

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -294,13 +294,11 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   detailParamsChange(queryParams) {
     const sgId = queryParams.get('sgId');
     if (sgId) {
-      const searchBarFilters = [];
       const paramKeys = Object.keys(queryParams.params);
-      paramKeys.forEach((key: string) => {
-        if (some({'type': key}, this.categoryTypes)) {
-          searchBarFilters.push({ type: key, text: queryParams.params[key] });
-        }
-      });
+
+      const searchBarFilters = paramKeys.filter((key: string) => 
+          some({'type': key}, this.categoryTypes)
+        ).map((key: string) => ({ type: key, text: queryParams.params[key] }));
 
       const servicesFilters: GroupServicesFilters = {
         service_group_id: sgId,
@@ -309,6 +307,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
         health: queryParams.get('sgStatus') || 'total',
         searchBar: searchBarFilters
       };
+      
       this.updateServicesSidebar(servicesFilters);
     }
   }

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -296,7 +296,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
     if (sgId) {
       const paramKeys = Object.keys(queryParams.params);
 
-      const searchBarFilters = paramKeys.filter((key: string) => 
+      const searchBarFilters = paramKeys.filter((key: string) =>
           some({'type': key}, this.categoryTypes)
         ).map((key: string) => ({ type: key, text: queryParams.params[key] }));
 
@@ -307,7 +307,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
         health: queryParams.get('sgStatus') || 'total',
         searchBar: searchBarFilters
       };
-      
+
       this.updateServicesSidebar(servicesFilters);
     }
   }

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -90,7 +90,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
       allowWildcards: true
     },
     {
-      type: 'service_name',
+      type: 'service',
       text: 'Service Name',
       allowWildcards: true
     },
@@ -125,7 +125,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
       allowWildcards: true
     },
     {
-      type: 'group_name',
+      type: 'group',
       text: 'Group Name',
       allowWildcards: true
     }
@@ -294,11 +294,20 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   detailParamsChange(queryParams) {
     const sgId = queryParams.get('sgId');
     if (sgId) {
+      const searchBarFilters = [];
+      const paramKeys = Object.keys(queryParams.params);
+      paramKeys.forEach((key: string) => {
+        if (some({'type': key}, this.categoryTypes)) {
+          searchBarFilters.push({ type: key, text: queryParams.params[key] });
+        }
+      });
+
       const servicesFilters: GroupServicesFilters = {
         service_group_id: sgId,
         page: parseInt(queryParams.get('sgPage'), 10) || 1,
         pageSize: parseInt(queryParams.get('sgPageSize'), 10) || 25,
-        health: queryParams.get('sgStatus') || 'total'
+        health: queryParams.get('sgStatus') || 'total',
+        searchBar: searchBarFilters
       };
       this.updateServicesSidebar(servicesFilters);
     }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
1531
When filters are applied through the search bar,
update the count in the health status filters above the table
update the pagination under the table
1296
When using the filter bar, we want to only show matching services on the right side detail panel. This should help users focus on only the services they are actually interested in; for example, when filtering on site, users only wish to see services from the given site.

### :chains: Related Resources
https://app.zenhub.com/workspaces/ui-team-5cba23a3b14fdc05970c8f87/issues/chef/automate/1296
https://app.zenhub.com/workspaces/ui-team-5cba23a3b14fdc05970c8f87/issues/chef/automate/1531

### :+1: Definition of Done
1296
A service group where all services match the given criteria is shown unchanged compared to the unfiltered view, and all of its services appear in the right-side panel;
A service group where some of the services match is shown in the left side table, but the content is modified to include only the services matching the filter criteria; that is the Health, Service Group and Release columns reflect only the services that match the filter criteria. The right side services list should show only the services that matched the filter criteria.

### :athletic_shoe: How to Build and Test the Change
hab studio enter
build components/automate-ui-devproxy
start_automate_ui_background
start_all_services
applications_populate_database

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [x] Docs added/updated?

### :camera: Screenshots, if applicable
![Screen Shot 2019-09-10 at 9 00 44 PM](https://user-images.githubusercontent.com/4108100/64662445-2496bd00-d40e-11e9-830d-18364db05378.png)
![Screen Shot 2019-09-10 at 9 02 28 PM](https://user-images.githubusercontent.com/4108100/64662512-5ad43c80-d40e-11e9-9931-8fda056e155e.png)
