### PR TITLE
[automate-1877] miscellaneous IAM v2.0 cleanup

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -142,7 +142,7 @@ start_all_services() {
      chef-automate license apply "/src/dev/license.jwt"
   fi
   chef-automate dev create-iam-dev-users
-  chef-automate iam upgrade-to-v2 --skip-policy-migration --beta2.1
+  chef-automate iam upgrade-to-v2 --skip-policy-migration
 }
 
 document "get_admin_token" <<DOC

--- a/components/authz-service/README.md
+++ b/components/authz-service/README.md
@@ -585,6 +585,15 @@ cfgmgmt:special             cfgmgmt:*                Allow
                           \ cfgmgmt:nodes:23:runs:* /
 ```
 
+## IAM v1 and IAM v2
+
+Authz-service can run in two different modes: IAM v1 and IAM v2.1 (or IAM v2 shorthand).
+The dev environment starts on IAM v2.1 by default.
+
+To reset to v1, run: `chef-automate iam reset-to-v1`.
+
+To upgrade back to v2.1, run: `chef-automate iam upgrade-to-v2`.
+
 ## Managing Policies
 
 ### So You Want to Create Policies
@@ -621,10 +630,13 @@ To add a new default policy, the following is needed:
 
 1. A new IAM v1 policy: these are defined in [migrations](storage/postgres/migration/sql/),
    and the [v1 constants package](constants/v1/constants.go#L3-L4).
-2. A new IAM v2 (system) policy: they are defined in [server/v2/system](server/v2/system.go#L31).
-3. A new IAM v2 default policy (which can be deleted by users), or any additions
-   to default roles, are done in [datamigrations](storage/postgres/datamigration/sql/).
-3. Migration logic: When upgrading from IAM v1 to v2 (v2.1), v1 policies are
+1. You will need to add ONE of the following (ask auth team if you're not sure which):
+
+- A new IAM v2 (system) policy: they are defined in [server/v2/system](server/v2/system.go#L31).
+- A new IAM v2 default policy (which can be deleted by users), or any additions
+    to default roles, which are done in [datamigrations](storage/postgres/datamigration/sql/).
+
+1. Migration logic: When upgrading from IAM v1 to v2.1, v1 policies are
    converted. The conversion logic needs to be made aware of the new v1 policies, and
    how (and if) they are to be migrated (if they haven't been deleted). The procedure for
    converting legacy policies is defined in [server/v2/migration](server/v2/migration.go).

--- a/components/authz-service/engine/opa/opa.go
+++ b/components/authz-service/engine/opa/opa.go
@@ -506,7 +506,7 @@ func (s *State) SetPolicies(ctx context.Context, policies map[string]interface{}
 }
 
 // V2p1SetPolicies replaces OPA's data with a new set of policies and roles
-// and resets the partial evaluation cache for v2.l
+// and resets the partial evaluation cache for v2.1
 func (s *State) V2p1SetPolicies(
 	ctx context.Context, policyMap map[string]interface{},
 	roleMap map[string]interface{}) error {

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -854,8 +854,8 @@ func roleFromInternal(role *storage.Role) (*api.Role, error) {
 
 func versionFromInternal(ms storage.MigrationStatus) *api.Version {
 	switch ms {
-	// the Successful status can only be directly set in the database
-	// the API can only revert to v1 or upgrade to v2.1
+	// the `Successful` status can only be directly set in the database
+	// since the API can only upgrade to v2.1 or revert to v1
 	case storage.Successful:
 		return &api.Version{
 			Major: api.Version_V2,

--- a/components/authz-service/server/v2/policy.go
+++ b/components/authz-service/server/v2/policy.go
@@ -854,6 +854,8 @@ func roleFromInternal(role *storage.Role) (*api.Role, error) {
 
 func versionFromInternal(ms storage.MigrationStatus) *api.Version {
 	switch ms {
+	// the Successful status can only be directly set in the database
+	// the API can only revert to v1 or upgrade to v2.1
 	case storage.Successful:
 		return &api.Version{
 			Major: api.Version_V2,
@@ -938,7 +940,7 @@ func (s *policyServer) logPolicies(policies []*storage.Policy) {
 }
 
 // setVersionForInterceptorSwitch informs the interceptor piece of this server
-// to deny v1 requests if set to v2/v2.1 and vice-versa.
+// to deny v1 requests if set to v2.1 and vice-versa.
 func (s *policyServer) setVersionForInterceptorSwitch(v api.Version) {
 	if s.vChan != nil {
 		s.vChan <- v

--- a/components/authz-service/server/v2/policy_refresher.go
+++ b/components/authz-service/server/v2/policy_refresher.go
@@ -254,7 +254,7 @@ func (refresher *policyRefresher) getIAMVersion(ctx context.Context) (api.Versio
 		return vsn, err
 	}
 	switch ms {
-	// this case shouldn't happen
+	// this case should no longer happen
 	// since the iam v2 upgrade command always upgrades to v2.1
 	case storage.Successful:
 		vsn = api.Version{Major: api.Version_V2, Minor: api.Version_V0}

--- a/components/authz-service/server/v2/policy_refresher.go
+++ b/components/authz-service/server/v2/policy_refresher.go
@@ -178,7 +178,7 @@ func (refresher *policyRefresher) updateEngineStore(ctx context.Context) error {
 	return refresher.engine.V2p1SetPolicies(ctx, policyMap, roleMap)
 
 	// Note 2019/06/04 (sr): v1?! Yes, IAM v1. Our POC code depends on this query
-	// to be answered regardless of whether IAM is v1, v2 or v2.1.
+	// to be answered regardless of whether IAM is v1 or v2.
 }
 
 func (refresher *policyRefresher) getPolicyMap(ctx context.Context) (map[string]interface{}, error) {
@@ -254,6 +254,8 @@ func (refresher *policyRefresher) getIAMVersion(ctx context.Context) (api.Versio
 		return vsn, err
 	}
 	switch ms {
+	// this case shouldn't happen
+	// since the iam v2 upgrade command always upgrades to v2.1
 	case storage.Successful:
 		vsn = api.Version{Major: api.Version_V2, Minor: api.Version_V0}
 	case storage.SuccessfulBeta1:

--- a/components/authz-service/server/v2/policy_test.go
+++ b/components/authz-service/server/v2/policy_test.go
@@ -2944,6 +2944,8 @@ func TestVersionChannel(t *testing.T) {
 	require := require.New(t)
 
 	iamV1 := api_v2.Version{Major: api_v2.Version_V1, Minor: api_v2.Version_V0}
+	// this version cannot be set via the API any longer
+	// upgrade-to-v2 automatically sets the IAM version to v2.1
 	iamV2 := api_v2.Version{Major: api_v2.Version_V2, Minor: api_v2.Version_V0}
 	iamV2Beta := api_v2.Version{Major: api_v2.Version_V2, Minor: api_v2.Version_V1}
 

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -1576,8 +1576,7 @@ func (p *pg) UpdateProject(ctx context.Context, project *v2.Project) (*v2.Projec
 		return nil, err
 	}
 
-	// Update project if ID found AND intersection between projects and projectsFilter,
-	// unless the projectsFilter is empty (v2.0 case).
+	// Update project if ID found AND intersection between projects and projectsFilter
 	res, err := p.db.ExecContext(ctx,
 		`UPDATE iam_projects SET name=$2
 		WHERE id=$1 AND (array_length($3::TEXT[], 1) IS NULL OR id=ANY($3));`,
@@ -1602,8 +1601,7 @@ func (p *pg) GetProject(ctx context.Context, id string) (*v2.Project, error) {
 	}
 
 	var project v2.Project
-	// Retrieve project if ID found AND intersection between projects and projectsFilter,
-	// unless the projectsFilter is empty (v2.0 case).
+	// Retrieve project if ID found AND intersection between projects and projectsFilter
 	row := p.db.QueryRowContext(ctx, `SELECT query_project($1, $2)`, id, pq.Array(projectsFilter))
 	if err := row.Scan(&project); err != nil {
 		return nil, p.processError(err)
@@ -1625,8 +1623,7 @@ func (p *pg) DeleteProject(ctx context.Context, id string) error {
 		return err
 	}
 
-	// Delete project if ID found AND intersection between projects and projectsFilter,
-	// unless the projectsFilter is empty (v2.0 case).
+	// Delete project if ID found AND intersection between projects and projectsFilter
 	res, err := tx.ExecContext(ctx,
 		`DELETE FROM iam_projects WHERE id=$1 AND (array_length($2::TEXT[], 1) IS NULL OR id=ANY($2));`,
 		id, pq.Array(projectsFilter),
@@ -1732,8 +1729,7 @@ func (p *pg) ListProjects(ctx context.Context) ([]*v2.Project, error) {
 		return nil, err
 	}
 
-	// List all projects that have intersection between projects and projectsFilter,
-	// unless the projectsFilter is empty (v2.0 case).
+	// List all projects that have intersection between projects and projectsFilter
 	rows, err := p.db.QueryContext(ctx, "SELECT query_projects($1)", pq.Array(projectsFilter))
 	if err != nil {
 		return nil, p.processError(err)

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -1576,7 +1576,8 @@ func (p *pg) UpdateProject(ctx context.Context, project *v2.Project) (*v2.Projec
 		return nil, err
 	}
 
-	// Update project if ID found AND intersection between projects and projectsFilter
+	// Update project if ID found
+	// AND there is an intersection between projects and a non-empty projectsFilter
 	res, err := p.db.ExecContext(ctx,
 		`UPDATE iam_projects SET name=$2
 		WHERE id=$1 AND (array_length($3::TEXT[], 1) IS NULL OR id=ANY($3));`,
@@ -1601,7 +1602,8 @@ func (p *pg) GetProject(ctx context.Context, id string) (*v2.Project, error) {
 	}
 
 	var project v2.Project
-	// Retrieve project if ID found AND intersection between projects and projectsFilter
+	// Update project if ID found
+	// AND there is an intersection between projects and a non-empty projectsFilter
 	row := p.db.QueryRowContext(ctx, `SELECT query_project($1, $2)`, id, pq.Array(projectsFilter))
 	if err := row.Scan(&project); err != nil {
 		return nil, p.processError(err)

--- a/components/authz-service/storage/v2/postgres/postgres_test.go
+++ b/components/authz-service/storage/v2/postgres/postgres_test.go
@@ -4987,30 +4987,6 @@ func TestListProjects(t *testing.T) {
 
 			assert.ElementsMatch(t, expectedProjects, ps)
 		}},
-		{"when multiple projects exist, returns everything when empty filter is specified (v2.0 case)", func(t *testing.T) {
-			ctx := context.Background()
-			ctx = insertProjectsIntoContext(ctx, []string{})
-			p1 := insertTestProject(t, db, "foo", "my foo project", storage.ChefManaged)
-			p2 := insertTestProject(t, db, "bar", "my bar project", storage.Custom)
-
-			ps, err := store.ListProjects(ctx)
-			require.NoError(t, err)
-			expectedProjects := []*storage.Project{&p1, &p2}
-
-			assert.ElementsMatch(t, expectedProjects, ps)
-		}},
-		{"when multiple projects exist, returns everything when no project filter is specified (v2.0 case)", func(t *testing.T) {
-			ctx := context.Background()
-			p1 := insertTestProject(t, db, "foo", "my foo project", storage.ChefManaged)
-			p2 := insertTestProject(t, db, "bar", "my bar project", storage.Custom)
-			p3 := insertTestProject(t, db, "baz", "my baz project", storage.Custom)
-
-			ps, err := store.ListProjects(ctx)
-			require.NoError(t, err)
-			expectedProjects := []*storage.Project{&p1, &p2, &p3}
-
-			assert.ElementsMatch(t, expectedProjects, ps)
-		}},
 		{"when multiple projects exist, returns all projects when * filter passed", func(t *testing.T) {
 			ctx := context.Background()
 			p1 := insertTestProject(t, db, "foo", "my foo project", storage.ChefManaged)

--- a/components/automate-cli/cmd/chef-automate/iam.go
+++ b/components/automate-cli/cmd/chef-automate/iam.go
@@ -165,6 +165,9 @@ func display(v *iam_common.Version) string {
 	switch x {
 	case vsn{Major: iam_common.Version_V2, Minor: iam_common.Version_V1}:
 		return "v2.1"
+	// this should not happen unless forced at the database level
+	case vsn{Major: iam_common.Version_V2, Minor: iam_common.Version_V0}:
+		return "v2.0"
 	default:
 		return "v1.0"
 	}

--- a/components/automate-cli/cmd/chef-automate/iam.go
+++ b/components/automate-cli/cmd/chef-automate/iam.go
@@ -165,8 +165,6 @@ func display(v *iam_common.Version) string {
 	switch x {
 	case vsn{Major: iam_common.Version_V2, Minor: iam_common.Version_V1}:
 		return "v2.1"
-	case vsn{Major: iam_common.Version_V2, Minor: iam_common.Version_V0}:
-		return "v2.0"
 	default:
 		return "v1.0"
 	}

--- a/components/automate-gateway/gateway/middleware/authv2/authv2.go
+++ b/components/automate-gateway/gateway/middleware/authv2/authv2.go
@@ -67,16 +67,15 @@ func (c *client) Handle(ctx context.Context, subjects []string, projectsToFilter
 		if status.Convert(err).Code() == codes.FailedPrecondition {
 			return nil, err
 		}
-		// TODO bd: add projects back into error message once v2.1 is GA
 		log.WithError(err).Error("error authorizing request")
 		return nil, status.Errorf(codes.PermissionDenied,
-			"error authorizing action %q on resource %q for subjects %q: %s",
-			action, resource, subjects, err.Error())
+			"error authorizing action %q on resource %q filtered by projects %q for subjects %q: %s",
+			action, resource, subjects, projectsToFilter, err.Error())
 	}
 	if len(filteredResp.Projects) == 0 {
 		return nil, status.Errorf(codes.PermissionDenied,
-			"unauthorized: subjects %q cannot perform action %q on resource %q",
-			subjects, action, resource)
+			"unauthorized: subjects %q cannot perform action %q on resource %q filtered by projects %q",
+			subjects, action, resource, projectsToFilter)
 	}
 	projects := filteredResp.Projects
 

--- a/components/automate-gateway/gateway/middleware/authv2/authv2.go
+++ b/components/automate-gateway/gateway/middleware/authv2/authv2.go
@@ -70,7 +70,7 @@ func (c *client) Handle(ctx context.Context, subjects []string, projectsToFilter
 		log.WithError(err).Error("error authorizing request")
 		return nil, status.Errorf(codes.PermissionDenied,
 			"error authorizing action %q on resource %q filtered by projects %q for subjects %q: %s",
-			action, resource, subjects, projectsToFilter, err.Error())
+			action, resource, projectsToFilter, subjects, err.Error())
 	}
 	if len(filteredResp.Projects) == 0 {
 		return nil, status.Errorf(codes.PermissionDenied,

--- a/components/automate-gateway/handler/iam/v2beta/policy/policy.go
+++ b/components/automate-gateway/handler/iam/v2beta/policy/policy.go
@@ -219,6 +219,9 @@ func (p *Server) RemovePolicyMembers(
 // migrates existing V1 policies
 func (p *Server) UpgradeToV2(
 	ctx context.Context, in *pb_req.UpgradeToV2Req) (*pb_resp.UpgradeToV2Resp, error) {
+	if in.Flag == pb_common.Flag_VERSION_2_0 {
+		return nil, errors.New("cannot upgrade to IAM v2.0, only v2.1")
+	}
 	// as of release of beta2.1, must pass this flag every time
 	upgradeReq := &authz.MigrateToV2Req{
 		Flag:           authz.Flag_VERSION_2_1,

--- a/components/automate-gateway/handler/iam/v2beta/policy/policy.go
+++ b/components/automate-gateway/handler/iam/v2beta/policy/policy.go
@@ -219,12 +219,10 @@ func (p *Server) RemovePolicyMembers(
 // migrates existing V1 policies
 func (p *Server) UpgradeToV2(
 	ctx context.Context, in *pb_req.UpgradeToV2Req) (*pb_resp.UpgradeToV2Resp, error) {
+	// as of release of beta2.1, must pass this flag every time
 	upgradeReq := &authz.MigrateToV2Req{
-		Flag:           authz.Flag_VERSION_2_0,
+		Flag:           authz.Flag_VERSION_2_1,
 		SkipV1Policies: in.SkipV1Policies,
-	}
-	if in.Flag == pb_common.Flag_VERSION_2_1 {
-		upgradeReq.Flag = authz.Flag_VERSION_2_1
 	}
 
 	resp, err := p.policies.MigrateToV2(ctx, upgradeReq)

--- a/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
+++ b/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
@@ -167,11 +167,6 @@ hab pkg binlink core/hab --force
 if [[ ! -f /root/a2-iamv2-enabled ]]; then
     case "${iam_version}" in
     "v2.1")
-      chef-automate iam upgrade-to-v2 --beta2.1 --skip-policy-migration
-      chef-automate dev create-iam-dev-users
-      touch /root/a2-iamv2-enabled
-      ;;
-    "v2")
       chef-automate iam upgrade-to-v2 --skip-policy-migration
       chef-automate dev create-iam-dev-users
       touch /root/a2-iamv2-enabled


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Now that `upgrade-to-v2` upgrades Automate to `IAM v2.1`, all of our v2.0-specific comments and come is no longer needed. Automate users can now only be on `v1` or `v2.1`; `v2.0` doesn't exist any more on the customer-side

This PR updates or removes comments referring specifically to `v2.0`, removes uses of `--beta2.1`, and cleans up a few other v2.0 references

### :chains: Related Resources
- https://github.com/chef/automate/pull/2042
- #2090 

### :+1: Definition of Done
- tests still pass

### :athletic_shoe: How to Build and Test the Change
the only real code changes is adding projects into the authz error response on v2:

```
$ export TOK=`chef-automate iam token create non-admin`
$ export TARGET_HOST=https://a2-dev.test

$ rebuild components/automate-gateway

$ curl -kH "api-token: $TOK" -d '{"id": "foofoo", "name": "foo foo" }' -H "projects: lala" $TARGET_HOST/apis/iam/v2beta/projects | jq
{
  "error": "unauthorized: subjects [\"token:random\"] cannot perform action \"iam:projects:create\" on resource \"iam:projects\" filtered by projects [\"lala\"]",
  "message": "unauthorized: subjects [\"token:random\"] cannot perform action \"iam:projects:create\" on resource \"iam:projects\" filtered by projects [\"lala\"]",
  "code": 7,
  "details": []
}
```

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable