### PR TITLE
Skip docs sync PR with no changes.

### DIFF
--- a/.expeditor/generate-automate-api-docs.sh
+++ b/.expeditor/generate-automate-api-docs.sh
@@ -12,12 +12,16 @@ pushd /go/src/github.com/chef/automate/components/automate-chef-io
   make sync_swagger_files
 popd
 
-git add components/automate-chef-io/data/docs/api_chef_automate
+if [[ `git status --porcelain` ]]; then
+  git add components/automate-chef-io/data/docs/api_chef_automate
 
-git commit --message "Sync swagger files for Automate docs." --message "This pull request was triggered automatically via Expeditor." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
+  git commit --message "Sync swagger files for Automate docs." --message "This pull request was triggered automatically via Expeditor." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
 
-open_pull_request
+  open_pull_request
 
-git checkout -
-git clean -fxd
-git branch -D "$branch"
+  git checkout -
+  git clean -fxd
+  git branch -D "$branch"
+else
+  echo "No changed files detected, skipping sync PR."
+fi

--- a/.expeditor/generate-automate-api-docs.sh
+++ b/.expeditor/generate-automate-api-docs.sh
@@ -12,7 +12,7 @@ pushd /go/src/github.com/chef/automate/components/automate-chef-io
   make sync_swagger_files
 popd
 
-if [[ `git status --porcelain` ]]; then
+if [[ $(git status --porcelain) ]]; then
   git add components/automate-chef-io/data/docs/api_chef_automate
 
   git commit --message "Sync swagger files for Automate docs." --message "This pull request was triggered automatically via Expeditor." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."


### PR DESCRIPTION
When #1412 was merged, (I think) this script failed because in the course of working on the docs I had already synced the files that this script is supposed to sync, so there was nothing update in git. In this PR I've modified the script to avoid trying to do any git work if the syncing has already occurred, which is going to be a more likely scenario now.