### PR TITLE
For control_tag value suggestions, prefer control tag keys without values

### DIFF
--- a/components/compliance-service/api/tests/07_suggestions_control_tags_spec.rb
+++ b/components/compliance-service/api/tests/07_suggestions_control_tags_spec.rb
@@ -172,4 +172,19 @@ describe File.basename(__FILE__) do
     expected = []
     assert_suggestions_text(expected, actual_data)
   end
+
+  it "suggests control tag values when full control tag filter exists" do
+    # suggest control tag values with a tag key filter without text
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+      type: 'control_tag_value',
+      filters: [
+        Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'control_tag:satisfies', values: ['apache-1', 'SRG-00006']),
+        Reporting::ListFilter.new(type: 'control_tag:scope', values: []),
+      ]
+    )
+    expected = ["Apache", "apalache"]
+    assert_suggestions_text(expected, actual_data)
+  end
 end

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -78,7 +78,10 @@ func (backend ES2Backend) GetSuggestions(ctx context.Context, typeParam string, 
 		if strings.HasPrefix(filterType, "control_tag:") {
 			_, controlTagFilterKey = leftSplit(filterType, ":")
 			useSummaryIndex = false
-			break
+			// For suggestions, prefer control_tag filter key with no values to avoid clash with full control_tag filters
+			if len(filters[filterType]) == 0 {
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes @vjeffrey 's reported bug:

<img width="673" alt="Screen Shot 2019-09-25 at 6 48 25 PM" src="https://user-images.githubusercontent.com/107378/65626286-2b543100-dfc5-11e9-9414-2ac28dcedff5.png">
