### PR TITLE
Revert "remove GNU-only option from `make revendor` (#2110)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ revendor: ## revendor dependencies in vendor/ and update .bldr.toml with deps
 
 	# Add files that go mod won't vendor that we need
 	@mkdir -p $(grpcGatewayVendorPath)
-	@cp -rf $(grpcGatewayModPath)/* $(grpcGatewayVendorPath)
+	@cp -rf --no-preserve=mode $(grpcGatewayModPath)/* $(grpcGatewayVendorPath)
 
 	# Clean up files that go mod will vendor that we don't need
 	@find ./vendor -type f \( -name .gitignore -o -name .travis.yml -o -name package.json -o -name Makefile -o -name Dockerfile -o -name MAINTAINERS -o -name \*.md -o -name \*.vim -o -name \*.yml \) -delete


### PR DESCRIPTION
This reverts commit fa722408560224ebdd41337a01c7cd2116b7a233.

This is a bit of a bummer since it won't work on OSX again. But, without this
we will fail on permissions problems trying to remove read-only files in the grpc-gateway
directory.