### PR TITLE
Remove 'beta' requirement where no longer needed

### DIFF
--- a/components/compliance-service/docs/adding_test_data.md
+++ b/components/compliance-service/docs/adding_test_data.md
@@ -39,12 +39,10 @@ AWS:
 _Note: to add an ec2 integration for aws, change type from "aws-api" to "aws-ec2"_
 
 Azure:
-- turn on the integration by typing 'beta' into your browser and enabling it
 - search for 'Compliance Azure Creds' in LastPass
 - use these credentials to create your Azure integrations
 
 GCP:
-- turn on the integration by typing 'beta' into your browser and enabling it
 - search for 'GCP creds (compliance)' in LastPass
 - use these credentials to create your GCP integration
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Updated the Readme for adding data.  Previously adding Node credentials required sending `beta` to the browser.  This is no longer necessary.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [x] Docs added/updated?

### :camera: Screenshots, if applicable