### PR TITLE
added note about being on the latest automate version before upgrading iam

### DIFF
--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -15,6 +15,10 @@ After upgrading to IAM v2, you'll add members to Chef-managed v2 policies, delet
 
 ## Upgrade to IAM v2
 
+{{< info >}}
+To get the best possible IAM v2 experience, Chef Automate should be running the latest version before upgrading to IAM v2.
+{{< /info >}}
+
 Perform the upgrade to IAM v2 with `chef-automate iam upgrade-to-v2`; the response should look something like:
 
 ```terminal


### PR DESCRIPTION
Signed-off-by: susanev <susan.ra.evans@gmail.com>

### :nut_and_bolt: Description: What code changed, and why?

Recently, in internal slack we learned about a customer who was on an older version of Automate when they upgraded to iam v2 this caused some bugs we had fixed in later versions. This pr adds a note to the iam v2 docs encouraging users to be on the latest Chef Automate version before upgrading iam.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [x] Docs added/updated?

### :camera: Screenshots, if applicable
<img width="882" alt="docs-upgrade-automate-info" src="https://user-images.githubusercontent.com/5489125/64895781-66a04880-d632-11e9-84d8-ea59d7e24c12.png">
