### PR TITLE
automate-gateway: trigger detect job with newly-created ID

### DIFF
--- a/components/automate-gateway/handler/nodes.go
+++ b/components/automate-gateway/handler/nodes.go
@@ -5,15 +5,16 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/golang/protobuf/proto"
+	gp "github.com/golang/protobuf/ptypes/empty"
+	"github.com/sirupsen/logrus"
+
 	"github.com/chef/automate/components/automate-gateway/api/nodes"
 	"github.com/chef/automate/components/automate-gateway/protobuf"
 	jobsService "github.com/chef/automate/components/compliance-service/api/jobs"
 	"github.com/chef/automate/components/compliance-service/dao/pgdb"
 	"github.com/chef/automate/components/compliance-service/inspec-agent/types"
 	nodesService "github.com/chef/automate/components/nodemanager-service/api/nodes"
-	"github.com/golang/protobuf/proto"
-	gp "github.com/golang/protobuf/ptypes/empty"
-	"github.com/sirupsen/logrus"
 )
 
 type Nodes struct {
@@ -56,7 +57,7 @@ func (a *Nodes) Create(ctx context.Context, in *nodes.Node) (*nodes.Id, error) {
 		return nil, err
 	}
 	if autoDetect {
-		a.runDetectJob(ctx, in.Id)
+		a.runDetectJob(ctx, out.Id)
 	}
 	return out, nil
 }


### PR DESCRIPTION
While investigating #1598 we observed that the creation of a new node
during the diagnostics tests was generating a detect job that always
failed to resolve any nodes.

The incoming node in the case of a Create does not have an ID because
the ID is created after calling the nodemanager service. It is this
newly created ID that should be used to trigger the detect job.  It
appears that BulkCreate already does the right thing. Update also uses
in.ID but in that case I believe the incoming node should already have
an ID set since it is an update.

Signed-off-by: Steven Danna <steve@chef.io>