### PR TITLE
Account for -mod=vendor in `go list` usages

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -187,7 +187,7 @@ steps:
   - label: "gateway-integration-tests"
     command:
       - . scripts/verify_setup.sh
-      - hab studio run "source scripts/verify_studio_init.sh && start_all_services && go_test components/automate-gateway/integration/license_usage_nodes_test.go && go_test components/automate-gateway/integration/nodes_test.go"
+      - hab studio run "source scripts/verify_studio_init.sh && start_all_services && go_test -tags=integration components/automate-gateway/integration/license_usage_nodes_test.go && go_test -tags=integration components/automate-gateway/integration/nodes_test.go"
     timeout_in_minutes: 20
     retry:
       automatic:

--- a/.studio/event-gateway
+++ b/.studio/event-gateway
@@ -13,6 +13,5 @@ document "event_gateway_integration" <<DOC
   Run event gateway integration tests
 DOC
 function event_gateway_integration() {
-  go_test -v "github.com/chef/automate/components/event-gateway/integration_test"
+  go_test -tags=integration -v "github.com/chef/automate/components/event-gateway/integration_test"
 }
-

--- a/.studio/event-service
+++ b/.studio/event-service
@@ -13,5 +13,5 @@ document "event_integration" <<DOC
   Run event service integration tests
 DOC
 function event_integration() {
-  go_test -v "github.com/chef/automate/components/event-service/integration_test"
+  go_test -v -tags=integration "github.com/chef/automate/components/event-service/integration_test"
 }

--- a/components/applications-service/Makefile
+++ b/components/applications-service/Makefile
@@ -1,13 +1,12 @@
-GOFILES=$(shell go list ./... | grep -Ev '/vendor|asset\.go|proto|/integration_test' | sed 's/^_//')
-GOPATH=$(shell go env GOPATH)
-
 include ../../Makefile.common_go
+
+GOFILES=$(shell GOFLAGS='$(GOFLAGS)' go list ./... | grep -Ev '/vendor|asset\.go|proto|/integration_test' | sed 's/^_//')
 
 default: ci
 
-ci: build lint vet test
+ci: build lint test
 
-review: lint vet
+review: lint
 
 # Utilities
 build:
@@ -15,19 +14,13 @@ build:
 
 clean:
 	@echo "Removing artifacts..."
-	rm -f event-gateway
+	rm -f applications-service
 
 proto:
-	cd ../../ && hab studio run 'source .studiorc; compile_go_protobuf_component event-gateway'
+	cd ../../ && hab studio run 'source .studiorc; compile_go_protobuf_component applications-service'
 
 test:
 	GOMAXPROCS=4 go test -v -cover $(GOFILES)
-
-vet:
-	go vet $(GOFILES)
-
-run:
-	go run cmd/event-gateway/event-gateway.go serve --config config.dev.toml
 
 # Etc
 edit:
@@ -37,7 +30,7 @@ view:
 	$(PAGER) Makefile || cat Makefile
 
 .PHONY: ci review setup clean
-.PHONY: build clean fmt lint proto test vet
+.PHONY: build clean fmt lint proto test
 .PHONY: edit view
 .PHONY: run
 .PHONY: generate

--- a/components/automate-cli/Makefile
+++ b/components/automate-cli/Makefile
@@ -59,4 +59,4 @@ linux darwin windows:
 	@echo Done: ${CROSS_TARGET_DIR}/${BUILD_TARGET}
 
 unit:
-	@go test --count 1 $(shell go list ./cmd/... ./pkg/...)
+	@go test --count 1 ./...

--- a/components/automate-deployment/Makefile
+++ b/components/automate-deployment/Makefile
@@ -113,7 +113,7 @@ clean:
 	rm -f cover/cover.out
 
 unit: golang_version_check
-	@go test $(shell go list ./cmd/... ./pkg/...)
+	@go test ./...
 
 # https://stackoverflow.com/questions/4728810/makefile-variable-as-prerequisite
 guard-%:

--- a/components/automate-gateway/Makefile
+++ b/components/automate-gateway/Makefile
@@ -21,4 +21,4 @@ proto:
 	@echo "# compile_go_protobuf_component automate-gateway"
 
 unit:
-	@go test -v $(shell go list ./... | grep -v '/vendor/' | grep -v '/integration') -cover
+	@go test -v -cover ./...

--- a/components/automate-gateway/integration/license_usage_nodes_test.go
+++ b/components/automate-gateway/integration/license_usage_nodes_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package compliance
 
 import (

--- a/components/automate-gateway/integration/nodes_test.go
+++ b/components/automate-gateway/integration/nodes_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package compliance
 
 import (

--- a/components/cereal-service/Makefile
+++ b/components/cereal-service/Makefile
@@ -16,7 +16,7 @@ echo-build-data:
 	@echo "version: ${VERSION}"
 
 unit:
-	@go test --count 1 -v $(shell go list ./... | grep -v '/vendor/' | grep -v 'integration') -cover
+	@go test --count 1 -v -cover ./...
 .PHONY: unit
 
 PG_URL ?= "postgresql://postgres@127.0.0.1:5432/cereal_test?sslmode=disable&timezone=UTC"

--- a/components/compliance-service/Makefile
+++ b/components/compliance-service/Makefile
@@ -113,16 +113,6 @@ generate-ruby-grpc-secrets-service:
 		--grpc_out=. \
 		$<
 
-check-go-version:
-	@required_version=$(shell cat ../../GOLANG_VERSION); \
-	my_version=$(shell go version | sed 's/.* go\([^ ]*\).*/\1/'); \
-	if ! printf "$$required_version\n$$my_version\n" | sort -CV ; then \
-		printf "===> ${red}Go version "$$my_version" found; $$required_version required.${reset}\n" ; \
-		exit 1; \
-	else \
-		printf "===> ${green}Your go version "$$my_version" is good, moving on...${reset}\n" ; \
-	fi;
-
 proto:
 	@printf "\n===> ${blue}Generating compliance-service protos${reset}\n"
 	cd ../../ && hab studio run 'source .studiorc; compile_go_protobuf_component compliance-service'
@@ -159,7 +149,7 @@ run-log-level-info: clean build-inspec-runner $(MARKET_PATH) $(PROFILES_PATH)
 	@$(MAKE) wait-for-compliance-service
 
 run: clean build-inspec-runner $(MARKET_PATH) $(PROFILES_PATH)
-	@$(MAKE) check-go-version
+	@$(MAKE) golang_version_check
 	$(MAKE) run-nodemanager
 	@printf "\n===> ${blue}Running compliance-service in background${reset} with logs redirected to ${yellow}$(COMPLIANCE_LOG_PATH)${reset}\n"
 	$(RUN_COMMAND_DEBUG) &> $(COMPLIANCE_LOG_PATH)&
@@ -167,7 +157,7 @@ run: clean build-inspec-runner $(MARKET_PATH) $(PROFILES_PATH)
 	@$(MAKE) wait-for-compliance-service
 
 run-debug: clean build-inspec-runner $(MARKET_PATH) $(PROFILES_PATH)
-	@$(MAKE) check-go-version
+	@$(MAKE) golang_version_check
 	$(MAKE) run-nodemanager
 	@printf "\n===> ${blue}Running compliance-service${reset}\n"
 	$(DEBUG_COMMAND)
@@ -362,7 +352,7 @@ test-db: run-with-es-pg run-db-tests
 
 run-db-tests:
 	@POSTGRES_URI="$(POSTGRES_URI)" CGO_ENABLED=0 \
-		go test -v $(shell go list ./dao/... ./profiles/db ./scanner/ ./inspec-agent/scheduler) -cover -database -parallel=1 -p 1 -failfast
+		go test -v ./dao/... ./profiles/db ./scanner/... ./inspec-agent/scheduler -cover -database -parallel=1 -p 1 -failfast
 
 test-integration: start-es start-pg
 	printf "\n===> ${blue}Running integration tests with ES_VER=$(ES_VER)${reset}\n"
@@ -483,7 +473,7 @@ test-polling: start-ssh-node
 
 test-unit:
 	@printf "\n ===> ${blue}Running compliance-service go unit-tests...${reset}\n"
-	@go test $(shell go list ./... |  grep -v '^github.com/chef/automate/components/compliance-service/\(examples\|feed/\|api/automate-feed\|api/automate-event\|api/tests\|scanner\|integration_test\)') -cover
+	@go test $(shell GOFLAGS='$(GOFLAGS)' go list ./... |  grep -v '^github.com/chef/automate/components/compliance-service/\(examples\|feed/\|api/automate-feed\|api/automate-event\|api/tests\|scanner\|integration_test\)') -cover
 
 send-ingest-report:
 	go run examples/ingest/ingest_client.go --file ingest/examples/compliance-success-tiny-report.json --threads 1 --reports-per-thread 1

--- a/components/data-feed-service/Makefile
+++ b/components/data-feed-service/Makefile
@@ -1,13 +1,10 @@
-GOFILES=$(shell go list ./... | grep -v '/vendor|asset\.go|proto/' | sed 's/^_//')
-GOPATH=$(shell go env GOPATH)
-
 include ../../Makefile.common_go
 
 default: ci
 
 ci: review build
 
-review: lint vet
+review: lint
 
 # Utilities
 build:
@@ -21,12 +18,9 @@ proto:
 	cd ../../ && hab studio run 'source .studiorc; compile_go_protobuf_component data-feed-service'
 
 test:
-	mkdir .cover
-	GOMAXPROCS=4 go test -v -covermode=atomic -coverprofile=.cover/cover.out $(GOFILES)
+	mkdir -p .cover
+	GOMAXPROCS=4 go test -v -covermode=atomic -coverprofile=.cover/cover.out ./...
 	go tool cover -html=.cover/cover.out -o .cover/coverage.html
-
-vet:
-	go vet $(GOFILES)
 
 run:
 	go run cmd/data-feed-service/data-feed-service.go serve --config config.dev.toml

--- a/components/es-sidecar-service/Makefile
+++ b/components/es-sidecar-service/Makefile
@@ -12,8 +12,6 @@ GO_LDFLAGS = --ldflags "-X ${LIBRARY_PATH}/version.Version=${BUILD_TIME} -X ${LI
 ELASTICSEARCH_PORT   ?= 9200
 ELASTICSEARCH_URL     = http://127.0.0.1:$(ELASTICSEARCH_PORT)
 
-GOPATH = $(shell go env GOPATH)
-
 default: build
 
 ci: lint unit integration
@@ -33,13 +31,10 @@ habitat-build:
 	hab pkg build .
 
 unit:
-	go test -v $(shell go list ./... | grep -v '/vendor/' | grep -v '/integration_test') -cover
+	go test -v $(shell GOFLAGS='$(GOFLAGS)' go list ./... | grep -v '/integration_test') -cover
 
 integration:
 	cd ../..; hab studio -D $(STUDIO_OPTS) run "source .studiorc; es_sidecar_service_integration"
-
-vet:
-	@go vet $(shell go list ./... | grep -v '/vendor/')
 
 purge-es6:
 	rm -rf "$(PWD)/.tmp/es-sidecar-service-es6-data"

--- a/components/event-gateway/Makefile
+++ b/components/event-gateway/Makefile
@@ -1,13 +1,10 @@
-GOFILES=$(shell go list ./... | grep -Ev '/vendor|asset\.go|proto|/integration_test' | sed 's/^_//')
-GOPATH=$(shell go env GOPATH)
-
 include ../../Makefile.common_go
 
 default: ci
 
-ci: build lint vet test
+ci: build lint test
 
-review: lint vet
+review: lint
 
 # Utilities
 build:
@@ -21,10 +18,7 @@ proto:
 	cd ../../ && hab studio run 'source .studiorc; compile_go_protobuf_component event-gateway'
 
 test:
-	GOMAXPROCS=4 go test -v -cover $(GOFILES)
-
-vet:
-	go vet $(GOFILES)
+	GOMAXPROCS=4 go test -v -cover ./...
 
 run:
 	go run cmd/event-gateway/event-gateway.go serve --config config.dev.toml
@@ -37,7 +31,7 @@ view:
 	$(PAGER) Makefile || cat Makefile
 
 .PHONY: ci review setup clean
-.PHONY: build clean fmt lint proto test vet
+.PHONY: build clean fmt lint proto test
 .PHONY: edit view
 .PHONY: run
 .PHONY: generate

--- a/components/event-gateway/integration_test/nats_auth_test.go
+++ b/components/event-gateway/integration_test/nats_auth_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package integration_test
 
 import (

--- a/components/event-gateway/integration_test/suite_test.go
+++ b/components/event-gateway/integration_test/suite_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package integration_test
 
 import (

--- a/components/event-service/Makefile
+++ b/components/event-service/Makefile
@@ -1,13 +1,10 @@
-GOFILES=$(shell go list ./... | grep -v '/vendor|asset\.go|proto/' | sed 's/^_//')
-GOPATH=$(shell go env GOPATH)
-
 include ../../Makefile.common_go
 
 default: ci
 
 ci: build
 
-review: lint vet
+review: lint
 
 # Utilities
 build:
@@ -21,10 +18,7 @@ proto:
 	cd ../../ && hab studio run 'source .studiorc; compile_go_protobuf_component event-service'
 
 test:
-	GOMAXPROCS=4 go test -v -cover $(GOFILES)
-
-vet:
-	go vet $(GOFILES)
+	GOMAXPROCS=4 go test -v -cover ./...
 
 run:
 	go run cmd/event-service/event-service.go serve --config config.dev.toml
@@ -37,7 +31,7 @@ view:
 	$(PAGER) Makefile || cat Makefile
 
 .PHONY: ci review setup clean
-.PHONY: build clean fmt lint proto test vet
+.PHONY: build clean fmt lint proto test
 .PHONY: edit view
 .PHONY: run
 .PHONY: generate

--- a/components/event-service/integration_test/global_test.go
+++ b/components/event-service/integration_test/global_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package integration_test
 
 import (

--- a/components/event-service/integration_test/publish_test.go
+++ b/components/event-service/integration_test/publish_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package integration_test
 
 import (

--- a/components/event-service/integration_test/suite_test.go
+++ b/components/event-service/integration_test/suite_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package integration_test
 
 import (

--- a/components/nodemanager-service/Makefile
+++ b/components/nodemanager-service/Makefile
@@ -129,7 +129,7 @@ clear-pg:
 
 ##### TESTING
 test-unit:
-	@go test -v $(shell go list ./... |  grep -v '/tests') -cover
+	@go test -v $(shell GOFLAGS='$(GOFLAGS)' go list ./... |  grep -v '/tests') -cover
 
 ruby-grpc-tools:
 	@if ! gem list grpc -i; then gem install grpc; fi > /dev/null
@@ -180,11 +180,11 @@ test-integration:
 
 run-db-tests:
 	@POSTGRES_URI="$(POSTGRES_URI)" CGO_ENABLED=0 \
-		go test -v $(shell go list ./pgdb/...) -cover -database
+		go test -v -cover -database ./pgdb/...
 
 run-one-db-test:
 	@POSTGRES_URI="$(POSTGRES_URI)" \
-		go test -v $(shell go list ./pgdb/...) -run TestRunNodesIntegrationSuite/TestBulkAddNodesAndTagsUpdate -cover -database
+		go test -v ./pgdb/... -run TestRunNodesIntegrationSuite/TestBulkAddNodesAndTagsUpdate -cover -database
 
 
 test-compliance-ingestion-to-manager-conn: run-background


### PR DESCRIPTION
We've seen CI failures that indicate that we are still not using
-mod=vendor everywhere.  This PR accounts for uses of `go list`.

At the heart of this change is the fact that doing:

    export GOFLAGS = -mod=vendor

in a Makefile does not affect commands started with `$(shell
CMD)` (see http://savannah.gnu.org/bugs/?10593 for details).

To account for this, I've take the following strategies:

- Remove unnecessary uses of `$(shell go list)`. Most go commands can
  take package list directly.

- Replacing some uses of `go list | grep -v some_package` with build
  tags.

- Adding GOFLAGS='$(GOFLAGS)' to `go list` invocations that appeared
  harder to replace.

In addition to this I've

- Removed explicit `go vet` Make targets since we also run govet as
  part of golangci-lint.

- Replaced a custom check-go-version implementation in
  compliance-service with the shared implementation.

Signed-off-by: Steven Danna <steve@chef.io>