### PR TITLE
Clone Release Notes wiki with correct GitHub Auth

### DIFF
--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -9,7 +9,7 @@ aws s3 cp "s3://chef-automate-artifacts/${source_channel}/latest/automate/manife
 
 build_version=$(jq -r -c ".build"  manifest.json)
 
-git clone https://github.com/chef/automate.wiki.git
+git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/chef/automate.wiki.git"
 
 pushd ./automate.wiki
   # Publish release notes to S3


### PR DESCRIPTION
This change is required now that we execute all GitHub actions with the chef-expeditor GitHub App. More details at:
https://chefio.slack.com/archives/C09U1TA1Z/p1568905267009200

Signed-off-by: Seth Chisamore <schisamo@chef.io>
