### PR TITLE
[automate-1722] Delete iam-members-viewer role

### DIFF
--- a/components/authz-service/constants/v2/constants.go
+++ b/components/authz-service/constants/v2/constants.go
@@ -33,12 +33,11 @@ const (
 
 // IAM v2 well-known role IDs
 const (
-	OwnerRoleID            = "owner"
-	EditorRoleID           = "editor"
-	ViewerRoleID           = "viewer"
-	IngestRoleID           = "ingest"
-	ProjectOwnerRoleID     = "project-owner"
-	IAMMembersViewerRoleID = "iam-members-viewer"
+	OwnerRoleID        = "owner"
+	EditorRoleID       = "editor"
+	ViewerRoleID       = "viewer"
+	IngestRoleID       = "ingest"
+	ProjectOwnerRoleID = "project-owner"
 )
 
 // IAM v2 well-known project IDs

--- a/components/authz-service/server/v2/system.go
+++ b/components/authz-service/server/v2/system.go
@@ -146,7 +146,6 @@ func SystemPolicies() []*storage.Policy {
 					"iam:roles:" + constants.ViewerRoleID,
 					"iam:roles:" + constants.IngestRoleID,
 					"iam:roles:" + constants.ProjectOwnerRoleID,
-					"iam:roles:" + constants.IAMMembersViewerRoleID,
 				},
 				Projects: []string{constants.AllProjectsID},
 			},

--- a/components/authz-service/storage/postgres/datamigration/sql/11_remove_iam-members-viewer_role.up.sql
+++ b/components/authz-service/storage/postgres/datamigration/sql/11_remove_iam-members-viewer_role.up.sql
@@ -1,0 +1,3 @@
+DELETE from iam_roles
+    WHERE
+        id = 'iam-members-viewer';

--- a/components/authz-service/storage/postgres/datamigration/sql/README.md
+++ b/components/authz-service/storage/postgres/datamigration/sql/README.md
@@ -10,3 +10,4 @@
 - [`08_update_v2_projects.up.sql`](08_update_v2_projects.up.sql)
 - [`09_update_project_admin.up.sql`](09_update_project_admin.up.sql)
 - [`10_add_owner_role_to_admin_pol.up.sql`](10_add_owner_role_to_admin_pol.up.sql)
+- [`11_remove_iam-members-viewer_role.up.sql`](11_remove_iam-members-viewer_role.up.sql)

--- a/inspec/a2-iam-v2-integration/controls/base.rb
+++ b/inspec/a2-iam-v2-integration/controls/base.rb
@@ -79,8 +79,7 @@ EOF
     "editor",
     "viewer",
     "ingest",
-    "project-owner",
-    "iam-members-viewer"
+    "project-owner"
   ]
 
   NON_ADMIN_USERNAME_V2 = 'inspec_test_non_admin_with_iam_v2'

--- a/inspec/a2-iam-v2p1-only-integration/controls/role_projects.rb
+++ b/inspec/a2-iam-v2p1-only-integration/controls/role_projects.rb
@@ -19,8 +19,7 @@ control 'iam-v2-projects-1' do
     "editor",
     "viewer",
     "ingest",
-    "project-owner",
-    "iam-members-viewer"
+    "project-owner"
   ]
 
   CUSTOM_ROLE_1 = {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Removing `iam-members-viewer` role as it has already been accounted for in the `project-owner` role and is no longer needed.

See https://github.com/chef/automate/issues/1722 for details.

### :chains: Related Resources

### :+1: Definition of Done

`iam-members-viewer` no longer shows up in the list of roles in the UI.

### :athletic_shoe: How to Build and Test the Change

```
rebuild components/authz-service
```
View the roles page in the UI (Settings >> Roles).
![image](https://user-images.githubusercontent.com/6817500/65741916-c7079f00-e0a2-11e9-9bae-8e0f895711a7.png)
