### PR TITLE
cereal: allow empty task result in SingleTaskWorkflow

### DIFF
--- a/lib/cereal/cereal.go
+++ b/lib/cereal/cereal.go
@@ -200,7 +200,7 @@ func (r *TaskResultData) Get(obj interface{}) error {
 	if r.Err() != nil {
 		return r.Err()
 	}
-	if r.Result != nil {
+	if len(r.Result) != 0 {
 		return json.Unmarshal(r.Result, obj)
 	}
 	return nil


### PR DESCRIPTION
Commit 677ddc94774df0c406bdc6642d653d8139094992 converted ingest
service to using the cereal library's SingleTaskWorkflow. This
resulted in us seeing the following error in the application log:

    ingest-service.default(O): time="2019-10-08T19:24:30Z" level=error
    msg="failed to get task result" error="unexpected end of JSON
    input"

The task executors return a nil result in the case of success. The
json module does not expect to unmarshal from empty byte slices.
While we had a nil check in our Get() method for TaskResultData, we
did not account for a non-nil but empty slice.

Signed-off-by: Steven Danna <steve@chef.io>