### PR TITLE
Fix to code_coverage pipeline

### DIFF
--- a/.expeditor/coverage/automate-ui.sh
+++ b/.expeditor/coverage/automate-ui.sh
@@ -6,6 +6,7 @@ export COVERAGE_DATE
 COVERAGE_DATE="$(date +"%Y-%m-%dT%H:%M:%S")"
 
 pushd ./components/automate-ui
+	npm install
 	npm run install:ui-library
   # https://github.com/sass/node-sass/issues/1579
   # We were failing with a missing node-sass file and that bug recommended to rebuild it - fixed the error we were seeing


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

My previous attempt replaced a line when I should have added a line. This reinstates that needed line.

### :chains: Related Resources

https://github.com/chef/automate/pull/1824

### :+1: Definition of Done

code_coverage pipeline reports no errors