### PR TITLE
Introspection fixes for perm-based routing

### DIFF
--- a/components/automate-gateway/handler/authz.go
+++ b/components/automate-gateway/handler/authz.go
@@ -118,11 +118,9 @@ func (a *AuthzServer) IntrospectAll(
 	mapByResourceAndActionV1 := pairs.InvertMapNonParameterized(methodsInfoV1)
 	mapByResourceAndActionV2 := pairs.InvertMapNonParameterized(methodsInfoV2)
 
-	// Extra work of hydrating not needed for IntrospectAll; already does that.
 	endpointMap, err := a.getAllowedMap(ctx,
 		mapByResourceAndActionV1, mapByResourceAndActionV2,
-		methodsInfoV1, methodsInfoV2,
-		false)
+		methodsInfoV1, methodsInfoV2)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +153,7 @@ func (a *AuthzServer) IntrospectSome(
 
 	endpointMap, err := a.getAllowedMap(ctx,
 		mapByResourceAndActionV1, mapByResourceAndActionV2,
-		methodsInfoV1, methodsInfoV2, true)
+		methodsInfoV1, methodsInfoV2)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +193,7 @@ func (a *AuthzServer) Introspect(
 
 	endpointMap, err := a.getAllowedMap(ctx,
 		mapByResourceAndActionV1, mapByResourceAndActionV2,
-		methodsInfoV1, methodsInfoV2, true)
+		methodsInfoV1, methodsInfoV2)
 	if err != nil {
 		return nil, err
 	}
@@ -296,8 +294,7 @@ func reportBadPaths(log *logrus.Entry, lookupHash map[string]bool) {
 func (a *AuthzServer) getAllowedMap(
 	ctx context.Context,
 	mapByResourceAndActionV1, mapByResourceAndActionV2 map[pairs.Pair][]string,
-	methodsInfoV1, methodsInfoV2 map[string]pairs.Info,
-	fullyHydrate bool) (map[string]*gwAuthzRes.MethodsAllowed, error) {
+	methodsInfoV1, methodsInfoV2 map[string]pairs.Info) (map[string]*gwAuthzRes.MethodsAllowed, error) {
 
 	log := ctxlogrus.Extract(ctx)
 
@@ -312,7 +309,7 @@ func (a *AuthzServer) getAllowedMap(
 		return nil, err
 	}
 	endpointMap, err := pairs.GetEndpointMapFromResponse(
-		resp.Pairs, resp.MethodsInfo, resp.MapByResourceAndAction, fullyHydrate)
+		resp.Pairs, resp.MethodsInfo, resp.MapByResourceAndAction, true)
 	if err != nil {
 		log.WithError(err).Debug("Error on pairs.GetEndpointMapFromResponse")
 		return nil, err

--- a/components/automate-gateway/handler/authz_test.go
+++ b/components/automate-gateway/handler/authz_test.go
@@ -47,16 +47,6 @@ func TestIntrospectAllV1(t *testing.T) {
 		authzResp *authz.FilterAuthorizedPairsResp
 		expected  map[string]*response.MethodsAllowed
 	}{
-		"empty response": {
-			&authz.FilterAuthorizedPairsResp{},
-			map[string]*response.MethodsAllowed{},
-		},
-		"one response pair, unmapped": {
-			&authz.FilterAuthorizedPairsResp{Pairs: []*authz.Pair{
-				{Resource: "foo:thing", Action: "foo:ing"},
-			}},
-			map[string]*response.MethodsAllowed{},
-		},
 		"one response pair, mapped": {
 			&authz.FilterAuthorizedPairsResp{Pairs: []*authz.Pair{
 				{Resource: "auth:policies", Action: "create"},
@@ -94,7 +84,10 @@ func TestIntrospectAllV1(t *testing.T) {
 			resp, err := hdlr.IntrospectAll(ctx, req)
 			require.NoError(t, err)
 			require.NotNil(t, resp)
-			assert.Equal(t, tc.expected, resp.Endpoints)
+			for key, value := range tc.expected {
+				assert.Contains(t, resp.Endpoints, key)
+				assert.Equal(t, value, resp.Endpoints[key])
+			}
 		})
 		reset()
 	}
@@ -112,16 +105,6 @@ func TestIntrospectAllV2(t *testing.T) {
 		authzResp *authz_v2.FilterAuthorizedPairsResp
 		expected  map[string]*response.MethodsAllowed
 	}{
-		"empty response": {
-			&authz_v2.FilterAuthorizedPairsResp{},
-			map[string]*response.MethodsAllowed{},
-		},
-		"one response pair, unmapped": {
-			&authz_v2.FilterAuthorizedPairsResp{Pairs: []*authz_v2.Pair{
-				{Resource: "foo:thing", Action: "foo:ing"},
-			}},
-			map[string]*response.MethodsAllowed{},
-		},
 		"one response pair, mapped": {
 			&authz_v2.FilterAuthorizedPairsResp{Pairs: []*authz_v2.Pair{
 				{Resource: "iam:policies", Action: "iam:policies:create"},
@@ -159,7 +142,10 @@ func TestIntrospectAllV2(t *testing.T) {
 			resp, err := hdlr.IntrospectAll(ctx, req)
 			require.NoError(t, err)
 			require.NotNil(t, resp)
-			assert.Equal(t, tc.expected, resp.Endpoints)
+			for key, value := range tc.expected {
+				assert.Contains(t, resp.Endpoints, key)
+				assert.Equal(t, value, resp.Endpoints[key])
+			}
 		})
 		reset()
 	}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The recent PR that introduced introspection caching introduced a bug that caused permission-based routing to fail for non-admin users.
This manifested as a mostly blank screen when navigating to settings:
![image](https://user-images.githubusercontent.com/6817500/65214140-b2e9ef00-da5d-11e9-82d5-700fd8eb3c1a.png)

There were actually two problems:
First, this revealed a bug in `IntrospectAll`. Some time ago all introspection methods were changed to allegedly return all requested endpoints, whether they had any permissions on them or not. This worked for `Introspect(One)` and `IntrospectSome` but it turns out not for `IntrospectAll`.

The `LandingComponent`, which does permission-based routing to the first page amongst a set of pages for which the user has permission, waits until all of the pages on its list are accounted for in the ngrx store, but because of the bug in `IntrospectAll` that never happened.

Once that was fixed, the next issue was that the `LandingComponent` was relying on a subscription to `allPerms` to kick off the next check in the list of pages. But the way caching was implemented, there were no subsequent fetches, so again it waited in vain. This was fixed by enhancing the caching so that regardless of whether it made a network call or not, it completed the "cycle" of get/get-success, and that allowed the proper triggers to work.

### :chains: Related Resources

### :+1: Definition of Done

No more blank pages.
The simple test is to assign the non-admin user to the viewers team. But that would land you on the very first page in the set of possible pages. So just to make it a little more interesting, here I did *not* include the user on the viewers team, but rather used this custom policy:
```
{
  "id": "perm-test",
  "name": "testing",
  "members": ["user:local:bob"],
  "projects": [],
  "statements": [
    {
      "effect": "ALLOW",
      "actions": ["iam:teams:get","iam:teams:list","iam:projects:*"],
      "projects": ["*"]
    }
  ]
}
```
You will see, then, that the user correctly lands on the Teams page, which is several items down in the list of possible pages, but is the first allowable page for this user:

![image](https://user-images.githubusercontent.com/6817500/65214360-8e424700-da5e-11e9-814d-83f246ca09d7.png)


### :athletic_shoe: How to Build and Test the Change

rebuild automate-gateway
rebuild automate-ui
add a non-admin user
assign to a team or use a custom policy
navigate to settings
