### PR TITLE
Jamie/buttons hide profile description

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.html
@@ -35,23 +35,25 @@
       <chef-page-header>
         <chef-heading>{{ profile.title }}</chef-heading>
         <chef-subheading>{{ profile.summary }}</chef-subheading>
-        <div slot="header-buttons">
-          <ng-container *ngIf="!isInstalled">
-            <chef-button secondary caution id="install-btn" (click)="installProfile(profile)">
-              <chef-icon>get_app</chef-icon>
-              <span>Get</span>
+        <div class="header-buttons-container">
+          <div slot="header-buttons">
+            <ng-container *ngIf="!isInstalled">
+              <chef-button secondary caution id="install-btn" (click)="installProfile(profile)">
+                <chef-icon>get_app</chef-icon>
+                <span>Get</span>
+              </chef-button>
+            </ng-container>
+            <ng-container *ngIf="isInstalled">
+              <chef-button secondary caution id="uninstall-btn" (click)="showDeleteModal()">
+                <chef-icon>delete</chef-icon>
+                <span>Remove</span>
+              </chef-button>
+            </ng-container>
+            <chef-button secondary id="download-btn" (click)="downloadProfile(profile)">
+              <chef-icon>cloud_download</chef-icon>
+              <span>Download</span>
             </chef-button>
-          </ng-container>
-          <ng-container *ngIf="isInstalled">
-            <chef-button secondary caution id="uninstall-btn" (click)="showDeleteModal()">
-              <chef-icon>delete</chef-icon>
-              <span>Remove</span>
-            </chef-button>
-          </ng-container>
-          <chef-button secondary id="download-btn" (click)="downloadProfile(profile)">
-            <chef-icon>cloud_download</chef-icon>
-            <span>Download</span>
-          </chef-button>
+          </div>
         </div>
       </chef-page-header>
 

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
@@ -10,6 +10,15 @@ chef-page-header {
   chef-subheading {
     max-width: 610px;
   }
+  // unable to modify slot content from chef-page-header.scss or here?
+  .header-buttons {
+    @media (min-width: 1024px) {
+      margin: 0;
+      position: absolute;
+      top: 55px;
+      right: 35px;
+    }
+  }
 }
 
 .metadata {

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
@@ -8,7 +8,7 @@ chef-loading-spinner {
 
 chef-page-header {
   chef-subheading {
-    max-width: 610px;
+    max-width: 520px;
   }
   
   .header-buttons-container {

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
@@ -1,9 +1,15 @@
-@import "~styles/variables";
+@import '~styles/variables';
 
 chef-loading-spinner {
   display: block;
   margin: 100px auto;
   width: 100px;
+}
+
+chef-page-header {
+  chef-subheading {
+    max-width: 610px;
+  }
 }
 
 .metadata {
@@ -94,7 +100,7 @@ chef-loading-spinner {
 #delete-modal {
   text-align: center;
 
-  [slot=title] {
+  [slot='title'] {
     font-weight: bold;
     margin-top: 1em;
     padding-bottom: 12px;

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
@@ -1,4 +1,4 @@
-@import '~styles/variables';
+@import "~styles/variables";
 
 chef-loading-spinner {
   display: block;
@@ -108,7 +108,7 @@ chef-page-header {
 #delete-modal {
   text-align: center;
 
-  [slot='title'] {
+  [slot=title] {
     font-weight: bold;
     margin-top: 1em;
     padding-bottom: 12px;

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
@@ -10,10 +10,9 @@ chef-page-header {
   chef-subheading {
     max-width: 610px;
   }
-  // unable to modify slot content from chef-page-header.scss or here?
-  .header-buttons {
+  
+  .header-buttons-container {
     @media (min-width: 1024px) {
-      margin: 0;
       position: absolute;
       top: 55px;
       right: 35px;

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
@@ -10,7 +10,7 @@ chef-page-header {
   chef-subheading {
     max-width: 65%;
   }
-  
+
   .header-buttons-container {
     @media (min-width: 1024px) {
       position: absolute;

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.scss
@@ -8,7 +8,7 @@ chef-loading-spinner {
 
 chef-page-header {
   chef-subheading {
-    max-width: 520px;
+    max-width: 65%;
   }
   
   .header-buttons-container {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
On Profile pages, the description of the profile would sometimes be hidden by the Remove and Download buttons, preventing a user from being able to read the full description.

To resolve, a container was placed around the slot element (the buttons) to more easily target that container's style.  A max width was set on `chef-subheadings` within profile pages, preventing the buttons from ever reaching a point where they can cause overlap.  The buttons container was also shifted down ~10px in order not cover the profile title.

### :chains: Related Resources

### :+1: Definition of Done
The buttons container no longer covers the profile title or description.

### :athletic_shoe: How to Build and Test the Change
1. Build components/automate-ui-devproxy && start_all_services
2. Navigate to https://a2-dev.test/compliance/compliance-profiles
3. Click on Available profiles tab
4. Click on profiles titles to view various profiles from list
5. Drag the screen in and out - buttons should not overlap content

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
![buttons-hide-content](https://user-images.githubusercontent.com/16737484/65271615-6096e580-dad2-11e9-99a7-33f71ecd3f6e.gif)
