### PR TITLE
Jamie/chef input touched

### DIFF
--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -14,10 +14,10 @@
         <chef-form-field id="create-name">
           <label>
             <span class="label">Rule Name <span aria-hidden="true">*</span></span>
-            <chef-input ngDefaultControl formControlName="name" (keyup)="handleNameInput($event)"></chef-input>
+            <chef-input ngDefaultControl #test formControlName="name" (keyup)="handleNameInput($event)"></chef-input>
           </label>
           <chef-error
-            *ngIf="(ruleForm.get('name').hasError('required') || ruleForm.get('name').hasError('pattern')) && ruleForm.get('name').dirty"
+            *ngIf="(ruleForm.get('name').hasError('required') || ruleForm.get('name').hasError('pattern')) && test.classList.contains('ng-touched')"
           >Rule Name is required.</chef-error>
         </chef-form-field>
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -14,7 +14,7 @@
         <chef-form-field id="create-name">
           <label>
             <span class="label">Rule Name <span aria-hidden="true">*</span></span>
-            <input formControlName="name" (keyup)="handleNameInput($event)"/>
+            <input chefInput formControlName="name" (keyup)="handleNameInput($event)"/>
           </label>
           <chef-error
             *ngIf="(ruleForm.get('name').hasError('required') || ruleForm.get('name').hasError('pattern')) && ruleForm.get('name').touched"
@@ -25,7 +25,7 @@
           <chef-form-field id="create-id">
             <label>
               <span class="label">Rule ID <span aria-hidden="true">*</span> </span>
-              <input formControlName="id" (keyup)="handleIDInput($event)" />
+              <input chefInput formControlName="id" (keyup)="handleIDInput($event)" />
             </label>
             <chef-error *ngIf="ruleForm.get('id').hasError('maxlength') && ruleForm.get('id').dirty">
               Rule ID must be 64 characters or less.
@@ -113,6 +113,7 @@
                 <label>
                   <span class="label">Value</span>
                   <input
+                    chefInput
                     formControlName="values"
                     [value]="condition.controls.values.value"
                     data-cy="rule-value"

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -112,11 +112,8 @@
               <chef-form-field class="attribute-field">
                 <label>
                   <span class="label">Value</span>
-                  <input
-                  chefInput
-                  formControlName="values"
-                  [value]="condition.controls.values.value"
-                  data-cy="rule-value"
+                  <input chefInput formControlName="values" 
+                        [value]="condition.controls.values.value" data-cy="rule-value"
                   />
                 </label>
                 <div>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -121,7 +121,8 @@
                 </label>
                 <div>
                   <chef-error
-                      *ngIf="(ruleForm.get('conditions').controls[i].get('values').hasError('required') || ruleForm.get('conditions').controls[i].get('values').hasError('pattern')) && ruleForm.get('conditions').controls[i].get('values').touched"
+                      *ngIf="( ruleForm.get('conditions').controls[i].get('values').hasError('required') && ruleForm.get('conditions').controls[i].get('values').touched )
+                              || ( ruleForm.get('conditions').controls[i].get('values').hasError('pattern') && ruleForm.get('conditions').controls[i].get('values').dirty )"
                     >Value is required.</chef-error>
                 </div>
                 <small class="help"

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -110,19 +110,19 @@
               </chef-form-field>
 
               <chef-form-field class="attribute-field">
+                <label>
+                  <span class="label">Value</span>
+                  <input
+                  chefInput
+                  formControlName="values"
+                  [value]="condition.controls.values.value"
+                  data-cy="rule-value"
+                  />
+                </label>
                 <div>
-                  <label>
-                    <span class="label">Value</span>
-                    <input
-                      chefInput
-                      formControlName="values"
-                      [value]="condition.controls.values.value"
-                      data-cy="rule-value"
-                    />
-                  </label>
                   <chef-error
-                    *ngIf="(ruleForm.get('conditions').controls[i].get('values').hasError('required') || ruleForm.get('conditions').controls[i].get('values').hasError('pattern')) && ruleForm.get('conditions').controls[i].get('values').touched"
-                  >Value is required.</chef-error>
+                      *ngIf="(ruleForm.get('conditions').controls[i].get('values').hasError('required') || ruleForm.get('conditions').controls[i].get('values').hasError('pattern')) && ruleForm.get('conditions').controls[i].get('values').touched"
+                    >Value is required.</chef-error>
                 </div>
                 <small class="help"
                   *ngIf="condition.controls.operator.value === 'EQUALS'">

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -17,7 +17,7 @@
             <input chefInput formControlName="name" (keyup)="handleNameInput($event)"/>
           </label>
           <chef-error
-            *ngIf="(ruleForm.get('name').hasError('required') || ruleForm.get('name').hasError('pattern')) && ruleForm.get('name').touched"
+            *ngIf="( ruleForm.get('name').hasError('required') && ruleForm.get('name').touched ) || ( ruleForm.get('name').hasError('pattern') && ruleForm.get('name').dirty )"
           >Rule Name is required.</chef-error>
         </chef-form-field>
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -25,7 +25,7 @@
           <chef-form-field id="create-id">
             <label>
               <span class="label">Rule ID <span aria-hidden="true">*</span> </span>
-              <chef-input ngDefaultControl formControlName="id" (keyup)="handleIDInput($event)"></chef-input>
+              <chef-input class="someclass" ngDefaultControl formControlName="id" (keyup)="handleIDInput($event)"></chef-input>
             </label>
             <chef-error *ngIf="ruleForm.get('id').hasError('maxlength') && ruleForm.get('id').dirty">
               Rule ID must be 64 characters or less.

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -110,18 +110,20 @@
               </chef-form-field>
 
               <chef-form-field class="attribute-field">
-                <label>
-                  <span class="label">Value</span>
-                  <input
-                    chefInput
-                    formControlName="values"
-                    [value]="condition.controls.values.value"
-                    data-cy="rule-value"
-                  />
-                </label>
-                <chef-error
-                  *ngIf="(ruleForm.get('conditions').controls[i].get('values').hasError('required') || ruleForm.get('conditions').controls[i].get('values').hasError('pattern')) && ruleForm.get('conditions').controls[i].get('values').touched"
-                >Value is required.</chef-error>
+                <div>
+                  <label>
+                    <span class="label">Value</span>
+                    <input
+                      chefInput
+                      formControlName="values"
+                      [value]="condition.controls.values.value"
+                      data-cy="rule-value"
+                    />
+                  </label>
+                  <chef-error
+                    *ngIf="(ruleForm.get('conditions').controls[i].get('values').hasError('required') || ruleForm.get('conditions').controls[i].get('values').hasError('pattern')) && ruleForm.get('conditions').controls[i].get('values').touched"
+                  >Value is required.</chef-error>
+                </div>
                 <small class="help"
                   *ngIf="condition.controls.operator.value === 'EQUALS'">
                     Case sensitive, must match exactly.

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -53,7 +53,7 @@
           <label>
             <span class="label">Resource Type <span aria-hidden="true">*</span></span>
             <span class="custom-dropdown">
-              <select id="create-type-dropdown" ngDefaultControl formControlName="type">
+              <select id="create-type-dropdown" formControlName="type">
                 <option value='NODE'>Node</option>
                 <option value='EVENT'>Event</option>
               </select>
@@ -80,7 +80,7 @@
                 <label>
                   <span class="label">{{ getAttributeLabel() }}</span>
                   <span class="custom-dropdown">
-                    <select ngDefaultControl formControlName="attribute" data-cy="attribute-dropdown">
+                    <select formControlName="attribute" data-cy="attribute-dropdown">
                       <option
                         *ngFor="let option of attributeList"
                         [value]="option.key"
@@ -97,7 +97,7 @@
                 <label>
                   <span class="label">Operator</span>
                   <span class="custom-dropdown">
-                    <select class="operator-dropdown" ngDefaultControl formControlName="operator" data-cy="operator-dropdown">
+                    <select class="operator-dropdown" formControlName="operator" data-cy="operator-dropdown">
                       <option *ngFor="let operator of operators"
                         [value]="operator.key"
                       >{{ operator.value }}</option>

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -14,10 +14,10 @@
         <chef-form-field id="create-name">
           <label>
             <span class="label">Rule Name <span aria-hidden="true">*</span></span>
-            <chef-input ngDefaultControl formControlName="name" (keyup)="handleNameInput($event)"></chef-input>
+            <input formControlName="name" (keyup)="handleNameInput($event)"/>
           </label>
           <chef-error
-            *ngIf="(ruleForm.get('name').hasError('required') || ruleForm.get('name').hasError('pattern')) && ruleForm.get('name').dirty"
+            *ngIf="(ruleForm.get('name').hasError('required') || ruleForm.get('name').hasError('pattern')) && ruleForm.get('name').touched"
           >Rule Name is required.</chef-error>
         </chef-form-field>
 
@@ -25,7 +25,7 @@
           <chef-form-field id="create-id">
             <label>
               <span class="label">Rule ID <span aria-hidden="true">*</span> </span>
-              <chef-input ngDefaultControl formControlName="id" (keyup)="handleIDInput($event)"></chef-input>
+              <input formControlName="id" (keyup)="handleIDInput($event)" />
             </label>
             <chef-error *ngIf="ruleForm.get('id').hasError('maxlength') && ruleForm.get('id').dirty">
               Rule ID must be 64 characters or less.
@@ -112,14 +112,14 @@
               <chef-form-field class="attribute-field">
                 <label>
                   <span class="label">Value</span>
-                  <chef-input ngDefaultControl
+                  <input
                     formControlName="values"
                     [value]="condition.controls.values.value"
                     data-cy="rule-value"
-                  ></chef-input>
+                  />
                 </label>
                 <chef-error
-                  *ngIf="(ruleForm.get('conditions').controls[i].get('values').hasError('required') || ruleForm.get('conditions').controls[i].get('values').hasError('pattern')) && ruleForm.get('conditions').controls[i].get('values').dirty"
+                  *ngIf="(ruleForm.get('conditions').controls[i].get('values').hasError('required') || ruleForm.get('conditions').controls[i].get('values').hasError('pattern')) && ruleForm.get('conditions').controls[i].get('values').touched"
                 >Value is required.</chef-error>
                 <small class="help"
                   *ngIf="condition.controls.operator.value === 'EQUALS'">

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -14,10 +14,10 @@
         <chef-form-field id="create-name">
           <label>
             <span class="label">Rule Name <span aria-hidden="true">*</span></span>
-            <chef-input ngDefaultControl #test formControlName="name" (keyup)="handleNameInput($event)"></chef-input>
+            <chef-input ngDefaultControl formControlName="name" (keyup)="handleNameInput($event)"></chef-input>
           </label>
           <chef-error
-            *ngIf="(ruleForm.get('name').hasError('required') || ruleForm.get('name').hasError('pattern')) && test.classList.contains('ng-touched')"
+            *ngIf="(ruleForm.get('name').hasError('required') || ruleForm.get('name').hasError('pattern')) && ruleForm.get('name').dirty"
           >Rule Name is required.</chef-error>
         </chef-form-field>
 
@@ -25,7 +25,7 @@
           <chef-form-field id="create-id">
             <label>
               <span class="label">Rule ID <span aria-hidden="true">*</span> </span>
-              <chef-input class="someclass" ngDefaultControl formControlName="id" (keyup)="handleIDInput($event)"></chef-input>
+              <chef-input ngDefaultControl formControlName="id" (keyup)="handleIDInput($event)"></chef-input>
             </label>
             <chef-error *ngIf="ruleForm.get('id').hasError('maxlength') && ruleForm.get('id').dirty">
               Rule ID must be 64 characters or less.

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -19,22 +19,7 @@ chef-page {
   input {
     height: 45px;
     width: 100%;
-    padding: 12px 16px 12px 12px;
-    border-radius: 6px;
-    border: solid 1px $chef-grey;
-    outline: none;
-    color: $chef-primary-dark;
-    text-indent: 0.01px;
-    text-overflow: '';
-    font-weight: 400;
-    font-stretch: normal;
-    font-style: normal;
-    line-height: 1.5;
-    letter-spacing: 0.2px;
-
-    &:focus {
-      border: solid 1px $chef-primary-bright;
-    }
+    outline: 0;
   }
 
   #create-name,
@@ -170,11 +155,6 @@ chef-page {
       padding-bottom: 0;
     }
 
-    input[disabled] {
-      background-color: $chef-light-grey;
-      opacity: 0.5;
-    }
-
     &.attribute-field {
       display: inline-block;
       position: relative;
@@ -189,8 +169,7 @@ chef-page {
         font-weight: 200;
       }
 
-      select,
-      input {
+      select {
         min-width: 0;
         width: 100%;
       }

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -22,6 +22,12 @@ chef-page {
     outline: 0;
   }
 
+  chef-error {
+    background-color: #DC267F;
+    color: #FFFFFF;
+    border-radius: 0 0 4px 4px;
+  }
+
   #create-name,
   #create-id,
   #create-type,

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -16,9 +16,25 @@ chef-page {
     overflow-y: scroll;
   }
 
-  chef-input {
+  input {
     height: 45px;
     width: 100%;
+    padding: 12px 16px 12px 12px;
+    border-radius: 6px;
+    border: solid 1px $chef-grey;
+    outline: none;
+    color: $chef-primary-dark;
+    text-indent: 0.01px;
+    text-overflow: '';
+    font-weight: 400;
+    font-stretch: normal;
+    font-style: normal;
+    line-height: 1.5;
+    letter-spacing: 0.2px;
+
+    &:focus {
+      border: solid 1px $chef-primary-bright;
+    }
   }
 
   #create-name,
@@ -154,7 +170,7 @@ chef-page {
       padding-bottom: 0;
     }
 
-    chef-input[disabled] {
+    input[disabled] {
       background-color: $chef-light-grey;
       opacity: 0.5;
     }
@@ -174,7 +190,7 @@ chef-page {
       }
 
       select,
-      chef-input {
+      input {
         min-width: 0;
         width: 100%;
       }

--- a/components/chef-ui-library/src/atoms/chef-input/chef-input.tsx
+++ b/components/chef-ui-library/src/atoms/chef-input/chef-input.tsx
@@ -61,11 +61,9 @@ export class ChefInput {
    */
   @Prop() autocomplete = 'off';
 
-  @State() focused: boolean;
-  @State() touched: boolean;
+  @State() focused = false;
 
   @Listen('focusin') handleFocusin() {
-    this.touched = true;
     this.focused = true;
   }
 
@@ -73,20 +71,9 @@ export class ChefInput {
     this.focused = false;
   }
 
-  isFocused(): boolean {
-    return this.focused === true ? true : false;
-  }
-
-  isTouched(): boolean {
-    return this.touched === true ? true : false;
-  }
-
   render() {
     return (
-      <Host class={{
-        'focused': this.isFocused(),
-        'ng-touched': this.isTouched()
-      }}>
+      <Host class={this.focused ? 'focused' : ''}>
         {this.renderContent()}
       </Host>
     );

--- a/components/chef-ui-library/src/atoms/chef-input/chef-input.tsx
+++ b/components/chef-ui-library/src/atoms/chef-input/chef-input.tsx
@@ -61,9 +61,11 @@ export class ChefInput {
    */
   @Prop() autocomplete = 'off';
 
-  @State() focused = false;
+  @State() focused: boolean;
+  @State() touched: boolean;
 
   @Listen('focusin') handleFocusin() {
+    this.touched = true;
     this.focused = true;
   }
 
@@ -71,9 +73,20 @@ export class ChefInput {
     this.focused = false;
   }
 
+  isFocused(): boolean {
+    return this.focused === true ? true : false;
+  }
+
+  isTouched(): boolean {
+    return this.touched === true ? true : false;
+  }
+
   render() {
     return (
-      <Host class={this.focused ? 'focused' : ''}>
+      <Host class={{
+        'focused': this.isFocused(),
+        'touched': this.isTouched()
+      }}>
         {this.renderContent()}
       </Host>
     );

--- a/components/chef-ui-library/src/atoms/chef-input/chef-input.tsx
+++ b/components/chef-ui-library/src/atoms/chef-input/chef-input.tsx
@@ -85,7 +85,7 @@ export class ChefInput {
     return (
       <Host class={{
         'focused': this.isFocused(),
-        'touched': this.isTouched()
+        'ng-touched': this.isTouched()
       }}>
         {this.renderContent()}
       </Host>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The `chef-input` component does not properly register ng-untouched/ng-touched classes.   Rather than build in a workaround, we have opted to use plain html `input` until a new `chef-input` is used across the site.  This also required an update to the input styling in the respective scss file.

### :chains: Related Resources
https://github.com/chef/ui-team/issues/7 created to update chef-input across Automate

### :+1: Definition of Done
Inputs on the Create Rule page, show errors after they have been touched.  Tabbing through is one way of touching inputs.

### :athletic_shoe: How to Build and Test the Change
1. build components/automate-ui-devproxy && start_all_services
2. navigate to https://a2-dev.test/settings/projects and click on any one of your projects or create a new project if you do not yet have any projects.
3. click on `Create Rule`
4. focus in on the typeable inputs but don't type anything.  When you exit the inputs, you should see errors which will then disappear once they've been typed in.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable

![Tabbingthroughrulecreate](https://user-images.githubusercontent.com/16737484/67793195-a206a300-fa37-11e9-95d0-dae5c12a6a7b.gif)
