### PR TITLE
Increase min chef-server version to 12.11

### DIFF
--- a/components/automate-chef-io/content/docs/data-collection.md
+++ b/components/automate-chef-io/content/docs/data-collection.md
@@ -106,9 +106,9 @@ To apply the changes, run:
 sudo chef-server-ctl reconfigure
 ```
 
-### Setting Up Data Collection on Chef Server for Versions 12.8 through 12.13
+### Setting Up Data Collection on Chef Server for Versions 12.11 through 12.13
 
-For Chef Infra Server versions between 12.8 and 12.13, simply add the `root_url` and `token` values in
+For Chef Infra Server versions between 12.11 and 12.13, simply add the `root_url` and `token` values in
 `/etc/opscode/chef-server.rb`:
 
 ```ruby


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Automate requires at least TLSv1.2 for web connections and Chef-Server 12.11.0 is the first version with OpenSSL 1.0.2 that includes TLSv1.2 support needed for the data-collector proxy to work.

Chef Server 12.11.0 is also needed to use proxying Inspec profiles to Automate `profile['root_url']`

You can configure the data-collector with 12.8.0 but the `profile` config option will throw an error.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [x] Docs added/updated?

### :camera: Screenshots, if applicable