### PR TITLE
Add smoke tests for builder

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -820,4 +820,7 @@ steps:
         A2_LICENSE:
           path: secret/a2/license
           field: license
+      executor:
+        linux:
+          privileged: true
 

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -810,3 +810,14 @@ steps:
         linux:
           single-use: true
           privileged: true
+
+  - label: "builder smoke tests"
+    command:
+      - integration/run_test integration/tests/bldr_smoke.sh
+    timeout_in_minutes: 20
+    expeditor:
+      secrets:
+        A2_LICENSE:
+          path: secret/a2/license
+          field: license
+

--- a/e2e/cypress/integration/bldr-smoke/smoke.spec.ts
+++ b/e2e/cypress/integration/bldr-smoke/smoke.spec.ts
@@ -16,7 +16,7 @@ if (Cypress.env('TEST_BUILDER')) {
             cy.get('#login').type('admin');
             cy.get('#password').type('chefautomate');
             cy.get('[type=submit]').click();
-
+            cy.location('hash').should('include', '#/origins');
             cy.log('Creating token');
             cy.visit('/bldr/#/profile');
             cy.get('.generate').contains('Generate Token').click();

--- a/e2e/cypress/integration/bldr-smoke/smoke.spec.ts
+++ b/e2e/cypress/integration/bldr-smoke/smoke.spec.ts
@@ -1,0 +1,42 @@
+if (Cypress.env('TEST_BUILDER')) {
+    describe('builder smoke', () => {
+        it('can login, create a token and an origin', () => {
+            cy.visit('/bldr/');
+            cy.log("Logging in");
+            cy.get('.button').contains('Sign In').click();
+            cy.location('hash').should('include', '#/sign-in');
+            cy.get('.button').contains('Sign In with Chef Automate').click();
+            cy.location('pathname')
+                .then((path: any) => path.startsWith('/dex/auth/local'))
+                .then((local: any) => {
+                    if (!local) {
+                        return cy.get('a').contains('Sign in as a local user').click();
+                    }
+                });
+            cy.get('#login').type('admin');
+            cy.get('#password').type('chefautomate');
+            cy.get('[type=submit]').click();
+
+            cy.log("Creating token");
+            cy.visit('/bldr/#/profile');
+            cy.get('.generate').contains('Generate Token').click();
+            cy.get('.copyable-component>span').first().then(el => {
+                return cy.writeFile('token', el.text());
+            });
+
+            let origin = Math.random().toString(36).substring(7);
+
+            cy.log(`Creating Origin "${origin}"`);
+            cy.visit('/bldr/#/origins/create');
+            cy.get('[type=text]').clear().type(origin);
+            // we have to wait because there's no easy way to tell if the save button is
+            // clickable. It has a disabled attribute when its not clickable, however its
+            // value is "". Cypress assertions seem to think thats the same as not being
+            // there.
+            cy.get('button').contains('Save & Continue').wait(5000).click().then(() => {
+                return cy.writeFile('origin', origin);
+            })
+            cy.location('hash').should('include', `#/origins/${origin}/packages`);
+        });
+    });
+}

--- a/e2e/cypress/integration/bldr-smoke/smoke.spec.ts
+++ b/e2e/cypress/integration/bldr-smoke/smoke.spec.ts
@@ -2,7 +2,7 @@ if (Cypress.env('TEST_BUILDER')) {
     describe('builder smoke', () => {
         it('can login, create a token and an origin', () => {
             cy.visit('/bldr/');
-            cy.log("Logging in");
+            cy.log('Logging in');
             cy.get('.button').contains('Sign In').click();
             cy.location('hash').should('include', '#/sign-in');
             cy.get('.button').contains('Sign In with Chef Automate').click();
@@ -17,14 +17,14 @@ if (Cypress.env('TEST_BUILDER')) {
             cy.get('#password').type('chefautomate');
             cy.get('[type=submit]').click();
 
-            cy.log("Creating token");
+            cy.log('Creating token');
             cy.visit('/bldr/#/profile');
             cy.get('.generate').contains('Generate Token').click();
             cy.get('.copyable-component>span').first().then(el => {
                 return cy.writeFile('token', el.text());
             });
 
-            let origin = Math.random().toString(36).substring(7);
+            const origin = Math.random().toString(36).substring(7);
 
             cy.log(`Creating Origin "${origin}"`);
             cy.visit('/bldr/#/origins/create');
@@ -35,7 +35,7 @@ if (Cypress.env('TEST_BUILDER')) {
             // there.
             cy.get('button').contains('Save & Continue').wait(5000).click().then(() => {
                 return cy.writeFile('origin', origin);
-            })
+            });
             cy.location('hash').should('include', `#/origins/${origin}/packages`);
         });
     });

--- a/integration/fixtures/test_plan/plan.sh
+++ b/integration/fixtures/test_plan/plan.sh
@@ -1,0 +1,24 @@
+pkg_name="builder-test-plan"
+pkg_description="Automate Builder Test Plan"
+pkg_origin="chef"
+pkg_version="0.0.1"
+vendor_origin="chef"
+pkg_maintainer="Chef Software Inc. <support@chef.io>"
+pkg_license=("Chef-MLSA")
+pkg_upstream_url="https://www.chef.io/automate"
+
+do_prepare() {
+    :
+}
+
+do_build() {
+    :
+}
+
+do_install() {
+    :
+}
+
+do_strip() {
+    :
+}

--- a/integration/tests/bldr_smoke.sh
+++ b/integration/tests/bldr_smoke.sh
@@ -50,5 +50,5 @@ do_test_deploy() {
 
     hab origin key generate "$TEST_ORIGIN"
     HAB_ORIGIN=$TEST_ORIGIN hab pkg build "integration/fixtures/test_plan/"
-    SSL_CERT_FILE="/hab/svc/automate-load-balancer/data/$CONTAINER_HOSTNAME.cert" hab pkg upload -z "$TEST_TOKEN" -u "https://$CONTAINER_HOSTNAME/bldr/v1" "$A2_ROOT_DIR/$TEST_ORIGIN*".hart
+    SSL_CERT_FILE="/hab/svc/automate-load-balancer/data/$CONTAINER_HOSTNAME.cert" hab pkg upload -z "$TEST_TOKEN" -u "https://$CONTAINER_HOSTNAME/bldr/v1" "results/$TEST_ORIGIN*".hart
 }

--- a/integration/tests/bldr_smoke.sh
+++ b/integration/tests/bldr_smoke.sh
@@ -28,7 +28,7 @@ do_deploy() {
 do_test_deploy() {
     log_info "running cypress in e2e"
 
-    pushd e2e
+    pushd e2e || return 1
 
     export CYPRESS_SKIP_SSO=true
     export CYPRESS_BASE_URL="https://$CONTAINER_HOSTNAME"
@@ -46,7 +46,7 @@ do_test_deploy() {
     export TEST_ORIGIN
     export TEST_TOKEN
 
-    popd
+    popd || return 1
 
     hab origin key generate "$TEST_ORIGIN"
     HAB_ORIGIN=$TEST_ORIGIN hab pkg build "integration/fixtures/test_plan/"

--- a/integration/tests/bldr_smoke.sh
+++ b/integration/tests/bldr_smoke.sh
@@ -2,13 +2,14 @@
 
 #shellcheck disable=SC2034
 test_name="bldr_smoke"
-# Note: we only run cypress here, ignore diagnostics and inspec
+
 test_deploy_inspec_profiles=()
 test_skip_diagnostics=true
 
 do_deploy() {
     do_deploy_default
 
+    #shellcheck disable=SC2154
     chef-automate deploy config.toml \
         --product automate \
         --product builder \
@@ -40,9 +41,12 @@ do_test_deploy() {
         return 1
     fi
 
-    export TEST_ORIGIN="$(cat origin)"
-    export TEST_TOKEN="$(cat token)"
+    TEST_ORIGIN="$(cat origin)"
+    TEST_TOKEN="$(cat token)"
+    export TEST_ORIGIN
+    export TEST_TOKEN
+
     hab origin key generate "$TEST_ORIGIN"
     HAB_ORIGIN=$TEST_ORIGIN hab pkg build "$A2_ROOT_DIR/integration/fixtures/test_plan/"
-    SSL_CERT_FILE=/hab/svc/automate-load-balancer/data/$CONTAINER_HOSTNAME.cert hab pkg upload -z "$TEST_TOKEN" -u https://$CONTAINER_HOSTNAME/bldr/v1 $A2_ROOT_DIR/$TEST_ORIGIN*.hart
+    SSL_CERT_FILE="/hab/svc/automate-load-balancer/data/$CONTAINER_HOSTNAME.cert" hab pkg upload -z "$TEST_TOKEN" -u "https://$CONTAINER_HOSTNAME/bldr/v1" $A2_ROOT_DIR/$TEST_ORIGIN*.hart
 }

--- a/integration/tests/bldr_smoke.sh
+++ b/integration/tests/bldr_smoke.sh
@@ -48,5 +48,5 @@ do_test_deploy() {
 
     hab origin key generate "$TEST_ORIGIN"
     HAB_ORIGIN=$TEST_ORIGIN hab pkg build "$A2_ROOT_DIR/integration/fixtures/test_plan/"
-    SSL_CERT_FILE="/hab/svc/automate-load-balancer/data/$CONTAINER_HOSTNAME.cert" hab pkg upload -z "$TEST_TOKEN" -u "https://$CONTAINER_HOSTNAME/bldr/v1" $A2_ROOT_DIR/$TEST_ORIGIN*.hart
+    SSL_CERT_FILE="/hab/svc/automate-load-balancer/data/$CONTAINER_HOSTNAME.cert" hab pkg upload -z "$TEST_TOKEN" -u "https://$CONTAINER_HOSTNAME/bldr/v1" "$A2_ROOT_DIR/$TEST_ORIGIN*".hart
 }

--- a/integration/tests/bldr_smoke.sh
+++ b/integration/tests/bldr_smoke.sh
@@ -7,8 +7,6 @@ test_deploy_inspec_profiles=()
 test_skip_diagnostics=true
 
 do_deploy() {
-    do_deploy_default
-
     #shellcheck disable=SC2154
     chef-automate deploy config.toml \
         --product automate \

--- a/integration/tests/bldr_smoke.sh
+++ b/integration/tests/bldr_smoke.sh
@@ -45,6 +45,7 @@ do_test_deploy() {
     export TEST_TOKEN
 
     hab origin key generate "$TEST_ORIGIN"
+    ls -lah "$A2_ROOT_DIR/integration/fixtures/test_plan/"
     HAB_ORIGIN=$TEST_ORIGIN hab pkg build "$A2_ROOT_DIR/integration/fixtures/test_plan/"
     SSL_CERT_FILE="/hab/svc/automate-load-balancer/data/$CONTAINER_HOSTNAME.cert" hab pkg upload -z "$TEST_TOKEN" -u "https://$CONTAINER_HOSTNAME/bldr/v1" "$A2_ROOT_DIR/$TEST_ORIGIN*".hart
 }

--- a/integration/tests/bldr_smoke.sh
+++ b/integration/tests/bldr_smoke.sh
@@ -19,9 +19,7 @@ do_deploy() {
 
     log_info "applying dev license"
     chef-automate license apply "$A2_LICENSE"
-    timestamp=$(date +"%m-%d-%y-%H-%M")
 
-    log_info "fixing dns resolution for '${CONTAINER_HOSTNAME}'"
     echo "127.0.0.1 ${CONTAINER_HOSTNAME}" >> /etc/hosts
 }
 
@@ -35,9 +33,9 @@ do_test_deploy() {
     export CYPRESS_INTEGRATION_FOLDER=cypress/integration/bldr-smoke 
     export CYPRESS_SUPPORT_FILE='false'
     export CYPRESS_TEST_BUILDER='true'
-    npm install # get dependencies defined in e2e/package.json
+    npm install 
     if ! npm run cypress:run; then
-        buildkite-agent artifact upload "cypress/videos/*;cypress/videos/**/*;cypress/screenshots/*;cypress/screenshots/**/*"
+        buildkite-agent artifact upload "cypress/videos/**/*;cypress/screenshots/**/*"
         return 1
     fi
 

--- a/integration/tests/bldr_smoke.sh
+++ b/integration/tests/bldr_smoke.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+#shellcheck disable=SC2034
+test_name="bldr_smoke"
+# Note: we only run cypress here, ignore diagnostics and inspec
+test_deploy_inspec_profiles=()
+test_skip_diagnostics=true
+
+do_deploy() {
+    do_deploy_default
+
+    chef-automate deploy config.toml \
+        --product automate \
+        --product builder \
+        --hartifacts "$test_hartifacts_path" \
+        --override-origin "$HAB_ORIGIN" \
+        --manifest-dir "$test_manifest_path" \
+        --admin-password chefautomate \
+        --accept-terms-and-mlsa
+
+    log_info "applying dev license"
+    chef-automate license apply "$A2_LICENSE"
+    timestamp=$(date +"%m-%d-%y-%H-%M")
+
+    log_info "fixing dns resolution for '${CONTAINER_HOSTNAME}'"
+    echo "127.0.0.1 ${CONTAINER_HOSTNAME}" >> /etc/hosts
+}
+
+do_test_deploy() {
+    log_info "running cypress in e2e"
+    cd "${A2_ROOT_DIR}/e2e" || return 1
+    export CYPRESS_SKIP_SSO=true
+    export CYPRESS_BASE_URL="https://$CONTAINER_HOSTNAME"
+    export CYPRESS_INTEGRATION_FOLDER=cypress/integration/bldr-smoke 
+    export CYPRESS_SUPPORT_FILE='false'
+    export CYPRESS_TEST_BUILDER='true'
+    npm install # get dependencies defined in e2e/package.json
+    if ! npm run cypress:run; then
+        buildkite-agent artifact upload "cypress/videos/*;cypress/videos/**/*;cypress/screenshots/*;cypress/screenshots/**/*"
+        return 1
+    fi
+
+    export TEST_ORIGIN="$(cat origin)"
+    export TEST_TOKEN="$(cat token)"
+    hab origin key generate "$TEST_ORIGIN"
+    HAB_ORIGIN=$TEST_ORIGIN hab pkg build "$A2_ROOT_DIR/integration/fixtures/test_plan/"
+    SSL_CERT_FILE=/hab/svc/automate-load-balancer/data/$CONTAINER_HOSTNAME.cert hab pkg upload -z "$TEST_TOKEN" -u https://$CONTAINER_HOSTNAME/bldr/v1 $A2_ROOT_DIR/$TEST_ORIGIN*.hart
+}

--- a/integration/tests/bldr_smoke.sh
+++ b/integration/tests/bldr_smoke.sh
@@ -27,7 +27,9 @@ do_deploy() {
 
 do_test_deploy() {
     log_info "running cypress in e2e"
-    cd "${A2_ROOT_DIR}/e2e" || return 1
+
+    pushd e2e
+
     export CYPRESS_SKIP_SSO=true
     export CYPRESS_BASE_URL="https://$CONTAINER_HOSTNAME"
     export CYPRESS_INTEGRATION_FOLDER=cypress/integration/bldr-smoke 
@@ -44,8 +46,9 @@ do_test_deploy() {
     export TEST_ORIGIN
     export TEST_TOKEN
 
+    popd
+
     hab origin key generate "$TEST_ORIGIN"
-    ls -lah "$A2_ROOT_DIR/integration/fixtures/test_plan/"
-    HAB_ORIGIN=$TEST_ORIGIN hab pkg build "$A2_ROOT_DIR/integration/fixtures/test_plan/"
+    HAB_ORIGIN=$TEST_ORIGIN hab pkg build "integration/fixtures/test_plan/"
     SSL_CERT_FILE="/hab/svc/automate-load-balancer/data/$CONTAINER_HOSTNAME.cert" hab pkg upload -z "$TEST_TOKEN" -u "https://$CONTAINER_HOSTNAME/bldr/v1" "$A2_ROOT_DIR/$TEST_ORIGIN*".hart
 }

--- a/integration/tests/bldr_smoke.sh
+++ b/integration/tests/bldr_smoke.sh
@@ -50,5 +50,5 @@ do_test_deploy() {
 
     hab origin key generate "$TEST_ORIGIN"
     HAB_ORIGIN=$TEST_ORIGIN hab pkg build "integration/fixtures/test_plan/"
-    SSL_CERT_FILE="/hab/svc/automate-load-balancer/data/$CONTAINER_HOSTNAME.cert" hab pkg upload -z "$TEST_TOKEN" -u "https://$CONTAINER_HOSTNAME/bldr/v1" "results/$TEST_ORIGIN*".hart
+    SSL_CERT_FILE="/hab/svc/automate-load-balancer/data/$CONTAINER_HOSTNAME.cert" hab pkg upload -z "$TEST_TOKEN" -u "https://$CONTAINER_HOSTNAME/bldr/v1" "results/$TEST_ORIGIN"*.hart
 }


### PR DESCRIPTION
These tests deploy builder. Then they log in with the admin user, create a token, and create a random origin all through the web ui.  The token and origin are saved a file in the process and used to build and upload a package to the depot.

Fixes #2106