### PR TITLE
[automate-1755] Reset checked projects list upon opening create modal

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -48,7 +48,8 @@
           <app-projects-dropdown
             [projects]="projects"
             (onProjectChecked)="onProjectChecked($event)"
-            [disabled]="dropdownDisabled()">
+            [disabled]="dropdownDisabled()"
+            [projectsUpdated]="projectsUpdatedEvent">
           </app-projects-dropdown>
         </div>
         <div id="button-bar">

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
@@ -1,8 +1,10 @@
+import { EventEmitter, SimpleChange } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { MockComponent } from 'ng2-mock-component';
 
 import { using } from 'app/testing/spec-helpers';
+import { Project } from 'app/entities/projects/project.model';
 import { CreateObjectModalComponent } from './create-object-modal.component';
 
 describe('CreateObjectModalComponent', () => {
@@ -20,7 +22,8 @@ describe('CreateObjectModalComponent', () => {
         MockComponent({ selector: 'chef-toolbar' }),
         MockComponent({ selector: 'chef-modal', inputs: ['visible'] }),
         MockComponent({ selector: 'app-projects-dropdown',
-          inputs: ['projects', 'disabled'], outputs: ['onProjectChecked'] })
+          inputs: ['projects', 'disabled', 'projectsUpdated'],
+          outputs: ['onProjectChecked'] })
       ],
      imports: [
         ReactiveFormsModule
@@ -31,6 +34,7 @@ describe('CreateObjectModalComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CreateObjectModalComponent);
     component = fixture.componentInstance;
+    component.conflictErrorEvent = new EventEmitter();
     component.createForm = new FormBuilder().group({
       name: ['', null],
       id: ['', null]
@@ -55,6 +59,37 @@ describe('CreateObjectModalComponent', () => {
         <any>{bubbles : true, cancelable : true, key : inputVal, char : inputVal, shiftKey : true
       }));
       expect(component.createForm.controls['id'].value).toBe(outputVal);
+    });
+  });
+
+  it('ngOnChanges initializes checked status to false for all projects ', () => {
+    const assignableProjects: Project[] = [
+      {id: 'proj1', name: 'proj1', type: 'CHEF_MANAGED', status: 'NO_RULES'},
+      {id: 'proj3', name: 'proj3', type: 'CUSTOM', status: 'EDITS_PENDING'},
+      { id: 'proj2', name: 'proj2', type: 'CUSTOM', status: 'RULES_APPLIED' }
+    ];
+    component.ngOnChanges(
+      { assignableProjects: new SimpleChange({}, assignableProjects, true) });
+    expect(Object.values(component.projects).length).toEqual(assignableProjects.length);
+    assignableProjects.forEach(p => {
+      const proj = component.projects[p.id];
+      expect(proj).toEqual({ ...p, checked: false });
+    });
+  });
+
+  it('ngOnChanges resets checked status to false for all projects ', () => {
+    component.projects = {
+      'proj1':
+        { id: 'proj1', name: 'proj1', type: 'CHEF_MANAGED', status: 'NO_RULES', checked: true },
+      'proj3':
+        { id: 'proj3', name: 'proj3', type: 'CUSTOM', status: 'EDITS_PENDING', checked: false },
+      'proj2':
+        { id: 'proj2', name: 'proj2', type: 'CUSTOM', status: 'RULES_APPLIED', checked: true }
+    };
+    component.ngOnChanges(
+      { visible: new SimpleChange(false, true, true) });
+    Object.values(component.projects).forEach(p => {
+      expect(p.checked).toBe(false);
     });
   });
 

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -33,6 +33,7 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
   // Whether the edit ID form is open or not.
   public modifyID = false;
   public conflictError = false;
+  public projectsUpdatedEvent = new EventEmitter<boolean>();
 
   ngOnInit(): void {
     this.conflictErrorEvent.subscribe((isConflict: boolean) => {
@@ -49,6 +50,11 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
       this.projects = {};
       changes.assignableProjects.currentValue.forEach((proj: Project) =>
         this.projects[proj.id] = { ...proj, checked });
+    }
+    // clear checked projects when opening
+    if (changes.visible && (changes.visible.currentValue as boolean)) {
+      Object.values(this.projects).forEach(p => p.checked = false);
+      this.projectsUpdatedEvent.emit(true);
     }
   }
 

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -33,7 +33,7 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
   // Whether the edit ID form is open or not.
   public modifyID = false;
   public conflictError = false;
-  public projectsUpdatedEvent = new EventEmitter<boolean>();
+  public projectsUpdatedEvent = new EventEmitter();
 
   ngOnInit(): void {
     this.conflictErrorEvent.subscribe((isConflict: boolean) => {
@@ -54,7 +54,7 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
     // clear checked projects when opening
     if (changes.visible && (changes.visible.currentValue as boolean)) {
       Object.values(this.projects).forEach(p => p.checked = false);
-      this.projectsUpdatedEvent.emit(true);
+      this.projectsUpdatedEvent.emit();
     }
   }
 

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -2,7 +2,6 @@ import {
   Component, EventEmitter, Input, Output, OnInit, OnChanges, SimpleChanges
 } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { hasIn } from 'lodash/fp';
 
 import { IdMapper } from 'app/helpers/auth/id-mapper';
 import { Project } from 'app/entities/projects/project.model';
@@ -29,9 +28,7 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
   @Output() createClicked = new EventEmitter<Project[]>();
 
   public projects: ProjectCheckedMap = {};
-
-  // Whether the edit ID form is open or not.
-  public modifyID = false;
+  public modifyID = false; // Whether the edit ID form is open or not.
   public conflictError = false;
   public projectsUpdatedEvent = new EventEmitter();
 
@@ -44,12 +41,11 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    // if a new list of projects to populate dropdown with is passed in we update the dropdown
-    const checked = false;
-    if (hasIn('assignableProjects.currentValue', changes)) {
+    // update project dropdown if list changes
+    if (changes.assignableProjects) {
       this.projects = {};
       changes.assignableProjects.currentValue.forEach((proj: Project) =>
-        this.projects[proj.id] = { ...proj, checked });
+        this.projects[proj.id] = { ...proj, checked: false });
     }
     // clear checked projects when opening
     if (changes.visible && (changes.visible.currentValue as boolean)) {
@@ -68,7 +64,7 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
     return Object.values(this.projects).length === 0;
   }
 
-  public handleNameInput(event: KeyboardEvent): void {
+  handleNameInput(event: KeyboardEvent): void {
     if (!this.modifyID && !this.isNavigationKey(event)) {
       this.conflictError = false;
       this.createForm.controls.id.setValue(
@@ -76,7 +72,7 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
     }
   }
 
-  public handleIDInput(event: KeyboardEvent): void {
+  handleIDInput(event: KeyboardEvent): void {
     if (this.isNavigationKey(event)) {
       return;
     }

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
@@ -15,12 +15,12 @@
   <chef-click-outside (clickOutside)="closeDropdown()">
     <chef-dropdown [attr.visible]="active">
       <chef-checkbox
-        *ngFor="let project of projectsArray()"
+        *ngFor="let project of projectsArray"
         [checked]="project.checked"
         [attr.title]="project.name"
         (change)="projectChecked($event.detail, project)"
-        (keydown.enter)="closeColumnDropdown()"
-        (keydown.esc)="closeColumnDropdown()"
+        (keydown.enter)="closeDropdown()"
+        (keydown.esc)="closeDropdown()"
         (keydown.arrowup)="moveFocus($event)"
         (keydown.arrowdown)="moveFocus($event)">{{ project['name'] }}</chef-checkbox>
     </chef-dropdown>

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, EventEmitter } from '@angular/core';
 
 import { ProjectsDropdownComponent } from './projects-dropdown.component';
 
@@ -18,6 +18,7 @@ describe('ProjectsDropdownComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ProjectsDropdownComponent);
     component = fixture.componentInstance;
+    component.projectsUpdated = new EventEmitter();
     fixture.detectChanges();
   });
 

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -1,5 +1,5 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA, EventEmitter } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProjectsDropdownComponent } from './projects-dropdown.component';
 

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, OnChanges } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnChanges, OnInit } from '@angular/core';
 
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { ProjectConstants, Project } from 'app/entities/projects/project.model';
@@ -21,13 +21,19 @@ export interface ProjectCheckedMap {
   templateUrl: './projects-dropdown.component.html',
   styleUrls: ['./projects-dropdown.component.scss']
 })
-export class ProjectsDropdownComponent implements OnChanges {
+export class ProjectsDropdownComponent implements OnInit, OnChanges {
   // The map of ProjectChecked by id. Any checked changes propagated via
   // onProjectChecked. Updates should be applied to parent component state.
   @Input() projects: ProjectCheckedMap = {};
 
   // Setting disabled to true means the dropdown will be unusable and will have a grey background
   @Input() disabled = false;
+
+  // Used to re-synchronize summary label if the set of checked items has changed.
+  // This optional input is needed only when re-displaying the project dropdown
+  // for *additional* resources, as with the create-object-modal-component.
+  // Other consumers, e.g. team-details.component use it only for a single resource.
+  @Input() projectsUpdated: EventEmitter<boolean>;
 
   // Emits a project that changed as a result of a check or uncheck.
   @Output() onProjectChecked = new EventEmitter<ProjectChecked>();
@@ -38,6 +44,12 @@ export class ProjectsDropdownComponent implements OnChanges {
   projectsArray(): ProjectChecked[] {
     const projects = Object.values(this.projects);
     return ChefSorters.naturalSort(projects, 'name');
+  ngOnInit(): void {
+    if (this.projectsUpdated) { // an optional setting
+      this.projectsUpdated.subscribe(() => {
+        this.updateLabel();
+      });
+    }
   }
 
   ngOnChanges(): void {

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -38,12 +38,9 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
   // Emits a project that changed as a result of a check or uncheck.
   @Output() onProjectChecked = new EventEmitter<ProjectChecked>();
 
-  active = false;
-  label = UNASSIGNED_PROJECT_ID;
+  public active = false;
+  public label = UNASSIGNED_PROJECT_ID;
 
-  projectsArray(): ProjectChecked[] {
-    const projects = Object.values(this.projects);
-    return ChefSorters.naturalSort(projects, 'name');
   ngOnInit(): void {
     if (this.projectsUpdated) { // an optional setting
       this.projectsUpdated.subscribe(() => {
@@ -54,6 +51,10 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
 
   ngOnChanges(): void {
     this.updateLabel();
+  }
+
+  get projectsArray(): ProjectChecked[] {
+    return ChefSorters.naturalSort(Object.values(this.projects), 'name');
   }
 
   toggleDropdown(event: MouseEvent): void {
@@ -96,7 +97,7 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
   }
 
   private updateLabel(): void {
-    const checkedProjects = this.projectsArray().filter(p => p.checked);
+    const checkedProjects = Object.values(this.projects).filter(p => p.checked);
     switch (checkedProjects.length) {
       case 1: {
         const onlyProject = checkedProjects[0];

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.selectors.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.selectors.ts
@@ -8,7 +8,7 @@ export const projectsFilterState = state => state.projectsFilter;
 export const options = createSelector(projectsFilterState, state => state.options);
 
 export const assignableProjects = createSelector(projectsFilterState, state => {
-  let projectOptions = state.options.filter((p: ProjectsFilterOption) => p.checked);
+  let projectOptions = (state.options as ProjectsFilterOption[]).filter(p => p.checked);
 
   // there is no project filter, populate all projects.
   if (projectOptions.length === 0) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The `CreateObjectModalComponent` (used for creating tokens and teams at present) appeared to retain the last set of selected projects. However, that was a phantom. They were not really selected. So upon saving the new token/team, it would show in the tokens/teams list with just `(unassigned)`, leaving the user confused.

Two separate things to fix:
Resetting all projects on the dropdown to unchecked.
Updating the dropdown label when it is closed to reflect that no projects are checked.

### :chains: Related Resources
NA

### :+1: Definition of Done
Opening the "create team" (or "create token") modal for the second time in succession shows an unchecked projects list.

### :athletic_shoe: How to Build and Test the Change

rebuild automate-ui
Create one or more projects (Settings >> Projects >> Create Project)
Create a team (Settings >> Teams >> Create Team), selecting one or more projects.
Save that team.
Select "Create Team" a second time.
Observe (1) the projects dropdown labels and (2) the 


### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable

![image](https://user-images.githubusercontent.com/6817500/66623823-4799c580-eba2-11e9-974f-6cde98719812.png)
