### PR TITLE
Fixing get nodes to concat filters on correctly

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.spec.ts
@@ -5,9 +5,11 @@ import { ReportingProfileComponent } from '../+reporting-profile/reporting-profi
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
 import { MockChefSessionService } from 'app/testing/mock-chef-session.service';
 import { CookieModule } from 'ngx-cookie';
-import { StatsService, ReportQueryService, ScanResultsService } from '../../shared/reporting';
+import { StatsService, ReportQueryService,
+  ScanResultsService, ReportQuery } from '../../shared/reporting';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { of as observableOf } from 'rxjs';
+import * as moment from 'moment';
 
 describe('ReportingProfileComponent', () => {
   let fixture, component, element, statsService;
@@ -58,12 +60,27 @@ describe('ReportingProfileComponent', () => {
   describe('getNodes', () => {
     it('calls statsService.getNodes with the paginationOverride value', () => {
       spyOn(statsService, 'getNodes').and.returnValue(observableOf({items: []}));
-      component.getNodes([], {profileId: '123', controlId: '321'});
-      expect(statsService.getNodes).toHaveBeenCalledWith(
-        [
+      const endDate = moment().utc().startOf('day').add(12, 'hours');
+      const reportQuery: ReportQuery = {
+        startDate: moment(endDate).subtract(10, 'days'),
+        endDate: endDate,
+        interval: 0,
+        filters: [ ]
+      };
+      component.getNodes(reportQuery, {profileId: '123', controlId: '321'});
+
+      const expectedReportQuery: ReportQuery = {
+        startDate: moment(endDate).subtract(10, 'days'),
+        endDate: endDate,
+        interval: 0,
+        filters: [
           {type: { name: 'profile_id' }, value: { text: '123'} },
           {type: { name: 'control_id' }, value: { text: '321'} }
-        ],
+        ]
+      };
+
+      expect(statsService.getNodes).toHaveBeenCalledWith(
+        expectedReportQuery,
         { perPage: 1000, page: 1, sort: 'latest_report.end_time', order: 'desc' });
     });
   });


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Fixing the 'getNodes' function to add filters correctly. With the 1268 PR filters changed from an array of 'any' to a defined interface 'ReportQuery'. 

### :chains: Related Resources

PR that introduced the bug - https://github.com/chef/automate/pull/1268

https://github.com/chef/automate/issues/1648

### :+1: Definition of Done
Nodes are loaded in the right sidebar from the profile's page. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui && start_all_services`
1. Add some compliance nodes `chef_load_compliance_scans -N100 -D10 -M1 -T1000`
1. Go to https://a2-dev.test/compliance/reports/profiles.
1. Click on the "Scan Results" button for one of the profiles. 
1. Ensure a list of nodes appears in the right sidebar

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
![scan_results](https://user-images.githubusercontent.com/1679247/65189438-ce390800-da25-11e9-850a-1eb4432b5f10.png)
