### PR TITLE
deployment: use semver-style comparison for hab-sup versions

### DIFF
--- a/components/automate-deployment/pkg/habpkg/habpkg.go
+++ b/components/automate-deployment/pkg/habpkg/habpkg.go
@@ -39,26 +39,6 @@ type Installable interface {
 	InstallIdent() string
 }
 
-// GreaterOrEqual returns true if VersionedArtifact fully qualified
-// version is greater or equal to b.  It assumes Version() and
-// Release() return lexically sortable strings.
-func GreaterOrEqual(a VersionedArtifact, b VersionedArtifact) bool {
-	if a.Version() > b.Version() {
-		return true
-	}
-
-	if b.Version() > a.Version() {
-		return false
-	}
-
-	// a.Version() and b.Version() are equal, check release
-	if a.Release() >= b.Release() {
-		return true
-	}
-
-	return false
-}
-
 // VersionString (ugh, bad name) returns a string representing the
 // version information available in the VersionedArtifact
 func VersionString(v VersionedArtifact) string {

--- a/components/automate-deployment/pkg/habpkg/habpkg_test.go
+++ b/components/automate-deployment/pkg/habpkg/habpkg_test.go
@@ -4,9 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFromString(t *testing.T) {

--- a/components/automate-deployment/pkg/habpkg/hartifact_test.go
+++ b/components/automate-deployment/pkg/habpkg/hartifact_test.go
@@ -66,10 +66,8 @@ func TestFindHartReturnsErrorIfABadGlobIsGenerated(t *testing.T) {
 func TestHartFromPathSuccess(t *testing.T) {
 	h, err := HartFromPath("/some/path/ssd-deployment-service-0.1.0-20180119115432-x86_64-linux.hart")
 	assert.NoError(t, err)
-	assert.Equal(t, 0, h.major)
-	assert.Equal(t, 1, h.minor)
-	assert.Equal(t, 0, h.patch)
-	assert.Equal(t, 20180119115432, h.Timestamp())
+	assert.Equal(t, "0.1.0", h.version)
+	assert.Equal(t, "20180119115432", h.release)
 }
 
 func TestHartFromPathFailure(t *testing.T) {
@@ -102,10 +100,8 @@ func TestHartStringMarshalUnmarshal(t *testing.T) {
 
 	assert.Equal(t, "ssd", unmarshalled.origin)
 	assert.Equal(t, "deployment-service", unmarshalled.name)
-	assert.Equal(t, 0, unmarshalled.major)
-	assert.Equal(t, 1, unmarshalled.minor)
-	assert.Equal(t, 0, unmarshalled.patch)
-	assert.Equal(t, 20180119115432, unmarshalled.Timestamp())
+	assert.Equal(t, "0.1.0", unmarshalled.version)
+	assert.Equal(t, "20180119115432", unmarshalled.release)
 }
 
 func TestHartJsonMarshalUnmarshal(t *testing.T) {
@@ -123,10 +119,8 @@ func TestHartJsonMarshalUnmarshal(t *testing.T) {
 
 	assert.Equal(t, "ssd", unmarshalled.origin)
 	assert.Equal(t, "deployment-service", unmarshalled.name)
-	assert.Equal(t, 0, unmarshalled.major)
-	assert.Equal(t, 1, unmarshalled.minor)
-	assert.Equal(t, 0, unmarshalled.patch)
-	assert.Equal(t, 20180119115432, unmarshalled.Timestamp())
+	assert.Equal(t, "0.1.0", unmarshalled.version)
+	assert.Equal(t, "20180119115432", unmarshalled.release)
 }
 
 func TestSortableHartsFromPaths(t *testing.T) {

--- a/components/automate-deployment/pkg/habpkg/semverish.go
+++ b/components/automate-deployment/pkg/habpkg/semverish.go
@@ -1,0 +1,139 @@
+package habpkg
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// SemverishVersion holds a semver-like version. It supports the
+// following format:
+//
+// [v]VERSION_PART[.VERSION_PART...][-PRERELEASE][+METADATA]
+//
+// Unlike traditional semver, it supports any non-zero number of
+// version parts.
+//
+type SemverishVersion struct {
+	parts      []int
+	prerelease string
+	metadata   string
+}
+
+func ParseSemverishVersion(s string) (SemverishVersion, error) {
+	var (
+		ret = SemverishVersion{
+			parts: make([]int, 0, 3),
+		}
+		err     error
+		nextInt int
+	)
+
+	if s[0] == 'v' {
+		s = s[1:]
+	}
+	nextInt, s, err = getInt(s)
+	if err != nil {
+		return ret, err
+	}
+
+	ret.parts = append(ret.parts, nextInt)
+	for len(s) != 0 {
+		switch s[0] {
+		case '.':
+			s = s[1:]
+			nextInt, s, err = getInt(s)
+			if err != nil {
+				return ret, err
+			}
+			ret.parts = append(ret.parts, nextInt)
+		case '-':
+			s = s[1:]
+			idx := strings.Index(s, "+")
+			if idx == -1 {
+				ret.prerelease = s
+				return ret, nil
+			}
+			ret.prerelease = s[0:idx]
+			s = s[idx:]
+		case '+':
+			ret.metadata = s[1:]
+			return ret, nil
+		default:
+			return ret, errors.Errorf("unexpected character in semver version: %s", s)
+		}
+	}
+	return ret, nil
+}
+
+func getInt(s string) (int, string, error) {
+	end := 0
+	for len(s) > end && s[end] >= '0' && s[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return 0, s, errors.New("could not parse expected integer")
+	}
+	ret, err := strconv.Atoi(s[0:end])
+	return ret, s[end:], err
+}
+
+func CompareSemverish(a SemverishVersion, b SemverishVersion) int {
+	for i := 0; i < len(a.parts); i++ {
+		if len(b.parts) > i {
+			if a.parts[i] < b.parts[i] {
+				return -1
+			} else if a.parts[i] > b.parts[i] {
+				return 1
+			}
+		} else {
+			return 1
+		}
+	}
+	if len(b.parts) > len(a.parts) {
+		return -1
+	}
+
+	// No-prerelease always wins
+	if a.prerelease == "" && b.prerelease != "" {
+		return 1
+	} else if a.prerelease != "" && b.prerelease == "" {
+		return -1
+	}
+
+	// Otherwise, just lexigraphically sort the pre-release, this
+	// is not what the spec says to do.
+	if a.prerelease < b.prerelease {
+		return -1
+	} else if a.prerelease > b.prerelease {
+		return 1
+	}
+
+	return 0
+}
+
+// GreaterOrEqual returns true if a is greater or equal to b, assuming
+// both VersionedArtifacts use Semverish versions. It assumes
+// Release() return lexically sortable string in case of a tie.
+func SemverishGreaterOrEqual(a VersionedArtifact, b VersionedArtifact) (bool, error) {
+	semverA, err := ParseSemverishVersion(a.Version())
+	if err != nil {
+		return false, err
+	}
+	semverB, err := ParseSemverishVersion(b.Version())
+	if err != nil {
+		return false, err
+	}
+
+	switch CompareSemverish(semverA, semverB) {
+	case 1: // greater
+		return true, nil
+	case -1: // less than
+		return false, nil
+	case 0: // equal
+		return a.Release() >= b.Release(), nil
+	default:
+		return false, nil
+	}
+}

--- a/components/automate-deployment/pkg/habpkg/semverish_test.go
+++ b/components/automate-deployment/pkg/habpkg/semverish_test.go
@@ -1,0 +1,131 @@
+package habpkg
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var semverTests = []struct {
+	input  string
+	output SemverishVersion
+}{
+	// The basics
+	{"1", SemverishVersion{parts: []int{1}}},
+	{"1.2", SemverishVersion{parts: []int{1, 2}}},
+	{"1.2.3", SemverishVersion{parts: []int{1, 2, 3}}},
+	{"123.456.789", SemverishVersion{parts: []int{123, 456, 789}}},
+	// We support arbitrary parts
+	{"1.2.3.4", SemverishVersion{parts: []int{1, 2, 3, 4}}},
+	{"1.2.3.4.5", SemverishVersion{parts: []int{1, 2, 3, 4, 5}}},
+
+	// Parts with 0s
+	{"0.0.3", SemverishVersion{parts: []int{0, 0, 3}}},
+	{"0.2.3", SemverishVersion{parts: []int{0, 2, 3}}},
+
+	// Leading zeros
+	{"01", SemverishVersion{parts: []int{1}}},
+	{"00.02", SemverishVersion{parts: []int{0, 2}}},
+
+	// Initial v
+	{"v1.2.3", SemverishVersion{parts: []int{1, 2, 3}}},
+
+	// Prerelease and metadata
+	{"1.2.3-dev", SemverishVersion{parts: []int{1, 2, 3}, prerelease: "dev"}},
+	{"1.2.3-dev+123", SemverishVersion{parts: []int{1, 2, 3}, prerelease: "dev", metadata: "123"}},
+	{"1.2.3+123", SemverishVersion{parts: []int{1, 2, 3}, metadata: "123"}},
+	{"1.2.3-dev.dev+123.456", SemverishVersion{parts: []int{1, 2, 3}, prerelease: "dev.dev", metadata: "123.456"}},
+	{"1.2.3-dev-dev+123-456", SemverishVersion{parts: []int{1, 2, 3}, prerelease: "dev-dev", metadata: "123-456"}},
+}
+
+func TestParseSemverString(t *testing.T) {
+	for _, test := range semverTests {
+		parsed, err := ParseSemverishVersion(test.input)
+		assert.NoError(t, err)
+		assert.Equal(t, test.output, parsed)
+	}
+}
+
+func TestParseSemverStringErrorCases(t *testing.T) {
+	t.Run("version must have one decimal part", func(t *testing.T) {
+		_, err := ParseSemverishVersion("a10")
+		assert.Error(t, err)
+		_, err = ParseSemverishVersion("+a10")
+		assert.Error(t, err)
+		_, err = ParseSemverishVersion("-a10")
+		assert.Error(t, err)
+	})
+	t.Run("all dotted parts must be decimal", func(t *testing.T) {
+		_, err := ParseSemverishVersion("10.a")
+		assert.Error(t, err)
+	})
+	t.Run("all dotted parts must be decimal", func(t *testing.T) {
+		_, err := ParseSemverishVersion("10.a")
+		assert.Error(t, err)
+	})
+	t.Run("non-dotted parts must look like pre-release or metadata", func(t *testing.T) {
+		_, err := ParseSemverishVersion("10~foo")
+		assert.Error(t, err)
+	})
+}
+
+func TestSemverCompare(t *testing.T) {
+	compareTests := []struct {
+		a      string
+		b      string
+		result int
+	}{
+		{"1.2.3", "1.2.3", 0},
+		{"1.2.3", "1.2.3-pre", 1},
+		{"1", "1", 0},
+		{"1", "2", -1},
+		{"1.2", "1", 1},
+		{"1.2.3-pre1", "1.2.3-pre2", -1},
+	}
+	for _, test := range compareTests {
+		t.Run(fmt.Sprintf("Compare(%s, %s) == %d", test.a, test.b, test.result),
+			func(t *testing.T) {
+				a, err := ParseSemverishVersion(test.a)
+				require.NoError(t, err)
+				b, err := ParseSemverishVersion(test.b)
+				require.NoError(t, err)
+				assert.Equal(t, test.result, CompareSemverish(a, b))
+			})
+		if test.result != 0 {
+			t.Run(fmt.Sprintf("Compare(%s, %s) == %d", test.b, test.a, -test.result),
+				func(t *testing.T) {
+					a, err := ParseSemverishVersion(test.a)
+					require.NoError(t, err)
+					b, err := ParseSemverishVersion(test.b)
+					require.NoError(t, err)
+					assert.Equal(t, -test.result, CompareSemverish(b, a))
+				})
+		}
+	}
+}
+
+func BenchmarkParseSemverishVerionBasic(b *testing.B) {
+	v := "1.2.3"
+	for n := 0; n < b.N; n++ {
+		ParseSemverishVersion(v)
+	}
+}
+
+func BenchmarkParseSemverishVerionAll(b *testing.B) {
+	l := len(semverTests)
+	for n := 0; n < b.N; n++ {
+		ParseSemverishVersion(semverTests[n%l].input)
+	}
+}
+
+func BenchmarkCompareBasic(b *testing.B) {
+	v0, err := ParseSemverishVersion("1.2.3")
+	assert.NoError(b, err)
+	v1, err := ParseSemverishVersion("1.2.4")
+	assert.NoError(b, err)
+	for n := 0; n < b.N; n++ {
+		CompareSemverish(v0, v1)
+	}
+}

--- a/components/automate-deployment/pkg/target/hab_sup.go
+++ b/components/automate-deployment/pkg/target/hab_sup.go
@@ -39,7 +39,12 @@ type HabSup interface {
 // SupportsSupHup returns true if the provided hab-sup version supports
 // restarting hab-sup via SIGHUP
 func SupportsSupHup(habSupP habpkg.HabPkg) bool {
-	return habpkg.GreaterOrEqual(&habSupP, &minimumHabSupSighupFeature)
+	ge, err := habpkg.SemverishGreaterOrEqual(&habSupP, &minimumHabSupSighupFeature)
+	if err != nil {
+		logrus.WithError(err).Warnf("Could not do semantic version comparison of hab-sup package")
+		return false
+	}
+	return ge
 }
 
 // SupportsCleanShutdown returns true if the provided hab-sup version supports customized service shutdown behavior.

--- a/components/automate-deployment/pkg/target/hab_sup_test.go
+++ b/components/automate-deployment/pkg/target/hab_sup_test.go
@@ -49,3 +49,10 @@ func TestHabSupHappyPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, habpkg.NewFQ("core", "hab-sup", "0.63.0", "20180914145954"), supPkg)
 }
+
+func TestSupportsSupHup(t *testing.T) {
+	assert.Equal(t, false, SupportsSupHup(habpkg.NewFQ("core", "hab-sup", "0.62.0", "")))
+	assert.Equal(t, true, SupportsSupHup(habpkg.NewFQ("core", "hab-sup", "0.63.0", "20180914030447")))
+	assert.Equal(t, true, SupportsSupHup(habpkg.NewFQ("core", "hab-sup", "0.65.0", "")))
+	assert.Equal(t, true, SupportsSupHup(habpkg.NewFQ("core", "hab-sup", "0.90.0-dev", "")))
+}


### PR DESCRIPTION
It is possible we get to hab-sup 0.100.0 soon, which would break the
string-based comparison we were previously doing.

I've implemented a small semver-ish version parser. It doesn't handle
all the rules about pre-release version sorting.

```
> go test -bench=. -benchmem ./pkg/habpkg/
goos: linux
goarch: amd64
pkg: github.com/chef/automate/components/automate-deployment/pkg/habpkg
BenchmarkParseSemverishVerionBasic-8    15147255                74.5 ns/op            32 B/op          1 allocs/op
BenchmarkParseSemverishVerionAll-8      11580704               103 ns/op              38 B/op          1 allocs/op
BenchmarkCompareBasic-8                 188691100                6.11 ns/op            0 B/op          0 allocs/op
PASS
ok      github.com/chef/automate/components/automate-deployment/pkg/habpkg      4.344s
```

Part of me wants to say we should forgo all of this and just compare
on Release().

Signed-off-by: Steven Danna <steve@chef.io>