### PR TITLE
Don't let our unit tests fail specifically on 2019-10-23 xD

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -145,16 +145,16 @@ describe('ReportingComponent', () => {
 
     it('specific string date', () => {
       spyOn(router, 'navigate');
-      const event = {detail: '2019-10-23'};
+      const event = {detail: '2017-10-23'};
       component.onEndDateChanged(event);
-      expect(router.navigate).toHaveBeenCalledWith([], {queryParams: { end_time: '2019-10-23'}});
+      expect(router.navigate).toHaveBeenCalledWith([], {queryParams: { end_time: '2017-10-23'}});
     });
 
     it('specific date object', () => {
       spyOn(router, 'navigate');
-      const event = {detail: new Date('2019-10-23')};
+      const event = {detail: new Date('2017-10-23')};
       component.onEndDateChanged(event);
-      expect(router.navigate).toHaveBeenCalledWith([], {queryParams: { end_time: '2019-10-23'}});
+      expect(router.navigate).toHaveBeenCalledWith([], {queryParams: { end_time: '2017-10-23'}});
     });
   });
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

We wrote a test that will fail specifically on today LOL. Let's put the magical day it will fail in the past so that we can punish our past selves instead of the other way around for once.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable