### PR TITLE
protos: bump guard for protoc version

### DIFF
--- a/api/config/scripts/grpc.sh
+++ b/api/config/scripts/grpc.sh
@@ -2,7 +2,7 @@
 set -e
 
 protoc_repo=github.com/golang/protobuf/protoc-gen-go
-protoc_version="3.6.1"
+protoc_version="3.9.2"
 
 [[ $(type -P "protoc") ]] || (echo "unable to proceed. protobuf is not installed" && exit 1)
 protoc --version | grep -q $protoc_version  || (echo "unable to proceed. protobuf must be version $protoc_version" && exit 1)

--- a/components/automate-deployment/scripts/grpc.sh
+++ b/components/automate-deployment/scripts/grpc.sh
@@ -4,7 +4,7 @@ set -e
 # shellcheck disable=SC2043
 
 protoc_repo=github.com/golang/protobuf/protoc-gen-go
-protoc_version="3.6.1"
+protoc_version="3.9.2"
 
 [[ $(type -P "protoc") ]] || (echo "unable to proceed. protobuf is not installed" && exit 1)
 [[ $(protoc --version | grep $protoc_version) ]] || (echo "unable to proceed. protobuf must be version $protoc_version" && exit 1)


### PR DESCRIPTION
This bumps the protoc version guard to the latest available via
Habitat.  Rebuilding all protos with the version produced no changes.

Signed-off-by: Steven Danna <steve@chef.io>