### PR TITLE
Add min CS version that supports the data collector

### DIFF
--- a/components/automate-chef-io/content/docs/data-collection.md
+++ b/components/automate-chef-io/content/docs/data-collection.md
@@ -106,9 +106,9 @@ To apply the changes, run:
 sudo chef-server-ctl reconfigure
 ```
 
-### Setting Up Data Collection on Chef Server Versions 12.13 and Lower
+### Setting Up Data Collection on Chef Server for Versions 12.8 through 12.13
 
-On versions 12.13 and prior, simply add the `root_url` and `token` values in
+For Chef Infra Server versions between 12.8 and 12.13, simply add the `root_url` and `token` values in
 `/etc/opscode/chef-server.rb`:
 
 ```ruby


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Update the docs to include the minimum version of Chef-Server that supports the data-collector.  

The data-collector was added to Chef-Server in version 12.8.0.  Users will need to make sure they are running at least that version before they can configure the data-collector.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable