### PR TITLE
load more compliance reports

### DIFF
--- a/.studio/compliance-service
+++ b/.studio/compliance-service
@@ -92,7 +92,7 @@ document "load_compliance_reports" <<DOC
   Loads compliance report.
 DOC
 function load_compliance_reports() {
-    cd components/compliance-service/test_data/audit_reports
+    pushd components/compliance-service/test_data/audit_reports &> /dev/null
     ./send_to_data_collector.sh https://a2-dev.test "$(get_admin_token)"
-    cd ../../../../
+    popd &> /dev/null
 }

--- a/.studio/compliance-service
+++ b/.studio/compliance-service
@@ -87,3 +87,12 @@ function compliance_configure_purge() {
     }
   }"
 }
+
+document "load_compliance_reports" <<DOC
+  Loads compliance report.
+DOC
+function load_compliance_reports() {
+    cd components/compliance-service/test_data/audit_reports
+    ./send_to_data_collector.sh https://a2-dev.test "$(get_admin_token)"
+    cd ../../../../
+}

--- a/components/compliance-service/test_data/audit_reports/send_to_data_collector.sh
+++ b/components/compliance-service/test_data/audit_reports/send_to_data_collector.sh
@@ -58,6 +58,7 @@ echo "Sending the following compliance reports to Automate ( $AUTOMATE_URL )"
 
 # Send all report files prefixed with '2018-03-07' with today's date
 send_to_automate '2018-03-07' $(past_date 0)
+send_to_automate '2018-02-09' $(past_date 0)
 
 # Send all report files prefixed with '2018-03-05' dated two days ago
 send_to_automate '2018-03-05' $(past_date 2)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
just wanted to add a studio function to make it easier to load the data in audit_reports. this data is what we use in testing and has control tags, roles, environments -- more diverse data. 
this came up in slack when a developer was trying to work on control tags but didn't have data to populate the control tags with the existing commands in the studio.

### :chains: Related Resources
https://github.com/chef/automate/issues/1713#issuecomment-547622738

### :+1: Definition of Done
can load reports with control tags easily in the studio
