### PR TITLE
Auto-upgrade installs on 2.0 to 2.1 on authz server startup

### DIFF
--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -110,7 +110,12 @@ func NewPoliciesServer(
 	case storage.SuccessfulBeta1:
 		v = api.Version{Major: api.Version_V2, Minor: api.Version_V1}
 	case storage.Successful:
-		v = api.Version{Major: api.Version_V2, Minor: api.Version_V0}
+		// auto-upgrade a 2.0 installation to 2.1
+		_, err := srv.handleMinorUpgrade(ctx, ms, api.Flag_VERSION_2_1)
+		if err != nil {
+			return nil, errors.Wrap(err, "auto-upgrade a 2.0 installation to 2.1")
+		}
+		v = api.Version{Major: api.Version_V2, Minor: api.Version_V1}
 	default:
 		v = api.Version{Major: api.Version_V1, Minor: api.Version_V0}
 	}

--- a/components/authz-service/storage/v2/memstore/memstore.go
+++ b/components/authz-service/storage/v2/memstore/memstore.go
@@ -48,6 +48,7 @@ func (s *State) CreatePolicy(_ context.Context, inputPol *storage.Policy, checkP
 			return nil, storage_errors.ErrConflict
 		}
 	}
+
 	copyPol := *inputPol
 	if err := s.policies.Add(inputPol.ID, &copyPol, cache.NoExpiration); err != nil {
 		return nil, storage_errors.ErrConflict


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

We want installs on IAM v2.0 to be auto-upgraded to IAM v2.1. That will now happen on authz server restart.

IAM v1.0 will not be affected.

### Depends On

Need to rebase on this before integration tests will pass:

https://github.com/chef/automate/pull/1861

### :athletic_shoe: How to Build and Test the Change

This change is bit easier to test before we rebase on this PR https://github.com/chef/automate/pull/1861 since we can still use the CLI to get into v2.0 mode:

Auto-upgrades from v2.0 to v2.1

```
# chef-automate iam version
IAM v2.0

# restart authz by rebuilding
# rebuild components/authz-service
...
# chef-automate iam version
IAM v2.1
```

Doesn't auto-upgrade on v1.0 but does on v2.0:

```
# chef-automate iam reset-to-v1

Resetting to IAM v1.0 (with pre-upgrade v1 policies)...
# chef-automate iam version
IAM v1.0

# restart authz
# chef-automate status | grep authz-service | tr -s ' ' | cut -d ' ' -f 5 | xargs kill

# nothing happened
# chef-automate iam version
IAM v1.0

# upgrade to v2.0, restart, then auto-upgrade will happen
# chef-automate iam upgrade-to-v2
# chef-automate iam version
IAM v2.0
# chef-automate status | grep authz-service | tr -s ' ' | cut -d ' ' -f 5 | xargs kill
# chef-automate iam version
IAM v2.1
```

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?
