### PR TITLE
support `chef-automate upgrade run --version VERSION`

### DIFF
--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -221,13 +221,11 @@ func init() {
 		"airgap-bundle",
 		"",
 		"Path to an airgap install bundle")
-	// upgradeRunCmd.PersistentFlags().StringVar(
-	// 	&upgradeRunCmdFlags.version,
-	// 	"version",
-	// 	"",
-	// 	"The exact Chef Automate version to install")
-
-	// upgradeRunCmd.PersistentFlags().MarkHidden("version") // nolint: errcheck
+	upgradeRunCmd.PersistentFlags().StringVar(
+		&upgradeRunCmdFlags.version,
+		"version",
+		"",
+		"The exact Chef Automate version to install")
 	upgradeCmd.AddCommand(upgradeRunCmd)
 	upgradeCmd.AddCommand(upgradeStatusCmd)
 	RootCmd.AddCommand(upgradeCmd)

--- a/integration/tests/manual_upgrade.sh
+++ b/integration/tests/manual_upgrade.sh
@@ -69,6 +69,7 @@ do_upgrade() {
 
     curl -vv --insecure "https://packages.chef.io/set/$release" -X POST -d @"$target_manifest"
     log_info "Upgrading to $release"
+    # Uncomment once the --version flag is on dev
     # chef-automate upgrade run --version "$release"
     chef-automate dev grpcurl deployment-service -- \
         chef.automate.domain.deployment.Deployment.Upgrade -d "{\"version\": \"$release\"}"


### PR DESCRIPTION
This change allows users to run

       chef-automate upgrade run --version RELEASE

to upgrade to a specific version of Chef Automate. It does not allow
downgrades and does not allow specific version upgrades when in airgap
mode.

Signed-off-by: Steven Danna <steve@chef.io>