### PR TITLE
Fixing wrong trend graph date with time zone + UTC

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.spec.ts
@@ -1,0 +1,37 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { OverviewTrendComponent } from './overview-trend.component';
+
+describe('OverviewTrendComponent', () => {
+  let fixture: ComponentFixture<OverviewTrendComponent>;
+  let component: OverviewTrendComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+      ],
+      declarations: [
+        OverviewTrendComponent
+      ],
+      providers: [
+      ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+    });
+
+    fixture = TestBed.createComponent(OverviewTrendComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('initializes', () => {
+    expect(component).not.toBeNull();
+  });
+
+  it('create UTC date from string date with timezone', () => {
+    for ( let hour = 0; hour < 10; hour++ ) {
+      expect(component.createUtcDate('2019-09-14T0' + hour + ':59:59Z').getDate()).toEqual(14);
+    }
+    for ( let hour = 10; hour < 24; hour++ ) {
+      expect(component.createUtcDate('2019-09-14T' + hour + ':59:59Z').getDate()).toEqual(14);
+    }
+  });
+});


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The problem this PR is trying to fix is, when a user has their local timezone set to any time larger that UTC the trend graph shifts each column one day ahead. This can be seen better in the screenshot below. 

This problem was caused by a timezone shift. The data sent from the API has the dates like this '2019-09-14T23:59:59Z'. When this time was parse into a date object it would be '2019-09-15T00:59:59GMT+01:00'. Therefore the 15th would be displayed and not the 14th. 

### :chains: Related Resources

Similar timezone problems. 
https://github.com/chef/automate/pull/1624

### :+1: Definition of Done
When a user has local timezone UTC +1 the trend graph does not shift the columns one day ahead. 

### :athletic_shoe: How to Build and Test the Change
1. Switch your local computer time to UTC +1 (London)
1. `build components/automate-ui && start_all_services`
1. Add some compliance nodes with `chef_load_compliance_scans -N100 -D10 -M1 -T1000`
1. Open https://a2-dev.test/compliance/reports/overview
1. Ensure the date selected on the calendar matches the last trend graph date.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
The below image shows the error with the local time set to UTC+1
![trend_graph_bad_date](https://user-images.githubusercontent.com/1679247/65081074-ad77a080-d99a-11e9-96b4-c4fae5a77b30.png)
