### PR TITLE
Jamie/css on version automate user menu

### DIFF
--- a/components/automate-ui/src/app/page-components/profile/profile.component.html
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.html
@@ -27,8 +27,14 @@
         </li>
       </app-authorized>
       <li class="dropdown-list-item">
-        <span class="version">Version: 2</span>
-        <span class="build">Build: {{ buildVersion }}</span>
+        <ul>
+          <li>
+            <span class="version">Version: 2</span>
+          </li>
+          <li>
+            <span class="build">Build: {{ buildVersion }}</span>
+          </li>
+        </ul>
         <ul class="dropdown-sub-list">
           <li>
             <button (click)="showWelcomeModal()"

--- a/components/automate-ui/src/app/page-components/profile/profile.component.html
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.html
@@ -27,7 +27,7 @@
         </li>
       </app-authorized>
       <li class="dropdown-list-item">
-        <ul>
+        <ul class="dropdown-sub-list">
           <li>
             <span class="version">Version: 2</span>
           </li>

--- a/components/automate-ui/src/app/page-components/profile/profile.component.scss
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.scss
@@ -99,7 +99,7 @@ a, button:not(.dropdown-toggle) {
   top: 8px;
 }
 
-.version:after {
-  content: '\A';
-  white-space: pre;
-}
+// .version:after {
+//   content: '\A';
+//   white-space: pre;
+// }

--- a/components/automate-ui/src/app/page-components/profile/profile.component.scss
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.scss
@@ -82,6 +82,11 @@ a, button:not(.dropdown-toggle) {
   &:first-child {
     border-bottom: 1px solid $chef-grey;
   }
+
+  .version,
+  .build {
+    line-height: 24px;
+  }
 }
 
 .dropdown-display-name {
@@ -97,9 +102,4 @@ a, button:not(.dropdown-toggle) {
   position: absolute;
   right: 16px;
   top: 8px;
-}
-
-.version,
-.build {
-  line-height: 24px;
 }

--- a/components/automate-ui/src/app/page-components/profile/profile.component.scss
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.scss
@@ -99,7 +99,7 @@ a, button:not(.dropdown-toggle) {
   top: 8px;
 }
 
-// .version:after {
-//   content: '\A';
-//   white-space: pre;
-// }
+.version,
+.build {
+  line-height: 24px;
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Inside the user menu, the Value and Build values were placed in two stacked spans with added css for spacing.  This branch alters those spans to be placed inside an unordered list for better consistency with the rest of the elements in the menu and to remove unfamiliar CSS.

### :chains: Related Resources
https://github.com/chef/automate/pull/502#discussion_r290900357
fixes #547 

### :+1: Definition of Done
Menu looks the same, but uses markup/css that has less potential to break

### :athletic_shoe: How to Build and Test the Change

1. build components/automate-ui-devproxy && start_all_services
2. Navigate to https://a2-dev.test
3. Click on User dropdown

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
<img width="1370" alt="Screen Shot 2019-09-17 at 4 58 25 PM" src="https://user-images.githubusercontent.com/16737484/65087938-6c689780-d96c-11e9-95fe-2e1cf5ec892d.png">