### PR TITLE
Making compliance overview bubble graphs clickable

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-failures/overview-failures.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-failures/overview-failures.component.scss
@@ -14,6 +14,7 @@
     .bubble {
       circle {
         fill: $chef-critical;
+        cursor: pointer;
       }
 
       text {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-failures/overview-failures.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-failures/overview-failures.component.ts
@@ -1,4 +1,5 @@
-import { Component, Inject, Input, OnChanges, OnDestroy, ViewChild } from '@angular/core';
+import { Component, Inject, Input, Output, OnChanges,
+  OnDestroy, ViewChild, EventEmitter } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import * as d3 from 'd3';
 
@@ -22,6 +23,8 @@ export class OverviewFailuresComponent implements OnChanges, OnDestroy {
   @Input() vbWidth = 400;
 
   @Input() vbHeight = 300;
+
+  @Output() itemSelected: EventEmitter<any> = new EventEmitter<any>();
 
   @ViewChild('svg') svg;
 
@@ -85,6 +88,10 @@ export class OverviewFailuresComponent implements OnChanges, OnDestroy {
       d3.selectAll(ns).transition()
         .style('opacity', 1);
     };
+
+    enter.on('click', (node) => {
+      this.itemSelected.next(node.data);
+    });
 
     enter
       .attr('class', 'bubble');

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.html
@@ -68,7 +68,8 @@
         </div>
         <app-overview-failures
           *ngIf="!nodeBubbleLoading && !platformBubbleEmpty"
-          [data]="bubblePlatformFailures">
+          [data]="bubblePlatformFailures"
+          (itemSelected)="onPlatformChanged($event)">
         </app-overview-failures>
       </div>
       <figcaption>Top Platform Failures</figcaption>
@@ -83,7 +84,8 @@
         </div>
         <app-overview-failures
           *ngIf="!nodeBubbleLoading && !envBubbleEmpty"
-          [data]="bubbleEnvFailures">
+          [data]="bubbleEnvFailures"
+          (itemSelected)="onEnvironmentChanged($event)">
         </app-overview-failures>
       </div>
       <figcaption>Top Environment Failures</figcaption>
@@ -156,7 +158,8 @@
         </div>
         <app-overview-failures
           *ngIf="!profileBubbleLoading && !profileBubbleEmpty"
-          [data]="bubbleProfileFailures">
+          [data]="bubbleProfileFailures"
+          (itemSelected)="onProfileChanged($event)">
         </app-overview-failures>
       </div>
       <figcaption>Top Profile Failures</figcaption>
@@ -171,7 +174,8 @@
         </div>
         <app-overview-failures
           *ngIf="!profileBubbleLoading && !controlBubbleEmpty"
-          [data]="bubbleControlFailures">
+          [data]="bubbleControlFailures"
+          (itemSelected)="onControlChanged($event)">
         </app-overview-failures>
       </div>
       <figcaption>Top Control Failures</figcaption>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
@@ -5,6 +5,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CookieModule } from 'ngx-cookie';
 import { of as observableOf } from 'rxjs';
 import * as moment from 'moment';
+import { Router } from '@angular/router';
 import { ReportingOverviewComponent } from './reporting-overview.component';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
 import { StatsService, ReportQueryService, ReportDataService } from '../../shared/reporting';
@@ -19,6 +20,7 @@ describe('ReportingOverviewComponent', () => {
   let component: ReportingOverviewComponent;
   let element: DebugElement;
   let statsService: StatsService;
+  let router: Router;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -44,6 +46,7 @@ describe('ReportingOverviewComponent', () => {
     component = fixture.componentInstance;
     element = fixture.debugElement;
     statsService = element.injector.get(StatsService);
+    router = TestBed.get(Router);
   });
 
   describe('ngOnInit()', () => {
@@ -257,6 +260,114 @@ describe('ReportingOverviewComponent', () => {
           }
         ]);
       });
+    });
+  });
+
+  describe('onPlatformChanged()', () => {
+    it('valid item', () => {
+      spyOn(router, 'navigate');
+
+      component.onPlatformChanged({name: 'ubuntu'});
+
+      expect(router.navigate).toHaveBeenCalledWith(['/compliance', 'reports', 'nodes'],
+        {queryParams: { platform: ['ubuntu'] }});
+    });
+
+    it('invalid item', () => {
+      spyOn(router, 'navigate');
+
+      component.onPlatformChanged({name: ''});
+
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+
+    it('null item', () => {
+      spyOn(router, 'navigate');
+
+      component.onPlatformChanged(null);
+
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onEnvironmentChanged()', () => {
+    it('valid item', () => {
+      spyOn(router, 'navigate');
+
+      component.onEnvironmentChanged({name: 'dev'});
+
+      expect(router.navigate).toHaveBeenCalledWith(['/compliance', 'reports', 'nodes'],
+        {queryParams: { environment: ['dev'] }});
+    });
+
+    it('invalid item', () => {
+      spyOn(router, 'navigate');
+
+      component.onEnvironmentChanged({name: ''});
+
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+
+    it('null item', () => {
+      spyOn(router, 'navigate');
+
+      component.onEnvironmentChanged(null);
+
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onProfileChanged()', () => {
+    it('valid item', () => {
+      spyOn(router, 'navigate');
+
+      component.onProfileChanged({id: 'id-1234'});
+
+      expect(router.navigate).toHaveBeenCalledWith(['/compliance', 'reports', 'nodes'],
+        {queryParams: { profile_id: ['id-1234'] }});
+    });
+
+    it('invalid item', () => {
+      spyOn(router, 'navigate');
+
+      component.onProfileChanged({name: ''});
+
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+
+    it('null item', () => {
+      spyOn(router, 'navigate');
+
+      component.onProfileChanged(null);
+
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onControlChanged()', () => {
+    it('valid item', () => {
+      spyOn(router, 'navigate');
+
+      component.onControlChanged({name: 'id-1234'});
+
+      expect(router.navigate).toHaveBeenCalledWith(['/compliance', 'reports', 'nodes'],
+        {queryParams: { control_id: ['id-1234'] }});
+    });
+
+    it('invalid item', () => {
+      spyOn(router, 'navigate');
+
+      component.onControlChanged({name: ''});
+
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+
+    it('null item', () => {
+      spyOn(router, 'navigate');
+
+      component.onControlChanged(null);
+
+      expect(router.navigate).not.toHaveBeenCalled();
     });
   });
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.ts
@@ -114,6 +114,63 @@ export class ReportingOverviewComponent implements OnInit, OnDestroy {
     }
   }
 
+  onPlatformChanged(platformItem) {
+    const typeName = 'platform';
+    if (platformItem && platformItem.name) {
+      const {queryParamMap} = this.route.snapshot;
+      const queryParams = {...this.route.snapshot.queryParams};
+      const existingValues = queryParamMap.getAll(typeName).filter(
+        v => v !== platformItem.name).concat(platformItem.name);
+
+      queryParams[typeName] = existingValues;
+
+      this.router.navigate(['/compliance', 'reports', 'nodes'], {queryParams});
+    }
+  }
+
+  onEnvironmentChanged(environmentItem) {
+    const typeName = 'environment';
+    if (environmentItem && environmentItem.name) {
+      const {queryParamMap} = this.route.snapshot;
+      const queryParams = {...this.route.snapshot.queryParams};
+      const existingValues = queryParamMap.getAll(typeName).filter(
+        v => v !== environmentItem.name).concat(environmentItem.name);
+
+      queryParams[typeName] = existingValues;
+
+      this.router.navigate(['/compliance', 'reports', 'nodes'], {queryParams});
+    }
+  }
+
+  onProfileChanged(profileItem) {
+    const typeName = 'profile_id';
+    if (profileItem && profileItem.id) {
+      const {queryParamMap} = this.route.snapshot;
+      const queryParams = {...this.route.snapshot.queryParams};
+      const existingValues = queryParamMap.getAll(typeName).filter(
+        v => v !== profileItem.id).concat(profileItem.id);
+
+      this.reportQuery.setFilterTitle(typeName, profileItem.id, profileItem.name);
+      queryParams[typeName] = existingValues;
+
+      this.router.navigate(['/compliance', 'reports', 'nodes'], {queryParams});
+    }
+  }
+
+  onControlChanged(controlItem) {
+    const typeName = 'control_id';
+    if (controlItem && controlItem.name) {
+      const {queryParamMap} = this.route.snapshot;
+      const queryParams = {...this.route.snapshot.queryParams};
+      const existingValues = queryParamMap.getAll(typeName).filter(
+        v => v !== controlItem.name).concat(controlItem.name);
+
+      queryParams[typeName] = existingValues;
+
+      this.router.navigate(['/compliance', 'reports', 'nodes'], {queryParams});
+    }
+  }
+
   getNodeStatusData(reportQuery: ReportQuery) {
     this.getNodeStatusFailures(reportQuery);
     this.getNodeSummary(reportQuery);

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.ts
@@ -8,6 +8,7 @@ import {
   ReportQuery
 } from '../../shared/reporting';
 import { ActivatedRoute, Router } from '@angular/router';
+import { union } from 'lodash/fp';
 
 type Tab = 'Node Status' | 'Profile Status';
 
@@ -115,59 +116,28 @@ export class ReportingOverviewComponent implements OnInit, OnDestroy {
   }
 
   onPlatformChanged(platformItem) {
-    const typeName = 'platform';
     if (platformItem && platformItem.name) {
-      const {queryParamMap} = this.route.snapshot;
-      const queryParams = {...this.route.snapshot.queryParams};
-      const existingValues = queryParamMap.getAll(typeName).filter(
-        v => v !== platformItem.name).concat(platformItem.name);
-
-      queryParams[typeName] = existingValues;
-
-      this.router.navigate(['/compliance', 'reports', 'nodes'], {queryParams});
+      this.updateUrlWithFilter(platformItem.name, 'platform');
     }
   }
 
   onEnvironmentChanged(environmentItem) {
-    const typeName = 'environment';
     if (environmentItem && environmentItem.name) {
-      const {queryParamMap} = this.route.snapshot;
-      const queryParams = {...this.route.snapshot.queryParams};
-      const existingValues = queryParamMap.getAll(typeName).filter(
-        v => v !== environmentItem.name).concat(environmentItem.name);
-
-      queryParams[typeName] = existingValues;
-
-      this.router.navigate(['/compliance', 'reports', 'nodes'], {queryParams});
+      this.updateUrlWithFilter(environmentItem.name, 'environment');
     }
   }
 
   onProfileChanged(profileItem) {
     const typeName = 'profile_id';
     if (profileItem && profileItem.id) {
-      const {queryParamMap} = this.route.snapshot;
-      const queryParams = {...this.route.snapshot.queryParams};
-      const existingValues = queryParamMap.getAll(typeName).filter(
-        v => v !== profileItem.id).concat(profileItem.id);
-
       this.reportQuery.setFilterTitle(typeName, profileItem.id, profileItem.name);
-      queryParams[typeName] = existingValues;
-
-      this.router.navigate(['/compliance', 'reports', 'nodes'], {queryParams});
+      this.updateUrlWithFilter(profileItem.id, typeName);
     }
   }
 
   onControlChanged(controlItem) {
-    const typeName = 'control_id';
     if (controlItem && controlItem.name) {
-      const {queryParamMap} = this.route.snapshot;
-      const queryParams = {...this.route.snapshot.queryParams};
-      const existingValues = queryParamMap.getAll(typeName).filter(
-        v => v !== controlItem.name).concat(controlItem.name);
-
-      queryParams[typeName] = existingValues;
-
-      this.router.navigate(['/compliance', 'reports', 'nodes'], {queryParams});
+      this.updateUrlWithFilter(controlItem.name, 'control_id');
     }
   }
 
@@ -275,5 +245,15 @@ export class ReportingOverviewComponent implements OnInit, OnDestroy {
       major: data.majors,
       minor: data.minors
     };
+  }
+
+  private updateUrlWithFilter(value: string, typeName: string) {
+    const {queryParamMap} = this.route.snapshot;
+    const queryParams = {...this.route.snapshot.queryParams};
+    const existingValues = union([value], queryParamMap.getAll(typeName));
+
+    queryParams[typeName] = existingValues;
+
+    this.router.navigate(['/compliance', 'reports', 'nodes'], {queryParams});
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When clicking one of the bubble graphs ("Top Platform Failures", "Top Environment Failures", "Top Profile Failures", and "Top Control Failures") on the compliance reporting overview page

### :chains: Related Resources

#441

### :+1: Definition of Done

Able to filter from clicking the bubble graph on the compliance reporting overview page. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui && start_all_services`
1. Load some compliance nodes `chef_load_compliance_scans -N10 -M100 -T10 -D1`
1. Go to https://a2-dev.test/compliance/reports/overview and select a bubble from the four bubble graphs. "Top Platform Failures", "Top Environment Failures", "Top Profile Failures", and "Top Control Failures"

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
![bubble_clicker](https://user-images.githubusercontent.com/1679247/64888277-6d719000-d61f-11e9-9332-50dd223952ec.gif)
