### PR TITLE
set GOFLAGS in Makefile.common_go

### DIFF
--- a/Makefile.common_go
+++ b/Makefile.common_go
@@ -16,6 +16,8 @@ GOLANGCILINTTARBALL:=golangci-lint-$(GOLANGCILINTVERSION)-$(PLATFORM).tar.gz
 
 LINTERARGS?=./...
 
+export GOFLAGS = -mod=vendor
+
 $(REPOROOT)/cache/$(GOLANGCILINTTARBALL):
 	curl --output $(REPOROOT)/cache/$(GOLANGCILINTTARBALL) -L https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCILINTVERSION)/$(GOLANGCILINTTARBALL)
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -9,7 +9,7 @@ PG_URL ?= "postgresql://postgres@127.0.0.1:5432/cereal_test?sslmode=disable&time
 PG_ADMIN_URL ?= "postgresql://postgres@127.0.0.1:5432/template1?sslmode=disable&timezone=UTC"
 
 cereal_integration:
-	@PG_URL=$(PG_URL) PG_ADMIN_URL=$(PG_ADMIN_URL) go test -mod=vendor -p 1 -v -parallel=1 -count=1 -tags integration ./cereal/integration/... ./cereal/postgres/...
+	@PG_URL=$(PG_URL) PG_ADMIN_URL=$(PG_ADMIN_URL) go test -p 1 -v -parallel=1 -count=1 -tags integration ./cereal/integration/... ./cereal/postgres/...
 
 setup_docker_pg:
 	docker run --name cereal-postgres -e POSTGRES_USER=postgres -e POSTGRES_DB=cereal_test -p 5432:5432 -d postgres:9


### PR DESCRIPTION
Many of our tests are downloading go dependencies because they use the
make targets directly rather than using the studio.

Signed-off-by: Steven Danna <steve@chef.io>