### PR TITLE
Restore with many indices

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -752,7 +752,7 @@ steps:
   - label: "backups"
     command:
       - integration/run_test integration/tests/backup.sh
-    timeout_in_minutes: 20
+    timeout_in_minutes: 25
     expeditor:
       secrets:
         A2_LICENSE:

--- a/components/automate-cli/cmd/chef-automate/diagnostics.go
+++ b/components/automate-cli/cmd/chef-automate/diagnostics.go
@@ -63,6 +63,7 @@ var diagnosticsRunCmdOpts = struct {
 	saveFilePath string
 	adminToken   string
 	lbURL        string
+	options      []string
 }{}
 
 func runDiagnosticsRunCmd(cmd *cobra.Command, args []string) error {
@@ -103,9 +104,19 @@ func runDiagnosticsRunCmd(cmd *cobra.Command, args []string) error {
 			)
 		}
 	} else {
+		opts, err := diagnostics.OptionsFromStrings(diagnosticsRunCmdOpts.options)
+		if err != nil {
+			return status.Wrap(
+				err,
+				status.DiagnosticsError,
+				"Failed to parse options",
+			)
+		}
 		tstContext = diagnostics.NewTestContext(dsClient,
 			diagnostics.WithLBURL(*lbURL),
-			diagnostics.WithAdminToken(strings.TrimSpace(diagnosticsRunCmdOpts.adminToken)))
+			diagnostics.WithAdminToken(strings.TrimSpace(diagnosticsRunCmdOpts.adminToken)),
+			diagnostics.WithOptions(opts),
+		)
 	}
 
 	r := runner.New(
@@ -169,6 +180,12 @@ func init() {
 		"lb-url",
 		"https://localhost",
 		"URL for the automate-load-balancer",
+	)
+	diagnosticsRunCmd.Flags().StringSliceVar(
+		&diagnosticsRunCmdOpts.options,
+		"opt",
+		[]string{},
+		"Set of options that can be used to configure tests",
 	)
 	RootCmd.AddCommand(diagnosticsCmd)
 }

--- a/components/automate-cli/pkg/diagnostics/integration/cfgmgmt_actions.go
+++ b/components/automate-cli/pkg/diagnostics/integration/cfgmgmt_actions.go
@@ -59,17 +59,15 @@ func CreateCfgmgmtActionsDiagnostic() diagnostics.Diagnostic {
 		Generate: func(tstCtx diagnostics.TestContext) error {
 			// Make sure we cover multiple days
 			now := time.Now().UTC()
-			days := []time.Time{
-				now,
-				now.AddDate(0, 0, -1),
-				now.AddDate(0, 0, -2),
-			}
+
+			days := tstCtx.GetOption("cfgmgmt-actions.days").AsInt(3)
+
 			save := cfgmgmtActionsSave{
 				CreatedEntities: []cfgmgmtActionsEntity{},
 			}
 
-			for _, day := range days {
-
+			for i := 0; i < days; i++ {
+				day := now.AddDate(0, 0, -1*i)
 				id := uuid.Must(uuid.NewV4()).String()
 				entityName := "chef-automate-diagnostics-integration-" + id
 				buf := bytes.NewBuffer([]byte{})

--- a/components/automate-cli/pkg/diagnostics/integration/cfgmgmt_ccr.go
+++ b/components/automate-cli/pkg/diagnostics/integration/cfgmgmt_ccr.go
@@ -135,16 +135,15 @@ func CreateCfgmgmtCCRDiagnostic() diagnostics.Diagnostic {
 		Generate: func(tstCtx diagnostics.TestContext) error {
 			// Make sure we cover multiple days
 			now := time.Now().UTC()
-			days := []time.Time{
-				now,
-				now.AddDate(0, 0, -1),
-				now.AddDate(0, 0, -2),
-			}
+
+			days := tstCtx.GetOption("cfgmgmt-ccr.days").AsInt(3)
+
 			save := cfgmgmtCCRSave{
 				CreatedEntities: []cfgmgmtCCREntity{},
 			}
 
-			for _, day := range days {
+			for i := 0; i < days; i++ {
+				day := now.AddDate(0, 0, -1*i)
 				entityUUID := uuid.Must(uuid.NewV4()).String()
 				runID := uuid.Must(uuid.NewV4()).String()
 				nodeName := "chef-automate-diagnostics-integration-" + entityUUID

--- a/components/automate-cli/pkg/diagnostics/integration/compliance_report.go
+++ b/components/automate-cli/pkg/diagnostics/integration/compliance_report.go
@@ -118,7 +118,7 @@ func CreateComplianceReportDiagnostic() diagnostics.Diagnostic {
 				CreatedEntities: []complianceReportEntity{},
 			}
 
-			days := tstCtx.GetOption("compliance-report.days").GetInt(3)
+			days := tstCtx.GetOption("compliance-report.days").AsInt(3)
 
 			for i := 0; i < days; i++ {
 				day := now.AddDate(0, 0, -1*i)

--- a/components/automate-cli/pkg/diagnostics/integration/compliance_report.go
+++ b/components/automate-cli/pkg/diagnostics/integration/compliance_report.go
@@ -118,7 +118,9 @@ func CreateComplianceReportDiagnostic() diagnostics.Diagnostic {
 				CreatedEntities: []complianceReportEntity{},
 			}
 
-			for i := 0; i <= 120; i++ {
+			days := tstCtx.GetOption("compliance-report.days").GetInt(3)
+
+			for i := 0; i < days; i++ {
 				day := now.AddDate(0, 0, -1*i)
 				nodeUUID := uuid.Must(uuid.NewV4()).String()
 				reportUUID := uuid.Must(uuid.NewV4()).String()

--- a/components/automate-cli/pkg/diagnostics/integration/compliance_report.go
+++ b/components/automate-cli/pkg/diagnostics/integration/compliance_report.go
@@ -113,16 +113,13 @@ func CreateComplianceReportDiagnostic() diagnostics.Diagnostic {
 		Generate: func(tstCtx diagnostics.TestContext) error {
 			// Make sure we cover multiple days
 			now := time.Now().UTC()
-			days := []time.Time{
-				now,
-				now.AddDate(0, 0, -1),
-				now.AddDate(0, 0, -2),
-			}
+
 			save := complianceReportSave{
 				CreatedEntities: []complianceReportEntity{},
 			}
 
-			for _, day := range days {
+			for i := 0; i <= 120; i++ {
+				day := now.AddDate(0, 0, -1*i)
 				nodeUUID := uuid.Must(uuid.NewV4()).String()
 				reportUUID := uuid.Must(uuid.NewV4()).String()
 				jobUUID := uuid.Must(uuid.NewV4()).String()

--- a/components/automate-cli/pkg/diagnostics/option.go
+++ b/components/automate-cli/pkg/diagnostics/option.go
@@ -39,14 +39,14 @@ func OptionFromString(option string) (*Option, error) {
 	}, nil
 }
 
-func (o *Option) GetString(defaultVal string) string {
+func (o *Option) AsString(defaultVal string) string {
 	if o == nil || o.Value == "" {
 		return defaultVal
 	}
 	return o.Value
 }
 
-func (o *Option) GetInt(defaultVal int) int {
+func (o *Option) AsInt(defaultVal int) int {
 	if o == nil || o.Value == "" {
 		return defaultVal
 	}

--- a/components/automate-cli/pkg/diagnostics/option.go
+++ b/components/automate-cli/pkg/diagnostics/option.go
@@ -1,0 +1,75 @@
+package diagnostics
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var ErrInvalidOption = errors.New("Invalid option")
+
+type Option struct {
+	Key   string
+	Value string
+}
+
+func OptionsFromStrings(options []string) ([]*Option, error) {
+	out := make([]*Option, len(options))
+	for i, o := range options {
+		opt, err := OptionFromString(o)
+		if err != nil {
+			return nil, errors.Wrapf(err, "%q is not a valid option", o)
+		}
+		out[i] = opt
+	}
+	return out, nil
+}
+
+func OptionFromString(option string) (*Option, error) {
+	parts := strings.SplitN(option, ":", 2)
+	if len(parts) == 0 {
+		return nil, ErrInvalidOption
+	}
+	return &Option{
+		Key:   parts[0],
+		Value: parts[1],
+	}, nil
+}
+
+func (o *Option) GetString(defaultVal string) string {
+	if o == nil || o.Value == "" {
+		return defaultVal
+	}
+	return o.Value
+}
+
+func (o *Option) GetInt(defaultVal int) int {
+	if o == nil || o.Value == "" {
+		return defaultVal
+	}
+	i, err := strconv.Atoi(o.Value)
+	if err != nil {
+		logrus.WithError(err).Warnf("could not parse int (%s)", o.Value)
+		return defaultVal
+	}
+	return i
+}
+
+func (o *Option) MarshalText() (text []byte, err error) {
+	if o == nil {
+		return nil, ErrInvalidOption
+	}
+	return []byte(fmt.Sprintf("%s:%s", o.Key, o.Value)), nil
+}
+
+func (o *Option) UnmarshalText(text []byte) error {
+	opt, err := OptionFromString(string(text))
+	if err != nil {
+		return err
+	}
+	*o = *opt
+	return nil
+}

--- a/integration/base.sh
+++ b/integration/base.sh
@@ -21,6 +21,7 @@ test_upgrade_inspec_profiles=()
 test_skip_diagnostics=false
 test_diagnostics_filters=""
 test_diagnostics_pre_upgrade_filters=""
+test_diagnostics_opts=""
 test_external_services=()
 
 # test_detect_broken_cli detects if we broke the cli. There was a
@@ -197,7 +198,8 @@ do_test_deploy() {
 
 do_test_deploy_default() {
     if [ $test_skip_diagnostics = false ]; then
-        run_diagnostics_pre_upgrade $test_loadbalancer_url "$test_diagnostics_filters" "$test_diagnostics_pre_upgrade_filters"
+        run_diagnostics_pre_upgrade $test_loadbalancer_url "$test_diagnostics_filters" "$test_diagnostics_pre_upgrade_filters" \
+            "$test_diagnostics_opts"
     fi
 
     run_inspec_tests "$A2_ROOT_DIR" "${test_deploy_inspec_profiles[@]}"
@@ -228,7 +230,8 @@ do_test_upgrade() {
 
 do_test_upgrade_default() {
     if [ $test_skip_diagnostics = false ]; then
-        run_diagnostics_post_upgrade $test_loadbalancer_url "$test_diagnostics_filters" "$test_diagnostics_pre_upgrade_filters"
+        run_diagnostics_post_upgrade $test_loadbalancer_url "$test_diagnostics_filters" "$test_diagnostics_pre_upgrade_filters" \
+            "$test_diagnostics_opts"
     fi
 
     run_inspec_tests "$A2_ROOT_DIR" "${test_upgrade_inspec_profiles[@]}"

--- a/integration/helpers/testing.sh
+++ b/integration/helpers/testing.sh
@@ -4,21 +4,23 @@ run_diagnostics_pre_upgrade() {
     local loadbalancer_url="$1"
     local filters="$2"
     local pre_upgrade_filters="$3"
+    local opts="$4"
     # shellcheck disable=SC2086
-    chef-automate diagnostics run $filters $pre_upgrade_filters --lb-url "$loadbalancer_url" --skip-cleanup
+    chef-automate diagnostics run $filters $pre_upgrade_filters --lb-url "$loadbalancer_url" --skip-cleanup $opts
 }
 
 run_diagnostics_post_upgrade() {
     local loadbalancer_url="$1"
     local filters="$2"
     local pre_upgrade_filters="$3"
+    local opts="$4"
     # Verify the old data made it
     # shellcheck disable=SC2086
     chef-automate diagnostics run $filters $pre_upgrade_filters --lb-url "$loadbalancer_url" --skip-generate
 
     # Make sure we can exercise the entirety of the tests post upgrade
     # shellcheck disable=SC2086
-    chef-automate diagnostics run $filters --lb-url "$loadbalancer_url" --skip-cleanup
+    chef-automate diagnostics run $filters --lb-url "$loadbalancer_url" --skip-cleanup $opts
 }
 
 run_inspec_tests() {

--- a/integration/tests/backup.sh
+++ b/integration/tests/backup.sh
@@ -3,6 +3,7 @@
 #shellcheck disable=SC2034
 test_name="backup"
 test_backup_restore=true
+test_diagnostics_opts="--opt compliance-report.days:10"
 
 do_deploy() {
     do_deploy_default

--- a/integration/tests/backup.sh
+++ b/integration/tests/backup.sh
@@ -3,7 +3,7 @@
 #shellcheck disable=SC2034
 test_name="backup"
 test_backup_restore=true
-test_diagnostics_opts="--opt compliance-report.days:10"
+test_diagnostics_opts="--opt compliance-report.days:120"
 
 do_deploy() {
     do_deploy_default

--- a/integration/tests/backup.sh
+++ b/integration/tests/backup.sh
@@ -9,6 +9,59 @@ do_deploy() {
     do_deploy_default
     log_info "applying dev license"
     chef-automate license apply "$A2_LICENSE"
+
+    ## We define the purge policies to not delete any data we might generate
+    chef-automate dev grpcurl compliance-service -- chef.automate.infra.data_lifecycle.api.Purge.Configure -d '{
+      "enabled":true,
+      "recurrence":"FREQ=DAILY;DTSTART=20190820T221315Z;INTERVAL=1",
+      "policy_update": {
+        "es": [
+          {
+            "disabled": false,
+            "policy_name":"compliance-scans",
+            "older_than_days":"150"
+          },
+          {
+            "disabled": false,
+            "policy_name":"compliance-reports",
+            "older_than_days":"150"
+          }
+        ]
+      }
+    }'
+
+    chef-automate dev grpcurl ingest-service -- chef.automate.infra.data_lifecycle.api.Purge.Configure -d '{
+      "enabled":true,
+      "recurrence":"FREQ=DAILY;DTSTART=20190820T221315Z;INTERVAL=1",
+      "policy_update": {
+        "es": [
+          {
+            "disabled": false,
+            "policy_name":"converge-history",
+            "older_than_days":"150"
+          },
+          {
+            "disabled": false,
+            "policy_name":"actions",
+            "older_than_days":"150"
+          }
+        ]
+      }
+    }'
+
+    chef-automate dev grpcurl event-feed-service -- chef.automate.infra.data_lifecycle.api.Purge.Configure -d '{
+      "enabled":true,
+      "recurrence":"FREQ=DAILY;DTSTART=20190820T221315Z;INTERVAL=1",
+      "policy_update": {
+        "es": [
+          {
+            "disabled": false,
+            "policy_name":"feed",
+            "older_than_days":"150"
+          }
+        ]
+      }
+    }'
 }
 
 do_restore() {

--- a/integration/tests/backup.sh
+++ b/integration/tests/backup.sh
@@ -3,7 +3,7 @@
 #shellcheck disable=SC2034
 test_name="backup"
 test_backup_restore=true
-test_diagnostics_opts="--opt compliance-report.days:120"
+test_diagnostics_opts="--opt compliance-report.days:120 --opt cfgmgmt-actions.days:120 --opt cfgmgmt-ccr.days:120"
 
 do_deploy() {
     do_deploy_default


### PR DESCRIPTION
Restores seem to fail if you have too many indices. This is an attempt to find alternatives / skip calls that put indexes in the URL