### PR TITLE
event-service: fix minor lint violations

### DIFF
--- a/components/event-service/cmd/event-service/commands/serve.go
+++ b/components/event-service/cmd/event-service/commands/serve.go
@@ -5,13 +5,14 @@ import (
 
 	"fmt"
 
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/chef/automate/components/event-service/config"
 	"github.com/chef/automate/components/event-service/nats"
 	"github.com/chef/automate/components/event-service/server"
 	"github.com/chef/automate/lib/tracing"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 func newServeCmd() *cobra.Command {
@@ -36,7 +37,7 @@ func newServeCmd() *cobra.Command {
 
 			closer, err := tracing.NewGlobalTracer("event-service")
 			if err != nil {
-				errors.Wrap(err, "starting tracer for event-service")
+				return errors.Wrap(err, "starting tracer for event-service")
 			}
 			if closer != nil {
 				defer tracing.CloseQuietly(closer)

--- a/components/event-service/nats/server.go
+++ b/components/event-service/nats/server.go
@@ -10,7 +10,7 @@ import (
 
 	natsd "github.com/nats-io/gnatsd/server"
 	"github.com/nats-io/go-nats"
-	streamd "github.com/nats-io/nats-streaming-server/server"
+	streamd "github.com/nats-io/nats-streaming-server/server" // nolint: misspell
 	stores "github.com/nats-io/nats-streaming-server/stores"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"


### PR DESCRIPTION
This service doesn't have any unit/static tests so I haven't
integrated the linter, but I noticed that there were only a couple of
violations using our current linter configuration and they were mostly
in test code so they were pretty low risk to fix.

Signed-off-by: Steven Danna <steve@chef.io>