### PR TITLE
Docs Website Formatting Fix

### DIFF
--- a/components/automate-chef-io/layouts/shortcodes/danger.html
+++ b/components/automate-chef-io/layouts/shortcodes/danger.html
@@ -1,1 +1,1 @@
-<div class="alert alert-danger">{{.Inner}}</div>
+<div class="alert alert-danger">{{ .Inner | markdownify }}</div>

--- a/components/automate-chef-io/layouts/shortcodes/info.html
+++ b/components/automate-chef-io/layouts/shortcodes/info.html
@@ -1,1 +1,1 @@
-<div class="alert alert-info">{{.Inner}}</div>
+<div class="alert alert-info">{{ .Inner | markdownify }}</div>

--- a/components/automate-chef-io/layouts/shortcodes/success.html
+++ b/components/automate-chef-io/layouts/shortcodes/success.html
@@ -1,6 +1,6 @@
 <!-- Alert -->
 <div class="alert alert-success">
-  {{.Inner}}
+  {{ .Inner | markdownify }}
 </div>
 <!-- Alert -->
 

--- a/components/automate-chef-io/layouts/shortcodes/tip.html
+++ b/components/automate-chef-io/layouts/shortcodes/tip.html
@@ -1,3 +1,3 @@
 <!-- Alert -->
-<div class="alert alert-tip">{{.Inner}}</div>
+<div class="alert alert-tip">{{ .Inner | markdownify }}</div>
 <!-- Alert -->

--- a/components/automate-chef-io/layouts/shortcodes/warning.html
+++ b/components/automate-chef-io/layouts/shortcodes/warning.html
@@ -1,1 +1,1 @@
-<div class="alert alert-warning">{{.Inner}}</div>
+<div class="alert alert-warning">{{ .Inner | markdownify }}</div>


### PR DESCRIPTION
Signed-off-by: Mary Jinglewski <mjinglewski@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Content within warnings, tips, and other content blocks highlighted by hugo shortcodes was not displaying the proper format. For example, words were not being italicized within a warning block, but instead showing underscores (`_two_`). Hyperlinks were also not properly displaying. Research found that adding markdownify allowed for the content to be rendered properly within the shortcodes, so all shortcode files were updated.

### :chains: Related Resources
N/A

### :+1: Definition of Done

If it builds, 🆗 !

### :athletic_shoe: How to Build and Test the Change

Spin this PR up with `make serve`!

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ x ] Docs added/updated?
