### PR TITLE
Fix proto compilation generated file CI task

### DIFF
--- a/.studio/common
+++ b/.studio/common
@@ -119,14 +119,10 @@ DOC
 function verify_all_protobuf_components() {
   install_if_missing core/git git
 
-  if ! compile_all_protobuf_components; then
-    return $?
-  fi
+  compile_all_protobuf_components || return $?
 
   git add .
-  if ! git diff --staged --exit-code --ignore-submodules=all; then
-    return $?
-  fi
+  git diff --staged --exit-code --ignore-submodules=all || return $?
 
   go_component_make api lint unit
 }

--- a/api/config/builder_api/config_request.pb.a2svc.go
+++ b/api/config/builder_api/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/builder_api_proxy/config_request.pb.a2svc.go
+++ b/api/config/builder_api_proxy/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "http":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/builder_memcached/config_request.pb.a2svc.go
+++ b/api/config/builder_memcached/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/api/config/minio/config_request.pb.a2svc.go
+++ b/api/config/minio/config_request.pb.a2svc.go
@@ -47,7 +47,7 @@ func (m *ConfigRequest) ListPorts() []a2conf.PortInfo {
 }
 
 // GetPort gets the port tagged with the given name. If the value is not set, it returns 0.
-func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
+func (m *ConfigRequest) GetPort(name string) (uint16, error) {
 	switch name {
 	case "service":
 		v0 := m.V1
@@ -63,7 +63,7 @@ func (m *ConfigRequest) GetPort(name string, value uint16) (uint16, error) {
 			return 0, nil
 		}
 		v3 := v2.Port
-		return uint16(v3.Value), nil
+		return uint16(v3.GetValue()), nil
 	default:
 		return 0, a2conf.ErrPortNotFound
 	}

--- a/integration/helpers/ssl_filters.jq
+++ b/integration/helpers/ssl_filters.jq
@@ -24,6 +24,7 @@ map(select(
          # automate-lb is responsible for adding required headers for
          # now
          (.id != "HSTS" or .port != "2000") and                 # HSTS doesn't seem relevant for this API
+         (.id != "HSTS" or .port != "10106") and
          (.id != "HSTS" or .port != "10115") and
          (.id != "HSTS" or .port != "10117") and
          (.id != "HSTS" or .port != "10161") and

--- a/integration/tests/security.sh
+++ b/integration/tests/security.sh
@@ -12,8 +12,10 @@ do_deploy() {
         --override-origin "$HAB_ORIGIN" \
         --manifest-dir "$test_manifest_path" \
         --admin-password chefautomate \
-        --enable-chef-server \
-        --enable-workflow \
+        --product workflow \
+        --product automate \
+        --product chef-server \
+        --product builder \
         --accept-terms-and-mlsa \
         --debug
 }


### PR DESCRIPTION
This CI task was changed in #1837 from being specified inline in the buildkite config:

https://github.com/chef/automate/blob/6f05b7a037f2457852ee540bfc5b9439c3581035/.expeditor/verify.pipeline.yml#L13-L20

to being a bash function:

https://github.com/chef/automate/blob/91329cbb7d6093152eacbc8053bc5cfde163cb2f/.studio/common#L116-L132

My guess is that this if statement does not do the correct thing, the `if !` is two bash commands so one of them must change the exit code before the `return $?` statement.

The first commit changes the code buildkite runs, so it failed as expected because there are proto differences between what's checked in on master and what is generated by compiling the protos.

The second commit adds the proto file changes that are missing, so it should pass.