### PR TITLE
changed add condition button to secondary

### DIFF
--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -66,7 +66,7 @@
         <div id="condition-section" *ngIf="ruleForm.get('type').value">
           <div class="label">Conditions</div>
           <small>All conditions must be true for the rule to be true.</small>
-          <chef-button primary (click)="addCondition()">Add Condition</chef-button>
+          <chef-button secondary (click)="addCondition()">Add Condition</chef-button>
 
           <div id="condition-list" formArrayName="conditions">
 


### PR DESCRIPTION
Signed-off-by: susanev <susan.ra.evans@gmail.com>

### :nut_and_bolt: Description: What code changed, and why?
There were two primary buttons on this page, _Add Condition_ and _Save Rule_ the ux teams standard is 1 primary button whenever possible. _Add Condition_ is not a primary action, so changing this to a secondary button.

### :camera: Screenshots, if applicable
![ingest-rule](https://user-images.githubusercontent.com/5489125/64730973-2192df80-d495-11e9-96e6-570f5c663590.png)
