### PR TITLE
added css changes to make project dropdowns scrollable

### DIFF
--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
@@ -69,6 +69,8 @@ chef-dropdown {
   border-top: none;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
+  overflow-y: auto;
+  max-height: 125px;
 }
 
 chef-checkbox {

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -123,7 +123,7 @@
 }
 
 chef-click-outside {
-  chef-dropdown{
+  chef-dropdown {
     overflow-y: auto;
     max-height: 300px;
   }

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -121,3 +121,10 @@
     padding: 0 8px 8px 8px;
   }
 }
+
+chef-click-outside {
+  chef-dropdown{
+    overflow-y: auto;
+    max-height: 300px;
+  }
+}

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -125,6 +125,6 @@
 chef-click-outside {
   chef-dropdown {
     overflow-y: auto;
-    max-height: 300px;
+    max-height: 325px;
   }
 }


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed
We will soon be allowing folks to configure the project limit, which means we need to allow the two project dropdowns to be scrollable so they are still usable.
Added CSS changes for project dropdowns.

### :chains: Related Resources
fixes #1956
### :+1: Definition of Done
In existing project dropdown is not scrolling if we add multiple projects, so I have added CSS for the `chef-dropdown`  for project filters.
### :athletic_shoe: How to Build and Test the Change
For the test, need to rebuild the `automate-ui`
### :camera: Screenshots
![Chef Automate_MSYS-1147-2](https://user-images.githubusercontent.com/12297653/67472296-833a9200-f66e-11e9-855c-7dfd79755668.png)
![Chef Automate_MSYS-1147](https://user-images.githubusercontent.com/12297653/67472307-8766af80-f66e-11e9-9ec1-b182fe4934d3.png)
