### PR TITLE
protoc-gen-a2-config: Ensure GetPort() doesn't panic, fix signature

### DIFF
--- a/api/config/applications/config_request.pb.a2svc.go
+++ b/api/config/applications/config_request.pb.a2svc.go
@@ -66,7 +66,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -82,7 +82,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	case "prometheus":
 		v0 := m.V1
 		if v0 == nil {
@@ -97,7 +97,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.MetricsPort
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/authn/config_request.pb.a2svc.go
+++ b/api/config/authn/config_request.pb.a2svc.go
@@ -66,7 +66,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -82,7 +82,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	case "http1":
 		v0 := m.V1
 		if v0 == nil {
@@ -97,7 +97,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/authz/config_request.pb.a2svc.go
+++ b/api/config/authz/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/backup_gateway/config_request.pb.a2svc.go
+++ b/api/config/backup_gateway/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/bifrost/config_request.pb.a2svc.go
+++ b/api/config/bifrost/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/bookshelf/config_request.pb.a2svc.go
+++ b/api/config/bookshelf/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/cereal/config_request.pb.a2svc.go
+++ b/api/config/cereal/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/cfgmgmt/config_request.pb.a2svc.go
+++ b/api/config/cfgmgmt/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/compliance/config_request.pb.a2svc.go
+++ b/api/config/compliance/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/cs_nginx/config_request.pb.a2svc.go
+++ b/api/config/cs_nginx/config_request.pb.a2svc.go
@@ -66,7 +66,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -82,7 +82,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	case "status":
 		v0 := m.V1
 		if v0 == nil {
@@ -97,7 +97,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.StatusPort
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/data_feed/config_request.pb.a2svc.go
+++ b/api/config/data_feed/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/deployment/config_request.pb.a2svc.go
+++ b/api/config/deployment/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/dex/config_request.pb.a2svc.go
+++ b/api/config/dex/config_request.pb.a2svc.go
@@ -66,7 +66,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -82,7 +82,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	case "grpc":
 		v0 := m.V1
 		if v0 == nil {
@@ -97,7 +97,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/elasticsearch/config_request.pb.a2svc.go
+++ b/api/config/elasticsearch/config_request.pb.a2svc.go
@@ -69,7 +69,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -85,7 +85,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	case "transport":
 		v0 := m.V1
 		if v0 == nil {

--- a/api/config/erchef/config_request.pb.a2svc.go
+++ b/api/config/erchef/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/es_sidecar/config_request.pb.a2svc.go
+++ b/api/config/es_sidecar/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/esgateway/config_request.pb.a2svc.go
+++ b/api/config/esgateway/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/event/config_request.pb.a2svc.go
+++ b/api/config/event/config_request.pb.a2svc.go
@@ -85,7 +85,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -101,7 +101,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	case "internal_messaging":
 		v0 := m.V1
 		if v0 == nil {
@@ -116,7 +116,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	case "internal_messaging_gw":
 		v0 := m.V1
 		if v0 == nil {
@@ -131,7 +131,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.GatewayPort
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/event_feed/config_request.pb.a2svc.go
+++ b/api/config/event_feed/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "event-feed-service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/event_gateway/config_request.pb.a2svc.go
+++ b/api/config/event_gateway/config_request.pb.a2svc.go
@@ -66,7 +66,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -82,7 +82,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	case "nats_gateway":
 		v0 := m.V1
 		if v0 == nil {
@@ -97,7 +97,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.GatewayPort
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/gateway/config_request.pb.a2svc.go
+++ b/api/config/gateway/config_request.pb.a2svc.go
@@ -66,7 +66,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "http":
 		v0 := m.V1
@@ -82,7 +82,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	case "service":
 		v0 := m.V1
 		if v0 == nil {
@@ -97,7 +97,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.GrpcPort
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/ingest/config_request.pb.a2svc.go
+++ b/api/config/ingest/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/license_control/config_request.pb.a2svc.go
+++ b/api/config/license_control/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/load_balancer/config_request.pb.a2svc.go
+++ b/api/config/load_balancer/config_request.pb.a2svc.go
@@ -66,7 +66,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "https":
 		v0 := m.V1
@@ -82,7 +82,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.HttpsPort
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	case "http":
 		v0 := m.V1
 		if v0 == nil {
@@ -97,7 +97,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.HttpPort
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/local_user/config_request.pb.a2svc.go
+++ b/api/config/local_user/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/nodemanager/config_request.pb.a2svc.go
+++ b/api/config/nodemanager/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/notifications/config_request.pb.a2svc.go
+++ b/api/config/notifications/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/pg_gateway/config_request.pb.a2svc.go
+++ b/api/config/pg_gateway/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/pg_sidecar/config_request.pb.a2svc.go
+++ b/api/config/pg_sidecar/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/postgresql/config_request.pb.a2svc.go
+++ b/api/config/postgresql/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "pgsql":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/prometheus/config_request.pb.a2svc.go
+++ b/api/config/prometheus/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/secrets/config_request.pb.a2svc.go
+++ b/api/config/secrets/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/session/config_request.pb.a2svc.go
+++ b/api/config/session/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/teams/config_request.pb.a2svc.go
+++ b/api/config/teams/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/ui/config_request.pb.a2svc.go
+++ b/api/config/ui/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/workflow_nginx/config_request.pb.a2svc.go
+++ b/api/config/workflow_nginx/config_request.pb.a2svc.go
@@ -25,7 +25,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	default:
 		return 0, a2conf.ErrPortNotFound

--- a/api/config/workflow_server/config_request.pb.a2svc.go
+++ b/api/config/workflow_server/config_request.pb.a2svc.go
@@ -62,7 +62,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "git":
 		v0 := m.V1
@@ -78,7 +78,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	case "service":
 		v0 := m.V1
 		if v0 == nil {
@@ -89,7 +89,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v2 := v1.ApiPort
-		return uint16(v2.Value), nil
+		return uint16(v2.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/components/automate-cli/cmd/chef-automate/dev.go
+++ b/components/automate-cli/cmd/chef-automate/dev.go
@@ -824,7 +824,6 @@ func newDevPortCmd() *cobra.Command {
 				f := a.Field(i)
 				if f.Type.Implements(a2ServiceConfigType) {
 					v := (reflect.New(f.Type.Elem()).Interface()).(a2conf.A2ServiceConfig)
-					//writer.Titlef("%s [%s]", v.ServiceName(), f.Name)
 					ports := v.ListPorts()
 					for _, p := range ports {
 						writer.Bodyf("%-30s%-10s\t%-10d\t%-10s", v.ServiceName(), p.Name, p.Default, p.Protocol)

--- a/components/automate-grpc/protoc-gen-a2-config/api/a2conf/port.go
+++ b/components/automate-grpc/protoc-gen-a2-config/api/a2conf/port.go
@@ -5,7 +5,7 @@ import "errors"
 type PortBind interface {
 	BindPort(name string, value uint16) error
 	ListPorts() []PortInfo
-	GetPort(name string, value uint16) (uint16, error)
+	GetPort(name string) (uint16, error)
 }
 
 // PortInfo describes a bindable port

--- a/components/automate-grpc/protoc-gen-a2-config/gen/service_config.go
+++ b/components/automate-grpc/protoc-gen-a2-config/gen/service_config.go
@@ -313,7 +313,6 @@ func (m *A2ServiceConfigModule) generateGetPortMethod(message pgs.Message, acc *
 		jen.Id("m").Id("*"+m.ctx.Name(message).String()),
 	).Id("GetPort").Params(
 		jen.Id("name").String(),
-		jen.Id("value").Uint16(),
 	).Params(jen.Uint16(), jen.Error()).BlockFunc(func(g *jen.Group) {
 		// switch name {
 		g.Switch(jen.Id("name")).BlockFunc(func(sg *jen.Group) {
@@ -346,8 +345,8 @@ func (m *A2ServiceConfigModule) generateGetPortMethod(message pgs.Message, acc *
 							switch path.Type().Embed().FullyQualifiedName() {
 							case ".google.protobuf.Int32Value":
 								// Example:
-								// return v3.Value, nil
-								cg.Return(jen.Uint16().Call(jen.Id(cur).Dot("Value")), jen.Nil())
+								// return v3.GetValue(), nil
+								cg.Return(jen.Uint16().Call(jen.Id(cur).Dot("GetValue()")), jen.Nil())
 							case ".google.protobuf.StringValue":
 								// Example:
 								// parts := strings.Split(v3.Value, "-")


### PR DESCRIPTION
This changes

   GetPort(name string, value uint32)

to

  GetPort(name string)

as the value was previously unused. It also uses GetValue() to ensure
that we don't panic on unset configuration entries.

Signed-off-by: Steven Danna <steve@chef.io>