### PR TITLE
Declare moreContentEl variable in json-tree

### DIFF
--- a/components/automate-ui/src/app/page-components/json-tree/vendor/json-tree.js
+++ b/components/automate-ui/src/app/page-components/json-tree/vendor/json-tree.js
@@ -372,6 +372,7 @@ var jsonTree = (function() {
               },
               childNodesUl,
               labelEl,
+              moreContentEl,
               childNodes = [];
   
           self.label = label;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

In client run history, the node attributes JSON we are displaying went disappearing.  This was the result of a variable not being declared and throwing an error while building the tree. 

Fix: The necessary variable is now being declared in the JSON tree template.

### :chains: Related Resources
#fixes #1955 

### :+1: Definition of Done
Attributes JSON tree is back in the client run history attributes tab and is able to be manipulated (expanded/collapsed) as expected.

### :athletic_shoe: How to Build and Test the Change

1. build components/automate-ui-devproxy && start_all_services
2. navigate to https://a2-dev.test/infrastructure/client-runs and click on any node in the list
3. click on the 'attributes' tab
4. click across various filters (All, Default, Normal, Override, Automatic)
5. View JSON beneath any filters that contain data

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
Before:
![Client Runs Attribute JSON - Before](https://user-images.githubusercontent.com/16737484/67436645-c11eb400-f5a3-11e9-8083-9797f5e90719.png)

After:
![Client Runs Attribute JSON - After](https://user-images.githubusercontent.com/16737484/67436575-92084280-f5a3-11e9-9d42-25d9a1448bb7.png)

