### PR TITLE
Update chromedriver

### DIFF
--- a/components/automate-ui/package.json
+++ b/components/automate-ui/package.json
@@ -41,6 +41,7 @@
     "@ngrx/store": "^8.3.0",
     "@ngrx/store-devtools": "^8.3.0",
     "@nguniversal/express-engine": "^8.1.1",
+    "chromedriver": "^78.0.1",
     "classlist.js": "^1.1.20150312",
     "core-js": "^3.2.1",
     "d3": "^5.12.0",


### PR DESCRIPTION
Signed-off-by: Blake Johnson <bstier@chef.io>

Was seeing 

```** Angular Live Development Server is listening on localhost:4200, open your browser on http://localhost:4200/ **
ℹ ｢wdm｣: Compiled successfully.
[09:23:33] I/launcher - Running 1 instances of WebDriver
[09:23:33] I/direct - Using ChromeDriver directly...
[09:23:33] E/launcher - session not created: This version of ChromeDriver only supports Chrome version 76
  (Driver info: chromedriver=76.0.3809.68 (420c9498db8ce8fcd190a954d51297672c1515d5-refs/branch-heads/3809@{#864}),platform=Mac OS X 10.12.6 x86_64)
```

When trying to run tests.

