### PR TITLE
Jamie/date time rebase

### DIFF
--- a/components/automate-ui/src/app/entities/license/license.model.ts
+++ b/components/automate-ui/src/app/entities/license/license.model.ts
@@ -1,4 +1,5 @@
 import * as moment from 'moment';
+import { DateTime } from '../../helpers/datetime/datetime';
 
 // Example JSON returned from gateway:
 // {
@@ -52,8 +53,5 @@ export interface RequestLicenseResponse {
 }
 
 export function parsedExpirationDate(license: LicenseStatus): string {
-  // Use short form, localized date (momentjs.com/docs/#localized-formats) to render date.
-  // At the time of writing, Angular's date pipe is *not* locale-aware.
-  // e.g., Wed, 03 Jul 2019 17:08:53 UTC
-  return moment(license.licensed_period.end).format('ddd, DD MMM YYYY HH:mm:ss [UTC]');
+  return moment(license.licensed_period.end).format(DateTime.RFC2822);
 }

--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -1,0 +1,3 @@
+
+
+export const rfc2822 = 'ddd, DD MMM YYYY HH: mm:ss [UTC]';

--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -1,5 +1,5 @@
 export class DateTime {
-    // formatted for use with moment.js -- https://momentjs.com/docs/#/displaying/format/
-    // RFC2822 format like: Wed, 03 Jul 2019 17:08:53 UTC
-    public static readonly RFC2822: string = 'ddd, DD MMM YYYY HH:mm:ss [UTC]';
+  // formatted for use with moment.js -- https://momentjs.com/docs/#/displaying/format/
+  // RFC2822 format like: Wed, 03 Jul 2019 17:08:53 UTC
+  public static readonly RFC2822: string = 'ddd, DD MMM YYYY HH:mm:ss [UTC]';
 }

--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -1,4 +1,5 @@
 export class DateTime {
     // formatted for use with moment.js -- https://momentjs.com/docs/#/displaying/format/
+    // RFC2822 format like: Wed, 03 Jul 2019 17:08:53 UTC
     public static readonly RFC2822: string = 'ddd, DD MMM YYYY HH:mm:ss [UTC]';
 }

--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -1,3 +1,3 @@
-
-
-export const rfc2822 = 'ddd, DD MMM YYYY HH: mm:ss [UTC]';
+export class DateTime {
+    public static readonly RFC2822 = 'ddd, DD MMM YYYY HH:mm:ss [UTC]';
+}

--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -1,3 +1,4 @@
 export class DateTime {
+    // formatted for use with moment.js -- https://momentjs.com/docs/#/displaying/format/
     public static readonly RFC2822: string = 'ddd, DD MMM YYYY HH:mm:ss [UTC]';
 }

--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -1,3 +1,3 @@
 export class DateTime {
-    public static readonly RFC2822 = 'ddd, DD MMM YYYY HH:mm:ss [UTC]';
+    public static readonly RFC2822: string = 'ddd, DD MMM YYYY HH:mm:ss [UTC]';
 }

--- a/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
@@ -13,7 +13,6 @@ import { EntityStatus } from 'app/entities/entities';
 import { ApplyStatus } from 'app/entities/license/license.reducer';
 import { LicenseStatus } from 'app/entities/license/license.model';
 import { LicenseApplyComponent } from './license-apply.component';
-import { DateTime } from 'app/helpers/datetime/datetime';
 
 function genErrorResp(status: number, msg: string): any /* HttpErrorResponse */ {
   // not a full-fledged HttpErrorResponse but enough for our needs

--- a/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
@@ -4,6 +4,7 @@ import { Store, StoreModule } from '@ngrx/store';
 import * as moment from 'moment';
 import { MockComponent } from 'ng2-mock-component';
 import { using } from 'app/testing/spec-helpers';
+import { DateTime } from 'app/helpers/datetime/datetime';
 import { HttpStatus } from 'app/types/types';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
 import { TelemetryService } from 'app/services/telemetry/telemetry.service';
@@ -12,7 +13,6 @@ import { EntityStatus } from 'app/entities/entities';
 import { ApplyStatus } from 'app/entities/license/license.reducer';
 import { LicenseStatus } from 'app/entities/license/license.model';
 import { LicenseApplyComponent } from './license-apply.component';
-import { DateTime } from 'app/helpers/datetime/datetime';
 
 function genErrorResp(status: number, msg: string): any /* HttpErrorResponse */ {
   // not a full-fledged HttpErrorResponse but enough for our needs

--- a/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
@@ -13,6 +13,7 @@ import { EntityStatus } from 'app/entities/entities';
 import { ApplyStatus } from 'app/entities/license/license.reducer';
 import { LicenseStatus } from 'app/entities/license/license.model';
 import { LicenseApplyComponent } from './license-apply.component';
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 function genErrorResp(status: number, msg: string): any /* HttpErrorResponse */ {
   // not a full-fledged HttpErrorResponse but enough for our needs

--- a/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
@@ -12,6 +12,7 @@ import { EntityStatus } from 'app/entities/entities';
 import { ApplyStatus } from 'app/entities/license/license.reducer';
 import { LicenseStatus } from 'app/entities/license/license.model';
 import { LicenseApplyComponent } from './license-apply.component';
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 function genErrorResp(status: number, msg: string): any /* HttpErrorResponse */ {
   // not a full-fledged HttpErrorResponse but enough for our needs
@@ -63,8 +64,7 @@ describe('LicenseApplyComponent', () => {
       expect(component.permissionDenied).toBeFalsy();
       expect(component.applyLicenseInternalError).toBeFalsy();
       expect(component.badRequestReason).toBe('');
-      expect(component.expirationDate).toEqual(futureDate
-                                      .format('ddd, DD MMM YYYY HH:mm:ss [UTC]'));
+      expect(component.expirationDate).toEqual(futureDate.format(DateTime.RFC2822));
     });
 
     it('reflects permission denied', () => {

--- a/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
@@ -64,7 +64,7 @@ describe('LicenseLockoutComponent', () => {
       expect(component).toBeTruthy();
     });
 
-    fit('reflects current license', () => {
+    it('reflects current license', () => {
       const futureDate = moment().add(2, 'months');
       setup(genLicenseFetchReducer(futureDate));
 

--- a/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
@@ -16,7 +16,6 @@ import { FetchStatus, RequestStatus } from 'app/entities/license/license.reducer
 import { LicenseLockoutComponent } from './license-lockout.component';
 import { using } from 'app/testing/spec-helpers';
 import { LicenseStatus } from 'app/entities/license/license.model';
-import { DateTime } from 'app/helpers/datetime/datetime';
 
 class MockTelemetryService {
   enabled = observableOf(false);

--- a/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
@@ -15,6 +15,7 @@ import { FetchStatus, RequestStatus } from 'app/entities/license/license.reducer
 import { LicenseLockoutComponent } from './license-lockout.component';
 import { using } from 'app/testing/spec-helpers';
 import { LicenseStatus } from 'app/entities/license/license.model';
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 class MockTelemetryService {
   enabled = observableOf(false);
@@ -62,7 +63,7 @@ describe('LicenseLockoutComponent', () => {
       expect(component).toBeTruthy();
     });
 
-    it('reflects current license', () => {
+    fit('reflects current license', () => {
       const futureDate = moment().add(2, 'months');
       setup(genLicenseFetchReducer(futureDate));
 
@@ -70,7 +71,7 @@ describe('LicenseLockoutComponent', () => {
       expect(component.fetchStatusInternalError).toBeFalsy();
       // Note using moment formatting so this unit test will still pass outside the US!
       expect(component.expirationDate).toEqual(futureDate
-                                      .format('ddd, DD MMM YYYY HH:mm:ss [UTC]'));
+                                      .format(DateTime.RFC2822));
     });
 
     // this test is failing in wallaby with "Expression has changed after it was checked"

--- a/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
@@ -63,7 +63,7 @@ describe('LicenseLockoutComponent', () => {
       expect(component).toBeTruthy();
     });
 
-    fit('reflects current license', () => {
+    it('reflects current license', () => {
       const futureDate = moment().add(2, 'months');
       setup(genLicenseFetchReducer(futureDate));
 

--- a/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
@@ -16,6 +16,7 @@ import { FetchStatus, RequestStatus } from 'app/entities/license/license.reducer
 import { LicenseLockoutComponent } from './license-lockout.component';
 import { using } from 'app/testing/spec-helpers';
 import { LicenseStatus } from 'app/entities/license/license.model';
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 class MockTelemetryService {
   enabled = observableOf(false);
@@ -63,7 +64,7 @@ describe('LicenseLockoutComponent', () => {
       expect(component).toBeTruthy();
     });
 
-    it('reflects current license', () => {
+    fit('reflects current license', () => {
       const futureDate = moment().add(2, 'months');
       setup(genLicenseFetchReducer(futureDate));
 

--- a/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
@@ -5,6 +5,7 @@ import { MockComponent } from 'ng2-mock-component';
 import * as moment from 'moment';
 import { of as observableOf } from 'rxjs';
 
+import { DateTime } from 'app/helpers/datetime/datetime';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
 import { SessionStorageService } from 'app/services/storage/sessionstorage.service';
 import { TelemetryService } from 'app/services/telemetry/telemetry.service';
@@ -15,7 +16,6 @@ import { FetchStatus, RequestStatus } from 'app/entities/license/license.reducer
 import { LicenseLockoutComponent } from './license-lockout.component';
 import { using } from 'app/testing/spec-helpers';
 import { LicenseStatus } from 'app/entities/license/license.model';
-import { DateTime } from 'app/helpers/datetime/datetime';
 
 class MockTelemetryService {
   enabled = observableOf(false);

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
@@ -23,10 +23,15 @@ export class CredentialsListRowComponent {
 
   getLastModified(lastModifiedDate): string {
 <<<<<<< HEAD
+<<<<<<< HEAD
     return moment(lastModifiedDate).format(DateTime.RFC2822);
 =======
     return moment(lastModifiedDate).format('ddd, DD MMM YYYY HH: mm:ss [UTC]');
 >>>>>>> Update time/date format of node credentials last modified column
+=======
+    console.log(DateTime.RFC2822);
+    return moment(lastModifiedDate).format(DateTime.RFC2822);
+>>>>>>> Exporting RFC2822 from helper file
   }
 
   public startCredentialDelete(): void {

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
@@ -22,7 +22,11 @@ export class CredentialsListRowComponent {
   }
 
   getLastModified(lastModifiedDate): string {
+<<<<<<< HEAD
     return moment(lastModifiedDate).format(DateTime.RFC2822);
+=======
+    return moment(lastModifiedDate).format('ddd, DD MMM YYYY HH: mm:ss [UTC]');
+>>>>>>> Update time/date format of node credentials last modified column
   }
 
   public startCredentialDelete(): void {

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
@@ -2,6 +2,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { Credential } from '../credentials.state';
 import * as moment from 'moment';
 import { CredentialsLogic } from '../credentials.logic';
+import { DateTime } from '../../../../helpers/datetime/datetime';
 
 @Component({
   selector: 'app-credentials-list-row',
@@ -21,7 +22,8 @@ export class CredentialsListRowComponent {
   }
 
   getLastModified(lastModifiedDate): string {
-    return moment(lastModifiedDate).format('ddd, DD MMM YYYY HH: mm:ss [UTC]');
+    console.log(DateTime.RFC2822);
+    return moment(lastModifiedDate).format(DateTime.RFC2822);
   }
 
   public startCredentialDelete(): void {

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
@@ -22,10 +22,6 @@ export class CredentialsListRowComponent {
   }
 
   getLastModified(lastModifiedDate): string {
-<<<<<<< HEAD
-=======
-    console.log(DateTime.RFC2822);
->>>>>>> Exporting RFC2822 from helper file
     return moment(lastModifiedDate).format(DateTime.RFC2822);
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
@@ -1,8 +1,8 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { Credential } from '../credentials.state';
 import * as moment from 'moment';
-import { CredentialsLogic } from '../credentials.logic';
 import { DateTime } from '../../../../helpers/datetime/datetime';
+import { CredentialsLogic } from '../credentials.logic';
 
 @Component({
   selector: 'app-credentials-list-row',

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
@@ -21,7 +21,7 @@ export class CredentialsListRowComponent {
   }
 
   getLastModified(lastModifiedDate): string {
-    return moment(lastModifiedDate).format('MMMM Do YYYY');
+    return moment(lastModifiedDate).format('ddd, DD MMM YYYY HH: mm:ss [UTC]');
   }
 
   public startCredentialDelete(): void {

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
@@ -22,7 +22,6 @@ export class CredentialsListRowComponent {
   }
 
   getLastModified(lastModifiedDate): string {
-    console.log(DateTime.RFC2822);
     return moment(lastModifiedDate).format(DateTime.RFC2822);
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
@@ -22,6 +22,10 @@ export class CredentialsListRowComponent {
   }
 
   getLastModified(lastModifiedDate): string {
+<<<<<<< HEAD
+=======
+    console.log(DateTime.RFC2822);
+>>>>>>> Exporting RFC2822 from helper file
     return moment(lastModifiedDate).format(DateTime.RFC2822);
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
@@ -22,16 +22,7 @@ export class CredentialsListRowComponent {
   }
 
   getLastModified(lastModifiedDate): string {
-<<<<<<< HEAD
-<<<<<<< HEAD
     return moment(lastModifiedDate).format(DateTime.RFC2822);
-=======
-    return moment(lastModifiedDate).format('ddd, DD MMM YYYY HH: mm:ss [UTC]');
->>>>>>> Update time/date format of node credentials last modified column
-=======
-    console.log(DateTime.RFC2822);
-    return moment(lastModifiedDate).format(DateTime.RFC2822);
->>>>>>> Exporting RFC2822 from helper file
   }
 
   public startCredentialDelete(): void {

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
@@ -63,7 +63,7 @@
                 <span *ngIf="token.projects.length === 1">{{ token.projects[0] }}</span>
                 <span *ngIf="token.projects.length > 1">{{ token.projects.length }} projects</span>
               </chef-td>
-              <chef-td>{{ token.created_at | datetime:'ddd, MMMM D, YYYY [at] H:mm a' }}</chef-td>
+              <chef-td>{{ token.created_at | datetime:'ddd, DD MMM YYYY HH:mm:ss [UTC]' }}</chef-td>
               <chef-td>
                 <ng-container *ngIf="token.active">Active</ng-container>
                 <ng-container *ngIf="!token.active">Inactive</ng-container>

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
@@ -63,7 +63,7 @@
                 <span *ngIf="token.projects.length === 1">{{ token.projects[0] }}</span>
                 <span *ngIf="token.projects.length > 1">{{ token.projects.length }} projects</span>
               </chef-td>
-              <chef-td>{{ token.created_at | datetime:'ddd, DD MMM YYYY HH:mm:ss [UTC]' }}</chef-td>
+              <chef-td>{{ token.created_at | datetime: RFC2822 }}</chef-td>
               <chef-td>
                 <ng-container *ngIf="token.active">Active</ng-container>
                 <ng-container *ngIf="!token.active">Inactive</ng-container>

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.ts
@@ -27,7 +27,6 @@ import { IAMMajorVersion } from 'app/entities/policies/policy.model';
 import { assignableProjects } from 'app/services/projects-filter/projects-filter.selectors';
 import { Project, ProjectConstants } from 'app/entities/projects/project.model';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
-import { DateTime } from 'app/helpers/datetime/datetime';
 
 @Component({
   selector: 'app-api-tokens',

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.ts
@@ -27,6 +27,7 @@ import { IAMMajorVersion } from 'app/entities/policies/policy.model';
 import { assignableProjects } from 'app/services/projects-filter/projects-filter.selectors';
 import { Project, ProjectConstants } from 'app/entities/projects/project.model';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 @Component({
   selector: 'app-api-tokens',

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.ts
@@ -26,6 +26,7 @@ import { IAMMajorVersion } from 'app/entities/policies/policy.model';
 import { assignableProjects } from 'app/services/projects-filter/projects-filter.selectors';
 import { Project, ProjectConstants } from 'app/entities/projects/project.model';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 @Component({
   selector: 'app-api-tokens',
@@ -47,6 +48,7 @@ export class ApiTokenListComponent implements OnInit {
   public projectsEnabled$: Observable<boolean>;
   public dropdownProjects: Project[] = [];
   public unassigned = ProjectConstants.UNASSIGNED_PROJECT_ID;
+  public readonly RFC2822 = DateTime.RFC2822;
 
   constructor(
     private store: Store<NgrxStateAtom>,

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.ts
@@ -5,6 +5,7 @@ import { Observable, Subject } from 'rxjs';
 import { filter, takeUntil, map } from 'rxjs/operators';
 import { identity } from 'lodash/fp';
 
+import { DateTime } from 'app/helpers/datetime/datetime';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Regex } from 'app/helpers/auth/regex';
 import { HttpStatus } from 'app/types/types';
@@ -26,7 +27,6 @@ import { IAMMajorVersion } from 'app/entities/policies/policy.model';
 import { assignableProjects } from 'app/services/projects-filter/projects-filter.selectors';
 import { Project, ProjectConstants } from 'app/entities/projects/project.model';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
-import { DateTime } from 'app/helpers/datetime/datetime';
 
 @Component({
   selector: 'app-api-tokens',

--- a/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.html
+++ b/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.html
@@ -51,7 +51,7 @@
               <a class="link" [routerLink]="['/settings/node-integrations', manager.id]">{{ manager.name }}</a>
             </chef-td>
             <chef-td>{{ manager.type }}</chef-td>
-            <chef-td class="column-date">{{ manager.date_added | datetime:'ddd, MMMM D, YYYY [at] H:mm a' }}</chef-td>
+            <chef-td class="column-date">{{ manager.date_added | datetime:'ddd, DD MMM YYYY HH:mm:ss [UTC]' }}</chef-td>
             <chef-td>{{ manager.status }}</chef-td>
             <chef-td class="controls">
               <chef-control-menu>

--- a/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.html
+++ b/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.html
@@ -51,7 +51,7 @@
               <a class="link" [routerLink]="['/settings/node-integrations', manager.id]">{{ manager.name }}</a>
             </chef-td>
             <chef-td>{{ manager.type }}</chef-td>
-            <chef-td class="column-date">{{ manager.date_added | datetime:'ddd, DD MMM YYYY HH:mm:ss [UTC]' }}</chef-td>
+            <chef-td class="column-date">{{ manager.date_added | datetime: RFC2822 }}</chef-td>
             <chef-td>{{ manager.status }}</chef-td>
             <chef-td class="controls">
               <chef-control-menu>

--- a/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.html
+++ b/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.html
@@ -51,11 +51,7 @@
               <a class="link" [routerLink]="['/settings/node-integrations', manager.id]">{{ manager.name }}</a>
             </chef-td>
             <chef-td>{{ manager.type }}</chef-td>
-<<<<<<< HEAD
             <chef-td class="column-date">{{ manager.date_added | datetime: RFC2822 }}</chef-td>
-=======
-            <chef-td class="column-date">{{ manager.date_added | datetime:'ddd, DD MMM YYYY HH:mm:ss [UTC]' }}</chef-td>
->>>>>>> Update date/time format of Node Integrations created at
             <chef-td>{{ manager.status }}</chef-td>
             <chef-td class="controls">
               <chef-control-menu>

--- a/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.html
+++ b/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.html
@@ -51,7 +51,11 @@
               <a class="link" [routerLink]="['/settings/node-integrations', manager.id]">{{ manager.name }}</a>
             </chef-td>
             <chef-td>{{ manager.type }}</chef-td>
+<<<<<<< HEAD
             <chef-td class="column-date">{{ manager.date_added | datetime: RFC2822 }}</chef-td>
+=======
+            <chef-td class="column-date">{{ manager.date_added | datetime:'ddd, DD MMM YYYY HH:mm:ss [UTC]' }}</chef-td>
+>>>>>>> Update date/time format of Node Integrations created at
             <chef-td>{{ manager.status }}</chef-td>
             <chef-td class="controls">
               <chef-control-menu>

--- a/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Store } from '@ngrx/store';
 
+import { DateTime } from '../../../helpers/datetime/datetime';
 import { NgrxStateAtom } from '../../../ngrx.reducers';
 import { EntityStatus } from '../../../entities/entities';
 import { Manager } from '../../../entities/managers/manager.model';
@@ -11,7 +12,6 @@ import {
 } from '../../../entities/managers/manager.selectors';
 import { DeleteManager } from '../../../entities/managers/manager.actions';
 import { routeParams } from '../../../route.selectors';
-import { DateTime } from '../../../helpers/datetime/datetime';
 
 @Component({
   selector: 'app-integrations',

--- a/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.ts
@@ -12,7 +12,6 @@ import {
 } from '../../../entities/managers/manager.selectors';
 import { DeleteManager } from '../../../entities/managers/manager.actions';
 import { routeParams } from '../../../route.selectors';
-import { DateTime } from '../../../helpers/datetime/datetime';
 
 @Component({
   selector: 'app-integrations',

--- a/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../entities/managers/manager.selectors';
 import { DeleteManager } from '../../../entities/managers/manager.actions';
 import { routeParams } from '../../../route.selectors';
+import { DateTime } from '../../../helpers/datetime/datetime';
 
 @Component({
   selector: 'app-integrations',
@@ -23,6 +24,8 @@ export class IntegrationsListComponent {
   public automateManager$: Observable<Manager>;
   private sort: string;
   private order: string;
+
+  public readonly RFC2822 = DateTime.RFC2822;
 
   constructor(
     private store: Store<NgrxStateAtom>,

--- a/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../entities/managers/manager.selectors';
 import { DeleteManager } from '../../../entities/managers/manager.actions';
 import { routeParams } from '../../../route.selectors';
+import { DateTime } from '../../../helpers/datetime/datetime';
 
 @Component({
   selector: 'app-integrations',


### PR DESCRIPTION
Note: This is the same Branch as https://github.com/chef/automate/pull/1690 , I had to redo because of a Rebase issue

### :nut_and_bolt: Description: What code changed, and why?
This branch updates the time/date format in API Tokens, Node Credentials, and Node integrations to be more consistent across the site.  ie.: Wed, 03 Jul 2019 17:08:53 UTC

Adds a helper file where the proper datetime formatting can be accessed across the site

Updates https://github.com/chef/automate/pull/1689 to use the new formatting helper as well.

### :chains: Related Resources
Fixes https://github.com/chef/automate/issues/1678
https://github.com/chef/automate/pull/1689

### :+1: Definition of Done
Formatting string is accessible from one location across components.

Timestamps on API Tokens, Node Credentials, and Node Integrations pages read as `Wed, 03 Jul 2019 17:08:53 UTC`

### :athletic_shoe: How to Build and Test the Change
ALL
1. build components/automate-ui-devproxy && start_all_services

API Tokens
2. Navigate to https://a2-dev.test/settings/tokens
3. Create a token
4. View timestamp in Created Date column

Node Credentials
5. Navigate to https://a2-dev.test/settings/node-credentials
6. Add a Credential
7. view timestamp in Last Modified column

Node Integrations
8. Navigate to https://a2-dev.test/settings/node-integrations
9. Create an Integration (follow instructions [here](https://github.com/chef/automate/blob/master/components/compliance-service/docs/adding_test_data.md#adding-cloud-integrations) - GCP was easiest)
10. View timestamp in date created column


### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
API TOKENS: 
<img width="1386" alt="API Tokens" src="https://user-images.githubusercontent.com/16737484/65467737-ff934880-de16-11e9-8d2f-07fb7b15bd5a.png">

NODE INTEGRATIONS
<img width="1384" alt="Node Integrations" src="https://user-images.githubusercontent.com/16737484/65467749-05892980-de17-11e9-98ba-aa3d241fed19.png">

NODE CREDENTIALS
<img width="1530" alt="Node Credentials" src="https://user-images.githubusercontent.com/16737484/65467756-0cb03780-de17-11e9-835b-eb2f79fe2906.png">
