### PR TITLE
Remove utc from calculation s its not really necessary, not sure if t…

### DIFF
--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.html
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.html
@@ -46,7 +46,7 @@
               <p>
                 <strong>{{ history.startTime | datetime: RFC2822 }}</strong>
               </p>
-              <p>{{ getDuration(history.startTime, history.endTime) }} ago</p>
+              <p><span>Duration: </span>{{ getDuration(history.startTime, history.endTime) }}</p>
             </div>
             <chef-button secondary (click)="onSelect(history)">
               <chef-icon>chevron_right</chef-icon>

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.ts
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.ts
@@ -110,7 +110,7 @@ export class RunHistoryComponent implements OnInit, OnDestroy {
   }
 
   getDuration(start_time, end_time) {
-    return moment.duration(moment.utc(end_time).diff(moment.utc(start_time))).humanize();
+    return moment.duration(moment(end_time).diff(moment(start_time))).humanize();
   }
 
   onDownloadRunsReport() {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why? 
Recently when updating UTC across client run, I updated the `getDuration` function inside the Client Runs Drawer as well.  While the code works fine locally, when using real data it is spitting out "a few seconds" as the result to all time differences.  Because this is duration and it doesn't actually need to be UTC for the correct answer, i've reverted the `getDuration` function back to the way it was before the UTC change.

### :chains: Related Resources
https://github.com/chef/automate/pull/1944

### :+1: Definition of Done
Client runs history drawer shows the correct amount of time since the client has been run, not just "a few seconds ago"

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
navigate to https://a2-dev.test/infrastructure/client-runs
click on any specific node
Click on 'run history' button in top right

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
![Screen Shot 2019-10-29 at 11 42 59 AM](https://user-images.githubusercontent.com/16737484/67798750-56f18d80-fa41-11e9-94ea-829da2c914ee.png)
