### PR TITLE
Build empty data lifecycle service

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1947,6 +1947,12 @@ plan_path = "components/automate-builder-api-proxy"
 paths = [
   "components/automate-builder-api-proxy/*"
 ]
+
+[data-lifecycle-service]
+plan_path = "components/data-lifecycle-service"
+paths = [
+  "components/data-lifecycle-service/*"
+]
 # GENERATED_HAB_PACKAGE_CONFIG_END
 
 [automate-workflow-ctl]

--- a/HABITAT_PACKAGES
+++ b/HABITAT_PACKAGES
@@ -73,3 +73,4 @@ automate-minio components/automate-minio
 automate-builder-memcached components/automate-builder-memcached
 automate-builder-api components/automate-builder-api
 automate-builder-api-proxy components/automate-builder-api-proxy
+data-lifecycle-service components/data-lifecycle-service

--- a/components/data-lifecycle-service/README
+++ b/components/data-lifecycle-service/README
@@ -1,0 +1,6 @@
+This component has been removed. We create an empty build
+because deployment-service cannot continue if we remove a
+service from the manifest. The empty package is the least 
+bad of our options because it has no dependencies, so it
+wont cause us to install in data-lifecycle-service's old 
+deps.

--- a/components/data-lifecycle-service/habitat/plan.sh
+++ b/components/data-lifecycle-service/habitat/plan.sh
@@ -1,0 +1,24 @@
+pkg_name="data-lifecycle-service"
+pkg_description="Automate Data Lifecycle Service"
+pkg_origin="chef"
+pkg_version="0.0.1"
+vendor_origin="chef"
+pkg_maintainer="Chef Software Inc. <support@chef.io>"
+pkg_license=("Chef-MLSA")
+pkg_upstream_url="https://www.chef.io/automate"
+
+do_prepare() {
+    :
+}
+
+do_build() {
+    :
+}
+
+do_install() {
+    :
+}
+
+do_strip() {
+    :
+}


### PR DESCRIPTION
We create an empty build because deployment-service cannot continue if we
remove a service from the manifest. The empty package is the least  bad of
our options because it has no dependencies, so it wont cause us to install
in data-lifecycle-service's old deps.

This will be a 2 part PR. We'll pin data-lifecycle-service in
products.meta once its built.

Fixes #2058 