### PR TITLE
make scheduler scanner job less flaky

### DIFF
--- a/components/compliance-service/api/tests/50_scheduler_spec.rb
+++ b/components/compliance-service/api/tests/50_scheduler_spec.rb
@@ -158,6 +158,7 @@ describe File.basename(__FILE__) do
   it "creates new jobs as children of existing ones" do
     counter = 0
     while counter <= 10
+      puts "sleeping 10sec, counter is: ", counter
       sleep 10
       all_jobs = GRPC jobs, :list, Jobs::Query.new()
       if all_jobs.total >= 7 

--- a/components/compliance-service/api/tests/50_scheduler_spec.rb
+++ b/components/compliance-service/api/tests/50_scheduler_spec.rb
@@ -156,8 +156,15 @@ describe File.basename(__FILE__) do
   end
 
   it "creates new jobs as children of existing ones" do
-    sleep 70
-    all_jobs = GRPC jobs, :list, Jobs::Query.new()
+    counter = 0
+    while counter <= 10
+      sleep 10
+      all_jobs = GRPC jobs, :list, Jobs::Query.new()
+      if all_jobs.total >= 7 
+        break
+      end
+      counter += 1
+    end
     # we should have seven jobs now, the three from above, our scheduled-for-the-future one,
     # our child job from the first one, our child job from the test_count_max_job job
     # and our child job from the date_only job

--- a/components/compliance-service/api/tests/50_scheduler_spec.rb
+++ b/components/compliance-service/api/tests/50_scheduler_spec.rb
@@ -156,16 +156,15 @@ describe File.basename(__FILE__) do
   end
 
   it "creates new jobs as children of existing ones" do
-    counter = 0
-    while counter <= 10
-      puts "sleeping 10sec, counter is: ", counter
+    all_jobs = GRPC jobs, :list, Jobs::Query.new()    
+    10.times {|i| 
+      puts "sleeping 10sec, iteration: ", i
       sleep 10
       all_jobs = GRPC jobs, :list, Jobs::Query.new()
       if all_jobs.total >= 7 
         break
       end
-      counter += 1
-    end
+    }
     # we should have seven jobs now, the three from above, our scheduled-for-the-future one,
     # our child job from the first one, our child job from the test_count_max_job job
     # and our child job from the date_only job

--- a/components/compliance-service/api/tests/50_scheduler_spec.rb
+++ b/components/compliance-service/api/tests/50_scheduler_spec.rb
@@ -222,12 +222,23 @@ describe File.basename(__FILE__) do
         Common::Filter.new( key: "parent_job", values: [@job_id1])
       ]
     )
-    assert_equal(1, job_list.total)
+    # if we take a while to get here, we may have two jobs instead of just one
+    if job_list.total == 1 
+      puts "one child job found"
+      job = job_list.jobs.first
 
-    job = job_list.jobs.first
+      assert_equal(@job_id1, job.parent_id)
+      assert_equal('My exec job1 - run 1', job.name)
+    else 
+      # should never really be more than two...
+      assert_equal(2, job_list.total)
+      puts "two child jobs found"
 
-    assert_equal(@job_id1, job.parent_id)
-    assert_equal('My exec job1 - run 1', job.name)
+      job_list.jobs.each do |job|
+        assert_equal(@job_id1, job.parent_id)
+        assert_equal(true, job.name.start_with?('My exec job1 - run'))
+      end
+    end
   end
 
   it "can filter out child jobs" do


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Just trying to address flakiness we've recently seen. pete awesomely modified the file so we could see what was failing, and this seems to be one of the common failures

### :chains: Related Resources
N/A

### :+1: Definition of Done
scanner tests less flaky

