### PR TITLE
Compliance page: Adding back the report date in the summary

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.html
@@ -132,11 +132,11 @@
     <figure>
       <label class="interval">
         <span>Showing:</span>
-        <chef-select (change)="onTrendIntervalChange($event)" [value]="reportQuery.interval">
+        <chef-select (change)="onTrendIntervalChange($event)" [value]="interval$ | async">
           <chef-option
             *ngFor="let interval of reportQuery.intervals; index as i"
             [value]="i">
-            {{interval[0]}}
+            {{interval.name}}
           </chef-option>
         </chef-select>
         <chef-loading-spinner *ngIf="profileTrendLoading" size="16"></chef-loading-spinner>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
@@ -83,7 +83,7 @@
                 Report Date
                 <chef-tooltip for="report-date-label">Latest information available for everything at this date.</chef-tooltip>
               </chef-th>
-              <chef-td>{{ reportQuery.endDate | date: 'longDate' }}</chef-td>
+              <chef-td>{{ endDate$ | async | date: 'longDate' }}</chef-td>
             </chef-tr>
             <chef-tr>
               <chef-th>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Adding the missing report date in the summary section of the compliance reporting page. Also fixing the interval selection dropbox to display the date range labels. 

### :chains: Related Resources

This bug was caused in this PR https://github.com/chef/automate/pull/1268

### :+1: Definition of Done
The report date is displayed in the summary section. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui` && start_all_services`
1. Go to https://a2-dev.test/compliance/reports/overview
1. Open the summary section and ensure the "Report Date" is shown. 
1. Select to view the "Profile Status" ![Screen Shot 2019-09-11 at 11 40 11 AM](https://user-images.githubusercontent.com/1679247/64725184-ee4a5380-d488-11e9-9ba3-9b4a298326db.png)
1. Ensure the "Control Status Over Time" shows the date interval selection drop box correctly. 
 

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
Below shows the problem before this change. 
![Screen Shot 2019-09-11 at 10 36 58 AM](https://user-images.githubusercontent.com/1679247/64720870-4cbf0400-d480-11e9-925d-74e2d5735a1f.png)
Below shows the problem with the profile control overview panel
![Screen Shot 2019-09-11 at 11 38 15 AM](https://user-images.githubusercontent.com/1679247/64725093-b80cd400-d488-11e9-854f-b1cf3344271e.png)
