### PR TITLE
nodemanager project filtering

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1175,6 +1175,7 @@ paths = [
   "api/interservice/authz/*",
   "api/interservice/cereal/*",
   "api/interservice/event/*",
+  "components/authz-service/*",
   "components/automate-gateway/api/authz/*",
   "components/automate-gateway/authz/policy_v2/*",
   "components/automate-grpc/*",

--- a/components/nodemanager-service/api/manager/server/server.go
+++ b/components/nodemanager-service/api/manager/server/server.go
@@ -587,7 +587,8 @@ func (srv *Server) searchAwsNodes(ctx context.Context, in *manager.NodeQuery) (*
 	return &nodeIds, nil
 }
 
-func (srv *Server) addManagerNodesToDB(ctx context.Context, managerId string, managerName string, managerType string, managerAcctId string, instanceCredentials []*manager.CredentialsByTags, credential string) error {
+func (srv *Server) addManagerNodesToDB(ctx context.Context, managerId string, managerName string,
+	managerType string, managerAcctId string, instanceCredentials []*manager.CredentialsByTags, credential string) error {
 	var nodeIds []string
 	var err error
 

--- a/components/nodemanager-service/api/nodes/server/server.go
+++ b/components/nodemanager-service/api/nodes/server/server.go
@@ -266,6 +266,7 @@ func (srv *Server) Delete(ctx context.Context, in *nodes.Id) (*pb.Empty, error) 
 
 // List nodes based on a query
 func (srv *Server) List(ctx context.Context, in *nodes.Query) (*nodes.Nodes, error) {
+	logrus.Debugf("Getting Nodes with query: %+v", in)
 	filters, err := addProjectFilters(ctx, in.Filters)
 	if err != nil {
 		return nil, errorutils.FormatErrorMsg(err, "")

--- a/components/nodemanager-service/pgdb/filtering.go
+++ b/components/nodemanager-service/pgdb/filtering.go
@@ -96,6 +96,10 @@ func buildWhereHavingFilter(mergeableFilters []*common.Filter, tableAbbrev strin
 			}
 		}
 
+		if newCondition == "" {
+			continue
+		}
+
 		if err != nil {
 			return "", "", errors.Wrap(err, "buildWhereHavingFilter error")
 		}
@@ -245,6 +249,10 @@ func whereNodeManagerNodeExists(field string, arr []string, tableAbbrev string) 
 
 func whereProjectsMatch(_ string, arr []string, tableAbbrev string) (string, error) {
 	var condition string
+
+	if len(arr) == 0 {
+		return "", nil
+	}
 
 	refinedValues := stringutils.SliceFilter(arr, func(projectId string) bool {
 		return projectId != authzConstants.UnassignedProjectID

--- a/components/nodemanager-service/pgdb/filtering.go
+++ b/components/nodemanager-service/pgdb/filtering.go
@@ -267,5 +267,8 @@ func whereProjectsMatch(_ string, arr []string, tableAbbrev string) (string, err
 		}
 	}
 
+	// Or the node is manually added
+	condition = condition + " OR n.manager <> ''"
+
 	return condition, nil
 }

--- a/components/nodemanager-service/pgdb/filtering.go
+++ b/components/nodemanager-service/pgdb/filtering.go
@@ -9,10 +9,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	authzConstants "github.com/chef/automate/components/authz-service/constants/v2"
 	"github.com/chef/automate/components/compliance-service/api/common"
 	"github.com/chef/automate/components/compliance-service/utils"
 	"github.com/chef/automate/lib/errorutils"
 	"github.com/chef/automate/lib/pgutils"
+	"github.com/chef/automate/lib/stringutils"
 )
 
 func mergeFilters(mergeableFilters []*common.Filter) ([]common.Filter, error) {
@@ -244,14 +246,25 @@ func whereNodeManagerNodeExists(field string, arr []string, tableAbbrev string) 
 func whereProjectsMatch(_ string, arr []string, tableAbbrev string) (string, error) {
 	var condition string
 
-	if len(arr) == 0 {
-		condition = fmt.Sprintf("not exists (select 1 from projects p join nodes_projects np on p.id = np.project_id where np.node_id = %s.id)", tableAbbrev)
-	} else {
-		value, err := pq.Array(arr).Value()
+	refinedValues := stringutils.SliceFilter(arr, func(projectId string) bool {
+		return projectId != authzConstants.UnassignedProjectID
+	})
+
+	if len(refinedValues) > 0 {
+		value, err := pq.Array(refinedValues).Value()
 		if err != nil {
 			return "", err
 		}
 		condition = fmt.Sprintf("exists (select 1 from projects p join nodes_projects np on p.id = np.project_id where np.node_id = %s.id and p.project_id = ANY('%s'::text[]))", tableAbbrev, value)
+	}
+
+	if stringutils.SliceContains(arr, authzConstants.UnassignedProjectID) {
+		unassignedCondition := fmt.Sprintf("not exists (select 1 from projects p join nodes_projects np on p.id = np.project_id where np.node_id = %s.id)", tableAbbrev)
+		if condition == "" {
+			condition = unassignedCondition
+		} else {
+			condition = condition + " OR " + unassignedCondition
+		}
 	}
 
 	return condition, nil

--- a/components/nodemanager-service/pgdb/nodes.go
+++ b/components/nodemanager-service/pgdb/nodes.go
@@ -475,7 +475,9 @@ type TotalCount struct {
 	Total, Unreachable, Reachable, Unknown int32
 }
 
-func (db *DB) GetNodes(sortField string, insortOrder nodes.Query_OrderType, pageNr int32, perPage int32, filters []*common.Filter) ([]*nodes.Node, *TotalCount, error) {
+func (db *DB) GetNodes(sortField string, insortOrder nodes.Query_OrderType, pageNr int32,
+	perPage int32, filters []*common.Filter) ([]*nodes.Node, *TotalCount, error) {
+	logrus.Infof("GetNodes")
 	var sortOrder string
 	sortField = valueOrDefaultStr(sortField, "name")
 	if insortOrder == 1 {

--- a/components/nodemanager-service/pgdb/nodes.go
+++ b/components/nodemanager-service/pgdb/nodes.go
@@ -477,7 +477,6 @@ type TotalCount struct {
 
 func (db *DB) GetNodes(sortField string, insortOrder nodes.Query_OrderType, pageNr int32,
 	perPage int32, filters []*common.Filter) ([]*nodes.Node, *TotalCount, error) {
-	logrus.Infof("GetNodes")
 	var sortOrder string
 	sortField = valueOrDefaultStr(sortField, "name")
 	if insortOrder == 1 {

--- a/components/nodemanager-service/pgdb/nodes_integration_test.go
+++ b/components/nodemanager-service/pgdb/nodes_integration_test.go
@@ -261,26 +261,6 @@ func (suite *NodesIntegrationSuite) TestGetNodesCanFilterByProjects() {
 	suite.Equal("Taco Node", fetchedNodes[0].Name)
 }
 
-func (suite *NodesIntegrationSuite) TestGetNodesCanFilterByNoProjects() {
-	node1Id, err := suite.Database.AddNode(&nodes.Node{Name: "Taco Node"})
-	suite.Require().NoError(err)
-
-	_, err = suite.Database.AddNode(&nodes.Node{Name: "Spaghetti Node", Projects: []string{"Best Pastas", "Favorite Food"}})
-	suite.Require().NoError(err)
-
-	filter := &common.Filter{
-		Key:    "project",
-		Values: []string{},
-	}
-	fetchedNodes, count, err := suite.Database.GetNodes("name", nodes.Query_ASC, 1, 100, []*common.Filter{filter})
-	suite.Require().NoError(err)
-	suite.Require().Equal(1, len(fetchedNodes))
-	suite.Equal(&pgdb.TotalCount{Total: 1, Unreachable: 0, Reachable: 0, Unknown: 2}, count)
-
-	suite.Equal(node1Id, fetchedNodes[0].Id)
-	suite.Equal("Taco Node", fetchedNodes[0].Name)
-}
-
 func (suite *NodesIntegrationSuite) TestDeleteNodesWithQuery() {
 	_, err := suite.Database.AddNode(&nodes.Node{Name: "Taco Node", Manager: "automate", Tags: []*common.Kv{}, TargetConfig: &nodes.TargetConfig{}})
 	suite.Require().NoError(err)

--- a/components/nodemanager-service/tests/project_requests_test.go
+++ b/components/nodemanager-service/tests/project_requests_test.go
@@ -1,0 +1,94 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/chef/automate/components/nodemanager-service/api/manager"
+	"github.com/chef/automate/components/nodemanager-service/api/nodes"
+	"github.com/chef/automate/components/nodemanager-service/tests/mgrtesthelpers"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/chef/automate/lib/grpc/auth_context"
+)
+
+func TestProjectRequests(t *testing.T) {
+
+	mgrConn, err := mgrtesthelpers.GetManagerConn()
+	require.NoError(t, err)
+	defer mgrConn.Close()
+
+	db, err := createPGDB()
+	require.NoError(t, err)
+
+	// setup clients
+	mgrClient := nodes.NewNodesServiceClient(mgrConn)
+	assert.NotNil(t, mgrClient)
+
+	timestamp, err := ptypes.TimestampProto(time.Now())
+
+	cases := []struct {
+		description     string
+		ctx             context.Context
+		ingestedNodes   []*manager.NodeMetadata
+		expectedNodeIDs []string
+	}{
+		{
+			description: "Two nodes with only one with a matching project",
+			ctx:         contextWithProjects([]string{"target_project"}),
+			ingestedNodes: []*manager.NodeMetadata{
+				{
+					Uuid:     "node1",
+					Projects: []string{"target_project"},
+				},
+				{
+					Uuid:     "node2",
+					Projects: []string{"project8"},
+				},
+			},
+			expectedNodeIDs: []string{"node1"},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(fmt.Sprintf("Project filter: %s", test.description),
+			func(t *testing.T) {
+				// Ingest nodes
+				for _, node := range test.ingestedNodes {
+					node.LastContact = timestamp
+					node.RunData = &nodes.LastContactData{
+						Id:      createUUID(),
+						EndTime: timestamp,
+						Status:  nodes.LastContactData_PASSED,
+					}
+
+					err = db.ProcessIncomingNode(node)
+					require.NoError(t, err)
+				}
+				defer func() {
+					for _, node := range test.ingestedNodes {
+						db.DeleteNode(node.Uuid)
+					}
+				}()
+
+				mgrs, err := mgrClient.List(test.ctx, &nodes.Query{})
+				require.NoError(t, err)
+
+				actualNodeIDs := []string{}
+				for _, node := range mgrs.Nodes {
+					actualNodeIDs = append(actualNodeIDs, node.Id)
+				}
+
+				assert.ElementsMatch(t, test.expectedNodeIDs, actualNodeIDs)
+			})
+	}
+}
+
+func contextWithProjects(projects []string) context.Context {
+	ctx := context.Background()
+	return auth_context.NewContext(ctx, []string{}, projects, "", "", "")
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Adding project filtering to the "api/v0/nodes/search"/List RPC function. This is needed before IAMv2 GA because the nodemanager stores both ingested nodes and manually added nodes. These changes filter the ingested nodes only. The manually added nodes will not be filtered by the project tags in the context object. 

### :chains: Related Resources
#1894

### :+1: Definition of Done
All ingested client run and compliance nodes are filtered by projects. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/nodemanager-service && start_all_services`
1. Turn on IAMv2.1 `chef-automate iam upgrade-to-v2 --beta2.1`
1. Ingest some client run nodes with `chef_load_nodes 10`
1. Ingest some compliance nodes with `chef_load_compliance_nodes 10`
1. ...

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable