### PR TITLE
Gatherlogs fixes

### DIFF
--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -484,8 +484,8 @@ func runGatherLogsLocalCmd(outfileOverride string, logLines uint64) error {
 	g.AddCopy("/etc/hosts")
 	g.AddCopy("/proc/cpuinfo")
 	g.AddCopy("/proc/sys/crypto/fips_enabled")
-	g.AddCopiesFromPath("syslog", "/var/log")
-	g.AddCopiesFromPath("messages", "/var/log")
+	g.AddTail("/var/log/syslog", logLines)
+	g.AddTail("/var/log/messages", logLines)
 
 	// automate-gateway metrics
 	// FIXME: Move this to using config.

--- a/components/automate-deployment/pkg/gatherlogs/copy.go
+++ b/components/automate-deployment/pkg/gatherlogs/copy.go
@@ -62,7 +62,7 @@ func (c *Tail) execute() error {
 
 	lines := c.Lines
 	if lines <= 0 {
-		lines = 10
+		lines = 1000
 	}
 	tailArgs := command.Args(
 		"-n",

--- a/components/automate-deployment/pkg/gatherlogs/copy.go
+++ b/components/automate-deployment/pkg/gatherlogs/copy.go
@@ -1,6 +1,10 @@
 package gatherlogs
 
 import (
+	"fmt"
+	"os"
+	"path"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/chef/automate/lib/platform/command"
@@ -30,6 +34,67 @@ func (c *Copy) execute() error {
 				"output": out,
 			},
 		).Info("Failed to copy file")
+
+		return err
+	}
+
+	return nil
+}
+
+type Tail struct {
+	SrcPath  string
+	DestPath string
+	Lines    uint64
+}
+
+func (c *Tail) execute() error {
+	if _, err := os.Stat(c.SrcPath); err != nil {
+		if err == os.ErrNotExist {
+			return nil
+		}
+		return err
+	}
+
+	dname := path.Dir(c.DestPath)
+	if err := os.MkdirAll(dname, 0600); err != nil {
+		return err
+	}
+
+	lines := c.Lines
+	if lines <= 0 {
+		lines = 10
+	}
+	tailArgs := command.Args(
+		"-n",
+		fmt.Sprintf("%d", lines),
+		c.SrcPath,
+	)
+
+	out, err := os.OpenFile(c.DestPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		log.WithError(err).WithFields(
+			log.Fields{
+				"path":   c.SrcPath,
+				"output": c.DestPath,
+			},
+		).Error("Failed to tail file")
+		return err
+	}
+	defer out.Close() // nolint: errcheck
+
+	err = command.Run(
+		"tail",
+		tailArgs,
+		command.Stdout(out),
+		command.Stderr(out),
+	)
+	if err != nil {
+		log.WithError(err).WithFields(
+			log.Fields{
+				"path":   c.SrcPath,
+				"output": c.DestPath,
+			},
+		).Error("Failed to tail file")
 
 		return err
 	}

--- a/components/automate-deployment/pkg/gatherlogs/gatherer.go
+++ b/components/automate-deployment/pkg/gatherlogs/gatherer.go
@@ -158,6 +158,14 @@ func (g *Gatherer) AddURL(name, url string) {
 	})
 }
 
+func (g *Gatherer) AddTail(srcPath string, maxLines uint64) {
+	g.addOperation(&Tail{
+		SrcPath:  srcPath,
+		DestPath: path.Join(g.targetDir, srcPath),
+		Lines:    maxLines,
+	})
+}
+
 // AddCopy adds a copy operation for a given path
 func (g *Gatherer) AddCopy(srcPath string) {
 	g.addOperation(&Copy{

--- a/components/automate-deployment/pkg/gatherlogs/gatherer.go
+++ b/components/automate-deployment/pkg/gatherlogs/gatherer.go
@@ -159,6 +159,10 @@ func (g *Gatherer) AddURL(name, url string) {
 }
 
 func (g *Gatherer) AddTail(srcPath string, maxLines uint64) {
+	if maxLines == 0 {
+		g.AddCopy(srcPath)
+		return
+	}
 	g.addOperation(&Tail{
 		SrcPath:  srcPath,
 		DestPath: path.Join(g.targetDir, srcPath),

--- a/components/automate-deployment/pkg/server/gather-logs.go
+++ b/components/automate-deployment/pkg/server/gather-logs.go
@@ -65,6 +65,7 @@ func (s *server) GatherLogs(ctx context.Context, req *api.GatherLogsRequest,
 	if req.LogLines > 0 {
 		logLinesStr := strconv.FormatUint(req.LogLines, 10)
 		g.AddCommand("journalctl_chef-automate", "journalctl", "--utc", "-u", "chef-automate", "-n", logLinesStr)
+
 	} else {
 		g.AddCommand("journalctl_chef-automate", "journalctl", "--utc", "-u", "chef-automate")
 	}
@@ -103,8 +104,8 @@ func (s *server) GatherLogs(ctx context.Context, req *api.GatherLogsRequest,
 	g.AddCopy("/etc/resolv.conf")
 	g.AddCopy("/etc/hosts")
 	g.AddCopy("/proc/sys/crypto/fips_enabled")
-	g.AddCopiesFromPath("syslog", "/var/log")
-	g.AddCopiesFromPath("messages", "/var/log")
+	g.AddTail("/var/log/syslog", req.GetLogLines())
+	g.AddTail("/var/log/messages", req.GetLogLines())
 	// Distro version/release of the underlying operating system.
 	// If a distro uses systemd, it provides distro information in
 	// /etc/os-release

--- a/components/automate-deployment/pkg/server/gather-logs.go
+++ b/components/automate-deployment/pkg/server/gather-logs.go
@@ -140,7 +140,7 @@ func (s *server) GatherLogs(ctx context.Context, req *api.GatherLogsRequest,
 
 	// Elasticsearch
 	// FIXME: Move this to using config.
-	elasticsearchURL := "http://localhost:10141"
+	elasticsearchURL := "http://localhost:10144"
 	g.AddURL("elasticsearch_cat_health", elasticsearchURL+"/_cat/health?v")
 	g.AddURL("elasticsearch_cluster_health", elasticsearchURL+"/_cluster/health?human&pretty")
 	g.AddURL("elasticsearch_cluster_pending_tasks", elasticsearchURL+"/_cluster/pending_tasks?human&pretty")


### PR DESCRIPTION
Fixes:
- Go through es gateway for elasticsearch logs
- limit log lines for `/var/log/messages` and `/var/log/syslog`
- We shouldn't gather anaconda logs (these were happening because they had syslog and messages)

Fixes #611
Fixes #1530