### PR TITLE
Code coverage fix due to Angular upgrade

### DIFF
--- a/.expeditor/coverage/automate-ui.sh
+++ b/.expeditor/coverage/automate-ui.sh
@@ -6,7 +6,7 @@ export COVERAGE_DATE
 COVERAGE_DATE="$(date +"%Y-%m-%dT%H:%M:%S")"
 
 pushd ./components/automate-ui
-  npm install
+	npm run install:ui-library
   # https://github.com/sass/node-sass/issues/1579
   # We were failing with a missing node-sass file and that bug recommended to rebuild it - fixed the error we were seeing
   npm rebuild node-sass


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Code coverage fails to run if ui-lib assets are not installed.
(This same issue was fixed for the main build previously
on commit b4042b3d1923c15f1262ef60ac1cc6d60454c041.)

The pipeline failure first occurred here, with the Angular upgrade:
https://buildkite.com/chef/chef-automate-master-code-coverage/builds/1007#58d2bc39-f9dc-49d4-bcf1-2f41db8ed235

Error Text:
```
ERROR in ./src/styles.scss (./node_modules/@angular-devkit/build-angular/src/angular-cli-files/plugins/raw-css-loader.js!./node_modules/postcss-loader/src??embedded!./node_modules/sass-loader/lib/loader.js??ref--15-3!./src/styles.scss)
Module build failed (from ./node_modules/postcss-loader/src/index.js):
Error: Failed to find 'assets/chef-ui-library/chef/chef.css'
  in [
    /workdir/components/automate-ui/src
  ]
    at resolveModule.catch.catch (/workdir/components/automate-ui/node_modules/postcss-import/lib/resolve-id.js:35:13)
 @ ./src/styles.scss 1:14-241
 @ multi ./src/styles.scss
```

### :chains: Related Resources
https://github.com/chef/automate/pull/1707

### :+1: Definition of Done
code_coverage pipeline reports no errors
