### PR TITLE
Add control_tag filters to reports search bar 

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
@@ -11,7 +11,6 @@
     [hidden]="!keyInputVisible"
     placeholder="Filter reports by..."
     (click)="handleFocus($event)"
-    (focus)="handleFocus($event)"
     (change)="onKeyChange($event)"
     (keyup)="handleInput($event.key, keyInput.value)"
     autocomplete="off"/>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
@@ -468,10 +468,10 @@ export class ReportingSearchbarComponent implements OnInit {
   // When value is clicked for the control tag key
   onControlTagKeyValueClick(value: any) {
     const reportQuery = this.reportQuery.getReportQuery();
-    const type = { ...this.selectedType,
-      name: `control_tag:${value.text}`,
-      title: `Control Tag | ${value.text}`,
-      placeholder: 'Enter Control Tag Values...'};
+    const type = this.selectedType;
+    type.name = `control_tag:${value.text}`;
+    type.title = `Control Tag | ${value.text}`;
+    type.placeholder = 'Enter Control Tag Values...';
     reportQuery.filters.push({
       type: type,
       value: {text: undefined }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
@@ -200,13 +200,18 @@ export class ReportingSearchbarComponent implements OnInit {
     if (this.highlightedIndex >= 0) {
       const search = this.filterValues[this.highlightedIndex];
       const type = this.selectedType;
-      this.ClearAll();
-      this.filterAdded.emit({
-        detail: {
-          value: search,
-          type: type
-        }
-      });
+      if (type.name === 'control_tag_key') {
+        this.onControlTagKeyValueClick(search);
+      } else {
+        this.ClearAll();
+        this.suggestionsVisible = false;
+        this.filterAdded.emit({
+          detail: {
+            value: search,
+            type: type
+          }
+        });
+      }
     } else {
       if (currentText.indexOf('?') >= 0 || currentText.indexOf('*') >= 0) {
         const type = this.selectedType;

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
@@ -14,9 +14,10 @@ import {
   debounceTime, switchMap, distinctUntilChanged
 } from 'rxjs/operators';
 import { FilterC } from '../types';
+import { Chicklet } from 'app/types/types';
 import {
   ReportQueryService
-} from '../../shared/reporting';
+} from 'app/pages/+compliance/shared/reporting';
 
 @Component({
   selector: 'app-reporting-searchbar',
@@ -440,7 +441,7 @@ export class ReportingSearchbarComponent implements OnInit {
     this.highlightedIndex = -1;
   }
 
-  requestForSuggestions(c: any): void {
+  requestForSuggestions(c: Chicklet): void {
     if (c.type) {
       c.type = this.formatType(c.type);
       this.suggestionSearchTermDebounce.next(c);
@@ -467,10 +468,10 @@ export class ReportingSearchbarComponent implements OnInit {
   // When value is clicked for the control tag key
   onControlTagKeyValueClick(value: any) {
     const reportQuery = this.reportQuery.getReportQuery();
-    const type = this.selectedType;
-    type.name = `control_tag:${value.text}`;
-    type.title = `Control Tag | ${value.text}`;
-    type.placeholder = 'Enter Control Tag Values...';
+    const type = { ...this.selectedType,
+      name: `control_tag:${value.text}`,
+      title: `Control Tag | ${value.text}`,
+      placeholder: 'Enter Control Tag Values...'};
     reportQuery.filters.push({
       type: type,
       value: {text: undefined }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -92,8 +92,9 @@ describe('ReportingComponent', () => {
       const availableFilterTypesNames = component.availableFilterTypes.map( type => type.name);
 
       const expected = [
-        'chef_server', 'chef_tags', 'control', 'control_tag_key', 'environment', 'node', 'organization', 'platform',
-        'policy_group', 'policy_name', 'profile', 'recipe', 'role', 'inspec_version'];
+        'chef_server', 'chef_tags', 'control', 'control_tag_key',
+        'environment', 'node', 'organization', 'platform', 'policy_group',
+        'policy_name', 'profile', 'recipe', 'role', 'inspec_version'];
 
       expect(expected.sort()).toEqual(availableFilterTypesNames.sort());
     });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -92,7 +92,7 @@ describe('ReportingComponent', () => {
       const availableFilterTypesNames = component.availableFilterTypes.map( type => type.name);
 
       const expected = [
-        'chef_server', 'chef_tags', 'control', 'environment', 'node', 'organization', 'platform',
+        'chef_server', 'chef_tags', 'control', 'control_tag_key', 'environment', 'node', 'organization', 'platform',
         'policy_group', 'policy_name', 'profile', 'recipe', 'role', 'inspec_version'];
 
       expect(expected.sort()).toEqual(availableFilterTypesNames.sort());

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -13,7 +13,7 @@ import {
   OnDestroy
 } from '@angular/core';
 import { ActivatedRoute, Router, ParamMap } from '@angular/router';
-import { Subject, of as observableOf, Observable } from 'rxjs';
+import { Subject, Observable } from 'rxjs';
 import * as moment from 'moment';
 import {
   StatsService,
@@ -40,6 +40,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
     'chef_tags',
     'control_id',
     'control_name',
+    'control_tag_key',
     'environment',
     'inspec_version',
     'job_id',
@@ -76,9 +77,15 @@ export class ReportingComponent implements OnInit, OnDestroy {
     },
     {
       'name': 'control',
-      'title': 'Control',
+      'title': 'Controls',
       'description': 'Add the title to filter this report against a control',
       'placeholder': 'Title'
+    },
+    {
+      'name': 'control_tag_key',
+      'title': 'Control Tag',
+      'description': '',
+      'placeholder': 'Control Tag'
     },
     {
       'name': 'environment',
@@ -203,16 +210,13 @@ export class ReportingComponent implements OnInit, OnDestroy {
       // switch to new search observable each time the term changes
       switchMap(([terms, reportQuery]) => {
         const { type, text } = terms;
-        if (text && text.length > 0) {
-          return this.getSuggestions(type, text, reportQuery);
-        }
-        return observableOf([]);
+        return this.getSuggestions(type, text, reportQuery);
       }),
       takeUntil(this.isDestroyed)
     ).subscribe(suggestions => this.availableFilterValues = suggestions.filter(e => e.text));
 
     this.filters$ = this.reportQuery.state.pipe(map((reportQuery: ReportQuery) =>
-      reportQuery.filters.map(filter => {
+      reportQuery.filters.filter((filter) => filter.value.text !== undefined).map(filter => {
         filter.value.id = filter.value.text;
         if (['profile_id', 'node_id', 'control_id'].indexOf(filter.type.name) >= 0) {
           const name = this.reportQuery.getFilterTitle(filter.type.name, filter.value.id);
@@ -427,7 +431,8 @@ export class ReportingComponent implements OnInit, OnDestroy {
     const reportQuery = this.reportQuery.getReportQuery();
 
     reportQuery.filters = urlFilters.filter(
-      (urlParm: Chicklet) => this.allowedURLFilterTypes.indexOf(urlParm.type) >= 0)
+      (urlParm: Chicklet) => this.isTypeControlTag(urlParm.type)
+        || this.allowedURLFilterTypes.indexOf(urlParm.type) >= 0)
       .map((urlParm: Chicklet) => {
         return { type: { name: urlParm.type }, value: { text: urlParm.text } };
       });
@@ -438,6 +443,10 @@ export class ReportingComponent implements OnInit, OnDestroy {
       reportQuery.interval, reportQuery.endDate);
 
     this.reportQuery.setState(reportQuery);
+  }
+
+  isTypeControlTag(type: string) {
+    return type.search('control_tag:') !== -1;
   }
 
   getEndDate(urlFilters: Chicklet[]): moment.Moment {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -76,16 +76,16 @@ export class ReportingComponent implements OnInit, OnDestroy {
       'placeholder': 'Chef Tag'
     },
     {
-      'name': 'control',
-      'title': 'Controls',
-      'description': 'Add the title to filter this report against a control',
-      'placeholder': 'Title'
-    },
-    {
       'name': 'control_tag_key',
       'title': 'Control Tag',
       'description': '',
       'placeholder': 'Control Tag'
+    },
+    {
+      'name': 'control',
+      'title': 'Controls',
+      'description': 'Add the title to filter this report against a control',
+      'placeholder': 'Title'
     },
     {
       'name': 'environment',

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -271,7 +271,8 @@ export class StatsService {
         if (group) {
           group.values.push(value);
         } else {
-          formatted.push({type, values: [value]});
+          const typeValue = value === undefined ? [] : [value];
+          formatted.push({type, values: typeValue});
         }
       return formatted;
     }, []);


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
InSpec provides a mechanism that can be used for 'grouping' controls across profiles (tags)
Users would like to filter their set of nodes being scanned in Automate by selecting a control tag, so they can narrow their query to a group of controls across several profiles.

### :chains: Related Resources
https://github.com/chef/automate/issues/1311

### :+1: Definition of Done
Can search (get suggestions and filter on) control tags in Automate

### :athletic_shoe: How to Build and Test the Change
hab studio enter
build components/automate-ui-devproxy
start_automate_ui_background
start_all_services
chef_load_compliance_scans -N20

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [x] Docs added/updated?

### :camera: Screenshots, if applicable
![compliance-reports-control-tag-filter](https://user-images.githubusercontent.com/4108100/65468953-4db24700-de2b-11e9-9393-ff180a5f1c2e.gif)
