### PR TITLE
Update NO_MIXED_WILDCARD to include hypens

### DIFF
--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -15,7 +15,7 @@ export class Regex {
     // Only allows wildcard alone or words and numbers, but not combined
     // Legal Values: *, chef, _state, etc.
     // Illegal Values: abc*, *chef, c*h*e*f, **
-    NO_MIXED_WILDCARD: '^(\\*|\\w+)$'
+    NO_MIXED_WILDCARD: '^(\\*|[-\\w]+)$'
   };
 
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The validation for member expressions that disallowed a `*` when mixed with text also disallowed hypens `-`.

This branch is a small fix to the regex that handles the NO_MIXED_WILDCARDS validation by allowing users to input hyphens.

### :chains: Related Resources
https://github.com/chef/automate/pull/1757

### :+1: Definition of Done
Name/ID input in member expressions allows the use of hypens.  Mixed `*` is still not allowed
i.e. 
passes:  `ui-team-5`
fails: `ui-team-5*`

### :athletic_shoe: How to Build and Test the Change

1. build components/automate-ui-devproxy && start_all_services
2. navigate to https://a2-dev.test/settings/policies/editor-access/add-members
3. click "add member expression" button in bottom left
4. in dropdown, select Type -> user
5. in next dropdown, select Identity Provider -> local
6. in typeable input, type a phrase with hyphens `-` -> it should pass
7. try typing a phrase with * and text -> it should show an error

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable

AFTER
passing:
<img width="834" alt="Screen Shot 2019-10-23 at 11 02 29 AM" src="https://user-images.githubusercontent.com/16737484/67421094-a852d600-f584-11e9-8da6-4c15af53c6ab.png">

failing:
<img width="682" alt="Screen Shot 2019-10-23 at 11 03 03 AM" src="https://user-images.githubusercontent.com/16737484/67421131-b7398880-f584-11e9-85a6-b09491f9974d.png">
