### PR TITLE
Passing date as a string

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
@@ -405,9 +405,9 @@ export class ReportingSearchbarComponent implements OnInit {
     this.visibleDate.setFullYear(year);
   }
 
-  onDaySelect(date) {
+  onDaySelect(date: string) {
     this.visibleDate = new Date(date);
-    this.dateChanged.emit({ detail: new Date(this.visibleDate) });
+    this.dateChanged.emit({ detail: date });
   }
 
   handleFocusOut() {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -124,12 +124,33 @@ describe('ReportingComponent', () => {
   });
 
   describe('onEndDateChanged', () => {
-    it('sets date range on report query', () => {
+    it('no date set when today is selected with date object', () => {
       spyOn(router, 'navigate');
       const endDate = new Date();
       const event = {detail: endDate};
       component.onEndDateChanged(event);
-      expect(router.navigate).toHaveBeenCalled();
+      expect(router.navigate).toHaveBeenCalledWith([], {queryParams: { }});
+    });
+
+    it('no date set when today is selected with string', () => {
+      spyOn(router, 'navigate');
+      const event = {detail: moment().utc().format('YYYY-MM-DD')};
+      component.onEndDateChanged(event);
+      expect(router.navigate).toHaveBeenCalledWith([], {queryParams: { }});
+    });
+
+    it('specific string date', () => {
+      spyOn(router, 'navigate');
+      const event = {detail: '2019-10-23'};
+      component.onEndDateChanged(event);
+      expect(router.navigate).toHaveBeenCalledWith([], {queryParams: { end_time: '2019-10-23'}});
+    });
+
+    it('specific date object', () => {
+      spyOn(router, 'navigate');
+      const event = {detail: new Date('2019-10-23')};
+      component.onEndDateChanged(event);
+      expect(router.navigate).toHaveBeenCalledWith([], {queryParams: { end_time: '2019-10-23'}});
     });
   });
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -285,9 +285,8 @@ export class ReportingComponent implements OnInit, OnDestroy {
   }
 
   onEndDateChanged(event) {
-    const endDate = event.detail;
-
     const queryParams = {...this.route.snapshot.queryParams};
+    const endDate = moment.utc(event.detail);
 
     if (moment().utc().format('YYYY-MM-DD') === moment(endDate).format('YYYY-MM-DD')) {
       delete queryParams['end_time'];


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Fix a bug where the calendar selects the day before. 

### :chains: Related Resources

The two PR that caused the problem
https://github.com/chef/automate/pull/1638
https://github.com/chef/automate/pull/1610

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui && start_all_services`
1. Open https://a2-dev.test/compliance/reports/overview
1. Test that the calendar selects the date that is clicked. 

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
Below is showing the bug. When the 24th is clicked the 23 will be selected. 
![calendar](https://user-images.githubusercontent.com/1679247/65470301-877d5080-de1f-11e9-9301-ef0c61a20bb3.gif)
