### PR TITLE
Jamie/chef input from stencil

### DIFF
--- a/components/automate-ui/e2e/integrations.e2e-spec.ts
+++ b/components/automate-ui/e2e/integrations.e2e-spec.ts
@@ -165,7 +165,7 @@ describe('Integrations', () => {
 
       it('has a name input', () => {
         const label = element(by.cssContainingText('.label', 'Name'));
-        const input = $('chef-input[formcontrolname="name"]');
+        const input = $('input[formcontrolname="name"]');
 
         expect(label.isDisplayed()).toEqual(true);
         expect(input.isDisplayed()).toEqual(true);
@@ -252,7 +252,7 @@ describe('Integrations', () => {
     describe('gcp form', () => {
       it('has a name input filled with correct value', () => {
         const label = element(by.cssContainingText('.label', 'Name'));
-        const input = $('chef-input[formcontrolname="name"]');
+        const input = $('input[formcontrolname="name"]');
 
         expect(label.isDisplayed()).toEqual(true);
         expect(input.isDisplayed()).toEqual(true);

--- a/components/automate-ui/src/app/components/input/input.directive.scss
+++ b/components/automate-ui/src/app/components/input/input.directive.scss
@@ -17,10 +17,10 @@
 
 ::ng-deep .chef-input, ::ng-deep [compound-input] {
   width: 100%;
+  height: 45px;
   background-color: $white;
   padding: 1em;
-  // testing
-  // font-size: 0.75em;
+  font-size: 14px;
   border: 1px solid $chef-light-grey;
   border-radius: $global-radius;
   box-sizing: border-box;

--- a/components/automate-ui/src/app/components/input/input.directive.scss
+++ b/components/automate-ui/src/app/components/input/input.directive.scss
@@ -19,7 +19,8 @@
   width: 100%;
   background-color: $white;
   padding: 1em;
-  font-size: 0.75em;
+  // testing
+  // font-size: 0.75em;
   border: 1px solid $chef-light-grey;
   border-radius: $global-radius;
   box-sizing: border-box;

--- a/components/automate-ui/src/app/components/input/input.directive.scss
+++ b/components/automate-ui/src/app/components/input/input.directive.scss
@@ -29,6 +29,7 @@
   &:focus,
   &:active {
     border-color: $chef-primary-bright;
+    outline: none;
   }
 
   &[disabled] {

--- a/components/automate-ui/src/app/components/input/input.directive.scss
+++ b/components/automate-ui/src/app/components/input/input.directive.scss
@@ -12,7 +12,6 @@
   color: $chef-primary-dark;
   font-size: 0.75em;
   font-weight: bold;
-  padding-bottom: 0.5em;
 }
 
 ::ng-deep .chef-input, ::ng-deep [compound-input] {

--- a/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.html
@@ -66,10 +66,7 @@
                 [@dropInAnimation]="{ value: triggerValue, params: { height: 109.219 }}">
                 <label>
                   <span class="label">{{ nameOrId }} <span aria-hidden="true">*</span></span>
-                  <chef-input id="expression-name-dropdown" 
-                              ngDefaultControl 
-                              (keyup)="updateFormDisplay('name')"
-                              formControlName="name"></chef-input>
+                  <input chefInput id="expression-name-dropdown" formControlName="name" (keyup)="updateFormDisplay('name')" />
                 </label>
                 <p class="note">A single wildcard (*) is allowed.</p>
 

--- a/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.scss
+++ b/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.scss
@@ -18,8 +18,7 @@ chef-page {
       chef-form-field {
         padding-bottom: 1em;
 
-        select,
-        chef-input {
+        select {
           width: 100%;
         }
 

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.html
@@ -25,7 +25,7 @@
                 <chef-form-field class="display3">
                   <label>
                     <span class="label">Full Name <span aria-hidden="true">*</span></span>
-                    <chef-input ngDefaultControl formControlName="fullName"></chef-input>
+                    <chef chefInput formControlName="fullName"/>
                   </label>
                   <chef-error
                     *ngIf="(editForm.get('fullName').hasError('required') || editForm.get('fullName').hasError('pattern')) && editForm.get('fullName').dirty">
@@ -77,7 +77,7 @@
           <chef-form-field *ngIf="!isAdminView" class="password">
             <label>
               <span class="label">Old Password <span aria-hidden="true">*</span></span>
-              <chef-input ngDefaultControl formControlName="oldPassword" type="password"></chef-input>
+              <input chefInput formControlName="oldPassword" type="password"/>
             </label>
             <chef-error
               *ngIf="passwordForm.get('oldPassword').hasError('required') && passwordForm.get('oldPassword').dirty">
@@ -91,7 +91,7 @@
           <chef-form-field class="password">
             <label>
               <span class="label">New Password <span aria-hidden="true">*</span></span>
-              <chef-input ngDefaultControl formControlName="newPassword" type="password"></chef-input>
+              <input chefInput formControlName="newPassword" type="password"/>
             </label>
             <chef-error
               *ngIf="(passwordForm.get('newPassword').hasError('required') || passwordForm.get('newPassword').hasError('pattern')) && passwordForm.get('newPassword').dirty">
@@ -105,7 +105,7 @@
           <chef-form-field class="password">
             <label>
               <span class="label">Confirm New Password <span aria-hidden="true">*</span></span>
-              <chef-input ngDefaultControl formControlName="confirmPassword" type="password"></chef-input>
+              <input chefInput formControlName="confirmPassword" type="password"/>
             </label>
             <chef-error
               *ngIf="passwordForm.get('confirmPassword').hasError('noMatch') && passwordForm.get('confirmPassword').dirty">

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.html
@@ -25,7 +25,7 @@
                 <chef-form-field class="display3">
                   <label>
                     <span class="label">Full Name <span aria-hidden="true">*</span></span>
-                    <chef chefInput formControlName="fullName"/>
+                    <input chefInput formControlName="fullName"/>
                   </label>
                   <chef-error
                     *ngIf="(editForm.get('fullName').hasError('required') || editForm.get('fullName').hasError('pattern')) && editForm.get('fullName').dirty">

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.scss
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.scss
@@ -20,10 +20,6 @@
 
 .password {
   width: 450px;
-
-  chef-input {
-    width: 100%;
-  }
 }
 
 chef-form-field:first-child.password label {

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
@@ -19,8 +19,7 @@
             chefInput
             type="text"
             placeholder="Search profiles..."
-            (input)="onSearchInput($event)">
-          </input>
+            (input)="onSearchInput($event)"/>
         </div>
 
         <chef-tab-selector class="profiles-tabs" [value]="selectedTab" (change)="onTabChange($event)">

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
@@ -15,11 +15,12 @@
         <chef-subheading>Compliance profiles manage security and compliance scans.</chef-subheading>
 
         <div class="profiles-search">
-          <chef-input
+          <input
+            chefInput
             type="text"
             placeholder="Search profiles..."
             (input)="onSearchInput($event)">
-          </chef-input>
+          </input>
         </div>
 
         <chef-tab-selector class="profiles-tabs" [value]="selectedTab" (change)="onTabChange($event)">

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
@@ -28,7 +28,7 @@
                 </chef-checkbox>
               </chef-td>
               <chef-td class="input">
-                <chef-input ngDefaultControl formControlName="threshold"></chef-input>
+                <input chefInput formControlName="threshold"/>
               </chef-td>
               <chef-td class="input">
                 <chef-select ngDefaultControl formControlName="unit" (change)="patchUnitValue(missingNodesForm, $event)">
@@ -49,7 +49,7 @@
                 </chef-checkbox>
               </chef-td>
               <chef-td class="input">
-                <chef-input ngDefaultControl formControlName="threshold"></chef-input>
+                <input chefInput formControlName="threshold"/>
               </chef-td>
               <chef-td class="input">
                 <chef-select ngDefaultControl formControlName="unit" (change)="patchUnitValue(deleteMissingNodesForm, $event)">

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.scss
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.scss
@@ -10,8 +10,9 @@ chef-td {
   }
 }
 
-chef-input {
+input {
   width: 60px;
+  height: 100%;
 }
 
 chef-select {

--- a/components/automate-ui/src/app/pages/integrations/aws-form/aws-form.component.html
+++ b/components/automate-ui/src/app/pages/integrations/aws-form/aws-form.component.html
@@ -16,12 +16,12 @@
   <ng-container *ngIf="showInstanceCreds()" [formGroup]="formGroup.controls.credentials">
     <label class="form-field">
       <span class="label">Enter your AWS access key ID</span>
-      <chef-input ngDefaultControl type="password" formControlName="aws_access_key_id"></chef-input>
+      <input chefInput type="password" formControlName="aws_access_key_id" />
     </label>
 
     <label class="form-field">
       <span class="label">Enter your AWS secret access key</span>
-      <chef-input ngDefaultControl type="password" formControlName="aws_secret_access_key"></chef-input>
+      <input chefInput type="password" formControlName="aws_secret_access_key" />
     </label>
   </ng-container>
 

--- a/components/automate-ui/src/app/pages/integrations/azure-form/azure-form.component.html
+++ b/components/automate-ui/src/app/pages/integrations/azure-form/azure-form.component.html
@@ -16,17 +16,17 @@
   <ng-container *ngIf="showInstanceCreds()" [formGroup]="formGroup.controls.credentials">
     <label class="form-field">
       <span class="label">Client ID</span>
-      <chef-input ngDefaultControl type="password" formControlName="azure_client_id"></chef-input>
+      <input chefInput type="password" formControlName="azure_client_id" />
     </label>
 
     <label class="form-field">
       <span class="label">Client Secret</span>
-      <chef-input ngDefaultControl type="password" formControlName="azure_client_secret"></chef-input>
+      <input chefInput type="password" formControlName="azure_client_secret" />
     </label>
 
     <label class="form-field">
       <span class="label">Tenant ID</span>
-      <chef-input ngDefaultControl type="password" formControlName="azure_tenant_id"></chef-input>
+      <input chefInput type="password" formControlName="azure_tenant_id" />
     </label>
   </ng-container>
 

--- a/components/automate-ui/src/app/pages/integrations/integrations-form/integrations-form.component.html
+++ b/components/automate-ui/src/app/pages/integrations/integrations-form/integrations-form.component.html
@@ -15,7 +15,7 @@
 
     <label class="form-field">
       <span class="label">Name</span>
-      <chef-input ngDefaultControl formControlName="name"></chef-input>
+      <input chefInput formControlName="name" />
     </label>
 
     <ng-container [ngSwitch]="integrationsForm.controls.type.value">
@@ -38,8 +38,8 @@
 
     <div *ngFor="let cred of instance_credentials.controls; let i=index" [formGroupName]="i" class="cred">
       <span>Where</span>
-      <chef-input placeholder="Tag Key" ngDefaultControl formControlName="tag_key"></chef-input>
-      <chef-input placeholder="Value" ngDefaultControl formControlName="tag_value"></chef-input>
+      <input chefInput placeholder="Tag Key" formControlName="tag_key" />
+      <input chefInput placeholder="Value" formControlName="tag_value" />
       <span>use</span>
 
       <select multiple formControlName="credential_ids" class="credential-ids">

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -14,7 +14,7 @@
         <chef-form-field id="create-name">
           <label>
             <span class="label">Rule Name <span aria-hidden="true">*</span></span>
-            <input chefInput formControlName="name" (keyup)="handleNameInput($event)"/>
+            <input chefInput formControlName="name" (keyup)="handleNameInput($event)" />
           </label>
           <chef-error
             *ngIf="( ruleForm.get('name').hasError('required') && ruleForm.get('name').touched ) || ( ruleForm.get('name').hasError('pattern') && ruleForm.get('name').dirty )"

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -18,18 +18,9 @@ chef-page {
 
   input {
     height: 45px;
-<<<<<<< HEAD
     width: 100%;
     outline: 0;
     font-size: 1em;
-  }
-
-  chef-error {
-    background-color: #DC267F;
-    color: #FFFFFF;
-    border-radius: 0 0 4px 4px;
-=======
->>>>>>> Remove chef-input from project-rules-component, update CSS note: these inputs have an explicit 45px height to them where as none other others do and they all come out to about 42px
   }
 
   chef-error {

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -18,6 +18,7 @@ chef-page {
 
   input {
     height: 45px;
+<<<<<<< HEAD
     width: 100%;
     outline: 0;
     font-size: 1em;
@@ -27,6 +28,8 @@ chef-page {
     background-color: #DC267F;
     color: #FFFFFF;
     border-radius: 0 0 4px 4px;
+=======
+>>>>>>> Remove chef-input from project-rules-component, update CSS note: these inputs have an explicit 45px height to them where as none other others do and they all come out to about 42px
   }
 
   #create-name,

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -32,6 +32,12 @@ chef-page {
 >>>>>>> Remove chef-input from project-rules-component, update CSS note: these inputs have an explicit 45px height to them where as none other others do and they all come out to about 42px
   }
 
+  chef-error {
+    background-color: #DC267F;
+    color: #FFFFFF;
+    border-radius: 0 0 4px 4px;
+  }
+
   #create-name,
   #create-id,
   #create-type,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As we move away from stencil based components, we will be removing them from the codebase one tag at a time.  This time its `<chef-input>`.  Because `<chef-input>` holds no logic in it, it will be replaced with a native `input` and styled using the `chefInput` directive

### :chains: Related Resources
https://github.com/chef/automate/issues/2061

### :+1: Definition of Done
`<chef-input>` stencil component is no longer used anywhere on the site, and has been replaced with a native `<input>` tag.  Visual appearance should remain the same.

### :athletic_shoe: How to Build and Test the Change
1.  build components/automate-ui-devproxy && start_all_services
2. Navigate across the site and all modals to see that <chef-input> has been replaced with native inputs.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable