### PR TITLE
Changing to return chef tags for tags in the node export JSON

### DIFF
--- a/components/config-mgmt-service/grpcserver/node_export.go
+++ b/components/config-mgmt-service/grpcserver/node_export.go
@@ -260,7 +260,7 @@ func nodeToDisplayNode(node backend.Node) displayNode {
 		Source:             node.Source,
 		Status:             node.Status,
 		TotalResourceCount: node.TotalResourceCount,
-		Tags:               node.Tags,
+		Tags:               node.ChefTags,
 		ResourceNames:      node.ResourceNames,
 		Recipes:            node.Recipes,
 		Cookbooks:          node.Cookbooks,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Changing to return chef tags for tags in the JSON node export.

### :chains: Related Resources
https://github.com/chef/automate/issues/1565

### :+1: Definition of Done
The client runs JSON node export returns chef tags. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/config-mgmt-service && start_all_services`
1. Load a node with tags `send_chef_run_example`
1. Go to https://a2-dev.test/infrastructure/client-runs
1. Confirm this is tags with the search bar by looking at the "Chef Tag" suggestions. 
1. Export the one node's JSON with the ![Screen Shot 2019-09-11 at 4 39 57 PM](https://user-images.githubusercontent.com/1679247/64742931-d7b8f200-d4b2-11e9-9db2-26f47532d888.png) button. 
1. Ensure the "slave", "supermarket", and "builder" tags are present. 

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable