### PR TITLE
Changing compliance reporting search bar type names

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -57,6 +57,12 @@ export class ReportingComponent implements OnInit, OnDestroy {
   // Query search bar
   availableFilterTypes = [
     {
+      'name': 'organization',
+      'title': 'Chef Organization',
+      'description': 'Add the organization to filter this report to a specific organization',
+      'placeholder': 'Organization'
+    },
+    {
       'name': 'chef_server',
       'title': 'Chef Server',
       'description': '',
@@ -64,9 +70,9 @@ export class ReportingComponent implements OnInit, OnDestroy {
     },
     {
       'name': 'chef_tags',
-      'title': 'Chef Tags',
+      'title': 'Chef Tag',
       'description': '',
-      'placeholder': 'Chef Tags'
+      'placeholder': 'Chef Tag'
     },
     {
       'name': 'control',
@@ -91,12 +97,6 @@ export class ReportingComponent implements OnInit, OnDestroy {
       'title': 'Node Name',
       'description': 'Add the node name to filter this report against a specific node',
       'placeholder': 'Node Name'
-    },
-    {
-      'name': 'organization',
-      'title': 'Organization',
-      'description': 'Add the organization to filter this report to a specific organization',
-      'placeholder': 'Organization'
     },
     {
       'name': 'platform',

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -60,7 +60,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
       'name': 'organization',
       'title': 'Chef Organization',
       'description': 'Add the organization to filter this report to a specific organization',
-      'placeholder': 'Organization'
+      'placeholder': 'Chef Organization'
     },
     {
       'name': 'chef_server',


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Currently, the compliance reports filter search in the UI uses Organization and Chef Tags but this does not align with the names of things in client runs or project ingest rules.

### :chains: Related Resources
#1498

### :+1: Definition of Done
The compliance reporting search bar has types "Chef Organization" and "Chef Tag"

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui && start_all_services`
1. Open https://a2-dev.test/compliance/reports/overview
1. Check the search bar types are correct. 

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
![Screen Shot 2019-09-13 at 2 02 38 PM](https://user-images.githubusercontent.com/1679247/64894660-2a1f1d80-d62f-11e9-919e-683b94832c5e.png)
