### PR TITLE
Authz makefile enhancement

### DIFF
--- a/components/authz-service/Makefile
+++ b/components/authz-service/Makefile
@@ -34,14 +34,15 @@ test:
 	@go test $(verbose) -cover -count=1 -parallel=1 -p 1 $(packages)
 
 PG_URL ?= "postgresql://postgres@127.0.0.1:5432/authz_test?sslmode=disable"
+DOCKER_CLEAN_MSG = "\nDocker container still up; run 'make kill_docker_pg' to clean it up when finished."
 
 test_with_db: db_container
 	@PGTZ=UTC PG_URL=$(PG_URL) go test -cover -count=1 -parallel=1 -p 1 $(packages)
-	@echo "Docker containers still up, run 'make kill_docker_pg' to bring them down or test again with make test_with_db."
+	@echo $(DOCKER_CLEAN_MSG)
 
 test_properties_with_db: db_container
 	@PGTZ=UTC PG_URL=$(PG_URL) go test -cover -count=1 -parallel=1 -p 1 $(packages) -run Properties
-	@echo "Docker containers still up, run 'make kill_docker_pg' to bring them down or test again with make test_with_db."
+	@echo $(DOCKER_CLEAN_MSG)
 
 .PHONY: db_container
 db_container:

--- a/components/authz-service/Makefile
+++ b/components/authz-service/Makefile
@@ -33,6 +33,10 @@ build: ${BINS}
 test:
 	@go test $(verbose) -cover -count=1 -parallel=1 -p 1 $(packages)
 
+# See https://github.com/chef/automate/pull/1996 for examples/details
+test/%:
+	go test -v -cover -count=1 -parallel=1 -p 1 $(PACKAGE_PATH)/$(subst test/,,$(@D))/... -run $(@F)
+
 PG_URL ?= "postgresql://postgres@127.0.0.1:5432/authz_test?sslmode=disable"
 DOCKER_CLEAN_MSG = "\nDocker container still up; run 'make kill_docker_pg' to clean it up when finished."
 
@@ -42,6 +46,12 @@ test_with_db: db_container
 
 test_properties_with_db: db_container
 	@PGTZ=UTC PG_URL=$(PG_URL) go test -cover -count=1 -parallel=1 -p 1 $(packages) -run Properties
+	@echo $(DOCKER_CLEAN_MSG)
+
+# Example: make test_with_db/server/v2/ValidateProjectAssignment
+# turns into: go test...$(PACKAGE_PATH)/server/v2 -run ValidateProjectAssignment
+test_with_db/%: db_container
+	@PGTZ=UTC PG_URL=$(PG_URL) go test -cover -count=1 -parallel=1 -p 1 -v $(PACKAGE_PATH)/$(subst test_with_db/,,$(@D))/... -run $(@F)
 	@echo $(DOCKER_CLEAN_MSG)
 
 .PHONY: db_container


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Add a convenience function to the authz-service makefile.
So instead of having to do this:
```
go test -v -p 1 --parallel=1 -count=1 \
    github.com/chef/automate/components/authz-service/server/v2 \
    -run TestIntegrationValidateProjectAssignment
```
you will be able to drill down to be very targeted in the directory tree and in the specific set of tests:

![image](https://user-images.githubusercontent.com/6817500/67587590-0dcfcf80-f709-11e9-928d-c8d6b82fac6e.png)

### :chains: Related Resources
NA

### :+1: Definition of Done

Now we have these testing targets available:
```
test                    - runs all authz-service tests; no db
test/%                  - runs authz-service tests with any subpath and name; no db 

test_with_db            - runs all authz-service tests
test_properties_with_db - runs all authz-service tests with Properties in the name
test_with_db/%          - runs authz-service tests with any subpath and name fragment
```

### :athletic_shoe: How to Build and Test the Change

Navigate to the authz-service directory.

```
$ make test_with_db/server/v2/TestIsAuthorized
--- PASS: TestIsAuthorized (0.01s)
    --- PASS: TestIsAuthorized/when_the_engine_response_is_true,_returns_Authorized:_true (0.00s)
    --- PASS: TestIsAuthorized/when_the_engine_response_is_false,_returns_Authorized:_false (0.00s)
```
Or with a bit more directory coverage, move up one directory:
```
$ make test_with_db/server/TestIsAuthorized
--- PASS: TestIsAuthorized (0.08s)
    --- PASS: TestIsAuthorized/memstore (0.00s)
        --- PASS: TestIsAuthorized/memstore/when_the_engine_response_is_true,_returns_Authorized:_true (0.00s)
        --- PASS: TestIsAuthorized/memstore/when_the_engine_response_is_false,_returns_Authorized:_false (0.00s)
    --- PASS: TestIsAuthorized/postgres (0.01s)
        --- PASS: TestIsAuthorized/postgres/when_the_engine_response_is_true,_returns_Authorized:_true (0.00s)
        --- PASS: TestIsAuthorized/post
```
Or for all directories, use a dot in the path segment:
```
$ make test_with_db/./TestIsAuthorized
```
Same thing is available for non-db tests, e.g.:
```
$ make test/engine/conformance/TestIsAuthorized
```
