### PR TITLE
[automate-1618] expand ingest rule integration tests + refactor tokens in API-only tests

### DIFF
--- a/.expeditor/buildkite/cypress.sh
+++ b/.expeditor/buildkite/cypress.sh
@@ -25,7 +25,7 @@ do
           return 1
         fi
       else 
-        if ! token=$(chef-automate iam token create $timestamp-tok --admin); then
+        if ! token=$(chef-automate iam token create "$timestamp-tok" --admin); then
           echo "Non-zero exit code, output:"
           echo "$token"
           return 1

--- a/.expeditor/buildkite/cypress.sh
+++ b/.expeditor/buildkite/cypress.sh
@@ -7,6 +7,7 @@ cd /workdir/e2e
 data=$(curl --silent "https://a2-${CHANNEL}.cd.chef.co/assets/data.json")
 instances_to_test=$(jq -nr --argjson data "$data" '$data[] | select(.tags | any(. == "e2e")) | .fqdn')
 versions=(v1 v2 v2.1)
+timestamp=$(date +"%m-%d-%y-%H-%M")
 
 for instance in ${instances_to_test[*]}
 do
@@ -17,6 +18,21 @@ do
   for version in ${versions[*]}
   do
     if jq -enr --arg version "$version" --arg fqdn "$instance" --argjson data "$data" '$data[] | select(.fqdn == $fqdn) | .tags | any(. == $version)'; then
+      if [[ "$version" == "v1" ]]; then
+        if ! token=$(chef-automate admin-token); then
+          echo "Non-zero exit code, output:"
+          echo "$token"
+          return 1
+        fi
+      else 
+        if ! token=$(chef-automate iam token create $timestamp-tok --admin); then
+          echo "Non-zero exit code, output:"
+          echo "$token"
+          return 1
+        fi
+      fi
+      
+      export CYPRESS_ADMIN_TOKEN=$token
       export CYPRESS_IAM_VERSION=$version
     fi
   done

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -412,7 +412,7 @@ steps:
   #
   - label: ":cypress: (flaky included) IAMv1"
     command:
-      - IAM=v1.0 integration/run_test integration/tests/cypress_e2e.sh
+      - IAM=v1 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
     soft_fail: true
     expeditor:
@@ -437,7 +437,7 @@ steps:
 
   - label: ":cypress: (flaky included) IAMv2"
     command:
-      - IAM=v2.0 integration/run_test integration/tests/cypress_e2e.sh
+      - IAM=v2 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
     soft_fail: true
     expeditor:
@@ -463,7 +463,7 @@ steps:
 
   - label: ":cypress: IAMv1"
     command:
-      - IAM=v1.0 integration/run_test integration/tests/cypress_e2e.sh
+      - IAM=v1 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
     expeditor:
       secrets: &cypress_secrets

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -49,15 +49,15 @@ according to your targeted Automate instance's IAM version.
 
 ```bash
 export CYPRESS_IAM_VERSION=v1
-export CYPRESS_ADMIN_TOKEN=`chef-automate admin-token`
+export CYPRESS_ADMIN_TOKEN=`chef-automate admin-token` # or copy an admin token from the UI or CLI
 
 # or
 export CYPRESS_IAM_VERSION=v2
-export CYPRESS_ADMIN_TOKEN=`chef-automate iam token create TEST --admin`
+export CYPRESS_ADMIN_TOKEN=`chef-automate iam token create TEST --admin` # or copy an admin token from the UI or CLI
 
 # or
 export CYPRESS_IAM_VERSION=v2.1
-export CYPRESS_ADMIN_TOKEN=`chef-automate iam token create TEST --admin`
+export CYPRESS_ADMIN_TOKEN=`chef-automate iam token create TEST --admin` # or copy an admin token from the UI or CLI
 ```
 
 If you are developing Cypress tests, you'll want to open the Cypress

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -33,7 +33,7 @@ If your secrets become out of date, you'll likely need to re-fetch
 `sercrets-env.sh` and re-source. You might get a strange error like
 this if your secrets are out of date:
 
-```
+```bash
 InvalidCharacterError: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.
 ```
 
@@ -42,6 +42,22 @@ dev or acceptance; typically start with your local box with this:
 
 ```bash
 export CYPRESS_BASE_URL=https://a2-dev.test
+```
+
+Most Cypress tests also expect the following IAM-related environment variables. Set them
+according to your targeted Automate instance's IAM version.
+
+```bash
+export CYPRESS_IAM_VERSION=v1
+export CYPRESS_ADMIN_TOKEN=`chef-automate admin-token`
+
+# or
+export CYPRESS_IAM_VERSION=v2
+export CYPRESS_ADMIN_TOKEN=`chef-automate iam token create TEST --admin`
+
+# or
+export CYPRESS_IAM_VERSION=v2.1
+export CYPRESS_ADMIN_TOKEN=`chef-automate iam token create TEST --admin`
 ```
 
 If you are developing Cypress tests, you'll want to open the Cypress
@@ -91,7 +107,7 @@ To target those specific sets of tests set that environment variable when starti
 CYPRESS_IAM_VERSION="v2.1" npm run cypress:run
 ```
 
-Possible values are `"v1.0"`, `"v2.0"`, and `"v2.1"`.
+Possible values are `"v1"`, `"v2"`, and `"v2.1"`.
 
 Your dev environment's IAM version MUST match the value of CYPRESS_IAM_VERSION for the tests to pass locally.
 
@@ -99,7 +115,7 @@ Your dev environment's IAM version MUST match the value of CYPRESS_IAM_VERSION f
 
 There are some known flaky tests we are trying to debug. By default, they do not run. If you wish to run them:
 
-```
+```bash
 CYPRESS_RUN_FLAKY=true npm run cypress:run
 ```
 

--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,8 +1,5 @@
 {
   "projectId": "yvg8zo",
   "defaultCommandTimeout": 25000,
-  "pageLoadTimeout": 80000,
-  "env": {
-    "adminTokenValue": ""
-  }
+  "pageLoadTimeout": 80000
 }

--- a/e2e/cypress/fixtures/converge/avengers1.json
+++ b/e2e/cypress/fixtures/converge/avengers1.json
@@ -37,7 +37,7 @@
   "message_version": "1.1.0",
   "message_type": "run_converge",
   "node": {
-    "name": "chef-client-dev.test",
+    "name": "testing_projects",
     "chef_environment": "_default",
     "json_class": "Chef::Node",
     "automatic": {
@@ -5077,7 +5077,7 @@
         "timezone": "UTC"
       },
       "chef_guid": "f6a5c33f-bef5-433b-815e-a8f6e69e6b1b",
-      "name": "chef-client-dev.test",
+      "name": "testing_projects",
       "chef_environment": "_default",
       "recipes": [
         "chef-client",
@@ -5184,7 +5184,7 @@
       }
     },
     "normal": {
-      "tags": []
+      "tags": [ "test_tag" ]
     },
     "chef_type": "node",
     "default": {
@@ -6013,8 +6013,8 @@
   "run_list": [
     "role[web]"
   ],
-  "policy_name": null,
-  "policy_group": null,
+  "policy_name": "test_name",
+  "policy_group": "test_group",
   "start_time": "2018-09-13T20:43:01Z",
   "end_time": "2018-09-13T20:43:01Z",
   "source": "chef_client",

--- a/e2e/cypress/fixtures/converge/xmen1.json
+++ b/e2e/cypress/fixtures/converge/xmen1.json
@@ -7910,9 +7910,7 @@
     },
     "normal": {
       "tags": [
-        "chefdk",
-        "slave",
-        "tester"
+        "chefdk"
       ],
       "omnibus": {
         "build_user": "jenkins",

--- a/e2e/cypress/fixtures/converge/xmen2.json
+++ b/e2e/cypress/fixtures/converge/xmen2.json
@@ -4845,9 +4845,7 @@
     },
     "normal": {
       "tags": [
-        "chefdk",
-        "slave",
-        "tester"
+        "chefdk"
       ],
       "omnibus": {
         "build_user": "jenkins",

--- a/e2e/cypress/index.d.ts
+++ b/e2e/cypress/index.d.ts
@@ -7,9 +7,8 @@ declare namespace Cypress {
     saveStorage(): void
     restoreStorage(): void
     applyProjectsFilter(projectsToFilterOn: string[]): void
-    generateAdminToken(idToken: string): void
-    cleanupV2IAMObjectsByIDPrefixes(idToken: string, idPrefix: string, objectPlurals: string[]): void
-    cleanupUsersByNamePrefix(idToken: string, namePrefix: string): void
-    cleanupTeamsByDescriptionPrefix(idToken: string, namePrefix: string): void
+    cleanupV2IAMObjectsByIDPrefixes(idPrefix: string, objectPlurals: string[]): void
+    cleanupUsersByNamePrefix(namePrefix: string): void
+    cleanupTeamsByDescriptionPrefix(namePrefix: string): void
   }
 }

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -472,6 +472,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     });
   });
 
+  // must correspond to enum type in automate-gateway/.../common/rules.proto
   const attributeValuesMap = new Map([
     ['CHEF_SERVER', 'chef-server-dev.test'],
     ['ENVIRONMENT', '_default'],
@@ -533,6 +534,8 @@ describeIfIAMV2p1('projects API: applying project', () => {
         headers: { 'api-token': adminApiToken },
         method: 'DELETE',
         url: `/apis/iam/v2beta/projects/${avengersRule.project_id}/rules/${rule.id}`
+      }).then((response) => {
+        expect(response.status).to.equal(200);
       });
 
       // apply rules to reset node to unassigned
@@ -540,6 +543,8 @@ describeIfIAMV2p1('projects API: applying project', () => {
         headers: { 'api-token': adminApiToken },
         method: 'POST',
         url: '/apis/iam/v2beta/apply-rules'
+      }).then((response) => {
+        expect(response.status).to.equal(200);
       });
       waitUntilApplyRulesNotRunning(100);
     });

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -1,4 +1,4 @@
-import { describeIfIAMV2p1, adminToken } from '../../constants';
+import { describeIfIAMV2p1, adminApiToken } from '../../constants';
 
 describeIfIAMV2p1('projects API: applying project', () => {
   const cypressPrefix = 'test-projects-api';
@@ -59,7 +59,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['projects']);
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'POST',
       url: 'api/v0/ingest/events/chef/node-multiple-deletes',
       body: {
@@ -75,7 +75,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
 
     for (const project of [avengersProject, xmenProject]) {
       cy.request({
-        headers: { 'api-token': adminToken },
+        headers: { 'api-token': adminApiToken },
         method: 'POST',
         url: '/apis/iam/v2beta/projects',
         body: project
@@ -85,7 +85,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     let totalNodes = 0;
     cy.request({
       headers: {
-        'api-token': adminToken,
+        'api-token': adminApiToken,
         projects: '(unassigned)'
       },
       method: 'GET',
@@ -100,7 +100,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
           cy.fixture('converge/xmen2.json').then(node4 => {
             for (const node of [node1, node2, node3, node4]) {
               cy.request({
-                headers: { 'api-token': adminToken },
+                headers: { 'api-token': adminApiToken },
                 method: 'POST',
                 url: '/data-collector/v0',
                 body: node
@@ -117,7 +117,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     // confirm nodes are unassigned
     cy.request({
       headers: {
-        'api-token': adminToken,
+        'api-token': adminApiToken,
         projects: '(unassigned)'
       },
       method: 'GET',
@@ -128,7 +128,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
 
     cy.request({
       headers: {
-        'api-token': adminToken,
+        'api-token': adminApiToken,
         projects: avengersProject.id
       },
       method: 'GET',
@@ -139,7 +139,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
 
     cy.request({
       headers: {
-        'api-token': adminToken,
+        'api-token': adminApiToken,
         projects: xmenProject.id
       },
       method: 'GET',
@@ -157,7 +157,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     // initially no rules
     for (const project of [avengersProject, xmenProject]) {
       cy.request({
-        headers: { 'api-token': adminToken },
+        headers: { 'api-token': adminApiToken },
         method: 'GET',
         url: `/apis/iam/v2beta/projects/${project.id}/rules`
       }).then((response) => {
@@ -165,7 +165,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
       });
 
       cy.request({
-        headers: { 'api-token': adminToken },
+        headers: { 'api-token': adminApiToken },
         method: 'GET',
         url: `/apis/iam/v2beta/projects/${project.id}`
       }).then((response) => {
@@ -174,7 +174,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     }
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((response) => {
@@ -185,7 +185,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
 
     for (const rule of [avengersRule, xmenRule]) {
       cy.request({
-        headers: { 'api-token': adminToken },
+        headers: { 'api-token': adminApiToken },
         method: 'POST',
         url: `/apis/iam/v2beta/projects/${rule.project_id}/rules`,
         body: rule
@@ -195,7 +195,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     // confirm rules are staged
     for (const project of [avengersProject, xmenProject]) {
       cy.request({
-        headers: { 'api-token': adminToken },
+        headers: { 'api-token': adminApiToken },
         method: 'GET',
         url: `/apis/iam/v2beta/projects/${project.id}/rules`
       }).then((response) => {
@@ -206,7 +206,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
       });
 
       cy.request({
-        headers: { 'api-token': adminToken },
+        headers: { 'api-token': adminApiToken },
         method: 'GET',
         url: `/apis/iam/v2beta/projects/${project.id}`
       }).then((response) => {
@@ -215,7 +215,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     }
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((response) => {
@@ -225,7 +225,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'POST',
       url: '/apis/iam/v2beta/apply-rules'
     });
@@ -234,7 +234,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     // confirm rules are applied
     for (const project of [avengersProject, xmenProject]) {
       cy.request({
-        headers: { 'api-token': adminToken },
+        headers: { 'api-token': adminApiToken },
         method: 'GET',
         url: `/apis/iam/v2beta/projects/${project.id}/rules`
       }).then((response) => {
@@ -245,7 +245,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
       });
 
       cy.request({
-        headers: { 'api-token': adminToken },
+        headers: { 'api-token': adminApiToken },
         method: 'GET',
         url: `/apis/iam/v2beta/projects/${project.id}`
       }).then((response) => {
@@ -254,7 +254,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     }
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((response) => {
@@ -266,7 +266,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     // confirm nodes are assigned to projects correctly
     cy.request({
       headers: {
-        'api-token': adminToken,
+        'api-token': adminApiToken,
         projects: avengersProject.id
       },
       method: 'GET',
@@ -277,7 +277,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
 
     cy.request({
       headers: {
-        'api-token': adminToken,
+        'api-token': adminApiToken,
         projects: xmenProject.id
       },
       method: 'GET',
@@ -301,7 +301,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     ];
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: `/apis/iam/v2beta/projects/${avengersProject.id}`
     }).then((response) => {
@@ -309,7 +309,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((response) => {
@@ -319,14 +319,14 @@ describeIfIAMV2p1('projects API: applying project', () => {
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'PUT',
       url: `/apis/iam/v2beta/projects/${avengersRule.project_id}/rules/${avengersRule.id}`,
       body: updatedAvengersRule
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: `/apis/iam/v2beta/projects/${avengersProject.id}`
     }).then((response) => {
@@ -334,7 +334,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((response) => {
@@ -344,7 +344,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'POST',
       url: '/apis/iam/v2beta/apply-rules'
     });
@@ -352,7 +352,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
 
     cy.request({
       headers: {
-        'api-token': adminToken,
+        'api-token': adminApiToken,
         projects: avengersProject.id
       },
       method: 'GET',
@@ -362,7 +362,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: `/apis/iam/v2beta/projects/${avengersProject.id}`
     }).then((response) => {
@@ -370,7 +370,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((response) => {
@@ -383,7 +383,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
   it('deleted rules get applied to nodes', () => {
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: `/apis/iam/v2beta/projects/${avengersProject.id}`
     }).then((response) => {
@@ -391,7 +391,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((response) => {
@@ -401,13 +401,13 @@ describeIfIAMV2p1('projects API: applying project', () => {
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'DELETE',
       url: `/apis/iam/v2beta/projects/${avengersRule.project_id}/rules/${avengersRule.id}`
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: `/apis/iam/v2beta/projects/${avengersProject.id}`
     }).then((response) => {
@@ -415,7 +415,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((response) => {
@@ -425,14 +425,14 @@ describeIfIAMV2p1('projects API: applying project', () => {
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'POST',
       url: '/apis/iam/v2beta/apply-rules'
     });
     waitUntilApplyRulesNotRunning(100);
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: `/apis/iam/v2beta/projects/${avengersProject.id}`
     }).then((response) => {
@@ -440,7 +440,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
     });
 
     cy.request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((response) => {
@@ -451,7 +451,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
 
     cy.request({
       headers: {
-        'api-token': adminToken,
+        'api-token': adminApiToken,
         projects: avengersProject.id
       },
       method: 'GET',
@@ -462,7 +462,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
 
     cy.request({
       headers: {
-        'api-token': adminToken,
+        'api-token': adminApiToken,
         projects: '(unassigned)'
       },
       method: 'GET',
@@ -501,7 +501,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
       };
       // create rule with attribute value
       cy.request({
-        headers: { 'api-token': adminToken },
+        headers: { 'api-token': adminApiToken },
         method: 'POST',
         url: `/apis/iam/v2beta/projects/${rule.project_id}/rules`,
         body: rule
@@ -509,7 +509,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
 
       // apply rules
       cy.request({
-        headers: { 'api-token': adminToken },
+        headers: { 'api-token': adminApiToken },
         method: 'POST',
         url: '/apis/iam/v2beta/apply-rules'
       });
@@ -518,7 +518,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
       // see filter works
       cy.request({
         headers: {
-          'api-token': adminToken,
+          'api-token': adminApiToken,
           projects: avengersProject.id
         },
         method: 'GET',
@@ -530,14 +530,14 @@ describeIfIAMV2p1('projects API: applying project', () => {
 
       // delete rule
       cy.request({
-        headers: { 'api-token': adminToken },
+        headers: { 'api-token': adminApiToken },
         method: 'DELETE',
         url: `/apis/iam/v2beta/projects/${avengersRule.project_id}/rules/${rule.id}`
       });
 
       // apply rules to reset node to unassigned
       cy.request({
-        headers: { 'api-token': adminToken },
+        headers: { 'api-token': adminApiToken },
         method: 'POST',
         url: '/apis/iam/v2beta/apply-rules'
       });
@@ -549,7 +549,7 @@ describeIfIAMV2p1('projects API: applying project', () => {
 function waitForNodes(totalNodes: number, maxRetries: number) {
   cy
     .request({
-      headers: { 'api-token': adminToken },
+      headers: { 'api-token': adminApiToken },
       method: 'GET',
       url: '/api/v0/cfgmgmt/nodes?pagination.size=10'
     })
@@ -571,7 +571,7 @@ function waitUntilApplyRulesNotRunning(attempts: number): void {
     throw new Error('apply-rules never finished');
   }
   cy.request({
-    headers: { 'api-token': adminToken },
+    headers: { 'api-token': adminApiToken },
     url: '/apis/iam/v2beta/apply-rules'
   }).then((response) => {
     if (response.body.state === 'not_running') {

--- a/e2e/cypress/integration/api/iam/02_policies_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/02_policies_api.spec.ts
@@ -1,8 +1,8 @@
-import { describeIfIAMV2, describeIfIAMV2p1, adminToken } from '../../constants';
+import { describeIfIAMV2, describeIfIAMV2p1, adminApiToken } from '../../constants';
 
 describeIfIAMV2('policies API', () => {
   const defaultAdminReq = {
-    headers: { 'api-token': adminToken },
+    headers: { 'api-token': adminApiToken },
     method: 'GET',
     url: '/apis/iam/v2beta/policies'
   };
@@ -22,7 +22,7 @@ describeIfIAMV2('policies API', () => {
 
     for (const project of [project1, project2]) {
       cy.request({
-          headers: { 'api-token': adminToken },
+          headers: { 'api-token': adminApiToken },
           method: 'POST',
           url: '/apis/iam/v2beta/projects',
           body: project

--- a/e2e/cypress/integration/api/iam/02_policies_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/02_policies_api.spec.ts
@@ -1,9 +1,8 @@
-import { describeIfIAMV2, describeIfIAMV2p1 } from '../../constants';
+import { describeIfIAMV2, describeIfIAMV2p1, adminToken } from '../../constants';
 
 describeIfIAMV2('policies API', () => {
-  let adminToken = '';
   const defaultAdminReq = {
-    auth: { bearer: adminToken },
+    headers: { 'api-token': adminToken },
     method: 'GET',
     url: '/apis/iam/v2beta/policies'
   };
@@ -19,34 +18,29 @@ describeIfIAMV2('policies API', () => {
   };
 
   before(() => {
-    cy.adminLogin('/').then(() => {
-      const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
-      adminToken = admin.id_token;
-      defaultAdminReq.auth.bearer = adminToken;
-      cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['policies', 'projects']);
+    cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['policies', 'projects']);
 
-      for (const project of [project1, project2]) {
-        cy.request({
-            auth: { bearer: adminToken },
-            method: 'POST',
-            url: '/apis/iam/v2beta/projects',
-            body: project
-        });
-      }
-    });
+    for (const project of [project1, project2]) {
+      cy.request({
+          headers: { 'api-token': adminToken },
+          method: 'POST',
+          url: '/apis/iam/v2beta/projects',
+          body: project
+      });
+    }
   });
 
   after(() => {
-    cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['policies', 'projects']);
+    cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['policies', 'projects']);
   });
 
   describe('POST /apis/iam/v2beta/policies', () => {
     beforeEach(() => {
-      cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['policies']);
+      cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['policies']);
     });
 
     afterEach(() => {
-      cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['policies']);
+      cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['policies']);
     });
 
     it('returns 400 when there are no statements',  () => {
@@ -67,11 +61,11 @@ describeIfIAMV2('policies API', () => {
 
   describe('PUT /apis/iam/v2beta/policies', () => {
     beforeEach(() => {
-      cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['policies']);
+      cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['policies']);
     });
 
     afterEach(() => {
-      cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['policies']);
+      cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['policies']);
     });
 
     const policyID = `${cypressPrefix}-policy-${now}`;
@@ -159,7 +153,7 @@ describeIfIAMV2('policies API', () => {
     });
 
     after(() => {
-      cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix,
+      cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix,
           ['projects', 'policies', 'tokens']);
     });
 

--- a/e2e/cypress/integration/api/iam/03_roles_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/03_roles_api.spec.ts
@@ -1,4 +1,4 @@
-import { describeIfIAMV2p1, adminToken } from '../../constants';
+import { describeIfIAMV2p1, adminApiToken } from '../../constants';
 
 describe('roles API', () => {
     const cypressPrefix = 'test-roles-api';
@@ -23,7 +23,7 @@ describe('roles API', () => {
                 ['projects', 'roles', 'policies', 'tokens']);
             for (const project of [project1, project2]) {
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/projects',
                     body: project
@@ -31,7 +31,7 @@ describe('roles API', () => {
             }
 
             cy.request({
-                headers: { 'api-token': adminToken },
+                headers: { 'api-token': adminApiToken },
                 method: 'POST',
                 url: '/apis/iam/v2beta/tokens',
                 body: {
@@ -44,7 +44,7 @@ describe('roles API', () => {
             });
 
             cy.request({
-                headers: { 'api-token': adminToken },
+                headers: { 'api-token': adminApiToken },
                 method: 'POST',
                 url: '/apis/iam/v2beta/policies',
                 body: {
@@ -80,7 +80,7 @@ describe('roles API', () => {
         describe('POST /apis/iam/v2beta/roles', () => {
             it('admin can create a new role with no projects', () => {
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -96,7 +96,7 @@ describe('roles API', () => {
 
             it('admin can create a new role with multiple projects', () => {
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -113,7 +113,7 @@ describe('roles API', () => {
             it('admin gets a 404 when it attempts to create ' +
                'a role with a project that does not exist', () => {
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     failOnStatusCode: false,
@@ -202,7 +202,7 @@ describe('roles API', () => {
         describe('PUT /apis/iam/v2beta/roles', () => {
             it('admin can update a role with no projects to have projects', () => {
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -216,7 +216,7 @@ describe('roles API', () => {
                 });
 
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'PUT',
                     url: `/apis/iam/v2beta/roles/${roleID}`,
                     body: {
@@ -231,7 +231,7 @@ describe('roles API', () => {
 
             it('admin can update a role with projects to have no projects', () => {
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -245,7 +245,7 @@ describe('roles API', () => {
                 });
 
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'PUT',
                     url: `/apis/iam/v2beta/roles/${roleID}`,
                     body: {
@@ -260,7 +260,7 @@ describe('roles API', () => {
 
             it('admin cannot update a role to have projects that do not exist', () => {
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -274,7 +274,7 @@ describe('roles API', () => {
                 });
 
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'PUT',
                     url: `/apis/iam/v2beta/roles/${roleID}`,
                     failOnStatusCode: false,
@@ -291,7 +291,7 @@ describe('roles API', () => {
             it('non-admin with project1 assignment access can update ' +
             'a role with no projects to have project1', () => {
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -321,7 +321,7 @@ describe('roles API', () => {
             it('non-admin with project1 assignment access can update ' +
             'a role to remove project1', () => {
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -351,7 +351,7 @@ describe('roles API', () => {
             it('non-admin with project1 assignment access gets a 404 ' +
             'when updating a role to have non-existent roles', () => {
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -382,7 +382,7 @@ describe('roles API', () => {
             it('non-admin with project1 assignment access cannot update ' +
             'a role with no projects to have other projects', () => {
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -413,7 +413,7 @@ describe('roles API', () => {
             it('non-admin with project1 assignment access cannot update ' +
             'a role to remove other projects', () => {
                 cy.request({
-                    headers: { 'api-token': adminToken },
+                    headers: { 'api-token': adminApiToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {

--- a/e2e/cypress/integration/api/iam/03_roles_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/03_roles_api.spec.ts
@@ -1,16 +1,9 @@
-import { describeIfIAMV2p1 } from '../../constants';
+import { describeIfIAMV2p1, adminToken } from '../../constants';
 
 describe('roles API', () => {
     const cypressPrefix = 'test-roles-api';
-    let adminIdToken = '';
     let nonAdminToken = '';
     const nonAdminTokenID = `${cypressPrefix}-nonadmin-token`;
-    before(() => {
-        cy.adminLogin('/').then(() => {
-            adminIdToken = JSON.parse(
-                <string>localStorage.getItem('chef-automate-user')).id_token;
-        });
-    });
 
     describeIfIAMV2p1('project assignment enforcement', () => {
         const project1 = {
@@ -26,11 +19,11 @@ describe('roles API', () => {
         const roleID = `${cypressPrefix}-role1`;
 
         before(() => {
-            cy.cleanupV2IAMObjectsByIDPrefixes(adminIdToken, cypressPrefix,
+            cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix,
                 ['projects', 'roles', 'policies', 'tokens']);
             for (const project of [project1, project2]) {
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/projects',
                     body: project
@@ -38,7 +31,7 @@ describe('roles API', () => {
             }
 
             cy.request({
-                auth: { bearer: adminIdToken },
+                headers: { 'api-token': adminToken },
                 method: 'POST',
                 url: '/apis/iam/v2beta/tokens',
                 body: {
@@ -51,7 +44,7 @@ describe('roles API', () => {
             });
 
             cy.request({
-                auth: { bearer: adminIdToken },
+                headers: { 'api-token': adminToken },
                 method: 'POST',
                 url: '/apis/iam/v2beta/policies',
                 body: {
@@ -76,18 +69,18 @@ describe('roles API', () => {
         });
 
         after(() => {
-            cy.cleanupV2IAMObjectsByIDPrefixes(adminIdToken, cypressPrefix,
+            cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix,
                 ['projects', 'roles', 'policies', 'tokens']);
         });
 
         afterEach(() => {
-            cy.cleanupV2IAMObjectsByIDPrefixes(adminIdToken, cypressPrefix, ['roles']);
+            cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['roles']);
         });
 
         describe('POST /apis/iam/v2beta/roles', () => {
             it('admin can create a new role with no projects', () => {
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -103,7 +96,7 @@ describe('roles API', () => {
 
             it('admin can create a new role with multiple projects', () => {
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -120,7 +113,7 @@ describe('roles API', () => {
             it('admin gets a 404 when it attempts to create ' +
                'a role with a project that does not exist', () => {
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     failOnStatusCode: false,
@@ -209,7 +202,7 @@ describe('roles API', () => {
         describe('PUT /apis/iam/v2beta/roles', () => {
             it('admin can update a role with no projects to have projects', () => {
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -223,7 +216,7 @@ describe('roles API', () => {
                 });
 
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'PUT',
                     url: `/apis/iam/v2beta/roles/${roleID}`,
                     body: {
@@ -238,7 +231,7 @@ describe('roles API', () => {
 
             it('admin can update a role with projects to have no projects', () => {
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -252,7 +245,7 @@ describe('roles API', () => {
                 });
 
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'PUT',
                     url: `/apis/iam/v2beta/roles/${roleID}`,
                     body: {
@@ -267,7 +260,7 @@ describe('roles API', () => {
 
             it('admin cannot update a role to have projects that do not exist', () => {
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -281,7 +274,7 @@ describe('roles API', () => {
                 });
 
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'PUT',
                     url: `/apis/iam/v2beta/roles/${roleID}`,
                     failOnStatusCode: false,
@@ -298,7 +291,7 @@ describe('roles API', () => {
             it('non-admin with project1 assignment access can update ' +
             'a role with no projects to have project1', () => {
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -328,7 +321,7 @@ describe('roles API', () => {
             it('non-admin with project1 assignment access can update ' +
             'a role to remove project1', () => {
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -358,7 +351,7 @@ describe('roles API', () => {
             it('non-admin with project1 assignment access gets a 404 ' +
             'when updating a role to have non-existent roles', () => {
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -389,7 +382,7 @@ describe('roles API', () => {
             it('non-admin with project1 assignment access cannot update ' +
             'a role with no projects to have other projects', () => {
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {
@@ -420,7 +413,7 @@ describe('roles API', () => {
             it('non-admin with project1 assignment access cannot update ' +
             'a role to remove other projects', () => {
                 cy.request({
-                    auth: { bearer: adminIdToken },
+                    headers: { 'api-token': adminToken },
                     method: 'POST',
                     url: '/apis/iam/v2beta/roles',
                     body: {

--- a/e2e/cypress/integration/api/iam/04_teams_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/04_teams_api.spec.ts
@@ -1,9 +1,8 @@
-import { describeIfIAMV2p1 } from '../../constants';
+import { describeIfIAMV2p1, adminToken } from '../../constants';
 
 describe('teams API', () => {
-  let adminToken = '';
   const defaultAdminReq = {
-    auth: { bearer: adminToken },
+    headers: { 'api-token': adminToken },
     method: 'GET',
     url: '/apis/iam/v2beta/teams'
   };
@@ -19,18 +18,11 @@ describe('teams API', () => {
   };
 
   before(() => {
-    cy.adminLogin('/').then(() => {
-      const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
-      adminToken = admin.id_token;
-      defaultAdminReq.auth.bearer = adminToken;
-      cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix,
-        ['policies', 'projects', 'teams']);
-    });
+    cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['policies', 'projects', 'teams']);
   });
 
   after(() => {
-    cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix,
-      ['policies', 'projects', 'teams']);
+    cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['policies', 'projects', 'teams']);
   });
 
   describeIfIAMV2p1('project assignment enforcement', () => {
@@ -50,7 +42,7 @@ describe('teams API', () => {
     before(() => {
       for (const project of [project1, project2]) {
         cy.request({
-            auth: { bearer: adminToken },
+            headers: { 'api-token': adminToken },
             method: 'POST',
             url: '/apis/iam/v2beta/projects',
             body: project
@@ -94,11 +86,11 @@ describe('teams API', () => {
     });
 
     beforeEach(() => {
-      cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['teams']);
+      cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['teams']);
     });
 
     afterEach(() => {
-      cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['teams']);
+      cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['teams']);
     });
 
     describe('POST /apis/iam/v2beta/teams', () => {

--- a/e2e/cypress/integration/api/iam/04_teams_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/04_teams_api.spec.ts
@@ -1,8 +1,8 @@
-import { describeIfIAMV2p1, adminToken } from '../../constants';
+import { describeIfIAMV2p1, adminApiToken } from '../../constants';
 
 describe('teams API', () => {
   const defaultAdminReq = {
-    headers: { 'api-token': adminToken },
+    headers: { 'api-token': adminApiToken },
     method: 'GET',
     url: '/apis/iam/v2beta/teams'
   };
@@ -42,7 +42,7 @@ describe('teams API', () => {
     before(() => {
       for (const project of [project1, project2]) {
         cy.request({
-            headers: { 'api-token': adminToken },
+            headers: { 'api-token': adminApiToken },
             method: 'POST',
             url: '/apis/iam/v2beta/projects',
             body: project

--- a/e2e/cypress/integration/api/iam/05_iam_integration.spec.ts
+++ b/e2e/cypress/integration/api/iam/05_iam_integration.spec.ts
@@ -25,7 +25,7 @@ describeIfIAMV2p1('assigning projects', () => {
       adminIdToken = JSON.parse(<string>localStorage.getItem('chef-automate-user')).id_token;
 
       // TODO cleanup everything in resources + projects
-      cy.cleanupV2IAMObjectsByIDPrefixes(adminIdToken, cypressPrefix, objectsToCleanUp);
+      cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, objectsToCleanUp);
 
       for (const id of [unauthorizedProjectId, authorizedProject1, authorizedProject2]) {
         cy.request({
@@ -83,7 +83,7 @@ describeIfIAMV2p1('assigning projects', () => {
   });
 
   after(() => {
-    cy.cleanupV2IAMObjectsByIDPrefixes(adminIdToken, cypressPrefix, objectsToCleanUp);
+    cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, objectsToCleanUp);
   });
 
   // iterate over iam resources

--- a/e2e/cypress/integration/constants.ts
+++ b/e2e/cypress/integration/constants.ts
@@ -3,3 +3,4 @@ export const describeIfIAMV2 = iamVersion.match(/v2/) ? describe : describe.skip
 export const describeIfIAMV2p1 = iamVersion === 'v2.1' ? describe : describe.skip;
 export const runFlaky: boolean = Cypress.env('RUN_FLAKY') || false;
 export const itFlaky = runFlaky ? it : it.skip;
+export const adminToken: string = Cypress.env('ADMIN_TOKEN');

--- a/e2e/cypress/integration/constants.ts
+++ b/e2e/cypress/integration/constants.ts
@@ -1,4 +1,5 @@
-export const iamVersion: string = Cypress.env('IAM_VERSION') || 'v2.0';
+export type IAMVersion = 'v1' | 'v2' | 'v2.1';
+export const iamVersion: IAMVersion = Cypress.env('IAM_VERSION') || 'v2';
 export const describeIfIAMV2 = iamVersion.match(/v2/) ? describe : describe.skip;
 export const describeIfIAMV2p1 = iamVersion === 'v2.1' ? describe : describe.skip;
 export const runFlaky: boolean = Cypress.env('RUN_FLAKY') || false;

--- a/e2e/cypress/integration/constants.ts
+++ b/e2e/cypress/integration/constants.ts
@@ -3,4 +3,4 @@ export const describeIfIAMV2 = iamVersion.match(/v2/) ? describe : describe.skip
 export const describeIfIAMV2p1 = iamVersion === 'v2.1' ? describe : describe.skip;
 export const runFlaky: boolean = Cypress.env('RUN_FLAKY') || false;
 export const itFlaky = runFlaky ? it : it.skip;
-export const adminToken: string = Cypress.env('ADMIN_TOKEN');
+export const adminApiToken: string = Cypress.env('ADMIN_TOKEN');

--- a/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
@@ -3,10 +3,7 @@ import { itFlaky } from '../../constants';
 describe('user management', () => {
   before(() => {
     cy.adminLogin('/settings/users').then(() => {
-
-      // clean up leftover users in case of previous test failures
-      const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
-      cy.cleanupUsersByNamePrefix(admin.id_token, 'cypress test user ');
+      cy.cleanupUsersByNamePrefix('cypress test user ');
     });
   });
 

--- a/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/02_team_mgmt.spec.ts
@@ -1,7 +1,6 @@
 import { describeIfIAMV2, describeIfIAMV2p1, itFlaky } from '../../constants';
 
 describe('team management', () => {
-  let adminToken = '';
   const now = Cypress.moment().format('MMDDYYhhmm');
   const cypressPrefix = 'test-team-mgmt';
   const teamName = `${cypressPrefix} team ${now}`;
@@ -16,11 +15,10 @@ describe('team management', () => {
   before(() => {
     cy.adminLogin('/settings/teams').then(() => {
       const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
-      adminToken = admin.id_token;
-      cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['projects']);
-      cy.cleanupTeamsByDescriptionPrefix(adminToken, cypressPrefix);
+      cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['projects']);
+      cy.cleanupTeamsByDescriptionPrefix(cypressPrefix);
       cy.request({
-        auth: { bearer: adminToken },
+        auth: { bearer: admin.id_token },
         method: 'POST',
         url: '/apis/iam/v2beta/projects',
         body: {
@@ -29,7 +27,7 @@ describe('team management', () => {
         }
       });
       cy.request({
-        auth: { bearer: adminToken },
+        auth: { bearer: admin.id_token },
         method: 'POST',
         url: '/apis/iam/v2beta/projects',
         body: {
@@ -51,11 +49,11 @@ describe('team management', () => {
 
   afterEach(() => {
     cy.saveStorage();
-    cy.cleanupTeamsByDescriptionPrefix(adminToken, cypressPrefix);
+    cy.cleanupTeamsByDescriptionPrefix(cypressPrefix);
   });
 
   after(() => {
-    cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['projects']);
+    cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['projects']);
   });
 
   context('no custom initial page state', () => {
@@ -165,11 +163,11 @@ describe('team management', () => {
       });
 
       after(() => {
-        cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['projects']);
+        cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['projects']);
       });
 
       afterEach(() => {
-        cy.cleanupTeamsByDescriptionPrefix(adminToken, cypressPrefix);
+        cy.cleanupTeamsByDescriptionPrefix(cypressPrefix);
       });
 
       itFlaky('can create a team with multiple projects', () => {

--- a/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
+++ b/e2e/cypress/integration/ui/settings/03_team_add_users.spec.ts
@@ -8,20 +8,20 @@ describe('team add users', () => {
   const descriptionForTeam = cypressPrefix + ' team ' + now;
   const nameForTeam = 'testing-team-' + now;
   let teamID = '';
-  let adminToken = '';
+  let adminIdToken = '';
   let teamUIRouteIdentifier = '';
 
   before(() => {
     cy.adminLogin('/settings/teams').then(() => {
       // clean up leftover teams in case of previous test failures
       const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
-      adminToken = admin.id_token;
-      cy.cleanupUsersByNamePrefix(adminToken, cypressPrefix);
-      cy.cleanupTeamsByDescriptionPrefix(adminToken, cypressPrefix);
+      adminIdToken = admin.id_token;
+      cy.cleanupUsersByNamePrefix(cypressPrefix);
+      cy.cleanupTeamsByDescriptionPrefix(cypressPrefix);
 
       // create custom user and team
       cy.request({
-        auth: { bearer: adminToken },
+        auth: { bearer: adminIdToken },
         method: 'POST',
         url: '/api/v0/auth/users',
         body: {
@@ -32,7 +32,7 @@ describe('team add users', () => {
       });
 
       cy.request({
-        auth: { bearer: adminToken },
+        auth: { bearer: adminIdToken },
         method: 'POST',
         url: '/api/v0/auth/teams',
         body: {
@@ -73,8 +73,8 @@ describe('team add users', () => {
   });
 
   after(() => {
-    cy.cleanupUsersByNamePrefix(adminToken, cypressPrefix);
-    cy.cleanupTeamsByDescriptionPrefix(adminToken, cypressPrefix);
+    cy.cleanupUsersByNamePrefix(cypressPrefix);
+    cy.cleanupTeamsByDescriptionPrefix(cypressPrefix);
   });
 
   it('when the x is clicked, it returns to the team details page', () => {
@@ -115,12 +115,12 @@ describe('team add users', () => {
 
     // remove user from team
     cy.request({
-      auth: { bearer: adminToken },
+      auth: { bearer: adminIdToken },
       method: 'GET',
       url: `/api/v0/auth/users/${usernameForUser}`
     }).then((resp) => {
       cy.request({
-        auth: { bearer: adminToken },
+        auth: { bearer: adminIdToken },
         method: 'PUT',
         url: `/api/v0/auth/teams/${teamID}/users`,
         body: {

--- a/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
+++ b/e2e/cypress/integration/ui/settings/04_team_details.spec.ts
@@ -1,7 +1,7 @@
 import { describeIfIAMV2p1, iamVersion, itFlaky } from '../../constants';
 
 describe('team details', () => {
-  let adminToken = '';
+  let adminIdToken = '';
   const now = Cypress.moment().format('MMDDYYhhmm');
   const cypressPrefix = 'test-team-details';
   const teamName = `${cypressPrefix} team ${now}`;
@@ -19,14 +19,14 @@ describe('team details', () => {
   before(() => {
     cy.adminLogin('/').then(() => {
       const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
-      adminToken = admin.id_token;
+      adminIdToken = admin.id_token;
 
-      cy.cleanupUsersByNamePrefix(adminToken, cypressPrefix);
-      cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['projects']);
-      cy.cleanupTeamsByDescriptionPrefix(adminToken, cypressPrefix);
+      cy.cleanupUsersByNamePrefix(cypressPrefix);
+      cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['projects']);
+      cy.cleanupTeamsByDescriptionPrefix(cypressPrefix);
 
       cy.request({
-        auth: { bearer: adminToken },
+        auth: { bearer: adminIdToken },
         method: 'POST',
         url: '/api/v0/auth/users',
         body: {
@@ -39,7 +39,7 @@ describe('team details', () => {
       });
 
       cy.request({
-        auth: { bearer: adminToken },
+        auth: { bearer: adminIdToken },
         method: 'POST',
         url: '/apis/iam/v2beta/projects',
         body: {
@@ -49,7 +49,7 @@ describe('team details', () => {
       });
 
       cy.request({
-        auth: { bearer: adminToken },
+        auth: { bearer: adminIdToken },
         method: 'POST',
         url: '/apis/iam/v2beta/projects',
         body: {
@@ -59,7 +59,7 @@ describe('team details', () => {
       });
 
       cy.request({
-        auth: { bearer: adminToken },
+        auth: { bearer: adminIdToken },
         method: 'POST',
         url: '/api/v0/auth/teams',
         body: {
@@ -76,7 +76,7 @@ describe('team details', () => {
         }
 
         cy.request({
-          auth: { bearer: adminToken },
+          auth: { bearer: adminIdToken },
           method: 'POST',
           url: `/apis/iam/v2beta/teams/${teamID}/users:add`,
           body: {
@@ -99,7 +99,7 @@ describe('team details', () => {
   });
 
   after(() => {
-    cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['projects']);
+    cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['projects']);
   });
 
   it('displays team details for admins team', () => {
@@ -151,7 +151,7 @@ describe('team details', () => {
     context('when the team contains a project', () => {
       beforeEach(() => {
         cy.request({
-          auth: { bearer: adminToken },
+          auth: { bearer: adminIdToken },
           method: 'PUT',
           url: `/apis/iam/v2beta/teams/${teamUIRouteIdentifier}`,
           body: {
@@ -165,7 +165,7 @@ describe('team details', () => {
 
       afterEach(() => {
         cy.request({
-          auth: { bearer: adminToken },
+          auth: { bearer: adminIdToken },
           method: 'PUT',
           url: `/apis/iam/v2beta/teams/${teamUIRouteIdentifier}`,
           body: {

--- a/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/05_project_mgmt.spec.ts
@@ -10,7 +10,7 @@ describeIfIAMV2p1('project management', () => {
   // only need this for input values upon which later test assertions depend
   // ref: https://github.com/cypress-io/cypress/issues/534
   const typeDelay = 50;
-  let adminToken = '';
+  let adminIdToken = '';
   const now = Cypress.moment().format('MMDDYYhhmm');
   const cypressPrefix = 'cypress-test';
   const projectID = `${cypressPrefix}-project1-${now}`;
@@ -22,8 +22,8 @@ describeIfIAMV2p1('project management', () => {
   before(() => {
     cy.adminLogin('/settings/projects').then(() => {
       const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
-      adminToken = admin.id_token;
-      cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['projects']);
+      adminIdToken = admin.id_token;
+      cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['projects']);
         // Set the projects filter to all projects
         cy.applyProjectsFilter([]);
     });
@@ -38,7 +38,7 @@ describeIfIAMV2p1('project management', () => {
   });
 
   after(() => {
-    cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['projects']);
+    cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['projects']);
   });
 
   it('has a disabled button when there are no rules', () => {
@@ -48,7 +48,7 @@ describeIfIAMV2p1('project management', () => {
 
   it('displays a list of projects', () => {
     cy.request({
-      auth: { bearer: adminToken },
+      auth: { bearer: adminIdToken },
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((response) => {
@@ -229,7 +229,7 @@ describeIfIAMV2p1('project management', () => {
     // so now we can check if there are other projects or not.
     cy.get('chef-notification.info').contains(`Deleted project ${projectID}`);
     cy.request({
-      auth: { bearer: adminToken },
+      auth: { bearer: adminIdToken },
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((response) => {
@@ -246,7 +246,7 @@ describeIfIAMV2p1('project management', () => {
 
   // these tests are currently interdependent so mark as flaky until the above isn't
   itFlaky('can create a project with a custom ID', () => {
-    cy.cleanupV2IAMObjectsByIDPrefixes(adminToken, cypressPrefix, ['projects']);
+    cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['projects']);
 
     cy.get('[data-cy=create-project]').contains('Create Project').click();
     cy.get('app-project-list chef-modal').should('have.class', 'visible');

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -107,57 +107,24 @@ Cypress.Commands.add('restoreStorage', () => {
   }
 });
 
-Cypress.Commands.add('generateAdminToken', (idToken: string) => {
-  const adminTokenObj = {
-    id: 'cypress-api-test-admin-token',
-    name: 'cypress-api-test-admin-token'
-  };
-
-  // cleanup token from previous test
-  cy.request({
-    auth: { bearer: idToken },
-    method: 'DELETE',
-    url: '/apis/iam/v2beta/tokens/cypress-api-test-admin-token',
-    failOnStatusCode: false
-  });
-
-  cy.request({
-    auth: { bearer: idToken },
-    method: 'POST',
-    url: '/apis/iam/v2beta/tokens',
-    body: adminTokenObj
-  }).then((response: Cypress.ObjectLike) => {
-    Cypress.env('adminTokenValue', response.body.token.value);
-  });
-  cy.request({
-    auth: { bearer: idToken },
-    method: 'POST',
-    url: '/apis/iam/v2beta/policies/administrator-access/members:add',
-    body: {
-      members: [`token:${adminTokenObj.id}`]
-    }
-  });
-});
-
 Cypress.Commands.add('cleanupV2IAMObjectsByIDPrefixes',
-  (idToken: string, idPrefix: string, iamObjects: string[]) => {
+  (idPrefix: string, iamObjects: string[]) => {
 
   iamObjects.forEach((iamObject) => {
-    cleanupV2IAMObjectByIDPrefix(idToken, idPrefix, iamObject);
+    cleanupV2IAMObjectByIDPrefix(idPrefix, iamObject);
   });
 });
 
-function cleanupV2IAMObjectByIDPrefix(
-  idToken: string, idPrefix: string, iamObject: string): void {
+function cleanupV2IAMObjectByIDPrefix(idPrefix: string, iamObject: string): void {
   cy.request({
-    auth: { bearer: idToken },
+    headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
     method: 'GET',
     url: `/apis/iam/v2beta/${iamObject}`
   }).then((resp) => {
     for (const object of resp.body[iamObject]) {
       if (object.id.startsWith(idPrefix)) {
         cy.request({
-          auth: { bearer: idToken },
+          headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
           method: 'DELETE',
           url: `/apis/iam/v2beta/${iamObject}/${object.id}`
         }).then((deleteResp) => {
@@ -168,9 +135,9 @@ function cleanupV2IAMObjectByIDPrefix(
   });
 }
 
-Cypress.Commands.add('cleanupUsersByNamePrefix', (idToken: string, namePrefix: string) => {
+Cypress.Commands.add('cleanupUsersByNamePrefix', (namePrefix: string) => {
   cy.request({
-    auth: { bearer: idToken },
+    headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
     method: 'GET',
     url: '/api/v0/auth/users',
     failOnStatusCode: false
@@ -179,7 +146,7 @@ Cypress.Commands.add('cleanupUsersByNamePrefix', (idToken: string, namePrefix: s
     for (const user of body.users) {
       if (user.name.startsWith(namePrefix)) {
         cy.request({
-          auth: { bearer: idToken },
+          headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
           method: 'DELETE',
           url: `/api/v0/auth/users/${user.username}`,
           failOnStatusCode: false
@@ -189,9 +156,9 @@ Cypress.Commands.add('cleanupUsersByNamePrefix', (idToken: string, namePrefix: s
   });
 });
 
-Cypress.Commands.add('cleanupTeamsByDescriptionPrefix', (idToken: string, namePrefix: string) => {
+Cypress.Commands.add('cleanupTeamsByDescriptionPrefix', (namePrefix: string) => {
   cy.request({
-    auth: { bearer: idToken },
+    headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
     method: 'GET',
     url: '/api/v0/auth/teams',
     failOnStatusCode: false
@@ -200,7 +167,7 @@ Cypress.Commands.add('cleanupTeamsByDescriptionPrefix', (idToken: string, namePr
     for (const team of body.teams) {
       if (team.description.startsWith(namePrefix)) {
         cy.request({
-          auth: { bearer: idToken },
+          headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
           method: 'DELETE',
           url: `/api/v0/auth/teams/${team.id}`,
           failOnStatusCode: false

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -30,7 +30,7 @@
         "convert-source-map": "1.6.0",
         "debug": "4.1.1",
         "json5": "2.1.0",
-        "lodash": "4.17.11",
+        "lodash": "4.17.15",
         "resolve": "1.11.1",
         "semver": "5.7.0",
         "source-map": "0.5.7"
@@ -56,7 +56,7 @@
       "requires": {
         "@babel/types": "7.5.0",
         "jsesc": "2.5.2",
-        "lodash": "4.17.11",
+        "lodash": "4.17.15",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
       }
@@ -102,7 +102,7 @@
       "requires": {
         "@babel/helper-function-name": "7.1.0",
         "@babel/types": "7.5.0",
-        "lodash": "4.17.11"
+        "lodash": "4.17.15"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -174,7 +174,7 @@
         "@babel/helper-split-export-declaration": "7.4.4",
         "@babel/template": "7.4.4",
         "@babel/types": "7.5.0",
-        "lodash": "4.17.11"
+        "lodash": "4.17.15"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -198,7 +198,7 @@
       "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
+        "lodash": "4.17.15"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -439,7 +439,7 @@
       "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
-        "lodash": "4.17.11"
+        "lodash": "4.17.15"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -822,7 +822,7 @@
         "@babel/types": "7.5.0",
         "debug": "4.1.1",
         "globals": "11.12.0",
-        "lodash": "4.17.11"
+        "lodash": "4.17.15"
       },
       "dependencies": {
         "debug": {
@@ -843,7 +843,7 @@
       "dev": true,
       "requires": {
         "esutils": "2.0.2",
-        "lodash": "4.17.11",
+        "lodash": "4.17.15",
         "to-fast-properties": "2.0.0"
       }
     },
@@ -1384,7 +1384,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.11"
+        "lodash": "4.17.15"
       }
     },
     "async-each": {

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -3,8 +3,9 @@
     "strict": true,
     "baseUrl": "../node_modules",
     "target": "es5",
+    "downlevelIteration": true,
     "lib": [
-      "es5",
+      "es2017",
       "dom"
     ],
     "types": [

--- a/integration/tests/cypress_e2e.sh
+++ b/integration/tests/cypress_e2e.sh
@@ -14,7 +14,7 @@ do_deploy() {
     do_deploy_default
     log_info "applying dev license"
     chef-automate license apply "$A2_LICENSE"
-    local timestamp=$(date +"%m-%d-%y-%H-%M")
+    timestamp=$(date +"%m-%d-%y-%H-%M")
 
     case $IAM in
         v1)
@@ -34,7 +34,7 @@ do_deploy() {
             fi
 
             log_info "generating admin token"
-            if ! token=$(chef-automate iam token create $timestamp-tok --admin); then
+            if ! token=$(chef-automate iam token create "$timestamp-tok" --admin); then
                 log_error "Non-zero exit code, output:"
                 log_error "$token"
                 return 1
@@ -49,7 +49,7 @@ do_deploy() {
             fi
 
             log_info "generating admin token"
-            if ! token=$(chef-automate iam token create $timestamp-tok --admin); then
+            if ! token=$(chef-automate iam token create "$timestamp-tok" --admin); then
                 log_error "Non-zero exit code, output:"
                 log_error "$token"
                 return 1

--- a/integration/tests/cypress_e2e.sh
+++ b/integration/tests/cypress_e2e.sh
@@ -14,13 +14,29 @@ do_deploy() {
     do_deploy_default
     log_info "applying dev license"
     chef-automate license apply "$A2_LICENSE"
+    local timestamp=$(date +"%m-%d-%y-%H-%M")
 
     case $IAM in
+        v1)
+            log_info "generating admin token"
+            if ! token=$(chef-automate admin-token); then
+                log_error "Non-zero exit code, output:"
+                log_error "$token"
+                return 1
+            fi
+            ;;
         v2)
             log_info "run chef-automate iam upgrade-to-v2 --skip-policy-migration"
             if ! output=$(chef-automate iam upgrade-to-v2 --skip-policy-migration); then
                 log_error "Non-zero exit code, output:"
                 log_error "$output"
+                return 1
+            fi
+
+            log_info "generating admin token"
+            if ! token=$(chef-automate iam token create $timestamp-tok --admin); then
+                log_error "Non-zero exit code, output:"
+                log_error "$token"
                 return 1
             fi
             ;;
@@ -31,10 +47,18 @@ do_deploy() {
                 log_error "$output"
                 return 1
             fi
+
+            log_info "generating admin token"
+            if ! token=$(chef-automate iam token create $timestamp-tok --admin); then
+                log_error "Non-zero exit code, output:"
+                log_error "$token"
+                return 1
+            fi
             ;;
     esac
 
     export CYPRESS_IAM_VERSION=$IAM
+    export CYPRESS_ADMIN_TOKEN=$token
 
     log_info "fixing dns resolution for '${CONTAINER_HOSTNAME}'"
     echo "127.0.0.1 ${CONTAINER_HOSTNAME}" >> /etc/hosts


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Added some extra due diligence tests to ensure ingest project rules get correctly applied to infra nodes for each available attribute.

EDIT: starting with [this commit](https://github.com/chef/automate/pull/1659/commits/33ac8baa0e09daf1daa613b0f29cd72a8c7d83a0), I also refactored our API-only tests so they don't have to open the browser to log in. That should save some test run time!

### :chains: Related Resources
follow-up issue adds Compliance node and Event test coverage: https://github.com/chef/automate/issues/1594

### :+1: Definition of Done
- tests pass

### :athletic_shoe: How to Build and Test the Change
[how to run cypress tests locally](https://github.com/chef/automate/blob/master/e2e/README.md#running-cypress-locally)

### :white_check_mark: Checklist

- [x] Tests added/updated?