### PR TITLE
Filter services by disconnected status

### DIFF
--- a/components/applications-service/pkg/server/server.go
+++ b/components/applications-service/pkg/server/server.go
@@ -221,11 +221,12 @@ func (app *ApplicationsServer) GetServicesBySG(
 		Group:    sgName,
 		Services: convertStorageServicesToApplicationsServices(services),
 		ServicesHealthCounts: &applications.HealthCounts{
-			Total:    svcsHealthCounts.Total,
-			Ok:       svcsHealthCounts.Ok,
-			Warning:  svcsHealthCounts.Warning,
-			Critical: svcsHealthCounts.Critical,
-			Unknown:  svcsHealthCounts.Unknown,
+			Total:        svcsHealthCounts.Total,
+			Ok:           svcsHealthCounts.Ok,
+			Warning:      svcsHealthCounts.Warning,
+			Critical:     svcsHealthCounts.Critical,
+			Unknown:      svcsHealthCounts.Unknown,
+			Disconnected: svcsHealthCounts.Disconnected,
 		},
 	}, nil
 }

--- a/components/applications-service/pkg/storage/postgres/services.go
+++ b/components/applications-service/pkg/storage/postgres/services.go
@@ -416,6 +416,12 @@ func buildWhereConstraintsFromFilters(filters map[string][]string) (string, erro
 		case "service":
 			WhereConstraints = WhereConstraints + buildORStatementFromValues("name", values)
 
+		case "disconnectedStatus":
+			// FIXME: fail on other values?
+			if values[0] == "disconnected" {
+				WhereConstraints = WhereConstraints + " disconnected"
+			}
+
 		default:
 			return "", errors.Errorf("invalid filter. (%s:%s)", filter, values)
 		}

--- a/components/applications-service/pkg/storage/postgres/services.go
+++ b/components/applications-service/pkg/storage/postgres/services.go
@@ -147,6 +147,7 @@ SELECT COUNT(*) AS total
   , COUNT(*) FILTER (WHERE s.health = 'UNKNOWN') AS unknown
   , COUNT(*) FILTER (WHERE s.health = 'WARNING') AS warning
   , COUNT(*) FILTER (WHERE s.health = 'OK') AS ok
+  , COUNT(*) FILTER (WHERE s.disconnected ) AS disconnected
 FROM service_full AS s
  %s
 `


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Services can be filtered by disconnected status. This will support filtering services on the right side detail panel by disconnectedness in a future UI update.

Also, the count of disconnected services is included in the health counts part of the `GetServicesBySG` response; this number will be shown on the filter button for disconnected services in the UI.

### :chains: Related Resources

#1191 

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

Build applications service, start all services, run `applications_populate_database` to create sample data.

Run this to show the disconnected services in the given service group:

```
export T=$(get_admin_token)
curl -k -H "api-token: $T" https://a2-dev.test/apis/beta/applications/service-groups/9162d5b1ca807573a74f635a881f120d699512f6620a1c758217886147e2aa27?filter=disconnectedStatus:disconnected |jq
```

It should initially be empty. You can use this to make the services disconnected more quickly:

```
curl -k -H "api-token: $T" -X POST https://a2-dev.test/apis/beta/retention/service_groups/disconnected_services/config -d '{"running":true,"threshold":"1m"}'
```

Eventually services should get marked disconnected and show up in the service-groups API response.

The health counts section of the response should initially show `"disconnected": 0` and then ` "disconnected": 1` once the services become disconnected.

### :white_check_mark: Checklist

- [x] Tests added/updated?