### PR TITLE
Jamie/date time trial modal

### DIFF
--- a/components/automate-ui/src/app/entities/license/license.model.ts
+++ b/components/automate-ui/src/app/entities/license/license.model.ts
@@ -54,5 +54,6 @@ export interface RequestLicenseResponse {
 export function parsedExpirationDate(license: LicenseStatus): string {
   // Use short form, localized date (momentjs.com/docs/#localized-formats) to render date.
   // At the time of writing, Angular's date pipe is *not* locale-aware.
-  return moment(license.licensed_period.end).format('l');
+  // e.g., Wed, 03 Jul 2019 17:08:53 UTC
+  return moment(license.licensed_period.end).format('ddd, DD MMM YYYY HH:mm:ss [UTC]');
 }

--- a/components/automate-ui/src/app/page-components/license-apply/license-apply.component.html
+++ b/components/automate-ui/src/app/page-components/license-apply/license-apply.component.html
@@ -75,7 +75,7 @@
       </div>
       <div class="info">
         <div class="subtitle">Your new Chef Automate license will expire on
-          <strong class="date">{{ expirationDate }}.</strong>
+          <strong class="date">{{ expirationDate }}</strong>.
           We will keep you informed about your license's status, and will alert you
           <strong>90 days prior</strong> to your license expiration date.
         </div>

--- a/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
@@ -63,7 +63,7 @@ describe('LicenseApplyComponent', () => {
       expect(component.permissionDenied).toBeFalsy();
       expect(component.applyLicenseInternalError).toBeFalsy();
       expect(component.badRequestReason).toBe('');
-      expect(component.expirationDate).toEqual(futureDate.format('l'));
+      expect(component.expirationDate).toEqual(futureDate.format('ddd, DD MMM YYYY HH:mm:ss [UTC]'));
     });
 
     it('reflects permission denied', () => {

--- a/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
@@ -63,7 +63,8 @@ describe('LicenseApplyComponent', () => {
       expect(component.permissionDenied).toBeFalsy();
       expect(component.applyLicenseInternalError).toBeFalsy();
       expect(component.badRequestReason).toBe('');
-      expect(component.expirationDate).toEqual(futureDate.format('ddd, DD MMM YYYY HH:mm:ss [UTC]'));
+      expect(component.expirationDate).toEqual(futureDate
+                                      .format('ddd, DD MMM YYYY HH:mm:ss [UTC]'));
     });
 
     it('reflects permission denied', () => {

--- a/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.html
+++ b/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.html
@@ -79,7 +79,7 @@
         </div>
         <div class="info">
           <div class="subtitle">Your trial license will expire on
-            <strong class="date">{{ expirationDate }}.</strong>
+            <strong class="date">{{ expirationDate }}</strong>.
             Keep your eye on the banner at the top of the Chef Automate UI to see
             a countdown of the time you have left on your trial.
           </div>

--- a/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
@@ -69,7 +69,8 @@ describe('LicenseLockoutComponent', () => {
       expect(component.licenseExpired).toBeFalsy();
       expect(component.fetchStatusInternalError).toBeFalsy();
       // Note using moment formatting so this unit test will still pass outside the US!
-      expect(component.expirationDate).toEqual(futureDate.format('l'));
+      expect(component.expirationDate).toEqual(futureDate
+                                      .format('ddd, DD MMM YYYY HH:mm:ss [UTC]'));
     });
 
     // this test is failing in wallaby with "Expression has changed after it was checked"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This branch updates the time time/date format of the trial license application modal windows to match a more consistent format found around the chef site ie.: Wed, 03 Jul 2019 17:08:53 UTC

The initial function that parses the date uses moment.js to format the date.  This formatting/parsing function was altered to return the requested format, along with the tests that accompany them.

It was also requested that the period after time/date be removed from pink/bold.

### :chains: Related Resources
fixes #1679 

### :+1: Definition of Done
Modal matches the desired design and date/time reads `Wed, 03 Jul 2019 17:08:53 UTC`

### :athletic_shoe: How to Build and Test the Change
1. build components/automate-ui-devproxy && start_all_services
2. `chef-automate dev psql chef_license_control_service -- -c "UPDATE licenses SET active=NULL"` to remove the current license
3. Navigate to https://a2-dev.test/
4. Fill out the trial license form and submit
5. Observe the trial expiration modal


### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
Before: 
<img width="702" alt="Before" src="https://user-images.githubusercontent.com/16737484/65463773-44b27d00-de0d-11e9-9ae0-eb05049c81be.png">

After:
<img width="1083" alt="After" src="https://user-images.githubusercontent.com/16737484/65463782-4aa85e00-de0d-11e9-9426-59b9be0f8d25.png">
