### PR TITLE
Fix selecting a date outside current month

### DIFF
--- a/components/automate-ui/src/app/components/calendar/calendar.component.html
+++ b/components/automate-ui/src/app/components/calendar/calendar.component.html
@@ -11,7 +11,7 @@
   <span class="column-header" *ngFor="let name of weekdays">
     {{ name }}
   </span>
-  <span (click)="onDayClick(day[1])" [ngClass]="[ 'day', day[0] ]" *ngFor="let day of days; trackBy: trackBy">
-    {{ day[1] }}
+  <span (click)="onDayClick(day)" [ngClass]="[ 'day', day[0] ]" *ngFor="let day of days; trackBy: trackBy">
+    {{ day[1].date() }}
   </span>
 </div>

--- a/components/automate-ui/src/app/components/calendar/calendar.component.scss
+++ b/components/automate-ui/src/app/components/calendar/calendar.component.scss
@@ -61,5 +61,11 @@ $day-size: $size * 2.75;
 
   &.i {
     color: $chef-grey;
+    cursor: pointer;
+  }
+
+  &.i:hover {
+    background-color: $chef-primary-bright;
+    color: $chef-white;
   }
 }

--- a/components/automate-ui/src/app/components/calendar/calendar.component.spec.ts
+++ b/components/automate-ui/src/app/components/calendar/calendar.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, DebugElement, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import * as moment from 'moment';
 
 import { CalendarComponent } from './calendar.component';
 
@@ -121,12 +120,6 @@ describe('CalendarComponent', () => {
       const inactiveDays = calendarDateEl.queryAll(By.css('.day.i'));
 
       expect(inactiveDays.length).toBe(7);
-    });
-
-    it('displays the correct number of inactive days', () => {
-      const d = moment('2017-02-21');
-
-      expect(d.date()).toEqual(21);
     });
 
     it('selects the correct day', () => {

--- a/components/automate-ui/src/app/components/calendar/calendar.component.spec.ts
+++ b/components/automate-ui/src/app/components/calendar/calendar.component.spec.ts
@@ -1,6 +1,7 @@
 import { Component, DebugElement, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import * as moment from 'moment';
 
 import { CalendarComponent } from './calendar.component';
 
@@ -120,6 +121,12 @@ describe('CalendarComponent', () => {
       const inactiveDays = calendarDateEl.queryAll(By.css('.day.i'));
 
       expect(inactiveDays.length).toBe(7);
+    });
+
+    it('displays the correct number of inactive days', () => {
+      const d = moment('2017-02-21');
+
+      expect(d.date()).toEqual(21);
     });
 
     it('selects the correct day', () => {

--- a/components/automate-ui/src/app/components/calendar/calendar.component.ts
+++ b/components/automate-ui/src/app/components/calendar/calendar.component.ts
@@ -25,7 +25,7 @@ export class CalendarComponent {
 
   @Output() onNextMonth: EventEmitter<[number, number]> = new EventEmitter();
   @Output() onPrevMonth: EventEmitter<[number, number]> = new EventEmitter();
-  @Output() onDaySelect: EventEmitter<m.Moment> = new EventEmitter();
+  @Output() onDaySelect: EventEmitter<string> = new EventEmitter();
 
   constructor() {
     this.month = this.date.month().toString();
@@ -156,7 +156,7 @@ export class CalendarComponent {
   }
 
   public onDayClick(day) {
-    this.onDaySelect.emit(day[1].clone());
+    this.onDaySelect.emit(day[1].format('YYYY-MM-DD'));
   }
 
   trackBy(index, _item) {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
@@ -406,7 +406,7 @@ export class ReportingSearchbarComponent implements OnInit {
   }
 
   onDaySelect(day) {
-    this.visibleDate.setDate(day);
+    this.visibleDate = day.toDate();
     this.dateChanged.emit({ detail: new Date(this.visibleDate) });
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
@@ -405,8 +405,8 @@ export class ReportingSearchbarComponent implements OnInit {
     this.visibleDate.setFullYear(year);
   }
 
-  onDaySelect(day) {
-    this.visibleDate = day.toDate();
+  onDaySelect(date) {
+    this.visibleDate = new Date(date);
     this.dateChanged.emit({ detail: new Date(this.visibleDate) });
   }
 

--- a/components/automate-ui/src/app/pages/component-library/demos/demo-calendar/demo-calendar.component.ts
+++ b/components/automate-ui/src/app/pages/component-library/demos/demo-calendar/demo-calendar.component.ts
@@ -15,7 +15,7 @@ export class DemoCalendarComponent {
     this.date.year(year);
   }
 
-  handleDaySelect(day) {
-    this.date = day.clone();
+  handleDaySelect(date) {
+    this.date = moment(date);
   }
 }

--- a/components/automate-ui/src/app/pages/component-library/demos/demo-calendar/demo-calendar.component.ts
+++ b/components/automate-ui/src/app/pages/component-library/demos/demo-calendar/demo-calendar.component.ts
@@ -16,6 +16,6 @@ export class DemoCalendarComponent {
   }
 
   handleDaySelect(day) {
-    this.date.date(day);
+    this.date = day.clone();
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This change fixes the problem on the compliance page if you attempt to change the date using the Calendar popup it takes you to the wrong date when clicking on one of the grey'd out days for the previous or next month. 

### :chains: Related Resources
#1469
### :+1: Definition of Done
The calendar selects the correct date when days for the previous and next month are selected. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui && start_all_services`
1. Go to https://a2-dev.test/compliance/reports/overview and select dates in the search bar. 

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
Before
![before2](https://user-images.githubusercontent.com/1679247/64900824-48454780-d648-11e9-99f5-452f81d04b35.gif)

After
As you can see below what was also add is the highting and curser change. 
![after2](https://user-images.githubusercontent.com/1679247/65001578-dd447c80-d8a4-11e9-8f28-409acbf55490.gif)


