### PR TITLE
[AUTH-1477] If there are no projects with pending rule edits, disable the update button with proper text

### DIFF
--- a/components/automate-ui/src/app/pages/project/list/project-list.component.html
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.html
@@ -21,8 +21,8 @@
               data-cy="create-project" primary (click)="openCreateModal()">Create Project</chef-button>
           </app-authorized>
           <app-authorized [allOf]="['/iam/v2beta/apply-rules', 'post']">
-            <chef-button secondary [disabled]="(projects.applyRulesStatus$ | async)?.state === ApplyRulesStatusState.Running"
-              id="update-start-button" (click)="openConfirmUpdateStartModal()">{{ applyRulesButtonText$ | async }}</chef-button>
+            <chef-button secondary [disabled]="!projectsHaveStagedChanges || (projects.applyRulesStatus$ | async)?.state === ApplyRulesStatusState.Running"
+              id="update-start-button" (click)="openConfirmUpdateStartModal()">{{ updateButtonLabel() }}</chef-button>
           </app-authorized>
           <app-authorized [allOf]="['/iam/v2beta/apply-rules', 'delete']">
             <chef-button *ngIf="(projects.applyRulesStatus$ | async)?.state === ApplyRulesStatusState.Running"

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.html
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.html
@@ -22,7 +22,7 @@
           </app-authorized>
           <app-authorized [allOf]="['/iam/v2beta/apply-rules', 'post']">
             <chef-button secondary [disabled]="!projectsHaveStagedChanges || (projects.applyRulesStatus$ | async)?.state === ApplyRulesStatusState.Running"
-              id="update-start-button" (click)="openConfirmUpdateStartModal()">{{ updateButtonLabel() }}</chef-button>
+              id="update-start-button" (click)="openConfirmUpdateStartModal()">{{ getButtonText() }}</chef-button>
           </app-authorized>
           <app-authorized [allOf]="['/iam/v2beta/apply-rules', 'delete']">
             <chef-button *ngIf="(projects.applyRulesStatus$ | async)?.state === ApplyRulesStatusState.Running"

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
@@ -558,6 +558,46 @@ describe('ProjectListComponent', () => {
 
   });
 
+  describe('updateButtonLabel', () => {
+    it('labels the button "Update Projects" when at least one project is edited', () => {
+      const editedProject = genProject('uuid-99', 'EDITS_PENDING');
+      const uneditedProject1 = genProject('uuid-111', 'RULES_APPLIED');
+      const uneditedProject2 = genProject('uuid-112', 'RULES_APPLIED');
+      store.dispatch(new GetProjectsSuccess({
+        projects: [uneditedProject1, editedProject, uneditedProject2]
+      }));
+
+      expect(component.updateButtonLabel()).toEqual('Update Projects');
+    });
+
+    it('labels the button "Projects Up-to-Date" when no projects are edited', () => {
+      const uneditedProject1 = genProject('uuid-111', 'RULES_APPLIED');
+      const uneditedProject2 = genProject('uuid-112', 'RULES_APPLIED');
+      store.dispatch(new GetProjectsSuccess({
+        projects: [uneditedProject1, uneditedProject2]
+      }));
+
+      expect(component.updateButtonLabel()).toEqual('Projects Up-to-date');
+    });
+
+    it('labels the button with percentage only during an update', () => {
+      const editedProject = genProject('uuid-99', 'EDITS_PENDING');
+      store.dispatch(new GetProjectsSuccess({
+        projects: [editedProject]
+      }));
+      expect(component.updateButtonLabel()).toEqual('Update Projects');
+
+      component.confirmApplyStart(); // start the update
+      store.dispatch(new GetApplyRulesStatusSuccess( // side effect of the update
+        genState(ApplyRulesStatusState.Running)));
+
+      expect(component.updateButtonLabel()).toEqual('Updating Projects 50%...');
+
+      store.dispatch(new GetApplyRulesStatusSuccess(
+        genState(ApplyRulesStatusState.NotRunning)));
+      expect(component.updateButtonLabel()).not.toEqual('Updating Projects 50%...');
+    });
+  });
 });
 
 function genProject(id: string, status: ProjectStatus): Project {

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
@@ -558,7 +558,7 @@ describe('ProjectListComponent', () => {
 
   });
 
-  describe('updateButtonLabel', () => {
+  describe('getButtonText', () => {
     it('labels the button "Update Projects" when at least one project is edited', () => {
       const editedProject = genProject('uuid-99', 'EDITS_PENDING');
       const uneditedProject1 = genProject('uuid-111', 'RULES_APPLIED');
@@ -567,17 +567,17 @@ describe('ProjectListComponent', () => {
         projects: [uneditedProject1, editedProject, uneditedProject2]
       }));
 
-      expect(component.updateButtonLabel()).toEqual('Update Projects');
+      expect(component.getButtonText()).toEqual('Update Projects');
     });
 
-    it('labels the button "Projects Up-to-Date" when no projects are edited', () => {
+    it('labels the button "Projects Up-To-Date" when no projects are edited', () => {
       const uneditedProject1 = genProject('uuid-111', 'RULES_APPLIED');
       const uneditedProject2 = genProject('uuid-112', 'RULES_APPLIED');
       store.dispatch(new GetProjectsSuccess({
         projects: [uneditedProject1, uneditedProject2]
       }));
 
-      expect(component.updateButtonLabel()).toEqual('Projects Up-to-date');
+      expect(component.getButtonText()).toEqual('Projects Up-To-Date');
     });
 
     it('labels the button with percentage only during an update', () => {
@@ -585,17 +585,17 @@ describe('ProjectListComponent', () => {
       store.dispatch(new GetProjectsSuccess({
         projects: [editedProject]
       }));
-      expect(component.updateButtonLabel()).toEqual('Update Projects');
+      expect(component.getButtonText()).toEqual('Update Projects');
 
       component.confirmApplyStart(); // start the update
       store.dispatch(new GetApplyRulesStatusSuccess( // side effect of the update
         genState(ApplyRulesStatusState.Running)));
 
-      expect(component.updateButtonLabel()).toEqual('Updating Projects 50%...');
+      expect(component.getButtonText()).toEqual('Updating Projects 50%...');
 
       store.dispatch(new GetApplyRulesStatusSuccess(
         genState(ApplyRulesStatusState.NotRunning)));
-      expect(component.updateButtonLabel()).not.toEqual('Updating Projects 50%...');
+      expect(component.getButtonText()).not.toEqual('Updating Projects 50%...');
     });
   });
 });

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -112,7 +112,7 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       takeUntil(this.isDestroyed)
     ).subscribe((projectList: Project[]) => {
       this.projectsHaveStagedChanges =
-        projectList.filter(p => p.status === 'EDITS_PENDING').length > 0;
+        projectList.some(p => p.status === 'EDITS_PENDING');
     });
 
     this.createProjectForm = fb.group({

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -96,7 +96,9 @@ export class ProjectListComponent implements OnInit, OnDestroy {
           this.applyRulesInProgress = false;
           this.updateProjectsFailed = failed;
           this.updateProjectsCancelled = cancelled;
-          this.percentageComplete = percentageComplete;
+          if (!this.cancelRulesInProgress) {
+            this.percentageComplete = percentageComplete;
+          }
         }
       });
 

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -94,11 +94,11 @@ export class ProjectListComponent implements OnInit, OnDestroy {
             this.closeConfirmApplyStopModal();
           }
           this.applyRulesInProgress = false;
-          this.updateProjectsFailed = failed;
-          this.updateProjectsCancelled = cancelled;
-          if (!this.cancelRulesInProgress) {
-            this.percentageComplete = percentageComplete;
-          }
+        }
+        this.updateProjectsFailed = failed;
+        this.updateProjectsCancelled = cancelled;
+        if (!this.cancelRulesInProgress) {
+          this.percentageComplete = percentageComplete;
         }
       });
 
@@ -108,13 +108,7 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       filter(() => !this.applyRulesInProgress)
     ).subscribe((projectList: Project[]) => {
       this.statusCache = projectList.reduce((m, p) => ({ ...m, [p.id]: p.status }), {});
-    });
-
-    store.select(allProjects).pipe(
-      takeUntil(this.isDestroyed)
-    ).subscribe((projectList: Project[]) => {
-      this.projectsHaveStagedChanges =
-        projectList.some(p => p.status === 'EDITS_PENDING');
+      this.projectsHaveStagedChanges = projectList.some(p => p.status === 'EDITS_PENDING');
     });
 
     this.createProjectForm = fb.group({
@@ -154,14 +148,14 @@ export class ProjectListComponent implements OnInit, OnDestroy {
     return '';
   }
 
-  updateButtonLabel(): string {
+  getButtonText(): string {
     if (this.applyRulesInProgress) {
       return `Updating Projects ${Math.round(this.percentageComplete * 100)}%...`;
     }
     if (this.projectsHaveStagedChanges) {
       return 'Update Projects';
     }
-    return 'Projects Up-to-date';
+    return 'Projects Up-To-Date';
   }
 
   public createProject(): void {

--- a/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
@@ -41,6 +41,11 @@ describeIfIAMV2p1('project management', () => {
     cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['projects']);
   });
 
+  it('has a disabled button when there are no rules', () => {
+    cy.get('app-project-list chef-button#update-start-button')
+      .contains('Projects Up-to-date').should('have.attr', 'disabled');
+  });
+
   it('displays a list of projects', () => {
     cy.request({
       auth: { bearer: adminToken },

--- a/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
@@ -43,7 +43,7 @@ describeIfIAMV2p1('project management', () => {
 
   it('has a disabled button when there are no rules', () => {
     cy.get('app-project-list chef-button#update-start-button')
-      .contains('Projects Up-to-date').should('have.attr', 'disabled');
+      .contains('Projects Up-To-Date').should('have.attr', 'disabled');
   });
 
   it('displays a list of projects', () => {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The rest of the button's behavior should be exactly the same as before.

### :athletic_shoe: How to Build and Test the Change

```
start_all_services
rebuild components/automate-ui-devproxy
# start webserver locally
```

1. Button is disabled with text `Projects Up-to-date` when no projects
1. Create a project (or multiple)
1. Button still disabled because no pending edits
1. Add a rule to 1 or more projects
1. Button behaves as before
1. Apply projects
1. Button goes back to `Projects Up-to-date` disabled state

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable

![Screen Shot 2019-09-11 at 1 33 52 PM](https://user-images.githubusercontent.com/1899715/64733421-97994580-d499-11e9-904c-905a8b3b0723.png)
