### PR TITLE
Don't wait for shards to relocate

### DIFF
--- a/components/es-sidecar-service/pkg/elastic/snapshot.go
+++ b/components/es-sidecar-service/pkg/elastic/snapshot.go
@@ -551,7 +551,7 @@ func (es *Elastic) waitForYellow(ctx context.Context) error {
 	waitForYellowTimeout, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	_, err := es.client.ClusterHealth().WaitForYellowStatus().WaitForNoRelocatingShards(true).Do(waitForYellowTimeout)
+	_, err := es.client.ClusterHealth().WaitForYellowStatus().Do(waitForYellowTimeout)
 	return err
 }
 


### PR DESCRIPTION
This seems to cause problems in large clusters (#1871) and shouldn't
affect any internal ES use cases as there is nowhere to relocate to
