### PR TITLE
Add ability to set base ref for git_difference_expression

### DIFF
--- a/scripts/git_difference_expression.rb
+++ b/scripts/git_difference_expression.rb
@@ -20,7 +20,11 @@ end
 
 current_rev = `git rev-parse HEAD`.chomp!
 master_rev = `git rev-parse origin/master`.chomp!
-dev_rev = get_dev_manifest_sha
+dev_rev = if ENV['GIT_DIFF_BASE']
+            ENV['GIT_DIFF_BASE']
+          else
+            get_dev_manifest_sha
+          end
 
 # check if the dev_rev is actually from this tree.  we only expect to
 # see this until we can get a build through dev.


### PR DESCRIPTION
This makes it possible to do something like:

    GIT_DIFF_BASE=20190904132002 ./scripts/changed_components.rb

which can come in handy.

Signed-off-by: Steven Danna <steve@chef.io>