### PR TITLE
preflight: skip workflow ports in check during a1migration

### DIFF
--- a/components/automate-deployment/pkg/preflight/checks.go
+++ b/components/automate-deployment/pkg/preflight/checks.go
@@ -369,7 +369,7 @@ func ConnectivityCheck(urls []string) Check {
 	}
 }
 
-var a1MigratePorts = []uint16{80, 443, 2133, 2134, 5432}
+var a1MigratePorts = []uint16{80, 443, 2133, 2134, 5432, 8989, 9611}
 
 func skippablePort(port uint16) bool {
 	for _, p := range a1MigratePorts {


### PR DESCRIPTION
These ports were previously unchecked. They were automatically
included in the preflight checks when we moved to dynamic port
checking; however, they need to be skipped during the a1 migration
because they are also used by A1.

Note, that while we could move port 9611, I'm not sure we can move 8989
as this is also used in the people's git-remote configuration.

Further note that automate-workflow-nginx's ports are currently
hard-coded and not included as part of the dynamic check.

Signed-off-by: Steven Danna <steve@chef.io>