### PR TITLE
Turn off periodic test during integration test to reduce flakiness

### DIFF
--- a/components/applications-service/integration_test/disconnected_services_job_test.go
+++ b/components/applications-service/integration_test/disconnected_services_job_test.go
@@ -23,6 +23,10 @@ func TestPeriodicDisconnectedServices(t *testing.T) {
 	err := suite.JobScheduler.ResetParams()
 	require.NoError(t, err)
 
+	// Re-enable
+	suite.JobScheduler.EnableDisconnectedServicesJob(ctx)
+	defer suite.JobScheduler.DisableDisconnectedServicesJob(ctx)
+
 	// We can only start the job runners with cereal once so we do it here.
 	runners := server.NewJobRunnerSet(suite.ApplicationsServer)
 	err = runners.Start(suite.JobScheduler.CerealSvc)

--- a/components/applications-service/integration_test/suite_test.go
+++ b/components/applications-service/integration_test/suite_test.go
@@ -6,6 +6,7 @@
 package integration_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -132,10 +133,16 @@ func NewSuite(database string) *Suite {
 func (s *Suite) GlobalSetup() {
 	// Make sure our database is empty for our integration tests
 	s.DeleteDataFromStorage()
+	// Turn off the periodic job so that it doesn't interfere with tests
+	// This could be causing flaky tests
+	s.JobScheduler.DisableDisconnectedServicesJob(context.Background())
 }
 
 // GlobalTeardown tear everything down after finishing executing all our test suite
 func (s *Suite) GlobalTeardown() {
+	// Re-enable the periodic job so we can continue with business as usual.
+	// This is a mandatory job and should always be running (except for testing)
+	s.JobScheduler.EnableDisconnectedServicesJob(context.Background())
 }
 
 // DeleteDataFromStorage will drop the entire database, you can use this function

--- a/components/applications-service/pkg/server/periodic.go
+++ b/components/applications-service/pkg/server/periodic.go
@@ -237,6 +237,29 @@ func (j *JobScheduler) DisableDeleteDisconnectedServicesJob(ctx context.Context)
 
 }
 
+func (j *JobScheduler) EnableDisconnectedServicesJob(ctx context.Context) error {
+	err := j.CerealSvc.UpdateWorkflowScheduleByName(
+		ctx,
+		DisconnectedServicesScheduleName, DisconnectedServicesJobName,
+		cereal.UpdateEnabled(true))
+	if err != nil {
+		return errors.Wrap(err, "failed to set disconnected_services job to enabled")
+	}
+	return nil
+}
+
+func (j *JobScheduler) DisableDisconnectedServicesJob(ctx context.Context) error {
+	err := j.CerealSvc.UpdateWorkflowScheduleByName(
+		ctx,
+		DisconnectedServicesScheduleName, DisconnectedServicesJobName,
+		cereal.UpdateEnabled(false))
+	if err != nil {
+		return errors.Wrap(err, "failed to set disconnected_services job to disabled")
+	}
+	return nil
+
+}
+
 // RunAllJobsConstantly sets all the jobs to run every 1 second. Intended for
 // use in testing scenarios.
 func (j *JobScheduler) RunAllJobsConstantly(ctx context.Context) error {


### PR DESCRIPTION
We have seen some flakey tests around disconnected services within
the applications service, it is suspected that the periodic job that always
runs is interfereing with the tests every once in a while.

The mark disconnected services periodic job is a mandatory job,
but we can turn it off before and after running integration tests during the
suite setup. Then we turn it on for testing the periodic jobs again.

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

There is no way to test this, we just keep an eye out for failing tests over the next week or so. 

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable