### PR TITLE
Delete all custom projects and clear projects from all postgres objects

### DIFF
--- a/components/authn-service/tokens/pg/sql/14_reset_projects.up.sql
+++ b/components/authn-service/tokens/pg/sql/14_reset_projects.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+UPDATE chef_authn_tokens SET project_ids='{}';
+
+COMMIT;

--- a/components/authn-service/tokens/pg/sql/README.md
+++ b/components/authn-service/tokens/pg/sql/README.md
@@ -13,3 +13,4 @@
 - [`11_add_default_empty_array_for_project_ids.up.sql`](11_add_default_empty_array_for_project_ids.up.sql)
 - [`12_add_filter_function_for_token_projects.up.sql`](12_add_filter_function_for_token_projects.up.sql)
 - [`13_add_db_id_column_to_tokens.up.sql`](13_add_db_id_column_to_tokens.up.sql)
+- [`14_reset_projects.up.sql`](14_reset_projects.up.sql)

--- a/components/authz-service/Makefile~
+++ b/components/authz-service/Makefile~
@@ -1,0 +1,72 @@
+include ../../Makefile.common_go
+
+PACKAGE_PATH = github.com/chef/automate/components/authz-service
+
+BINS = ${PACKAGE_PATH}/cmd/authz-service
+MIGRATION_READMES = storage/postgres/migration/sql/README.md storage/postgres/datamigration/sql/README.md
+VERSION ?= $(shell git rev-pasrse HEAD)
+BUILD_TIME ?= $(shell date -u '+%Y%m%d%H%M%S')
+GO_LDFLAGS = --ldflags "-X ${LIBRARY_PATH}/version.Version=${BUILD_TIME} -X ${LIBRARY_PATH}/version.GitSHA=${GIT_SHA}"
+
+packages:=${PACKAGE_PATH}/...
+ifdef CI
+    verbose?="-v"
+endif
+
+all: lint build test
+static: lint ${MIGRATION_READMES}
+unit: build test
+
+.PHONY: ${MIGRATION_READMES}
+${MIGRATION_READMES}:
+	../../scripts/generate_and_check_migration_files.sh $@
+
+${BINS}: bin
+	@echo "GO $@"
+	@cd bin; go build --race ${GO_LDFLAGS} $@
+
+bin:
+	mkdir -p bin
+
+build: ${BINS}
+
+test:
+	@go test $(verbose) -cover -count=1 -parallel=1 -p 1 $(packages)
+
+PG_URL ?= "postgresql://postgres@127.0.0.1:5432/authz_test?sslmode=disable"
+
+test_with_db: db_container
+	@PGTZ=UTC PG_URL=$(PG_URL) go test -cover -count=1 -parallel=1 -p 1 $(packages)
+	@echo "Docker containers still up, run 'make kill_docker_pg' to bring them down or test again with make test_with_db."
+
+test_properties_with_db: db_container
+	@PGTZ=UTC PG_URL=$(PG_URL) go test -cover -count=1 -parallel=1 -p 1 $(packages) -run Properties
+	@echo "Docker containers still up, run 'make kill_docker_pg' to bring them down or test again with make test_with_db."
+
+.PHONY: db_container
+db_container:
+	@docker ps | grep authz-postgres || (echo "Docker postgres not up. Run make setup_docker_pg and try this command again."; exit 1)
+	psql -d $(PG_URL) -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""
+
+setup_docker_pg:
+	docker run --name authz-postgres -e POSTGRES_USER=postgres -e POSTGRES_DB=authz_test -p 5432:5432 -d postgres:9
+
+
+kill_docker_pg:
+	docker rm -f authz-postgres || true
+
+# Regenerates OPA data from rego files
+HAVE_GO_BINDATA := $(shell command -v go-bindata 2> /dev/null)
+generate:
+ifndef HAVE_GO_BINDATA
+	@echo "requires 'go-bindata' (go get -u github.com/kevinburke/go-bindata/go-bindata)"
+	@exit 1 # fail
+else
+	go generate ./...
+endif
+
+# Regenerate all *.pb.go files
+proto:
+	cd ../../ && hab studio run 'source .studiorc; compile_go_protobuf_component authz-service'
+
+.PHONY: all static unit build compile test lint

--- a/components/authz-service/storage/postgres/migration/sql/73_reset_projects.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/73_reset_projects.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DELETE FROM iam_projects WHERE type='custom';
+DELETE FROM iam_projects_graveyard;
+
+COMMIT;

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -72,3 +72,4 @@
 - [`70_fix_status_for_list_projects.up.sql`](70_fix_status_for_list_projects.up.sql)
 - [`71_sync_query_projects_with_query_project.up.sql`](71_sync_query_projects_with_query_project.up.sql)
 - [`72_create_projects_graveyard_table.up.sql`](72_create_projects_graveyard_table.up.sql)
+- [`73_reset_projects.up.sql`](73_reset_projects.up.sql)

--- a/components/teams-service/storage/postgres/migration/sql/09_reset_projects.up.sql
+++ b/components/teams-service/storage/postgres/migration/sql/09_reset_projects.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+UPDATE teams SET projects='{}';
+
+COMMIT;

--- a/components/teams-service/storage/postgres/migration/sql/README.md
+++ b/components/teams-service/storage/postgres/migration/sql/README.md
@@ -8,3 +8,4 @@
 - [`06_add-filter-function.up.sql`](06_add-filter-function.up.sql)
 - [`07_add_db_id_field.up.sql`](07_add_db_id_field.up.sql)
 - [`08_update_admin_team_name.up.sql`](08_update_admin_team_name.up.sql)
+- [`09_reset_projects.up.sql`](09_reset_projects.up.sql)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Any statement which has only a custom project (which is only possible to create in v2.1 mode) will be removed. All policies, teams, roles, and tokens become unassigned.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable