### PR TITLE
word wrap the connectivity error message for node

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.scss
@@ -144,6 +144,7 @@
       border-radius: $global-radius;
       background: $chef-lightest-grey;
       font-size: 14px;
+      white-space: pre-wrap;
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
It looks that currently, we are utilizing the side drawer only for the Error message on this Nodes view. Since that is the only thing we are doing on this page, we may be able to just word wrap the whole message, and we can cover the whole side drawer with the message.
I have added CSS changes for word warp the error message. 

### Repro Steps

1. `rebuild components/automate-ui-devproxy`
1. inside studio `CHEF_USERNAME=username scripts/get_secrets.sh` if you haven't in a while
1. outside of studio `source dev/secrets-env.sh`
1. outside of studio `A2_URL='https://a2-dev.test' A2_TOKEN='token_val' components/compliance-service/scripts/create-pg-data.sh`

### :chains: Related Resources
https://github.com/chef/automate/issues/285

### :+1: Definition of Done
Node connectivity error is easier to read

### :camera: Screenshots
![Screenshot from 2019-09-16 17-27-00](https://user-images.githubusercontent.com/12297653/64956129-812f2780-d8a7-11e9-9238-f3f471cb4237.png)
