### PR TITLE
PurgeProject for teams and tokens

### DIFF
--- a/components/authn-service/tokens/mock/erroronly.go
+++ b/components/authn-service/tokens/mock/erroronly.go
@@ -51,3 +51,6 @@ func (s *state) GetTokenIDWithValue(context.Context, string) (string, error) {
 func (s *state) GetTokens(context.Context) ([]*tokens.Token, error) {
 	return nil, s.err
 }
+func (s *state) PurgeProject(context.Context, string) error {
+	return s.err
+}

--- a/components/authn-service/tokens/mock/mock.go
+++ b/components/authn-service/tokens/mock/mock.go
@@ -127,6 +127,22 @@ func (m *mock) DeleteToken(ctx context.Context, id string) error {
 	return nil
 }
 
+func (m *mock) PurgeProject(ctx context.Context, projectID string) error {
+	for _, tok := range m.tokens {
+		for i, v := range tok.Projects {
+			if v == projectID {
+				tok.Projects = append(tok.Projects[:i], tok.Projects[i+1:]...)
+				break
+			}
+		}
+		_, err := m.UpdateToken(ctx, tok.ID, tok.Description, tok.Active, tok.Projects)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (m *mock) UpdateToken(ctx context.Context,
 	id, description string,
 	active bool,

--- a/components/authn-service/tokens/pg/adapter.go
+++ b/components/authn-service/tokens/pg/adapter.go
@@ -52,6 +52,15 @@ func (a *adapter) CreateLegacyTokenWithValue(ctx context.Context, value string) 
 	return a.insertToken(ctx, id.String(), tokens.LegacyTokenDescription, value, true, []string{})
 }
 
+// PurgeProject removes a project from every token it exists in
+func (a *adapter) PurgeProject(ctx context.Context, projectID string) error {
+	_, err := a.db.ExecContext(ctx, "UPDATE chef_authn_tokens SET project_ids=array_remove(project_ids, $1)", projectID)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (a *adapter) insertToken(ctx context.Context,
 	id string, description string, value string, active bool, projects []string) (*tokens.Token, error) {
 

--- a/components/authn-service/tokens/pg/pg_test.go
+++ b/components/authn-service/tokens/pg/pg_test.go
@@ -479,6 +479,124 @@ func TestCreateToken(t *testing.T) {
 	}
 }
 
+func TestPurgeProject(t *testing.T) {
+	ctx := context.Background()
+	store, db := setup(t)
+	assert := assert.New(t)
+	description := "Test Token Description"
+	projectToPurge := "projectToPurge"
+
+	cases := map[string]func(*testing.T){
+		"when the token is unassigned, the token remains unassigned": func(t *testing.T) {
+			id := "unassigned"
+			projects := []string{}
+			resp, err := store.CreateToken(ctx, id, description, true, projects)
+			assert.NoError(err, "failed to store token")
+			assert.ElementsMatch(projects, resp.Projects)
+
+			err = store.PurgeProject(ctx, projectToPurge)
+			assert.NoError(err, "failed to purge project")
+
+			purgeCheck, err := store.GetToken(ctx, id)
+			assert.NoError(err, "failed to get token")
+			assert.ElementsMatch([]string{}, purgeCheck.Projects)
+		},
+		"when the token only has the project to purge, the token becomes unassigned": func(t *testing.T) {
+			id := "projectToPurge_only"
+			projects := []string{projectToPurge}
+			resp, err := store.CreateToken(ctx, id, description, true, projects)
+			assert.NoError(err, "failed to store token")
+			assert.ElementsMatch(projects, resp.Projects)
+
+			err = store.PurgeProject(ctx, projectToPurge)
+			assert.NoError(err, "failed to purge project")
+
+			purgeCheck, err := store.GetToken(ctx, id)
+			assert.NoError(err, "failed to get token")
+			assert.ElementsMatch([]string{}, purgeCheck.Projects)
+		},
+		"when the token only has projects other than the one to purge, the token's projects do not change": func(t *testing.T) {
+			id := "other_projects"
+			projects := []string{"otherproject", "otherproject2"}
+			resp, err := store.CreateToken(ctx, id, description, true, projects)
+			assert.NoError(err, "failed to store token")
+			assert.ElementsMatch(projects, resp.Projects)
+
+			err = store.PurgeProject(ctx, projectToPurge)
+			assert.NoError(err, "failed to purge project")
+
+			purgeCheck, err := store.GetToken(ctx, id)
+			assert.NoError(err, "failed to get token")
+			assert.ElementsMatch(projects, purgeCheck.Projects)
+		},
+		"when the token has multiple projects including the one to purge, only that project is removed from the token": func(t *testing.T) {
+			id := "projectToPurge_and_others"
+			projects := []string{"otherproject", projectToPurge, "otherproject2"}
+			resp, err := store.CreateToken(ctx, id, description, true, projects)
+			assert.NoError(err, "failed to store token")
+			assert.ElementsMatch(projects, resp.Projects)
+
+			err = store.PurgeProject(ctx, projectToPurge)
+			assert.NoError(err, "failed to purge project")
+
+			purgeCheck, err := store.GetToken(ctx, id)
+			assert.NoError(err, "failed to get token")
+			assert.ElementsMatch([]string{"otherproject", "otherproject2"}, purgeCheck.Projects)
+		},
+		"when there are mulitple tokens, some with, some without the project to purge": func(t *testing.T) {
+			id1 := "other_projects"
+			projects1 := []string{"otherproject", "otherproject2"}
+			resp1, err := store.CreateToken(ctx, id1, description, true, projects1)
+			assert.NoError(err, "failed to store token1")
+			assert.ElementsMatch(projects1, resp1.Projects)
+
+			id2 := "unassigned"
+			projects2 := []string{}
+			resp2, err := store.CreateToken(ctx, id2, description, true, projects2)
+			assert.NoError(err, "failed to store token2")
+			assert.ElementsMatch(projects2, resp2.Projects)
+
+			id3 := "projectToPurge_and_others"
+			projects3 := []string{"otherproject", projectToPurge, "otherproject2"}
+			resp3, err := store.CreateToken(ctx, id3, description, true, projects3)
+			assert.NoError(err, "failed to store token3")
+			assert.ElementsMatch(projects3, resp3.Projects)
+
+			id4 := "projectToPurge_only"
+			projects4 := []string{projectToPurge}
+			resp4, err := store.CreateToken(ctx, id4, description, true, projects4)
+			assert.NoError(err, "failed to store token4")
+			assert.ElementsMatch(projects4, resp4.Projects)
+
+			err = store.PurgeProject(ctx, projectToPurge)
+			assert.NoError(err, "failed to purge project")
+
+			// unchanged projects
+			purgeCheck1, err := store.GetToken(ctx, id1)
+			assert.NoError(err, "failed to get token1")
+			assert.ElementsMatch(projects1, purgeCheck1.Projects)
+
+			purgeCheck2, err := store.GetToken(ctx, id2)
+			assert.NoError(err, "failed to get token2")
+			assert.ElementsMatch(projects2, purgeCheck2.Projects)
+
+			// project removed
+			purgeCheck3, err := store.GetToken(ctx, id3)
+			assert.NoError(err, "failed to get token3")
+			assert.ElementsMatch([]string{"otherproject", "otherproject2"}, purgeCheck3.Projects)
+
+			purgeCheck4, err := store.GetToken(ctx, id4)
+			assert.NoError(err, "failed to get token4")
+			assert.ElementsMatch([]string{}, purgeCheck4.Projects)
+		},
+	}
+
+	for name, test := range cases {
+		reset(t, db)
+		t.Run(name, test)
+	}
+}
+
 func TestCreateTokenWithValue(t *testing.T) {
 	ctx := context.Background()
 	store, db := setup(t)

--- a/components/authn-service/tokens/types/types.go
+++ b/components/authn-service/tokens/types/types.go
@@ -34,6 +34,7 @@ type Storage interface {
 	GetToken(context.Context, string) (*Token, error)
 	GetTokenIDWithValue(ctx context.Context, value string) (string, error)
 	GetTokens(context.Context) ([]*Token, error)
+	PurgeProject(context.Context, string) error
 }
 
 // Resetter allows resetting the adapter to factory settings (e.g. deletes all

--- a/components/teams-service/storage/memstore/memstore.go
+++ b/components/teams-service/storage/memstore/memstore.go
@@ -314,6 +314,20 @@ func (m *memstore) UpgradeToV2(ctx context.Context) error {
 	return nil
 }
 
+func (m *memstore) PurgeProject(ctx context.Context, projectID string) error {
+	for _, team := range m.teams {
+		for i, v := range team.Projects {
+			if v == projectID {
+				team.Projects = append(team.Projects[:i], team.Projects[i+1:]...)
+				break
+			}
+		}
+		m.teams[team.ID] = team
+		m.teamsV2[team.Name] = team
+	}
+	return nil
+}
+
 // keeps in-memory team safe
 func copyTeam(team storage.Team) storage.Team {
 	copyTeam := storage.Team{

--- a/components/teams-service/storage/postgres/postgres.go
+++ b/components/teams-service/storage/postgres/postgres.go
@@ -481,6 +481,15 @@ func (p *postgres) GetTeamsForUser(ctx context.Context, userID string) ([]storag
 	return teams, nil
 }
 
+// PurgeProject removes a project from every team it exists in
+func (p *postgres) PurgeProject(ctx context.Context, projectID string) error {
+	_, err := p.db.ExecContext(ctx, "UPDATE teams SET projects=array_remove(projects, $1)", projectID)
+	if err != nil {
+		return p.processError(err)
+	}
+	return nil
+}
+
 func (p *postgres) touchTeam(ctx context.Context, q querier, teamID uuid.UUID) (storage.Team, error) {
 	var t storage.Team
 	err := q.QueryRowContext(ctx,

--- a/components/teams-service/storage/storage.go
+++ b/components/teams-service/storage/storage.go
@@ -32,6 +32,7 @@ type Storage interface {
 	DeleteTeamByName(context.Context, string) (Team, error)
 	EditTeamByName(context.Context, string, string, []string) (Team, error)
 	UpgradeToV2(context.Context) error
+	PurgeProject(context.Context, string) error
 }
 
 // Resetter is, if exposed, used for tests to reset the storage backend to a


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Implements the database functions for teams and tokens to purge a project from any entry

### :athletic_shoe: How to Build and Test the Change

Will be used in [this branch](https://github.com/chef/automate/compare/auth-1471/project-deletion-from-domains?expand=1) soon. For now, just running the database tests.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?
