### PR TITLE
ensure refs with objects of type ref, url/uri are correctly read in and included on report

### DIFF
--- a/components/compliance-service/api/tests/03_reports_spec.rb
+++ b/components/compliance-service/api/tests/03_reports_spec.rb
@@ -755,6 +755,9 @@ describe File.basename(__FILE__) do
       assert_equal('nginx-01', res['profiles'][0]['controls'][0]['id'])
       assert_equal(1, res['profiles'][0]['controls'][0]['impact'])
       assert_equal(Google::Protobuf::Map, res['profiles'][0]['controls'][0]['tags'].class)
+      assert_equal("testing-ref", res['profiles'][0]['controls'][0]['refs'][0]['ref'])
+      assert_equal("test-url", res['profiles'][0]['controls'][0]['refs'][0]['url'])
+
       assert_equal('Running worker process as non-privileged user', res['profiles'][0]['controls'][0]['title'])
       assert_equal(1, res['profiles'][0]['controls'][0]['results'].length)
 

--- a/components/compliance-service/ingest/events/compliance/helper_methods_test.go
+++ b/components/compliance-service/ingest/events/compliance/helper_methods_test.go
@@ -315,6 +315,11 @@ func parseProfilesMin(js *string) (profiles []relaxting.ESInSpecReportProfile) {
 		if profiles[i].Depends == nil {
 			profiles[i].Depends = []relaxting.ESInSpecReportDepends{}
 		}
+		for ci := range profiles[i].Controls {
+			if profiles[i].Controls[ci].Refs == nil {
+				profiles[i].Controls[ci].Refs = []relaxting.ESInSpecReportControlRefs{}
+			}
+		}
 	}
 	return profiles
 }

--- a/components/compliance-service/ingest/ingestic/mappings/comp-rep-date.go
+++ b/components/compliance-service/ingest/ingestic/mappings/comp-rep-date.go
@@ -228,6 +228,37 @@ var ComplianceRepDate = Mapping{
                     }
                   }
                 },
+                "refs": {
+                  "type": "nested",
+                  "properties": {
+                    "key": {
+                      "type": "keyword",
+                      "fields": {
+                        "engram": {
+                          "type": "text",
+                          "analyzer": "autocomplete"
+                        },
+                        "lower": {
+                          "type": "keyword",
+                          "normalizer": "case_insensitive"
+                        }
+                      }
+                    },
+                    "values": {
+                      "type": "keyword",
+                      "fields": {
+                        "engram": {
+                          "type": "text",
+                          "analyzer": "autocomplete"
+                        },
+                        "lower": {
+                          "type": "keyword",
+                          "normalizer": "case_insensitive"
+                        }
+                      }
+                    }
+                  }
+                },
                 "string_tags": {
                   "type": "nested",
                   "properties": {

--- a/components/compliance-service/reporting/relaxting/es_types.go
+++ b/components/compliance-service/reporting/relaxting/es_types.go
@@ -103,6 +103,11 @@ type ESInSpecReportControlStringTags struct {
 	Values []string `json:"values"`
 }
 
+type ESInSpecReportControlRefs struct {
+	Ref string `json:"ref"`
+	Url string `json:"url"`
+}
+
 type ESInSpecReportControl struct {
 	ID         string                            `json:"id"`
 	Impact     float32                           `json:"impact"`
@@ -110,6 +115,7 @@ type ESInSpecReportControl struct {
 	Status     string                            `json:"status"`
 	Results    []*ESInSpecReportControlsResult   `json:"results"`
 	StringTags []ESInSpecReportControlStringTags `json:"string_tags"`
+	Refs       []ESInSpecReportControlRefs       `json:"refs"`
 }
 
 type ESInSpecReportProfile struct {

--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -553,8 +553,14 @@ func convertControl(profileControlsMap map[string]*reportingapi.Control, reportC
 
 	convertedControl.StringTags = jsonTags
 	var jsonRefs []*reportingapi.Ref
-	refs, _ := json.Marshal(profileControl.Refs)
-	json.Unmarshal(refs, &jsonRefs) // nolint: errcheck
+	refs, err := json.Marshal(reportControlMin.Refs)
+	if err == nil {
+		err = json.Unmarshal(refs, &jsonRefs)
+	}
+	if err != nil {
+		// don't return error on this failure, it's ok
+		logrus.Errorf("unable to unmarshal refs: %v", refs)
+	}
 	convertedControl.Refs = jsonRefs
 	return &convertedControl
 

--- a/components/compliance-service/test_data/audit_reports/2018-03-04_centos(3)-beta-nginx(p)-apache(s)-fake(s)-passed.json
+++ b/components/compliance-service/test_data/audit_reports/2018-03-04_centos(3)-beta-nginx(p)-apache(s)-fake(s)-passed.json
@@ -66,7 +66,11 @@
           "title": "Running worker process as non-privileged user",
           "desc": "The NGINX worker processes should run as non-privileged user. In case of compromise of the process, an attacker has full access to the system.",
           "impact": 1,
-          "refs": [],
+          "refs":[ 
+            { 
+               "ref":"testing-ref", "url": "test-url"
+            }
+          ],
           "tags": {
             "web": null,
             "scope": "NginX"

--- a/components/compliance-service/test_data/audit_reports/2018-03-04_redhat(2)-beta-nginx(f)-apache(s)-failed.json
+++ b/components/compliance-service/test_data/audit_reports/2018-03-04_redhat(2)-beta-nginx(f)-apache(s)-failed.json
@@ -97,7 +97,11 @@
           "title": "Check NGINX config file owner, group and permissions.",
           "desc": "The NGINX config file should owned by root, only be writable by owner and not write- and readable by others.",
           "impact": 1,
-          "refs": [],
+          "refs":[ 
+            { 
+              "ref":"testing-ref", "url": "test-url"
+            }
+          ],
           "tags": {},
           "code": "control 'nginx-02' do\n  impact 1.0\n  title 'Check NGINX config file owner, group and permissions.'\n  desc 'The NGINX config file should owned by root, only be writable by owner and not write- and readable by others.'\n  describe file(nginx_conf) do\n    it { should be_owned_by 'root' }\n    it { should be_grouped_into 'root' }\n    it { should_not be_readable.by('others') }\n    it { should_not be_writable.by('others') }\n    it { should_not be_executable.by('others') }\n  end\nend\n",
           "source_location": {

--- a/components/compliance-service/test_data/audit_reports/2018-03-05_centos(2)-beta-nginx(p)-apache(s)-passed.json
+++ b/components/compliance-service/test_data/audit_reports/2018-03-05_centos(2)-beta-nginx(p)-apache(s)-passed.json
@@ -58,7 +58,11 @@
           "title": "Running worker process as non-privileged user",
           "desc": "The NGINX worker processes should run as non-privileged user. In case of compromise of the process, an attacker has full access to the system.",
           "impact": 1,
-          "refs": [],
+          "refs":[ 
+            { 
+              "ref":"testing-ref", "url": "test-url"
+            }
+          ],
           "tags": {},
           "code": "control 'nginx-01' do\n  impact 1.0\n  title 'Running worker process as non-privileged user'\n  desc 'The NGINX worker processes should run as non-privileged user. In case of compromise of the process, an attacker has full access to the system.'\n  describe user(nginx_lib.valid_users) do\n    it { should exist }\n  end\n  describe parse_config_file(nginx_conf, options) do\n    its('user') { should eq nginx_lib.valid_users }\n  end\n\n  describe parse_config_file(nginx_conf, options) do\n    its('group') { should_not eq 'root' }\n  end\nend\n",
           "source_location": {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?  
This change modifies the ingestion path to correctly read refs (or supported type, see https://github.com/chef/automate/issues/1862#issuecomment-542972093).
It also modified the report retrieval code to ensure the refs are included on the outputted report.

### :chains: Related Resources
https://github.com/chef/automate/issues/1862

### :+1: Definition of Done
A report sent into Automate with refs includes those refs in the outputted report from Automate.

### :athletic_shoe: How to Build and Test the Change
run a scan job using a profile with refs: 
[ref-test-0.1.0.tar.gz](https://github.com/chef/automate/files/3748255/ref-test-0.1.0.tar.gz)
ensure the downloaded json report includes the refs

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated? N/A

### :camera: Screenshots, if applicable
N/A