### PR TITLE
Downloads goes to downloads page

### DIFF
--- a/components/automate-chef-io/config.toml
+++ b/components/automate-chef-io/config.toml
@@ -43,7 +43,7 @@ weight = 25
 
 [[menu.main]]
 name = "Downloads"
-url = "https://www.chef.io/chef/get-chef/"
+url = "https://downloads.chef.io/"
 weight = 30
 
 # Define the top level sidebar items so we can reference them explicitly


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### :nut_and_bolt: Description: Changes the download redirect in the header to the downloads page. 

Sadly, a controversial decision because the download button redirects us to the docs. But I hope we will fix the download page separately.

Staying with the use of "Downloads" in the header to redirect to the downloads page is consistent (I think) with how we use "Downloads" in the header in our products.