### PR TITLE
Jamie/client run history drawer styling

### DIFF
--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.html
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.html
@@ -10,7 +10,7 @@
         <chef-icon>close</chef-icon>
       </chef-button>
     </div>
-<!--  -->
+
     <div class="side-panel-body">
       <div class="side-panel-body-header">
         <div>
@@ -18,18 +18,18 @@
         </div>
 
         <div class="filter-selectors">
-          <div class="selector all" (click)="onStatusChange(selectedStatus.All)" [ngClass]="{active: selected == selectedStatus.All}">
+          <button class="selector all" (click)="onStatusChange(selectedStatus.All)" [ngClass]="{active: selected == selectedStatus.All}">
               <chef-icon>check_circle</chef-icon>
               <div>{{stats(selectedStatus.All)}}</div>
-          </div>
-          <div class="selector failed" (click)="onStatusChange(selectedStatus.Failure)" [ngClass]="{active: selected == selectedStatus.Failure}">
+          </button>
+          <button class="selector failed" (click)="onStatusChange(selectedStatus.Failure)" [ngClass]="{active: selected == selectedStatus.Failure}">
             <chef-icon>warning</chef-icon>
             <div>{{stats(selectedStatus.Failure)}}</div>
-          </div>
-          <div class="selector successful" (click)="onStatusChange(selectedStatus.Success)" [ngClass]="{active: selected == selectedStatus.Success}">
+          </button>
+          <button class="selector successful" (click)="onStatusChange(selectedStatus.Success)" [ngClass]="{active: selected == selectedStatus.Success}">
             <chef-icon>check_circle</chef-icon>
             <div>{{stats(selectedStatus.Success)}}</div>
-          </div>
+          </button>
           <div>
             <app-date-selector (select)="dateSelected($event)" [initialDateTerm]="defaultSelectionTerm"> </app-date-selector>
           </div>
@@ -39,6 +39,7 @@
       <ul class="run-history-list">
         <li *ngFor="let history of nodeHistory" 
             class="run-history-list-item"
+            [class.selected]="history.runId === activeRunId"
             (click)="onSelect(history)">
           <div class="list-item-summary">
             <chef-icon [ngClass]="history.status">{{ history.status | chefStatusIcon }}</chef-icon>

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.html
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.html
@@ -39,8 +39,7 @@
       <ul class="run-history-list">
         <li *ngFor="let history of nodeHistory" 
             class="run-history-list-item"
-            [class.selected]="history.runId === activeRunId"
-            (click)="onSelect(history)">
+            [class.selected]="history.runId === activeRunId">
           <div class="list-item-summary">
             <chef-icon [ngClass]="history.status">{{ history.status | chefStatusIcon }}</chef-icon>
             <div class="list-item-text">
@@ -49,7 +48,7 @@
               </p>
               <p>{{ getDuration(history.startTime, history.endTime) }} ago</p>
             </div>
-            <chef-button secondary>
+            <chef-button secondary (click)="onSelect(history)">
               <chef-icon>chevron_right</chef-icon>
             </chef-button>
           </div>

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.html
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.html
@@ -49,9 +49,9 @@
               </p>
               <p>{{ getDuration(history.startTime, history.endTime) }} ago</p>
             </div>
-            <!-- <chef-button secondary>
+            <chef-button secondary>
               <chef-icon>chevron_right</chef-icon>
-            </chef-button> -->
+            </chef-button>
           </div>
         </li>
         <li class="no-runs-small" *ngIf="stats(selected) == 0">

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.html
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.html
@@ -10,49 +10,59 @@
         <chef-icon>close</chef-icon>
       </chef-button>
     </div>
-    <div class="filter-selectors">
-      <div class="selector all" (click)="onStatusChange(selectedStatus.All)" [ngClass]="{active: selected == selectedStatus.All}">
-          <chef-icon>check_circle</chef-icon>
-          <div>{{stats(selectedStatus.All)}}</div>
-      </div>
-      <div class="selector failed" (click)="onStatusChange(selectedStatus.Failure)" [ngClass]="{active: selected == selectedStatus.Failure}">
-        <chef-icon>warning</chef-icon>
-        <div>{{stats(selectedStatus.Failure)}}</div>
-      </div>
-      <div class="selector successful" (click)="onStatusChange(selectedStatus.Success)" [ngClass]="{active: selected == selectedStatus.Success}">
-        <chef-icon>check_circle</chef-icon><div>{{stats(selectedStatus.Success)}}</div>
-      </div>
-      <div>
-        <app-date-selector (select)="dateSelected($event)" [initialDateTerm]="defaultSelectionTerm"> </app-date-selector>
-      </div>
-    </div>
-    <ul>
-      <li class="history-item" *ngFor="let history of nodeHistory" (click)="onSelect(history)">
-        <div class="arrow">
-          <chef-icon *ngIf="activeRunId === history.runId">chevron_left</chef-icon>
+<!--  -->
+    <div class="side-panel-body">
+      <div class="side-panel-body-header">
+        <div>
+          <p>Select a run below to view results on that date</p>
         </div>
-        <div class="status" [ngClass]="history.status">
-          <chef-icon>{{ history.status | chefStatusIcon }}</chef-icon>
-        </div>
-        <div class="duration">
-          <p><strong>{{ history.startTime | datetime: RFC2822 }}</strong></p>
-        </div>
-        <div class="date-time">
-          {{getDuration(history.startTime, history.endTime)}}
-        </div>
-      </li>
-      <li class="no-runs-small" *ngIf="stats(selected) == 0">
-        <span>There are no runs for this node that match the criteria selected.</span>
-      </li>
-    </ul>
 
-    <app-page-picker
-      class="history-pagination"
-      [total]="stats(selected)"
-      [perPage]="pageSize"
-      [page]="currentPage"
-      [maxPageItems]="3"
-      (pageChanged)="updatePageNumber($event)">
-    </app-page-picker>
+        <div class="filter-selectors">
+          <div class="selector all" (click)="onStatusChange(selectedStatus.All)" [ngClass]="{active: selected == selectedStatus.All}">
+              <chef-icon>check_circle</chef-icon>
+              <div>{{stats(selectedStatus.All)}}</div>
+          </div>
+          <div class="selector failed" (click)="onStatusChange(selectedStatus.Failure)" [ngClass]="{active: selected == selectedStatus.Failure}">
+            <chef-icon>warning</chef-icon>
+            <div>{{stats(selectedStatus.Failure)}}</div>
+          </div>
+          <div class="selector successful" (click)="onStatusChange(selectedStatus.Success)" [ngClass]="{active: selected == selectedStatus.Success}">
+            <chef-icon>check_circle</chef-icon><div>{{stats(selectedStatus.Success)}}</div>
+          </div>
+          <div>
+            <app-date-selector (select)="dateSelected($event)" [initialDateTerm]="defaultSelectionTerm"> </app-date-selector>
+          </div>
+        </div>
+      </div>
+<!--  -->
+      <ul>
+        <li class="history-item" *ngFor="let history of nodeHistory" (click)="onSelect(history)">
+          <div class="arrow">
+            <chef-icon *ngIf="activeRunId === history.runId">chevron_left</chef-icon>
+          </div>
+          <div class="status" [ngClass]="history.status">
+            <chef-icon>{{ history.status | chefStatusIcon }}</chef-icon>
+          </div>
+          <div class="duration">
+            <p><strong>{{ history.startTime | datetime: RFC2822 }}</strong></p>
+          </div>
+          <div class="date-time">
+            {{getDuration(history.startTime, history.endTime)}}
+          </div>
+        </li>
+        <li class="no-runs-small" *ngIf="stats(selected) == 0">
+          <span>There are no runs for this node that match the criteria selected.</span>
+        </li>
+      </ul>
+
+      <app-page-picker
+        class="history-pagination"
+        [total]="stats(selected)"
+        [perPage]="pageSize"
+        [page]="currentPage"
+        [maxPageItems]="3"
+        (pageChanged)="updatePageNumber($event)">
+      </app-page-picker>
+    </div>
   </chef-side-panel>
 </chef-click-outside>

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.html
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.html
@@ -27,27 +27,30 @@
             <div>{{stats(selectedStatus.Failure)}}</div>
           </div>
           <div class="selector successful" (click)="onStatusChange(selectedStatus.Success)" [ngClass]="{active: selected == selectedStatus.Success}">
-            <chef-icon>check_circle</chef-icon><div>{{stats(selectedStatus.Success)}}</div>
+            <chef-icon>check_circle</chef-icon>
+            <div>{{stats(selectedStatus.Success)}}</div>
           </div>
           <div>
             <app-date-selector (select)="dateSelected($event)" [initialDateTerm]="defaultSelectionTerm"> </app-date-selector>
           </div>
         </div>
       </div>
-<!--  -->
-      <ul>
-        <li class="history-item" *ngFor="let history of nodeHistory" (click)="onSelect(history)">
-          <div class="arrow">
-            <chef-icon *ngIf="activeRunId === history.runId">chevron_left</chef-icon>
-          </div>
-          <div class="status" [ngClass]="history.status">
-            <chef-icon>{{ history.status | chefStatusIcon }}</chef-icon>
-          </div>
-          <div class="duration">
-            <p><strong>{{ history.startTime | datetime: RFC2822 }}</strong></p>
-          </div>
-          <div class="date-time">
-            {{getDuration(history.startTime, history.endTime)}}
+
+      <ul class="run-history-list">
+        <li *ngFor="let history of nodeHistory" 
+            class="run-history-list-item"
+            (click)="onSelect(history)">
+          <div class="list-item-summary">
+            <chef-icon [ngClass]="history.status">{{ history.status | chefStatusIcon }}</chef-icon>
+            <div class="list-item-text">
+              <p>
+                <strong>{{ history.startTime | datetime: RFC2822 }}</strong>
+              </p>
+              <p>{{ getDuration(history.startTime, history.endTime) }} ago</p>
+            </div>
+            <!-- <chef-button secondary>
+              <chef-icon>chevron_right</chef-icon>
+            </chef-button> -->
           </div>
         </li>
         <li class="no-runs-small" *ngIf="stats(selected) == 0">

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.html
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.html
@@ -4,7 +4,7 @@
       <chef-icon class="header-icon">restore</chef-icon>
       <div class="header-text">
         <h4><strong>Run history for node:</strong></h4>
-        <p>{{ node name here }}</p>
+        <p>{{ nodeName }}</p>
       </div>
       <chef-button secondary label="close" (click)="closeRunHistory()">
         <chef-icon>close</chef-icon>

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.html
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.html
@@ -19,7 +19,7 @@
 
         <div class="filter-selectors">
           <button class="selector all" (click)="onStatusChange(selectedStatus.All)" [ngClass]="{active: selected == selectedStatus.All}">
-              <chef-icon>check_circle</chef-icon>
+              <chef-icon>list</chef-icon>
               <div>{{stats(selectedStatus.All)}}</div>
           </button>
           <button class="selector failed" (click)="onStatusChange(selectedStatus.Failure)" [ngClass]="{active: selected == selectedStatus.Failure}">

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.html
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.html
@@ -1,8 +1,12 @@
 <chef-click-outside omit="run-history-button" (clickOutside)="closeRunHistory()">
   <chef-side-panel id="run-history-panel" tabindex="0" [visible]="visible">
-    <div class="history-header">
-      <h2 class="history-heading"> Run History</h2>
-      <chef-button (click)="closeRunHistory()" secondary class="close-button" label="close">
+    <div class="side-panel-header">
+      <chef-icon class="header-icon">restore</chef-icon>
+      <div class="header-text">
+        <h4><strong>Run history for node:</strong></h4>
+        <p>{{ node name here }}</p>
+      </div>
+      <chef-button secondary label="close" (click)="closeRunHistory()">
         <chef-icon>close</chef-icon>
       </chef-button>
     </div>

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
@@ -33,68 +33,67 @@
   }
 }
 
-.side-panel-body {
-  .side-panel-body-header {
-    display: flex;
-    flex-direction: column;
-    padding: 1em;
-    border-bottom: 1px solid $chef-grey;
+.side-panel-body-header {
+  display: flex;
+  flex-direction: column;
+  padding: 1em;
+  border-bottom: 1px solid $chef-grey;
 
-    chef-button {
-      margin: 0 1em 0 0;
-    }
+  chef-button {
+    margin: 0 1em 0 0;
+  }
 
-    p {
-      margin: 0;
-    }
+  p {
+    margin: 0;
   }
 }
 
-  .run-history-list {
-    margin: 0;
-    padding: 0;
-    list-style: none;
+.run-history-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.run-history-list-item {
+  border-bottom: 1px solid $chef-grey;
+  border-left: 4px solid transparent;
+  background: $chef-white;
+
+  &.selected {
+    border-left: 4px solid $chef-primary-bright;
   }
+}
 
-  .run-history-list-item {
-    border-bottom: 1px solid $chef-grey;
-    border-left: 4px solid transparent;
-    background: $chef-white;
+.list-item-summary {
+  display: flex;
+  align-items: center;
+  padding: 1em;
+  cursor: pointer;
 
-    &.selected {
-      border-left: 4px solid $chef-primary-bright;
+  chef-icon {
+    &.failure {
+      color: $chef-critical;
+    }
+
+    &.success {
+      color: $chef-primary-bright;
     }
   }
 
-  .list-item-summary {
-    display: flex;
-    align-items: center;
-    padding: 1em;
+  .list-item-text {
+    margin: 0 1em;
+    flex-grow: 1;
 
-    chef-icon {
-      &.failure {
-        color: $chef-critical;
-      }
-
-      &.success {
-        color: $chef-primary-bright;
-      }
+    chef-button,
+    p {
+      margin: 0;
     }
 
-    .list-item-text {
-      margin: 0 1em;
-      flex-grow: 1;
-
-      chef-button,
-      p {
-        margin: 0;
-      }
-
-      p {
-        line-height: 1.5;
-      }
+    p {
+      line-height: 1.5;
     }
   }
+}
 
 
 app-date-selector {

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
@@ -50,6 +50,53 @@
   }
 }
 
+  .run-history-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .run-history-list-item {
+    border-bottom: 1px solid $chef-grey;
+    border-left: 4px solid transparent;
+    background: $chef-white;
+
+    &.selected {
+      border-left: 4px solid $chef-primary-bright;
+    }
+  }
+
+  .list-item-summary {
+    display: flex;
+    align-items: center;
+    padding: 1em;
+
+    chef-icon {
+
+      &.failure {
+        color: $chef-critical;
+      }
+
+      &.success {
+        color: $chef-primary-bright;
+      }
+    }
+
+    .list-item-text {
+      margin: 0 1em;
+      flex-grow: 1;
+
+      chef-button,
+      p {
+        margin: 0;
+      }
+
+      p {
+        line-height: 1.5;
+      }
+    }
+  }
+
 
 app-date-selector {
   .date-selector .selector {
@@ -116,67 +163,6 @@ app-date-selector {
     &:hover, &.active {
       background-color: lighten($gray, 10%);
     }
-  }
-}
-
-.history-item {
-  @include modal-box();
-  display: block;
-  margin-bottom: .25em;
-  margin-left: 1em;
-  padding: .5em;
-  position: relative;
-  border-radius: 0;
-  cursor: pointer;
-  transition: all .2s;
-
-  &:hover {
-    margin-left: .75em;
-    margin-right: .25em;
-    transition: all .2s;
-  }
-
-  .arrow {
-    display: inline-block;
-    font-size: 1.5em;
-    left: -0.5em;
-    position: absolute;
-  }
-
-  .status {
-    display: inline-block;
-    font-size: .875em;
-    margin-right: .5em;
-    position: relative;
-
-    & > chef-icon {
-      position: relative;
-      top: 2px;
-    }
-  }
-
-  .date-time {
-    display: inline-block;
-    margin-left: 2.5em;
-    position: relative;
-    width: 80%;
-    color: $gray;
-    font-size: .625em;
-  }
-
-  .duration {
-    display: inline-block;
-    position: relative;
-    width: 80%;
-
-    p {
-      margin-bottom: 0;
-    }
-  }
-
-  > div span {
-    position: absolute;
-    right: 0;
   }
 }
 

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
@@ -1,22 +1,36 @@
 @import "~styles/variables";
 @import "~styles/mixins";
 
-.history-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 19px 35px;
-  border-bottom: 1px solid $chef-grey;
-  background-color: $chef-white;
-}
 
-.history-heading {
-  font-size: 18px;
-  font-weight: bold;
-}
+#run-history-panel {
+  chef-button {
+    margin: 0;
+  }
 
-.close-button {
-  margin: 0;
+  .side-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1em;
+    background: $chef-white;
+    border-bottom: 1px solid $chef-grey;
+
+    .header-icon {
+      font-size: 2em;
+      color: $chef-dark-grey;
+    }
+
+    .header-text {
+      margin: 0 1em;
+      flex-grow: 1;
+      word-break: break-all;
+
+      p {
+        margin: 0;
+        color: $chef-dark-grey;
+      }
+    }
+  }
 }
 
 app-date-selector {

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
@@ -75,7 +75,7 @@
     }
 
     &.success {
-      color: $chef-primary-bright;
+      color: $chef-success;
     }
   }
 
@@ -145,12 +145,12 @@ app-date-selector {
   }
 
   .successful, .passed {
-    color: $chef-primary-bright;
+    color: $chef-success;
     background-color: $chef-white;
 
     &.active {
       color: $chef-white;
-      background-color: $chef-primary-bright;
+      background-color: $chef-success;
     }
   }
 

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
@@ -72,7 +72,6 @@
     padding: 1em;
 
     chef-icon {
-
       &.failure {
         color: $chef-critical;
       }

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
@@ -68,7 +68,6 @@
   display: flex;
   align-items: center;
   padding: 1em;
-  cursor: pointer;
 
   chef-icon {
     &.failure {

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
@@ -33,6 +33,24 @@
   }
 }
 
+.side-panel-body {
+  .side-panel-body-header {
+    display: flex;
+    flex-direction: column;
+    padding: 1em;
+    border-bottom: 1px solid $chef-grey;
+
+    chef-button {
+      margin: 0 1em 0 0;
+    }
+
+    p {
+      margin: 0;
+    }
+  }
+}
+
+
 app-date-selector {
   .date-selector .selector {
     border: 1px solid $gray-shadow;
@@ -41,9 +59,9 @@ app-date-selector {
 
 .filter-selectors {
   display: flex;
-  justify-content: space-evenly;
-  align-items: stretch;
-  padding: 15px 0 0 35px;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding-top: 1em;
 
   .selector {
     display: flex;
@@ -54,7 +72,8 @@ app-date-selector {
     height: 60px;
     border-color: $chef-grey;
     border-radius: 4px;
-
+    margin-right: 20px;
+    cursor: pointer;
   }
 
   .all {
@@ -74,6 +93,10 @@ app-date-selector {
     &.active {
       color: $chef-white;
       background-color: $chef-critical;
+
+      chef-icon {
+        color: $chef-white;
+      }
     }
   }
 

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.ts
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.ts
@@ -22,6 +22,7 @@ import * as moment from 'moment';
 })
 export class RunHistoryComponent implements OnInit, OnDestroy {
 
+  @Input() nodeName: string;
   @Input() nodeId: string;
   @Input() initialRunId: string;
   @Input() initialDate: Date;

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.ts
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.ts
@@ -22,7 +22,6 @@ import * as moment from 'moment';
 })
 export class RunHistoryComponent implements OnInit, OnDestroy {
 
-  @Input() nodeName: string;
   @Input() nodeId: string;
   @Input() initialRunId: string;
   @Input() initialDate: Date;

--- a/components/automate-ui/src/app/pages/node-details/node-details.component.html
+++ b/components/automate-ui/src/app/pages/node-details/node-details.component.html
@@ -40,6 +40,7 @@
       <app-run-history
         [visible]="runHistoryVisible"
         class="run-history-container"
+        [nodeName]="nodeRun.nodeName"
         [nodeId]="nodeId"
         (on_run_change)="updateRunId($event)"
         (closeRunHistoryEvent)="closeRunHistory()"

--- a/components/automate-ui/src/app/pages/node-details/node-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/node-details/node-details.component.spec.ts
@@ -98,7 +98,7 @@ function createTestFixture(
       MockComponent({ selector: 'app-resources', inputs: ['nodeRun'] }),
       MockComponent({
         selector: 'app-run-history',
-        inputs: ['nodeId', 'initialRunId', 'initialDate']
+        inputs: ['nodeId', 'nodeName', 'initialRunId', 'initialDate']
       }),
       MockComponent({ selector: 'app-run-list', inputs: ['nodeRun'] }),
       MockComponent({ selector: 'app-attributes', inputs: ['nodeId'] }),


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
In an effort to add consistency across the application, the Run History drawer is being restyled to match the other drawers across the site.  This primarily involved changing the HTML markup and CSS in the run-history component.  The overall functionality of the drawer has not changed.

### :chains: Related Resources

### :+1: Definition of Done
The Run History drawer matches specs given by UX, which mimics the same look found in the Nodes Scan Job History drawer. 

### :athletic_shoe: How to Build and Test the Change

1. build components/automate-ui-devproxy && start_all_services
2. navigate to https://a2-dev.test/infrastructure/client-runs
3. click on any Node from the list below
4. Click `Run History` button on the top right to see the drawer slide out
5. Click on different Runs in the drawer to see the content on the page reflect that specific run.
6. Click the Success, All, and Failure buttons to see the appropriate runs display or a "There are no runs for this node that match the criteria selected." message.


### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
After
<img width="1153" alt="Infrastructure Run HIstory Drawer" src="https://user-images.githubusercontent.com/16737484/67129202-c601f300-f1b2-11e9-9203-a93c9c79ddc6.png">
