### PR TITLE
Removing Duplicate requests for details pages

### DIFF
--- a/components/automate-ui/src/app/pages/policy/details/policy-details.component.ts
+++ b/components/automate-ui/src/app/pages/policy/details/policy-details.component.ts
@@ -7,7 +7,6 @@ import { filter, map, takeUntil, distinctUntilChanged } from 'rxjs/operators';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams } from 'app/route.selectors';
-import { Params } from '@angular/router';
 import { routeURL } from 'app/route.selectors';
 import { GetPolicy } from 'app/entities/policies/policy.actions';
 import { policyFromRoute } from 'app/entities/policies/policy.selectors';
@@ -80,15 +79,15 @@ export class PolicyDetailsComponent implements OnInit, OnDestroy {
       this.store.select(routeURL)
     ]).pipe(
       takeUntil(this.isDestroyed),
-      map(([params, url]: [Params, string]) => [params.id, url]),
+      map(([params, url]) => [params.id as string, url]),
       // Only fetch if we are on the policy details route, otherwise
       // we'll trigger GetPolicy with the wrong input on any route
       // away to a page that also uses the :id param.
-      filter(([id, url]: [string, string]) => POLICY_DETAILS_ROUTE.test(url) && id !== undefined),
+      filter(([id, url]) => POLICY_DETAILS_ROUTE.test(url) && id !== undefined),
       // Remove the url because we only need to check if the id has changed
-      map(([id, _url]: [string, string]) => id),
+      map(([id, _url]) => id),
       distinctUntilChanged()
-    ).subscribe((id: string) => this.store.dispatch(new GetPolicy({ id })));
+    ).subscribe(id => this.store.dispatch(new GetPolicy({ id })));
   }
 
   ngOnDestroy() {

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -5,7 +5,6 @@ import { Store, select } from '@ngrx/store';
 import { isEmpty, identity, keyBy, at, xor } from 'lodash/fp';
 import { combineLatest, Subject } from 'rxjs';
 import { filter, map, takeUntil, distinctUntilChanged } from 'rxjs/operators';
-import { Params } from '@angular/router';
 
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
@@ -208,15 +207,15 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
       this.store.select(routeURL)
     ]).pipe(
       takeUntil(this.isDestroyed),
-      map(([params, url]: [Params, string]) => [params.id, url]),
+      map(([params, url]) => [params.id as string, url]),
       // Only fetch if we are on the team details route, otherwise
       // we'll trigger GetTeam with the wrong input on any route
       // away to a page that also uses the :id param.
-      filter(([id, url]: [string, string]) => TEAM_DETAILS_ROUTE.test(url) && id !== undefined),
+      filter(([id, url]) => TEAM_DETAILS_ROUTE.test(url) && id !== undefined),
       // Remove the url because we only need to check if the id has changed
-      map(([id, _url]: [string, string]) => id),
+      map(([id, _url]) => id),
       distinctUntilChanged()
-    ).subscribe((id: string) => this.store.dispatch(new GetTeam({ id })));
+    ).subscribe(id => this.store.dispatch(new GetTeam({ id })));
  }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Updating the policy details and team details pages to not request data when the page's internal tabs are changed. This solution combines two observers that are triggered off URL updates. Added the "distinctUntilChanged" filter to prevent extra data request when the internal tabs are changed. The "distinctUntilChanged" filter prevents multiple events from being sent when the data has not changed. 

### :chains: Related Resources
https://github.com/chef/automate/issues/2104

### :+1: Definition of Done
The data on the policy details and team details pages is only requested once when the page is first loaded. Changing the page's internal tabs does not re-request data. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui && start_all_services`
1. Open the Teams detail page for the admin https://a2-dev.test/settings/teams/admins
1. Open the Chrome inspect tool then select the network tab. 
1. On the page move between the "Users" and "Details" tab. 
1. Ensure that there are no calls to the https://a2-dev.test/apis/iam/v2beta/teams/admins API.
1. Do the same for the Policies details page https://a2-dev.test/settings/policies. 

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable