### PR TITLE
Resync query_projects function

### DIFF
--- a/components/authz-service/storage/postgres/migration/sql/71_sync_query_projects_with_query_project.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/71_sync_query_projects_with_query_project.up.sql
@@ -1,0 +1,39 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION
+  query_projects(_projects_filter TEXT[])
+  RETURNS setof json AS $$
+
+WITH
+staged AS (
+  SELECT r.project_id
+  FROM iam_staged_project_rules AS r
+  WHERE projects_match_for_rule(r.project_id, _projects_filter)
+  GROUP BY r.project_id
+),
+applied AS (
+  SELECT r.project_id
+  FROM iam_project_rules AS r
+  WHERE projects_match_for_rule(r.project_id, _projects_filter)
+  GROUP BY r.project_id
+)
+SELECT json_build_object(
+  'id', p.id,
+  'name', p.name,
+  'type', p.type,
+  'status',
+  CASE WHEN staged.project_id IS NULL AND applied.project_id IS NULL THEN 'no-rules'
+       WHEN staged.project_id IS NULL THEN 'applied'
+       ELSE 'edits-pending'
+  END
+)
+FROM iam_projects AS p
+LEFT JOIN applied
+  ON applied.project_id = p.db_id
+LEFT JOIN staged
+  ON staged.project_id = p.db_id
+WHERE projects_match_for_rule(p.id, _projects_filter)
+
+$$ LANGUAGE sql;
+
+COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -70,3 +70,4 @@
 - [`68_add_status_to_projects.up.sql`](68_add_status_to_projects.up.sql)
 - [`69_add_status_to_get_project.up.sql`](69_add_status_to_get_project.up.sql)
 - [`70_fix_status_for_list_projects.up.sql`](70_fix_status_for_list_projects.up.sql)
+- [`71_sync_query_projects_with_query_project.up.sql`](71_sync_query_projects_with_query_project.up.sql)


### PR DESCRIPTION
## :nut_and_bolt: Description: What code changed, and why?
Mirror recent changes to `query_project` (singular) back to `query_projects` (plural) for consistency, (while still fresh).

### :chains: Related Resources
NA

### :+1: Definition of Done
Everything should still work.

### :athletic_shoe: How to Build and Test the Change
rebuild components/authz-service
