### PR TITLE
Generate fully namespaced entity names in swagger docs

### DIFF
--- a/api/external/applications/applications.swagger.json
+++ b/api/external/applications/applications.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesRes"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/applicationsDisconnectedServicesReq"
+              "$ref": "#/definitions/chef.automate.api.applications.DisconnectedServicesReq"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesRes"
             }
           }
         },
@@ -73,7 +73,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServiceGroups"
+              "$ref": "#/definitions/chef.automate.api.applications.ServiceGroups"
             }
           }
         },
@@ -132,7 +132,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesBySGRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesBySGRes"
             }
           }
         },
@@ -203,7 +203,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsHealthCounts"
+              "$ref": "#/definitions/chef.automate.api.applications.HealthCounts"
             }
           }
         },
@@ -231,7 +231,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesRes"
             }
           }
         },
@@ -290,7 +290,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesDistinctValuesRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesDistinctValuesRes"
             }
           }
         },
@@ -330,7 +330,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesStatsRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesStatsRes"
             }
           }
         },
@@ -346,7 +346,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -362,7 +362,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsPeriodicJobConfig"
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicJobConfig"
             }
           }
         },
@@ -376,7 +376,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsUpdateDeleteDisconnectedServicesConfigRes"
+              "$ref": "#/definitions/chef.automate.api.applications.UpdateDeleteDisconnectedServicesConfigRes"
             }
           }
         },
@@ -386,7 +386,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/applicationsPeriodicJobConfig"
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicJobConfig"
             }
           }
         ],
@@ -402,7 +402,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsPeriodicMandatoryJobConfig"
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicMandatoryJobConfig"
             }
           }
         },
@@ -416,7 +416,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsUpdateDisconnectedServicesConfigRes"
+              "$ref": "#/definitions/chef.automate.api.applications.UpdateDisconnectedServicesConfigRes"
             }
           }
         },
@@ -426,7 +426,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/applicationsPeriodicMandatoryJobConfig"
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicMandatoryJobConfig"
             }
           }
         ],
@@ -437,7 +437,7 @@
     }
   },
   "definitions": {
-    "applicationsDisconnectedServicesReq": {
+    "chef.automate.api.applications.DisconnectedServicesReq": {
       "type": "object",
       "properties": {
         "threshold_seconds": {
@@ -446,7 +446,7 @@
         }
       }
     },
-    "applicationsHealthCounts": {
+    "chef.automate.api.applications.HealthCounts": {
       "type": "object",
       "properties": {
         "total": {
@@ -475,7 +475,7 @@
         }
       }
     },
-    "applicationsHealthStatus": {
+    "chef.automate.api.applications.HealthStatus": {
       "type": "string",
       "enum": [
         "OK",
@@ -488,7 +488,7 @@
       "description": "- NONE: The representation of NO health check status\nTODO @afiune how much effort would be to change\nthe OK enum to be NONE",
       "title": "The HealthStatus enum matches the habitat implementation for health-check status:\n=\u003e https://www.habitat.sh/docs/reference/#health-check"
     },
-    "applicationsPeriodicJobConfig": {
+    "chef.automate.api.applications.PeriodicJobConfig": {
       "type": "object",
       "properties": {
         "running": {
@@ -501,7 +501,7 @@
         }
       }
     },
-    "applicationsPeriodicMandatoryJobConfig": {
+    "chef.automate.api.applications.PeriodicMandatoryJobConfig": {
       "type": "object",
       "properties": {
         "threshold": {
@@ -511,7 +511,7 @@
       },
       "title": "it's like a PeriodicJobConfig but the user isn't allowed to change whether\nor not the job runs"
     },
-    "applicationsService": {
+    "chef.automate.api.applications.Service": {
       "type": "object",
       "properties": {
         "supervisor_id": {
@@ -524,10 +524,10 @@
           "type": "string"
         },
         "health_check": {
-          "$ref": "#/definitions/applicationsHealthStatus"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthStatus"
         },
         "status": {
-          "$ref": "#/definitions/applicationsServiceStatus"
+          "$ref": "#/definitions/chef.automate.api.applications.ServiceStatus"
         },
         "application": {
           "type": "string"
@@ -548,7 +548,7 @@
           "type": "string"
         },
         "previous_health_check": {
-          "$ref": "#/definitions/applicationsHealthStatus"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthStatus"
         },
         "current_health_since": {
           "type": "string"
@@ -570,7 +570,7 @@
         }
       }
     },
-    "applicationsServiceGroup": {
+    "chef.automate.api.applications.ServiceGroup": {
       "type": "object",
       "properties": {
         "name": {
@@ -581,7 +581,7 @@
           "title": "Combination of the version and release in a single string like:\nExample: 0.1.0/8743278934278923"
         },
         "status": {
-          "$ref": "#/definitions/applicationsHealthStatus"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthStatus"
         },
         "health_percentage": {
           "type": "integer",
@@ -589,7 +589,7 @@
           "title": "The health_percentage can be a number between 0-100"
         },
         "services_health_counts": {
-          "$ref": "#/definitions/applicationsHealthCounts"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthCounts"
         },
         "id": {
           "type": "string"
@@ -611,18 +611,18 @@
       },
       "title": "A service group message is the representation of one single service group that\nis internally generated by aggregating all the services"
     },
-    "applicationsServiceGroups": {
+    "chef.automate.api.applications.ServiceGroups": {
       "type": "object",
       "properties": {
         "service_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/applicationsServiceGroup"
+            "$ref": "#/definitions/chef.automate.api.applications.ServiceGroup"
           }
         }
       }
     },
-    "applicationsServiceStatus": {
+    "chef.automate.api.applications.ServiceStatus": {
       "type": "string",
       "enum": [
         "RUNNING",
@@ -633,7 +633,7 @@
       "default": "RUNNING",
       "title": "The ServiceStatus enum describes the status of the service\n@afiune have we defined these states somewhere?"
     },
-    "applicationsServicesBySGRes": {
+    "chef.automate.api.applications.ServicesBySGRes": {
       "type": "object",
       "properties": {
         "group": {
@@ -642,15 +642,15 @@
         "services": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/applicationsService"
+            "$ref": "#/definitions/chef.automate.api.applications.Service"
           }
         },
         "services_health_counts": {
-          "$ref": "#/definitions/applicationsHealthCounts"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthCounts"
         }
       }
     },
-    "applicationsServicesDistinctValuesRes": {
+    "chef.automate.api.applications.ServicesDistinctValuesRes": {
       "type": "object",
       "properties": {
         "values": {
@@ -661,18 +661,18 @@
         }
       }
     },
-    "applicationsServicesRes": {
+    "chef.automate.api.applications.ServicesRes": {
       "type": "object",
       "properties": {
         "services": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/applicationsService"
+            "$ref": "#/definitions/chef.automate.api.applications.Service"
           }
         }
       }
     },
-    "applicationsServicesStatsRes": {
+    "chef.automate.api.applications.ServicesStatsRes": {
       "type": "object",
       "properties": {
         "total_service_groups": {
@@ -693,13 +693,13 @@
         }
       }
     },
-    "applicationsUpdateDeleteDisconnectedServicesConfigRes": {
+    "chef.automate.api.applications.UpdateDeleteDisconnectedServicesConfigRes": {
       "type": "object"
     },
-    "applicationsUpdateDisconnectedServicesConfigRes": {
+    "chef.automate.api.applications.UpdateDisconnectedServicesConfigRes": {
       "type": "object"
     },
-    "queryPagination": {
+    "chef.automate.api.common.query.Pagination": {
       "type": "object",
       "properties": {
         "page": {
@@ -712,7 +712,7 @@
         }
       }
     },
-    "querySortOrder": {
+    "chef.automate.api.common.query.SortOrder": {
       "type": "string",
       "enum": [
         "ASC",
@@ -720,18 +720,18 @@
       ],
       "default": "ASC"
     },
-    "querySorting": {
+    "chef.automate.api.common.query.Sorting": {
       "type": "object",
       "properties": {
         "field": {
           "type": "string"
         },
         "order": {
-          "$ref": "#/definitions/querySortOrder"
+          "$ref": "#/definitions/chef.automate.api.common.query.SortOrder"
         }
       }
     },
-    "versionVersionInfo": {
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
         "name": {

--- a/api/external/cfgmgmt/cfgmgmt.swagger.json
+++ b/api/external/cfgmgmt/cfgmgmt.swagger.json
@@ -84,7 +84,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseNodeAttribute"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.NodeAttribute"
             }
           }
         },
@@ -172,7 +172,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseRun"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Run"
             }
           }
         },
@@ -228,7 +228,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responsePolicyCookbooks"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.PolicyCookbooks"
             }
           }
         },
@@ -271,7 +271,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/cfgmgmtresponseNodesCounts"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.NodesCounts"
             }
           }
         },
@@ -299,7 +299,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/cfgmgmtresponseRunsCounts"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.RunsCounts"
             }
           }
         },
@@ -388,7 +388,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -399,85 +399,7 @@
     }
   },
   "definitions": {
-    "cfgmgmtresponseNodesCounts": {
-      "type": "object",
-      "properties": {
-        "total": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "success": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "failure": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "missing": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "cfgmgmtresponseRunsCounts": {
-      "type": "object",
-      "properties": {
-        "total": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "success": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "failure": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "protobufNullValue": {
-      "type": "string",
-      "enum": [
-        "NULL_VALUE"
-      ],
-      "default": "NULL_VALUE",
-      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
-    },
-    "queryPagination": {
-      "type": "object",
-      "properties": {
-        "page": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "size": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "querySortOrder": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "querySorting": {
-      "type": "object",
-      "properties": {
-        "field": {
-          "type": "string"
-        },
-        "order": {
-          "$ref": "#/definitions/querySortOrder"
-        }
-      }
-    },
-    "responseChefError": {
+    "chef.automate.api.cfgmgmt.response.ChefError": {
       "type": "object",
       "properties": {
         "class": {
@@ -493,11 +415,11 @@
           }
         },
         "description": {
-          "$ref": "#/definitions/responseDescription"
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Description"
         }
       }
     },
-    "responseCookbookLock": {
+    "chef.automate.api.cfgmgmt.response.CookbookLock": {
       "type": "object",
       "properties": {
         "cookbook": {
@@ -508,7 +430,7 @@
         }
       }
     },
-    "responseDeprecation": {
+    "chef.automate.api.cfgmgmt.response.Deprecation": {
       "type": "object",
       "properties": {
         "message": {
@@ -522,7 +444,7 @@
         }
       }
     },
-    "responseDescription": {
+    "chef.automate.api.cfgmgmt.response.Description": {
       "type": "object",
       "properties": {
         "title": {
@@ -536,7 +458,7 @@
         }
       }
     },
-    "responseExpandedRunList": {
+    "chef.automate.api.cfgmgmt.response.ExpandedRunList": {
       "type": "object",
       "properties": {
         "id": {
@@ -545,12 +467,12 @@
         "run_list": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseRunList"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.RunList"
           }
         }
       }
     },
-    "responseNodeAttribute": {
+    "chef.automate.api.cfgmgmt.response.NodeAttribute": {
       "type": "object",
       "properties": {
         "node_id": {
@@ -602,7 +524,28 @@
         }
       }
     },
-    "responsePolicyCookbooks": {
+    "chef.automate.api.cfgmgmt.response.NodesCounts": {
+      "type": "object",
+      "properties": {
+        "total": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "success": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "failure": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "missing": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.PolicyCookbooks": {
       "type": "object",
       "properties": {
         "policy_name": {
@@ -611,12 +554,12 @@
         "cookbook_locks": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseCookbookLock"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.CookbookLock"
           }
         }
       }
     },
-    "responseResource": {
+    "chef.automate.api.cfgmgmt.response.Resource": {
       "type": "object",
       "properties": {
         "type": {
@@ -659,7 +602,7 @@
         }
       }
     },
-    "responseRun": {
+    "chef.automate.api.cfgmgmt.response.Run": {
       "type": "object",
       "properties": {
         "id": {
@@ -718,7 +661,7 @@
         "resources": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseResource"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Resource"
           }
         },
         "run_list": {
@@ -730,11 +673,11 @@
         "deprecations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseDeprecation"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Deprecation"
           }
         },
         "error": {
-          "$ref": "#/definitions/responseChefError"
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.ChefError"
         },
         "tags": {
           "type": "array",
@@ -791,11 +734,11 @@
           "type": "string"
         },
         "expanded_run_list": {
-          "$ref": "#/definitions/responseExpandedRunList"
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.ExpandedRunList"
         }
       }
     },
-    "responseRunList": {
+    "chef.automate.api.cfgmgmt.response.RunList": {
       "type": "object",
       "properties": {
         "type": {
@@ -814,12 +757,61 @@
         "children": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseRunList"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.RunList"
           }
         }
       }
     },
-    "versionVersionInfo": {
+    "chef.automate.api.cfgmgmt.response.RunsCounts": {
+      "type": "object",
+      "properties": {
+        "total": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "success": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "failure": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.common.query.Pagination": {
+      "type": "object",
+      "properties": {
+        "page": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.common.query.SortOrder": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.common.query.Sorting": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "order": {
+          "$ref": "#/definitions/chef.automate.api.common.query.SortOrder"
+        }
+      }
+    },
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
         "name": {
@@ -835,6 +827,14 @@
           "type": "string"
         }
       }
+    },
+    "google.protobuf.NullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
     }
   }
 }

--- a/api/external/data_feed/data_feed.swagger.json
+++ b/api/external/data_feed/data_feed.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedAddDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.AddDestinationResponse"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/datafeedAddDestinationRequest"
+              "$ref": "#/definitions/chef.automate.api.datafeed.AddDestinationRequest"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedGetDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.GetDestinationResponse"
             }
           }
         },
@@ -71,7 +71,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedDeleteDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.DeleteDestinationResponse"
             }
           }
         },
@@ -94,7 +94,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedUpdateDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.UpdateDestinationResponse"
             }
           }
         },
@@ -111,7 +111,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/datafeedUpdateDestinationRequest"
+              "$ref": "#/definitions/chef.automate.api.datafeed.UpdateDestinationRequest"
             }
           }
         ],
@@ -127,7 +127,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedListDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.ListDestinationResponse"
             }
           }
         },
@@ -137,7 +137,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/datafeedListDestinationRequest"
+              "$ref": "#/definitions/chef.automate.api.datafeed.ListDestinationRequest"
             }
           }
         ],
@@ -153,7 +153,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedTestDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.TestDestinationResponse"
             }
           }
         },
@@ -163,7 +163,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/datafeedURLValidationRequest"
+              "$ref": "#/definitions/chef.automate.api.datafeed.URLValidationRequest"
             }
           }
         ],
@@ -174,7 +174,7 @@
     }
   },
   "definitions": {
-    "datafeedAddDestinationRequest": {
+    "chef.automate.api.datafeed.AddDestinationRequest": {
       "type": "object",
       "properties": {
         "id": {
@@ -192,7 +192,7 @@
         }
       }
     },
-    "datafeedAddDestinationResponse": {
+    "chef.automate.api.datafeed.AddDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -201,7 +201,7 @@
         }
       }
     },
-    "datafeedDeleteDestinationResponse": {
+    "chef.automate.api.datafeed.DeleteDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -210,7 +210,7 @@
         }
       }
     },
-    "datafeedGetDestinationResponse": {
+    "chef.automate.api.datafeed.GetDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -232,21 +232,21 @@
         }
       }
     },
-    "datafeedListDestinationRequest": {
+    "chef.automate.api.datafeed.ListDestinationRequest": {
       "type": "object"
     },
-    "datafeedListDestinationResponse": {
+    "chef.automate.api.datafeed.ListDestinationResponse": {
       "type": "object",
       "properties": {
         "destinations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/datafeedGetDestinationResponse"
+            "$ref": "#/definitions/chef.automate.api.datafeed.GetDestinationResponse"
           }
         }
       }
     },
-    "datafeedSecretId": {
+    "chef.automate.api.datafeed.SecretId": {
       "type": "object",
       "properties": {
         "id": {
@@ -254,7 +254,7 @@
         }
       }
     },
-    "datafeedTestDestinationResponse": {
+    "chef.automate.api.datafeed.TestDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -263,21 +263,21 @@
         }
       }
     },
-    "datafeedURLValidationRequest": {
+    "chef.automate.api.datafeed.URLValidationRequest": {
       "type": "object",
       "properties": {
         "url": {
           "type": "string"
         },
         "username_password": {
-          "$ref": "#/definitions/datafeedUsernamePassword"
+          "$ref": "#/definitions/chef.automate.api.datafeed.UsernamePassword"
         },
         "secret_id": {
-          "$ref": "#/definitions/datafeedSecretId"
+          "$ref": "#/definitions/chef.automate.api.datafeed.SecretId"
         }
       }
     },
-    "datafeedUpdateDestinationRequest": {
+    "chef.automate.api.datafeed.UpdateDestinationRequest": {
       "type": "object",
       "properties": {
         "id": {
@@ -295,7 +295,7 @@
         }
       }
     },
-    "datafeedUpdateDestinationResponse": {
+    "chef.automate.api.datafeed.UpdateDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -304,7 +304,7 @@
         }
       }
     },
-    "datafeedUsernamePassword": {
+    "chef.automate.api.datafeed.UsernamePassword": {
       "type": "object",
       "properties": {
         "username": {

--- a/api/external/ingest/chef.swagger.json
+++ b/api/external/ingest/chef.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessChefActionResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessChefActionResponse"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestAction"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Action"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessLivenessResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessLivenessResponse"
             }
           }
         },
@@ -58,7 +58,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestLiveness"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Liveness"
             }
           }
         ],
@@ -74,7 +74,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessMultipleNodeDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessMultipleNodeDeleteResponse"
             }
           }
         },
@@ -84,7 +84,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestMultipleNodeDeleteRequest"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.MultipleNodeDeleteRequest"
             }
           }
         ],
@@ -100,7 +100,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessNodeDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessNodeDeleteResponse"
             }
           }
         },
@@ -110,7 +110,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestDelete"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Delete"
             }
           }
         ],
@@ -126,7 +126,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessChefRunResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessChefRunResponse"
             }
           }
         },
@@ -136,7 +136,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestRun"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Run"
             }
           }
         ],
@@ -152,7 +152,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -163,15 +163,24 @@
     }
   },
   "definitions": {
-    "protobufNullValue": {
-      "type": "string",
-      "enum": [
-        "NULL_VALUE"
-      ],
-      "default": "NULL_VALUE",
-      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+    "chef.automate.api.common.version.VersionInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "built": {
+          "type": "string"
+        }
+      }
     },
-    "requestAction": {
+    "chef.automate.api.ingest.request.Action": {
       "type": "object",
       "properties": {
         "id": {
@@ -242,7 +251,7 @@
         }
       }
     },
-    "requestDelete": {
+    "chef.automate.api.ingest.request.Delete": {
       "type": "object",
       "properties": {
         "id": {
@@ -266,7 +275,7 @@
         }
       }
     },
-    "requestDeprecation": {
+    "chef.automate.api.ingest.request.Deprecation": {
       "type": "object",
       "properties": {
         "message": {
@@ -280,7 +289,7 @@
         }
       }
     },
-    "requestDescription": {
+    "chef.automate.api.ingest.request.Description": {
       "type": "object",
       "properties": {
         "title": {
@@ -294,7 +303,7 @@
         }
       }
     },
-    "requestError": {
+    "chef.automate.api.ingest.request.Error": {
       "type": "object",
       "properties": {
         "class": {
@@ -310,11 +319,11 @@
           }
         },
         "description": {
-          "$ref": "#/definitions/requestDescription"
+          "$ref": "#/definitions/chef.automate.api.ingest.request.Description"
         }
       }
     },
-    "requestExpandedRunList": {
+    "chef.automate.api.ingest.request.ExpandedRunList": {
       "type": "object",
       "properties": {
         "id": {
@@ -323,12 +332,12 @@
         "run_list": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestRunList"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.RunList"
           }
         }
       }
     },
-    "requestLiveness": {
+    "chef.automate.api.ingest.request.Liveness": {
       "type": "object",
       "properties": {
         "event_type": {
@@ -354,7 +363,7 @@
         }
       }
     },
-    "requestMultipleNodeDeleteRequest": {
+    "chef.automate.api.ingest.request.MultipleNodeDeleteRequest": {
       "type": "object",
       "properties": {
         "node_ids": {
@@ -365,7 +374,7 @@
         }
       }
     },
-    "requestResource": {
+    "chef.automate.api.ingest.request.Resource": {
       "type": "object",
       "properties": {
         "type": {
@@ -412,7 +421,7 @@
         }
       }
     },
-    "requestRun": {
+    "chef.automate.api.ingest.request.Run": {
       "type": "object",
       "properties": {
         "id": {
@@ -466,12 +475,12 @@
           "type": "string"
         },
         "expanded_run_list": {
-          "$ref": "#/definitions/requestExpandedRunList"
+          "$ref": "#/definitions/chef.automate.api.ingest.request.ExpandedRunList"
         },
         "resources": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestResource"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.Resource"
           }
         },
         "run_list": {
@@ -484,7 +493,7 @@
           "type": "object"
         },
         "error": {
-          "$ref": "#/definitions/requestError"
+          "$ref": "#/definitions/chef.automate.api.ingest.request.Error"
         },
         "policy_name": {
           "type": "string"
@@ -495,7 +504,7 @@
         "deprecations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestDeprecation"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.Deprecation"
           }
         },
         "tags": {
@@ -506,7 +515,7 @@
         }
       }
     },
-    "requestRunList": {
+    "chef.automate.api.ingest.request.RunList": {
       "type": "object",
       "properties": {
         "type": {
@@ -525,42 +534,33 @@
         "children": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestRunList"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.RunList"
           }
         }
       }
     },
-    "responseProcessChefActionResponse": {
+    "chef.automate.api.ingest.response.ProcessChefActionResponse": {
       "type": "object"
     },
-    "responseProcessChefRunResponse": {
+    "chef.automate.api.ingest.response.ProcessChefRunResponse": {
       "type": "object"
     },
-    "responseProcessLivenessResponse": {
+    "chef.automate.api.ingest.response.ProcessLivenessResponse": {
       "type": "object"
     },
-    "responseProcessMultipleNodeDeleteResponse": {
+    "chef.automate.api.ingest.response.ProcessMultipleNodeDeleteResponse": {
       "type": "object"
     },
-    "responseProcessNodeDeleteResponse": {
+    "chef.automate.api.ingest.response.ProcessNodeDeleteResponse": {
       "type": "object"
     },
-    "versionVersionInfo": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "version": {
-          "type": "string"
-        },
-        "sha": {
-          "type": "string"
-        },
-        "built": {
-          "type": "string"
-        }
-      }
+    "google.protobuf.NullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
     }
   }
 }

--- a/api/external/ingest/job_scheduler.swagger.json
+++ b/api/external/ingest/job_scheduler.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseConfigureDeleteNodesScheduler"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ConfigureDeleteNodesScheduler"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestSchedulerConfig"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.SchedulerConfig"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseConfigureMissingNodesForDeletionScheduler"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ConfigureMissingNodesForDeletionScheduler"
             }
           }
         },
@@ -58,7 +58,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestSchedulerConfig"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.SchedulerConfig"
             }
           }
         ],
@@ -74,7 +74,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseConfigureNodesMissingScheduler"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ConfigureNodesMissingScheduler"
             }
           }
         },
@@ -84,7 +84,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestSchedulerConfig"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.SchedulerConfig"
             }
           }
         ],
@@ -100,7 +100,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseJobSchedulerStatus"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.JobSchedulerStatus"
             }
           }
         },
@@ -111,7 +111,7 @@
     }
   },
   "definitions": {
-    "requestSchedulerConfig": {
+    "chef.automate.api.ingest.request.SchedulerConfig": {
       "type": "object",
       "properties": {
         "every": {
@@ -127,16 +127,16 @@
       },
       "description": "SchedulerConfig\nThe job message to configure the Delete Node Job\nevery - It accepts '1h30m', '1m', '2h30m', ..."
     },
-    "responseConfigureDeleteNodesScheduler": {
+    "chef.automate.api.ingest.response.ConfigureDeleteNodesScheduler": {
       "type": "object"
     },
-    "responseConfigureMissingNodesForDeletionScheduler": {
+    "chef.automate.api.ingest.response.ConfigureMissingNodesForDeletionScheduler": {
       "type": "object"
     },
-    "responseConfigureNodesMissingScheduler": {
+    "chef.automate.api.ingest.response.ConfigureNodesMissingScheduler": {
       "type": "object"
     },
-    "responseJob": {
+    "chef.automate.api.ingest.response.Job": {
       "type": "object",
       "properties": {
         "running": {
@@ -166,7 +166,7 @@
         }
       }
     },
-    "responseJobSchedulerStatus": {
+    "chef.automate.api.ingest.response.JobSchedulerStatus": {
       "type": "object",
       "properties": {
         "running": {
@@ -176,7 +176,7 @@
         "jobs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseJob"
+            "$ref": "#/definitions/chef.automate.api.ingest.response.Job"
           }
         }
       }

--- a/api/external/secrets/secrets.swagger.json
+++ b/api/external/secrets/secrets.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsId"
+              "$ref": "#/definitions/chef.automate.api.secrets.Id"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/secretsSecret"
+              "$ref": "#/definitions/chef.automate.api.secrets.Secret"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsSecret"
+              "$ref": "#/definitions/chef.automate.api.secrets.Secret"
             }
           }
         },
@@ -70,7 +70,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.secrets.DeleteResponse"
             }
           }
         },
@@ -92,7 +92,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsUpdateResponse"
+              "$ref": "#/definitions/chef.automate.api.secrets.UpdateResponse"
             }
           }
         },
@@ -108,7 +108,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/secretsSecret"
+              "$ref": "#/definitions/chef.automate.api.secrets.Secret"
             }
           }
         ],
@@ -124,7 +124,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsSecrets"
+              "$ref": "#/definitions/chef.automate.api.secrets.Secrets"
             }
           }
         },
@@ -134,7 +134,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/secretsQuery"
+              "$ref": "#/definitions/chef.automate.api.secrets.Query"
             }
           }
         ],
@@ -145,18 +145,10 @@
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "secretsDeleteResponse": {
+    "chef.automate.api.secrets.DeleteResponse": {
       "type": "object"
     },
-    "secretsFilter": {
+    "chef.automate.api.secrets.Filter": {
       "type": "object",
       "properties": {
         "key": {
@@ -174,7 +166,7 @@
         }
       }
     },
-    "secretsId": {
+    "chef.automate.api.secrets.Id": {
       "type": "object",
       "properties": {
         "id": {
@@ -182,7 +174,7 @@
         }
       }
     },
-    "secretsKv": {
+    "chef.automate.api.secrets.Kv": {
       "type": "object",
       "properties": {
         "key": {
@@ -193,17 +185,17 @@
         }
       }
     },
-    "secretsQuery": {
+    "chef.automate.api.secrets.Query": {
       "type": "object",
       "properties": {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/secretsFilter"
+            "$ref": "#/definitions/chef.automate.api.secrets.Filter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.secrets.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -218,7 +210,15 @@
         }
       }
     },
-    "secretsSecret": {
+    "chef.automate.api.secrets.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.secrets.Secret": {
       "type": "object",
       "properties": {
         "id": {
@@ -237,24 +237,24 @@
         "tags": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/secretsKv"
+            "$ref": "#/definitions/chef.automate.api.secrets.Kv"
           }
         },
         "data": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/secretsKv"
+            "$ref": "#/definitions/chef.automate.api.secrets.Kv"
           }
         }
       }
     },
-    "secretsSecrets": {
+    "chef.automate.api.secrets.Secrets": {
       "type": "object",
       "properties": {
         "secrets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/secretsSecret"
+            "$ref": "#/definitions/chef.automate.api.secrets.Secret"
           }
         },
         "total": {
@@ -263,7 +263,7 @@
         }
       }
     },
-    "secretsUpdateResponse": {
+    "chef.automate.api.secrets.UpdateResponse": {
       "type": "object"
     }
   }

--- a/api/interservice/authn/authenticate.swagger.json
+++ b/api/interservice/authn/authenticate.swagger.json
@@ -23,7 +23,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/authnAuthenticateResponse"
+              "$ref": "#/definitions/chef.automate.domain.authn.AuthenticateResponse"
             }
           }
         },
@@ -34,7 +34,7 @@
     }
   },
   "definitions": {
-    "authnAuthenticateResponse": {
+    "chef.automate.domain.authn.AuthenticateResponse": {
       "type": "object",
       "properties": {
         "subject": {

--- a/api/interservice/authn/tokens.swagger.json
+++ b/api/interservice/authn/tokens.swagger.json
@@ -16,10 +16,10 @@
   ],
   "paths": {},
   "definitions": {
-    "authnDeleteTokenResp": {
+    "chef.automate.domain.authn.DeleteTokenResp": {
       "type": "object"
     },
-    "authnToken": {
+    "chef.automate.domain.authn.Token": {
       "type": "object",
       "properties": {
         "id": {
@@ -49,13 +49,13 @@
         }
       }
     },
-    "authnTokens": {
+    "chef.automate.domain.authn.Tokens": {
       "type": "object",
       "properties": {
         "tokens": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/authnToken"
+            "$ref": "#/definitions/chef.automate.domain.authn.Token"
           }
         }
       }

--- a/api/interservice/ingest/automate_event.swagger.json
+++ b/api/interservice/ingest/automate_event.swagger.json
@@ -16,7 +16,7 @@
   ],
   "paths": {},
   "definitions": {
-    "apiActor": {
+    "chef.automate.domain.event.api.Actor": {
       "type": "object",
       "properties": {
         "ID": {
@@ -30,7 +30,7 @@
         }
       }
     },
-    "apiEventResponse": {
+    "chef.automate.domain.event.api.EventResponse": {
       "type": "object",
       "properties": {
         "Success": {
@@ -39,7 +39,7 @@
         }
       }
     },
-    "apiEventType": {
+    "chef.automate.domain.event.api.EventType": {
       "type": "object",
       "properties": {
         "Name": {
@@ -47,7 +47,7 @@
         }
       }
     },
-    "apiObject": {
+    "chef.automate.domain.event.api.Object": {
       "type": "object",
       "properties": {
         "ID": {
@@ -61,7 +61,7 @@
         }
       }
     },
-    "apiProducer": {
+    "chef.automate.domain.event.api.Producer": {
       "type": "object",
       "properties": {
         "ID": {
@@ -81,7 +81,7 @@
         }
       }
     },
-    "apiTarget": {
+    "chef.automate.domain.event.api.Target": {
       "type": "object",
       "properties": {
         "ID": {
@@ -95,7 +95,7 @@
         }
       }
     },
-    "ingestProjectUpdateStatusResp": {
+    "chef.automate.domain.ingest.ProjectUpdateStatusResp": {
       "type": "object",
       "properties": {
         "state": {
@@ -111,7 +111,7 @@
         }
       }
     },
-    "protobufNullValue": {
+    "google.protobuf.NullValue": {
       "type": "string",
       "enum": [
         "NULL_VALUE"

--- a/api/interservice/ingest/chef.swagger.json
+++ b/api/interservice/ingest/chef.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessChefActionResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessChefActionResponse"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestAction"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Action"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessLivenessResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessLivenessResponse"
             }
           }
         },
@@ -58,7 +58,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestLiveness"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Liveness"
             }
           }
         ],
@@ -74,7 +74,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessNodeDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessNodeDeleteResponse"
             }
           }
         },
@@ -84,7 +84,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestDelete"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Delete"
             }
           }
         ],
@@ -100,7 +100,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessChefRunResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessChefRunResponse"
             }
           }
         },
@@ -110,7 +110,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestRun"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Run"
             }
           }
         ],
@@ -126,7 +126,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/ingestVersion"
+              "$ref": "#/definitions/chef.automate.domain.ingest.Version"
             }
           }
         },
@@ -137,34 +137,7 @@
     }
   },
   "definitions": {
-    "ingestVersion": {
-      "type": "object",
-      "properties": {
-        "version": {
-          "type": "string"
-        },
-        "built": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "sha": {
-          "type": "string"
-        }
-      },
-      "description": "The ingest-service version constructed with:\n* Service name\n* Built time\n* Semantic version\n* Git SHA",
-      "title": "Version message"
-    },
-    "protobufNullValue": {
-      "type": "string",
-      "enum": [
-        "NULL_VALUE"
-      ],
-      "default": "NULL_VALUE",
-      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
-    },
-    "requestAction": {
+    "chef.automate.api.ingest.request.Action": {
       "type": "object",
       "properties": {
         "id": {
@@ -235,7 +208,7 @@
         }
       }
     },
-    "requestDelete": {
+    "chef.automate.api.ingest.request.Delete": {
       "type": "object",
       "properties": {
         "id": {
@@ -259,7 +232,7 @@
         }
       }
     },
-    "requestDeprecation": {
+    "chef.automate.api.ingest.request.Deprecation": {
       "type": "object",
       "properties": {
         "message": {
@@ -273,7 +246,7 @@
         }
       }
     },
-    "requestDescription": {
+    "chef.automate.api.ingest.request.Description": {
       "type": "object",
       "properties": {
         "title": {
@@ -287,7 +260,7 @@
         }
       }
     },
-    "requestError": {
+    "chef.automate.api.ingest.request.Error": {
       "type": "object",
       "properties": {
         "class": {
@@ -303,11 +276,11 @@
           }
         },
         "description": {
-          "$ref": "#/definitions/requestDescription"
+          "$ref": "#/definitions/chef.automate.api.ingest.request.Description"
         }
       }
     },
-    "requestExpandedRunList": {
+    "chef.automate.api.ingest.request.ExpandedRunList": {
       "type": "object",
       "properties": {
         "id": {
@@ -316,12 +289,12 @@
         "run_list": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestRunList"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.RunList"
           }
         }
       }
     },
-    "requestLiveness": {
+    "chef.automate.api.ingest.request.Liveness": {
       "type": "object",
       "properties": {
         "event_type": {
@@ -347,7 +320,7 @@
         }
       }
     },
-    "requestResource": {
+    "chef.automate.api.ingest.request.Resource": {
       "type": "object",
       "properties": {
         "type": {
@@ -394,7 +367,7 @@
         }
       }
     },
-    "requestRun": {
+    "chef.automate.api.ingest.request.Run": {
       "type": "object",
       "properties": {
         "id": {
@@ -448,12 +421,12 @@
           "type": "string"
         },
         "expanded_run_list": {
-          "$ref": "#/definitions/requestExpandedRunList"
+          "$ref": "#/definitions/chef.automate.api.ingest.request.ExpandedRunList"
         },
         "resources": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestResource"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.Resource"
           }
         },
         "run_list": {
@@ -466,7 +439,7 @@
           "type": "object"
         },
         "error": {
-          "$ref": "#/definitions/requestError"
+          "$ref": "#/definitions/chef.automate.api.ingest.request.Error"
         },
         "policy_name": {
           "type": "string"
@@ -477,7 +450,7 @@
         "deprecations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestDeprecation"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.Deprecation"
           }
         },
         "tags": {
@@ -488,7 +461,7 @@
         }
       }
     },
-    "requestRunList": {
+    "chef.automate.api.ingest.request.RunList": {
       "type": "object",
       "properties": {
         "type": {
@@ -507,25 +480,52 @@
         "children": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestRunList"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.RunList"
           }
         }
       }
     },
-    "responseProcessChefActionResponse": {
+    "chef.automate.api.ingest.response.ProcessChefActionResponse": {
       "type": "object"
     },
-    "responseProcessChefRunResponse": {
+    "chef.automate.api.ingest.response.ProcessChefRunResponse": {
       "type": "object"
     },
-    "responseProcessLivenessResponse": {
+    "chef.automate.api.ingest.response.ProcessLivenessResponse": {
       "type": "object"
     },
-    "responseProcessMultipleNodeDeleteResponse": {
+    "chef.automate.api.ingest.response.ProcessMultipleNodeDeleteResponse": {
       "type": "object"
     },
-    "responseProcessNodeDeleteResponse": {
+    "chef.automate.api.ingest.response.ProcessNodeDeleteResponse": {
       "type": "object"
+    },
+    "chef.automate.domain.ingest.Version": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "built": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        }
+      },
+      "description": "The ingest-service version constructed with:\n* Service name\n* Built time\n* Semantic version\n* Git SHA",
+      "title": "Version message"
+    },
+    "google.protobuf.NullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
     }
   }
 }

--- a/api/interservice/ingest/job_scheduler.swagger.json
+++ b/api/interservice/ingest/job_scheduler.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/ingestConfigureDeleteNodesSchedulerResponse"
+              "$ref": "#/definitions/chef.automate.domain.ingest.ConfigureDeleteNodesSchedulerResponse"
             }
           }
         },
@@ -39,7 +39,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/ingestDeleteMarkedNodesResponse"
+              "$ref": "#/definitions/chef.automate.domain.ingest.DeleteMarkedNodesResponse"
             }
           }
         },
@@ -55,7 +55,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/ingestStartDeleteNodesSchedulerResponse"
+              "$ref": "#/definitions/chef.automate.domain.ingest.StartDeleteNodesSchedulerResponse"
             }
           }
         },
@@ -71,7 +71,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/ingestStopDeleteNodesSchedulerResponse"
+              "$ref": "#/definitions/chef.automate.domain.ingest.StopDeleteNodesSchedulerResponse"
             }
           }
         },
@@ -87,7 +87,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/ingestJobSchedulerStatus"
+              "$ref": "#/definitions/chef.automate.domain.ingest.JobSchedulerStatus"
             }
           }
         },
@@ -103,7 +103,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/ingestConfigureNodesMissingSchedulerResponse"
+              "$ref": "#/definitions/chef.automate.domain.ingest.ConfigureNodesMissingSchedulerResponse"
             }
           }
         },
@@ -119,7 +119,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/ingestMarkNodesMissingResponse"
+              "$ref": "#/definitions/chef.automate.domain.ingest.MarkNodesMissingResponse"
             }
           }
         },
@@ -135,7 +135,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/ingestStartNodesMissingSchedulerResponse"
+              "$ref": "#/definitions/chef.automate.domain.ingest.StartNodesMissingSchedulerResponse"
             }
           }
         },
@@ -151,7 +151,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/ingestStopNodesMissingSchedulerResponse"
+              "$ref": "#/definitions/chef.automate.domain.ingest.StopNodesMissingSchedulerResponse"
             }
           }
         },
@@ -162,19 +162,19 @@
     }
   },
   "definitions": {
-    "ingestConfigureDeleteNodesSchedulerResponse": {
+    "chef.automate.domain.ingest.ConfigureDeleteNodesSchedulerResponse": {
       "type": "object"
     },
-    "ingestConfigureMissingNodesForDeletionSchedulerResponse": {
+    "chef.automate.domain.ingest.ConfigureMissingNodesForDeletionSchedulerResponse": {
       "type": "object"
     },
-    "ingestConfigureNodesMissingSchedulerResponse": {
+    "chef.automate.domain.ingest.ConfigureNodesMissingSchedulerResponse": {
       "type": "object"
     },
-    "ingestDeleteMarkedNodesResponse": {
+    "chef.automate.domain.ingest.DeleteMarkedNodesResponse": {
       "type": "object"
     },
-    "ingestJob": {
+    "chef.automate.domain.ingest.Job": {
       "type": "object",
       "properties": {
         "running": {
@@ -204,7 +204,7 @@
         }
       }
     },
-    "ingestJobSchedulerStatus": {
+    "chef.automate.domain.ingest.JobSchedulerStatus": {
       "type": "object",
       "properties": {
         "running": {
@@ -214,34 +214,34 @@
         "jobs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ingestJob"
+            "$ref": "#/definitions/chef.automate.domain.ingest.Job"
           }
         }
       }
     },
-    "ingestMarkMissingNodesForDeletionResponse": {
+    "chef.automate.domain.ingest.MarkMissingNodesForDeletionResponse": {
       "type": "object",
       "title": "MissingNodesForDeletionScheduler"
     },
-    "ingestMarkNodesMissingResponse": {
+    "chef.automate.domain.ingest.MarkNodesMissingResponse": {
       "type": "object"
     },
-    "ingestStartDeleteNodesSchedulerResponse": {
+    "chef.automate.domain.ingest.StartDeleteNodesSchedulerResponse": {
       "type": "object"
     },
-    "ingestStartMissingNodesForDeletionSchedulerResponse": {
+    "chef.automate.domain.ingest.StartMissingNodesForDeletionSchedulerResponse": {
       "type": "object"
     },
-    "ingestStartNodesMissingSchedulerResponse": {
+    "chef.automate.domain.ingest.StartNodesMissingSchedulerResponse": {
       "type": "object"
     },
-    "ingestStopDeleteNodesSchedulerResponse": {
+    "chef.automate.domain.ingest.StopDeleteNodesSchedulerResponse": {
       "type": "object"
     },
-    "ingestStopMissingNodesForDeletionSchedulerResponse": {
+    "chef.automate.domain.ingest.StopMissingNodesForDeletionSchedulerResponse": {
       "type": "object"
     },
-    "ingestStopNodesMissingSchedulerResponse": {
+    "chef.automate.domain.ingest.StopNodesMissingSchedulerResponse": {
       "type": "object"
     }
   }

--- a/api/interservice/ingest/status.swagger.json
+++ b/api/interservice/ingest/status.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/ingestHealth"
+              "$ref": "#/definitions/chef.automate.domain.ingest.Health"
             }
           }
         },
@@ -38,7 +38,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/ingestMigrationStatus"
+              "$ref": "#/definitions/chef.automate.domain.ingest.MigrationStatus"
             }
           }
         },
@@ -49,7 +49,7 @@
     }
   },
   "definitions": {
-    "ingestHealth": {
+    "chef.automate.domain.ingest.Health": {
       "type": "object",
       "properties": {
         "status": {
@@ -59,7 +59,7 @@
       "description": "The ingest-service health is constructed with:\n* Status:\n           =\u003e ok:             Everything is alright\n           =\u003e initialization: The service is in its initialization process\n           =\u003e warning:        Something might be wrong?\n           =\u003e critical:       Something is wrong!\n\n@afiune: Here we can add more health information to the response",
       "title": "Health message"
     },
-    "ingestMetrics": {
+    "chef.automate.domain.ingest.Metrics": {
       "type": "object",
       "properties": {
         "uptime": {
@@ -67,12 +67,12 @@
           "format": "double"
         },
         "pipeline": {
-          "$ref": "#/definitions/ingestPipelineMetrics"
+          "$ref": "#/definitions/chef.automate.domain.ingest.PipelineMetrics"
         }
       },
       "title": "Metrics message"
     },
-    "ingestMigrationStatus": {
+    "chef.automate.domain.ingest.MigrationStatus": {
       "type": "object",
       "properties": {
         "total": {
@@ -93,7 +93,7 @@
       },
       "title": "Migration message"
     },
-    "ingestPipelineMetrics": {
+    "chef.automate.domain.ingest.PipelineMetrics": {
       "type": "object",
       "properties": {
         "total_run_messages": {

--- a/api/scripts/grpc.sh
+++ b/api/scripts/grpc.sh
@@ -31,7 +31,7 @@ for i in api/external/**/; do
     # generates swagger output, only generate if a gateway file was generated
     gogw=(`find $i -maxdepth 1 -name "*.gw.go"`)
     if [ ${#gogw[@]} -gt 0 ]; then
-        protoc  ${IMPORTS[@]} --swagger_out=logtostderr=true:$PWD ${list[@]} || exit 1
+        protoc  ${IMPORTS[@]} --swagger_out=logtostderr=true,fqn_for_swagger_name=true:$PWD ${list[@]} || exit 1
     fi
   fi
 done
@@ -74,7 +74,7 @@ for i in api/interservice/**/; do
     # generates swagger output, only generate if a gateway file was generated
     gogw=(`find $i -maxdepth 1 -name "*.gw.go"`)
     if [ ${#gogw[@]} -gt 0 ]; then
-        protoc  ${IMPORTS[@]} --swagger_out=logtostderr=true:$PWD ${list[@]} || exit 1
+        protoc  ${IMPORTS[@]} --swagger_out=logtostderr=true,fqn_for_swagger_name=true:$PWD ${list[@]} || exit 1
     fi
 
 

--- a/components/automate-chef-io/Makefile
+++ b/components/automate-chef-io/Makefile
@@ -3,11 +3,8 @@
 SHELL=bash
 SWAGGER_RESULT_FILE=static/api-docs/all-apis.swagger.json
 SWAGGER_DIR=data/docs/api_chef_automate
-#SWAGGER_FILES=$(shell find $(SWAGGER_DIR) -name '*.swagger.json')
-SWAGGER_FILES=data/docs/api_chef_automate/compliance/reporting/reporting.swagger.json
+SWAGGER_FILES=$(shell find $(SWAGGER_DIR) -name '*.swagger.json')
 STATIC_SWAGGER_FILES=$(shell find data/docs/api-static/ -type f | sort -n)
-
-EXPECTED_CONFLICTS=46
 
 themes/chef:
 	scripts/clone_hugo.sh
@@ -41,11 +38,8 @@ sync_swagger_files: clean_swagger_files
 
 $(SWAGGER_RESULT_FILE): $(SWAGGER_FILES)
 
-#generate_swagger: $(SWAGGER_RESULT_FILE)
-#	swagger mixin --quiet -c=$(EXPECTED_CONFLICTS) $(SWAGGER_FILES) > $(SWAGGER_RESULT_FILE)
-
 generate_swagger: $(SWAGGER_RESULT_FILE)
-	swagger mixin $(STATIC_SWAGGER_FILES) $(SWAGGER_FILES) | \
+	swagger mixin -c=0 $(STATIC_SWAGGER_FILES) $(SWAGGER_FILES) | \
 		jq '.paths = (.paths | with_entries( select( all( .value[].tags[]; . != "hidden") ) ) )' \
 		> $(SWAGGER_RESULT_FILE)
 

--- a/components/automate-chef-io/data/docs/api-static/01-reporting-export.swagger.json
+++ b/components/automate-chef-io/data/docs/api-static/01-reporting-export.swagger.json
@@ -9,7 +9,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ExportData"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ExportData"
             }
           }
         },
@@ -19,7 +19,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Query"
             }
           }
         ],

--- a/components/automate-chef-io/data/docs/api_chef_automate/applications/applications.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/applications/applications.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesRes"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/applicationsDisconnectedServicesReq"
+              "$ref": "#/definitions/chef.automate.api.applications.DisconnectedServicesReq"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesRes"
             }
           }
         },
@@ -73,7 +73,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServiceGroups"
+              "$ref": "#/definitions/chef.automate.api.applications.ServiceGroups"
             }
           }
         },
@@ -132,7 +132,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesBySGRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesBySGRes"
             }
           }
         },
@@ -203,7 +203,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsHealthCounts"
+              "$ref": "#/definitions/chef.automate.api.applications.HealthCounts"
             }
           }
         },
@@ -231,7 +231,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesRes"
             }
           }
         },
@@ -290,7 +290,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesDistinctValuesRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesDistinctValuesRes"
             }
           }
         },
@@ -330,7 +330,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesStatsRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesStatsRes"
             }
           }
         },
@@ -346,7 +346,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -362,7 +362,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsPeriodicJobConfig"
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicJobConfig"
             }
           }
         },
@@ -376,7 +376,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsUpdateDeleteDisconnectedServicesConfigRes"
+              "$ref": "#/definitions/chef.automate.api.applications.UpdateDeleteDisconnectedServicesConfigRes"
             }
           }
         },
@@ -386,7 +386,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/applicationsPeriodicJobConfig"
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicJobConfig"
             }
           }
         ],
@@ -402,7 +402,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsPeriodicMandatoryJobConfig"
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicMandatoryJobConfig"
             }
           }
         },
@@ -416,7 +416,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsUpdateDisconnectedServicesConfigRes"
+              "$ref": "#/definitions/chef.automate.api.applications.UpdateDisconnectedServicesConfigRes"
             }
           }
         },
@@ -426,7 +426,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/applicationsPeriodicMandatoryJobConfig"
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicMandatoryJobConfig"
             }
           }
         ],
@@ -437,7 +437,7 @@
     }
   },
   "definitions": {
-    "applicationsDisconnectedServicesReq": {
+    "chef.automate.api.applications.DisconnectedServicesReq": {
       "type": "object",
       "properties": {
         "threshold_seconds": {
@@ -446,7 +446,7 @@
         }
       }
     },
-    "applicationsHealthCounts": {
+    "chef.automate.api.applications.HealthCounts": {
       "type": "object",
       "properties": {
         "total": {
@@ -475,7 +475,7 @@
         }
       }
     },
-    "applicationsHealthStatus": {
+    "chef.automate.api.applications.HealthStatus": {
       "type": "string",
       "enum": [
         "OK",
@@ -488,7 +488,7 @@
       "description": "- NONE: The representation of NO health check status\nTODO @afiune how much effort would be to change\nthe OK enum to be NONE",
       "title": "The HealthStatus enum matches the habitat implementation for health-check status:\n=\u003e https://www.habitat.sh/docs/reference/#health-check"
     },
-    "applicationsPeriodicJobConfig": {
+    "chef.automate.api.applications.PeriodicJobConfig": {
       "type": "object",
       "properties": {
         "running": {
@@ -501,7 +501,7 @@
         }
       }
     },
-    "applicationsPeriodicMandatoryJobConfig": {
+    "chef.automate.api.applications.PeriodicMandatoryJobConfig": {
       "type": "object",
       "properties": {
         "threshold": {
@@ -511,7 +511,7 @@
       },
       "title": "it's like a PeriodicJobConfig but the user isn't allowed to change whether\nor not the job runs"
     },
-    "applicationsService": {
+    "chef.automate.api.applications.Service": {
       "type": "object",
       "properties": {
         "supervisor_id": {
@@ -524,10 +524,10 @@
           "type": "string"
         },
         "health_check": {
-          "$ref": "#/definitions/applicationsHealthStatus"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthStatus"
         },
         "status": {
-          "$ref": "#/definitions/applicationsServiceStatus"
+          "$ref": "#/definitions/chef.automate.api.applications.ServiceStatus"
         },
         "application": {
           "type": "string"
@@ -548,7 +548,7 @@
           "type": "string"
         },
         "previous_health_check": {
-          "$ref": "#/definitions/applicationsHealthStatus"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthStatus"
         },
         "current_health_since": {
           "type": "string"
@@ -570,7 +570,7 @@
         }
       }
     },
-    "applicationsServiceGroup": {
+    "chef.automate.api.applications.ServiceGroup": {
       "type": "object",
       "properties": {
         "name": {
@@ -581,7 +581,7 @@
           "title": "Combination of the version and release in a single string like:\nExample: 0.1.0/8743278934278923"
         },
         "status": {
-          "$ref": "#/definitions/applicationsHealthStatus"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthStatus"
         },
         "health_percentage": {
           "type": "integer",
@@ -589,7 +589,7 @@
           "title": "The health_percentage can be a number between 0-100"
         },
         "services_health_counts": {
-          "$ref": "#/definitions/applicationsHealthCounts"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthCounts"
         },
         "id": {
           "type": "string"
@@ -611,18 +611,18 @@
       },
       "title": "A service group message is the representation of one single service group that\nis internally generated by aggregating all the services"
     },
-    "applicationsServiceGroups": {
+    "chef.automate.api.applications.ServiceGroups": {
       "type": "object",
       "properties": {
         "service_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/applicationsServiceGroup"
+            "$ref": "#/definitions/chef.automate.api.applications.ServiceGroup"
           }
         }
       }
     },
-    "applicationsServiceStatus": {
+    "chef.automate.api.applications.ServiceStatus": {
       "type": "string",
       "enum": [
         "RUNNING",
@@ -633,7 +633,7 @@
       "default": "RUNNING",
       "title": "The ServiceStatus enum describes the status of the service\n@afiune have we defined these states somewhere?"
     },
-    "applicationsServicesBySGRes": {
+    "chef.automate.api.applications.ServicesBySGRes": {
       "type": "object",
       "properties": {
         "group": {
@@ -642,15 +642,15 @@
         "services": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/applicationsService"
+            "$ref": "#/definitions/chef.automate.api.applications.Service"
           }
         },
         "services_health_counts": {
-          "$ref": "#/definitions/applicationsHealthCounts"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthCounts"
         }
       }
     },
-    "applicationsServicesDistinctValuesRes": {
+    "chef.automate.api.applications.ServicesDistinctValuesRes": {
       "type": "object",
       "properties": {
         "values": {
@@ -661,18 +661,18 @@
         }
       }
     },
-    "applicationsServicesRes": {
+    "chef.automate.api.applications.ServicesRes": {
       "type": "object",
       "properties": {
         "services": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/applicationsService"
+            "$ref": "#/definitions/chef.automate.api.applications.Service"
           }
         }
       }
     },
-    "applicationsServicesStatsRes": {
+    "chef.automate.api.applications.ServicesStatsRes": {
       "type": "object",
       "properties": {
         "total_service_groups": {
@@ -693,13 +693,13 @@
         }
       }
     },
-    "applicationsUpdateDeleteDisconnectedServicesConfigRes": {
+    "chef.automate.api.applications.UpdateDeleteDisconnectedServicesConfigRes": {
       "type": "object"
     },
-    "applicationsUpdateDisconnectedServicesConfigRes": {
+    "chef.automate.api.applications.UpdateDisconnectedServicesConfigRes": {
       "type": "object"
     },
-    "queryPagination": {
+    "chef.automate.api.common.query.Pagination": {
       "type": "object",
       "properties": {
         "page": {
@@ -712,7 +712,7 @@
         }
       }
     },
-    "querySortOrder": {
+    "chef.automate.api.common.query.SortOrder": {
       "type": "string",
       "enum": [
         "ASC",
@@ -720,18 +720,18 @@
       ],
       "default": "ASC"
     },
-    "querySorting": {
+    "chef.automate.api.common.query.Sorting": {
       "type": "object",
       "properties": {
         "field": {
           "type": "string"
         },
         "order": {
-          "$ref": "#/definitions/querySortOrder"
+          "$ref": "#/definitions/chef.automate.api.common.query.SortOrder"
         }
       }
     },
-    "versionVersionInfo": {
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
         "name": {

--- a/components/automate-chef-io/data/docs/api_chef_automate/auth/teams/teams.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/auth/teams/teams.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseTeams"
+              "$ref": "#/definitions/chef.automate.api.teams.response.Teams"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseCreateTeamResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.CreateTeamResp"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestCreateTeamReq"
+              "$ref": "#/definitions/chef.automate.api.teams.request.CreateTeamReq"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -78,7 +78,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseGetTeamResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.GetTeamResp"
             }
           }
         },
@@ -100,7 +100,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseDeleteTeamResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.DeleteTeamResp"
             }
           }
         },
@@ -122,7 +122,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUpdateTeamResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.UpdateTeamResp"
             }
           }
         },
@@ -138,7 +138,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestUpdateTeamReq"
+              "$ref": "#/definitions/chef.automate.api.teams.request.UpdateTeamReq"
             }
           }
         ],
@@ -154,7 +154,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseGetUsersResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.GetUsersResp"
             }
           }
         },
@@ -176,7 +176,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseAddUsersResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.AddUsersResp"
             }
           }
         },
@@ -192,7 +192,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestAddUsersReq"
+              "$ref": "#/definitions/chef.automate.api.teams.request.AddUsersReq"
             }
           }
         ],
@@ -206,7 +206,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseRemoveUsersResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.RemoveUsersResp"
             }
           }
         },
@@ -222,7 +222,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestRemoveUsersReq"
+              "$ref": "#/definitions/chef.automate.api.teams.request.RemoveUsersReq"
             }
           }
         ],
@@ -238,7 +238,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseGetTeamsForUserResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.GetTeamsForUserResp"
             }
           }
         },
@@ -257,155 +257,7 @@
     }
   },
   "definitions": {
-    "requestAddUsersReq": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "user_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "requestCreateTeamReq": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        }
-      }
-    },
-    "requestRemoveUsersReq": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "user_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "requestUpdateTeamReq": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        }
-      }
-    },
-    "responseAddUsersResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseCreateTeamResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseDeleteTeamResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseGetTeamResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseGetTeamsForUserResp": {
-      "type": "object",
-      "properties": {
-        "teams": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/teamsresponseTeam"
-          }
-        }
-      }
-    },
-    "responseGetUsersResp": {
-      "type": "object",
-      "properties": {
-        "user_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "responseRemoveUsersResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseTeams": {
-      "type": "object",
-      "properties": {
-        "teams": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/teamsresponseTeam"
-          }
-        }
-      }
-    },
-    "responseUpdateTeamResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "teamsresponseTeam": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        }
-      }
-    },
-    "versionVersionInfo": {
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
         "name": {
@@ -419,6 +271,154 @@
         },
         "built": {
           "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.teams.request.AddUsersReq": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.request.CreateTeamReq": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.teams.request.RemoveUsersReq": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.request.UpdateTeamReq": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.AddUsersResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.CreateTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.DeleteTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.GetTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.GetTeamsForUserResp": {
+      "type": "object",
+      "properties": {
+        "teams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.response.GetUsersResp": {
+      "type": "object",
+      "properties": {
+        "user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.response.RemoveUsersResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.Team": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.Teams": {
+      "type": "object",
+      "properties": {
+        "teams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.response.UpdateTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
         }
       }
     }

--- a/components/automate-chef-io/data/docs/api_chef_automate/auth/tokens/tokens.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/auth/tokens/tokens.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseTokens"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.Tokens"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.Token"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestCreateToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.request.CreateToken"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.Token"
             }
           }
         },
@@ -84,7 +84,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseDeleteTokenResp"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.DeleteTokenResp"
             }
           }
         },
@@ -106,7 +106,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.Token"
             }
           }
         },
@@ -122,7 +122,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestUpdateToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.request.UpdateToken"
             }
           }
         ],
@@ -133,7 +133,7 @@
     }
   },
   "definitions": {
-    "requestCreateToken": {
+    "chef.automate.api.tokens.request.CreateToken": {
       "type": "object",
       "properties": {
         "description": {
@@ -151,7 +151,7 @@
         }
       }
     },
-    "requestUpdateToken": {
+    "chef.automate.api.tokens.request.UpdateToken": {
       "type": "object",
       "properties": {
         "id": {
@@ -166,10 +166,10 @@
         }
       }
     },
-    "responseDeleteTokenResp": {
+    "chef.automate.api.tokens.response.DeleteTokenResp": {
       "type": "object"
     },
-    "responseToken": {
+    "chef.automate.api.tokens.response.Token": {
       "type": "object",
       "properties": {
         "id": {
@@ -193,13 +193,13 @@
         }
       }
     },
-    "responseTokens": {
+    "chef.automate.api.tokens.response.Tokens": {
       "type": "object",
       "properties": {
         "tokens": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseToken"
+            "$ref": "#/definitions/chef.automate.api.tokens.response.Token"
           }
         }
       }

--- a/components/automate-chef-io/data/docs/api_chef_automate/auth/users/users.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/auth/users/users.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUsers"
+              "$ref": "#/definitions/chef.automate.api.users.response.Users"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUser"
+              "$ref": "#/definitions/chef.automate.api.users.response.User"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestCreateUser"
+              "$ref": "#/definitions/chef.automate.api.users.request.CreateUser"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUser"
+              "$ref": "#/definitions/chef.automate.api.users.response.User"
             }
           }
         },
@@ -84,7 +84,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseDeleteUserResp"
+              "$ref": "#/definitions/chef.automate.api.users.response.DeleteUserResp"
             }
           }
         },
@@ -106,7 +106,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUser"
+              "$ref": "#/definitions/chef.automate.api.users.response.User"
             }
           }
         },
@@ -122,7 +122,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestUpdateUser"
+              "$ref": "#/definitions/chef.automate.api.users.request.UpdateUser"
             }
           }
         ],
@@ -138,7 +138,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUser"
+              "$ref": "#/definitions/chef.automate.api.users.response.User"
             }
           }
         },
@@ -154,7 +154,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestUpdateSelf"
+              "$ref": "#/definitions/chef.automate.api.users.request.UpdateSelf"
             }
           }
         ],
@@ -165,7 +165,7 @@
     }
   },
   "definitions": {
-    "requestCreateUser": {
+    "chef.automate.api.users.request.CreateUser": {
       "type": "object",
       "properties": {
         "id": {
@@ -185,7 +185,7 @@
         }
       }
     },
-    "requestUpdateSelf": {
+    "chef.automate.api.users.request.UpdateSelf": {
       "type": "object",
       "properties": {
         "id": {
@@ -205,7 +205,7 @@
         }
       }
     },
-    "requestUpdateUser": {
+    "chef.automate.api.users.request.UpdateUser": {
       "type": "object",
       "properties": {
         "id": {
@@ -225,10 +225,10 @@
         }
       }
     },
-    "responseDeleteUserResp": {
+    "chef.automate.api.users.response.DeleteUserResp": {
       "type": "object"
     },
-    "responseUser": {
+    "chef.automate.api.users.response.User": {
       "type": "object",
       "properties": {
         "id": {
@@ -245,13 +245,13 @@
         }
       }
     },
-    "responseUsers": {
+    "chef.automate.api.users.response.Users": {
       "type": "object",
       "properties": {
         "users": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseUser"
+            "$ref": "#/definitions/chef.automate.api.users.response.User"
           }
         }
       }

--- a/components/automate-chef-io/data/docs/api_chef_automate/authz/authz.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/authz/authz.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseIntrospectResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.IntrospectResp"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseIntrospectResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.IntrospectResp"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestIntrospectReq"
+              "$ref": "#/definitions/chef.automate.api.authz.request.IntrospectReq"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseIntrospectResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.IntrospectResp"
             }
           }
         },
@@ -72,7 +72,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestIntrospectSomeReq"
+              "$ref": "#/definitions/chef.automate.api.authz.request.IntrospectSomeReq"
             }
           }
         ],
@@ -88,7 +88,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseListPoliciesResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.ListPoliciesResp"
             }
           }
         },
@@ -102,7 +102,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseCreatePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.CreatePolicyResp"
             }
           }
         },
@@ -112,7 +112,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestCreatePolicyReq"
+              "$ref": "#/definitions/chef.automate.api.authz.request.CreatePolicyReq"
             }
           }
         ],
@@ -128,7 +128,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -144,7 +144,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseDeletePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.DeletePolicyResp"
             }
           }
         },
@@ -163,7 +163,7 @@
     }
   },
   "definitions": {
-    "requestCreatePolicyReq": {
+    "chef.automate.api.authz.request.CreatePolicyReq": {
       "type": "object",
       "properties": {
         "action": {
@@ -180,7 +180,7 @@
         }
       }
     },
-    "requestIntrospectReq": {
+    "chef.automate.api.authz.request.IntrospectReq": {
       "type": "object",
       "properties": {
         "path": {
@@ -194,7 +194,7 @@
         }
       }
     },
-    "requestIntrospectSomeReq": {
+    "chef.automate.api.authz.request.IntrospectSomeReq": {
       "type": "object",
       "properties": {
         "paths": {
@@ -205,7 +205,7 @@
         }
       }
     },
-    "responseCreatePolicyResp": {
+    "chef.automate.api.authz.response.CreatePolicyResp": {
       "type": "object",
       "properties": {
         "action": {
@@ -237,7 +237,7 @@
       },
       "description": "We aren't using a Policy message here since we want to\nreturn a flat object via our external HTTP API."
     },
-    "responseDeletePolicyResp": {
+    "chef.automate.api.authz.response.DeletePolicyResp": {
       "type": "object",
       "properties": {
         "action": {
@@ -268,29 +268,29 @@
         }
       }
     },
-    "responseIntrospectResp": {
+    "chef.automate.api.authz.response.IntrospectResp": {
       "type": "object",
       "properties": {
         "endpoints": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/responseMethodsAllowed"
+            "$ref": "#/definitions/chef.automate.api.authz.response.MethodsAllowed"
           }
         }
       }
     },
-    "responseListPoliciesResp": {
+    "chef.automate.api.authz.response.ListPoliciesResp": {
       "type": "object",
       "properties": {
         "policies": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responsePolicy"
+            "$ref": "#/definitions/chef.automate.api.authz.response.Policy"
           }
         }
       }
     },
-    "responseMethodsAllowed": {
+    "chef.automate.api.authz.response.MethodsAllowed": {
       "type": "object",
       "properties": {
         "get": {
@@ -315,7 +315,7 @@
         }
       }
     },
-    "responsePolicy": {
+    "chef.automate.api.authz.response.Policy": {
       "type": "object",
       "properties": {
         "action": {
@@ -346,7 +346,7 @@
         }
       }
     },
-    "versionVersionInfo": {
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
         "name": {

--- a/components/automate-chef-io/data/docs/api_chef_automate/cfgmgmt/cfgmgmt.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/cfgmgmt/cfgmgmt.swagger.json
@@ -84,7 +84,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseNodeAttribute"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.NodeAttribute"
             }
           }
         },
@@ -172,7 +172,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseRun"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Run"
             }
           }
         },
@@ -228,7 +228,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responsePolicyCookbooks"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.PolicyCookbooks"
             }
           }
         },
@@ -271,7 +271,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/cfgmgmtresponseNodesCounts"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.NodesCounts"
             }
           }
         },
@@ -299,7 +299,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/cfgmgmtresponseRunsCounts"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.RunsCounts"
             }
           }
         },
@@ -388,7 +388,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -399,85 +399,7 @@
     }
   },
   "definitions": {
-    "cfgmgmtresponseNodesCounts": {
-      "type": "object",
-      "properties": {
-        "total": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "success": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "failure": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "missing": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "cfgmgmtresponseRunsCounts": {
-      "type": "object",
-      "properties": {
-        "total": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "success": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "failure": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "protobufNullValue": {
-      "type": "string",
-      "enum": [
-        "NULL_VALUE"
-      ],
-      "default": "NULL_VALUE",
-      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
-    },
-    "queryPagination": {
-      "type": "object",
-      "properties": {
-        "page": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "size": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "querySortOrder": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "querySorting": {
-      "type": "object",
-      "properties": {
-        "field": {
-          "type": "string"
-        },
-        "order": {
-          "$ref": "#/definitions/querySortOrder"
-        }
-      }
-    },
-    "responseChefError": {
+    "chef.automate.api.cfgmgmt.response.ChefError": {
       "type": "object",
       "properties": {
         "class": {
@@ -493,11 +415,11 @@
           }
         },
         "description": {
-          "$ref": "#/definitions/responseDescription"
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Description"
         }
       }
     },
-    "responseCookbookLock": {
+    "chef.automate.api.cfgmgmt.response.CookbookLock": {
       "type": "object",
       "properties": {
         "cookbook": {
@@ -508,7 +430,7 @@
         }
       }
     },
-    "responseDeprecation": {
+    "chef.automate.api.cfgmgmt.response.Deprecation": {
       "type": "object",
       "properties": {
         "message": {
@@ -522,7 +444,7 @@
         }
       }
     },
-    "responseDescription": {
+    "chef.automate.api.cfgmgmt.response.Description": {
       "type": "object",
       "properties": {
         "title": {
@@ -536,7 +458,7 @@
         }
       }
     },
-    "responseExpandedRunList": {
+    "chef.automate.api.cfgmgmt.response.ExpandedRunList": {
       "type": "object",
       "properties": {
         "id": {
@@ -545,12 +467,12 @@
         "run_list": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseRunList"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.RunList"
           }
         }
       }
     },
-    "responseNodeAttribute": {
+    "chef.automate.api.cfgmgmt.response.NodeAttribute": {
       "type": "object",
       "properties": {
         "node_id": {
@@ -602,7 +524,28 @@
         }
       }
     },
-    "responsePolicyCookbooks": {
+    "chef.automate.api.cfgmgmt.response.NodesCounts": {
+      "type": "object",
+      "properties": {
+        "total": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "success": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "failure": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "missing": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.PolicyCookbooks": {
       "type": "object",
       "properties": {
         "policy_name": {
@@ -611,12 +554,12 @@
         "cookbook_locks": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseCookbookLock"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.CookbookLock"
           }
         }
       }
     },
-    "responseResource": {
+    "chef.automate.api.cfgmgmt.response.Resource": {
       "type": "object",
       "properties": {
         "type": {
@@ -659,7 +602,7 @@
         }
       }
     },
-    "responseRun": {
+    "chef.automate.api.cfgmgmt.response.Run": {
       "type": "object",
       "properties": {
         "id": {
@@ -718,7 +661,7 @@
         "resources": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseResource"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Resource"
           }
         },
         "run_list": {
@@ -730,11 +673,11 @@
         "deprecations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseDeprecation"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Deprecation"
           }
         },
         "error": {
-          "$ref": "#/definitions/responseChefError"
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.ChefError"
         },
         "tags": {
           "type": "array",
@@ -791,11 +734,11 @@
           "type": "string"
         },
         "expanded_run_list": {
-          "$ref": "#/definitions/responseExpandedRunList"
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.ExpandedRunList"
         }
       }
     },
-    "responseRunList": {
+    "chef.automate.api.cfgmgmt.response.RunList": {
       "type": "object",
       "properties": {
         "type": {
@@ -814,12 +757,61 @@
         "children": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseRunList"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.RunList"
           }
         }
       }
     },
-    "versionVersionInfo": {
+    "chef.automate.api.cfgmgmt.response.RunsCounts": {
+      "type": "object",
+      "properties": {
+        "total": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "success": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "failure": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.common.query.Pagination": {
+      "type": "object",
+      "properties": {
+        "page": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.common.query.SortOrder": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.common.query.Sorting": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "order": {
+          "$ref": "#/definitions/chef.automate.api.common.query.SortOrder"
+        }
+      }
+    },
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
         "name": {
@@ -835,6 +827,14 @@
           "type": "string"
         }
       }
+    },
+    "google.protobuf.NullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
     }
   }
 }

--- a/components/automate-chef-io/data/docs/api_chef_automate/compliance/profiles/profiles.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/compliance/profiles/profiles.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Profile"
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profile"
             }
           }
         },
@@ -58,7 +58,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Profile"
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profile"
             }
           }
         },
@@ -94,7 +94,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Profiles"
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profiles"
             }
           }
         },
@@ -104,7 +104,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Query"
             }
           }
         ],
@@ -151,63 +151,18 @@
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "protobufAny": {
-      "type": "object",
-      "properties": {
-        "type_url": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string",
-          "format": "byte"
-        }
-      }
-    },
-    "runtimeStreamError": {
-      "type": "object",
-      "properties": {
-        "grpc_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "http_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
-          "type": "string"
-        },
-        "http_status": {
-          "type": "string"
-        },
-        "details": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/protobufAny"
-          }
-        }
-      }
-    },
-    "v1Attribute": {
+    "chef.automate.api.compliance.profiles.v1.Attribute": {
       "type": "object",
       "properties": {
         "name": {
           "type": "string"
         },
         "options": {
-          "$ref": "#/definitions/v1Option"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Option"
         }
       }
     },
-    "v1CheckMessage": {
+    "chef.automate.api.compliance.profiles.v1.CheckMessage": {
       "type": "object",
       "properties": {
         "file": {
@@ -229,27 +184,27 @@
         }
       }
     },
-    "v1CheckResult": {
+    "chef.automate.api.compliance.profiles.v1.CheckResult": {
       "type": "object",
       "properties": {
         "summary": {
-          "$ref": "#/definitions/v1ResultSummary"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.ResultSummary"
         },
         "errors": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1CheckMessage"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.CheckMessage"
           }
         },
         "warnings": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1CheckMessage"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.CheckMessage"
           }
         }
       }
     },
-    "v1Chunk": {
+    "chef.automate.api.compliance.profiles.v1.Chunk": {
       "type": "object",
       "properties": {
         "data": {
@@ -262,7 +217,7 @@
         }
       }
     },
-    "v1Control": {
+    "chef.automate.api.compliance.profiles.v1.Control": {
       "type": "object",
       "properties": {
         "id": {
@@ -282,18 +237,18 @@
           "type": "string"
         },
         "source_location": {
-          "$ref": "#/definitions/v1SourceLocation"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.SourceLocation"
         },
         "results": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Result"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Result"
           }
         },
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Ref"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Ref"
           }
         },
         "tags": {
@@ -304,7 +259,7 @@
         }
       }
     },
-    "v1Dependency": {
+    "chef.automate.api.compliance.profiles.v1.Dependency": {
       "type": "object",
       "properties": {
         "name": {
@@ -342,7 +297,7 @@
         }
       }
     },
-    "v1Group": {
+    "chef.automate.api.compliance.profiles.v1.Group": {
       "type": "object",
       "properties": {
         "id": {
@@ -359,7 +314,7 @@
         }
       }
     },
-    "v1ListFilter": {
+    "chef.automate.api.compliance.profiles.v1.ListFilter": {
       "type": "object",
       "properties": {
         "values": {
@@ -373,7 +328,7 @@
         }
       }
     },
-    "v1Metadata": {
+    "chef.automate.api.compliance.profiles.v1.Metadata": {
       "type": "object",
       "properties": {
         "name": {
@@ -387,7 +342,7 @@
         }
       }
     },
-    "v1Option": {
+    "chef.automate.api.compliance.profiles.v1.Option": {
       "type": "object",
       "properties": {
         "description": {
@@ -398,7 +353,7 @@
         }
       }
     },
-    "v1Profile": {
+    "chef.automate.api.compliance.profiles.v1.Profile": {
       "type": "object",
       "properties": {
         "name": {
@@ -431,13 +386,13 @@
         "supports": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Support"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Support"
           }
         },
         "depends": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Dependency"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Dependency"
           }
         },
         "sha256": {
@@ -446,19 +401,19 @@
         "groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Group"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Group"
           }
         },
         "controls": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Control"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Control"
           }
         },
         "attributes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Attribute"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Attribute"
           }
         },
         "latest_version": {
@@ -466,7 +421,7 @@
         }
       }
     },
-    "v1ProfileData": {
+    "chef.automate.api.compliance.profiles.v1.ProfileData": {
       "type": "object",
       "properties": {
         "owner": {
@@ -484,13 +439,13 @@
         }
       }
     },
-    "v1Profiles": {
+    "chef.automate.api.compliance.profiles.v1.Profiles": {
       "type": "object",
       "properties": {
         "profiles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Profile"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profile"
           }
         },
         "total": {
@@ -499,17 +454,17 @@
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.compliance.profiles.v1.Query": {
       "type": "object",
       "properties": {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ListFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.ListFilter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -533,7 +488,15 @@
         }
       }
     },
-    "v1Ref": {
+    "chef.automate.api.compliance.profiles.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.compliance.profiles.v1.Ref": {
       "type": "object",
       "properties": {
         "url": {
@@ -544,7 +507,7 @@
         }
       }
     },
-    "v1Result": {
+    "chef.automate.api.compliance.profiles.v1.Result": {
       "type": "object",
       "properties": {
         "status": {
@@ -568,7 +531,7 @@
         }
       }
     },
-    "v1ResultSummary": {
+    "chef.automate.api.compliance.profiles.v1.ResultSummary": {
       "type": "object",
       "properties": {
         "valid": {
@@ -587,7 +550,7 @@
         }
       }
     },
-    "v1SourceLocation": {
+    "chef.automate.api.compliance.profiles.v1.SourceLocation": {
       "type": "object",
       "properties": {
         "ref": {
@@ -599,7 +562,7 @@
         }
       }
     },
-    "v1Support": {
+    "chef.automate.api.compliance.profiles.v1.Support": {
       "type": "object",
       "properties": {
         "os_name": {
@@ -618,20 +581,57 @@
           "type": "string"
         }
       }
+    },
+    "google.protobuf.Any": {
+      "type": "object",
+      "properties": {
+        "type_url": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "grpc.gateway.runtime.StreamError": {
+      "type": "object",
+      "properties": {
+        "grpc_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "http_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "http_status": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/google.protobuf.Any"
+          }
+        }
+      }
     }
   },
   "x-stream-definitions": {
-    "v1ProfileData": {
+    "chef.automate.api.compliance.profiles.v1.ProfileData": {
       "type": "object",
       "properties": {
         "result": {
-          "$ref": "#/definitions/v1ProfileData"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.ProfileData"
         },
         "error": {
-          "$ref": "#/definitions/runtimeStreamError"
+          "$ref": "#/definitions/grpc.gateway.runtime.StreamError"
         }
       },
-      "title": "Stream result of v1ProfileData"
+      "title": "Stream result of chef.automate.api.compliance.profiles.v1.ProfileData"
     }
   }
 }

--- a/components/automate-chef-io/data/docs/api_chef_automate/compliance/reporting/reporting.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/compliance/reporting/reporting.swagger.json
@@ -24,7 +24,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ControlItems"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlItems"
             }
           }
         },
@@ -34,7 +34,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1ControlItemRequest"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlItemRequest"
             }
           }
         ],
@@ -52,7 +52,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Node"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Node"
             }
           }
         },
@@ -79,7 +79,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Nodes"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Nodes"
             }
           }
         },
@@ -89,7 +89,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -107,7 +107,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ProfileMins"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMins"
             }
           }
         },
@@ -117,7 +117,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -135,7 +135,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ReportIds"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ReportIds"
             }
           }
         },
@@ -145,7 +145,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -163,7 +163,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Reports"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Reports"
             }
           }
         },
@@ -173,7 +173,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -191,7 +191,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Report"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Report"
             }
           }
         },
@@ -208,7 +208,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -226,7 +226,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Suggestions"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Suggestions"
             }
           }
         },
@@ -236,7 +236,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1SuggestionRequest"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.SuggestionRequest"
             }
           }
         ],
@@ -252,7 +252,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -263,56 +263,24 @@
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC",
-      "title": "The two allowed values for ordering results"
-    },
-    "protobufAny": {
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
-        "type_url": {
-          "type": "string",
-          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
-        },
-        "value": {
-          "type": "string",
-          "format": "byte",
-          "description": "Must be a valid serialized protocol buffer of the above specified type."
-        }
-      },
-      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := ptypes.MarshalAny(foo)\n     ...\n     foo := \u0026pb.Foo{}\n     if err := ptypes.UnmarshalAny(any, foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
-    },
-    "runtimeStreamError": {
-      "type": "object",
-      "properties": {
-        "grpc_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "http_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
+        "name": {
           "type": "string"
         },
-        "http_status": {
+        "version": {
           "type": "string"
         },
-        "details": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/protobufAny"
-          }
+        "sha": {
+          "type": "string"
+        },
+        "built": {
+          "type": "string"
         }
       }
     },
-    "v1Attribute": {
+    "chef.automate.api.compliance.reporting.v1.Attribute": {
       "type": "object",
       "properties": {
         "name": {
@@ -320,12 +288,12 @@
           "title": "The name of the attribute"
         },
         "options": {
-          "$ref": "#/definitions/v1Option",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Option",
           "title": "The options defined for the attribute"
         }
       }
     },
-    "v1Control": {
+    "chef.automate.api.compliance.reporting.v1.Control": {
       "type": "object",
       "properties": {
         "id": {
@@ -350,20 +318,20 @@
           "title": "The compact description of the control"
         },
         "source_location": {
-          "$ref": "#/definitions/v1SourceLocation",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.SourceLocation",
           "title": "Intentionally blank"
         },
         "results": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Result"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Result"
           },
           "title": "The results of running all tests defined in the control against the node"
         },
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Ref"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Ref"
           },
           "title": "External supporting documents for the control"
         },
@@ -376,7 +344,7 @@
         }
       }
     },
-    "v1ControlItem": {
+    "chef.automate.api.compliance.reporting.v1.ControlItem": {
       "type": "object",
       "properties": {
         "id": {
@@ -388,7 +356,7 @@
           "title": "The compact description of the control"
         },
         "profile": {
-          "$ref": "#/definitions/v1ProfileMin",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMin",
           "title": "Intentionally blank"
         },
         "impact": {
@@ -402,12 +370,12 @@
           "title": "The time the report using the control was submitted at"
         },
         "control_summary": {
-          "$ref": "#/definitions/v1ControlSummary",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary",
           "title": "Intentionally blank"
         }
       }
     },
-    "v1ControlItemRequest": {
+    "chef.automate.api.compliance.reporting.v1.ControlItemRequest": {
       "type": "object",
       "properties": {
         "text": {
@@ -422,25 +390,25 @@
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ListFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ListFilter"
           },
           "title": "The criteria used to filter the controls returned"
         }
       }
     },
-    "v1ControlItems": {
+    "chef.automate.api.compliance.reporting.v1.ControlItems": {
       "type": "object",
       "properties": {
         "control_items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ControlItem"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlItem"
           },
           "title": "The paginated results of controls matching the filters"
         }
       }
     },
-    "v1ControlSummary": {
+    "chef.automate.api.compliance.reporting.v1.ControlSummary": {
       "type": "object",
       "properties": {
         "total": {
@@ -449,21 +417,21 @@
           "title": "The total number of controls"
         },
         "passed": {
-          "$ref": "#/definitions/v1Total",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Total",
           "title": "Intentionally blank"
         },
         "skipped": {
-          "$ref": "#/definitions/v1Total",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Total",
           "title": "Intentionally blank"
         },
         "failed": {
-          "$ref": "#/definitions/v1Failed",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Failed",
           "title": "Intentionally blank"
         }
       },
       "title": "A minimal represenation of the statuses of the controls"
     },
-    "v1Dependency": {
+    "chef.automate.api.compliance.reporting.v1.Dependency": {
       "type": "object",
       "properties": {
         "name": {
@@ -520,7 +488,7 @@
         }
       }
     },
-    "v1ExportData": {
+    "chef.automate.api.compliance.reporting.v1.ExportData": {
       "type": "object",
       "properties": {
         "content": {
@@ -530,7 +498,7 @@
         }
       }
     },
-    "v1Failed": {
+    "chef.automate.api.compliance.reporting.v1.Failed": {
       "type": "object",
       "properties": {
         "total": {
@@ -556,7 +524,7 @@
       },
       "title": "Stats of failed controls"
     },
-    "v1Group": {
+    "chef.automate.api.compliance.reporting.v1.Group": {
       "type": "object",
       "properties": {
         "id": {
@@ -576,7 +544,7 @@
         }
       }
     },
-    "v1Kv": {
+    "chef.automate.api.compliance.reporting.v1.Kv": {
       "type": "object",
       "properties": {
         "key": {
@@ -589,7 +557,7 @@
         }
       }
     },
-    "v1LatestReportSummary": {
+    "chef.automate.api.compliance.reporting.v1.LatestReportSummary": {
       "type": "object",
       "properties": {
         "id": {
@@ -606,13 +574,13 @@
           "title": "The status of the run the report was made from"
         },
         "controls": {
-          "$ref": "#/definitions/v1ControlSummary",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary",
           "title": "Intentionally blank"
         }
       },
       "title": "A summary of the information contained in the latest report for this node"
     },
-    "v1ListFilter": {
+    "chef.automate.api.compliance.reporting.v1.ListFilter": {
       "type": "object",
       "properties": {
         "values": {
@@ -628,7 +596,7 @@
         }
       }
     },
-    "v1Node": {
+    "chef.automate.api.compliance.reporting.v1.Node": {
       "type": "object",
       "properties": {
         "id": {
@@ -640,7 +608,7 @@
           "title": "The name assigned to the node"
         },
         "platform": {
-          "$ref": "#/definitions/v1Platform",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Platform",
           "title": "Intentionally blank"
         },
         "environment": {
@@ -648,32 +616,32 @@
           "title": "The environment assigned to the node"
         },
         "latest_report": {
-          "$ref": "#/definitions/v1LatestReportSummary",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.LatestReportSummary",
           "title": "A summary of the information contained in the latest report for this node"
         },
         "tags": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Kv"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Kv"
           },
           "title": "The tags assigned to this node"
         },
         "profiles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ProfileMeta"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMeta"
           },
           "title": "A minimal represenation of the compliance profiles run against the node"
         }
       }
     },
-    "v1Nodes": {
+    "chef.automate.api.compliance.reporting.v1.Nodes": {
       "type": "object",
       "properties": {
         "nodes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Node"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Node"
           },
           "title": "The nodes matching the request filters"
         },
@@ -699,7 +667,7 @@
         }
       }
     },
-    "v1Option": {
+    "chef.automate.api.compliance.reporting.v1.Option": {
       "type": "object",
       "properties": {
         "description": {
@@ -712,7 +680,7 @@
         }
       }
     },
-    "v1Platform": {
+    "chef.automate.api.compliance.reporting.v1.Platform": {
       "type": "object",
       "properties": {
         "name": {
@@ -730,7 +698,7 @@
       },
       "title": "The name and version of the node's operating system"
     },
-    "v1Profile": {
+    "chef.automate.api.compliance.reporting.v1.Profile": {
       "type": "object",
       "properties": {
         "name": {
@@ -776,14 +744,14 @@
         "supports": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Support"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Support"
           },
           "title": "The supported platform targets"
         },
         "depends": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Dependency"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Dependency"
           },
           "title": "Other profiles that this profile depends on"
         },
@@ -794,21 +762,21 @@
         "groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Group"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Group"
           },
           "title": "The groups of controls defined in the profile"
         },
         "controls": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Control"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Control"
           },
           "title": "The controls defined on the profile"
         },
         "attributes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Attribute"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Attribute"
           },
           "title": "The attributes defined on the profile"
         },
@@ -826,7 +794,7 @@
         }
       }
     },
-    "v1ProfileCounts": {
+    "chef.automate.api.compliance.reporting.v1.ProfileCounts": {
       "type": "object",
       "properties": {
         "total": {
@@ -852,7 +820,7 @@
       },
       "title": "Stats on the statuses of nodes matching the filters"
     },
-    "v1ProfileMeta": {
+    "chef.automate.api.compliance.reporting.v1.ProfileMeta": {
       "type": "object",
       "properties": {
         "name": {
@@ -877,7 +845,7 @@
         }
       }
     },
-    "v1ProfileMin": {
+    "chef.automate.api.compliance.reporting.v1.ProfileMin": {
       "type": "object",
       "properties": {
         "name": {
@@ -903,23 +871,23 @@
       },
       "title": "Minimal represenation of a profile"
     },
-    "v1ProfileMins": {
+    "chef.automate.api.compliance.reporting.v1.ProfileMins": {
       "type": "object",
       "properties": {
         "profiles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ProfileMin"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMin"
           },
           "title": "Minimal represenations of the profiles matching the filters"
         },
         "counts": {
-          "$ref": "#/definitions/v1ProfileCounts",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileCounts",
           "title": "Intentionally blank"
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.compliance.reporting.v1.Query": {
       "type": "object",
       "properties": {
         "id": {
@@ -933,12 +901,12 @@
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ListFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ListFilter"
           },
           "title": "The list of filters used to narrow down the list"
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query.OrderType",
           "title": "Whether to sort in ascending or descending order"
         },
         "sort": {
@@ -957,7 +925,16 @@
         }
       }
     },
-    "v1Ref": {
+    "chef.automate.api.compliance.reporting.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC",
+      "title": "The two allowed values for ordering results"
+    },
+    "chef.automate.api.compliance.reporting.v1.Ref": {
       "type": "object",
       "properties": {
         "url": {
@@ -970,7 +947,7 @@
         }
       }
     },
-    "v1Report": {
+    "chef.automate.api.compliance.reporting.v1.Report": {
       "type": "object",
       "properties": {
         "id": {
@@ -995,7 +972,7 @@
           "title": "The status of the run the report was made from"
         },
         "controls": {
-          "$ref": "#/definitions/v1ControlSummary",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary",
           "title": "Intentionally blank"
         },
         "environment": {
@@ -1007,17 +984,17 @@
           "title": "The version of the report"
         },
         "platform": {
-          "$ref": "#/definitions/v1Platform",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Platform",
           "title": "Intentionally blank"
         },
         "statistics": {
-          "$ref": "#/definitions/v1Statistics",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Statistics",
           "title": "Intentionally blank"
         },
         "profiles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Profile"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Profile"
           },
           "title": "The profiles run as part of this report"
         },
@@ -1035,7 +1012,7 @@
         }
       }
     },
-    "v1ReportIds": {
+    "chef.automate.api.compliance.reporting.v1.ReportIds": {
       "type": "object",
       "properties": {
         "ids": {
@@ -1047,13 +1024,13 @@
         }
       }
     },
-    "v1Reports": {
+    "chef.automate.api.compliance.reporting.v1.Reports": {
       "type": "object",
       "properties": {
         "reports": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Report"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Report"
           },
           "title": "The paginated results of reports matching the filters"
         },
@@ -1064,7 +1041,7 @@
         }
       }
     },
-    "v1Result": {
+    "chef.automate.api.compliance.reporting.v1.Result": {
       "type": "object",
       "properties": {
         "status": {
@@ -1094,7 +1071,7 @@
         }
       }
     },
-    "v1SourceLocation": {
+    "chef.automate.api.compliance.reporting.v1.SourceLocation": {
       "type": "object",
       "properties": {
         "ref": {
@@ -1108,7 +1085,7 @@
         }
       }
     },
-    "v1Statistics": {
+    "chef.automate.api.compliance.reporting.v1.Statistics": {
       "type": "object",
       "properties": {
         "duration": {
@@ -1119,7 +1096,7 @@
       },
       "title": "Statistics of the report's run"
     },
-    "v1Suggestion": {
+    "chef.automate.api.compliance.reporting.v1.Suggestion": {
       "type": "object",
       "properties": {
         "text": {
@@ -1141,7 +1118,7 @@
         }
       }
     },
-    "v1SuggestionRequest": {
+    "chef.automate.api.compliance.reporting.v1.SuggestionRequest": {
       "type": "object",
       "properties": {
         "type": {
@@ -1160,25 +1137,25 @@
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ListFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ListFilter"
           },
           "title": "The criteria used to filter the suggestions returned"
         }
       }
     },
-    "v1Suggestions": {
+    "chef.automate.api.compliance.reporting.v1.Suggestions": {
       "type": "object",
       "properties": {
         "suggestions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Suggestion"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Suggestion"
           },
           "title": "The list of returned suggestions"
         }
       }
     },
-    "v1Support": {
+    "chef.automate.api.compliance.reporting.v1.Support": {
       "type": "object",
       "properties": {
         "os_name": {
@@ -1203,7 +1180,7 @@
         }
       }
     },
-    "v1Total": {
+    "chef.automate.api.compliance.reporting.v1.Total": {
       "type": "object",
       "properties": {
         "total": {
@@ -1214,36 +1191,59 @@
       },
       "title": "A subtotal of controls"
     },
-    "versionVersionInfo": {
+    "google.protobuf.Any": {
       "type": "object",
       "properties": {
-        "name": {
+        "type_url": {
+          "type": "string",
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
+        },
+        "value": {
+          "type": "string",
+          "format": "byte",
+          "description": "Must be a valid serialized protocol buffer of the above specified type."
+        }
+      },
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := ptypes.MarshalAny(foo)\n     ...\n     foo := \u0026pb.Foo{}\n     if err := ptypes.UnmarshalAny(any, foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+    },
+    "grpc.gateway.runtime.StreamError": {
+      "type": "object",
+      "properties": {
+        "grpc_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "http_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
           "type": "string"
         },
-        "version": {
+        "http_status": {
           "type": "string"
         },
-        "sha": {
-          "type": "string"
-        },
-        "built": {
-          "type": "string"
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/google.protobuf.Any"
+          }
         }
       }
     }
   },
   "x-stream-definitions": {
-    "v1ExportData": {
+    "chef.automate.api.compliance.reporting.v1.ExportData": {
       "type": "object",
       "properties": {
         "result": {
-          "$ref": "#/definitions/v1ExportData"
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ExportData"
         },
         "error": {
-          "$ref": "#/definitions/runtimeStreamError"
+          "$ref": "#/definitions/grpc.gateway.runtime.StreamError"
         }
       },
-      "title": "Stream result of v1ExportData"
+      "title": "Stream result of chef.automate.api.compliance.reporting.v1.ExportData"
     }
   }
 }

--- a/components/automate-chef-io/data/docs/api_chef_automate/compliance/reporting/stats/stats.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/compliance/reporting/stats/stats.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Failures"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Failures"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
             }
           }
         ],
@@ -49,7 +49,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Profile"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Profile"
             }
           }
         },
@@ -59,7 +59,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
             }
           }
         ],
@@ -76,7 +76,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Summary"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Summary"
             }
           }
         },
@@ -86,7 +86,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
             }
           }
         ],
@@ -103,7 +103,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Trends"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Trends"
             }
           }
         },
@@ -113,7 +113,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
             }
           }
         ],
@@ -124,114 +124,7 @@
     }
   },
   "definitions": {
-    "reportingstatsv1ListFilter": {
-      "type": "object",
-      "properties": {
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "type": {
-          "type": "string"
-        }
-      }
-    },
-    "reportingstatsv1Profile": {
-      "type": "object",
-      "properties": {
-        "profile_list": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1ProfileList"
-          }
-        },
-        "profile_summary": {
-          "$ref": "#/definitions/v1ProfileSummary"
-        },
-        "control_stats": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1ControlStats"
-          }
-        }
-      }
-    },
-    "reportingstatsv1Query": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "size": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "interval": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "filters": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/reportingstatsv1ListFilter"
-          }
-        },
-        "order": {
-          "$ref": "#/definitions/reportingstatsv1QueryOrderType"
-        },
-        "sort": {
-          "type": "string"
-        },
-        "page": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "per_page": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "reportingstatsv1QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "reportingstatsv1Support": {
-      "type": "object",
-      "properties": {
-        "os_name": {
-          "type": "string"
-        },
-        "os_family": {
-          "type": "string"
-        },
-        "release": {
-          "type": "string"
-        },
-        "inspec_version": {
-          "type": "string"
-        },
-        "platform_name": {
-          "type": "string"
-        },
-        "platform_family": {
-          "type": "string"
-        },
-        "platform": {
-          "type": "string"
-        }
-      }
-    },
-    "v1ControlStats": {
+    "chef.automate.api.compliance.reporting.stats.v1.ControlStats": {
       "type": "object",
       "properties": {
         "control": {
@@ -258,7 +151,7 @@
         }
       }
     },
-    "v1ControlsSummary": {
+    "chef.automate.api.compliance.reporting.stats.v1.ControlsSummary": {
       "type": "object",
       "properties": {
         "failures": {
@@ -287,7 +180,383 @@
         }
       }
     },
-    "v1Dependency": {
+    "chef.automate.api.compliance.reporting.stats.v1.FailureSummary": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "failures": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "id": {
+          "type": "string"
+        },
+        "profile": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Failures": {
+      "type": "object",
+      "properties": {
+        "profiles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        },
+        "platforms": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        },
+        "controls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ListFilter": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.NodeSummary": {
+      "type": "object",
+      "properties": {
+        "compliant": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "noncompliant": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "high_risk": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "medium_risk": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "low_risk": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Profile": {
+      "type": "object",
+      "properties": {
+        "profile_list": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ProfileList"
+          }
+        },
+        "profile_summary": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ProfileSummary"
+        },
+        "control_stats": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ControlStats"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ProfileList": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "failures": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "majors": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "minors": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "criticals": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "passed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ProfileSummary": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "license": {
+          "type": "string"
+        },
+        "maintainer": {
+          "type": "string"
+        },
+        "copyright": {
+          "type": "string"
+        },
+        "copyright_email": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "supports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Support"
+          }
+        },
+        "stats": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ProfileSummaryStats"
+        },
+        "depends": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Dependency"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ProfileSummaryStats": {
+      "type": "object",
+      "properties": {
+        "failed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "passed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "failed_nodes": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_nodes": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Query": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "interval": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ListFilter"
+          }
+        },
+        "order": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query.OrderType"
+        },
+        "sort": {
+          "type": "string"
+        },
+        "page": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "per_page": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ReportSummary": {
+      "type": "object",
+      "properties": {
+        "stats": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Stats"
+        },
+        "status": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "number",
+          "format": "double"
+        },
+        "start_date": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Stats": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "string",
+          "format": "int64",
+          "title": "int64 types render into string types when serialized to satisfy all browsers\nwe don't really need for nodes counts to be int64 as int32 limits us to 2billion nodes which is plenty for now\nwe are therefore deprecating nodes and favor nodesCnt"
+        },
+        "platforms": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "environments": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "profiles": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "nodes_cnt": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Summary": {
+      "type": "object",
+      "properties": {
+        "controls_summary": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ControlsSummary"
+        },
+        "node_summary": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.NodeSummary"
+        },
+        "report_summary": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ReportSummary"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Support": {
+      "type": "object",
+      "properties": {
+        "os_name": {
+          "type": "string"
+        },
+        "os_family": {
+          "type": "string"
+        },
+        "release": {
+          "type": "string"
+        },
+        "inspec_version": {
+          "type": "string"
+        },
+        "platform_name": {
+          "type": "string"
+        },
+        "platform_family": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Trend": {
+      "type": "object",
+      "properties": {
+        "report_time": {
+          "type": "string"
+        },
+        "passed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "failed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Trends": {
+      "type": "object",
+      "properties": {
+        "trends": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Trend"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Dependency": {
       "type": "object",
       "properties": {
         "name": {
@@ -341,275 +610,6 @@
         "skip_message": {
           "type": "string",
           "title": "The reason this profile was skipped in the generated report, if any"
-        }
-      }
-    },
-    "v1FailureSummary": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "failures": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "id": {
-          "type": "string"
-        },
-        "profile": {
-          "type": "string"
-        }
-      }
-    },
-    "v1Failures": {
-      "type": "object",
-      "properties": {
-        "profiles": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1FailureSummary"
-          }
-        },
-        "platforms": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1FailureSummary"
-          }
-        },
-        "controls": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1FailureSummary"
-          }
-        },
-        "environments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1FailureSummary"
-          }
-        }
-      }
-    },
-    "v1NodeSummary": {
-      "type": "object",
-      "properties": {
-        "compliant": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skipped": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "noncompliant": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "high_risk": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "medium_risk": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "low_risk": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1ProfileList": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "id": {
-          "type": "string"
-        },
-        "failures": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "majors": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "minors": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "criticals": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "passed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skipped": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1ProfileSummary": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "version": {
-          "type": "string"
-        },
-        "license": {
-          "type": "string"
-        },
-        "maintainer": {
-          "type": "string"
-        },
-        "copyright": {
-          "type": "string"
-        },
-        "copyright_email": {
-          "type": "string"
-        },
-        "summary": {
-          "type": "string"
-        },
-        "supports": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/reportingstatsv1Support"
-          }
-        },
-        "stats": {
-          "$ref": "#/definitions/v1ProfileSummaryStats"
-        },
-        "depends": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1Dependency"
-          }
-        }
-      }
-    },
-    "v1ProfileSummaryStats": {
-      "type": "object",
-      "properties": {
-        "failed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "passed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skipped": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "failed_nodes": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "total_nodes": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1ReportSummary": {
-      "type": "object",
-      "properties": {
-        "stats": {
-          "$ref": "#/definitions/v1Stats"
-        },
-        "status": {
-          "type": "string"
-        },
-        "duration": {
-          "type": "number",
-          "format": "double"
-        },
-        "start_date": {
-          "type": "string"
-        }
-      }
-    },
-    "v1Stats": {
-      "type": "object",
-      "properties": {
-        "nodes": {
-          "type": "string",
-          "format": "int64",
-          "title": "int64 types render into string types when serialized to satisfy all browsers\nwe don't really need for nodes counts to be int64 as int32 limits us to 2billion nodes which is plenty for now\nwe are therefore deprecating nodes and favor nodesCnt"
-        },
-        "platforms": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "environments": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "profiles": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "nodes_cnt": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1Summary": {
-      "type": "object",
-      "properties": {
-        "controls_summary": {
-          "$ref": "#/definitions/v1ControlsSummary"
-        },
-        "node_summary": {
-          "$ref": "#/definitions/v1NodeSummary"
-        },
-        "report_summary": {
-          "$ref": "#/definitions/v1ReportSummary"
-        }
-      }
-    },
-    "v1Trend": {
-      "type": "object",
-      "properties": {
-        "report_time": {
-          "type": "string"
-        },
-        "passed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "failed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skipped": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1Trends": {
-      "type": "object",
-      "properties": {
-        "trends": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1Trend"
-          }
         }
       }
     }

--- a/components/automate-chef-io/data/docs/api_chef_automate/compliance/scanner/jobs/jobs.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/compliance/scanner/jobs/jobs.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Id"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Id"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Job"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Job"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
             }
           }
         },
@@ -108,7 +108,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Job"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
             }
           }
         ],
@@ -124,7 +124,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1RerunResponse"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.RerunResponse"
             }
           }
         },
@@ -148,7 +148,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Jobs"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Jobs"
             }
           }
         },
@@ -158,7 +158,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Query"
             }
           }
         ],
@@ -169,44 +169,7 @@
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "commonFilter": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "exclude": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "commonKv": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "v1Id": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Id": {
       "type": "object",
       "properties": {
         "id": {
@@ -214,7 +177,7 @@
         }
       }
     },
-    "v1Job": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Job": {
       "type": "object",
       "properties": {
         "id": {
@@ -233,7 +196,7 @@
         "tags": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonKv"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Kv"
           }
         },
         "start_time": {
@@ -258,7 +221,7 @@
         "results": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ResultsRow"
+            "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.ResultsRow"
           }
         },
         "nodes": {
@@ -284,7 +247,7 @@
         "node_selectors": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ManagerFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.ManagerFilter"
           }
         },
         "scheduled_time": {
@@ -307,13 +270,13 @@
         }
       }
     },
-    "v1Jobs": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Jobs": {
       "type": "object",
       "properties": {
         "jobs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Job"
+            "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
           }
         },
         "total": {
@@ -322,7 +285,7 @@
         }
       }
     },
-    "v1ManagerFilter": {
+    "chef.automate.api.compliance.scanner.jobs.v1.ManagerFilter": {
       "type": "object",
       "properties": {
         "manager_id": {
@@ -331,22 +294,22 @@
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonFilter"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Filter"
           }
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Query": {
       "type": "object",
       "properties": {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonFilter"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Filter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -361,10 +324,18 @@
         }
       }
     },
-    "v1RerunResponse": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.compliance.scanner.jobs.v1.RerunResponse": {
       "type": "object"
     },
-    "v1ResultsRow": {
+    "chef.automate.api.compliance.scanner.jobs.v1.ResultsRow": {
       "type": "object",
       "properties": {
         "node_id": {
@@ -389,6 +360,35 @@
         "end_time": {
           "type": "string",
           "format": "date-time"
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Filter": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "exclude": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Kv": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
         }
       }
     }

--- a/components/automate-chef-io/data/docs/api_chef_automate/data_feed/data_feed.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/data_feed/data_feed.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedAddDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.AddDestinationResponse"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/datafeedAddDestinationRequest"
+              "$ref": "#/definitions/chef.automate.api.datafeed.AddDestinationRequest"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedGetDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.GetDestinationResponse"
             }
           }
         },
@@ -71,7 +71,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedDeleteDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.DeleteDestinationResponse"
             }
           }
         },
@@ -94,7 +94,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedUpdateDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.UpdateDestinationResponse"
             }
           }
         },
@@ -111,7 +111,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/datafeedUpdateDestinationRequest"
+              "$ref": "#/definitions/chef.automate.api.datafeed.UpdateDestinationRequest"
             }
           }
         ],
@@ -127,7 +127,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedListDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.ListDestinationResponse"
             }
           }
         },
@@ -137,7 +137,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/datafeedListDestinationRequest"
+              "$ref": "#/definitions/chef.automate.api.datafeed.ListDestinationRequest"
             }
           }
         ],
@@ -153,7 +153,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedTestDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.TestDestinationResponse"
             }
           }
         },
@@ -163,7 +163,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/datafeedURLValidationRequest"
+              "$ref": "#/definitions/chef.automate.api.datafeed.URLValidationRequest"
             }
           }
         ],
@@ -174,7 +174,7 @@
     }
   },
   "definitions": {
-    "datafeedAddDestinationRequest": {
+    "chef.automate.api.datafeed.AddDestinationRequest": {
       "type": "object",
       "properties": {
         "id": {
@@ -192,7 +192,7 @@
         }
       }
     },
-    "datafeedAddDestinationResponse": {
+    "chef.automate.api.datafeed.AddDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -201,7 +201,7 @@
         }
       }
     },
-    "datafeedDeleteDestinationResponse": {
+    "chef.automate.api.datafeed.DeleteDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -210,7 +210,7 @@
         }
       }
     },
-    "datafeedGetDestinationResponse": {
+    "chef.automate.api.datafeed.GetDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -232,21 +232,21 @@
         }
       }
     },
-    "datafeedListDestinationRequest": {
+    "chef.automate.api.datafeed.ListDestinationRequest": {
       "type": "object"
     },
-    "datafeedListDestinationResponse": {
+    "chef.automate.api.datafeed.ListDestinationResponse": {
       "type": "object",
       "properties": {
         "destinations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/datafeedGetDestinationResponse"
+            "$ref": "#/definitions/chef.automate.api.datafeed.GetDestinationResponse"
           }
         }
       }
     },
-    "datafeedSecretId": {
+    "chef.automate.api.datafeed.SecretId": {
       "type": "object",
       "properties": {
         "id": {
@@ -254,7 +254,7 @@
         }
       }
     },
-    "datafeedTestDestinationResponse": {
+    "chef.automate.api.datafeed.TestDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -263,21 +263,21 @@
         }
       }
     },
-    "datafeedURLValidationRequest": {
+    "chef.automate.api.datafeed.URLValidationRequest": {
       "type": "object",
       "properties": {
         "url": {
           "type": "string"
         },
         "username_password": {
-          "$ref": "#/definitions/datafeedUsernamePassword"
+          "$ref": "#/definitions/chef.automate.api.datafeed.UsernamePassword"
         },
         "secret_id": {
-          "$ref": "#/definitions/datafeedSecretId"
+          "$ref": "#/definitions/chef.automate.api.datafeed.SecretId"
         }
       }
     },
-    "datafeedUpdateDestinationRequest": {
+    "chef.automate.api.datafeed.UpdateDestinationRequest": {
       "type": "object",
       "properties": {
         "id": {
@@ -295,7 +295,7 @@
         }
       }
     },
-    "datafeedUpdateDestinationResponse": {
+    "chef.automate.api.datafeed.UpdateDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -304,7 +304,7 @@
         }
       }
     },
-    "datafeedUsernamePassword": {
+    "chef.automate.api.datafeed.UsernamePassword": {
       "type": "object",
       "properties": {
         "username": {

--- a/components/automate-chef-io/data/docs/api_chef_automate/deployment/deployment.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/deployment/deployment.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/deploymentServiceVersionsResponse"
+              "$ref": "#/definitions/chef.automate.api.deployment.ServiceVersionsResponse"
             }
           }
         },
@@ -38,7 +38,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/deploymentVersion"
+              "$ref": "#/definitions/chef.automate.api.deployment.Version"
             }
           }
         },
@@ -49,7 +49,7 @@
     }
   },
   "definitions": {
-    "deploymentServiceVersion": {
+    "chef.automate.api.deployment.ServiceVersion": {
       "type": "object",
       "properties": {
         "name": {
@@ -66,18 +66,18 @@
         }
       }
     },
-    "deploymentServiceVersionsResponse": {
+    "chef.automate.api.deployment.ServiceVersionsResponse": {
       "type": "object",
       "properties": {
         "services": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/deploymentServiceVersion"
+            "$ref": "#/definitions/chef.automate.api.deployment.ServiceVersion"
           }
         }
       }
     },
-    "deploymentVersion": {
+    "chef.automate.api.deployment.Version": {
       "type": "object",
       "properties": {
         "build_timestamp": {

--- a/components/automate-chef-io/data/docs/api_chef_automate/event_feed/event_feed.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/event_feed/event_feed.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseEventCounts"
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCounts"
             }
           }
         },
@@ -64,7 +64,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseEventCounts"
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCounts"
             }
           }
         },
@@ -106,7 +106,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseEvents"
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.Events"
             }
           }
         },
@@ -182,7 +182,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/event_feedresponseEventStrings"
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.EventStrings"
             }
           }
         },
@@ -230,28 +230,7 @@
     }
   },
   "definitions": {
-    "event_feedresponseEventStrings": {
-      "type": "object",
-      "properties": {
-        "strings": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/responseEventString"
-          }
-        },
-        "start": {
-          "type": "string"
-        },
-        "end": {
-          "type": "string"
-        },
-        "hours_between": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "responseEvent": {
+    "chef.automate.api.event_feed.response.Event": {
       "type": "object",
       "properties": {
         "event_type": {
@@ -298,18 +277,18 @@
         }
       }
     },
-    "responseEventCollection": {
+    "chef.automate.api.event_feed.response.EventCollection": {
       "type": "object",
       "properties": {
         "events_count": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseEventCount"
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCount"
           }
         }
       }
     },
-    "responseEventCount": {
+    "chef.automate.api.event_feed.response.EventCount": {
       "type": "object",
       "properties": {
         "name": {
@@ -321,7 +300,7 @@
         }
       }
     },
-    "responseEventCounts": {
+    "chef.automate.api.event_feed.response.EventCounts": {
       "type": "object",
       "properties": {
         "total": {
@@ -331,18 +310,18 @@
         "counts": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseEventCount"
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCount"
           }
         }
       }
     },
-    "responseEventString": {
+    "chef.automate.api.event_feed.response.EventString": {
       "type": "object",
       "properties": {
         "collection": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseEventCollection"
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCollection"
           }
         },
         "event_action": {
@@ -350,13 +329,34 @@
         }
       }
     },
-    "responseEvents": {
+    "chef.automate.api.event_feed.response.EventStrings": {
+      "type": "object",
+      "properties": {
+        "strings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventString"
+          }
+        },
+        "start": {
+          "type": "string"
+        },
+        "end": {
+          "type": "string"
+        },
+        "hours_between": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.event_feed.response.Events": {
       "type": "object",
       "properties": {
         "events": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseEvent"
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.Event"
           }
         },
         "total_events": {

--- a/components/automate-chef-io/data/docs/api_chef_automate/gateway/gateway.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/gateway/gateway.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiHealth"
+              "$ref": "#/definitions/chef.automate.api.Health"
             }
           }
         },
@@ -38,7 +38,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiVersion"
+              "$ref": "#/definitions/chef.automate.api.Version"
             }
           }
         },
@@ -49,7 +49,7 @@
     }
   },
   "definitions": {
-    "apiHealth": {
+    "chef.automate.api.Health": {
       "type": "object",
       "properties": {
         "status": {
@@ -59,7 +59,7 @@
       "description": "The automate-gateway service health is constructed with:\n* Status:\n           =\u003e ok:             Everything is alright\n           =\u003e initialization: The service is in its initialization process\n           =\u003e warning:        Something might be wrong?\n           =\u003e critical:       Something is wrong!\n\n@afiune: Here we can add more health information to the response",
       "title": "Health message"
     },
-    "apiVersion": {
+    "chef.automate.api.Version": {
       "type": "object",
       "properties": {
         "version": {

--- a/components/automate-chef-io/data/docs/api_chef_automate/iam/v2beta/policy.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/iam/v2beta/policy.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListProjectsResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListProjectsResp"
             }
           }
         },
@@ -38,7 +38,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListPoliciesResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListPoliciesResp"
             }
           }
         },
@@ -52,7 +52,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreatePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreatePolicyResp"
             }
           }
         },
@@ -62,7 +62,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreatePolicyReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreatePolicyReq"
             }
           }
         ],
@@ -78,7 +78,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetPolicyResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetPolicyResp"
             }
           }
         },
@@ -100,7 +100,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeletePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeletePolicyResp"
             }
           }
         },
@@ -122,7 +122,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdatePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdatePolicyResp"
             }
           }
         },
@@ -138,7 +138,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdatePolicyReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdatePolicyReq"
             }
           }
         ],
@@ -154,7 +154,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListPolicyMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListPolicyMembersResp"
             }
           }
         },
@@ -176,7 +176,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaReplacePolicyMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ReplacePolicyMembersResp"
             }
           }
         },
@@ -192,7 +192,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaReplacePolicyMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ReplacePolicyMembersReq"
             }
           }
         ],
@@ -208,7 +208,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaAddPolicyMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.AddPolicyMembersResp"
             }
           }
         },
@@ -224,7 +224,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaAddPolicyMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.AddPolicyMembersReq"
             }
           }
         ],
@@ -240,7 +240,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaRemovePolicyMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.RemovePolicyMembersResp"
             }
           }
         },
@@ -256,7 +256,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaRemovePolicyMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.RemovePolicyMembersReq"
             }
           }
         ],
@@ -272,7 +272,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetPolicyVersionResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetPolicyVersionResp"
             }
           }
         },
@@ -288,7 +288,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListProjectsResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListProjectsResp"
             }
           }
         },
@@ -302,7 +302,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateProjectResp"
             }
           }
         },
@@ -312,7 +312,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateProjectReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateProjectReq"
             }
           }
         ],
@@ -328,7 +328,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetProjectResp"
             }
           }
         },
@@ -350,7 +350,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteProjectResp"
             }
           }
         },
@@ -372,7 +372,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateProjectResp"
             }
           }
         },
@@ -388,7 +388,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateProjectReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateProjectReq"
             }
           }
         ],
@@ -404,7 +404,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListRolesResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListRolesResp"
             }
           }
         },
@@ -418,7 +418,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateRoleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateRoleResp"
             }
           }
         },
@@ -428,7 +428,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateRoleReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateRoleReq"
             }
           }
         ],
@@ -444,7 +444,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetRoleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetRoleResp"
             }
           }
         },
@@ -466,7 +466,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteRoleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteRoleResp"
             }
           }
         },
@@ -488,7 +488,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateRoleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateRoleResp"
             }
           }
         },
@@ -504,7 +504,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateRoleReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateRoleReq"
             }
           }
         ],
@@ -515,32 +515,7 @@
     }
   },
   "definitions": {
-    "StatementEffect": {
-      "type": "string",
-      "enum": [
-        "ALLOW",
-        "DENY"
-      ],
-      "default": "ALLOW"
-    },
-    "VersionVersionNumber": {
-      "type": "string",
-      "enum": [
-        "V0",
-        "V1",
-        "V2"
-      ],
-      "default": "V0"
-    },
-    "iamv2betaType": {
-      "type": "string",
-      "enum": [
-        "CHEF_MANAGED",
-        "CUSTOM"
-      ],
-      "default": "CHEF_MANAGED"
-    },
-    "v2betaAddPolicyMembersReq": {
+    "chef.automate.api.iam.v2beta.AddPolicyMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -554,7 +529,7 @@
         }
       }
     },
-    "v2betaAddPolicyMembersResp": {
+    "chef.automate.api.iam.v2beta.AddPolicyMembersResp": {
       "type": "object",
       "properties": {
         "members": {
@@ -565,7 +540,7 @@
         }
       }
     },
-    "v2betaCreatePolicyReq": {
+    "chef.automate.api.iam.v2beta.CreatePolicyReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -583,7 +558,7 @@
         "statements": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaStatement"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Statement"
           }
         },
         "projects": {
@@ -595,15 +570,15 @@
       },
       "description": "Does not contain type as the enduser can only create 'custom' policies."
     },
-    "v2betaCreatePolicyResp": {
+    "chef.automate.api.iam.v2beta.CreatePolicyResp": {
       "type": "object",
       "properties": {
         "policy": {
-          "$ref": "#/definitions/v2betaPolicy"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Policy"
         }
       }
     },
-    "v2betaCreateProjectReq": {
+    "chef.automate.api.iam.v2beta.CreateProjectReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -614,15 +589,15 @@
         }
       }
     },
-    "v2betaCreateProjectResp": {
+    "chef.automate.api.iam.v2beta.CreateProjectResp": {
       "type": "object",
       "properties": {
         "project": {
-          "$ref": "#/definitions/v2betaProject"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Project"
         }
       }
     },
-    "v2betaCreateRoleReq": {
+    "chef.automate.api.iam.v2beta.CreateRoleReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -646,24 +621,24 @@
       },
       "description": "Does not contain type as the enduser can only create 'custom' roles."
     },
-    "v2betaCreateRoleResp": {
+    "chef.automate.api.iam.v2beta.CreateRoleResp": {
       "type": "object",
       "properties": {
         "role": {
-          "$ref": "#/definitions/v2betaRole"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Role"
         }
       }
     },
-    "v2betaDeletePolicyResp": {
+    "chef.automate.api.iam.v2beta.DeletePolicyResp": {
       "type": "object"
     },
-    "v2betaDeleteProjectResp": {
+    "chef.automate.api.iam.v2beta.DeleteProjectResp": {
       "type": "object"
     },
-    "v2betaDeleteRoleResp": {
+    "chef.automate.api.iam.v2beta.DeleteRoleResp": {
       "type": "object"
     },
-    "v2betaFlag": {
+    "chef.automate.api.iam.v2beta.Flag": {
       "type": "string",
       "enum": [
         "VERSION_2_0",
@@ -672,50 +647,50 @@
       "default": "VERSION_2_0",
       "title": "passed to UpgradeToV2 to set version"
     },
-    "v2betaGetPolicyResp": {
+    "chef.automate.api.iam.v2beta.GetPolicyResp": {
       "type": "object",
       "properties": {
         "policy": {
-          "$ref": "#/definitions/v2betaPolicy"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Policy"
         }
       }
     },
-    "v2betaGetPolicyVersionResp": {
+    "chef.automate.api.iam.v2beta.GetPolicyVersionResp": {
       "type": "object",
       "properties": {
         "version": {
-          "$ref": "#/definitions/v2betaVersion"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Version"
         }
       }
     },
-    "v2betaGetProjectResp": {
+    "chef.automate.api.iam.v2beta.GetProjectResp": {
       "type": "object",
       "properties": {
         "project": {
-          "$ref": "#/definitions/v2betaProject"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Project"
         }
       }
     },
-    "v2betaGetRoleResp": {
+    "chef.automate.api.iam.v2beta.GetRoleResp": {
       "type": "object",
       "properties": {
         "role": {
-          "$ref": "#/definitions/v2betaRole"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Role"
         }
       }
     },
-    "v2betaListPoliciesResp": {
+    "chef.automate.api.iam.v2beta.ListPoliciesResp": {
       "type": "object",
       "properties": {
         "policies": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaPolicy"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Policy"
           }
         }
       }
     },
-    "v2betaListPolicyMembersResp": {
+    "chef.automate.api.iam.v2beta.ListPolicyMembersResp": {
       "type": "object",
       "properties": {
         "members": {
@@ -726,29 +701,29 @@
         }
       }
     },
-    "v2betaListProjectsResp": {
+    "chef.automate.api.iam.v2beta.ListProjectsResp": {
       "type": "object",
       "properties": {
         "projects": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaProject"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Project"
           }
         }
       }
     },
-    "v2betaListRolesResp": {
+    "chef.automate.api.iam.v2beta.ListRolesResp": {
       "type": "object",
       "properties": {
         "roles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaRole"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Role"
           }
         }
       }
     },
-    "v2betaPolicy": {
+    "chef.automate.api.iam.v2beta.Policy": {
       "type": "object",
       "properties": {
         "name": {
@@ -758,7 +733,7 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/iamv2betaType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Type"
         },
         "members": {
           "type": "array",
@@ -769,7 +744,7 @@
         "statements": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaStatement"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Statement"
           }
         },
         "projects": {
@@ -780,7 +755,7 @@
         }
       }
     },
-    "v2betaProject": {
+    "chef.automate.api.iam.v2beta.Project": {
       "type": "object",
       "properties": {
         "name": {
@@ -790,14 +765,14 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/iamv2betaType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Type"
         },
         "status": {
-          "$ref": "#/definitions/v2betaProjectRulesStatus"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.ProjectRulesStatus"
         }
       }
     },
-    "v2betaProjectRulesStatus": {
+    "chef.automate.api.iam.v2beta.ProjectRulesStatus": {
       "type": "string",
       "enum": [
         "PROJECT_RULES_STATUS_UNSET",
@@ -807,7 +782,7 @@
       ],
       "default": "PROJECT_RULES_STATUS_UNSET"
     },
-    "v2betaRemovePolicyMembersReq": {
+    "chef.automate.api.iam.v2beta.RemovePolicyMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -821,7 +796,7 @@
         }
       }
     },
-    "v2betaRemovePolicyMembersResp": {
+    "chef.automate.api.iam.v2beta.RemovePolicyMembersResp": {
       "type": "object",
       "properties": {
         "members": {
@@ -832,7 +807,7 @@
         }
       }
     },
-    "v2betaReplacePolicyMembersReq": {
+    "chef.automate.api.iam.v2beta.ReplacePolicyMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -846,7 +821,7 @@
         }
       }
     },
-    "v2betaReplacePolicyMembersResp": {
+    "chef.automate.api.iam.v2beta.ReplacePolicyMembersResp": {
       "type": "object",
       "properties": {
         "members": {
@@ -857,10 +832,10 @@
         }
       }
     },
-    "v2betaResetToV1Resp": {
+    "chef.automate.api.iam.v2beta.ResetToV1Resp": {
       "type": "object"
     },
-    "v2betaRole": {
+    "chef.automate.api.iam.v2beta.Role": {
       "type": "object",
       "properties": {
         "name": {
@@ -870,7 +845,7 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/iamv2betaType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Type"
         },
         "actions": {
           "type": "array",
@@ -886,11 +861,11 @@
         }
       }
     },
-    "v2betaStatement": {
+    "chef.automate.api.iam.v2beta.Statement": {
       "type": "object",
       "properties": {
         "effect": {
-          "$ref": "#/definitions/StatementEffect"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Statement.Effect"
         },
         "actions": {
           "type": "array",
@@ -918,7 +893,23 @@
         }
       }
     },
-    "v2betaUpdatePolicyReq": {
+    "chef.automate.api.iam.v2beta.Statement.Effect": {
+      "type": "string",
+      "enum": [
+        "ALLOW",
+        "DENY"
+      ],
+      "default": "ALLOW"
+    },
+    "chef.automate.api.iam.v2beta.Type": {
+      "type": "string",
+      "enum": [
+        "CHEF_MANAGED",
+        "CUSTOM"
+      ],
+      "default": "CHEF_MANAGED"
+    },
+    "chef.automate.api.iam.v2beta.UpdatePolicyReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -933,7 +924,7 @@
         "statements": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaStatement"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Statement"
           }
         },
         "name": {
@@ -948,15 +939,15 @@
       },
       "description": "Does not contain type as the enduser can only create 'custom' policies."
     },
-    "v2betaUpdatePolicyResp": {
+    "chef.automate.api.iam.v2beta.UpdatePolicyResp": {
       "type": "object",
       "properties": {
         "policy": {
-          "$ref": "#/definitions/v2betaPolicy"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Policy"
         }
       }
     },
-    "v2betaUpdateProjectReq": {
+    "chef.automate.api.iam.v2beta.UpdateProjectReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -967,15 +958,15 @@
         }
       }
     },
-    "v2betaUpdateProjectResp": {
+    "chef.automate.api.iam.v2beta.UpdateProjectResp": {
       "type": "object",
       "properties": {
         "project": {
-          "$ref": "#/definitions/v2betaProject"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Project"
         }
       }
     },
-    "v2betaUpdateRoleReq": {
+    "chef.automate.api.iam.v2beta.UpdateRoleReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -998,15 +989,15 @@
         }
       }
     },
-    "v2betaUpdateRoleResp": {
+    "chef.automate.api.iam.v2beta.UpdateRoleResp": {
       "type": "object",
       "properties": {
         "role": {
-          "$ref": "#/definitions/v2betaRole"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Role"
         }
       }
     },
-    "v2betaUpgradeToV2Resp": {
+    "chef.automate.api.iam.v2beta.UpgradeToV2Resp": {
       "type": "object",
       "properties": {
         "reports": {
@@ -1017,17 +1008,26 @@
         }
       }
     },
-    "v2betaVersion": {
+    "chef.automate.api.iam.v2beta.Version": {
       "type": "object",
       "properties": {
         "major": {
-          "$ref": "#/definitions/VersionVersionNumber"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Version.VersionNumber"
         },
         "minor": {
-          "$ref": "#/definitions/VersionVersionNumber"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Version.VersionNumber"
         }
       },
       "title": "the only values that may be returned by GetPolicyVersion"
+    },
+    "chef.automate.api.iam.v2beta.Version.VersionNumber": {
+      "type": "string",
+      "enum": [
+        "V0",
+        "V1",
+        "V2"
+      ],
+      "default": "V0"
     }
   }
 }

--- a/components/automate-chef-io/data/docs/api_chef_automate/iam/v2beta/rules.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/iam/v2beta/rules.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaApplyRulesStatusResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ApplyRulesStatusResp"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaApplyRulesCancelResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ApplyRulesCancelResp"
             }
           }
         },
@@ -50,7 +50,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaApplyRulesStartResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ApplyRulesStartResp"
             }
           }
         },
@@ -66,7 +66,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListRulesForProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListRulesForProjectResp"
             }
           }
         },
@@ -90,7 +90,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateRuleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateRuleResp"
             }
           }
         },
@@ -106,7 +106,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateRuleReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateRuleReq"
             }
           }
         ],
@@ -122,7 +122,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetRuleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetRuleResp"
             }
           }
         },
@@ -150,7 +150,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteRuleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteRuleResp"
             }
           }
         },
@@ -178,7 +178,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateRuleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateRuleResp"
             }
           }
         },
@@ -200,7 +200,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateRuleReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateRuleReq"
             }
           }
         ],
@@ -211,13 +211,13 @@
     }
   },
   "definitions": {
-    "v2betaApplyRulesCancelResp": {
+    "chef.automate.api.iam.v2beta.ApplyRulesCancelResp": {
       "type": "object"
     },
-    "v2betaApplyRulesStartResp": {
+    "chef.automate.api.iam.v2beta.ApplyRulesStartResp": {
       "type": "object"
     },
-    "v2betaApplyRulesStatusResp": {
+    "chef.automate.api.iam.v2beta.ApplyRulesStatusResp": {
       "type": "object",
       "properties": {
         "state": {
@@ -244,11 +244,11 @@
         }
       }
     },
-    "v2betaCondition": {
+    "chef.automate.api.iam.v2beta.Condition": {
       "type": "object",
       "properties": {
         "attribute": {
-          "$ref": "#/definitions/v2betaConditionAttribute"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.ConditionAttribute"
         },
         "values": {
           "type": "array",
@@ -257,11 +257,11 @@
           }
         },
         "operator": {
-          "$ref": "#/definitions/v2betaConditionOperator"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.ConditionOperator"
         }
       }
     },
-    "v2betaConditionAttribute": {
+    "chef.automate.api.iam.v2beta.ConditionAttribute": {
       "type": "string",
       "enum": [
         "CONDITION_ATTRIBUTE_UNSET",
@@ -275,7 +275,7 @@
       ],
       "default": "CONDITION_ATTRIBUTE_UNSET"
     },
-    "v2betaConditionOperator": {
+    "chef.automate.api.iam.v2beta.ConditionOperator": {
       "type": "string",
       "enum": [
         "CONDITION_OPERATOR_UNSET",
@@ -284,7 +284,7 @@
       ],
       "default": "CONDITION_OPERATOR_UNSET"
     },
-    "v2betaCreateRuleReq": {
+    "chef.automate.api.iam.v2beta.CreateRuleReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -297,50 +297,50 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/v2betaRuleType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.RuleType"
         },
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaCondition"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Condition"
           }
         }
       }
     },
-    "v2betaCreateRuleResp": {
+    "chef.automate.api.iam.v2beta.CreateRuleResp": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/v2betaRule"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Rule"
         }
       }
     },
-    "v2betaDeleteRuleResp": {
+    "chef.automate.api.iam.v2beta.DeleteRuleResp": {
       "type": "object"
     },
-    "v2betaGetRuleResp": {
+    "chef.automate.api.iam.v2beta.GetRuleResp": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/v2betaRule"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Rule"
         }
       }
     },
-    "v2betaListRulesForProjectResp": {
+    "chef.automate.api.iam.v2beta.ListRulesForProjectResp": {
       "type": "object",
       "properties": {
         "rules": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaRule"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Rule"
           }
         },
         "status": {
-          "$ref": "#/definitions/v2betaProjectRulesStatus"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.ProjectRulesStatus"
         }
       }
     },
-    "v2betaProjectRulesStatus": {
+    "chef.automate.api.iam.v2beta.ProjectRulesStatus": {
       "type": "string",
       "enum": [
         "PROJECT_RULES_STATUS_UNSET",
@@ -350,7 +350,7 @@
       ],
       "default": "PROJECT_RULES_STATUS_UNSET"
     },
-    "v2betaRule": {
+    "chef.automate.api.iam.v2beta.Rule": {
       "type": "object",
       "properties": {
         "id": {
@@ -363,20 +363,20 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/v2betaRuleType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.RuleType"
         },
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaCondition"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Condition"
           }
         },
         "status": {
-          "$ref": "#/definitions/v2betaRuleStatus"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.RuleStatus"
         }
       }
     },
-    "v2betaRuleStatus": {
+    "chef.automate.api.iam.v2beta.RuleStatus": {
       "type": "string",
       "enum": [
         "RULE_STATUS_UNSET",
@@ -385,7 +385,7 @@
       ],
       "default": "RULE_STATUS_UNSET"
     },
-    "v2betaRuleType": {
+    "chef.automate.api.iam.v2beta.RuleType": {
       "type": "string",
       "enum": [
         "RULE_TYPE_UNSET",
@@ -394,7 +394,7 @@
       ],
       "default": "RULE_TYPE_UNSET"
     },
-    "v2betaUpdateRuleReq": {
+    "chef.automate.api.iam.v2beta.UpdateRuleReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -407,21 +407,21 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/v2betaRuleType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.RuleType"
         },
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaCondition"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Condition"
           }
         }
       }
     },
-    "v2betaUpdateRuleResp": {
+    "chef.automate.api.iam.v2beta.UpdateRuleResp": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/v2betaRule"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Rule"
         }
       }
     }

--- a/components/automate-chef-io/data/docs/api_chef_automate/iam/v2beta/teams.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/iam/v2beta/teams.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListTeamsResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListTeamsResp"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateTeamResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateTeamResp"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateTeamReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateTeamReq"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetTeamResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetTeamResp"
             }
           }
         },
@@ -84,7 +84,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteTeamResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteTeamResp"
             }
           }
         },
@@ -106,7 +106,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateTeamResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateTeamResp"
             }
           }
         },
@@ -122,7 +122,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateTeamReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateTeamReq"
             }
           }
         ],
@@ -138,7 +138,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetTeamMembershipResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetTeamMembershipResp"
             }
           }
         },
@@ -162,7 +162,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaAddTeamMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.AddTeamMembersResp"
             }
           }
         },
@@ -178,7 +178,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaAddTeamMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.AddTeamMembersReq"
             }
           }
         ],
@@ -194,7 +194,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaRemoveTeamMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.RemoveTeamMembersResp"
             }
           }
         },
@@ -210,7 +210,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaRemoveTeamMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.RemoveTeamMembersReq"
             }
           }
         ],
@@ -226,7 +226,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetTeamsForMemberResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetTeamsForMemberResp"
             }
           }
         },
@@ -245,7 +245,7 @@
     }
   },
   "definitions": {
-    "v2betaAddTeamMembersReq": {
+    "chef.automate.api.iam.v2beta.AddTeamMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -259,7 +259,7 @@
         }
       }
     },
-    "v2betaAddTeamMembersResp": {
+    "chef.automate.api.iam.v2beta.AddTeamMembersResp": {
       "type": "object",
       "properties": {
         "user_ids": {
@@ -270,10 +270,10 @@
         }
       }
     },
-    "v2betaApplyV2DataMigrationsResp": {
+    "chef.automate.api.iam.v2beta.ApplyV2DataMigrationsResp": {
       "type": "object"
     },
-    "v2betaCreateTeamReq": {
+    "chef.automate.api.iam.v2beta.CreateTeamReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -290,23 +290,23 @@
         }
       }
     },
-    "v2betaCreateTeamResp": {
+    "chef.automate.api.iam.v2beta.CreateTeamResp": {
       "type": "object",
       "properties": {
         "team": {
-          "$ref": "#/definitions/v2betaTeam"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
         }
       }
     },
-    "v2betaDeleteTeamResp": {
+    "chef.automate.api.iam.v2beta.DeleteTeamResp": {
       "type": "object",
       "properties": {
         "team": {
-          "$ref": "#/definitions/v2betaTeam"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
         }
       }
     },
-    "v2betaGetTeamMembershipResp": {
+    "chef.automate.api.iam.v2beta.GetTeamMembershipResp": {
       "type": "object",
       "properties": {
         "user_ids": {
@@ -317,37 +317,37 @@
         }
       }
     },
-    "v2betaGetTeamResp": {
+    "chef.automate.api.iam.v2beta.GetTeamResp": {
       "type": "object",
       "properties": {
         "team": {
-          "$ref": "#/definitions/v2betaTeam"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
         }
       }
     },
-    "v2betaGetTeamsForMemberResp": {
+    "chef.automate.api.iam.v2beta.GetTeamsForMemberResp": {
       "type": "object",
       "properties": {
         "teams": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaTeam"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
           }
         }
       }
     },
-    "v2betaListTeamsResp": {
+    "chef.automate.api.iam.v2beta.ListTeamsResp": {
       "type": "object",
       "properties": {
         "teams": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaTeam"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
           }
         }
       }
     },
-    "v2betaRemoveTeamMembersReq": {
+    "chef.automate.api.iam.v2beta.RemoveTeamMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -361,7 +361,7 @@
         }
       }
     },
-    "v2betaRemoveTeamMembersResp": {
+    "chef.automate.api.iam.v2beta.RemoveTeamMembersResp": {
       "type": "object",
       "properties": {
         "user_ids": {
@@ -372,7 +372,7 @@
         }
       }
     },
-    "v2betaTeam": {
+    "chef.automate.api.iam.v2beta.Team": {
       "type": "object",
       "properties": {
         "id": {
@@ -389,7 +389,7 @@
         }
       }
     },
-    "v2betaUpdateTeamReq": {
+    "chef.automate.api.iam.v2beta.UpdateTeamReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -406,11 +406,11 @@
         }
       }
     },
-    "v2betaUpdateTeamResp": {
+    "chef.automate.api.iam.v2beta.UpdateTeamResp": {
       "type": "object",
       "properties": {
         "team": {
-          "$ref": "#/definitions/v2betaTeam"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
         }
       }
     }

--- a/components/automate-chef-io/data/docs/api_chef_automate/iam/v2beta/tokens.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/iam/v2beta/tokens.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListTokensResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListTokensResp"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateTokenResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateTokenResp"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateTokenReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateTokenReq"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetTokenResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetTokenResp"
             }
           }
         },
@@ -84,7 +84,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteTokenResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteTokenResp"
             }
           }
         },
@@ -106,7 +106,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateTokenResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateTokenResp"
             }
           }
         },
@@ -123,7 +123,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateTokenReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateTokenReq"
             }
           }
         ],
@@ -134,7 +134,7 @@
     }
   },
   "definitions": {
-    "v2betaCreateTokenReq": {
+    "chef.automate.api.iam.v2beta.CreateTokenReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -158,37 +158,37 @@
         }
       }
     },
-    "v2betaCreateTokenResp": {
+    "chef.automate.api.iam.v2beta.CreateTokenResp": {
       "type": "object",
       "properties": {
         "token": {
-          "$ref": "#/definitions/v2betaToken"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Token"
         }
       }
     },
-    "v2betaDeleteTokenResp": {
+    "chef.automate.api.iam.v2beta.DeleteTokenResp": {
       "type": "object"
     },
-    "v2betaGetTokenResp": {
+    "chef.automate.api.iam.v2beta.GetTokenResp": {
       "type": "object",
       "properties": {
         "token": {
-          "$ref": "#/definitions/v2betaToken"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Token"
         }
       }
     },
-    "v2betaListTokensResp": {
+    "chef.automate.api.iam.v2beta.ListTokensResp": {
       "type": "object",
       "properties": {
         "tokens": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaToken"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Token"
           }
         }
       }
     },
-    "v2betaToken": {
+    "chef.automate.api.iam.v2beta.Token": {
       "type": "object",
       "properties": {
         "id": {
@@ -218,7 +218,7 @@
         }
       }
     },
-    "v2betaUpdateTokenReq": {
+    "chef.automate.api.iam.v2beta.UpdateTokenReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -240,11 +240,11 @@
         }
       }
     },
-    "v2betaUpdateTokenResp": {
+    "chef.automate.api.iam.v2beta.UpdateTokenResp": {
       "type": "object",
       "properties": {
         "token": {
-          "$ref": "#/definitions/v2betaToken"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Token"
         }
       }
     }

--- a/components/automate-chef-io/data/docs/api_chef_automate/iam/v2beta/users.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/iam/v2beta/users.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateSelfResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateSelfResp"
             }
           }
         },
@@ -39,7 +39,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateSelfReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateSelfReq"
             }
           }
         ],
@@ -55,7 +55,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListUsersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListUsersResp"
             }
           }
         },
@@ -69,7 +69,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateUserResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateUserResp"
             }
           }
         },
@@ -79,7 +79,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateUserReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateUserReq"
             }
           }
         ],
@@ -95,7 +95,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetUserResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetUserResp"
             }
           }
         },
@@ -117,7 +117,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteUserResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteUserResp"
             }
           }
         },
@@ -139,7 +139,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateUserResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateUserResp"
             }
           }
         },
@@ -156,7 +156,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateUserReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateUserReq"
             }
           }
         ],
@@ -167,7 +167,7 @@
     }
   },
   "definitions": {
-    "v2betaCreateUserReq": {
+    "chef.automate.api.iam.v2beta.CreateUserReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -181,37 +181,37 @@
         }
       }
     },
-    "v2betaCreateUserResp": {
+    "chef.automate.api.iam.v2beta.CreateUserResp": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/v2betaUser"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
         }
       }
     },
-    "v2betaDeleteUserResp": {
+    "chef.automate.api.iam.v2beta.DeleteUserResp": {
       "type": "object"
     },
-    "v2betaGetUserResp": {
+    "chef.automate.api.iam.v2beta.GetUserResp": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/v2betaUser"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
         }
       }
     },
-    "v2betaListUsersResp": {
+    "chef.automate.api.iam.v2beta.ListUsersResp": {
       "type": "object",
       "properties": {
         "users": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaUser"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
           }
         }
       }
     },
-    "v2betaUpdateSelfReq": {
+    "chef.automate.api.iam.v2beta.UpdateSelfReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -230,15 +230,15 @@
         }
       }
     },
-    "v2betaUpdateSelfResp": {
+    "chef.automate.api.iam.v2beta.UpdateSelfResp": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/v2betaUser"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
         }
       }
     },
-    "v2betaUpdateUserReq": {
+    "chef.automate.api.iam.v2beta.UpdateUserReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -253,15 +253,15 @@
         }
       }
     },
-    "v2betaUpdateUserResp": {
+    "chef.automate.api.iam.v2beta.UpdateUserResp": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/v2betaUser"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
         }
       }
     },
-    "v2betaUser": {
+    "chef.automate.api.iam.v2beta.User": {
       "type": "object",
       "properties": {
         "name": {

--- a/components/automate-chef-io/data/docs/api_chef_automate/ingest/chef.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/ingest/chef.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessChefActionResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessChefActionResponse"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestAction"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Action"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessLivenessResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessLivenessResponse"
             }
           }
         },
@@ -58,7 +58,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestLiveness"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Liveness"
             }
           }
         ],
@@ -74,7 +74,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessMultipleNodeDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessMultipleNodeDeleteResponse"
             }
           }
         },
@@ -84,7 +84,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestMultipleNodeDeleteRequest"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.MultipleNodeDeleteRequest"
             }
           }
         ],
@@ -100,7 +100,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessNodeDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessNodeDeleteResponse"
             }
           }
         },
@@ -110,7 +110,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestDelete"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Delete"
             }
           }
         ],
@@ -126,7 +126,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessChefRunResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessChefRunResponse"
             }
           }
         },
@@ -136,7 +136,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestRun"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Run"
             }
           }
         ],
@@ -152,7 +152,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -163,15 +163,24 @@
     }
   },
   "definitions": {
-    "protobufNullValue": {
-      "type": "string",
-      "enum": [
-        "NULL_VALUE"
-      ],
-      "default": "NULL_VALUE",
-      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+    "chef.automate.api.common.version.VersionInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "built": {
+          "type": "string"
+        }
+      }
     },
-    "requestAction": {
+    "chef.automate.api.ingest.request.Action": {
       "type": "object",
       "properties": {
         "id": {
@@ -242,7 +251,7 @@
         }
       }
     },
-    "requestDelete": {
+    "chef.automate.api.ingest.request.Delete": {
       "type": "object",
       "properties": {
         "id": {
@@ -266,7 +275,7 @@
         }
       }
     },
-    "requestDeprecation": {
+    "chef.automate.api.ingest.request.Deprecation": {
       "type": "object",
       "properties": {
         "message": {
@@ -280,7 +289,7 @@
         }
       }
     },
-    "requestDescription": {
+    "chef.automate.api.ingest.request.Description": {
       "type": "object",
       "properties": {
         "title": {
@@ -294,7 +303,7 @@
         }
       }
     },
-    "requestError": {
+    "chef.automate.api.ingest.request.Error": {
       "type": "object",
       "properties": {
         "class": {
@@ -310,11 +319,11 @@
           }
         },
         "description": {
-          "$ref": "#/definitions/requestDescription"
+          "$ref": "#/definitions/chef.automate.api.ingest.request.Description"
         }
       }
     },
-    "requestExpandedRunList": {
+    "chef.automate.api.ingest.request.ExpandedRunList": {
       "type": "object",
       "properties": {
         "id": {
@@ -323,12 +332,12 @@
         "run_list": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestRunList"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.RunList"
           }
         }
       }
     },
-    "requestLiveness": {
+    "chef.automate.api.ingest.request.Liveness": {
       "type": "object",
       "properties": {
         "event_type": {
@@ -354,7 +363,7 @@
         }
       }
     },
-    "requestMultipleNodeDeleteRequest": {
+    "chef.automate.api.ingest.request.MultipleNodeDeleteRequest": {
       "type": "object",
       "properties": {
         "node_ids": {
@@ -365,7 +374,7 @@
         }
       }
     },
-    "requestResource": {
+    "chef.automate.api.ingest.request.Resource": {
       "type": "object",
       "properties": {
         "type": {
@@ -412,7 +421,7 @@
         }
       }
     },
-    "requestRun": {
+    "chef.automate.api.ingest.request.Run": {
       "type": "object",
       "properties": {
         "id": {
@@ -466,12 +475,12 @@
           "type": "string"
         },
         "expanded_run_list": {
-          "$ref": "#/definitions/requestExpandedRunList"
+          "$ref": "#/definitions/chef.automate.api.ingest.request.ExpandedRunList"
         },
         "resources": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestResource"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.Resource"
           }
         },
         "run_list": {
@@ -484,7 +493,7 @@
           "type": "object"
         },
         "error": {
-          "$ref": "#/definitions/requestError"
+          "$ref": "#/definitions/chef.automate.api.ingest.request.Error"
         },
         "policy_name": {
           "type": "string"
@@ -495,7 +504,7 @@
         "deprecations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestDeprecation"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.Deprecation"
           }
         },
         "tags": {
@@ -506,7 +515,7 @@
         }
       }
     },
-    "requestRunList": {
+    "chef.automate.api.ingest.request.RunList": {
       "type": "object",
       "properties": {
         "type": {
@@ -525,42 +534,33 @@
         "children": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestRunList"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.RunList"
           }
         }
       }
     },
-    "responseProcessChefActionResponse": {
+    "chef.automate.api.ingest.response.ProcessChefActionResponse": {
       "type": "object"
     },
-    "responseProcessChefRunResponse": {
+    "chef.automate.api.ingest.response.ProcessChefRunResponse": {
       "type": "object"
     },
-    "responseProcessLivenessResponse": {
+    "chef.automate.api.ingest.response.ProcessLivenessResponse": {
       "type": "object"
     },
-    "responseProcessMultipleNodeDeleteResponse": {
+    "chef.automate.api.ingest.response.ProcessMultipleNodeDeleteResponse": {
       "type": "object"
     },
-    "responseProcessNodeDeleteResponse": {
+    "chef.automate.api.ingest.response.ProcessNodeDeleteResponse": {
       "type": "object"
     },
-    "versionVersionInfo": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "version": {
-          "type": "string"
-        },
-        "sha": {
-          "type": "string"
-        },
-        "built": {
-          "type": "string"
-        }
-      }
+    "google.protobuf.NullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
     }
   }
 }

--- a/components/automate-chef-io/data/docs/api_chef_automate/ingest/job_scheduler.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/ingest/job_scheduler.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseConfigureDeleteNodesScheduler"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ConfigureDeleteNodesScheduler"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestSchedulerConfig"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.SchedulerConfig"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseConfigureMissingNodesForDeletionScheduler"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ConfigureMissingNodesForDeletionScheduler"
             }
           }
         },
@@ -58,7 +58,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestSchedulerConfig"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.SchedulerConfig"
             }
           }
         ],
@@ -74,7 +74,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseConfigureNodesMissingScheduler"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ConfigureNodesMissingScheduler"
             }
           }
         },
@@ -84,7 +84,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestSchedulerConfig"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.SchedulerConfig"
             }
           }
         ],
@@ -100,7 +100,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseJobSchedulerStatus"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.JobSchedulerStatus"
             }
           }
         },
@@ -111,7 +111,7 @@
     }
   },
   "definitions": {
-    "requestSchedulerConfig": {
+    "chef.automate.api.ingest.request.SchedulerConfig": {
       "type": "object",
       "properties": {
         "every": {
@@ -127,16 +127,16 @@
       },
       "description": "SchedulerConfig\nThe job message to configure the Delete Node Job\nevery - It accepts '1h30m', '1m', '2h30m', ..."
     },
-    "responseConfigureDeleteNodesScheduler": {
+    "chef.automate.api.ingest.response.ConfigureDeleteNodesScheduler": {
       "type": "object"
     },
-    "responseConfigureMissingNodesForDeletionScheduler": {
+    "chef.automate.api.ingest.response.ConfigureMissingNodesForDeletionScheduler": {
       "type": "object"
     },
-    "responseConfigureNodesMissingScheduler": {
+    "chef.automate.api.ingest.response.ConfigureNodesMissingScheduler": {
       "type": "object"
     },
-    "responseJob": {
+    "chef.automate.api.ingest.response.Job": {
       "type": "object",
       "properties": {
         "running": {
@@ -166,7 +166,7 @@
         }
       }
     },
-    "responseJobSchedulerStatus": {
+    "chef.automate.api.ingest.response.JobSchedulerStatus": {
       "type": "object",
       "properties": {
         "running": {
@@ -176,7 +176,7 @@
         "jobs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseJob"
+            "$ref": "#/definitions/chef.automate.api.ingest.response.Job"
           }
         }
       }

--- a/components/automate-chef-io/data/docs/api_chef_automate/legacy/legacy.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/legacy/legacy.swagger.json
@@ -23,7 +23,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/legacyStatusResponse"
+              "$ref": "#/definitions/chef.automate.api.legacy.StatusResponse"
             }
           }
         },
@@ -34,7 +34,7 @@
     }
   },
   "definitions": {
-    "legacyStatusResponse": {
+    "chef.automate.api.legacy.StatusResponse": {
       "type": "object",
       "properties": {
         "status": {

--- a/components/automate-chef-io/data/docs/api_chef_automate/license/license.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/license/license.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/licenseApplyLicenseResp"
+              "$ref": "#/definitions/chef.automate.api.license.ApplyLicenseResp"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/licenseApplyLicenseReq"
+              "$ref": "#/definitions/chef.automate.api.license.ApplyLicenseReq"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/licenseRequestLicenseResp"
+              "$ref": "#/definitions/chef.automate.api.license.RequestLicenseResp"
             }
           }
         },
@@ -58,7 +58,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/licenseRequestLicenseReq"
+              "$ref": "#/definitions/chef.automate.api.license.RequestLicenseReq"
             }
           }
         ],
@@ -74,7 +74,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/licenseGetStatusResp"
+              "$ref": "#/definitions/chef.automate.api.license.GetStatusResp"
             }
           }
         },
@@ -85,7 +85,41 @@
     }
   },
   "definitions": {
-    "GetStatusRespDateRange": {
+    "chef.automate.api.license.ApplyLicenseReq": {
+      "type": "object",
+      "properties": {
+        "license": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.license.ApplyLicenseResp": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/chef.automate.api.license.GetStatusResp"
+        }
+      }
+    },
+    "chef.automate.api.license.GetStatusResp": {
+      "type": "object",
+      "properties": {
+        "license_id": {
+          "type": "string"
+        },
+        "configured_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "licensed_period": {
+          "$ref": "#/definitions/chef.automate.api.license.GetStatusResp.DateRange"
+        },
+        "customer_name": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.license.GetStatusResp.DateRange": {
       "type": "object",
       "properties": {
         "start": {
@@ -98,41 +132,7 @@
         }
       }
     },
-    "licenseApplyLicenseReq": {
-      "type": "object",
-      "properties": {
-        "license": {
-          "type": "string"
-        }
-      }
-    },
-    "licenseApplyLicenseResp": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/licenseGetStatusResp"
-        }
-      }
-    },
-    "licenseGetStatusResp": {
-      "type": "object",
-      "properties": {
-        "license_id": {
-          "type": "string"
-        },
-        "configured_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "licensed_period": {
-          "$ref": "#/definitions/GetStatusRespDateRange"
-        },
-        "customer_name": {
-          "type": "string"
-        }
-      }
-    },
-    "licenseRequestLicenseReq": {
+    "chef.automate.api.license.RequestLicenseReq": {
       "type": "object",
       "properties": {
         "first_name": {
@@ -150,14 +150,14 @@
         }
       }
     },
-    "licenseRequestLicenseResp": {
+    "chef.automate.api.license.RequestLicenseResp": {
       "type": "object",
       "properties": {
         "license": {
           "type": "string"
         },
         "status": {
-          "$ref": "#/definitions/licenseGetStatusResp"
+          "$ref": "#/definitions/chef.automate.api.license.GetStatusResp"
         }
       }
     }

--- a/components/automate-chef-io/data/docs/api_chef_automate/nodes/manager/manager.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/nodes/manager/manager.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Ids"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Ids"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1NodeManager"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1NodeManager"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
             }
           }
         },
@@ -108,7 +108,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1NodeManager"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
             }
           }
         ],
@@ -172,7 +172,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Ids"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Ids"
             }
           }
         },
@@ -196,7 +196,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Fields"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Fields"
             }
           }
         },
@@ -212,7 +212,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1FieldQuery"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.FieldQuery"
             }
           }
         ],
@@ -228,7 +228,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Nodes"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Nodes"
             }
           }
         },
@@ -244,7 +244,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1NodeQuery"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeQuery"
             }
           }
         ],
@@ -260,7 +260,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ConnectResponse"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.ConnectResponse"
             }
           }
         },
@@ -276,7 +276,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Id"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Id"
             }
           }
         ],
@@ -292,7 +292,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1NodeManagers"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManagers"
             }
           }
         },
@@ -302,7 +302,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query"
             }
           }
         ],
@@ -313,47 +313,10 @@
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "commonFilter": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "exclude": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "commonKv": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "v1ConnectResponse": {
+    "chef.automate.api.nodes.manager.v1.ConnectResponse": {
       "type": "object"
     },
-    "v1CredentialsByTags": {
+    "chef.automate.api.nodes.manager.v1.CredentialsByTags": {
       "type": "object",
       "properties": {
         "tag_key": {
@@ -370,11 +333,11 @@
         }
       }
     },
-    "v1FieldQuery": {
+    "chef.automate.api.nodes.manager.v1.FieldQuery": {
       "type": "object",
       "properties": {
         "query": {
-          "$ref": "#/definitions/v1Query"
+          "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query"
         },
         "field": {
           "type": "string"
@@ -384,7 +347,7 @@
         }
       }
     },
-    "v1Fields": {
+    "chef.automate.api.nodes.manager.v1.Fields": {
       "type": "object",
       "properties": {
         "fields": {
@@ -395,7 +358,7 @@
         }
       }
     },
-    "v1Id": {
+    "chef.automate.api.nodes.manager.v1.Id": {
       "type": "object",
       "properties": {
         "id": {
@@ -403,18 +366,18 @@
         }
       }
     },
-    "v1Ids": {
+    "chef.automate.api.nodes.manager.v1.Ids": {
       "type": "object",
       "properties": {
         "ids": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Id"
+            "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Id"
           }
         }
       }
     },
-    "v1NodeManager": {
+    "chef.automate.api.nodes.manager.v1.NodeManager": {
       "type": "object",
       "properties": {
         "id": {
@@ -432,7 +395,7 @@
         "instance_credentials": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1CredentialsByTags"
+            "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.CredentialsByTags"
           }
         },
         "status": {
@@ -448,18 +411,18 @@
         "credential_data": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonKv"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Kv"
           }
         }
       }
     },
-    "v1NodeManagers": {
+    "chef.automate.api.nodes.manager.v1.NodeManagers": {
       "type": "object",
       "properties": {
         "managers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1NodeManager"
+            "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
           }
         },
         "total": {
@@ -468,18 +431,18 @@
         }
       }
     },
-    "v1NodeQuery": {
+    "chef.automate.api.nodes.manager.v1.NodeQuery": {
       "type": "object",
       "properties": {
         "query": {
-          "$ref": "#/definitions/v1Query"
+          "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query"
         },
         "node_manager_id": {
           "type": "string"
         }
       }
     },
-    "v1Nodes": {
+    "chef.automate.api.nodes.manager.v1.Nodes": {
       "type": "object",
       "properties": {
         "nodes": {
@@ -494,17 +457,17 @@
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.nodes.manager.v1.Query": {
       "type": "object",
       "properties": {
         "filter_map": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonFilter"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Filter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -516,6 +479,43 @@
         "per_page": {
           "type": "integer",
           "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.domain.compliance.api.common.Filter": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "exclude": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Kv": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
         }
       }
     }

--- a/components/automate-chef-io/data/docs/api_chef_automate/nodes/nodes.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/nodes/nodes.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Id"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Id"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Node"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Ids"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Ids"
             }
           }
         },
@@ -58,7 +58,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Nodes"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Nodes"
             }
           }
         ],
@@ -74,7 +74,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1BulkDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.BulkDeleteResponse"
             }
           }
         },
@@ -84,7 +84,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Query"
             }
           }
         ],
@@ -100,7 +100,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1BulkDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.BulkDeleteResponse"
             }
           }
         },
@@ -110,7 +110,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Ids"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Ids"
             }
           }
         ],
@@ -126,7 +126,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Node"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
             }
           }
         },
@@ -186,7 +186,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Node"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
             }
           }
         ],
@@ -202,7 +202,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1RerunResponse"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.RerunResponse"
             }
           }
         },
@@ -226,7 +226,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Nodes"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Nodes"
             }
           }
         },
@@ -236,7 +236,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Query"
             }
           }
         ],
@@ -247,54 +247,7 @@
     }
   },
   "definitions": {
-    "LastContactDataStatus": {
-      "type": "string",
-      "enum": [
-        "UNKNOWN",
-        "PASSED",
-        "FAILED",
-        "SKIPPED"
-      ],
-      "default": "UNKNOWN"
-    },
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "commonFilter": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "exclude": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "commonKv": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "v1BulkDeleteResponse": {
+    "chef.automate.api.nodes.v1.BulkDeleteResponse": {
       "type": "object",
       "properties": {
         "names": {
@@ -305,7 +258,7 @@
         }
       }
     },
-    "v1Id": {
+    "chef.automate.api.nodes.v1.Id": {
       "type": "object",
       "properties": {
         "id": {
@@ -313,7 +266,7 @@
         }
       }
     },
-    "v1Ids": {
+    "chef.automate.api.nodes.v1.Ids": {
       "type": "object",
       "properties": {
         "ids": {
@@ -324,17 +277,17 @@
         }
       }
     },
-    "v1LastContactData": {
+    "chef.automate.api.nodes.v1.LastContactData": {
       "type": "object",
       "properties": {
         "id": {
           "type": "string"
         },
         "status": {
-          "$ref": "#/definitions/LastContactDataStatus"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData.Status"
         },
         "penultimate_status": {
-          "$ref": "#/definitions/LastContactDataStatus"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData.Status"
         },
         "end_time": {
           "type": "string",
@@ -342,7 +295,17 @@
         }
       }
     },
-    "v1Node": {
+    "chef.automate.api.nodes.v1.LastContactData.Status": {
+      "type": "string",
+      "enum": [
+        "UNKNOWN",
+        "PASSED",
+        "FAILED",
+        "SKIPPED"
+      ],
+      "default": "UNKNOWN"
+    },
+    "chef.automate.api.nodes.v1.Node": {
       "type": "object",
       "properties": {
         "id": {
@@ -363,7 +326,7 @@
         "tags": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonKv"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Kv"
           }
         },
         "last_contact": {
@@ -374,10 +337,10 @@
           "type": "string"
         },
         "last_job": {
-          "$ref": "#/definitions/v1ResultsRow"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.ResultsRow"
         },
         "target_config": {
-          "$ref": "#/definitions/v1TargetConfig"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.TargetConfig"
         },
         "manager_ids": {
           "type": "array",
@@ -401,20 +364,20 @@
           }
         },
         "run_data": {
-          "$ref": "#/definitions/v1LastContactData"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData"
         },
         "scan_data": {
-          "$ref": "#/definitions/v1LastContactData"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData"
         }
       }
     },
-    "v1Nodes": {
+    "chef.automate.api.nodes.v1.Nodes": {
       "type": "object",
       "properties": {
         "nodes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Node"
+            "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
           }
         },
         "total": {
@@ -435,17 +398,17 @@
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.nodes.v1.Query": {
       "type": "object",
       "properties": {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonFilter"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Filter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -460,10 +423,18 @@
         }
       }
     },
-    "v1RerunResponse": {
+    "chef.automate.api.nodes.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.nodes.v1.RerunResponse": {
       "type": "object"
     },
-    "v1ResultsRow": {
+    "chef.automate.api.nodes.v1.ResultsRow": {
       "type": "object",
       "properties": {
         "node_id": {
@@ -491,7 +462,7 @@
         }
       }
     },
-    "v1TargetConfig": {
+    "chef.automate.api.nodes.v1.TargetConfig": {
       "type": "object",
       "properties": {
         "secrets": {
@@ -551,6 +522,35 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Filter": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "exclude": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Kv": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
         }
       }
     }

--- a/components/automate-chef-io/data/docs/api_chef_automate/notifications/notifications.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/notifications/notifications.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleListResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleListResponse"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleAddResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleAddResponse"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/notificationsRuleAddRequest"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleAddRequest"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleGetResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleGetResponse"
             }
           }
         },
@@ -84,7 +84,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleDeleteResponse"
             }
           }
         },
@@ -106,7 +106,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleUpdateResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleUpdateResponse"
             }
           }
         },
@@ -122,7 +122,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/notificationsRuleUpdateRequest"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleUpdateRequest"
             }
           }
         ],
@@ -138,7 +138,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsVersionResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.VersionResponse"
             }
           }
         },
@@ -154,7 +154,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsURLValidationResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.URLValidationResponse"
             }
           }
         },
@@ -164,7 +164,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/notificationsURLValidationRequest"
+              "$ref": "#/definitions/chef.automate.api.notifications.URLValidationRequest"
             }
           }
         ],
@@ -175,20 +175,10 @@
     }
   },
   "definitions": {
-    "RuleEvent": {
-      "type": "string",
-      "enum": [
-        "CCRFailure",
-        "CCRSuccess",
-        "ComplianceFailure",
-        "ComplianceSuccess"
-      ],
-      "default": "CCRFailure"
-    },
-    "notificationsEmpty": {
+    "chef.automate.api.notifications.Empty": {
       "type": "object"
     },
-    "notificationsRule": {
+    "chef.automate.api.notifications.Rule": {
       "type": "object",
       "properties": {
         "id": {
@@ -198,28 +188,38 @@
           "type": "string"
         },
         "event": {
-          "$ref": "#/definitions/RuleEvent"
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule.Event"
         },
         "SlackAlert": {
-          "$ref": "#/definitions/notificationsSlackAlert"
+          "$ref": "#/definitions/chef.automate.api.notifications.SlackAlert"
         },
         "WebhookAlert": {
-          "$ref": "#/definitions/notificationsWebhookAlert"
+          "$ref": "#/definitions/chef.automate.api.notifications.WebhookAlert"
         },
         "ServiceNowAlert": {
-          "$ref": "#/definitions/notificationsServiceNowAlert"
+          "$ref": "#/definitions/chef.automate.api.notifications.ServiceNowAlert"
         }
       }
     },
-    "notificationsRuleAddRequest": {
+    "chef.automate.api.notifications.Rule.Event": {
+      "type": "string",
+      "enum": [
+        "CCRFailure",
+        "CCRSuccess",
+        "ComplianceFailure",
+        "ComplianceSuccess"
+      ],
+      "default": "CCRFailure"
+    },
+    "chef.automate.api.notifications.RuleAddRequest": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/notificationsRule"
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule"
         }
       }
     },
-    "notificationsRuleAddResponse": {
+    "chef.automate.api.notifications.RuleAddResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -233,7 +233,7 @@
         }
       }
     },
-    "notificationsRuleDeleteResponse": {
+    "chef.automate.api.notifications.RuleDeleteResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -244,7 +244,7 @@
         }
       }
     },
-    "notificationsRuleGetResponse": {
+    "chef.automate.api.notifications.RuleGetResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -254,11 +254,11 @@
           }
         },
         "rule": {
-          "$ref": "#/definitions/notificationsRule"
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule"
         }
       }
     },
-    "notificationsRuleListResponse": {
+    "chef.automate.api.notifications.RuleListResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -270,23 +270,23 @@
         "rules": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/notificationsRule"
+            "$ref": "#/definitions/chef.automate.api.notifications.Rule"
           }
         }
       }
     },
-    "notificationsRuleUpdateRequest": {
+    "chef.automate.api.notifications.RuleUpdateRequest": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/notificationsRule"
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule"
         },
         "id": {
           "type": "string"
         }
       }
     },
-    "notificationsRuleUpdateResponse": {
+    "chef.automate.api.notifications.RuleUpdateResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -297,7 +297,7 @@
         }
       }
     },
-    "notificationsSecretId": {
+    "chef.automate.api.notifications.SecretId": {
       "type": "object",
       "properties": {
         "id": {
@@ -305,7 +305,7 @@
         }
       }
     },
-    "notificationsServiceNowAlert": {
+    "chef.automate.api.notifications.ServiceNowAlert": {
       "type": "object",
       "properties": {
         "url": {
@@ -320,7 +320,7 @@
         }
       }
     },
-    "notificationsSlackAlert": {
+    "chef.automate.api.notifications.SlackAlert": {
       "type": "object",
       "properties": {
         "url": {
@@ -328,27 +328,27 @@
         }
       }
     },
-    "notificationsURLValidationRequest": {
+    "chef.automate.api.notifications.URLValidationRequest": {
       "type": "object",
       "properties": {
         "url": {
           "type": "string"
         },
         "username_password": {
-          "$ref": "#/definitions/notificationsUsernamePassword"
+          "$ref": "#/definitions/chef.automate.api.notifications.UsernamePassword"
         },
         "secret_id": {
-          "$ref": "#/definitions/notificationsSecretId"
+          "$ref": "#/definitions/chef.automate.api.notifications.SecretId"
         },
         "none": {
-          "$ref": "#/definitions/notificationsEmpty"
+          "$ref": "#/definitions/chef.automate.api.notifications.Empty"
         }
       }
     },
-    "notificationsURLValidationResponse": {
+    "chef.automate.api.notifications.URLValidationResponse": {
       "type": "object"
     },
-    "notificationsUsernamePassword": {
+    "chef.automate.api.notifications.UsernamePassword": {
       "type": "object",
       "properties": {
         "username": {
@@ -359,7 +359,7 @@
         }
       }
     },
-    "notificationsVersionResponse": {
+    "chef.automate.api.notifications.VersionResponse": {
       "type": "object",
       "properties": {
         "version": {
@@ -367,7 +367,7 @@
         }
       }
     },
-    "notificationsWebhookAlert": {
+    "chef.automate.api.notifications.WebhookAlert": {
       "type": "object",
       "properties": {
         "url": {

--- a/components/automate-chef-io/data/docs/api_chef_automate/secrets/secrets.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/secrets/secrets.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsId"
+              "$ref": "#/definitions/chef.automate.api.secrets.Id"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/secretsSecret"
+              "$ref": "#/definitions/chef.automate.api.secrets.Secret"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsSecret"
+              "$ref": "#/definitions/chef.automate.api.secrets.Secret"
             }
           }
         },
@@ -70,7 +70,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.secrets.DeleteResponse"
             }
           }
         },
@@ -92,7 +92,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsUpdateResponse"
+              "$ref": "#/definitions/chef.automate.api.secrets.UpdateResponse"
             }
           }
         },
@@ -108,7 +108,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/secretsSecret"
+              "$ref": "#/definitions/chef.automate.api.secrets.Secret"
             }
           }
         ],
@@ -124,7 +124,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsSecrets"
+              "$ref": "#/definitions/chef.automate.api.secrets.Secrets"
             }
           }
         },
@@ -134,7 +134,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/secretsQuery"
+              "$ref": "#/definitions/chef.automate.api.secrets.Query"
             }
           }
         ],
@@ -145,18 +145,10 @@
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "secretsDeleteResponse": {
+    "chef.automate.api.secrets.DeleteResponse": {
       "type": "object"
     },
-    "secretsFilter": {
+    "chef.automate.api.secrets.Filter": {
       "type": "object",
       "properties": {
         "key": {
@@ -174,7 +166,7 @@
         }
       }
     },
-    "secretsId": {
+    "chef.automate.api.secrets.Id": {
       "type": "object",
       "properties": {
         "id": {
@@ -182,7 +174,7 @@
         }
       }
     },
-    "secretsKv": {
+    "chef.automate.api.secrets.Kv": {
       "type": "object",
       "properties": {
         "key": {
@@ -193,17 +185,17 @@
         }
       }
     },
-    "secretsQuery": {
+    "chef.automate.api.secrets.Query": {
       "type": "object",
       "properties": {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/secretsFilter"
+            "$ref": "#/definitions/chef.automate.api.secrets.Filter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.secrets.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -218,7 +210,15 @@
         }
       }
     },
-    "secretsSecret": {
+    "chef.automate.api.secrets.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.secrets.Secret": {
       "type": "object",
       "properties": {
         "id": {
@@ -237,24 +237,24 @@
         "tags": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/secretsKv"
+            "$ref": "#/definitions/chef.automate.api.secrets.Kv"
           }
         },
         "data": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/secretsKv"
+            "$ref": "#/definitions/chef.automate.api.secrets.Kv"
           }
         }
       }
     },
-    "secretsSecrets": {
+    "chef.automate.api.secrets.Secrets": {
       "type": "object",
       "properties": {
         "secrets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/secretsSecret"
+            "$ref": "#/definitions/chef.automate.api.secrets.Secret"
           }
         },
         "total": {
@@ -263,7 +263,7 @@
         }
       }
     },
-    "secretsUpdateResponse": {
+    "chef.automate.api.secrets.UpdateResponse": {
       "type": "object"
     }
   }

--- a/components/automate-chef-io/data/docs/api_chef_automate/telemetry/telemetry.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/telemetry/telemetry.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/telemetryTelemetryResponse"
+              "$ref": "#/definitions/chef.automate.api.telemetry.TelemetryResponse"
             }
           }
         },
@@ -33,7 +33,7 @@
     }
   },
   "definitions": {
-    "telemetryTelemetryResponse": {
+    "chef.automate.api.telemetry.TelemetryResponse": {
       "type": "object",
       "properties": {
         "license_id": {

--- a/components/automate-gateway/api/applications.pb.swagger.go
+++ b/components/automate-gateway/api/applications.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesRes"
             }
           }
         },
@@ -35,7 +35,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/applicationsDisconnectedServicesReq"
+              "$ref": "#/definitions/chef.automate.api.applications.DisconnectedServicesReq"
             }
           }
         ],
@@ -51,7 +51,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesRes"
             }
           }
         },
@@ -76,7 +76,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServiceGroups"
+              "$ref": "#/definitions/chef.automate.api.applications.ServiceGroups"
             }
           }
         },
@@ -135,7 +135,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesBySGRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesBySGRes"
             }
           }
         },
@@ -206,7 +206,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsHealthCounts"
+              "$ref": "#/definitions/chef.automate.api.applications.HealthCounts"
             }
           }
         },
@@ -234,7 +234,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesRes"
             }
           }
         },
@@ -293,7 +293,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesDistinctValuesRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesDistinctValuesRes"
             }
           }
         },
@@ -333,7 +333,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsServicesStatsRes"
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesStatsRes"
             }
           }
         },
@@ -349,7 +349,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -365,7 +365,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsPeriodicJobConfig"
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicJobConfig"
             }
           }
         },
@@ -379,7 +379,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsUpdateDeleteDisconnectedServicesConfigRes"
+              "$ref": "#/definitions/chef.automate.api.applications.UpdateDeleteDisconnectedServicesConfigRes"
             }
           }
         },
@@ -389,7 +389,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/applicationsPeriodicJobConfig"
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicJobConfig"
             }
           }
         ],
@@ -405,7 +405,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsPeriodicMandatoryJobConfig"
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicMandatoryJobConfig"
             }
           }
         },
@@ -419,7 +419,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/applicationsUpdateDisconnectedServicesConfigRes"
+              "$ref": "#/definitions/chef.automate.api.applications.UpdateDisconnectedServicesConfigRes"
             }
           }
         },
@@ -429,7 +429,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/applicationsPeriodicMandatoryJobConfig"
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicMandatoryJobConfig"
             }
           }
         ],
@@ -440,7 +440,7 @@ func init() {
     }
   },
   "definitions": {
-    "applicationsDisconnectedServicesReq": {
+    "chef.automate.api.applications.DisconnectedServicesReq": {
       "type": "object",
       "properties": {
         "threshold_seconds": {
@@ -449,7 +449,7 @@ func init() {
         }
       }
     },
-    "applicationsHealthCounts": {
+    "chef.automate.api.applications.HealthCounts": {
       "type": "object",
       "properties": {
         "total": {
@@ -478,7 +478,7 @@ func init() {
         }
       }
     },
-    "applicationsHealthStatus": {
+    "chef.automate.api.applications.HealthStatus": {
       "type": "string",
       "enum": [
         "OK",
@@ -491,7 +491,7 @@ func init() {
       "description": "- NONE: The representation of NO health check status\nTODO @afiune how much effort would be to change\nthe OK enum to be NONE",
       "title": "The HealthStatus enum matches the habitat implementation for health-check status:\n=\u003e https://www.habitat.sh/docs/reference/#health-check"
     },
-    "applicationsPeriodicJobConfig": {
+    "chef.automate.api.applications.PeriodicJobConfig": {
       "type": "object",
       "properties": {
         "running": {
@@ -504,7 +504,7 @@ func init() {
         }
       }
     },
-    "applicationsPeriodicMandatoryJobConfig": {
+    "chef.automate.api.applications.PeriodicMandatoryJobConfig": {
       "type": "object",
       "properties": {
         "threshold": {
@@ -514,7 +514,7 @@ func init() {
       },
       "title": "it's like a PeriodicJobConfig but the user isn't allowed to change whether\nor not the job runs"
     },
-    "applicationsService": {
+    "chef.automate.api.applications.Service": {
       "type": "object",
       "properties": {
         "supervisor_id": {
@@ -527,10 +527,10 @@ func init() {
           "type": "string"
         },
         "health_check": {
-          "$ref": "#/definitions/applicationsHealthStatus"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthStatus"
         },
         "status": {
-          "$ref": "#/definitions/applicationsServiceStatus"
+          "$ref": "#/definitions/chef.automate.api.applications.ServiceStatus"
         },
         "application": {
           "type": "string"
@@ -551,7 +551,7 @@ func init() {
           "type": "string"
         },
         "previous_health_check": {
-          "$ref": "#/definitions/applicationsHealthStatus"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthStatus"
         },
         "current_health_since": {
           "type": "string"
@@ -573,7 +573,7 @@ func init() {
         }
       }
     },
-    "applicationsServiceGroup": {
+    "chef.automate.api.applications.ServiceGroup": {
       "type": "object",
       "properties": {
         "name": {
@@ -584,7 +584,7 @@ func init() {
           "title": "Combination of the version and release in a single string like:\nExample: 0.1.0/8743278934278923"
         },
         "status": {
-          "$ref": "#/definitions/applicationsHealthStatus"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthStatus"
         },
         "health_percentage": {
           "type": "integer",
@@ -592,7 +592,7 @@ func init() {
           "title": "The health_percentage can be a number between 0-100"
         },
         "services_health_counts": {
-          "$ref": "#/definitions/applicationsHealthCounts"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthCounts"
         },
         "id": {
           "type": "string"
@@ -614,18 +614,18 @@ func init() {
       },
       "title": "A service group message is the representation of one single service group that\nis internally generated by aggregating all the services"
     },
-    "applicationsServiceGroups": {
+    "chef.automate.api.applications.ServiceGroups": {
       "type": "object",
       "properties": {
         "service_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/applicationsServiceGroup"
+            "$ref": "#/definitions/chef.automate.api.applications.ServiceGroup"
           }
         }
       }
     },
-    "applicationsServiceStatus": {
+    "chef.automate.api.applications.ServiceStatus": {
       "type": "string",
       "enum": [
         "RUNNING",
@@ -636,7 +636,7 @@ func init() {
       "default": "RUNNING",
       "title": "The ServiceStatus enum describes the status of the service\n@afiune have we defined these states somewhere?"
     },
-    "applicationsServicesBySGRes": {
+    "chef.automate.api.applications.ServicesBySGRes": {
       "type": "object",
       "properties": {
         "group": {
@@ -645,15 +645,15 @@ func init() {
         "services": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/applicationsService"
+            "$ref": "#/definitions/chef.automate.api.applications.Service"
           }
         },
         "services_health_counts": {
-          "$ref": "#/definitions/applicationsHealthCounts"
+          "$ref": "#/definitions/chef.automate.api.applications.HealthCounts"
         }
       }
     },
-    "applicationsServicesDistinctValuesRes": {
+    "chef.automate.api.applications.ServicesDistinctValuesRes": {
       "type": "object",
       "properties": {
         "values": {
@@ -664,18 +664,18 @@ func init() {
         }
       }
     },
-    "applicationsServicesRes": {
+    "chef.automate.api.applications.ServicesRes": {
       "type": "object",
       "properties": {
         "services": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/applicationsService"
+            "$ref": "#/definitions/chef.automate.api.applications.Service"
           }
         }
       }
     },
-    "applicationsServicesStatsRes": {
+    "chef.automate.api.applications.ServicesStatsRes": {
       "type": "object",
       "properties": {
         "total_service_groups": {
@@ -696,13 +696,13 @@ func init() {
         }
       }
     },
-    "applicationsUpdateDeleteDisconnectedServicesConfigRes": {
+    "chef.automate.api.applications.UpdateDeleteDisconnectedServicesConfigRes": {
       "type": "object"
     },
-    "applicationsUpdateDisconnectedServicesConfigRes": {
+    "chef.automate.api.applications.UpdateDisconnectedServicesConfigRes": {
       "type": "object"
     },
-    "queryPagination": {
+    "chef.automate.api.common.query.Pagination": {
       "type": "object",
       "properties": {
         "page": {
@@ -715,7 +715,7 @@ func init() {
         }
       }
     },
-    "querySortOrder": {
+    "chef.automate.api.common.query.SortOrder": {
       "type": "string",
       "enum": [
         "ASC",
@@ -723,18 +723,18 @@ func init() {
       ],
       "default": "ASC"
     },
-    "querySorting": {
+    "chef.automate.api.common.query.Sorting": {
       "type": "object",
       "properties": {
         "field": {
           "type": "string"
         },
         "order": {
-          "$ref": "#/definitions/querySortOrder"
+          "$ref": "#/definitions/chef.automate.api.common.query.SortOrder"
         }
       }
     },
-    "versionVersionInfo": {
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
         "name": {

--- a/components/automate-gateway/api/auth/teams/teams.swagger.json
+++ b/components/automate-gateway/api/auth/teams/teams.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseTeams"
+              "$ref": "#/definitions/chef.automate.api.teams.response.Teams"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseCreateTeamResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.CreateTeamResp"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestCreateTeamReq"
+              "$ref": "#/definitions/chef.automate.api.teams.request.CreateTeamReq"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -78,7 +78,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseGetTeamResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.GetTeamResp"
             }
           }
         },
@@ -100,7 +100,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseDeleteTeamResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.DeleteTeamResp"
             }
           }
         },
@@ -122,7 +122,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUpdateTeamResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.UpdateTeamResp"
             }
           }
         },
@@ -138,7 +138,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestUpdateTeamReq"
+              "$ref": "#/definitions/chef.automate.api.teams.request.UpdateTeamReq"
             }
           }
         ],
@@ -154,7 +154,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseGetUsersResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.GetUsersResp"
             }
           }
         },
@@ -176,7 +176,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseAddUsersResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.AddUsersResp"
             }
           }
         },
@@ -192,7 +192,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestAddUsersReq"
+              "$ref": "#/definitions/chef.automate.api.teams.request.AddUsersReq"
             }
           }
         ],
@@ -206,7 +206,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseRemoveUsersResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.RemoveUsersResp"
             }
           }
         },
@@ -222,7 +222,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestRemoveUsersReq"
+              "$ref": "#/definitions/chef.automate.api.teams.request.RemoveUsersReq"
             }
           }
         ],
@@ -238,7 +238,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseGetTeamsForUserResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.GetTeamsForUserResp"
             }
           }
         },
@@ -257,155 +257,7 @@
     }
   },
   "definitions": {
-    "requestAddUsersReq": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "user_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "requestCreateTeamReq": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        }
-      }
-    },
-    "requestRemoveUsersReq": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "user_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "requestUpdateTeamReq": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        }
-      }
-    },
-    "responseAddUsersResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseCreateTeamResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseDeleteTeamResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseGetTeamResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseGetTeamsForUserResp": {
-      "type": "object",
-      "properties": {
-        "teams": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/teamsresponseTeam"
-          }
-        }
-      }
-    },
-    "responseGetUsersResp": {
-      "type": "object",
-      "properties": {
-        "user_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "responseRemoveUsersResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseTeams": {
-      "type": "object",
-      "properties": {
-        "teams": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/teamsresponseTeam"
-          }
-        }
-      }
-    },
-    "responseUpdateTeamResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "teamsresponseTeam": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        }
-      }
-    },
-    "versionVersionInfo": {
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
         "name": {
@@ -419,6 +271,154 @@
         },
         "built": {
           "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.teams.request.AddUsersReq": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.request.CreateTeamReq": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.teams.request.RemoveUsersReq": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.request.UpdateTeamReq": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.AddUsersResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.CreateTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.DeleteTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.GetTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.GetTeamsForUserResp": {
+      "type": "object",
+      "properties": {
+        "teams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.response.GetUsersResp": {
+      "type": "object",
+      "properties": {
+        "user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.response.RemoveUsersResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.Team": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.Teams": {
+      "type": "object",
+      "properties": {
+        "teams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.response.UpdateTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
         }
       }
     }

--- a/components/automate-gateway/api/auth/tokens/tokens.swagger.json
+++ b/components/automate-gateway/api/auth/tokens/tokens.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseTokens"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.Tokens"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.Token"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestCreateToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.request.CreateToken"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.Token"
             }
           }
         },
@@ -84,7 +84,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseDeleteTokenResp"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.DeleteTokenResp"
             }
           }
         },
@@ -106,7 +106,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.Token"
             }
           }
         },
@@ -122,7 +122,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestUpdateToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.request.UpdateToken"
             }
           }
         ],
@@ -133,7 +133,7 @@
     }
   },
   "definitions": {
-    "requestCreateToken": {
+    "chef.automate.api.tokens.request.CreateToken": {
       "type": "object",
       "properties": {
         "description": {
@@ -151,7 +151,7 @@
         }
       }
     },
-    "requestUpdateToken": {
+    "chef.automate.api.tokens.request.UpdateToken": {
       "type": "object",
       "properties": {
         "id": {
@@ -166,10 +166,10 @@
         }
       }
     },
-    "responseDeleteTokenResp": {
+    "chef.automate.api.tokens.response.DeleteTokenResp": {
       "type": "object"
     },
-    "responseToken": {
+    "chef.automate.api.tokens.response.Token": {
       "type": "object",
       "properties": {
         "id": {
@@ -193,13 +193,13 @@
         }
       }
     },
-    "responseTokens": {
+    "chef.automate.api.tokens.response.Tokens": {
       "type": "object",
       "properties": {
         "tokens": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseToken"
+            "$ref": "#/definitions/chef.automate.api.tokens.response.Token"
           }
         }
       }

--- a/components/automate-gateway/api/auth/users/users.swagger.json
+++ b/components/automate-gateway/api/auth/users/users.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUsers"
+              "$ref": "#/definitions/chef.automate.api.users.response.Users"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUser"
+              "$ref": "#/definitions/chef.automate.api.users.response.User"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestCreateUser"
+              "$ref": "#/definitions/chef.automate.api.users.request.CreateUser"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUser"
+              "$ref": "#/definitions/chef.automate.api.users.response.User"
             }
           }
         },
@@ -84,7 +84,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseDeleteUserResp"
+              "$ref": "#/definitions/chef.automate.api.users.response.DeleteUserResp"
             }
           }
         },
@@ -106,7 +106,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUser"
+              "$ref": "#/definitions/chef.automate.api.users.response.User"
             }
           }
         },
@@ -122,7 +122,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestUpdateUser"
+              "$ref": "#/definitions/chef.automate.api.users.request.UpdateUser"
             }
           }
         ],
@@ -138,7 +138,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUser"
+              "$ref": "#/definitions/chef.automate.api.users.response.User"
             }
           }
         },
@@ -154,7 +154,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestUpdateSelf"
+              "$ref": "#/definitions/chef.automate.api.users.request.UpdateSelf"
             }
           }
         ],
@@ -165,7 +165,7 @@
     }
   },
   "definitions": {
-    "requestCreateUser": {
+    "chef.automate.api.users.request.CreateUser": {
       "type": "object",
       "properties": {
         "id": {
@@ -185,7 +185,7 @@
         }
       }
     },
-    "requestUpdateSelf": {
+    "chef.automate.api.users.request.UpdateSelf": {
       "type": "object",
       "properties": {
         "id": {
@@ -205,7 +205,7 @@
         }
       }
     },
-    "requestUpdateUser": {
+    "chef.automate.api.users.request.UpdateUser": {
       "type": "object",
       "properties": {
         "id": {
@@ -225,10 +225,10 @@
         }
       }
     },
-    "responseDeleteUserResp": {
+    "chef.automate.api.users.response.DeleteUserResp": {
       "type": "object"
     },
-    "responseUser": {
+    "chef.automate.api.users.response.User": {
       "type": "object",
       "properties": {
         "id": {
@@ -245,13 +245,13 @@
         }
       }
     },
-    "responseUsers": {
+    "chef.automate.api.users.response.Users": {
       "type": "object",
       "properties": {
         "users": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseUser"
+            "$ref": "#/definitions/chef.automate.api.users.response.User"
           }
         }
       }

--- a/components/automate-gateway/api/auth_teams_teams.pb.swagger.go
+++ b/components/automate-gateway/api/auth_teams_teams.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseTeams"
+              "$ref": "#/definitions/chef.automate.api.teams.response.Teams"
             }
           }
         },
@@ -39,7 +39,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseCreateTeamResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.CreateTeamResp"
             }
           }
         },
@@ -49,7 +49,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestCreateTeamReq"
+              "$ref": "#/definitions/chef.automate.api.teams.request.CreateTeamReq"
             }
           }
         ],
@@ -65,7 +65,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -81,7 +81,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseGetTeamResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.GetTeamResp"
             }
           }
         },
@@ -103,7 +103,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseDeleteTeamResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.DeleteTeamResp"
             }
           }
         },
@@ -125,7 +125,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUpdateTeamResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.UpdateTeamResp"
             }
           }
         },
@@ -141,7 +141,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestUpdateTeamReq"
+              "$ref": "#/definitions/chef.automate.api.teams.request.UpdateTeamReq"
             }
           }
         ],
@@ -157,7 +157,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseGetUsersResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.GetUsersResp"
             }
           }
         },
@@ -179,7 +179,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseAddUsersResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.AddUsersResp"
             }
           }
         },
@@ -195,7 +195,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestAddUsersReq"
+              "$ref": "#/definitions/chef.automate.api.teams.request.AddUsersReq"
             }
           }
         ],
@@ -209,7 +209,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseRemoveUsersResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.RemoveUsersResp"
             }
           }
         },
@@ -225,7 +225,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestRemoveUsersReq"
+              "$ref": "#/definitions/chef.automate.api.teams.request.RemoveUsersReq"
             }
           }
         ],
@@ -241,7 +241,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseGetTeamsForUserResp"
+              "$ref": "#/definitions/chef.automate.api.teams.response.GetTeamsForUserResp"
             }
           }
         },
@@ -260,155 +260,7 @@ func init() {
     }
   },
   "definitions": {
-    "requestAddUsersReq": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "user_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "requestCreateTeamReq": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        }
-      }
-    },
-    "requestRemoveUsersReq": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "user_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "requestUpdateTeamReq": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        }
-      }
-    },
-    "responseAddUsersResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseCreateTeamResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseDeleteTeamResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseGetTeamResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseGetTeamsForUserResp": {
-      "type": "object",
-      "properties": {
-        "teams": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/teamsresponseTeam"
-          }
-        }
-      }
-    },
-    "responseGetUsersResp": {
-      "type": "object",
-      "properties": {
-        "user_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "responseRemoveUsersResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "responseTeams": {
-      "type": "object",
-      "properties": {
-        "teams": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/teamsresponseTeam"
-          }
-        }
-      }
-    },
-    "responseUpdateTeamResp": {
-      "type": "object",
-      "properties": {
-        "team": {
-          "$ref": "#/definitions/teamsresponseTeam"
-        }
-      }
-    },
-    "teamsresponseTeam": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        }
-      }
-    },
-    "versionVersionInfo": {
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
         "name": {
@@ -422,6 +274,154 @@ func init() {
         },
         "built": {
           "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.teams.request.AddUsersReq": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.request.CreateTeamReq": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.teams.request.RemoveUsersReq": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.request.UpdateTeamReq": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.AddUsersResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.CreateTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.DeleteTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.GetTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.GetTeamsForUserResp": {
+      "type": "object",
+      "properties": {
+        "teams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.response.GetUsersResp": {
+      "type": "object",
+      "properties": {
+        "user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.response.RemoveUsersResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.Team": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.teams.response.Teams": {
+      "type": "object",
+      "properties": {
+        "teams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.teams.response.Team"
+          }
+        }
+      }
+    },
+    "chef.automate.api.teams.response.UpdateTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.teams.response.Team"
         }
       }
     }

--- a/components/automate-gateway/api/auth_tokens_tokens.pb.swagger.go
+++ b/components/automate-gateway/api/auth_tokens_tokens.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseTokens"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.Tokens"
             }
           }
         },
@@ -39,7 +39,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.Token"
             }
           }
         },
@@ -49,7 +49,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestCreateToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.request.CreateToken"
             }
           }
         ],
@@ -65,7 +65,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.Token"
             }
           }
         },
@@ -87,7 +87,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseDeleteTokenResp"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.DeleteTokenResp"
             }
           }
         },
@@ -109,7 +109,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.response.Token"
             }
           }
         },
@@ -125,7 +125,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestUpdateToken"
+              "$ref": "#/definitions/chef.automate.api.tokens.request.UpdateToken"
             }
           }
         ],
@@ -136,7 +136,7 @@ func init() {
     }
   },
   "definitions": {
-    "requestCreateToken": {
+    "chef.automate.api.tokens.request.CreateToken": {
       "type": "object",
       "properties": {
         "description": {
@@ -154,7 +154,7 @@ func init() {
         }
       }
     },
-    "requestUpdateToken": {
+    "chef.automate.api.tokens.request.UpdateToken": {
       "type": "object",
       "properties": {
         "id": {
@@ -169,10 +169,10 @@ func init() {
         }
       }
     },
-    "responseDeleteTokenResp": {
+    "chef.automate.api.tokens.response.DeleteTokenResp": {
       "type": "object"
     },
-    "responseToken": {
+    "chef.automate.api.tokens.response.Token": {
       "type": "object",
       "properties": {
         "id": {
@@ -196,13 +196,13 @@ func init() {
         }
       }
     },
-    "responseTokens": {
+    "chef.automate.api.tokens.response.Tokens": {
       "type": "object",
       "properties": {
         "tokens": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseToken"
+            "$ref": "#/definitions/chef.automate.api.tokens.response.Token"
           }
         }
       }

--- a/components/automate-gateway/api/auth_users_users.pb.swagger.go
+++ b/components/automate-gateway/api/auth_users_users.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUsers"
+              "$ref": "#/definitions/chef.automate.api.users.response.Users"
             }
           }
         },
@@ -39,7 +39,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUser"
+              "$ref": "#/definitions/chef.automate.api.users.response.User"
             }
           }
         },
@@ -49,7 +49,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestCreateUser"
+              "$ref": "#/definitions/chef.automate.api.users.request.CreateUser"
             }
           }
         ],
@@ -65,7 +65,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUser"
+              "$ref": "#/definitions/chef.automate.api.users.response.User"
             }
           }
         },
@@ -87,7 +87,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseDeleteUserResp"
+              "$ref": "#/definitions/chef.automate.api.users.response.DeleteUserResp"
             }
           }
         },
@@ -109,7 +109,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUser"
+              "$ref": "#/definitions/chef.automate.api.users.response.User"
             }
           }
         },
@@ -125,7 +125,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestUpdateUser"
+              "$ref": "#/definitions/chef.automate.api.users.request.UpdateUser"
             }
           }
         ],
@@ -141,7 +141,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseUser"
+              "$ref": "#/definitions/chef.automate.api.users.response.User"
             }
           }
         },
@@ -157,7 +157,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestUpdateSelf"
+              "$ref": "#/definitions/chef.automate.api.users.request.UpdateSelf"
             }
           }
         ],
@@ -168,7 +168,7 @@ func init() {
     }
   },
   "definitions": {
-    "requestCreateUser": {
+    "chef.automate.api.users.request.CreateUser": {
       "type": "object",
       "properties": {
         "id": {
@@ -188,7 +188,7 @@ func init() {
         }
       }
     },
-    "requestUpdateSelf": {
+    "chef.automate.api.users.request.UpdateSelf": {
       "type": "object",
       "properties": {
         "id": {
@@ -208,7 +208,7 @@ func init() {
         }
       }
     },
-    "requestUpdateUser": {
+    "chef.automate.api.users.request.UpdateUser": {
       "type": "object",
       "properties": {
         "id": {
@@ -228,10 +228,10 @@ func init() {
         }
       }
     },
-    "responseDeleteUserResp": {
+    "chef.automate.api.users.response.DeleteUserResp": {
       "type": "object"
     },
-    "responseUser": {
+    "chef.automate.api.users.response.User": {
       "type": "object",
       "properties": {
         "id": {
@@ -248,13 +248,13 @@ func init() {
         }
       }
     },
-    "responseUsers": {
+    "chef.automate.api.users.response.Users": {
       "type": "object",
       "properties": {
         "users": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseUser"
+            "$ref": "#/definitions/chef.automate.api.users.response.User"
           }
         }
       }

--- a/components/automate-gateway/api/authz/authz.swagger.json
+++ b/components/automate-gateway/api/authz/authz.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseIntrospectResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.IntrospectResp"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseIntrospectResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.IntrospectResp"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestIntrospectReq"
+              "$ref": "#/definitions/chef.automate.api.authz.request.IntrospectReq"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseIntrospectResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.IntrospectResp"
             }
           }
         },
@@ -72,7 +72,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestIntrospectSomeReq"
+              "$ref": "#/definitions/chef.automate.api.authz.request.IntrospectSomeReq"
             }
           }
         ],
@@ -88,7 +88,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseListPoliciesResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.ListPoliciesResp"
             }
           }
         },
@@ -102,7 +102,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseCreatePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.CreatePolicyResp"
             }
           }
         },
@@ -112,7 +112,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestCreatePolicyReq"
+              "$ref": "#/definitions/chef.automate.api.authz.request.CreatePolicyReq"
             }
           }
         ],
@@ -128,7 +128,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -144,7 +144,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseDeletePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.DeletePolicyResp"
             }
           }
         },
@@ -163,7 +163,7 @@
     }
   },
   "definitions": {
-    "requestCreatePolicyReq": {
+    "chef.automate.api.authz.request.CreatePolicyReq": {
       "type": "object",
       "properties": {
         "action": {
@@ -180,7 +180,7 @@
         }
       }
     },
-    "requestIntrospectReq": {
+    "chef.automate.api.authz.request.IntrospectReq": {
       "type": "object",
       "properties": {
         "path": {
@@ -194,7 +194,7 @@
         }
       }
     },
-    "requestIntrospectSomeReq": {
+    "chef.automate.api.authz.request.IntrospectSomeReq": {
       "type": "object",
       "properties": {
         "paths": {
@@ -205,7 +205,7 @@
         }
       }
     },
-    "responseCreatePolicyResp": {
+    "chef.automate.api.authz.response.CreatePolicyResp": {
       "type": "object",
       "properties": {
         "action": {
@@ -237,7 +237,7 @@
       },
       "description": "We aren't using a Policy message here since we want to\nreturn a flat object via our external HTTP API."
     },
-    "responseDeletePolicyResp": {
+    "chef.automate.api.authz.response.DeletePolicyResp": {
       "type": "object",
       "properties": {
         "action": {
@@ -268,29 +268,29 @@
         }
       }
     },
-    "responseIntrospectResp": {
+    "chef.automate.api.authz.response.IntrospectResp": {
       "type": "object",
       "properties": {
         "endpoints": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/responseMethodsAllowed"
+            "$ref": "#/definitions/chef.automate.api.authz.response.MethodsAllowed"
           }
         }
       }
     },
-    "responseListPoliciesResp": {
+    "chef.automate.api.authz.response.ListPoliciesResp": {
       "type": "object",
       "properties": {
         "policies": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responsePolicy"
+            "$ref": "#/definitions/chef.automate.api.authz.response.Policy"
           }
         }
       }
     },
-    "responseMethodsAllowed": {
+    "chef.automate.api.authz.response.MethodsAllowed": {
       "type": "object",
       "properties": {
         "get": {
@@ -315,7 +315,7 @@
         }
       }
     },
-    "responsePolicy": {
+    "chef.automate.api.authz.response.Policy": {
       "type": "object",
       "properties": {
         "action": {
@@ -346,7 +346,7 @@
         }
       }
     },
-    "versionVersionInfo": {
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
         "name": {

--- a/components/automate-gateway/api/authz_authz.pb.swagger.go
+++ b/components/automate-gateway/api/authz_authz.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseIntrospectResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.IntrospectResp"
             }
           }
         },
@@ -39,7 +39,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseIntrospectResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.IntrospectResp"
             }
           }
         },
@@ -49,7 +49,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestIntrospectReq"
+              "$ref": "#/definitions/chef.automate.api.authz.request.IntrospectReq"
             }
           }
         ],
@@ -65,7 +65,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseIntrospectResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.IntrospectResp"
             }
           }
         },
@@ -75,7 +75,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestIntrospectSomeReq"
+              "$ref": "#/definitions/chef.automate.api.authz.request.IntrospectSomeReq"
             }
           }
         ],
@@ -91,7 +91,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseListPoliciesResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.ListPoliciesResp"
             }
           }
         },
@@ -105,7 +105,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseCreatePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.CreatePolicyResp"
             }
           }
         },
@@ -115,7 +115,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestCreatePolicyReq"
+              "$ref": "#/definitions/chef.automate.api.authz.request.CreatePolicyReq"
             }
           }
         ],
@@ -131,7 +131,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -147,7 +147,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseDeletePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.authz.response.DeletePolicyResp"
             }
           }
         },
@@ -166,7 +166,7 @@ func init() {
     }
   },
   "definitions": {
-    "requestCreatePolicyReq": {
+    "chef.automate.api.authz.request.CreatePolicyReq": {
       "type": "object",
       "properties": {
         "action": {
@@ -183,7 +183,7 @@ func init() {
         }
       }
     },
-    "requestIntrospectReq": {
+    "chef.automate.api.authz.request.IntrospectReq": {
       "type": "object",
       "properties": {
         "path": {
@@ -197,7 +197,7 @@ func init() {
         }
       }
     },
-    "requestIntrospectSomeReq": {
+    "chef.automate.api.authz.request.IntrospectSomeReq": {
       "type": "object",
       "properties": {
         "paths": {
@@ -208,7 +208,7 @@ func init() {
         }
       }
     },
-    "responseCreatePolicyResp": {
+    "chef.automate.api.authz.response.CreatePolicyResp": {
       "type": "object",
       "properties": {
         "action": {
@@ -240,7 +240,7 @@ func init() {
       },
       "description": "We aren't using a Policy message here since we want to\nreturn a flat object via our external HTTP API."
     },
-    "responseDeletePolicyResp": {
+    "chef.automate.api.authz.response.DeletePolicyResp": {
       "type": "object",
       "properties": {
         "action": {
@@ -271,29 +271,29 @@ func init() {
         }
       }
     },
-    "responseIntrospectResp": {
+    "chef.automate.api.authz.response.IntrospectResp": {
       "type": "object",
       "properties": {
         "endpoints": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/responseMethodsAllowed"
+            "$ref": "#/definitions/chef.automate.api.authz.response.MethodsAllowed"
           }
         }
       }
     },
-    "responseListPoliciesResp": {
+    "chef.automate.api.authz.response.ListPoliciesResp": {
       "type": "object",
       "properties": {
         "policies": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responsePolicy"
+            "$ref": "#/definitions/chef.automate.api.authz.response.Policy"
           }
         }
       }
     },
-    "responseMethodsAllowed": {
+    "chef.automate.api.authz.response.MethodsAllowed": {
       "type": "object",
       "properties": {
         "get": {
@@ -318,7 +318,7 @@ func init() {
         }
       }
     },
-    "responsePolicy": {
+    "chef.automate.api.authz.response.Policy": {
       "type": "object",
       "properties": {
         "action": {
@@ -349,7 +349,7 @@ func init() {
         }
       }
     },
-    "versionVersionInfo": {
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
         "name": {

--- a/components/automate-gateway/api/cfgmgmt.pb.swagger.go
+++ b/components/automate-gateway/api/cfgmgmt.pb.swagger.go
@@ -87,7 +87,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseNodeAttribute"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.NodeAttribute"
             }
           }
         },
@@ -175,7 +175,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseRun"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Run"
             }
           }
         },
@@ -231,7 +231,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responsePolicyCookbooks"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.PolicyCookbooks"
             }
           }
         },
@@ -274,7 +274,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/cfgmgmtresponseNodesCounts"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.NodesCounts"
             }
           }
         },
@@ -302,7 +302,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/cfgmgmtresponseRunsCounts"
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.RunsCounts"
             }
           }
         },
@@ -391,7 +391,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -402,85 +402,7 @@ func init() {
     }
   },
   "definitions": {
-    "cfgmgmtresponseNodesCounts": {
-      "type": "object",
-      "properties": {
-        "total": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "success": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "failure": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "missing": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "cfgmgmtresponseRunsCounts": {
-      "type": "object",
-      "properties": {
-        "total": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "success": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "failure": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "protobufNullValue": {
-      "type": "string",
-      "enum": [
-        "NULL_VALUE"
-      ],
-      "default": "NULL_VALUE",
-      "description": "` + "`" + `NullValue` + "`" + ` is a singleton enumeration to represent the null value for the\n` + "`" + `Value` + "`" + ` type union.\n\n The JSON representation for ` + "`" + `NullValue` + "`" + ` is JSON ` + "`" + `null` + "`" + `.\n\n - NULL_VALUE: Null value."
-    },
-    "queryPagination": {
-      "type": "object",
-      "properties": {
-        "page": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "size": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "querySortOrder": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "querySorting": {
-      "type": "object",
-      "properties": {
-        "field": {
-          "type": "string"
-        },
-        "order": {
-          "$ref": "#/definitions/querySortOrder"
-        }
-      }
-    },
-    "responseChefError": {
+    "chef.automate.api.cfgmgmt.response.ChefError": {
       "type": "object",
       "properties": {
         "class": {
@@ -496,11 +418,11 @@ func init() {
           }
         },
         "description": {
-          "$ref": "#/definitions/responseDescription"
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Description"
         }
       }
     },
-    "responseCookbookLock": {
+    "chef.automate.api.cfgmgmt.response.CookbookLock": {
       "type": "object",
       "properties": {
         "cookbook": {
@@ -511,7 +433,7 @@ func init() {
         }
       }
     },
-    "responseDeprecation": {
+    "chef.automate.api.cfgmgmt.response.Deprecation": {
       "type": "object",
       "properties": {
         "message": {
@@ -525,7 +447,7 @@ func init() {
         }
       }
     },
-    "responseDescription": {
+    "chef.automate.api.cfgmgmt.response.Description": {
       "type": "object",
       "properties": {
         "title": {
@@ -539,7 +461,7 @@ func init() {
         }
       }
     },
-    "responseExpandedRunList": {
+    "chef.automate.api.cfgmgmt.response.ExpandedRunList": {
       "type": "object",
       "properties": {
         "id": {
@@ -548,12 +470,12 @@ func init() {
         "run_list": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseRunList"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.RunList"
           }
         }
       }
     },
-    "responseNodeAttribute": {
+    "chef.automate.api.cfgmgmt.response.NodeAttribute": {
       "type": "object",
       "properties": {
         "node_id": {
@@ -605,7 +527,28 @@ func init() {
         }
       }
     },
-    "responsePolicyCookbooks": {
+    "chef.automate.api.cfgmgmt.response.NodesCounts": {
+      "type": "object",
+      "properties": {
+        "total": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "success": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "failure": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "missing": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.PolicyCookbooks": {
       "type": "object",
       "properties": {
         "policy_name": {
@@ -614,12 +557,12 @@ func init() {
         "cookbook_locks": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseCookbookLock"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.CookbookLock"
           }
         }
       }
     },
-    "responseResource": {
+    "chef.automate.api.cfgmgmt.response.Resource": {
       "type": "object",
       "properties": {
         "type": {
@@ -662,7 +605,7 @@ func init() {
         }
       }
     },
-    "responseRun": {
+    "chef.automate.api.cfgmgmt.response.Run": {
       "type": "object",
       "properties": {
         "id": {
@@ -721,7 +664,7 @@ func init() {
         "resources": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseResource"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Resource"
           }
         },
         "run_list": {
@@ -733,11 +676,11 @@ func init() {
         "deprecations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseDeprecation"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Deprecation"
           }
         },
         "error": {
-          "$ref": "#/definitions/responseChefError"
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.ChefError"
         },
         "tags": {
           "type": "array",
@@ -794,11 +737,11 @@ func init() {
           "type": "string"
         },
         "expanded_run_list": {
-          "$ref": "#/definitions/responseExpandedRunList"
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.ExpandedRunList"
         }
       }
     },
-    "responseRunList": {
+    "chef.automate.api.cfgmgmt.response.RunList": {
       "type": "object",
       "properties": {
         "type": {
@@ -817,12 +760,61 @@ func init() {
         "children": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseRunList"
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.RunList"
           }
         }
       }
     },
-    "versionVersionInfo": {
+    "chef.automate.api.cfgmgmt.response.RunsCounts": {
+      "type": "object",
+      "properties": {
+        "total": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "success": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "failure": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.common.query.Pagination": {
+      "type": "object",
+      "properties": {
+        "page": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.common.query.SortOrder": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.common.query.Sorting": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "order": {
+          "$ref": "#/definitions/chef.automate.api.common.query.SortOrder"
+        }
+      }
+    },
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
         "name": {
@@ -838,6 +830,14 @@ func init() {
           "type": "string"
         }
       }
+    },
+    "google.protobuf.NullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "` + "`" + `NullValue` + "`" + ` is a singleton enumeration to represent the null value for the\n` + "`" + `Value` + "`" + ` type union.\n\n The JSON representation for ` + "`" + `NullValue` + "`" + ` is JSON ` + "`" + `null` + "`" + `.\n\n - NULL_VALUE: Null value."
     }
   }
 }

--- a/components/automate-gateway/api/chef.pb.swagger.go
+++ b/components/automate-gateway/api/chef.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessChefActionResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessChefActionResponse"
             }
           }
         },
@@ -35,7 +35,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestAction"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Action"
             }
           }
         ],
@@ -51,7 +51,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessLivenessResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessLivenessResponse"
             }
           }
         },
@@ -61,7 +61,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestLiveness"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Liveness"
             }
           }
         ],
@@ -77,7 +77,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessMultipleNodeDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessMultipleNodeDeleteResponse"
             }
           }
         },
@@ -87,7 +87,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestMultipleNodeDeleteRequest"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.MultipleNodeDeleteRequest"
             }
           }
         ],
@@ -103,7 +103,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessNodeDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessNodeDeleteResponse"
             }
           }
         },
@@ -113,7 +113,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestDelete"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Delete"
             }
           }
         ],
@@ -129,7 +129,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseProcessChefRunResponse"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessChefRunResponse"
             }
           }
         },
@@ -139,7 +139,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestRun"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Run"
             }
           }
         ],
@@ -155,7 +155,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -166,15 +166,24 @@ func init() {
     }
   },
   "definitions": {
-    "protobufNullValue": {
-      "type": "string",
-      "enum": [
-        "NULL_VALUE"
-      ],
-      "default": "NULL_VALUE",
-      "description": "` + "`" + `NullValue` + "`" + ` is a singleton enumeration to represent the null value for the\n` + "`" + `Value` + "`" + ` type union.\n\n The JSON representation for ` + "`" + `NullValue` + "`" + ` is JSON ` + "`" + `null` + "`" + `.\n\n - NULL_VALUE: Null value."
+    "chef.automate.api.common.version.VersionInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "built": {
+          "type": "string"
+        }
+      }
     },
-    "requestAction": {
+    "chef.automate.api.ingest.request.Action": {
       "type": "object",
       "properties": {
         "id": {
@@ -245,7 +254,7 @@ func init() {
         }
       }
     },
-    "requestDelete": {
+    "chef.automate.api.ingest.request.Delete": {
       "type": "object",
       "properties": {
         "id": {
@@ -269,7 +278,7 @@ func init() {
         }
       }
     },
-    "requestDeprecation": {
+    "chef.automate.api.ingest.request.Deprecation": {
       "type": "object",
       "properties": {
         "message": {
@@ -283,7 +292,7 @@ func init() {
         }
       }
     },
-    "requestDescription": {
+    "chef.automate.api.ingest.request.Description": {
       "type": "object",
       "properties": {
         "title": {
@@ -297,7 +306,7 @@ func init() {
         }
       }
     },
-    "requestError": {
+    "chef.automate.api.ingest.request.Error": {
       "type": "object",
       "properties": {
         "class": {
@@ -313,11 +322,11 @@ func init() {
           }
         },
         "description": {
-          "$ref": "#/definitions/requestDescription"
+          "$ref": "#/definitions/chef.automate.api.ingest.request.Description"
         }
       }
     },
-    "requestExpandedRunList": {
+    "chef.automate.api.ingest.request.ExpandedRunList": {
       "type": "object",
       "properties": {
         "id": {
@@ -326,12 +335,12 @@ func init() {
         "run_list": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestRunList"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.RunList"
           }
         }
       }
     },
-    "requestLiveness": {
+    "chef.automate.api.ingest.request.Liveness": {
       "type": "object",
       "properties": {
         "event_type": {
@@ -357,7 +366,7 @@ func init() {
         }
       }
     },
-    "requestMultipleNodeDeleteRequest": {
+    "chef.automate.api.ingest.request.MultipleNodeDeleteRequest": {
       "type": "object",
       "properties": {
         "node_ids": {
@@ -368,7 +377,7 @@ func init() {
         }
       }
     },
-    "requestResource": {
+    "chef.automate.api.ingest.request.Resource": {
       "type": "object",
       "properties": {
         "type": {
@@ -415,7 +424,7 @@ func init() {
         }
       }
     },
-    "requestRun": {
+    "chef.automate.api.ingest.request.Run": {
       "type": "object",
       "properties": {
         "id": {
@@ -469,12 +478,12 @@ func init() {
           "type": "string"
         },
         "expanded_run_list": {
-          "$ref": "#/definitions/requestExpandedRunList"
+          "$ref": "#/definitions/chef.automate.api.ingest.request.ExpandedRunList"
         },
         "resources": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestResource"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.Resource"
           }
         },
         "run_list": {
@@ -487,7 +496,7 @@ func init() {
           "type": "object"
         },
         "error": {
-          "$ref": "#/definitions/requestError"
+          "$ref": "#/definitions/chef.automate.api.ingest.request.Error"
         },
         "policy_name": {
           "type": "string"
@@ -498,7 +507,7 @@ func init() {
         "deprecations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestDeprecation"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.Deprecation"
           }
         },
         "tags": {
@@ -509,7 +518,7 @@ func init() {
         }
       }
     },
-    "requestRunList": {
+    "chef.automate.api.ingest.request.RunList": {
       "type": "object",
       "properties": {
         "type": {
@@ -528,42 +537,33 @@ func init() {
         "children": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/requestRunList"
+            "$ref": "#/definitions/chef.automate.api.ingest.request.RunList"
           }
         }
       }
     },
-    "responseProcessChefActionResponse": {
+    "chef.automate.api.ingest.response.ProcessChefActionResponse": {
       "type": "object"
     },
-    "responseProcessChefRunResponse": {
+    "chef.automate.api.ingest.response.ProcessChefRunResponse": {
       "type": "object"
     },
-    "responseProcessLivenessResponse": {
+    "chef.automate.api.ingest.response.ProcessLivenessResponse": {
       "type": "object"
     },
-    "responseProcessMultipleNodeDeleteResponse": {
+    "chef.automate.api.ingest.response.ProcessMultipleNodeDeleteResponse": {
       "type": "object"
     },
-    "responseProcessNodeDeleteResponse": {
+    "chef.automate.api.ingest.response.ProcessNodeDeleteResponse": {
       "type": "object"
     },
-    "versionVersionInfo": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "version": {
-          "type": "string"
-        },
-        "sha": {
-          "type": "string"
-        },
-        "built": {
-          "type": "string"
-        }
-      }
+    "google.protobuf.NullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "` + "`" + `NullValue` + "`" + ` is a singleton enumeration to represent the null value for the\n` + "`" + `Value` + "`" + ` type union.\n\n The JSON representation for ` + "`" + `NullValue` + "`" + ` is JSON ` + "`" + `null` + "`" + `.\n\n - NULL_VALUE: Null value."
     }
   }
 }

--- a/components/automate-gateway/api/compliance/profiles/profiles.swagger.json
+++ b/components/automate-gateway/api/compliance/profiles/profiles.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Profile"
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profile"
             }
           }
         },
@@ -58,7 +58,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Profile"
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profile"
             }
           }
         },
@@ -94,7 +94,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Profiles"
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profiles"
             }
           }
         },
@@ -104,7 +104,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Query"
             }
           }
         ],
@@ -151,63 +151,18 @@
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "protobufAny": {
-      "type": "object",
-      "properties": {
-        "type_url": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string",
-          "format": "byte"
-        }
-      }
-    },
-    "runtimeStreamError": {
-      "type": "object",
-      "properties": {
-        "grpc_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "http_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
-          "type": "string"
-        },
-        "http_status": {
-          "type": "string"
-        },
-        "details": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/protobufAny"
-          }
-        }
-      }
-    },
-    "v1Attribute": {
+    "chef.automate.api.compliance.profiles.v1.Attribute": {
       "type": "object",
       "properties": {
         "name": {
           "type": "string"
         },
         "options": {
-          "$ref": "#/definitions/v1Option"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Option"
         }
       }
     },
-    "v1CheckMessage": {
+    "chef.automate.api.compliance.profiles.v1.CheckMessage": {
       "type": "object",
       "properties": {
         "file": {
@@ -229,27 +184,27 @@
         }
       }
     },
-    "v1CheckResult": {
+    "chef.automate.api.compliance.profiles.v1.CheckResult": {
       "type": "object",
       "properties": {
         "summary": {
-          "$ref": "#/definitions/v1ResultSummary"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.ResultSummary"
         },
         "errors": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1CheckMessage"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.CheckMessage"
           }
         },
         "warnings": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1CheckMessage"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.CheckMessage"
           }
         }
       }
     },
-    "v1Chunk": {
+    "chef.automate.api.compliance.profiles.v1.Chunk": {
       "type": "object",
       "properties": {
         "data": {
@@ -262,7 +217,7 @@
         }
       }
     },
-    "v1Control": {
+    "chef.automate.api.compliance.profiles.v1.Control": {
       "type": "object",
       "properties": {
         "id": {
@@ -282,18 +237,18 @@
           "type": "string"
         },
         "source_location": {
-          "$ref": "#/definitions/v1SourceLocation"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.SourceLocation"
         },
         "results": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Result"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Result"
           }
         },
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Ref"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Ref"
           }
         },
         "tags": {
@@ -304,7 +259,7 @@
         }
       }
     },
-    "v1Dependency": {
+    "chef.automate.api.compliance.profiles.v1.Dependency": {
       "type": "object",
       "properties": {
         "name": {
@@ -342,7 +297,7 @@
         }
       }
     },
-    "v1Group": {
+    "chef.automate.api.compliance.profiles.v1.Group": {
       "type": "object",
       "properties": {
         "id": {
@@ -359,7 +314,7 @@
         }
       }
     },
-    "v1ListFilter": {
+    "chef.automate.api.compliance.profiles.v1.ListFilter": {
       "type": "object",
       "properties": {
         "values": {
@@ -373,7 +328,7 @@
         }
       }
     },
-    "v1Metadata": {
+    "chef.automate.api.compliance.profiles.v1.Metadata": {
       "type": "object",
       "properties": {
         "name": {
@@ -387,7 +342,7 @@
         }
       }
     },
-    "v1Option": {
+    "chef.automate.api.compliance.profiles.v1.Option": {
       "type": "object",
       "properties": {
         "description": {
@@ -398,7 +353,7 @@
         }
       }
     },
-    "v1Profile": {
+    "chef.automate.api.compliance.profiles.v1.Profile": {
       "type": "object",
       "properties": {
         "name": {
@@ -431,13 +386,13 @@
         "supports": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Support"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Support"
           }
         },
         "depends": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Dependency"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Dependency"
           }
         },
         "sha256": {
@@ -446,19 +401,19 @@
         "groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Group"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Group"
           }
         },
         "controls": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Control"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Control"
           }
         },
         "attributes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Attribute"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Attribute"
           }
         },
         "latest_version": {
@@ -466,7 +421,7 @@
         }
       }
     },
-    "v1ProfileData": {
+    "chef.automate.api.compliance.profiles.v1.ProfileData": {
       "type": "object",
       "properties": {
         "owner": {
@@ -484,13 +439,13 @@
         }
       }
     },
-    "v1Profiles": {
+    "chef.automate.api.compliance.profiles.v1.Profiles": {
       "type": "object",
       "properties": {
         "profiles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Profile"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profile"
           }
         },
         "total": {
@@ -499,17 +454,17 @@
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.compliance.profiles.v1.Query": {
       "type": "object",
       "properties": {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ListFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.ListFilter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -533,7 +488,15 @@
         }
       }
     },
-    "v1Ref": {
+    "chef.automate.api.compliance.profiles.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.compliance.profiles.v1.Ref": {
       "type": "object",
       "properties": {
         "url": {
@@ -544,7 +507,7 @@
         }
       }
     },
-    "v1Result": {
+    "chef.automate.api.compliance.profiles.v1.Result": {
       "type": "object",
       "properties": {
         "status": {
@@ -568,7 +531,7 @@
         }
       }
     },
-    "v1ResultSummary": {
+    "chef.automate.api.compliance.profiles.v1.ResultSummary": {
       "type": "object",
       "properties": {
         "valid": {
@@ -587,7 +550,7 @@
         }
       }
     },
-    "v1SourceLocation": {
+    "chef.automate.api.compliance.profiles.v1.SourceLocation": {
       "type": "object",
       "properties": {
         "ref": {
@@ -599,7 +562,7 @@
         }
       }
     },
-    "v1Support": {
+    "chef.automate.api.compliance.profiles.v1.Support": {
       "type": "object",
       "properties": {
         "os_name": {
@@ -618,20 +581,57 @@
           "type": "string"
         }
       }
+    },
+    "google.protobuf.Any": {
+      "type": "object",
+      "properties": {
+        "type_url": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "grpc.gateway.runtime.StreamError": {
+      "type": "object",
+      "properties": {
+        "grpc_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "http_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "http_status": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/google.protobuf.Any"
+          }
+        }
+      }
     }
   },
   "x-stream-definitions": {
-    "v1ProfileData": {
+    "chef.automate.api.compliance.profiles.v1.ProfileData": {
       "type": "object",
       "properties": {
         "result": {
-          "$ref": "#/definitions/v1ProfileData"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.ProfileData"
         },
         "error": {
-          "$ref": "#/definitions/runtimeStreamError"
+          "$ref": "#/definitions/grpc.gateway.runtime.StreamError"
         }
       },
-      "title": "Stream result of v1ProfileData"
+      "title": "Stream result of chef.automate.api.compliance.profiles.v1.ProfileData"
     }
   }
 }

--- a/components/automate-gateway/api/compliance/reporting/reporting.swagger.json
+++ b/components/automate-gateway/api/compliance/reporting/reporting.swagger.json
@@ -24,7 +24,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ControlItems"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlItems"
             }
           }
         },
@@ -34,7 +34,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1ControlItemRequest"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlItemRequest"
             }
           }
         ],
@@ -52,7 +52,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Node"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Node"
             }
           }
         },
@@ -79,7 +79,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Nodes"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Nodes"
             }
           }
         },
@@ -89,7 +89,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -107,7 +107,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ProfileMins"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMins"
             }
           }
         },
@@ -117,7 +117,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -135,7 +135,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ReportIds"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ReportIds"
             }
           }
         },
@@ -145,7 +145,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -163,7 +163,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Reports"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Reports"
             }
           }
         },
@@ -173,7 +173,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -191,7 +191,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Report"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Report"
             }
           }
         },
@@ -208,7 +208,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -226,7 +226,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Suggestions"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Suggestions"
             }
           }
         },
@@ -236,7 +236,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1SuggestionRequest"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.SuggestionRequest"
             }
           }
         ],
@@ -252,7 +252,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -263,56 +263,24 @@
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC",
-      "title": "The two allowed values for ordering results"
-    },
-    "protobufAny": {
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
-        "type_url": {
-          "type": "string",
-          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
-        },
-        "value": {
-          "type": "string",
-          "format": "byte",
-          "description": "Must be a valid serialized protocol buffer of the above specified type."
-        }
-      },
-      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := ptypes.MarshalAny(foo)\n     ...\n     foo := \u0026pb.Foo{}\n     if err := ptypes.UnmarshalAny(any, foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
-    },
-    "runtimeStreamError": {
-      "type": "object",
-      "properties": {
-        "grpc_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "http_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
+        "name": {
           "type": "string"
         },
-        "http_status": {
+        "version": {
           "type": "string"
         },
-        "details": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/protobufAny"
-          }
+        "sha": {
+          "type": "string"
+        },
+        "built": {
+          "type": "string"
         }
       }
     },
-    "v1Attribute": {
+    "chef.automate.api.compliance.reporting.v1.Attribute": {
       "type": "object",
       "properties": {
         "name": {
@@ -320,12 +288,12 @@
           "title": "The name of the attribute"
         },
         "options": {
-          "$ref": "#/definitions/v1Option",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Option",
           "title": "The options defined for the attribute"
         }
       }
     },
-    "v1Control": {
+    "chef.automate.api.compliance.reporting.v1.Control": {
       "type": "object",
       "properties": {
         "id": {
@@ -350,20 +318,20 @@
           "title": "The compact description of the control"
         },
         "source_location": {
-          "$ref": "#/definitions/v1SourceLocation",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.SourceLocation",
           "title": "Intentionally blank"
         },
         "results": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Result"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Result"
           },
           "title": "The results of running all tests defined in the control against the node"
         },
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Ref"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Ref"
           },
           "title": "External supporting documents for the control"
         },
@@ -376,7 +344,7 @@
         }
       }
     },
-    "v1ControlItem": {
+    "chef.automate.api.compliance.reporting.v1.ControlItem": {
       "type": "object",
       "properties": {
         "id": {
@@ -388,7 +356,7 @@
           "title": "The compact description of the control"
         },
         "profile": {
-          "$ref": "#/definitions/v1ProfileMin",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMin",
           "title": "Intentionally blank"
         },
         "impact": {
@@ -402,12 +370,12 @@
           "title": "The time the report using the control was submitted at"
         },
         "control_summary": {
-          "$ref": "#/definitions/v1ControlSummary",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary",
           "title": "Intentionally blank"
         }
       }
     },
-    "v1ControlItemRequest": {
+    "chef.automate.api.compliance.reporting.v1.ControlItemRequest": {
       "type": "object",
       "properties": {
         "text": {
@@ -422,25 +390,25 @@
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ListFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ListFilter"
           },
           "title": "The criteria used to filter the controls returned"
         }
       }
     },
-    "v1ControlItems": {
+    "chef.automate.api.compliance.reporting.v1.ControlItems": {
       "type": "object",
       "properties": {
         "control_items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ControlItem"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlItem"
           },
           "title": "The paginated results of controls matching the filters"
         }
       }
     },
-    "v1ControlSummary": {
+    "chef.automate.api.compliance.reporting.v1.ControlSummary": {
       "type": "object",
       "properties": {
         "total": {
@@ -449,21 +417,21 @@
           "title": "The total number of controls"
         },
         "passed": {
-          "$ref": "#/definitions/v1Total",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Total",
           "title": "Intentionally blank"
         },
         "skipped": {
-          "$ref": "#/definitions/v1Total",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Total",
           "title": "Intentionally blank"
         },
         "failed": {
-          "$ref": "#/definitions/v1Failed",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Failed",
           "title": "Intentionally blank"
         }
       },
       "title": "A minimal represenation of the statuses of the controls"
     },
-    "v1Dependency": {
+    "chef.automate.api.compliance.reporting.v1.Dependency": {
       "type": "object",
       "properties": {
         "name": {
@@ -520,7 +488,7 @@
         }
       }
     },
-    "v1ExportData": {
+    "chef.automate.api.compliance.reporting.v1.ExportData": {
       "type": "object",
       "properties": {
         "content": {
@@ -530,7 +498,7 @@
         }
       }
     },
-    "v1Failed": {
+    "chef.automate.api.compliance.reporting.v1.Failed": {
       "type": "object",
       "properties": {
         "total": {
@@ -556,7 +524,7 @@
       },
       "title": "Stats of failed controls"
     },
-    "v1Group": {
+    "chef.automate.api.compliance.reporting.v1.Group": {
       "type": "object",
       "properties": {
         "id": {
@@ -576,7 +544,7 @@
         }
       }
     },
-    "v1Kv": {
+    "chef.automate.api.compliance.reporting.v1.Kv": {
       "type": "object",
       "properties": {
         "key": {
@@ -589,7 +557,7 @@
         }
       }
     },
-    "v1LatestReportSummary": {
+    "chef.automate.api.compliance.reporting.v1.LatestReportSummary": {
       "type": "object",
       "properties": {
         "id": {
@@ -606,13 +574,13 @@
           "title": "The status of the run the report was made from"
         },
         "controls": {
-          "$ref": "#/definitions/v1ControlSummary",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary",
           "title": "Intentionally blank"
         }
       },
       "title": "A summary of the information contained in the latest report for this node"
     },
-    "v1ListFilter": {
+    "chef.automate.api.compliance.reporting.v1.ListFilter": {
       "type": "object",
       "properties": {
         "values": {
@@ -628,7 +596,7 @@
         }
       }
     },
-    "v1Node": {
+    "chef.automate.api.compliance.reporting.v1.Node": {
       "type": "object",
       "properties": {
         "id": {
@@ -640,7 +608,7 @@
           "title": "The name assigned to the node"
         },
         "platform": {
-          "$ref": "#/definitions/v1Platform",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Platform",
           "title": "Intentionally blank"
         },
         "environment": {
@@ -648,32 +616,32 @@
           "title": "The environment assigned to the node"
         },
         "latest_report": {
-          "$ref": "#/definitions/v1LatestReportSummary",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.LatestReportSummary",
           "title": "A summary of the information contained in the latest report for this node"
         },
         "tags": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Kv"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Kv"
           },
           "title": "The tags assigned to this node"
         },
         "profiles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ProfileMeta"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMeta"
           },
           "title": "A minimal represenation of the compliance profiles run against the node"
         }
       }
     },
-    "v1Nodes": {
+    "chef.automate.api.compliance.reporting.v1.Nodes": {
       "type": "object",
       "properties": {
         "nodes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Node"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Node"
           },
           "title": "The nodes matching the request filters"
         },
@@ -699,7 +667,7 @@
         }
       }
     },
-    "v1Option": {
+    "chef.automate.api.compliance.reporting.v1.Option": {
       "type": "object",
       "properties": {
         "description": {
@@ -712,7 +680,7 @@
         }
       }
     },
-    "v1Platform": {
+    "chef.automate.api.compliance.reporting.v1.Platform": {
       "type": "object",
       "properties": {
         "name": {
@@ -730,7 +698,7 @@
       },
       "title": "The name and version of the node's operating system"
     },
-    "v1Profile": {
+    "chef.automate.api.compliance.reporting.v1.Profile": {
       "type": "object",
       "properties": {
         "name": {
@@ -776,14 +744,14 @@
         "supports": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Support"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Support"
           },
           "title": "The supported platform targets"
         },
         "depends": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Dependency"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Dependency"
           },
           "title": "Other profiles that this profile depends on"
         },
@@ -794,21 +762,21 @@
         "groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Group"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Group"
           },
           "title": "The groups of controls defined in the profile"
         },
         "controls": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Control"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Control"
           },
           "title": "The controls defined on the profile"
         },
         "attributes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Attribute"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Attribute"
           },
           "title": "The attributes defined on the profile"
         },
@@ -826,7 +794,7 @@
         }
       }
     },
-    "v1ProfileCounts": {
+    "chef.automate.api.compliance.reporting.v1.ProfileCounts": {
       "type": "object",
       "properties": {
         "total": {
@@ -852,7 +820,7 @@
       },
       "title": "Stats on the statuses of nodes matching the filters"
     },
-    "v1ProfileMeta": {
+    "chef.automate.api.compliance.reporting.v1.ProfileMeta": {
       "type": "object",
       "properties": {
         "name": {
@@ -877,7 +845,7 @@
         }
       }
     },
-    "v1ProfileMin": {
+    "chef.automate.api.compliance.reporting.v1.ProfileMin": {
       "type": "object",
       "properties": {
         "name": {
@@ -903,23 +871,23 @@
       },
       "title": "Minimal represenation of a profile"
     },
-    "v1ProfileMins": {
+    "chef.automate.api.compliance.reporting.v1.ProfileMins": {
       "type": "object",
       "properties": {
         "profiles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ProfileMin"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMin"
           },
           "title": "Minimal represenations of the profiles matching the filters"
         },
         "counts": {
-          "$ref": "#/definitions/v1ProfileCounts",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileCounts",
           "title": "Intentionally blank"
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.compliance.reporting.v1.Query": {
       "type": "object",
       "properties": {
         "id": {
@@ -933,12 +901,12 @@
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ListFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ListFilter"
           },
           "title": "The list of filters used to narrow down the list"
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query.OrderType",
           "title": "Whether to sort in ascending or descending order"
         },
         "sort": {
@@ -957,7 +925,16 @@
         }
       }
     },
-    "v1Ref": {
+    "chef.automate.api.compliance.reporting.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC",
+      "title": "The two allowed values for ordering results"
+    },
+    "chef.automate.api.compliance.reporting.v1.Ref": {
       "type": "object",
       "properties": {
         "url": {
@@ -970,7 +947,7 @@
         }
       }
     },
-    "v1Report": {
+    "chef.automate.api.compliance.reporting.v1.Report": {
       "type": "object",
       "properties": {
         "id": {
@@ -995,7 +972,7 @@
           "title": "The status of the run the report was made from"
         },
         "controls": {
-          "$ref": "#/definitions/v1ControlSummary",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary",
           "title": "Intentionally blank"
         },
         "environment": {
@@ -1007,17 +984,17 @@
           "title": "The version of the report"
         },
         "platform": {
-          "$ref": "#/definitions/v1Platform",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Platform",
           "title": "Intentionally blank"
         },
         "statistics": {
-          "$ref": "#/definitions/v1Statistics",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Statistics",
           "title": "Intentionally blank"
         },
         "profiles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Profile"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Profile"
           },
           "title": "The profiles run as part of this report"
         },
@@ -1035,7 +1012,7 @@
         }
       }
     },
-    "v1ReportIds": {
+    "chef.automate.api.compliance.reporting.v1.ReportIds": {
       "type": "object",
       "properties": {
         "ids": {
@@ -1047,13 +1024,13 @@
         }
       }
     },
-    "v1Reports": {
+    "chef.automate.api.compliance.reporting.v1.Reports": {
       "type": "object",
       "properties": {
         "reports": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Report"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Report"
           },
           "title": "The paginated results of reports matching the filters"
         },
@@ -1064,7 +1041,7 @@
         }
       }
     },
-    "v1Result": {
+    "chef.automate.api.compliance.reporting.v1.Result": {
       "type": "object",
       "properties": {
         "status": {
@@ -1094,7 +1071,7 @@
         }
       }
     },
-    "v1SourceLocation": {
+    "chef.automate.api.compliance.reporting.v1.SourceLocation": {
       "type": "object",
       "properties": {
         "ref": {
@@ -1108,7 +1085,7 @@
         }
       }
     },
-    "v1Statistics": {
+    "chef.automate.api.compliance.reporting.v1.Statistics": {
       "type": "object",
       "properties": {
         "duration": {
@@ -1119,7 +1096,7 @@
       },
       "title": "Statistics of the report's run"
     },
-    "v1Suggestion": {
+    "chef.automate.api.compliance.reporting.v1.Suggestion": {
       "type": "object",
       "properties": {
         "text": {
@@ -1141,7 +1118,7 @@
         }
       }
     },
-    "v1SuggestionRequest": {
+    "chef.automate.api.compliance.reporting.v1.SuggestionRequest": {
       "type": "object",
       "properties": {
         "type": {
@@ -1160,25 +1137,25 @@
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ListFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ListFilter"
           },
           "title": "The criteria used to filter the suggestions returned"
         }
       }
     },
-    "v1Suggestions": {
+    "chef.automate.api.compliance.reporting.v1.Suggestions": {
       "type": "object",
       "properties": {
         "suggestions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Suggestion"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Suggestion"
           },
           "title": "The list of returned suggestions"
         }
       }
     },
-    "v1Support": {
+    "chef.automate.api.compliance.reporting.v1.Support": {
       "type": "object",
       "properties": {
         "os_name": {
@@ -1203,7 +1180,7 @@
         }
       }
     },
-    "v1Total": {
+    "chef.automate.api.compliance.reporting.v1.Total": {
       "type": "object",
       "properties": {
         "total": {
@@ -1214,36 +1191,59 @@
       },
       "title": "A subtotal of controls"
     },
-    "versionVersionInfo": {
+    "google.protobuf.Any": {
       "type": "object",
       "properties": {
-        "name": {
+        "type_url": {
+          "type": "string",
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
+        },
+        "value": {
+          "type": "string",
+          "format": "byte",
+          "description": "Must be a valid serialized protocol buffer of the above specified type."
+        }
+      },
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := ptypes.MarshalAny(foo)\n     ...\n     foo := \u0026pb.Foo{}\n     if err := ptypes.UnmarshalAny(any, foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+    },
+    "grpc.gateway.runtime.StreamError": {
+      "type": "object",
+      "properties": {
+        "grpc_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "http_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
           "type": "string"
         },
-        "version": {
+        "http_status": {
           "type": "string"
         },
-        "sha": {
-          "type": "string"
-        },
-        "built": {
-          "type": "string"
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/google.protobuf.Any"
+          }
         }
       }
     }
   },
   "x-stream-definitions": {
-    "v1ExportData": {
+    "chef.automate.api.compliance.reporting.v1.ExportData": {
       "type": "object",
       "properties": {
         "result": {
-          "$ref": "#/definitions/v1ExportData"
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ExportData"
         },
         "error": {
-          "$ref": "#/definitions/runtimeStreamError"
+          "$ref": "#/definitions/grpc.gateway.runtime.StreamError"
         }
       },
-      "title": "Stream result of v1ExportData"
+      "title": "Stream result of chef.automate.api.compliance.reporting.v1.ExportData"
     }
   }
 }

--- a/components/automate-gateway/api/compliance/reporting/stats/stats.swagger.json
+++ b/components/automate-gateway/api/compliance/reporting/stats/stats.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Failures"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Failures"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
             }
           }
         ],
@@ -49,7 +49,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Profile"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Profile"
             }
           }
         },
@@ -59,7 +59,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
             }
           }
         ],
@@ -76,7 +76,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Summary"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Summary"
             }
           }
         },
@@ -86,7 +86,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
             }
           }
         ],
@@ -103,7 +103,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Trends"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Trends"
             }
           }
         },
@@ -113,7 +113,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
             }
           }
         ],
@@ -124,114 +124,7 @@
     }
   },
   "definitions": {
-    "reportingstatsv1ListFilter": {
-      "type": "object",
-      "properties": {
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "type": {
-          "type": "string"
-        }
-      }
-    },
-    "reportingstatsv1Profile": {
-      "type": "object",
-      "properties": {
-        "profile_list": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1ProfileList"
-          }
-        },
-        "profile_summary": {
-          "$ref": "#/definitions/v1ProfileSummary"
-        },
-        "control_stats": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1ControlStats"
-          }
-        }
-      }
-    },
-    "reportingstatsv1Query": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "size": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "interval": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "filters": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/reportingstatsv1ListFilter"
-          }
-        },
-        "order": {
-          "$ref": "#/definitions/reportingstatsv1QueryOrderType"
-        },
-        "sort": {
-          "type": "string"
-        },
-        "page": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "per_page": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "reportingstatsv1QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "reportingstatsv1Support": {
-      "type": "object",
-      "properties": {
-        "os_name": {
-          "type": "string"
-        },
-        "os_family": {
-          "type": "string"
-        },
-        "release": {
-          "type": "string"
-        },
-        "inspec_version": {
-          "type": "string"
-        },
-        "platform_name": {
-          "type": "string"
-        },
-        "platform_family": {
-          "type": "string"
-        },
-        "platform": {
-          "type": "string"
-        }
-      }
-    },
-    "v1ControlStats": {
+    "chef.automate.api.compliance.reporting.stats.v1.ControlStats": {
       "type": "object",
       "properties": {
         "control": {
@@ -258,7 +151,7 @@
         }
       }
     },
-    "v1ControlsSummary": {
+    "chef.automate.api.compliance.reporting.stats.v1.ControlsSummary": {
       "type": "object",
       "properties": {
         "failures": {
@@ -287,7 +180,387 @@
         }
       }
     },
-    "v1Dependency": {
+    "chef.automate.api.compliance.reporting.stats.v1.FailureSummary": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "failures": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "id": {
+          "type": "string"
+        },
+        "profile": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Failures": {
+      "type": "object",
+      "properties": {
+        "profiles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        },
+        "platforms": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        },
+        "controls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ListFilter": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.NodeSummary": {
+      "type": "object",
+      "properties": {
+        "compliant": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "noncompliant": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "high_risk": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "medium_risk": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "low_risk": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Profile": {
+      "type": "object",
+      "properties": {
+        "profile_list": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ProfileList"
+          }
+        },
+        "profile_summary": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ProfileSummary"
+        },
+        "control_stats": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ControlStats"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ProfileList": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "failures": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "majors": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "minors": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "criticals": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "passed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ProfileSummary": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "license": {
+          "type": "string"
+        },
+        "maintainer": {
+          "type": "string"
+        },
+        "copyright": {
+          "type": "string"
+        },
+        "copyright_email": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "supports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Support"
+          }
+        },
+        "stats": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ProfileSummaryStats"
+        },
+        "depends": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Dependency"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ProfileSummaryStats": {
+      "type": "object",
+      "properties": {
+        "failed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "passed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "failed_nodes": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_nodes": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Query": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "interval": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ListFilter"
+          }
+        },
+        "order": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query.OrderType"
+        },
+        "sort": {
+          "type": "string"
+        },
+        "page": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "per_page": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ReportSummary": {
+      "type": "object",
+      "properties": {
+        "stats": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Stats"
+        },
+        "status": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "number",
+          "format": "double"
+        },
+        "start_date": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Stats": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "string",
+          "format": "int64",
+          "title": "int64 types render into string types when serialized to satisfy all browsers\nwe don't really need for nodes counts to be int64 as int32 limits us to 2billion nodes which is plenty for now\nwe are therefore deprecating nodes and favor nodesCnt"
+        },
+        "platforms": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "environments": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "profiles": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "nodes_cnt": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "controls": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Summary": {
+      "type": "object",
+      "properties": {
+        "controls_summary": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ControlsSummary"
+        },
+        "node_summary": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.NodeSummary"
+        },
+        "report_summary": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ReportSummary"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Support": {
+      "type": "object",
+      "properties": {
+        "os_name": {
+          "type": "string"
+        },
+        "os_family": {
+          "type": "string"
+        },
+        "release": {
+          "type": "string"
+        },
+        "inspec_version": {
+          "type": "string"
+        },
+        "platform_name": {
+          "type": "string"
+        },
+        "platform_family": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Trend": {
+      "type": "object",
+      "properties": {
+        "report_time": {
+          "type": "string"
+        },
+        "passed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "failed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Trends": {
+      "type": "object",
+      "properties": {
+        "trends": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Trend"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Dependency": {
       "type": "object",
       "properties": {
         "name": {
@@ -341,279 +614,6 @@
         "skip_message": {
           "type": "string",
           "title": "The reason this profile was skipped in the generated report, if any"
-        }
-      }
-    },
-    "v1FailureSummary": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "failures": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "id": {
-          "type": "string"
-        },
-        "profile": {
-          "type": "string"
-        }
-      }
-    },
-    "v1Failures": {
-      "type": "object",
-      "properties": {
-        "profiles": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1FailureSummary"
-          }
-        },
-        "platforms": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1FailureSummary"
-          }
-        },
-        "controls": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1FailureSummary"
-          }
-        },
-        "environments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1FailureSummary"
-          }
-        }
-      }
-    },
-    "v1NodeSummary": {
-      "type": "object",
-      "properties": {
-        "compliant": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skipped": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "noncompliant": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "high_risk": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "medium_risk": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "low_risk": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1ProfileList": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "id": {
-          "type": "string"
-        },
-        "failures": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "majors": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "minors": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "criticals": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "passed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skipped": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1ProfileSummary": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "version": {
-          "type": "string"
-        },
-        "license": {
-          "type": "string"
-        },
-        "maintainer": {
-          "type": "string"
-        },
-        "copyright": {
-          "type": "string"
-        },
-        "copyright_email": {
-          "type": "string"
-        },
-        "summary": {
-          "type": "string"
-        },
-        "supports": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/reportingstatsv1Support"
-          }
-        },
-        "stats": {
-          "$ref": "#/definitions/v1ProfileSummaryStats"
-        },
-        "depends": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1Dependency"
-          }
-        }
-      }
-    },
-    "v1ProfileSummaryStats": {
-      "type": "object",
-      "properties": {
-        "failed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "passed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skipped": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "failed_nodes": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "total_nodes": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1ReportSummary": {
-      "type": "object",
-      "properties": {
-        "stats": {
-          "$ref": "#/definitions/v1Stats"
-        },
-        "status": {
-          "type": "string"
-        },
-        "duration": {
-          "type": "number",
-          "format": "double"
-        },
-        "start_date": {
-          "type": "string"
-        }
-      }
-    },
-    "v1Stats": {
-      "type": "object",
-      "properties": {
-        "nodes": {
-          "type": "string",
-          "format": "int64",
-          "title": "int64 types render into string types when serialized to satisfy all browsers\nwe don't really need for nodes counts to be int64 as int32 limits us to 2billion nodes which is plenty for now\nwe are therefore deprecating nodes and favor nodesCnt"
-        },
-        "platforms": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "environments": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "profiles": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "nodes_cnt": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "controls": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1Summary": {
-      "type": "object",
-      "properties": {
-        "controls_summary": {
-          "$ref": "#/definitions/v1ControlsSummary"
-        },
-        "node_summary": {
-          "$ref": "#/definitions/v1NodeSummary"
-        },
-        "report_summary": {
-          "$ref": "#/definitions/v1ReportSummary"
-        }
-      }
-    },
-    "v1Trend": {
-      "type": "object",
-      "properties": {
-        "report_time": {
-          "type": "string"
-        },
-        "passed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "failed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skipped": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1Trends": {
-      "type": "object",
-      "properties": {
-        "trends": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1Trend"
-          }
         }
       }
     }

--- a/components/automate-gateway/api/compliance/scanner/jobs/jobs.swagger.json
+++ b/components/automate-gateway/api/compliance/scanner/jobs/jobs.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Id"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Id"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Job"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Job"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
             }
           }
         },
@@ -108,7 +108,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Job"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
             }
           }
         ],
@@ -124,7 +124,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1RerunResponse"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.RerunResponse"
             }
           }
         },
@@ -148,7 +148,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Jobs"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Jobs"
             }
           }
         },
@@ -158,7 +158,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Query"
             }
           }
         ],
@@ -169,44 +169,7 @@
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "commonFilter": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "exclude": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "commonKv": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "v1Id": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Id": {
       "type": "object",
       "properties": {
         "id": {
@@ -214,7 +177,7 @@
         }
       }
     },
-    "v1Job": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Job": {
       "type": "object",
       "properties": {
         "id": {
@@ -233,7 +196,7 @@
         "tags": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonKv"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Kv"
           }
         },
         "start_time": {
@@ -258,7 +221,7 @@
         "results": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ResultsRow"
+            "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.ResultsRow"
           }
         },
         "nodes": {
@@ -284,7 +247,7 @@
         "node_selectors": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ManagerFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.ManagerFilter"
           }
         },
         "scheduled_time": {
@@ -307,13 +270,13 @@
         }
       }
     },
-    "v1Jobs": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Jobs": {
       "type": "object",
       "properties": {
         "jobs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Job"
+            "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
           }
         },
         "total": {
@@ -322,7 +285,7 @@
         }
       }
     },
-    "v1ManagerFilter": {
+    "chef.automate.api.compliance.scanner.jobs.v1.ManagerFilter": {
       "type": "object",
       "properties": {
         "manager_id": {
@@ -331,22 +294,22 @@
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonFilter"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Filter"
           }
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Query": {
       "type": "object",
       "properties": {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonFilter"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Filter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -361,10 +324,18 @@
         }
       }
     },
-    "v1RerunResponse": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.compliance.scanner.jobs.v1.RerunResponse": {
       "type": "object"
     },
-    "v1ResultsRow": {
+    "chef.automate.api.compliance.scanner.jobs.v1.ResultsRow": {
       "type": "object",
       "properties": {
         "node_id": {
@@ -389,6 +360,35 @@
         "end_time": {
           "type": "string",
           "format": "date-time"
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Filter": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "exclude": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Kv": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
         }
       }
     }

--- a/components/automate-gateway/api/compliance_profiles_profiles.pb.swagger.go
+++ b/components/automate-gateway/api/compliance_profiles_profiles.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Profile"
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profile"
             }
           }
         },
@@ -61,7 +61,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Profile"
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profile"
             }
           }
         },
@@ -97,7 +97,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Profiles"
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profiles"
             }
           }
         },
@@ -107,7 +107,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Query"
             }
           }
         ],
@@ -154,63 +154,18 @@ func init() {
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "protobufAny": {
-      "type": "object",
-      "properties": {
-        "type_url": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string",
-          "format": "byte"
-        }
-      }
-    },
-    "runtimeStreamError": {
-      "type": "object",
-      "properties": {
-        "grpc_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "http_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
-          "type": "string"
-        },
-        "http_status": {
-          "type": "string"
-        },
-        "details": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/protobufAny"
-          }
-        }
-      }
-    },
-    "v1Attribute": {
+    "chef.automate.api.compliance.profiles.v1.Attribute": {
       "type": "object",
       "properties": {
         "name": {
           "type": "string"
         },
         "options": {
-          "$ref": "#/definitions/v1Option"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Option"
         }
       }
     },
-    "v1CheckMessage": {
+    "chef.automate.api.compliance.profiles.v1.CheckMessage": {
       "type": "object",
       "properties": {
         "file": {
@@ -232,27 +187,27 @@ func init() {
         }
       }
     },
-    "v1CheckResult": {
+    "chef.automate.api.compliance.profiles.v1.CheckResult": {
       "type": "object",
       "properties": {
         "summary": {
-          "$ref": "#/definitions/v1ResultSummary"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.ResultSummary"
         },
         "errors": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1CheckMessage"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.CheckMessage"
           }
         },
         "warnings": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1CheckMessage"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.CheckMessage"
           }
         }
       }
     },
-    "v1Chunk": {
+    "chef.automate.api.compliance.profiles.v1.Chunk": {
       "type": "object",
       "properties": {
         "data": {
@@ -265,7 +220,7 @@ func init() {
         }
       }
     },
-    "v1Control": {
+    "chef.automate.api.compliance.profiles.v1.Control": {
       "type": "object",
       "properties": {
         "id": {
@@ -285,18 +240,18 @@ func init() {
           "type": "string"
         },
         "source_location": {
-          "$ref": "#/definitions/v1SourceLocation"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.SourceLocation"
         },
         "results": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Result"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Result"
           }
         },
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Ref"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Ref"
           }
         },
         "tags": {
@@ -307,7 +262,7 @@ func init() {
         }
       }
     },
-    "v1Dependency": {
+    "chef.automate.api.compliance.profiles.v1.Dependency": {
       "type": "object",
       "properties": {
         "name": {
@@ -345,7 +300,7 @@ func init() {
         }
       }
     },
-    "v1Group": {
+    "chef.automate.api.compliance.profiles.v1.Group": {
       "type": "object",
       "properties": {
         "id": {
@@ -362,7 +317,7 @@ func init() {
         }
       }
     },
-    "v1ListFilter": {
+    "chef.automate.api.compliance.profiles.v1.ListFilter": {
       "type": "object",
       "properties": {
         "values": {
@@ -376,7 +331,7 @@ func init() {
         }
       }
     },
-    "v1Metadata": {
+    "chef.automate.api.compliance.profiles.v1.Metadata": {
       "type": "object",
       "properties": {
         "name": {
@@ -390,7 +345,7 @@ func init() {
         }
       }
     },
-    "v1Option": {
+    "chef.automate.api.compliance.profiles.v1.Option": {
       "type": "object",
       "properties": {
         "description": {
@@ -401,7 +356,7 @@ func init() {
         }
       }
     },
-    "v1Profile": {
+    "chef.automate.api.compliance.profiles.v1.Profile": {
       "type": "object",
       "properties": {
         "name": {
@@ -434,13 +389,13 @@ func init() {
         "supports": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Support"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Support"
           }
         },
         "depends": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Dependency"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Dependency"
           }
         },
         "sha256": {
@@ -449,19 +404,19 @@ func init() {
         "groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Group"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Group"
           }
         },
         "controls": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Control"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Control"
           }
         },
         "attributes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Attribute"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Attribute"
           }
         },
         "latest_version": {
@@ -469,7 +424,7 @@ func init() {
         }
       }
     },
-    "v1ProfileData": {
+    "chef.automate.api.compliance.profiles.v1.ProfileData": {
       "type": "object",
       "properties": {
         "owner": {
@@ -487,13 +442,13 @@ func init() {
         }
       }
     },
-    "v1Profiles": {
+    "chef.automate.api.compliance.profiles.v1.Profiles": {
       "type": "object",
       "properties": {
         "profiles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Profile"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profile"
           }
         },
         "total": {
@@ -502,17 +457,17 @@ func init() {
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.compliance.profiles.v1.Query": {
       "type": "object",
       "properties": {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ListFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.ListFilter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -536,7 +491,15 @@ func init() {
         }
       }
     },
-    "v1Ref": {
+    "chef.automate.api.compliance.profiles.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.compliance.profiles.v1.Ref": {
       "type": "object",
       "properties": {
         "url": {
@@ -547,7 +510,7 @@ func init() {
         }
       }
     },
-    "v1Result": {
+    "chef.automate.api.compliance.profiles.v1.Result": {
       "type": "object",
       "properties": {
         "status": {
@@ -571,7 +534,7 @@ func init() {
         }
       }
     },
-    "v1ResultSummary": {
+    "chef.automate.api.compliance.profiles.v1.ResultSummary": {
       "type": "object",
       "properties": {
         "valid": {
@@ -590,7 +553,7 @@ func init() {
         }
       }
     },
-    "v1SourceLocation": {
+    "chef.automate.api.compliance.profiles.v1.SourceLocation": {
       "type": "object",
       "properties": {
         "ref": {
@@ -602,7 +565,7 @@ func init() {
         }
       }
     },
-    "v1Support": {
+    "chef.automate.api.compliance.profiles.v1.Support": {
       "type": "object",
       "properties": {
         "os_name": {
@@ -621,20 +584,57 @@ func init() {
           "type": "string"
         }
       }
+    },
+    "google.protobuf.Any": {
+      "type": "object",
+      "properties": {
+        "type_url": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "grpc.gateway.runtime.StreamError": {
+      "type": "object",
+      "properties": {
+        "grpc_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "http_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "http_status": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/google.protobuf.Any"
+          }
+        }
+      }
     }
   },
   "x-stream-definitions": {
-    "v1ProfileData": {
+    "chef.automate.api.compliance.profiles.v1.ProfileData": {
       "type": "object",
       "properties": {
         "result": {
-          "$ref": "#/definitions/v1ProfileData"
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.ProfileData"
         },
         "error": {
-          "$ref": "#/definitions/runtimeStreamError"
+          "$ref": "#/definitions/grpc.gateway.runtime.StreamError"
         }
       },
-      "title": "Stream result of v1ProfileData"
+      "title": "Stream result of chef.automate.api.compliance.profiles.v1.ProfileData"
     }
   }
 }

--- a/components/automate-gateway/api/compliance_reporting_reporting.pb.swagger.go
+++ b/components/automate-gateway/api/compliance_reporting_reporting.pb.swagger.go
@@ -27,7 +27,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ControlItems"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlItems"
             }
           }
         },
@@ -37,7 +37,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1ControlItemRequest"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlItemRequest"
             }
           }
         ],
@@ -55,7 +55,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Node"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Node"
             }
           }
         },
@@ -82,7 +82,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Nodes"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Nodes"
             }
           }
         },
@@ -92,7 +92,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -110,7 +110,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ProfileMins"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMins"
             }
           }
         },
@@ -120,7 +120,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -138,7 +138,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ReportIds"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ReportIds"
             }
           }
         },
@@ -148,7 +148,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -166,7 +166,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Reports"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Reports"
             }
           }
         },
@@ -176,7 +176,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -194,7 +194,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Report"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Report"
             }
           }
         },
@@ -211,7 +211,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
             }
           }
         ],
@@ -229,7 +229,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Suggestions"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Suggestions"
             }
           }
         },
@@ -239,7 +239,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1SuggestionRequest"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.SuggestionRequest"
             }
           }
         ],
@@ -255,7 +255,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/versionVersionInfo"
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           }
         },
@@ -266,56 +266,24 @@ func init() {
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC",
-      "title": "The two allowed values for ordering results"
-    },
-    "protobufAny": {
+    "chef.automate.api.common.version.VersionInfo": {
       "type": "object",
       "properties": {
-        "type_url": {
-          "type": "string",
-          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n` + "`" + `path/google.protobuf.Duration` + "`" + `). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme ` + "`" + `http` + "`" + `, ` + "`" + `https` + "`" + `, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, ` + "`" + `https` + "`" + ` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than ` + "`" + `http` + "`" + `, ` + "`" + `https` + "`" + ` (or the empty scheme) might be\nused with implementation specific semantics."
-        },
-        "value": {
-          "type": "string",
-          "format": "byte",
-          "description": "Must be a valid serialized protocol buffer of the above specified type."
-        }
-      },
-      "description": "` + "`" + `Any` + "`" + ` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := ptypes.MarshalAny(foo)\n     ...\n     foo := \u0026pb.Foo{}\n     if err := ptypes.UnmarshalAny(any, foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an ` + "`" + `Any` + "`" + ` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field ` + "`" + `@type` + "`" + ` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n` + "`" + `value` + "`" + ` which holds the custom JSON in addition to the ` + "`" + `@type` + "`" + `\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
-    },
-    "runtimeStreamError": {
-      "type": "object",
-      "properties": {
-        "grpc_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "http_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
+        "name": {
           "type": "string"
         },
-        "http_status": {
+        "version": {
           "type": "string"
         },
-        "details": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/protobufAny"
-          }
+        "sha": {
+          "type": "string"
+        },
+        "built": {
+          "type": "string"
         }
       }
     },
-    "v1Attribute": {
+    "chef.automate.api.compliance.reporting.v1.Attribute": {
       "type": "object",
       "properties": {
         "name": {
@@ -323,12 +291,12 @@ func init() {
           "title": "The name of the attribute"
         },
         "options": {
-          "$ref": "#/definitions/v1Option",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Option",
           "title": "The options defined for the attribute"
         }
       }
     },
-    "v1Control": {
+    "chef.automate.api.compliance.reporting.v1.Control": {
       "type": "object",
       "properties": {
         "id": {
@@ -353,20 +321,20 @@ func init() {
           "title": "The compact description of the control"
         },
         "source_location": {
-          "$ref": "#/definitions/v1SourceLocation",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.SourceLocation",
           "title": "Intentionally blank"
         },
         "results": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Result"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Result"
           },
           "title": "The results of running all tests defined in the control against the node"
         },
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Ref"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Ref"
           },
           "title": "External supporting documents for the control"
         },
@@ -379,7 +347,7 @@ func init() {
         }
       }
     },
-    "v1ControlItem": {
+    "chef.automate.api.compliance.reporting.v1.ControlItem": {
       "type": "object",
       "properties": {
         "id": {
@@ -391,7 +359,7 @@ func init() {
           "title": "The compact description of the control"
         },
         "profile": {
-          "$ref": "#/definitions/v1ProfileMin",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMin",
           "title": "Intentionally blank"
         },
         "impact": {
@@ -405,12 +373,12 @@ func init() {
           "title": "The time the report using the control was submitted at"
         },
         "control_summary": {
-          "$ref": "#/definitions/v1ControlSummary",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary",
           "title": "Intentionally blank"
         }
       }
     },
-    "v1ControlItemRequest": {
+    "chef.automate.api.compliance.reporting.v1.ControlItemRequest": {
       "type": "object",
       "properties": {
         "text": {
@@ -425,25 +393,25 @@ func init() {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ListFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ListFilter"
           },
           "title": "The criteria used to filter the controls returned"
         }
       }
     },
-    "v1ControlItems": {
+    "chef.automate.api.compliance.reporting.v1.ControlItems": {
       "type": "object",
       "properties": {
         "control_items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ControlItem"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlItem"
           },
           "title": "The paginated results of controls matching the filters"
         }
       }
     },
-    "v1ControlSummary": {
+    "chef.automate.api.compliance.reporting.v1.ControlSummary": {
       "type": "object",
       "properties": {
         "total": {
@@ -452,21 +420,21 @@ func init() {
           "title": "The total number of controls"
         },
         "passed": {
-          "$ref": "#/definitions/v1Total",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Total",
           "title": "Intentionally blank"
         },
         "skipped": {
-          "$ref": "#/definitions/v1Total",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Total",
           "title": "Intentionally blank"
         },
         "failed": {
-          "$ref": "#/definitions/v1Failed",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Failed",
           "title": "Intentionally blank"
         }
       },
       "title": "A minimal represenation of the statuses of the controls"
     },
-    "v1Dependency": {
+    "chef.automate.api.compliance.reporting.v1.Dependency": {
       "type": "object",
       "properties": {
         "name": {
@@ -523,7 +491,7 @@ func init() {
         }
       }
     },
-    "v1ExportData": {
+    "chef.automate.api.compliance.reporting.v1.ExportData": {
       "type": "object",
       "properties": {
         "content": {
@@ -533,7 +501,7 @@ func init() {
         }
       }
     },
-    "v1Failed": {
+    "chef.automate.api.compliance.reporting.v1.Failed": {
       "type": "object",
       "properties": {
         "total": {
@@ -559,7 +527,7 @@ func init() {
       },
       "title": "Stats of failed controls"
     },
-    "v1Group": {
+    "chef.automate.api.compliance.reporting.v1.Group": {
       "type": "object",
       "properties": {
         "id": {
@@ -579,7 +547,7 @@ func init() {
         }
       }
     },
-    "v1Kv": {
+    "chef.automate.api.compliance.reporting.v1.Kv": {
       "type": "object",
       "properties": {
         "key": {
@@ -592,7 +560,7 @@ func init() {
         }
       }
     },
-    "v1LatestReportSummary": {
+    "chef.automate.api.compliance.reporting.v1.LatestReportSummary": {
       "type": "object",
       "properties": {
         "id": {
@@ -609,13 +577,13 @@ func init() {
           "title": "The status of the run the report was made from"
         },
         "controls": {
-          "$ref": "#/definitions/v1ControlSummary",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary",
           "title": "Intentionally blank"
         }
       },
       "title": "A summary of the information contained in the latest report for this node"
     },
-    "v1ListFilter": {
+    "chef.automate.api.compliance.reporting.v1.ListFilter": {
       "type": "object",
       "properties": {
         "values": {
@@ -631,7 +599,7 @@ func init() {
         }
       }
     },
-    "v1Node": {
+    "chef.automate.api.compliance.reporting.v1.Node": {
       "type": "object",
       "properties": {
         "id": {
@@ -643,7 +611,7 @@ func init() {
           "title": "The name assigned to the node"
         },
         "platform": {
-          "$ref": "#/definitions/v1Platform",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Platform",
           "title": "Intentionally blank"
         },
         "environment": {
@@ -651,32 +619,32 @@ func init() {
           "title": "The environment assigned to the node"
         },
         "latest_report": {
-          "$ref": "#/definitions/v1LatestReportSummary",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.LatestReportSummary",
           "title": "A summary of the information contained in the latest report for this node"
         },
         "tags": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Kv"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Kv"
           },
           "title": "The tags assigned to this node"
         },
         "profiles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ProfileMeta"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMeta"
           },
           "title": "A minimal represenation of the compliance profiles run against the node"
         }
       }
     },
-    "v1Nodes": {
+    "chef.automate.api.compliance.reporting.v1.Nodes": {
       "type": "object",
       "properties": {
         "nodes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Node"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Node"
           },
           "title": "The nodes matching the request filters"
         },
@@ -702,7 +670,7 @@ func init() {
         }
       }
     },
-    "v1Option": {
+    "chef.automate.api.compliance.reporting.v1.Option": {
       "type": "object",
       "properties": {
         "description": {
@@ -715,7 +683,7 @@ func init() {
         }
       }
     },
-    "v1Platform": {
+    "chef.automate.api.compliance.reporting.v1.Platform": {
       "type": "object",
       "properties": {
         "name": {
@@ -733,7 +701,7 @@ func init() {
       },
       "title": "The name and version of the node's operating system"
     },
-    "v1Profile": {
+    "chef.automate.api.compliance.reporting.v1.Profile": {
       "type": "object",
       "properties": {
         "name": {
@@ -779,14 +747,14 @@ func init() {
         "supports": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Support"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Support"
           },
           "title": "The supported platform targets"
         },
         "depends": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Dependency"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Dependency"
           },
           "title": "Other profiles that this profile depends on"
         },
@@ -797,21 +765,21 @@ func init() {
         "groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Group"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Group"
           },
           "title": "The groups of controls defined in the profile"
         },
         "controls": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Control"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Control"
           },
           "title": "The controls defined on the profile"
         },
         "attributes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Attribute"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Attribute"
           },
           "title": "The attributes defined on the profile"
         },
@@ -829,7 +797,7 @@ func init() {
         }
       }
     },
-    "v1ProfileCounts": {
+    "chef.automate.api.compliance.reporting.v1.ProfileCounts": {
       "type": "object",
       "properties": {
         "total": {
@@ -855,7 +823,7 @@ func init() {
       },
       "title": "Stats on the statuses of nodes matching the filters"
     },
-    "v1ProfileMeta": {
+    "chef.automate.api.compliance.reporting.v1.ProfileMeta": {
       "type": "object",
       "properties": {
         "name": {
@@ -880,7 +848,7 @@ func init() {
         }
       }
     },
-    "v1ProfileMin": {
+    "chef.automate.api.compliance.reporting.v1.ProfileMin": {
       "type": "object",
       "properties": {
         "name": {
@@ -906,23 +874,23 @@ func init() {
       },
       "title": "Minimal represenation of a profile"
     },
-    "v1ProfileMins": {
+    "chef.automate.api.compliance.reporting.v1.ProfileMins": {
       "type": "object",
       "properties": {
         "profiles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ProfileMin"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMin"
           },
           "title": "Minimal represenations of the profiles matching the filters"
         },
         "counts": {
-          "$ref": "#/definitions/v1ProfileCounts",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileCounts",
           "title": "Intentionally blank"
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.compliance.reporting.v1.Query": {
       "type": "object",
       "properties": {
         "id": {
@@ -936,12 +904,12 @@ func init() {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ListFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ListFilter"
           },
           "title": "The list of filters used to narrow down the list"
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query.OrderType",
           "title": "Whether to sort in ascending or descending order"
         },
         "sort": {
@@ -960,7 +928,16 @@ func init() {
         }
       }
     },
-    "v1Ref": {
+    "chef.automate.api.compliance.reporting.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC",
+      "title": "The two allowed values for ordering results"
+    },
+    "chef.automate.api.compliance.reporting.v1.Ref": {
       "type": "object",
       "properties": {
         "url": {
@@ -973,7 +950,7 @@ func init() {
         }
       }
     },
-    "v1Report": {
+    "chef.automate.api.compliance.reporting.v1.Report": {
       "type": "object",
       "properties": {
         "id": {
@@ -998,7 +975,7 @@ func init() {
           "title": "The status of the run the report was made from"
         },
         "controls": {
-          "$ref": "#/definitions/v1ControlSummary",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary",
           "title": "Intentionally blank"
         },
         "environment": {
@@ -1010,17 +987,17 @@ func init() {
           "title": "The version of the report"
         },
         "platform": {
-          "$ref": "#/definitions/v1Platform",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Platform",
           "title": "Intentionally blank"
         },
         "statistics": {
-          "$ref": "#/definitions/v1Statistics",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Statistics",
           "title": "Intentionally blank"
         },
         "profiles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Profile"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Profile"
           },
           "title": "The profiles run as part of this report"
         },
@@ -1038,7 +1015,7 @@ func init() {
         }
       }
     },
-    "v1ReportIds": {
+    "chef.automate.api.compliance.reporting.v1.ReportIds": {
       "type": "object",
       "properties": {
         "ids": {
@@ -1050,13 +1027,13 @@ func init() {
         }
       }
     },
-    "v1Reports": {
+    "chef.automate.api.compliance.reporting.v1.Reports": {
       "type": "object",
       "properties": {
         "reports": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Report"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Report"
           },
           "title": "The paginated results of reports matching the filters"
         },
@@ -1067,7 +1044,7 @@ func init() {
         }
       }
     },
-    "v1Result": {
+    "chef.automate.api.compliance.reporting.v1.Result": {
       "type": "object",
       "properties": {
         "status": {
@@ -1097,7 +1074,7 @@ func init() {
         }
       }
     },
-    "v1SourceLocation": {
+    "chef.automate.api.compliance.reporting.v1.SourceLocation": {
       "type": "object",
       "properties": {
         "ref": {
@@ -1111,7 +1088,7 @@ func init() {
         }
       }
     },
-    "v1Statistics": {
+    "chef.automate.api.compliance.reporting.v1.Statistics": {
       "type": "object",
       "properties": {
         "duration": {
@@ -1122,7 +1099,7 @@ func init() {
       },
       "title": "Statistics of the report's run"
     },
-    "v1Suggestion": {
+    "chef.automate.api.compliance.reporting.v1.Suggestion": {
       "type": "object",
       "properties": {
         "text": {
@@ -1144,7 +1121,7 @@ func init() {
         }
       }
     },
-    "v1SuggestionRequest": {
+    "chef.automate.api.compliance.reporting.v1.SuggestionRequest": {
       "type": "object",
       "properties": {
         "type": {
@@ -1163,25 +1140,25 @@ func init() {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ListFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ListFilter"
           },
           "title": "The criteria used to filter the suggestions returned"
         }
       }
     },
-    "v1Suggestions": {
+    "chef.automate.api.compliance.reporting.v1.Suggestions": {
       "type": "object",
       "properties": {
         "suggestions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Suggestion"
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Suggestion"
           },
           "title": "The list of returned suggestions"
         }
       }
     },
-    "v1Support": {
+    "chef.automate.api.compliance.reporting.v1.Support": {
       "type": "object",
       "properties": {
         "os_name": {
@@ -1206,7 +1183,7 @@ func init() {
         }
       }
     },
-    "v1Total": {
+    "chef.automate.api.compliance.reporting.v1.Total": {
       "type": "object",
       "properties": {
         "total": {
@@ -1217,36 +1194,59 @@ func init() {
       },
       "title": "A subtotal of controls"
     },
-    "versionVersionInfo": {
+    "google.protobuf.Any": {
       "type": "object",
       "properties": {
-        "name": {
+        "type_url": {
+          "type": "string",
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n` + "`" + `path/google.protobuf.Duration` + "`" + `). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme ` + "`" + `http` + "`" + `, ` + "`" + `https` + "`" + `, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, ` + "`" + `https` + "`" + ` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than ` + "`" + `http` + "`" + `, ` + "`" + `https` + "`" + ` (or the empty scheme) might be\nused with implementation specific semantics."
+        },
+        "value": {
+          "type": "string",
+          "format": "byte",
+          "description": "Must be a valid serialized protocol buffer of the above specified type."
+        }
+      },
+      "description": "` + "`" + `Any` + "`" + ` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := ptypes.MarshalAny(foo)\n     ...\n     foo := \u0026pb.Foo{}\n     if err := ptypes.UnmarshalAny(any, foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an ` + "`" + `Any` + "`" + ` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field ` + "`" + `@type` + "`" + ` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n` + "`" + `value` + "`" + ` which holds the custom JSON in addition to the ` + "`" + `@type` + "`" + `\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+    },
+    "grpc.gateway.runtime.StreamError": {
+      "type": "object",
+      "properties": {
+        "grpc_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "http_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
           "type": "string"
         },
-        "version": {
+        "http_status": {
           "type": "string"
         },
-        "sha": {
-          "type": "string"
-        },
-        "built": {
-          "type": "string"
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/google.protobuf.Any"
+          }
         }
       }
     }
   },
   "x-stream-definitions": {
-    "v1ExportData": {
+    "chef.automate.api.compliance.reporting.v1.ExportData": {
       "type": "object",
       "properties": {
         "result": {
-          "$ref": "#/definitions/v1ExportData"
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ExportData"
         },
         "error": {
-          "$ref": "#/definitions/runtimeStreamError"
+          "$ref": "#/definitions/grpc.gateway.runtime.StreamError"
         }
       },
-      "title": "Stream result of v1ExportData"
+      "title": "Stream result of chef.automate.api.compliance.reporting.v1.ExportData"
     }
   }
 }

--- a/components/automate-gateway/api/compliance_reporting_stats_stats.pb.swagger.go
+++ b/components/automate-gateway/api/compliance_reporting_stats_stats.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Failures"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Failures"
             }
           }
         },
@@ -35,7 +35,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
             }
           }
         ],
@@ -52,7 +52,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Profile"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Profile"
             }
           }
         },
@@ -62,7 +62,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
             }
           }
         ],
@@ -79,7 +79,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Summary"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Summary"
             }
           }
         },
@@ -89,7 +89,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
             }
           }
         ],
@@ -106,7 +106,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Trends"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Trends"
             }
           }
         },
@@ -116,7 +116,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/reportingstatsv1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
             }
           }
         ],
@@ -127,114 +127,7 @@ func init() {
     }
   },
   "definitions": {
-    "reportingstatsv1ListFilter": {
-      "type": "object",
-      "properties": {
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "type": {
-          "type": "string"
-        }
-      }
-    },
-    "reportingstatsv1Profile": {
-      "type": "object",
-      "properties": {
-        "profile_list": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1ProfileList"
-          }
-        },
-        "profile_summary": {
-          "$ref": "#/definitions/v1ProfileSummary"
-        },
-        "control_stats": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1ControlStats"
-          }
-        }
-      }
-    },
-    "reportingstatsv1Query": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "size": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "interval": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "filters": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/reportingstatsv1ListFilter"
-          }
-        },
-        "order": {
-          "$ref": "#/definitions/reportingstatsv1QueryOrderType"
-        },
-        "sort": {
-          "type": "string"
-        },
-        "page": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "per_page": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "reportingstatsv1QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "reportingstatsv1Support": {
-      "type": "object",
-      "properties": {
-        "os_name": {
-          "type": "string"
-        },
-        "os_family": {
-          "type": "string"
-        },
-        "release": {
-          "type": "string"
-        },
-        "inspec_version": {
-          "type": "string"
-        },
-        "platform_name": {
-          "type": "string"
-        },
-        "platform_family": {
-          "type": "string"
-        },
-        "platform": {
-          "type": "string"
-        }
-      }
-    },
-    "v1ControlStats": {
+    "chef.automate.api.compliance.reporting.stats.v1.ControlStats": {
       "type": "object",
       "properties": {
         "control": {
@@ -261,7 +154,7 @@ func init() {
         }
       }
     },
-    "v1ControlsSummary": {
+    "chef.automate.api.compliance.reporting.stats.v1.ControlsSummary": {
       "type": "object",
       "properties": {
         "failures": {
@@ -290,7 +183,387 @@ func init() {
         }
       }
     },
-    "v1Dependency": {
+    "chef.automate.api.compliance.reporting.stats.v1.FailureSummary": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "failures": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "id": {
+          "type": "string"
+        },
+        "profile": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Failures": {
+      "type": "object",
+      "properties": {
+        "profiles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        },
+        "platforms": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        },
+        "controls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ListFilter": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.NodeSummary": {
+      "type": "object",
+      "properties": {
+        "compliant": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "noncompliant": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "high_risk": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "medium_risk": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "low_risk": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Profile": {
+      "type": "object",
+      "properties": {
+        "profile_list": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ProfileList"
+          }
+        },
+        "profile_summary": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ProfileSummary"
+        },
+        "control_stats": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ControlStats"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ProfileList": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "failures": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "majors": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "minors": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "criticals": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "passed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ProfileSummary": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "license": {
+          "type": "string"
+        },
+        "maintainer": {
+          "type": "string"
+        },
+        "copyright": {
+          "type": "string"
+        },
+        "copyright_email": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "supports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Support"
+          }
+        },
+        "stats": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ProfileSummaryStats"
+        },
+        "depends": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Dependency"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ProfileSummaryStats": {
+      "type": "object",
+      "properties": {
+        "failed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "passed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "failed_nodes": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_nodes": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Query": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "interval": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ListFilter"
+          }
+        },
+        "order": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query.OrderType"
+        },
+        "sort": {
+          "type": "string"
+        },
+        "page": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "per_page": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ReportSummary": {
+      "type": "object",
+      "properties": {
+        "stats": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Stats"
+        },
+        "status": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "number",
+          "format": "double"
+        },
+        "start_date": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Stats": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "string",
+          "format": "int64",
+          "title": "int64 types render into string types when serialized to satisfy all browsers\nwe don't really need for nodes counts to be int64 as int32 limits us to 2billion nodes which is plenty for now\nwe are therefore deprecating nodes and favor nodesCnt"
+        },
+        "platforms": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "environments": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "profiles": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "nodes_cnt": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "controls": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Summary": {
+      "type": "object",
+      "properties": {
+        "controls_summary": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ControlsSummary"
+        },
+        "node_summary": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.NodeSummary"
+        },
+        "report_summary": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ReportSummary"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Support": {
+      "type": "object",
+      "properties": {
+        "os_name": {
+          "type": "string"
+        },
+        "os_family": {
+          "type": "string"
+        },
+        "release": {
+          "type": "string"
+        },
+        "inspec_version": {
+          "type": "string"
+        },
+        "platform_name": {
+          "type": "string"
+        },
+        "platform_family": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Trend": {
+      "type": "object",
+      "properties": {
+        "report_time": {
+          "type": "string"
+        },
+        "passed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "failed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Trends": {
+      "type": "object",
+      "properties": {
+        "trends": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Trend"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Dependency": {
       "type": "object",
       "properties": {
         "name": {
@@ -344,279 +617,6 @@ func init() {
         "skip_message": {
           "type": "string",
           "title": "The reason this profile was skipped in the generated report, if any"
-        }
-      }
-    },
-    "v1FailureSummary": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "failures": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "id": {
-          "type": "string"
-        },
-        "profile": {
-          "type": "string"
-        }
-      }
-    },
-    "v1Failures": {
-      "type": "object",
-      "properties": {
-        "profiles": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1FailureSummary"
-          }
-        },
-        "platforms": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1FailureSummary"
-          }
-        },
-        "controls": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1FailureSummary"
-          }
-        },
-        "environments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1FailureSummary"
-          }
-        }
-      }
-    },
-    "v1NodeSummary": {
-      "type": "object",
-      "properties": {
-        "compliant": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skipped": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "noncompliant": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "high_risk": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "medium_risk": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "low_risk": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1ProfileList": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "id": {
-          "type": "string"
-        },
-        "failures": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "majors": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "minors": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "criticals": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "passed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skipped": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1ProfileSummary": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "version": {
-          "type": "string"
-        },
-        "license": {
-          "type": "string"
-        },
-        "maintainer": {
-          "type": "string"
-        },
-        "copyright": {
-          "type": "string"
-        },
-        "copyright_email": {
-          "type": "string"
-        },
-        "summary": {
-          "type": "string"
-        },
-        "supports": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/reportingstatsv1Support"
-          }
-        },
-        "stats": {
-          "$ref": "#/definitions/v1ProfileSummaryStats"
-        },
-        "depends": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1Dependency"
-          }
-        }
-      }
-    },
-    "v1ProfileSummaryStats": {
-      "type": "object",
-      "properties": {
-        "failed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "passed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skipped": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "failed_nodes": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "total_nodes": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1ReportSummary": {
-      "type": "object",
-      "properties": {
-        "stats": {
-          "$ref": "#/definitions/v1Stats"
-        },
-        "status": {
-          "type": "string"
-        },
-        "duration": {
-          "type": "number",
-          "format": "double"
-        },
-        "start_date": {
-          "type": "string"
-        }
-      }
-    },
-    "v1Stats": {
-      "type": "object",
-      "properties": {
-        "nodes": {
-          "type": "string",
-          "format": "int64",
-          "title": "int64 types render into string types when serialized to satisfy all browsers\nwe don't really need for nodes counts to be int64 as int32 limits us to 2billion nodes which is plenty for now\nwe are therefore deprecating nodes and favor nodesCnt"
-        },
-        "platforms": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "environments": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "profiles": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "nodes_cnt": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "controls": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1Summary": {
-      "type": "object",
-      "properties": {
-        "controls_summary": {
-          "$ref": "#/definitions/v1ControlsSummary"
-        },
-        "node_summary": {
-          "$ref": "#/definitions/v1NodeSummary"
-        },
-        "report_summary": {
-          "$ref": "#/definitions/v1ReportSummary"
-        }
-      }
-    },
-    "v1Trend": {
-      "type": "object",
-      "properties": {
-        "report_time": {
-          "type": "string"
-        },
-        "passed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "failed": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skipped": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "v1Trends": {
-      "type": "object",
-      "properties": {
-        "trends": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1Trend"
-          }
         }
       }
     }

--- a/components/automate-gateway/api/compliance_scanner_jobs_jobs.pb.swagger.go
+++ b/components/automate-gateway/api/compliance_scanner_jobs_jobs.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Id"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Id"
             }
           }
         },
@@ -35,7 +35,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Job"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
             }
           }
         ],
@@ -51,7 +51,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Job"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
             }
           }
         },
@@ -111,7 +111,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Job"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
             }
           }
         ],
@@ -127,7 +127,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1RerunResponse"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.RerunResponse"
             }
           }
         },
@@ -151,7 +151,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Jobs"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Jobs"
             }
           }
         },
@@ -161,7 +161,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Query"
             }
           }
         ],
@@ -172,44 +172,7 @@ func init() {
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "commonFilter": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "exclude": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "commonKv": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "v1Id": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Id": {
       "type": "object",
       "properties": {
         "id": {
@@ -217,7 +180,7 @@ func init() {
         }
       }
     },
-    "v1Job": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Job": {
       "type": "object",
       "properties": {
         "id": {
@@ -236,7 +199,7 @@ func init() {
         "tags": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonKv"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Kv"
           }
         },
         "start_time": {
@@ -261,7 +224,7 @@ func init() {
         "results": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ResultsRow"
+            "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.ResultsRow"
           }
         },
         "nodes": {
@@ -287,7 +250,7 @@ func init() {
         "node_selectors": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1ManagerFilter"
+            "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.ManagerFilter"
           }
         },
         "scheduled_time": {
@@ -310,13 +273,13 @@ func init() {
         }
       }
     },
-    "v1Jobs": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Jobs": {
       "type": "object",
       "properties": {
         "jobs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Job"
+            "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
           }
         },
         "total": {
@@ -325,7 +288,7 @@ func init() {
         }
       }
     },
-    "v1ManagerFilter": {
+    "chef.automate.api.compliance.scanner.jobs.v1.ManagerFilter": {
       "type": "object",
       "properties": {
         "manager_id": {
@@ -334,22 +297,22 @@ func init() {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonFilter"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Filter"
           }
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Query": {
       "type": "object",
       "properties": {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonFilter"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Filter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -364,10 +327,18 @@ func init() {
         }
       }
     },
-    "v1RerunResponse": {
+    "chef.automate.api.compliance.scanner.jobs.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.compliance.scanner.jobs.v1.RerunResponse": {
       "type": "object"
     },
-    "v1ResultsRow": {
+    "chef.automate.api.compliance.scanner.jobs.v1.ResultsRow": {
       "type": "object",
       "properties": {
         "node_id": {
@@ -392,6 +363,35 @@ func init() {
         "end_time": {
           "type": "string",
           "format": "date-time"
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Filter": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "exclude": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Kv": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
         }
       }
     }

--- a/components/automate-gateway/api/data_feed.pb.swagger.go
+++ b/components/automate-gateway/api/data_feed.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedAddDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.AddDestinationResponse"
             }
           }
         },
@@ -35,7 +35,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/datafeedAddDestinationRequest"
+              "$ref": "#/definitions/chef.automate.api.datafeed.AddDestinationRequest"
             }
           }
         ],
@@ -51,7 +51,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedGetDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.GetDestinationResponse"
             }
           }
         },
@@ -74,7 +74,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedDeleteDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.DeleteDestinationResponse"
             }
           }
         },
@@ -97,7 +97,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedUpdateDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.UpdateDestinationResponse"
             }
           }
         },
@@ -114,7 +114,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/datafeedUpdateDestinationRequest"
+              "$ref": "#/definitions/chef.automate.api.datafeed.UpdateDestinationRequest"
             }
           }
         ],
@@ -130,7 +130,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedListDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.ListDestinationResponse"
             }
           }
         },
@@ -140,7 +140,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/datafeedListDestinationRequest"
+              "$ref": "#/definitions/chef.automate.api.datafeed.ListDestinationRequest"
             }
           }
         ],
@@ -156,7 +156,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/datafeedTestDestinationResponse"
+              "$ref": "#/definitions/chef.automate.api.datafeed.TestDestinationResponse"
             }
           }
         },
@@ -166,7 +166,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/datafeedURLValidationRequest"
+              "$ref": "#/definitions/chef.automate.api.datafeed.URLValidationRequest"
             }
           }
         ],
@@ -177,7 +177,7 @@ func init() {
     }
   },
   "definitions": {
-    "datafeedAddDestinationRequest": {
+    "chef.automate.api.datafeed.AddDestinationRequest": {
       "type": "object",
       "properties": {
         "id": {
@@ -195,7 +195,7 @@ func init() {
         }
       }
     },
-    "datafeedAddDestinationResponse": {
+    "chef.automate.api.datafeed.AddDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -204,7 +204,7 @@ func init() {
         }
       }
     },
-    "datafeedDeleteDestinationResponse": {
+    "chef.automate.api.datafeed.DeleteDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -213,7 +213,7 @@ func init() {
         }
       }
     },
-    "datafeedGetDestinationResponse": {
+    "chef.automate.api.datafeed.GetDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -235,21 +235,21 @@ func init() {
         }
       }
     },
-    "datafeedListDestinationRequest": {
+    "chef.automate.api.datafeed.ListDestinationRequest": {
       "type": "object"
     },
-    "datafeedListDestinationResponse": {
+    "chef.automate.api.datafeed.ListDestinationResponse": {
       "type": "object",
       "properties": {
         "destinations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/datafeedGetDestinationResponse"
+            "$ref": "#/definitions/chef.automate.api.datafeed.GetDestinationResponse"
           }
         }
       }
     },
-    "datafeedSecretId": {
+    "chef.automate.api.datafeed.SecretId": {
       "type": "object",
       "properties": {
         "id": {
@@ -257,7 +257,7 @@ func init() {
         }
       }
     },
-    "datafeedTestDestinationResponse": {
+    "chef.automate.api.datafeed.TestDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -266,21 +266,21 @@ func init() {
         }
       }
     },
-    "datafeedURLValidationRequest": {
+    "chef.automate.api.datafeed.URLValidationRequest": {
       "type": "object",
       "properties": {
         "url": {
           "type": "string"
         },
         "username_password": {
-          "$ref": "#/definitions/datafeedUsernamePassword"
+          "$ref": "#/definitions/chef.automate.api.datafeed.UsernamePassword"
         },
         "secret_id": {
-          "$ref": "#/definitions/datafeedSecretId"
+          "$ref": "#/definitions/chef.automate.api.datafeed.SecretId"
         }
       }
     },
-    "datafeedUpdateDestinationRequest": {
+    "chef.automate.api.datafeed.UpdateDestinationRequest": {
       "type": "object",
       "properties": {
         "id": {
@@ -298,7 +298,7 @@ func init() {
         }
       }
     },
-    "datafeedUpdateDestinationResponse": {
+    "chef.automate.api.datafeed.UpdateDestinationResponse": {
       "type": "object",
       "properties": {
         "success": {
@@ -307,7 +307,7 @@ func init() {
         }
       }
     },
-    "datafeedUsernamePassword": {
+    "chef.automate.api.datafeed.UsernamePassword": {
       "type": "object",
       "properties": {
         "username": {

--- a/components/automate-gateway/api/deployment/deployment.swagger.json
+++ b/components/automate-gateway/api/deployment/deployment.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/deploymentServiceVersionsResponse"
+              "$ref": "#/definitions/chef.automate.api.deployment.ServiceVersionsResponse"
             }
           }
         },
@@ -38,7 +38,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/deploymentVersion"
+              "$ref": "#/definitions/chef.automate.api.deployment.Version"
             }
           }
         },
@@ -49,7 +49,7 @@
     }
   },
   "definitions": {
-    "deploymentServiceVersion": {
+    "chef.automate.api.deployment.ServiceVersion": {
       "type": "object",
       "properties": {
         "name": {
@@ -66,18 +66,18 @@
         }
       }
     },
-    "deploymentServiceVersionsResponse": {
+    "chef.automate.api.deployment.ServiceVersionsResponse": {
       "type": "object",
       "properties": {
         "services": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/deploymentServiceVersion"
+            "$ref": "#/definitions/chef.automate.api.deployment.ServiceVersion"
           }
         }
       }
     },
-    "deploymentVersion": {
+    "chef.automate.api.deployment.Version": {
       "type": "object",
       "properties": {
         "build_timestamp": {

--- a/components/automate-gateway/api/deployment_deployment.pb.swagger.go
+++ b/components/automate-gateway/api/deployment_deployment.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/deploymentServiceVersionsResponse"
+              "$ref": "#/definitions/chef.automate.api.deployment.ServiceVersionsResponse"
             }
           }
         },
@@ -41,7 +41,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/deploymentVersion"
+              "$ref": "#/definitions/chef.automate.api.deployment.Version"
             }
           }
         },
@@ -52,7 +52,7 @@ func init() {
     }
   },
   "definitions": {
-    "deploymentServiceVersion": {
+    "chef.automate.api.deployment.ServiceVersion": {
       "type": "object",
       "properties": {
         "name": {
@@ -69,18 +69,18 @@ func init() {
         }
       }
     },
-    "deploymentServiceVersionsResponse": {
+    "chef.automate.api.deployment.ServiceVersionsResponse": {
       "type": "object",
       "properties": {
         "services": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/deploymentServiceVersion"
+            "$ref": "#/definitions/chef.automate.api.deployment.ServiceVersion"
           }
         }
       }
     },
-    "deploymentVersion": {
+    "chef.automate.api.deployment.Version": {
       "type": "object",
       "properties": {
         "build_timestamp": {

--- a/components/automate-gateway/api/event_feed/event_feed.swagger.json
+++ b/components/automate-gateway/api/event_feed/event_feed.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseEventCounts"
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCounts"
             }
           }
         },
@@ -64,7 +64,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseEventCounts"
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCounts"
             }
           }
         },
@@ -106,7 +106,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseEvents"
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.Events"
             }
           }
         },
@@ -182,7 +182,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/event_feedresponseEventStrings"
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.EventStrings"
             }
           }
         },
@@ -230,28 +230,7 @@
     }
   },
   "definitions": {
-    "event_feedresponseEventStrings": {
-      "type": "object",
-      "properties": {
-        "strings": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/responseEventString"
-          }
-        },
-        "start": {
-          "type": "string"
-        },
-        "end": {
-          "type": "string"
-        },
-        "hours_between": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "responseEvent": {
+    "chef.automate.api.event_feed.response.Event": {
       "type": "object",
       "properties": {
         "event_type": {
@@ -298,18 +277,18 @@
         }
       }
     },
-    "responseEventCollection": {
+    "chef.automate.api.event_feed.response.EventCollection": {
       "type": "object",
       "properties": {
         "events_count": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseEventCount"
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCount"
           }
         }
       }
     },
-    "responseEventCount": {
+    "chef.automate.api.event_feed.response.EventCount": {
       "type": "object",
       "properties": {
         "name": {
@@ -321,7 +300,7 @@
         }
       }
     },
-    "responseEventCounts": {
+    "chef.automate.api.event_feed.response.EventCounts": {
       "type": "object",
       "properties": {
         "total": {
@@ -331,18 +310,18 @@
         "counts": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseEventCount"
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCount"
           }
         }
       }
     },
-    "responseEventString": {
+    "chef.automate.api.event_feed.response.EventString": {
       "type": "object",
       "properties": {
         "collection": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseEventCollection"
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCollection"
           }
         },
         "event_action": {
@@ -350,13 +329,34 @@
         }
       }
     },
-    "responseEvents": {
+    "chef.automate.api.event_feed.response.EventStrings": {
+      "type": "object",
+      "properties": {
+        "strings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventString"
+          }
+        },
+        "start": {
+          "type": "string"
+        },
+        "end": {
+          "type": "string"
+        },
+        "hours_between": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.event_feed.response.Events": {
       "type": "object",
       "properties": {
         "events": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseEvent"
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.Event"
           }
         },
         "total_events": {

--- a/components/automate-gateway/api/event_feed_event_feed.pb.swagger.go
+++ b/components/automate-gateway/api/event_feed_event_feed.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseEventCounts"
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCounts"
             }
           }
         },
@@ -67,7 +67,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseEventCounts"
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCounts"
             }
           }
         },
@@ -109,7 +109,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseEvents"
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.Events"
             }
           }
         },
@@ -185,7 +185,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/event_feedresponseEventStrings"
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.EventStrings"
             }
           }
         },
@@ -233,28 +233,7 @@ func init() {
     }
   },
   "definitions": {
-    "event_feedresponseEventStrings": {
-      "type": "object",
-      "properties": {
-        "strings": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/responseEventString"
-          }
-        },
-        "start": {
-          "type": "string"
-        },
-        "end": {
-          "type": "string"
-        },
-        "hours_between": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "responseEvent": {
+    "chef.automate.api.event_feed.response.Event": {
       "type": "object",
       "properties": {
         "event_type": {
@@ -301,18 +280,18 @@ func init() {
         }
       }
     },
-    "responseEventCollection": {
+    "chef.automate.api.event_feed.response.EventCollection": {
       "type": "object",
       "properties": {
         "events_count": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseEventCount"
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCount"
           }
         }
       }
     },
-    "responseEventCount": {
+    "chef.automate.api.event_feed.response.EventCount": {
       "type": "object",
       "properties": {
         "name": {
@@ -324,7 +303,7 @@ func init() {
         }
       }
     },
-    "responseEventCounts": {
+    "chef.automate.api.event_feed.response.EventCounts": {
       "type": "object",
       "properties": {
         "total": {
@@ -334,18 +313,18 @@ func init() {
         "counts": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseEventCount"
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCount"
           }
         }
       }
     },
-    "responseEventString": {
+    "chef.automate.api.event_feed.response.EventString": {
       "type": "object",
       "properties": {
         "collection": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseEventCollection"
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCollection"
           }
         },
         "event_action": {
@@ -353,13 +332,34 @@ func init() {
         }
       }
     },
-    "responseEvents": {
+    "chef.automate.api.event_feed.response.EventStrings": {
+      "type": "object",
+      "properties": {
+        "strings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventString"
+          }
+        },
+        "start": {
+          "type": "string"
+        },
+        "end": {
+          "type": "string"
+        },
+        "hours_between": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.event_feed.response.Events": {
       "type": "object",
       "properties": {
         "events": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseEvent"
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.Event"
           }
         },
         "total_events": {

--- a/components/automate-gateway/api/gateway/gateway.swagger.json
+++ b/components/automate-gateway/api/gateway/gateway.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiHealth"
+              "$ref": "#/definitions/chef.automate.api.Health"
             }
           }
         },
@@ -38,7 +38,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiVersion"
+              "$ref": "#/definitions/chef.automate.api.Version"
             }
           }
         },
@@ -49,7 +49,7 @@
     }
   },
   "definitions": {
-    "apiHealth": {
+    "chef.automate.api.Health": {
       "type": "object",
       "properties": {
         "status": {
@@ -59,7 +59,7 @@
       "description": "The automate-gateway service health is constructed with:\n* Status:\n           =\u003e ok:             Everything is alright\n           =\u003e initialization: The service is in its initialization process\n           =\u003e warning:        Something might be wrong?\n           =\u003e critical:       Something is wrong!\n\n@afiune: Here we can add more health information to the response",
       "title": "Health message"
     },
-    "apiVersion": {
+    "chef.automate.api.Version": {
       "type": "object",
       "properties": {
         "version": {

--- a/components/automate-gateway/api/gateway_gateway.pb.swagger.go
+++ b/components/automate-gateway/api/gateway_gateway.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiHealth"
+              "$ref": "#/definitions/chef.automate.api.Health"
             }
           }
         },
@@ -41,7 +41,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiVersion"
+              "$ref": "#/definitions/chef.automate.api.Version"
             }
           }
         },
@@ -52,7 +52,7 @@ func init() {
     }
   },
   "definitions": {
-    "apiHealth": {
+    "chef.automate.api.Health": {
       "type": "object",
       "properties": {
         "status": {
@@ -62,7 +62,7 @@ func init() {
       "description": "The automate-gateway service health is constructed with:\n* Status:\n           =\u003e ok:             Everything is alright\n           =\u003e initialization: The service is in its initialization process\n           =\u003e warning:        Something might be wrong?\n           =\u003e critical:       Something is wrong!\n\n@afiune: Here we can add more health information to the response",
       "title": "Health message"
     },
-    "apiVersion": {
+    "chef.automate.api.Version": {
       "type": "object",
       "properties": {
         "version": {

--- a/components/automate-gateway/api/iam/v2beta/policy.swagger.json
+++ b/components/automate-gateway/api/iam/v2beta/policy.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListProjectsResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListProjectsResp"
             }
           }
         },
@@ -38,7 +38,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListPoliciesResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListPoliciesResp"
             }
           }
         },
@@ -52,7 +52,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreatePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreatePolicyResp"
             }
           }
         },
@@ -62,7 +62,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreatePolicyReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreatePolicyReq"
             }
           }
         ],
@@ -78,7 +78,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetPolicyResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetPolicyResp"
             }
           }
         },
@@ -100,7 +100,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeletePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeletePolicyResp"
             }
           }
         },
@@ -122,7 +122,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdatePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdatePolicyResp"
             }
           }
         },
@@ -138,7 +138,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdatePolicyReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdatePolicyReq"
             }
           }
         ],
@@ -154,7 +154,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListPolicyMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListPolicyMembersResp"
             }
           }
         },
@@ -176,7 +176,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaReplacePolicyMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ReplacePolicyMembersResp"
             }
           }
         },
@@ -192,7 +192,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaReplacePolicyMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ReplacePolicyMembersReq"
             }
           }
         ],
@@ -208,7 +208,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaAddPolicyMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.AddPolicyMembersResp"
             }
           }
         },
@@ -224,7 +224,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaAddPolicyMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.AddPolicyMembersReq"
             }
           }
         ],
@@ -240,7 +240,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaRemovePolicyMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.RemovePolicyMembersResp"
             }
           }
         },
@@ -256,7 +256,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaRemovePolicyMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.RemovePolicyMembersReq"
             }
           }
         ],
@@ -272,7 +272,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetPolicyVersionResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetPolicyVersionResp"
             }
           }
         },
@@ -288,7 +288,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListProjectsResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListProjectsResp"
             }
           }
         },
@@ -302,7 +302,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateProjectResp"
             }
           }
         },
@@ -312,7 +312,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateProjectReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateProjectReq"
             }
           }
         ],
@@ -328,7 +328,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetProjectResp"
             }
           }
         },
@@ -350,7 +350,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteProjectResp"
             }
           }
         },
@@ -372,7 +372,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateProjectResp"
             }
           }
         },
@@ -388,7 +388,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateProjectReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateProjectReq"
             }
           }
         ],
@@ -404,7 +404,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListRolesResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListRolesResp"
             }
           }
         },
@@ -418,7 +418,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateRoleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateRoleResp"
             }
           }
         },
@@ -428,7 +428,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateRoleReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateRoleReq"
             }
           }
         ],
@@ -444,7 +444,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetRoleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetRoleResp"
             }
           }
         },
@@ -466,7 +466,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteRoleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteRoleResp"
             }
           }
         },
@@ -488,7 +488,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateRoleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateRoleResp"
             }
           }
         },
@@ -504,7 +504,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateRoleReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateRoleReq"
             }
           }
         ],
@@ -515,32 +515,7 @@
     }
   },
   "definitions": {
-    "StatementEffect": {
-      "type": "string",
-      "enum": [
-        "ALLOW",
-        "DENY"
-      ],
-      "default": "ALLOW"
-    },
-    "VersionVersionNumber": {
-      "type": "string",
-      "enum": [
-        "V0",
-        "V1",
-        "V2"
-      ],
-      "default": "V0"
-    },
-    "iamv2betaType": {
-      "type": "string",
-      "enum": [
-        "CHEF_MANAGED",
-        "CUSTOM"
-      ],
-      "default": "CHEF_MANAGED"
-    },
-    "v2betaAddPolicyMembersReq": {
+    "chef.automate.api.iam.v2beta.AddPolicyMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -554,7 +529,7 @@
         }
       }
     },
-    "v2betaAddPolicyMembersResp": {
+    "chef.automate.api.iam.v2beta.AddPolicyMembersResp": {
       "type": "object",
       "properties": {
         "members": {
@@ -565,7 +540,7 @@
         }
       }
     },
-    "v2betaCreatePolicyReq": {
+    "chef.automate.api.iam.v2beta.CreatePolicyReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -583,7 +558,7 @@
         "statements": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaStatement"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Statement"
           }
         },
         "projects": {
@@ -595,15 +570,15 @@
       },
       "description": "Does not contain type as the enduser can only create 'custom' policies."
     },
-    "v2betaCreatePolicyResp": {
+    "chef.automate.api.iam.v2beta.CreatePolicyResp": {
       "type": "object",
       "properties": {
         "policy": {
-          "$ref": "#/definitions/v2betaPolicy"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Policy"
         }
       }
     },
-    "v2betaCreateProjectReq": {
+    "chef.automate.api.iam.v2beta.CreateProjectReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -614,15 +589,15 @@
         }
       }
     },
-    "v2betaCreateProjectResp": {
+    "chef.automate.api.iam.v2beta.CreateProjectResp": {
       "type": "object",
       "properties": {
         "project": {
-          "$ref": "#/definitions/v2betaProject"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Project"
         }
       }
     },
-    "v2betaCreateRoleReq": {
+    "chef.automate.api.iam.v2beta.CreateRoleReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -646,24 +621,24 @@
       },
       "description": "Does not contain type as the enduser can only create 'custom' roles."
     },
-    "v2betaCreateRoleResp": {
+    "chef.automate.api.iam.v2beta.CreateRoleResp": {
       "type": "object",
       "properties": {
         "role": {
-          "$ref": "#/definitions/v2betaRole"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Role"
         }
       }
     },
-    "v2betaDeletePolicyResp": {
+    "chef.automate.api.iam.v2beta.DeletePolicyResp": {
       "type": "object"
     },
-    "v2betaDeleteProjectResp": {
+    "chef.automate.api.iam.v2beta.DeleteProjectResp": {
       "type": "object"
     },
-    "v2betaDeleteRoleResp": {
+    "chef.automate.api.iam.v2beta.DeleteRoleResp": {
       "type": "object"
     },
-    "v2betaFlag": {
+    "chef.automate.api.iam.v2beta.Flag": {
       "type": "string",
       "enum": [
         "VERSION_2_0",
@@ -672,50 +647,50 @@
       "default": "VERSION_2_0",
       "title": "passed to UpgradeToV2 to set version"
     },
-    "v2betaGetPolicyResp": {
+    "chef.automate.api.iam.v2beta.GetPolicyResp": {
       "type": "object",
       "properties": {
         "policy": {
-          "$ref": "#/definitions/v2betaPolicy"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Policy"
         }
       }
     },
-    "v2betaGetPolicyVersionResp": {
+    "chef.automate.api.iam.v2beta.GetPolicyVersionResp": {
       "type": "object",
       "properties": {
         "version": {
-          "$ref": "#/definitions/v2betaVersion"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Version"
         }
       }
     },
-    "v2betaGetProjectResp": {
+    "chef.automate.api.iam.v2beta.GetProjectResp": {
       "type": "object",
       "properties": {
         "project": {
-          "$ref": "#/definitions/v2betaProject"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Project"
         }
       }
     },
-    "v2betaGetRoleResp": {
+    "chef.automate.api.iam.v2beta.GetRoleResp": {
       "type": "object",
       "properties": {
         "role": {
-          "$ref": "#/definitions/v2betaRole"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Role"
         }
       }
     },
-    "v2betaListPoliciesResp": {
+    "chef.automate.api.iam.v2beta.ListPoliciesResp": {
       "type": "object",
       "properties": {
         "policies": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaPolicy"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Policy"
           }
         }
       }
     },
-    "v2betaListPolicyMembersResp": {
+    "chef.automate.api.iam.v2beta.ListPolicyMembersResp": {
       "type": "object",
       "properties": {
         "members": {
@@ -726,29 +701,29 @@
         }
       }
     },
-    "v2betaListProjectsResp": {
+    "chef.automate.api.iam.v2beta.ListProjectsResp": {
       "type": "object",
       "properties": {
         "projects": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaProject"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Project"
           }
         }
       }
     },
-    "v2betaListRolesResp": {
+    "chef.automate.api.iam.v2beta.ListRolesResp": {
       "type": "object",
       "properties": {
         "roles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaRole"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Role"
           }
         }
       }
     },
-    "v2betaPolicy": {
+    "chef.automate.api.iam.v2beta.Policy": {
       "type": "object",
       "properties": {
         "name": {
@@ -758,7 +733,7 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/iamv2betaType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Type"
         },
         "members": {
           "type": "array",
@@ -769,7 +744,7 @@
         "statements": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaStatement"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Statement"
           }
         },
         "projects": {
@@ -780,7 +755,7 @@
         }
       }
     },
-    "v2betaProject": {
+    "chef.automate.api.iam.v2beta.Project": {
       "type": "object",
       "properties": {
         "name": {
@@ -790,14 +765,14 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/iamv2betaType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Type"
         },
         "status": {
-          "$ref": "#/definitions/v2betaProjectRulesStatus"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.ProjectRulesStatus"
         }
       }
     },
-    "v2betaProjectRulesStatus": {
+    "chef.automate.api.iam.v2beta.ProjectRulesStatus": {
       "type": "string",
       "enum": [
         "PROJECT_RULES_STATUS_UNSET",
@@ -807,7 +782,7 @@
       ],
       "default": "PROJECT_RULES_STATUS_UNSET"
     },
-    "v2betaRemovePolicyMembersReq": {
+    "chef.automate.api.iam.v2beta.RemovePolicyMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -821,7 +796,7 @@
         }
       }
     },
-    "v2betaRemovePolicyMembersResp": {
+    "chef.automate.api.iam.v2beta.RemovePolicyMembersResp": {
       "type": "object",
       "properties": {
         "members": {
@@ -832,7 +807,7 @@
         }
       }
     },
-    "v2betaReplacePolicyMembersReq": {
+    "chef.automate.api.iam.v2beta.ReplacePolicyMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -846,7 +821,7 @@
         }
       }
     },
-    "v2betaReplacePolicyMembersResp": {
+    "chef.automate.api.iam.v2beta.ReplacePolicyMembersResp": {
       "type": "object",
       "properties": {
         "members": {
@@ -857,10 +832,10 @@
         }
       }
     },
-    "v2betaResetToV1Resp": {
+    "chef.automate.api.iam.v2beta.ResetToV1Resp": {
       "type": "object"
     },
-    "v2betaRole": {
+    "chef.automate.api.iam.v2beta.Role": {
       "type": "object",
       "properties": {
         "name": {
@@ -870,7 +845,7 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/iamv2betaType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Type"
         },
         "actions": {
           "type": "array",
@@ -886,11 +861,11 @@
         }
       }
     },
-    "v2betaStatement": {
+    "chef.automate.api.iam.v2beta.Statement": {
       "type": "object",
       "properties": {
         "effect": {
-          "$ref": "#/definitions/StatementEffect"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Statement.Effect"
         },
         "actions": {
           "type": "array",
@@ -918,7 +893,23 @@
         }
       }
     },
-    "v2betaUpdatePolicyReq": {
+    "chef.automate.api.iam.v2beta.Statement.Effect": {
+      "type": "string",
+      "enum": [
+        "ALLOW",
+        "DENY"
+      ],
+      "default": "ALLOW"
+    },
+    "chef.automate.api.iam.v2beta.Type": {
+      "type": "string",
+      "enum": [
+        "CHEF_MANAGED",
+        "CUSTOM"
+      ],
+      "default": "CHEF_MANAGED"
+    },
+    "chef.automate.api.iam.v2beta.UpdatePolicyReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -933,7 +924,7 @@
         "statements": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaStatement"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Statement"
           }
         },
         "name": {
@@ -948,15 +939,15 @@
       },
       "description": "Does not contain type as the enduser can only create 'custom' policies."
     },
-    "v2betaUpdatePolicyResp": {
+    "chef.automate.api.iam.v2beta.UpdatePolicyResp": {
       "type": "object",
       "properties": {
         "policy": {
-          "$ref": "#/definitions/v2betaPolicy"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Policy"
         }
       }
     },
-    "v2betaUpdateProjectReq": {
+    "chef.automate.api.iam.v2beta.UpdateProjectReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -967,15 +958,15 @@
         }
       }
     },
-    "v2betaUpdateProjectResp": {
+    "chef.automate.api.iam.v2beta.UpdateProjectResp": {
       "type": "object",
       "properties": {
         "project": {
-          "$ref": "#/definitions/v2betaProject"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Project"
         }
       }
     },
-    "v2betaUpdateRoleReq": {
+    "chef.automate.api.iam.v2beta.UpdateRoleReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -998,15 +989,15 @@
         }
       }
     },
-    "v2betaUpdateRoleResp": {
+    "chef.automate.api.iam.v2beta.UpdateRoleResp": {
       "type": "object",
       "properties": {
         "role": {
-          "$ref": "#/definitions/v2betaRole"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Role"
         }
       }
     },
-    "v2betaUpgradeToV2Resp": {
+    "chef.automate.api.iam.v2beta.UpgradeToV2Resp": {
       "type": "object",
       "properties": {
         "reports": {
@@ -1017,17 +1008,26 @@
         }
       }
     },
-    "v2betaVersion": {
+    "chef.automate.api.iam.v2beta.Version": {
       "type": "object",
       "properties": {
         "major": {
-          "$ref": "#/definitions/VersionVersionNumber"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Version.VersionNumber"
         },
         "minor": {
-          "$ref": "#/definitions/VersionVersionNumber"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Version.VersionNumber"
         }
       },
       "title": "the only values that may be returned by GetPolicyVersion"
+    },
+    "chef.automate.api.iam.v2beta.Version.VersionNumber": {
+      "type": "string",
+      "enum": [
+        "V0",
+        "V1",
+        "V2"
+      ],
+      "default": "V0"
     }
   }
 }

--- a/components/automate-gateway/api/iam/v2beta/rules.swagger.json
+++ b/components/automate-gateway/api/iam/v2beta/rules.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaApplyRulesStatusResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ApplyRulesStatusResp"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaApplyRulesCancelResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ApplyRulesCancelResp"
             }
           }
         },
@@ -50,7 +50,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaApplyRulesStartResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ApplyRulesStartResp"
             }
           }
         },
@@ -66,7 +66,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListRulesForProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListRulesForProjectResp"
             }
           }
         },
@@ -90,7 +90,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateRuleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateRuleResp"
             }
           }
         },
@@ -106,7 +106,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateRuleReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateRuleReq"
             }
           }
         ],
@@ -122,7 +122,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetRuleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetRuleResp"
             }
           }
         },
@@ -150,7 +150,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteRuleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteRuleResp"
             }
           }
         },
@@ -178,7 +178,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateRuleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateRuleResp"
             }
           }
         },
@@ -200,7 +200,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateRuleReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateRuleReq"
             }
           }
         ],
@@ -211,13 +211,13 @@
     }
   },
   "definitions": {
-    "v2betaApplyRulesCancelResp": {
+    "chef.automate.api.iam.v2beta.ApplyRulesCancelResp": {
       "type": "object"
     },
-    "v2betaApplyRulesStartResp": {
+    "chef.automate.api.iam.v2beta.ApplyRulesStartResp": {
       "type": "object"
     },
-    "v2betaApplyRulesStatusResp": {
+    "chef.automate.api.iam.v2beta.ApplyRulesStatusResp": {
       "type": "object",
       "properties": {
         "state": {
@@ -244,11 +244,11 @@
         }
       }
     },
-    "v2betaCondition": {
+    "chef.automate.api.iam.v2beta.Condition": {
       "type": "object",
       "properties": {
         "attribute": {
-          "$ref": "#/definitions/v2betaConditionAttribute"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.ConditionAttribute"
         },
         "values": {
           "type": "array",
@@ -257,11 +257,11 @@
           }
         },
         "operator": {
-          "$ref": "#/definitions/v2betaConditionOperator"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.ConditionOperator"
         }
       }
     },
-    "v2betaConditionAttribute": {
+    "chef.automate.api.iam.v2beta.ConditionAttribute": {
       "type": "string",
       "enum": [
         "CONDITION_ATTRIBUTE_UNSET",
@@ -275,7 +275,7 @@
       ],
       "default": "CONDITION_ATTRIBUTE_UNSET"
     },
-    "v2betaConditionOperator": {
+    "chef.automate.api.iam.v2beta.ConditionOperator": {
       "type": "string",
       "enum": [
         "CONDITION_OPERATOR_UNSET",
@@ -284,7 +284,7 @@
       ],
       "default": "CONDITION_OPERATOR_UNSET"
     },
-    "v2betaCreateRuleReq": {
+    "chef.automate.api.iam.v2beta.CreateRuleReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -297,50 +297,50 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/v2betaRuleType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.RuleType"
         },
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaCondition"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Condition"
           }
         }
       }
     },
-    "v2betaCreateRuleResp": {
+    "chef.automate.api.iam.v2beta.CreateRuleResp": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/v2betaRule"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Rule"
         }
       }
     },
-    "v2betaDeleteRuleResp": {
+    "chef.automate.api.iam.v2beta.DeleteRuleResp": {
       "type": "object"
     },
-    "v2betaGetRuleResp": {
+    "chef.automate.api.iam.v2beta.GetRuleResp": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/v2betaRule"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Rule"
         }
       }
     },
-    "v2betaListRulesForProjectResp": {
+    "chef.automate.api.iam.v2beta.ListRulesForProjectResp": {
       "type": "object",
       "properties": {
         "rules": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaRule"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Rule"
           }
         },
         "status": {
-          "$ref": "#/definitions/v2betaProjectRulesStatus"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.ProjectRulesStatus"
         }
       }
     },
-    "v2betaProjectRulesStatus": {
+    "chef.automate.api.iam.v2beta.ProjectRulesStatus": {
       "type": "string",
       "enum": [
         "PROJECT_RULES_STATUS_UNSET",
@@ -350,7 +350,7 @@
       ],
       "default": "PROJECT_RULES_STATUS_UNSET"
     },
-    "v2betaRule": {
+    "chef.automate.api.iam.v2beta.Rule": {
       "type": "object",
       "properties": {
         "id": {
@@ -363,20 +363,20 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/v2betaRuleType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.RuleType"
         },
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaCondition"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Condition"
           }
         },
         "status": {
-          "$ref": "#/definitions/v2betaRuleStatus"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.RuleStatus"
         }
       }
     },
-    "v2betaRuleStatus": {
+    "chef.automate.api.iam.v2beta.RuleStatus": {
       "type": "string",
       "enum": [
         "RULE_STATUS_UNSET",
@@ -385,7 +385,7 @@
       ],
       "default": "RULE_STATUS_UNSET"
     },
-    "v2betaRuleType": {
+    "chef.automate.api.iam.v2beta.RuleType": {
       "type": "string",
       "enum": [
         "RULE_TYPE_UNSET",
@@ -394,7 +394,7 @@
       ],
       "default": "RULE_TYPE_UNSET"
     },
-    "v2betaUpdateRuleReq": {
+    "chef.automate.api.iam.v2beta.UpdateRuleReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -407,21 +407,21 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/v2betaRuleType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.RuleType"
         },
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaCondition"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Condition"
           }
         }
       }
     },
-    "v2betaUpdateRuleResp": {
+    "chef.automate.api.iam.v2beta.UpdateRuleResp": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/v2betaRule"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Rule"
         }
       }
     }

--- a/components/automate-gateway/api/iam/v2beta/teams.swagger.json
+++ b/components/automate-gateway/api/iam/v2beta/teams.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListTeamsResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListTeamsResp"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateTeamResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateTeamResp"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateTeamReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateTeamReq"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetTeamResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetTeamResp"
             }
           }
         },
@@ -84,7 +84,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteTeamResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteTeamResp"
             }
           }
         },
@@ -106,7 +106,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateTeamResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateTeamResp"
             }
           }
         },
@@ -122,7 +122,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateTeamReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateTeamReq"
             }
           }
         ],
@@ -138,7 +138,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetTeamMembershipResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetTeamMembershipResp"
             }
           }
         },
@@ -162,7 +162,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaAddTeamMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.AddTeamMembersResp"
             }
           }
         },
@@ -178,7 +178,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaAddTeamMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.AddTeamMembersReq"
             }
           }
         ],
@@ -194,7 +194,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaRemoveTeamMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.RemoveTeamMembersResp"
             }
           }
         },
@@ -210,7 +210,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaRemoveTeamMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.RemoveTeamMembersReq"
             }
           }
         ],
@@ -226,7 +226,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetTeamsForMemberResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetTeamsForMemberResp"
             }
           }
         },
@@ -245,7 +245,7 @@
     }
   },
   "definitions": {
-    "v2betaAddTeamMembersReq": {
+    "chef.automate.api.iam.v2beta.AddTeamMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -259,7 +259,7 @@
         }
       }
     },
-    "v2betaAddTeamMembersResp": {
+    "chef.automate.api.iam.v2beta.AddTeamMembersResp": {
       "type": "object",
       "properties": {
         "user_ids": {
@@ -270,10 +270,10 @@
         }
       }
     },
-    "v2betaApplyV2DataMigrationsResp": {
+    "chef.automate.api.iam.v2beta.ApplyV2DataMigrationsResp": {
       "type": "object"
     },
-    "v2betaCreateTeamReq": {
+    "chef.automate.api.iam.v2beta.CreateTeamReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -290,23 +290,23 @@
         }
       }
     },
-    "v2betaCreateTeamResp": {
+    "chef.automate.api.iam.v2beta.CreateTeamResp": {
       "type": "object",
       "properties": {
         "team": {
-          "$ref": "#/definitions/v2betaTeam"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
         }
       }
     },
-    "v2betaDeleteTeamResp": {
+    "chef.automate.api.iam.v2beta.DeleteTeamResp": {
       "type": "object",
       "properties": {
         "team": {
-          "$ref": "#/definitions/v2betaTeam"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
         }
       }
     },
-    "v2betaGetTeamMembershipResp": {
+    "chef.automate.api.iam.v2beta.GetTeamMembershipResp": {
       "type": "object",
       "properties": {
         "user_ids": {
@@ -317,37 +317,37 @@
         }
       }
     },
-    "v2betaGetTeamResp": {
+    "chef.automate.api.iam.v2beta.GetTeamResp": {
       "type": "object",
       "properties": {
         "team": {
-          "$ref": "#/definitions/v2betaTeam"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
         }
       }
     },
-    "v2betaGetTeamsForMemberResp": {
+    "chef.automate.api.iam.v2beta.GetTeamsForMemberResp": {
       "type": "object",
       "properties": {
         "teams": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaTeam"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
           }
         }
       }
     },
-    "v2betaListTeamsResp": {
+    "chef.automate.api.iam.v2beta.ListTeamsResp": {
       "type": "object",
       "properties": {
         "teams": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaTeam"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
           }
         }
       }
     },
-    "v2betaRemoveTeamMembersReq": {
+    "chef.automate.api.iam.v2beta.RemoveTeamMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -361,7 +361,7 @@
         }
       }
     },
-    "v2betaRemoveTeamMembersResp": {
+    "chef.automate.api.iam.v2beta.RemoveTeamMembersResp": {
       "type": "object",
       "properties": {
         "user_ids": {
@@ -372,7 +372,7 @@
         }
       }
     },
-    "v2betaTeam": {
+    "chef.automate.api.iam.v2beta.Team": {
       "type": "object",
       "properties": {
         "id": {
@@ -389,7 +389,7 @@
         }
       }
     },
-    "v2betaUpdateTeamReq": {
+    "chef.automate.api.iam.v2beta.UpdateTeamReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -406,11 +406,11 @@
         }
       }
     },
-    "v2betaUpdateTeamResp": {
+    "chef.automate.api.iam.v2beta.UpdateTeamResp": {
       "type": "object",
       "properties": {
         "team": {
-          "$ref": "#/definitions/v2betaTeam"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
         }
       }
     }

--- a/components/automate-gateway/api/iam/v2beta/tokens.swagger.json
+++ b/components/automate-gateway/api/iam/v2beta/tokens.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListTokensResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListTokensResp"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateTokenResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateTokenResp"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateTokenReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateTokenReq"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetTokenResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetTokenResp"
             }
           }
         },
@@ -84,7 +84,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteTokenResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteTokenResp"
             }
           }
         },
@@ -106,7 +106,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateTokenResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateTokenResp"
             }
           }
         },
@@ -123,7 +123,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateTokenReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateTokenReq"
             }
           }
         ],
@@ -134,7 +134,7 @@
     }
   },
   "definitions": {
-    "v2betaCreateTokenReq": {
+    "chef.automate.api.iam.v2beta.CreateTokenReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -158,37 +158,37 @@
         }
       }
     },
-    "v2betaCreateTokenResp": {
+    "chef.automate.api.iam.v2beta.CreateTokenResp": {
       "type": "object",
       "properties": {
         "token": {
-          "$ref": "#/definitions/v2betaToken"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Token"
         }
       }
     },
-    "v2betaDeleteTokenResp": {
+    "chef.automate.api.iam.v2beta.DeleteTokenResp": {
       "type": "object"
     },
-    "v2betaGetTokenResp": {
+    "chef.automate.api.iam.v2beta.GetTokenResp": {
       "type": "object",
       "properties": {
         "token": {
-          "$ref": "#/definitions/v2betaToken"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Token"
         }
       }
     },
-    "v2betaListTokensResp": {
+    "chef.automate.api.iam.v2beta.ListTokensResp": {
       "type": "object",
       "properties": {
         "tokens": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaToken"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Token"
           }
         }
       }
     },
-    "v2betaToken": {
+    "chef.automate.api.iam.v2beta.Token": {
       "type": "object",
       "properties": {
         "id": {
@@ -218,7 +218,7 @@
         }
       }
     },
-    "v2betaUpdateTokenReq": {
+    "chef.automate.api.iam.v2beta.UpdateTokenReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -240,11 +240,11 @@
         }
       }
     },
-    "v2betaUpdateTokenResp": {
+    "chef.automate.api.iam.v2beta.UpdateTokenResp": {
       "type": "object",
       "properties": {
         "token": {
-          "$ref": "#/definitions/v2betaToken"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Token"
         }
       }
     }

--- a/components/automate-gateway/api/iam/v2beta/users.swagger.json
+++ b/components/automate-gateway/api/iam/v2beta/users.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateSelfResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateSelfResp"
             }
           }
         },
@@ -39,7 +39,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateSelfReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateSelfReq"
             }
           }
         ],
@@ -55,7 +55,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListUsersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListUsersResp"
             }
           }
         },
@@ -69,7 +69,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateUserResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateUserResp"
             }
           }
         },
@@ -79,7 +79,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateUserReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateUserReq"
             }
           }
         ],
@@ -95,7 +95,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetUserResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetUserResp"
             }
           }
         },
@@ -117,7 +117,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteUserResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteUserResp"
             }
           }
         },
@@ -139,7 +139,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateUserResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateUserResp"
             }
           }
         },
@@ -156,7 +156,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateUserReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateUserReq"
             }
           }
         ],
@@ -167,7 +167,7 @@
     }
   },
   "definitions": {
-    "v2betaCreateUserReq": {
+    "chef.automate.api.iam.v2beta.CreateUserReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -181,37 +181,37 @@
         }
       }
     },
-    "v2betaCreateUserResp": {
+    "chef.automate.api.iam.v2beta.CreateUserResp": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/v2betaUser"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
         }
       }
     },
-    "v2betaDeleteUserResp": {
+    "chef.automate.api.iam.v2beta.DeleteUserResp": {
       "type": "object"
     },
-    "v2betaGetUserResp": {
+    "chef.automate.api.iam.v2beta.GetUserResp": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/v2betaUser"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
         }
       }
     },
-    "v2betaListUsersResp": {
+    "chef.automate.api.iam.v2beta.ListUsersResp": {
       "type": "object",
       "properties": {
         "users": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaUser"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
           }
         }
       }
     },
-    "v2betaUpdateSelfReq": {
+    "chef.automate.api.iam.v2beta.UpdateSelfReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -230,15 +230,15 @@
         }
       }
     },
-    "v2betaUpdateSelfResp": {
+    "chef.automate.api.iam.v2beta.UpdateSelfResp": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/v2betaUser"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
         }
       }
     },
-    "v2betaUpdateUserReq": {
+    "chef.automate.api.iam.v2beta.UpdateUserReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -253,15 +253,15 @@
         }
       }
     },
-    "v2betaUpdateUserResp": {
+    "chef.automate.api.iam.v2beta.UpdateUserResp": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/v2betaUser"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
         }
       }
     },
-    "v2betaUser": {
+    "chef.automate.api.iam.v2beta.User": {
       "type": "object",
       "properties": {
         "name": {

--- a/components/automate-gateway/api/iam_v2beta_policy.pb.swagger.go
+++ b/components/automate-gateway/api/iam_v2beta_policy.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListProjectsResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListProjectsResp"
             }
           }
         },
@@ -41,7 +41,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListPoliciesResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListPoliciesResp"
             }
           }
         },
@@ -55,7 +55,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreatePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreatePolicyResp"
             }
           }
         },
@@ -65,7 +65,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreatePolicyReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreatePolicyReq"
             }
           }
         ],
@@ -81,7 +81,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetPolicyResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetPolicyResp"
             }
           }
         },
@@ -103,7 +103,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeletePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeletePolicyResp"
             }
           }
         },
@@ -125,7 +125,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdatePolicyResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdatePolicyResp"
             }
           }
         },
@@ -141,7 +141,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdatePolicyReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdatePolicyReq"
             }
           }
         ],
@@ -157,7 +157,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListPolicyMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListPolicyMembersResp"
             }
           }
         },
@@ -179,7 +179,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaReplacePolicyMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ReplacePolicyMembersResp"
             }
           }
         },
@@ -195,7 +195,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaReplacePolicyMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ReplacePolicyMembersReq"
             }
           }
         ],
@@ -211,7 +211,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaAddPolicyMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.AddPolicyMembersResp"
             }
           }
         },
@@ -227,7 +227,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaAddPolicyMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.AddPolicyMembersReq"
             }
           }
         ],
@@ -243,7 +243,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaRemovePolicyMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.RemovePolicyMembersResp"
             }
           }
         },
@@ -259,7 +259,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaRemovePolicyMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.RemovePolicyMembersReq"
             }
           }
         ],
@@ -275,7 +275,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetPolicyVersionResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetPolicyVersionResp"
             }
           }
         },
@@ -291,7 +291,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListProjectsResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListProjectsResp"
             }
           }
         },
@@ -305,7 +305,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateProjectResp"
             }
           }
         },
@@ -315,7 +315,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateProjectReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateProjectReq"
             }
           }
         ],
@@ -331,7 +331,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetProjectResp"
             }
           }
         },
@@ -353,7 +353,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteProjectResp"
             }
           }
         },
@@ -375,7 +375,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateProjectResp"
             }
           }
         },
@@ -391,7 +391,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateProjectReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateProjectReq"
             }
           }
         ],
@@ -407,7 +407,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListRolesResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListRolesResp"
             }
           }
         },
@@ -421,7 +421,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateRoleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateRoleResp"
             }
           }
         },
@@ -431,7 +431,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateRoleReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateRoleReq"
             }
           }
         ],
@@ -447,7 +447,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetRoleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetRoleResp"
             }
           }
         },
@@ -469,7 +469,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteRoleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteRoleResp"
             }
           }
         },
@@ -491,7 +491,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateRoleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateRoleResp"
             }
           }
         },
@@ -507,7 +507,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateRoleReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateRoleReq"
             }
           }
         ],
@@ -518,32 +518,7 @@ func init() {
     }
   },
   "definitions": {
-    "StatementEffect": {
-      "type": "string",
-      "enum": [
-        "ALLOW",
-        "DENY"
-      ],
-      "default": "ALLOW"
-    },
-    "VersionVersionNumber": {
-      "type": "string",
-      "enum": [
-        "V0",
-        "V1",
-        "V2"
-      ],
-      "default": "V0"
-    },
-    "iamv2betaType": {
-      "type": "string",
-      "enum": [
-        "CHEF_MANAGED",
-        "CUSTOM"
-      ],
-      "default": "CHEF_MANAGED"
-    },
-    "v2betaAddPolicyMembersReq": {
+    "chef.automate.api.iam.v2beta.AddPolicyMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -557,7 +532,7 @@ func init() {
         }
       }
     },
-    "v2betaAddPolicyMembersResp": {
+    "chef.automate.api.iam.v2beta.AddPolicyMembersResp": {
       "type": "object",
       "properties": {
         "members": {
@@ -568,7 +543,7 @@ func init() {
         }
       }
     },
-    "v2betaCreatePolicyReq": {
+    "chef.automate.api.iam.v2beta.CreatePolicyReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -586,7 +561,7 @@ func init() {
         "statements": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaStatement"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Statement"
           }
         },
         "projects": {
@@ -598,15 +573,15 @@ func init() {
       },
       "description": "Does not contain type as the enduser can only create 'custom' policies."
     },
-    "v2betaCreatePolicyResp": {
+    "chef.automate.api.iam.v2beta.CreatePolicyResp": {
       "type": "object",
       "properties": {
         "policy": {
-          "$ref": "#/definitions/v2betaPolicy"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Policy"
         }
       }
     },
-    "v2betaCreateProjectReq": {
+    "chef.automate.api.iam.v2beta.CreateProjectReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -617,15 +592,15 @@ func init() {
         }
       }
     },
-    "v2betaCreateProjectResp": {
+    "chef.automate.api.iam.v2beta.CreateProjectResp": {
       "type": "object",
       "properties": {
         "project": {
-          "$ref": "#/definitions/v2betaProject"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Project"
         }
       }
     },
-    "v2betaCreateRoleReq": {
+    "chef.automate.api.iam.v2beta.CreateRoleReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -649,24 +624,24 @@ func init() {
       },
       "description": "Does not contain type as the enduser can only create 'custom' roles."
     },
-    "v2betaCreateRoleResp": {
+    "chef.automate.api.iam.v2beta.CreateRoleResp": {
       "type": "object",
       "properties": {
         "role": {
-          "$ref": "#/definitions/v2betaRole"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Role"
         }
       }
     },
-    "v2betaDeletePolicyResp": {
+    "chef.automate.api.iam.v2beta.DeletePolicyResp": {
       "type": "object"
     },
-    "v2betaDeleteProjectResp": {
+    "chef.automate.api.iam.v2beta.DeleteProjectResp": {
       "type": "object"
     },
-    "v2betaDeleteRoleResp": {
+    "chef.automate.api.iam.v2beta.DeleteRoleResp": {
       "type": "object"
     },
-    "v2betaFlag": {
+    "chef.automate.api.iam.v2beta.Flag": {
       "type": "string",
       "enum": [
         "VERSION_2_0",
@@ -675,50 +650,50 @@ func init() {
       "default": "VERSION_2_0",
       "title": "passed to UpgradeToV2 to set version"
     },
-    "v2betaGetPolicyResp": {
+    "chef.automate.api.iam.v2beta.GetPolicyResp": {
       "type": "object",
       "properties": {
         "policy": {
-          "$ref": "#/definitions/v2betaPolicy"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Policy"
         }
       }
     },
-    "v2betaGetPolicyVersionResp": {
+    "chef.automate.api.iam.v2beta.GetPolicyVersionResp": {
       "type": "object",
       "properties": {
         "version": {
-          "$ref": "#/definitions/v2betaVersion"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Version"
         }
       }
     },
-    "v2betaGetProjectResp": {
+    "chef.automate.api.iam.v2beta.GetProjectResp": {
       "type": "object",
       "properties": {
         "project": {
-          "$ref": "#/definitions/v2betaProject"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Project"
         }
       }
     },
-    "v2betaGetRoleResp": {
+    "chef.automate.api.iam.v2beta.GetRoleResp": {
       "type": "object",
       "properties": {
         "role": {
-          "$ref": "#/definitions/v2betaRole"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Role"
         }
       }
     },
-    "v2betaListPoliciesResp": {
+    "chef.automate.api.iam.v2beta.ListPoliciesResp": {
       "type": "object",
       "properties": {
         "policies": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaPolicy"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Policy"
           }
         }
       }
     },
-    "v2betaListPolicyMembersResp": {
+    "chef.automate.api.iam.v2beta.ListPolicyMembersResp": {
       "type": "object",
       "properties": {
         "members": {
@@ -729,29 +704,29 @@ func init() {
         }
       }
     },
-    "v2betaListProjectsResp": {
+    "chef.automate.api.iam.v2beta.ListProjectsResp": {
       "type": "object",
       "properties": {
         "projects": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaProject"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Project"
           }
         }
       }
     },
-    "v2betaListRolesResp": {
+    "chef.automate.api.iam.v2beta.ListRolesResp": {
       "type": "object",
       "properties": {
         "roles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaRole"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Role"
           }
         }
       }
     },
-    "v2betaPolicy": {
+    "chef.automate.api.iam.v2beta.Policy": {
       "type": "object",
       "properties": {
         "name": {
@@ -761,7 +736,7 @@ func init() {
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/iamv2betaType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Type"
         },
         "members": {
           "type": "array",
@@ -772,7 +747,7 @@ func init() {
         "statements": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaStatement"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Statement"
           }
         },
         "projects": {
@@ -783,7 +758,7 @@ func init() {
         }
       }
     },
-    "v2betaProject": {
+    "chef.automate.api.iam.v2beta.Project": {
       "type": "object",
       "properties": {
         "name": {
@@ -793,14 +768,14 @@ func init() {
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/iamv2betaType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Type"
         },
         "status": {
-          "$ref": "#/definitions/v2betaProjectRulesStatus"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.ProjectRulesStatus"
         }
       }
     },
-    "v2betaProjectRulesStatus": {
+    "chef.automate.api.iam.v2beta.ProjectRulesStatus": {
       "type": "string",
       "enum": [
         "PROJECT_RULES_STATUS_UNSET",
@@ -810,7 +785,7 @@ func init() {
       ],
       "default": "PROJECT_RULES_STATUS_UNSET"
     },
-    "v2betaRemovePolicyMembersReq": {
+    "chef.automate.api.iam.v2beta.RemovePolicyMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -824,7 +799,7 @@ func init() {
         }
       }
     },
-    "v2betaRemovePolicyMembersResp": {
+    "chef.automate.api.iam.v2beta.RemovePolicyMembersResp": {
       "type": "object",
       "properties": {
         "members": {
@@ -835,7 +810,7 @@ func init() {
         }
       }
     },
-    "v2betaReplacePolicyMembersReq": {
+    "chef.automate.api.iam.v2beta.ReplacePolicyMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -849,7 +824,7 @@ func init() {
         }
       }
     },
-    "v2betaReplacePolicyMembersResp": {
+    "chef.automate.api.iam.v2beta.ReplacePolicyMembersResp": {
       "type": "object",
       "properties": {
         "members": {
@@ -860,10 +835,10 @@ func init() {
         }
       }
     },
-    "v2betaResetToV1Resp": {
+    "chef.automate.api.iam.v2beta.ResetToV1Resp": {
       "type": "object"
     },
-    "v2betaRole": {
+    "chef.automate.api.iam.v2beta.Role": {
       "type": "object",
       "properties": {
         "name": {
@@ -873,7 +848,7 @@ func init() {
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/iamv2betaType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Type"
         },
         "actions": {
           "type": "array",
@@ -889,11 +864,11 @@ func init() {
         }
       }
     },
-    "v2betaStatement": {
+    "chef.automate.api.iam.v2beta.Statement": {
       "type": "object",
       "properties": {
         "effect": {
-          "$ref": "#/definitions/StatementEffect"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Statement.Effect"
         },
         "actions": {
           "type": "array",
@@ -921,7 +896,23 @@ func init() {
         }
       }
     },
-    "v2betaUpdatePolicyReq": {
+    "chef.automate.api.iam.v2beta.Statement.Effect": {
+      "type": "string",
+      "enum": [
+        "ALLOW",
+        "DENY"
+      ],
+      "default": "ALLOW"
+    },
+    "chef.automate.api.iam.v2beta.Type": {
+      "type": "string",
+      "enum": [
+        "CHEF_MANAGED",
+        "CUSTOM"
+      ],
+      "default": "CHEF_MANAGED"
+    },
+    "chef.automate.api.iam.v2beta.UpdatePolicyReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -936,7 +927,7 @@ func init() {
         "statements": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaStatement"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Statement"
           }
         },
         "name": {
@@ -951,15 +942,15 @@ func init() {
       },
       "description": "Does not contain type as the enduser can only create 'custom' policies."
     },
-    "v2betaUpdatePolicyResp": {
+    "chef.automate.api.iam.v2beta.UpdatePolicyResp": {
       "type": "object",
       "properties": {
         "policy": {
-          "$ref": "#/definitions/v2betaPolicy"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Policy"
         }
       }
     },
-    "v2betaUpdateProjectReq": {
+    "chef.automate.api.iam.v2beta.UpdateProjectReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -970,15 +961,15 @@ func init() {
         }
       }
     },
-    "v2betaUpdateProjectResp": {
+    "chef.automate.api.iam.v2beta.UpdateProjectResp": {
       "type": "object",
       "properties": {
         "project": {
-          "$ref": "#/definitions/v2betaProject"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Project"
         }
       }
     },
-    "v2betaUpdateRoleReq": {
+    "chef.automate.api.iam.v2beta.UpdateRoleReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -1001,15 +992,15 @@ func init() {
         }
       }
     },
-    "v2betaUpdateRoleResp": {
+    "chef.automate.api.iam.v2beta.UpdateRoleResp": {
       "type": "object",
       "properties": {
         "role": {
-          "$ref": "#/definitions/v2betaRole"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Role"
         }
       }
     },
-    "v2betaUpgradeToV2Resp": {
+    "chef.automate.api.iam.v2beta.UpgradeToV2Resp": {
       "type": "object",
       "properties": {
         "reports": {
@@ -1020,17 +1011,26 @@ func init() {
         }
       }
     },
-    "v2betaVersion": {
+    "chef.automate.api.iam.v2beta.Version": {
       "type": "object",
       "properties": {
         "major": {
-          "$ref": "#/definitions/VersionVersionNumber"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Version.VersionNumber"
         },
         "minor": {
-          "$ref": "#/definitions/VersionVersionNumber"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Version.VersionNumber"
         }
       },
       "title": "the only values that may be returned by GetPolicyVersion"
+    },
+    "chef.automate.api.iam.v2beta.Version.VersionNumber": {
+      "type": "string",
+      "enum": [
+        "V0",
+        "V1",
+        "V2"
+      ],
+      "default": "V0"
     }
   }
 }

--- a/components/automate-gateway/api/iam_v2beta_rules.pb.swagger.go
+++ b/components/automate-gateway/api/iam_v2beta_rules.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaApplyRulesStatusResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ApplyRulesStatusResp"
             }
           }
         },
@@ -39,7 +39,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaApplyRulesCancelResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ApplyRulesCancelResp"
             }
           }
         },
@@ -53,7 +53,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaApplyRulesStartResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ApplyRulesStartResp"
             }
           }
         },
@@ -69,7 +69,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListRulesForProjectResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListRulesForProjectResp"
             }
           }
         },
@@ -93,7 +93,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateRuleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateRuleResp"
             }
           }
         },
@@ -109,7 +109,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateRuleReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateRuleReq"
             }
           }
         ],
@@ -125,7 +125,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetRuleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetRuleResp"
             }
           }
         },
@@ -153,7 +153,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteRuleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteRuleResp"
             }
           }
         },
@@ -181,7 +181,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateRuleResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateRuleResp"
             }
           }
         },
@@ -203,7 +203,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateRuleReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateRuleReq"
             }
           }
         ],
@@ -214,13 +214,13 @@ func init() {
     }
   },
   "definitions": {
-    "v2betaApplyRulesCancelResp": {
+    "chef.automate.api.iam.v2beta.ApplyRulesCancelResp": {
       "type": "object"
     },
-    "v2betaApplyRulesStartResp": {
+    "chef.automate.api.iam.v2beta.ApplyRulesStartResp": {
       "type": "object"
     },
-    "v2betaApplyRulesStatusResp": {
+    "chef.automate.api.iam.v2beta.ApplyRulesStatusResp": {
       "type": "object",
       "properties": {
         "state": {
@@ -247,11 +247,11 @@ func init() {
         }
       }
     },
-    "v2betaCondition": {
+    "chef.automate.api.iam.v2beta.Condition": {
       "type": "object",
       "properties": {
         "attribute": {
-          "$ref": "#/definitions/v2betaConditionAttribute"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.ConditionAttribute"
         },
         "values": {
           "type": "array",
@@ -260,11 +260,11 @@ func init() {
           }
         },
         "operator": {
-          "$ref": "#/definitions/v2betaConditionOperator"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.ConditionOperator"
         }
       }
     },
-    "v2betaConditionAttribute": {
+    "chef.automate.api.iam.v2beta.ConditionAttribute": {
       "type": "string",
       "enum": [
         "CONDITION_ATTRIBUTE_UNSET",
@@ -278,7 +278,7 @@ func init() {
       ],
       "default": "CONDITION_ATTRIBUTE_UNSET"
     },
-    "v2betaConditionOperator": {
+    "chef.automate.api.iam.v2beta.ConditionOperator": {
       "type": "string",
       "enum": [
         "CONDITION_OPERATOR_UNSET",
@@ -287,7 +287,7 @@ func init() {
       ],
       "default": "CONDITION_OPERATOR_UNSET"
     },
-    "v2betaCreateRuleReq": {
+    "chef.automate.api.iam.v2beta.CreateRuleReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -300,50 +300,50 @@ func init() {
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/v2betaRuleType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.RuleType"
         },
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaCondition"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Condition"
           }
         }
       }
     },
-    "v2betaCreateRuleResp": {
+    "chef.automate.api.iam.v2beta.CreateRuleResp": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/v2betaRule"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Rule"
         }
       }
     },
-    "v2betaDeleteRuleResp": {
+    "chef.automate.api.iam.v2beta.DeleteRuleResp": {
       "type": "object"
     },
-    "v2betaGetRuleResp": {
+    "chef.automate.api.iam.v2beta.GetRuleResp": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/v2betaRule"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Rule"
         }
       }
     },
-    "v2betaListRulesForProjectResp": {
+    "chef.automate.api.iam.v2beta.ListRulesForProjectResp": {
       "type": "object",
       "properties": {
         "rules": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaRule"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Rule"
           }
         },
         "status": {
-          "$ref": "#/definitions/v2betaProjectRulesStatus"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.ProjectRulesStatus"
         }
       }
     },
-    "v2betaProjectRulesStatus": {
+    "chef.automate.api.iam.v2beta.ProjectRulesStatus": {
       "type": "string",
       "enum": [
         "PROJECT_RULES_STATUS_UNSET",
@@ -353,7 +353,7 @@ func init() {
       ],
       "default": "PROJECT_RULES_STATUS_UNSET"
     },
-    "v2betaRule": {
+    "chef.automate.api.iam.v2beta.Rule": {
       "type": "object",
       "properties": {
         "id": {
@@ -366,20 +366,20 @@ func init() {
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/v2betaRuleType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.RuleType"
         },
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaCondition"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Condition"
           }
         },
         "status": {
-          "$ref": "#/definitions/v2betaRuleStatus"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.RuleStatus"
         }
       }
     },
-    "v2betaRuleStatus": {
+    "chef.automate.api.iam.v2beta.RuleStatus": {
       "type": "string",
       "enum": [
         "RULE_STATUS_UNSET",
@@ -388,7 +388,7 @@ func init() {
       ],
       "default": "RULE_STATUS_UNSET"
     },
-    "v2betaRuleType": {
+    "chef.automate.api.iam.v2beta.RuleType": {
       "type": "string",
       "enum": [
         "RULE_TYPE_UNSET",
@@ -397,7 +397,7 @@ func init() {
       ],
       "default": "RULE_TYPE_UNSET"
     },
-    "v2betaUpdateRuleReq": {
+    "chef.automate.api.iam.v2beta.UpdateRuleReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -410,21 +410,21 @@ func init() {
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/v2betaRuleType"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.RuleType"
         },
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaCondition"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Condition"
           }
         }
       }
     },
-    "v2betaUpdateRuleResp": {
+    "chef.automate.api.iam.v2beta.UpdateRuleResp": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/v2betaRule"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Rule"
         }
       }
     }

--- a/components/automate-gateway/api/iam_v2beta_teams.pb.swagger.go
+++ b/components/automate-gateway/api/iam_v2beta_teams.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListTeamsResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListTeamsResp"
             }
           }
         },
@@ -39,7 +39,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateTeamResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateTeamResp"
             }
           }
         },
@@ -49,7 +49,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateTeamReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateTeamReq"
             }
           }
         ],
@@ -65,7 +65,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetTeamResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetTeamResp"
             }
           }
         },
@@ -87,7 +87,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteTeamResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteTeamResp"
             }
           }
         },
@@ -109,7 +109,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateTeamResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateTeamResp"
             }
           }
         },
@@ -125,7 +125,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateTeamReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateTeamReq"
             }
           }
         ],
@@ -141,7 +141,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetTeamMembershipResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetTeamMembershipResp"
             }
           }
         },
@@ -165,7 +165,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaAddTeamMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.AddTeamMembersResp"
             }
           }
         },
@@ -181,7 +181,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaAddTeamMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.AddTeamMembersReq"
             }
           }
         ],
@@ -197,7 +197,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaRemoveTeamMembersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.RemoveTeamMembersResp"
             }
           }
         },
@@ -213,7 +213,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaRemoveTeamMembersReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.RemoveTeamMembersReq"
             }
           }
         ],
@@ -229,7 +229,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetTeamsForMemberResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetTeamsForMemberResp"
             }
           }
         },
@@ -248,7 +248,7 @@ func init() {
     }
   },
   "definitions": {
-    "v2betaAddTeamMembersReq": {
+    "chef.automate.api.iam.v2beta.AddTeamMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -262,7 +262,7 @@ func init() {
         }
       }
     },
-    "v2betaAddTeamMembersResp": {
+    "chef.automate.api.iam.v2beta.AddTeamMembersResp": {
       "type": "object",
       "properties": {
         "user_ids": {
@@ -273,10 +273,10 @@ func init() {
         }
       }
     },
-    "v2betaApplyV2DataMigrationsResp": {
+    "chef.automate.api.iam.v2beta.ApplyV2DataMigrationsResp": {
       "type": "object"
     },
-    "v2betaCreateTeamReq": {
+    "chef.automate.api.iam.v2beta.CreateTeamReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -293,23 +293,23 @@ func init() {
         }
       }
     },
-    "v2betaCreateTeamResp": {
+    "chef.automate.api.iam.v2beta.CreateTeamResp": {
       "type": "object",
       "properties": {
         "team": {
-          "$ref": "#/definitions/v2betaTeam"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
         }
       }
     },
-    "v2betaDeleteTeamResp": {
+    "chef.automate.api.iam.v2beta.DeleteTeamResp": {
       "type": "object",
       "properties": {
         "team": {
-          "$ref": "#/definitions/v2betaTeam"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
         }
       }
     },
-    "v2betaGetTeamMembershipResp": {
+    "chef.automate.api.iam.v2beta.GetTeamMembershipResp": {
       "type": "object",
       "properties": {
         "user_ids": {
@@ -320,37 +320,37 @@ func init() {
         }
       }
     },
-    "v2betaGetTeamResp": {
+    "chef.automate.api.iam.v2beta.GetTeamResp": {
       "type": "object",
       "properties": {
         "team": {
-          "$ref": "#/definitions/v2betaTeam"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
         }
       }
     },
-    "v2betaGetTeamsForMemberResp": {
+    "chef.automate.api.iam.v2beta.GetTeamsForMemberResp": {
       "type": "object",
       "properties": {
         "teams": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaTeam"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
           }
         }
       }
     },
-    "v2betaListTeamsResp": {
+    "chef.automate.api.iam.v2beta.ListTeamsResp": {
       "type": "object",
       "properties": {
         "teams": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaTeam"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
           }
         }
       }
     },
-    "v2betaRemoveTeamMembersReq": {
+    "chef.automate.api.iam.v2beta.RemoveTeamMembersReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -364,7 +364,7 @@ func init() {
         }
       }
     },
-    "v2betaRemoveTeamMembersResp": {
+    "chef.automate.api.iam.v2beta.RemoveTeamMembersResp": {
       "type": "object",
       "properties": {
         "user_ids": {
@@ -375,7 +375,7 @@ func init() {
         }
       }
     },
-    "v2betaTeam": {
+    "chef.automate.api.iam.v2beta.Team": {
       "type": "object",
       "properties": {
         "id": {
@@ -392,7 +392,7 @@ func init() {
         }
       }
     },
-    "v2betaUpdateTeamReq": {
+    "chef.automate.api.iam.v2beta.UpdateTeamReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -409,11 +409,11 @@ func init() {
         }
       }
     },
-    "v2betaUpdateTeamResp": {
+    "chef.automate.api.iam.v2beta.UpdateTeamResp": {
       "type": "object",
       "properties": {
         "team": {
-          "$ref": "#/definitions/v2betaTeam"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Team"
         }
       }
     }

--- a/components/automate-gateway/api/iam_v2beta_tokens.pb.swagger.go
+++ b/components/automate-gateway/api/iam_v2beta_tokens.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListTokensResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListTokensResp"
             }
           }
         },
@@ -39,7 +39,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateTokenResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateTokenResp"
             }
           }
         },
@@ -49,7 +49,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateTokenReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateTokenReq"
             }
           }
         ],
@@ -65,7 +65,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetTokenResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetTokenResp"
             }
           }
         },
@@ -87,7 +87,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteTokenResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteTokenResp"
             }
           }
         },
@@ -109,7 +109,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateTokenResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateTokenResp"
             }
           }
         },
@@ -126,7 +126,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateTokenReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateTokenReq"
             }
           }
         ],
@@ -137,7 +137,7 @@ func init() {
     }
   },
   "definitions": {
-    "v2betaCreateTokenReq": {
+    "chef.automate.api.iam.v2beta.CreateTokenReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -161,37 +161,37 @@ func init() {
         }
       }
     },
-    "v2betaCreateTokenResp": {
+    "chef.automate.api.iam.v2beta.CreateTokenResp": {
       "type": "object",
       "properties": {
         "token": {
-          "$ref": "#/definitions/v2betaToken"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Token"
         }
       }
     },
-    "v2betaDeleteTokenResp": {
+    "chef.automate.api.iam.v2beta.DeleteTokenResp": {
       "type": "object"
     },
-    "v2betaGetTokenResp": {
+    "chef.automate.api.iam.v2beta.GetTokenResp": {
       "type": "object",
       "properties": {
         "token": {
-          "$ref": "#/definitions/v2betaToken"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Token"
         }
       }
     },
-    "v2betaListTokensResp": {
+    "chef.automate.api.iam.v2beta.ListTokensResp": {
       "type": "object",
       "properties": {
         "tokens": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaToken"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.Token"
           }
         }
       }
     },
-    "v2betaToken": {
+    "chef.automate.api.iam.v2beta.Token": {
       "type": "object",
       "properties": {
         "id": {
@@ -221,7 +221,7 @@ func init() {
         }
       }
     },
-    "v2betaUpdateTokenReq": {
+    "chef.automate.api.iam.v2beta.UpdateTokenReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -243,11 +243,11 @@ func init() {
         }
       }
     },
-    "v2betaUpdateTokenResp": {
+    "chef.automate.api.iam.v2beta.UpdateTokenResp": {
       "type": "object",
       "properties": {
         "token": {
-          "$ref": "#/definitions/v2betaToken"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.Token"
         }
       }
     }

--- a/components/automate-gateway/api/iam_v2beta_users.pb.swagger.go
+++ b/components/automate-gateway/api/iam_v2beta_users.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateSelfResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateSelfResp"
             }
           }
         },
@@ -42,7 +42,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateSelfReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateSelfReq"
             }
           }
         ],
@@ -58,7 +58,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaListUsersResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.ListUsersResp"
             }
           }
         },
@@ -72,7 +72,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaCreateUserResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateUserResp"
             }
           }
         },
@@ -82,7 +82,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaCreateUserReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.CreateUserReq"
             }
           }
         ],
@@ -98,7 +98,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaGetUserResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.GetUserResp"
             }
           }
         },
@@ -120,7 +120,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaDeleteUserResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.DeleteUserResp"
             }
           }
         },
@@ -142,7 +142,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateUserResp"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateUserResp"
             }
           }
         },
@@ -159,7 +159,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v2betaUpdateUserReq"
+              "$ref": "#/definitions/chef.automate.api.iam.v2beta.UpdateUserReq"
             }
           }
         ],
@@ -170,7 +170,7 @@ func init() {
     }
   },
   "definitions": {
-    "v2betaCreateUserReq": {
+    "chef.automate.api.iam.v2beta.CreateUserReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -184,37 +184,37 @@ func init() {
         }
       }
     },
-    "v2betaCreateUserResp": {
+    "chef.automate.api.iam.v2beta.CreateUserResp": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/v2betaUser"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
         }
       }
     },
-    "v2betaDeleteUserResp": {
+    "chef.automate.api.iam.v2beta.DeleteUserResp": {
       "type": "object"
     },
-    "v2betaGetUserResp": {
+    "chef.automate.api.iam.v2beta.GetUserResp": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/v2betaUser"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
         }
       }
     },
-    "v2betaListUsersResp": {
+    "chef.automate.api.iam.v2beta.ListUsersResp": {
       "type": "object",
       "properties": {
         "users": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2betaUser"
+            "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
           }
         }
       }
     },
-    "v2betaUpdateSelfReq": {
+    "chef.automate.api.iam.v2beta.UpdateSelfReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -233,15 +233,15 @@ func init() {
         }
       }
     },
-    "v2betaUpdateSelfResp": {
+    "chef.automate.api.iam.v2beta.UpdateSelfResp": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/v2betaUser"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
         }
       }
     },
-    "v2betaUpdateUserReq": {
+    "chef.automate.api.iam.v2beta.UpdateUserReq": {
       "type": "object",
       "properties": {
         "id": {
@@ -256,15 +256,15 @@ func init() {
         }
       }
     },
-    "v2betaUpdateUserResp": {
+    "chef.automate.api.iam.v2beta.UpdateUserResp": {
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/v2betaUser"
+          "$ref": "#/definitions/chef.automate.api.iam.v2beta.User"
         }
       }
     },
-    "v2betaUser": {
+    "chef.automate.api.iam.v2beta.User": {
       "type": "object",
       "properties": {
         "name": {

--- a/components/automate-gateway/api/job_scheduler.pb.swagger.go
+++ b/components/automate-gateway/api/job_scheduler.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseConfigureDeleteNodesScheduler"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ConfigureDeleteNodesScheduler"
             }
           }
         },
@@ -35,7 +35,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestSchedulerConfig"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.SchedulerConfig"
             }
           }
         ],
@@ -51,7 +51,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseConfigureMissingNodesForDeletionScheduler"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ConfigureMissingNodesForDeletionScheduler"
             }
           }
         },
@@ -61,7 +61,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestSchedulerConfig"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.SchedulerConfig"
             }
           }
         ],
@@ -77,7 +77,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseConfigureNodesMissingScheduler"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ConfigureNodesMissingScheduler"
             }
           }
         },
@@ -87,7 +87,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/requestSchedulerConfig"
+              "$ref": "#/definitions/chef.automate.api.ingest.request.SchedulerConfig"
             }
           }
         ],
@@ -103,7 +103,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/responseJobSchedulerStatus"
+              "$ref": "#/definitions/chef.automate.api.ingest.response.JobSchedulerStatus"
             }
           }
         },
@@ -114,7 +114,7 @@ func init() {
     }
   },
   "definitions": {
-    "requestSchedulerConfig": {
+    "chef.automate.api.ingest.request.SchedulerConfig": {
       "type": "object",
       "properties": {
         "every": {
@@ -130,16 +130,16 @@ func init() {
       },
       "description": "SchedulerConfig\nThe job message to configure the Delete Node Job\nevery - It accepts '1h30m', '1m', '2h30m', ..."
     },
-    "responseConfigureDeleteNodesScheduler": {
+    "chef.automate.api.ingest.response.ConfigureDeleteNodesScheduler": {
       "type": "object"
     },
-    "responseConfigureMissingNodesForDeletionScheduler": {
+    "chef.automate.api.ingest.response.ConfigureMissingNodesForDeletionScheduler": {
       "type": "object"
     },
-    "responseConfigureNodesMissingScheduler": {
+    "chef.automate.api.ingest.response.ConfigureNodesMissingScheduler": {
       "type": "object"
     },
-    "responseJob": {
+    "chef.automate.api.ingest.response.Job": {
       "type": "object",
       "properties": {
         "running": {
@@ -169,7 +169,7 @@ func init() {
         }
       }
     },
-    "responseJobSchedulerStatus": {
+    "chef.automate.api.ingest.response.JobSchedulerStatus": {
       "type": "object",
       "properties": {
         "running": {
@@ -179,7 +179,7 @@ func init() {
         "jobs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/responseJob"
+            "$ref": "#/definitions/chef.automate.api.ingest.response.Job"
           }
         }
       }

--- a/components/automate-gateway/api/legacy/legacy.swagger.json
+++ b/components/automate-gateway/api/legacy/legacy.swagger.json
@@ -23,7 +23,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/legacyStatusResponse"
+              "$ref": "#/definitions/chef.automate.api.legacy.StatusResponse"
             }
           }
         },
@@ -34,7 +34,7 @@
     }
   },
   "definitions": {
-    "legacyStatusResponse": {
+    "chef.automate.api.legacy.StatusResponse": {
       "type": "object",
       "properties": {
         "status": {

--- a/components/automate-gateway/api/legacy_legacy.pb.swagger.go
+++ b/components/automate-gateway/api/legacy_legacy.pb.swagger.go
@@ -26,7 +26,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/legacyStatusResponse"
+              "$ref": "#/definitions/chef.automate.api.legacy.StatusResponse"
             }
           }
         },
@@ -37,7 +37,7 @@ func init() {
     }
   },
   "definitions": {
-    "legacyStatusResponse": {
+    "chef.automate.api.legacy.StatusResponse": {
       "type": "object",
       "properties": {
         "status": {

--- a/components/automate-gateway/api/license/license.swagger.json
+++ b/components/automate-gateway/api/license/license.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/licenseApplyLicenseResp"
+              "$ref": "#/definitions/chef.automate.api.license.ApplyLicenseResp"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/licenseApplyLicenseReq"
+              "$ref": "#/definitions/chef.automate.api.license.ApplyLicenseReq"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/licenseRequestLicenseResp"
+              "$ref": "#/definitions/chef.automate.api.license.RequestLicenseResp"
             }
           }
         },
@@ -58,7 +58,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/licenseRequestLicenseReq"
+              "$ref": "#/definitions/chef.automate.api.license.RequestLicenseReq"
             }
           }
         ],
@@ -74,7 +74,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/licenseGetStatusResp"
+              "$ref": "#/definitions/chef.automate.api.license.GetStatusResp"
             }
           }
         },
@@ -85,7 +85,41 @@
     }
   },
   "definitions": {
-    "GetStatusRespDateRange": {
+    "chef.automate.api.license.ApplyLicenseReq": {
+      "type": "object",
+      "properties": {
+        "license": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.license.ApplyLicenseResp": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/chef.automate.api.license.GetStatusResp"
+        }
+      }
+    },
+    "chef.automate.api.license.GetStatusResp": {
+      "type": "object",
+      "properties": {
+        "license_id": {
+          "type": "string"
+        },
+        "configured_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "licensed_period": {
+          "$ref": "#/definitions/chef.automate.api.license.GetStatusResp.DateRange"
+        },
+        "customer_name": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.license.GetStatusResp.DateRange": {
       "type": "object",
       "properties": {
         "start": {
@@ -98,41 +132,7 @@
         }
       }
     },
-    "licenseApplyLicenseReq": {
-      "type": "object",
-      "properties": {
-        "license": {
-          "type": "string"
-        }
-      }
-    },
-    "licenseApplyLicenseResp": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/licenseGetStatusResp"
-        }
-      }
-    },
-    "licenseGetStatusResp": {
-      "type": "object",
-      "properties": {
-        "license_id": {
-          "type": "string"
-        },
-        "configured_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "licensed_period": {
-          "$ref": "#/definitions/GetStatusRespDateRange"
-        },
-        "customer_name": {
-          "type": "string"
-        }
-      }
-    },
-    "licenseRequestLicenseReq": {
+    "chef.automate.api.license.RequestLicenseReq": {
       "type": "object",
       "properties": {
         "first_name": {
@@ -150,14 +150,14 @@
         }
       }
     },
-    "licenseRequestLicenseResp": {
+    "chef.automate.api.license.RequestLicenseResp": {
       "type": "object",
       "properties": {
         "license": {
           "type": "string"
         },
         "status": {
-          "$ref": "#/definitions/licenseGetStatusResp"
+          "$ref": "#/definitions/chef.automate.api.license.GetStatusResp"
         }
       }
     }

--- a/components/automate-gateway/api/license_license.pb.swagger.go
+++ b/components/automate-gateway/api/license_license.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/licenseApplyLicenseResp"
+              "$ref": "#/definitions/chef.automate.api.license.ApplyLicenseResp"
             }
           }
         },
@@ -35,7 +35,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/licenseApplyLicenseReq"
+              "$ref": "#/definitions/chef.automate.api.license.ApplyLicenseReq"
             }
           }
         ],
@@ -51,7 +51,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/licenseRequestLicenseResp"
+              "$ref": "#/definitions/chef.automate.api.license.RequestLicenseResp"
             }
           }
         },
@@ -61,7 +61,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/licenseRequestLicenseReq"
+              "$ref": "#/definitions/chef.automate.api.license.RequestLicenseReq"
             }
           }
         ],
@@ -77,7 +77,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/licenseGetStatusResp"
+              "$ref": "#/definitions/chef.automate.api.license.GetStatusResp"
             }
           }
         },
@@ -88,7 +88,41 @@ func init() {
     }
   },
   "definitions": {
-    "GetStatusRespDateRange": {
+    "chef.automate.api.license.ApplyLicenseReq": {
+      "type": "object",
+      "properties": {
+        "license": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.license.ApplyLicenseResp": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/chef.automate.api.license.GetStatusResp"
+        }
+      }
+    },
+    "chef.automate.api.license.GetStatusResp": {
+      "type": "object",
+      "properties": {
+        "license_id": {
+          "type": "string"
+        },
+        "configured_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "licensed_period": {
+          "$ref": "#/definitions/chef.automate.api.license.GetStatusResp.DateRange"
+        },
+        "customer_name": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.license.GetStatusResp.DateRange": {
       "type": "object",
       "properties": {
         "start": {
@@ -101,41 +135,7 @@ func init() {
         }
       }
     },
-    "licenseApplyLicenseReq": {
-      "type": "object",
-      "properties": {
-        "license": {
-          "type": "string"
-        }
-      }
-    },
-    "licenseApplyLicenseResp": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/licenseGetStatusResp"
-        }
-      }
-    },
-    "licenseGetStatusResp": {
-      "type": "object",
-      "properties": {
-        "license_id": {
-          "type": "string"
-        },
-        "configured_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "licensed_period": {
-          "$ref": "#/definitions/GetStatusRespDateRange"
-        },
-        "customer_name": {
-          "type": "string"
-        }
-      }
-    },
-    "licenseRequestLicenseReq": {
+    "chef.automate.api.license.RequestLicenseReq": {
       "type": "object",
       "properties": {
         "first_name": {
@@ -153,14 +153,14 @@ func init() {
         }
       }
     },
-    "licenseRequestLicenseResp": {
+    "chef.automate.api.license.RequestLicenseResp": {
       "type": "object",
       "properties": {
         "license": {
           "type": "string"
         },
         "status": {
-          "$ref": "#/definitions/licenseGetStatusResp"
+          "$ref": "#/definitions/chef.automate.api.license.GetStatusResp"
         }
       }
     }

--- a/components/automate-gateway/api/nodes/manager/manager.swagger.json
+++ b/components/automate-gateway/api/nodes/manager/manager.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Ids"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Ids"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1NodeManager"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1NodeManager"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
             }
           }
         },
@@ -108,7 +108,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1NodeManager"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
             }
           }
         ],
@@ -172,7 +172,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Ids"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Ids"
             }
           }
         },
@@ -196,7 +196,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Fields"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Fields"
             }
           }
         },
@@ -212,7 +212,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1FieldQuery"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.FieldQuery"
             }
           }
         ],
@@ -228,7 +228,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Nodes"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Nodes"
             }
           }
         },
@@ -244,7 +244,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1NodeQuery"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeQuery"
             }
           }
         ],
@@ -260,7 +260,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ConnectResponse"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.ConnectResponse"
             }
           }
         },
@@ -276,7 +276,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Id"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Id"
             }
           }
         ],
@@ -292,7 +292,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1NodeManagers"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManagers"
             }
           }
         },
@@ -302,7 +302,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query"
             }
           }
         ],
@@ -313,47 +313,10 @@
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "commonFilter": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "exclude": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "commonKv": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "v1ConnectResponse": {
+    "chef.automate.api.nodes.manager.v1.ConnectResponse": {
       "type": "object"
     },
-    "v1CredentialsByTags": {
+    "chef.automate.api.nodes.manager.v1.CredentialsByTags": {
       "type": "object",
       "properties": {
         "tag_key": {
@@ -370,11 +333,11 @@
         }
       }
     },
-    "v1FieldQuery": {
+    "chef.automate.api.nodes.manager.v1.FieldQuery": {
       "type": "object",
       "properties": {
         "query": {
-          "$ref": "#/definitions/v1Query"
+          "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query"
         },
         "field": {
           "type": "string"
@@ -384,7 +347,7 @@
         }
       }
     },
-    "v1Fields": {
+    "chef.automate.api.nodes.manager.v1.Fields": {
       "type": "object",
       "properties": {
         "fields": {
@@ -395,7 +358,7 @@
         }
       }
     },
-    "v1Id": {
+    "chef.automate.api.nodes.manager.v1.Id": {
       "type": "object",
       "properties": {
         "id": {
@@ -403,18 +366,18 @@
         }
       }
     },
-    "v1Ids": {
+    "chef.automate.api.nodes.manager.v1.Ids": {
       "type": "object",
       "properties": {
         "ids": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Id"
+            "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Id"
           }
         }
       }
     },
-    "v1NodeManager": {
+    "chef.automate.api.nodes.manager.v1.NodeManager": {
       "type": "object",
       "properties": {
         "id": {
@@ -432,7 +395,7 @@
         "instance_credentials": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1CredentialsByTags"
+            "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.CredentialsByTags"
           }
         },
         "status": {
@@ -448,18 +411,18 @@
         "credential_data": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonKv"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Kv"
           }
         }
       }
     },
-    "v1NodeManagers": {
+    "chef.automate.api.nodes.manager.v1.NodeManagers": {
       "type": "object",
       "properties": {
         "managers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1NodeManager"
+            "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
           }
         },
         "total": {
@@ -468,18 +431,18 @@
         }
       }
     },
-    "v1NodeQuery": {
+    "chef.automate.api.nodes.manager.v1.NodeQuery": {
       "type": "object",
       "properties": {
         "query": {
-          "$ref": "#/definitions/v1Query"
+          "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query"
         },
         "node_manager_id": {
           "type": "string"
         }
       }
     },
-    "v1Nodes": {
+    "chef.automate.api.nodes.manager.v1.Nodes": {
       "type": "object",
       "properties": {
         "nodes": {
@@ -494,17 +457,17 @@
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.nodes.manager.v1.Query": {
       "type": "object",
       "properties": {
         "filter_map": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonFilter"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Filter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -516,6 +479,43 @@
         "per_page": {
           "type": "integer",
           "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.domain.compliance.api.common.Filter": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "exclude": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Kv": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
         }
       }
     }

--- a/components/automate-gateway/api/nodes/nodes.swagger.json
+++ b/components/automate-gateway/api/nodes/nodes.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Id"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Id"
             }
           }
         },
@@ -32,7 +32,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Node"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
             }
           }
         ],
@@ -48,7 +48,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Ids"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Ids"
             }
           }
         },
@@ -58,7 +58,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Nodes"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Nodes"
             }
           }
         ],
@@ -74,7 +74,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1BulkDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.BulkDeleteResponse"
             }
           }
         },
@@ -84,7 +84,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Query"
             }
           }
         ],
@@ -100,7 +100,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1BulkDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.BulkDeleteResponse"
             }
           }
         },
@@ -110,7 +110,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Ids"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Ids"
             }
           }
         ],
@@ -126,7 +126,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Node"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
             }
           }
         },
@@ -186,7 +186,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Node"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
             }
           }
         ],
@@ -202,7 +202,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1RerunResponse"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.RerunResponse"
             }
           }
         },
@@ -226,7 +226,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Nodes"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Nodes"
             }
           }
         },
@@ -236,7 +236,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Query"
             }
           }
         ],
@@ -247,54 +247,7 @@
     }
   },
   "definitions": {
-    "LastContactDataStatus": {
-      "type": "string",
-      "enum": [
-        "UNKNOWN",
-        "PASSED",
-        "FAILED",
-        "SKIPPED"
-      ],
-      "default": "UNKNOWN"
-    },
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "commonFilter": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "exclude": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "commonKv": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "v1BulkDeleteResponse": {
+    "chef.automate.api.nodes.v1.BulkDeleteResponse": {
       "type": "object",
       "properties": {
         "names": {
@@ -305,7 +258,7 @@
         }
       }
     },
-    "v1Id": {
+    "chef.automate.api.nodes.v1.Id": {
       "type": "object",
       "properties": {
         "id": {
@@ -313,7 +266,7 @@
         }
       }
     },
-    "v1Ids": {
+    "chef.automate.api.nodes.v1.Ids": {
       "type": "object",
       "properties": {
         "ids": {
@@ -324,17 +277,17 @@
         }
       }
     },
-    "v1LastContactData": {
+    "chef.automate.api.nodes.v1.LastContactData": {
       "type": "object",
       "properties": {
         "id": {
           "type": "string"
         },
         "status": {
-          "$ref": "#/definitions/LastContactDataStatus"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData.Status"
         },
         "penultimate_status": {
-          "$ref": "#/definitions/LastContactDataStatus"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData.Status"
         },
         "end_time": {
           "type": "string",
@@ -342,7 +295,17 @@
         }
       }
     },
-    "v1Node": {
+    "chef.automate.api.nodes.v1.LastContactData.Status": {
+      "type": "string",
+      "enum": [
+        "UNKNOWN",
+        "PASSED",
+        "FAILED",
+        "SKIPPED"
+      ],
+      "default": "UNKNOWN"
+    },
+    "chef.automate.api.nodes.v1.Node": {
       "type": "object",
       "properties": {
         "id": {
@@ -363,7 +326,7 @@
         "tags": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonKv"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Kv"
           }
         },
         "last_contact": {
@@ -374,10 +337,10 @@
           "type": "string"
         },
         "last_job": {
-          "$ref": "#/definitions/v1ResultsRow"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.ResultsRow"
         },
         "target_config": {
-          "$ref": "#/definitions/v1TargetConfig"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.TargetConfig"
         },
         "manager_ids": {
           "type": "array",
@@ -401,20 +364,20 @@
           }
         },
         "run_data": {
-          "$ref": "#/definitions/v1LastContactData"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData"
         },
         "scan_data": {
-          "$ref": "#/definitions/v1LastContactData"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData"
         }
       }
     },
-    "v1Nodes": {
+    "chef.automate.api.nodes.v1.Nodes": {
       "type": "object",
       "properties": {
         "nodes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Node"
+            "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
           }
         },
         "total": {
@@ -435,17 +398,17 @@
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.nodes.v1.Query": {
       "type": "object",
       "properties": {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonFilter"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Filter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -460,10 +423,18 @@
         }
       }
     },
-    "v1RerunResponse": {
+    "chef.automate.api.nodes.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.nodes.v1.RerunResponse": {
       "type": "object"
     },
-    "v1ResultsRow": {
+    "chef.automate.api.nodes.v1.ResultsRow": {
       "type": "object",
       "properties": {
         "node_id": {
@@ -491,7 +462,7 @@
         }
       }
     },
-    "v1TargetConfig": {
+    "chef.automate.api.nodes.v1.TargetConfig": {
       "type": "object",
       "properties": {
         "secrets": {
@@ -551,6 +522,35 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Filter": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "exclude": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Kv": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
         }
       }
     }

--- a/components/automate-gateway/api/nodes_manager_manager.pb.swagger.go
+++ b/components/automate-gateway/api/nodes_manager_manager.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Ids"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Ids"
             }
           }
         },
@@ -35,7 +35,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1NodeManager"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
             }
           }
         ],
@@ -51,7 +51,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1NodeManager"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
             }
           }
         },
@@ -111,7 +111,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1NodeManager"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
             }
           }
         ],
@@ -175,7 +175,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Ids"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Ids"
             }
           }
         },
@@ -199,7 +199,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Fields"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Fields"
             }
           }
         },
@@ -215,7 +215,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1FieldQuery"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.FieldQuery"
             }
           }
         ],
@@ -231,7 +231,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Nodes"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Nodes"
             }
           }
         },
@@ -247,7 +247,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1NodeQuery"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeQuery"
             }
           }
         ],
@@ -263,7 +263,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1ConnectResponse"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.ConnectResponse"
             }
           }
         },
@@ -279,7 +279,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Id"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Id"
             }
           }
         ],
@@ -295,7 +295,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1NodeManagers"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManagers"
             }
           }
         },
@@ -305,7 +305,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query"
             }
           }
         ],
@@ -316,47 +316,10 @@ func init() {
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "commonFilter": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "exclude": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "commonKv": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "v1ConnectResponse": {
+    "chef.automate.api.nodes.manager.v1.ConnectResponse": {
       "type": "object"
     },
-    "v1CredentialsByTags": {
+    "chef.automate.api.nodes.manager.v1.CredentialsByTags": {
       "type": "object",
       "properties": {
         "tag_key": {
@@ -373,11 +336,11 @@ func init() {
         }
       }
     },
-    "v1FieldQuery": {
+    "chef.automate.api.nodes.manager.v1.FieldQuery": {
       "type": "object",
       "properties": {
         "query": {
-          "$ref": "#/definitions/v1Query"
+          "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query"
         },
         "field": {
           "type": "string"
@@ -387,7 +350,7 @@ func init() {
         }
       }
     },
-    "v1Fields": {
+    "chef.automate.api.nodes.manager.v1.Fields": {
       "type": "object",
       "properties": {
         "fields": {
@@ -398,7 +361,7 @@ func init() {
         }
       }
     },
-    "v1Id": {
+    "chef.automate.api.nodes.manager.v1.Id": {
       "type": "object",
       "properties": {
         "id": {
@@ -406,18 +369,18 @@ func init() {
         }
       }
     },
-    "v1Ids": {
+    "chef.automate.api.nodes.manager.v1.Ids": {
       "type": "object",
       "properties": {
         "ids": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Id"
+            "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Id"
           }
         }
       }
     },
-    "v1NodeManager": {
+    "chef.automate.api.nodes.manager.v1.NodeManager": {
       "type": "object",
       "properties": {
         "id": {
@@ -435,7 +398,7 @@ func init() {
         "instance_credentials": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1CredentialsByTags"
+            "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.CredentialsByTags"
           }
         },
         "status": {
@@ -451,18 +414,18 @@ func init() {
         "credential_data": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonKv"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Kv"
           }
         }
       }
     },
-    "v1NodeManagers": {
+    "chef.automate.api.nodes.manager.v1.NodeManagers": {
       "type": "object",
       "properties": {
         "managers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1NodeManager"
+            "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
           }
         },
         "total": {
@@ -471,18 +434,18 @@ func init() {
         }
       }
     },
-    "v1NodeQuery": {
+    "chef.automate.api.nodes.manager.v1.NodeQuery": {
       "type": "object",
       "properties": {
         "query": {
-          "$ref": "#/definitions/v1Query"
+          "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query"
         },
         "node_manager_id": {
           "type": "string"
         }
       }
     },
-    "v1Nodes": {
+    "chef.automate.api.nodes.manager.v1.Nodes": {
       "type": "object",
       "properties": {
         "nodes": {
@@ -497,17 +460,17 @@ func init() {
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.nodes.manager.v1.Query": {
       "type": "object",
       "properties": {
         "filter_map": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonFilter"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Filter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -519,6 +482,43 @@ func init() {
         "per_page": {
           "type": "integer",
           "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.domain.compliance.api.common.Filter": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "exclude": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Kv": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
         }
       }
     }

--- a/components/automate-gateway/api/nodes_nodes.pb.swagger.go
+++ b/components/automate-gateway/api/nodes_nodes.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Id"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Id"
             }
           }
         },
@@ -35,7 +35,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Node"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
             }
           }
         ],
@@ -51,7 +51,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Ids"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Ids"
             }
           }
         },
@@ -61,7 +61,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Nodes"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Nodes"
             }
           }
         ],
@@ -77,7 +77,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1BulkDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.BulkDeleteResponse"
             }
           }
         },
@@ -87,7 +87,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Query"
             }
           }
         ],
@@ -103,7 +103,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1BulkDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.BulkDeleteResponse"
             }
           }
         },
@@ -113,7 +113,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Ids"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Ids"
             }
           }
         ],
@@ -129,7 +129,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Node"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
             }
           }
         },
@@ -189,7 +189,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Node"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
             }
           }
         ],
@@ -205,7 +205,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1RerunResponse"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.RerunResponse"
             }
           }
         },
@@ -229,7 +229,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1Nodes"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Nodes"
             }
           }
         },
@@ -239,7 +239,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1Query"
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Query"
             }
           }
         ],
@@ -250,54 +250,7 @@ func init() {
     }
   },
   "definitions": {
-    "LastContactDataStatus": {
-      "type": "string",
-      "enum": [
-        "UNKNOWN",
-        "PASSED",
-        "FAILED",
-        "SKIPPED"
-      ],
-      "default": "UNKNOWN"
-    },
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "commonFilter": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "exclude": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "commonKv": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "v1BulkDeleteResponse": {
+    "chef.automate.api.nodes.v1.BulkDeleteResponse": {
       "type": "object",
       "properties": {
         "names": {
@@ -308,7 +261,7 @@ func init() {
         }
       }
     },
-    "v1Id": {
+    "chef.automate.api.nodes.v1.Id": {
       "type": "object",
       "properties": {
         "id": {
@@ -316,7 +269,7 @@ func init() {
         }
       }
     },
-    "v1Ids": {
+    "chef.automate.api.nodes.v1.Ids": {
       "type": "object",
       "properties": {
         "ids": {
@@ -327,17 +280,17 @@ func init() {
         }
       }
     },
-    "v1LastContactData": {
+    "chef.automate.api.nodes.v1.LastContactData": {
       "type": "object",
       "properties": {
         "id": {
           "type": "string"
         },
         "status": {
-          "$ref": "#/definitions/LastContactDataStatus"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData.Status"
         },
         "penultimate_status": {
-          "$ref": "#/definitions/LastContactDataStatus"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData.Status"
         },
         "end_time": {
           "type": "string",
@@ -345,7 +298,17 @@ func init() {
         }
       }
     },
-    "v1Node": {
+    "chef.automate.api.nodes.v1.LastContactData.Status": {
+      "type": "string",
+      "enum": [
+        "UNKNOWN",
+        "PASSED",
+        "FAILED",
+        "SKIPPED"
+      ],
+      "default": "UNKNOWN"
+    },
+    "chef.automate.api.nodes.v1.Node": {
       "type": "object",
       "properties": {
         "id": {
@@ -366,7 +329,7 @@ func init() {
         "tags": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonKv"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Kv"
           }
         },
         "last_contact": {
@@ -377,10 +340,10 @@ func init() {
           "type": "string"
         },
         "last_job": {
-          "$ref": "#/definitions/v1ResultsRow"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.ResultsRow"
         },
         "target_config": {
-          "$ref": "#/definitions/v1TargetConfig"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.TargetConfig"
         },
         "manager_ids": {
           "type": "array",
@@ -404,20 +367,20 @@ func init() {
           }
         },
         "run_data": {
-          "$ref": "#/definitions/v1LastContactData"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData"
         },
         "scan_data": {
-          "$ref": "#/definitions/v1LastContactData"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData"
         }
       }
     },
-    "v1Nodes": {
+    "chef.automate.api.nodes.v1.Nodes": {
       "type": "object",
       "properties": {
         "nodes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v1Node"
+            "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
           }
         },
         "total": {
@@ -438,17 +401,17 @@ func init() {
         }
       }
     },
-    "v1Query": {
+    "chef.automate.api.nodes.v1.Query": {
       "type": "object",
       "properties": {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/commonFilter"
+            "$ref": "#/definitions/chef.automate.domain.compliance.api.common.Filter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -463,10 +426,18 @@ func init() {
         }
       }
     },
-    "v1RerunResponse": {
+    "chef.automate.api.nodes.v1.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.nodes.v1.RerunResponse": {
       "type": "object"
     },
-    "v1ResultsRow": {
+    "chef.automate.api.nodes.v1.ResultsRow": {
       "type": "object",
       "properties": {
         "node_id": {
@@ -494,7 +465,7 @@ func init() {
         }
       }
     },
-    "v1TargetConfig": {
+    "chef.automate.api.nodes.v1.TargetConfig": {
       "type": "object",
       "properties": {
         "secrets": {
@@ -554,6 +525,35 @@ func init() {
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Filter": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "exclude": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.domain.compliance.api.common.Kv": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
         }
       }
     }

--- a/components/automate-gateway/api/notifications/notifications.swagger.json
+++ b/components/automate-gateway/api/notifications/notifications.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleListResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleListResponse"
             }
           }
         },
@@ -36,7 +36,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleAddResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleAddResponse"
             }
           }
         },
@@ -46,7 +46,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/notificationsRuleAddRequest"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleAddRequest"
             }
           }
         ],
@@ -62,7 +62,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleGetResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleGetResponse"
             }
           }
         },
@@ -84,7 +84,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleDeleteResponse"
             }
           }
         },
@@ -106,7 +106,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleUpdateResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleUpdateResponse"
             }
           }
         },
@@ -122,7 +122,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/notificationsRuleUpdateRequest"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleUpdateRequest"
             }
           }
         ],
@@ -138,7 +138,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsVersionResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.VersionResponse"
             }
           }
         },
@@ -154,7 +154,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsURLValidationResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.URLValidationResponse"
             }
           }
         },
@@ -164,7 +164,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/notificationsURLValidationRequest"
+              "$ref": "#/definitions/chef.automate.api.notifications.URLValidationRequest"
             }
           }
         ],
@@ -175,20 +175,10 @@
     }
   },
   "definitions": {
-    "RuleEvent": {
-      "type": "string",
-      "enum": [
-        "CCRFailure",
-        "CCRSuccess",
-        "ComplianceFailure",
-        "ComplianceSuccess"
-      ],
-      "default": "CCRFailure"
-    },
-    "notificationsEmpty": {
+    "chef.automate.api.notifications.Empty": {
       "type": "object"
     },
-    "notificationsRule": {
+    "chef.automate.api.notifications.Rule": {
       "type": "object",
       "properties": {
         "id": {
@@ -198,28 +188,38 @@
           "type": "string"
         },
         "event": {
-          "$ref": "#/definitions/RuleEvent"
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule.Event"
         },
         "SlackAlert": {
-          "$ref": "#/definitions/notificationsSlackAlert"
+          "$ref": "#/definitions/chef.automate.api.notifications.SlackAlert"
         },
         "WebhookAlert": {
-          "$ref": "#/definitions/notificationsWebhookAlert"
+          "$ref": "#/definitions/chef.automate.api.notifications.WebhookAlert"
         },
         "ServiceNowAlert": {
-          "$ref": "#/definitions/notificationsServiceNowAlert"
+          "$ref": "#/definitions/chef.automate.api.notifications.ServiceNowAlert"
         }
       }
     },
-    "notificationsRuleAddRequest": {
+    "chef.automate.api.notifications.Rule.Event": {
+      "type": "string",
+      "enum": [
+        "CCRFailure",
+        "CCRSuccess",
+        "ComplianceFailure",
+        "ComplianceSuccess"
+      ],
+      "default": "CCRFailure"
+    },
+    "chef.automate.api.notifications.RuleAddRequest": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/notificationsRule"
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule"
         }
       }
     },
-    "notificationsRuleAddResponse": {
+    "chef.automate.api.notifications.RuleAddResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -233,7 +233,7 @@
         }
       }
     },
-    "notificationsRuleDeleteResponse": {
+    "chef.automate.api.notifications.RuleDeleteResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -244,7 +244,7 @@
         }
       }
     },
-    "notificationsRuleGetResponse": {
+    "chef.automate.api.notifications.RuleGetResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -254,11 +254,11 @@
           }
         },
         "rule": {
-          "$ref": "#/definitions/notificationsRule"
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule"
         }
       }
     },
-    "notificationsRuleListResponse": {
+    "chef.automate.api.notifications.RuleListResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -270,23 +270,23 @@
         "rules": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/notificationsRule"
+            "$ref": "#/definitions/chef.automate.api.notifications.Rule"
           }
         }
       }
     },
-    "notificationsRuleUpdateRequest": {
+    "chef.automate.api.notifications.RuleUpdateRequest": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/notificationsRule"
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule"
         },
         "id": {
           "type": "string"
         }
       }
     },
-    "notificationsRuleUpdateResponse": {
+    "chef.automate.api.notifications.RuleUpdateResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -297,7 +297,7 @@
         }
       }
     },
-    "notificationsSecretId": {
+    "chef.automate.api.notifications.SecretId": {
       "type": "object",
       "properties": {
         "id": {
@@ -305,7 +305,7 @@
         }
       }
     },
-    "notificationsServiceNowAlert": {
+    "chef.automate.api.notifications.ServiceNowAlert": {
       "type": "object",
       "properties": {
         "url": {
@@ -320,7 +320,7 @@
         }
       }
     },
-    "notificationsSlackAlert": {
+    "chef.automate.api.notifications.SlackAlert": {
       "type": "object",
       "properties": {
         "url": {
@@ -328,27 +328,27 @@
         }
       }
     },
-    "notificationsURLValidationRequest": {
+    "chef.automate.api.notifications.URLValidationRequest": {
       "type": "object",
       "properties": {
         "url": {
           "type": "string"
         },
         "username_password": {
-          "$ref": "#/definitions/notificationsUsernamePassword"
+          "$ref": "#/definitions/chef.automate.api.notifications.UsernamePassword"
         },
         "secret_id": {
-          "$ref": "#/definitions/notificationsSecretId"
+          "$ref": "#/definitions/chef.automate.api.notifications.SecretId"
         },
         "none": {
-          "$ref": "#/definitions/notificationsEmpty"
+          "$ref": "#/definitions/chef.automate.api.notifications.Empty"
         }
       }
     },
-    "notificationsURLValidationResponse": {
+    "chef.automate.api.notifications.URLValidationResponse": {
       "type": "object"
     },
-    "notificationsUsernamePassword": {
+    "chef.automate.api.notifications.UsernamePassword": {
       "type": "object",
       "properties": {
         "username": {
@@ -359,7 +359,7 @@
         }
       }
     },
-    "notificationsVersionResponse": {
+    "chef.automate.api.notifications.VersionResponse": {
       "type": "object",
       "properties": {
         "version": {
@@ -367,7 +367,7 @@
         }
       }
     },
-    "notificationsWebhookAlert": {
+    "chef.automate.api.notifications.WebhookAlert": {
       "type": "object",
       "properties": {
         "url": {

--- a/components/automate-gateway/api/notifications_notifications.pb.swagger.go
+++ b/components/automate-gateway/api/notifications_notifications.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleListResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleListResponse"
             }
           }
         },
@@ -39,7 +39,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleAddResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleAddResponse"
             }
           }
         },
@@ -49,7 +49,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/notificationsRuleAddRequest"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleAddRequest"
             }
           }
         ],
@@ -65,7 +65,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleGetResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleGetResponse"
             }
           }
         },
@@ -87,7 +87,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleDeleteResponse"
             }
           }
         },
@@ -109,7 +109,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsRuleUpdateResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleUpdateResponse"
             }
           }
         },
@@ -125,7 +125,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/notificationsRuleUpdateRequest"
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleUpdateRequest"
             }
           }
         ],
@@ -141,7 +141,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsVersionResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.VersionResponse"
             }
           }
         },
@@ -157,7 +157,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/notificationsURLValidationResponse"
+              "$ref": "#/definitions/chef.automate.api.notifications.URLValidationResponse"
             }
           }
         },
@@ -167,7 +167,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/notificationsURLValidationRequest"
+              "$ref": "#/definitions/chef.automate.api.notifications.URLValidationRequest"
             }
           }
         ],
@@ -178,20 +178,10 @@ func init() {
     }
   },
   "definitions": {
-    "RuleEvent": {
-      "type": "string",
-      "enum": [
-        "CCRFailure",
-        "CCRSuccess",
-        "ComplianceFailure",
-        "ComplianceSuccess"
-      ],
-      "default": "CCRFailure"
-    },
-    "notificationsEmpty": {
+    "chef.automate.api.notifications.Empty": {
       "type": "object"
     },
-    "notificationsRule": {
+    "chef.automate.api.notifications.Rule": {
       "type": "object",
       "properties": {
         "id": {
@@ -201,28 +191,38 @@ func init() {
           "type": "string"
         },
         "event": {
-          "$ref": "#/definitions/RuleEvent"
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule.Event"
         },
         "SlackAlert": {
-          "$ref": "#/definitions/notificationsSlackAlert"
+          "$ref": "#/definitions/chef.automate.api.notifications.SlackAlert"
         },
         "WebhookAlert": {
-          "$ref": "#/definitions/notificationsWebhookAlert"
+          "$ref": "#/definitions/chef.automate.api.notifications.WebhookAlert"
         },
         "ServiceNowAlert": {
-          "$ref": "#/definitions/notificationsServiceNowAlert"
+          "$ref": "#/definitions/chef.automate.api.notifications.ServiceNowAlert"
         }
       }
     },
-    "notificationsRuleAddRequest": {
+    "chef.automate.api.notifications.Rule.Event": {
+      "type": "string",
+      "enum": [
+        "CCRFailure",
+        "CCRSuccess",
+        "ComplianceFailure",
+        "ComplianceSuccess"
+      ],
+      "default": "CCRFailure"
+    },
+    "chef.automate.api.notifications.RuleAddRequest": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/notificationsRule"
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule"
         }
       }
     },
-    "notificationsRuleAddResponse": {
+    "chef.automate.api.notifications.RuleAddResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -236,7 +236,7 @@ func init() {
         }
       }
     },
-    "notificationsRuleDeleteResponse": {
+    "chef.automate.api.notifications.RuleDeleteResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -247,7 +247,7 @@ func init() {
         }
       }
     },
-    "notificationsRuleGetResponse": {
+    "chef.automate.api.notifications.RuleGetResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -257,11 +257,11 @@ func init() {
           }
         },
         "rule": {
-          "$ref": "#/definitions/notificationsRule"
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule"
         }
       }
     },
-    "notificationsRuleListResponse": {
+    "chef.automate.api.notifications.RuleListResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -273,23 +273,23 @@ func init() {
         "rules": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/notificationsRule"
+            "$ref": "#/definitions/chef.automate.api.notifications.Rule"
           }
         }
       }
     },
-    "notificationsRuleUpdateRequest": {
+    "chef.automate.api.notifications.RuleUpdateRequest": {
       "type": "object",
       "properties": {
         "rule": {
-          "$ref": "#/definitions/notificationsRule"
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule"
         },
         "id": {
           "type": "string"
         }
       }
     },
-    "notificationsRuleUpdateResponse": {
+    "chef.automate.api.notifications.RuleUpdateResponse": {
       "type": "object",
       "properties": {
         "messages": {
@@ -300,7 +300,7 @@ func init() {
         }
       }
     },
-    "notificationsSecretId": {
+    "chef.automate.api.notifications.SecretId": {
       "type": "object",
       "properties": {
         "id": {
@@ -308,7 +308,7 @@ func init() {
         }
       }
     },
-    "notificationsServiceNowAlert": {
+    "chef.automate.api.notifications.ServiceNowAlert": {
       "type": "object",
       "properties": {
         "url": {
@@ -323,7 +323,7 @@ func init() {
         }
       }
     },
-    "notificationsSlackAlert": {
+    "chef.automate.api.notifications.SlackAlert": {
       "type": "object",
       "properties": {
         "url": {
@@ -331,27 +331,27 @@ func init() {
         }
       }
     },
-    "notificationsURLValidationRequest": {
+    "chef.automate.api.notifications.URLValidationRequest": {
       "type": "object",
       "properties": {
         "url": {
           "type": "string"
         },
         "username_password": {
-          "$ref": "#/definitions/notificationsUsernamePassword"
+          "$ref": "#/definitions/chef.automate.api.notifications.UsernamePassword"
         },
         "secret_id": {
-          "$ref": "#/definitions/notificationsSecretId"
+          "$ref": "#/definitions/chef.automate.api.notifications.SecretId"
         },
         "none": {
-          "$ref": "#/definitions/notificationsEmpty"
+          "$ref": "#/definitions/chef.automate.api.notifications.Empty"
         }
       }
     },
-    "notificationsURLValidationResponse": {
+    "chef.automate.api.notifications.URLValidationResponse": {
       "type": "object"
     },
-    "notificationsUsernamePassword": {
+    "chef.automate.api.notifications.UsernamePassword": {
       "type": "object",
       "properties": {
         "username": {
@@ -362,7 +362,7 @@ func init() {
         }
       }
     },
-    "notificationsVersionResponse": {
+    "chef.automate.api.notifications.VersionResponse": {
       "type": "object",
       "properties": {
         "version": {
@@ -370,7 +370,7 @@ func init() {
         }
       }
     },
-    "notificationsWebhookAlert": {
+    "chef.automate.api.notifications.WebhookAlert": {
       "type": "object",
       "properties": {
         "url": {

--- a/components/automate-gateway/api/secrets.pb.swagger.go
+++ b/components/automate-gateway/api/secrets.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsId"
+              "$ref": "#/definitions/chef.automate.api.secrets.Id"
             }
           }
         },
@@ -35,7 +35,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/secretsSecret"
+              "$ref": "#/definitions/chef.automate.api.secrets.Secret"
             }
           }
         ],
@@ -51,7 +51,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsSecret"
+              "$ref": "#/definitions/chef.automate.api.secrets.Secret"
             }
           }
         },
@@ -73,7 +73,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsDeleteResponse"
+              "$ref": "#/definitions/chef.automate.api.secrets.DeleteResponse"
             }
           }
         },
@@ -95,7 +95,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsUpdateResponse"
+              "$ref": "#/definitions/chef.automate.api.secrets.UpdateResponse"
             }
           }
         },
@@ -111,7 +111,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/secretsSecret"
+              "$ref": "#/definitions/chef.automate.api.secrets.Secret"
             }
           }
         ],
@@ -127,7 +127,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/secretsSecrets"
+              "$ref": "#/definitions/chef.automate.api.secrets.Secrets"
             }
           }
         },
@@ -137,7 +137,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/secretsQuery"
+              "$ref": "#/definitions/chef.automate.api.secrets.Query"
             }
           }
         ],
@@ -148,18 +148,10 @@ func init() {
     }
   },
   "definitions": {
-    "QueryOrderType": {
-      "type": "string",
-      "enum": [
-        "ASC",
-        "DESC"
-      ],
-      "default": "ASC"
-    },
-    "secretsDeleteResponse": {
+    "chef.automate.api.secrets.DeleteResponse": {
       "type": "object"
     },
-    "secretsFilter": {
+    "chef.automate.api.secrets.Filter": {
       "type": "object",
       "properties": {
         "key": {
@@ -177,7 +169,7 @@ func init() {
         }
       }
     },
-    "secretsId": {
+    "chef.automate.api.secrets.Id": {
       "type": "object",
       "properties": {
         "id": {
@@ -185,7 +177,7 @@ func init() {
         }
       }
     },
-    "secretsKv": {
+    "chef.automate.api.secrets.Kv": {
       "type": "object",
       "properties": {
         "key": {
@@ -196,17 +188,17 @@ func init() {
         }
       }
     },
-    "secretsQuery": {
+    "chef.automate.api.secrets.Query": {
       "type": "object",
       "properties": {
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/secretsFilter"
+            "$ref": "#/definitions/chef.automate.api.secrets.Filter"
           }
         },
         "order": {
-          "$ref": "#/definitions/QueryOrderType"
+          "$ref": "#/definitions/chef.automate.api.secrets.Query.OrderType"
         },
         "sort": {
           "type": "string"
@@ -221,7 +213,15 @@ func init() {
         }
       }
     },
-    "secretsSecret": {
+    "chef.automate.api.secrets.Query.OrderType": {
+      "type": "string",
+      "enum": [
+        "ASC",
+        "DESC"
+      ],
+      "default": "ASC"
+    },
+    "chef.automate.api.secrets.Secret": {
       "type": "object",
       "properties": {
         "id": {
@@ -240,24 +240,24 @@ func init() {
         "tags": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/secretsKv"
+            "$ref": "#/definitions/chef.automate.api.secrets.Kv"
           }
         },
         "data": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/secretsKv"
+            "$ref": "#/definitions/chef.automate.api.secrets.Kv"
           }
         }
       }
     },
-    "secretsSecrets": {
+    "chef.automate.api.secrets.Secrets": {
       "type": "object",
       "properties": {
         "secrets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/secretsSecret"
+            "$ref": "#/definitions/chef.automate.api.secrets.Secret"
           }
         },
         "total": {
@@ -266,7 +266,7 @@ func init() {
         }
       }
     },
-    "secretsUpdateResponse": {
+    "chef.automate.api.secrets.UpdateResponse": {
       "type": "object"
     }
   }

--- a/components/automate-gateway/api/telemetry/telemetry.swagger.json
+++ b/components/automate-gateway/api/telemetry/telemetry.swagger.json
@@ -22,7 +22,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/telemetryTelemetryResponse"
+              "$ref": "#/definitions/chef.automate.api.telemetry.TelemetryResponse"
             }
           }
         },
@@ -33,7 +33,7 @@
     }
   },
   "definitions": {
-    "telemetryTelemetryResponse": {
+    "chef.automate.api.telemetry.TelemetryResponse": {
       "type": "object",
       "properties": {
         "license_id": {

--- a/components/automate-gateway/api/telemetry_telemetry.pb.swagger.go
+++ b/components/automate-gateway/api/telemetry_telemetry.pb.swagger.go
@@ -25,7 +25,7 @@ func init() {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/telemetryTelemetryResponse"
+              "$ref": "#/definitions/chef.automate.api.telemetry.TelemetryResponse"
             }
           }
         },
@@ -36,7 +36,7 @@ func init() {
     }
   },
   "definitions": {
-    "telemetryTelemetryResponse": {
+    "chef.automate.api.telemetry.TelemetryResponse": {
       "type": "object",
       "properties": {
         "license_id": {

--- a/components/automate-gateway/scripts/grpc.sh
+++ b/components/automate-gateway/scripts/grpc.sh
@@ -47,7 +47,7 @@ for i in components/automate-gateway/api/**/; do
     # generates swagger output, only generate if a gateway file was generated
     gw_files=("$i"*.gw.go)
     if [ ${#gw_files[@]} -ne 0 ]; then
-        protoc "${IMPORTS[@]}" --swagger_out=logtostderr=true:"$PWD" "${list[@]}" || exit 1
+        protoc "${IMPORTS[@]}" --swagger_out=logtostderr=true,fqn_for_swagger_name=true:"$PWD" "${list[@]}" || exit 1
     fi
   fi
 done


### PR DESCRIPTION
This PR makes a change to our proto compilation to force it to prepend the entire package name onto the entity names generated in the swagger files. There were two things happening that made this necessary:

* The package names defined in our proto files often do not have a unique trailing section, for example a few proto's package names end in `.v1`. A few examples:
  * https://github.com/chef/automate/blob/master/components/automate-gateway/api/compliance/reporting/reporting.proto
   * https://github.com/chef/automate/blob/master/components/automate-gateway/api/compliance/reporting/stats/stats.proto
* `protoc-gen-swagger` attempts to generate unique strings to identify each entity by concatenating the trailing section of the package name and the name of the entity, resulting in strings like `v1Query` being generated for entities in different proto files.

The result of this was conflicts between different proto files causing things to be overwritten when generating the final swagger file used for API documentation. I had been working exclusively with the `compliance/reporting/reporting.proto` for so long I hadn't noticed this problem until I tried generating the docs for every endpoint.

The commit that updates the manually generated swagger file is a good illustration of the changes this PR has.
