### PR TITLE
Jamie/close member expression

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -1,4 +1,4 @@
-<chef-modal [visible]="visible" (close)="closeEvent()">
+<chef-modal [visible]="visible" (closeModal)="closeEvent()">
   <h2 slot="title">Create {{ objectNoun | titlecase }}</h2>
     <div class="flex-container">
       <form [formGroup]="createForm">

--- a/components/automate-ui/src/app/components/delete-object-modal/delete-object-modal.component.html
+++ b/components/automate-ui/src/app/components/delete-object-modal/delete-object-modal.component.html
@@ -1,4 +1,4 @@
-<chef-modal [visible]="visible" (close)="closeEvent()">
+<chef-modal [visible]="visible" (closeModal)="closeEvent()">
   <h2 slot="title">{{objectAction}} {{objectNoun | titlecase}}?</h2>
   <div>
     <span *ngIf="moreDetails">

--- a/components/automate-ui/src/app/page-components/create-v1-team-modal/create-v1-team-modal.component.html
+++ b/components/automate-ui/src/app/page-components/create-v1-team-modal/create-v1-team-modal.component.html
@@ -1,4 +1,4 @@
-<chef-modal [visible]="visible" (close)="closeEvent()">
+<chef-modal [visible]="visible" (closeModal)="closeEvent()">
   <h2 slot="title">Create Team</h2>
     <div class="flex-container">
       <form [formGroup]="createForm">

--- a/components/automate-ui/src/app/page-components/deletable-node-control/deletable-node-control.component.html
+++ b/components/automate-ui/src/app/page-components/deletable-node-control/deletable-node-control.component.html
@@ -8,7 +8,7 @@
   <!-- {{nodesSelectedForDelete.size }} item{{ nodesSelectedForDelete.size | i18nPlural: pluralMapping }} selected -->
 </span>
 
-<chef-modal label="confirm-delete-modal-label" [visible]="deleteConfirmModalVisible" (close)="closeModal(false)">
+<chef-modal label="confirm-delete-modal-label" [visible]="deleteConfirmModalVisible" (closeModal)="closeModal(false)">
   <div class="status-modal">
     <h2 id="confirm-delete-modal-label" class="status-modal-heading">Warning</h2>
     <p>

--- a/components/automate-ui/src/app/page-components/license-apply/license-apply.component.html
+++ b/components/automate-ui/src/app/page-components/license-apply/license-apply.component.html
@@ -1,4 +1,4 @@
-<chef-modal label="license-lockout-label" [locked]="modalLocked" [visible]="modalVisible" (close)="closeModal()">
+<chef-modal label="license-lockout-label" [locked]="modalLocked" [visible]="modalVisible" (closeModal)="closeModal()">
   <div class="license-wrapper">
     <ng-container *ngIf="!licenseApplied">
 

--- a/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.html
+++ b/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.html
@@ -1,4 +1,4 @@
-<chef-modal label="license-lockout-label" [locked]="modalLocked" [visible]="modalVisible" (close)="closeModal()">
+<chef-modal label="license-lockout-label" [locked]="modalLocked" [visible]="modalVisible" (closeModal)="closeModal()">
   <div class="license-wrapper">
 
     <ng-container *ngIf="!fetchStatusInternalError">

--- a/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.html
+++ b/components/automate-ui/src/app/page-components/logs-modal/logs-modal.component.html
@@ -1,4 +1,4 @@
-<chef-modal class="logs-modal" label="logs-modal-label" [visible]="isVisible" (close)="closeModal()">
+<chef-modal class="logs-modal" label="logs-modal-label" [visible]="isVisible" (closeModal)="closeModal()">
   <h2 id="logs-modal-label" class="logs-modal-heading">
     <chef-icon aria-hidden="true">description</chef-icon>
     Run Logs

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.html
@@ -135,7 +135,7 @@
     <chef-modal
       id="delete-modal"
       [visible]="deleteModalVisible"
-      (close)="hideDeleteModal()">
+      (closeModal)="hideDeleteModal()">
       <h2 slot="title">Delete Profile?</h2>
       <p>Once deleted, you will be required to reinstall this profile.</p>
       <div class="actions">

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
@@ -53,7 +53,7 @@
         <chef-modal
           id="upload-modal"
           [visible]="uploadModalVisible"
-          (close)="hideUploadModal()">
+          (closeModal)="hideUploadModal()">
           <h2 id="upload-modal-title" slot="title">Upload an archived profile (.tar.gz or .zip)</h2>
           <p id="upload-modal-subtitle">See the <a href="https://www.inspec.io/docs/reference/cli/#archive" target="_blank">Inspec CLI documentation</a> for more info on creating a profile archive.</p>
           <chef-table class="file-upload-list">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
@@ -153,7 +153,7 @@
       id="download-modal"
       title="download-title"
       [visible]="downloadStatusVisible"
-      (close)="hideDownloadStatus()">
+      (closeModal)="hideDownloadStatus()">
       <h4 id="download-title" slot="title">
         <ng-container *ngIf="downloadInProgress">Downloading report...</ng-container>
         <ng-container *ngIf="downloadFailed">Download failed.</ng-container>

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/job-scans-list/job-scans-list.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/job-scans-list/job-scans-list.component.html
@@ -113,7 +113,7 @@
         *ngIf="jobDeletePrompt$ | async as prompt"
         id="delete-prompt"
         [visible]="prompt.visible"
-        (close)="cancelDeleteJob(prompt.job)">
+        (closeModal)="cancelDeleteJob(prompt.job)">
         <h2 id="delete-prompt-title" slot="title">Are you sure you want to delete this job?</h2>
         <div>
           <p>{{ prompt.job?.name }}</p>

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
@@ -115,7 +115,7 @@
   *ngIf="jobDeletePrompt$ | async as prompt"
   id="delete-prompt"
   [visible]="prompt.visible"
-  (close)="cancelDeleteJob(prompt.job)">
+  (closeModal)="cancelDeleteJob(prompt.job)">
   <h2 id="delete-prompt-title" slot="title">Are you sure you want to delete this job?</h2>
   <div>
     <p>{{ prompt.job?.name }}</p>

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
@@ -119,7 +119,7 @@
       id="download-modal"
       title="download-title"
       [visible]="downloadStatusVisible"
-      (close)="hideDownloadStatus()">
+      (closeModal)="hideDownloadStatus()">
       <h4 id="download-title" slot="title">
         <ng-container *ngIf="downloadInProgress">Downloading report...</ng-container>
         <ng-container *ngIf="downloadFailed">Download failed.</ng-container>

--- a/components/automate-ui/src/app/pages/data-feed-form/data-feed-form.component.html
+++ b/components/automate-ui/src/app/pages/data-feed-form/data-feed-form.component.html
@@ -101,7 +101,7 @@
     </main>
   </div>
 
-<chef-modal label="url-modal-label" [visible]="urlStatusModalVisible" (close)="closeModal('url')">
+<chef-modal label="url-modal-label" [visible]="urlStatusModalVisible" (closeModal)="closeModal('url')">
   <div class="status-modal">
     <ng-container *ngIf="hookStatus === urlState.Failure">
       <div class="status-icon failure">
@@ -123,7 +123,7 @@
   </div>
 </chef-modal>
 
-<chef-modal label="save-modal-label" [visible]="saveStatusModalVisible" (close)="closeModal('save')">
+<chef-modal label="save-modal-label" [visible]="saveStatusModalVisible" (closeModal)="closeModal('save')">
   <div class="status-modal">
     <ng-container *ngIf="saveStatus === saveState.Failure">
       <div class="status-icon failure">

--- a/components/automate-ui/src/app/pages/notification-form/notification-form.component.html
+++ b/components/automate-ui/src/app/pages/notification-form/notification-form.component.html
@@ -165,7 +165,7 @@
     </main>
   </div>
 
-<chef-modal label="url-modal-label" [visible]="urlStatusModalVisible" (close)="closeModal('url')">
+<chef-modal label="url-modal-label" [visible]="urlStatusModalVisible" (closeModal)="closeModal('url')">
   <div class="status-modal">
     <ng-container *ngIf="hookStatus === urlState.Failure">
       <div class="status-icon failure">
@@ -190,7 +190,7 @@
   </div>
 </chef-modal>
 
-<chef-modal label="save-modal-label" [visible]="saveStatusModalVisible" (close)="closeModal('save')">
+<chef-modal label="save-modal-label" [visible]="saveStatusModalVisible" (closeModal)="closeModal('save')">
   <div class="status-modal">
     <ng-container *ngIf="saveStatus === saveState.Failure">
       <div class="status-icon failure">

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -12,7 +12,7 @@
   (confirm)="addMembers()"
   (close)="closePage()">
     <div *ngIf="!loading">
-      <chef-modal label="member-expression-label" class="member-expression-modal" [visible]="modalVisible" (close)="closeModal()">
+      <chef-modal label="member-expression-label" class="member-expression-modal" [visible]="modalVisible" (closeModal)="closeModal()">
         <h2>Add Member Expression</h2>
         <div id="modal-content-container">
           <form [formGroup]="expressionForm">

--- a/components/automate-ui/src/app/pages/project/confirm-apply-start-modal/confirm-apply-start-modal.component.html
+++ b/components/automate-ui/src/app/pages/project/confirm-apply-start-modal/confirm-apply-start-modal.component.html
@@ -1,4 +1,4 @@
-<chef-modal id="confirm-apply-start-modal" [visible]="visible" (close)="cancel.emit()">
+<chef-modal id="confirm-apply-start-modal" [visible]="visible" (closeModal)="cancel.emit()">
   <h2 id="title" slot="title">Update Projects?</h2>
   <div class="modal-content">
     <p>Updating projects will apply all pending edits and move ingested resources into the correct projects. This background process can take up to <strong>12 hours</strong> to complete.</p>

--- a/components/automate-ui/src/app/pages/project/confirm-apply-stop-modal/confirm-apply-stop-modal.component.html
+++ b/components/automate-ui/src/app/pages/project/confirm-apply-stop-modal/confirm-apply-stop-modal.component.html
@@ -1,4 +1,4 @@
-<chef-modal id="confirm-apply-stop-modal" [visible]="visible" [locked]="stopRulesInProgress" (close)="cancel.emit()">
+<chef-modal id="confirm-apply-stop-modal" [visible]="visible" [locked]="stopRulesInProgress" (closeModal)="cancel.emit()">
   <h2 id="title" slot="title">Stop Updating Projects?</h2>
   <div class="modal-content">
     <chef-progress-bar

--- a/components/automate-ui/src/app/pages/user-management/user-management.component.html
+++ b/components/automate-ui/src/app/pages/user-management/user-management.component.html
@@ -16,7 +16,7 @@
       <chef-subheading>Chef Automate only displays local users.</chef-subheading>
     </chef-page-header>
 
-    <chef-modal label="create-user-label" class="user-modal" [visible]="createModalVisible" (close)="closeCreateModal()">
+    <chef-modal label="create-user-label" class="user-modal" [visible]="createModalVisible" (closeModal)="closeCreateModal()">
       <h2 id="create-user-label" class="title" slot="title">
         Create User
       </h2>

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.spec.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.spec.tsx
@@ -34,13 +34,13 @@ describe('chef-modal', () => {
 
     it('emits a close event', () => {
       modal.visible = true;
-      modal.close = {
+      modal.closeModal = {
         emit: jest.fn()
       };
 
       modal.handleClose();
 
-      expect(modal.close.emit.mock.calls.length).toBe(1);
+      expect(modal.closeModal.emit.mock.calls.length).toBe(1);
     });
 
   });

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
@@ -10,6 +10,7 @@ import {
   Watch,
   h
 } from '@stencil/core';
+// import { createPartiallyEmittedExpression } from 'typescript';
 
 /**
  * @description
@@ -91,7 +92,7 @@ export class ChefModal {
   /**
    * Emitted when the modal closes.
    */
-  @Event() close: EventEmitter;
+  @Event() closeModal: EventEmitter;
 
   /**
    * The html element of the modal.
@@ -166,7 +167,7 @@ export class ChefModal {
 
   private handleClose() {
     if (!this.locked) {
-      this.close.emit();
+      this.closeModal.emit();
 
       // return focus to last focused element on page before modal opened
       if (this.prevFocusedElement) {

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
@@ -10,7 +10,6 @@ import {
   Watch,
   h
 } from '@stencil/core';
-// import { createPartiallyEmittedExpression } from 'typescript';
 
 /**
  * @description


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Current: Clicking the 'X' button on the Modal in member expression not only closes the modal, but also closes the page.
Desired: Clicking the 'X' button on the Modal in member expression only closes the modal.

The Fix:  Member expression consists of two nested stencil components which are both listening for different event emitters that happen to have the same name: `close`.  As a result, when the inner component emits `close`, both components are reacting to it.   To fix, I've renamed the event emitter in `chef-modal` component, and updated all uses of `chef-modal` in automate so that we don't run into this anywhere else again in the future.

Before
```
<chef-page (close)="closePage()">
    <chef-modal (close)="closeModal()">
    </chef-modal>
</chef-page>
```

After
```
<chef-page (close)="closePage()">
    <chef-modal (closeModal)="closeModal()">
    </chef-modal>
</chef-page>
```

### :chains: Related Resources
https://github.com/chef/automate/pull/1757

### :+1: Definition of Done
When member expression modal is clicked, only the modal closes.

### :athletic_shoe: How to Build and Test the Change
1. build components/automate-ui-devproxy && start_all_services
2. (you might need) In terminal, navigate to automate-ui/ and run `make update-ui-lib`
3. Navigate to https://a2-dev.test/settings/policies/editor-access/add-members
4. Click 'add member expression' on bottom left to see modal
5. click 'X' on modal to see ONLY the modal close, yet still view ID list.

Visit any other modals that currently exist on the site and confirm that they operate as expected.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable