### PR TITLE
Jamie/fix ingest save rule button

### DIFF
--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -1,6 +1,6 @@
 <chef-page
   subheading="Resources that match the type and all conditions are included in the project."
-  [attr.confirm-btn-text]="getConfirmBtnText()"
+  [attr.confirm-btn-text]=" saving ? 'Saving Rule...' : 'Save Rule' "
   [attr.heading]="getHeading()"
   [attr.disable-confirm]="!ruleForm.valid || !ruleForm.dirty"
   [attr.page-loading]="isLoading"

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -1,6 +1,6 @@
 <chef-page
   subheading="Resources that match the type and all conditions are included in the project."
-  confirm-btn-text="Save Rule"
+  [attr.confirm-btn-text]="getConfirmBtnText()"
   [attr.heading]="getHeading()"
   [attr.disable-confirm]="!ruleForm.valid || !ruleForm.dirty"
   [attr.page-loading]="isLoading"

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -3,7 +3,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
-import { DebugElement } from '@angular/core';
 
 import { using } from 'app/testing/spec-helpers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
@@ -256,16 +255,18 @@ describe('ProjectRulesComponent', () => {
       expect(component.showDelete()).toBeTruthy();
     });
 
-    fit('should show "Save Rule" Button by default', () => {
-      const componentDebug: DebugElement = fixture.debugElement.nativeElement;
-      const confirmButton = componentDebug.querySelector('#right-buttons button:first-child');
-      expect(confirmButton).toContain('Save Rule');
+    it('should show "Save Rule" Button by default', () => {
+      const element = fixture.nativeElement;
+      const confirmBtnText = element.querySelector('chef-page').getAttribute('confirm-btn-text');
+      expect(confirmBtnText).toEqual('Save Rule');
     });
 
-    fit('should show "Saving Rules" Button when saving', () => {
-      const componentDebug: DebugElement = fixture.debugElement.nativeElement;
-      const confirmButton = componentDebug.querySelector('#right-buttons button:first-child');
-      expect(confirmButton).toContain('Saving Rule...');
+    it('should show "Saving Rules" Button when saving', () => {
+      component.saving = true;
+      fixture.detectChanges();
+      const element = fixture.nativeElement;
+      const confirmBtnText = element.querySelector('chef-page').getAttribute('confirm-btn-text');
+      expect(confirmBtnText).toEqual('Saving Rule...');
     });
   });
 });

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -3,6 +3,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
+import { DebugElement } from '@angular/core';
 
 import { using } from 'app/testing/spec-helpers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
@@ -255,13 +256,18 @@ describe('ProjectRulesComponent', () => {
       expect(component.showDelete()).toBeTruthy();
     });
 
-    it('should show "Save Rule" Button by default', () => {
-      expect(component.getConfirmBtnText()).toEqual('Save Rule');
+    fit('should show "Save Rule" Button by default', () => {
+      const componentDebug: DebugElement = fixture.debugElement;
+      const componentHtml: HTMLElement = componentDebug.nativeElement;
+      const confirmButton = componentHtml.querySelector('#right-buttons button:first-child');
+      expect(confirmButton.textContent).toEqual('Save Rule');
     });
 
-    it('should show "Saving Rules" Button when saving', () => {
-      component.saving = true;
-      expect(component.getConfirmBtnText()).toEqual('Saving Rule...');
+    fit('should show "Saving Rules" Button when saving', () => {
+      const componentDebug: DebugElement = fixture.debugElement;
+      const componentHtml: HTMLElement = componentDebug.nativeElement;
+      const confirmButton = componentHtml.querySelector('#right-buttons button:first-child');
+      expect(confirmButton.textContent).toEqual('Saving Rule...');
     });
   });
 });

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -257,17 +257,15 @@ describe('ProjectRulesComponent', () => {
     });
 
     fit('should show "Save Rule" Button by default', () => {
-      const componentDebug: DebugElement = fixture.debugElement;
-      const componentHtml: HTMLElement = componentDebug.nativeElement;
-      const confirmButton = componentHtml.querySelector('#right-buttons button:first-child');
-      expect(confirmButton.textContent).toEqual('Save Rule');
+      const componentDebug: DebugElement = fixture.debugElement.nativeElement;
+      const confirmButton = componentDebug.querySelector('#right-buttons button:first-child');
+      expect(confirmButton).toContain('Save Rule');
     });
 
     fit('should show "Saving Rules" Button when saving', () => {
-      const componentDebug: DebugElement = fixture.debugElement;
-      const componentHtml: HTMLElement = componentDebug.nativeElement;
-      const confirmButton = componentHtml.querySelector('#right-buttons button:first-child');
-      expect(confirmButton.textContent).toEqual('Saving Rule...');
+      const componentDebug: DebugElement = fixture.debugElement.nativeElement;
+      const confirmButton = componentDebug.querySelector('#right-buttons button:first-child');
+      expect(confirmButton).toContain('Saving Rule...');
     });
   });
 });

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -254,5 +254,14 @@ describe('ProjectRulesComponent', () => {
       component.addCondition();
       expect(component.showDelete()).toBeTruthy();
     });
+
+    it('should show "Save Rule" Button by default', () => {
+      expect(component.getConfirmBtnText()).toEqual('Save Rule');
+    });
+
+    it('should show "Saving Rules" Button when saving', () => {
+      component.saving = true;
+      expect(component.getConfirmBtnText()).toEqual('Saving Rule...');
+    });
   });
 });

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -266,7 +266,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
           if (!loading(state)) {
             pendingSave.next(true);
             pendingSave.complete();
-            // this.saving = false;
+            this.saving = false;
             if (state === EntityStatus.loadingSuccess) {
               this.closePage();
             } else if (state === EntityStatus.loadingFailure) {

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -266,7 +266,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
           if (!loading(state)) {
             pendingSave.next(true);
             pendingSave.complete();
-            this.saving = false;
+            // this.saving = false;
             if (state === EntityStatus.loadingSuccess) {
               this.closePage();
             } else if (state === EntityStatus.loadingFailure) {
@@ -288,6 +288,10 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
           }
         });
     }
+  }
+
+  getConfirmBtnText(): string {
+    return this.saving ? 'Saving Rule...' : 'Save Rule';
   }
 
   public handleNameInput(event: KeyboardEvent): void {

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -290,10 +290,6 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
     }
   }
 
-  getConfirmBtnText(): string {
-    return this.saving ? 'Saving Rule...' : 'Save Rule';
-  }
-
   public handleNameInput(event: KeyboardEvent): void {
     if (!this.modifyID && !this.isNavigationKey(event) && !this.editingRule) {
       this.conflictError = false;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When creating an Ingest Rule inside a Project, after the user clicks on Save Button, a small loading icon is shown until complete.  Currently the text remains the same. 

In this branch, a small function was added to determine what the button text should be, depending on the state of the saving operation.  If the rule is in process of being saved, it will read as "Rule Saving..."

### :chains: Related Resources

### :+1: Definition of Done
The Save Rule button reads as "Save Rule" by default, and changes to "Saving Rule..." when in the process of saving.

### :athletic_shoe: How to Build and Test the Change
Visually
1. Build components/automate-ui-devproxy && start_all_services
1. Change your settings to slow down ur network, in chrome, dev tools > network > change online to slow 3g
1. Navigate to https://a2-dev.test/settings/projects
1. Create a project and click to enter that project
1. Click 'Create Rule'
1. Complete the steps to create the rule
1. Click "Save Rule"

Programmatically
Run the Spec file at Automate/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
Full Speed
![SavingButtonsFull](https://user-images.githubusercontent.com/16737484/65284902-d2c9f300-daef-11e9-8e37-8235dcd53ab4.gif)


Slow Speed
![SavingRule2](https://user-images.githubusercontent.com/16737484/65284898-cfcf0280-daef-11e9-9c02-8ab708fe8f5e.gif)

