### PR TITLE
More github access token fixes

### DIFF
--- a/.expeditor/build.habitat.yml
+++ b/.expeditor/build.habitat.yml
@@ -3,5 +3,5 @@ origin: chef
 smart_build: true
 studio_secrets:
   GITHUB_TOKEN:
-    account: github/chef-ci
+    account: github
     field: token

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -40,7 +40,7 @@ steps:
     expeditor:
       secrets:
         GITHUB_TOKEN:
-          account: github/chef-ci
+          account: github
           field: token
       executor:
         docker:
@@ -58,7 +58,7 @@ steps:
       HAB_NONINTERACTIVE: true
     expeditor:
       secrets:
-        HAB_STUDIO_SECRET_GITHUB_APP_TOKEN:
+        HAB_STUDIO_SECRET_GITHUB_TOKEN:
           account: github
           field: token
       executor:

--- a/components/automate-chef-io/scripts/clone_hugo.sh
+++ b/components/automate-chef-io/scripts/clone_hugo.sh
@@ -2,9 +2,7 @@
 
 clone_url="https://github.com/chef/chef-hugo-theme.git"
 if [[ -n "$GITHUB_TOKEN" ]];then
-    clone_url="https://${GITHUB_TOKEN}@github.com/chef/chef-hugo-theme.git"
-elif [[ -n "$GITHUB_APP_TOKEN" ]];then
-    clone_url="https://x-access-token:${GITHUB_APP_TOKEN}@github.com/chef/chef-hugo-theme.git"
+    clone_url="https://x-access-token:${GITHUB_TOKEN}@github.com/chef/chef-hugo-theme.git"
 fi
 
 git clone "$clone_url" themes/chef


### PR DESCRIPTION
In the previous fix I was under the mistaken impression that only App
tokens supported the x-access-token prefix, but I've now tested this
with personal access tokens as well and it appears they both work with
that as the username. Using this single method will hopefully keep us
a bit more consistent.

This hopefully also fixes the build issues as the core problem was
that I forgot to rename the environment variable in that pipeline.

> There may be times when we are powerless to prevent injustice, but
> there must never be a time when we fail to protest.
>
> -Elie Wiesel

Signed-off-by: Steven Danna <steve@chef.io>