### PR TITLE
Fix time locale-dependent spec failures

### DIFF
--- a/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-apply/license-apply.component.spec.ts
@@ -56,7 +56,7 @@ describe('LicenseApplyComponent', () => {
   describe('ApplyLicense Action', () => {
 
     it('reflects successfully applied license', () => {
-      const futureDate = moment().add(2, 'months');
+      const futureDate = moment().utc().add(2, 'months');
       const { state } = setup(genLicenseApplyReducer(futureDate));
       component.applyingLicense = true;
       component.handleLicenseApply(state.apply);
@@ -182,7 +182,7 @@ describe('LicenseApplyComponent', () => {
         errorResp: null
       },
       fetch: {
-        license: genLicenseResp(expiry || moment().add(2, 'months')),
+        license: genLicenseResp(expiry || moment().utc().add(2, 'months')),
         status: EntityStatus.loadingSuccess,
         expiryMessage: '',
         errorResp: null

--- a/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/license-lockout/license-lockout.component.spec.ts
@@ -65,7 +65,7 @@ describe('LicenseLockoutComponent', () => {
     });
 
     it('reflects current license', () => {
-      const futureDate = moment().add(2, 'months');
+      const futureDate = moment().utc().add(2, 'months');
       setup(genLicenseFetchReducer(futureDate));
 
       expect(component.licenseExpired).toBeFalsy();
@@ -77,7 +77,7 @@ describe('LicenseLockoutComponent', () => {
 
     // this test is failing in wallaby with "Expression has changed after it was checked"
     xit('reflects expired license', () => {
-      const pastDate = moment().subtract(2, 'months');
+      const pastDate = moment().utc().subtract(2, 'months');
       setup(genLicenseFetchReducer(pastDate));
 
       expect(component.licenseExpired).toBeTruthy();
@@ -211,7 +211,7 @@ describe('LicenseLockoutComponent', () => {
   function genLicenseFetchReducer(licenseEndDate: moment.Moment): () => { fetch: FetchStatus } {
    return () => ({
       fetch: {
-        license: genLicenseResp(licenseEndDate || moment().add(2, 'months')),
+        license: genLicenseResp(licenseEndDate || moment().utc().add(2, 'months')),
         status: EntityStatus.loadingSuccess,
         expiryMessage: '',
         errorResp: null


### PR DESCRIPTION
Some locale-dependent spec failures snuck through Buildkite:

```
HeadlessChrome 77.0.3865 (Mac OS X 10.14.5) LicenseLockoutComponent GetLicenseStatus Action reflects current license FAILED
  Error: Expected 'Tue, 24 Dec 2019 22:53:06 UTC' to equal 'Tue, 24 Dec 2019 15:53:06 UTC'.

HeadlessChrome 77.0.3865 (Mac OS X 10.14.5) LicenseApplyComponent ApplyLicense Action reflects successfully applied license FAILED
  Error: Expected 'Tue, 24 Dec 2019 22:53:31 UTC' to equal 'Tue, 24 Dec 2019 15:53:31 UTC'.
```

Resolved by updating the specs to use expected UTC date objects:  https://github.com/chef/automate/pull/1944/commits/aa4bbb47aa666f9842cb1aad72a568f7e3810fb7