### PR TITLE
ci: bump max pg connections to 128

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/main.tf
+++ b/terraform/test-environments/modules/chef_automate_install/main.tf
@@ -263,6 +263,9 @@ EOF
 [license_control.v1.sys.telemetry]
   url = "https://telemetry-acceptance.chef.io"
 
+[postgresql.v1.sys.pg]
+  max_connections = 128
+
 ${var.saml == "true" ? local.saml_config : ""}
 
 [elasticsearch.v1.sys.runtime]


### PR DESCRIPTION
In a "fully configured" setup, it seems easy to hit the default
limit (100) as chef-server and workflow currently take 80
connections. Let's try a modest bump in CI and then consider changing
the default.

Signed-off-by: Steven Danna <steve@chef.io>