### PR TITLE
fix funcs so that they don't shadow variables that are returned

### DIFF
--- a/components/compliance-service/reporting/relaxting/depth.go
+++ b/components/compliance-service/reporting/relaxting/depth.go
@@ -110,12 +110,13 @@ func getDeepControlsSums(hit *elastic.SearchHit,
 				for _, profileHit := range innerHit.Hits.Hits {
 					var profile ProfileSource
 					if profileHit.Source != nil {
-						err := json.Unmarshal(*profileHit.Source, &profile)
+						err = json.Unmarshal(*profileHit.Source, &profile)
 						if err == nil {
 							if queryInfo.level == ControlLevel {
-								return getControlLevelControlSums(profileHit)
+								nodeControlSummary, status, err = getControlLevelControlSums(profileHit)
 							} else {
-								return profile.ControlsSums, profile.Status, nil
+								nodeControlSummary = profile.ControlsSums
+								status = profile.Status
 							}
 						}
 					}
@@ -123,7 +124,7 @@ func getDeepControlsSums(hit *elastic.SearchHit,
 			}
 		}
 	}
-	return nodeControlSummary, status, nil
+	return
 }
 
 func getControlLevelControlSums(hit *elastic.SearchHit) (nodeControlSummary reporting.NodeControlSummary,
@@ -134,7 +135,7 @@ func getControlLevelControlSums(hit *elastic.SearchHit) (nodeControlSummary repo
 				for _, controlHit := range innerHit.Hits.Hits {
 					var control ControlSource
 					if controlHit.Source != nil {
-						err := json.Unmarshal(*controlHit.Source, &control)
+						err = json.Unmarshal(*controlHit.Source, &control)
 						if err == nil {
 							// this is for one node and since this control should only be in this profile once, it's
 							// reasonable to list it with a cardinality of 1
@@ -153,7 +154,7 @@ func getControlLevelControlSums(hit *elastic.SearchHit) (nodeControlSummary repo
 								nodeControlSummary.Skipped.Total = 1
 							}
 							nodeControlSummary.Total = 1
-							return nodeControlSummary, control.Status, nil
+							status = control.Status
 						}
 					}
 				}
@@ -171,20 +172,15 @@ func getDeepInspecProfiles(hit *elastic.SearchHit,
 				for _, profileHit := range innerHit.Hits.Hits {
 					var profile ESInSpecReportProfile
 					if profileHit.Source != nil {
-						err := json.Unmarshal(*profileHit.Source, &profile)
+						err = json.Unmarshal(*profileHit.Source, &profile)
 						if err == nil {
 							if queryInfo.level == ControlLevel {
-								controls, status, err := getControlLevelControls(profileHit)
-								if err != nil {
-									return profiles, status, err
-								}
-								profile.Controls = controls
+								profile.Controls, status, err = getControlLevelControls(profileHit)
 								profile.Status = status
 								profiles = append(profiles, profile)
-								return profiles, status, err
 							} else {
 								profiles = append(profiles, profile)
-								return profiles, profile.Status, nil
+								status = profile.Status
 							}
 						}
 					}
@@ -192,7 +188,7 @@ func getDeepInspecProfiles(hit *elastic.SearchHit,
 			}
 		}
 	}
-	return profiles, status, nil
+	return
 }
 
 func getControlLevelControls(hit *elastic.SearchHit) (controls []ESInSpecReportControl, status string, err error) {
@@ -203,7 +199,7 @@ func getControlLevelControls(hit *elastic.SearchHit) (controls []ESInSpecReportC
 				for _, controlHit := range innerHit.Hits.Hits {
 					var control ESInSpecReportControl
 					if controlHit.Source != nil {
-						err := json.Unmarshal(*controlHit.Source, &control)
+						err = json.Unmarshal(*controlHit.Source, &control)
 						if err == nil {
 							status = control.Status
 							controls = append(controls, control)
@@ -213,5 +209,5 @@ func getControlLevelControls(hit *elastic.SearchHit) (controls []ESInSpecReportC
 			}
 		}
 	}
-	return controls, status, err
+	return
 }


### PR DESCRIPTION
Signed-off-by: Rick Marry <rmarry@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
This change fixes funcs with naked returns which, at times, shadow the variables before returning

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable