### PR TITLE
ci: avoid downloading chefdk

### DIFF
--- a/integration/base.sh
+++ b/integration/base.sh
@@ -90,10 +90,6 @@ do_setup() {
 }
 
 do_setup_default() {
-    if [ ${#test_deploy_inspec_profiles[@]} -ne 0 ] || [ ${#test_upgrade_inspec_profiles[@]} -ne 0 ]; then
-        install_chefdk "stable"
-    fi
-
     umask 077
     echo "umask 077" >> /etc/profile
     # this is needed for the preflight checks to pass

--- a/integration/helpers/testing.sh
+++ b/integration/helpers/testing.sh
@@ -28,7 +28,7 @@ run_inspec_tests() {
     for test_name in "${test_names[@]}"
     do
         log_info "Running inspec profile ${test_name}"
-        CHEF_LICENSE="accept-no-persist" inspec exec --no-backend-cache "${root_dir}/inspec/${test_name}" || errcode=$? && true;
+        HAB_LICENSE="accept-no-persist" CHEF_LICENSE="accept-no-persist" hab pkg exec chef/inspec inspec exec --no-backend-cache "${root_dir}/inspec/${test_name}" || errcode=$? && true;
 
         if [[ $errcode -ne 0 && $errcode -ne 101  ]]
         then


### PR DESCRIPTION
We already should have inspec via Habitat if we've installed Automate. 
Let's use it from there rather than downloading it again.

Signed-off-by: Steven Danna <steve@chef.io>