### PR TITLE
Depend on latest version of go-swagger.

### DIFF
--- a/components/automate-chef-io/Makefile
+++ b/components/automate-chef-io/Makefile
@@ -4,7 +4,7 @@ SHELL=bash
 SWAGGER_RESULT_FILE=static/api-docs/all-apis.swagger.json
 SWAGGER_DIR=data/docs/api_chef_automate
 SWAGGER_FILES = $(shell find $(SWAGGER_DIR) -name '*.swagger.json')
-EXPECTED_CONFLICTS=45
+EXPECTED_CONFLICTS=46
 
 themes/chef:
 	scripts/clone_hugo.sh

--- a/components/automate-chef-io/README.md
+++ b/components/automate-chef-io/README.md
@@ -14,11 +14,20 @@ A new static website for Automate is based on [Hugo](https://gohugo.io), the Go-
     brew install hugo
     ```
 
-1. [Install go-swagger](https://goswagger.io/install.html). If you're using homebrew:
+1. [Install go-swagger](https://goswagger.io/install.html). The currently supported version is 0.20.1. If you're using homebrew:
 
     ```
     brew tap go-swagger/go-swagger
     brew install go-swagger
+    ```
+
+    If everything is up to date you should see output like this when running `swagger version`:
+
+    ```
+    $ swagger version
+    version: v0.20.1
+    commit: 9004771f77bedabb792a48dc846ba7fc800398a0
+
     ```
 
 ### Development

--- a/components/automate-chef-io/habitat/plan.sh
+++ b/components/automate-chef-io/habitat/plan.sh
@@ -12,9 +12,9 @@ pkg_build_deps=(
 )
 
 do_build() {
-  download_file "https://github.com/go-swagger/go-swagger/releases/download/v0.19.0/swagger_linux_amd64" \
+  download_file "https://github.com/go-swagger/go-swagger/releases/download/v0.20.1/swagger_linux_amd64" \
     "$CACHE_PATH/swagger" \
-    "9a5dd86578a93d0e829f3607e12b8e6567fd0b5dc9ad805e1097978f30e060e2"
+    "c69da2ff7a58ee05b4fc63dbb29764cb027a97e0eaae316e1d56f586188d92b3"
   chmod +x "$CACHE_PATH/swagger"
   export PATH="$PATH:$CACHE_PATH"
 


### PR DESCRIPTION
Building the docs with the latest version of `go-swagger` fails. Anyone doing `brew install go-swagger` today will get a different version than I used initially and that wasn't specified anywhere, so I added the version we're expecting to the README.