### PR TITLE
Jamie/utc compliance calendar scan job

### DIFF
--- a/components/automate-ui/e2e/job-add.e2e-spec.ts
+++ b/components/automate-ui/e2e/job-add.e2e-spec.ts
@@ -556,7 +556,7 @@ describe('Job Add', () => {
           scheduleToggle.click();
 
           expect(scheduleToggle.isSelected()).toEqual(true);
-          expect(startInputs.count()).toEqual(6);
+          expect(startInputs.count()).toEqual(5);
         });
 
         it('provides optional end datetime input', () => {
@@ -575,7 +575,7 @@ describe('Job Add', () => {
           endFormGroupToggle.click();
 
           expect(endFormGroupToggle.isSelected()).toEqual(true);
-          expect(endInputs.count()).toEqual(6);
+          expect(endInputs.count()).toEqual(5);
         });
 
         it('provides optional repeat interval input', () => {

--- a/components/automate-ui/src/app/components/calendar/calendar.component.ts
+++ b/components/automate-ui/src/app/components/calendar/calendar.component.ts
@@ -17,8 +17,8 @@ import { concat,
 })
 export class CalendarComponent {
 
-  private _date: m.Moment = m();
-  private _selected: m.Moment = m();
+  private _date: m.Moment = m.utc();
+  private _selected: m.Moment = m.utc();
 
   private _month: string;
   private _year: number;
@@ -34,7 +34,7 @@ export class CalendarComponent {
 
   @Input()
   set date(input) {
-    const date = m.isMoment(input) ? input : m(input);
+    const date = m.isMoment(input) ? input : m.utc(input);
     this._date = date;
     this._month = m.months(date.month());
     this._year = date.year();
@@ -45,7 +45,7 @@ export class CalendarComponent {
 
   @Input()
   set selected(input) {
-    const date = m.isMoment(input) ? input : m(input);
+    const date = m.isMoment(input) ? input : m.utc(input);
     this._selected = date;
   }
   get selected() {
@@ -79,7 +79,7 @@ export class CalendarComponent {
     const vy = this.date.year();
     const sm = this.selected.month();
     const sy = this.selected.year();
-    const today = m().month() === this.date.month() ? m().date() : null;
+    const today = m.utc().month() === this.date.month() ? m.utc().date() : null;
     const selected = (vm === sm && vy === sy) ? this.selected.date() : null;
     const tag = (marker) => (d: m.Moment) => [marker, d];
     const tagActive = (d: m.Moment) => {

--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -16,4 +16,6 @@ export class DateTime {
   // Format for filenames of report downloads
   // 2019-09-24-09:59:59
   public static readonly REPORT_DATE_TIME: string = 'YYYY-MM-DD-HHmmss';
+  // 25 Oct 2019
+  public static readonly CHEF_SHORT_DATE: string = 'DD MMM YYYY';
 }

--- a/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.html
+++ b/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.html
@@ -38,11 +38,11 @@
         <div class="field">
           <chef-form-field formGroupName="datetime">
             <div class="datetime">
-              <select formControlName="month">
-                <option *ngFor="let n of months" [value]="n">{{ n | number:'2.0-0' }}</option>
-              </select>
               <select formControlName="date">
                 <option *ngFor="let n of dates" [value]="n">{{ n | number:'2.0-0' }}</option>
+              </select>
+              <select formControlName="month">
+                <option *ngFor="let n of months" [value]="n">{{ n }}</option>
               </select>
               <select formControlName="year">
                 <option *ngFor="let n of years" [value]="n">{{ n }}</option>
@@ -53,13 +53,14 @@
               <select formControlName="hour">
                 <option *ngFor="let n of hours" [value]="n">{{ n | number:'2.0-0' }}</option>
               </select>
+              <span>:</span>
               <select formControlName="minute">
                 <option *ngFor="let n of minutes" [value]="n">{{ n | number:'2.0-0' }}</option>
               </select>
-              <select formControlName="meridiem">
+              <!-- <select formControlName="meridiem">
                 <option value="AM">AM</option>
                 <option value="PM">PM</option>
-              </select>
+              </select> -->
             </div>
           </chef-form-field>
         </div>
@@ -73,7 +74,7 @@
           <chef-form-field formGroupName="datetime">
             <div class="datetime">
               <select formControlName="month">
-                <option *ngFor="let n of months" [value]="n">{{ n | number:'2.0-0' }}</option>
+                <option *ngFor="let n of months" [value]="n">{{ n }}</option>
               </select>
               <select formControlName="date">
                 <option *ngFor="let n of dates" [value]="n">{{ n | number:'2.0-0' }}</option>

--- a/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.html
+++ b/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.html
@@ -78,7 +78,7 @@
                 <option *ngFor="let n of dates" [value]="n">{{ n | number:'2.0-0' }}</option>
               </select>
               <select formControlName="month">
-                <option *ngFor="let n of months" [value]="n"></option>
+                <!-- <option *ngFor="let n of months | keyvalue" [value]="n.key">{{ n.value }}</option> -->
               </select>
               <select formControlName="year">
                 <option *ngFor="let n of years" [value]="n">{{ n }}</option>

--- a/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.html
+++ b/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.html
@@ -42,7 +42,7 @@
                 <option *ngFor="let n of dates" [value]="n">{{ n | number:'2.0-0' }}</option>
               </select>
               <select formControlName="month">
-                <option *ngFor="let n of months" [value]="n">{{ n }}</option>
+                <option *ngFor="let n of months | keyvalue" [value]="n.key">{{ n.value }}</option>
               </select>
               <select formControlName="year">
                 <option *ngFor="let n of years" [value]="n">{{ n }}</option>
@@ -78,7 +78,7 @@
                 <option *ngFor="let n of dates" [value]="n">{{ n | number:'2.0-0' }}</option>
               </select>
               <select formControlName="month">
-                <option *ngFor="let n of months" [value]="n">{{ n }}</option>
+                <option *ngFor="let n of months" [value]="n"></option>
               </select>
               <select formControlName="year">
                 <option *ngFor="let n of years" [value]="n">{{ n }}</option>

--- a/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.html
+++ b/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.html
@@ -57,6 +57,7 @@
               <select formControlName="minute">
                 <option *ngFor="let n of minutes" [value]="n">{{ n | number:'2.0-0' }}</option>
               </select>
+              <span>UTC</span>
               <!-- <select formControlName="meridiem">
                 <option value="AM">AM</option>
                 <option value="PM">PM</option>
@@ -73,11 +74,11 @@
         <div class="field" *ngIf="form.controls['end'].controls['include'].value">
           <chef-form-field formGroupName="datetime">
             <div class="datetime">
-              <select formControlName="month">
-                <option *ngFor="let n of months" [value]="n">{{ n }}</option>
-              </select>
               <select formControlName="date">
                 <option *ngFor="let n of dates" [value]="n">{{ n | number:'2.0-0' }}</option>
+              </select>
+              <select formControlName="month">
+                <option *ngFor="let n of months" [value]="n">{{ n }}</option>
               </select>
               <select formControlName="year">
                 <option *ngFor="let n of years" [value]="n">{{ n }}</option>
@@ -88,13 +89,15 @@
               <select formControlName="hour">
                 <option *ngFor="let n of hours" [value]="n">{{ n | number:'2.0-0' }}</option>
               </select>
+              <span>:</span>
               <select formControlName="minute">
                 <option *ngFor="let n of minutes" [value]="n">{{ n | number:'2.0-0' }}</option>
               </select>
-              <select formControlName="meridiem">
+              <span>UTC</span>
+              <!-- <select formControlName="meridiem">
                 <option value="AM">AM</option>
                 <option value="PM">PM</option>
-              </select>
+              </select> -->
             </div>
           </chef-form-field>
         </div>

--- a/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.html
+++ b/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.html
@@ -58,10 +58,6 @@
                 <option *ngFor="let n of minutes" [value]="n">{{ n | number:'2.0-0' }}</option>
               </select>
               <span>UTC</span>
-              <!-- <select formControlName="meridiem">
-                <option value="AM">AM</option>
-                <option value="PM">PM</option>
-              </select> -->
             </div>
           </chef-form-field>
         </div>
@@ -94,10 +90,6 @@
                 <option *ngFor="let n of minutes" [value]="n">{{ n | number:'2.0-0' }}</option>
               </select>
               <span>UTC</span>
-              <!-- <select formControlName="meridiem">
-                <option value="AM">AM</option>
-                <option value="PM">PM</option>
-              </select> -->
             </div>
           </chef-form-field>
         </div>

--- a/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.html
+++ b/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.html
@@ -42,7 +42,7 @@
                 <option *ngFor="let n of dates" [value]="n">{{ n | number:'2.0-0' }}</option>
               </select>
               <select formControlName="month">
-                <option *ngFor="let n of months | keyvalue" [value]="n.key">{{ n.value }}</option>
+                <option *ngFor="let n of months" [value]="n">{{ monthsStringArray[n] }}</option>
               </select>
               <select formControlName="year">
                 <option *ngFor="let n of years" [value]="n">{{ n }}</option>
@@ -78,7 +78,7 @@
                 <option *ngFor="let n of dates" [value]="n">{{ n | number:'2.0-0' }}</option>
               </select>
               <select formControlName="month">
-                <!-- <option *ngFor="let n of months | keyvalue" [value]="n.key">{{ n.value }}</option> -->
+                <option *ngFor="let n of months" [value]="n">{{ monthsStringArray[n] }}</option>
               </select>
               <select formControlName="year">
                 <option *ngFor="let n of years" [value]="n">{{ n }}</option>

--- a/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.scss
+++ b/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.scss
@@ -54,7 +54,7 @@
   select,
   span {
     &:not(:first-child) {
-      margin-left: 1em;
+      margin-left: 8px;
     }
   }
 
@@ -67,9 +67,5 @@
     display: flex;
     align-items: center;
     justify-content: stretch;
-
-    select {
-      flex: 1;
-    }
   }
 }

--- a/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.ts
+++ b/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.ts
@@ -14,6 +14,8 @@ export class JobScheduleFormComponent {
   public RRule = RRule;
 
   public months = Array(12).fill(1).map((_, i) => i);
+
+  // returns an Array of months in short form i.e. ['Jan', 'Feb', 'Mar', ...]
   public monthsStringArray = moment.monthsShort();
 
   public dates = Array(31).fill(1).map((_, i) => i + 1);

--- a/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.ts
+++ b/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.ts
@@ -20,7 +20,7 @@ export class JobScheduleFormComponent {
 
   public years = Array(20).fill(1).map((_, i) => i + 2018);
 
-  public hours = Array(12).fill(1).map((_, i) => i + 1);
+  public hours = Array(24).fill(1).map((_, i) => i);
 
   public minutes = Array(60).fill(1).map((_, i) => i);
 

--- a/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.ts
+++ b/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
-import * as moment from 'moment';
 import { FormGroup } from '@angular/forms';
 import { RRule } from 'rrule';
+import * as moment from 'moment';
 
 @Component({
   selector: 'chef-job-schedule-form',
@@ -14,9 +14,9 @@ export class JobScheduleFormComponent {
 
 
   public RRule = RRule;
+  private monthObject: {} = {};
 
   // public months = Array(12).fill(1).map((_, i) => i + 1);
-  public months = moment.monthsShort();
 
   public dates = Array(31).fill(1).map((_, i) => i + 1);
 
@@ -25,5 +25,10 @@ export class JobScheduleFormComponent {
   public hours = Array(12).fill(1).map((_, i) => i + 1);
 
   public minutes = Array(60).fill(1).map((_, i) => i);
+
+  public months = moment.monthsShort().forEach( (month, i) => {
+    console.log(month);
+    return this.monthObject[i] = month;
+  });
 
 }

--- a/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.ts
+++ b/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import * as moment from 'moment';
 import { FormGroup } from '@angular/forms';
 import { RRule } from 'rrule';
 
@@ -10,9 +11,12 @@ import { RRule } from 'rrule';
 export class JobScheduleFormComponent {
   @Input() form: FormGroup;
 
+
+
   public RRule = RRule;
 
-  public months = Array(12).fill(1).map((_, i) => i + 1);
+  // public months = Array(12).fill(1).map((_, i) => i + 1);
+  public months = moment.monthsShort();
 
   public dates = Array(31).fill(1).map((_, i) => i + 1);
 

--- a/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.ts
+++ b/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.ts
@@ -14,9 +14,9 @@ export class JobScheduleFormComponent {
 
 
   public RRule = RRule;
-  private monthObject: {} = {};
 
   // public months = Array(12).fill(1).map((_, i) => i + 1);
+  public months = this.buildMonthsObject();
 
   public dates = Array(31).fill(1).map((_, i) => i + 1);
 
@@ -26,9 +26,14 @@ export class JobScheduleFormComponent {
 
   public minutes = Array(60).fill(1).map((_, i) => i);
 
-  public months = moment.monthsShort().forEach( (month, i) => {
-    console.log(month);
-    return this.monthObject[i] = month;
-  });
+
+  private buildMonthsObject() {
+    //need to be sorted?
+    const monthsObject = {};
+    moment.monthsShort().forEach((month, i) => {
+      monthsObject[i] = month;
+    });
+    return monthsObject;
+  }
 
 }

--- a/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.ts
+++ b/components/automate-ui/src/app/page-components/job-schedule-form/job-schedule-form.component.ts
@@ -11,12 +11,10 @@ import * as moment from 'moment';
 export class JobScheduleFormComponent {
   @Input() form: FormGroup;
 
-
-
   public RRule = RRule;
 
-  // public months = Array(12).fill(1).map((_, i) => i + 1);
-  public months = this.buildMonthsObject();
+  public months = Array(12).fill(1).map((_, i) => i);
+  public monthsStringArray = moment.monthsShort();
 
   public dates = Array(31).fill(1).map((_, i) => i + 1);
 
@@ -25,15 +23,5 @@ export class JobScheduleFormComponent {
   public hours = Array(12).fill(1).map((_, i) => i + 1);
 
   public minutes = Array(60).fill(1).map((_, i) => i);
-
-
-  private buildMonthsObject() {
-    //need to be sorted?
-    const monthsObject = {};
-    moment.monthsShort().forEach((month, i) => {
-      monthsObject[i] = month;
-    });
-    return monthsObject;
-  }
 
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.ts
@@ -144,9 +144,9 @@ export class ReportingOverviewComponent implements OnInit, OnDestroy {
 
   onDateChanged(endDate) {
     const queryParams = {...this.route.snapshot.queryParams};
-    const endDateMoment = moment(endDate);
+    const endDateMoment = moment.utc(endDate);
     if (endDate && endDateMoment.isValid()) {
-      if (moment().utc().format('YYYY-MM-DD') === endDateMoment.format('YYYY-MM-DD')) {
+      if (moment.utc().format('YYYY-MM-DD') === endDateMoment.format('YYYY-MM-DD')) {
         delete queryParams['end_time'];
       } else {
         queryParams['end_time'] = endDateMoment.format('YYYY-MM-DD');

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
@@ -66,7 +66,7 @@
     </chef-button>
     <chef-button class="calendar-btn" secondary (click)="toggleCalendar()">
       <chef-icon>date_range</chef-icon>
-      <span>{{ date | date:'shortDate' }}</span>
+      <span>{{ date | datetime: CHEF_SHORT_DATE }}</span>
     </chef-button>
     <chef-dropdown [attr.visible]="calendarVisible">
       <chef-click-outside omit="calendar-btn" (clickOutside)="hideCalendar()">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.spec.ts
@@ -6,6 +6,7 @@ import * as moment from 'moment';
 import {
   ReportQueryService
 } from 'app/pages/+compliance/shared/reporting';
+import { DatetimePipe } from 'app/pipes/datetime.pipe';
 
 describe('ReportingSearchbarComponent', () => {
   let fixture: ComponentFixture<ReportingSearchbarComponent>,
@@ -16,7 +17,8 @@ describe('ReportingSearchbarComponent', () => {
       imports: [
       ],
       declarations: [
-        ReportingSearchbarComponent
+        ReportingSearchbarComponent,
+        DatetimePipe
       ],
       providers: [
         ReportQueryService
@@ -44,7 +46,7 @@ describe('ReportingSearchbarComponent', () => {
       ['beginning of the next month', '2019-11-01', 10]
     ], function (description: string, dateString: string, month) {
       it('selection of ' + description, () => {
-        component.visibleDate = moment('20191023', 'YYYYMMDD');
+        component.visibleDate = moment.utc('20191023', 'YYYYMMDD');
         component.onDaySelect(dateString);
 
         expect(component.visibleDate.month()).toEqual(month);

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
@@ -19,6 +19,7 @@ import { Chicklet } from 'app/types/types';
 import {
   ReportQueryService
 } from 'app/pages/+compliance/shared/reporting';
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 @Component({
   selector: 'app-reporting-searchbar',
@@ -43,6 +44,7 @@ export class ReportingSearchbarComponent implements OnInit {
 
   private suggestionsVisibleStream = new Subject<boolean>();
   private suggestionSearchTermDebounce = new Subject<any>();
+  public CHEF_SHORT_DATE = DateTime.CHEF_SHORT_DATE;
 
   filterTypesCategories = [];
   calendarVisible = false;

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -442,7 +442,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
     return type.search('control_tag:') !== -1;
   }
 
-  getEndDate(urlFilters: Chicklet[]): moment.utc.Moment.utc {
+  getEndDate(urlFilters: Chicklet[]): moment.Moment {
     const foundFilter = urlFilters.find( (filter: Chicklet) => filter.type === 'end_time');
 
     if (foundFilter !== undefined) {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -408,7 +408,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
   }
 
   formatDate(timestamp) {
-    return moment(timestamp).format('MMMM Do[,] YYYY');
+    return moment.utc.utc(timestamp).format('MMMM Do[,] YYYY');
   }
 
   getSuggestions(type: string, text: string, reportQuery: ReportQuery) {
@@ -442,11 +442,11 @@ export class ReportingComponent implements OnInit, OnDestroy {
     return type.search('control_tag:') !== -1;
   }
 
-  getEndDate(urlFilters: Chicklet[]): moment.Moment {
+  getEndDate(urlFilters: Chicklet[]): moment.utc.Moment.utc {
     const foundFilter = urlFilters.find( (filter: Chicklet) => filter.type === 'end_time');
 
     if (foundFilter !== undefined) {
-      const endDate = moment(foundFilter.text + 'GMT+00:00', 'YYYY-MM-DDZ');
+      const endDate = moment.utc(foundFilter.text + 'GMT+00:00', 'YYYY-MM-DDZ');
       if (endDate.isValid()) {
         return endDate.utc().startOf('day').add(12, 'hours');
       } else {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -408,7 +408,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
   }
 
   formatDate(timestamp) {
-    return moment.utc.utc(timestamp).format('MMMM Do[,] YYYY');
+    return moment.utc(timestamp).format('MMMM Do[,] YYYY');
   }
 
   getSuggestions(type: string, text: string, reportQuery: ReportQuery) {

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.spec.ts
@@ -76,7 +76,7 @@ describe('JobsListComponent', () => {
       const time = '2018-01-01T00:00:00.000Z';
       component.viewReport('fake_id', time);
       expect(router.navigate).toHaveBeenCalledWith(['/compliance', 'reports', 'overview'],
-        {queryParams: {job_id: 'fake_id', end_time: moment(time).format('YYYY-MM-DD')}});
+        {queryParams: {job_id: 'fake_id', end_time: moment.utc(time).format('YYYY-MM-DD')}});
     });
 
     it('null end date', () => {

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.ts
@@ -108,17 +108,17 @@ export class JobsListComponent implements OnInit, OnDestroy {
   // date formatting needs.
   timeFromNow(time) {
     // `null` dates from API are currently sent as "beginning of time"
-    if (moment(time).isBefore('2000-01-01T00:00:00.000Z')) { return '-'; }
-    return moment(time).fromNow();
+    if (moment.utc(time).isBefore('2000-01-01T00:00:00.000Z')) { return '-'; }
+    return moment.utc(time).fromNow();
   }
 
   viewReport(jobID: string, endDate) {
     // `null` dates from API are currently sent as "beginning of time"
-    if (!endDate || moment(endDate).isBefore('2000-01-01T00:00:00.000Z')) {
+    if (!endDate || moment.utc(endDate).isBefore('2000-01-01T00:00:00.000Z')) {
       this.router.navigate(['/compliance', 'reports', 'overview'],
         {queryParams: {job_id: jobID}});
     } else {
-      const endDateString = moment(endDate).format('YYYY-MM-DD');
+      const endDateString = moment.utc(endDate).format('YYYY-MM-DD');
 
       this.router.navigate(['/compliance', 'reports', 'overview'],
         {queryParams: {job_id: jobID, end_time: endDateString}});

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -187,7 +187,7 @@ export class StatsService {
 
     // for export, we want to send the start_time as the beg of day of end time
     // so we find the endtime in the filters, and then set start time to beg of that day
-    reportQuery.startDate = moment(reportQuery.endDate).startOf('day');
+    reportQuery.startDate = moment.utc(reportQuery.endDate).startOf('day');
 
     const body = { type: format, filters: this.formatFilters(reportQuery) };
     return this.httpClient.post(url, body, { responseType: 'text' });
@@ -224,8 +224,8 @@ export class StatsService {
   addDateRange(filters, dateRange) {
     if (filters) {
       filters.push(
-        {'end_time': moment(dateRange.end).format('YYYY-MM-DDTHH:mm:ssZ')},
-        {'start_time': moment(dateRange.start).format('YYYY-MM-DDTHH:mm:ssZ')}
+        {'end_time': moment.utc(dateRange.end).format('YYYY-MM-DDTHH:mm:ssZ')},
+        {'start_time': moment.utc(dateRange.start).format('YYYY-MM-DDTHH:mm:ssZ')}
       );
     }
     return filters;

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -251,13 +251,12 @@ export class JobAddComponent implements OnDestroy {
     }
 
     const {start, end, repeat} = scheduleOpts;
-    console.log(scheduleOpts);
     const ruleOpts = {
       dtstart: new Date(
         parseInt(start.datetime.year, 10),
         parseInt(start.datetime.month, 10) - 1,
         parseInt(start.datetime.date, 10),
-        this.hours12to24(parseInt(start.datetime.hour, 10), start.datetime.meridiem === 'PM'),
+        parseInt(start.datetime.hour, 10),
         parseInt(start.datetime.minute, 10)
       )
     };
@@ -267,7 +266,7 @@ export class JobAddComponent implements OnDestroy {
         parseInt(end.datetime.year, 10),
         parseInt(end.datetime.month, 10) - 1,
         parseInt(end.datetime.date, 10),
-        this.hours12to24(parseInt(end.datetime.hour, 10), end.datetime.meridiem === 'PM'),
+        parseInt(end.datetime.hour, 10),
         parseInt(end.datetime.minute, 10)
       );
     }
@@ -305,10 +304,6 @@ export class JobAddComponent implements OnDestroy {
         const {key, values, include} = tag;
         return {key, values, exclude: !include};
       });
-  }
-
-  public hours12to24(h, pm) {
-    return h === 12 ? pm ? 12 : 0 : pm ? h + 12 : h;
   }
 
   public hours24to12(h) {

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -108,17 +108,17 @@ export class JobAddComponent implements OnDestroy {
           month: defaultStart.format('MMM'),
           date: defaultStart.date(),
           year: defaultStart.year(),
-          hour: this.hours24to12(defaultStart.hour())
+          hour: this.hours24to12(defaultStart.hour()),
+          minute: defaultStart.minute()
         })
       }),
       end: this.fb.group({
         datetime: this.fb.group({
-          month: defaultEnd.month() + 1,
+          month: defaultEnd.add(1, 'months').format('MMM'),
           date: defaultEnd.date(),
           year: defaultEnd.year(),
           hour: this.hours24to12(defaultEnd.hour()),
-          minute: defaultEnd.minute(),
-          meridiem: defaultEnd.hour() - 12 > 0 ? 'PM' : 'AM'
+          minute: defaultEnd.minute()
         }),
         include: false
       }),

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -105,7 +105,7 @@ export class JobAddComponent implements OnDestroy {
       include: false,
       start: this.fb.group({
         datetime: this.fb.group({
-          month: defaultStart.format('MMM'),
+          month: defaultStart.month() + 1,
           date: defaultStart.date(),
           year: defaultStart.year(),
           hour: this.hours24to12(defaultStart.hour()),
@@ -114,7 +114,7 @@ export class JobAddComponent implements OnDestroy {
       }),
       end: this.fb.group({
         datetime: this.fb.group({
-          month: defaultEnd.add(1, 'months').format('MMM'),
+          month: defaultEnd.month() + 1,
           date: defaultEnd.date(),
           year: defaultEnd.year(),
           hour: this.hours24to12(defaultEnd.hour()),

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -98,19 +98,17 @@ export class JobAddComponent implements OnDestroy {
     }, {
       validator: profileSelectionRequiredValidator
     });
-    const defaultStart = moment();
-    const defaultEnd = moment(defaultStart).add(1, 'days');
+    const defaultStart = moment.utc();
+    const defaultEnd = moment.utc(defaultStart).add(1, 'days');
     const scheduleGroup = this.fb.group({
       name: ['', Validators.required],
       include: false,
       start: this.fb.group({
         datetime: this.fb.group({
-          month: defaultStart.month() + 1,
+          month: defaultStart.format('MMM'),
           date: defaultStart.date(),
           year: defaultStart.year(),
-          hour: this.hours24to12(defaultStart.hour()),
-          minute: defaultStart.minute(),
-          meridiem: defaultStart.hour() - 12 > 0 ? 'PM' : 'AM'
+          hour: this.hours24to12(defaultStart.hour())
         })
       }),
       end: this.fb.group({

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -105,8 +105,8 @@ export class JobAddComponent implements OnDestroy {
       include: false,
       start: this.fb.group({
         datetime: this.fb.group({
-          month: defaultStart.month() + 1,
-          date: defaultStart.date(),
+          month: defaultStart.month(),
+          date: defaultStart.date() - 1,
           year: defaultStart.year(),
           hour: this.hours24to12(defaultStart.hour()),
           minute: defaultStart.minute()
@@ -114,8 +114,8 @@ export class JobAddComponent implements OnDestroy {
       }),
       end: this.fb.group({
         datetime: this.fb.group({
-          month: defaultEnd.month() + 1,
-          date: defaultEnd.date(),
+          month: defaultEnd.month(),
+          date: defaultEnd.date() - 1,
           year: defaultEnd.year(),
           hour: this.hours24to12(defaultEnd.hour()),
           minute: defaultEnd.minute()

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -106,18 +106,18 @@ export class JobAddComponent implements OnDestroy {
       start: this.fb.group({
         datetime: this.fb.group({
           month: defaultStart.month(),
-          date: defaultStart.date() - 1,
+          date: defaultStart.date(),
           year: defaultStart.year(),
-          hour: this.hours24to12(defaultStart.hour()),
+          hour: defaultStart.hour(),
           minute: defaultStart.minute()
         })
       }),
       end: this.fb.group({
         datetime: this.fb.group({
           month: defaultEnd.month(),
-          date: defaultEnd.date() - 1,
+          date: defaultEnd.date(),
           year: defaultEnd.year(),
-          hour: this.hours24to12(defaultEnd.hour()),
+          hour: defaultEnd.hour(),
           minute: defaultEnd.minute()
         }),
         include: false
@@ -254,7 +254,7 @@ export class JobAddComponent implements OnDestroy {
     const ruleOpts = {
       dtstart: new Date(
         parseInt(start.datetime.year, 10),
-        parseInt(start.datetime.month, 10) - 1,
+        parseInt(start.datetime.month, 10),
         parseInt(start.datetime.date, 10),
         parseInt(start.datetime.hour, 10),
         parseInt(start.datetime.minute, 10)
@@ -264,12 +264,13 @@ export class JobAddComponent implements OnDestroy {
     if (end.include) {
       ruleOpts['until'] = new Date(
         parseInt(end.datetime.year, 10),
-        parseInt(end.datetime.month, 10) - 1,
+        parseInt(end.datetime.month, 10),
         parseInt(end.datetime.date, 10),
         parseInt(end.datetime.hour, 10),
         parseInt(end.datetime.minute, 10)
       );
     }
+
 
     if (repeat.include) {
       ruleOpts['freq'] = repeat.freq;
@@ -304,10 +305,6 @@ export class JobAddComponent implements OnDestroy {
         const {key, values, include} = tag;
         return {key, values, exclude: !include};
       });
-  }
-
-  public hours24to12(h) {
-    return (h + 11) % 12 + 1;
   }
 
   public nextStep(current: Step): Step {

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -251,6 +251,7 @@ export class JobAddComponent implements OnDestroy {
     }
 
     const {start, end, repeat} = scheduleOpts;
+    console.log(scheduleOpts);
     const ruleOpts = {
       dtstart: new Date(
         parseInt(start.datetime.year, 10),

--- a/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
+++ b/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
@@ -111,29 +111,27 @@ export class JobEditComponent implements OnDestroy {
     }, {
       validator: profileSelectionRequiredValidator
     });
-    const defaultStart = moment();
-    const defaultEnd = moment(defaultStart).add(1, 'days');
+    const defaultStart = moment.utc();
+    const defaultEnd = moment.utc(defaultStart).add(1, 'days');
     const scheduleGroup = this.fb.group({
       name: ['', Validators.required],
       include: false,
       start: this.fb.group({
         datetime: this.fb.group({
-          month: defaultStart.month() + 1,
+          month: defaultStart.month(),
           date: defaultStart.date(),
           year: defaultStart.year(),
-          hour: this.hours24to12(defaultStart.hour()),
-          minute: defaultStart.minute(),
-          meridiem: defaultStart.hour() - 12 > 0 ? 'PM' : 'AM'
+          hour: defaultStart.hour(),
+          minute: defaultStart.minute()
         })
       }),
       end: this.fb.group({
         datetime: this.fb.group({
-          month: defaultEnd.month() + 1,
+          month: defaultEnd.month(),
           date: defaultEnd.date(),
           year: defaultEnd.year(),
-          hour: this.hours24to12(defaultEnd.hour()),
-          minute: defaultEnd.minute(),
-          meridiem: defaultEnd.hour() - 12 > 0 ? 'PM' : 'AM'
+          hour: defaultEnd.hour(),
+          minute: defaultEnd.minute()
         }),
         include: false
       }),
@@ -265,27 +263,25 @@ export class JobEditComponent implements OnDestroy {
           const rule = RRule.parseString(job.recurrence);
           const hasUntil = !!rule.until;
           const hasRepeat = !!rule.interval;
-          const start = moment(rule.dtstart);
+          const start = moment.utc(rule.dtstart);
 
           scheduleGroup.get('start.datetime').setValue({
-            month: start.month() + 1,
+            month: start.month(),
             date: start.date(),
             year: start.year(),
-            hour: this.hours24to12(start.hour()),
-            minute: start.minute(),
-            meridiem: start.hour() - 12 > 0 ? 'PM' : 'AM'
+            hour: start.hour(),
+            minute: start.minute()
           });
 
           if (hasUntil) {
-            const end = moment(rule.until);
+            const end = moment.utc(rule.until);
             scheduleGroup.get('end.include').setValue(hasUntil);
             scheduleGroup.get('end.datetime').setValue({
-              month: end.month() + 1,
+              month: end.month(),
               date: end.date(),
               year: end.year(),
-              hour: this.hours24to12(end.hour()),
-              minute: end.minute(),
-              meridiem: end.hour() - 12 > 0 ? 'PM' : 'AM'
+              hour: end.hour(),
+              minute: end.minute()
             });
           }
 
@@ -339,9 +335,9 @@ export class JobEditComponent implements OnDestroy {
     const ruleOpts = {
       dtstart: new Date(
         parseInt(start.datetime.year, 10),
-        parseInt(start.datetime.month, 10) - 1,
+        parseInt(start.datetime.month, 10),
         parseInt(start.datetime.date, 10),
-        this.hours12to24(parseInt(start.datetime.hour, 10), start.datetime.meridiem === 'PM'),
+        parseInt(start.datetime.hour, 10),
         parseInt(start.datetime.minute, 10)
       )
     };
@@ -349,9 +345,9 @@ export class JobEditComponent implements OnDestroy {
     if (end.include) {
       ruleOpts['until'] = new Date(
         parseInt(end.datetime.year, 10),
-        parseInt(end.datetime.month, 10) - 1,
+        parseInt(end.datetime.month, 10),
         parseInt(end.datetime.date, 10),
-        this.hours12to24(parseInt(end.datetime.hour, 10), end.datetime.meridiem === 'PM'),
+        parseInt(end.datetime.hour, 10),
         parseInt(end.datetime.minute, 10)
       );
     }
@@ -389,14 +385,6 @@ export class JobEditComponent implements OnDestroy {
         const {key, values, include} = tag;
         return {key, values, exclude: !include};
       });
-  }
-
-  public hours12to24(h, pm) {
-    return h === 12 ? pm ? 12 : 0 : pm ? h + 12 : h;
-  }
-
-  public hours24to12(h) {
-    return (h + 11) % 12 + 1;
   }
 
   public nextStep(current: Step): Step {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This is an ongoing effort to update Automate to use UTC across the site.  This particular branch updates the calendar component, scan job scheduling, and compliance reports calendar button.

### :chains: Related Resources
fixes #1978 

### :+1: Definition of Done

- [x] Calendar Component uses of moment altered to use UTC
- [x]  Scan Job Schedule selectors use UTC time
- [x] Compliance reports calendar button shows UTC time and `25 Oct 2019` format

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
navigate to https://a2-dev.test/compliance/reports/overview --> view calendar button with new formatting in UTC time
navigate to https://a2-dev.test/compliance/scan-jobs/jobs
click `Create New Job` button --> follow steps to create new Job
when at `Add Schedule` Section, click on `Set Schedule` to see new UTC formats
Save your new job
In not already there, navigate back to navigate to https://a2-dev.test/compliance/scan-jobs/jobs
Click on button to edit your job, run through same steps, and change your schedule timing.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable