### PR TITLE
deps: bump OPA pre-1.14.0 -> 0.14.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -847,12 +847,16 @@
   version = "v6.2.16"
 
 [[projects]]
-  digest = "1:2c92a3d315c2605f6cb16ccb05aa14fdf9b375d678badb653cd2e8c54c36d40e"
+  digest = "1:2e9a0991621e2376b1cceb29d1b2524554a4b8eef815dae51d891fdd71f217d6"
   name = "github.com/open-policy-agent/opa"
   packages = [
     "ast",
+    "bundle",
     "internal/compiler/wasm",
     "internal/compiler/wasm/opa",
+    "internal/file",
+    "internal/file/archive",
+    "internal/file/url",
     "internal/ir",
     "internal/leb128",
     "internal/planner",
@@ -863,6 +867,7 @@
     "internal/wasm/module",
     "internal/wasm/opcode",
     "internal/wasm/types",
+    "loader",
     "metrics",
     "rego",
     "storage",
@@ -881,7 +886,8 @@
     "version",
   ]
   pruneopts = "NUT"
-  revision = "0d70daa545f5a4bf2e6edf3c1b2d635920299bc9"
+  revision = "8d1cc7e7e9cf019e1e9fd114d61b14dc82460e80"
+  version = "v0.14.0"
 
 [[projects]]
   digest = "1:7da29c22bcc5c2ffb308324377dc00b5084650348c2799e573ed226d8cc9faf0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -198,7 +198,7 @@ required = [
 # more easily.)
 [[constraint]]
   name = "github.com/open-policy-agent/opa"
-  revision = "0d70daa545f5a4bf2e6edf3c1b2d635920299bc9"
+  version = "0.14.0"
 
 [[constraint]]
   name = "github.com/chef/toml"

--- a/vendor/github.com/open-policy-agent/opa/ast/check.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/check.go
@@ -124,9 +124,13 @@ func (tc *typeChecker) checkClosures(env *TypeEnv, expr *Expr) Errors {
 	return result
 }
 
-func (tc *typeChecker) checkLanguageBuiltins() *TypeEnv {
-	env := NewTypeEnv()
-	for _, bi := range Builtins {
+func (tc *typeChecker) checkLanguageBuiltins(env *TypeEnv, builtins map[string]*Builtin) *TypeEnv {
+	if env == nil {
+		env = NewTypeEnv()
+	} else {
+		env = env.wrap()
+	}
+	for _, bi := range builtins {
 		env.tree.Put(bi.Ref(), bi.Decl)
 	}
 	return env

--- a/vendor/github.com/open-policy-agent/opa/ast/compare.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/compare.go
@@ -5,6 +5,7 @@
 package ast
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 )
@@ -84,6 +85,18 @@ func Compare(a, b interface{}) int {
 		}
 		return 1
 	case Number:
+		if ai, err := json.Number(a).Int64(); err == nil {
+			if bi, err := json.Number(b.(Number)).Int64(); err == nil {
+				if ai == bi {
+					return 0
+				}
+				if ai < bi {
+					return -1
+				}
+				return 1
+			}
+		}
+
 		bigA, ok := new(big.Float).SetString(string(a))
 		if !ok {
 			panic("illegal value")

--- a/vendor/github.com/open-policy-agent/opa/ast/compile.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/compile.go
@@ -86,14 +86,12 @@ type Compiler struct {
 		metricName string
 		f          func()
 	}
-	maxErrs    int
-	sorted     []string // list of sorted module names
-	pathExists func([]string) (bool, error)
-	after      map[string][]CompilerStageDefinition
-	metrics    metrics.Metrics
-
-	// This is a set of unsafe built-in functions that we are not allowed to
-	// use.
+	maxErrs           int
+	sorted            []string // list of sorted module names
+	pathExists        func([]string) (bool, error)
+	after             map[string][]CompilerStageDefinition
+	metrics           metrics.Metrics
+	builtins          map[string]*Builtin
 	unsafeBuiltinsMap map[string]struct{}
 }
 
@@ -219,8 +217,11 @@ func NewCompiler() *Compiler {
 	c.ModuleTree = NewModuleTree(nil)
 	c.RuleTree = NewRuleTree(c.ModuleTree)
 
+	// Initialize the compiler with the statically compiled built-in functions.
+	// If the caller customizes the compiler, a copy will be made.
+	c.builtins = BuiltinMap
 	checker := newTypeChecker()
-	c.TypeEnv = checker.checkLanguageBuiltins()
+	c.TypeEnv = checker.checkLanguageBuiltins(nil, c.builtins)
 
 	c.stages = []struct {
 		name       string
@@ -288,6 +289,25 @@ func (c *Compiler) WithMetrics(metrics metrics.Metrics) *Compiler {
 	return c
 }
 
+// WithBuiltins adds a set of custom built-in functions to the compiler.
+func (c *Compiler) WithBuiltins(builtins map[string]*Builtin) *Compiler {
+	if len(builtins) == 0 {
+		return c
+	}
+	cpy := make(map[string]*Builtin, len(c.builtins)+len(builtins))
+	for k, v := range c.builtins {
+		cpy[k] = v
+	}
+	for k, v := range builtins {
+		cpy[k] = v
+	}
+	c.builtins = cpy
+	// Build type env for custom functions and wrap existing one.
+	checker := newTypeChecker()
+	c.TypeEnv = checker.checkLanguageBuiltins(c.TypeEnv, builtins)
+	return c
+}
+
 // WithUnsafeBuiltins will add all built-ins in the map to the "blacklist".
 func (c *Compiler) WithUnsafeBuiltins(unsafeBuiltins map[string]struct{}) *Compiler {
 	for name := range unsafeBuiltins {
@@ -328,7 +348,7 @@ func (c *Compiler) Failed() bool {
 // ref refers to built-in function, the built-in declaration is consulted,
 // otherwise, the ref is used to perform a ruleset lookup.
 func (c *Compiler) GetArity(ref Ref) int {
-	if bi := BuiltinMap[ref.String()]; bi != nil {
+	if bi := c.builtins[ref.String()]; bi != nil {
 		return len(bi.Decl.Args())
 	}
 	rules := c.GetRulesExact(ref)
@@ -477,6 +497,82 @@ func (c *Compiler) GetRules(ref Ref) (rules []*Rule) {
 	}
 
 	return rules
+}
+
+// GetRulesDynamic returns a slice of rules that could be referred to by a ref.
+// When parts of the ref are statically known, we use that information to narrow
+// down which rules the ref could refer to, but in the most general case this
+// will be an over-approximation.
+//
+// E.g., given the following modules:
+//
+//  package a.b.c
+//
+//  r1 = 1  # rule1
+//
+// and:
+//
+//  package a.d.c
+//
+//  r2 = 2  # rule2
+//
+// The following calls yield the rules on the right.
+//
+//  GetRulesDynamic("data.a[x].c[y]")			=> [rule1, rule2]
+//  GetRulesDynamic("data.a[x].c.r2")	=> [rule2]
+//  GetRulesDynamic("data.a.b[x][y]")	=> [rule1]
+func (c *Compiler) GetRulesDynamic(ref Ref) (rules []*Rule) {
+	node := c.RuleTree
+
+	set := map[*Rule]struct{}{}
+	var walk func(node *TreeNode, i int)
+	walk = func(node *TreeNode, i int) {
+		if i >= len(ref) {
+			// We've reached the end of the reference and want to collect everything
+			// under this "prefix".
+			node.DepthFirst(func(descendant *TreeNode) bool {
+				insertRules(set, descendant.Values)
+				return descendant.Hide
+			})
+		} else if i == 0 || IsConstant(ref[i].Value) {
+			// The head of the ref is always grounded.  In case another part of the
+			// ref is also grounded, we can lookup the exact child.  If it's not found
+			// we can immediately return...
+			if child := node.Child(ref[i].Value); child == nil {
+				return
+			} else if len(child.Values) > 0 {
+				// If there are any rules at this position, it's what the ref would
+				// refer to.  We can just append those and stop here.
+				insertRules(set, child.Values)
+			} else {
+				// Otherwise, we continue using the child node.
+				walk(child, i+1)
+			}
+		} else {
+			// This part of the ref is a dynamic term.  We can't know what it refers
+			// to and will just need to try all of the children.
+			for _, child := range node.Children {
+				if child.Hide {
+					continue
+				}
+				insertRules(set, child.Values)
+				walk(child, i+1)
+			}
+		}
+	}
+
+	walk(node, 0)
+	for rule := range set {
+		rules = append(rules, rule)
+	}
+	return rules
+}
+
+// Utility: add all rule values to the set.
+func insertRules(set map[*Rule]struct{}, rules []util.T) {
+	for _, rule := range rules {
+		set[rule.(*Rule)] = struct{}{}
+	}
 }
 
 // RuleIndex returns a RuleIndex built for the rule set referred to by path.
@@ -637,7 +733,7 @@ func (c *Compiler) checkSafetyRuleBodies() {
 }
 
 func (c *Compiler) checkBodySafety(safe VarSet, m *Module, b Body) Body {
-	reordered, unsafe := reorderBodyForSafety(c.GetArity, safe, b)
+	reordered, unsafe := reorderBodyForSafety(c.builtins, c.GetArity, safe, b)
 	if errs := safetyErrorSlice(unsafe); len(errs) > 0 {
 		for _, err := range errs {
 			c.err(err)
@@ -1039,7 +1135,7 @@ func (c *Compiler) setRuleTree() {
 }
 
 func (c *Compiler) setGraph() {
-	c.Graph = NewGraph(c.Modules, c.GetRules)
+	c.Graph = NewGraph(c.Modules, c.GetRulesDynamic)
 }
 
 type queryCompiler struct {
@@ -1208,7 +1304,7 @@ func (qc *queryCompiler) rewriteLocalVars(_ *QueryContext, body Body) (Body, err
 
 func (qc *queryCompiler) checkSafety(_ *QueryContext, body Body) (Body, error) {
 	safe := ReservedVars.Copy()
-	reordered, unsafe := reorderBodyForSafety(qc.compiler.GetArity, safe, body)
+	reordered, unsafe := reorderBodyForSafety(qc.compiler.builtins, qc.compiler.GetArity, safe, body)
 	if errs := safetyErrorSlice(unsafe); len(errs) > 0 {
 		return nil, errs
 	}
@@ -1404,7 +1500,7 @@ func NewGraph(modules map[string]*Module, list func(Ref) []*Rule) *Graph {
 		return NewGenericVisitor(func(x interface{}) bool {
 			switch x := x.(type) {
 			case Ref:
-				for _, b := range list(x.GroundPrefix()) {
+				for _, b := range list(x) {
 					for node := b; node != nil; node = node.Else {
 						graph.addDependency(a, node)
 					}
@@ -1626,9 +1722,9 @@ func (vs unsafeVars) Slice() (result []unsafePair) {
 //
 // If the body cannot be reordered to ensure safety, the second return value
 // contains a mapping of expressions to unsafe variables in those expressions.
-func reorderBodyForSafety(arity func(Ref) int, globals VarSet, body Body) (Body, unsafeVars) {
+func reorderBodyForSafety(builtins map[string]*Builtin, arity func(Ref) int, globals VarSet, body Body) (Body, unsafeVars) {
 
-	body, unsafe := reorderBodyForClosures(arity, globals, body)
+	body, unsafe := reorderBodyForClosures(builtins, arity, globals, body)
 	if len(unsafe) != 0 {
 		return nil, unsafe
 	}
@@ -1654,7 +1750,7 @@ func reorderBodyForSafety(arity func(Ref) int, globals VarSet, body Body) (Body,
 				continue
 			}
 
-			safe.Update(outputVarsForExpr(e, arity, safe))
+			safe.Update(outputVarsForExpr(e, builtins, arity, safe))
 
 			for v := range unsafe[e] {
 				if safe.Contains(v) {
@@ -1682,10 +1778,11 @@ func reorderBodyForSafety(arity func(Ref) int, globals VarSet, body Body) (Body,
 			g.Update(reordered[i-1].Vars(safetyCheckVarVisitorParams))
 		}
 		vis := &bodySafetyVisitor{
-			arity:   arity,
-			current: e,
-			globals: g,
-			unsafe:  unsafe,
+			builtins: builtins,
+			arity:    arity,
+			current:  e,
+			globals:  g,
+			unsafe:   unsafe,
 		}
 		Walk(vis, e)
 	}
@@ -1698,10 +1795,11 @@ func reorderBodyForSafety(arity func(Ref) int, globals VarSet, body Body) (Body,
 }
 
 type bodySafetyVisitor struct {
-	arity   func(Ref) int
-	current *Expr
-	globals VarSet
-	unsafe  unsafeVars
+	builtins map[string]*Builtin
+	arity    func(Ref) int
+	current  *Expr
+	globals  VarSet
+	unsafe   unsafeVars
 }
 
 func (vis *bodySafetyVisitor) Visit(x interface{}) Visitor {
@@ -1733,7 +1831,7 @@ func (vis *bodySafetyVisitor) checkComprehensionSafety(tv VarSet, body Body) Bod
 	}
 
 	// Check body for safety, reordering as necessary.
-	r, u := reorderBodyForSafety(vis.arity, vis.globals, body)
+	r, u := reorderBodyForSafety(vis.builtins, vis.arity, vis.globals, body)
 	if len(u) == 0 {
 		return r
 	}
@@ -1759,7 +1857,7 @@ func (vis *bodySafetyVisitor) checkSetComprehensionSafety(sc *SetComprehension) 
 // reorderBodyForClosures returns a copy of the body ordered such that
 // expressions (such as array comprehensions) that close over variables are ordered
 // after other expressions that contain the same variable in an output position.
-func reorderBodyForClosures(arity func(Ref) int, globals VarSet, body Body) (Body, unsafeVars) {
+func reorderBodyForClosures(builtins map[string]*Builtin, arity func(Ref) int, globals VarSet, body Body) (Body, unsafeVars) {
 
 	reordered := Body{}
 	unsafe := unsafeVars{}
@@ -1785,7 +1883,7 @@ func reorderBodyForClosures(arity func(Ref) int, globals VarSet, body Body) (Bod
 			// contained in the output position of an expression in the reordered
 			// body. These vars are considered unsafe.
 			cv := vs.Intersect(body.Vars(safetyCheckVarVisitorParams)).Diff(globals)
-			uv := cv.Diff(outputVarsForBody(reordered, arity, globals))
+			uv := cv.Diff(outputVarsForBody(reordered, builtins, arity, globals))
 
 			if len(uv) == 0 {
 				reordered = append(reordered, e)
@@ -1803,15 +1901,15 @@ func reorderBodyForClosures(arity func(Ref) int, globals VarSet, body Body) (Bod
 	return reordered, unsafe
 }
 
-func outputVarsForBody(body Body, arity func(Ref) int, safe VarSet) VarSet {
+func outputVarsForBody(body Body, builtins map[string]*Builtin, arity func(Ref) int, safe VarSet) VarSet {
 	o := safe.Copy()
 	for _, e := range body {
-		o.Update(outputVarsForExpr(e, arity, o))
+		o.Update(outputVarsForExpr(e, builtins, arity, o))
 	}
 	return o.Diff(safe)
 }
 
-func outputVarsForExpr(expr *Expr, arity func(Ref) int, safe VarSet) VarSet {
+func outputVarsForExpr(expr *Expr, builtins map[string]*Builtin, arity func(Ref) int, safe VarSet) VarSet {
 
 	// Negated expressions must be safe.
 	if expr.Negated {
@@ -1840,14 +1938,14 @@ func outputVarsForExpr(expr *Expr, arity func(Ref) int, safe VarSet) VarSet {
 	terms := expr.Terms.([]*Term)
 	name := terms[0].String()
 
-	if b := BuiltinMap[name]; b != nil {
+	if b := builtins[name]; b != nil {
 		if b.Name == Equality.Name {
 			return outputVarsForExprEq(expr, safe)
 		}
 		return outputVarsForExprBuiltin(expr, b, safe)
 	}
 
-	return outputVarsForExprCall(expr, arity, safe, terms)
+	return outputVarsForExprCall(expr, builtins, arity, safe, terms)
 }
 
 func outputVarsForExprBuiltin(expr *Expr, b *Builtin, safe VarSet) VarSet {
@@ -1900,7 +1998,7 @@ func outputVarsForExprEq(expr *Expr, safe VarSet) VarSet {
 	return output.Diff(safe)
 }
 
-func outputVarsForExprCall(expr *Expr, arity func(Ref) int, safe VarSet, terms []*Term) VarSet {
+func outputVarsForExprCall(expr *Expr, builtins map[string]*Builtin, arity func(Ref) int, safe VarSet, terms []*Term) VarSet {
 
 	output := outputVarsForExprRefs(expr, safe)
 

--- a/vendor/github.com/open-policy-agent/opa/ast/fuzz.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/fuzz.go
@@ -1,0 +1,28 @@
+// +build gofuzz
+
+package ast
+
+import (
+	"regexp"
+)
+
+// nested { and [ tokens cause the parse time to explode.
+// see: https://github.com/mna/pigeon/issues/75
+var blacklistRegexp = regexp.MustCompile(`[{(\[]{5,}`)
+
+func Fuzz(data []byte) int {
+
+	if blacklistRegexp.Match(data) {
+		return -1
+	}
+
+	str := string(data)
+	_, _, err := ParseStatements("", str)
+
+	if err == nil {
+		CompileModules(map[string]string{"": str})
+		return 1
+	}
+
+	return 0
+}

--- a/vendor/github.com/open-policy-agent/opa/ast/term.go
+++ b/vendor/github.com/open-policy-agent/opa/ast/term.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"math/big"
 	"net/url"
 	"regexp"
 	"sort"
@@ -175,6 +177,20 @@ func InterfaceToValue(x interface{}) (Value, error) {
 	default:
 		return nil, fmt.Errorf("ast: illegal value: %T", x)
 	}
+}
+
+// ValueFromReader returns an AST value from a JSON serialized value in the reader.
+func ValueFromReader(r io.Reader) (Value, error) {
+	var x interface{}
+	if err := util.NewJSONDecoder(r).Decode(&x); err != nil {
+		return nil, err
+	}
+	return InterfaceToValue(x)
+}
+
+// As converts v into a Go native type referred to by x.
+func As(v Value, x interface{}) error {
+	return util.NewJSONDecoder(bytes.NewBufferString(v.String())).Decode(x)
 }
 
 // Resolver defines the interface for resolving references to native Go values.
@@ -376,6 +392,8 @@ func (term *Term) Equal(other *Term) bool {
 	case Null:
 		return v.Equal(other.Value)
 	case Boolean:
+		return v.Equal(other.Value)
+	case Number:
 		return v.Equal(other.Value)
 	case String:
 		return v.Equal(other.Value)
@@ -1426,8 +1444,48 @@ func (s *set) Slice() []*Term {
 
 func (s *set) insert(x *Term) {
 	hash := x.Hash()
+	var equal func(v Value) bool
+
+	switch x := x.Value.(type) {
+	case Null, Boolean, String, Var:
+		equal = func(y Value) bool { return x == y }
+	case Number:
+		if xi, err := json.Number(x).Int64(); err == nil {
+			equal = func(y Value) bool {
+				if y, ok := y.(Number); ok {
+					if yi, err := json.Number(y).Int64(); err == nil {
+						return xi == yi
+					}
+				}
+
+				return false
+			}
+			break
+		}
+
+		a, ok := new(big.Float).SetString(string(x))
+		if !ok {
+			panic("illegal value")
+		}
+
+		equal = func(b Value) bool {
+			if b, ok := b.(Number); ok {
+				b, ok := new(big.Float).SetString(string(b))
+				if !ok {
+					panic("illegal value")
+				}
+
+				return a.Cmp(b) == 0
+			}
+
+			return false
+		}
+	default:
+		equal = func(y Value) bool { return Compare(x, y) == 0 }
+	}
+
 	for curr, ok := s.elems[hash]; ok; {
-		if Compare(curr, x) == 0 {
+		if equal(curr.Value) {
 			return
 		}
 
@@ -1441,8 +1499,48 @@ func (s *set) insert(x *Term) {
 
 func (s *set) get(x *Term) *Term {
 	hash := x.Hash()
+	var equal func(v Value) bool
+
+	switch x := x.Value.(type) {
+	case Null, Boolean, String, Var:
+		equal = func(y Value) bool { return x == y }
+	case Number:
+		if xi, err := json.Number(x).Int64(); err == nil {
+			equal = func(y Value) bool {
+				if y, ok := y.(Number); ok {
+					if yi, err := json.Number(y).Int64(); err == nil {
+						return xi == yi
+					}
+				}
+
+				return false
+			}
+			break
+		}
+
+		a, ok := new(big.Float).SetString(string(x))
+		if !ok {
+			panic("illegal value")
+		}
+
+		equal = func(b Value) bool {
+			if b, ok := b.(Number); ok {
+				b, ok := new(big.Float).SetString(string(b))
+				if !ok {
+					panic("illegal value")
+				}
+
+				return a.Cmp(b) == 0
+			}
+
+			return false
+		}
+	default:
+		equal = func(y Value) bool { return Compare(x, y) == 0 }
+	}
+
 	for curr, ok := s.elems[hash]; ok; {
-		if Compare(curr, x) == 0 {
+		if equal(curr.Value) {
 			return curr
 		}
 
@@ -1747,8 +1845,49 @@ func (obj object) String() string {
 
 func (obj *object) get(k *Term) *objectElem {
 	hash := k.Hash()
+
+	var equal func(v Value) bool
+
+	switch x := k.Value.(type) {
+	case Null, Boolean, String, Var:
+		equal = func(y Value) bool { return x == y }
+	case Number:
+		if xi, err := json.Number(x).Int64(); err == nil {
+			equal = func(y Value) bool {
+				if y, ok := y.(Number); ok {
+					if yi, err := json.Number(y).Int64(); err == nil {
+						return xi == yi
+					}
+				}
+
+				return false
+			}
+			break
+		}
+
+		a, ok := new(big.Float).SetString(string(x))
+		if !ok {
+			panic("illegal value")
+		}
+
+		equal = func(b Value) bool {
+			if b, ok := b.(Number); ok {
+				b, ok := new(big.Float).SetString(string(b))
+				if !ok {
+					panic("illegal value")
+				}
+
+				return a.Cmp(b) == 0
+			}
+
+			return false
+		}
+	default:
+		equal = func(y Value) bool { return Compare(x, y) == 0 }
+	}
+
 	for curr := obj.elems[hash]; curr != nil; curr = curr.next {
-		if Compare(curr.key, k) == 0 {
+		if equal(curr.key.Value) {
 			return curr
 		}
 	}
@@ -1758,8 +1897,48 @@ func (obj *object) get(k *Term) *objectElem {
 func (obj *object) insert(k, v *Term) {
 	hash := k.Hash()
 	head := obj.elems[hash]
+	var equal func(v Value) bool
+
+	switch x := k.Value.(type) {
+	case Null, Boolean, String, Var:
+		equal = func(y Value) bool { return x == y }
+	case Number:
+		if xi, err := json.Number(x).Int64(); err == nil {
+			equal = func(y Value) bool {
+				if y, ok := y.(Number); ok {
+					if yi, err := json.Number(y).Int64(); err == nil {
+						return xi == yi
+					}
+				}
+
+				return false
+			}
+			break
+		}
+
+		a, ok := new(big.Float).SetString(string(x))
+		if !ok {
+			panic("illegal value")
+		}
+
+		equal = func(b Value) bool {
+			if b, ok := b.(Number); ok {
+				b, ok := new(big.Float).SetString(string(b))
+				if !ok {
+					panic("illegal value")
+				}
+
+				return a.Cmp(b) == 0
+			}
+
+			return false
+		}
+	default:
+		equal = func(y Value) bool { return Compare(x, y) == 0 }
+	}
+
 	for curr := head; curr != nil; curr = curr.next {
-		if Compare(curr.key, k) == 0 {
+		if equal(curr.key.Value) {
 			curr.value = v
 			return
 		}

--- a/vendor/github.com/open-policy-agent/opa/bundle/bundle.go
+++ b/vendor/github.com/open-policy-agent/opa/bundle/bundle.go
@@ -1,0 +1,432 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package bundle implements bundle loading.
+package bundle
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/open-policy-agent/opa/internal/file/archive"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/internal/file"
+	"github.com/open-policy-agent/opa/util"
+	"github.com/pkg/errors"
+)
+
+// Common file extensions and file names.
+const (
+	RegoExt      = ".rego"
+	manifestExt  = ".manifest"
+	dataFile     = "data.json"
+	yamlDataFile = "data.yaml"
+)
+
+const bundleLimitBytes = (1024 * 1024 * 1024) + 1 // limit bundle reads to 1GB to protect against gzip bombs
+
+// Bundle represents a loaded bundle. The bundle can contain data and policies.
+type Bundle struct {
+	Manifest Manifest
+	Data     map[string]interface{}
+	Modules  []ModuleFile
+}
+
+// Manifest represents the manifest from a bundle. The manifest may contain
+// metadata such as the bundle revision.
+type Manifest struct {
+	Revision string    `json:"revision"`
+	Roots    *[]string `json:"roots,omitempty"`
+}
+
+// Init initializes the manifest. If you instantiate a manifest
+// manually, call Init to ensure that the roots are set properly.
+func (m *Manifest) Init() {
+	if m.Roots == nil {
+		defaultRoots := []string{""}
+		m.Roots = &defaultRoots
+	}
+}
+
+func (m *Manifest) validateAndInjectDefaults(b Bundle) error {
+
+	m.Init()
+
+	// Validate roots in bundle.
+	roots := *m.Roots
+
+	// Standardize the roots (no starting or trailing slash)
+	for i := range roots {
+		roots[i] = strings.Trim(roots[i], "/")
+	}
+
+	for i := 0; i < len(roots)-1; i++ {
+		for j := i + 1; j < len(roots); j++ {
+			if RootPathsOverlap(roots[i], roots[j]) {
+				return fmt.Errorf("manifest has overlapped roots: %v and %v", roots[i], roots[j])
+			}
+		}
+	}
+
+	// Validate modules in bundle.
+	for _, module := range b.Modules {
+		found := false
+		if path, err := module.Parsed.Package.Path.Ptr(); err == nil {
+			for i := range roots {
+				if strings.HasPrefix(path, roots[i]) {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			return fmt.Errorf("manifest roots do not permit '%v' in %v", module.Parsed.Package, module.Path)
+		}
+	}
+
+	// Validate data in bundle.
+	return dfs(b.Data, "", func(path string, node interface{}) (bool, error) {
+		path = strings.Trim(path, "/")
+		for i := range roots {
+			if strings.HasPrefix(path, roots[i]) {
+				return true, nil
+			}
+		}
+		if _, ok := node.(map[string]interface{}); ok {
+			for i := range roots {
+				if strings.HasPrefix(roots[i], path) {
+					return false, nil
+				}
+			}
+		}
+		return false, fmt.Errorf("manifest roots do not permit data at path %v", path)
+	})
+}
+
+// ModuleFile represents a single module contained a bundle.
+type ModuleFile struct {
+	Path   string
+	Raw    []byte
+	Parsed *ast.Module
+}
+
+// Reader contains the reader to load the bundle from.
+type Reader struct {
+	loader                file.DirectoryLoader
+	includeManifestInData bool
+}
+
+// NewReader returns a new Reader.
+// Deprecated: Use NewCustomReader with TarballLoader instead
+func NewReader(r io.Reader) *Reader {
+	return NewCustomReader(file.NewTarballLoader(r))
+}
+
+// NewCustomReader returns a new Reader configured to use the
+// specified DirectoryLoader.
+func NewCustomReader(loader file.DirectoryLoader) *Reader {
+	nr := Reader{
+		loader: loader,
+	}
+	return &nr
+}
+
+// IncludeManifestInData sets whether the manifest metadata should be
+// included in the bundle's data.
+func (r *Reader) IncludeManifestInData(includeManifestInData bool) *Reader {
+	r.includeManifestInData = includeManifestInData
+	return r
+}
+
+// Read returns a new Bundle loaded from the reader.
+func (r *Reader) Read() (Bundle, error) {
+
+	var bundle Bundle
+
+	bundle.Data = map[string]interface{}{}
+
+	for {
+		f, err := r.loader.NextFile()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return bundle, errors.Wrap(err, "bundle read failed")
+		}
+
+		var buf bytes.Buffer
+		n, err := f.Read(&buf, bundleLimitBytes)
+		f.Close() // always close, even on error
+		if err != nil && err != io.EOF {
+			return bundle, err
+		} else if err == nil && n >= bundleLimitBytes {
+			return bundle, fmt.Errorf("bundle exceeded max size (%v bytes)", bundleLimitBytes-1)
+		}
+
+		// Normalize the paths to use `/` separators
+		path := filepath.ToSlash(f.Path())
+
+		if strings.HasSuffix(path, RegoExt) {
+			module, err := ast.ParseModule(path, buf.String())
+			if err != nil {
+				return bundle, err
+			}
+			if module == nil {
+				return bundle, fmt.Errorf("module '%s' is empty", path)
+			}
+
+			mf := ModuleFile{
+				Path:   path,
+				Raw:    buf.Bytes(),
+				Parsed: module,
+			}
+			bundle.Modules = append(bundle.Modules, mf)
+
+		} else if filepath.Base(path) == dataFile {
+			var value interface{}
+			if err := util.NewJSONDecoder(&buf).Decode(&value); err != nil {
+				return bundle, errors.Wrapf(err, "bundle load failed on %v", path)
+			}
+
+			if err := insertValue(&bundle, path, value); err != nil {
+				return bundle, err
+			}
+
+		} else if filepath.Base(path) == yamlDataFile {
+
+			var value interface{}
+			if err := util.Unmarshal(buf.Bytes(), &value); err != nil {
+				return bundle, errors.Wrapf(err, "bundle load failed on %v", path)
+			}
+
+			if err := insertValue(&bundle, path, value); err != nil {
+				return bundle, err
+			}
+
+		} else if strings.HasSuffix(path, manifestExt) {
+			if err := util.NewJSONDecoder(&buf).Decode(&bundle.Manifest); err != nil {
+				return bundle, errors.Wrap(err, "bundle load failed on manifest decode")
+			}
+		}
+	}
+
+	if err := bundle.Manifest.validateAndInjectDefaults(bundle); err != nil {
+		return bundle, err
+	}
+
+	if r.includeManifestInData {
+		var metadata map[string]interface{}
+
+		b, err := json.Marshal(&bundle.Manifest)
+		if err != nil {
+			return bundle, errors.Wrap(err, "bundle load failed on manifest marshal")
+		}
+
+		err = util.UnmarshalJSON(b, &metadata)
+		if err != nil {
+			return bundle, errors.Wrap(err, "bundle load failed on manifest unmarshal")
+		}
+
+		// For backwards compatibility always write to the old unnamed manifest path
+		// This will *not* be correct if >1 bundle is in use...
+		if err := bundle.insert(legacyManifestStoragePath, metadata); err != nil {
+			return bundle, errors.Wrapf(err, "bundle load failed on %v", legacyRevisionStoragePath)
+		}
+	}
+
+	return bundle, nil
+}
+
+// Write serializes the Bundle and writes it to w.
+func Write(w io.Writer, bundle Bundle) error {
+	gw := gzip.NewWriter(w)
+	tw := tar.NewWriter(gw)
+
+	var buf bytes.Buffer
+
+	if err := json.NewEncoder(&buf).Encode(bundle.Data); err != nil {
+		return err
+	}
+
+	if err := archive.WriteFile(tw, "data.json", buf.Bytes()); err != nil {
+		return err
+	}
+
+	for _, module := range bundle.Modules {
+		if err := archive.WriteFile(tw, module.Path, module.Raw); err != nil {
+			return err
+		}
+	}
+
+	if err := writeManifest(tw, bundle); err != nil {
+		return err
+	}
+
+	if err := tw.Close(); err != nil {
+		return err
+	}
+
+	return gw.Close()
+}
+
+func writeManifest(tw *tar.Writer, bundle Bundle) error {
+
+	var buf bytes.Buffer
+
+	if err := json.NewEncoder(&buf).Encode(bundle.Manifest); err != nil {
+		return err
+	}
+
+	return archive.WriteFile(tw, manifestExt, buf.Bytes())
+}
+
+// ParsedModules returns a map of parsed modules with names that are
+// unique and human readable for the given a bundle name.
+func (b *Bundle) ParsedModules(bundleName string) map[string]*ast.Module {
+
+	mods := make(map[string]*ast.Module, len(b.Modules))
+
+	for _, mf := range b.Modules {
+		mods[modulePathWithPrefix(bundleName, mf.Path)] = mf.Parsed
+	}
+
+	return mods
+}
+
+// Equal returns true if this bundle's contents equal the other bundle's
+// contents.
+func (b Bundle) Equal(other Bundle) bool {
+	if !reflect.DeepEqual(b.Data, other.Data) {
+		return false
+	}
+	if len(b.Modules) != len(other.Modules) {
+		return false
+	}
+	for i := range b.Modules {
+		if b.Modules[i].Path != other.Modules[i].Path {
+			return false
+		}
+		if !b.Modules[i].Parsed.Equal(other.Modules[i].Parsed) {
+			return false
+		}
+		if !bytes.Equal(b.Modules[i].Raw, other.Modules[i].Raw) {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *Bundle) insert(key []string, value interface{}) error {
+	if len(key) == 0 {
+		obj, ok := value.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("root value must be object")
+		}
+		b.Data = obj
+		return nil
+	}
+
+	obj, err := b.mkdir(key[:len(key)-1])
+	if err != nil {
+		return err
+	}
+
+	obj[key[len(key)-1]] = value
+	return nil
+}
+
+func (b *Bundle) mkdir(key []string) (map[string]interface{}, error) {
+	obj := b.Data
+	for i := 0; i < len(key); i++ {
+		node, ok := obj[key[i]]
+		if !ok {
+			node = map[string]interface{}{}
+			obj[key[i]] = node
+		}
+		obj, ok = node.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("non-leaf value must be object")
+		}
+	}
+	return obj, nil
+}
+
+// RootPathsOverlap takes in two bundle root paths and returns
+// true if they overlap.
+func RootPathsOverlap(pathA string, pathB string) bool {
+
+	// Special case for empty prefixes, they always overlap
+	if pathA == "" || pathB == "" {
+		return true
+	}
+
+	aParts := strings.Split(pathA, "/")
+	bParts := strings.Split(pathB, "/")
+
+	for i := 0; i < len(aParts) && i < len(bParts); i++ {
+		if aParts[i] != bParts[i] {
+			// Found diverging path segments, no overlap
+			return false
+		}
+	}
+	return true
+}
+
+func insertValue(b *Bundle, path string, value interface{}) error {
+
+	// Remove leading / and . characters from the directory path. If the bundle
+	// was written with OPA then the paths will contain a leading slash. On the
+	// other hand, if the path is empty, filepath.Dir will return '.'.
+	dirpath := strings.TrimLeft(filepath.Dir(path), "/.")
+	var key []string
+	if dirpath != "" {
+		key = strings.Split(dirpath, "/")
+	}
+	if err := b.insert(key, value); err != nil {
+		return errors.Wrapf(err, "bundle load failed on %v", path)
+	}
+
+	return nil
+}
+
+func dfs(value interface{}, path string, fn func(string, interface{}) (bool, error)) error {
+	if stop, err := fn(path, value); err != nil {
+		return err
+	} else if stop {
+		return nil
+	}
+	obj, ok := value.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	for key := range obj {
+		if err := dfs(obj[key], path+"/"+key, fn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func modulePathWithPrefix(bundleName string, modulePath string) string {
+	// Default prefix is just the bundle name
+	prefix := bundleName
+
+	// Bundle names are sometimes just file paths, some of which
+	// are full urls (file:///foo/). Parse these and only use the path.
+	parsed, err := url.Parse(bundleName)
+	if err == nil {
+		prefix = filepath.Join(parsed.Host, parsed.Path)
+	}
+
+	return filepath.Join(prefix, modulePath)
+}

--- a/vendor/github.com/open-policy-agent/opa/bundle/store.go
+++ b/vendor/github.com/open-policy-agent/opa/bundle/store.go
@@ -1,0 +1,526 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package bundle
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/open-policy-agent/opa/metrics"
+
+	"github.com/open-policy-agent/opa/ast"
+
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/util"
+)
+
+var bundlesBasePath = storage.MustParsePath("/system/bundles")
+
+// Note: As needed these helpers could be memoized.
+
+// ManifestStoragePath is the storage path used for the given named bundle manifest.
+func ManifestStoragePath(name string) storage.Path {
+	return append(bundlesBasePath, name, "manifest")
+}
+
+func namedBundlePath(name string) storage.Path {
+	return append(bundlesBasePath, name)
+}
+
+func rootsPath(name string) storage.Path {
+	return append(bundlesBasePath, name, "manifest", "roots")
+}
+
+func revisionPath(name string) storage.Path {
+	return append(bundlesBasePath, name, "manifest", "revision")
+}
+
+// ReadBundleNamesFromStore will return a list of bundle names which have had their metadata stored.
+func ReadBundleNamesFromStore(ctx context.Context, store storage.Store, txn storage.Transaction) ([]string, error) {
+	value, err := store.Read(ctx, txn, bundlesBasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	bundleMap, ok := value.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("corrupt manifest roots")
+	}
+
+	bundles := make([]string, len(bundleMap))
+	idx := 0
+	for name := range bundleMap {
+		bundles[idx] = name
+		idx++
+	}
+	return bundles, nil
+}
+
+// WriteManifestToStore will write the manifest into the storage. This function is called when
+// the bundle is activated.
+func WriteManifestToStore(ctx context.Context, store storage.Store, txn storage.Transaction, name string, manifest Manifest) error {
+	return write(ctx, store, txn, ManifestStoragePath(name), manifest)
+}
+
+func write(ctx context.Context, store storage.Store, txn storage.Transaction, path storage.Path, manifest Manifest) error {
+	var value interface{} = manifest
+	if err := util.RoundTrip(&value); err != nil {
+		return err
+	}
+
+	var dir []string
+	if len(path) > 1 {
+		dir = path[:len(path)-1]
+	}
+
+	if err := storage.MakeDir(ctx, store, txn, dir); err != nil {
+		return err
+	}
+
+	return store.Write(ctx, txn, storage.AddOp, path, value)
+}
+
+// EraseManifestFromStore will remove the manifest from storage. This function is called
+// when the bundle is deactivated.
+func EraseManifestFromStore(ctx context.Context, store storage.Store, txn storage.Transaction, name string) error {
+	path := namedBundlePath(name)
+	err := store.Write(ctx, txn, storage.RemoveOp, path, nil)
+	if err != nil && !storage.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+// ReadBundleRootsFromStore returns the roots in the specified bundle.
+// If the bundle is not activated, this function will return
+// storage NotFound error.
+func ReadBundleRootsFromStore(ctx context.Context, store storage.Store, txn storage.Transaction, name string) ([]string, error) {
+	value, err := store.Read(ctx, txn, rootsPath(name))
+	if err != nil {
+		return nil, err
+	}
+
+	sl, ok := value.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("corrupt manifest roots")
+	}
+
+	roots := make([]string, len(sl))
+
+	for i := range sl {
+		roots[i], ok = sl[i].(string)
+		if !ok {
+			return nil, fmt.Errorf("corrupt manifest root")
+		}
+	}
+
+	return roots, nil
+}
+
+// ReadBundleRevisionFromStore returns the revision in the specified bundle.
+// If the bundle is not activated, this function will return
+// storage NotFound error.
+func ReadBundleRevisionFromStore(ctx context.Context, store storage.Store, txn storage.Transaction, name string) (string, error) {
+	return readRevisionFromStore(ctx, store, txn, revisionPath(name))
+}
+
+func readRevisionFromStore(ctx context.Context, store storage.Store, txn storage.Transaction, path storage.Path) (string, error) {
+	value, err := store.Read(ctx, txn, path)
+	if err != nil {
+		return "", err
+	}
+
+	str, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("corrupt manifest revision")
+	}
+
+	return str, nil
+}
+
+// ActivateOpts defines options for the Activate API call.
+type ActivateOpts struct {
+	Ctx          context.Context
+	Store        storage.Store
+	Txn          storage.Transaction
+	Compiler     *ast.Compiler
+	Metrics      metrics.Metrics
+	Bundles      map[string]*Bundle     // Optional
+	ExtraModules map[string]*ast.Module // Optional
+
+	legacy bool
+}
+
+// Activate the bundle(s) by loading into the given Store. This will load policies, data, and record
+// the manifest in storage. The compiler provided will have had the polices compiled on it.
+func Activate(opts *ActivateOpts) error {
+	opts.legacy = false
+	return activateBundles(opts)
+}
+
+// DeactivateOpts defines options for the Deactivate API call
+type DeactivateOpts struct {
+	Ctx         context.Context
+	Store       storage.Store
+	Txn         storage.Transaction
+	BundleNames map[string]struct{}
+}
+
+// Deactivate the bundle(s). This will erase associated data, policies, and the manifest entry from the store.
+func Deactivate(opts *DeactivateOpts) error {
+	erase := map[string]struct{}{}
+	for name := range opts.BundleNames {
+		if roots, err := ReadBundleRootsFromStore(opts.Ctx, opts.Store, opts.Txn, name); err == nil {
+			for _, root := range roots {
+				erase[root] = struct{}{}
+			}
+		} else if !storage.IsNotFound(err) {
+			return err
+		}
+	}
+	_, err := eraseBundles(opts.Ctx, opts.Store, opts.Txn, opts.BundleNames, erase)
+	return err
+}
+
+func activateBundles(opts *ActivateOpts) error {
+
+	// Build collections of bundle names, modules, and roots to erase
+	erase := map[string]struct{}{}
+	names := map[string]struct{}{}
+
+	for name, b := range opts.Bundles {
+		names[name] = struct{}{}
+
+		if roots, err := ReadBundleRootsFromStore(opts.Ctx, opts.Store, opts.Txn, name); err == nil {
+			for _, root := range roots {
+				erase[root] = struct{}{}
+			}
+		} else if !storage.IsNotFound(err) {
+			return err
+		}
+
+		// Erase data at new roots to prepare for writing the new data
+		for _, root := range *b.Manifest.Roots {
+			erase[root] = struct{}{}
+		}
+	}
+
+	// Before changing anything make sure the roots don't collide with any
+	// other bundles that already are activated or other bundles being activated.
+	err := hasRootsOverlap(opts.Ctx, opts.Store, opts.Txn, opts.Bundles)
+	if err != nil {
+		return err
+	}
+
+	// Erase data and policies at new + old roots, and remove the old
+	// manifests before activating a new bundles.
+	remaining, err := eraseBundles(opts.Ctx, opts.Store, opts.Txn, names, erase)
+	if err != nil {
+		return err
+	}
+
+	for _, b := range opts.Bundles {
+		// Write data from each new bundle into the store. Only write under the
+		// roots contained in their manifest. This should be done *before* the
+		// policies so that path conflict checks can occur.
+		if err := writeData(opts.Ctx, opts.Store, opts.Txn, *b.Manifest.Roots, b.Data); err != nil {
+			return err
+		}
+	}
+
+	// Write and compile the modules all at once to avoid having to re-do work.
+	remainingAndExtra := make(map[string]*ast.Module)
+	for name, mod := range remaining {
+		remainingAndExtra[name] = mod
+	}
+	for name, mod := range opts.ExtraModules {
+		remainingAndExtra[name] = mod
+	}
+
+	err = writeModules(opts.Ctx, opts.Store, opts.Txn, opts.Compiler, opts.Metrics, opts.Bundles, remainingAndExtra, opts.legacy)
+	if err != nil {
+		return err
+	}
+
+	for name, b := range opts.Bundles {
+		// Always write manifests to the named location. If the plugin is in the older style config
+		// then also write to the old legacy unnamed location.
+		if err := WriteManifestToStore(opts.Ctx, opts.Store, opts.Txn, name, b.Manifest); err != nil {
+			return err
+		}
+		if opts.legacy {
+			if err := LegacyWriteManifestToStore(opts.Ctx, opts.Store, opts.Txn, b.Manifest); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// erase bundles by name and roots. This will clear all policies and data at its roots and remove its
+// manifest from storage.
+func eraseBundles(ctx context.Context, store storage.Store, txn storage.Transaction, names map[string]struct{}, roots map[string]struct{}) (map[string]*ast.Module, error) {
+
+	if err := eraseData(ctx, store, txn, roots); err != nil {
+		return nil, err
+	}
+
+	remaining, err := erasePolicies(ctx, store, txn, roots)
+	if err != nil {
+		return nil, err
+	}
+
+	for name := range names {
+		if err := EraseManifestFromStore(ctx, store, txn, name); err != nil && !storage.IsNotFound(err) {
+			return nil, err
+		}
+
+		if err := LegacyEraseManifestFromStore(ctx, store, txn); err != nil && !storage.IsNotFound(err) {
+			return nil, err
+		}
+	}
+
+	return remaining, nil
+}
+
+func eraseData(ctx context.Context, store storage.Store, txn storage.Transaction, roots map[string]struct{}) error {
+	for root := range roots {
+		path, ok := storage.ParsePathEscaped("/" + root)
+		if !ok {
+			return fmt.Errorf("manifest root path invalid: %v", root)
+		}
+		if len(path) > 0 {
+			if err := store.Write(ctx, txn, storage.RemoveOp, path, nil); err != nil {
+				if !storage.IsNotFound(err) {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func erasePolicies(ctx context.Context, store storage.Store, txn storage.Transaction, roots map[string]struct{}) (map[string]*ast.Module, error) {
+
+	ids, err := store.ListPolicies(ctx, txn)
+	if err != nil {
+		return nil, err
+	}
+
+	remaining := map[string]*ast.Module{}
+
+	for _, id := range ids {
+		bs, err := store.GetPolicy(ctx, txn, id)
+		if err != nil {
+			return nil, err
+		}
+		module, err := ast.ParseModule(id, string(bs))
+		if err != nil {
+			return nil, err
+		}
+		path, err := module.Package.Path.Ptr()
+		if err != nil {
+			return nil, err
+		}
+		deleted := false
+		for root := range roots {
+			if strings.HasPrefix(path, root) {
+				if err := store.DeletePolicy(ctx, txn, id); err != nil {
+					return nil, err
+				}
+				deleted = true
+				break
+			}
+		}
+		if !deleted {
+			remaining[id] = module
+		}
+	}
+
+	return remaining, nil
+}
+
+func writeData(ctx context.Context, store storage.Store, txn storage.Transaction, roots []string, data map[string]interface{}) error {
+	for _, root := range roots {
+		path, ok := storage.ParsePathEscaped("/" + root)
+		if !ok {
+			return fmt.Errorf("manifest root path invalid: %v", root)
+		}
+		if value, ok := lookup(path, data); ok {
+			if len(path) > 0 {
+				if err := storage.MakeDir(ctx, store, txn, path[:len(path)-1]); err != nil {
+					return err
+				}
+			}
+			if err := store.Write(ctx, txn, storage.AddOp, path, value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeModules(ctx context.Context, store storage.Store, txn storage.Transaction, compiler *ast.Compiler, m metrics.Metrics, bundles map[string]*Bundle, extraModules map[string]*ast.Module, legacy bool) error {
+
+	m.Timer(metrics.RegoModuleCompile)
+	defer m.Timer(metrics.RegoModuleCompile)
+
+	modules := map[string]*ast.Module{}
+
+	// preserve any modules already on the compiler
+	for name, module := range compiler.Modules {
+		modules[name] = module
+	}
+
+	// preserve any modules passed in from the store
+	for name, module := range extraModules {
+		modules[name] = module
+	}
+
+	// include all the new bundle modules
+	for bundleName, b := range bundles {
+		if legacy {
+			for _, mf := range b.Modules {
+				modules[mf.Path] = mf.Parsed
+			}
+		} else {
+			for name, module := range b.ParsedModules(bundleName) {
+				modules[name] = module
+			}
+		}
+	}
+
+	if compiler.Compile(modules); compiler.Failed() {
+		return compiler.Errors
+	}
+	for bundleName, b := range bundles {
+		for _, mf := range b.Modules {
+			var path string
+
+			// For backwards compatibility, in legacy mode, upsert policies to
+			// the unprefixed path.
+			if legacy {
+				path = mf.Path
+			} else {
+				path = modulePathWithPrefix(bundleName, mf.Path)
+			}
+
+			if err := store.UpsertPolicy(ctx, txn, path, mf.Raw); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func lookup(path storage.Path, data map[string]interface{}) (interface{}, bool) {
+	if len(path) == 0 {
+		return data, true
+	}
+	for i := 0; i < len(path)-1; i++ {
+		value, ok := data[path[i]]
+		if !ok {
+			return nil, false
+		}
+		obj, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		data = obj
+	}
+	value, ok := data[path[len(path)-1]]
+	return value, ok
+}
+
+func hasRootsOverlap(ctx context.Context, store storage.Store, txn storage.Transaction, bundles map[string]*Bundle) error {
+	collisions := map[string][]string{}
+	allBundles, err := ReadBundleNamesFromStore(ctx, store, txn)
+	if err != nil && !storage.IsNotFound(err) {
+		return err
+	}
+
+	allRoots := map[string][]string{}
+
+	// Build a map of roots for existing bundles already in the system
+	for _, name := range allBundles {
+		roots, err := ReadBundleRootsFromStore(ctx, store, txn, name)
+		if err != nil && !storage.IsNotFound(err) {
+			return err
+		}
+		allRoots[name] = roots
+	}
+
+	// Add in any bundles that are being activated, overwrite existing roots
+	// with new ones where bundles are in both groups.
+	for name, bundle := range bundles {
+		allRoots[name] = *bundle.Manifest.Roots
+	}
+
+	// Now check for each new bundle if it conflicts with any of the others
+	for name, bundle := range bundles {
+		for otherBundle, otherRoots := range allRoots {
+			if name == otherBundle {
+				// Skip the current bundle being checked
+				continue
+			}
+
+			// Compare the "new" roots with other existing (or a different bundles new roots)
+			for _, newRoot := range *bundle.Manifest.Roots {
+				for _, otherRoot := range otherRoots {
+					if RootPathsOverlap(newRoot, otherRoot) {
+						collisions[otherBundle] = append(collisions[otherBundle], newRoot)
+					}
+				}
+			}
+		}
+	}
+
+	if len(collisions) > 0 {
+		var bundleNames []string
+		for name := range collisions {
+			bundleNames = append(bundleNames, name)
+		}
+		return fmt.Errorf("detected overlapping roots in bundle manifest with: %s", bundleNames)
+	}
+	return nil
+}
+
+// Helpers for the older single (unnamed) bundle style manifest storage.
+
+// LegacyManifestStoragePath is the older unnamed bundle path for manifests to be stored.
+// Deprecated: Use ManifestStoragePath and named bundles instead.
+var legacyManifestStoragePath = storage.MustParsePath("/system/bundle/manifest")
+var legacyRevisionStoragePath = append(legacyManifestStoragePath, "revision")
+
+// LegacyWriteManifestToStore will write the bundle manifest to the older single (unnamed) bundle manifest location.
+// Deprecated: Use WriteManifestToStore and named bundles instead.
+func LegacyWriteManifestToStore(ctx context.Context, store storage.Store, txn storage.Transaction, manifest Manifest) error {
+	return write(ctx, store, txn, legacyManifestStoragePath, manifest)
+}
+
+// LegacyEraseManifestFromStore will erase the bundle manifest from the older single (unnamed) bundle manifest location.
+// Deprecated: Use WriteManifestToStore and named bundles instead.
+func LegacyEraseManifestFromStore(ctx context.Context, store storage.Store, txn storage.Transaction) error {
+	err := store.Write(ctx, txn, storage.RemoveOp, legacyManifestStoragePath, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// LegacyReadRevisionFromStore will read the bundle manifest revision from the older single (unnamed) bundle manifest location.
+// Deprecated: Use ReadBundleRevisionFromStore and named bundles instead.
+func LegacyReadRevisionFromStore(ctx context.Context, store storage.Store, txn storage.Transaction) (string, error) {
+	return readRevisionFromStore(ctx, store, txn, legacyRevisionStoragePath)
+}
+
+// ActivateLegacy calls Activate for the bundles but will also write their manifest to the older unnamed store location.
+// Deprecated: Use Activate with named bundles instead.
+func ActivateLegacy(opts *ActivateOpts) error {
+	opts.legacy = true
+	return activateBundles(opts)
+}

--- a/vendor/github.com/open-policy-agent/opa/internal/file/archive/tarball.go
+++ b/vendor/github.com/open-policy-agent/opa/internal/file/archive/tarball.go
@@ -1,0 +1,42 @@
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"strings"
+)
+
+// MustWriteTarGz write the list of file names and content
+// into a tarball.
+func MustWriteTarGz(files [][2]string) *bytes.Buffer {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+	for _, file := range files {
+		if err := WriteFile(tw, file[0], []byte(file[1])); err != nil {
+			panic(err)
+		}
+	}
+	return &buf
+}
+
+// WriteFile adds a file header with content to the given tar writer
+func WriteFile(tw *tar.Writer, path string, bs []byte) error {
+
+	hdr := &tar.Header{
+		Name:     "/" + strings.TrimLeft(path, "/"),
+		Mode:     0600,
+		Typeflag: tar.TypeReg,
+		Size:     int64(len(bs)),
+	}
+
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+
+	_, err := tw.Write(bs)
+	return err
+}

--- a/vendor/github.com/open-policy-agent/opa/internal/file/loader.go
+++ b/vendor/github.com/open-policy-agent/opa/internal/file/loader.go
@@ -1,0 +1,166 @@
+package file
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// Descriptor contains information about a file and
+// can be used to read the file contents.
+type Descriptor struct {
+	path      string
+	reader    io.Reader
+	closer    io.Closer
+	closeOnce *sync.Once
+}
+
+func newDescriptor(path string, reader io.Reader) *Descriptor {
+	return &Descriptor{
+		path:   path,
+		reader: reader,
+	}
+}
+
+func (d *Descriptor) withCloser(closer io.Closer) *Descriptor {
+	d.closer = closer
+	d.closeOnce = new(sync.Once)
+	return d
+}
+
+// Path returns the path of the file.
+func (d *Descriptor) Path() string {
+	return d.path
+}
+
+// Read will read all the contents from the file the Descriptor refers to
+// into the dest writer up n bytes. Will return an io.EOF error
+// if EOF is encountered before n bytes are read.
+func (d *Descriptor) Read(dest io.Writer, n int64) (int64, error) {
+	n, err := io.CopyN(dest, d.reader, n)
+	return n, err
+}
+
+// Close the file, on some Loader implementations this might be a no-op.
+// It should *always* be called regardless of file.
+func (d *Descriptor) Close() error {
+	var err error
+	if d.closer != nil {
+		d.closeOnce.Do(func() {
+			err = d.closer.Close()
+		})
+	}
+	return err
+}
+
+// DirectoryLoader defines an interface which can be used to load
+// files from a directory by iterating over each one in the tree.
+type DirectoryLoader interface {
+	// NextFile must return io.EOF if there is no next value. The returned
+	// descriptor should *always* be closed when no longer needed.
+	NextFile() (*Descriptor, error)
+}
+
+type dirLoader struct {
+	root  string
+	files []string
+	idx   int
+}
+
+// NewDirectoryLoader returns a basic DirectoryLoader implementation
+// that will load files from a given root directory path.
+func NewDirectoryLoader(root string) DirectoryLoader {
+	d := dirLoader{
+		root: root,
+	}
+	return &d
+}
+
+// NextFile iterates to the next file in the directory tree
+// and returns a file Descriptor for the file.
+func (d *dirLoader) NextFile() (*Descriptor, error) {
+	// build a list of all files we will iterate over and read, but only one time
+	if d.files == nil {
+		d.files = []string{}
+		err := filepath.Walk(d.root, func(path string, info os.FileInfo, err error) error {
+			if info != nil && info.Mode().IsRegular() {
+				d.files = append(d.files, path)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to list files")
+		}
+	}
+
+	// If done reading files then just return io.EOF
+	// errors for each NextFile() call
+	if d.idx >= len(d.files) {
+		return nil, io.EOF
+	}
+
+	fileName := d.files[d.idx]
+	d.idx++
+	fh, err := os.Open(fileName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open file %s", fileName)
+	}
+
+	// Trim off the root directory and return path as if chrooted
+	cleanedPath := strings.TrimPrefix(fileName, d.root)
+	if !strings.HasPrefix(cleanedPath, "/") {
+		cleanedPath = "/" + cleanedPath
+	}
+
+	f := newDescriptor(cleanedPath, fh).withCloser(fh)
+	return f, nil
+}
+
+type tarballLoader struct {
+	r  io.Reader
+	tr *tar.Reader
+}
+
+// NewTarballLoader returns a new DirectoryLoader that reads
+// files out of a gzipped tar archive.
+func NewTarballLoader(r io.Reader) DirectoryLoader {
+	l := tarballLoader{
+		r: r,
+	}
+	return &l
+}
+
+// NextFile iterates to the next file in the directory tree
+// and returns a file Descriptor for the file.
+func (t *tarballLoader) NextFile() (*Descriptor, error) {
+	if t.tr == nil {
+		gr, err := gzip.NewReader(t.r)
+		if err != nil {
+			return nil, errors.Wrap(err, "archive read failed")
+		}
+
+		t.tr = tar.NewReader(gr)
+	}
+
+	for {
+		header, err := t.tr.Next()
+		// Eventually we will get an io.EOF error when finished
+		// iterating through the archive
+		if err != nil {
+			return nil, err
+		}
+
+		// Keep iterating on the archive until we find a normal file
+		if header.Typeflag == tar.TypeReg {
+			// no need to close this descriptor after reading
+			f := newDescriptor(header.Name, t.tr)
+			return f, nil
+		}
+	}
+}

--- a/vendor/github.com/open-policy-agent/opa/internal/file/url/url.go
+++ b/vendor/github.com/open-policy-agent/opa/internal/file/url/url.go
@@ -1,0 +1,42 @@
+// Copyright 2019 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package url contains helpers for dealing with file paths and URLs.
+package url
+
+import (
+	"fmt"
+	"net/url"
+	"runtime"
+	"strings"
+)
+
+var goos = runtime.GOOS
+
+// Clean returns a cleaned file path that may or may not be a URL.
+func Clean(path string) (string, error) {
+
+	if strings.Contains(path, "://") {
+
+		url, err := url.Parse(path)
+		if err != nil {
+			return "", err
+		}
+
+		if url.Scheme != "file" {
+			return "", fmt.Errorf("unsupported URL scheme: %v", path)
+		}
+
+		path = url.Path
+
+		// Trim leading slash on Windows if present. The url.Path field returned
+		// by url.Parse has leading slash that causes CreateFile() calls to fail
+		// on Windows. See https://github.com/golang/go/issues/6027 for details.
+		if goos == "windows" && len(path) >= 1 && path[0] == '/' {
+			path = path[1:]
+		}
+	}
+
+	return path, nil
+}

--- a/vendor/github.com/open-policy-agent/opa/internal/wasm/encoding/reader.go
+++ b/vendor/github.com/open-policy-agent/opa/internal/wasm/encoding/reader.go
@@ -142,7 +142,7 @@ func readSections(r io.Reader, m *module.Module) error {
 
 		switch id {
 		case constant.CustomSectionID, constant.ElementSectionID, constant.StartSectionID, constant.MemorySectionID:
-			break
+			continue
 		case constant.TypeSectionID:
 			if err := readTypeSection(bufr, &m.Type); err != nil {
 				return errors.Wrap(err, "type section")

--- a/vendor/github.com/open-policy-agent/opa/loader/errors.go
+++ b/vendor/github.com/open-policy-agent/opa/loader/errors.go
@@ -1,0 +1,74 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package loader
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+type loaderErrors []error
+
+func (e loaderErrors) Error() string {
+	if len(e) == 0 {
+		return "no error(s)"
+	}
+	if len(e) == 1 {
+		return "1 error occurred during loading: " + e[0].Error()
+	}
+	buf := make([]string, len(e))
+	for i := range buf {
+		buf[i] = e[i].Error()
+	}
+	return fmt.Sprintf("%v errors occurred during loading:\n", len(e)) + strings.Join(buf, "\n")
+}
+
+func (e *loaderErrors) Add(err error) {
+	if errs, ok := err.(ast.Errors); ok {
+		for i := range errs {
+			*e = append(*e, errs[i])
+		}
+	} else {
+		*e = append(*e, err)
+	}
+}
+
+func newResult() *Result {
+	return &Result{
+		Documents: map[string]interface{}{},
+		Modules:   map[string]*RegoFile{},
+	}
+}
+
+type unsupportedDocumentType string
+
+func (path unsupportedDocumentType) Error() string {
+	return string(path) + ": bad document type"
+}
+
+type unrecognizedFile string
+
+func (path unrecognizedFile) Error() string {
+	return string(path) + ": can't recognize file type"
+}
+
+func isUnrecognizedFile(err error) bool {
+	_, ok := err.(unrecognizedFile)
+	return ok
+}
+
+type mergeError string
+
+func (e mergeError) Error() string {
+	return string(e) + ": merge error"
+}
+
+type emptyModuleError string
+
+func (e emptyModuleError) Error() string {
+	return string(e) + ": empty policy"
+}

--- a/vendor/github.com/open-policy-agent/opa/loader/loader.go
+++ b/vendor/github.com/open-policy-agent/opa/loader/loader.go
@@ -1,0 +1,411 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package loader contains utilities for loading files into OPA.
+package loader
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/internal/file"
+	fileurl "github.com/open-policy-agent/opa/internal/file/url"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
+	"github.com/open-policy-agent/opa/util"
+	"github.com/pkg/errors"
+)
+
+// Result represents the result of successfully loading zero or more files.
+type Result struct {
+	Documents map[string]interface{}
+	Modules   map[string]*RegoFile
+	path      []string
+}
+
+// ParsedModules returns the parsed modules stored on the result.
+func (l *Result) ParsedModules() map[string]*ast.Module {
+	modules := make(map[string]*ast.Module)
+	for _, module := range l.Modules {
+		modules[module.Name] = module.Parsed
+	}
+	return modules
+}
+
+// Compiler returns a Compiler object with the compiled modules from this loader
+// result.
+func (l *Result) Compiler() (*ast.Compiler, error) {
+	compiler := ast.NewCompiler()
+	compiler.Compile(l.ParsedModules())
+	if compiler.Failed() {
+		return nil, compiler.Errors
+	}
+	return compiler, nil
+}
+
+// Store returns a Store object with the documents from this loader result.
+func (l *Result) Store() (storage.Store, error) {
+	return inmem.NewFromObject(l.Documents), nil
+}
+
+// RegoFile represents the result of loading a single Rego source file.
+type RegoFile struct {
+	Name   string
+	Parsed *ast.Module
+	Raw    []byte
+}
+
+// Filter defines the interface for filtering files during loading. If the
+// filter returns true, the file should be excluded from the result.
+type Filter func(abspath string, info os.FileInfo, depth int) bool
+
+// GlobExcludeName excludes files and directories whose names do not match the
+// shell style pattern at minDepth or greater.
+func GlobExcludeName(pattern string, minDepth int) Filter {
+	return func(abspath string, info os.FileInfo, depth int) bool {
+		match, _ := filepath.Match(pattern, info.Name())
+		return match && depth >= minDepth
+	}
+}
+
+// All returns a Result object loaded (recursively) from the specified paths.
+func All(paths []string) (*Result, error) {
+	return Filtered(paths, nil)
+}
+
+// AllRegos returns a Result object loaded (recursively) with all Rego source
+// files from the specified paths.
+func AllRegos(paths []string) (*Result, error) {
+	return Filtered(paths, func(_ string, info os.FileInfo, depth int) bool {
+		return !info.IsDir() && !strings.HasSuffix(info.Name(), bundle.RegoExt)
+	})
+}
+
+// Filtered returns a Result object loaded (recursively) from the specified
+// paths while applying the given filters. If any filter returns true, the
+// file/directory is excluded.
+func Filtered(paths []string, filter Filter) (*Result, error) {
+	return all(paths, filter, func(curr *Result, path string, depth int) error {
+
+		bs, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		result, err := loadKnownTypes(path, bs)
+		if err != nil {
+			if !isUnrecognizedFile(err) {
+				return err
+			}
+			if depth > 0 {
+				return nil
+			}
+			result, err = loadFileForAnyType(path, bs)
+			if err != nil {
+				return err
+			}
+		}
+
+		return curr.merge(path, result)
+	})
+}
+
+// Rego returns a RegoFile object loaded from the given path.
+func Rego(path string) (*RegoFile, error) {
+	path, err := fileurl.Clean(path)
+	if err != nil {
+		return nil, err
+	}
+	bs, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return loadRego(path, bs)
+}
+
+// AsBundle loads a path as a bundle. If it is a single file
+// it will be treated as a normal tarball bundle. If a directory
+// is supplied it will be loaded as an unzipped bundle tree.
+func AsBundle(path string) (*bundle.Bundle, error) {
+	path, err := fileurl.Clean(path)
+	if err != nil {
+		return nil, err
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %q: %s", path, err)
+	}
+
+	var bundleLoader file.DirectoryLoader
+
+	if fi.IsDir() {
+		bundleLoader = file.NewDirectoryLoader(path)
+	} else {
+		fh, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		bundleLoader = file.NewTarballLoader(fh)
+	}
+
+	br := bundle.NewCustomReader(bundleLoader)
+	b, err := br.Read()
+	return &b, err
+}
+
+// CleanPath returns the normalized version of a path that can be used as an identifier.
+func CleanPath(path string) string {
+	return strings.Trim(path, "/")
+}
+
+// Paths returns a sorted list of files contained at path. If recurse is true
+// and path is a directory, then Paths will walk the directory structure
+// recursively and list files at each level.
+func Paths(path string, recurse bool) (paths []string, err error) {
+	path, err = fileurl.Clean(path)
+	if err != nil {
+		return nil, err
+	}
+	err = filepath.Walk(path, func(f string, info os.FileInfo, err error) error {
+		if !recurse {
+			if path != f && path != filepath.Dir(f) {
+				return filepath.SkipDir
+			}
+		}
+		paths = append(paths, f)
+		return nil
+	})
+	return paths, err
+}
+
+// SplitPrefix returns a tuple specifying the document prefix and the file
+// path.
+func SplitPrefix(path string) ([]string, string) {
+	// Non-prefixed URLs can be returned without modification and their contents
+	// can be rooted directly under data.
+	if strings.Index(path, "://") == strings.Index(path, ":") {
+		return nil, path
+	}
+	parts := strings.SplitN(path, ":", 2)
+	if len(parts) == 2 && len(parts[0]) > 0 {
+		return strings.Split(parts[0], "."), parts[1]
+	}
+	return nil, path
+}
+
+func (l *Result) merge(path string, result interface{}) error {
+	switch result := result.(type) {
+	case bundle.Bundle:
+		for _, module := range result.Modules {
+			l.Modules[module.Path] = &RegoFile{
+				Name:   module.Path,
+				Parsed: module.Parsed,
+				Raw:    module.Raw,
+			}
+		}
+		return l.mergeDocument(path, result.Data)
+	case *RegoFile:
+		l.Modules[CleanPath(path)] = result
+		return nil
+	default:
+		return l.mergeDocument(path, result)
+	}
+}
+
+func (l *Result) mergeDocument(path string, doc interface{}) error {
+	obj, ok := makeDir(l.path, doc)
+	if !ok {
+		return unsupportedDocumentType(path)
+	}
+	merged, ok := mergeInterfaces(l.Documents, obj)
+	if !ok {
+		return mergeError(path)
+	}
+	for k := range merged {
+		l.Documents[k] = merged[k]
+	}
+	return nil
+}
+
+func (l *Result) withParent(p string) *Result {
+	path := append(l.path, p)
+	return &Result{
+		Documents: l.Documents,
+		Modules:   l.Modules,
+		path:      path,
+	}
+}
+
+func all(paths []string, filter Filter, f func(*Result, string, int) error) (*Result, error) {
+	errors := loaderErrors{}
+	root := newResult()
+
+	for _, path := range paths {
+
+		// Paths can be prefixed with a string that specifies where content should be
+		// loaded under data. E.g., foo.bar:/path/to/some.json will load the content
+		// of some.json under {"foo": {"bar": ...}}.
+		loaded := root
+		prefix, path := SplitPrefix(path)
+		if len(prefix) > 0 {
+			for _, part := range prefix {
+				loaded = loaded.withParent(part)
+			}
+		}
+
+		allRec(path, filter, &errors, loaded, 0, f)
+	}
+
+	if len(errors) > 0 {
+		return nil, errors
+	}
+
+	return root, nil
+}
+
+func allRec(path string, filter Filter, errors *loaderErrors, loaded *Result, depth int, f func(*Result, string, int) error) {
+
+	path, err := fileurl.Clean(path)
+	if err != nil {
+		errors.Add(err)
+		return
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		errors.Add(err)
+		return
+	}
+
+	if filter != nil && filter(path, info, depth) {
+		return
+	}
+
+	if !info.IsDir() {
+		if err := f(loaded, path, depth); err != nil {
+			errors.Add(err)
+		}
+		return
+	}
+
+	// If we are recursing on directories then content must be loaded under path
+	// specified by directory hierarchy.
+	if depth > 0 {
+		loaded = loaded.withParent(info.Name())
+	}
+
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		errors.Add(err)
+		return
+	}
+
+	for _, file := range files {
+		allRec(filepath.Join(path, file.Name()), filter, errors, loaded, depth+1, f)
+	}
+}
+
+func exclude(filters []Filter, path string, info os.FileInfo, depth int) bool {
+	for _, f := range filters {
+		if f(path, info, depth) {
+			return true
+		}
+	}
+	return false
+}
+
+func loadKnownTypes(path string, bs []byte) (interface{}, error) {
+	switch filepath.Ext(path) {
+	case ".json":
+		return loadJSON(path, bs)
+	case ".rego":
+		return Rego(path)
+	case ".yaml", ".yml":
+		return loadYAML(path, bs)
+	default:
+		if strings.HasSuffix(path, ".tar.gz") {
+			return loadBundleFile(bs)
+		}
+	}
+	return nil, unrecognizedFile(path)
+}
+
+func loadFileForAnyType(path string, bs []byte) (interface{}, error) {
+	module, err := loadRego(path, bs)
+	if err == nil {
+		return module, nil
+	}
+	doc, err := loadJSON(path, bs)
+	if err == nil {
+		return doc, nil
+	}
+	doc, err = loadYAML(path, bs)
+	if err == nil {
+		return doc, nil
+	}
+	return nil, unrecognizedFile(path)
+}
+
+func loadBundleFile(bs []byte) (bundle.Bundle, error) {
+	tl := file.NewTarballLoader(bytes.NewBuffer(bs))
+	br := bundle.NewCustomReader(tl).IncludeManifestInData(true)
+	return br.Read()
+}
+
+func loadBundleDir(path string) (bundle.Bundle, error) {
+	return bundle.Bundle{}, nil
+}
+
+func loadRego(path string, bs []byte) (*RegoFile, error) {
+	module, err := ast.ParseModule(path, string(bs))
+	if err != nil {
+		return nil, err
+	}
+	if module == nil {
+		return nil, emptyModuleError(path)
+	}
+	result := &RegoFile{
+		Name:   path,
+		Parsed: module,
+		Raw:    bs,
+	}
+	return result, nil
+}
+
+func loadJSON(path string, bs []byte) (interface{}, error) {
+	buf := bytes.NewBuffer(bs)
+	decoder := util.NewJSONDecoder(buf)
+	var x interface{}
+	if err := decoder.Decode(&x); err != nil {
+		return nil, errors.Wrap(err, path)
+	}
+	return x, nil
+}
+
+func loadYAML(path string, bs []byte) (interface{}, error) {
+	bs, err := yaml.YAMLToJSON(bs)
+	if err != nil {
+		return nil, fmt.Errorf("%v: error converting YAML to JSON: %v", path, err)
+	}
+	return loadJSON(path, bs)
+}
+
+func makeDir(path []string, x interface{}) (map[string]interface{}, bool) {
+	if len(path) == 0 {
+		obj, ok := x.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		return obj, true
+	}
+	return makeDir(path[:len(path)-1], map[string]interface{}{path[len(path)-1]: x})
+}

--- a/vendor/github.com/open-policy-agent/opa/loader/merge.go
+++ b/vendor/github.com/open-policy-agent/opa/loader/merge.go
@@ -1,0 +1,38 @@
+// Copyright 2017 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package loader
+
+// mergeInterfaces returns the result of merging a and b. If a and b cannot be
+// merged because of conflicting key-value pairs, ok is false.
+func mergeInterfaces(a map[string]interface{}, b map[string]interface{}) (c map[string]interface{}, ok bool) {
+
+	c = map[string]interface{}{}
+	for k := range a {
+		c[k] = a[k]
+	}
+
+	for k := range b {
+
+		add := b[k]
+		exist, ok := c[k]
+		if !ok {
+			c[k] = add
+			continue
+		}
+
+		existObj, existOk := exist.(map[string]interface{})
+		addObj, addOk := add.(map[string]interface{})
+		if !existOk || !addOk {
+			return nil, false
+		}
+
+		c[k], ok = mergeInterfaces(existObj, addObj)
+		if !ok {
+			return nil, false
+		}
+	}
+
+	return c, true
+}

--- a/vendor/github.com/open-policy-agent/opa/metrics/metrics.go
+++ b/vendor/github.com/open-policy-agent/opa/metrics/metrics.go
@@ -27,6 +27,8 @@ const (
 	RegoModuleCompile = "rego_module_compile"
 	RegoPartialEval   = "rego_partial_eval"
 	RegoInputParse    = "rego_input_parse"
+	RegoLoadFiles     = "rego_load_files"
+	RegoLoadBundles   = "rego_load_bundles"
 )
 
 // Info contains attributes describing the underlying metrics provider.

--- a/vendor/github.com/open-policy-agent/opa/rego/rego.go
+++ b/vendor/github.com/open-policy-agent/opa/rego/rego.go
@@ -13,6 +13,11 @@ import (
 	"io"
 	"strings"
 
+	"github.com/open-policy-agent/opa/loader"
+	"github.com/open-policy-agent/opa/types"
+
+	"github.com/open-policy-agent/opa/bundle"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/internal/compiler/wasm"
 	"github.com/open-policy-agent/opa/internal/ir"
@@ -161,6 +166,22 @@ func EvalParsedUnknowns(unknowns []*ast.Term) EvalOption {
 	return func(e *EvalContext) {
 		e.parsedUnknowns = unknowns
 	}
+}
+
+func (pq preparedQuery) Modules() map[string]*ast.Module {
+	mods := make(map[string]*ast.Module)
+
+	for name, mod := range pq.r.parsedModules {
+		mods[name] = mod
+	}
+
+	for path, b := range pq.r.bundles {
+		for name, mod := range b.ParsedModules(path) {
+			mods[name] = mod
+		}
+	}
+
+	return mods
 }
 
 // newEvalContext creates a new EvalContext overlaying any EvalOptions over top
@@ -372,6 +393,11 @@ const (
 	compileQueryType       queryType = iota
 )
 
+type loadPaths struct {
+	paths  []string
+	filter loader.Filter
+}
+
 // Rego constructs a query and can be evaluated to obtain results.
 type Rego struct {
 	query            string
@@ -391,6 +417,7 @@ type Rego struct {
 	parsedModules    map[string]*ast.Module
 	compiler         *ast.Compiler
 	store            storage.Store
+	ownStore         bool
 	txn              storage.Transaction
 	metrics          metrics.Metrics
 	tracers          []topdown.Tracer
@@ -402,7 +429,123 @@ type Rego struct {
 	termVarID        int
 	dump             io.Writer
 	runtime          *ast.Term
+	builtinDecls     map[string]*ast.Builtin
+	builtinFuncs     map[string]*topdown.Builtin
 	unsafeBuiltins   map[string]struct{}
+	loadPaths        loadPaths
+	bundlePaths      []string
+	bundles          map[string]*bundle.Bundle
+}
+
+// Function represents a built-in function that is callable in Rego.
+type Function struct {
+	Name    string
+	Decl    *types.Function
+	Memoize bool
+}
+
+// BuiltinContext contains additional attributes from the evaluator that
+// built-in functions can use, e.g., the request context.Context, caches, etc.
+type BuiltinContext = topdown.BuiltinContext
+
+type (
+	// Builtin1 defines a built-in function that accepts 1 argument.
+	Builtin1 func(bctx BuiltinContext, op1 *ast.Term) (*ast.Term, error)
+
+	// Builtin2 defines a built-in function that accepts 2 arguments.
+	Builtin2 func(bctx BuiltinContext, op1, op2 *ast.Term) (*ast.Term, error)
+
+	// Builtin3 defines a built-in function that accepts 3 argument.
+	Builtin3 func(bctx BuiltinContext, op1, op2, op3 *ast.Term) (*ast.Term, error)
+
+	// Builtin4 defines a built-in function that accepts 4 argument.
+	Builtin4 func(bctx BuiltinContext, op1, op2, op3, op4 *ast.Term) (*ast.Term, error)
+
+	// BuiltinDyn defines a built-in function  that accepts a list of arguments.
+	BuiltinDyn func(bctx BuiltinContext, terms []*ast.Term) (*ast.Term, error)
+)
+
+// Function1 returns an option that adds a built-in function to the Rego object.
+func Function1(decl *Function, f Builtin1) func(*Rego) {
+	return newFunction(decl, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
+		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return f(bctx, terms[0]) })
+		return finishFunction(decl.Name, bctx, result, err, iter)
+	})
+}
+
+// Function2 returns an option that adds a built-in function to the Rego object.
+func Function2(decl *Function, f Builtin2) func(*Rego) {
+	return newFunction(decl, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
+		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return f(bctx, terms[0], terms[1]) })
+		return finishFunction(decl.Name, bctx, result, err, iter)
+	})
+}
+
+// Function3 returns an option that adds a built-in function to the Rego object.
+func Function3(decl *Function, f Builtin3) func(*Rego) {
+	return newFunction(decl, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
+		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return f(bctx, terms[0], terms[1], terms[2]) })
+		return finishFunction(decl.Name, bctx, result, err, iter)
+	})
+}
+
+// Function4 returns an option that adds a built-in function to the Rego object.
+func Function4(decl *Function, f Builtin4) func(*Rego) {
+	return newFunction(decl, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
+		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return f(bctx, terms[0], terms[1], terms[2], terms[3]) })
+		return finishFunction(decl.Name, bctx, result, err, iter)
+	})
+}
+
+// FunctionDyn returns an option that adds a built-in function to the Rego object.
+func FunctionDyn(decl *Function, f BuiltinDyn) func(*Rego) {
+	return newFunction(decl, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
+		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return f(bctx, terms) })
+		return finishFunction(decl.Name, bctx, result, err, iter)
+	})
+}
+
+type memo struct {
+	term *ast.Term
+	err  error
+}
+
+type memokey string
+
+func memoize(decl *Function, bctx BuiltinContext, terms []*ast.Term, ifEmpty func() (*ast.Term, error)) (*ast.Term, error) {
+
+	if !decl.Memoize {
+		return ifEmpty()
+	}
+
+	// NOTE(tsandall): we assume memoization is applied to infrequent built-in
+	// calls that do things like fetch data from remote locations. As such,
+	// converting the terms to strings is acceptable for now.
+	var b strings.Builder
+	if _, err := b.WriteString(decl.Name); err != nil {
+		return nil, err
+	}
+
+	// The term slice _may_ include an output term depending on how the caller
+	// referred to the built-in function. Only use the arguments as the cache
+	// key. Unification ensures we don't get false positive matches.
+	for i := 0; i < len(decl.Decl.Args()); i++ {
+		if _, err := b.WriteString(terms[i].String()); err != nil {
+			return nil, err
+		}
+	}
+
+	key := memokey(b.String())
+	hit, ok := bctx.Cache.Get(key)
+	var m memo
+	if ok {
+		m = hit.(memo)
+	} else {
+		m.term, m.err = ifEmpty()
+		bctx.Cache.Put(key, m)
+	}
+
+	return m.term, m.err
 }
 
 // Dump returns an argument that sets the writer to dump debugging information to.
@@ -529,6 +672,36 @@ func ParsedModule(module *ast.Module) func(*Rego) {
 	}
 }
 
+// Load returns an argument that adds a filesystem path to load data
+// and Rego modules from. Any file with a *.rego, *.yaml, or *.json
+// extension will be loaded. The path can be either a directory or file,
+// directories are loaded recursively. The optional ignore string patterns
+// can be used to filter which files are used.
+// The Load option can only be used once.
+// Note: Loading files will require a write transaction on the store.
+func Load(paths []string, filter loader.Filter) func(r *Rego) {
+	return func(r *Rego) {
+		r.loadPaths = loadPaths{paths, filter}
+	}
+}
+
+// LoadBundle returns an argument that adds a filesystem path to load
+// a bundle from. The path can be a compressed bundle file or a directory
+// to be loaded as a bundle.
+// Note: Loading bundles will require a write transaction on the store.
+func LoadBundle(path string) func(r *Rego) {
+	return func(r *Rego) {
+		r.bundlePaths = append(r.bundlePaths, path)
+	}
+}
+
+// ParsedBundle returns an argument that adds a bundle to be loaded.
+func ParsedBundle(name string, b *bundle.Bundle) func(r *Rego) {
+	return func(r *Rego) {
+		r.bundles[name] = b
+	}
+}
+
 // Compiler returns an argument that sets the Rego compiler.
 func Compiler(c *ast.Compiler) func(r *Rego) {
 	return func(r *Rego) {
@@ -537,6 +710,10 @@ func Compiler(c *ast.Compiler) func(r *Rego) {
 }
 
 // Store returns an argument that sets the policy engine's data storage layer.
+//
+// If using the Load, LoadBundle, or ParsedBundle options then a transaction
+// must also be provided via the Transaction() option. After loading files
+// or bundles the transaction should be aborted or committed.
 func Store(s storage.Store) func(r *Rego) {
 	return func(r *Rego) {
 		r.store = s
@@ -545,6 +722,10 @@ func Store(s storage.Store) func(r *Rego) {
 
 // Transaction returns an argument that sets the transaction to use for storage
 // layer operations.
+//
+// Requires the store associated with the transaction to be provided via the
+// Store() option. If using Load(), LoadBundle(), or ParsedBundle() options
+// the transaction will likely require write params.
 func Transaction(txn storage.Transaction) func(r *Rego) {
 	return func(r *Rego) {
 		r.txn = txn
@@ -616,6 +797,8 @@ func New(options ...func(r *Rego)) *Rego {
 		parsedModules:   map[string]*ast.Module{},
 		capture:         map[*ast.Expr]ast.Var{},
 		compiledQueries: map[queryType]compiledQuery{},
+		builtinDecls:    map[string]*ast.Builtin{},
+		builtinFuncs:    map[string]*topdown.Builtin{},
 	}
 
 	for _, option := range options {
@@ -623,11 +806,16 @@ func New(options ...func(r *Rego)) *Rego {
 	}
 
 	if r.compiler == nil {
-		r.compiler = ast.NewCompiler().WithUnsafeBuiltins(r.unsafeBuiltins)
+		r.compiler = ast.NewCompiler().
+			WithUnsafeBuiltins(r.unsafeBuiltins).
+			WithBuiltins(r.builtinDecls)
 	}
 
 	if r.store == nil {
 		r.store = inmem.New()
+		r.ownStore = true
+	} else {
+		r.ownStore = false
 	}
 
 	if r.metrics == nil {
@@ -648,26 +836,34 @@ func New(options ...func(r *Rego)) *Rego {
 		r.partialNamespace = defaultPartialNamespace
 	}
 
+	if r.bundles == nil {
+		r.bundles = map[string]*bundle.Bundle{}
+	}
+
 	return r
 }
 
 // Eval evaluates this Rego object and returns a ResultSet.
 func (r *Rego) Eval(ctx context.Context) (ResultSet, error) {
 	var err error
-	if r.txn == nil {
-		r.txn, err = r.store.NewTransaction(ctx)
-		if err != nil {
-			return nil, err
-		}
-		defer r.store.Abort(ctx, r.txn)
-	}
-
-	pq, err := r.PrepareForEval(ctx)
+	var txnClose transactionCloser
+	r.txn, txnClose, err = r.getTxn(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return pq.Eval(ctx, EvalTransaction(r.txn))
+	pq, err := r.PrepareForEval(ctx)
+	if err != nil {
+		txnClose(ctx, err) // Ignore error
+		return nil, err
+	}
+
+	rs, err := pq.Eval(ctx, EvalTransaction(r.txn))
+	txnErr := txnClose(ctx, err) // Always call closer
+	if err == nil {
+		err = txnErr
+	}
+	return rs, err
 }
 
 // PartialEval has been deprecated and renamed to PartialResult.
@@ -678,17 +874,19 @@ func (r *Rego) PartialEval(ctx context.Context) (PartialResult, error) {
 // PartialResult partially evaluates this Rego object and returns a PartialResult.
 func (r *Rego) PartialResult(ctx context.Context) (PartialResult, error) {
 	var err error
-	if r.txn == nil {
-		r.txn, err = r.store.NewTransaction(ctx)
-		if err != nil {
-			return PartialResult{}, err
-		}
-		defer r.store.Abort(ctx, r.txn)
+	var txnClose transactionCloser
+	r.txn, txnClose, err = r.getTxn(ctx)
+	if err != nil {
+		return PartialResult{}, err
 	}
 
 	pq, err := r.PrepareForEval(ctx, WithPartialEval())
+	txnErr := txnClose(ctx, err) // Always call closer
 	if err != nil {
 		return PartialResult{}, err
+	}
+	if txnErr != nil {
+		return PartialResult{}, txnErr
 	}
 
 	pr := PartialResult{
@@ -703,20 +901,24 @@ func (r *Rego) PartialResult(ctx context.Context) (PartialResult, error) {
 // Partial runs partial evaluation on r and returns the result.
 func (r *Rego) Partial(ctx context.Context) (*PartialQueries, error) {
 	var err error
-	if r.txn == nil {
-		r.txn, err = r.store.NewTransaction(ctx)
-		if err != nil {
-			return nil, err
-		}
-		defer r.store.Abort(ctx, r.txn)
-	}
-
-	pq, err := r.PrepareForPartial(ctx)
+	var txnClose transactionCloser
+	r.txn, txnClose, err = r.getTxn(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return pq.Partial(ctx, EvalTransaction(r.txn))
+	pq, err := r.PrepareForPartial(ctx)
+	if err != nil {
+		txnClose(ctx, err) // Ignore error
+		return nil, err
+	}
+
+	pqs, err := pq.Partial(ctx, EvalTransaction(r.txn))
+	txnErr := txnClose(ctx, err) // Always call closer
+	if err == nil {
+		err = txnErr
+	}
+	return pqs, err
 }
 
 // CompileOption defines a function to set options on Compile calls.
@@ -781,37 +983,32 @@ func (r *Rego) Compile(ctx context.Context, opts ...CompileOption) (*CompileResu
 			modules = append(modules, module)
 		}
 	} else {
-
-		// execute block inside a closure so that transaction is closed before
-		// planner runs.
+		var err error
+		// If creating a new transacation it should be closed before calling the
+		// planner to avoid holding open the transaction longer than needed.
 		//
 		// TODO(tsandall): in future, planner could make use of store, in which
 		// case this will need to change.
-		err := func() error {
-			var err error
-			if r.txn == nil {
-				r.txn, err = r.store.NewTransaction(ctx)
-				if err != nil {
-					return err
-				}
-				defer r.store.Abort(ctx, r.txn)
-			}
-
-			if err := r.prepare(ctx, r.txn, compileQueryType, nil); err != nil {
-				return err
-			}
-
-			for _, module := range r.compiler.Modules {
-				modules = append(modules, module)
-			}
-
-			queries = []ast.Body{r.compiledQueries[compileQueryType].query}
-			return nil
-		}()
-
+		var txnClose transactionCloser
+		r.txn, txnClose, err = r.getTxn(ctx)
 		if err != nil {
 			return nil, err
 		}
+
+		err = r.prepare(ctx, compileQueryType, nil)
+		txnErr := txnClose(ctx, err) // Always call closer
+		if err != nil {
+			return nil, err
+		}
+		if txnErr != nil {
+			return nil, err
+		}
+
+		for _, module := range r.compiler.Modules {
+			modules = append(modules, module)
+		}
+
+		queries = []ast.Body{r.compiledQueries[compileQueryType].query}
 	}
 
 	policy, err := planner.New().WithQueries(queries).WithModules(modules).Plan()
@@ -883,64 +1080,33 @@ func (r *Rego) PrepareForEval(ctx context.Context, opts ...PrepareOption) (Prepa
 		o(pCfg)
 	}
 
-	txn := r.txn
-
 	var err error
-	if txn == nil {
-		txn, err = r.store.NewTransaction(ctx)
-		if err != nil {
-			return PreparedEvalQuery{}, err
-		}
-		defer r.store.Abort(ctx, txn)
+	var txnClose transactionCloser
+	r.txn, txnClose, err = r.getTxn(ctx)
+	if err != nil {
+		return PreparedEvalQuery{}, err
 	}
 
 	// If the caller wanted to do partial evaluation as part of preparation
 	// do it now and use the new Rego object.
 	if pCfg.doPartialEval {
-		err := r.prepare(ctx, txn, partialResultQueryType, []extraStage{
-			{
-				after: "ResolveRefs",
-				stage: ast.QueryCompilerStageDefinition{
-					Name:       "RewriteForPartialEval",
-					MetricName: "query_compile_stage_rewrite_for_partial_eval",
-					Stage:      r.rewriteQueryForPartialEval,
-				},
-			},
-		})
+
+		pr, err := r.partialResult(ctx, pCfg)
 		if err != nil {
+			txnClose(ctx, err) // Ignore error
 			return PreparedEvalQuery{}, err
 		}
 
-		ectx := &EvalContext{
-			parsedInput:      r.parsedInput,
-			metrics:          r.metrics,
-			txn:              txn,
-			partialNamespace: r.partialNamespace,
-			tracers:          r.tracers,
-			compiledQuery:    r.compiledQueries[partialResultQueryType],
-			instrumentation:  r.instrumentation,
-		}
-
-		disableInlining := r.disableInlining
-
-		if pCfg.disableInlining != nil {
-			disableInlining = *pCfg.disableInlining
-		}
-
-		ectx.disableInlining, err = parseStringsToRefs(disableInlining)
+		// Prepare the new query using the result of partial evaluation
+		pq, err := pr.Rego(Transaction(r.txn)).PrepareForEval(ctx)
+		txnErr := txnClose(ctx, err)
 		if err != nil {
-			return PreparedEvalQuery{}, err
+			return pq, err
 		}
-
-		pr, err := r.partialResult(ctx, ectx, ast.Wildcard)
-		if err != nil {
-			return PreparedEvalQuery{}, err
-		}
-		// Prepare the new query
-		return pr.Rego().PrepareForEval(ctx)
+		return pq, txnErr
 	}
 
-	err = r.prepare(ctx, txn, evalQueryType, []extraStage{
+	err = r.prepare(ctx, evalQueryType, []extraStage{
 		{
 			after: "ResolveRefs",
 			stage: ast.QueryCompilerStageDefinition{
@@ -950,8 +1116,12 @@ func (r *Rego) PrepareForEval(ctx context.Context, opts ...PrepareOption) (Prepa
 			},
 		},
 	})
+	txnErr := txnClose(ctx, err) // Always call closer
 	if err != nil {
 		return PreparedEvalQuery{}, err
+	}
+	if txnErr != nil {
+		return PreparedEvalQuery{}, txnErr
 	}
 
 	return PreparedEvalQuery{preparedQuery{r, pCfg}}, err
@@ -969,18 +1139,14 @@ func (r *Rego) PrepareForPartial(ctx context.Context, opts ...PrepareOption) (Pr
 		o(pCfg)
 	}
 
-	txn := r.txn
-
 	var err error
-	if txn == nil {
-		txn, err = r.store.NewTransaction(ctx)
-		if err != nil {
-			return PreparedPartialQuery{}, err
-		}
-		defer r.store.Abort(ctx, txn)
+	var txnClose transactionCloser
+	r.txn, txnClose, err = r.getTxn(ctx)
+	if err != nil {
+		return PreparedPartialQuery{}, err
 	}
 
-	err = r.prepare(ctx, txn, partialQueryType, []extraStage{
+	err = r.prepare(ctx, partialQueryType, []extraStage{
 		{
 			after: "CheckSafety",
 			stage: ast.QueryCompilerStageDefinition{
@@ -990,29 +1156,42 @@ func (r *Rego) PrepareForPartial(ctx context.Context, opts ...PrepareOption) (Pr
 			},
 		},
 	})
-
+	txnErr := txnClose(ctx, err) // Always call closer
 	if err != nil {
 		return PreparedPartialQuery{}, err
 	}
-
+	if txnErr != nil {
+		return PreparedPartialQuery{}, txnErr
+	}
 	return PreparedPartialQuery{preparedQuery{r, pCfg}}, err
 }
 
-func (r *Rego) prepare(ctx context.Context, txn storage.Transaction, qType queryType, extras []extraStage) error {
+func (r *Rego) prepare(ctx context.Context, qType queryType, extras []extraStage) error {
 	var err error
+
 	r.parsedInput, err = r.parseInput()
 	if err != nil {
 		return err
 	}
 
-	err = r.parseModules(r.metrics)
+	err = r.loadFiles(ctx, r.txn, r.metrics)
+	if err != nil {
+		return err
+	}
+
+	err = r.loadBundles(ctx, r.txn, r.metrics)
+	if err != nil {
+		return err
+	}
+
+	err = r.parseModules(ctx, r.txn, r.metrics)
 	if err != nil {
 		return err
 	}
 
 	// Compile the modules *before* the query, else functions
 	// defined in the module won't be found...
-	err = r.compileModules(ctx, txn, r.parsedModules, r.metrics)
+	err = r.compileModules(ctx, r.txn, r.metrics)
 	if err != nil {
 		return err
 	}
@@ -1022,14 +1201,50 @@ func (r *Rego) prepare(ctx context.Context, txn storage.Transaction, qType query
 		return err
 	}
 
-	return r.compileAndCacheQuery(qType, r.parsedQuery, r.metrics, extras)
+	err = r.compileAndCacheQuery(qType, r.parsedQuery, r.metrics, extras)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func (r *Rego) parseModules(m metrics.Metrics) error {
+func (r *Rego) parseModules(ctx context.Context, txn storage.Transaction, m metrics.Metrics) error {
 	m.Timer(metrics.RegoModuleParse).Start()
 	defer m.Timer(metrics.RegoModuleParse).Stop()
 	var errs Errors
 
+	// Parse any modules in the are saved to the store, but only if
+	// another compile step is going to occur (ie. we have parsed modules
+	// that need to be compiled).
+	if len(r.modules) > 0 {
+		ids, err := r.store.ListPolicies(ctx, txn)
+		if err != nil {
+			return err
+		}
+
+		for _, id := range ids {
+			// if it is already on the compiler we're using
+			// then don't bother to re-parse it from source
+			if _, haveMod := r.compiler.Modules[id]; haveMod {
+				continue
+			}
+
+			bs, err := r.store.GetPolicy(ctx, txn, id)
+			if err != nil {
+				return err
+			}
+
+			parsed, err := ast.ParseModule(id, string(bs))
+			if err != nil {
+				errs = append(errs, err)
+			}
+
+			r.parsedModules[id] = parsed
+		}
+	}
+
+	// Parse any passed in as arguments to the Rego object
 	for _, module := range r.modules {
 		p, err := module.Parse()
 		if err != nil {
@@ -1040,6 +1255,42 @@ func (r *Rego) parseModules(m metrics.Metrics) error {
 
 	if len(errs) > 0 {
 		return errors.New(errs.Error())
+	}
+
+	return nil
+}
+
+func (r *Rego) loadFiles(ctx context.Context, txn storage.Transaction, m metrics.Metrics) error {
+	m.Timer(metrics.RegoLoadFiles).Start()
+	defer m.Timer(metrics.RegoLoadFiles).Stop()
+
+	result, err := loader.Filtered(r.loadPaths.paths, r.loadPaths.filter)
+	if err != nil {
+		return fmt.Errorf("error loading paths: %s", err)
+	}
+	for name, mod := range result.Modules {
+		r.parsedModules[name] = mod.Parsed
+	}
+
+	if len(result.Documents) > 0 {
+		err = r.store.Write(ctx, txn, storage.AddOp, storage.Path{}, result.Documents)
+		if err != nil {
+			return fmt.Errorf("error writing loaded documents to store: %s", err)
+		}
+	}
+	return nil
+}
+
+func (r *Rego) loadBundles(ctx context.Context, txn storage.Transaction, m metrics.Metrics) error {
+	m.Timer(metrics.RegoLoadBundles).Start()
+	defer m.Timer(metrics.RegoLoadBundles).Stop()
+
+	for _, path := range r.bundlePaths {
+		bndl, err := loader.AsBundle(path)
+		if err != nil {
+			return fmt.Errorf("error loading bundle path %s: %s", path, err)
+		}
+		r.bundles[path] = bndl
 	}
 
 	return nil
@@ -1091,22 +1342,31 @@ func (r *Rego) parseQuery(m metrics.Metrics) (ast.Body, error) {
 	return query, nil
 }
 
-func (r *Rego) compileModules(ctx context.Context, txn storage.Transaction, modules map[string]*ast.Module, m metrics.Metrics) error {
+func (r *Rego) compileModules(ctx context.Context, txn storage.Transaction, m metrics.Metrics) error {
 
-	m.Timer(metrics.RegoModuleCompile).Start()
-	defer m.Timer(metrics.RegoModuleCompile).Stop()
+	// Only compile again if there are new modules.
+	if len(r.bundles) > 0 || len(r.parsedModules) > 0 {
 
-	if len(modules) > 0 {
-		r.compiler.WithPathConflictsCheck(storage.NonEmpty(ctx, r.store, txn)).Compile(modules)
-		if r.compiler.Failed() {
-			var errs Errors
-			for _, err := range r.compiler.Errors {
-				errs = append(errs, err)
-			}
-			return errs
+		// The bundle.Activate call will activate any bundles passed in
+		// (ie compile + handle data store changes), and include any of
+		// the additional modules passed in. If no bundles are provided
+		// it will only compile the passed in modules.
+		// Use this as the single-point of compiling everything only a
+		// single time.
+		opts := &bundle.ActivateOpts{
+			Ctx:          ctx,
+			Store:        r.store,
+			Txn:          txn,
+			Compiler:     r.compiler.WithPathConflictsCheck(storage.NonEmpty(ctx, r.store, txn)),
+			Metrics:      m,
+			Bundles:      r.bundles,
+			ExtraModules: r.parsedModules,
+		}
+		err := bundle.Activate(opts)
+		if err != nil {
+			return err
 		}
 	}
-
 	return nil
 }
 
@@ -1195,6 +1455,7 @@ func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 		WithCompiler(r.compiler).
 		WithStore(r.store).
 		WithTransaction(ectx.txn).
+		WithBuiltins(r.builtinFuncs).
 		WithMetrics(ectx.metrics).
 		WithInstrumentation(ectx.instrumentation).
 		WithRuntime(r.runtime)
@@ -1262,7 +1523,42 @@ func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 	return rs, nil
 }
 
-func (r *Rego) partialResult(ctx context.Context, ectx *EvalContext, output *ast.Term) (PartialResult, error) {
+func (r *Rego) partialResult(ctx context.Context, pCfg *PrepareConfig) (PartialResult, error) {
+
+	err := r.prepare(ctx, partialResultQueryType, []extraStage{
+		{
+			after: "ResolveRefs",
+			stage: ast.QueryCompilerStageDefinition{
+				Name:       "RewriteForPartialEval",
+				MetricName: "query_compile_stage_rewrite_for_partial_eval",
+				Stage:      r.rewriteQueryForPartialEval,
+			},
+		},
+	})
+	if err != nil {
+		return PartialResult{}, err
+	}
+
+	ectx := &EvalContext{
+		parsedInput:      r.parsedInput,
+		metrics:          r.metrics,
+		txn:              r.txn,
+		partialNamespace: r.partialNamespace,
+		tracers:          r.tracers,
+		compiledQuery:    r.compiledQueries[partialResultQueryType],
+		instrumentation:  r.instrumentation,
+	}
+
+	disableInlining := r.disableInlining
+
+	if pCfg.disableInlining != nil {
+		disableInlining = *pCfg.disableInlining
+	}
+
+	ectx.disableInlining, err = parseStringsToRefs(disableInlining)
+	if err != nil {
+		return PartialResult{}, err
+	}
 
 	pq, err := r.partial(ctx, ectx)
 	if err != nil {
@@ -1274,7 +1570,7 @@ func (r *Rego) partialResult(ctx context.Context, ectx *EvalContext, output *ast
 	module.Rules = make([]*ast.Rule, len(pq.Queries))
 	for i, body := range pq.Queries {
 		module.Rules[i] = &ast.Rule{
-			Head:   ast.NewHead(ast.Var("__result__"), nil, output),
+			Head:   ast.NewHead(ast.Var("__result__"), nil, ast.Wildcard),
 			Body:   body,
 			Module: module,
 		}
@@ -1334,6 +1630,7 @@ func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries,
 		WithCompiler(r.compiler).
 		WithStore(r.store).
 		WithTransaction(ectx.txn).
+		WithBuiltins(r.builtinFuncs).
 		WithMetrics(ectx.metrics).
 		WithInstrumentation(ectx.instrumentation).
 		WithUnknowns(unknowns).
@@ -1464,6 +1761,61 @@ func (r Rego) hasQuery() bool {
 	return len(r.query) != 0 || len(r.parsedQuery) != 0
 }
 
+type transactionCloser func(ctx context.Context, err error) error
+
+// getTxn will conditionally create a read or write transaction suitable for
+// the configured Rego object. The returned function should be used to close the txn
+// regardless of status.
+func (r *Rego) getTxn(ctx context.Context) (storage.Transaction, transactionCloser, error) {
+
+	noopCloser := func(ctx context.Context, err error) error {
+		return nil // no-op default
+	}
+
+	if r.txn != nil {
+		// Externally provided txn
+		return r.txn, noopCloser, nil
+	}
+
+	// Create a new transaction..
+	params := storage.TransactionParams{}
+
+	// Bundles and data paths may require writing data files or manifests to storage
+	if len(r.bundles) > 0 || len(r.bundlePaths) > 0 || len(r.loadPaths.paths) > 0 {
+
+		// If we were given a store we will *not* write to it, only do that on one
+		// which was created automatically on behalf of the user.
+		if !r.ownStore {
+			return nil, noopCloser, errors.New("unable to start write transaction when store was provided")
+		}
+
+		params.Write = true
+	}
+
+	txn, err := r.store.NewTransaction(ctx, params)
+	if err != nil {
+		return nil, noopCloser, err
+	}
+
+	// Setup a closer function that will abort or commit as needed.
+	closer := func(ctx context.Context, txnErr error) error {
+		var err error
+
+		if txnErr == nil && params.Write {
+			err = r.store.Commit(ctx, txn)
+		} else {
+			r.store.Abort(ctx, txn)
+		}
+
+		// Clear the auto created transaction now that it is closed.
+		r.txn = nil
+
+		return err
+	}
+
+	return txn, closer, nil
+}
+
 func isTermVar(v ast.Var) bool {
 	return strings.HasPrefix(string(v), ast.WildcardPrefix+"term")
 }
@@ -1539,4 +1891,35 @@ func parseStringsToRefs(s []string) ([]ast.Ref, error) {
 	}
 
 	return refs, nil
+}
+
+// helper function to finish a built-in function call. If an error occured,
+// wrap the error and return it. Otherwise, invoke the iterator if the result
+// was defined.
+func finishFunction(name string, bctx topdown.BuiltinContext, result *ast.Term, err error, iter func(*ast.Term) error) error {
+	if err != nil {
+		return &topdown.Error{
+			Code:     topdown.BuiltinErr,
+			Message:  fmt.Sprintf("%v: %v", name, err.Error()),
+			Location: bctx.Location,
+		}
+	}
+	if result == nil {
+		return nil
+	}
+	return iter(result)
+}
+
+// helper function to return an option that sets a custom built-in function.
+func newFunction(decl *Function, f topdown.BuiltinFunc) func(*Rego) {
+	return func(r *Rego) {
+		r.builtinDecls[decl.Name] = &ast.Builtin{
+			Name: decl.Name,
+			Decl: decl.Decl,
+		}
+		r.builtinFuncs[decl.Name] = &topdown.Builtin{
+			Decl: r.builtinDecls[decl.Name],
+			Func: f,
+		}
+	}
 }

--- a/vendor/github.com/open-policy-agent/opa/topdown/bindings.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/bindings.go
@@ -128,11 +128,6 @@ func (u *bindings) plugNamespaced(a *ast.Term, caller *bindings) *ast.Term {
 }
 
 func (u *bindings) bind(a *ast.Term, b *ast.Term, other *bindings) *undo {
-	// See note in apply about non-var terms.
-	_, ok := a.Value.(ast.Var)
-	if !ok {
-		panic("illegal value")
-	}
 	u.values.Put(a, value{
 		u: other,
 		v: b,

--- a/vendor/github.com/open-policy-agent/opa/topdown/builtins.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/builtins.go
@@ -5,6 +5,7 @@
 package topdown
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -12,55 +13,28 @@ import (
 )
 
 type (
-	// FunctionalBuiltin1 defines an interface for simple functional built-ins.
-	//
-	// Implement this interface if your built-in function takes one input and
-	// produces one output.
-	//
-	// If an error occurs, the functional built-in should return a descriptive
-	// message. The message should not be prefixed with the built-in name as the
-	// framework takes care of this.
+	// FunctionalBuiltin1 is deprecated. Use BuiltinFunc instead.
 	FunctionalBuiltin1 func(op1 ast.Value) (output ast.Value, err error)
 
-	// FunctionalBuiltin2 defines an interface for simple functional built-ins.
-	//
-	// Implement this interface if your built-in function takes two inputs and
-	// produces one output.
-	//
-	// If an error occurs, the functional built-in should return a descriptive
-	// message. The message should not be prefixed with the built-in name as the
-	// framework takes care of this.
+	// FunctionalBuiltin2 is deprecated. Use BuiltinFunc instead.
 	FunctionalBuiltin2 func(op1, op2 ast.Value) (output ast.Value, err error)
 
-	// FunctionalBuiltin3 defines an interface for simple functional built-ins.
-	//
-	// Implement this interface if your built-in function takes three inputs and
-	// produces one output.
-	//
-	// If an error occurs, the functional built-in should return a descriptive
-	// message. The message should not be prefixed with the built-in name as the
-	// framework takes care of this.
+	// FunctionalBuiltin3 is deprecated. Use BuiltinFunc instead.
 	FunctionalBuiltin3 func(op1, op2, op3 ast.Value) (output ast.Value, err error)
 
-	// FunctionalBuiltin4 defines an interface for simple functional built-ins.
-	//
-	// Implement this interface if your built-in function takes four inputs and
-	// produces one output.
-	//
-	// If an error occurs, the functional built-in should return a descriptive
-	// message. The message should not be prefixed with the built-in name as the
-	// framework takes care of this.
+	// FunctionalBuiltin4 is deprecated. Use BuiltinFunc instead.
 	FunctionalBuiltin4 func(op1, op2, op3, op4 ast.Value) (output ast.Value, err error)
 
 	// BuiltinContext contains context from the evaluator that may be used by
 	// built-in functions.
 	BuiltinContext struct {
-		Runtime  *ast.Term      // runtime information on the OPA instance
-		Cache    builtins.Cache // built-in function state cache
-		Location *ast.Location  // location of built-in call
-		Tracers  []Tracer       // tracer objects for trace() built-in function
-		QueryID  uint64         // identifies query being evaluated
-		ParentID uint64         // identifies parent of query being evaluated
+		Context  context.Context // request context that was passed when query started
+		Runtime  *ast.Term       // runtime information on the OPA instance
+		Cache    builtins.Cache  // built-in function state cache
+		Location *ast.Location   // location of built-in call
+		Tracers  []Tracer        // tracer objects for trace() built-in function
+		QueryID  uint64          // identifies query being evaluated
+		ParentID uint64          // identifies parent of query being evaluated
 	}
 
 	// BuiltinFunc defines an interface for implementing built-in functions.
@@ -76,32 +50,27 @@ func RegisterBuiltinFunc(name string, f BuiltinFunc) {
 	builtinFunctions[name] = f
 }
 
-// RegisterFunctionalBuiltin1 adds a new built-in function to the evaluation
-// engine.
+// RegisterFunctionalBuiltin1 is deprecated use RegisterBuiltinFunc instead.
 func RegisterFunctionalBuiltin1(name string, fun FunctionalBuiltin1) {
 	builtinFunctions[name] = functionalWrapper1(name, fun)
 }
 
-// RegisterFunctionalBuiltin2 adds a new built-in function to the evaluation
-// engine.
+// RegisterFunctionalBuiltin2 is deprecated use RegisterBuiltinFunc instead.
 func RegisterFunctionalBuiltin2(name string, fun FunctionalBuiltin2) {
 	builtinFunctions[name] = functionalWrapper2(name, fun)
 }
 
-// RegisterFunctionalBuiltin3 adds a new built-in function to the evaluation
-// engine.
+// RegisterFunctionalBuiltin3 is deprecated use RegisterBuiltinFunc instead.
 func RegisterFunctionalBuiltin3(name string, fun FunctionalBuiltin3) {
 	builtinFunctions[name] = functionalWrapper3(name, fun)
 }
 
-// RegisterFunctionalBuiltin4 adds a new built-in function to the evaluation
-// engine.
+// RegisterFunctionalBuiltin4 is deprecated use RegisterBuiltinFunc instead.
 func RegisterFunctionalBuiltin4(name string, fun FunctionalBuiltin4) {
 	builtinFunctions[name] = functionalWrapper4(name, fun)
 }
 
-// BuiltinEmpty is used to signal that the built-in function evaluated, but the
-// result is undefined so evaluation should not continue.
+// BuiltinEmpty is deprecated.
 type BuiltinEmpty struct{}
 
 func (BuiltinEmpty) Error() string {

--- a/vendor/github.com/open-policy-agent/opa/topdown/query.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/query.go
@@ -34,6 +34,13 @@ type Query struct {
 	disableInlining  []ast.Ref
 	genvarprefix     string
 	runtime          *ast.Term
+	builtins         map[string]*Builtin
+}
+
+// Builtin represents a built-in function that queries can call.
+type Builtin struct {
+	Decl *ast.Builtin
+	Func BuiltinFunc
 }
 
 // NewQuery returns a new Query object that can be run.
@@ -128,6 +135,13 @@ func (q *Query) WithRuntime(runtime *ast.Term) *Query {
 	return q
 }
 
+// WithBuiltins adds a set of built-in functions that can be called by the
+// query.
+func (q *Query) WithBuiltins(builtins map[string]*Builtin) *Query {
+	q.builtins = builtins
+	return q
+}
+
 // PartialRun executes partial evaluation on the query with respect to unknown
 // values. Partial evaluation attempts to evaluate as much of the query as
 // possible without requiring values for the unknowns set on the query. The
@@ -156,6 +170,7 @@ func (q *Query) PartialRun(ctx context.Context) (partials []ast.Body, support []
 		input:           q.input,
 		tracers:         q.tracers,
 		instr:           q.instr,
+		builtins:        q.builtins,
 		builtinCache:    builtins.Cache{},
 		virtualCache:    newVirtualCache(),
 		saveSet:         newSaveSet(q.unknowns, b, q.instr),
@@ -244,6 +259,7 @@ func (q *Query) Iter(ctx context.Context, iter func(QueryResult) error) error {
 		input:        q.input,
 		tracers:      q.tracers,
 		instr:        q.instr,
+		builtins:     q.builtins,
 		builtinCache: builtins.Cache{},
 		virtualCache: newVirtualCache(),
 		genvarprefix: q.genvarprefix,


### PR DESCRIPTION
We had previously pinned a revision between releases, to get the
performance improvements in quick.

Now, there's been a formal release including those, so let's fix this.

Concretely, these commits are pulled in: https://github.com/open-policy-agent/opa/compare/0d70daa545f5a4bf2e6edf3c1b2d635920299bc9...v0.14.0 -- how the changes affect us code-wise can be gathered from the vendor diff here.
