### PR TITLE
Jamie/member expression dialog improvement

### DIFF
--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -15,8 +15,6 @@ export class Regex {
     // Only allowed wildcard alone or words and numbers, but not combined
     // Legal Values: *, chef, _state, etc.
     // Illegal Values: abc*, *chef, c*h*e*f, **
-    // NO_MIXED_WILDCARD: `[*][A - Za - z0 - 9] | [A - Za - z0 - 9][*]`
-    // NO_MIXED_WILDCARD: '\*(?=[A-Za-z0-9 ])|\*(?![A-Za-z0-9 ])'
     NO_MIXED_WILDCARD: '\\*[A-Za-z0-9* ]|[A-Za-z0-9* ]\\*'
   };
 

--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -15,7 +15,9 @@ export class Regex {
     // Only allowed wildcard alone or words and numbers, but not combined
     // Legal Values: *, chef, _state, etc.
     // Illegal Values: abc*, *chef, c*h*e*f, **
-    NO_MIXED_WILDCARD: '\\*[A-Za-z0-9* ]|[A-Za-z0-9* ]\\*'
+    // NO_MIXED_WILDCARD: '\\*[A-Za-z0-9* ]|[A-Za-z0-9* ]\\*'
+    // NO_MIXED_WILDCARD: '^\\*|[A-Za-z0-9]+$'
+    NO_MIXED_WILDCARD: '^(\\*|\\w+)$'
   };
 
 }

--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -10,7 +10,12 @@ export class Regex {
     ID: '[0-9a-z-_]+',
 
     // NB: neither \S nor ^\s work inside the brackets in this regex language.
-    NON_BLANK: '.*[^ ].*'
+    NON_BLANK: '.*[^ ].*',
+
+    // Only allowed wildcard alone or words and numbers, but not combined
+    // Legal Values: *, chef, _state, etc.
+    // Illegal Values: abc*, *chef, c*h*e*f, **
+    NO_MIXED_WILDCARD: `[*][A - Za - z0 - 9] | [A - Za - z0 - 9][*]`
   };
 
 }

--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -12,11 +12,9 @@ export class Regex {
     // NB: neither \S nor ^\s work inside the brackets in this regex language.
     NON_BLANK: '.*[^ ].*',
 
-    // Only allowed wildcard alone or words and numbers, but not combined
+    // Only allows wildcard alone or words and numbers, but not combined
     // Legal Values: *, chef, _state, etc.
     // Illegal Values: abc*, *chef, c*h*e*f, **
-    // NO_MIXED_WILDCARD: '\\*[A-Za-z0-9* ]|[A-Za-z0-9* ]\\*'
-    // NO_MIXED_WILDCARD: '^\\*|[A-Za-z0-9]+$'
     NO_MIXED_WILDCARD: '^(\\*|\\w+)$'
   };
 

--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -10,12 +10,13 @@ export class Regex {
     ID: '[0-9a-z-_]+',
 
     // NB: neither \S nor ^\s work inside the brackets in this regex language.
-    NON_BLANK: '.*[^ ].*',
+    NON_BLANK: '.*[^ ].*'
 
     // Only allowed wildcard alone or words and numbers, but not combined
     // Legal Values: *, chef, _state, etc.
     // Illegal Values: abc*, *chef, c*h*e*f, **
-    NO_MIXED_WILDCARD: `[*][A - Za - z0 - 9] | [A - Za - z0 - 9][*]`
+    // NO_MIXED_WILDCARD: `[*][A - Za - z0 - 9] | [A - Za - z0 - 9][*]`
+    // NO_MIXED_WILDCARD: '\*(?=[A-Za-z0-9 ])|\*(?![A-Za-z0-9 ])'
   };
 
 }

--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -10,13 +10,14 @@ export class Regex {
     ID: '[0-9a-z-_]+',
 
     // NB: neither \S nor ^\s work inside the brackets in this regex language.
-    NON_BLANK: '.*[^ ].*'
+    NON_BLANK: '.*[^ ].*',
 
     // Only allowed wildcard alone or words and numbers, but not combined
     // Legal Values: *, chef, _state, etc.
     // Illegal Values: abc*, *chef, c*h*e*f, **
     // NO_MIXED_WILDCARD: `[*][A - Za - z0 - 9] | [A - Za - z0 - 9][*]`
     // NO_MIXED_WILDCARD: '\*(?=[A-Za-z0-9 ])|\*(?![A-Za-z0-9 ])'
+    NO_MIXED_WILDCARD: '\\*[A-Za-z0-9* ]|[A-Za-z0-9* ]\\*'
   };
 
 }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -72,7 +72,7 @@
                 <chef-error *ngIf="expressionForm.get('name').hasError('required') && expressionForm.get('name').touched">
                   {{ nameOrId }} is a required field.
                 </chef-error>
-                <chef-error *ngIf="expressionForm.get('name').hasError('pattern') && expressionForm.get('name').touched">
+                <chef-error *ngIf="expressionForm.get('name').hasError('pattern') && expressionForm.get('name').dirty">
                   {{ nameOrId }} must be a text or a wildcard but not both.
                 </chef-error>
               </chef-form-field>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -73,7 +73,7 @@
                   {{ nameOrId }} is a required field.
                 </chef-error>
                 <chef-error *ngIf="expressionForm.get('name').hasError('pattern') && expressionForm.get('name').dirty">
-                  {{ nameOrId }} must be a text or a wildcard but not both.
+                  {{ nameOrId }} must be text or a wildcard but not both.
                 </chef-error>
               </chef-form-field>
 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -64,7 +64,7 @@
                   <span class="label">Name<span aria-hidden="true">*</span></span>
                   <chef-input id="expression-name-dropdown" 
                               ngDefaultControl 
-                              (change)="displayExpressionOutput()"
+                              (keyup)="displayExpressionOutput()"
                               formControlName="name"></chef-input>
                 </label>
                 <p class="note">Wildcards (*) are allowed.</p>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -22,7 +22,7 @@
                   <span class="label">Type<span aria-hidden="true">*</span></span>
                   <select id="expression-type-dropdown"
                           ngDefaultControl 
-                          (change)="updateFormDisplay('identity')"
+                          (change)="updateFormDisplay('type')"
                           formControlName="type">
                     <option value='user'>User</option>
                     <option value='team'>Team</option>
@@ -37,13 +37,13 @@
 
               <chef-form-field 
                 id="create-identity" 
-                *ngIf="showIdentity === true"
+                *ngIf="expressionForm.contains('identity')"
                 [@dropInAnimation]="{ value: triggerValue, params: { height: 74.6875 }}" >
                 <label>
                   <span class="label">Identity Provider<span aria-hidden="true">*</span></span>
                   <select id="expression-identity-dropdown" 
                           ngDefaultControl 
-                          (change)="updateFormDisplay('name')"
+                          (change)="updateFormDisplay('identity')"
                           formControlName="identity">
                     <option value="ldap">LDAP</option>
                     <option value="local">local</option>
@@ -58,13 +58,13 @@
 
               <chef-form-field 
                 id="create-name" 
-                *ngIf="showName === true"
+                *ngIf="expressionForm.contains('name')"
                 [@dropInAnimation]="{ value: triggerValue, params: { height: 119.427 }}">
                 <label>
                   <span class="label">{{ nameOrId }}<span aria-hidden="true">*</span></span>
                   <chef-input id="expression-name-dropdown" 
                               ngDefaultControl 
-                              (keyup)="updateFormDisplay()"
+                              (keyup)="updateFormDisplay('name')"
                               formControlName="name"></chef-input>
                 </label>
                 <p class="note">Wildcards (*) are allowed.</p>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -39,7 +39,8 @@
               <chef-form-field 
                 id="create-identity" 
                 *ngIf="showInputs('identity')"
-                [@dropInAnimation]="{ value: triggerValue, params: {height: 75}}" >
+                [@dropInAnimation]="{ value: triggerValue, params: { height: 74.6875 }}" 
+                >
                 <label>
                   <span class="label">Identity Provider<span aria-hidden="true">*</span></span>
                   <select id="expression-identity-dropdown" 
@@ -59,7 +60,7 @@
               <chef-form-field 
                 id="create-name" 
                 *ngIf="showInputs('name')"
-                [@dropInAnimation]="{ value: triggerValue, params: {height: 118}}">
+                [@dropInAnimation]="{ value: triggerValue, params: { height: 119.427 }}">
                 <label>
                   <span class="label">Name<span aria-hidden="true">*</span></span>
                   <chef-input id="expression-name-dropdown" 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -37,7 +37,7 @@
               <chef-form-field 
                 id="create-identity" 
                 *ngIf="showInputs('identity')"
-                [@dropInAnimation]>
+                [@dropInAnimation]="{ value: triggerValue, params: {height: 75}}" >
                 <label>
                   <span class="label">Identity Provider<span aria-hidden="true">*</span></span>
                   <select id="expression-identity-dropdown" 
@@ -55,7 +55,7 @@
               <chef-form-field 
                 id="create-name" 
                 *ngIf="showInputs('name')"
-                [@dropInAnimation]>
+                [@dropInAnimation]="{ value: triggerValue, params: {height: 118}}">
                 <label>
                   <span class="label">Name<span aria-hidden="true">*</span></span>
                   <chef-input id="expression-name-dropdown" 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -12,8 +12,6 @@
   (confirm)="addMembers()"
   (close)="closePage()">
     <div *ngIf="!loading">
-
-      <!-- MODAL START -->
       <chef-modal label="member-expression-label" class="member-expression-modal" [visible]="modalVisible" (close)="closeModal()">
         <h2>Add Member Expression</h2>
         <div id="modal-content-container">
@@ -93,8 +91,6 @@
           </div>
         </div>
       </chef-modal>
-      <!-- MODAL END -->
-
 
       <div id="no-members-container" *ngIf="sortedMembersAvailable.length === 0">
         <h3>Create more local users or local teams first, or add a member expression.</h3>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -46,7 +46,7 @@
                     <option value="LDAP">LDAP</option>
                     <option value="LOCAL">local</option>
                     <option value="SAML">SAML</option>
-                    <option value="*">All teams (*)</option>
+                    <option value="*">All {{ allIdentity | titlecase }}s (*)</option>
                   </select>
                 </label>
                 <!-- Note: might not need the errors in this stepper setup  -->

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -31,8 +31,10 @@
                     <option value='*'>All members (*)</option>
                   </select>
                 </label>
-                <!-- Note: might not need the errors in this stepper setup  -->
               </chef-form-field>
+              <chef-error *ngIf="expressionForm.get('type').hasError('required') && expressionForm.get('type').touched">
+                Type is a required field.
+              </chef-error>
 
               <chef-form-field 
                 id="create-identity" 
@@ -49,8 +51,10 @@
                     <option value="*">All {{ allIdentity | titlecase }}s (*)</option>
                   </select>
                 </label>
-                <!-- Note: might not need the errors in this stepper setup  -->
               </chef-form-field>
+              <chef-error *ngIf="expressionForm.get('identity').hasError('required') && expressionForm.get('identity').touched">
+                Identity Provider is a required field.
+              </chef-error>
 
               <chef-form-field 
                 id="create-name" 
@@ -63,9 +67,9 @@
                               formControlName="name"></chef-input>
                 </label>
                 <p class="note">Wildcards (*) are allowed.</p>
-                <!-- Note: probably need errors here  -->
+
                 <chef-error *ngIf="expressionForm.get('name').hasError('required') && expressionForm.get('name').touched">
-                  Some sort of error goes here for name selection
+                  Name is a required field.
                 </chef-error>
               </chef-form-field>
 
@@ -77,7 +81,6 @@
             </chef-form-field>
           </form>
 
-          <!-- expression builder output -->
           <div *ngIf="expressionOutput">
             <p id="expression-output" class="note">Member expression: {{ expressionOutput }}</p>
           </div>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -22,7 +22,7 @@
                   <span class="label">Type<span aria-hidden="true">*</span></span>
                   <select id="expression-type-dropdown"
                           ngDefaultControl 
-                          (change)="displayExpressionOutput()"
+                          (change)="updateFormDisplay('identity')"
                           formControlName="type">
                     <option value='user'>User</option>
                     <option value='team'>Team</option>
@@ -37,13 +37,13 @@
 
               <chef-form-field 
                 id="create-identity" 
-                *ngIf="showInputs('identity')"
+                *ngIf="showIdentity === true"
                 [@dropInAnimation]="{ value: triggerValue, params: { height: 74.6875 }}" >
                 <label>
                   <span class="label">Identity Provider<span aria-hidden="true">*</span></span>
                   <select id="expression-identity-dropdown" 
                           ngDefaultControl 
-                          (change)="displayExpressionOutput()"
+                          (change)="updateFormDisplay('name')"
                           formControlName="identity">
                     <option value="ldap">LDAP</option>
                     <option value="local">local</option>
@@ -58,19 +58,22 @@
 
               <chef-form-field 
                 id="create-name" 
-                *ngIf="showInputs('name')"
+                *ngIf="showName === true"
                 [@dropInAnimation]="{ value: triggerValue, params: { height: 119.427 }}">
                 <label>
                   <span class="label">{{ nameOrId }}<span aria-hidden="true">*</span></span>
                   <chef-input id="expression-name-dropdown" 
                               ngDefaultControl 
-                              (keyup)="displayExpressionOutput()"
+                              (keyup)="updateFormDisplay()"
                               formControlName="name"></chef-input>
                 </label>
                 <p class="note">Wildcards (*) are allowed.</p>
 
-                <chef-error *ngIf="expressionForm.get('name').hasError('required') && expressionForm.get('name').touched">
+                <chef-error *ngIf="expressionForm.get('name').hasError('required') && expressionForm.get('name').dirty">
                   Name is a required field.
+                </chef-error>
+                <chef-error *ngIf="expressionForm.get('name').hasError('pattern') && expressionForm.get('name').dirty">
+                  This is a pattern error. --> consult for text
                 </chef-error>
               </chef-form-field>
 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -23,9 +23,9 @@
                   <select id="expression-type-dropdown"
                           ngDefaultControl 
                           formControlName="type">
-                    <option value='USER'>User</option>
-                    <option value='TEAM'>Team</option>
-                    <option value='TOKEN'>Token</option>
+                    <option value='user'>User</option>
+                    <option value='team'>Team</option>
+                    <option value='token'>Token</option>
                     <option value='*'>All members (*)</option>
                   </select>
                 </label>
@@ -43,9 +43,9 @@
                   <select id="expression-identity-dropdown" 
                           ngDefaultControl 
                           formControlName="identity">
-                    <option value="LDAP">LDAP</option>
-                    <option value="LOCAL">local</option>
-                    <option value="SAML">SAML</option>
+                    <option value="ldap">LDAP</option>
+                    <option value="local">local</option>
+                    <option value="saml">SAML</option>
                     <option value="*">All {{ allIdentity | titlecase }}s (*)</option>
                   </select>
                 </label>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -22,6 +22,7 @@
                   <span class="label">Type<span aria-hidden="true">*</span></span>
                   <select id="expression-type-dropdown"
                           ngDefaultControl 
+                          (change)="displayExpressionOutput()"
                           formControlName="type">
                     <option value='user'>User</option>
                     <option value='team'>Team</option>
@@ -42,6 +43,7 @@
                   <span class="label">Identity Provider<span aria-hidden="true">*</span></span>
                   <select id="expression-identity-dropdown" 
                           ngDefaultControl 
+                          (change)="displayExpressionOutput()"
                           formControlName="identity">
                     <option value="ldap">LDAP</option>
                     <option value="local">local</option>
@@ -62,6 +64,7 @@
                   <span class="label">Name<span aria-hidden="true">*</span></span>
                   <chef-input id="expression-name-dropdown" 
                               ngDefaultControl 
+                              (change)="displayExpressionOutput()"
                               formControlName="name"></chef-input>
                 </label>
                 <p class="note">Wildcards (*) are allowed.</p>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -70,10 +70,10 @@
                 <p class="note">Wildcards (*) are allowed.</p>
 
                 <chef-error *ngIf="expressionForm.get('name').hasError('required') && expressionForm.get('name').dirty">
-                  Name is a required field.
+                  {{ nameOrId }} is a required field.
                 </chef-error>
                 <chef-error *ngIf="expressionForm.get('name').hasError('pattern') && expressionForm.get('name').dirty">
-                  This is a pattern error. --> consult for text
+                  {{ nameOrId }} must be a text or a wildcard but not both.
                 </chef-error>
               </chef-form-field>
 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -61,7 +61,7 @@
                 *ngIf="showInputs('name')"
                 [@dropInAnimation]="{ value: triggerValue, params: { height: 119.427 }}">
                 <label>
-                  <span class="label">Name<span aria-hidden="true">*</span></span>
+                  <span class="label">{{ nameOrId }}<span aria-hidden="true">*</span></span>
                   <chef-input id="expression-name-dropdown" 
                               ngDefaultControl 
                               (keyup)="displayExpressionOutput()"
@@ -90,7 +90,7 @@
             <chef-button primary 
                         [disabled]="!expressionForm.valid" 
                         (click)="validateAndAddExpression()">Add Expression</chef-button>
-            <chef-button secondary (click)="closeModal()">Cancel</chef-button>
+            <chef-button tertiary (click)="closeModal()">Cancel</chef-button>
           </div>
         </div>
       </chef-modal>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -69,10 +69,10 @@
                 </label>
                 <p class="note">Wildcards (*) are allowed.</p>
 
-                <chef-error *ngIf="expressionForm.get('name').hasError('required') && expressionForm.get('name').dirty">
+                <chef-error *ngIf="expressionForm.get('name').hasError('required') && expressionForm.get('name').touched">
                   {{ nameOrId }} is a required field.
                 </chef-error>
-                <chef-error *ngIf="expressionForm.get('name').hasError('pattern') && expressionForm.get('name').dirty">
+                <chef-error *ngIf="expressionForm.get('name').hasError('pattern') && expressionForm.get('name').touched">
                   {{ nameOrId }} must be a text or a wildcard but not both.
                 </chef-error>
               </chef-form-field>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -31,16 +31,15 @@
                     <option value='*'>All members (*)</option>
                   </select>
                 </label>
+                <chef-error *ngIf="expressionForm.get('type').hasError('required') && expressionForm.get('type').touched">
+                  Type is a required field.
+                </chef-error>
               </chef-form-field>
-              <chef-error *ngIf="expressionForm.get('type').hasError('required') && expressionForm.get('type').touched">
-                Type is a required field.
-              </chef-error>
 
               <chef-form-field 
                 id="create-identity" 
                 *ngIf="showInputs('identity')"
-                [@dropInAnimation]="{ value: triggerValue, params: { height: 74.6875 }}" 
-                >
+                [@dropInAnimation]="{ value: triggerValue, params: { height: 74.6875 }}" >
                 <label>
                   <span class="label">Identity Provider<span aria-hidden="true">*</span></span>
                   <select id="expression-identity-dropdown" 
@@ -52,10 +51,10 @@
                     <option value="*">All {{ allIdentity | titlecase }}s (*)</option>
                   </select>
                 </label>
+                <chef-error *ngIf="expressionForm.get('identity').hasError('required') && expressionForm.get('identity').touched">
+                  Identity Provider is a required field.
+                </chef-error>
               </chef-form-field>
-              <chef-error *ngIf="expressionForm.get('identity').hasError('required') && expressionForm.get('identity').touched">
-                Identity Provider is a required field.
-              </chef-error>
 
               <chef-form-field 
                 id="create-name" 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -40,10 +40,10 @@
                 *ngIf="expressionForm.contains('identityProvider')"
                 [@dropInAnimation]="{ value: triggerValue, params: { height: 74.6875 }}" >
                 <label>
-                  <span class="label">Identity Provider<span aria-hidden="true">*</span></span>
+                  <span class="label">Identity<span aria-hidden="true">*</span></span>
                   <select id="expression-identity-dropdown" 
                           ngDefaultControl 
-                          (change)="updateFormDisplay('identity')"
+                          (change)="updateFormDisplay('identityProvider')"
                           formControlName="identityProvider">
                     <option value="ldap">LDAP</option>
                     <option value="local">local</option>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -37,21 +37,21 @@
 
               <chef-form-field 
                 id="create-identity" 
-                *ngIf="expressionForm.contains('identity')"
+                *ngIf="expressionForm.contains('identityProvider')"
                 [@dropInAnimation]="{ value: triggerValue, params: { height: 74.6875 }}" >
                 <label>
                   <span class="label">Identity Provider<span aria-hidden="true">*</span></span>
                   <select id="expression-identity-dropdown" 
                           ngDefaultControl 
                           (change)="updateFormDisplay('identity')"
-                          formControlName="identity">
+                          formControlName="identityProvider">
                     <option value="ldap">LDAP</option>
                     <option value="local">local</option>
                     <option value="saml">SAML</option>
                     <option value="*">All {{ allIdentity | titlecase }}s (*)</option>
                   </select>
                 </label>
-                <chef-error *ngIf="expressionForm.get('identity').hasError('required') && expressionForm.get('identity').touched">
+                <chef-error *ngIf="expressionForm.get('identityProvider').hasError('required') && expressionForm.get('identityProvider').touched">
                   Identity Provider is a required field.
                 </chef-error>
               </chef-form-field>

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -19,7 +19,7 @@
 
               <chef-form-field id="create-type">
                 <label>
-                  <span class="label">Type<span aria-hidden="true">*</span></span>
+                  <span class="label">Type <span aria-hidden="true">*</span></span>
                   <select id="expression-type-dropdown"
                           ngDefaultControl 
                           (change)="updateFormDisplay('type')"
@@ -40,7 +40,7 @@
                 *ngIf="expressionForm.contains('identityProvider')"
                 [@dropInAnimation]="{ value: triggerValue, params: { height: 74.6875 }}" >
                 <label>
-                  <span class="label">Identity Provider<span aria-hidden="true">*</span></span>
+                  <span class="label">Identity Provider <span aria-hidden="true">*</span></span>
                   <select id="expression-identity-dropdown" 
                           ngDefaultControl 
                           (change)="updateFormDisplay('identityProvider')"
@@ -61,13 +61,13 @@
                 *ngIf="expressionForm.contains('name')"
                 [@dropInAnimation]="{ value: triggerValue, params: { height: 119.427 }}">
                 <label>
-                  <span class="label">{{ nameOrId }}<span aria-hidden="true">*</span></span>
+                  <span class="label">{{ nameOrId }} <span aria-hidden="true">*</span></span>
                   <chef-input id="expression-name-dropdown" 
                               ngDefaultControl 
                               (keyup)="updateFormDisplay('name')"
                               formControlName="name"></chef-input>
                 </label>
-                <p class="note">Wildcards (*) are allowed.</p>
+                <p class="note">A single wildcard (*) is allowed.</p>
 
                 <chef-error *ngIf="expressionForm.get('name').hasError('required') && expressionForm.get('name').touched">
                   {{ nameOrId }} is a required field.

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -20,15 +20,17 @@
               <chef-form-field id="create-type">
                 <label>
                   <span class="label">Type <span aria-hidden="true">*</span></span>
-                  <select id="expression-type-dropdown"
-                          ngDefaultControl 
-                          (change)="updateFormDisplay('type')"
-                          formControlName="type">
-                    <option value='user'>User</option>
-                    <option value='team'>Team</option>
-                    <option value='token'>Token</option>
-                    <option value='*'>All members (*)</option>
-                  </select>
+                  <span class="custom-dropdown">
+                    <select id="expression-type-dropdown"
+                            ngDefaultControl 
+                            (change)="updateFormDisplay('type')"
+                            formControlName="type">
+                      <option value='user'>User</option>
+                      <option value='team'>Team</option>
+                      <option value='token'>Token</option>
+                      <option value='*'>All members (*)</option>
+                    </select>
+                  </span>
                 </label>
                 <chef-error *ngIf="expressionForm.get('type').hasError('required') && expressionForm.get('type').touched">
                   Type is a required field.
@@ -38,18 +40,20 @@
               <chef-form-field 
                 id="create-identity" 
                 *ngIf="expressionForm.contains('identityProvider')"
-                [@dropInAnimation]="{ value: triggerValue, params: { height: 74.6875 }}" >
+                [@dropInAnimation]="{ value: triggerValue, params: { height: 88.2422 }}" >
                 <label>
                   <span class="label">Identity Provider <span aria-hidden="true">*</span></span>
-                  <select id="expression-identity-dropdown" 
-                          ngDefaultControl 
-                          (change)="updateFormDisplay('identityProvider')"
-                          formControlName="identityProvider">
-                    <option value="ldap">LDAP</option>
-                    <option value="local">local</option>
-                    <option value="saml">SAML</option>
-                    <option value="*">All {{ allIdentity | titlecase }}s (*)</option>
-                  </select>
+                  <span class="custom-dropdown">
+                    <select id="expression-identity-dropdown" 
+                            ngDefaultControl 
+                            (change)="updateFormDisplay('identityProvider')"
+                            formControlName="identityProvider">
+                      <option value="ldap">LDAP</option>
+                      <option value="local">local</option>
+                      <option value="saml">SAML</option>
+                      <option value="*">All {{ allIdentity | titlecase }}s (*)</option>
+                    </select>
+                  </span>
                 </label>
                 <chef-error *ngIf="expressionForm.get('identityProvider').hasError('required') && expressionForm.get('identityProvider').touched">
                   Identity Provider is a required field.
@@ -59,7 +63,7 @@
               <chef-form-field 
                 id="create-name" 
                 *ngIf="expressionForm.contains('name')"
-                [@dropInAnimation]="{ value: triggerValue, params: { height: 119.427 }}">
+                [@dropInAnimation]="{ value: triggerValue, params: { height: 109.219 }}">
                 <label>
                   <span class="label">{{ nameOrId }} <span aria-hidden="true">*</span></span>
                   <chef-input id="expression-name-dropdown" 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -40,7 +40,7 @@
                 *ngIf="expressionForm.contains('identityProvider')"
                 [@dropInAnimation]="{ value: triggerValue, params: { height: 74.6875 }}" >
                 <label>
-                  <span class="label">Identity<span aria-hidden="true">*</span></span>
+                  <span class="label">Identity Provider<span aria-hidden="true">*</span></span>
                   <select id="expression-identity-dropdown" 
                           ngDefaultControl 
                           (change)="updateFormDisplay('identityProvider')"

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
@@ -15,7 +15,6 @@ chef-page {
 
       chef-form-field {
         padding-bottom: 1em;
-        transform-origin: top;
 
         &#create-type {
           height: 75px;

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
@@ -9,9 +9,9 @@ chef-page {
     }
 
     #modal-content-container {
+      margin: 1.5em auto 0;
       width: 40%;
       min-width: 300px;
-      margin: 1.5em auto 0;
 
       chef-form-field {
         padding-bottom: 1em;
@@ -54,7 +54,7 @@ chef-page {
           }
         }
       }
-        
+
     }
   }
 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
@@ -16,10 +16,6 @@ chef-page {
       chef-form-field {
         padding-bottom: 1em;
 
-        &#create-type {
-          height: 75px;
-        }
-
         select,
         chef-input {
           width: 100%;

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
@@ -17,11 +17,15 @@ chef-page {
         padding-bottom: 1em;
         transform-origin: top;
 
+        &#create-type {
+          height: 75px;
+        }
+
         select,
         chef-input {
           width: 100%;
         }
-  
+
         .label {
           font-weight: normal;
           font-size: 14px;

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
@@ -28,8 +28,8 @@ chef-page {
         }
 
         .select {
-            width: 340px;
-            max-width: 340px;
+          width: 340px;
+          max-width: 340px;
         }
       }
 
@@ -48,7 +48,7 @@ chef-page {
     }
   }
 
-    /* Custom dropdown */
+  /* Custom dropdown */
   .custom-dropdown {
     position: relative;
     vertical-align: middle;

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
@@ -22,8 +22,14 @@ chef-page {
         }
 
         .label {
-          font-weight: normal;
           font-size: 14px;
+          font-weight: 600;
+          padding-bottom: 0;
+        }
+
+        .select {
+            width: 340px;
+            max-width: 340px;
         }
       }
 
@@ -40,6 +46,73 @@ chef-page {
       }
 
     }
+  }
+
+    /* Custom dropdown */
+  .custom-dropdown {
+    position: relative;
+    vertical-align: middle;
+
+    & select {
+      margin: 0;
+      background-color: $chef-white;
+      color: $chef-primary-dark;
+      font-size: inherit;
+      padding: 12px;
+      padding-right: 16px;
+      height: 45px;
+      border-radius: 4px;
+      border: solid 1px $chef-grey;
+      text-indent: 0.01px;
+      text-overflow: '';
+      font-weight: 400;
+      font-stretch: normal;
+      font-style: normal;
+      line-height: 1.5;
+      letter-spacing: 0.2px;
+      outline: none;
+      /* Hiding the select arrow for firefox */
+      -moz-appearance: none;
+      /* Hiding the select arrow for chrome */
+      -webkit-appearance: none;
+      /* Hiding the select arrow default implementation */
+      appearance: none;
+    }
+
+    & select [disabled] {
+      color: $chef-dark-grey;
+      border: solid 1px $chef-grey;
+      background-color: $chef-grey;
+    }
+
+    & select:focus {
+      border: solid 1px $chef-primary-bright;
+    }
+
+    /* Hiding the select arrow for IE10 */
+
+    & select::-ms-expand {
+      display: none;
+    }
+  }
+
+  .custom-dropdown::before,
+  .custom-dropdown::after {
+    content: "";
+    position: absolute;
+    pointer-events: none;
+  }
+
+  .custom-dropdown::after {
+    /* Custom dropdown arrow */
+    content: "⌄";
+    height: 1em;
+    font-size: 18px;
+    line-height: 1;
+    right: 1.2em;
+    top: 50%;
+    margin-top: -.5em;
+    color: $chef-primary-dark;
   }
 
   #no-members-container {

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.scss
@@ -36,19 +36,7 @@ chef-page {
       }
 
       #buttons-container {
-        display: flex;
-
-        chef-button {
-          width: 50%;
-
-          &:first-child {
-            margin-left: unset;
-          }
-
-          &:last-child {
-            margin-right: unset;
-          }
-        }
+        text-align: center;
       }
 
     }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -251,16 +251,18 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   }
 
   public closeModal(): void {
-    this.formSubscription.unsubscribe();
+    // this.formSubscription.unsubscribe();
     this.resetModal();
     this.modalVisible = false;
   }
 
   public openModal(): void {
     this.resetModal();
-    const expressionValueChanges = this.expressionForm.valueChanges;
-    this.formSubscription = expressionValueChanges.subscribe(formValues =>
-      this.displayExpressionOutput(formValues));
+    // const expressionValueChanges = this.expressionForm.valueChanges;
+    // this.formSubscription = expressionValueChanges.subscribe(formValues => {
+    //   this.updateValidations2(formValues);
+    //   this.displayExpressionOutput(formValues);
+    // });
     this.modalVisible = true;
   }
 
@@ -377,13 +379,28 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     updateInput.updateValueAndValidity();
   }
 
+  private updateValidations2(formGroup: object): void {
+    console.log('%c formGroup ', 'background: orange; color: white;');
+    console.log(formGroup);
+  }
 
-  private displayExpressionOutput(formValues: object): void {
-    const values: string[] = Object.values(formValues);
-    const output: string[] = values.filter(value => value != null && value.length > 0);
+  // private displayExpressionOutput(formValues: object): void {
+  //   const values: string[] = Object.values(formValues);
+  //   const output: string[] = values.filter(value => value != null && value.length > 0);
     
-    console.log('%c output ', 'background: orange; color: white;');
-    console.log(output);
+  //   // console.log('%c output ', 'background: orange; color: white;');
+  //   // console.log(output);
+
+  //   this.expressionOutput = output.join(':');
+  // }
+
+  public displayExpressionOutput(): void {
+    const values: string[] = Object.values(this.expressionForm.value);
+    // console.log(values);
+    const output: string[] = values.filter(value => value != null && value.length > 0);
+
+    // // console.log('%c output ', 'background: orange; color: white;');
+    // // console.log(output);
 
     this.expressionOutput = output.join(':');
   }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -39,14 +39,14 @@ import { Regex } from 'app/helpers/auth/regex';
   animations: [
     trigger('dropInAnimation', [
       state('void', style({ 'opacity': '0', 'height' : '0' })),
-      transition('void => *', animate(500, keyframes([
+      transition('void => *', animate(400, keyframes([
         style({opacity: 0, offset: 0}),
         style({opacity: 0, height: '{{height}}px', offset: 0.3}),
         style({opacity: 1, height: '{{height}}px', offset: 1})
       ]))),
-      transition('* => void', animate(250, keyframes([
+      transition('* => void', animate(150, keyframes([
         style({ opacity: 1, height: '{{height}}px', offset: 0 }),
-        style({ opacity: 0, height: '{{height}}px', offset: 0.3 }),
+        style({ opacity: 0, height: '{{height}}px', offset: 0.1 }),
         style({ opacity: 0, height: '0px', offset: 1 })
       ])))
     ])

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -339,7 +339,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
     switch (inputName) {
       case 'identity':
-        if (typeValue === 'USER' || typeValue === 'TEAM') {
+        if (typeValue === 'user' || typeValue === 'team') {
             this.allIdentity = typeValue;
             this.updateValidations(inputName, true);
             return true;
@@ -350,7 +350,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
           }
         break;
       case 'name':
-        if ( typeValue === 'TOKEN' || (identityValue && identityValue !== '*') ) {
+        if ( typeValue === 'token' || (identityValue && identityValue !== '*') ) {
           this.updateValidations(inputName, true);
           return true;
         } else {
@@ -379,17 +379,17 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
 
   private displayExpressionOutput(formValues: object): void {
-    const entries = Object.entries(formValues);
+    const values: string[] = Object.values(formValues);
     const output = [];
-
-    entries.forEach( ([key, value]) => {
-      if (key === 'name' && value != null && value.length > 0) {
+    
+    values.forEach( value => {
+      if (value != null && value.length > 0) {
         return output.push(value);
-      } else if (value != null && value.length > 0) {
-        return output.push(value.toLowerCase());
       }
     });
-
+    console.log('%c output ', 'background: orange; color: white;');
+    console.log(output);
+    
     this.expressionOutput = output.join(':');
   }
 }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -192,14 +192,14 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     this.store.select(addPolicyMembersStatus).pipe(
       filter(identity),
       takeUntil(pendingAdd))
-      .subscribe((state) => {
-        if (state === EntityStatus.loadingSuccess) {
+      .subscribe((p_state) => {
+        if (p_state === EntityStatus.loadingSuccess) {
           pendingAdd.next(true);
           pendingAdd.complete();
           this.addingMembers = false;
           this.router.navigate(this.backRoute(), { fragment: 'members' });
         }
-        if (state === EntityStatus.loadingFailure) {
+        if (p_state === EntityStatus.loadingFailure) {
           this.store.select(addPolicyMembersHTTPError).pipe(
             filter(identity),
             takeUntil(pendingAdd)).subscribe((error: HttpErrorResponse) => {

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -365,13 +365,15 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   private updateValidations(inputName: string, active: boolean): void {
     const updateInput = this.expressionForm.get(inputName);
 
-    active === true
-      ? updateInput.setValidators([Validators.required,
-        Validators.pattern(Regex.patterns.NON_BLANK)])
-      : updateInput.clearValidators();
-
-      updateInput.updateValueAndValidity();
+    if (active) {
+      updateInput.setValidators([Validators.required,
+                                 Validators.pattern(Regex.patterns.NON_BLANK)]);
+    } else {
+      updateInput.clearValidators();
     }
+
+    updateInput.updateValueAndValidity();
+  }
 
 
   private displayExpressionOutput(formValues: object): void {

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -373,8 +373,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
       : updateInput.clearValidators();
 
       updateInput.updateValueAndValidity();
-
-      return;
     }
 
 
@@ -391,8 +389,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     });
 
     this.expressionOutput = output.join(':');
-
-    return;
   }
 
   private subscribeToExpressionFormChanges(): void {
@@ -401,10 +397,9 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     // subscribe to form changes
     this.formSubscription = expressionValueChanges.subscribe(formValues =>
               this.displayExpressionOutput(formValues));
-    return;
   }
 
   private unsubscribeFromExpressionFormChanges(): void {
-    return this.formSubscription.unsubscribe();
+    this.formSubscription.unsubscribe();
   }
 }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { identity } from 'lodash/fp';
 import { filter, pluck, takeUntil } from 'rxjs/operators';
-import { combineLatest, Subject, Subscription } from 'rxjs';
+import { combineLatest, Subject } from 'rxjs';
 
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
@@ -84,7 +84,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   // Form info
   public expressionForm: FormGroup;
   public expressionOutput: string;
-  private formSubscription: Subscription;
   public allIdentity: string;
 
 
@@ -251,18 +250,12 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   }
 
   public closeModal(): void {
-    // this.formSubscription.unsubscribe();
     this.resetModal();
     this.modalVisible = false;
   }
 
   public openModal(): void {
     this.resetModal();
-    // const expressionValueChanges = this.expressionForm.valueChanges;
-    // this.formSubscription = expressionValueChanges.subscribe(formValues => {
-    //   this.updateValidations2(formValues);
-    //   this.displayExpressionOutput(formValues);
-    // });
     this.modalVisible = true;
   }
 
@@ -378,21 +371,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
     updateInput.updateValueAndValidity();
   }
-
-  private updateValidations2(formGroup: object): void {
-    console.log('%c formGroup ', 'background: orange; color: white;');
-    console.log(formGroup);
-  }
-
-  // private displayExpressionOutput(formValues: object): void {
-  //   const values: string[] = Object.values(formValues);
-  //   const output: string[] = values.filter(value => value != null && value.length > 0);
-    
-  //   // console.log('%c output ', 'background: orange; color: white;');
-  //   // console.log(output);
-
-  //   this.expressionOutput = output.join(':');
-  // }
 
   public displayExpressionOutput(): void {
     const values: string[] = Object.values(this.expressionForm.value);

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -363,8 +363,12 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     const updateInput = this.expressionForm.get(inputName);
 
     if (active) {
-      updateInput.setValidators([Validators.required,
-                                 Validators.pattern(Regex.patterns.NON_BLANK)]);
+      return inputName === 'name'
+              ? updateInput.setValidators([Validators.required,
+                                      Validators.pattern(Regex.patterns.NON_BLANK),
+                                      Validators.pattern(Regex.patterns.NO_MIXED_WILDCARD)])
+              : updateInput.setValidators([Validators.required,
+                                      Validators.pattern(Regex.patterns.NON_BLANK)]);
     } else {
       updateInput.clearValidators();
     }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -364,7 +364,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     }
   }
 
-  updateValidations(inputName: string, active: boolean): void {
+  private updateValidations(inputName: string, active: boolean): void {
     const updateInput = this.expressionForm.get(inputName);
 
     active === true
@@ -378,7 +378,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     }
 
 
-  displayExpressionOutput(formValues: object): void {
+  private displayExpressionOutput(formValues: object): void {
     const entries = Object.entries(formValues);
     const output = [];
 
@@ -395,7 +395,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     return;
   }
 
-  subscribeToExpressionFormChanges(): void {
+  private subscribeToExpressionFormChanges(): void {
     // initialize stream
     const expressionValueChanges = this.expressionForm.valueChanges;
     // subscribe to form changes
@@ -404,7 +404,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     return;
   }
 
-  unsubscribeFromExpressionFormChanges(): void {
+  private unsubscribeFromExpressionFormChanges(): void {
     return this.formSubscription.unsubscribe();
   }
 }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -44,7 +44,7 @@ import { Regex } from 'app/helpers/auth/regex';
         style({opacity: 0, height: '{{height}}px', offset: 0.3}),
         style({opacity: 1, height: '{{height}}px', offset: 1})
       ]))),
-      transition('* => void', animate(300, keyframes([
+      transition('* => void', animate(250, keyframes([
         style({ opacity: 1, height: '{{height}}px', offset: 0 }),
         style({ opacity: 0, height: '{{height}}px', offset: 0.3 }),
         style({ opacity: 0, height: '0px', offset: 1 })

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -328,7 +328,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     this.closeModal();
   }
 
-  public showInputs(inputName) {
+  public showInputs(inputName: string): void {
 
     const formValues = this.expressionForm.value;
     const matchAllWildCard = '*';

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -192,14 +192,14 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     this.store.select(addPolicyMembersStatus).pipe(
       filter(identity),
       takeUntil(pendingAdd))
-      .subscribe((p_state) => {
-        if (p_state === EntityStatus.loadingSuccess) {
+      .subscribe((addPolicyState) => {
+        if (addPolicyState === EntityStatus.loadingSuccess) {
           pendingAdd.next(true);
           pendingAdd.complete();
           this.addingMembers = false;
           this.router.navigate(this.backRoute(), { fragment: 'members' });
         }
-        if (p_state === EntityStatus.loadingFailure) {
+        if (addPolicyState === EntityStatus.loadingFailure) {
           this.store.select(addPolicyMembersHTTPError).pipe(
             filter(identity),
             takeUntil(pendingAdd)).subscribe((error: HttpErrorResponse) => {

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -251,14 +251,16 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   }
 
   public closeModal(): void {
-    this.unsubscribeFromExpressionFormChanges();
+    this.formSubscription.unsubscribe();
     this.resetModal();
     this.modalVisible = false;
   }
 
   public openModal(): void {
     this.resetModal();
-    this.subscribeToExpressionFormChanges();
+    const expressionValueChanges = this.expressionForm.valueChanges;
+    this.formSubscription = expressionValueChanges.subscribe(formValues =>
+      this.displayExpressionOutput(formValues));
     this.modalVisible = true;
   }
 
@@ -389,17 +391,5 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     });
 
     this.expressionOutput = output.join(':');
-  }
-
-  private subscribeToExpressionFormChanges(): void {
-    // initialize stream
-    const expressionValueChanges = this.expressionForm.valueChanges;
-    // subscribe to form changes
-    this.formSubscription = expressionValueChanges.subscribe(formValues =>
-              this.displayExpressionOutput(formValues));
-  }
-
-  private unsubscribeFromExpressionFormChanges(): void {
-    this.formSubscription.unsubscribe();
   }
 }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -380,16 +380,11 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
   private displayExpressionOutput(formValues: object): void {
     const values: string[] = Object.values(formValues);
-    const output = [];
+    const output: string[] = values.filter(value => value != null && value.length > 0);
     
-    values.forEach( value => {
-      if (value != null && value.length > 0) {
-        return output.push(value);
-      }
-    });
     console.log('%c output ', 'background: orange; color: white;');
     console.log(output);
-    
+
     this.expressionOutput = output.join(':');
   }
 }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -340,8 +340,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
         this.resetFormControls();
         if (formValues.type === 'user' || formValues.type === 'team') {
           this.addIdentityControl();
-        }
-        if (formValues.type === 'token') {
+        } else if (formValues.type === 'token') {
           this.addNameControl();
         }
         break;

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -85,6 +85,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   public expressionForm: FormGroup;
   public expressionOutput: string;
   public allIdentity: string;
+  public nameOrId: string;
 
 
   constructor(
@@ -332,10 +333,11 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     const typeValue = this.expressionForm.get('type').value;
     const identityValue = this.expressionForm.get('identity').value;
 
+    this.setFormLabels(typeValue);
+
     switch (inputName) {
       case 'identity':
         if (typeValue === 'user' || typeValue === 'team') {
-            this.allIdentity = typeValue;
             this.updateValidations(inputName, true);
             return true;
           } else {
@@ -356,6 +358,15 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
         break;
       default:
         return false;
+    }
+  }
+
+  private setFormLabels(typeValue: string): void {
+    if (typeValue === 'token') {
+      this.nameOrId = 'ID';
+    } else {
+      this.allIdentity = typeValue;
+      this.nameOrId = 'Name';
     }
   }
 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -75,7 +75,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   public addMembersFailed = '';
 
   // Add expression modal and modal error cases
-
   public modalVisible = false;
   public unparsableMember = false;
   public duplicateMember = false;
@@ -158,7 +157,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
     this.store.dispatch(new GetTeams());
     this.store.dispatch(new GetUsers());
-
   }
 
   addAvailableMember(member: Member, refresh: boolean): void {
@@ -328,14 +326,14 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     this.closeModal();
   }
 
-  private showInputs(inputName: string): void {
+  private showInputs(fieldName: string): void {
 
     const formValues = this.expressionForm.value;
     const matchAllWildCard = '*';
 
     this.setFormLabels(formValues.type);
 
-    switch (inputName) {
+    switch (fieldName) {
       case 'type':
         this.resetFormControls();
         if (formValues.type === 'user' || formValues.type === 'team') {
@@ -385,7 +383,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     this.expressionForm.addControl('name', new FormControl('',
       [
         Validators.required,
-        Validators.pattern(Regex.patterns.NON_BLANK),
         Validators.pattern(Regex.patterns.NO_MIXED_WILDCARD)
       ]
     )
@@ -393,13 +390,14 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   }
 
   private setExpressionOutput(): void {
-    const values: string[] = Object.values(this.expressionForm.value);
-    const output = values.filter(value => value != null && value.length > 0);
-    this.expressionOutput = output.join(':');
+    this.expressionOutput =
+      (Object.values(this.expressionForm.value) as string[])
+             .filter(value => value != null && value.length > 0)
+             .join(':');
   }
 
-  public updateFormDisplay(inputName: string): void {
-    this.showInputs(inputName);
+  public updateFormDisplay(fieldName: string): void {
+    this.showInputs(fieldName);
     this.setExpressionOutput();
   }
 }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -364,8 +364,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
     if (active) {
       updateInput.setValidators([Validators.required,
-                                 Validators.pattern(Regex.patterns.NON_BLANK),
-                                 Validators.pattern(Regex.patterns.NO_MIXED_WILDCARD)]);
+                                 Validators.pattern(Regex.patterns.NON_BLANK)]);
     } else {
       updateInput.clearValidators();
     }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -339,21 +339,21 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
       case 'identity':
         if (typeValue === 'USER' || typeValue === 'TEAM') {
             this.allIdentity = typeValue;
-            this.updateValidations('identity', true);
+            this.updateValidations(inputName, true);
             return true;
           } else {
-            this.updateValidations('identity', false);
-            this.expressionForm.get('identity').reset();
+            this.updateValidations(inputName, false);
+            this.expressionForm.get(inputName).reset();
             return false;
           }
         break;
       case 'name':
         if ( typeValue === 'TOKEN' || (identityValue && identityValue !== '*') ) {
-          this.updateValidations('name', true);
+          this.updateValidations(inputName, true);
           return true;
         } else {
-          this.updateValidations('name', false);
-          this.expressionForm.get('name').reset();
+          this.updateValidations(inputName, false);
+          this.expressionForm.get(inputName).reset();
           return false;
         }
         break;

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -335,7 +335,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
     this.setFormLabels(formValues.type);
 
-    switch(inputName) {
+    switch (inputName) {
       case 'type':
         this.resetFormControls();
         if (formValues.type === 'user' || formValues.type === 'team') {

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -386,7 +386,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
         return output.push(value.toLowerCase());
       }
     });
-    console.log(output);
 
     this.expressionOutput = output.join(':');
 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -83,6 +83,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   public expressionForm: FormGroup;
   public expressionOutput: string;
   private formSubscription: Subscription;
+  public allIdentity: string;
 
 
   constructor(
@@ -337,6 +338,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     switch (inputName) {
       case 'identity':
         if (typeValue === 'USER' || typeValue === 'TEAM') {
+            this.allIdentity = typeValue;
             this.updateValidations('identity', true);
             return true;
           } else {

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -251,7 +251,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   }
 
   public closeModal(): void {
-    // unsubscribe from Changes to the form
     this.unsubscribeFromExpressionFormChanges();
     this.resetModal();
     this.modalVisible = false;
@@ -259,7 +258,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
   public openModal(): void {
     this.resetModal();
-    // subscribe to expressionForm changes
     this.subscribeToExpressionFormChanges();
     this.modalVisible = true;
   }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -364,7 +364,8 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
     if (active) {
       updateInput.setValidators([Validators.required,
-                                 Validators.pattern(Regex.patterns.NON_BLANK)]);
+                                 Validators.pattern(Regex.patterns.NON_BLANK),
+                                 Validators.pattern(Regex.patterns.NO_MIXED_WILDCARD)]);
     } else {
       updateInput.clearValidators();
     }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { trigger, transition, style, animate, state } from '@angular/animations';
+import { trigger, transition, style, animate, state, keyframes } from '@angular/animations';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
@@ -38,15 +38,17 @@ import { Regex } from 'app/helpers/auth/regex';
   styleUrls: ['./policy-add-members.component.scss'],
   animations: [
     trigger('dropInAnimation', [
-      state('void', style({
-          'opacity': '0'
-        })),
-      state('open', style({
-          'opacity' : '1'
-      })),
-      // Would be great if could expand the modal smoothly and then fade in
-      transition('void => *', animate('.4s cubic-bezier(.8,0,.6,1)')),
-      transition('* => void', animate('.4s cubic-bezier(0,.2,.25,1)'))
+      state('void', style({ 'opacity': '0', 'height' : '0' })),
+      transition('void => *', animate(500, keyframes([
+        style({opacity: 0, offset: 0}),
+        style({opacity: 0, height: '{{height}}px', offset: 0.3}),
+        style({opacity: 1, height: '{{height}}px', offset: 1})
+      ]))),
+      transition('* => void', animate(300, keyframes([
+        style({ opacity: 1, height: '{{height}}px', offset: 0 }),
+        style({ opacity: 0, height: '{{height}}px', offset: 0.3 }),
+        style({ opacity: 0, height: '0px', offset: 1 })
+      ])))
     ])
   ]
 })

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -86,6 +86,8 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   public expressionOutput: string;
   public allIdentity: string;
   public nameOrId: string;
+  public showIdentity = false;
+  public showName = false;
 
 
   constructor(
@@ -263,6 +265,8 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
   resetModal(): void {
     this.expressionForm.reset();
+    this.showIdentity = false;
+    this.showName = false;
     this.unparsableMember = false;
     this.duplicateMember = false;
   }
@@ -330,7 +334,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     this.closeModal();
   }
 
-  public showInputs(inputName: string): boolean {
+  public showInputs(inputName: string): void {
     const typeValue = this.expressionForm.get('type').value;
     const identityValue = this.expressionForm.get('identity').value;
     const matchAllWildCard = '*';
@@ -339,31 +343,41 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
     switch (inputName) {
       case 'identity':
+        this.showIdentity = false;
+        this.showName = false;
         if (typeValue === 'user' || typeValue === 'team') {
-            this.updateValidations(inputName, true);
-            return true;
-          } else {
-            this.updateValidations(inputName, false);
-            this.expressionForm.get(inputName).reset();
-            return false;
-          }
-        break;
-      case 'name':
-        if ( typeValue === 'token' || (identityValue && identityValue !== matchAllWildCard) ) {
           this.updateValidations(inputName, true);
-          return true;
+          this.showIdentity = true;
+        } else if ( typeValue === 'token' ) {
+          this.showIdentity = false;
+          this.showName = true;
+          this.updateValidations('name', true);
+          this.updateValidations(inputName, false);
+          this.expressionForm.get(inputName).reset();
         } else {
           this.updateValidations(inputName, false);
           this.expressionForm.get(inputName).reset();
-          return false;
+          this.showIdentity = false;
+        }
+        break;
+      case 'name':
+        if (typeValue === 'token' || (identityValue && identityValue !== matchAllWildCard)) {
+          this.updateValidations(inputName, true);
+          this.showName = true;
+          return;
+        } else {
+          this.updateValidations(inputName, false);
+          this.expressionForm.get(inputName).reset();
+          this.showName = false;
+          return;
         }
         break;
       default:
-        return false;
+        return;
     }
   }
 
-  private setFormLabels(typeValue: string): void {
+  private setFormLabels(typeValue): void {
     if (typeValue === 'token') {
       this.nameOrId = 'ID';
     } else {
@@ -390,7 +404,10 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     updateInput.updateValueAndValidity();
   }
 
-  public displayExpressionOutput(): void {
+  public updateFormDisplay(inputName): void {
+
+    this.showInputs(inputName);
+
     const values: string[] = Object.values(this.expressionForm.value);
     const output = values.filter(value => value != null && value.length > 0);
     this.expressionOutput = output.join(':');

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -379,10 +379,13 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
 
   displayExpressionOutput(formValues: object): void {
-    const values = Object.values(formValues);
+    const entries = Object.entries(formValues);
     const output = [];
-    values.forEach(value => {
-      if (value != null && value.length > 0) {
+
+    entries.forEach( ([key, value]) => {
+      if (key === 'name' && value != null && value.length > 0) {
+        return output.push(value);
+      } else if (value != null && value.length > 0) {
         return output.push(value.toLowerCase());
       }
     });

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -328,7 +328,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     this.closeModal();
   }
 
-  public showInputs(inputName: string): void {
+  private showInputs(inputName: string): void {
 
     const formValues = this.expressionForm.value;
     const matchAllWildCard = '*';

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -95,7 +95,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
     this.expressionForm = fb.group({
       // Must stay in sync with error checks in policy-add-members.component.html
-      type: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      type: ['', [Validators.required]],
       identity: [''],
       name: ['']
     });
@@ -381,8 +381,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
                                       Validators.pattern(Regex.patterns.NON_BLANK),
                                       Validators.pattern(Regex.patterns.NO_MIXED_WILDCARD)]);
       } else {
-        updateInput.setValidators([Validators.required,
-                                      Validators.pattern(Regex.patterns.NON_BLANK)]);
+        updateInput.setValidators([Validators.required]);
       }
     } else {
       updateInput.clearValidators();

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -94,6 +94,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     fb: FormBuilder) {
 
     this.expressionForm = fb.group({
+      // Must stay in sync with error checks in policy-add-members.component.html
       type: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       identity: [''],
       name: ['']
@@ -374,12 +375,14 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     const updateInput = this.expressionForm.get(inputName);
 
     if (active) {
-      return inputName === 'name'
-              ? updateInput.setValidators([Validators.required,
+      if (inputName === 'name') {
+        updateInput.setValidators([Validators.required,
                                       Validators.pattern(Regex.patterns.NON_BLANK),
-                                      Validators.pattern(Regex.patterns.NO_MIXED_WILDCARD)])
-              : updateInput.setValidators([Validators.required,
+                                      Validators.pattern(Regex.patterns.NO_MIXED_WILDCARD)]);
+      } else {
+        updateInput.setValidators([Validators.required,
                                       Validators.pattern(Regex.patterns.NON_BLANK)]);
+      }
     } else {
       updateInput.clearValidators();
     }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -260,7 +260,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   }
 
   resetModal(): void {
-    this.expressionForm.reset();
+    this.resetForm();
     this.unparsableMember = false;
     this.duplicateMember = false;
   }
@@ -370,6 +370,12 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   private resetFormControls(): void {
     this.expressionForm.removeControl('identity');
     this.expressionForm.removeControl('name');
+  }
+
+  private resetForm(): void {
+    this.resetFormControls();
+    this.expressionForm.reset();
+    this.expressionOutput = '';
   }
 
   private addIdentityControl(): void {

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -341,6 +341,10 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
     this.setFormLabels(typeValue);
 
+    // Need to include all of the input types and each outcome
+      // case type
+      // case identity
+      // case name
     switch (inputName) {
       case 'identity':
         this.showIdentity = false;
@@ -398,6 +402,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
         updateInput.setValidators([Validators.required]);
       }
     } else {
+
       updateInput.clearValidators();
     }
 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -333,6 +333,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   public showInputs(inputName: string): boolean {
     const typeValue = this.expressionForm.get('type').value;
     const identityValue = this.expressionForm.get('identity').value;
+    const matchAllWildCard = '*';
 
     this.setFormLabels(typeValue);
 
@@ -348,7 +349,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
           }
         break;
       case 'name':
-        if ( typeValue === 'token' || (identityValue && identityValue !== '*') ) {
+        if ( typeValue === 'token' || (identityValue && identityValue !== matchAllWildCard) ) {
           this.updateValidations(inputName, true);
           return true;
         } else {

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -393,7 +393,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
   public displayExpressionOutput(): void {
     const values: string[] = Object.values(this.expressionForm.value);
-    const output: string[] = values.filter(value => value != null && value.length > 0);
+    const output = values.filter(value => value != null && value.length > 0);
     this.expressionOutput = output.join(':');
   }
 }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -396,12 +396,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
   public displayExpressionOutput(): void {
     const values: string[] = Object.values(this.expressionForm.value);
-    // console.log(values);
     const output: string[] = values.filter(value => value != null && value.length > 0);
-
-    // // console.log('%c output ', 'background: orange; color: white;');
-    // // console.log(output);
-
     this.expressionOutput = output.join(':');
   }
 }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -32,7 +32,7 @@ import {
 import { User } from 'app/entities/users/user.model';
 import { Regex } from 'app/helpers/auth/regex';
 
-type FieldName = 'type' | 'identity' | 'name';
+export type FieldName = 'type' | 'identity' | 'name';
 
 @Component({
   selector: 'app-policy-add-members',

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -32,6 +32,8 @@ import {
 import { User } from 'app/entities/users/user.model';
 import { Regex } from 'app/helpers/auth/regex';
 
+type FieldName = 'type' | 'identity' | 'name';
+
 @Component({
   selector: 'app-policy-add-members',
   templateUrl: './policy-add-members.component.html',
@@ -52,6 +54,7 @@ import { Regex } from 'app/helpers/auth/regex';
     ])
   ]
 })
+
 
 export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   // Data structures and state
@@ -326,7 +329,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     this.closeModal();
   }
 
-  private showInputs(fieldName: string): void {
+  private showInputs(fieldName: FieldName): void {
 
     const formValues = this.expressionForm.value;
     const matchAllWildCard = '*';
@@ -343,12 +346,13 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
         }
         break;
       case 'identity':
-        if (formValues.identity !== matchAllWildCard) {
+        if (formValues.identityProvider !== matchAllWildCard) {
           this.addNameControl();
         } else {
           this.expressionForm.removeControl('name');
         }
         break;
+      case 'name': // fallthrough
       default:
         break;
     }
@@ -365,7 +369,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   }
 
   private resetFormControls(): void {
-    this.expressionForm.removeControl('identity');
+    this.expressionForm.removeControl('identityProvider');
     this.expressionForm.removeControl('name');
   }
 
@@ -376,7 +380,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   }
 
   private addIdentityControl(): void {
-    this.expressionForm.addControl('identity', new FormControl('', Validators.required));
+    this.expressionForm.addControl('identityProvider', new FormControl('', Validators.required));
   }
 
   private addNameControl(): void {
@@ -396,7 +400,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
              .join(':');
   }
 
-  public updateFormDisplay(fieldName: string): void {
+  public updateFormDisplay(fieldName: FieldName): void {
     this.showInputs(fieldName);
     this.setExpressionOutput();
   }

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -262,8 +262,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
   resetModal(): void {
     this.resetForm();
-    this.unparsableMember = false;
-    this.duplicateMember = false;
+    this.resetErrors();
   }
 
   memberHasURL(member: Member): boolean {
@@ -296,7 +295,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     return member.name in this.membersToAdd;
   }
 
-  public resetErrors(): void {
+  private resetErrors(): void {
     this.unparsableMember = false;
     this.duplicateMember = false;
     this.alreadyPolicyMember = false;
@@ -339,6 +338,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     switch (fieldName) {
       case 'type':
         this.resetFormControls();
+        this.resetErrors();
         if (formValues.type === 'user' || formValues.type === 'team') {
           this.addIdentityControl();
         } else if (formValues.type === 'token') {
@@ -346,6 +346,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
         }
         break;
       case 'identityProvider':
+        this.resetErrors();
         if (formValues.identityProvider !== matchAllWildCard) {
           this.addNameControl();
         } else {

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -32,7 +32,7 @@ import {
 import { User } from 'app/entities/users/user.model';
 import { Regex } from 'app/helpers/auth/regex';
 
-export type FieldName = 'type' | 'identity' | 'name';
+export type FieldName = 'type' | 'identityProvider' | 'name';
 
 @Component({
   selector: 'app-policy-add-members',
@@ -345,7 +345,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
           this.addNameControl();
         }
         break;
-      case 'identity':
+      case 'identityProvider':
         if (formValues.identityProvider !== matchAllWildCard) {
           this.addNameControl();
         } else {

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -2,16 +2,13 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { StoreModule } from '@ngrx/store';
-// import { of as observableOf } from 'rxjs';
 import { MockComponent } from 'ng2-mock-component';
 
-// import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
-
+import { Regex } from 'app/helpers/auth/regex';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { customMatchers } from 'app/testing/custom-matchers';
+import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
 import { PolicyAddMembersComponent } from './policy-add-members.component';
-import { Regex } from 'app/helpers/auth/regex';
 
 
 

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -17,7 +17,6 @@ import { PolicyAddMembersComponent } from './policy-add-members.component';
 describe('PolicyAddMembersComponent', () => {
     let component: PolicyAddMembersComponent;
     let fixture: ComponentFixture<PolicyAddMembersComponent>;
-    let element: HTMLElement;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
@@ -58,7 +57,6 @@ describe('PolicyAddMembersComponent', () => {
             identity: [''],
             name: ['']
         });
-        element = fixture.debugElement.nativeElement;
         fixture.detectChanges();
     });
 
@@ -114,12 +112,11 @@ describe('PolicyAddMembersComponent', () => {
     });
 
     describe('updateValidations', () => {
-        beforeEach(() => {
-          component.expressionForm.setValue({ type: 'TEAM', identity: 'LOCAL', name: '' });
-        });
 
         it('clears validators when input is not active', () => {
-
+          component.expressionForm.setValue({ type: 'TEAM', identity: '', name: '' });
+        //   create spy here i think
+        //   expect(component.updateValidations('identity', false))
         });
 
         it('applies validators when input is active', () => {

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -9,6 +9,8 @@ import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { customMatchers } from 'app/testing/custom-matchers';
 import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
 import { PolicyAddMembersComponent } from './policy-add-members.component';
+// import { using } from 'rxjs';
+import { using } from 'app/testing/spec-helpers';
 
 
 
@@ -70,25 +72,26 @@ describe('PolicyAddMembersComponent', () => {
             expect(component.showInputs('blank')).toBe(false);
         });
 
-        it('should return true when inputName is identity and when typeValue equals USER', () => {
-            component.expressionForm.setValue({type: 'USER', identity: '', name: ''});
-            expect(component.showInputs('identity')).toBe(true);
+        using([
+            ['user', true, 'identity and when typeValue equals user', 'identity'],
+            ['team', true, 'identity and when typeValue equals team', 'identity'],
+            ['*', false, 'identity and typeValue does not equal team or user', 'identity'],
+            ['token', true, 'name and when typeValue equals token', 'name'],
+            ['team', false, 'name + typeValue is not token + identityValue does not exist', 'name']
+        ], function (type: string, outcome: boolean, description: string, input: string) {
+            it(`should return ${outcome} when inputName is ${description}`, () => {
+                component.expressionForm.setValue({ type: type, identity: '', name: '' });
+                expect(component.showInputs(input)).toBe(outcome);
+            });
         });
 
-        it('should return true when inputName is identity and when typeValue equals TEAM', () => {
-            component.expressionForm.setValue({ type: 'TEAM', identity: '', name: '' });
-            expect(component.showInputs('identity')).toBe(true);
-        });
+        using([
 
-        // tslint:disable-next-line: max-line-length
-        it('should return false when inputName is identity and typeValue does not equal TEAM or USER', () => {
-            component.expressionForm.setValue({ type: '*', identity: '', name: '' });
-            expect(component.showInputs('identity')).toBe(false);
-        });
-
-        it('should return true when inputName is name and when typeValue equals TOKEN', () => {
-            component.expressionForm.setValue({ type: 'TOKEN', identity: '', name: '' });
-            expect(component.showInputs('name')).toBe(true);
+        ], function(identity: string, outcome: boolean, description: string, input: string) {
+            it('should return true when inputName is name and when identityValue exists and isnt a star', () => {
+                // component.expressionForm.setValue({ type: '', identity: 'something', name: '' });
+                // expect(component.showInputs('name')).toBe(true);
+            });
         });
 
         // tslint:disable-next-line: max-line-length
@@ -103,10 +106,6 @@ describe('PolicyAddMembersComponent', () => {
             expect(component.showInputs('name')).toBe(false);
         });
 
-        // tslint:disable-next-line: max-line-length
-        it('should return false when inputName is name and when type is not TOKEN and identityValue does not exist', () => {
-            component.expressionForm.setValue({ type: 'TEAM', identity: '', name: '' });
-            expect(component.showInputs('name')).toBe(false);
-        });
+ 
     });
 });

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -69,13 +69,16 @@ describe('PolicyAddMembersComponent', () => {
 
         using([
             [{ type: 'team', identity: null, name: null }, 'type', 'team'],
-            [{ type: '*', identity: null, name: null}, 'team', '*'],
+            [{ type: '*', identity: null, name: null}, 'type', '*'],
             [{ type: 'team', identity: 'saml', name: null}, 'identity', 'team:saml'],
             [{ type: 'team', identity: 'saml', name: '*'}, 'identity', 'team:saml:*'],
             [{ type: 'user', identity: 'local', name: null}, 'identity', 'user:local'],
             [{ type: 'user', identity: 'ldap', name: 'square'}, 'name', 'user:ldap:square'],
             [{ type: 'token', identity: null, name: 'whatever'}, 'name', 'token:whatever'],
-            [{ type: 'token', identity: null, name: 'something'}, 'name', 'token:something']
+            [{ type: 'token', identity: null, name: 'something'}, 'name', 'token:something'],
+            [{ type: 'user', identity: null, name: '*'}, 'name', 'user:*'],
+            [{ type: 'team', identity: null, name: '*'}, 'name', 'team:*'],
+            [{ type: 'token', identity: null, name: '*'}, 'name', 'token:*']
         ], function (formValues: {}, inputName: string, output: string) {
             it(`sets expressionOutput to ${output} when formValues are ${formValues} and inputName is ${inputName}`, () => {
                 component.expressionForm.setValue(formValues);

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -4,7 +4,6 @@ import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
-import { Regex } from 'app/helpers/auth/regex';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { runtimeChecks } from 'app/ngrx.reducers';
 import { PolicyAddMembersComponent } from './policy-add-members.component';
@@ -76,7 +75,7 @@ describe('PolicyAddMembersComponent', () => {
             [{ type: 'user', identity: 'local', name: null}, 'identity', 'user:local'],
             [{ type: 'user', identity: 'ldap', name: 'square'}, 'name', 'user:ldap:square'],
             [{ type: 'token', identity: null, name: 'whatever'}, 'name', 'token:whatever'],
-            [{ type: 'token', identity: null, name: 'something'}, 'name', 'token:something'],
+            [{ type: 'token', identity: null, name: 'something'}, 'name', 'token:something']
         ], function (formValues: {}, inputName: string, output: string) {
             it(`sets expressionOutput to ${output} when formValues are ${formValues} and inputName is ${inputName}`, () => {
                 component.expressionForm.setValue(formValues);

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -55,9 +55,9 @@ describe('PolicyAddMembersComponent', () => {
         fixture = TestBed.createComponent(PolicyAddMembersComponent);
         component = fixture.componentInstance;
         component.expressionForm = new FormBuilder().group({
-            type: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
-            identity: [''],
-            name: ['']
+            type: ['', Validators.required],
+            identity: '',
+            name: ''
         });
         fixture.detectChanges();
     });
@@ -66,32 +66,22 @@ describe('PolicyAddMembersComponent', () => {
         expect(component).toBeTruthy();
     });
 
-    describe('showInputs', () => {
-
-        it('should return false when inputName is not identity or name', () => {
-            expect(component.showInputs('blank')).toBe(false);
-        });
+    describe('updateFormDisplay', () => {
 
         using([
-            ['and when typeValue equals user', 'user', 'identity', true],
-            ['and when typeValue equals team', 'team', 'identity', true],
-            ['and typeValue does not equal team or user', '*', 'identity', false],
-            ['and when typeValue equals token', 'token', 'name', true],
-            ['and typeValue is not token and identityValue does not exist', 'team', 'name', false]
-        ], function (description: string, type: string, input: string, outcome: boolean) {
-            it(`returns ${outcome} when inputName is ${input} ${description}`, () => {
-                component.expressionForm.setValue({ type: type, identity: '', name: '' });
-                expect(component.showInputs(input)).toBe(outcome);
-            });
-        });
-
-        using([
-            ['and identityValue exists and isnt a star', 'something', 'name', true],
-            ['and identityValue exists and is a star', '*', 'name', false]
-        ], function (description: string, identity: string, input: string, outcome: boolean) {
-            it(`returns ${outcome} when inputName is ${input} ${description}`, () => {
-                component.expressionForm.setValue({ type: '', identity: identity, name: '' });
-                expect(component.showInputs(input)).toBe(outcome);
+            [{ type: 'team', identity: null, name: null }, 'type', 'team'],
+            [{ type: '*', identity: null, name: null}, 'team', '*'],
+            [{ type: 'team', identity: 'saml', name: null}, 'identity', 'team:saml'],
+            [{ type: 'team', identity: 'saml', name: '*'}, 'identity', 'team:saml:*'],
+            [{ type: 'user', identity: 'local', name: null}, 'identity', 'user:local'],
+            [{ type: 'user', identity: 'ldap', name: 'square'}, 'name', 'user:ldap:square'],
+            [{ type: 'token', identity: null, name: 'whatever'}, 'name', 'token:whatever'],
+            [{ type: 'token', identity: null, name: 'something'}, 'name', 'token:something'],
+        ], function (formValues: {}, inputName: string, output: string) {
+            it(`sets expressionOutput to ${output} when formValues are ${formValues} and inputName is ${inputName}`, () => {
+                component.expressionForm.setValue(formValues);
+                component.updateFormDisplay(inputName);
+                expect(component.expressionOutput).toBe(output);
             });
         });
     });

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -73,23 +73,23 @@ describe('PolicyAddMembersComponent', () => {
         });
 
         using([
-            ['user', true, 'identity and when typeValue equals user', 'identity'],
-            ['team', true, 'identity and when typeValue equals team', 'identity'],
-            ['*', false, 'identity and typeValue does not equal team or user', 'identity'],
-            ['token', true, 'name and when typeValue equals token', 'name'],
-            ['team', false, 'name + typeValue is not token + identityValue does not exist', 'name']
-        ], function (type: string, outcome: boolean, description: string, input: string) {
-            it(`should return ${outcome} when inputName is ${description}`, () => {
+            ['and when typeValue equals user', 'user', 'identity', true],
+            ['and when typeValue equals team', 'team', 'identity', true],
+            ['and typeValue does not equal team or user', '*', 'identity', false],
+            ['and when typeValue equals token', 'token', 'name', true],
+            ['and typeValue is not token and identityValue does not exist', 'team', 'name', false]
+        ], function (description: string, type: string, input: string, outcome: boolean) {
+            it(`returns ${outcome} when inputName is ${input} ${description}`, () => {
                 component.expressionForm.setValue({ type: type, identity: '', name: '' });
                 expect(component.showInputs(input)).toBe(outcome);
             });
         });
 
         using([
-            ['something', true, 'name and when identityValue exists and isnt a star', 'name'],
-            ['*', false, 'name and when identityValue exists and is a star', 'name']
-        ], function(identity: string, outcome: boolean, description: string, input: string) {
-            it(`should return ${outcome} when inputName is ${description}`, () => {
+            ['and identityValue exists and isnt a star', 'something', 'name', true],
+            ['and identityValue exists and is a star', '*', 'name', false]
+        ], function (description: string, identity: string, input: string, outcome: boolean) {
+            it(`returns ${outcome} when inputName is ${input} ${description}`, () => {
                 component.expressionForm.setValue({ type: '', identity: identity, name: '' });
                 expect(component.showInputs(input)).toBe(outcome);
             });

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -6,7 +6,6 @@ import { MockComponent } from 'ng2-mock-component';
 
 import { Regex } from 'app/helpers/auth/regex';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
-import { customMatchers } from 'app/testing/custom-matchers';
 import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
 import { runtimeChecks } from 'app/ngrx.reducers';
 import { PolicyAddMembersComponent } from './policy-add-members.component';
@@ -51,7 +50,6 @@ describe('PolicyAddMembersComponent', () => {
     }));
 
     beforeEach(() => {
-        jasmine.addMatchers(customMatchers);
         fixture = TestBed.createComponent(PolicyAddMembersComponent);
         component = fixture.componentInstance;
         component.expressionForm = new FormBuilder().group({

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -93,6 +93,38 @@ describe('PolicyAddMembersComponent', () => {
             expect(component.showInputs('name')).toBe(true);
         });
 
+        // tslint:disable-next-line: max-line-length
+        it('should return true when inputName is name and when identityValue exists and isnt a star', () => {
+            component.expressionForm.setValue({ type: '', identity: 'something', name: '' });
+            expect(component.showInputs('name')).toBe(true);
+        });
+
+        // tslint:disable-next-line: max-line-length
+        it('should return false when inputName is name and when identityValue exists and is a star', () => {
+            component.expressionForm.setValue({ type: '', identity: '*', name: '' });
+            expect(component.showInputs('name')).toBe(false);
+        });
+
+        // tslint:disable-next-line: max-line-length
+        it('should return false when inputName is name and when type is not TOKEN and identityValue does not exist', () => {
+            component.expressionForm.setValue({ type: 'TEAM', identity: '', name: '' });
+            expect(component.showInputs('name')).toBe(false);
+        });
+
     });
+
+    describe('updateValidations', () => {
+        beforeEach(() => {
+          component.expressionForm.setValue({ type: 'TEAM', identity: 'LOCAL', name: '' });
+        })
+
+        it('clears validators when input is not active', () => {
+
+        })
+
+        it('applies validators when input is active', () => {
+
+        })
+    })
 
 });

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -66,13 +66,33 @@ describe('PolicyAddMembersComponent', () => {
         expect(component).toBeTruthy();
     });
 
-    it('contains key elements', () => {
-        component.loading = false;
-        component.modalVisible = true;
-        component.sortedMembersAvailable = [];
-        fixture.detectChanges();
-        // expect(element).toContainPath('chef-modal');
-        expect(element).toContainPath('chef-page');
+    describe('showInputs', () => {
+
+        it('should return false when inputName is not identity or name', () => {
+            expect(component.showInputs('blank')).toBe(false);
+        });
+
+        it('should return true when inputName is identity and when typeValue equals USER', () => {
+            component.expressionForm.setValue({type: 'USER', identity: '', name: ''});
+            expect(component.showInputs('identity')).toBe(true);
+        });
+
+        it('should return true when inputName is identity and when typeValue equals TEAM', () => {
+            component.expressionForm.setValue({ type: 'TEAM', identity: '', name: '' });
+            expect(component.showInputs('identity')).toBe(true);
+        });
+
+        // tslint:disable-next-line: max-line-length
+        it('should return false when inputName is identity and typeValue does not equal TEAM or USER', () => {
+            component.expressionForm.setValue({ type: '*', identity: '', name: '' });
+            expect(component.showInputs('identity')).toBe(false);
+        });
+
+        it('should return true when inputName is name and when typeValue equals TOKEN', () => {
+            component.expressionForm.setValue({ type: 'TOKEN', identity: '', name: '' });
+            expect(component.showInputs('name')).toBe(true);
+        });
+
     });
 
 });

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -86,26 +86,13 @@ describe('PolicyAddMembersComponent', () => {
         });
 
         using([
-
+            ['something', true, 'name and when identityValue exists and isnt a star', 'name'],
+            ['*', false, 'name and when identityValue exists and is a star', 'name']
         ], function(identity: string, outcome: boolean, description: string, input: string) {
-            it('should return true when inputName is name and when identityValue exists and isnt a star', () => {
-                // component.expressionForm.setValue({ type: '', identity: 'something', name: '' });
-                // expect(component.showInputs('name')).toBe(true);
+            it(`should return ${outcome} when inputName is ${description}`, () => {
+                component.expressionForm.setValue({ type: '', identity: identity, name: '' });
+                expect(component.showInputs(input)).toBe(outcome);
             });
         });
-
-        // tslint:disable-next-line: max-line-length
-        it('should return true when inputName is name and when identityValue exists and isnt a star', () => {
-            component.expressionForm.setValue({ type: '', identity: 'something', name: '' });
-            expect(component.showInputs('name')).toBe(true);
-        });
-
-        // tslint:disable-next-line: max-line-length
-        it('should return false when inputName is name and when identityValue exists and is a star', () => {
-            component.expressionForm.setValue({ type: '', identity: '*', name: '' });
-            expect(component.showInputs('name')).toBe(false);
-        });
-
- 
     });
 });

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -6,12 +6,9 @@ import { MockComponent } from 'ng2-mock-component';
 
 import { Regex } from 'app/helpers/auth/regex';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
-import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
 import { runtimeChecks } from 'app/ngrx.reducers';
 import { PolicyAddMembersComponent } from './policy-add-members.component';
 import { using } from 'app/testing/spec-helpers';
-
-
 
 
 
@@ -43,7 +40,12 @@ describe('PolicyAddMembersComponent', () => {
                 ReactiveFormsModule,
                 RouterTestingModule,
                 StoreModule.forRoot({
-                    policies: policyEntityReducer
+                    router: () => ({
+                        state: {
+                            url: '/settings/policies/editor-access/add-members',
+                            params: {}
+                        }
+                    })
                 }, { runtimeChecks })
             ]
         }).compileComponents();

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -8,8 +8,8 @@ import { Regex } from 'app/helpers/auth/regex';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { customMatchers } from 'app/testing/custom-matchers';
 import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
+import { runtimeChecks } from 'app/ngrx.reducers';
 import { PolicyAddMembersComponent } from './policy-add-members.component';
-// import { using } from 'rxjs';
 import { using } from 'app/testing/spec-helpers';
 
 
@@ -45,7 +45,7 @@ describe('PolicyAddMembersComponent', () => {
                 RouterTestingModule,
                 StoreModule.forRoot({
                     policies: policyEntityReducer
-                })
+                }, { runtimeChecks })
             ]
         }).compileComponents();
     }));

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -108,20 +108,5 @@ describe('PolicyAddMembersComponent', () => {
             component.expressionForm.setValue({ type: 'TEAM', identity: '', name: '' });
             expect(component.showInputs('name')).toBe(false);
         });
-
     });
-
-    describe('updateValidations', () => {
-
-        it('clears validators when input is not active', () => {
-          component.expressionForm.setValue({ type: 'TEAM', identity: '', name: '' });
-        //   create spy here i think
-        //   expect(component.updateValidations('identity', false))
-        });
-
-        it('applies validators when input is active', () => {
-
-        });
-    });
-
 });

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -116,15 +116,15 @@ describe('PolicyAddMembersComponent', () => {
     describe('updateValidations', () => {
         beforeEach(() => {
           component.expressionForm.setValue({ type: 'TEAM', identity: 'LOCAL', name: '' });
-        })
+        });
 
         it('clears validators when input is not active', () => {
 
-        })
+        });
 
         it('applies validators when input is active', () => {
 
-        })
-    })
+        });
+    });
 
 });

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -6,10 +6,8 @@ import { MockComponent } from 'ng2-mock-component';
 
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { runtimeChecks } from 'app/ngrx.reducers';
-import { PolicyAddMembersComponent } from './policy-add-members.component';
+import { PolicyAddMembersComponent, FieldName } from './policy-add-members.component';
 import { using } from 'app/testing/spec-helpers';
-
-type FieldName = 'type' | 'identity' | 'name';
 
 describe('PolicyAddMembersComponent', () => {
     let component: PolicyAddMembersComponent;

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.spec.ts
@@ -9,7 +9,7 @@ import { runtimeChecks } from 'app/ngrx.reducers';
 import { PolicyAddMembersComponent } from './policy-add-members.component';
 import { using } from 'app/testing/spec-helpers';
 
-
+type FieldName = 'type' | 'identity' | 'name';
 
 describe('PolicyAddMembersComponent', () => {
     let component: PolicyAddMembersComponent;
@@ -58,7 +58,6 @@ describe('PolicyAddMembersComponent', () => {
             identity: '',
             name: ''
         });
-        fixture.detectChanges();
     });
 
     it('should be created', () => {
@@ -79,7 +78,7 @@ describe('PolicyAddMembersComponent', () => {
             [{ type: 'user', identity: null, name: '*'}, 'name', 'user:*'],
             [{ type: 'team', identity: null, name: '*'}, 'name', 'team:*'],
             [{ type: 'token', identity: null, name: '*'}, 'name', 'token:*']
-        ], function (formValues: {}, inputName: string, output: string) {
+        ], function (formValues: {}, inputName: FieldName, output: string) {
             it(`sets expressionOutput to ${output} when formValues are ${formValues} and inputName is ${inputName}`, () => {
                 component.expressionForm.setValue(formValues);
                 component.updateFormDisplay(inputName);


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Currently, the member expression builder consists of a single text input, where the user must consult documentation in order to correctly input a member expression.  This branch updates the user experience of this modal so that the user is guided through the building of the member expression one step at a time.

### :chains: Related Resources

### :+1: Definition of Done
User is stepped through the member expression builder modal.
`Add Expression` button is disabled unless formatting is acceptable
Errors fire when the member expression is already being used
Documentation is updated

### :athletic_shoe: How to Build and Test the Change

build components/automate-ui-devproxy && start_all_services
Navigate to https://a2-dev.test/settings/policies/editor-access/add-members
Click on `Add Member Expression` in bottom left corner
Build Member expression step by step --> click add `Add Expression` when enabled

### :white_check_mark: Checklist

- [x] Tests added/updated?

It was determined that the Docs do not need to be updated at this time
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
Before:
![MemberExpression-Before](https://user-images.githubusercontent.com/16737484/66014822-22f86c00-e485-11e9-9cd8-2aca85e4d6c6.gif)

After:
![MemberExpressionDialog-After](https://user-images.githubusercontent.com/16737484/67232262-d5bd4980-f3f5-11e9-88b0-66efcd23aa57.gif)

