### PR TITLE
event-feed-service: Avoid printing usage on errors

### DIFF
--- a/components/event-feed-service/cmd/event-feed-service/commands/root.go
+++ b/components/event-feed-service/cmd/event-feed-service/commands/root.go
@@ -12,8 +12,10 @@ var cfgFile string
 
 // RootCmd is the command runner.
 var RootCmd = &cobra.Command{
-	Use:   "event-feed-service",
-	Short: "Chef Automate Event Feed Service",
+	Use:           "event-feed-service",
+	Short:         "Chef Automate Event Feed Service",
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.


### PR DESCRIPTION
The event-feed-service runs its subcommands via cobra's
runE. Unfortunately, when using this feature, any returned error also
ends up printing the usage message, which can be confusing for users.

Setting SilenceUsage and SilnceErrors silences both the usage message
and the double-printing of errors that we are already printing out
ourselves.

The downside of this is that now if you pass a bad flag, you only get
the error and not the entire usage message, but I think it is worth it
to avoid the log spam.

Signed-off-by: Steven Danna <steve@chef.io>