### PR TITLE
Fix Access Management heading render

### DIFF
--- a/components/automate-ui/src/app/components/settings-sidebar/settings-sidebar.component.html
+++ b/components/automate-ui/src/app/components/settings-sidebar/settings-sidebar.component.html
@@ -30,14 +30,14 @@
     </app-authorized>
 
     <div *ngIf="(iamMajorVersion$ | async) !== 'v1'">
-      <div class="group" *ngIf="policies.visible || roles.visible || (projects && projects.visible)">Access Management</div>
+      <div class="group" *ngIf="policies.visible || roles.visible || projects.visible">Access Management</div>
       <app-authorized #policies [allOf]="['/iam/v2beta/policies', 'get']">
         <chef-sidebar-entry route="/settings/policies" icon="security">Policies</chef-sidebar-entry>
       </app-authorized>
       <app-authorized #roles [allOf]="['/iam/v2beta/roles', 'get']">
         <chef-sidebar-entry route="/settings/roles" icon="assignment_ind">Roles</chef-sidebar-entry>
       </app-authorized>
-      <app-authorized #projects [allOf]="['/iam/v2beta/projects', 'get']" *ngIf="projectsEnabled$ | async">
+      <app-authorized #projects [allOf]="['/iam/v2beta/projects', 'get']">
         <chef-sidebar-entry route="/settings/projects" icon="work">Projects</chef-sidebar-entry>
       </app-authorized>
     </div>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Before, logged in as `editor`:
![settings-left-nav-sad](https://user-images.githubusercontent.com/21015366/67130440-221a4680-f1b6-11e9-9132-437fad8759a9.png)


After, logged in as `editor`:
<img width="186" alt="Screen Shot 2019-10-18 at 2 45 26 PM" src="https://user-images.githubusercontent.com/21015366/67130414-0d3db300-f1b6-11e9-8ca4-b2a7cd678286.png">

### :athletic_shoe: How to Build and Test the Change
- log in as editor, see `Access Management` heading on settings page

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable