### PR TITLE
ci: don't verify manifest in manual upgrade test

### DIFF
--- a/integration/tests/manual_upgrade.sh
+++ b/integration/tests/manual_upgrade.sh
@@ -33,7 +33,7 @@ do_deploy() {
     $upgrade_scaffold_bin setup "$test_manifest_path"
     $upgrade_scaffold_bin serve "$test_manifest_path" "$upgrade_scaffold_pid_file" &
     sleep 5
-
+    export CHEF_AUTOMATE_SKIP_MANIFEST_VERIFICATION=true
     #shellcheck disable=SC2154
     echo -e "[load_balancer.v1.sys.service]\\nhttps_port = 4443" >> "$test_config_path"
     #shellcheck disable=SC2154


### PR DESCRIPTION
This test suite downloads the manifest from a special test scaffolding
that pretends to be packages.chef.io. Since we don't have access to
the key (and don't want access to the key) we can't sign the manifest
in this test.

Manifest verification was already disabled for deployment-service in
this test suite, this disables it for automate-cli.

Signed-off-by: Steven Danna <steve@chef.io>