### PR TITLE
hide global projects filter if zero projects

### DIFF
--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -3,7 +3,8 @@
   aria-label="Projects filter"
   [attr.title]="selectionLabel"
   [disabled]="!dropdownCaretVisible"
-  (click)="handleLabelClick()">
+  (click)="handleLabelClick()"
+  *ngIf="filterVisible()">
   <span class="selection-label">{{ selectionLabel }}</span>
   <span class="selection-count"
     *ngIf="selectionCountVisible"

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -84,6 +84,6 @@ export class ProjectsFilterDropdownComponent implements OnChanges {
   }
 
   filterVisible() {
-    return this.selectionCount === 0 ? false : true;
+    return this.selectionCount > 0;
   }
 }

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -82,4 +82,8 @@ export class ProjectsFilterDropdownComponent implements OnChanges {
       (element as HTMLElement).focus();
     }
   }
+
+  filterVisible() {
+    return this.selectionCount === 0 ? false : true
+  }
 }

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -84,6 +84,6 @@ export class ProjectsFilterDropdownComponent implements OnChanges {
   }
 
   filterVisible() {
-    return this.selectionCount === 0 ? false : true
+    return this.selectionCount === 0 ? false : true;
   }
 }


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description: 
If a user has access to zero projects, the global project filter should be hidden from the top-nav. Currently, they are shown an all projects dropdown with a count of zero, that does not open because there are zero projects.
![project fileter](https://user-images.githubusercontent.com/12297653/67397142-6185d000-f5c6-11e9-840a-70ba8eb37a2f.png)

### :chains: Related Resources
fixes #1274

### :+1: Definition of Done
If a user logged in and if the project count is `0` then the project dropdown is hidden on the dashboard.
### :athletic_shoe: How to Build and Test the Change
logged in as non-admin user navigate to the dashboard.
### :camera: Screenshots
![Chef Automate_hide_project_dropdown](https://user-images.githubusercontent.com/12297653/67397480-da852780-f5c6-11e9-8958-4cdae0822923.png)
