### PR TITLE
deployment-service: Only wait 30 seconds for HUP

### DIFF
--- a/components/automate-deployment/pkg/converge/converger.go
+++ b/components/automate-deployment/pkg/converge/converger.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	waitingForReconfigureTimeout = 60 * time.Second
+	waitingForReconfigureTimeout = 30 * time.Second
 	waitingForRestartTimeout     = 600 * time.Second
 )
 


### PR DESCRIPTION
We increased this timeout from 30s to 60s. However, for the
deployment-service, almost all reconfigure requests go through this
code path because most of our configuration is not written to habitat
templates.

Signed-off-by: Steven Danna <steve@chef.io>