### PR TITLE
[AUTH-1501] Updated project details page to display pending edits message when rule deletes are staged

### DIFF
--- a/components/automate-ui/src/app/entities/projects/project.reducer.ts
+++ b/components/automate-ui/src/app/entities/projects/project.reducer.ts
@@ -79,7 +79,7 @@ export function projectEntityReducer(
 
     case ProjectActionTypes.GET_SUCCESS:
       return set(GET_STATUS, EntityStatus.loadingSuccess,
-        projectEntityAdapter.addOne(action.payload.project, state));
+        projectEntityAdapter.upsertOne(action.payload.project, state));
 
     case ProjectActionTypes.GET_FAILURE:
       return set(GET_STATUS, EntityStatus.loadingFailure, state);

--- a/components/automate-ui/src/app/entities/rules/rule.selectors.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.selectors.ts
@@ -36,10 +36,14 @@ export const createError = createSelector(
   (state) => state.createError
 );
 
-
 export const updateStatus = createSelector(
   ruleState,
   (state) => state.updateStatus
+);
+
+export const deleteStatus = createSelector(
+  ruleState,
+  (state) => state.deleteStatus
 );
 
 export const ruleFromRoute = createSelector(

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -61,7 +61,7 @@
           <app-authorized [allOf]="['/iam/v2beta/projects', 'post']">
             <chef-button [routerLink]="['/settings', 'projects', project?.id, 'rules']" id="create-button" primary>Create Rule</chef-button>
           </app-authorized>
-          <small *ngIf="project.status === 'EDITS_PENDING'">Edits are pending: update <a [routerLink]="['/settings/projects']">projects</a> to apply edits.</small>
+          <small *ngIf="project?.status === 'EDITS_PENDING'">Edits are pending: update <a [routerLink]="['/settings/projects']">projects</a> to apply edits.</small>
         </chef-toolbar>
         <app-authorized [allOf]="['/iam/v2beta/projects', 'get']">
           <chef-table id="project-rules-table">
@@ -96,18 +96,14 @@
           </chef-table>
         </app-authorized>
       </ng-container>
-      <ng-container *ngIf="showFirstRuleMessage()">
+      <ng-container *ngIf="showNoRulesMessage()">
         <app-authorized [allOf]="['/iam/v2beta/projects', 'post']">
           <div class="empty-case-container">
-            <div class="empty-case-entry">
-              <small *ngIf="project.status === 'EDITS_PENDING'">Deleted rules are pending: update <a [routerLink]="['/settings/projects']">projects</a> to apply edits.</small>
-            </div>
-            <div class="empty-case-entry">
-              <p>Create the first ingest rule to get started!</p>
-            </div>
-            <div class="empty-case-entry">
-              <chef-button primary [routerLink]="['/settings', 'projects', project?.id, 'rules']">Create Rule</chef-button>
-            </div>
+            <small class="empty-case-entry" *ngIf="project?.status === 'EDITS_PENDING'">
+              Edits are pending: update <a [routerLink]="['/settings/projects']">projects</a> to apply edits.
+            </small>
+            <p class="empty-case-entry">Create the first ingest rule to get started!</p>
+            <chef-button primary [routerLink]="['/settings', 'projects', project?.id, 'rules']" class="empty-case-entry">Create Rule</chef-button>
           </div>
         </app-authorized>
       </ng-container>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -61,7 +61,7 @@
           <app-authorized [allOf]="['/iam/v2beta/projects', 'post']">
             <chef-button [routerLink]="['/settings', 'projects', project?.id, 'rules']" id="create-button" primary>Create Rule</chef-button>
           </app-authorized>
-          <small *ngIf="showProjectLink()">Edits pending, update <a [routerLink]="['/settings/projects']">projects</a> to apply edits.</small>
+          <small *ngIf="project.status === 'EDITS_PENDING'">Edits are pending: update <a [routerLink]="['/settings/projects']">projects</a> to apply edits.</small>
         </chef-toolbar>
         <app-authorized [allOf]="['/iam/v2beta/projects', 'get']">
           <chef-table id="project-rules-table">
@@ -99,10 +99,15 @@
       <ng-container *ngIf="showFirstRuleMessage()">
         <app-authorized [allOf]="['/iam/v2beta/projects', 'post']">
           <div class="empty-case-container">
-            <p>Create the first ingest rule to get started!</p>
-          </div>
-          <div class="empty-case-container">
+            <div class="empty-case-entry">
+              <small *ngIf="project.status === 'EDITS_PENDING'">Deleted rules are pending: update <a [routerLink]="['/settings/projects']">projects</a> to apply edits.</small>
+            </div>
+            <div class="empty-case-entry">
+              <p>Create the first ingest rule to get started!</p>
+            </div>
+            <div class="empty-case-entry">
               <chef-button primary [routerLink]="['/settings', 'projects', project?.id, 'rules']">Create Rule</chef-button>
+            </div>
           </div>
         </app-authorized>
       </ng-container>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.scss
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.scss
@@ -108,21 +108,17 @@ chef-table {
 
 .empty-case-container {
   margin-top: 42px;
+  //display: flex;
+  justify-content: center;
+  //flex-direction: column;
+  text-align: center;
 
   .empty-case-entry {
-    display: flex;
-    justify-content: center;
     margin-top: 18px;
     margin-bottom: 0;
+  }
 
-    p {
-      font-size: 18px;
-      text-align: center;
-      margin: 0;
-    }
-
-    chef-button {
-      margin: 0;
-    }
+  p {
+    font-size: 18px;
   }
 }

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.scss
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.scss
@@ -107,17 +107,22 @@ chef-table {
 }
 
 .empty-case-container {
-  display: flex;
-  justify-content: center;
+  margin-top: 42px;
 
-  p {
-    margin-top: 42px;
-    font-size: 18px;
-    margin-bottom: 0;
-    text-align: center;
-  }
-
-  chef-button {
+  .empty-case-entry {
+    display: flex;
+    justify-content: center;
     margin-top: 18px;
+    margin-bottom: 0;
+
+    p {
+      font-size: 18px;
+      text-align: center;
+      margin: 0;
+    }
+
+    chef-button {
+      margin: 0;
+    }
   }
 }

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -23,7 +23,7 @@ describe('ProjectDetailsComponent', () => {
     id: 'uuid-1',
     name: 'Default',
     type: 'CHEF_MANAGED',
-    status: 'NO_RULES'
+    status: 'EDITS_PENDING'
   };
   const rules: Rule[] = [
     {
@@ -167,7 +167,7 @@ describe('ProjectDetailsComponent', () => {
     });
 
     it('displays create-your-first-rule message', () => {
-      expect(component.showFirstRuleMessage()).toBeTruthy();
+      expect(component.showNoRulesMessage()).toBeTruthy();
     });
   });
 
@@ -193,11 +193,11 @@ describe('ProjectDetailsComponent', () => {
     });
 
     it('does not display create-your-first-rule message', () => {
-      expect(component.showFirstRuleMessage()).toBeFalsy();
+      expect(component.showNoRulesMessage()).toBeFalsy();
     });
 
     it('shows a link back to project when a rule has edits pending', () => {
-      expect(component.showProjectLink()).toBeTruthy();
+      expect(component.project.status === 'EDITS_PENDING').toBeTruthy();
     });
 
     it('enables delete-rule button when a rule has edits pending', () => {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -109,12 +109,10 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
 
     // if a rule gets deleted, we need to refresh the project status
     this.store.select(deleteRuleStatus).pipe(
-      filter(() => this.id !== undefined),
+      filter(status => this.id !== undefined && status === EntityStatus.loadingSuccess),
       takeUntil(this.isDestroyed))
-      .subscribe((status) => {
-        if (status === EntityStatus.loadingSuccess) {
-          this.store.dispatch(new GetProject({ id: this.id }));
-        }
+      .subscribe(() => {
+        this.store.dispatch(new GetProject({ id: this.id }));
       });
   }
 
@@ -129,7 +127,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
     this.router.navigate([this.url.split('#')[0]], { fragment: event.target.value });
   }
 
-  showFirstRuleMessage(): boolean {
+  showNoRulesMessage(): boolean {
     return !this.isLoading && this.rules.length === 0;
   }
 

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Subject, combineLatest } from 'rxjs';
 import { filter, pluck, takeUntil } from 'rxjs/operators';
-import { identity, some } from 'lodash/fp';
+import { identity } from 'lodash/fp';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams, routeURL } from 'app/route.selectors';
@@ -16,8 +16,12 @@ import {
 import { Project } from 'app/entities/projects/project.model';
 import { GetProject, UpdateProject } from 'app/entities/projects/project.actions';
 import { GetRulesForProject, DeleteRule } from 'app/entities/rules/rule.actions';
-import { Rule, RuleStatus } from 'app/entities/rules/rule.model';
-import { allRules, getAllStatus } from 'app/entities/rules/rule.selectors';
+import { Rule } from 'app/entities/rules/rule.model';
+import {
+  allRules,
+  getAllStatus,
+  deleteStatus as deleteRuleStatus
+} from 'app/entities/rules/rule.selectors';
 
 export type ProjectTabName = 'rules' | 'details';
 
@@ -44,6 +48,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   public isLoading = true;
   public saving = false;
   private isDestroyed = new Subject<boolean>();
+  private id: string;
 
   constructor(
     private fb: FormBuilder,
@@ -98,7 +103,18 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
       filter(identity),
       takeUntil(this.isDestroyed))
       .subscribe((id: string) => {
+        this.id = id;
         this.store.dispatch(new GetProject({ id }));
+      });
+
+    // if a rule gets deleted, we need to refresh the project status
+    this.store.select(deleteRuleStatus).pipe(
+      filter(() => this.id !== undefined),
+      takeUntil(this.isDestroyed))
+      .subscribe((status) => {
+        if (status === EntityStatus.loadingSuccess) {
+          this.store.dispatch(new GetProject({ id: this.id }));
+        }
       });
   }
 
@@ -144,12 +160,6 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
 
   showDeleteRule(): boolean {
     return true; // TODO: return false when *project* status is "updating..."
-  }
-
-  showProjectLink(): boolean {
-    const statusPropertyName = 'status';
-    const ruleStatus: RuleStatus = 'STAGED';
-    return some([statusPropertyName, ruleStatus], this.rules);
   }
 
   saveProject(): void {

--- a/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
@@ -88,6 +88,7 @@ describeIfIAMV2p1('project management', () => {
 
   // something is occasionally resetting the projects filter to (unassigned)
   itFlaky('can create a rule for the new project', () => {
+    cy.get('app-project-details').contains('Edits are pending').should('not.exist');
     cy.get('app-project-details app-authorized button').contains('Create Rule').click();
 
     cy.url().should('include', `/settings/projects/${projectID}/rules`);
@@ -125,6 +126,7 @@ describeIfIAMV2p1('project management', () => {
 
     cy.url().should('include', `/settings/projects/${projectID}`);
     cy.get('app-project-details chef-td').contains(ruleID);
+    cy.get('app-project-details').contains('Edits are pending');
   });
 
   itFlaky('displays a list of rules for a project', () => {
@@ -140,6 +142,7 @@ describeIfIAMV2p1('project management', () => {
   });
 
   itFlaky('can update a project rule', () => {
+    cy.get('app-project-details').contains('Edits are pending');
     const updatedRuleName = `updated ${ruleName}`;
     cy.get('app-project-details a').contains(ruleName).click();
 
@@ -174,6 +177,7 @@ describeIfIAMV2p1('project management', () => {
     cy.url().should('include', '/settings/projects');
     cy.get('app-project-details chef-td').contains(updatedRuleName);
     cy.get('app-project-details chef-td').contains('2 conditions');
+    cy.get('app-project-details').contains('Edits are pending');
   });
 
   itFlaky('can update a project name', () => {
@@ -192,6 +196,7 @@ describeIfIAMV2p1('project management', () => {
   });
 
   itFlaky('can delete a project rule', () => {
+    cy.get('app-project-details').contains('Edits are pending');
     cy.get('[data-cy=rules-tab]').click();
 
     cy.get('app-project-details chef-td').contains(ruleID).parent()
@@ -206,6 +211,7 @@ describeIfIAMV2p1('project management', () => {
     // since this is a cypress custom project, we know this is the only rule.
     // the empty UI should show up so entire table will be missing.
     cy.get('app-project-details chef-tbody').should('not.exist');
+    cy.get('app-project-details').contains('Edits are pending').should('not.exist');
   });
 
   // sometimes the deleted successfully notification isn't showing up


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Also added a message for the empty rules UI in the case that there are deletes pending (needs Susan's review)

### :athletic_shoe: How to Build and Test the Change

1)Create two rules in a new projects
2)Apply both rules
3) Go to project and delete one rule, see `Edits are pending...`
4) Delete second rule, see empty UI case and see `Deleted rules are pending...`

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable

@susanev Added a case into the no rules UI. If there are no rules but there are staged deleted rules, it will have the extra message below:

<img width="1078" alt="Screen Shot 2019-09-13 at 10 53 00 AM" src="https://user-images.githubusercontent.com/1899715/64888473-f5f03080-d61f-11e9-88c9-8b962deae459.png">
