### PR TITLE
Update format for report export filenames

### DIFF
--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -1,10 +1,19 @@
 export class DateTime {
-  // formatted for use with moment.js -- https://momentjs.com/docs/#/displaying/format/
-  // RFC2822 format like: Wed, 03 Jul 2019 17:08:53 UTC
+  // Common date formats for use with moment.js -- https://momentjs.com/docs/#/displaying/format/
+
+  // Format for RFC2822 display
+  // Wed, 03 Jul 2019 17:08:53 UTC
   public static readonly RFC2822: string = 'ddd, DD MMM YYYY HH:mm:ss [UTC]';
 
+  // Format for date display
   // Tue, 24 Sept 2019
   public static readonly CHEF_DATE_TIME: string = 'ddd, DD MMM YYYY';
 
+  // Format for time display
+  // 09:59
   public static readonly CHEF_HOURS_MINS: string = 'HH:mm';
+
+  // Format for filenames of report downloads
+  // 2019-09-24-09:59:59
+  public static readonly REPORT_DATE_TIME: string = 'YYYY-MM-DD-HHmmss';
 }

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.ts
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.ts
@@ -115,7 +115,7 @@ export class RunHistoryComponent implements OnInit, OnDestroy {
 
   onDownloadRunsReport() {
     const format = 'csv'; // or 'json'
-    const filename = `${moment.utc().format('YYYY-M-D')}.${format}`;
+    const filename = `${moment.utc().format(DateTime.REPORT_DATE_TIME)}.${format}`;
 
     const onComplete = () => console.warn('completed downloading report');
     const onError = _e => console.error('error downloading report');

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -19,6 +19,7 @@ import {
 import { Store, createSelector } from '@ngrx/store';
 import { NgrxStateAtom } from '../../ngrx.reducers';
 import { find, filter as fpFilter, pickBy, some, includes } from 'lodash/fp';
+import { DateTime } from 'app/helpers/datetime/datetime';
 import {
   clientRunsLoading,
   clientRunsNodes,
@@ -515,7 +516,7 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
   onDownloadOptPressed(format) {
     this.downloadOptsVisible = false;
 
-    const filename = `${moment().format('YYYY-M-D')}.${format}`;
+    const filename = `${moment().utc().format(DateTime.REPORT_DATE_TIME)}.${format}`;
 
     const onComplete = () => this.downloadInProgress = false;
     const onError = _e => this.downloadFailed = true;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This commit updates the filenames of report downloads to use UTC datetime in 
`YYYY-MM-DD-HHmmss` format.

`2019-09-24-09:59:05.csv`

`2019-12-03-17:03:26.json`

### :chains: Related Resources

fixes #1972

### :+1: Definition of Done

Filenames for client-runs and compliance report downloads use `YYYY-MM-DD-HHmmss` format.

### :athletic_shoe: How to Build and Test the Change

1. Nav to `/infrastructure/client-runs`
2. Select download button and select json or csv
3. Nav to `/compliance/reports/overview`
4. Select download button and select json or csv

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
![Screen Shot 2019-10-24 at 4 57 48 PM](https://user-images.githubusercontent.com/479121/67531321-75d9d380-f67f-11e9-82cd-4ca49794c8b2.png)
