### PR TITLE
[automate-1703] Use persistent state info for project update st…

### DIFF
--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -87,14 +87,13 @@ export class ProjectListComponent implements OnInit, OnDestroy {
     this.projectsEnabled$ = store.select(atLeastV2p1);
 
     this.projects.applyRulesStatus$
+      .pipe(takeUntil(this.isDestroyed))
       .subscribe(({ state, failed, cancelled, percentageComplete }: ApplyRulesStatus) => {
-        if (state === ApplyRulesStatusState.NotRunning) {
-          if (this.applyRulesInProgress) {
-            this.cancelRulesInProgress = false;
-            this.closeConfirmApplyStopModal();
-          }
-          this.applyRulesInProgress = false;
+        if (this.applyRulesInProgress && state === ApplyRulesStatusState.NotRunning) {
+          this.cancelRulesInProgress = false;
+          this.closeConfirmApplyStopModal();
         }
+        this.applyRulesInProgress = state === ApplyRulesStatusState.Running;
         this.updateProjectsFailed = failed;
         this.updateProjectsCancelled = cancelled;
         if (!this.cancelRulesInProgress) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Previously, the project list page was using a local variable
based on the persistent state to determine the running/not-running
state that is used to dictate the content of the "Update Projects" button.
But that local variable was only being initialized when you
started the update. Thus, if you left the page, or if another user
visited the page, it would not be initialized correctly.

### :chains: Related Resources
NA

### :+1: Definition of Done
Visiting the projects list page while an update is running is reflected in the <kbd>Update Projects</kbd> button label.

### :athletic_shoe: How to Build and Test the Change

rebuild automate-ui

Create a project and add/edit a rule, as needed, to enable the <kbd>Update Projects</kbd> button on the projects list page.
Start the update.
(1) Navigate to some other page and then return to the projects list page; button should still show "Updating...". Previously it showed "Projects up-to-date".
(2) As another user (or even just another browser) login again and the page should show "Updating..." during the update.

### :camera: Screenshots, if applicable

![image](https://user-images.githubusercontent.com/6817500/65821998-0264b380-e1f2-11e9-9bc6-14ab27e94326.png)
