### PR TITLE
Fixing time zone problems

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -68,6 +68,18 @@ describe('ReportingComponent', () => {
     expect(qe).not.toBeNull();
   });
 
+  it('convertMomentToDateWithoutTimezone', () => {
+    const dateBefore = moment('20191023-2300', 'YYYYMMDD-HHMM');
+    const dateAfter = component.convertMomentToDateWithoutTimezone(dateBefore);
+    expect(dateBefore.hour()).toEqual(dateAfter.getHours());
+  });
+
+  it('getEndDate', () => {
+    const expectedDate = moment('20191023GMT+00:00', 'YYYYMMDDZ').startOf('day').add(12, 'hours');
+    const beforeEndDate = component.getEndDate([{type: 'end_time', text: '2019-10-23'}]);
+    expect(expectedDate).toEqual(beforeEndDate);
+  });
+
   describe('sets availableFilterTypes', () => {
     it('to include profile, platform, environment, node, and control', () => {
       const availableFilterTypesNames = component.availableFilterTypes.map( type => type.name);

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '../shared/reporting';
 import { TelemetryService } from '../../../services/telemetry/telemetry.service';
 import * as moment from 'moment';
+import { using } from 'app/testing/spec-helpers';
 
 class MockTelemetryService {
   track() { }
@@ -68,13 +69,19 @@ describe('ReportingComponent', () => {
     expect(qe).not.toBeNull();
   });
 
-  it('convertMomentToDateWithoutTimezone', () => {
-    const dateBefore = moment('20191023-2300', 'YYYYMMDD-HHMM');
-    const dateAfter = component.convertMomentToDateWithoutTimezone(dateBefore);
-    expect(dateBefore.hour()).toEqual(dateAfter.getHours());
+  using([
+    ['23', 'an hour before end of day'],
+    ['00', 'exactly end of day'],
+    ['01', 'an hour after end of day']
+  ], function (hour: string, description: string) {
+    it(`maps hour correctly without timezone for ${description}`, () => {
+      const dateBefore = moment(`20191023-${hour}00`, 'YYYYMMDD-HHMM');
+      const dateAfter = component.convertMomentToDateWithoutTimezone(dateBefore);
+      expect(dateBefore.hour()).toEqual(dateAfter.getHours());
+    });
   });
 
-  it('getEndDate', () => {
+  it('extracting end time from the URL', () => {
     const expectedDate = moment('20191023GMT+00:00', 'YYYYMMDDZ').startOf('day').add(12, 'hours');
     const beforeEndDate = component.getEndDate([{type: 'end_time', text: '2019-10-23'}]);
     expect(expectedDate.hours()).toEqual(beforeEndDate.hours());

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -77,7 +77,7 @@ describe('ReportingComponent', () => {
   it('getEndDate', () => {
     const expectedDate = moment('20191023GMT+00:00', 'YYYYMMDDZ').startOf('day').add(12, 'hours');
     const beforeEndDate = component.getEndDate([{type: 'end_time', text: '2019-10-23'}]);
-    expect(expectedDate).toEqual(beforeEndDate);
+    expect(expectedDate.hours()).toEqual(beforeEndDate.hours());
   });
 
   describe('sets availableFilterTypes', () => {
@@ -259,31 +259,6 @@ describe('ReportingComponent', () => {
       };
 
       component.applyParamFilters([{type: 'chef_tags', text: '123'}]);
-      expect(reportQueryService.setState).toHaveBeenCalledWith(
-        reportQuery
-      );
-    });
-
-    it('parse end date', () => {
-      spyOn(reportQueryService, 'setState');
-      // end date of three days ago end_time=2019-09-05
-      const endDate = moment('2019-09-05', 'YYYY-MM-DD').utc().
-        startOf('day').add(12, 'hours');
-      const interval = 0;
-      const startDate = reportQueryService.findTimeIntervalStartDate(interval, endDate);
-
-      const reportQuery: ReportQuery = {
-        startDate: startDate,
-        endDate: endDate,
-        interval: interval,
-        filters: [
-          {type: {name: 'chef_tags'}, value: { text: '123' }}
-        ]
-      };
-
-      component.applyParamFilters([
-        {type: 'chef_tags', text: '123'},
-        {type: 'end_time', text: '2019-09-05'}]);
       expect(reportQueryService.setState).toHaveBeenCalledWith(
         reportQuery
       );

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -180,7 +180,8 @@ export class ReportingComponent implements OnInit, OnDestroy {
     const allUrlParameters$ = this.getAllUrlParameters();
 
     this.endDate$ = this.reportQuery.state.pipe(map((reportQuery: ReportQuery) =>
-      reportQuery.endDate.toDate()));
+      new Date(reportQuery.endDate.year(), reportQuery.endDate.month(),
+      reportQuery.endDate.date())));
 
     allUrlParameters$.pipe(takeUntil(this.isDestroyed)).subscribe(
       allUrlParameters => this.applyParamFilters(allUrlParameters));
@@ -253,7 +254,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
     this.downloadOptsVisible = false;
 
     const reportQuery = this.reportQuery.getReportQuery();
-    const filename = `${moment(reportQuery.endDate).format('YYYY-M-D')}.${format}`;
+    const filename = `${reportQuery.endDate.format('YYYY-M-D')}.${format}`;
 
     const onComplete = () => this.downloadInProgress = false;
     const onError = _e => this.downloadFailed = true;
@@ -445,7 +446,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
     const foundFilter = urlFilters.find( (filter: Chicklet) => filter.type === 'end_time');
 
     if (foundFilter !== undefined) {
-      const endDate = moment(foundFilter.text, 'YYYY-MM-DD');
+      const endDate = moment(foundFilter.text + 'GMT+00:00', 'YYYY-MM-DDZ');
       if (endDate.isValid()) {
         return endDate.utc().startOf('day').add(12, 'hours');
       } else {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -180,8 +180,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
     const allUrlParameters$ = this.getAllUrlParameters();
 
     this.endDate$ = this.reportQuery.state.pipe(map((reportQuery: ReportQuery) =>
-      new Date(reportQuery.endDate.year(), reportQuery.endDate.month(),
-      reportQuery.endDate.date())));
+      this.convertMomentToDateWithoutTimezone(reportQuery.endDate)));
 
     allUrlParameters$.pipe(takeUntil(this.isDestroyed)).subscribe(
       allUrlParameters => this.applyParamFilters(allUrlParameters));
@@ -478,5 +477,9 @@ export class ReportingComponent implements OnInit, OnDestroy {
     }
 
     return 0;
+  }
+
+  convertMomentToDateWithoutTimezone(m: moment.Moment): Date {
+    return new Date(m.year(), m.month(), m.date());
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-query.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-query.service.ts
@@ -49,7 +49,7 @@ export class ReportQueryService {
       startDate: reportQuery.startDate.clone(),
       endDate: reportQuery.endDate.clone(),
       interval: reportQuery.interval,
-      filters: Object.assign([], reportQuery.filters)
+      filters: [...reportQuery.filters]
     };
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-query.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-query.service.ts
@@ -20,13 +20,13 @@ export class ReportQueryService {
 
   intervals: TimeIntervals[] = [
     { name: 'Last 10 days', findStartDate: (endDate: moment.Moment): moment.Moment =>
-      moment(endDate).subtract(10, 'days')},
+      endDate.clone().subtract(10, 'days')},
     { name: 'Last month', findStartDate: (endDate: moment.Moment): moment.Moment =>
-      moment(endDate).subtract(1, 'months')},
+      endDate.clone().subtract(1, 'months')},
     { name: 'Last 3 months', findStartDate: (endDate: moment.Moment): moment.Moment =>
-      moment(endDate).subtract(3, 'months')},
+      endDate.clone().subtract(3, 'months')},
     { name: 'Last year', findStartDate: (endDate: moment.Moment): moment.Moment =>
-      moment(endDate).subtract(1, 'years')}
+      endDate.clone().subtract(1, 'years')}
   ];
 
   private idToTitle: Map<string, string> = new Map<string, string>();
@@ -44,7 +44,13 @@ export class ReportQueryService {
   }
 
   getReportQuery(): ReportQuery {
-    return this.state.getValue();
+    const reportQuery = this.state.getValue();
+    return {
+      startDate: reportQuery.startDate.clone(),
+      endDate: reportQuery.endDate.clone(),
+      interval: reportQuery.interval,
+      filters: Object.assign([], reportQuery.filters)
+    };
   }
 
   setState(newState: ReportQuery) {
@@ -52,7 +58,7 @@ export class ReportQueryService {
   }
 
   findTimeIntervalStartDate(interval: number, endDate: moment.Moment): moment.Moment {
-    return this.intervals[interval].findStartDate(endDate);
+    return this.intervals[interval].findStartDate(endDate.clone());
   }
 
   setFilterTitle(type: string, id: string, title: string) {

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
@@ -186,6 +186,22 @@ describe('StatsService', () => {
         expect(actualUrlFilters).toContain(expectedUrlFilter));
     });
 
+    it('start and end date not modified', () => {
+      const reportQuery: ReportQuery = {
+        startDate: moment('2017-11-14T00:00:00Z').utc(),
+        endDate: moment('2017-11-15T23:59:59Z').utc(),
+        interval: 0,
+        filters: []
+      };
+      const startDateBefore = reportQuery.startDate.clone();
+      const endDateBefore = reportQuery.endDate.clone();
+
+      service.formatFilters(reportQuery);
+
+      expect(startDateBefore).toEqual(reportQuery.startDate);
+      expect(endDateBefore).toEqual(reportQuery.endDate);
+    });
+
     it('returns profile_name not profile_id', () => {
       const reportQuery: ReportQuery = {
         startDate: moment('2017-11-14T00:00:00Z').utc(),

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -278,7 +278,7 @@ export class StatsService {
 
     if (reportQuery.startDate) {
       const now = moment();
-      const value = reportQuery.startDate
+      const value = reportQuery.startDate.clone()
         .set({
           hour: now.get('hour'),
           minute: now.get('minute'),
@@ -290,13 +290,12 @@ export class StatsService {
 
     if (reportQuery.endDate) {
       const now = moment();
-      const value = reportQuery.endDate
+      const value = reportQuery.endDate.clone()
         .set({
           hour: now.get('hour'),
           minute: now.get('minute'),
           second: now.get('second')
         }).utc().endOf('day');
-
       apiFilters.push({type: 'end_time', values: [value.format()]});
     }
 

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -277,25 +277,13 @@ export class StatsService {
     }, []);
 
     if (reportQuery.startDate) {
-      const now = moment();
-      const value = reportQuery.startDate.clone()
-        .set({
-          hour: now.get('hour'),
-          minute: now.get('minute'),
-          second: now.get('second')
-        }).utc().startOf('day');
+      const value = reportQuery.startDate.clone().utc().startOf('day');
 
       apiFilters.push({type: 'start_time', values: [value.format()]});
     }
 
     if (reportQuery.endDate) {
-      const now = moment();
-      const value = reportQuery.endDate.clone()
-        .set({
-          hour: now.get('hour'),
-          minute: now.get('minute'),
-          second: now.get('second')
-        }).utc().endOf('day');
+      const value = reportQuery.endDate.clone().utc().endOf('day');
       apiFilters.push({type: 'end_time', values: [value.format()]});
     }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Fixing a bug where the compliance reporting page would not allow the user in UTC+1 view the current day. The problem was the reportQuery state was being changed unintentionally. There was also some sections of code that when converting from moment to date was switching the current hour because of time zones. 

### :+1: Definition of Done

When in timezone UTC+1 the current date can be selected. 

### :athletic_shoe: How to Build and Test the Change
1. Switch your local computer to London time (UTC+1)
1. `build components/automate-ui && start_all_services`
1. Open the https://a2-dev.test/compliance/reports/overview
1. Ensure today's UTC date is selected. 
1. Ensure the date can be switched to yesterday back to today. 

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable