### PR TITLE
Compliance reporting: Select date from the trend graph

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.scss
@@ -30,6 +30,7 @@
     }
 
     .dot-group {
+      cursor: pointer;
 
       .dot-group-tick {
         stroke: $chef-light-grey;

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -3,12 +3,15 @@ import {
   ElementRef,
   Inject,
   Input,
+  Output,
   OnChanges,
   OnDestroy,
-  ViewChild
+  ViewChild,
+  EventEmitter
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import * as d3 from 'd3';
+import * as moment from 'moment';
 
 @Component({
   selector: 'app-overview-trend',
@@ -23,6 +26,8 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
   ) {}
 
   @Input() data = [];
+
+  @Output() dateSelected: EventEmitter<moment.Moment> = new EventEmitter<moment.Moment>();
 
   @Input() type: 'nodes' | 'controls';
 
@@ -205,6 +210,10 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
 
     enter.append('rect')
       .attr('class', 'dot-group-bg');
+
+    enter.on('click', (line) => {
+      this.dateSelected.next(moment(line.report_time));
+    });
 
     update.select('.dot-group-tick')
       .attr('x1', d => this.scaleX(d.report_time))

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -1,13 +1,13 @@
 import {
   Component,
   ElementRef,
+  EventEmitter,
   Inject,
   Input,
   Output,
   OnChanges,
   OnDestroy,
-  ViewChild,
-  EventEmitter
+  ViewChild
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import * as d3 from 'd3';

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.html
@@ -53,7 +53,11 @@
         </chef-select>
         <chef-loading-spinner *ngIf="nodeTrendLoading" size="16"></chef-loading-spinner>
       </label>
-      <app-overview-trend [data]="nodeTrendData" type="nodes"></app-overview-trend>
+      <app-overview-trend 
+        [data]="nodeTrendData" 
+        (dateSelected)="onDateChanged($event)"
+        type="nodes">
+      </app-overview-trend>
       <figcaption>Node Status Over Time</figcaption>
     </figure>
   </div>
@@ -141,7 +145,11 @@
         </chef-select>
         <chef-loading-spinner *ngIf="profileTrendLoading" size="16"></chef-loading-spinner>
       </label>
-      <app-overview-trend [data]="profileTrendData" type="controls"></app-overview-trend>
+      <app-overview-trend 
+        [data]="profileTrendData" 
+        type="controls"
+        (dateSelected)="onDateChanged($event)">
+      </app-overview-trend>
       <figcaption>Control Status Over Time</figcaption>
     </figure>
   </div>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
@@ -5,6 +5,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CookieModule } from 'ngx-cookie';
 import { of as observableOf } from 'rxjs';
 import * as moment from 'moment';
+import { Router } from '@angular/router';
 import { ReportingOverviewComponent } from './reporting-overview.component';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
 import { StatsService, ReportQueryService, ReportDataService } from '../../shared/reporting';
@@ -19,6 +20,7 @@ describe('ReportingOverviewComponent', () => {
   let component: ReportingOverviewComponent;
   let element: DebugElement;
   let statsService: StatsService;
+  let router: Router;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -44,12 +46,40 @@ describe('ReportingOverviewComponent', () => {
     component = fixture.componentInstance;
     element = fixture.debugElement;
     statsService = element.injector.get(StatsService);
+    router = TestBed.get(Router);
   });
 
   describe('ngOnInit()', () => {
     it('sets the default selection to "Node Status"', () => {
       component.ngOnInit();
       expect(component.selectedButtonTab).toBe('Node Status');
+    });
+  });
+
+  describe('onDateChanged()', () => {
+    it('valid date', () => {
+      spyOn(router, 'navigate');
+
+      component.onDateChanged(moment('2019-09-05', 'YYYY-MM-DD'));
+
+      expect(router.navigate).toHaveBeenCalledWith([],
+        {queryParams: { end_time: '2019-09-05' }});
+    });
+
+    it('invalid date', () => {
+      spyOn(router, 'navigate');
+
+      component.onDateChanged('lkjasdl');
+
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+
+    it('null date', () => {
+      spyOn(router, 'navigate');
+
+      component.onDateChanged(null);
+
+      expect(router.navigate).not.toHaveBeenCalled();
     });
   });
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
@@ -57,6 +57,14 @@ describe('ReportingOverviewComponent', () => {
   });
 
   describe('onDateChanged()', () => {
+    it('change to todays date', () => {
+      spyOn(router, 'navigate');
+
+      component.onDateChanged(moment().utc());
+
+      expect(router.navigate).toHaveBeenCalledWith([], {queryParams: {}});
+    });
+
     it('valid date', () => {
       spyOn(router, 'navigate');
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.ts
@@ -8,6 +8,7 @@ import {
   ReportQuery
 } from '../../shared/reporting';
 import { ActivatedRoute, Router } from '@angular/router';
+import * as moment from 'moment';
 
 type Tab = 'Node Status' | 'Profile Status';
 
@@ -111,6 +112,20 @@ export class ReportingOverviewComponent implements OnInit, OnDestroy {
       this.getNodeStatusData(reportQuery);
     } else {
       this.getProfileStatusData(reportQuery);
+    }
+  }
+
+  onDateChanged(endDate) {
+    const queryParams = {...this.route.snapshot.queryParams};
+    const endDateMoment = moment(endDate);
+    if (endDate && endDateMoment.isValid()) {
+      if (moment().utc().format('YYYY-MM-DD') === endDateMoment.format('YYYY-MM-DD')) {
+        delete queryParams['end_time'];
+      } else {
+        queryParams['end_time'] = endDateMoment.format('YYYY-MM-DD');
+      }
+
+      this.router.navigate([], {queryParams});
     }
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Clicking a column on the trend graph selects the focused date. I always have to look down at the trend graph to see where reports are and then go up to the date selector to choose that date. With this change, one does not need to use the date selector. Just click the date on the trend graph. 

### :chains: Related Resources
#441

### :+1: Definition of Done
Able to update the date selected from clicking the trend graph

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui && start_all_services`
1. Load some compliance nodes `chef_load_compliance_scans -N10 -M100 -T10 -D1`
1. Go to https://a2-dev.test/compliance/reports/overview and select dates from the trend graph.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
![trend_graph_date_select](https://user-images.githubusercontent.com/1679247/64739930-6d02b900-d4a8-11e9-9a42-05b7835aaf58.gif)
