### PR TITLE
[AUTH-1501] Rules staged for delete should mark listed projects as EDITS_PENDING

### DIFF
--- a/components/authz-service/storage/postgres/migration/sql/70_fix_status_for_list_projects.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/70_fix_status_for_list_projects.up.sql
@@ -1,0 +1,39 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION
+  query_projects(_projects_filter TEXT[])
+  RETURNS setof json AS $$
+
+WITH
+staged AS (
+  SELECT r.project_id, count(r.id) AS count
+  FROM iam_staged_project_rules AS r
+  WHERE projects_match_for_rule(r.project_id, _projects_filter)
+  GROUP BY r.project_id
+),
+applied AS (
+  SELECT r.project_id, count(r.id) AS count
+  FROM iam_project_rules AS r
+  WHERE projects_match_for_rule(r.project_id, _projects_filter)
+  GROUP BY r.project_id
+)
+SELECT json_build_object(
+  'id', p.id,
+  'name', p.name,
+  'type', p.type,
+  'status',
+  CASE WHEN staged.count IS NULL AND applied.count IS NULL THEN 'no-rules'
+       WHEN staged.count IS NULL THEN 'applied'
+       ELSE 'edits-pending'
+  END
+)
+FROM staged
+    FULL JOIN applied
+    ON staged.project_id = applied.project_id
+RIGHT JOIN iam_projects p
+    ON p.db_id = COALESCE(staged.project_id, applied.project_id)
+    WHERE projects_match_for_rule(p.id, _projects_filter)
+
+$$ LANGUAGE sql;
+
+COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -69,3 +69,4 @@
 - [`67_update_rule_queries.up.sql`](67_update_rule_queries.up.sql)
 - [`68_add_status_to_projects.up.sql`](68_add_status_to_projects.up.sql)
 - [`69_add_status_to_get_project.up.sql`](69_add_status_to_get_project.up.sql)
+- [`70_fix_status_for_list_projects.up.sql`](70_fix_status_for_list_projects.up.sql)

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -5010,12 +5010,55 @@ func TestListProjects(t *testing.T) {
 			expectedProjects := []*storage.Project{&p1, &p2, &p3}
 			assert.ElementsMatch(t, expectedProjects, ps)
 		}},
-		{"returns rule status of staged for project with both staged and applied rules", func(t *testing.T) {
+		{"returns rule status of 'edits-pending' for project with both staged and applied rules", func(t *testing.T) {
 			ctx := context.Background()
 			p1 := insertTestProject(t, db, "foo", "my foo project", storage.ChefManaged)
 			insertStagedRuleWithMultipleConditions(t, db, "staged-rule-1", p1.ID, storage.Node, false)
-			insertAppliedRuleWithMultipleConditions(t, db, "staged-rule-2", p1.ID, storage.Node)
-			insertAppliedRuleWithMultipleConditions(t, db, "staged-rule-3", p1.ID, storage.Node)
+			insertAppliedRuleWithMultipleConditions(t, db, "applied-rule-1", p1.ID, storage.Node)
+			insertAppliedRuleWithMultipleConditions(t, db, "applied-rule-2", p1.ID, storage.Node)
+
+			ps, err := store.ListProjects(ctx)
+			require.NoError(t, err)
+
+			p1.Status = storage.EditsPending.String()
+			expectedProjects := []*storage.Project{&p1}
+			assert.ElementsMatch(t, expectedProjects, ps)
+		}},
+		{"returns rule status of 'edits-pending' for project with staged new rules, staged deletes, and applied rules", func(t *testing.T) {
+			ctx := context.Background()
+			p1 := insertTestProject(t, db, "foo", "my foo project", storage.ChefManaged)
+			insertStagedRuleWithMultipleConditions(t, db, "staged-rule-1", p1.ID, storage.Node, false)
+			insertStagedRuleWithMultipleConditions(t, db, "rule-1", p1.ID, storage.Node, true)
+			insertAppliedRuleWithMultipleConditions(t, db, "rule-1", p1.ID, storage.Node)
+			insertAppliedRuleWithMultipleConditions(t, db, "applied-rule-2", p1.ID, storage.Node)
+
+			ps, err := store.ListProjects(ctx)
+			require.NoError(t, err)
+
+			p1.Status = storage.EditsPending.String()
+			expectedProjects := []*storage.Project{&p1}
+			assert.ElementsMatch(t, expectedProjects, ps)
+		}},
+		{"returns rule status of 'edits-pending' for project with both staged deletes applied rules", func(t *testing.T) {
+			ctx := context.Background()
+			p1 := insertTestProject(t, db, "foo", "my foo project", storage.ChefManaged)
+			insertStagedRuleWithMultipleConditions(t, db, "rule-1", p1.ID, storage.Node, true)
+			insertStagedRuleWithMultipleConditions(t, db, "rule-2", p1.ID, storage.Node, true)
+			insertAppliedRuleWithMultipleConditions(t, db, "rule-1", p1.ID, storage.Node)
+			insertAppliedRuleWithMultipleConditions(t, db, "rule-2", p1.ID, storage.Node)
+
+			ps, err := store.ListProjects(ctx)
+			require.NoError(t, err)
+
+			p1.Status = storage.EditsPending.String()
+			expectedProjects := []*storage.Project{&p1}
+			assert.ElementsMatch(t, expectedProjects, ps)
+		}},
+		{"returns rule status of 'edits-pending' for project with staged deletes", func(t *testing.T) {
+			ctx := context.Background()
+			p1 := insertTestProject(t, db, "foo", "my foo project", storage.ChefManaged)
+			insertStagedRuleWithMultipleConditions(t, db, "rule-1", p1.ID, storage.Node, true)
+			insertStagedRuleWithMultipleConditions(t, db, "rule-2", p1.ID, storage.Node, true)
 
 			ps, err := store.ListProjects(ctx)
 			require.NoError(t, err)

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -7,6 +7,12 @@ describeIfIAMV2p1('projects API: applying project', () => {
     name: 'Test Avengers Project'
   };
 
+  interface Project {
+    id: string;
+    name: string;
+    status: string;
+  }
+
   const xmenProject = {
     id: `${cypressPrefix}-project2-${Cypress.moment().format('MMDDYYhhmm')}`,
     name: 'Test X-men Project'
@@ -40,6 +46,11 @@ describeIfIAMV2p1('projects API: applying project', () => {
     ]
   };
   let adminIdToken = '';
+
+  // testing values
+  const noRulesStr = 'NO_RULES';
+  const editsPendingStr = 'EDITS_PENDING';
+  const rulesAppliedStr = 'RULES_APPLIED';
 
   before(() => {
     cy.adminLogin('/').then(() => {
@@ -168,12 +179,21 @@ describeIfIAMV2p1('projects API: applying project', () => {
         method: 'GET',
         url: `/apis/iam/v2beta/projects/${project.id}`
       }).then((response) => {
-        expect(response.body.project.status).to.equal('NO_RULES');
+        expect(response.body.project.status).to.equal(noRulesStr);
       });
     }
 
-    for (const rule of [avengersRule, xmenRule]) {
+    cy.request({
+      headers: { 'api-token': Cypress.env('adminTokenValue') },
+      method: 'GET',
+      url: '/apis/iam/v2beta/projects'
+    }).then((response) => {
+      const projects: Project[] = response.body.projects;
+      projects.filter(({ id, status }) => id === avengersProject.id || id === xmenProject.id)
+        .forEach(({ status }) => expect(status).to.equal(noRulesStr));
+    });
 
+    for (const rule of [avengersRule, xmenRule]) {
       cy.request({
         headers: { 'api-token': Cypress.env('adminTokenValue') },
         method: 'POST',
@@ -200,9 +220,19 @@ describeIfIAMV2p1('projects API: applying project', () => {
         method: 'GET',
         url: `/apis/iam/v2beta/projects/${project.id}`
       }).then((response) => {
-        expect(response.body.project.status).to.equal('EDITS_PENDING');
+        expect(response.body.project.status).to.equal(editsPendingStr);
       });
     }
+
+    cy.request({
+      headers: { 'api-token': Cypress.env('adminTokenValue') },
+      method: 'GET',
+      url: '/apis/iam/v2beta/projects'
+    }).then((response) => {
+      const projects: Project[] = response.body.projects;
+      projects.filter(({ id, status }) => id === avengersProject.id || id === xmenProject.id)
+        .forEach(({ status }) => expect(status).to.equal(editsPendingStr));
+    });
 
     cy.request({
       headers: { 'api-token': Cypress.env('adminTokenValue') },
@@ -229,9 +259,19 @@ describeIfIAMV2p1('projects API: applying project', () => {
         method: 'GET',
         url: `/apis/iam/v2beta/projects/${project.id}`
       }).then((response) => {
-        expect(response.body.project.status).to.equal('RULES_APPLIED');
+        expect(response.body.project.status).to.equal(rulesAppliedStr);
       });
     }
+
+    cy.request({
+      headers: { 'api-token': Cypress.env('adminTokenValue') },
+      method: 'GET',
+      url: '/apis/iam/v2beta/projects'
+    }).then((response) => {
+      const projects: Project[] = response.body.projects;
+      projects.filter(({ id, status }) => id === avengersProject.id || id === xmenProject.id)
+        .forEach(({ status }) => expect(status).to.equal(rulesAppliedStr));
+    });
 
     // confirm nodes are assigned to projects correctly
     cy.request({
@@ -275,7 +315,17 @@ describeIfIAMV2p1('projects API: applying project', () => {
       method: 'GET',
       url: `/apis/iam/v2beta/projects/${avengersProject.id}`
     }).then((response) => {
-      expect(response.body.project.status).to.equal('RULES_APPLIED');
+      expect(response.body.project.status).to.equal(rulesAppliedStr);
+    });
+
+    cy.request({
+      headers: { 'api-token': Cypress.env('adminTokenValue') },
+      method: 'GET',
+      url: '/apis/iam/v2beta/projects'
+    }).then((response) => {
+      const projects: Project[] = response.body.projects;
+      projects.filter(({ id, status }) => id === avengersProject.id)
+        .forEach(({ status }) => expect(status).to.equal(rulesAppliedStr));
     });
 
     cy.request({
@@ -290,7 +340,17 @@ describeIfIAMV2p1('projects API: applying project', () => {
       method: 'GET',
       url: `/apis/iam/v2beta/projects/${avengersProject.id}`
     }).then((response) => {
-      expect(response.body.project.status).to.equal('EDITS_PENDING');
+      expect(response.body.project.status).to.equal(editsPendingStr);
+    });
+
+    cy.request({
+      headers: { 'api-token': Cypress.env('adminTokenValue') },
+      method: 'GET',
+      url: '/apis/iam/v2beta/projects'
+    }).then((response) => {
+        const projects: Project[] = response.body.projects;
+        projects.filter(({ id, status }) => id === avengersProject.id)
+          .forEach(({ status }) => expect(status).to.equal(editsPendingStr));
     });
 
     cy.request({
@@ -316,7 +376,17 @@ describeIfIAMV2p1('projects API: applying project', () => {
       method: 'GET',
       url: `/apis/iam/v2beta/projects/${avengersProject.id}`
     }).then((response) => {
-      expect(response.body.project.status).to.equal('RULES_APPLIED');
+      expect(response.body.project.status).to.equal(rulesAppliedStr);
+    });
+
+    cy.request({
+      headers: { 'api-token': Cypress.env('adminTokenValue') },
+      method: 'GET',
+      url: '/apis/iam/v2beta/projects'
+    }).then((response) => {
+      const projects: Project[] = response.body.projects;
+      projects.filter(({ id, status }) => id === avengersProject.id)
+        .forEach(({ status }) => expect(status).to.equal(rulesAppliedStr));
     });
   });
 
@@ -327,7 +397,17 @@ describeIfIAMV2p1('projects API: applying project', () => {
       method: 'GET',
       url: `/apis/iam/v2beta/projects/${avengersProject.id}`
     }).then((response) => {
-      expect(response.body.project.status).to.equal('RULES_APPLIED');
+      expect(response.body.project.status).to.equal(rulesAppliedStr);
+    });
+
+    cy.request({
+      headers: { 'api-token': Cypress.env('adminTokenValue') },
+      method: 'GET',
+      url: '/apis/iam/v2beta/projects'
+    }).then((response) => {
+      const projects: Project[] = response.body.projects;
+      projects.filter(({ id, status }) => id === avengersProject.id)
+        .forEach(({ status }) => expect(status).to.equal(rulesAppliedStr));
     });
 
     cy.request({
@@ -341,7 +421,17 @@ describeIfIAMV2p1('projects API: applying project', () => {
       method: 'GET',
       url: `/apis/iam/v2beta/projects/${avengersProject.id}`
     }).then((response) => {
-      expect(response.body.project.status).to.equal('EDITS_PENDING');
+      expect(response.body.project.status).to.equal(editsPendingStr);
+    });
+
+    cy.request({
+      headers: { 'api-token': Cypress.env('adminTokenValue') },
+      method: 'GET',
+      url: '/apis/iam/v2beta/projects'
+    }).then((response) => {
+      const projects: Project[] = response.body.projects;
+      projects.filter(({ id, status }) => id === avengersProject.id)
+        .forEach(({ status }) => expect(status).to.equal(editsPendingStr));
     });
 
     cy.request({
@@ -356,7 +446,17 @@ describeIfIAMV2p1('projects API: applying project', () => {
       method: 'GET',
       url: `/apis/iam/v2beta/projects/${avengersProject.id}`
     }).then((response) => {
-      expect(response.body.project.status).to.equal('NO_RULES');
+      expect(response.body.project.status).to.equal(noRulesStr);
+    });
+
+    cy.request({
+      headers: { 'api-token': Cypress.env('adminTokenValue') },
+      method: 'GET',
+      url: '/apis/iam/v2beta/projects'
+    }).then((response) => {
+      const projects: Project[] = response.body.projects;
+      projects.filter(({ id, status }) => id === avengersProject.id)
+        .forEach(({ status }) => expect(status).to.equal(noRulesStr));
     });
 
     cy.request({


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Fixing a bug that prevented staged rule deletes from properly modifying the project status to EDITS_PENDING for the ListRules endpoint.

### :athletic_shoe: How to Build and Test the Change

Setup:

```
# rebuild components/authz-service
# chef-automate iam upgrade-to-v2 --beta2.1
# export ADMINTOK=`chef-automate iam token create admin --admin`
```

```
# curl -H "api-token: $ADMINTOK" -XPOST -d '{"name":"project1", "id":"project1"}' https://a2-dev.test/apis/iam/v2beta/projects --insecure

# curl -H "api-token: $ADMINTOK" https://a2-dev.test/apis/iam/v2beta/projects?pretty --insecure
{
  "projects": [
    {
      "name": "project1",
      "id": "project1",
      "type": "CUSTOM",
      "status": "NO_RULES"
    }
  ]
}

# curl -H "api-token: $ADMINTOK" -XPOST -d '{"name":"rule1", "id":"rule1", "type":"NODE", "conditions": [{"attribute":"CHEF_ORGANIZATION", "operator":"EQUALS", "values":["rule1org"]}]}' https://a2-dev.test/apis/iam/v2beta/projects/project1/rules --insecure

# curl -H "api-token: $ADMINTOK" https://a2-dev.test/apis/iam/v2beta/projects?pretty --insecure
{
  "projects": [
    {
      "name": "project1",
      "id": "project1",
      "type": "CUSTOM",
      "status": "EDITS_PENDING"
    }
  ]
}

# curl -H "api-token: $ADMINTOK" -XPOST https://a2-dev.test/apis/iam/v2beta/apply-rules --insecure
.........
# curl -H "api-token: $ADMINTOK" https://a2-dev.test/apis/iam/v2beta/apply-rules --insecure
{"state":"not_running","estimated_time_complete":"2019-09-11T17:55:51.121857846Z","percentage_complete":1,"failed":false,"failure_message":""}[12]
# curl -H "api-token: $ADMINTOK" https://a2-dev.test/apis/iam/v2beta/projects?pretty --insecure
{
  "projects": [
    {
      "name": "project1",
      "id": "project1",
      "type": "CUSTOM",
      "status": "RULES_APPLIED"
    }
  ]
}

# curl -H "api-token: $ADMINTOK" -XPOST -d '{"name":"rule2", "id":"rule2", "type":"NODE", "conditions": [{"attribute":"CHEF_ORGANIZATION", "operator":"EQUALS", "values":["rule2org"]}]}' https://a2-dev.test/apis/iam/v2beta/projects/project1/rules --insecure
# curl -H "api-token: $ADMINTOK" https://a2-dev.test/apis/iam/v2beta/projects?pretty --insecure
{
  "projects": [
    {
      "name": "project1",
      "id": "project1",
      "type": "CUSTOM",
      "status": "EDITS_PENDING"
    }
  ]
}
# curl -H "api-token: $ADMINTOK" -XPOST https://a2-dev.test/apis/iam/v2beta/apply-rules --insecure
.......
# curl -H "api-token: $ADMINTOK" https://a2-dev.test/apis/iam/v2beta/projects?pretty --insecure
{
  "projects": [
    {
      "name": "project1",
      "id": "project1",
      "type": "CUSTOM",
      "status": "RULES_APPLIED"
    }
  ]
}
````

### Screenshot

<img width="1142" alt="Screen Shot 2019-09-12 at 12 59 15 PM" src="https://user-images.githubusercontent.com/1899715/64816749-2fac3300-d55d-11e9-8925-4fb9d59c6dbc.png">


### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?
