### PR TITLE
automate-load-balancer: Don't run reload hook with -x

### DIFF
--- a/components/automate-load-balancer/habitat/hooks/reload
+++ b/components/automate-load-balancer/habitat/hooks/reload
@@ -1,4 +1,4 @@
-#!{{pkgPathFor "core/bash"}}/bin/bash -ex
+#!{{pkgPathFor "core/bash"}}/bin/bash -e
 
 source {{pkg.svc_config_path}}/render-certs.sh
 


### PR DESCRIPTION
Signed-off-by: Steven Danna <steve@chef.io>
