### PR TITLE
Use a cypress bind to make user mgmt test less flaky

### DIFF
--- a/components/automate-ui/src/app/page-components/user-table/user-table.component.html
+++ b/components/automate-ui/src/app/page-components/user-table/user-table.component.html
@@ -7,8 +7,6 @@
   <chef-toolbar>
     <app-authorized [allOf]="createPermissionsPath" [overrideVisible]="overridePermissionsCheck">
       <div *ngIf="showEmptyMessage || showTable" [ngClass]="showEmptyMessage ? 'empty-state' : ''">
-        <!-- TC: be careful when writing cypress tests that use data-cy binds in a re-useable component.
-        if it's used twice in the same page it can lead to unexpected behavior. -->
         <chef-button primary data-cy="app-user-table-add-button" [disabled]="!addButtonEnabled" (click)="addClicked.emit($event)"> {{ addButtonText }}
         </chef-button>
       </div>

--- a/components/automate-ui/src/app/page-components/user-table/user-table.component.html
+++ b/components/automate-ui/src/app/page-components/user-table/user-table.component.html
@@ -7,7 +7,9 @@
   <chef-toolbar>
     <app-authorized [allOf]="createPermissionsPath" [overrideVisible]="overridePermissionsCheck">
       <div *ngIf="showEmptyMessage || showTable" [ngClass]="showEmptyMessage ? 'empty-state' : ''">
-        <chef-button primary [disabled]="!addButtonEnabled" (click)="addClicked.emit($event)"> {{ addButtonText }}
+        <!-- TC: be careful when writing cypress tests that use data-cy binds in a re-useable component.
+        if it's used twice in the same page it can lead to unexpected behavior. -->
+        <chef-button primary data-cy="app-user-table-add-button" [disabled]="!addButtonEnabled" (click)="addClicked.emit($event)"> {{ addButtonText }}
         </chef-button>
       </div>
     </app-authorized>

--- a/components/automate-ui/src/app/pages/user-management/user-management.component.html
+++ b/components/automate-ui/src/app/pages/user-management/user-management.component.html
@@ -37,7 +37,7 @@
     </chef-modal>
 
     <section class="page-body">
-      <app-user-table 
+      <app-user-table
         [addButtonText]="addButtonText"
         [removeText]="removeText"
         [users]="users"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -138,6 +138,14 @@ To do so, follow these steps.
 1. Run `.expeditor/buildkite/cypress.sh` to start running the tests
    against all the selected `CHANNEL` environments.
 
+## Cypress Selector Scope
+
+In general, we follow the [cypress best practices](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements)
+around selecting elements, mainly using `data-cy` to select elements specifically.
+However, be careful when using `data-cy` in a shared stencil or angular component.
+If you use it in a shared component that shows up more than once on the page,
+unexpected results might occur.
+
 ## Helpful Links
 
 [Best Practices Talk by Founder Brian

--- a/e2e/cypress/integration/ui/compliance/01_ssh_scan_job.spec.ts
+++ b/e2e/cypress/integration/ui/compliance/01_ssh_scan_job.spec.ts
@@ -18,7 +18,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
   const jobName = 'job ' + nowTime;
   const decoded = Base64.decode(Cypress.env('AUTOMATE_ACCEPTANCE_TARGET_KEY'));
 
-  it('can create a credential with a username and key', () => {
+  itFlaky('can create a credential with a username and key', () => {
     // we save the route that will be called when we navigate to the page
     // in order to be able to wait for it later
     cy.route('POST', '/api/v0/secrets/search').as('getSecrets');
@@ -52,7 +52,7 @@ describe('create a manual node ssh scan job and cleanup after', () => {
     cy.contains(credName).should('exist');
   });
 
-  it('can create a node and attach a credential', () => {
+  itFlaky('can create a node and attach a credential', () => {
     // navigate to node create page:
     // click on scan jobs
     cy.get('.nav-link').contains('Compliance').click();

--- a/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
@@ -27,7 +27,7 @@ describe('user management', () => {
     cy.get('app-user-table').should('exist');
 
     // open modal
-    cy.get('app-user-management chef-button').contains('Create User').click();
+    cy.get('[data-cy=app-user-table-add-button]').contains('Create User').click();
     cy.get('app-user-management chef-modal').should('exist');
 
     // we increase the default delay to mimic the average human's typing speed

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -214,7 +214,10 @@ Cypress.Commands.add('cleanupTeamsByDescriptionPrefix', (idToken: string, namePr
 function LoginHelper(username: string) {
   cy.url().should('include', '/dex/auth/local');
   cy.server();
-  cy.route('POST', '/api/v0/auth/introspect').as('getAuth');
+  // the gloabl permissions for the user that populates the initial permissions cache
+  cy.route('GET', '/api/v0/auth/introspect').as('getAuthPopulateCache');
+  // the parameterized permissions, called for the specific page loaded
+  cy.route('POST', '/api/v0/auth/introspect').as('getAuthParameterized');
 
   // login
   cy.get('#login').type(username);
@@ -227,6 +230,6 @@ function LoginHelper(username: string) {
     cy.get('app-welcome-modal').invoke('hide');
     cy.saveStorage();
 
-    cy.wait('@getAuth');
+    cy.wait(['@getAuthPopulateCache', '@getAuthParameterized']);
   });
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

1) Attempting to use a cy bind to make the test less flaky. Theory is other instances of 'Create User' on the page might be causing flakiness. Also added a comment about paying attention to how you use data-cy in re-useable components. We should never be using the component in question in the same page twice so we should be fine here but a good thing to be aware of.

2) Also added a check to make sure both global and parameterized introspection calls return as part of login helper.

3) Marked the remainder of the ssh scan job tests as flaky since they've been flaking :(

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?