### PR TITLE
error_utils: Don't log time into message

### DIFF
--- a/components/compliance-service/api/stats/server/server.go
+++ b/components/compliance-service/api/stats/server/server.go
@@ -34,24 +34,21 @@ func (srv *Server) ReadSummary(ctx context.Context, in *stats.Query) (*stats.Sum
 	if in.Type == "" {
 		reportSummary, err := srv.es.GetStatsSummary(formattedFilters)
 		if err != nil {
-			err = errorutils.FormatErrorMsg(err, "")
-			return nil, err
+			return nil, errorutils.FormatErrorMsg(err, "")
 		}
 		summary.ReportSummary = reportSummary
 	}
 	if in.Type == "nodes" {
 		nodeSummary, err := srv.es.GetStatsSummaryNodes(formattedFilters)
 		if err != nil {
-			err = errorutils.FormatErrorMsg(err, "")
-			return nil, err
+			return nil, errorutils.FormatErrorMsg(err, "")
 		}
 		summary.NodeSummary = nodeSummary
 	}
 	if in.Type == "controls" {
 		controlSummary, err := srv.es.GetStatsSummaryControls(formattedFilters)
 		if err != nil {
-			err = errorutils.FormatErrorMsg(err, "")
-			return nil, err
+			return nil, errorutils.FormatErrorMsg(err, "")
 		}
 		summary.ControlsSummary = controlSummary
 	}
@@ -80,8 +77,7 @@ func (srv *Server) ReadTrend(ctx context.Context, in *stats.Query) (*stats.Trend
 
 	trend, err = srv.es.GetTrend(formattedFilters, int(in.Interval), in.Type)
 	if err != nil {
-		err = errorutils.FormatErrorMsg(err, "")
-		return nil, err
+		return nil, errorutils.FormatErrorMsg(err, "")
 	}
 
 	trends.Trends = trend
@@ -107,8 +103,7 @@ func (srv *Server) ReadProfiles(ctx context.Context, in *stats.Query) (*stats.Pr
 		if in.Type == "summary" {
 			profileSummary, err := srv.es.GetProfileSummaryByProfileId(in.Id, formattedFilters)
 			if err != nil {
-				err = errorutils.FormatErrorMsg(err, "")
-				return nil, err
+				return nil, errorutils.FormatErrorMsg(err, "")
 			}
 			profile.ProfileSummary = profileSummary
 		}
@@ -119,16 +114,14 @@ func (srv *Server) ReadProfiles(ctx context.Context, in *stats.Query) (*stats.Pr
 			}
 			controlStats, err := srv.es.GetControlListStatsByProfileID(in.Id, int(from), int(perPage), formattedFilters, sort, order)
 			if err != nil {
-				err = errorutils.FormatErrorMsg(err, "")
-				return nil, err
+				return nil, errorutils.FormatErrorMsg(err, "")
 			}
 			profile.ControlStats = controlStats
 		}
 	} else {
 		profileList, err := srv.es.GetProfileListWithAggregatedComplianceSummaries(formattedFilters, in.Size)
 		if err != nil {
-			err = errorutils.FormatErrorMsg(err, "")
-			return nil, err
+			return nil, errorutils.FormatErrorMsg(err, "")
 		}
 		profile.ProfileList = profileList
 	}
@@ -155,8 +148,7 @@ func (srv *Server) ReadFailures(ctx context.Context, in *stats.Query) (*stats.Fa
 	}
 	failures, err := srv.es.GetStatsFailures(formattedFilters["types"], int(in.Size), formattedFilters)
 	if err != nil {
-		err = errorutils.FormatErrorMsg(err, "")
-		return nil, err
+		return nil, errorutils.FormatErrorMsg(err, "")
 	}
 	return failures, nil
 }

--- a/components/data-feed-service/server/server.go
+++ b/components/data-feed-service/server/server.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/pkg/errors"
+
 	datafeed "github.com/chef/automate/api/external/data_feed"
 	"github.com/chef/automate/api/external/secrets"
 	"github.com/chef/automate/components/data-feed-service/config"
@@ -19,7 +21,6 @@ import (
 	"github.com/chef/automate/lib/errorutils"
 	"github.com/chef/automate/lib/grpc/health"
 	"github.com/chef/automate/lib/grpc/secureconn"
-	"github.com/pkg/errors"
 )
 
 // DatafeedServer is the interface to this component.
@@ -147,22 +148,19 @@ func (datafeedServer *DatafeedServer) GetDestination(ctx context.Context, destin
 	log.Infof("GetDestination %s", destination)
 	response, err := datafeedServer.db.GetDestination(destination)
 	if err != nil {
-		err = errorutils.FormatErrorMsg(err, "")
+		return nil, errorutils.FormatErrorMsg(err, "")
 	}
-
-	return response, err
+	return response, nil
 }
 
 func (datafeedServer *DatafeedServer) ListDestinations(ctx context.Context, destination *datafeed.ListDestinationRequest) (*datafeed.ListDestinationResponse, error) {
 	log.Infof("ListDestinations %s", destination)
-
 	response, err := datafeedServer.db.ListDestinations()
-
 	if err != nil {
-		err = errorutils.FormatErrorMsg(err, "")
+		return nil, errorutils.FormatErrorMsg(err, "")
 	}
 
-	return response, err
+	return response, nil
 }
 
 func (datafeedServer *DatafeedServer) UpdateDestination(ctx context.Context, destination *datafeed.UpdateDestinationRequest) (*datafeed.UpdateDestinationResponse, error) {
@@ -171,9 +169,9 @@ func (datafeedServer *DatafeedServer) UpdateDestination(ctx context.Context, des
 	success, err := datafeedServer.db.UpdateDestination(destination)
 	response.Success = success
 	if err != nil {
-		err = errorutils.FormatErrorMsg(err, "")
+		return nil, errorutils.FormatErrorMsg(err, "")
 	}
-	return response, err
+	return response, nil
 }
 
 // Health returns the servers embedded health check service

--- a/components/nodemanager-service/api/nodes/server/server.go
+++ b/components/nodemanager-service/api/nodes/server/server.go
@@ -256,7 +256,7 @@ func (srv *Server) Update(ctx context.Context, in *nodes.Node) (*pb.Empty, error
 
 // Delete a node
 func (srv *Server) Delete(ctx context.Context, in *nodes.Id) (*pb.Empty, error) {
-	logrus.Infof("Node manager is deleting node id: %+v", in)
+	logrus.Infof("deleting node id: %+v", in)
 	_, err := srv.db.DeleteNode(in.Id)
 	if err != nil {
 		return nil, errorutils.FormatErrorMsg(err, in.Id)

--- a/lib/errorutils/error_utils.go
+++ b/lib/errorutils/error_utils.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"net"
-	"time"
 
 	"github.com/lib/pq"
 	"github.com/olivere/elastic"
@@ -85,7 +84,7 @@ func FormatErrorMsg(err error, id string) error {
 	if err == nil {
 		return nil
 	}
-	logrus.Error(fmt.Sprintf("%s:%s", time.Now().UTC(), err.Error()))
+	logrus.Error(err.Error())
 	return checkErrorMsg(err, id)
 }
 


### PR DESCRIPTION
Our standard Logrus setup already logs the timestamp. Additionally,
systemd will typically also log a timestamp. Including a timestamp
here meant that we were logging 3 timestamps for this message.

I've also done some minor formatting cleanups on our error returns
that I found when looking at callers to this function.

Signed-off-by: Steven Danna <steve@chef.io>