### PR TITLE
deployment: Look at HAB_LAUNCH_BINARY not HAB_LAUNCH_BIN

### DIFF
--- a/components/automate-deployment/pkg/converge/compiler.go
+++ b/components/automate-deployment/pkg/converge/compiler.go
@@ -717,7 +717,7 @@ func (phase *SupervisorUpgradePhase) systemdRestartRequired(systemdReloaded bool
 	//
 	// TODO(ssd) 2019-04-21: Ideally we would check _all_ of the
 	// configuration (perhaps via a hash we inject in the env?).
-	launcherBin := os.Getenv("HAB_LAUNCH_BIN")
+	launcherBin := os.Getenv("HAB_LAUNCH_BINARY")
 	if launcherBin != "" {
 		launchP := phase.desiredSupState.LauncherPkg()
 		expectedPath := path.Join(habpkg.PathFor(&launchP), "bin/hab-launch")


### PR DESCRIPTION
This code was looking at the wrong environment variable. This means if
we failed to restart our systemd unit, we would not correctly retry
that restart on the next converge.

Signed-off-by: Steven Danna <steve@chef.io>