### PR TITLE
compliance-service: increase task executor workers

### DIFF
--- a/components/compliance-service/inspec-agent/runner/runner.go
+++ b/components/compliance-service/inspec-agent/runner/runner.go
@@ -40,7 +40,7 @@ func InitCerealManager(m *cereal.Manager, workerCount int, ingestClient ingest.C
 
 	err = m.RegisterTaskExecutor("create-child", &CreateChildTask{
 		scanner,
-	}, cereal.TaskExecutorOpts{Workers: 1})
+	}, cereal.TaskExecutorOpts{Workers: workerCount})
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func InitCerealManager(m *cereal.Manager, workerCount int, ingestClient ingest.C
 		remoteInspecVersion,
 		scanner,
 		resolver,
-	}, cereal.TaskExecutorOpts{Workers: 1})
+	}, cereal.TaskExecutorOpts{Workers: workerCount})
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func InitCerealManager(m *cereal.Manager, workerCount int, ingestClient ingest.C
 
 	return m.RegisterTaskExecutor("scan-job-summary", &InspecJobSummaryTask{
 		scanner,
-	}, cereal.TaskExecutorOpts{Workers: 1})
+	}, cereal.TaskExecutorOpts{Workers: workerCount})
 }
 
 type LostJob struct {


### PR DESCRIPTION
We recently observed the following failure during the diagnostics test suite:

```
[✗] Verifying compliance-scanning

      	Error Trace:	compliance_report_scan_nodes.go:200
      	            				runner.go:50
      	            				asm_amd64.s:1337
      	Error:      	Received unexpected error:
      	            	Could not find node 1a728af9-6e92-47fc-8ad2-149ee04e9b4b in usage's list of scanned nodes
      	            	github.com/chef/automate/components/automate-cli/pkg/diagnostics/integration.CreateComplianceReportScanNodesDiagnostic.func2.1
      	            		/go/src/github.com/chef/automate/components/automate-cli/pkg/diagnostics/integration/compliance_report_scan_nodes.go:195
      	            	github.com/chef/automate/components/automate-cli/pkg/diagnostics/integration.Retry
      	            		/go/src/github.com/chef/automate/components/automate-cli/pkg/diagnostics/integration/helpers.go:80
      	            	github.com/chef/automate/components/automate-cli/pkg/diagnostics/integration.CreateComplianceReportScanNodesDiagnostic.func2
      	            		/go/src/github.com/chef/automate/components/automate-cli/pkg/diagnostics/integration/compliance_report_scan_nodes.go:173
      	            	github.com/chef/automate/components/automate-cli/pkg/diagnostics/runner.runVerifyInGoRoutine.func1
      	            		/go/src/github.com/chef/automate/components/automate-cli/pkg/diagnostics/runner/runner.go:50
      	            	runtime.goexit
      	            		/usr/local/go/src/runtime/asm_amd64.s:1337
```

The failing test creates a new scan job and then expects it to show up in the license usage reports within 15 seconds.

Based on analysis of the logs for a local reproduction of this failure, I have the following possible explanation. This explanation could be wrong as it is based on correlating log entries.

In the logs we see that it is taking 10 seconds for the resolve-job task to be dequeued. I believe that this 10 second pause in addition to the time it typically takes for the job to run and for Elasticsearch to commit our results is the most likely cause of the failure.

10 seconds corresponds to our default polling intervals:

https://github.com/chef/automate/blob/191d110ff5ff0739a6eee1c933a81bff72926977/lib/cereal/cereal.go#L34-L38

Those polling intervals are so high because we also do in-process notification of the polling threads when we expect a job to be available. However, because we had a limit of 1 worker on these tasks, I believe that if 2 resolve-jobs are enqueued with the right timing, one of them ends up waiting for the full poll interval because of a race. While a single worker will always check for new work when it is done with the old work, the following sequence can happen:

- Worker 1: Finishes task 1
- Worker 1: Starts DequeueTask transactions
- Enqueuer: Enqueues task 2
- Worker 2: Starts, hits max-worker check, exits 
- Worker 1: Completes DequeueTask but got back NoTasks because of the transaction.
- Worker 1: Exits

Now no workers are alive and we have to wait for the interval to restart us. Put another way, if a task is enqueued between these lines, we can end up in this situation:

https://github.com/chef/automate/blob/191d110ff5ff0739a6eee1c933a81bff72926977/lib/cereal/cereal.go#L765-L771

We can look into fixing this race, but bumping the worker counts for these other tasks also make sense since it is closer to what the old code would have been doing. We originally limited the worker count to 1 because cereal was using 1 database connection per task worker. As of 073d58134a03752a252191c1e149e2c25f6b88a2, all dequeue workers share a common pool, so this should not be an issue.

Signed-off-by: Steven Danna <steve@chef.io>