### PR TITLE
Use 1 << x rather than math.Pow(2.0, float64(x))

### DIFF
--- a/components/automate-deployment/pkg/airgap/bundle_creator.go
+++ b/components/automate-deployment/pkg/airgap/bundle_creator.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"os"
 	"path"
@@ -499,8 +498,7 @@ func (creator *InstallBundleCreator) withRetry(f retriableFunc) error {
 		if creator.retryDelay >= 0 {
 			nextRetryDelay = time.Second * time.Duration(creator.retryDelay)
 		} else {
-			sleep := math.Pow(2.0, float64(try))
-			nextRetryDelay = time.Second * time.Duration(sleep)
+			nextRetryDelay = time.Second * time.Duration(1<<uint(try))
 		}
 
 		err = f(try, retryInfo{

--- a/components/automate-deployment/pkg/server/restart.go
+++ b/components/automate-deployment/pkg/server/restart.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"errors"
-	"math"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -102,7 +101,7 @@ func (s *server) waitForDown(services []string) error {
 	ctx := context.Background()
 	for i := 0; i <= 5; i++ {
 		logrus.WithField("try", i).Info("Waiting for services to go down")
-		backoff := time.Duration(math.Pow(float64(2), float64(i)))
+		backoff := time.Duration(1 << uint(i))
 		time.Sleep(backoff * time.Second)
 
 		deployed, err := s.target().DeployedServices(ctx)


### PR DESCRIPTION
I noticed this when reading some code. Just a minor style thing.

Signed-off-by: Steven Danna <steve@chef.io>