### PR TITLE
automate-gateway: Move license usage log message to debug

### DIFF
--- a/components/automate-gateway/handler/compliance/reporting.go
+++ b/components/automate-gateway/handler/compliance/reporting.go
@@ -3,7 +3,11 @@ package compliance
 import (
 	"context"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	gp "github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	version "github.com/chef/automate/api/external/common/version"
 	"github.com/chef/automate/components/automate-gateway/api/compliance/reporting"
@@ -12,10 +16,6 @@ import (
 	jobsService "github.com/chef/automate/components/compliance-service/api/jobs"
 	reportingService "github.com/chef/automate/components/compliance-service/api/reporting"
 	versionService "github.com/chef/automate/components/compliance-service/api/version"
-	"github.com/golang/protobuf/proto"
-	gp "github.com/golang/protobuf/ptypes/empty"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type Reporting struct {
@@ -197,7 +197,7 @@ func (a *Reporting) LicenseUsageNodes(ctx context.Context, in *reporting.TimeQue
 		// append the nodesListNoAPIScans found from this job to the total reports
 		reports = append(reports, nodesListNoAPIScans...)
 	}
-	logrus.Infof("found license usage nodes %+v", reports)
+	logrus.Debugf("found license usage nodes %+v", reports)
 	return &reporting.Reports{Reports: reports, Total: int32(len(reports))}, nil
 }
 


### PR DESCRIPTION
This log message can be _very_ large on a machine that reports a lot
of nodes. I don't work in this code often, so I've just moved it to
Debug, but we might consider just logging the count rather then the
full report.

Signed-off-by: Steven Danna <steve@chef.io>