### PR TITLE
Fix compliance proto compilation script exit code problems.

### DIFF
--- a/components/compliance-service/scripts/grpc.sh
+++ b/components/compliance-service/scripts/grpc.sh
@@ -15,7 +15,8 @@ fauxpath=$(mktemp -d)
 function sync_from_fauxpath() {
     base_dir=$(dirname "${1}")
     gen_dir="${fauxpath}/github.com/chef/automate/${base_dir}/"
-    [[ -d "${gen_dir}" ]] && rsync -r "${gen_dir}" "/src/${base_dir}/"
+    [[ -d "${gen_dir}" ]] || return 0
+    rsync -r "${gen_dir}" "/src/${base_dir}/"
 }
 
 function cleanup() {
@@ -24,16 +25,16 @@ function cleanup() {
 trap cleanup EXIT
 
 for i in $(find components/compliance-service -name '*.proto') ; do
+  printf 'GEN: %s\n' "${i}"
   protoc -I /src \
-    -I src/components/compliance-service/api \
     -I vendor \
     -I vendor/github.com/grpc-ecosystem/grpc-gateway \
     -I vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
     --go_out=plugins=grpc,paths=source_relative:/src \
     --grpc-gateway_out=request_context=true,logtostderr=true:"${fauxpath}" \
     --a2-config_out=paths=source_relative:/src \
-    "${i}"
-  printf 'GEN: %s\n' "${i}"
+    "${i}" \
+    || exit $?
 
   sync_from_fauxpath "${i}"
 done


### PR DESCRIPTION
Supersedes #2045. 

This script was always exiting 1 after some recent changes. I also fixed a case where this script wouldn't necessarily fail when proto compilation failed.

On master when proto compilation succeeds:
```
[17][default:/src:0]# compile_go_protobuf_component compliance-service ; echo $?
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/ingest/ingest/compliance.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/ingest/events/inspec/inspec.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/ingest/events/compliance/compliance.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/api/reporting/reporting.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/api/status/status.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/api/common/common.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/api/version/version.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/api/profiles/profiles.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/api/jobs/jobs.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/api/stats/stats.proto
1
```

On master when proto compilation fails:
```
[18][default:/src:0]# compile_go_protobuf_component compliance-service ; echo $?
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/ingest/ingest/compliance.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/ingest/events/inspec/inspec.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/ingest/events/compliance/compliance.proto
src/components/compliance-service/api: warning: directory does not exist.
components/compliance-service/api/reporting/reporting.proto:20:1: Expected top-level statement (e.g. "message").
components/compliance-service/api/reporting/reporting.proto:20:1: Unmatched "}".
GEN: components/compliance-service/api/reporting/reporting.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/api/status/status.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/api/common/common.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/api/version/version.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/api/profiles/profiles.proto
src/components/compliance-service/api: warning: directory does not exist.
GEN: components/compliance-service/api/jobs/jobs.proto
src/components/compliance-service/api: warning: directory does not exist.
components/compliance-service/api/reporting/reporting.proto:20:1: Expected top-level statement (e.g. "message").
components/compliance-service/api/reporting/reporting.proto:20:1: Unmatched "}".
components/compliance-service/api/stats/stats.proto:7:1: Import "components/compliance-service/api/reporting/reporting.proto" was not found or had errors.
components/compliance-service/api/stats/stats.proto:114:18: "chef.automate.domain.compliance.api.reporting.Dependency" is not defined.
GEN: components/compliance-service/api/stats/stats.proto
1
```

On this PR when proto compilation succeeds:
```
[19][default:/src:0]# compile_go_protobuf_component compliance-service ; echo $?
GEN: components/compliance-service/ingest/ingest/compliance.proto
GEN: components/compliance-service/ingest/events/inspec/inspec.proto
GEN: components/compliance-service/ingest/events/compliance/compliance.proto
GEN: components/compliance-service/api/reporting/reporting.proto
GEN: components/compliance-service/api/status/status.proto
GEN: components/compliance-service/api/common/common.proto
GEN: components/compliance-service/api/version/version.proto
GEN: components/compliance-service/api/profiles/profiles.proto
GEN: components/compliance-service/api/jobs/jobs.proto
GEN: components/compliance-service/api/stats/stats.proto
0
```

On this PR when proto compilation fails:
```
[20][default:/src:0]# compile_go_protobuf_component compliance-service ; echo $?
GEN: components/compliance-service/ingest/ingest/compliance.proto
GEN: components/compliance-service/ingest/events/inspec/inspec.proto
GEN: components/compliance-service/ingest/events/compliance/compliance.proto
GEN: components/compliance-service/api/reporting/reporting.proto
components/compliance-service/api/reporting/reporting.proto:20:1: Expected top-level statement (e.g. "message").
components/compliance-service/api/reporting/reporting.proto:20:1: Unmatched "}".
1
```