### PR TITLE
lib/datalifecycle: w.Fail always needs to be returned

### DIFF
--- a/lib/datalifecycle/purge/workflow.go
+++ b/lib/datalifecycle/purge/workflow.go
@@ -125,7 +125,7 @@ func (s *Workflow) OnStart(w cereal.WorkflowInstance, _ cereal.StartEvent) cerea
 
 	err = w.EnqueueTask(taskName, policies)
 	if err != nil {
-		w.Fail(err)
+		return w.Fail(err)
 	}
 
 	return w.Continue(nil)


### PR DESCRIPTION
Signed-off-by: Steven Danna <steve@chef.io>
