### PR TITLE
Projects in dropdown should be Normally sorted

### DIFF
--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -24,8 +24,8 @@ describe('ProjectsDropdownComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('#projectsArray', () => {
-    it('#projectsArray returns an object naturally ordered by name', () => {
+  describe('projectsArray', () => {
+    it('returns an object naturally ordered by name', () => {
       const unsortedProjects: {} = [
         {
           checked: false,

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -9,8 +9,8 @@ describe('ProjectsDropdownComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ProjectsDropdownComponent],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+      declarations: [ ProjectsDropdownComponent ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     }).compileComponents();
   }));
 
@@ -72,13 +72,7 @@ describe('ProjectsDropdownComponent', () => {
 
       // expect sorted outcomes here
       expect(sortedProjects.length).toBe(5);
-      expect(sortedProjects).toEqual([
-        '123abc',
-        '123xyz',
-        '12345zero',
-        'abc123',
-        'project-6'
-      ]);
+      expect(sortedProjects).toEqual(['123abc', '123xyz', '12345zero', 'abc123', 'project-6']);
     });
   });
 });

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -1,9 +1,9 @@
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
-import { ProjectsDropdownComponent } from "./projects-dropdown.component";
+import { ProjectsDropdownComponent } from './projects-dropdown.component';
 
-describe("ProjectsDropdownComponent", () => {
+describe('ProjectsDropdownComponent', () => {
   let component: ProjectsDropdownComponent;
   let fixture: ComponentFixture<ProjectsDropdownComponent>;
 
@@ -20,47 +20,47 @@ describe("ProjectsDropdownComponent", () => {
     fixture.detectChanges();
   });
 
-  it("should create", () => {
+  it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  describe("#projectsArray", () => {
-    it("#projectsArray returns an object naturally ordered by name", () => {
+  describe('#projectsArray', () => {
+    it('#projectsArray returns an object naturally ordered by name', () => {
       const unsortedProjects: {} = [
         {
           checked: false,
-          id: "123abc",
-          name: "123abc",
-          status: "NO_RULES",
-          type: "CUSTOM"
+          id: '123abc',
+          name: '123abc',
+          status: 'NO_RULES',
+          type: 'CUSTOM'
         },
         {
           checked: false,
-          id: "project-6",
-          name: "project-6",
-          status: "NO_RULES",
-          type: "CUSTOM"
+          id: 'project-6',
+          name: 'project-6',
+          status: 'NO_RULES',
+          type: 'CUSTOM'
         },
         {
           checked: false,
-          id: "12345zero",
-          name: "12345zero",
-          status: "NO_RULES",
-          type: "CUSTOM"
+          id: '12345zero',
+          name: '12345zero',
+          status: 'NO_RULES',
+          type: 'CUSTOM'
         },
         {
           checked: false,
-          id: "123xyz",
-          name: "123xyz",
-          status: "NO_RULES",
-          type: "CUSTOM"
+          id: '123xyz',
+          name: '123xyz',
+          status: 'NO_RULES',
+          type: 'CUSTOM'
         },
         {
           checked: false,
-          id: "abc123",
-          name: "abc123",
-          status: "NO_RULES",
-          type: "CUSTOM"
+          id: 'abc123',
+          name: 'abc123',
+          status: 'NO_RULES',
+          type: 'CUSTOM'
         }
       ];
       // build the component
@@ -68,22 +68,22 @@ describe("ProjectsDropdownComponent", () => {
       // assign unsorted projects for the component to use
       dropdownComponent.projects = unsortedProjects;
 
-      //expect sorted outcomes here
+      // expect sorted outcomes here
       expect(dropdownComponent.projectsArray().length).toBe(5);
       expect(dropdownComponent.projectsArray()[0]).toEqual(
-        jasmine.objectContaining({ name: "123abc" })
+        jasmine.objectContaining({ name: '123abc' })
       );
       expect(dropdownComponent.projectsArray()[1]).toEqual(
-        jasmine.objectContaining({ name: "123xyz" })
+        jasmine.objectContaining({ name: '123xyz' })
       );
       expect(dropdownComponent.projectsArray()[2]).toEqual(
-        jasmine.objectContaining({ name: "12345zero" })
+        jasmine.objectContaining({ name: '12345zero' })
       );
       expect(dropdownComponent.projectsArray()[3]).toEqual(
-        jasmine.objectContaining({ name: "abc123" })
+        jasmine.objectContaining({ name: 'abc123' })
       );
       expect(dropdownComponent.projectsArray()[4]).toEqual(
-        jasmine.objectContaining({ name: "project-6" })
+        jasmine.objectContaining({ name: 'project-6' })
       );
     });
   });

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -24,15 +24,21 @@ describe("ProjectsDropdownComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  describe("projectsArray()", () => {
-    // might need a before each here
-    it("it returns an object naturally ordered by name", () => {
+  describe("#projectsArray", () => {
+    it("#projectsArray returns an object naturally ordered by name", () => {
       // tslint:disable-next-line: no-unused-expression
-      let projects: [
+      let unsortedProjects: [
         {
           checked: false;
           id: "123abc";
           name: "123abc";
+          status: "NO_RULES";
+          type: "CUSTOM";
+        },
+        {
+          checked: false;
+          id: "project-6";
+          name: "project-6";
           status: "NO_RULES";
           type: "CUSTOM";
         },
@@ -56,16 +62,12 @@ describe("ProjectsDropdownComponent", () => {
           name: "abc123";
           status: "NO_RULES";
           type: "CUSTOM";
-        },
-        {
-          checked: false;
-          id: "project-6";
-          name: "project-6";
-          status: "NO_RULES";
-          type: "CUSTOM";
         }
       ];
       // usage and expects go here
+      const dropdownComponent = new ProjectsDropdownComponent();
+      dropdownComponent.projects = { inputObj: unsortedProjects };
+      expect(dropdownComponent.projectsArray().length).toBe(1);
     });
   });
 });

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -1,18 +1,17 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 
-import { ProjectsDropdownComponent } from './projects-dropdown.component';
+import { ProjectsDropdownComponent } from "./projects-dropdown.component";
 
-describe('ProjectsDropdownComponent', () => {
+describe("ProjectsDropdownComponent", () => {
   let component: ProjectsDropdownComponent;
   let fixture: ComponentFixture<ProjectsDropdownComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ProjectsDropdownComponent ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
-    })
-    .compileComponents();
+      declarations: [ProjectsDropdownComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    }).compileComponents();
   }));
 
   beforeEach(() => {
@@ -21,7 +20,52 @@ describe('ProjectsDropdownComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  describe("projectsArray()", () => {
+    // might need a before each here
+    it("it returns an object naturally ordered by name", () => {
+      // tslint:disable-next-line: no-unused-expression
+      let projects: [
+        {
+          checked: false;
+          id: "123abc";
+          name: "123abc";
+          status: "NO_RULES";
+          type: "CUSTOM";
+        },
+        {
+          checked: false;
+          id: "12345zero";
+          name: "12345zero";
+          status: "NO_RULES";
+          type: "CUSTOM";
+        },
+        {
+          checked: false;
+          id: "123xyz";
+          name: "123xyz";
+          status: "NO_RULES";
+          type: "CUSTOM";
+        },
+        {
+          checked: false;
+          id: "abc123";
+          name: "abc123";
+          status: "NO_RULES";
+          type: "CUSTOM";
+        },
+        {
+          checked: false;
+          id: "project-6";
+          name: "project-6";
+          status: "NO_RULES";
+          type: "CUSTOM";
+        }
+      ];
+      // usage and expects go here
+    });
   });
 });

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -69,10 +69,12 @@ describe("ProjectsDropdownComponent", () => {
           type: "CUSTOM"
         }
       ];
-      // usage and expects go here
+      // build the component
       const dropdownComponent = new ProjectsDropdownComponent();
+      // assign unsorted projects for the component to use
       dropdownComponent.projects = unsortedProjects;
 
+      //expect sorted outcomes here
       expect(dropdownComponent.projectsArray().length).toBe(5);
       expect(dropdownComponent.projectsArray()[0]).toEqual(
         jasmine.objectContaining({ name: "123abc" })
@@ -81,13 +83,13 @@ describe("ProjectsDropdownComponent", () => {
         jasmine.objectContaining({ name: "123xyz" })
       );
       expect(dropdownComponent.projectsArray()[2]).toEqual(
-        jasmine.objectContaining({ name: "123xyz" })
+        jasmine.objectContaining({ name: "12345zero" })
       );
       expect(dropdownComponent.projectsArray()[3]).toEqual(
-        jasmine.objectContaining({ name: "123xyz" })
+        jasmine.objectContaining({ name: "abc123" })
       );
       expect(dropdownComponent.projectsArray()[4]).toEqual(
-        jasmine.objectContaining({ name: "123xyz" })
+        jasmine.objectContaining({ name: "project-6" })
       );
     });
   });

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -11,7 +11,8 @@ describe('ProjectsDropdownComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ ProjectsDropdownComponent ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
-    }).compileComponents();
+    })
+    .compileComponents();
   }));
 
   beforeEach(() => {

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -26,13 +26,7 @@ describe("ProjectsDropdownComponent", () => {
 
   describe("#projectsArray", () => {
     it("#projectsArray returns an object naturally ordered by name", () => {
-      const unsortedProjects: {
-        checked: boolean;
-        id: string;
-        name: string;
-        status: string;
-        type: string;
-      }[] = [
+      const unsortedProjects: {} = [
         {
           checked: false,
           id: "123abc",

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -66,24 +66,19 @@ describe('ProjectsDropdownComponent', () => {
 
       // assign unsorted projects for the component to use
       component.projects = unsortedProjects;
+      const sortedProjects = component
+        .projectsArray()
+        .map(project => project.name);
 
       // expect sorted outcomes here
-      expect(component.projectsArray().length).toBe(5);
-      expect(component.projectsArray()[0]).toEqual(
-        jasmine.objectContaining({ name: '123abc' })
-      );
-      expect(component.projectsArray()[1]).toEqual(
-        jasmine.objectContaining({ name: '123xyz' })
-      );
-      expect(component.projectsArray()[2]).toEqual(
-        jasmine.objectContaining({ name: '12345zero' })
-      );
-      expect(component.projectsArray()[3]).toEqual(
-        jasmine.objectContaining({ name: 'abc123' })
-      );
-      expect(component.projectsArray()[4]).toEqual(
-        jasmine.objectContaining({ name: 'project-6' })
-      );
+      expect(sortedProjects.length).toBe(5);
+      expect(sortedProjects).toEqual([
+        '123abc',
+        '123xyz',
+        '12345zero',
+        'abc123',
+        'project-6'
+      ]);
     });
   });
 });

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -26,48 +26,69 @@ describe("ProjectsDropdownComponent", () => {
 
   describe("#projectsArray", () => {
     it("#projectsArray returns an object naturally ordered by name", () => {
-      // tslint:disable-next-line: no-unused-expression
-      let unsortedProjects: [
+      const unsortedProjects: {
+        checked: boolean;
+        id: string;
+        name: string;
+        status: string;
+        type: string;
+      }[] = [
         {
-          checked: false;
-          id: "123abc";
-          name: "123abc";
-          status: "NO_RULES";
-          type: "CUSTOM";
+          checked: false,
+          id: "123abc",
+          name: "123abc",
+          status: "NO_RULES",
+          type: "CUSTOM"
         },
         {
-          checked: false;
-          id: "project-6";
-          name: "project-6";
-          status: "NO_RULES";
-          type: "CUSTOM";
+          checked: false,
+          id: "project-6",
+          name: "project-6",
+          status: "NO_RULES",
+          type: "CUSTOM"
         },
         {
-          checked: false;
-          id: "12345zero";
-          name: "12345zero";
-          status: "NO_RULES";
-          type: "CUSTOM";
+          checked: false,
+          id: "12345zero",
+          name: "12345zero",
+          status: "NO_RULES",
+          type: "CUSTOM"
         },
         {
-          checked: false;
-          id: "123xyz";
-          name: "123xyz";
-          status: "NO_RULES";
-          type: "CUSTOM";
+          checked: false,
+          id: "123xyz",
+          name: "123xyz",
+          status: "NO_RULES",
+          type: "CUSTOM"
         },
         {
-          checked: false;
-          id: "abc123";
-          name: "abc123";
-          status: "NO_RULES";
-          type: "CUSTOM";
+          checked: false,
+          id: "abc123",
+          name: "abc123",
+          status: "NO_RULES",
+          type: "CUSTOM"
         }
       ];
       // usage and expects go here
       const dropdownComponent = new ProjectsDropdownComponent();
-      dropdownComponent.projects = { inputObj: unsortedProjects };
-      expect(dropdownComponent.projectsArray().length).toBe(1);
+      dropdownComponent.projects = unsortedProjects;
+
+      expect(dropdownComponent.projectsArray().length).toBe(5);
+      expect(dropdownComponent.projectsArray()[0]).toEqual(
+        jasmine.objectContaining({ name: "123abc" })
+      );
+      expect(dropdownComponent.projectsArray()[1]).toEqual(
+        jasmine.objectContaining({ name: "123xyz" })
+      );
+      expect(dropdownComponent.projectsArray()[2]).toEqual(
+        jasmine.objectContaining({ name: "123xyz" })
+      );
+      expect(dropdownComponent.projectsArray()[3]).toEqual(
+        jasmine.objectContaining({ name: "123xyz" })
+      );
+      expect(dropdownComponent.projectsArray()[4]).toEqual(
+        jasmine.objectContaining({ name: "123xyz" })
+      );
     });
   });
 });

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -63,26 +63,25 @@ describe('ProjectsDropdownComponent', () => {
           type: 'CUSTOM'
         }
       ];
-      // build the component
-      const dropdownComponent = new ProjectsDropdownComponent();
+
       // assign unsorted projects for the component to use
-      dropdownComponent.projects = unsortedProjects;
+      component.projects = unsortedProjects;
 
       // expect sorted outcomes here
-      expect(dropdownComponent.projectsArray().length).toBe(5);
-      expect(dropdownComponent.projectsArray()[0]).toEqual(
+      expect(component.projectsArray().length).toBe(5);
+      expect(component.projectsArray()[0]).toEqual(
         jasmine.objectContaining({ name: '123abc' })
       );
-      expect(dropdownComponent.projectsArray()[1]).toEqual(
+      expect(component.projectsArray()[1]).toEqual(
         jasmine.objectContaining({ name: '123xyz' })
       );
-      expect(dropdownComponent.projectsArray()[2]).toEqual(
+      expect(component.projectsArray()[2]).toEqual(
         jasmine.objectContaining({ name: '12345zero' })
       );
-      expect(dropdownComponent.projectsArray()[3]).toEqual(
+      expect(component.projectsArray()[3]).toEqual(
         jasmine.objectContaining({ name: 'abc123' })
       );
-      expect(dropdownComponent.projectsArray()[4]).toEqual(
+      expect(component.projectsArray()[4]).toEqual(
         jasmine.objectContaining({ name: 'project-6' })
       );
     });

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -4,9 +4,9 @@ import {
   Input,
   Output,
   OnChanges
-} from "@angular/core";
+} from '@angular/core';
 
-import { ProjectConstants, Project } from "app/entities/projects/project.model";
+import { ProjectConstants, Project } from 'app/entities/projects/project.model';
 
 const { UNASSIGNED_PROJECT_ID } = ProjectConstants;
 
@@ -22,9 +22,9 @@ export interface ProjectCheckedMap {
 }
 
 @Component({
-  selector: "app-projects-dropdown",
-  templateUrl: "./projects-dropdown.component.html",
-  styleUrls: ["./projects-dropdown.component.scss"]
+  selector: 'app-projects-dropdown',
+  templateUrl: './projects-dropdown.component.html',
+  styleUrls: ['./projects-dropdown.component.scss']
 })
 export class ProjectsDropdownComponent implements OnChanges {
   // The map of ProjectChecked by id. Any checked changes propagated via
@@ -45,7 +45,7 @@ export class ProjectsDropdownComponent implements OnChanges {
 
     const opts = {
       numeric: true,
-      sensitivity: "base"
+      sensitivity: 'base'
     };
 
     // per @msorens https://github.com/chef/a2/pull/4434
@@ -89,9 +89,9 @@ export class ProjectsDropdownComponent implements OnChanges {
     let nextElement: HTMLElement;
 
     const targetElement = <Element>event.target;
-    if (event.key === "ArrowUp") {
+    if (event.key === 'ArrowUp') {
       nextElement = <HTMLElement>targetElement.previousElementSibling;
-    } else if (event.key === "ArrowDown") {
+    } else if (event.key === 'ArrowDown') {
       nextElement = <HTMLElement>targetElement.nextElementSibling;
     }
 

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -41,19 +41,20 @@ export class ProjectsDropdownComponent implements OnChanges {
   label = UNASSIGNED_PROJECT_ID;
 
   projectsArray(): ProjectChecked[] {
-    let sortedProjects = Object.values(this.projects);
-    // WIP
-    // reference: MDN Intl.Collator
-    // and See https://stackoverflow.com/a/38641281 from policy-list.component
+    const sortedProjects = Object.values(this.projects);
 
     const opts = {
       numeric: true,
       sensitivity: "base"
     };
 
-    // look at https://github.com/chef/a2/pull/4434 for "stable sort" example
-    sortedProjects.sort((a, b) =>
-      a.name.localeCompare(b.name, undefined, opts)
+    // per @msorens https://github.com/chef/a2/pull/4434
+    // Sort by name then by cased-name, since no other field is useful as a secondary sort;
+    // this ensures stable sort with respect to case, so 'a' always comes before 'A'.
+    sortedProjects.sort(
+      (a, b) =>
+        a.name.localeCompare(b.name, undefined, opts) ||
+        a.name.localeCompare(b.name, undefined, { numeric: true })
     );
     return sortedProjects;
   }

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, OnChanges} from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnChanges } from '@angular/core';
 
 import { ProjectConstants, Project } from 'app/entities/projects/project.model';
 

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -50,6 +50,8 @@ export class ProjectsDropdownComponent implements OnChanges {
       numeric: true,
       sensitivity: "base"
     };
+
+    // look at https://github.com/chef/a2/pull/4434 for "stable sort" example
     sortedProjects.sort((a, b) =>
       a.name.localeCompare(b.name, undefined, opts)
     );

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-  OnChanges
-} from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnChanges} from '@angular/core';
 
 import { ProjectConstants, Project } from 'app/entities/projects/project.model';
 

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -1,8 +1,12 @@
 import {
-  Component, EventEmitter, Input, Output, OnChanges
-} from '@angular/core';
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  OnChanges
+} from "@angular/core";
 
-import { ProjectConstants, Project } from 'app/entities/projects/project.model';
+import { ProjectConstants, Project } from "app/entities/projects/project.model";
 
 const { UNASSIGNED_PROJECT_ID } = ProjectConstants;
 
@@ -18,9 +22,9 @@ export interface ProjectCheckedMap {
 }
 
 @Component({
-  selector: 'app-projects-dropdown',
-  templateUrl: './projects-dropdown.component.html',
-  styleUrls: ['./projects-dropdown.component.scss']
+  selector: "app-projects-dropdown",
+  templateUrl: "./projects-dropdown.component.html",
+  styleUrls: ["./projects-dropdown.component.scss"]
 })
 export class ProjectsDropdownComponent implements OnChanges {
   // The map of ProjectChecked by id. Any checked changes propagated via
@@ -37,7 +41,19 @@ export class ProjectsDropdownComponent implements OnChanges {
   label = UNASSIGNED_PROJECT_ID;
 
   projectsArray(): ProjectChecked[] {
-    return Object.values(this.projects);
+    let sortedProjects = Object.values(this.projects);
+    // WIP
+    // reference: MDN Intl.Collator
+    // and See https://stackoverflow.com/a/38641281 from policy-list.component
+
+    const opts = {
+      numeric: true,
+      sensitivity: "base"
+    };
+    sortedProjects.sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, opts)
+    );
+    return sortedProjects;
   }
 
   ngOnChanges(): void {
@@ -46,7 +62,9 @@ export class ProjectsDropdownComponent implements OnChanges {
 
   toggleDropdown(event: MouseEvent): void {
     event.stopPropagation();
-    if (this.disabled) { return; }
+    if (this.disabled) {
+      return;
+    }
 
     this.active = !this.active;
   }
@@ -68,13 +86,13 @@ export class ProjectsDropdownComponent implements OnChanges {
     let nextElement: HTMLElement;
 
     const targetElement = <Element>event.target;
-    if (event.key === 'ArrowUp') {
+    if (event.key === "ArrowUp") {
       nextElement = <HTMLElement>targetElement.previousElementSibling;
-    } else if (event.key === 'ArrowDown') {
+    } else if (event.key === "ArrowDown") {
       nextElement = <HTMLElement>targetElement.nextElementSibling;
     }
 
-    if (nextElement == null)  {
+    if (nextElement == null) {
       return;
     } else {
       nextElement.focus();


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This change updates the default sorting of the projects dropdown component so that when a user views their projects in a dropdown, they see them sorted Normally.  This matches our tables as well as the sorting we use in some of our other components.

### :chains: Related Resources
[[A2-338] fix admin UI list sorting](https://github.com/chef/a2/pull/4434)

### :+1: Definition of Done
The dropdown is sorted Normally.  First by numbers, and then Alphabetically.

### :athletic_shoe: How to Build and Test the Change
Visually -
1. `build components/automate-ui-devproxy && start_all_services`
2. Navigate to https://a2-dev.test/settings/tokens
3. Create an API Token
4. Navigate to https://a2-dev.test/settings/projects
5. Create several projects
6. Navigate to https://a2-dev.test/settings/tokens/ your-api-token
7. Click on the projects dropdown to see your projects sorted normally.

Using the specfile
1. Run the spec file at src/app/components/projects-dropdown/projects-dropdown.component.spec.ts

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable

After: Dropdown is sorted normally.

![Screen Shot 2019-09-16 at 10 37 41 AM](https://user-images.githubusercontent.com/16737484/64980107-0d245d80-d86e-11e9-9e9b-11a358c73559.png)
