### PR TITLE
Replace data-lifecycle-service version

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1947,12 +1947,6 @@ plan_path = "components/automate-builder-api-proxy"
 paths = [
   "components/automate-builder-api-proxy/*"
 ]
-
-[data-lifecycle-service]
-plan_path = "components/data-lifecycle-service"
-paths = [
-  "components/data-lifecycle-service/*"
-]
 # GENERATED_HAB_PACKAGE_CONFIG_END
 
 [automate-workflow-ctl]

--- a/HABITAT_PACKAGES
+++ b/HABITAT_PACKAGES
@@ -73,4 +73,3 @@ automate-minio components/automate-minio
 automate-builder-memcached components/automate-builder-memcached
 automate-builder-api components/automate-builder-api
 automate-builder-api-proxy components/automate-builder-api-proxy
-data-lifecycle-service components/data-lifecycle-service

--- a/products.meta
+++ b/products.meta
@@ -46,7 +46,7 @@
   ],
 
   "deleted_packages": [
-    "chef/data-lifecycle-service/0.0.1/20190816162731"
+    "chef/data-lifecycle-service/0.0.1/20191101111721"
   ],
 
   "collections": [


### PR DESCRIPTION
The version we'll use has no dependencies. This will prevent us from
instaling old versions of things that aren't even going to be used

Actually fixes #2058