### PR TITLE
Reconfigure node sidebar to cut out API call

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.html
@@ -77,7 +77,7 @@
       <chef-td>
         <chef-button secondary caution
           *ngIf="node.status === 'unreachable'"
-          (click)="onNodeResultsShow($event, node.id)">
+          (click)="onNodeResultsShow(node.id)">
           Error
         </chef-button>
         <chef-button label="edit" secondary
@@ -107,7 +107,7 @@
     <chef-icon class="header-icon">equalizer</chef-icon>
     <div class="header-text">
       <h4><strong>Connectivity error for node:</strong></h4>
-      <p>{{ (nodeDetail$ | async)?.id }}</p>
+      <p>{{ failedNode?.id }}</p>
     </div>
     <chef-button secondary (click)="onNodeResultsHide($event)">
       <chef-icon>close</chef-icon>
@@ -115,10 +115,10 @@
   </div>
   <div class="side-panel-body">
     <div class="side-panel-body-header">
-      <p>Status: {{ (nodeDetail$ | async)?.status }}</p>
+      <p>Status: {{ failedNode?.status }}</p>
     </div>
     <div class="side-panel-body-detail">
-      <pre>{{ (nodeDetail$ | async)?.last_job?.result || (nodeDetail$ | async)?.connection_error }}</pre>
+      <pre>{{ failedNode?.last_job?.result || failedNode?.connection_error }}</pre>
     </div>
   </div>
 </chef-side-panel>

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.ts
@@ -29,6 +29,8 @@ export class NodesListComponent implements OnInit, OnDestroy {
 
   showNodeResults = false;
 
+  failedNode: object;
+
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
   ngOnInit(): void {
@@ -79,13 +81,19 @@ export class NodesListComponent implements OnInit, OnDestroy {
     this.router.navigate([], {queryParams});
   }
 
-  onNodeResultsShow(_event, id) {
+  onNodeResultsShow(id: string): void {
     this.showNodeResults = true;
-    this.store.dispatch(actions.getNode(id));
+
+    this.nodesList.items.map(node => {
+      if ( node.id === id ) {
+        this.failedNode = node;
+      }
+    });
   }
 
   onNodeResultsHide(_event) {
     this.showNodeResults = false;
+    this.failedNode = null;
   }
 
   trackBy(index, _item) {

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.ts
@@ -29,7 +29,7 @@ export class NodesListComponent implements OnInit, OnDestroy {
 
   showNodeResults = false;
 
-  failedNode: Object;
+  failedNode: { [key: string]: any };
 
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.ts
@@ -29,7 +29,7 @@ export class NodesListComponent implements OnInit, OnDestroy {
 
   showNodeResults = false;
 
-  failedNode: object;
+  failedNode: Object;
 
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
A now unnecessary API call was being made when a user looked at their failed
node information in the sidebar.  Now that the information is already available
we can snag that same information from an object that already exists on initialization of the component.

A new public variable was added to store the selected failed node information when the user clicks on the `Error` button from the Scan Jobs List.  The Sidebar now reads information from this failed node variable instead.

### :chains: Related Resources

### :+1: Definition of Done
Extra API Call removed from UI when looking at failed node information.

### :athletic_shoe: How to Build and Test the Change
1. build components/automate-ui-devproxy
2. Navigate to https://a2-dev.test/compliance/scan-jobs/nodes?page=1
( You may need to Add Nodes to scan - any basic bad info will do)
3. Open devtools and inspect the network tab.
4. Click on `Error` button.  Find that no API call is made upon viewing the failed node.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
Before:  (Note: `search` is an unrelated api call made every 5 seconds)
<img width="1252" alt="Before" src="https://user-images.githubusercontent.com/16737484/66169202-7a691a00-e5f4-11e9-9e00-be6364e0e021.png">

After: 
<img width="1250" alt="After" src="https://user-images.githubusercontent.com/16737484/66169205-7ccb7400-e5f4-11e9-8866-23377ac5bd4d.png">
