### PR TITLE
logs: silence a few more health checks

### DIFF
--- a/components/automate-cs-nginx/habitat/hooks/health-check
+++ b/components/automate-cs-nginx/habitat/hooks/health-check
@@ -1,24 +1,18 @@
 #!/bin/sh
 #
-
-# Health Check for Chef Server Load Balancer
-
-# default return code is 0
-rc=0
-
-curlOpts="-k -X GET -sS --fail --max-time 2"
+curlOpts="-sS --fail --max-time 2"
+curlOpts="$curlOpts --resolve automate-cs-nginx:{{cfg.service.port}}:{{sys.ip}}"
+curlOpts="$curlOpts --noproxy automate-cs-nginx"
+curlOpts="$curlOpts --cacert {{pkg.svc_config_path}}/root_ca.crt"
 curlOpts="$curlOpts --cert {{pkg.svc_config_path}}/service.crt"
 curlOpts="$curlOpts --key {{pkg.svc_config_path}}/service.key"
+
 # This gets routed to erchef which does a "deep" health check
-{{pkgPathFor "core/curl"}}/bin/curl $curlOpts https://localhost:{{cfg.service.port}}/_status
-
-case $? in
-    # Zero exit status means curl got back a 200 end everything is ok.
-    0)
-        rc=0 ;;
-    # Anything else is critical.
-    *)
-        rc=2 ;;
-esac
-
-exit $rc
+# shellcheck disable=SC2086
+output=$({{pkgPathFor "core/curl"}}/bin/curl $curlOpts "https://automate-cs-nginx:{{cfg.service.port}}/_status")
+res=$?
+if [ "0" != "$res" ]; then
+    echo "health check curl command returned exit code ${res}:"
+    echo "$output"
+    exit 2
+fi

--- a/components/automate-cs-oc-bifrost/habitat/hooks/health-check
+++ b/components/automate-cs-oc-bifrost/habitat/hooks/health-check
@@ -1,28 +1,16 @@
 #!/bin/sh
 #
-
-# Health Check for oc_bifrost
-
-# default return code is 0
-rc=0
-
-#shellcheck disable=SC2140 # shellcheck gets confused by the quotes in the templating
-"{{pkgPathFor "core/curl"}}/bin/curl" \
-  -X GET -sS --fail --max-time 2 \
-  --cert "{{pkg.svc_config_path}}/service.crt" \
-  --key "{{pkg.svc_config_path}}/service.key" \
-  --cacert "{{pkg.svc_config_path}}/root_ca.crt" \
-  --resolve "automate-cs-oc-bifrost:{{cfg.network.port}}:127.0.0.1" \
-  --noproxy automate-cs-oc-bifrost \
-  "https://automate-cs-oc-bifrost:{{cfg.network.port}}/_status"
-
-case $? in
-    # Zero exit status means curl got back a 200 end everything is ok.
-    0)
-        rc=0 ;;
-    # Anything else is critical.
-    *)
-        rc=2 ;;
-esac
-
-exit $rc
+curlOpts="-X GET -sS --fail --max-time 2"
+curlOpts="$curlOpts --cert {{pkg.svc_config_path}}/service.crt"
+curlOpts="$curlOpts --key {{pkg.svc_config_path}}/service.key"
+curlOpts="$curlOpts --cacert {{pkg.svc_config_path}}/root_ca.crt"
+curlOpts="$curlOpts --resolve automate-cs-oc-bifrost:{{cfg.network.port}}:127.0.0.1"
+curlOpts="$curlOpts --noproxy automate-cs-oc-bifrost"
+# shellcheck disable=SC2086
+output=$({{pkgPathFor "core/curl"}}/bin/curl $curlOpts "https://automate-cs-oc-bifrost:{{cfg.network.port}}/_status")
+res=$?
+if [ "0" != "$res" ]; then
+    echo "health check curl command returned exit code ${res}:"
+    echo "$output"
+    exit 2
+fi

--- a/components/automate-cs-oc-erchef/habitat/hooks/health-check
+++ b/components/automate-cs-oc-erchef/habitat/hooks/health-check
@@ -1,28 +1,16 @@
 #!/bin/sh
 #
-
-# Health Check for oc_erchef
-
-# default return code is 0
-rc=0
-
-#shellcheck disable=SC2140 # shellcheck gets confused by the quotes in the templating
-"{{pkgPathFor "core/curl"}}/bin/curl" \
-  -X GET -sS --fail --max-time 2 \
-  --cert "{{pkg.svc_config_path}}/service.crt" \
-  --key "{{pkg.svc_config_path}}/service.key" \
-  --cacert "{{pkg.svc_config_path}}/root_ca.crt" \
-  --resolve "automate-cs-oc-erchef:{{cfg.network.port}}:127.0.0.1" \
-  --noproxy automate-cs-oc-erchef \
-  "https://automate-cs-oc-erchef:{{cfg.network.port}}/_status"
-
-case $? in
-    # Zero exit status means curl got back a 200 end everything is ok.
-    0)
-        rc=0 ;;
-    # Anything else is critical.
-    *)
-        rc=2 ;;
-esac
-
-exit $rc
+curlOpts="-X GET -sS --fail --max-time 2"
+curlOpts="$curlOpts --cert {{pkg.svc_config_path}}/service.crt"
+curlOpts="$curlOpts --key {{pkg.svc_config_path}}/service.key"
+curlOpts="$curlOpts --cacert {{pkg.svc_config_path}}/root_ca.crt"
+curlOpts="$curlOpts --resolve automate-cs-oc-erchef:{{cfg.network.port}}:127.0.0.1"
+curlOpts="$curlOpts --noproxy automate-cs-oc-erchef"
+# shellcheck disable=SC2086
+output=$({{pkgPathFor "core/curl"}}/bin/curl $curlOpts "https://automate-cs-oc-erchef:{{cfg.network.port}}/_status")
+res=$?
+if [ "0" != "$res" ]; then
+    echo "health check curl command returned exit code ${res}:"
+    echo "$output"
+    exit 2
+fi

--- a/components/automate-workflow-nginx/habitat/hooks/health-check
+++ b/components/automate-workflow-nginx/habitat/hooks/health-check
@@ -1,7 +1,8 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
-if curl --max-time 2 -k --fail --silent --show-error "https://{{sys.ip}}:{{cfg.ssl_port}}/api/_status"; then
+if output=$(curl --max-time 2 -k --fail --silent --show-error "https://{{sys.ip}}:{{cfg.ssl_port}}/api/_status"); then
   exit 0
 else
+  echo "$output"
   exit 2
 fi

--- a/components/automate-workflow-server/habitat/hooks/health-check
+++ b/components/automate-workflow-server/habitat/hooks/health-check
@@ -1,7 +1,8 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
-if curl --max-time 2 --fail --silent --show-error "http://{{sys.ip}}:{{cfg.api_port}}/api/_status"; then
+if output=$(curl --max-time 2 --fail --silent --show-error "http://{{sys.ip}}:{{cfg.api_port}}/api/_status"); then
   exit 0
 else
+  echo "$output"
   exit 2
 fi


### PR DESCRIPTION
It might good to make a platform-tool or scaffolding helper for
normalizing using curl for health checks.

Signed-off-by: Steven Danna <steve@chef.io>