### PR TITLE
[automate-825] IAM v2 Reference Doc Updates

### DIFF
--- a/components/automate-chef-io/content/docs/iam-v2-api-reference.md
+++ b/components/automate-chef-io/content/docs/iam-v2-api-reference.md
@@ -10,60 +10,82 @@ toc = true
     weight = 30
 +++
 
-This guide shows you how to manage Chef Automate IAM v2 policies and roles from the command line.
+This API reference details Chef Automate IAM v2 features from the command line.
+If you are not already on IAM v2, see the [IAM v2 User's Guide]({{< relref "iam-v2-guide.md#upgrade-to-iam-v2" >}}) to upgrade.
 Any command with a browser equivalent includes brief directions for locating it on the corresponding page.
 See the [IAM v2 Overview]({{< relref "iam-v2-overview.md" >}}) for an overview and exposition of new concepts.
 See the [IAM v2 User's Guide]({{< relref "iam-v2-guide.md" >}}) for more information on setting up and using IAM v2 features.
 
-## Prerequisites
+## General Notes
 
-1. Upgrade to IAM v2 using the [IAM v2 User's Guide]({{< relref "iam-v2-guide.md#upgrade-to-iam-v2" >}}).
-
-2. _Optional_ Install the [jq](https://stedolan.github.io/jq/) JSON processor to ensure readable output.
-
-3. Generate a new admin token for IAM v2.
-   (The v1 command `chef-automate admin-token` will not work for v2, though any existing v1 admin tokens will still work.) Use:
+1. If you do not have one already, generate an admin token for IAM v2.
+   (Neither The v1 command `chef-automate admin-token` nor any v1 admin tokens will work for v2.)
+   Use this, filling in a token name of your choice:
 
    ```bash
-   export TOKEN=`chef-automate iam token create TEST_ADMIN --admin`
+   export TOKEN=`chef-automate iam token create <your-token-name-here> --admin`
    ```
+
+2. URIs are relative to `https://<your-domain-here>/apis/iam/v2beta`, unless otherwise noted.
+
+3. Attach the `?pretty` query string to an endpoint to get pretty-printed output.
+
+Putting it all together with the `/policies` endpoint as an example, this command fetches the list of policies with multi-line, formatted output:
+
+```bash
+curl -sH "api-token: $TOKEN" \
+  https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies?pretty
+```
+
+For those API methods that take JSON data (typically `create` and `update` methods)
+you can provide that data to the REST endpoint in a variety of ways.
+If it is a relatively small size payload, you can include it in a `curl` command inline, e.g.
+
+```bash
+curl -sH "api-token: $TOKEN" -d '<your JSON here>' ...
+```
+
+If the payload is larger, it is often convenient to store it in a file, then pass that file, e.g.,
+
+```bash
+curl -sH "api-token: $TOKEN" -d @policy.json ...
+```
+
+## Notes on the Projects Property
+
+Teams, tokens, roles, and policies all contain a top-level `projects` property; you will see that in the example JSON for each resource in the following sections.
+This property associates the particular IAM resource with one or more projects.
+Users must have permissions for those projects to be able to view or modify those resources.
+This `projects` property may be empty, which would give access only to users included on policies specifying the special `(unassigned)` project designation.
+This `projects` property may **not** specify `*` to indicate all projects.
+
+To create those permissions for users, there is a separate and distinct `projects` property on each policy statement.
+This `projects` property may **not** be empty; you must either specify specific projects or use a wildcard (`*`) to indicate all projects.
+
+Here is a summary:
+
+Type               | May be empty ? | Include * ? | May specify (unassigned) ?
+-------------------|----------------|-------------|------------
+top-level projects |    yes         |   no        |  no
+statement projects |    no          |   yes       |  yes
 
 ## Policies
 
-### Listing Policies
+Method | HTTP request              | Description
+-------|---------------------------|------------
+list   | GET /policies             | lists both *Chef-managed* and *Custom* policies
+get    | GET /policies/***id***    | gets the specified policy
+create | POST /policies            | creates a *Custom* policy
+update | PUT /policies/***id***    | updates a *Custom* policy
+delete | DELETE /policies/***id*** | deletes a *Custom* policy
 
-```bash
-curl -s -H "api-token: $TOKEN" https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies?pretty
-```
+**Example Policy:**
 
-The output includes both `Chef-managed` and `custom` policies.
-Policies migrated from IAM v1 are included as `custom` policies.
-Policy names that begin with `[Legacy]` are default policies migrated from v1.
-We recommend deleting these legacy policies and setting up new IAM v2 policies in their place.
-
-In the browser: Navigate to the *Policies* page under the **Settings**  tab.
-
-### Getting a Policy
-
-In order to fetch a policy on the command-line, you must know its ID.
-This may be obtained by first fetching the list of all policies; see [Listing Policies]({{< relref "iam-v2-api-reference.md#listing-policies" >}}).
-Find the `id` field for the policy of interest--for example, the ID from the default administrator policy is `administrator-access`.
-Plug that in to the URL as shown:
-
-```bash
-curl -s -H "api-token: $TOKEN" https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/administrator-access?pretty
-```
-
-In the browser: Navigate to the *Policies* page under the **Settings**  tab, and then select an individual policy to open its details.
-
-### Creating a Policy
-
-Create a policy by composing JSON with all the necessary policy data.
-
-This example policy is made up of two statements, each enforcing a different set of permissions.
-The first policy statement grants users list view access.
-The second statement grants editor access via the `editor` role.
-You can see the actions contained in the `editor` role in the [Roles section]({{< relref "iam-v2-api-reference.md#roles" >}}).
+This policy shows two statements, each enforcing a different set of permissions.
+The first policy statement grants list access to view users.
+The second statement grants access to all the actions comprising the `editor` role.
+Note that you may specify actions either inline with **actions** or using a **role** reference.
+(Within a single statement it is even OK to use both if you like; the set of actions is the union of the inline actions and the actions defined by the role.)
 
 ```json
 {
@@ -74,211 +96,366 @@ You can see the actions contained in the `editor` role in the [Roles section]({{
     {
       "effect": "ALLOW",
       "actions": [
-        "iam:users:list"
-      ]
+        "iam:users:list",
+        "iam:users:get"
+      ],
+      "projects": [
+        "*"
+      ],
     },
     {
       "effect": "ALLOW",
       "role": "editor"
     }
+  ],
+  "projects": [
+    "admin-group-1",
+    "it-support",
   ]
 }
 ```
 
-Assuming you stored the above JSON in the file "policy.json", pass it to `curl` to create the policy:
+### Listing Policies
 
-```bash
-curl -s -H "api-token: $TOKEN" -d @policy.json https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies?pretty
-```
+The output includes both *Chef-managed* and *Custom* policies.
+Policies migrated from IAM v1 are included as *Custom* policies.
+Policy names that begin with `[Legacy]` are default policies migrated from v1.
+We recommend deleting these legacy policies and setting up new IAM v2 policies in their place.
+
+*In the browser:* **Settings**  >> **Policies**
+
+### Getting a Policy
+
+In order to fetch a policy on the command-line, you must know its ID.
+This may be obtained by first fetching the list of all policies and getting the `id` field of the policy of interest.
+For example, the ID for the default administrator policy is `administrator-access`.
+
+*In the browser:* **Settings**  >> **Policies** >> [select a policy]
+
+### Creating a Policy
+
+Create a policy by composing JSON with all the necessary policy properties (see the beginning of the section above).
 
 ### Updating a Policy
 
-In the IAM beta, policies must be updated from the command line.
-
 * You can modify the *membership* of both Chef-managed and custom policies; see [Policy Membership]({{< relref "iam-v2-api-reference.md#policy-membership" >}}) for more information.
 * You can modify the *definition* of custom policies but not Chef-managed policies.
-* You can change the policy name, members, or statements, but you cannot change the policy ID.
-* Modifying any part of a policy resets *all* of its properties.
-  Properties that aren't included in the command are reset to empty values.
-  Thus, you must supply all of a policy's properties, not just the ones you wish to update.
-
-In order to update a policy, you must know its ID.
-Use the command from [Listing Policies]({{< relref "iam-v2-api-reference.md#listing-policies" >}}) to locate your policy ID.
-
-The simplest way to pass a policy is by storing it in a file; we used a sample `policy.json` in the previous section.
-To update that policy you still need to pass in the complete policy definition--plus its members--just as you did when creating it; any omitted properties will be erased from the policy!
-
-As an example, to update the example policy to keep the first policy statement allowing users list-access, while removing `editor` access, edit your `policy.json` file:
-
-```json
-{
-  "name": "Test Policy",
-  "id": "test-policy-1",
-  "members": ["team:local:alpha","team:ldap:beta"],
-  "statements": [
-    {
-      "effect": "ALLOW",
-      "actions": [
-        "iam:users:list"
-      ]
-    }
- ]
-}
-```
-
-To update your policy, replace the last component of the path in the command with the ID of the target policy.
-
-```bash
-curl -s -H "api-token: $TOKEN" -d @policy.json -X PUT https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}?pretty
-```
-
-You can also make the change specifying the data inline:
-
-```bash
-curl -s -H "api-token: $TOKEN" -d '{"name":"Test Policy", "id":"test-policy", "members":["team:local:alpha","team:ldap:beta"], "statements": [{"actions": [ "iam:users:list"], "effect": "ALLOW"}]}' -X PUT https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}?pretty
-```
-
-### Policy Membership
-
-Chef Automate supports two methods for updating policy membership.
-
-Using PUT lets you **set** membership for the entire policy; see [Setting Policy Membership]({{< relref "iam-v2-api-reference.md#setting-policy-membership" >}}).
-
-Using POST lets you add members to (or remove members from) an existing membership list.
-For more information, see [Adding Members to Policies]({{< relref "iam-v2-api-reference.md#adding-members-to-policies" >}}) and [Removing Members from Policies]({{< relref "iam-v2-api-reference.md#removing-members-from-policies" >}}).
-
-#### Setting Policy Membership
-
-From the command line, specifying a complete list of members is often simpler than keeping track of a policy's membership and adding or deleting specific members (whether users, team, or tokens).
-This command *replaces* the policy's membership.
-
-```bash
-curl -s -H "api-token: $TOKEN" -X PUT -d '{"members":["team:local:admins","token:admin-token"]}' https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}/members?pretty
-```
-
-#### Adding Members to Policies
-
-The `POST` operation adds new members to the existing set of members, rather than replacing it, so you only need to supply the new members. Building on the previous example, after using this command, the policy membership includes the `admins` team, a token, and the `editors` team.
-The `members` property must be an array argument, even if supplying only one member.
-Note that both the HTTP method (PUT above and POST here) and the URL are different than the command used for [setting policy membership]({{< relref "iam-v2-api-reference.md#setting-policy-membership" >}}).
-
-```bash
-curl -s -H "api-token: $TOKEN" -X POST -d '{"members":["team:local:editors"]}' https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}/members:add?pretty
-```
-
-In the browser: Navigate to the *Policies* page under the **Settings** tab. and select an individual policy to open its detail view.
-Select the **Members** to view the current membership.
-Use the **Add Members** button to open a list of candidate members.
-Select any members that should be added to the policy.
-Use the **Add # Members** button to complete the operation.
-
-#### Removing Members from Policies
-
-This example removes the `team:local:admins` team from the policy.
-(The removed member still exists within Chef Automate, but no longer has the permissions derived from this policy.)
-Note that the `members` property must be an array argument, even if only supplying one member.
-
-```bash
-curl -s -H "api-token: $TOKEN" -X POST -d '{"members":["team:local:admins"]}' https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}/members:remove?pretty
-```
-
-In the browser: Navigate to the *Policies* page under the **Settings** tab., and then select an individual policy to open its detail view.
-Select its **Members** tab to view the current membership.
-Identify the member you wish to remove from the policy, open the menu at the end of its row, and then select the **Remove Member** option.
+* The policy ID is immutable; it can only be set at creation time.
+* The update operation modifies *all* policy properties, not just the ones you specify.
+  Properties that you do not specify are reset to empty values.
+  Thus, you should supply all of a policy's properties, not just the ones you wish to update.
 
 ### Deleting a Policy
 
-In the IAM v2 beta, policies must be deleted from the command line.
+Deleting a policy is permanent and cannot be undone.
 
-See [Listing Policies]({{< relref "iam-v2-api-reference.md#listing-policies" >}}) to fetch a list of all your policies and locating the relevant policy ID.
-Use the policy ID as the final path component to delete a policy:
+*In the browser:* **Settings**  >> **Policies** >> [open control menu for target policy] >> Delete
 
-```bash
-curl -s -H "api-token: $TOKEN" -X DELETE https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/policies/{policy-id}?pretty
+## Policy Membership
+
+Chef Automate supports two methods for updating policy membership.
+
+Using `PUT` lets you set membership for the entire policy; see [Setting Policy Membership]({{< relref "iam-v2-api-reference.md#setting-policy-membership" >}}).
+
+Using `POST` lets you add members to (or remove members from) an existing membership list.
+For more information, see [Adding Members to Policies]({{< relref "iam-v2-api-reference.md#adding-members-to-policies" >}}) and [Removing Members from Policies]({{< relref "iam-v2-api-reference.md#removing-members-from-policies" >}}).
+
+Method | HTTP request                           | Description
+-------|----------------------------------------|------------
+list   | GET /policies/***id***/members         | lists the membership
+update | PUT /policies/***id***/members         | replaces the membership
+add    | POST /policies/***id***/members:add    | add to the membership
+remove | POST /policies/***id***/members:remove | remove from the membership
+
+**Example payload:**
+
+```json
+{
+  "members": [
+    "team:local:admins",
+    "token:admin-token"
+  ]
+}
 ```
 
-In the browser: Navigate to the *Policies* page under the **Settings** tab., and then find the policy you wish to delete.
-Use the menu at the end of the policy row and select the **Delete Policy** option to delete the policy.
+### Listing Policy Members
+
+The output lists all defined members of the specified policy.
+
+### Updating All Members on a Policy
+
+Specifying a complete list of members is often simpler than keeping track of a policy's membership and adding or deleting specific members (whether users, team, or tokens).
+Use this HTTP request to replace the policy's membership with a full, new list.
+
+### Adding Members to a Policy
+
+Specify just new members to add to a policy's membership via this HTTP request.
+
+*In the browser:* **Settings**  >> **Policies** >> [select a policy] >> **Members** >> **Add Members**
+
+Select any local users or teams listed to add to the policy, or use **Add Member Expressions** for tokens, or LDAP or SAML users or teams.
+
+### Removing Members from a Policy
+
+Specify just members to remove from a policy's membership via this HTTP request.
+The removed members still exists within Chef Automate, but are no longer associated with this policy.
+
+*In the browser:* **Settings**  >> **Policies** >> [select a policy] >> **Members** >> [open control menu for target member] >> Remove Member
 
 ## Roles
 
 A role encapsulates a list of actions.
-IAM v2 provides several default Chef-managed roles, which are essential to the operation of Chef Automate and cannot be altered.
-Roles you create are Custom roles.
+IAM v2 provides several default *Chef-managed* roles, which are essential to the operation of Chef Automate and cannot be altered.
+Roles you create are *Custom* roles.
+
+Method | HTTP request              | Description
+-------|---------------------------|------------
+list   | GET /roles                | lists both *Chef-managed* and *Custom* roles
+get    | GET /roles/***id***       | gets the specified role
+create | POST /roles               | creates a *Custom* role
+update | PUT /roles/***id***       | updates a *Custom* role
+delete | DELETE /roles/***id***    | deletes a *Custom* role
+
+**Default Chef-managed Roles:**
 
 Chef-managed Role Name | ID| Actions
 -----------------------|-----|--------
-Owner       | owner       | `*`
-Viewer      | viewer      | `infra:*:get`, `infra:*:list`, `compliance:*:get`, `compliance:*:list`, `system:*:get`, `system:*:list`, `event:*:get`, `event:*:list`, `ingest:*:get`, `ingest:*:list`, `applications:*:list`, `applications:*:get`
-Editor      | editor      | `infra:*`, `compliance:*`, `system:*`, `event:*`, `ingest:*`, `secrets:*`, `telemetry:*`, `applications:*`
-Ingest      | ingest      | `infra:ingest:*`, `compliance:profiles:get`, `compliance:profiles:list`
+Owner              | owner         | \*
+Viewer             | viewer        | secrets:\*:get, secrets:\*:list, infra:\*:get, infra:\*:list, compliance:\*:get, compliance:\*:list, system:\*:get, system:\*:list, event:\*:get, event:\*:list, ingest:\*:get, ingest:\*:list, iam:projects:list, iam:projects:get, applications:\*:list, applications:\*:get
+Editor             | editor        | infra:\*, compliance:\*, system:\*, event:\*, ingest:\*, secrets:\*, telemetry:\*, iam:projects:list, iam:projects:get, iam:projects:assign, applications:\*
+Project Owner      | project-owner | infra:\*, compliance:\*, system:\*, event:\*, ingest:\*, secrets:\*, telemetry:\*, iam:projects:list, iam:projects:get, iam:projects:assign, iam:policies:list, iam:policies:get, iam:policyMembers:\*, iam:teams:list, iam:teams:get, iam:teamUsers:\*, iam:users:get, iam:users:list
+Ingest             | ingest        | infra:ingest:\*, compliance:profiles:get, compliance:profiles:list
+
+**Example Role:**
+
+```json
+{
+  "name": "Test Role",
+  "id": "test-role-1",
+  "actions": [
+    "infra:*",
+    "compliance:*",
+    "teams:*",
+    "users:*"
+  ],
+  "projects": [
+    "east-region",
+    "west-region"
+  ]
+}
+```
 
 ### Listing Roles
 
-```bash
-curl -s -H "api-token: $TOKEN" https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles?pretty
-```
+The output includes both *Chef-managed* and *Custom* roles.
 
-The output details each role name, role type, and actions it contains.
-
-In the browser: Navigate to the *Roles* page under the **Settings** tab.
+*In the browser:* **Settings**  >> **Roles**
 
 ### Getting a Role
 
-Roles have unique IDs.
-For example, the Editor role's ID is `editor`.
-This may be obtained by first fetching the list of all roles; see [Listing Roles]({{< relref "iam-v2-api-reference.md#listing-roles" >}}).
-Use the role ID as the final path component to fetch a role:
+This shows the details of a single role, selected by its ID.
 
-```bash
-curl -s -H "api-token: $TOKEN" https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles/editor?pretty
-```
-
-In the browser: Navigate to the *Roles* page under the **Settings** tab, and then select an individual role to open its detail view.
+*In the browser:* **Settings**  >> **Roles** >> [select a role]
 
 ### Creating a Role
 
-In the IAM v2 beta, custom roles must be created on the command line.
-Use the following `curl` command to create a role combining some editor actions with some administrator actions:
-
-```bash
-curl -s -H "api-token: $TOKEN" -d '{"name": "Test Role", "id": "test-role-1", "actions": ["infra:*", "compliance:*", "teams:*", "users:*"] }' https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles?pretty
-```
+Create a role by composing JSON with all the necessary role properties (see the beginning of the section above).
 
 ### Updating a Role
 
-In the IAM v2 beta, custom roles must be updated on the command line.
-Use the following command to update the previously created role to remove the action `infra:*`:
+The update operation modifies *all* role properties, not just the ones you specify.
+Properties that you do not specify are reset to empty values.
+Thus, you should supply all of a role's properties, not just the ones you wish to update.
+Note that the ID is immutable; it can only be set at creation time.
 
-```bash
-curl -s -H "api-token: $TOKEN" -d '{"name": "Test Role", "actions": ["compliance:*", "teams:*", "users:*"] }' -X PUT https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles/test-role-1?pretty
-```
+### Deleting a Role
 
-It is important to note that for the `actions` property in the JSON you must specify the complete list of actions.
-Contrast this with managing members, where you specify only the members to be added ([Adding Members to Policies]({{< relref "iam-v2-api-reference.md#adding-members-to-policies" >}}))
+Deleting a role is permanent and cannot be undone.
 
-### Deleting Roles
-
-In the IAM v2 beta, custom roles must be deleted on the command line.
-Use the following command to delete the previously created role.
-Use the role ID as the final path component to delete a role:
-
-```bash
-curl -s -H "api-token: $TOKEN" -X DELETE https://{{< example_fqdn "automate" >}}/apis/iam/v2beta/roles/test-role-1?pretty
-```
+*In the browser:* **Settings**  >> **Roles** >> [open control menu for target role] >> Delete
 
 ## Tokens
 
-Tokens are unchanged for IAM v2.
-To specify tokens in a [member expression]({{< relref "iam-v2-overview.md#members-and-policies" >}}), first find that token's ID.
+Method | HTTP request              | Description
+-------|---------------------------|------------
+list   | GET /tokens               | lists all tokens
+get    | GET /tokens/***id***      | gets the specified token
+create | POST /tokens              | creates a *Custom* token
+update | PUT /tokens/***id***      | updates a *Custom* token
+delete | DELETE /tokens/***id***   | deletes a *Custom* token
+
+**Example Token:**
+
+```json
+{
+  "name": "token 1",
+  "id": "token-1",
+  "active": true,
+  "projects": [
+    "east-region",
+    "west-region"
+  ]
+}
+```
 
 ### Listing Tokens
 
-List all tokens with this command:
+The lists admin and non-admin tokens.
+
+### Getting a Token
+
+This shows the details of a single token, selected by its ID.
+
+### Creating a Token
+
+Create a token by composing JSON with all the necessary token properties (see the beginning of the section above).
+Note that this creates **non**-admin tokens that may then be assigned permissions via policies just like users or teams (unless you have already created policies that encompass all tokens using `tokens:*`).
+
+You cannot create admin tokens via the REST API.
+Admin tokens can only be created by specifying the `--admin` flag to this `chef-automate` sub-command:
 
 ```bash
-curl -s -H "api-token: $TOKEN" https://{{< example_fqdn "automate" >}}/api/v0/auth/tokens?pretty
+  chef-automate iam token create <your-token-name> --admin
 ```
+
+### Updating a Token
+
+The update operation modifies *all* token properties, not just the ones you specify.
+Properties that you do not specify are reset to empty values.
+Thus, you should supply all of a token's properties, not just the ones you wish to update.
+Note that the ID is immutable; it can only be set at creation time.
+
+### Deleting a Token
+
+Deleting a token is permanent and cannot be undone.
+
+*In the browser:* **Settings**  >> **API Tokens** >> [open control menu for target token] >> Delete Token
+
+## Projects
+
+Method | HTTP request              | Description
+-------|---------------------------|------------
+list   | GET /projects             | lists all projects
+get    | GET /projects/***id***    | gets the specified role
+create | POST /projects            | creates a project
+update | PUT /projects/***id***    | updates a project
+delete | DELETE /projects/***id*** | deletes a project
+
+**Example Project:**
+
+```json
+{
+  "name": "Test Project",
+  "id": "test-project-1"
+}
+```
+
+### Listing Projects
+
+The output lists all defined projects.
+
+*In the browser:* **Settings**  >> **Projects**
+
+### Getting a Project
+
+This shows the details of a single project, selected by its ID.
+
+*In the browser:* **Settings**  >> **Projects** >> [select a project]
+
+### Creating a Project
+
+Create a project by composing JSON with all the necessary project properties (see the beginning of the section above).
+
+### Updating a Project
+
+A project has only one modifiable property, the project name.
+The ID is immutable; it can only be set at creation time.
+
+### Deleting a Project
+
+Deleting a project is permanent and cannot be undone.
+
+*In the browser:* **Settings**  >> **Projects** >> [open control menu for target project] >> Delete Project
+
+## Project Rules
+
+Method | HTTP request                                          | Description
+-------|-------------------------------------------------------|------------
+list   | GET /projects/***project_id***/rules                  | lists rules for a project
+get    | GET /projects/***project_id***/rules/***rule_id***    | gets a project rule
+create | POST /projects/***project_id***/rules                 | creates a project rule
+update | PUT /projects/***project_id***/rules/***rule_id***    | updates a project rule
+delete | DELETE /projects/***project_id***/rules/***rule_id*** | deletes a project rule
+
+A rule specifies a non-empty array of conditions.
+Each rule **condition** specifies values to match for a particular **attribute**.
+The choice of attributes depends on the rule **type**.
+
+Rule Type  | Available Attributes
+-----------|---------------------
+EVENT      | CHEF_ORGANIZATION, CHEF_SERVER
+NODE       | CHEF_ORGANIZATION, CHEF_SERVER, ENVIRONMENT, CHEF_ROLE, CHEF_TAG, CHEF_POLICY_NAME, CHEF_POLICY_GROUP
+
+Each rule condition also specifies an **operator**, either `MEMBER_OF` or `EQUALS`.
+To match a single value, use `EQUALS` and include just a single value in the **values** array.
+To match any one of a set of values, use `MEMBER_OF` and include the choices in the **values** array.
+
+**Example Rule:**
+
+```json
+{
+  "id": "test-rule",
+  "name": "my test rule",
+  "type": "NODE",
+  "project_id": "eastern_region",
+  "conditions": [
+    {
+      "operator": "MEMBER_OF",
+      "attribute": "CHEF_SERVERS",
+      "values": [
+        "prod",
+        "staging"
+      ]
+    },
+    {
+      "operator": "EQUALS",
+      "attribute": "CHEF_ORGANIZATION",
+      "values": [
+        "org1"
+      ]
+    }
+  ]
+}
+```
+
+### Listing Rules for a Project
+
+The output lists all rules for a specified project.
+
+*In the browser:* **Settings**  >> **Projects** >> [select a project]
+
+### Getting a Project Rule
+
+This shows the details of a single project, selected by its ID.
+
+*In the browser:* **Settings**  >> **Projects** >> [select a project] >> [select a rule]
+
+### Creating a Project Rule
+
+Create a rule by composing JSON with all the necessary rule properties (see the beginning of the section above).
+
+### Updating a Project Rule
+
+The update operation modifies *all* rule properties, not just the ones you specify.
+Properties that you do not specify are reset to empty values.
+Thus, you should supply all of a rule's properties, not just the ones you wish to update.
+Note that the ID is immutable; it can only be set at creation time.
+
+### Deleting a Project Rule
+
+Deleting a rule is permanent and cannot be undone.
+
+*In the browser:* **Settings**  >> **Projects** >> [select a project] >> [open control menu for target rule] >> Delete Rule
 
 ## Restoring Admin Access
 
@@ -290,11 +467,11 @@ If you have root access to the node where Chef Automate is installed, use the fo
 * This command, which is also available on IAM v1, resets the local `admin` user's password and ensures that user is a member of the local `admins` team, which is a permanent member of the Chef-managed `Administrator` policy.
 
 ```bash
-  chef-automate iam admin-access restore NEW_PASSWORD
+  chef-automate iam admin-access restore <your new password here>
 ```
 
 * Generate a new token and add that token as a new member of the Chef-managed `Administrator` policy. This is the equivalent of the v1 command `chef-automate admin-token`.
 
 ```bash
-  chef-automate iam token create NAME --admin
+  chef-automate iam token create <your token name here> --admin
 ```


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

_Note to docs team: Feel free to peruse if you like, but you are not the intended audience for this partial update._ 😁 

Update the reference.md document file for IAM v2.1 beta.
This includes a major rewrite based on reviewing other API references out there.
Each section starts with a table summarizing the HTTP Requests, then an example JSON for the given resource, then notes on each method. I removed much redundancy by cutting out the curl call on every item, making the text tighter and easier to digest.

TODO: 
API calls for users and teams

### :chains: Related Resources
NA

### :+1: Definition of Done
Reference page describes all API calls.

### :athletic_shoe: How to Build and Test the Change

Launch hugo locally on your machine per the instructions in components/automate-chef-io/README.md, then browse to http://localhost:1313/docs/iam-v2-overview/