### PR TITLE
[automate-2104] reset items in ngrx/store between GET requests

### DIFF
--- a/components/automate-ui/src/app/entities/api-tokens/api-token.reducer.ts
+++ b/components/automate-ui/src/app/entities/api-tokens/api-token.reducer.ts
@@ -45,7 +45,12 @@ export function apiTokenEntityReducer(
   switch (action.type) {
 
     case ApiTokenActionTypes.GET_ALL: {
-      return set(STATUS, EntityStatus.loading, state) as ApiTokenEntityState;
+      return set(
+        STATUS,
+        EntityStatus.loading,
+        // clear token state to prevent data leakage
+        apiTokenEntityAdapter.removeAll(state)
+      ) as ApiTokenEntityState;
     }
 
     case ApiTokenActionTypes.GET_ALL_SUCCESS: {
@@ -61,7 +66,13 @@ export function apiTokenEntityReducer(
     }
 
     case ApiTokenActionTypes.GET: {
-      return set(GET_STATUS, EntityStatus.loading, state) as ApiTokenEntityState;
+      return set(
+        GET_STATUS,
+        EntityStatus.loading,
+        // clear token state to prevent data leakage
+        // for example, if the user visited the list page first
+        apiTokenEntityAdapter.removeAll(state)
+      ) as ApiTokenEntityState;
     }
 
     case ApiTokenActionTypes.GET_SUCCESS: {

--- a/components/automate-ui/src/app/entities/api-tokens/api-token.reducer.ts
+++ b/components/automate-ui/src/app/entities/api-tokens/api-token.reducer.ts
@@ -48,7 +48,7 @@ export function apiTokenEntityReducer(
       return set(
         STATUS,
         EntityStatus.loading,
-        // clear token state to prevent data leakage
+        // clear token state to avoid leaking potentially unauthorized data
         apiTokenEntityAdapter.removeAll(state)
       ) as ApiTokenEntityState;
     }
@@ -69,8 +69,7 @@ export function apiTokenEntityReducer(
       return set(
         GET_STATUS,
         EntityStatus.loading,
-        // clear token state to prevent data leakage
-        // for example, if the user visited the list page first
+        // clear token state to avoid leaking potentially unauthorized data
         apiTokenEntityAdapter.removeAll(state)
       ) as ApiTokenEntityState;
     }

--- a/components/automate-ui/src/app/entities/api-tokens/api-token.reducer.ts
+++ b/components/automate-ui/src/app/entities/api-tokens/api-token.reducer.ts
@@ -48,7 +48,7 @@ export function apiTokenEntityReducer(
       return set(
         STATUS,
         EntityStatus.loading,
-        // clear token state to avoid leaking potentially unauthorized data
+        // clear token state to ensure we fetch the latest data
         apiTokenEntityAdapter.removeAll(state)
       ) as ApiTokenEntityState;
     }
@@ -69,7 +69,7 @@ export function apiTokenEntityReducer(
       return set(
         GET_STATUS,
         EntityStatus.loading,
-        // clear token state to avoid leaking potentially unauthorized data
+        // clear token state to ensure we fetch the latest data
         apiTokenEntityAdapter.removeAll(state)
       ) as ApiTokenEntityState;
     }

--- a/components/automate-ui/src/app/entities/teams/team.reducer.ts
+++ b/components/automate-ui/src/app/entities/teams/team.reducer.ts
@@ -45,7 +45,7 @@ export function teamEntityReducer(state: TeamEntityState = TeamEntityInitialStat
       return set(
         'getAllStatus',
         EntityStatus.loading,
-        // clear team state to prevent leaking potentially unauthorized data
+        // clear team state to ensure we fetch the latest data
         teamEntityAdapter.removeAll(state)
       ) as TeamEntityState;
     }
@@ -81,7 +81,7 @@ export function teamEntityReducer(state: TeamEntityState = TeamEntityInitialStat
       return set(
         'getStatus',
         EntityStatus.loading,
-        // clear team state to prevent leaking potentially unauthorized data
+        // clear team state to ensure we fetch the latest data
         teamEntityAdapter.removeAll(state)
       ) as TeamEntityState;
     }

--- a/components/automate-ui/src/app/entities/teams/team.reducer.ts
+++ b/components/automate-ui/src/app/entities/teams/team.reducer.ts
@@ -42,7 +42,12 @@ export function teamEntityReducer(state: TeamEntityState = TeamEntityInitialStat
   switch (action.type) {
 
     case TeamActionTypes.GET_ALL: {
-      return set('getAllStatus', EntityStatus.loading, state) as TeamEntityState;
+      return set(
+        'getAllStatus',
+        EntityStatus.loading,
+        // clear team state to prevent data leakage
+        teamEntityAdapter.removeAll(state)
+      ) as TeamEntityState;
     }
 
     case TeamActionTypes.GET_ALL_SUCCESS: {
@@ -73,7 +78,12 @@ export function teamEntityReducer(state: TeamEntityState = TeamEntityInitialStat
     }
 
     case TeamActionTypes.GET: {
-      return set('getStatus', EntityStatus.loading, state) as TeamEntityState;
+      return set(
+        'getStatus',
+        EntityStatus.loading,
+        // clear team state to prevent data leakage
+        teamEntityAdapter.removeAll(state)
+      ) as TeamEntityState;
     }
 
     case TeamActionTypes.GET_SUCCESS: {

--- a/components/automate-ui/src/app/entities/teams/team.reducer.ts
+++ b/components/automate-ui/src/app/entities/teams/team.reducer.ts
@@ -45,7 +45,7 @@ export function teamEntityReducer(state: TeamEntityState = TeamEntityInitialStat
       return set(
         'getAllStatus',
         EntityStatus.loading,
-        // clear team state to prevent data leakage
+        // clear team state to prevent leaking potentially unauthorized data
         teamEntityAdapter.removeAll(state)
       ) as TeamEntityState;
     }
@@ -81,7 +81,7 @@ export function teamEntityReducer(state: TeamEntityState = TeamEntityInitialStat
       return set(
         'getStatus',
         EntityStatus.loading,
-        // clear team state to prevent data leakage
+        // clear team state to prevent leaking potentially unauthorized data
         teamEntityAdapter.removeAll(state)
       ) as TeamEntityState;
     }

--- a/components/automate-ui/src/app/entities/users/user.effects.ts
+++ b/components/automate-ui/src/app/entities/users/user.effects.ts
@@ -1,9 +1,10 @@
-import { catchError, mergeMap, map } from 'rxjs/operators';
+import { catchError, mergeMap, map, filter } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Store } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of, combineLatest } from 'rxjs';
+import { identity } from 'lodash/fp';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { CreateNotification } from 'app/entities/notifications/notification.actions';
@@ -43,7 +44,6 @@ export class UserEffects {
     private store$: Store<NgrxStateAtom>
   ) { }
 
-  // 7/6/18: TODO in follow-up PR: fetch teams for all users - bd
   @Effect()
   getUsers$ = combineLatest([
     this.actions$.pipe(ofType<GetUsers>(UserActionTypes.GET_ALL)),
@@ -65,11 +65,10 @@ export class UserEffects {
       });
     }));
 
-  // TODO rename
   @Effect()
   getUser$ = combineLatest([
     this.actions$.pipe(ofType<GetUser>(UserActionTypes.GET)),
-    this.store$.select(iamMajorVersion)])
+    this.store$.select(iamMajorVersion).pipe(filter(identity))])
     .pipe(
       mergeMap(([action, version]: [GetUser, IAMMajorVersion]) =>
         this.requests.getUser(action.payload.id, version).pipe(

--- a/components/automate-ui/src/app/entities/users/user.effects.ts
+++ b/components/automate-ui/src/app/entities/users/user.effects.ts
@@ -47,7 +47,7 @@ export class UserEffects {
   @Effect()
   getUsers$ = combineLatest([
     this.actions$.pipe(ofType<GetUsers>(UserActionTypes.GET_ALL)),
-    this.store$.select(iamMajorVersion)])
+    this.store$.select(iamMajorVersion).pipe(filter(identity))])
     .pipe(
       mergeMap(([_action, version]: [GetUsers, IAMMajorVersion]) =>
         this.requests.getUsers(version).pipe(
@@ -89,7 +89,7 @@ export class UserEffects {
   @Effect()
   updateUser$ = combineLatest([
     this.actions$.pipe(ofType<UpdateUser>(UserActionTypes.UPDATE)),
-    this.store$.select(iamMajorVersion)])
+    this.store$.select(iamMajorVersion).pipe(filter(identity))])
     .pipe(
       mergeMap(([action, version]: [UpdateUser, IAMMajorVersion]) =>
       this.requests.updateUser(action.payload, version).pipe(
@@ -118,7 +118,7 @@ export class UserEffects {
   @Effect()
   updateSelf$ = combineLatest([
     this.actions$.pipe(ofType<UpdateSelf>(UserActionTypes.UPDATE_SELF)),
-    this.store$.select(iamMajorVersion)])
+    this.store$.select(iamMajorVersion).pipe(filter(identity))])
     .pipe(
       mergeMap(([action, version]: [UpdateSelf, IAMMajorVersion]) =>
       this.requests.updateSelf(action.payload, version).pipe(
@@ -136,7 +136,7 @@ export class UserEffects {
   @Effect()
   deleteUser$ = combineLatest([
     this.actions$.pipe(ofType<DeleteUser>(UserActionTypes.DELETE)),
-    this.store$.select(iamMajorVersion)])
+    this.store$.select(iamMajorVersion).pipe(filter(identity))])
     .pipe(
       mergeMap(([action, version]: [DeleteUser, IAMMajorVersion]) =>
       this.requests.deleteUser(action.payload, version).pipe(
@@ -165,7 +165,7 @@ export class UserEffects {
   @Effect()
   createUser$ = combineLatest([
     this.actions$.pipe(ofType<CreateUser>(UserActionTypes.CREATE)),
-    this.store$.select(iamMajorVersion)])
+    this.store$.select(iamMajorVersion).pipe(filter(identity))])
     .pipe(
       mergeMap(([action, version]: [CreateUser, IAMMajorVersion]) =>
       this.requests.createUser(action.payload, version).pipe(

--- a/components/automate-ui/src/app/entities/users/user.reducer.spec.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.spec.ts
@@ -50,8 +50,8 @@ describe('userStatusEntityReducer', () => {
       const action = new GetUsers();
 
       it('sets status to loading', () => {
-        const { status } = userEntityReducer(initialState, action);
-        expect(status).toEqual(EntityStatus.loading);
+        const { getStatus } = userEntityReducer(initialState, action);
+        expect(getStatus).toEqual(EntityStatus.loading);
       });
     });
 
@@ -60,8 +60,18 @@ describe('userStatusEntityReducer', () => {
       const action = new GetUsersSuccess(payload);
 
       it('sets status to loadingSuccess', () => {
-        const { status } = userEntityReducer(initialState, action);
-        expect(status).toEqual(EntityStatus.loadingSuccess);
+        const { getStatus } = userEntityReducer(initialState, action);
+        expect(getStatus).toEqual(EntityStatus.loadingSuccess);
+      });
+
+      using([
+        [initialState, userState('get', user, user2), 'initial state'],
+        [userState('get', user), userState('get', user, user2), 'one-user state']
+      ], (prevState, nextState: UserEntityState, descr: string) => {
+        it(`with ${descr} fetches latest users`, () => {
+          const actualNext = userEntityReducer(prevState, action);
+          expect(actualNext).toEqual(nextState);
+        });
       });
     });
 
@@ -70,8 +80,8 @@ describe('userStatusEntityReducer', () => {
       const action = new GetUsersFailure(payload);
 
       it('sets status to loadingFailure', () => {
-        const { status } = userEntityReducer(initialState, action);
-        expect(status).toEqual(EntityStatus.loadingFailure);
+        const { getStatus } = userEntityReducer(initialState, action);
+        expect(getStatus).toEqual(EntityStatus.loadingFailure);
       });
     });
 
@@ -84,8 +94,8 @@ describe('userStatusEntityReducer', () => {
       const action = new CreateUser(payload);
 
       it('sets status to loading', () => {
-        const { status } = userEntityReducer(initialState, action);
-        expect(status).toEqual(EntityStatus.loading);
+        const { createStatus } = userEntityReducer(initialState, action);
+        expect(createStatus).toEqual(EntityStatus.loading);
       });
     });
 
@@ -94,8 +104,18 @@ describe('userStatusEntityReducer', () => {
       const action = new CreateUserSuccess(payload);
 
       it('sets status to loadingSuccess', () => {
-        const { status } = userEntityReducer(initialState, action);
-        expect(status).toEqual(EntityStatus.loadingSuccess);
+        const { createStatus } = userEntityReducer(initialState, action);
+        expect(createStatus).toEqual(EntityStatus.loadingSuccess);
+      });
+
+      using([
+        [initialState, userState('create', user), 'initial state'],
+        [userState('create', user2), userState('create', user2, user), 'one-user state']
+      ], (prevState, nextState: UserEntityState, descr: string) => {
+        it(`with ${descr} adds a new user to the state`, () => {
+          const actualNext = userEntityReducer(prevState, action);
+          expect(actualNext).toEqual(nextState);
+        });
       });
     });
 
@@ -104,8 +124,8 @@ describe('userStatusEntityReducer', () => {
       const action = new CreateUserFailure(payload);
 
       it('sets status to loadingFailure', () => {
-        const { status } = userEntityReducer(initialState, action);
-        expect(status).toEqual(EntityStatus.loadingFailure);
+        const { createStatus } = userEntityReducer(initialState, action);
+        expect(createStatus).toEqual(EntityStatus.loadingFailure);
       });
     });
 
@@ -114,8 +134,8 @@ describe('userStatusEntityReducer', () => {
       const action = new GetUser(payload);
 
       it('sets status to loading', () => {
-        const { status } = userEntityReducer(initialState, action);
-        expect(status).toEqual(EntityStatus.loading);
+        const { getStatus } = userEntityReducer(initialState, action);
+        expect(getStatus).toEqual(EntityStatus.loading);
       });
     });
 
@@ -125,8 +145,8 @@ describe('userStatusEntityReducer', () => {
 
       it('sets status to loadingSuccess', () => {
         const prevState = { ...initialState, state: EntityStatus.loading };
-        const { status } = userEntityReducer(prevState, action);
-        expect(status).toEqual(EntityStatus.loadingSuccess);
+        const { getStatus } = userEntityReducer(prevState, action);
+        expect(getStatus).toEqual(EntityStatus.loadingSuccess);
       });
 
       it('loads the one user into the users state', () => {
@@ -142,8 +162,8 @@ describe('userStatusEntityReducer', () => {
 
       it('sets status to loadingSuccess', () => {
         const prevState = { ...initialState, state: EntityStatus.loading };
-        const { status } = userEntityReducer(prevState, action);
-        expect(status).toEqual(EntityStatus.loadingFailure);
+        const { getStatus } = userEntityReducer(prevState, action);
+        expect(getStatus).toEqual(EntityStatus.loadingFailure);
       });
     });
 
@@ -243,35 +263,12 @@ function userState(action: string, ...us: User[]): UserEntityState {
     entities[u.id] = u;
     ids.push(u.id);
   }
-  switch (action) {
-    case 'get': {
-      return {
-        updateStatus: EntityStatus.notLoaded,
-        status: EntityStatus.loadingSuccess,
-        deleteStatus: EntityStatus.notLoaded,
-        entities,
-        ids
-      };
-    }
-    case 'update': {
-      return {
-        updateStatus: EntityStatus.loadingSuccess,
-        status: EntityStatus.notLoaded,
-        deleteStatus: EntityStatus.notLoaded,
-        entities,
-        ids
-      };
-    }
-    case 'delete': {
-      return {
-        updateStatus: EntityStatus.notLoaded,
-        status: EntityStatus.notLoaded,
-        deleteStatus: EntityStatus.loadingSuccess,
-        entities,
-        ids
-      };
-    }
-  }
+
+  return ['get', 'create', 'update', 'delete']
+    .reduce((state, a) => {
+      state[a + 'Status'] = a === action ? EntityStatus.loadingSuccess : EntityStatus.notLoaded;
+      return state;
+    }, { entities, ids }) as UserEntityState;
 }
 
 

--- a/components/automate-ui/src/app/entities/users/user.reducer.spec.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.spec.ts
@@ -169,9 +169,9 @@ describe('userStatusEntityReducer', () => {
 
 
       using([
-        [initialState, userState(true), 'initial state'],
-        [userState(true, user), userState(true, payload), 'one-user state'],
-        [userState(true, user, user2), userState(true, payload, user2), 'two-user state']
+        [initialState, userState('update'), 'initial state'],
+        [userState('update', user), userState('update', payload), 'one-user state'],
+        [userState('update', user, user2), userState('update', payload, user2), 'two-user state']
       ], (prevState, nextState: UserEntityState, descr: string) => {
         it(`with ${descr} updates the user if it's in the state`, () => {
           const actualNext = userEntityReducer(prevState, action);
@@ -196,8 +196,8 @@ describe('userStatusEntityReducer', () => {
       const action = new DeleteUser(payload);
 
       it('sets status to loading', () => {
-        const { status } = userEntityReducer(initialState, action);
-        expect(status).toEqual(EntityStatus.loading);
+        const { deleteStatus } = userEntityReducer(initialState, action);
+        expect(deleteStatus).toEqual(EntityStatus.loading);
       });
     });
 
@@ -205,16 +205,16 @@ describe('userStatusEntityReducer', () => {
       const payload = { ...user, name: 'test user 123'};
       const action = new DeleteUserSuccess(payload);
 
-      it('sets status to loadingSuccess', () => {
+      it('sets deleteStatus to loadingSuccess', () => {
         const prevState = { ...initialState, state: EntityStatus.loading };
-        const { status } = userEntityReducer(prevState, action);
-        expect(status).toEqual(EntityStatus.loadingSuccess);
+        const { deleteStatus } = userEntityReducer(prevState, action);
+        expect(deleteStatus).toEqual(EntityStatus.loadingSuccess);
       });
 
       using([
-        [initialState, userState(false), 'initial state'],
-        [userState(false, user), userState(false), 'one user state'],
-        [userState(false, user, user2), userState(false, user2), 'state with two users']
+        [initialState, userState('delete'), 'initial state'],
+        [userState('delete', user), userState('delete'), 'one user state'],
+        [userState('delete', user, user2), userState('delete', user2), 'state with two users']
       ], (prevState, nextState: UserEntityState, descr: string) => {
         it(`with ${descr} removes the one user if it's in the state`, () => {
           const actualNext = userEntityReducer(prevState, action);
@@ -227,28 +227,51 @@ describe('userStatusEntityReducer', () => {
       const payload = httpErrorResponse;
       const action = new DeleteUserFailure(payload);
 
-      it('sets status to loadingSuccess', () => {
+      it('sets deleteStatus to loadingSuccess', () => {
         const prevState = { ...initialState, state: EntityStatus.loading };
-        const { status } = userEntityReducer(prevState, action);
-        expect(status).toEqual(EntityStatus.loadingFailure);
+        const { deleteStatus } = userEntityReducer(prevState, action);
+        expect(deleteStatus).toEqual(EntityStatus.loadingFailure);
       });
     });
   });
 });
 
-function userState(isUpdate: boolean, ...us: User[]): UserEntityState {
+function userState(action: string, ...us: User[]): UserEntityState {
   const entities: { [id: string]: User } = {};
   const ids: string[] = [];
   for (const u of us) {
     entities[u.id] = u;
     ids.push(u.id);
   }
-  return {
-    updateStatus: isUpdate ? EntityStatus.loadingSuccess : EntityStatus.notLoaded,
-    status: isUpdate ? EntityStatus.notLoaded : EntityStatus.loadingSuccess,
-    entities,
-    ids
-  };
+  switch (action) {
+    case 'get': {
+      return {
+        updateStatus: EntityStatus.notLoaded,
+        status: EntityStatus.loadingSuccess,
+        deleteStatus: EntityStatus.notLoaded,
+        entities,
+        ids
+      };
+    }
+    case 'update': {
+      return {
+        updateStatus: EntityStatus.loadingSuccess,
+        status: EntityStatus.notLoaded,
+        deleteStatus: EntityStatus.notLoaded,
+        entities,
+        ids
+      };
+    }
+    case 'delete': {
+      return {
+        updateStatus: EntityStatus.notLoaded,
+        status: EntityStatus.notLoaded,
+        deleteStatus: EntityStatus.loadingSuccess,
+        entities,
+        ids
+      };
+    }
+  }
 }
 
 

--- a/components/automate-ui/src/app/entities/users/user.reducer.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.ts
@@ -30,7 +30,7 @@ export function userEntityReducer(state: UserEntityState = UserEntityInitialStat
       return set(
         'getStatus',
         EntityStatus.loading,
-        // clear user state to prevent leaking potentially unauthorized data
+        // clear user state to ensure we fetch the latest data
         userEntityAdapter.removeAll(state)
       ) as UserEntityState;
 
@@ -45,7 +45,7 @@ export function userEntityReducer(state: UserEntityState = UserEntityInitialStat
       return set(
         'getStatus',
         EntityStatus.loading,
-        // clear user state to prevent leaking potentially unauthorized data
+        // clear user state to ensure we fetch the latest data
         userEntityAdapter.removeAll(state)
       ) as UserEntityState;
 

--- a/components/automate-ui/src/app/entities/users/user.reducer.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.ts
@@ -6,17 +6,19 @@ import { UserActionTypes, UserActions } from './user.actions';
 import { User } from './user.model';
 
 export interface UserEntityState extends EntityState<User> {
-  status: EntityStatus;
+  getStatus: EntityStatus;
   updateStatus: EntityStatus;
   deleteStatus: EntityStatus;
+  createStatus: EntityStatus;
 }
 
 export const userEntityAdapter: EntityAdapter<User> = createEntityAdapter<User>();
 
 export const UserEntityInitialState: UserEntityState = userEntityAdapter.getInitialState({
-  status: EntityStatus.notLoaded,
+  getStatus: EntityStatus.notLoaded,
   updateStatus: EntityStatus.notLoaded,
-  deleteStatus: EntityStatus.notLoaded
+  deleteStatus: EntityStatus.notLoaded,
+  createStatus: EntityStatus.notLoaded
 });
 
 export function userEntityReducer(state: UserEntityState = UserEntityInitialState,
@@ -26,35 +28,33 @@ export function userEntityReducer(state: UserEntityState = UserEntityInitialStat
 
     case UserActionTypes.GET_ALL:
       return set(
-        'status',
+        'getStatus',
         EntityStatus.loading,
-        // clear user state to prevent data leakage
-        // for example, if the user visited the list page first
+        // clear user state to prevent leaking potentially unauthorized data
         userEntityAdapter.removeAll(state)
       ) as UserEntityState;
 
     case UserActionTypes.GET_ALL_SUCCESS:
-      return set('status', EntityStatus.loadingSuccess,
+      return set('getStatus', EntityStatus.loadingSuccess,
         userEntityAdapter.addAll(action.payload.users, state));
 
     case UserActionTypes.GET_ALL_FAILURE:
-      return set('status', EntityStatus.loadingFailure, state);
+      return set('getStatus', EntityStatus.loadingFailure, state);
 
     case UserActionTypes.GET:
       return set(
-        'status',
+        'getStatus',
         EntityStatus.loading,
-        // clear user state to prevent data leakage
-        // for example, if the user visited the list page first
+        // clear user state to prevent leaking potentially unauthorized data
         userEntityAdapter.removeAll(state)
       ) as UserEntityState;
 
     case UserActionTypes.GET_SUCCESS:
-      return set('status', EntityStatus.loadingSuccess,
+      return set('getStatus', EntityStatus.loadingSuccess,
         userEntityAdapter.addOne(action.payload, state));
 
     case UserActionTypes.GET_FAILURE:
-      return set('status', EntityStatus.loadingFailure, state);
+      return set('getStatus', EntityStatus.loadingFailure, state);
 
     case UserActionTypes.UPDATE:
       return set('updateStatus', EntityStatus.loading, state);
@@ -88,14 +88,14 @@ export function userEntityReducer(state: UserEntityState = UserEntityInitialStat
       return set('deleteStatus', EntityStatus.loadingFailure, state);
 
     case UserActionTypes.CREATE:
-      return set('status', EntityStatus.loading, state);
+      return set('createStatus', EntityStatus.loading, state);
 
     case UserActionTypes.CREATE_SUCCESS:
-      return set('status', EntityStatus.loadingSuccess,
+      return set('createStatus', EntityStatus.loadingSuccess,
                   userEntityAdapter.addOne(action.payload, state));
 
     case UserActionTypes.CREATE_FAILURE:
-      return set('status', EntityStatus.loadingFailure, state);
+      return set('createStatus', EntityStatus.loadingFailure, state);
 
     default:
       return state;

--- a/components/automate-ui/src/app/entities/users/user.reducer.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.ts
@@ -8,13 +8,15 @@ import { User } from './user.model';
 export interface UserEntityState extends EntityState<User> {
   status: EntityStatus;
   updateStatus: EntityStatus;
+  deleteStatus: EntityStatus;
 }
 
 export const userEntityAdapter: EntityAdapter<User> = createEntityAdapter<User>();
 
 export const UserEntityInitialState: UserEntityState = userEntityAdapter.getInitialState({
   status: EntityStatus.notLoaded,
-  updateStatus: EntityStatus.notLoaded
+  updateStatus: EntityStatus.notLoaded,
+  deleteStatus: EntityStatus.notLoaded
 });
 
 export function userEntityReducer(state: UserEntityState = UserEntityInitialState,
@@ -23,7 +25,13 @@ export function userEntityReducer(state: UserEntityState = UserEntityInitialStat
   switch (action.type) {
 
     case UserActionTypes.GET_ALL:
-      return set('status', EntityStatus.loading, state);
+      return set(
+        'status',
+        EntityStatus.loading,
+        // clear user state to prevent data leakage
+        // for example, if the user visited the list page first
+        userEntityAdapter.removeAll(state)
+      ) as UserEntityState;
 
     case UserActionTypes.GET_ALL_SUCCESS:
       return set('status', EntityStatus.loadingSuccess,
@@ -33,7 +41,13 @@ export function userEntityReducer(state: UserEntityState = UserEntityInitialStat
       return set('status', EntityStatus.loadingFailure, state);
 
     case UserActionTypes.GET:
-      return set('status', EntityStatus.loading, state);
+      return set(
+        'status',
+        EntityStatus.loading,
+        // clear user state to prevent data leakage
+        // for example, if the user visited the list page first
+        userEntityAdapter.removeAll(state)
+      ) as UserEntityState;
 
     case UserActionTypes.GET_SUCCESS:
       return set('status', EntityStatus.loadingSuccess,
@@ -64,14 +78,14 @@ export function userEntityReducer(state: UserEntityState = UserEntityInitialStat
           changes: action.payload}, state));
 
     case UserActionTypes.DELETE:
-      return set('status', EntityStatus.loading, state);
+      return set('deleteStatus', EntityStatus.loading, state);
 
     case UserActionTypes.DELETE_SUCCESS:
-      return set('status', EntityStatus.loadingSuccess,
+      return set('deleteStatus', EntityStatus.loadingSuccess,
         userEntityAdapter.removeOne(action.payload.id, state));
 
     case UserActionTypes.DELETE_FAILURE:
-      return set('status', EntityStatus.loadingFailure, state);
+      return set('deleteStatus', EntityStatus.loadingFailure, state);
 
     case UserActionTypes.CREATE:
       return set('status', EntityStatus.loading, state);

--- a/components/automate-ui/src/app/entities/users/user.selectors.ts
+++ b/components/automate-ui/src/app/entities/users/user.selectors.ts
@@ -21,6 +21,11 @@ export const updateStatus = createSelector(
   (state) => state.updateStatus
 );
 
+export const deleteStatus = createSelector(
+  userState,
+  (state) => state.deleteStatus
+);
+
 export const userFromRoute = createSelector(
   userEntities,
   routeParams,

--- a/components/automate-ui/src/app/entities/users/user.selectors.ts
+++ b/components/automate-ui/src/app/entities/users/user.selectors.ts
@@ -11,9 +11,9 @@ export const {
   selectEntities: userEntities
 } = userEntityAdapter.getSelectors(userState);
 
-export const userStatus = createSelector(
+export const getStatus = createSelector(
   userState,
-  (state) => state.status
+  (state) => state.getStatus
 );
 
 export const updateStatus = createSelector(
@@ -24,6 +24,11 @@ export const updateStatus = createSelector(
 export const deleteStatus = createSelector(
   userState,
   (state) => state.deleteStatus
+);
+
+export const createStatus = createSelector(
+  userState,
+  (state) => state.createStatus
 );
 
 export const userFromRoute = createSelector(

--- a/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.ts
@@ -25,7 +25,7 @@ import { Policy, Member, Type, stringToMember } from 'app/entities/policies/poli
 import { allTeams, getAllStatus as getAllTeamsStatus } from 'app/entities/teams/team.selectors';
 import { Team } from 'app/entities/teams/team.model';
 import { GetTeams } from 'app/entities/teams/team.actions';
-import { allUsers, userStatus } from 'app/entities/users/user.selectors';
+import { allUsers, getStatus as getAllUsersStatus } from 'app/entities/users/user.selectors';
 import {
   GetUsers
 } from 'app/entities/users/user.actions';
@@ -114,7 +114,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
     this.loading$ = combineLatest([
         this.store.select(getAllTeamsStatus),
-        this.store.select(userStatus),
+        this.store.select(getAllUsersStatus),
         this.store.select(getPolicyStatus)
       ]).pipe(
         map((statuses: EntityStatus[]) => !allLoadedSuccessfully(statuses)));

--- a/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.ts
@@ -12,7 +12,7 @@ import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeState } from 'app/route.selectors';
 import { EntityStatus, allLoadedSuccessfully } from 'app/entities/entities';
 import { User, HashMapOfUsers, userArrayToHash } from 'app/entities/users/user.model';
-import { allUsers, getStatus as getUsersStatus } from 'app/entities/users/user.selectors';
+import { allUsers, getStatus as getAllUsersStatus } from 'app/entities/users/user.selectors';
 import { GetUsers } from 'app/entities/users/user.actions';
 import { isIAMv2 } from 'app/entities/policies/policy.selectors';
 import {
@@ -88,7 +88,7 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
     ).subscribe(id => this.store.dispatch(new GetTeam({ id })));
 
     this.loading$ = combineLatest([
-      this.store.select(getUsersStatus),
+      this.store.select(getAllUsersStatus),
       this.store.select(getTeamUsersStatus)]).pipe(
         map((statuses: EntityStatus[]) => !allLoadedSuccessfully(statuses)));
 

--- a/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.ts
@@ -12,7 +12,7 @@ import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeState } from 'app/route.selectors';
 import { EntityStatus, allLoadedSuccessfully } from 'app/entities/entities';
 import { User, HashMapOfUsers, userArrayToHash } from 'app/entities/users/user.model';
-import { allUsers, userStatus } from 'app/entities/users/user.selectors';
+import { allUsers, getStatus as getUsersStatus } from 'app/entities/users/user.selectors';
 import { GetUsers } from 'app/entities/users/user.actions';
 import { isIAMv2 } from 'app/entities/policies/policy.selectors';
 import {
@@ -88,7 +88,7 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
     ).subscribe(id => this.store.dispatch(new GetTeam({ id })));
 
     this.loading$ = combineLatest([
-      this.store.select(userStatus),
+      this.store.select(getUsersStatus),
       this.store.select(getTeamUsersStatus)]).pipe(
         map((statuses: EntityStatus[]) => !allLoadedSuccessfully(statuses)));
 

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.html
@@ -1,16 +1,15 @@
 <div class="content-container">
   <div class="container">
     <main>
-      <chef-loading-spinner *ngIf="isLoadingTeam" size='50' fixed></chef-loading-spinner>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/settings/teams']">Teams</chef-breadcrumb>
-        <span *ngIf="!(isIAMv2$ | async)">{{ team.id }}</span>
-        <span *ngIf="isIAMv2$ | async">{{ team.name }}</span>
+        <span *ngIf="!(isIAMv2$ | async)">{{ team?.id }}</span>
+        <span *ngIf="isIAMv2$ | async">{{ team?.name }}</span>
       </chef-breadcrumbs>
-
+  
       <chef-page-header>
-        <chef-heading *ngIf="!(isIAMv2$ | async)">{{ team.id }}</chef-heading>
-        <chef-heading *ngIf="isIAMv2$ | async">{{ team.name }}</chef-heading>
+        <chef-heading *ngIf="!(isIAMv2$ | async)">{{ team?.id }}</chef-heading>
+        <chef-heading *ngIf="isIAMv2$ | async">{{ team?.name }}</chef-heading>
         <table>
           <thead>
             <tr class="detail-row">
@@ -25,42 +24,36 @@
             <tr class="detail-row">
               <td *ngIf="!(isIAMv2$ | async)" class="id-column">{{ team.name }}</td>
               <ng-container *ngIf="isIAMv2$ | async">
-                <td class="id-column">{{ team.id }}</td>
+                <td class="id-column">{{ team?.id }}</td>
                 <td class="projects-column" data-cy="team-details-projects">
-                  <ng-container *ngIf="team.projects.length === 0">
-                      {{ unassigned }}
+                  <ng-container *ngIf="team?.projects.length === 0">
+                    {{ unassigned }}
                   </ng-container>
-                  <ng-container *ngIf="team.projects.length === 1">
-                      {{ team.projects[0] }}
+                  <ng-container *ngIf="team?.projects.length === 1">
+                    {{ team?.projects[0] }}
                   </ng-container>
-                  <ng-container *ngIf="team.projects.length > 1">
-                      {{ team.projects.length }} projects
+                  <ng-container *ngIf="team?.projects.length > 1">
+                    {{ team?.projects.length }} projects
                   </ng-container>
                 </td>
               </ng-container>
             </tr>
           </tbody>
         </table>
-
+  
         <chef-tab-selector (change)="onSelectedTab($event)" [value]="tabValue">
           <chef-option value='users'>Users</chef-option>
           <chef-option value='details' data-cy="team-details-tab-details">Details</chef-option>
         </chef-tab-selector>
       </chef-page-header>
-      <section class="page-body" *ngIf="team.id && (tabValue === 'users')">
+      <section class="page-body" *ngIf="team?.id && (tabValue === 'users')">
         <div id="users-list">
           <div>
             <!-- TODO remove [overridePermissionsCheck]=true once the UI is able to check specific objects
             since the path to permission on here is /auth/teams/:id/users we'll have to show everything for now. -->
-            <app-user-table
-              [addButtonText]="addButtonText"
-              [removeText]="removeText"
-              [users]="users"
-              [baseUrl]="'/auth/users/' + team.id"
-              [overridePermissionsCheck]=true
-              [showTable]="showUsersTable()"
-              [showEmptyMessage]="showEmptyStateMessage()"
-              (addClicked)="toggleUserMembershipView()"
+            <app-user-table [addButtonText]="addButtonText" [removeText]="removeText" [users]="users"
+              [baseUrl]="'/auth/users/' + team.id" [overridePermissionsCheck]=true [showTable]="showUsersTable()"
+              [showEmptyMessage]="showEmptyStateMessage()" (addClicked)="toggleUserMembershipView()"
               (removeClicked)="removeUser($event)">
             </app-user-table>
           </div>
@@ -70,22 +63,21 @@
         <form [formGroup]="updateNameForm">
           <chef-form-field>
             <label>{{ descriptionOrName | titlecase }} <span aria-hidden="true">*</span></label>
-            <input chefInput formControlName="name" type="text" [resetOrigin]="saveSuccessful" autocomplete="off" data-cy="team-details-name-input">
+            <input chefInput formControlName="name" type="text" [resetOrigin]="saveSuccessful" autocomplete="off"
+              data-cy="team-details-name-input">
             <chef-error
               *ngIf="(updateNameForm.get('name').hasError('required') || updateNameForm.get('name').hasError('pattern')) && updateNameForm.get('name').dirty">
               {{ descriptionOrName | titlecase }} is required.
             </chef-error>
           </chef-form-field>
           <div id='projects-container' *ngIf="isIAMv2$ | async">
-            <app-projects-dropdown
-              [projects]="projects"
-              (onProjectChecked)="onProjectChecked($event)"
+            <app-projects-dropdown [projects]="projects" (onProjectChecked)="onProjectChecked($event)"
               [disabled]="dropdownDisabled()">
             </app-projects-dropdown>
           </div>
         </form>
-        <chef-button [disabled]="isLoadingTeam || !updateNameForm.valid || !updateNameForm.dirty"
-          primary inline (click)="saveTeam()" data-cy="team-details-submit-button">
+        <chef-button [disabled]="isLoadingTeam || !updateNameForm.valid || !updateNameForm.dirty" primary inline
+          (click)="saveTeam()" data-cy="team-details-submit-button">
           <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
           <span *ngIf="saving">Saving...</span>
           <span *ngIf="!saving">Save</span>

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.scss
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.scss
@@ -20,7 +20,7 @@ chef-page-header {
   }
 
   td {
-    height: 36px;
+    min-height: 36px;
   }
 
   tbody > .detail-row {

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.scss
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.scss
@@ -19,6 +19,10 @@ chef-page-header {
     padding: 0px;
   }
 
+  td {
+    height: 36px;
+  }
+
   tbody > .detail-row {
     padding-top: 0px;
     padding-bottom: 15px;

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
@@ -13,7 +13,7 @@ import { routeURL, routeState } from 'app/route.selectors';
 import { EntityStatus, loading } from 'app/entities/entities';
 import { User } from 'app/entities/users/user.model';
 import { Regex } from 'app/helpers/auth/regex';
-import { allUsers, userStatus } from 'app/entities/users/user.selectors';
+import { allUsers, getStatus as getAllUsersStatus } from 'app/entities/users/user.selectors';
 import { GetUsers } from 'app/entities/users/user.actions';
 import { isIAMv2 } from 'app/entities/policies/policy.selectors';
 import {
@@ -21,7 +21,7 @@ import {
   v2TeamFromRoute,
   teamUsers,
   getStatus,
-  getUsersStatus,
+  getUsersStatus as getTeamUsersStatus,
   updateStatus
 } from 'app/entities/teams/team.selectors';
 import { Team } from 'app/entities/teams/team.model';
@@ -126,7 +126,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     combineLatest([
       this.store.select(getStatus),
       this.store.select(updateStatus),
-      this.store.select(getUsersStatus)
+      this.store.select(getTeamUsersStatus)
     ]).pipe(
       takeUntil(this.isDestroyed)
     ).subscribe(([gStatus, uStatus, usersStatus]) => {
@@ -186,9 +186,9 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
 
     combineLatest([
       this.store.select(allUsers),
-      this.store.select(userStatus),
+      this.store.select(getAllUsersStatus),
       this.store.select(teamUsers),
-      this.store.select(getUsersStatus)]).pipe(
+      this.store.select(getTeamUsersStatus)]).pipe(
         takeUntil(this.isDestroyed),
         filter(([_allUsers, uStatus, _teamUsers, tuStatus]) =>
             uStatus === EntityStatus.loadingSuccess &&

--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
 import { Store, select } from '@ngrx/store';
+import { isEmpty, identity, xor, isNil } from 'lodash/fp';
 import { combineLatest, Subject } from 'rxjs';
 import { filter, pluck, takeUntil } from 'rxjs/operators';
-import { isEmpty, identity, xor } from 'lodash/fp';
 
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
@@ -83,8 +83,7 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
       this.store.select(getStatus),
       this.store.select(apiTokenFromRoute)
     ]).pipe(
-      filter(([gStatus, _]) => gStatus === EntityStatus.loadingSuccess),
-      filter(identity),
+      filter(([status, token]) => status === EntityStatus.loadingSuccess && !isNil(token)),
       takeUntil(this.isDestroyed))
       .subscribe(([_, token]) => {
         this.token = { ...token };

--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
 import { Store, select } from '@ngrx/store';
 import { combineLatest, Subject } from 'rxjs';
-import { filter, map, pluck, takeUntil } from 'rxjs/operators';
+import { filter, pluck, takeUntil } from 'rxjs/operators';
 import { isEmpty, identity, xor } from 'lodash/fp';
 
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
@@ -11,7 +11,7 @@ import { routeParams } from 'app/route.selectors';
 import { Regex } from 'app/helpers/auth/regex';
 import { pending, EntityStatus } from 'app/entities/entities';
 import { GetToken, UpdateToken } from 'app/entities/api-tokens/api-token.actions';
-import { apiTokenFromRoute, updateStatus } from 'app/entities/api-tokens/api-token.selectors';
+import { apiTokenFromRoute, getStatus, updateStatus } from 'app/entities/api-tokens/api-token.selectors';
 import { ApiToken } from 'app/entities/api-tokens/api-token.model';
 import { isIAMv2 } from 'app/entities/policies/policy.selectors';
 import { Project, ProjectConstants } from 'app/entities/projects/project.model';
@@ -58,28 +58,16 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
       status: [initialStatus],
       projects: [[]]
     });
+  }
+
+  ngOnInit(): void {
+    this.layoutFacade.showSettingsSidebar();
+
     this.store.pipe(
       select(isIAMv2),
       takeUntil(this.isDestroyed))
       .subscribe(latest => {
         this.isIAMv2 = latest;
-      });
-  }
-
-  ngOnInit(): void {
-    this.layoutFacade.showSettingsSidebar();
-    this.store.pipe(
-      select(apiTokenFromRoute),
-      filter(identity),
-      takeUntil(this.isDestroyed))
-      .subscribe((token) => {
-        this.token = { ...token };
-        this.updateForm.controls.name.setValue(this.token.name);
-        this.status = this.token.active ? 'active' : 'inactive';
-        this.updateForm.controls.status.setValue(this.status);
-        if (this.isIAMv2) {
-          this.store.dispatch(new GetProjects());
-        }
       });
 
     this.store.pipe(
@@ -92,21 +80,36 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
       });
 
     combineLatest([
+      this.store.select(getStatus),
+      this.store.select(apiTokenFromRoute)
+    ]).pipe(
+      filter(([gStatus, _]) => gStatus === EntityStatus.loadingSuccess),
+      filter(identity),
+      takeUntil(this.isDestroyed))
+      .subscribe(([_, token]) => {
+        this.token = { ...token };
+        this.updateForm.controls.name.setValue(this.token.name);
+        this.status = this.token.active ? 'active' : 'inactive';
+        this.updateForm.controls.status.setValue(this.status);
+        if (this.isIAMv2) {
+          this.store.dispatch(new GetProjects());
+        }
+      });
+
+    combineLatest([
       this.store.select(allProjects),
       this.store.select(getAllProjectStatus)
     ]).pipe(
-      takeUntil(this.isDestroyed),
       filter(([_, pStatus]: [Project[], EntityStatus]) => pStatus !== EntityStatus.loading),
       filter(() => !!this.token),
-      map(([allowedProjects, _]) => {
+      takeUntil(this.isDestroyed))
+      .subscribe(([allowedProjects, _]) => {
         this.projects = {};
-        allowedProjects
-          .forEach(p => {
+        allowedProjects.forEach(p => {
             this.projects[p.id] = { ...p, checked: this.token.projects.includes(p.id)
             };
           });
-      }))
-      .subscribe();
+      });
 
     this.store.pipe(
       select(updateStatus),

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.html
@@ -1,24 +1,24 @@
 <div class="content-container">
   <div class="container">
-    <main *ngIf="isAdminView || user.id">
+    <main *ngIf="isAdminView || user?.id">
       <app-delete-object-modal
-        [visible]="modalVisible"
-        objectNoun="user"
-        [objectName]="user.name"
-        (close)="closeDeleteConfirmationModal()"
-        (deleteClicked)="deleteUser()"
-        objectAction="Delete">
+      [visible]="modalVisible"
+      objectNoun="user"
+      [objectName]="user?.name"
+      (close)="closeDeleteConfirmationModal()"
+      (deleteClicked)="deleteUser()"
+      objectAction="Delete">
       </app-delete-object-modal>
       <chef-breadcrumbs *ngIf="isAdminView">
         <chef-breadcrumb [link]="['/settings/users']">Users</chef-breadcrumb>
-        {{ user.name }}
+        {{ user?.name }}
       </chef-breadcrumbs>
 
       <chef-page-header>
         <div class="detail-row">
           <div class="name-column">
             <ng-container *ngIf="!editMode">
-              <div class="display3">{{ user.name }}</div>
+              <div class="display3">{{ user?.name }}</div>
             </ng-container>
             <ng-container *ngIf="editMode">
               <form [formGroup]="editForm">
@@ -27,29 +27,38 @@
                     <span class="label">Full Name <span aria-hidden="true">*</span></span>
                     <chef-input ngDefaultControl formControlName="fullName"></chef-input>
                   </label>
-                  <chef-error *ngIf="(editForm.get('fullName').hasError('required') || editForm.get('fullName').hasError('pattern')) && editForm.get('fullName').dirty">
+                  <chef-error
+                    *ngIf="(editForm.get('fullName').hasError('required') || editForm.get('fullName').hasError('pattern')) && editForm.get('fullName').dirty">
                     Full Name is required.
                   </chef-error>
                 </chef-form-field>
               </form>
             </ng-container>
             <div class="container-big-header inline-container">
-              <span class="text"> {{ user.id }}</span>
+              <span class="text"> {{ user?.id }}</span>
             </div>
           </div>
           <div class="button-column">
             <ng-container *ngIf="!editMode">
-              <chef-button secondary class="edit-button" (click)="setEditMode(true)">
-                <chef-icon>mode_edit</chef-icon>
-                <span>Edit</span>
-              </chef-button>
-              <chef-button *ngIf="isAdminView" secondary caution class="delete-button" (click)="openDeleteConfirmationModal()">
-                <chef-icon>delete</chef-icon>
-                <span>Delete user</span>
-              </chef-button>
+              <app-authorized [allOf]="[['/auth/users/{username}', 'put', user?.id], ['/iam/v2beta/users/{username}', 'put', user?.id],
+                ['/auth/users/{username}', 'get', user?.id], ['/iam/v2beta/users/{username}', 'get', user?.id]]">
+                <chef-button secondary class="edit-button" (click)="setEditMode(true)">
+                  <chef-icon>mode_edit</chef-icon>
+                  <span>Edit</span>
+                </chef-button>
+              </app-authorized>
+              <app-authorized [allOf]="[['/auth/users/{username}', 'delete', user?.id], ['/iam/v2beta/users/{username}', 'delete', user?.id],
+                ['/auth/users/{username}', 'get', user?.id], ['/iam/v2beta/users/{username}', 'get', user?.id]]">
+                <chef-button *ngIf="isAdminView" secondary caution class="delete-button"
+                  (click)="openDeleteConfirmationModal()">
+                  <chef-icon>delete</chef-icon>
+                  <span>Delete user</span>
+                </chef-button>
+              </app-authorized>
             </ng-container>
             <ng-container *ngIf="editMode">
-              <chef-button primary class="save-button" [disabled]="!editForm.valid || !editForm.dirty" (click)="saveFullName()">
+              <chef-button primary class="save-button" [disabled]="!editForm.valid || !editForm.dirty"
+                (click)="saveFullName()">
                 <span>Save</span>
               </chef-button>
               <chef-button tertiary (click)="setEditMode(false)">Cancel</chef-button>
@@ -70,10 +79,12 @@
               <span class="label">Old Password <span aria-hidden="true">*</span></span>
               <chef-input ngDefaultControl formControlName="oldPassword" type="password"></chef-input>
             </label>
-            <chef-error *ngIf="passwordForm.get('oldPassword').hasError('required') && passwordForm.get('oldPassword').dirty">
+            <chef-error
+              *ngIf="passwordForm.get('oldPassword').hasError('required') && passwordForm.get('oldPassword').dirty">
               Old Password is required.
             </chef-error>
-            <chef-error *ngIf="passwordForm.get('oldPassword').hasError('minlength') && passwordForm.get('oldPassword').dirty">
+            <chef-error
+              *ngIf="passwordForm.get('oldPassword').hasError('minlength') && passwordForm.get('oldPassword').dirty">
               Old Password must be at least 8 characters.
             </chef-error>
           </chef-form-field>
@@ -82,10 +93,12 @@
               <span class="label">New Password <span aria-hidden="true">*</span></span>
               <chef-input ngDefaultControl formControlName="newPassword" type="password"></chef-input>
             </label>
-            <chef-error *ngIf="(passwordForm.get('newPassword').hasError('required') || passwordForm.get('newPassword').hasError('pattern')) && passwordForm.get('newPassword').dirty">
+            <chef-error
+              *ngIf="(passwordForm.get('newPassword').hasError('required') || passwordForm.get('newPassword').hasError('pattern')) && passwordForm.get('newPassword').dirty">
               New Password is required.
             </chef-error>
-            <chef-error *ngIf="passwordForm.get('newPassword').hasError('minlength') && passwordForm.get('newPassword').dirty">
+            <chef-error
+              *ngIf="passwordForm.get('newPassword').hasError('minlength') && passwordForm.get('newPassword').dirty">
               New Password must be at least 8 characters.
             </chef-error>
           </chef-form-field>
@@ -94,7 +107,8 @@
               <span class="label">Confirm New Password <span aria-hidden="true">*</span></span>
               <chef-input ngDefaultControl formControlName="confirmPassword" type="password"></chef-input>
             </label>
-            <chef-error *ngIf="passwordForm.get('confirmPassword').hasError('noMatch') && passwordForm.get('confirmPassword').dirty">
+            <chef-error
+              *ngIf="passwordForm.get('confirmPassword').hasError('noMatch') && passwordForm.get('confirmPassword').dirty">
               Passwords must match.
             </chef-error>
           </chef-form-field>

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.scss
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.scss
@@ -4,6 +4,7 @@
   display: flex;
   justify-content: space-between;
   padding: 0 0 25px 0;
+  height: 115px;
 
   .user-column {
     display: flex;

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.scss
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.scss
@@ -4,7 +4,7 @@
   display: flex;
   justify-content: space-between;
   padding: 0 0 25px 0;
-  height: 115px;
+  min-height: 115px;
 
   .user-column {
     display: flex;

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
@@ -18,7 +18,7 @@ import {
   UpdateSelf
  } from 'app/entities/users/user.actions';
 import {
-  userStatus, userFromRoute, updateStatus, deleteStatus
+  getStatus, userFromRoute, updateStatus, deleteStatus
 } from 'app/entities/users/user.selectors';
 import { User } from 'app/entities/users/user.model';
 import { Regex } from 'app/helpers/auth/regex';
@@ -58,7 +58,7 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
       });
 
     combineLatest([
-      this.store.select(userStatus),
+      this.store.select(getStatus),
       this.store.select(userFromRoute)
     ]).pipe(
       filter(([status, user]) => status === EntityStatus.loadingSuccess && !isNil(user)),

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
@@ -61,8 +61,7 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
       this.store.select(userStatus),
       this.store.select(userFromRoute)
     ]).pipe(
-      filter(([status, _]) => status === EntityStatus.loadingSuccess),
-      filter(([_, user]) => !isNil(user)),
+      filter(([status, user]) => status === EntityStatus.loadingSuccess && !isNil(user)),
       takeUntil(this.isDestroyed))
       .subscribe(([_, user]) => {
         this.user = { ...user };

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
@@ -1,17 +1,16 @@
-import { combineLatest, Observable, Subscription } from 'rxjs';
-
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { FormBuilder, Validators, FormGroup } from '@angular/forms';
-import { Store } from '@ngrx/store';
-import { filter, pluck, map } from 'rxjs/operators';
-import { find, identity } from 'lodash/fp';
+import { Store, select } from '@ngrx/store';
+import { combineLatest, Subject } from 'rxjs';
+import { filter, pluck, takeUntil } from 'rxjs/operators';
+import { identity, isNil } from 'lodash/fp';
 
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { ChefValidators } from 'app/helpers/auth/validator';
 import { routeParams } from 'app/route.selectors';
-import { EntityStatus } from 'app/entities/entities';
+import { EntityStatus, loading } from 'app/entities/entities';
 import {
   DeleteUser,
   GetUser,
@@ -19,7 +18,7 @@ import {
   UpdateSelf
  } from 'app/entities/users/user.actions';
 import {
-  allUsers, userStatus, userFromRoute, updateStatus
+  userStatus, userFromRoute, updateStatus, deleteStatus
 } from 'app/entities/users/user.selectors';
 import { User } from 'app/entities/users/user.model';
 import { Regex } from 'app/helpers/auth/regex';
@@ -36,8 +35,7 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
   public modalVisible = false;
   public editForm: FormGroup;
   public passwordForm: FormGroup;
-  private subscriptions: Subscription[];
-  private done$: Observable<boolean>;
+  private isDestroyed = new Subject<boolean>();
 
   constructor(
     private store: Store<NgrxStateAtom>,
@@ -47,61 +45,49 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
     private layoutFacade: LayoutFacadeService
   ) {
     this.createForms(this.fb);
-    // TODO (tc) This needs to be refactored to resemble our other patterns
-    // for specific object pages.
-    // combineLatest depends on the user object existing already.
-    this.user = {
-      id: '',
-      name: '',
-      membership_id: ''
-    };
-
-    this.done$ = <Observable<boolean>>combineLatest([
-      store.select(allUsers),
-      store.select(userStatus)])
-      .pipe(
-        map(([state, status]: [User[], EntityStatus]) => {
-          const id = this.user.id;
-          return status === EntityStatus.loadingSuccess && !find({ id }, state);
-        }));
-
-    this.subscriptions = [
-      store.select(userFromRoute).pipe(
-        filter(identity))
-        .subscribe((state) => {
-          this.user = <User>state;
-        }),
-      // Note: if the user browses directly to /settings/users/USERNAME, the state
-      // will not contain any user data -- so we need to fetch it.
-      store.select(routeParams).pipe(
-        pluck('id'),
-        filter(identity))
-        .subscribe((id: string) => {
-          store.dispatch(new GetUser({id}));
-        }),
-
-      // if the user is gone, go back to list
-      // note: we filter(identity) here -- so this will effectively only
-      // trigger when done$ is `true`
-      this.done$.pipe(filter(identity)).subscribe(
-        () => this.router.navigate(['/settings', 'users'])),
-
-      store.select(updateStatus).subscribe(this.handleUpdateStatus.bind(this))
-      ];
     }
 
   ngOnInit(): void {
-    if (this.isAdminView) {
-      this.layoutFacade.showSettingsSidebar();
-    } else {
-      this.layoutFacade.showUserProfileSidebar();
-    }
+    this.store.pipe(
+      select(routeParams),
+      pluck('id'),
+      filter(identity),
+      takeUntil(this.isDestroyed))
+      .subscribe((id: string) => {
+        this.store.dispatch(new GetUser({ id }));
+      });
+
+    combineLatest([
+      this.store.select(userStatus),
+      this.store.select(userFromRoute)
+    ]).pipe(
+      filter(([status, _]) => status === EntityStatus.loadingSuccess),
+      filter(([_, user]) => !isNil(user)),
+      takeUntil(this.isDestroyed))
+      .subscribe(([_, user]) => {
+        this.user = { ...user };
+      });
+
     this.route.data.subscribe((data: { isNonAdmin: boolean }) => {
       this.isAdminView = !data.isNonAdmin;
+
+      if (this.isAdminView) {
+        this.layoutFacade.showSettingsSidebar();
+      } else {
+        this.layoutFacade.showUserProfileSidebar();
+      }
+
       // Update the forms once this info has come in
       this.createForms(this.fb);
       this.resetForms();
     });
+
+    this.store.select(updateStatus).subscribe(this.handleUpdateStatus.bind(this));
+  }
+
+  ngOnDestroy(): void {
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
   }
 
   private handleUpdateStatus(state: EntityStatus): void {
@@ -125,10 +111,6 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
       confirmPassword: ['',
         [Validators.required, ChefValidators.matchFieldValidator('newPassword')]]
     });
-  }
-
-  ngOnDestroy() {
-    this.subscriptions.forEach((sub: Subscription) => sub.unsubscribe());
   }
 
   private resetForms(): void {
@@ -184,7 +166,20 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
 
   public deleteUser(): void {
     this.store.dispatch(new DeleteUser(this.user));
-    this.closeDeleteConfirmationModal();
+
+    const pendingDelete = new Subject<boolean>();
+    this.store.pipe(
+      select(deleteStatus),
+      filter(identity),
+      takeUntil(pendingDelete))
+      .subscribe((state) => {
+      if (!loading(state)) {
+          pendingDelete.next(true);
+          pendingDelete.complete();
+          this.closeDeleteConfirmationModal();
+          this.router.navigate(['/settings', 'users']);
+        }
+      });
   }
 
   public setEditMode(status: boolean): void {

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
@@ -81,19 +81,16 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
       this.resetForms();
     });
 
-    this.store.select(updateStatus).subscribe(this.handleUpdateStatus.bind(this));
+    this.store.select(updateStatus).pipe(
+      takeUntil(this.isDestroyed),
+      filter(status => status === EntityStatus.loadingSuccess))
+      // same status is used for updating password or full name, so we just reset both
+      .subscribe(() => this.resetForms());
   }
 
   ngOnDestroy(): void {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
-  }
-
-  private handleUpdateStatus(state: EntityStatus): void {
-    // same status is used for updating password or full name, so we just reset both
-    if (state === EntityStatus.loadingSuccess) {
-      this.resetForms();
-    }
   }
 
   private createForms(fb: FormBuilder): void {

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
@@ -10,7 +10,7 @@ import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Regex } from 'app/helpers/auth/regex';
 import { ChefValidators } from 'app/helpers/auth/validator';
 import { EntityStatus } from 'app/entities/entities';
-import { allUsers, userStatus } from 'app/entities/users/user.selectors';
+import { allUsers, getStatus } from 'app/entities/users/user.selectors';
 import {
   CreateUser, DeleteUser, GetUsers, CreateUserPayload
 } from 'app/entities/users/user.actions';
@@ -47,7 +47,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     private layoutFacade: LayoutFacadeService,
     fb: FormBuilder
   ) {
-    this.userStatus$ = store.select(userStatus);
+    this.userStatus$ = store.select(getStatus);
 
     this.createUserForm = fb.group({
       // Must stay in sync with error checks in user-form.component.html
@@ -68,7 +68,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     this.store.dispatch(new GetUsers());
     combineLatest([
       this.store.select(allUsers),
-      this.store.select(userStatus)
+      this.store.select(getStatus)
     ]).pipe(
       takeUntil(this.isDestroyed),
       filter(([_, uStatus]: [User[], EntityStatus]) =>

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
@@ -33,7 +33,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
   public isLoading = true;
   public userToDelete: User;
 
-  public userStatus$: Observable<EntityStatus>;
+  private getStatus$: Observable<EntityStatus>;
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
   // Inputs to app-user-table
@@ -47,7 +47,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     private layoutFacade: LayoutFacadeService,
     fb: FormBuilder
   ) {
-    this.userStatus$ = store.select(getStatus);
+    this.getStatus$ = store.select(getStatus);
 
     this.createUserForm = fb.group({
       // Must stay in sync with error checks in user-form.component.html
@@ -119,7 +119,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
 
     this.store.dispatch(new CreateUser(userCreateReq));
 
-    this.userStatus$.pipe(
+    this.getStatus$.pipe(
       takeUntil(this.isDestroyed))
       .subscribe((status) => {
         if (status !== EntityStatus.loading) {

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
@@ -71,9 +71,9 @@ export class UserManagementComponent implements OnInit, OnDestroy {
       this.store.select(getStatus)
     ]).pipe(
       takeUntil(this.isDestroyed),
-      filter(([_, uStatus]: [User[], EntityStatus]) =>
-        this.isLoading = uStatus === EntityStatus.loading
-      )).subscribe(([users, _]: [User[], EntityStatus]) => {
+      filter(([_, uStatus]) => uStatus !== EntityStatus.loading)
+      ).subscribe(([users, _]: [User[], EntityStatus]) => {
+        this.isLoading = false;
         // Sort naturally first by name, then by id
         this.users = ChefSorters.naturalSort(users, ['name', 'id']);
       });


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

We have some data leakage issues between the auth list and details pages. If you navigate to the list page and then go to one of the details pages, the data still exists in the store and gets loaded on the details page. This is a problem in cases when a user might have List permission but not Get permission.

- [x] tokens
- [x] users
- [x] teams

### :chains: Related Resources
- follow-up: https://github.com/chef/automate/issues/2138
- in the future we may rethink what data our List and Get APIs should be returning

### :+1: Definition of Done
- [x] the tokens details page always displays fresh data from the API instead of pulling stale data from the store
- [x] the teams details page always displays fresh data from the API instead of pulling stale data from the store
- [x] the users details page always displays fresh data from the API instead of pulling stale data from the store

### :athletic_shoe: How to Build and Test the Change

```
$ export TOK=`chef-automate iam token create adm --admin`

$ echo '{
    "name": "testing",
    "id": "test1",
    "members": [
      "user:local:coolbean"
    ],
    "statements": [
      {
        "effect": "ALLOW",
        "actions": ["iam:*:list"],
        "projects": [
          "*"
        ]
      }
    ],
    "projects": []
  }' >> pol.json

$ curl -kH "api-token: $TOK" -X POST -d @pol.json https://localhost/apis/iam/v2beta/policies | jq

{
  "policy": {
    "name": "testing",
    "id": "test1",
    "type": "CUSTOM",
    "members": [
      "user:local:coolbean"
    ],
    "statements": [
      {
        "effect": "ALLOW",
        "actions": [
          "iam:*:list"
        ],
        "role": "",
        "resources": [
          "*"
        ],
        "projects": [
          "*"
        ]
      }
    ],
    "projects": []
  }
}
```

- Log in to the UI
- Create some tokens, users, teams
- Create user `coolbean` and log in as that user
- Navigate to https://a2-dev.test/settings/tokens
- Make a token and go to its details page
- None of that token's data will load, all the fields will be blank
- Repeat with teams and users

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable