### PR TITLE
compliance: turn off cereal-service based managers in test mode

### DIFF
--- a/components/compliance-service/Makefile
+++ b/components/compliance-service/Makefile
@@ -467,7 +467,7 @@ test: generate-ruby-grpc wait-for-compliance-service
 	bundle exec ./run.rb $$TEST \
 	echo
 
-test-prep: $(MARKET_PATH) $(PROFILES_PATH) start-ssh-node download-sample-market-profiles install-inspec start-es-pg 
+test-prep: $(MARKET_PATH) $(PROFILES_PATH) start-ssh-node download-sample-market-profiles install-inspec start-es-pg
 
 install-inspec:
 	@inspec --version | grep -q $(shell cat ../../INSPEC_VERSION) || gem install inspec-bin --no-document --version $(shell cat ../../INSPEC_VERSION)

--- a/components/compliance-service/compliance.go
+++ b/components/compliance-service/compliance.go
@@ -437,16 +437,9 @@ func setupDataLifecyclePurgeInterface(ctx context.Context, connFactory *secureco
 
 	addr := conf.ElasticSearchSidecar.Address
 	logrus.WithField("address", addr).Info("Connecting to Elasticsearch Sidecar")
-	dialOpts := []grpc.DialOption{}
-
-	if os.Getenv("RUN_MODE") == "test" {
-		logrus.Info(`RUN_MODE is set to "test", not requiring block dial to es-sidecar-service`)
-	} else {
-		dialOpts = append(dialOpts, grpc.WithBlock())
-	}
 
 	esSidecarConn, err = connFactory.DialContext(timeoutCtx, "es-sidecar-service",
-		addr, dialOpts...)
+		addr, grpc.WithBlock())
 	if err != nil || esSidecarConn == nil {
 		logrus.WithFields(logrus.Fields{"error": err}).Fatal("Failed to create ES Sidecar connection")
 		return nil, err


### PR DESCRIPTION
Until we integrate cereal-service into compliance's test setup, having
these turned on means we get constant spamming of errors in the logs,
making it harder to debug problems.

Signed-off-by: Steven Danna <steve@chef.io>