### PR TITLE
[Automate-793] Add caching to introspect calls

### DIFF
--- a/components/automate-ui/e2e/admin.e2e-spec.ts
+++ b/components/automate-ui/e2e/admin.e2e-spec.ts
@@ -16,13 +16,7 @@ describe('Admin pages', () => {
         }));
 
       fakeServer()
-        .post('/api/v0/auth/introspect_some', JSON.stringify(
-          {
-            paths: [
-              '/auth/users'
-            ]
-          }
-        ))
+        .get('/api/v0/auth/introspect')
         .many()
         .reply(200, JSON.stringify(
           {
@@ -128,14 +122,7 @@ describe('Admin pages', () => {
 
       beforeEach(() => {
         fakeServer()
-          .post('/api/v0/auth/introspect_some', JSON.stringify(
-            {
-              paths: [
-                '/iam/v2beta/tokens',
-                '/auth/tokens'
-              ]
-            }
-          ))
+          .get('/api/v0/auth/introspect')
           .many()
           .reply(200, JSON.stringify(
             {
@@ -150,7 +137,7 @@ describe('Admin pages', () => {
               }
             }
           ));
-        // TODO: protect DELETE and TOGGLE, add mock introspect_some responses here
+        // TODO: protect DELETE and TOGGLE, add mock introspect responses here
 
         fakeServer()
           .get('/apis/iam/v2beta/tokens')
@@ -349,14 +336,7 @@ describe('Admin pages', () => {
 
       beforeEach(() => {
         fakeServer()
-          .post('/api/v0/auth/introspect_some', JSON.stringify(
-            {
-              paths: [
-                '/iam/v2beta/tokens',
-                '/auth/tokens'
-              ]
-            }
-          ))
+          .get('/api/v0/auth/introspect')
           .many()
           .reply(200, JSON.stringify(
             {
@@ -544,13 +524,7 @@ describe('Admin pages', () => {
   describe('Policies list', () => {
     beforeEach(() => {
       fakeServer()
-        .post('/api/v0/auth/introspect_some', JSON.stringify(
-          {
-            paths: [
-              '/iam/v2beta/policies'
-            ]
-          }
-        ))
+        .get('/api/v0/auth/introspect')
         .many()
         .reply(200, JSON.stringify(
           {
@@ -1007,13 +981,7 @@ describe('Admin pages', () => {
   describe('Roles list', () => {
     beforeEach(() => {
       fakeServer()
-        .post('/api/v0/auth/introspect_some', JSON.stringify(
-          {
-            paths: [
-              '/iam/v2beta/roles'
-            ]
-          }
-        ))
+        .get('/api/v0/auth/introspect')
         .many()
         .reply(200, JSON.stringify(
           {
@@ -1151,13 +1119,7 @@ describe('Admin pages', () => {
   describe('Projects list', () => {
     beforeEach(() => {
       fakeServer()
-        .post('/api/v0/auth/introspect_some', JSON.stringify(
-          {
-            paths: [
-              '/iam/v2beta/projects'
-            ]
-          }
-        ))
+        .get('/api/v0/auth/introspect')
         .many()
         .reply(200, JSON.stringify(
           {
@@ -1464,13 +1426,7 @@ describe('Admin pages', () => {
   describe('projects list when the max of 6 projects is reached', () => {
     beforeEach(() => {
       fakeServer()
-      .post('/api/v0/auth/introspect_some', JSON.stringify(
-        {
-          paths: [
-            '/iam/v2beta/projects'
-          ]
-        }
-      ))
+      .get('/api/v0/auth/introspect')
       .many()
       .reply(200, JSON.stringify(
         {

--- a/components/automate-ui/src/app/entities/userperms/userperms.effects.ts
+++ b/components/automate-ui/src/app/entities/userperms/userperms.effects.ts
@@ -3,7 +3,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Store } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import {
-  debounceTime,
+  throttleTime,
   mergeMap,
   map,
   catchError,
@@ -38,12 +38,11 @@ export class UserPermEffects {
     private store: Store<NgrxStateAtom>
   ) { }
 
+  private freshLimitInMilliseconds = 30000;
   @Effect()
   fetchAllPerms$ = this.actions$.pipe(
     ofType(UserPermsTypes.GET_ALL),
-    debounceTime(20), // each request of this type is a true duplicate so debounce them
-    withLatestFrom(this.store.select(getlastFetchTime)),
-    filter(([_action, lastTime]) => this.stale(lastTime)),
+    throttleTime(this.freshLimitInMilliseconds),
     switchMap(() => {
       return this.requests.fetchAll().pipe(
         map((resp: UserPermsResponsePayload) => new GetAllUserPermsSuccess(resp.endpoints)),

--- a/components/automate-ui/src/app/entities/userperms/userperms.effects.ts
+++ b/components/automate-ui/src/app/entities/userperms/userperms.effects.ts
@@ -1,9 +1,20 @@
-import { debounceTime, mergeMap, map, catchError } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
+import { Store } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
+import {
+  debounceTime,
+  mergeMap,
+  map,
+  catchError,
+  withLatestFrom,
+  switchMap,
+  filter
+} from 'rxjs/operators';
 import { of } from 'rxjs';
+import * as moment from 'moment';
 
+import { NgrxStateAtom } from 'app/ngrx.reducers';
 import {
   UserPermsTypes,
   GetAllUserPermsSuccess,
@@ -17,27 +28,35 @@ import {
   GetUserParamPermsFailure
 } from './userperms.actions';
 import { UserPermsRequests } from './userperms.requests';
+import { getlastFetchTime } from './userperms.selectors';
 
 @Injectable()
 export class UserPermEffects {
   constructor(
     private actions$: Actions,
-    private requests: UserPermsRequests
+    private requests: UserPermsRequests,
+    private store: Store<NgrxStateAtom>
   ) { }
 
-  // include debounce here because each request of this type is a true duplicate
   @Effect()
   fetchAllPerms$ = this.actions$.pipe(
     ofType(UserPermsTypes.GET_ALL),
-    debounceTime(20),
-    mergeMap(() => this.requests.fetchAll().pipe(
-      map((resp: UserPermsResponsePayload) => new GetAllUserPermsSuccess(resp.endpoints)),
-      catchError((error: HttpErrorResponse) => of(new GetAllUserPermsFailure(error))))));
+    debounceTime(20), // each request of this type is a true duplicate so debounce them
+    withLatestFrom(this.store.select(getlastFetchTime)),
+    filter(([_action, lastTime]) => this.stale(lastTime)),
+    switchMap(() => {
+      return this.requests.fetchAll().pipe(
+        map((resp: UserPermsResponsePayload) => new GetAllUserPermsSuccess(resp.endpoints)),
+        catchError((error: HttpErrorResponse) => of(new GetAllUserPermsFailure(error))));
+    }));
 
   @Effect()
   fetchSomePerms$ = this.actions$.pipe(
     ofType(UserPermsTypes.GET_SOME),
-    mergeMap((action: GetSomeUserPerms) => this.requests.fetchSome(action.payload).pipe(
+    withLatestFrom(this.store.select(getlastFetchTime)),
+    filter(([_action, lastTime]) => this.stale(lastTime)),
+    mergeMap(
+      ([action, _]: [GetSomeUserPerms, Date]) => this.requests.fetchSome(action.payload).pipe(
       map((resp: UserPermsResponsePayload) => new GetSomeUserPermsSuccess(resp.endpoints)),
       catchError((error: HttpErrorResponse) => of(new GetSomeUserPermsFailure(error))))));
 
@@ -47,4 +66,10 @@ export class UserPermEffects {
     mergeMap((action: GetUserParamPerms) => this.requests.fetchParameterized(action.payload).pipe(
       map((resp: UserPermsResponsePayload) => new GetUserParamPermsSuccess(resp.endpoints)),
       catchError((error: HttpErrorResponse) => of(new GetUserParamPermsFailure(error))))));
+
+  private freshLimitInSeconds = 30;
+
+  private stale(lastTime: Date): boolean {
+    return moment().diff(moment(lastTime), 'seconds') > this.freshLimitInSeconds;
+  }
 }

--- a/components/automate-ui/src/app/entities/userperms/userperms.effects.ts
+++ b/components/automate-ui/src/app/entities/userperms/userperms.effects.ts
@@ -38,7 +38,14 @@ export class UserPermEffects {
     private store: Store<NgrxStateAtom>
   ) { }
 
+  // the target limit
   private freshLimitInMilliseconds = 30000;
+
+  // to account for a flurry of IntrospectSome calls almost concurrent
+  // with our IntrospectAll call--this will happen frequently!--just
+  // extend the fresh limit by a nudge for the IntrospectSome calls
+  private freshLimitPlusANudge = 33000;
+
   @Effect()
   fetchAllPerms$ = this.actions$.pipe(
     ofType(UserPermsTypes.GET_ALL),
@@ -66,9 +73,7 @@ export class UserPermEffects {
       map((resp: UserPermsResponsePayload) => new GetUserParamPermsSuccess(resp.endpoints)),
       catchError((error: HttpErrorResponse) => of(new GetUserParamPermsFailure(error))))));
 
-  private freshLimitInSeconds = 30;
-
   private stale(lastTime: Date): boolean {
-    return moment().diff(moment(lastTime), 'seconds') > this.freshLimitInSeconds;
+    return moment().diff(moment(lastTime)) > this.freshLimitPlusANudge;
   }
 }

--- a/components/automate-ui/src/app/entities/userperms/userperms.reducer.ts
+++ b/components/automate-ui/src/app/entities/userperms/userperms.reducer.ts
@@ -23,12 +23,14 @@ export interface PermEntityState {
   readonly byId: IndexedEntities<UserPermEntity>;
   readonly allIds: string[];
   readonly status: Status;
+  readonly lastTimeFetchAll: Date;
 }
 
 const initialState: PermEntityState = {
   byId: {},
   allIds: [],
-  status: Status.notLoaded
+  status: Status.notLoaded,
+  lastTimeFetchAll: new Date(0)
 };
 
 export function permEntityReducer(
@@ -52,6 +54,7 @@ export function permEntityReducer(
       const allPerms = permIndexer(allPairs);
 
       return pipe(
+        set('lastTimeFetchAll', new Date()),
         set('status', Status.loadingSuccess),
         set('byId', allPerms),
         set('allIds', keys(allPerms))

--- a/components/automate-ui/src/app/entities/userperms/userperms.reducer.ts
+++ b/components/automate-ui/src/app/entities/userperms/userperms.reducer.ts
@@ -38,7 +38,13 @@ export function permEntityReducer(
 
   switch (action.type) {
 
-    case UserPermsTypes.GET_ALL:
+    case UserPermsTypes.GET_ALL: {
+      return pipe(
+        set('lastTimeFetchAll', new Date()),
+        set('status', Status.loading)
+      )(state) as PermEntityState;
+    }
+
     case UserPermsTypes.GET_SOME: {
       return set('status', Status.loading, state) as PermEntityState;
     }
@@ -56,7 +62,6 @@ export function permEntityReducer(
       const allPerms = defaults(state.byId, permIndexer(allPairs));
 
       return pipe(
-        set('lastTimeFetchAll', new Date()),
         set('status', Status.loadingSuccess),
         set('byId', allPerms),
         set('allIds', keys(allPerms))

--- a/components/automate-ui/src/app/entities/userperms/userperms.reducer.ts
+++ b/components/automate-ui/src/app/entities/userperms/userperms.reducer.ts
@@ -51,7 +51,9 @@ export function permEntityReducer(
       // toPairs converts each endpoint in the payload from
       // { <path>: <perms_map> } to [<path>, <perms_map> ].
       const allPairs = toPairs(action.payload);
-      const allPerms = permIndexer(allPairs);
+      // combine with what we already have so as not to erase parameterized endpoints
+      // that are not included here.
+      const allPerms = defaults(state.byId, permIndexer(allPairs));
 
       return pipe(
         set('lastTimeFetchAll', new Date()),

--- a/components/automate-ui/src/app/entities/userperms/userperms.selectors.ts
+++ b/components/automate-ui/src/app/entities/userperms/userperms.selectors.ts
@@ -21,3 +21,8 @@ export const loadStatus = createSelector(
   userpermsState,
   get('status')
 );
+
+export const getlastFetchTime = createSelector(
+  userpermsState,
+  (state) => state.lastTimeFetchAll
+);

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivationStart, ActivationEnd, Router } from '@angular/router';
+import { ActivationStart, ActivationEnd, Router, NavigationEnd } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -12,6 +12,7 @@ import { notificationState } from 'app/entities/notifications/notification.selec
 import { Notification } from 'app/entities/notifications/notification.model';
 import { DeleteNotification } from 'app/entities/notifications/notification.actions';
 import { LicenseApplyReason } from 'app/page-components/license-apply/license-apply.component';
+import { GetAllUserPerms } from './entities/userperms/userperms.actions';
 
 @Component({
   selector: 'app-ui',
@@ -62,6 +63,13 @@ export class UIComponent implements OnInit {
     this.router.events.pipe(
         filter(event => event instanceof ActivationStart)
     ).subscribe((event: any) => this.renderNavbar = !event.snapshot.data.hideNavBar);
+
+    this.router.events.pipe(
+        filter(event => event instanceof NavigationEnd)
+    ).subscribe(() => this.store.dispatch(new GetAllUserPerms()));
+
+    // Initial call
+    this.store.dispatch(new GetAllUserPerms());
 
     // Initial calls for polled events
     this.store.dispatch(new GetIamVersion());

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -52,7 +52,7 @@ export class UIComponent implements OnInit {
     // ActivationEnd specifically needs to be here in the constructor to catch early events.
     this.router.events.pipe(
       filter(event => event instanceof ActivationEnd)
-    ).subscribe((event: any) => {
+    ).subscribe((event: ActivationEnd) => {
       this.renderNavbar = typeof event.snapshot.data.hideNavBar !== 'undefined'
         ? !event.snapshot.data.hideNavBar
         : this.renderNavbar;
@@ -62,7 +62,7 @@ export class UIComponent implements OnInit {
   ngOnInit(): void {
     this.router.events.pipe(
         filter(event => event instanceof ActivationStart)
-    ).subscribe((event: any) => this.renderNavbar = !event.snapshot.data.hideNavBar);
+    ).subscribe((event: ActivationStart) => this.renderNavbar = !event.snapshot.data.hideNavBar);
 
     this.router.events.pipe(
         filter(event => event instanceof NavigationEnd)

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -214,7 +214,7 @@ Cypress.Commands.add('cleanupTeamsByDescriptionPrefix', (idToken: string, namePr
 function LoginHelper(username: string) {
   cy.url().should('include', '/dex/auth/local');
   cy.server();
-  cy.route('POST', '/api/v0/auth/introspect_some').as('getAuth');
+  cy.route('POST', '/api/v0/auth/introspect').as('getAuth');
 
   // login
   cy.get('#login').type(username);


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

There are a large number of introspection calls on each page and this continues to grow. That incurs a small--but not negligible--performance penalty. Also, it makes viewing a network trace very cumbersome as there is a lot of "noise" added to the list of network calls. This PR adds some simple caching with time-based degradation to eliminate the vast majority of network traffic but still keep the introspection data in the browser fresh.

### :chains: Related Resources
N/A

### :+1: Definition of Done
There should be no discernible difference in the exposed UI. However, if you open the network tab of dev tools you can see the effect. In this screen shot I opened Automate on the Dashboards tab. On the very first load, there will be a handful of network calls. (Note that I have filtered the network list to just show introspection calls.)

I then selected one call in the network tab--the arrow is pointing this out. Within a 30-second period, I then navigated around to different tabs across the top and different entries in the sidebar--_all with no introspection traffic at all!_ 

This PR causes all the `IntrospectSome` calls to be cached. Notice, though that there are a couple calls beyond the entry that the arrow points to. Those are parameterized `IntrospectOne` calls needed on the projects page, and those are **not** cached.

Once you go beyond the 30-second cache expiry time, the next time you go to a different tab or page, a single `IntrospectAll` will occur. (It's possible that a couple `IntrospectSome`s may sneak in there, too.)

![image](https://user-images.githubusercontent.com/6817500/64900907-0a94ee80-d649-11e9-9fe2-437638b4a527.png)

With the latest commit I added even further noise reduction. The "After" scenario shows the introspection calls from me navigating around Automate for more than 2 minutes. The "Before" scenario is many, many screenfuls long!

![image](https://user-images.githubusercontent.com/6817500/64925871-89a23800-d7ab-11e9-978e-c44b4646f4cd.png)

There is some noise reduction in the Redux Dev Tools pane also, but not quite as much: you will still see the introspection _requests_ but, when cached, no introspection _result_--so it cuts introspection entries down by about half.

### :athletic_shoe: How to Build and Test the Change

Rebuild automate-ui