### PR TITLE
Weird Ci Failures.... U Hate 2 See it

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -22,10 +22,8 @@ steps:
       automatic:
         limit: 1
     expeditor:
-      secrets:
-        GITHUB_TOKEN:
-          account: github/chef-ci
-          field: token
+      accounts:
+        - github
       executor:
         docker:
 
@@ -59,10 +57,8 @@ steps:
       HAB_STUDIO_SUP: false
       HAB_NONINTERACTIVE: true
     expeditor:
-      secrets:
-        HAB_STUDIO_SECRET_GITHUB_TOKEN:
-          account: github/chef-ci
-          field: token
+      accounts:
+        - github
       executor:
         linux:
           privileged: true

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -57,8 +57,10 @@ steps:
       HAB_STUDIO_SUP: false
       HAB_NONINTERACTIVE: true
     expeditor:
-      accounts:
-        - github
+      secrets:
+        HAB_STUDIO_SECRET_GITHUB_APP_TOKEN:
+          account: github
+          field: token
       executor:
         linux:
           privileged: true

--- a/components/automate-chef-io/Makefile
+++ b/components/automate-chef-io/Makefile
@@ -7,7 +7,7 @@ SWAGGER_FILES = $(shell find $(SWAGGER_DIR) -name '*.swagger.json')
 EXPECTED_CONFLICTS=45
 
 themes/chef:
-	git clone https://github.com/chef/chef-hugo-theme.git themes/chef
+	scripts/clone_hugo.sh
 
 clean:
 	rm -rf site/themes/chef

--- a/components/automate-chef-io/Makefile
+++ b/components/automate-chef-io/Makefile
@@ -7,7 +7,7 @@ SWAGGER_FILES = $(shell find $(SWAGGER_DIR) -name '*.swagger.json')
 EXPECTED_CONFLICTS=45
 
 themes/chef:
-	git clone https://${GITHUB_TOKEN}@github.com/chef/chef-hugo-theme.git themes/chef
+	git clone https://github.com/chef/chef-hugo-theme.git themes/chef
 
 clean:
 	rm -rf site/themes/chef

--- a/components/automate-chef-io/scripts/clone_hugo.sh
+++ b/components/automate-chef-io/scripts/clone_hugo.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+clone_url="https://github.com/chef/chef-hugo-theme.git"
+if [[ -n "$GITHUB_TOKEN" ]];then
+    clone_url="https://${GITHUB_TOKEN}@github.com/chef/chef-hugo-theme.git"
+elif [[ -n "$GITHUB_APP_TOKEN" ]];then
+    clone_url="https://x-access-token:${GITHUB_APP_TOKEN}@github.com/chef/chef-hugo-theme.git"
+fi
+
+git clone "$clone_url" themes/chef

--- a/scripts/verify_build.sh
+++ b/scripts/verify_build.sh
@@ -49,13 +49,6 @@ else
     buildkite-agent annotate --style "info" "This change rebuilds no components."
 fi
 
-if [[ "$changed_components_details" =~ "automate-chef-io" ]]; then
-    buildkite-agent annotate --style "warning" --context docs-warning <<EOF
-This change modifies automate-chef.io. The automate-chef-io Habitat
-package currently cannot be built in Buildkite and will be skipped.
-EOF
-fi
-
 mapfile -t modified_sql_files < <(git diff --name-status "$(./scripts/git_difference_expression.rb)" |\
                                     awk '!/datamigration/ && /^[RMD][0-9]*.*\.sql$/ { print $2 }')
 if [[ ${#modified_sql_files[@]} -ne 0 ]]; then
@@ -68,9 +61,6 @@ fi
 # Build all habitat packages that have changed
 build_commands=""
 for component in "${changed_components[@]}"; do
-    if [[ "$component" = "components/automate-chef-io" ]]; then
-        continue
-    fi
     component_build="echo \"--- [\$(date -u)] build $component\"; build $component"
     build_commands="${build_commands} $component_build;"
 done

--- a/scripts/verify_build.sh
+++ b/scripts/verify_build.sh
@@ -49,6 +49,13 @@ else
     buildkite-agent annotate --style "info" "This change rebuilds no components."
 fi
 
+if [[ "$changed_components_details" =~ "automate-chef-io" ]]; then
+    buildkite-agent annotate --style "warning" --context docs-warning <<EOF
+This change modifies automate-chef.io. The automate-chef-io Habitat
+package currently cannot be built in Buildkite and will be skipped.
+EOF
+fi
+
 mapfile -t modified_sql_files < <(git diff --name-status "$(./scripts/git_difference_expression.rb)" |\
                                     awk '!/datamigration/ && /^[RMD][0-9]*.*\.sql$/ { print $2 }')
 if [[ ${#modified_sql_files[@]} -ne 0 ]]; then
@@ -61,6 +68,9 @@ fi
 # Build all habitat packages that have changed
 build_commands=""
 for component in "${changed_components[@]}"; do
+    if [[ "$component" = "components/automate-chef-io" ]]; then
+        continue
+    fi
     component_build="echo \"--- [\$(date -u)] build $component\"; build $component"
     build_commands="${build_commands} $component_build;"
 done


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

I'm seeing Ci failures like this for the `lint Hugo site` job:

```

git clone https://v1.d3b2785e6371bcc6d4637cb5a26cd4363ab8e8f2@github.com/chef/chef-hugo-theme.git themes/chef
--
  | Cloning into 'themes/chef'...
  | Password for 'https://v1.d3b2785e6371bcc6d4637cb5a26cd4363ab8e8f2@github.com': # Received cancellation signal, interrupting
  | 🚨 Error: The command exited with status -1

```

### :+1: Definition of Done

can lint the Hugo site in Ci
