### PR TITLE
fix change to vendored files

### DIFF
--- a/vendor/github.com/grpc-ecosystem/grpc-gateway/go.mod
+++ b/vendor/github.com/grpc-ecosystem/grpc-gateway/go.mod
@@ -14,5 +14,3 @@ require (
 	gopkg.in/resty.v1 v1.12.0
 	gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7 // indirect
 )
-
-go 1.13


### PR DESCRIPTION
`go mod verify` does not verify the vendored copies of
dependencies:

https://github.com/golang/go/issues/27348

As such, it seems that this change snuck in. This commit is the result
of commit the all changes produced by `make revendor` on master.

Signed-off-by: Steven Danna <steve@chef.io>