### PR TITLE
ensure only nodes with no manager (ingested nodes) are updated by project mgr

### DIFF
--- a/components/nodemanager-service/pgdb/project_update.go
+++ b/components/nodemanager-service/pgdb/project_update.go
@@ -18,7 +18,8 @@ const selectNodesProjectData = `
 SELECT
   n.id,
   n.projects_data
-FROM nodes n
+FROM nodes n 
+WHERE n.manager == '';
 `
 
 type NodeProjectData struct {

--- a/components/nodemanager-service/pgdb/project_update.go
+++ b/components/nodemanager-service/pgdb/project_update.go
@@ -19,7 +19,7 @@ SELECT
   n.id,
   n.projects_data
 FROM nodes n 
-WHERE n.manager == '';
+WHERE n.manager = '';
 `
 
 type NodeProjectData struct {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
this is a bit of an "overly cautious" change.
-whenever a node report is ingested, we send a msg to nodemanager about it
-the project update manager ensures that when project updates are made, we update those nodemanager node references to be accurate
-this change ensures we're only grabbing non-managed nodes (ingested nodes). non-ingested nodes shouldn't ever have any "projects_data", so this is probably overly cautious, but it doesn't hurt, and the where clause should make the loop of nodes we go through smaller, which is good!

### :chains: Related Resources
https://github.com/chef/automate/issues/1863

### :+1: Definition of Done
making extra sure only ingested nodes get project updates

### :athletic_shoe: How to Build and Test the Change
N/A -- you could go through building it all and doing all the steps, but it's kinda overkill in this case.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

