### PR TITLE
Update hab helper remove_dev_license

### DIFF
--- a/.studio/license-control-service
+++ b/.studio/license-control-service
@@ -25,13 +25,9 @@ document "remove_dev_license" <<DOC
   This removes the dev-license that is usually applied when running
   'chef-automate dev deployinate'.
 
-  It removes the license file on disk then kills the running license-control-service
-  so that it'll come back up and find its license gone.
-
   This command is meant to be used for verifying changes related to the trial
   license lockout and license apply modals.
 DOC
 function remove_dev_license {
-  install_if_missing core/procps-ng pkill
-  rm /hab/svc/license-control-service/data/license_token.jwt && pkill -f license-control-service
+  chef-automate dev psql chef_license_control_service -- -c "UPDATE licenses SET active=NULL"
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The recent High-Availability changes included changing the implementation of how licenses are handled but the hab studio helper was missed. This brings `remove_dev_license` up-to-date.

### :chains: Related Resources
NA

### :+1: Definition of Done

In hab studio, you can use `remove_dev_license` to remove a developer license for testing.

### :athletic_shoe: How to Build and Test the Change

Either restart hab studio or just source the changed file directly (`. .studio/license-control-service`).
Invoke `remove_dev_license`.
Then in the browser login or refresh and you should get a licensing prompt.
