### PR TITLE
[automate-1840] bump the project limit on dev/acceptance environments

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/main.tf
+++ b/terraform/test-environments/modules/chef_automate_install/main.tf
@@ -233,6 +233,9 @@ EOF
 [global.v1]
   fqdn = "${var.alb_fqdn == "" ? element(var.instance_fqdn, count.index) : var.alb_fqdn}"
 
+[auth_z.v1.sys.service]
+  project_limit = 50
+
 [deployment.v1.svc]
   channel = "${var.channel}"
   deployment_type = "${var.deployment_type}"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This story makes the project limit configurable. I've bumped the project limit on our dev/acceptance envs so we can have more freedom to make projects for testing, without running into the limit and causing Cypress tests to fail (they create a few projects then delete them on each run).

### :chains: Related Resources
https://github.com/chef/automate/pull/2029

### :+1: Definition of Done
following the next deploy, we should be able to create up to 50 projects on:
- https://a2-iamv2p1-local-inplace-upgrade-acceptance.cd.chef.co/
- https://a2-iamv2p1-local-fresh-install-acceptance.cd.chef.co/
- https://a2-iamv2p1-local-inplace-upgrade-dev.cd.chef.co/
- https://a2-iamv2p1-local-fresh-install-dev.cd.chef.co/

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable