### PR TITLE
ci: Add test for deploying with the unstable Habitat build

### DIFF
--- a/.expeditor/create-manifest.rb
+++ b/.expeditor/create-manifest.rb
@@ -224,14 +224,13 @@ class ManifestGenerator
     manifest["hab_build"] = local_hab_version
     manifest["build"] = version
     manifest["hab"] = []
+
     ["hab", "hab-sup", "hab-launcher"].each do |p|
       pkg = package_querier.get_latest(hab_pkg_channel, "core", p)
       log.info "Adding package #{pkg.pretty}"
       manifest["hab"] << pkg
     end
 
-    manifest["hab"] << package_querier.get_latest(hab_pkg_channel, "core", "hab-sup")
-    manifest["hab"] << package_querier.get_latest(hab_pkg_channel, "core", "hab-launcher")
     manifest["git_sha"] = git_sha
     manifest["packages"] = []
 

--- a/.expeditor/create-manifest.rb
+++ b/.expeditor/create-manifest.rb
@@ -214,7 +214,7 @@ class PackageQuerier
 end
 
 class ManifestGenerator
-  def generate(package_querier, products_meta_file, version, skip_packages, log)
+  def generate(package_querier, products_meta_file, version, skip_packages, hab_pkg_channel, log)
     manifest = {}
     # The version of the manifest schema. WARNING: DO NOT CHANGE: Because
     # of an implementation mistake in deployment-service, changing this
@@ -224,9 +224,14 @@ class ManifestGenerator
     manifest["hab_build"] = local_hab_version
     manifest["build"] = version
     manifest["hab"] = []
-    manifest["hab"] << package_querier.get_latest("stable", "core", "hab")
-    manifest["hab"] << package_querier.get_latest("stable", "core", "hab-sup")
-    manifest["hab"] << package_querier.get_latest("stable", "core", "hab-launcher")
+    ["hab", "hab-sup", "hab-launcher"].each do |p|
+      pkg = package_querier.get_latest(hab_pkg_channel, "core", p)
+      log.info "Adding package #{pkg.pretty}"
+      manifest["hab"] << pkg
+    end
+
+    manifest["hab"] << package_querier.get_latest(hab_pkg_channel, "core", "hab-sup")
+    manifest["hab"] << package_querier.get_latest(hab_pkg_channel, "core", "hab-launcher")
     manifest["git_sha"] = git_sha
     manifest["packages"] = []
 
@@ -296,6 +301,7 @@ class ManifestGenerator
   end
 end
 
+no_pin_hab = ENV["NO_PIN_HAB"] == "true"
 pins = {
   # -- FIXME: PINNED DATABASES - sdelano 2018/07/19 --
   #
@@ -310,15 +316,17 @@ pins = {
   # libraries if any fixes are shipped there.
   "automate-postgresql"    => {"origin" => "chef", "name" => "automate-postgresql",    "version" => "9.6.11", "release" => "20190409151101"},
   "automate-elasticsearch" => {"origin" => "chef", "name" => "automate-elasticsearch", "version" => "6.2.2",  "release" => "20190123133819"},
+}
 
+unless no_pin_hab
   # IF YOU UPDATE THESE PINS YOU MUST ALSO UPDATE THE core/hab PIN IN
   # components/automate-deployment/habitat/plan.sh
   #
   # WARNING: These pins are managed by .expeditor/update_habitat.sh.
-  "hab"          => { "origin" => "core", "name" => "hab",          "version" => "0.69.0", "release" => "20181127182011"},
-  "hab-sup"      => { "origin" => "core", "name" => "hab-sup",      "version" => "0.69.0", "release" => "20181127183841"},
-  "hab-launcher" => { "origin" => "core", "name" => "hab-launcher", "version" => "9106",   "release" => "20181126205526"}
-}
+  pins["hab"]          = { "origin" => "core", "name" => "hab",          "version" => "0.69.0", "release" => "20181127182011"}
+  pins["hab-sup"]      = { "origin" => "core", "name" => "hab-sup",      "version" => "0.69.0", "release" => "20181127183841"}
+  pins["hab-launcher"] = { "origin" => "core", "name" => "hab-launcher", "version" => "9106",   "release" => "20181126205526"}
+end
 
 # CONFIGURATION
 #
@@ -331,6 +339,7 @@ allow_local_packages=(ENV["ALLOW_LOCAL_PACKAGES"] == "true")
 local_package_origin = ENV["HAB_ORIGIN"] || "chef"
 # The directory that we will look for local packages in.
 local_package_directory = "results"
+hab_pkg_channel = ENV["HAB_PKG_CHANNEL"] || "stable"
 # Whether or not we should lookup package idents using the
 # EXPEDITOR_PKG_IDENT_ environment variables. Enabled only if it
 # appears we are running as an Expeditor job.
@@ -366,6 +375,7 @@ log.info "  allow_local_packages=#{allow_local_packages}"
 log.info "  use_environment_idents=#{use_environment_idents}"
 log.info "  local_package_origin=#{local_package_origin}"
 log.info "  local_package_directory=#{local_package_directory}"
+log.info "  hab_pkg_channel=#{hab_pkg_channel}"
 log.info "  filename=#{filename}"
 log.info "  version=#{version}"
 log.info "  skip_packages=#{skip_packages}"
@@ -381,5 +391,11 @@ if allow_local_packages
 end
 package_querier = PackageQuerier::MustExistQuerier.new(PackageQuerier::ChainQuerier.new(package_queriers))
 
-manifest = ManifestGenerator.new.generate(package_querier, "products.meta", version, skip_packages, log)
+manifest = ManifestGenerator.new.generate(
+  package_querier,
+  "products.meta",
+  version,
+  skip_packages,
+  hab_pkg_channel,
+  log)
 File.open("#{filename}", "w") { |file| file.write(JSON.pretty_generate(manifest)) }

--- a/.expeditor/update_habitat.sh
+++ b/.expeditor/update_habitat.sh
@@ -21,9 +21,9 @@ HAB_LAUNCH_IDENT_JSON=$(curl "https://bldr.habitat.sh/v1/depot/channels/core/sta
 HAB_LAUNCH_VERSION=$(echo "$HAB_LAUNCH_IDENT_JSON" | jq -r .version)
 HAB_LAUNCH_RELEASE=$(echo "$HAB_LAUNCH_IDENT_JSON" | jq -r .release)
 
-sed -i -r "s|\"hab\".*\"version\" =>.*|\"hab\"          => { \"origin\" => \"core\", \"name\" => \"hab\",          \"version\" => \"$HAB_VERSION\", \"release\" => \"$HAB_RELEASE\"},|" .expeditor/create-manifest.rb
-sed -i -r "s|\"hab-sup\".*\"version\" =>.*|\"hab-sup\"      => { \"origin\" => \"core\", \"name\" => \"hab-sup\",      \"version\" => \"$HAB_SUP_VERSION\", \"release\" => \"$HAB_SUP_RELEASE\"},|" .expeditor/create-manifest.rb
-sed -i -r "s|\"hab-launcher\".*\"version\" =>.*|\"hab-launcher\" => { \"origin\" => \"core\", \"name\" => \"hab-launcher\", \"version\" => \"$HAB_LAUNCH_VERSION\",   \"release\" => \"$HAB_LAUNCH_RELEASE\"}|" .expeditor/create-manifest.rb
+sed -i -r "s|pins\[\"hab\"\].*\"version\" =>.*|pins[\"hab\"]          = { \"origin\" => \"core\", \"name\" => \"hab\",          \"version\" => \"$HAB_VERSION\", \"release\" => \"$HAB_RELEASE\"},|" .expeditor/create-manifest.rb
+sed -i -r "s|pins\[\"hab-sup\"\].*\"version\" =>.*|pins[\"hab-sup\"]      = { \"origin\" => \"core\", \"name\" => \"hab-sup\",      \"version\" => \"$HAB_SUP_VERSION\", \"release\" => \"$HAB_SUP_RELEASE\"},|" .expeditor/create-manifest.rb
+sed -i -r "s|pins\[\"hab-launcher\"\].*\"version\" =>.*|pins[\"hab-launcher\"] = { \"origin\" => \"core\", \"name\" => \"hab-launcher\", \"version\" => \"$HAB_LAUNCH_VERSION\",   \"release\" => \"$HAB_LAUNCH_RELEASE\"}|" .expeditor/create-manifest.rb
 
 sed -i -r "s|core/hab/[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]{14}|core/hab/$HAB_VERSION/$HAB_RELEASE|" components/automate-deployment/habitat/plan.sh
 sed -i -r "s|RECOMMENDED_HAB_VERSION=\".*\"|RECOMMENDED_HAB_VERSION=\"$HAB_VERSION\"|" .studiorc

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -721,6 +721,16 @@ steps:
         linux:
           privileged: true
 
+  - label: "upgrade current -> master (with latest hab)"
+    command:
+      - integration/run_test integration/tests/upgrade_current_master_habdev.sh
+    timeout_in_minutes: 25
+    soft_fail: true
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+
   - label: "manual upgrade current -> master"
     command:
       - integration/run_test integration/tests/manual_upgrade.sh

--- a/components/automate-deployment/pkg/server/server.go
+++ b/components/automate-deployment/pkg/server/server.go
@@ -1009,6 +1009,8 @@ func StartServer(config *Config) error {
 		return errors.Wrap(err, "failed to initialize deployment")
 	}
 
+	maybeResetHabPath(server)
+
 	err = server.initSecretStore()
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize secret store")

--- a/components/automate-deployment/pkg/server/startup_helpers.go
+++ b/components/automate-deployment/pkg/server/startup_helpers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/chef/automate/components/automate-deployment/pkg/habpkg"
 	"github.com/chef/automate/lib/platform/command"
 )
 
@@ -35,6 +36,37 @@ func habSupVersion() string {
 	// hab sup --version returns non-zero even when it hasn't errored
 	// so for now we can just return the output I guess.
 	return strings.TrimSpace(output)
+}
+
+// maybeResetHabPath adds the bindir from our manifest's hab package
+// to our PATH. This is a developent-mode only operation to account
+// for test cases where we want to deploy with the latest Habitat.
+func maybeResetHabPath(s *server) {
+	if os.Getenv("CHEF_DEV_ENVIRONMENT") != "true" {
+		return
+	}
+
+	if m := s.deployment.CurrentReleaseManifest; m != nil {
+		found, habP := m.PackageForServiceName("hab")
+		if !found {
+			logrus.Warn("No hab package found in manifest")
+			return
+		}
+		habPathEntry := fmt.Sprintf("%s/bin", habpkg.PathFor(&habP))
+		existingPath := os.Getenv("PATH")
+		if strings.Contains(existingPath, habPathEntry) {
+			return
+		}
+
+		logrus.Warnf("Adding hab bindir %s to PATH", habPathEntry)
+		var newPath string
+		if existingPath != "" {
+			newPath = strings.Join([]string{habPathEntry, existingPath}, ":")
+		} else {
+			newPath = habPathEntry
+		}
+		os.Setenv("PATH", newPath) // nolint:errcheck
+	}
 }
 
 func setAndLogProcessState() {

--- a/integration/base.sh
+++ b/integration/base.sh
@@ -50,14 +50,17 @@ test_with_s3=false
 #
 # * Available Manifests
 #
-# build.json: manifest created during the build process. Includes
-#             packages from unstable AND any newly created packages.
+# build.json:        manifest created during the build process. Includes
+#                    packages from unstable AND any newly created packages.
 #
-# dev.json:        manifest for the dev channel
+# build-habdev.json: Like build.json but with habitat packages from
+#                    unstable as well.
+
+# dev.json:          manifest for the dev channel
 #
-# acceptance.json: manifest for the acceptance channel
+# acceptance.json:   manifest for the acceptance channel
 #
-# current.json:    manifest for the current channel
+# current.json:      manifest for the current channel
 #
 # test_manifest_path is the path that will be passed to `chef-automate
 # deploy`. Manifest content is copied to this path before the deploy

--- a/integration/tests/upgrade_current_master_habdev.sh
+++ b/integration/tests/upgrade_current_master_habdev.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#shellcheck disable=SC2034
+test_name="upgrade_current_master_habdev"
+test_upgrades=true
+test_upgrade_inspec_profiles=()
+test_upgrade_begin_manifest="current.json"
+
+do_prepare_deploy() {
+    do_prepare_deploy_default
+    mkdir /etc/systemd/system/chef-automate.service.d
+    cat > /etc/systemd/system/chef-automate.service.d/custom.conf <<EOF
+[Service]
+Environment=CHEF_DEV_ENVIRONMENT=true
+EOF
+}
+
+do_prepare_upgrade() {
+    do_prepare_upgrade_default
+    set_test_manifest "build-habdev.json"
+}

--- a/scripts/verify_build.sh
+++ b/scripts/verify_build.sh
@@ -86,6 +86,10 @@ log_section_start "create manifest"
 .expeditor/create-manifest.rb
 mv manifest.json results/build.json
 
+log_section_start "create manifest (latest hab)"
+HAB_PKG_CHANNEL=unstable NO_PIN_HAB=true .expeditor/create-manifest.rb
+mv manifest.json results/build-habdev.json
+
 log_section_start "create buildkite artifact"
 # The integration test framework uses this file to decide whether or
 # not it needs to build packages directly.


### PR DESCRIPTION
We would like to be able to upgrade to the latest version to hab much
more quickly than we currently do. One issue that causes delay is that
we often don't test the latest version of Habitat until after it is
released. If we find an issue that we need to address upstream in
Habitat, this delays our upgrade as we need to submit the fix, wait
for the release, and then re-test.

The goal of this change is to get us continuously testing the dev
builds in unstable so we can catch issues or confirm fixes before the
release of Hab.

Signed-off-by: Steven Danna <steve@chef.io>