### PR TITLE
Fix incorrect border around compliance search

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.scss
@@ -7,6 +7,7 @@
   align-items: center;
   justify-content: space-between;
   flex-grow: 1;
+  background-color: $chef-white;
   border: 1px solid $chef-light-grey;
   border-radius: $global-radius;
 
@@ -14,8 +15,7 @@
     padding: 1.25em;
     width: 100%;
     border: none;
-    border-radius: $global-radius;
-    background-color: $chef-white;
+    background-color: transparent;
     font-family: inherit;
     font-size: 13px;
   }


### PR DESCRIPTION
This commit fixes issue where the border around compliance searchbar would render incorrectly in Firefox.

Before
![Screen Shot 2019-10-28 at 1 33 11 PM](https://user-images.githubusercontent.com/479121/67711666-0ff39180-f988-11e9-9dbc-3db0087ca46f.png)

After
![Screen Shot 2019-10-28 at 1 32 42 PM](https://user-images.githubusercontent.com/479121/67711668-11bd5500-f988-11e9-81e1-a12d1ca61e72.png)
