### PR TITLE
lib/cereal: Add StartGuard to replace WaitGroup-based start checks

### DIFF
--- a/lib/cereal/postgres/task_pinger.go
+++ b/lib/cereal/postgres/task_pinger.go
@@ -27,6 +27,7 @@ func newTaskPinger(db *sql.DB, taskID int64, pingInterval time.Duration) *taskPi
 		taskID:       taskID,
 		db:           db,
 		pingInterval: pingInterval,
+		sg:           cereal.NewStartGuard("Start(ctx, onTaskLost) called more than once on postgres.taskPinger!"),
 	}
 	return pinger
 }

--- a/lib/cereal/postgres/task_pinger.go
+++ b/lib/cereal/postgres/task_pinger.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/chef/automate/lib/cereal"
 )
 
 const defaultPingDuration = 15 * time.Second
@@ -14,8 +16,8 @@ const defaultPingDuration = 15 * time.Second
 type taskPinger struct {
 	taskID       int64
 	db           *sql.DB
-	wgStart      sync.WaitGroup
-	wgStop       sync.WaitGroup
+	wg           sync.WaitGroup
+	sg           cereal.StartGuard
 	stop         context.CancelFunc
 	pingInterval time.Duration
 }
@@ -26,7 +28,6 @@ func newTaskPinger(db *sql.DB, taskID int64, pingInterval time.Duration) *taskPi
 		db:           db,
 		pingInterval: pingInterval,
 	}
-	pinger.wgStart.Add(1)
 	return pinger
 }
 
@@ -37,10 +38,10 @@ func newTaskPinger(db *sql.DB, taskID int64, pingInterval time.Duration) *taskPi
 func (w *taskPinger) Start(ctx context.Context, onTaskLost func()) {
 	// Make sure this function is only called once. A second call will
 	// cause this to panic
-	w.wgStart.Done()
+	w.sg.Started()
 
-	// The wgStop will be used to wait for the goroutine to exit
-	w.wgStop.Add(1)
+	// The wg will be used to wait for the goroutine to exit
+	w.wg.Add(1)
 
 	// Create a cancelable context that we can stop from Stop
 	ctx, cancel := context.WithCancel(ctx)
@@ -66,7 +67,7 @@ func (w *taskPinger) Start(ctx context.Context, onTaskLost func()) {
 				}
 			}
 		}
-		w.wgStop.Done()
+		w.wg.Done()
 		logctx.Debug("Exiting taskPinger")
 	}()
 }
@@ -90,5 +91,5 @@ func (w *taskPinger) ping(ctx context.Context) (shouldExit bool, err error) {
 
 func (w *taskPinger) Stop() {
 	w.stop()
-	w.wgStop.Wait()
+	w.wg.Wait()
 }

--- a/lib/cereal/start_guard.go
+++ b/lib/cereal/start_guard.go
@@ -1,0 +1,36 @@
+package cereal
+
+import "sync"
+
+// StartGuard is used to enforce that Start is only called once for
+// various structures inside cereal.
+//
+// We were previously using sync.WaitGroup for this, but this allows
+// us to customize the error message a bit.
+//
+// The zero-value of this should work as expected, but you can create
+// a StartGuard with a custom message using NewStartGuard.
+type StartGuard struct {
+	msg     string
+	started bool
+	mu      sync.Mutex
+}
+
+func NewStartGuard(msg string) StartGuard {
+	return StartGuard{
+		msg: msg,
+	}
+}
+
+func (s *StartGuard) Started() {
+	s.mu.Lock()
+	if s.started {
+		if s.msg != "" {
+			panic(s.msg)
+		} else {
+			panic("Started() on StartGuard called more than once.")
+		}
+	}
+	s.started = true
+	s.mu.Unlock()
+}


### PR DESCRIPTION
We were using WaitGroup to help ensure that we weren't calling Start()
wasn't called twice on various structs that manage long-lived go
routines.

This replaces those uses with a new type, StartGuard, that allows us
to customize the message that users (developers) will get when they
make this mistake.

We could have done this with recover, but this felt a big better.

Signed-off-by: Steven Danna <steve@chef.io>