### PR TITLE
remove GNU-only option from `make revendor`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ revendor: ## revendor dependencies in vendor/ and update .bldr.toml with deps
 
 	# Add files that go mod won't vendor that we need
 	@mkdir -p $(grpcGatewayVendorPath)
-	@cp -rf --no-preserve=mode $(grpcGatewayModPath)/* $(grpcGatewayVendorPath)
+	@cp -rf $(grpcGatewayModPath)/* $(grpcGatewayVendorPath)
 
 	# Update .bldr with new dep information
 	@go run tools/bldr-config-gen/main.go


### PR DESCRIPTION
This should help people who try to run on this make target on OSX. We
don't currently believe it was needed.

Signed-off-by: Steven Danna <steve@chef.io>