### PR TITLE
datalifecycle: register correct workflow executor

### DIFF
--- a/components/compliance-service/compliance.go
+++ b/components/compliance-service/compliance.go
@@ -75,6 +75,7 @@ var SERVICE_STATE serviceState
 
 const (
 	PurgeJobName      = "purge"
+	PurgeWorkflowName = "purge"
 	PurgeScheduleName = "periodic_purge"
 )
 
@@ -447,7 +448,7 @@ func setupDataLifecyclePurgeInterface(ctx context.Context, connFactory *secureco
 
 	err = purge.ConfigureManager(
 		cerealManager,
-		PurgeScheduleName,
+		PurgeWorkflowName,
 		PurgeJobName,
 		purge.WithTaskEsSidecarClient(esSidecarClient),
 	)
@@ -468,7 +469,7 @@ func setupDataLifecyclePurgeInterface(ctx context.Context, connFactory *secureco
 		timeoutCtx,
 		cerealManager,
 		PurgeScheduleName,
-		PurgeJobName,
+		PurgeWorkflowName,
 		defaultPurgePolicies,
 		true,
 		recurrence,

--- a/components/event-feed-service/pkg/grpc/grpc.go
+++ b/components/event-feed-service/pkg/grpc/grpc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	libgrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
 	"github.com/chef/automate/api/interservice/data_lifecycle"
@@ -25,7 +26,6 @@ import (
 	"github.com/chef/automate/lib/datalifecycle/purge"
 	"github.com/chef/automate/lib/grpc/health"
 	"github.com/chef/automate/lib/grpc/secureconn"
-	libgrpc "google.golang.org/grpc"
 )
 
 // Spawn starts a gRPC server using the provided configuration
@@ -142,7 +142,7 @@ func newJobManager(
 
 	err = purge.ConfigureManager(
 		jobManager,
-		server.PurgeScheduleName,
+		server.PurgeWorkflowName,
 		server.PurgeJobName,
 		purge.WithTaskEsSidecarClient(esSidecarClient),
 	)

--- a/components/event-feed-service/pkg/server/jobs.go
+++ b/components/event-feed-service/pkg/server/jobs.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	PurgeWorkflowName   = "purge"
 	PurgeJobName        = "purge"
 	PurgeScheduleName   = "periodic_purge"
 	PurgeFeedPolicyName = "feed"
@@ -67,7 +68,7 @@ func ConfigureJobManager(man *cereal.Manager, config *config.EventFeed) error {
 		context.Background(),
 		man,
 		PurgeScheduleName,
-		PurgeJobName,
+		PurgeWorkflowName,
 		DefaultPurgePolicies,
 		true,
 		r,

--- a/components/ingest-service/server/jobs.go
+++ b/components/ingest-service/server/jobs.go
@@ -46,7 +46,7 @@ func InitializeJobManager(c *cereal.Manager, client backend.Client, esSidecarCli
 		}
 	}
 	err = purge.ConfigureManager(
-		c, PurgeScheduleName, PurgeJobName, purge.WithTaskEsSidecarClient(esSidecarClient),
+		c, PurgeWorkflowName, PurgeJobName, purge.WithTaskEsSidecarClient(esSidecarClient),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to configure purge workflow")

--- a/components/ingest-service/server/purge.go
+++ b/components/ingest-service/server/purge.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"time"
 
+	"github.com/pkg/errors"
+	rrule "github.com/teambition/rrule-go"
+
 	"github.com/chef/automate/components/ingest-service/serveropts"
 	"github.com/chef/automate/lib/cereal"
 	"github.com/chef/automate/lib/datalifecycle/purge"
-	"github.com/pkg/errors"
-	rrule "github.com/teambition/rrule-go"
 )
 
 const (
+	PurgeWorkflowName         = "purge_timeseries"
 	PurgeJobName              = "purge_timeseries"
 	PurgeScheduleName         = "periodic_purge_timeseries"
 	PurgeConvergeHistoryName  = "converge-history"
@@ -87,7 +89,7 @@ func ConfigurePurge(man *cereal.Manager, opts *serveropts.Opts) error {
 		context.Background(),
 		man,
 		PurgeScheduleName,
-		PurgeJobName,
+		PurgeWorkflowName,
 		DefaultPurgePolicies,
 		true,
 		r,

--- a/lib/datalifecycle/purge/workflow.go
+++ b/lib/datalifecycle/purge/workflow.go
@@ -10,8 +10,8 @@ import (
 	"github.com/chef/automate/lib/cereal"
 )
 
-// ConfigureManager registers the purge workflow schedule and job with purge
-// task and workflow executors.
+// ConfigureManager registers the purge workflow executor and task
+// executor.
 func ConfigureManager(man *cereal.Manager, workflowName string, taskName string, opts ...TaskOpt) error {
 	task := &Task{}
 	for _, o := range opts {

--- a/lib/datalifecycle/purge/workflow.go
+++ b/lib/datalifecycle/purge/workflow.go
@@ -12,17 +12,17 @@ import (
 
 // ConfigureManager registers the purge workflow schedule and job with purge
 // task and workflow executors.
-func ConfigureManager(man *cereal.Manager, scheduleName string, jobName string, opts ...TaskOpt) error {
+func ConfigureManager(man *cereal.Manager, workflowName string, taskName string, opts ...TaskOpt) error {
 	task := &Task{}
 	for _, o := range opts {
 		o(task)
 	}
 
-	err := man.RegisterTaskExecutor(jobName, task, cereal.TaskExecutorOpts{})
+	err := man.RegisterTaskExecutor(taskName, task, cereal.TaskExecutorOpts{})
 	if err != nil {
 		return err
 	}
-	err = man.RegisterWorkflowExecutor(scheduleName, &Workflow{})
+	err = man.RegisterWorkflowExecutor(workflowName, &Workflow{})
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func CreateOrUpdatePurgeWorkflow(
 	ctx context.Context,
 	man *cereal.Manager,
 	scheduleName string,
-	jobName string,
+	workflowName string,
 	defaultPolicies *Policies,
 	enabled bool,
 	recurrence *rrule.RRule) error {
@@ -45,14 +45,14 @@ func CreateOrUpdatePurgeWorkflow(
 	err := man.CreateWorkflowSchedule(
 		ctx,
 		scheduleName,
-		jobName,
+		workflowName,
 		defaultPolicies,
 		true,
 		recurrence,
 	)
 
 	if err == cereal.ErrWorkflowScheduleExists {
-		sched, err := man.GetWorkflowScheduleByName(ctx, scheduleName, jobName)
+		sched, err := man.GetWorkflowScheduleByName(ctx, scheduleName, workflowName)
 		if err != nil {
 			return errors.Wrap(err, "failed to get purge schedule from job manager")
 		}
@@ -91,7 +91,7 @@ func CreateOrUpdatePurgeWorkflow(
 		err = man.UpdateWorkflowScheduleByName(
 			context.Background(),
 			scheduleName,
-			jobName,
+			workflowName,
 			cereal.UpdateParameters(currentPolicies),
 		)
 		if err != nil {


### PR DESCRIPTION
A recent CI failure revealed we were not correctly purging data. This
was the result of registering our workflow executor under the wrong
name. We were registering the workflow executor under the name of the
"workflow instance" rather than the "workflow".

This fix should result in the purge operation running as expected
again.

As follow up work we need to add a test for purge operations and make
it much harder to make this mistake.