### PR TITLE
Add controls list tab to compliance reporting view

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.html
@@ -1,0 +1,63 @@
+<div class="empty-help" *ngIf="reportData.controlsListEmpty">
+  <img class="help-icon" src="/assets/img/profiles.svg" alt="">
+  <div class="help-msg">
+    <p>A list of of the compliance controls and their status for your scan report will appear here.</p>
+    <p>Learn how to start your first <a href="https://docs.chef.io/integrate_compliance_chef_automate.html" target="_blank">compliance scan</a>.</p>
+  </div>
+</div>
+
+<ng-container *ngIf="!reportData.controlsListEmpty">
+  <chef-table class="reporting-controls-table">
+    <chef-thead>
+      <chef-tr>
+        <chef-th>Control Name</chef-th>
+        <chef-th>Profile</chef-th>
+        <chef-th>Impact</chef-th>
+        <chef-th>Last Scan</chef-th>
+        <chef-th>Node Status</chef-th>
+        <chef-th></chef-th>
+      </chef-tr>
+    </chef-thead>
+    <chef-tbody *ngIf="!reportData.controlsListLoading">
+      <chef-tr *ngFor="let control of reportData.controlsList.items">
+        <chef-td>
+          <span><strong>{{ control.id }}:</strong> {{ control.title }}</span>
+        </chef-td>
+        <chef-td>{{ control.profile.title }}, {{ control.profile.version }}</chef-td>
+        <chef-td class="impact-status" [ngClass]="impactStatus(control)">
+          {{ impactStatus(control) | uppercase }} ({{ control.impact | number: '1.1' }})
+        </chef-td>
+        <chef-td>{{ control.end_time | timeFromNow }}</chef-td>
+        <chef-td *ngIf="control.control_summary as summary">
+          <span class="control-result" [ngClass]="{'failed': summary.failed.total > 0}">
+            <chef-icon>report_problem</chef-icon>
+            <span>{{ summary.failed.total | number }}</span>
+          </span>
+          <span class="control-result" [ngClass]="{'passed': summary.passed.total > 0}">
+            <chef-icon>check_circle</chef-icon>
+            <span>{{ summary.passed.total | number }}</span>
+          </span>
+          <span class="control-result" [ngClass]="{'skipped': summary.skipped.total > 0}">
+            <chef-icon>help</chef-icon>
+            <span>{{ summary.skipped.total | number }}</span>
+          </span>
+        </chef-td>
+        <chef-td class="actions-cell">
+          <chef-button secondary *ngIf="!hasFilter(control)" (click)="addFilter(control)">
+            <chef-icon>playlist_add</chef-icon>
+          </chef-button>
+          <chef-button secondary *ngIf="hasFilter(control)" (click)="removeFilter(control)">
+            <chef-icon>playlist_add_check</chef-icon>
+          </chef-button>
+        </chef-td>
+      </chef-tr>
+    </chef-tbody>
+    <chef-loading-spinner *ngIf="reportData.controlsListLoading" size="100"></chef-loading-spinner>
+  </chef-table>
+
+  <p class="item-count-warning" *ngIf="!reportData.controlsListLoading && reportData.controlsList.total === 100">
+    This query result set is too large to process. We have limited this list to 100 items for speed. Try filtering down your list.
+  </p>
+
+  <chef-scroll-top></chef-scroll-top>
+</ng-container>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.scss
@@ -1,0 +1,69 @@
+@import "~styles/variables";
+
+.reporting-controls-table {
+  margin: 2em 35px 0;
+
+  chef-th,
+  chef-td {
+    &:first-child {
+      flex-grow: 2;
+      word-break: break-all;
+
+      strong {
+        display: block;
+      }
+    }
+
+    &:last-child {
+      justify-content: flex-end;
+    }
+  }
+
+  .control-result {
+    display: flex;
+    margin-right: 1em;
+    align-items: center;
+    color: $chef-grey;
+
+    &:last-child {
+      margin-right: 0;
+    }
+
+    chef-icon {
+      margin-right: 5px;
+    }
+  }
+
+  .status-icon,
+  .impact-status,
+  .control-result {
+    &.failed {
+      color: $chef-critical;
+    }
+
+    &.passed {
+      color: $chef-success;
+    }
+
+    &.skipped {
+      color: $chef-dark-grey;
+    }
+
+    &.critical {
+      color: $chef-critical;
+    }
+
+    &.major {
+      color: $chef-major;
+    }
+
+    &.minor {
+      color: $chef-minor;
+    }
+  }
+}
+
+.item-count-warning {
+  margin: 35px 0;
+  text-align: center;
+}

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.spec.ts
@@ -1,0 +1,70 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
+import { TelemetryService } from 'app/services/telemetry/telemetry.service';
+import { ReportQueryService, ReportDataService, StatsService } from '../../shared/reporting';
+import { ReportingControlsComponent } from './reporting-controls.component';
+
+class MockTelemetryService {
+  track() { }
+}
+
+describe('ReportingControlsComponent', () => {
+  let fixture: ComponentFixture<ReportingControlsComponent>;
+  let component: ReportingControlsComponent;
+  let reportQueryService: ReportQueryService;
+  let reportDataService: ReportDataService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        ChefPipesModule
+      ],
+      declarations: [
+        ReportingControlsComponent
+      ],
+      providers: [
+        ReportQueryService,
+        ReportDataService,
+        StatsService,
+        { provide: TelemetryService, useClass: MockTelemetryService }
+      ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+    });
+
+    fixture = TestBed.createComponent(ReportingControlsComponent);
+    component = fixture.componentInstance;
+    reportQueryService = TestBed.get(ReportQueryService);
+    reportDataService = TestBed.get(ReportDataService);
+  });
+
+  describe('getData()', () => {
+    it('calls getReportingControlsList with applied filters', () => {
+      const reportQuery = reportQueryService.getReportQuery();
+      spyOn(reportDataService, 'getReportingControlsList');
+
+      component.getData(reportQuery);
+
+      expect(reportDataService.getReportingControlsList).toHaveBeenCalledWith(reportQuery);
+    });
+  });
+
+  describe('impactStatus()', () => {
+    it('returns the status name of the impact severity', () => {
+      [
+        [1.0, 'critical'],
+        [0.7, 'critical'],
+        [0.5, 'major'],
+        [0.4, 'major'],
+        [0.3, 'minor'],
+        [0.1, 'minor']
+      ].forEach(([impact, name]: [number, string]) => {
+        expect(component.impactStatus({ impact })).toEqual(name);
+      });
+    });
+  });
+});

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.ts
@@ -1,0 +1,87 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+import { ReportQueryService, ReportDataService, ReportQuery } from '../../shared/reporting';
+
+@Component({
+  selector: 'app-reporting-controls',
+  templateUrl: './reporting-controls.component.html',
+  styleUrls: [ './reporting-controls.component.scss' ]
+})
+export class ReportingControlsComponent implements OnInit, OnDestroy {
+
+  private isDestroyed: Subject<boolean> = new Subject<boolean>();
+
+  constructor(
+    public reportQuery: ReportQueryService,
+    public reportData: ReportDataService,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {}
+
+  ngOnInit() {
+    this.reportQuery.state.pipe(
+      takeUntil(this.isDestroyed))
+      .subscribe(this.getData.bind(this));
+  }
+
+  ngOnDestroy() {
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
+  }
+
+  getData(reportQuery: ReportQuery) {
+    this.reportData.getReportingControlsList(reportQuery);
+  }
+
+  impactStatus({ impact }) {
+    if (impact >= 0.7) { return 'critical'; }
+    if (impact >= 0.4) { return 'major'; }
+    return 'minor';
+  }
+
+  filterFor(control) {
+    return this.reportQuery.getReportQuery().filters.filter(f => {
+      return f.type && f.type.name === 'control_id' && f.value.id === control.id;
+    })[0];
+  }
+
+  hasFilter(control) {
+    return this.filterFor(control) !== undefined;
+  }
+
+  addFilter(control) {
+    const controlTypeName = 'control_id';
+    const profileTypeName = 'profile_id';
+    const {queryParamMap} = this.route.snapshot;
+    const queryParams = {...this.route.snapshot.queryParams};
+
+    queryParams[profileTypeName] = queryParamMap.getAll(profileTypeName)
+      .filter(v => v !== control.profile.id).concat(control.profile.id);
+    queryParams[controlTypeName] = queryParamMap.getAll(controlTypeName)
+      .filter(v => v !== control.id).concat(control.id);
+
+    this.reportQuery.setFilterTitle(controlTypeName, control.id, control.title);
+
+    this.router.navigate([], {queryParams});
+  }
+
+  removeFilter(control) {
+    const filter = this.filterFor(control);
+    const typeName = filter.type.name;
+
+    const {queryParamMap} = this.route.snapshot;
+    const queryParams = {...this.route.snapshot.queryParams};
+    const values = queryParamMap.getAll(typeName).filter(v => v !== filter.value.id);
+
+    if (values.length === 0) {
+      delete queryParams[typeName];
+    } else {
+      queryParams[typeName] = values;
+    }
+
+    this.router.navigate([], {queryParams});
+  }
+}

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.module.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.module.ts
@@ -1,0 +1,25 @@
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
+import { ComplianceSharedModule } from '../../shared/shared.module';
+import { ReportingControlsComponent } from './reporting-controls.component';
+import { ReportingControlsRoutingModule } from './reporting-controls.routing';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule,
+    ComplianceSharedModule,
+    ChefPipesModule,
+    ReportingControlsRoutingModule
+  ],
+  declarations: [
+    ReportingControlsComponent
+  ],
+  schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+  exports: [
+    ReportingControlsComponent
+  ]
+})
+export class ReportingControlsModule {}

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.routing.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.routing.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { ReportingControlsComponent } from './reporting-controls.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ReportingControlsComponent
+  }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes)
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class ReportingControlsRoutingModule {}

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
@@ -140,6 +140,11 @@
           {{reportData.reportingSummary?.stats.profiles | number }} Profiles
         </a>
       </li>
+      <li class="nav-tabs-item">
+        <a class="nav-tab" routerLink="/compliance/reports/controls" routerLinkActive="active" queryParamsHandling="preserve">
+          {{reportData.reportingSummary?.stats.controls | number }} Controls
+        </a>
+      </li>
     </ul>
 
     <router-outlet></router-outlet>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.routing.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.routing.ts
@@ -26,6 +26,11 @@ const routes: Routes = [
         path: 'profiles',
         loadChildren: () => import('./+reporting-profiles/reporting-profiles.module')
           .then(m => m.ReportingProfilesModule)
+      },
+      {
+        path: 'controls',
+        loadChildren: () => import('./+reporting-controls/reporting-controls.module')
+          .then(m => m.ReportingControlsModule)
       }
     ]
   },

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.spec.ts
@@ -121,4 +121,22 @@ describe('ReportDataService', () => {
       expect(service.profilesListLoading).toEqual(true);
     });
   });
+
+  describe('getReportingControlsList()', () => {
+    it('fetches controls data', () => {
+      const endDate = moment().utc().startOf('day').add(12, 'hours');
+      const reportQuery: ReportQuery = {
+        startDate: moment(endDate).subtract(10, 'days'),
+        endDate: endDate,
+        interval: 0,
+        filters: [ ]
+      };
+      const data = [];
+      spyOn(statsService, 'getControls').and.returnValue(observableOf(data));
+
+      service.getReportingControlsList(reportQuery);
+
+      expect(statsService.getControls).toHaveBeenCalledWith(reportQuery);
+    });
+  });
 });

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
@@ -43,6 +43,17 @@ export class ReportDataService {
     total: 0
   };
 
+  controlsListLoading = true;
+  controlsListParams: any = {
+    perPage: 100,
+    page: 1
+  };
+  controlsListEmpty = false;
+  controlsList: any = {
+    items: [],
+    total: 0
+  };
+
   constructor(
     private statsService: StatsService,
     private telemetryService: TelemetryService
@@ -80,6 +91,16 @@ export class ReportDataService {
         this.profilesListLoading = false;
         this.profilesListEmpty = this.isEmpty(data.items);
         this.profilesList = Object.assign({}, this.profilesList, data);
+      });
+  }
+
+  getReportingControlsList(reportQuery: ReportQuery) {
+    this.controlsListLoading = true;
+    this.statsService.getControls(reportQuery)
+      .subscribe(data => {
+        this.controlsListLoading = false;
+        this.controlsListEmpty = this.isEmpty(data.items);
+        this.controlsList = Object.assign({}, this.controlsList, data);
       });
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
@@ -103,6 +103,33 @@ describe('StatsService', () => {
     });
   });
 
+  describe('getControls()', () => {
+    it('fetches controls data', () => {
+      const endDate = moment().utc().startOf('day').add(12, 'hours');
+      const reportQuery: ReportQuery = {
+        startDate: moment(endDate).subtract(10, 'days'),
+        endDate: endDate,
+        interval: 0,
+        filters: [{type: {name: 'control_id'}, value: {id: 'sshd-1'}}]
+      };
+
+      const expectedUrl = `${COMPLIANCE_URL}/reporting/controls`;
+      const expectedItems = [{}, {}];
+      const expectedTotal = expectedItems.length;
+      const mockResp = { control_items: expectedItems };
+
+      service.getControls(reportQuery).subscribe(data => {
+        expect(data).toEqual({total: expectedTotal, items: expectedItems});
+      });
+
+      const req = httpTestingController.expectOne(expectedUrl);
+
+      expect(req.request.method).toEqual('POST');
+
+      req.flush(mockResp);
+    });
+  });
+
   describe('getNodeSummary()', () => {
     it('fetches node summary data', () => {
       const endDate = moment().utc().startOf('day').add(12, 'hours');

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -137,6 +137,15 @@ export class StatsService {
       map(({ profiles, counts: { total }}) => ({total, items: profiles})));
   }
 
+  getControls(reportQuery: ReportQuery) {
+    const url = `${CC_API_URL}/reporting/controls`;
+    const filters = this.formatFilters(reportQuery);
+    const body = { filters };
+
+    return this.httpClient.post<any>(url, body).pipe(
+      map(({ control_items }) => ({ total: control_items.length, items: control_items })));
+  }
+
   getStatsProfiles(reportQuery: ReportQuery, listParams: any): Observable<any> {
     const url = `${CC_API_URL}/reporting/stats/profiles`;
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Add controls list tab to the compliance reporting view.

![c](https://user-images.githubusercontent.com/479121/66546013-38ab0880-eaf9-11e9-9ade-a35495fe1b65.gif)

### :chains: Related Resources

https://github.com/chef/automate/issues/1310

### :+1: Definition of Done

A controls tab is available at `https://a2-dev.test/compliance/reports/controls` that displays a filterable list of controls.

### :athletic_shoe: How to Build and Test the Change

1. Navigate to https://a2-dev.test/compliance/reports/controls.
2. See list of controls.
3. Modify report filters via searchbar and/or other filter controls in reporting view.
4. See list of controls update accordingly.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?