### PR TITLE
Fix pkg_origin for scaffoldings

### DIFF
--- a/components/automate-scaffolding-go/habitat/plan.sh
+++ b/components/automate-scaffolding-go/habitat/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=automate-scaffolding-go
-pkg_origin=core
+pkg_origin=chef
 pkg_description="Scaffolding for Automate Go Applications internally at Chef Software Inc."
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_version="0.1.0"

--- a/components/automate-scaffolding/habitat/plan.sh
+++ b/components/automate-scaffolding/habitat/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=automate-scaffolding
-pkg_origin=core
+pkg_origin=chef
 pkg_description="Generic scaffolding for Automate Applications internally at Chef Software Inc."
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_version="0.1.0"


### PR DESCRIPTION
This should also have the side-effect of rebuilding most
Go services with Go 1.13.

Signed-off-by: Steven Danna <steve@chef.io>
