### PR TITLE
grpc: use absolute path in compliance-service/scripts/grpc.sh

### DIFF
--- a/components/compliance-service/scripts/grpc.sh
+++ b/components/compliance-service/scripts/grpc.sh
@@ -25,7 +25,7 @@ trap cleanup EXIT
 
 for i in $(find components/compliance-service -name '*.proto') ; do
   protoc -I /src \
-    -I src/components/compliance-service/api \
+    -I /src/components/compliance-service/api \
     -I vendor \
     -I vendor/github.com/grpc-ecosystem/grpc-gateway \
     -I vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \


### PR DESCRIPTION
We should move these protos and get rid of the mountains of shell
script we are using to basically run a couple of commands.

Signed-off-by: Steven Danna <steve@chef.io>