### PR TITLE
Fix bug where disconnected services aren't reconnecting

### DIFF
--- a/components/applications-service/pkg/storage/postgres/hab_event.go
+++ b/components/applications-service/pkg/storage/postgres/hab_event.go
@@ -43,10 +43,11 @@ INSERT INTO service_full (
 	application,
 	environment,
 	last_event_occurred_at,
-	service_group_id
+	service_group_id,
+	disconnected
 )
 VALUES (
-  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18
+  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19
   )
 ON CONFLICT ON CONSTRAINT service_full_name_supervisor_id_key
 DO UPDATE SET (
@@ -65,7 +66,8 @@ DO UPDATE SET (
 	application,
 	environment,
 	last_event_occurred_at,
-	service_group_id
+	service_group_id,
+	disconnected
 ) = (
 	EXCLUDED.origin,
 	EXCLUDED.version,
@@ -82,7 +84,8 @@ DO UPDATE SET (
 	EXCLUDED.application,
 	EXCLUDED.environment,
 	EXCLUDED.last_event_occurred_at,
-	EXCLUDED.service_group_id
+	EXCLUDED.service_group_id,
+	EXCLUDED.disconnected
 )
 ;
 `
@@ -232,24 +235,25 @@ func (db *Postgres) upsertServiceAndMetadata(
 	sgId := hex.EncodeToString(sgIdBytes[:])
 
 	_, err := db.DbMap.Exec(upsertServiceAndMetadata,
-		pkgIdent.Origin,                 // origin,
-		pkgIdent.Name,                   // name,
-		pkgIdent.Version,                // version,
-		pkgIdent.Release,                // release,
-		pkgIdent.FullPackageIdent(),     // package_ident,
-		health,                          // health,
-		"",                              // health_check_message, // TODO 13Aug2019 - hab isn't sending this yet
-		channel,                         // channel,
-		updateStrategy,                  // update_strategy,
-		eventMetadata.GetSupervisorId(), // supervisor_id,
-		eventMetadata.GetFqdn(),         // fqdn,
-		eventMetadata.GetSite(),         // site,
-		svcMetadata.GetServiceGroup(),   // service_group_name,
+		pkgIdent.Origin,             // origin,
+		pkgIdent.Name,               // name,
+		pkgIdent.Version,            // version,
+		pkgIdent.Release,            // release,
+		pkgIdent.FullPackageIdent(), // package_ident,
+		health,                                               // health,
+		"",                                                   // health_check_message, // TODO 13Aug2019 - hab isn't sending this yet
+		channel,                                              // channel,
+		updateStrategy,                                       // update_strategy,
+		eventMetadata.GetSupervisorId(),                      // supervisor_id,
+		eventMetadata.GetFqdn(),                              // fqdn,
+		eventMetadata.GetSite(),                              // site,
+		svcMetadata.GetServiceGroup(),                        // service_group_name,
 		trimSuffix(svcMetadata.GetServiceGroup()),            // service_group_name_suffix,
 		eventMetadata.GetApplication(),                       // application,
 		eventMetadata.GetEnvironment(),                       // environment
 		convertOrCreateGoTime(eventMetadata.GetOccurredAt()), // last_event_occurred_at
-		sgId, // service_group_id
+		sgId,  // service_group_id
+		false, // Disconnected (it is not disconnected since we are getting an event right now)
 	)
 
 	return err

--- a/components/applications-service/pkg/storage/postgres/hab_event.go
+++ b/components/applications-service/pkg/storage/postgres/hab_event.go
@@ -235,19 +235,19 @@ func (db *Postgres) upsertServiceAndMetadata(
 	sgId := hex.EncodeToString(sgIdBytes[:])
 
 	_, err := db.DbMap.Exec(upsertServiceAndMetadata,
-		pkgIdent.Origin,             // origin,
-		pkgIdent.Name,               // name,
-		pkgIdent.Version,            // version,
-		pkgIdent.Release,            // release,
-		pkgIdent.FullPackageIdent(), // package_ident,
-		health,                                               // health,
-		"",                                                   // health_check_message, // TODO 13Aug2019 - hab isn't sending this yet
-		channel,                                              // channel,
-		updateStrategy,                                       // update_strategy,
-		eventMetadata.GetSupervisorId(),                      // supervisor_id,
-		eventMetadata.GetFqdn(),                              // fqdn,
-		eventMetadata.GetSite(),                              // site,
-		svcMetadata.GetServiceGroup(),                        // service_group_name,
+		pkgIdent.Origin,                 // origin,
+		pkgIdent.Name,                   // name,
+		pkgIdent.Version,                // version,
+		pkgIdent.Release,                // release,
+		pkgIdent.FullPackageIdent(),     // package_ident,
+		health,                          // health,
+		"",                              // health_check_message, // TODO 13Aug2019 - hab isn't sending this yet
+		channel,                         // channel,
+		updateStrategy,                  // update_strategy,
+		eventMetadata.GetSupervisorId(), // supervisor_id,
+		eventMetadata.GetFqdn(),         // fqdn,
+		eventMetadata.GetSite(),         // site,
+		svcMetadata.GetServiceGroup(),   // service_group_name,
 		trimSuffix(svcMetadata.GetServiceGroup()),            // service_group_name_suffix,
 		eventMetadata.GetApplication(),                       // application,
 		eventMetadata.GetEnvironment(),                       // environment


### PR DESCRIPTION
After a service is disconnected, it should reconnect after receiving
a new health check message. The issue was cause by our reliance on pg
to set the disconnected status to false when first recieved. We now explicitly
set the disconnected flag to false when receiving a health check message

Signed-off-by: kmacgugan <kmacgugan@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable