### PR TITLE
Update webdriver-manager

### DIFF
--- a/.expeditor/nightly.pipeline.yml
+++ b/.expeditor/nightly.pipeline.yml
@@ -2,7 +2,7 @@ expeditor:
   defaults:
     executor:
       docker:
-        image_sha256: 7f8135b4db1eb7eb289f882239b52b6a11d7f03d6d2d6e6dae99b559fbedfa0c
+        image_sha256: e1a69550ef0bb562029e3cf1077f132bc778427ced33ffd929640ec429b04db2
         workdir: /go/src/github.com/chef/automate
 
 steps:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -2,7 +2,7 @@ expeditor:
   defaults:
     executor:
       docker:
-        image_sha256: 7f8135b4db1eb7eb289f882239b52b6a11d7f03d6d2d6e6dae99b559fbedfa0c
+        image_sha256: e1a69550ef0bb562029e3cf1077f132bc778427ced33ffd929640ec429b04db2
         workdir: /go/src/github.com/chef/automate
 
 steps:

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -6,7 +6,7 @@ expeditor:
   defaults:
     executor:
       docker:
-        image_sha256: 7f8135b4db1eb7eb289f882239b52b6a11d7f03d6d2d6e6dae99b559fbedfa0c
+        image_sha256: e1a69550ef0bb562029e3cf1077f132bc778427ced33ffd929640ec429b04db2
         workdir: /go/src/github.com/chef/automate
 
 steps:

--- a/components/automate-ui/package-lock.json
+++ b/components/automate-ui/package-lock.json
@@ -10621,9 +10621,9 @@
           "dev": true
         },
         "webdriver-manager": {
-          "version": "12.1.6",
-          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.6.tgz",
-          "integrity": "sha512-B1mOycNCrbk7xODw7Jgq/mdD3qzPxMaTsnKIQDy2nXlQoyjTrJTTD0vRpEZI9b8RibPEyQvh9zIZ0M1mpOxS3w==",
+          "version": "12.1.7",
+          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.7.tgz",
+          "integrity": "sha512-XINj6b8CYuUYC93SG3xPkxlyUc3IJbD6Vvo75CVGuG9uzsefDzWQrhz0Lq8vbPxtb4d63CZdYophF8k8Or/YiA==",
           "dev": true,
           "requires": {
             "adm-zip": "^0.4.9",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Reinstalled protractor to ensure package-lock specifies the latest webdriver-manager version. WDM no longer hardcodes what the latest Chrome release number is:

https://github.com/angular/webdriver-manager/blob/12.1.7/CHANGELOG.md#1217

Fixes
```
[13:25:20] I/launcher - Running 1 instances of WebDriver
[13:25:20] I/direct - Using ChromeDriver directly...
[13:25:20] E/launcher - session not created: This version of ChromeDriver only supports Chrome version 76
  (Driver info: chromedriver=76.0.3809.68 (420c9498db8ce8fcd190a954d51297672c1515d5-refs/branch-heads/3809@{#864}),platform=Mac OS X 10.14.5 x86_64)
[13:25:20] E/launcher - SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version 76
```
### :chains: Related Resources

https://github.com/chef/automate/pull/2060

### :+1: Definition of Done

Correct ChromeDriver version is used when running protractor tests.

### :athletic_shoe: How to Build and Test the Change

- `cd components/automate-ui`
- `rm -rf node_modules && npm install`
- `make e2e`

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable