### PR TITLE
[datalifecycle] Fix purging for old indices

### DIFF
--- a/components/compliance-service/ingest/ingestic/mappings/mappings.go
+++ b/components/compliance-service/ingest/ingestic/mappings/mappings.go
@@ -21,7 +21,6 @@ var AllMappings = []Mapping{
 }
 
 const (
-
 	//N.B. - the two IndicesVersion consts may very well be different from one another.  it's important to only change the one(s) that need migration.
 	//if we tied both to the same version, then a simple change to profiles structure would require us to do a full migration of timeseries (which is time consuming)
 	//the net result of separating them is that we can migrate them when one or both change by simply incrementing one or both.  cool, right!?

--- a/components/event-feed-service/pkg/integration_test/feed_purge_test.go
+++ b/components/event-feed-service/pkg/integration_test/feed_purge_test.go
@@ -138,7 +138,7 @@ func TestPurgeServer(t *testing.T) {
 				expectedRemaining: 100,
 				after:             func() { GetTestSuite().DeleteAllDocuments(); return },
 				before: func() {
-					for _, entry := range createEntries(time.Now().UTC(), 100, int(time.Hour)*-24) {
+					for _, entry := range createEntries(time.Now().UTC(), 900, int(time.Hour)*-24) {
 						testSuite.feedBackend.CreateFeedEntry(entry)
 					}
 
@@ -175,7 +175,7 @@ func TestPurgeServer(t *testing.T) {
 						Es: []*data_lifecycle.EsPolicyUpdate{
 							{
 								PolicyName:    server.PurgeFeedPolicyName,
-								OlderThanDays: 1,
+								OlderThanDays: 100,
 							},
 						},
 					},

--- a/components/event-feed-service/pkg/persistence/mappings.go
+++ b/components/event-feed-service/pkg/persistence/mappings.go
@@ -7,6 +7,8 @@ var AllMappings = []Mapping{
 }
 
 const (
+	// TODO: next person that changes the index version needs to fix the
+	// purging to happen for old indices
 	feedsIndicesVersion = "2"
 	DocType             = "_doc"
 	IndexNameFeeds      = "eventfeed-" + feedsIndicesVersion + "-feeds"

--- a/components/event-feed-service/pkg/server/jobs.go
+++ b/components/event-feed-service/pkg/server/jobs.go
@@ -25,7 +25,7 @@ var DefaultPurgePolicies = &purge.Policies{
 	Es: map[string]purge.EsPolicy{
 		PurgeFeedPolicyName: {
 			Name:             PurgeFeedPolicyName,
-			IndexName:        PurgeFeedIndexName,
+			IndexNames:       PurgeFeedIndexName,
 			CustomPurgeField: "pub_timestamp",
 		},
 	},

--- a/components/ingest-service/server/purge.go
+++ b/components/ingest-service/server/purge.go
@@ -28,12 +28,12 @@ var DefaultPurgePolicies = &purge.Policies{
 	Es: map[string]purge.EsPolicy{
 		PurgeConvergeHistoryName: {
 			Name:          PurgeConvergeHistoryName,
-			IndexName:     PurgeConvergeHistoryIndex,
+			IndexNames:    PurgeConvergeHistoryIndex,
 			OlderThanDays: 30,
 		},
 		PurgeActionsName: {
 			Name:          PurgeActionsName,
-			IndexName:     PurgeActionsIndex,
+			IndexNames:    PurgeActionsIndex,
 			OlderThanDays: 30,
 		},
 	},

--- a/lib/datalifecycle/purge/server.go
+++ b/lib/datalifecycle/purge/server.go
@@ -141,7 +141,7 @@ func (server *Server) Show(ctx context.Context,
 	for _, policy := range policies.Es {
 		dsEsPolicies = append(dsEsPolicies, &data_lifecycle.EsPolicy{
 			Name:             policy.Name,
-			Index:            policy.IndexName,
+			Index:            policy.IndexNames,
 			OlderThanDays:    policy.OlderThanDays,
 			CustomPurgeField: policy.CustomPurgeField,
 			Disabled:         policy.Disabled,

--- a/lib/datalifecycle/purge/workflow.go
+++ b/lib/datalifecycle/purge/workflow.go
@@ -69,7 +69,7 @@ func CreateOrUpdatePurgeWorkflow(
 		for name, dp := range defaultPolicies.Es {
 			p, ok := currentPolicies.Es[name]
 			if ok {
-				p.IndexName = dp.IndexName
+				p.IndexNames = dp.IndexNames
 				p.CustomPurgeField = dp.CustomPurgeField
 				currentPolicies.Es[name] = p
 			} else {


### PR DESCRIPTION
- fixes an issue where document based purging wasn't correctly
happening
- purges old versions of time series indices