### PR TITLE
ci: don't exit 0 in check function

### DIFF
--- a/components/automate-scaffolding-go/lib/scaffolding-go.sh
+++ b/components/automate-scaffolding-go/lib/scaffolding-go.sh
@@ -123,8 +123,6 @@ do_check() {
       check_static_binary "${tmp_bin}/${pkg_name}"
     fi
   fi
-
-  exit 0
 }
 
 do_default_after() {


### PR DESCRIPTION
This meant no Go things were getting built.

Signed-off-by: Steven Danna <steve@chef.io>