### PR TITLE
automate-es-gateway: silence health-check spam

### DIFF
--- a/components/automate-es-gateway/habitat/hooks/health-check
+++ b/components/automate-es-gateway/habitat/hooks/health-check
@@ -1,21 +1,11 @@
-#!/bin/sh
+#!{{pkgPathFor "core/bash"}}/bin/bash
 #
-
-# Health Check for Automate Es Gateway
-
-# default return code is 0
-rc=0
-
-# BUG: `-s` (`--silent`) is not working for me with `core/curl/7.62.0/20181212184320`
-{{pkgPathFor "core/curl"}}/bin/curl -k -X GET -sS --fail --max-time 2 http://localhost:{{cfg.service.port}}/automate_es_gateway_status
-
-case $? in
-    # Zero exit status means curl got back a 200 end everything is ok.
-    0)
-        rc=0 ;;
-    # Anything else is critical.
-    *)
-        rc=2 ;;
-esac
-
-exit $rc
+curlOpts="-sS --fail --max-time 2"
+# shellcheck disable=SC2086
+output=$({{pkgPathFor "core/curl"}}/bin/curl $curlOpts "http://localhost:{{cfg.service.port}}/automate_es_gateway_status")
+res=$?
+if [[ "$res" != "0" ]];then
+    echo "health check curl command returned ${res}:"
+    echo "$output"
+    exit 2
+fi


### PR DESCRIPTION
This silences the health check spam produced by not redirecting the
curl output.

We have a number of curl-based health check with the same problem
which I'll fix in a follow up change.

Signed-off-by: Steven Danna <steve@chef.io>