### PR TITLE
Jamie/reporting profile status visuals

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.spec.ts
@@ -84,4 +84,24 @@ describe('ReportingProfileComponent', () => {
         { perPage: 1000, page: 1, sort: 'latest_report.end_time', order: 'desc' });
     });
   });
+
+  describe('statusIcon', () => {
+    it('returns an empty string when no cases match', () => {
+      expect(component.statusIcon('whoops')).toBe('');
+      expect(component.statusIcon('')).toBe('');
+      expect(component.statusIcon('not matching')).toBe('');
+    });
+
+    it('returns "report_problem" when status argument is "failed" ', () => {
+      expect(component.statusIcon('failed')).toBe('report_problem');
+    });
+
+    it('returns "check_circle" when status argument is "passed" ', () => {
+      expect(component.statusIcon('passed')).toBe('check_circle');
+    });
+
+    it('returns "help" when status argument is "skipped" ', () => {
+      expect(component.statusIcon('skipped')).toBe('help');
+    });
+  });
 });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
@@ -124,7 +124,7 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
   hideScanResults() {
     this.scanResults.opened = false;
     this.scanResults.clearParams();
-    this.scanResults.control = null;
+    this.scanResults.control = {};
     this.openControls = {};
   }
 
@@ -135,13 +135,16 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
     params = paginationOverride;
     params['sort'] = 'latest_report.end_time';
     params['order'] = 'desc';
-    return this.statsService.getNodes(reportQuery, params).pipe(
+    const nodes = this.statsService.getNodes(reportQuery, params).pipe(
       map(data => {
         return data.items.map(node => {
           node.status = node.latest_report.status;
           return node;
         });
       }));
+    // reset the filters
+    reportQuery.filters = [];
+    return nodes;
   }
 
   getControl(reportQuery: ReportQuery, params: any): Observable<any> {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
@@ -129,10 +129,13 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
   }
 
   getNodes(reportQuery: ReportQuery, params: any): Observable<Array<any>> {
-    // Need to rethink this because it is removing all filters
+    // remove profile_id and control_id as filters if they are already applied
+    reportQuery.filters = reportQuery.filters.filter( filter => {
+      return filter.type.name !== 'profile_id' && filter.type.name !== 'control_id';
+    });
     const profileFilter: FilterC = {type: { name: 'profile_id' }, value: { text: params.profileId}};
     const controlFilter: FilterC = {type: { name: 'control_id' }, value: { text: params.controlId}};
-    reportQuery.filters = [profileFilter].concat(controlFilter);
+    reportQuery.filters = [profileFilter, controlFilter].concat(reportQuery.filters);
     params = paginationOverride;
     params['sort'] = 'latest_report.end_time';
     params['order'] = 'desc';

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
@@ -129,12 +129,9 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
   }
 
   getNodes(reportQuery: ReportQuery, params: any): Observable<Array<any>> {
-    // reset the filters incase values are stuck;
-    reportQuery.filters = [];
-
     const profileFilter: FilterC = {type: { name: 'profile_id' }, value: { text: params.profileId}};
     const controlFilter: FilterC = {type: { name: 'control_id' }, value: { text: params.controlId}};
-    reportQuery.filters = [profileFilter, controlFilter].concat(reportQuery.filters);
+    reportQuery.filters = [profileFilter].concat(controlFilter);
     params = paginationOverride;
     params['sort'] = 'latest_report.end_time';
     params['order'] = 'desc';

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
@@ -169,12 +169,19 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
     return 'minor';
   }
 
-  statusIcon(status) {
+  statusIcon(status: string): string {
     switch (status) {
-      case ('failed'): return 'report_problem';
-      case ('passed'): return 'check_circle';
-      case ('skipped'): return 'help';
-      default: return '';
+      case 'failed' :
+        return 'report_problem';
+        break;
+      case 'passed' :
+        return 'check_circle';
+        break;
+      case 'skipped' :
+        return 'help';
+        break;
+      default:
+        return '';
     }
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
@@ -129,22 +129,22 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
   }
 
   getNodes(reportQuery: ReportQuery, params: any): Observable<Array<any>> {
+    // reset the filters incase values are stuck;
+    reportQuery.filters = [];
+
     const profileFilter: FilterC = {type: { name: 'profile_id' }, value: { text: params.profileId}};
     const controlFilter: FilterC = {type: { name: 'control_id' }, value: { text: params.controlId}};
     reportQuery.filters = [profileFilter, controlFilter].concat(reportQuery.filters);
     params = paginationOverride;
     params['sort'] = 'latest_report.end_time';
     params['order'] = 'desc';
-    const nodes = this.statsService.getNodes(reportQuery, params).pipe(
+    return this.statsService.getNodes(reportQuery, params).pipe(
       map(data => {
         return data.items.map(node => {
           node.status = node.latest_report.status;
           return node;
         });
       }));
-    // reset the filters
-    reportQuery.filters = [];
-    return nodes;
   }
 
   getControl(reportQuery: ReportQuery, params: any): Observable<any> {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
@@ -124,7 +124,7 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
   hideScanResults() {
     this.scanResults.opened = false;
     this.scanResults.clearParams();
-    this.scanResults.control = {};
+    this.scanResults.control = null;
     this.openControls = {};
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
@@ -129,6 +129,7 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
   }
 
   getNodes(reportQuery: ReportQuery, params: any): Observable<Array<any>> {
+    // Need to rethink this because it is removing all filters
     const profileFilter: FilterC = {type: { name: 'profile_id' }, value: { text: params.profileId}};
     const controlFilter: FilterC = {type: { name: 'control_id' }, value: { text: params.controlId}};
     reportQuery.filters = [profileFilter].concat(controlFilter);


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When viewing compliance/reports/profiles, and then clicking to view a specific profile ==> then clicking on scan results of each control, a sidebar opens to show each specific node and its status.  After the node viewed, all nodes would show a `failure` icon, even when the node was successful.

It turned out that the way the two filters were being concatenated caused the `profileFilter` to add extras profile IDs to each call, stacking in multiples as it went.  

### :chains: Related Resources

### :+1: Definition of Done
Status sidebar shows the correct status icon when being viewed

### :athletic_shoe: How to Build and Test the Change
1. build components/automate-ui-devproxy && start_all_services
2. Navigate to https://a2-dev.test/compliance/reports/profiles
3. Click on a Profile to view
4. Click on `Scan Results` on the right side of any of the list items
5. View the correct Icon (blue check, pink triangle, grey circle) for related node.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
Before:  Icon does not match true status
<img width="1369" alt="Before" src="https://user-images.githubusercontent.com/16737484/66246805-026e2300-e6cc-11e9-8bae-80a741c9c380.png">
<img width="1370" alt="Before - Sidebar" src="https://user-images.githubusercontent.com/16737484/66246806-026e2300-e6cc-11e9-86cd-c8efa327c26e.png">

After:  Icon matches status
<img width="1238" alt="After" src="https://user-images.githubusercontent.com/16737484/66246811-0b5ef480-e6cc-11e9-9ed3-f251bd1b349f.png">
<img width="1239" alt="After - Sidebar" src="https://user-images.githubusercontent.com/16737484/66246812-0b5ef480-e6cc-11e9-8501-95acab017ad2.png">

