### PR TITLE
Project update for compliance and client runs elasticsearch bug

### DIFF
--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -500,6 +500,12 @@ func (backend *ESClient) JobStatus(ctx context.Context, jobID string) (project_u
 
 	percentageComplete := getPercentageComplete(tasksGetTaskResponse.Task.Status)
 
+	// If the task is marked complete but the percentage complete is not 1 then the task stopped unexpectedly
+	if tasksGetTaskResponse.Completed && percentageComplete != 1 {
+		return project_update_lib.JobStatus{}, fmt.Errorf("Task %s stopped unexpectedly. "+
+			"For more information go to http://localhost:10141/.tasks/task/%s", jobID, jobID)
+	}
+
 	if percentageComplete != 0 {
 		runningTimeNanos := float64(tasksGetTaskResponse.Task.RunningTimeInNanos)
 		timeLeftSec := int64(runningTimeNanos / percentageComplete / 1000000000.0)

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -518,6 +518,9 @@ func (backend *ESClient) JobStatus(ctx context.Context, jobID string) (project_u
 
 	// If the task is marked complete but the percentage complete is not 1 then the task stopped unexpectedly
 	if tasksGetTaskResponse.Completed && percentageComplete != 1 {
+		logrus.Errorf("Task %s stopped unexpectedly. "+
+			"For more information go to http://localhost:10141/.tasks/task/%s", jobID, jobID)
+
 		return project_update_lib.JobStatus{}, fmt.Errorf("Task %s stopped unexpectedly. "+
 			"For more information go to http://localhost:10141/.tasks/task/%s", jobID, jobID)
 	}

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -284,6 +284,10 @@ func (backend *ESClient) UpdateReportProjectsTags(ctx context.Context, projectTa
 						}
 					}
 					if (condition.roles.length > 0) {
+						if (ctx._source['roles'] == null) {
+							match = false;
+							break;
+						}
 						def found = false;
 						for (def ruleRole : condition.roles){
 							for (def ccrRole : ctx._source.roles){
@@ -300,6 +304,10 @@ func (backend *ESClient) UpdateReportProjectsTags(ctx context.Context, projectTa
 						}
 					}
 					if (condition.chefTags.length > 0) {
+						if (ctx._source['chef_tags'] == null) {
+							match = false;
+							break;
+						}
 						def found = false;
 						for (def ruleChefTag : condition.chefTags) {
 							for (def ccrChefTag : ctx._source.chef_tags) {
@@ -416,6 +424,10 @@ func (backend *ESClient) UpdateSummaryProjectsTags(ctx context.Context, projectT
 						}
 					}
 					if (condition.roles.length > 0) {
+						if (ctx._source['roles'] == null) {
+							match = false;
+							break;
+						}
 						def found = false;
 						for (def ruleRole : condition.roles){
 							for (def ccrRole : ctx._source.roles){
@@ -432,6 +444,10 @@ func (backend *ESClient) UpdateSummaryProjectsTags(ctx context.Context, projectT
 						}
 					}
 					if (condition.chefTags.length > 0) {
+						if (ctx._source['chef_tags'] == null) {
+							match = false;
+							break;
+						}
 						def found = false;
 						for (def ruleChefTag : condition.chefTags) {
 							for (def ccrChefTag : ctx._source.chef_tags) {

--- a/components/compliance-service/integration_test/reports_projects_update_test.go
+++ b/components/compliance-service/integration_test/reports_projects_update_test.go
@@ -410,6 +410,30 @@ func TestProjectUpdate(t *testing.T) {
 			},
 			projectIDs: []string{},
 		},
+		{
+			description: "roles: setting the project to unassigned when there are no roles",
+			report: &relaxting.ESInSpecReport{
+				Projects: []string{"old_tag"},
+			},
+			summary: &relaxting.ESInSpecSummary{
+				Projects: []string{"old_tag"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project9": {
+					Rules: []*iam_v2.ProjectRule{
+						{
+							Conditions: []*iam_v2.Condition{
+								{
+									Attribute: iam_v2.ProjectRuleConditionAttributes_CHEF_ROLE,
+									Values:    []string{"area_54"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{},
+		},
 
 		// ChefServers
 		{
@@ -1265,6 +1289,30 @@ func TestProjectUpdate(t *testing.T) {
 			summary: &relaxting.ESInSpecSummary{
 				Projects: []string{"old_tag"},
 				ChefTags: []string{"area_51", "area_52", "area_53"},
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project9": {
+					Rules: []*iam_v2.ProjectRule{
+						{
+							Conditions: []*iam_v2.Condition{
+								{
+									Attribute: iam_v2.ProjectRuleConditionAttributes_CHEF_TAG,
+									Values:    []string{"area_54"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{},
+		},
+		{
+			description: "chefTags: setting the project to unassigned when there are no chef tags",
+			report: &relaxting.ESInSpecReport{
+				Projects: []string{"old_tag"},
+			},
+			summary: &relaxting.ESInSpecSummary{
+				Projects: []string{"old_tag"},
 			},
 			projects: map[string]*iam_v2.ProjectRules{
 				"project9": {

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -12,7 +12,6 @@ import (
 	project_update_lib "github.com/chef/automate/lib/authz"
 	"github.com/olivere/elastic"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -44,7 +43,7 @@ func (es *Backend) Initializing() bool {
 }
 
 func (es *Backend) UpdateProjectTags(ctx context.Context, projectTaggingRules map[string]*iam_v2.ProjectRules) ([]string, error) {
-	logrus.Debug("starting project updater")
+	log.Debug("starting project updater")
 
 	esNodeJobID, err := es.UpdateNodeProjectTags(ctx, projectTaggingRules)
 	if err != nil {
@@ -56,7 +55,7 @@ func (es *Backend) UpdateProjectTags(ctx context.Context, projectTaggingRules ma
 		return []string{}, errors.Wrap(err, "Failed to start Elasticsearch Action project tags update")
 	}
 
-	logrus.Debugf("Started Project rule updates with node job ID: %q action job ID %q", esNodeJobID, esActionJobID)
+	log.Debugf("Started Project rule updates with node job ID: %q action job ID %q", esNodeJobID, esActionJobID)
 
 	return []string{esNodeJobID, esActionJobID}, nil
 }
@@ -78,10 +77,19 @@ func (es *Backend) JobStatus(ctx context.Context, jobID string) (project_update_
 
 	var estimatedEndTimeInSec int64
 
-	percentageComplete := getPercentageComplete(tasksGetTaskResponse.Task.Status)
+	percentageComplete, ok := getPercentageComplete(tasksGetTaskResponse.Task.Status)
+	if !ok {
+		return project_update_lib.JobStatus{
+			Completed:             tasksGetTaskResponse.Completed,
+			PercentageComplete:    0,
+			EstimatedEndTimeInSec: estimatedEndTimeInSec,
+		}, nil
+	}
 
 	// If the task is marked complete but the percentage complete is not 1 then the task stopped unexpectedly
 	if tasksGetTaskResponse.Completed && percentageComplete != 1 {
+		log.Errorf("Task %s stopped unexpectedly. "+
+			"For more information go to http://localhost:10141/.tasks/task/%s", jobID, jobID)
 		return project_update_lib.JobStatus{}, fmt.Errorf("Task %s stopped unexpectedly. "+
 			"For more information go to http://localhost:10141/.tasks/task/%s", jobID, jobID)
 	}
@@ -359,24 +367,35 @@ func newBoolQueryFromFilters(filters map[string]string) *elastic.BoolQuery {
 	return boolQuery
 }
 
-func getPercentageComplete(status interface{}) float64 {
+func getPercentageComplete(status interface{}) (float64, bool) {
 	statusMap, ok := status.(map[string]interface{})
 	if !ok {
-		return 0
+		return 0, false
+	}
+
+	created, ok := statusMap["created"].(float64)
+	if !ok {
+		return 0, false
+	}
+
+	deleted, ok := statusMap["deleted"].(float64)
+	if !ok {
+		return 0, false
 	}
 
 	updated, ok := statusMap["updated"].(float64)
 	if !ok {
-		return 0
+		return 0, false
 	}
+
 	total, ok := statusMap["total"].(float64)
 	if !ok {
-		return 0
+		return 0, false
 	}
 
 	if total == 0 {
-		return 0
+		return 1, true
 	}
 
-	return updated / total
+	return (created + deleted + updated) / total, true
 }

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -1,6 +1,7 @@
 package elastic
 
 import (
+	"fmt"
 	"time"
 
 	"context"
@@ -78,6 +79,12 @@ func (es *Backend) JobStatus(ctx context.Context, jobID string) (project_update_
 	var estimatedEndTimeInSec int64
 
 	percentageComplete := getPercentageComplete(tasksGetTaskResponse.Task.Status)
+
+	// If the task is marked complete but the percentage complete is not 1 then the task stopped unexpectedly
+	if tasksGetTaskResponse.Completed && percentageComplete != 1 {
+		return project_update_lib.JobStatus{}, fmt.Errorf("Task %s stopped unexpectedly. "+
+			"For more information go to http://localhost:10141/.tasks/task/%s", jobID, jobID)
+	}
 
 	if percentageComplete != 0 {
 		runningTimeNanos := float64(tasksGetTaskResponse.Task.RunningTimeInNanos)

--- a/components/ingest-service/backend/elastic/nodes.go
+++ b/components/ingest-service/backend/elastic/nodes.go
@@ -169,6 +169,10 @@ func (es *Backend) UpdateNodeProjectTags(ctx context.Context, projectTaggingRule
 						}
 					}
 					if (condition.roles.length > 0) {
+						if (ctx._source['roles'] == null) {
+							match = false;
+							break;
+						}
 						def found = false;
 						for (def ruleRole : condition.roles){
 							for (def ccrRole : ctx._source.roles){
@@ -185,6 +189,10 @@ func (es *Backend) UpdateNodeProjectTags(ctx context.Context, projectTaggingRule
 						}
 					}
 					if (condition.chefTags.length > 0) {
+						if (ctx._source['chef_tags'] == null) {
+							match = false;
+							break;
+						}
 						def found = false;
 						for (def ruleChefTag : condition.chefTags) {
 							for (def ccrChefTag : ctx._source.chef_tags) {

--- a/components/ingest-service/integration_test/project_update_test.go
+++ b/components/ingest-service/integration_test/project_update_test.go
@@ -1525,6 +1525,20 @@ func TestProjectUpdatePainlessElasticsearchScript(t *testing.T) {
 			},
 			projectIDs: []string{},
 		},
+		{
+			description: "project update with no nodes",
+			node:        iBackend.Node{},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project 9": {
+					Rules: []*iam_v2.ProjectRule{
+						{
+							Conditions: []*iam_v2.Condition{},
+						},
+					},
+				},
+			},
+			projectIDs: []string{},
+		},
 	}
 
 	for _, test := range cases {

--- a/components/ingest-service/integration_test/project_update_test.go
+++ b/components/ingest-service/integration_test/project_update_test.go
@@ -797,6 +797,32 @@ func TestProjectUpdatePainlessElasticsearchScript(t *testing.T) {
 			},
 			projectIDs: []string{},
 		},
+		{
+			description: "roles: setting the project to unassigned when there are no roles",
+			node: iBackend.Node{
+				NodeInfo: iBackend.NodeInfo{
+					EntityUuid: newUUID(),
+					NodeName:   "node_1",
+				},
+				Projects: []string{"old_tag"},
+				Exists:   true,
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project9": {
+					Rules: []*iam_v2.ProjectRule{
+						{
+							Conditions: []*iam_v2.Condition{
+								{
+									Attribute: iam_v2.ProjectRuleConditionAttributes_CHEF_ROLE,
+									Values:    []string{"area_54"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{},
+		},
 
 		// chefTags
 		{
@@ -1045,6 +1071,32 @@ func TestProjectUpdatePainlessElasticsearchScript(t *testing.T) {
 					EntityUuid: newUUID(),
 					NodeName:   "node_1",
 					ChefTags:   []string{"area_51", "area_52", "area_53"},
+				},
+				Projects: []string{"old_tag"},
+				Exists:   true,
+			},
+			projects: map[string]*iam_v2.ProjectRules{
+				"project9": {
+					Rules: []*iam_v2.ProjectRule{
+						{
+							Conditions: []*iam_v2.Condition{
+								{
+									Attribute: iam_v2.ProjectRuleConditionAttributes_CHEF_TAG,
+									Values:    []string{"area_54"},
+								},
+							},
+						},
+					},
+				},
+			},
+			projectIDs: []string{},
+		},
+		{
+			description: "chefTags: setting the project to unassigned when there are no chef tags",
+			node: iBackend.Node{
+				NodeInfo: iBackend.NodeInfo{
+					EntityUuid: newUUID(),
+					NodeName:   "node_1",
 				},
 				Projects: []string{"old_tag"},
 				Exists:   true,

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -270,7 +270,7 @@ describeIfIAMV2p1('projects API', () => {
         method: 'POST',
         url: '/apis/iam/v2beta/apply-rules'
       });
-      waitUntilApplyRulesNotRunning(100);
+      waitUntilApplyRulesNotRunning(500);
 
       // confirm rules are applied
       for (const project of [avengersProject, xmenProject]) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When running a project update with a chef tag project rule the compliance-service would fail to update. The problem is that the array field is sometimes stored as "null" and not an empty array. The solution is to check if the field is null before using it. 

Client runs had the same problem which is fixed in the PR also. 

### :chains: Related Resources

#1494

### :+1: Definition of Done
Able to successfully run a project update with a project with chef tag ingest rules when there are compliance reports with empty chef tags. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/compliance-service && start_all_services`
1. Add some compliance nodes with `chef_load_compliance_nodes 100`
1. Open the compliance page https://a2-dev.test/compliance/reports/nodes
1. Copy one of the node's environment, its displayed in the list view
    - or use the environment filter at the top of the page to identify what a node's enviornment is
1. Create a project with two rules. One matching on a chef tag with any value. The second rule matching the environment found above. 
1. Update the projects
1. Go back to the https://a2-dev.test/compliance/reports/nodes page and filter by the project created to ensure the project update worked correctly. 

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable