### PR TITLE
[Automate-1634] Re-enable "Update Projects" button upon cancel…

### DIFF
--- a/components/automate-ui/src/app/pages/project/list/project-list.component.html
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.html
@@ -21,7 +21,7 @@
               data-cy="create-project" primary (click)="openCreateModal()">Create Project</chef-button>
           </app-authorized>
           <app-authorized [allOf]="['/iam/v2beta/apply-rules', 'post']">
-            <chef-button secondary [disabled]="!projectsHaveStagedChanges || (projects.applyRulesStatus$ | async)?.state === ApplyRulesStatusState.Running"
+            <chef-button secondary [disabled]="isDisabled()"
               id="update-start-button" (click)="openConfirmUpdateStartModal()">{{ getButtonText() }}</chef-button>
           </app-authorized>
           <app-authorized [allOf]="['/iam/v2beta/apply-rules', 'delete']">

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
@@ -559,14 +559,14 @@ describe('ProjectListComponent', () => {
   });
 
   describe('getButtonText', () => {
-    it('labels the button "Projects Up-To-Date" when no projects are edited', () => {
+    it('labels the button "Projects Up-to-Date" when no projects are edited', () => {
       const uneditedProject1 = genProject('uuid-111', 'RULES_APPLIED');
       const uneditedProject2 = genProject('uuid-112', 'RULES_APPLIED');
       store.dispatch(new GetProjectsSuccess({
         projects: [uneditedProject1, uneditedProject2]
       }));
 
-      expect(component.getButtonText()).toEqual('Projects Up-To-Date');
+      expect(component.getButtonText()).toEqual('Projects Up-to-Date');
     });
 
     it('labels the button "Update Projects" when at least one project is edited', () => {

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
@@ -559,6 +559,16 @@ describe('ProjectListComponent', () => {
   });
 
   describe('getButtonText', () => {
+    it('labels the button "Projects Up-To-Date" when no projects are edited', () => {
+      const uneditedProject1 = genProject('uuid-111', 'RULES_APPLIED');
+      const uneditedProject2 = genProject('uuid-112', 'RULES_APPLIED');
+      store.dispatch(new GetProjectsSuccess({
+        projects: [uneditedProject1, uneditedProject2]
+      }));
+
+      expect(component.getButtonText()).toEqual('Projects Up-To-Date');
+    });
+
     it('labels the button "Update Projects" when at least one project is edited', () => {
       const editedProject = genProject('uuid-99', 'EDITS_PENDING');
       const uneditedProject1 = genProject('uuid-111', 'RULES_APPLIED');
@@ -570,32 +580,26 @@ describe('ProjectListComponent', () => {
       expect(component.getButtonText()).toEqual('Update Projects');
     });
 
-    it('labels the button "Projects Up-To-Date" when no projects are edited', () => {
-      const uneditedProject1 = genProject('uuid-111', 'RULES_APPLIED');
-      const uneditedProject2 = genProject('uuid-112', 'RULES_APPLIED');
-      store.dispatch(new GetProjectsSuccess({
-        projects: [uneditedProject1, uneditedProject2]
-      }));
-
-      expect(component.getButtonText()).toEqual('Projects Up-To-Date');
-    });
-
-    it('labels the button with percentage only during an update', () => {
-      const editedProject = genProject('uuid-99', 'EDITS_PENDING');
-      store.dispatch(new GetProjectsSuccess({
-        projects: [editedProject]
-      }));
-      expect(component.getButtonText()).toEqual('Update Projects');
-
+    it('labels the button with percentage during an update', () => {
       component.confirmApplyStart(); // start the update
       store.dispatch(new GetApplyRulesStatusSuccess( // side effect of the update
         genState(ApplyRulesStatusState.Running)));
 
       expect(component.getButtonText()).toEqual('Updating Projects 50%...');
+    });
 
+    it('labels the button "Update Projects" if update has failed', () => {
       store.dispatch(new GetApplyRulesStatusSuccess(
-        genState(ApplyRulesStatusState.NotRunning)));
-      expect(component.getButtonText()).not.toEqual('Updating Projects 50%...');
+        genState(ApplyRulesStatusState.NotRunning, true, false)));
+
+      expect(component.getButtonText()).toEqual('Update Projects');
+    });
+
+    it('labels the button "Update Projects" if update was cancelled', () => {
+      store.dispatch(new GetApplyRulesStatusSuccess(
+        genState(ApplyRulesStatusState.NotRunning, false, true)));
+
+      expect(component.getButtonText()).toEqual('Update Projects');
     });
   });
 

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -281,7 +281,9 @@ export class ProjectListComponent implements OnInit, OnDestroy {
     if (this.applyRulesInProgress) {
       return `Updating Projects ${Math.round(this.percentageComplete * 100)}%...`;
     }
-    if (this.projectsHaveStagedChanges) {
+    if (this.projectsHaveStagedChanges
+      || this.updateProjectsCancelled
+      || this.updateProjectsFailed) {
       return 'Update Projects';
     }
     return 'Projects Up-To-Date';

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -148,16 +148,6 @@ export class ProjectListComponent implements OnInit, OnDestroy {
     return '';
   }
 
-  getButtonText(): string {
-    if (this.applyRulesInProgress) {
-      return `Updating Projects ${Math.round(this.percentageComplete * 100)}%...`;
-    }
-    if (this.projectsHaveStagedChanges) {
-      return 'Update Projects';
-    }
-    return 'Projects Up-To-Date';
-  }
-
   public createProject(): void {
     this.creatingProject = true;
     const project = {
@@ -286,4 +276,22 @@ export class ProjectListComponent implements OnInit, OnDestroy {
     // TODO: check how often this is hit
     return result;
   }
+
+  public getButtonText(): string {
+    if (this.applyRulesInProgress) {
+      return `Updating Projects ${Math.round(this.percentageComplete * 100)}%...`;
+    }
+    if (this.projectsHaveStagedChanges) {
+      return 'Update Projects';
+    }
+    return 'Projects Up-To-Date';
+  }
+
+  public isDisabled(): boolean {
+    return this.applyRulesInProgress ||
+      (!this.projectsHaveStagedChanges
+        && !this.updateProjectsCancelled
+        && !this.updateProjectsFailed);
+  }
+
 }

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -287,7 +287,7 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       || this.updateProjectsFailed) {
       return 'Update Projects';
     }
-    return 'Projects Up-To-Date';
+    return 'Projects Up-to-Date';
   }
 
   public isDisabled(): boolean {

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -103,11 +103,12 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       });
 
     store.select(allProjects).pipe(
-      takeUntil(this.isDestroyed),
-      // do not update this cache while an update is in progress
-      filter(() => !this.applyRulesInProgress)
+      takeUntil(this.isDestroyed)
     ).subscribe((projectList: Project[]) => {
-      this.statusCache = projectList.reduce((m, p) => ({ ...m, [p.id]: p.status }), {});
+      if (!this.applyRulesInProgress) {
+        // do not update this cache while an update is in progress
+        this.statusCache = projectList.reduce((m, p) => ({ ...m, [p.id]: p.status }), {});
+      }
       this.projectsHaveStagedChanges = projectList.some(p => p.status === 'EDITS_PENDING');
     });
 

--- a/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
@@ -43,7 +43,7 @@ describeIfIAMV2p1('project management', () => {
 
   it('has a disabled button when there are no rules', () => {
     cy.get('app-project-list chef-button#update-start-button')
-      .contains('Projects Up-To-Date').should('have.attr', 'disabled');
+      .contains('Projects Up-to-Date').should('have.attr', 'disabled');
   });
 
   it('displays a list of projects', () => {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The user needs to be able to restart a project update if (a) the prior run failed or (b) the prior run was cancelled by a user. As soon as an update starts the pending rules are moved from "staging" to "applied", which updates the "Ingest Rules" column on screen. That means there are no longer any staged rules, which was what previously dictated the enabled/disabled state of the <kbd>Update Projects</kbd> button. This PR adds cancel/fail awareness to that button enable/disable condition.

These two additional issues fell out of that seemingly innocuous change, and have been included in this PR:
- [x] Update the button label with the same cancel/fail awareness, so it changes from <kbd>Projects Up-to-Date</kbd> to <kbd>Update Projects</kbd> appropriately.
- [x] Adjust when the check for staged projects occurs so that the button label can change from <kbd>Updating Projects...</kbd> to <kbd>Projects Up-to-Date</kbd> upon successful completion of an update.

### :chains: Related Resources

### :+1: Definition of Done
In the following [phenakistiscope](https://en.wikipedia.org/wiki/Phenakistiscope) pay close attention to the project update button near the top, as well as the value in the "Ingest Rules" and "Project Update Status" columns.

(1) Starting with a project having no rules...
![image](https://user-images.githubusercontent.com/6817500/65088978-34fbea00-d970-11e9-8ad0-143a39f24810.png)

(2) We add a rule so that the project now has edits pending. The button label changes and it becomes enabled:
![image](https://user-images.githubusercontent.com/6817500/65088996-4c3ad780-d970-11e9-9891-811febaf0c9c.png)

(3) We select that button and things begin to happen!
![image](https://user-images.githubusercontent.com/6817500/65089015-6674b580-d970-11e9-96cf-ebbf7ef0f68e.png)

(4) When the update finishes, things settle down again to this:
![image](https://user-images.githubusercontent.com/6817500/65089051-8efcaf80-d970-11e9-952b-e77c70483e59.png)

(5) Now let's add in a couple more projects in different initial states:
![image](https://user-images.githubusercontent.com/6817500/65089076-9fad2580-d970-11e9-81c5-541f65e48119.png)

(6) And start an update. Notice that as soon as we do, p1 and p2 are now indistinguishable under "Ingest Rules" with "Applied".
![image](https://user-images.githubusercontent.com/6817500/65101888-5532a580-d97e-11e9-9b2e-9f1147edd8bb.png)

(7) And now to throw a twist in, let's select "Stop Updating Projects":
![image](https://user-images.githubusercontent.com/6817500/65101986-9c209b00-d97e-11e9-886a-d72eb4acddec.png)

(8) By cancelling, we put all project updates in question. But more than that, as we have discussed in team meetings, **Issue 1** is that we currently cannot even distinguish those projects that did not need updates at all (p1 in this case), so now both p1 and p2 look the same with "Needs updating"--but note that <kbd>Update Projects</kbd> is now re-enabled, which was where this PR started!
![image](https://user-images.githubusercontent.com/6817500/65102101-f28dd980-d97e-11e9-81cc-3bd1ca920ead.png)

(9) A further side effect of cancelling the update is **Issue 2**: now when we start a fresh update, the "Project Update Status" column now immediately goes to "OK" rather than "Updating..." (because those projects did not start in an "edits pending" state).

Both issues 1 and 2 could be ameliorated with #1368 (Correct project update status for other users) unless we change the UX experience as some have suggested.

![image](https://user-images.githubusercontent.com/6817500/65102457-fa9a4900-d97f-11e9-80c2-55e8817d9a56.png)

(10) Of course, once the update finishes, all is again well with the world:
![image](https://user-images.githubusercontent.com/6817500/65102498-1a317180-d980-11e9-9afb-4e3407cc1fd1.png)

### :athletic_shoe: How to Build and Test the Change

Rebuild automate-ui
Go to Settings >> Projects
Create projects and rules as you will, or follow the phenakistiscope above.