### PR TITLE
es-sidecar-service: remove custom linter args

### DIFF
--- a/components/es-sidecar-service/Makefile
+++ b/components/es-sidecar-service/Makefile
@@ -1,5 +1,4 @@
 include ../../Makefile.common_go
-LINTERARGS=-D lll ./... ../../api/config/es-sidecar-service/...
 PROJECT=es-sidecar-service
 ORG_PATH=github.com/chef/automate/components
 PACKAGE_PATH = $(ORG_PATH)/es-sidecar-service


### PR DESCRIPTION
These don't appear to be necessary and removing them helps us keep the
various projects a bit more consistent.

Signed-off-by: Steven Danna <steve@chef.io>