### PR TITLE
Update Timestamps to use UTC

### DIFF
--- a/components/automate-ui/src/app/entities/license/license.model.ts
+++ b/components/automate-ui/src/app/entities/license/license.model.ts
@@ -53,5 +53,5 @@ export interface RequestLicenseResponse {
 }
 
 export function parsedExpirationDate(license: LicenseStatus): string {
-  return moment(license.licensed_period.end).format(DateTime.RFC2822);
+  return moment.utc(license.licensed_period.end).format(DateTime.RFC2822);
 }

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.ts
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.ts
@@ -102,20 +102,20 @@ export class RunHistoryComponent implements OnInit, OnDestroy {
 
   // returning US date format
   renderDate(datestamp) {
-    return moment(datestamp).format('MM/DD/YY');
+    return moment.utc(datestamp).format('MM/DD/YY');
   }
 
   renderTime(datestamp) {
-    return moment(datestamp).format('HH:mm:ss');
+    return moment.utc(datestamp).format('HH:mm:ss');
   }
 
   getDuration(start_time, end_time) {
-    return moment.duration(moment(end_time).diff(moment(start_time))).humanize();
+    return moment.duration(moment.utc(end_time).diff(moment.utc(start_time))).humanize();
   }
 
   onDownloadRunsReport() {
     const format = 'csv'; // or 'json'
-    const filename = `${moment().format('YYYY-M-D')}.${format}`;
+    const filename = `${moment.utc().format('YYYY-M-D')}.${format}`;
 
     const onComplete = () => console.warn('completed downloading report');
     const onError = _e => console.error('error downloading report');
@@ -176,7 +176,7 @@ export class RunHistoryComponent implements OnInit, OnDestroy {
   }
 
   private formatDate(dateString: string): string {
-    return moment(dateString).format('YYYY-MM-DD');
+    return moment.utc(dateString).format('YYYY-MM-DD');
   }
 
   updatePageNumber(pageNumber) {

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-list-row.ts
@@ -22,7 +22,7 @@ export class CredentialsListRowComponent {
   }
 
   getLastModified(lastModifiedDate): string {
-    return moment(lastModifiedDate).format(DateTime.RFC2822);
+    return moment.utc(lastModifiedDate).format(DateTime.RFC2822);
   }
 
   public startCredentialDelete(): void {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -155,8 +155,8 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
       .attr('y', this.vbHeight - 3)
       .text(() => {
         return [
-          moment(this.domainX[0]).format(DateTime.CHEF_DATE_TIME),
-          moment(this.domainX[1]).format(DateTime.CHEF_DATE_TIME)
+          moment.utc(this.domainX[0]).format(DateTime.CHEF_DATE_TIME),
+          moment.utc(this.domainX[1]).format(DateTime.CHEF_DATE_TIME)
         ].join(' - ');
       });
 

--- a/components/automate-ui/src/app/pipes/datetime.pipe.ts
+++ b/components/automate-ui/src/app/pipes/datetime.pipe.ts
@@ -12,7 +12,7 @@ import * as moment from 'moment';
 export class DatetimePipe implements PipeTransform {
 
   public transform(value: moment.Moment | string, formatStr: string): string {
-    const datetime = moment.isMoment(value) ? value : moment(value);
+    const datetime = moment.isMoment(value) ? value : moment.utc(value);
     return datetime.format(formatStr);
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Problem: Time across the site (not just run history drawer) is showing in local time instead of UTC as desired.

For times converted in our HTML, I've added a `.utc()` to our datetime pipe, which uses moment.js.  this will return UTC instead of local time.

For times requested where the conversion is done in component.ts files, i've added `.utc()` to the moment conversion.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/1678
https://github.com/chef/automate/issues/1679
https://github.com/chef/automate/issues/1705
fixes #1938 

### :+1: Definition of Done
Time is being displayed in UTC where labeled as such
- liscense lockoutcomponents
- node scan results and scan history
- compliance run results and drawer

### :athletic_shoe: How to Build and Test the Change
1. build components/automate-ui-devproxy && start_all_services

License Lockout modal
1. chef-automate dev psql chef_license_control_service -- -c "UPDATE licenses SET active=NULL" to remove the current license
2. Navigate to https://a2-dev.test/
3. Fill out the trial license form and submit
4. Observe the trial expiration modal

Node Details
1. Navigate to https://a2-dev.test/infrastructure/client-runs
2. Click on any of your nodes available in the list
3. View the Failure or Success Tag Timestamp in Bold Blue or Pink Div
4. View the Run Duration Time Stamp on Node Home
5. Click View Error Log to see Timestamp in Modal
6. Click on Run History button in top right to view sidebar -> view updated timestamp.

Node Credentials
1. Navigate to https://a2-dev.test/settings/node-credentials
2. Add a Credential
3. view timestamp in Last Modified column

Node Integrations
1. Navigate to https://a2-dev.test/settings/node-integrations
2. Create an Integration (follow instructions here - GCP was easiest)
3. View timestamp in date created column

API Tokens
1. Navigate to https://a2-dev.test/settings/tokens
2. Create a token
3. View timestamp in Created Date column

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable