### PR TITLE
Jamie/fix datetime infra node details

### DIFF
--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -3,5 +3,5 @@ export class DateTime {
   // RFC2822 format like: Wed, 03 Jul 2019 17:08:53 UTC
   public static readonly RFC2822: string = 'ddd, DD MMM YYYY HH:mm:ss [UTC]';
 
-  public static readonly CHEF_TIME: string = 'HH:mm';
+  public static readonly CHEF_HOURS_MINS: string = 'HH:mm';
 }

--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -2,4 +2,6 @@ export class DateTime {
   // formatted for use with moment.js -- https://momentjs.com/docs/#/displaying/format/
   // RFC2822 format like: Wed, 03 Jul 2019 17:08:53 UTC
   public static readonly RFC2822: string = 'ddd, DD MMM YYYY HH:mm:ss [UTC]';
+
+  public static readonly CHEF_TIME: string = 'HH:mm';
 }

--- a/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.html
+++ b/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.html
@@ -8,7 +8,7 @@
       <ul>
         <li><strong class="nodename">{{nodeRun.nodeName}}</strong></li>
         <li><strong>Run ID:</strong> {{nodeRun.runId}}</li>
-        <li>{{renderTime(nodeRun.startTime)}} - {{renderTime(nodeRun.endTime)}}</li>
+        <li>{{renderTime(nodeRun.startTime)}} - {{renderTime(nodeRun.endTime)}} UTC</li>
       </ul>
     </div>
 

--- a/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.html
+++ b/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.html
@@ -8,7 +8,7 @@
       <ul>
         <li><strong class="nodename">{{nodeRun.nodeName}}</strong></li>
         <li><strong>Run ID:</strong> {{nodeRun.runId}}</li>
-        <li>{{ nodeRun.startTime | datetime: ChefTime }} - {{ nodeRun.endTime | datetime: ChefTime }} UTC</li>
+        <li>{{ nodeRun.startTime | datetime: ChefHoursMins }} - {{ nodeRun.endTime | datetime: ChefHoursMins }} UTC</li>
       </ul>
     </div>
 

--- a/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.html
+++ b/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.html
@@ -8,7 +8,7 @@
       <ul>
         <li><strong class="nodename">{{nodeRun.nodeName}}</strong></li>
         <li><strong>Run ID:</strong> {{nodeRun.runId}}</li>
-        <li>{{renderTime(nodeRun.startTime)}} - {{renderTime(nodeRun.endTime)}} UTC</li>
+        <li>{{ nodeRun.startTime | datetime: ChefTime }} - {{ nodeRun.endTime | datetime: ChefTime }} UTC</li>
       </ul>
     </div>
 

--- a/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { LogsModalComponent } from './logs-modal.component';
 import { NodeDetailsService } from '../../services/node-details/node-details.service';
 import { NodeRun } from '../../types/types';
+import { DatetimePipe } from 'app/pipes/datetime.pipe';
 
 describe('LogsModalComponent', () => {
   let fixture, component, eventService;
@@ -57,7 +58,8 @@ describe('LogsModalComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [
-        LogsModalComponent
+        LogsModalComponent,
+        DatetimePipe
       ],
       providers: [
         NodeDetailsService

--- a/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.ts
+++ b/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.ts
@@ -28,7 +28,7 @@ export class LogsModalComponent implements OnChanges {
   }
 
   renderTime(timestamp) {
-    return moment(timestamp).format('LT');
+    return moment(timestamp).format('HH:mm');
   }
 
   errorSections() {

--- a/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.ts
+++ b/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.ts
@@ -15,7 +15,7 @@ export class LogsModalComponent implements OnChanges {
   @Input() isVisible = false;
 
   hideBacktrace = true;
-  ChefTime = DateTime.CHEF_TIME;
+  ChefHoursMins = DateTime.CHEF_HOURS_MINS;
 
   constructor(private eventService: NodeDetailsService) {}
 

--- a/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.ts
+++ b/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.ts
@@ -1,8 +1,8 @@
 import { Component, Input, OnChanges, SimpleChange } from '@angular/core';
-import * as moment from 'moment';
 import { NodeDetailsService } from '../../services/node-details/node-details.service';
 import { NodeRun } from '../../types/types';
 import { saveAs } from 'file-saver';
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 @Component({
   selector: 'app-logs-modal',
@@ -15,6 +15,7 @@ export class LogsModalComponent implements OnChanges {
   @Input() isVisible = false;
 
   hideBacktrace = true;
+  ChefTime = DateTime.CHEF_TIME;
 
   constructor(private eventService: NodeDetailsService) {}
 
@@ -25,10 +26,6 @@ export class LogsModalComponent implements OnChanges {
     if (changes['isVisible']) {
       this.isVisible = changes['isVisible'].currentValue;
     }
-  }
-
-  renderTime(timestamp) {
-    return moment(timestamp).format('HH:mm');
   }
 
   errorSections() {

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.html
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.html
@@ -31,10 +31,10 @@
           <chef-icon>{{ history.status | chefStatusIcon }}</chef-icon>
         </div>
         <div class="duration">
-          {{renderDate(history.startTime)}} <span>{{renderTime(history.startTime)}}</span>
+          {{ history.startTime | datetime: RFC2822 }}
         </div>
         <div class="date-time">
-          {{getDuration(history.startTime, history.endTime)}} <span>{{renderTime(history.endTime)}}</span>
+          {{getDuration(history.startTime, history.endTime)}}
         </div>
       </li>
       <li class="no-runs-small" *ngIf="stats(selected) == 0">

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.html
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.html
@@ -31,7 +31,7 @@
           <chef-icon>{{ history.status | chefStatusIcon }}</chef-icon>
         </div>
         <div class="duration">
-          {{ history.startTime | datetime: RFC2822 }}
+          <p><strong>{{ history.startTime | datetime: RFC2822 }}</strong></p>
         </div>
         <div class="date-time">
           {{getDuration(history.startTime, history.endTime)}}

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
@@ -129,10 +129,12 @@ app-date-selector {
 
   .duration {
     display: inline-block;
-    font-size: .75em;
-    font-style: italic;
     position: relative;
     width: 80%;
+
+    p {
+      margin-bottom: 0;
+    }
   }
 
   > div span {

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.spec.ts
@@ -4,6 +4,7 @@ import { RunHistoryStore } from '../../services/run-history-store/run-history.st
 import { DateSelectorComponent } from '../date-selector/date-selector.component';
 import { StatusSelectorPipe } from '../../pipes/status-selector.pipe';
 import { ChefStatusIconPipe } from '../../pipes/chef-status-icon.pipe';
+import { DatetimePipe } from '../../pipes/datetime.pipe';
 import { HistorySelection } from '../../helpers/history-selection/history-selection';
 import { AbridgedNodeRun, NodeHistoryCountsFilter, NodeRunsCount } from '../../types/types';
 import { NodeRunsService } from '../../services/node-details/node-runs.service';
@@ -31,6 +32,7 @@ describe('RunHistoryComponent', () => {
         DateSelectorComponent,
         StatusSelectorPipe,
         ChefStatusIconPipe,
+        DatetimePipe
         MockComponent({selector: 'chef-icon'})
       ],
       providers: [

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.spec.ts
@@ -32,7 +32,7 @@ describe('RunHistoryComponent', () => {
         DateSelectorComponent,
         StatusSelectorPipe,
         ChefStatusIconPipe,
-        DatetimePipe
+        DatetimePipe,
         MockComponent({selector: 'chef-icon'})
       ],
       providers: [

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.ts
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.ts
@@ -7,6 +7,7 @@ import {
   NodeHistoryFilter,
   NodeHistoryCountsFilter,
   RunInfo } from '../../types/types';
+import { DateTime } from 'app/helpers/datetime/datetime';
 import { NodeRunsService } from '../../services/node-details/node-runs.service';
 import { HistorySelection } from '../../helpers/history-selection/history-selection';
 import { RunHistoryStore } from '../../services/run-history-store/run-history.store';
@@ -32,6 +33,7 @@ export class RunHistoryComponent implements OnInit, OnDestroy {
   nodeHistory: AbridgedNodeRun[];
   currentPage = 1;
   pageSize = 10;
+  RFC2822 = DateTime.RFC2822;
   // store enum as member to be able to access it via html templates
   selectedStatus = SelectedStatus;
   // store selection

--- a/components/automate-ui/src/app/page-components/run-summary/run-summary.component.html
+++ b/components/automate-ui/src/app/page-components/run-summary/run-summary.component.html
@@ -1,14 +1,14 @@
 
 <div class="node-run-message">
   <chef-alert type="error" *ngIf="nodeRun.status === 'failure'">
-    This run failed on {{renderDate(nodeRun.endTime)}} at {{renderTime(nodeRun.endTime)}}  &nbsp;
+    This run failed on {{ nodeRun.endTime | datetime: RFC2822 }} &nbsp;
     <span *ngIf="nodeRun.error?.description?.title">
       because there was a {{nodeRun.error?.description?.title}} &nbsp;
     </span>
     <chef-button secondary (click)="activateModal()">View error log</chef-button>
   </chef-alert>
   <chef-alert type="success" *ngIf="nodeRun.status === 'success'">
-    This run succeeded on {{renderDate(nodeRun.endTime)}} at {{renderTime(nodeRun.endTime)}}.
+    This run succeeded on {{ nodeRun.endTime | datetime: RFC2822 }}.
     All resources ran successfully!
   </chef-alert>
 </div>

--- a/components/automate-ui/src/app/page-components/run-summary/run-summary.component.html
+++ b/components/automate-ui/src/app/page-components/run-summary/run-summary.component.html
@@ -27,7 +27,7 @@
   <div class="run-detail-labels flex-block">
     <div class="run-metadata">
       <div class="label">Run Duration</div>
-      <div class="value">{{ renderTime(nodeRun.startTime) }} - {{ renderTime(nodeRun.endTime) }}</div>
+      <div class="value">{{ renderTime(nodeRun.startTime) }} - {{ renderTime(nodeRun.endTime) }} UTC</div>
     </div>
     <div class="run-metadata">
       <div class="label">Node ID</div>

--- a/components/automate-ui/src/app/page-components/run-summary/run-summary.component.html
+++ b/components/automate-ui/src/app/page-components/run-summary/run-summary.component.html
@@ -27,7 +27,7 @@
   <div class="run-detail-labels flex-block">
     <div class="run-metadata">
       <div class="label">Run Duration</div>
-      <div class="value">{{ nodeRun.startTime | datetime: ChefTime }} - {{ nodeRun.endTime | datetime: ChefTime }} UTC</div>
+      <div class="value">{{ nodeRun.startTime | datetime: ChefHoursMins }} - {{ nodeRun.endTime | datetime: ChefHoursMins }} UTC</div>
     </div>
     <div class="run-metadata">
       <div class="label">Node ID</div>

--- a/components/automate-ui/src/app/page-components/run-summary/run-summary.component.html
+++ b/components/automate-ui/src/app/page-components/run-summary/run-summary.component.html
@@ -27,7 +27,7 @@
   <div class="run-detail-labels flex-block">
     <div class="run-metadata">
       <div class="label">Run Duration</div>
-      <div class="value">{{ renderTime(nodeRun.startTime) }} - {{ renderTime(nodeRun.endTime) }} UTC</div>
+      <div class="value">{{ nodeRun.startTime | datetime: ChefTime }} - {{ nodeRun.endTime | datetime: ChefTime }} UTC</div>
     </div>
     <div class="run-metadata">
       <div class="label">Node ID</div>

--- a/components/automate-ui/src/app/page-components/run-summary/run-summary.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/run-summary/run-summary.component.spec.ts
@@ -5,6 +5,7 @@ import {
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RunSummaryComponent } from './run-summary.component';
 import { MockComponent } from 'ng2-mock-component';
+import { DatetimePipe } from '../../pipes/datetime.pipe';
 import { NodeRun } from '../../types/types';
 
 describe('RunSummaryComponent', () => {
@@ -14,6 +15,7 @@ describe('RunSummaryComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         RunSummaryComponent,
+        DatetimePipe,
         MockComponent({ selector: 'chef-radial-chart',
                 inputs: ['chartData', 'chartColors', 'labelIcon', 'labelText'] })
       ],

--- a/components/automate-ui/src/app/page-components/run-summary/run-summary.component.ts
+++ b/components/automate-ui/src/app/page-components/run-summary/run-summary.component.ts
@@ -48,7 +48,7 @@ export class RunSummaryComponent implements OnChanges, AfterContentInit {
   }
 
   renderTime(timestamp) {
-    return moment(timestamp).format('HH:mm [UTC]');
+    return moment(timestamp).format('HH:mm');
   }
 
   renderDate(timestamp) {

--- a/components/automate-ui/src/app/page-components/run-summary/run-summary.component.ts
+++ b/components/automate-ui/src/app/page-components/run-summary/run-summary.component.ts
@@ -5,6 +5,7 @@ import {
 } from '../../services/node-details/node-details.service';
 import * as moment from 'moment';
 import { NodeRun } from '../../types/types';
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 @Component({
   selector: 'app-run-summary',
@@ -20,6 +21,7 @@ export class RunSummaryComponent implements OnChanges, AfterContentInit {
   public chartSucceeded;
   public chartFailed;
   public chartOther;
+  public RFC2822 = DateTime.RFC2822;
 
   constructor(
     private eventService: NodeDetailsService
@@ -46,7 +48,7 @@ export class RunSummaryComponent implements OnChanges, AfterContentInit {
   }
 
   renderTime(timestamp) {
-    return moment(timestamp).format('LT');
+    return moment(timestamp).format('HH:mm [UTC]');
   }
 
   renderDate(timestamp) {

--- a/components/automate-ui/src/app/page-components/run-summary/run-summary.component.ts
+++ b/components/automate-ui/src/app/page-components/run-summary/run-summary.component.ts
@@ -22,7 +22,7 @@ export class RunSummaryComponent implements OnChanges, AfterContentInit {
   public chartFailed;
   public chartOther;
   public RFC2822 = DateTime.RFC2822;
-  public ChefTime = DateTime.CHEF_TIME;
+  public ChefHoursMins = DateTime.CHEF_HOURS_MINS;
 
   constructor(
     private eventService: NodeDetailsService

--- a/components/automate-ui/src/app/page-components/run-summary/run-summary.component.ts
+++ b/components/automate-ui/src/app/page-components/run-summary/run-summary.component.ts
@@ -22,6 +22,7 @@ export class RunSummaryComponent implements OnChanges, AfterContentInit {
   public chartFailed;
   public chartOther;
   public RFC2822 = DateTime.RFC2822;
+  public ChefTime = DateTime.CHEF_TIME;
 
   constructor(
     private eventService: NodeDetailsService
@@ -45,10 +46,6 @@ export class RunSummaryComponent implements OnChanges, AfterContentInit {
 
   renderDuration(totalSeconds) {
     return moment.duration(totalSeconds, 'seconds').humanize();
-  }
-
-  renderTime(timestamp) {
-    return moment(timestamp).format('HH:mm');
   }
 
   renderDate(timestamp) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This is a continued effort to standardize how timestamps are shown across the site.  This branch addresses time updates in the Infrastructure tab.

### :chains: Related Resources
https://github.com/chef/automate/issues/1678
https://github.com/chef/automate/issues/1679
https://github.com/chef/automate/pull/1821

### :+1: Definition of Done
Timestamps across the Infrastructure tab are updated as requested by UX https://github.com/chef/automate/issues/1705

### :athletic_shoe: How to Build and Test the Change
1. build components/automate-ui-devproxy && start_all_services
2. Navigate to https://a2-dev.test/infrastructure/client-runs
3. Click on any of your nodes available in the list
4. View the Failure or Success Tag Timestamp in Bold Blue or Pink Div
5.  View the Run Duration Time Stamp on Node Home
6. Click `View Error Log` to see Timestamp in Modal
7.  Click on Run History button in top right to view sidebar -> view updated timestamp.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
Run History Sidebar
<img width="1084" alt="Run History Sidebar" src="https://user-images.githubusercontent.com/16737484/66433424-2a63cc00-e9d5-11e9-853e-2ad6ee75144a.png">

Run Logs Error Modal
<img width="1080" alt="Run Logs Error Modal" src="https://user-images.githubusercontent.com/16737484/66433425-2a63cc00-e9d5-11e9-8330-d08cf09bdb6a.png">

Node Main Scree 
<img width="1084" alt="Node Main Screen" src="https://user-images.githubusercontent.com/16737484/66433426-2afc6280-e9d5-11e9-8939-7481d2dcbec8.png">

