### PR TITLE
Removing duplicate requests

### DIFF
--- a/components/automate-ui/src/app/entities/entities.ts
+++ b/components/automate-ui/src/app/entities/entities.ts
@@ -41,3 +41,7 @@ export function pendingState(state: StateWithStatus): boolean {
 export function loading(status: EntityStatus): boolean {
   return status === EntityStatus.loading;
 }
+
+export function allLoadedSuccessfully(statuses: EntityStatus[]): boolean {
+  return statuses.every(status => status === EntityStatus.loadingSuccess);
+}

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.html
@@ -4,14 +4,14 @@
   [attr.secondary-btn-show]="sortedMembersAvailable && sortedMembersAvailable.length > 0"
   [attr.heading]="getHeading()"
   [attr.confirm-btn-text]="getMemberConfirmBtnText()"
-  [attr.page-loading]="loading"
+  [attr.page-loading]="loading$ | async"
   [attr.confirm-loading]="addingMembers"
   [attr.disable-confirm]="membersToAddValues().length === 0"
   [attr.error-message]="getErrorMessage()"
   (secondaryConfirm)="openModal()"
   (confirm)="addMembers()"
   (close)="closePage()">
-    <div *ngIf="!loading">
+    <div *ngIf="!(loading$ | async)">
       <chef-modal label="member-expression-label" class="member-expression-modal" [visible]="modalVisible" (closeModal)="closeModal()">
         <h2>Add Member Expression</h2>
         <div id="modal-content-container">

--- a/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/pages/policy/add-members/policy-add-members.component.ts
@@ -11,7 +11,7 @@ import { combineLatest, Subject, Observable } from 'rxjs';
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams } from 'app/route.selectors';
-import { EntityStatus } from 'app/entities/entities';
+import { EntityStatus, allLoadedSuccessfully } from 'app/entities/entities';
 import {
   GetPolicy, AddPolicyMembers, PolicyMembersMgmtPayload
 } from 'app/entities/policies/policy.actions';
@@ -117,9 +117,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
         this.store.select(userStatus),
         this.store.select(getPolicyStatus)
       ]).pipe(
-        takeUntil(this.isDestroyed),
-        map((statuses: EntityStatus[]) => !statuses.every(status =>
-          status === EntityStatus.loadingSuccess)));
+        map((statuses: EntityStatus[]) => !allLoadedSuccessfully(statuses)));
 
     combineLatest([
         this.store.select(allTeams),

--- a/components/automate-ui/src/app/pages/policy/details/policy-details.component.ts
+++ b/components/automate-ui/src/app/pages/policy/details/policy-details.component.ts
@@ -2,12 +2,11 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { identity } from 'lodash/fp';
-import { Observable, Subject, combineLatest } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { filter, map, takeUntil, distinctUntilChanged } from 'rxjs/operators';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { routeParams } from 'app/route.selectors';
-import { routeURL } from 'app/route.selectors';
+import { routeURL, routeState } from 'app/route.selectors';
 import { GetPolicy } from 'app/entities/policies/policy.actions';
 import { policyFromRoute } from 'app/entities/policies/policy.selectors';
 import {
@@ -74,12 +73,9 @@ export class PolicyDetailsComponent implements OnInit, OnDestroy {
       }));
     this.members$.subscribe();
 
-    combineLatest([
-      this.store.select(routeParams),
-      this.store.select(routeURL)
-    ]).pipe(
+    this.store.select(routeState).pipe(
       takeUntil(this.isDestroyed),
-      map(([params, url]) => [params.id as string, url]),
+      map(state => [state.params.id as string, state.url]),
       // Only fetch if we are on the policy details route, otherwise
       // we'll trigger GetPolicy with the wrong input on any route
       // away to a page that also uses the :id param.

--- a/components/automate-ui/src/app/pages/team-add-users/team-add-users.component.html
+++ b/components/automate-ui/src/app/pages/team-add-users/team-add-users.component.html
@@ -3,13 +3,13 @@
   [attr.secondary-btn-show]="showSecondary"
   [attr.heading]="getHeading()"
   [attr.confirm-btn-text]="getConfirmBtnText()"
-  [attr.page-loading]="loading"
+  [attr.page-loading]="loading$ | async"
   [attr.confirm-loading]="addingUsers"
   [attr.disable-confirm]="usersToAddValues().length === 0"
   [attr.error-message]="getErrorMessage()"
   (confirm)="addUsers()"
   (close)="closePage()">
-  <div *ngIf="!loading">
+  <div *ngIf="!(loading$ | async)">
     <div id="no-users-container" *ngIf="usersNotFiltered().length === 0">
       <p>There are no more local <a [routerLink]="['/settings', 'users']" target="_blank">users</a> to add; create some more!</p>
     </div>

--- a/components/automate-ui/src/app/pages/team-add-users/team-add-users.component.ts
+++ b/components/automate-ui/src/app/pages/team-add-users/team-add-users.component.ts
@@ -9,7 +9,7 @@ import { filter as lodashFilter } from 'lodash/fp';
 
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { routeParams, routeURL } from 'app/route.selectors';
+import { routeState } from 'app/route.selectors';
 import { EntityStatus, allLoadedSuccessfully } from 'app/entities/entities';
 import { User, HashMapOfUsers, userArrayToHash } from 'app/entities/users/user.model';
 import { allUsers, userStatus } from 'app/entities/users/user.selectors';
@@ -76,12 +76,9 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
         this.store.dispatch(new GetTeamUsers({ id: teamId}));
       });
 
-    combineLatest([
-      this.store.select(routeParams),
-      this.store.select(routeURL)
-    ]).pipe(
+    this.store.select(routeState).pipe(
       takeUntil(this.isDestroyed),
-      map(([params, url]) => [params.id as string, url]),
+      map(state => [state.params.id as string, state.url]),
       // Only fetch if we are on the team details route, otherwise
       // we'll trigger GetTeam with the wrong input on any route
       // away to a page that also uses the :id param.

--- a/components/automate-ui/src/app/pages/team-add-users/team-add-users.component.ts
+++ b/components/automate-ui/src/app/pages/team-add-users/team-add-users.component.ts
@@ -2,9 +2,9 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Router } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
-import { combineLatest, Subject } from 'rxjs';
+import { combineLatest, Subject, Observable } from 'rxjs';
 import { identity, keyBy, at } from 'lodash/fp';
-import { filter, map, pluck, takeUntil } from 'rxjs/operators';
+import { filter, map, takeUntil, distinctUntilChanged } from 'rxjs/operators';
 import { filter as lodashFilter } from 'lodash/fp';
 
 import { ChefSorters } from 'app/helpers/auth/sorter';
@@ -41,86 +41,92 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
   public team: Team;
   public users: User[] = [];
   private mapOfUsersToFilter: HashMapOfUsers = {};
-  public isIAMv2: boolean;
+  public isIAMv2$: Observable<boolean>;
   private isDestroyed = new Subject<boolean>();
   public addingUsers = false;
   private usersToAdd: { [id: string]: User } = {};
   public showSecondary = false;
   public addUsersFailed = '';
-  public loading = true;
+  public loading$: Observable<boolean>;
+  public teamId = '';
 
   constructor(
     private store: Store<NgrxStateAtom>,
     private router: Router) {
-      store.select(isIAMv2).subscribe(latest => this.isIAMv2 = latest);
   }
 
   ngOnInit(): void {
-    this.store.select(isIAMv2)
-      .pipe(takeUntil(this.isDestroyed))
-      .subscribe((version) => {
-        if (version === null) { return; }
+    this.store.dispatch(new GetUsers());
+    this.isIAMv2$ = this.store.select(isIAMv2);
 
-        if (this.isIAMv2) {
-          this.store.select(v2TeamFromRoute)
-            .pipe(filter(identity), takeUntil(this.isDestroyed))
-            .subscribe(this.getUsersForTeam.bind(this));
-        } else {
-          this.store.select(v1TeamFromRoute)
-            .pipe(filter(identity), takeUntil(this.isDestroyed))
-            .subscribe(this.getUsersForTeam.bind(this));
-        }
+    combineLatest([
+      this.isIAMv2$,
+      this.store.select(v2TeamFromRoute),
+      this.store.select(v1TeamFromRoute)
+    ]).pipe(
+        takeUntil(this.isDestroyed),
+        filter(([isV2, _v2TeamFromRoute, _v1TeamFromRoute]) => isV2 !== null),
+        map(([isV2, v2Team, v1Team]) => {
+          let team: Team;
+          let teamId: string;
+          if (isV2) {
+            team = v2Team;
+            teamId = v2Team.id;
+          } else {
+            team = v1Team;
+            teamId = v2Team.guid;
+          }
+          return [team, teamId];
+        }),
+        distinctUntilChanged(
+          ([_teamA, teamIdA]: [Team, string], [_teamB, teamIdB]: [Team, string]) =>
+          teamIdA === teamIdB)
+      ).subscribe(([team, teamId]: [Team, string]) => {
+        this.team = team;
+        this.teamId = teamId;
+        this.store.dispatch(new GetTeamUsers({ id: teamId}));
       });
 
-    this.store.select(routeParams).pipe(
-      pluck('id'),
-      filter(identity),
-      takeUntil(this.isDestroyed))
-      .subscribe((id: string) => {
-        this.store.select(routeURL).pipe(
-          filter(identity),
-          takeUntil(this.isDestroyed))
-          .subscribe((url: string) => {
-            // Only fetch if we are on the team details route, otherwise
-            // we'll trigger GetTeam with the wrong input on any route
-            // away to a page that also uses the :id param.
-            if (TEAM_ADD_USERS_ROUTE.test(url)) {
-              this.store.dispatch(new GetTeam({ id }));
-            }
-          });
-      });
+    combineLatest([
+      this.store.select(routeParams),
+      this.store.select(routeURL)
+    ]).pipe(
+      takeUntil(this.isDestroyed),
+      map(([params, url]) => [params.id as string, url]),
+      // Only fetch if we are on the team details route, otherwise
+      // we'll trigger GetTeam with the wrong input on any route
+      // away to a page that also uses the :id param.
+      filter(([id, url]) => TEAM_ADD_USERS_ROUTE.test(url) && id !== undefined),
+      map(([id, _url]) => id),
+      distinctUntilChanged()
+    ).subscribe(id => this.store.dispatch(new GetTeam({ id })));
 
-      // select all local users, the users for this team, and the query status for both.
-      // when both queries are finished we'll find all users that are not yet a member of the team.
-      combineLatest([
-        this.store.select(allUsers),
-        this.store.select(userStatus),
-        this.store.select(teamUsers),
-        this.store.select(getTeamUsersStatus)])
-        .pipe(
-          map(([users, uStatus, tUsers, tStatus]:
-              [User[], EntityStatus, string[], EntityStatus]) => {
-            if (uStatus !== EntityStatus.loadingSuccess ||
-              tStatus !== EntityStatus.loadingSuccess) {
-              this.loading = true;
-              return [];
-            }
+    this.loading$ = combineLatest([
+      this.store.select(userStatus),
+      this.store.select(getTeamUsersStatus)]).pipe(
+        takeUntil(this.isDestroyed),
+        map((statuses: EntityStatus[]) => !statuses.every(status =>
+          status === EntityStatus.loadingSuccess)));
 
-            // Sort users naturally first by name, then by id
-            this.users = ChefSorters.naturalSort(users, ['name', 'id']);
+    // select all local users, the users for this team, and the query status for both.
+    // when both queries are finished we'll find all users that are not yet a member of the team.
+    combineLatest([
+      this.loading$,
+      this.store.select(allUsers),
+      this.store.select(teamUsers)])
+    .pipe(
+      takeUntil(this.isDestroyed),
+      filter(([loading, _users, _tUsers]) => !loading)
+    ).subscribe(([_loading, users, tUsers]) => {
+      // Sort users naturally first by name, then by id
+      this.users = ChefSorters.naturalSort(users, ['name', 'id']);
 
-            // Map UUID membership to user records and remove any entries that don't
-            // map to user records.
-            return at(tUsers, keyBy('membership_id', users))
-              .filter(userRecord => userRecord !== undefined);
-          }),
-          map((users: User[]) => {
-            this.mapOfUsersToFilter = userArrayToHash(users);
-            this.loading = false;
-          }),
-          takeUntil(this.isDestroyed)
-        ).subscribe();
- }
+      const membershipUsers = at(tUsers, keyBy('membership_id', users))
+        .filter(userRecord => userRecord !== undefined);
+
+      this.mapOfUsersToFilter = userArrayToHash(membershipUsers);
+    });
+  }
 
   ngOnDestroy() {
     this.isDestroyed.next(true);
@@ -206,21 +212,11 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
     }
   }
 
-  private getUsersForTeam(team: Team): void {
-    this.team = team;
-    this.store.dispatch(new GetTeamUsers({ id: this.teamId }));
-    this.store.dispatch(new GetUsers());
-  }
-
   closePage(): void {
     this.router.navigate(['/settings', 'teams', this.teamId]);
   }
 
   getErrorMessage(): string {
     return this.addUsersFailed.length > 0 ? this.addUsersFailed : undefined;
-  }
-
-  private get teamId(): string {
-    return this.isIAMv2 ? this.team.id : this.team.guid;
   }
 }

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.html
@@ -5,18 +5,18 @@
   <main>
     <chef-breadcrumbs>
       <chef-breadcrumb [link]="['/settings/teams']">Teams</chef-breadcrumb>
-      <span *ngIf="!isIAMv2">{{ team.id }}</span>
-      <span *ngIf="isIAMv2">{{ team.name }}</span>
+      <span *ngIf="!(isIAMv2$ | async)">{{ team.id }}</span>
+      <span *ngIf="isIAMv2$ | async">{{ team.name }}</span>
     </chef-breadcrumbs>
 
     <chef-page-header>
-      <chef-heading *ngIf="!isIAMv2">{{ team.id }}</chef-heading>
-      <chef-heading *ngIf="isIAMv2">{{ team.name }}</chef-heading>
+      <chef-heading *ngIf="!(isIAMv2$ | async)">{{ team.id }}</chef-heading>
+      <chef-heading *ngIf="isIAMv2$ | async">{{ team.name }}</chef-heading>
       <table>
         <thead>
           <tr class="detail-row">
-            <th *ngIf="!isIAMv2" class="id-column">Description</th>
-            <ng-container *ngIf="isIAMv2">
+            <th *ngIf="!(isIAMv2$ | async)" class="id-column">Description</th>
+            <ng-container *ngIf="isIAMv2$ | async">
               <th class="id-column">ID</th>
               <th class="projects-column">Projects</th>
             </ng-container>
@@ -24,8 +24,8 @@
         </thead>
         <tbody>
           <tr class="detail-row">
-            <td *ngIf="!isIAMv2" class="id-column">{{ team.name }}</td>
-            <ng-container *ngIf="isIAMv2">
+            <td *ngIf="!(isIAMv2$ | async)" class="id-column">{{ team.name }}</td>
+            <ng-container *ngIf="isIAMv2$ | async">
               <td class="id-column">{{ team.id }}</td>
               <td class="projects-column" data-cy="team-details-projects">
                 <ng-container *ngIf="team.projects.length === 0">
@@ -77,7 +77,7 @@
             {{ descriptionOrName | titlecase }} is required.
           </chef-error>
         </chef-form-field>
-        <div id='projects-container' *ngIf="isIAMv2">
+        <div id='projects-container' *ngIf="isIAMv2$ | async">
           <app-projects-dropdown
             [projects]="projects"
             (onProjectChecked)="onProjectChecked($event)"

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -3,7 +3,7 @@ import { FormBuilder, FormGroup, FormControl, Validators } from '@angular/forms'
 import { Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 import { isEmpty, identity, keyBy, at, xor } from 'lodash/fp';
-import { combineLatest, Subject } from 'rxjs';
+import { combineLatest, Subject, Observable } from 'rxjs';
 import { filter, map, takeUntil, distinctUntilChanged } from 'rxjs/operators';
 
 import { ChefSorters } from 'app/helpers/auth/sorter';
@@ -41,7 +41,7 @@ import {
   allProjects,
   getAllStatus as getAllProjectStatus
 } from 'app/entities/projects/project.selectors';
-import { ProjectConstants, Project } from 'app/entities/projects/project.model';
+import { ProjectConstants } from 'app/entities/projects/project.model';
 
 const TEAM_DETAILS_ROUTE = /^\/settings\/teams/;
 
@@ -69,7 +69,9 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   public addButtonText = 'Add User';
   public removeText = 'Remove User';
 
-  public isIAMv2: boolean;
+  public isIAMv2$: Observable<boolean>;
+  public teamId = '';
+  public descriptionOrName = '';
   public projects: ProjectCheckedMap = {};
   public unassigned = ProjectConstants.UNASSIGNED_PROJECT_ID;
 
@@ -94,15 +96,10 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     });
   }
 
-  private get teamId(): string {
-    return this.isIAMv2 ? this.team.id : this.team.guid;
-  }
-
-  public get descriptionOrName(): string {
-    return this.isIAMv2 ? 'name' : 'description';
-  }
-
   ngOnInit(): void {
+    this.store.dispatch(new GetUsers());
+
+    this.isIAMv2$ = this.store.select(isIAMv2);
     this.store.select(routeURL).pipe(takeUntil(this.isDestroyed))
       .subscribe((url: string) => {
         this.url = url;
@@ -110,12 +107,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
         // goes to #users if (1) explicit #users, (2) no fragment, or (3) invalid fragment
         this.tabValue = (fragment === 'details') ? 'details' : 'users';
       });
-    this.store.pipe(
-      select(isIAMv2),
-      takeUntil(this.isDestroyed))
-      .subscribe(latest => {
-        this.isIAMv2 = latest;
-    });
+
     combineLatest([
       this.store.select(getStatus),
       this.store.select(updateStatus),
@@ -134,37 +126,52 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
       }
     });
 
-    combineLatest([
+    const team$ = combineLatest([
+      this.isIAMv2$,
       this.store.select(v1TeamFromRoute),
       this.store.select(v2TeamFromRoute)
     ]).pipe(
       takeUntil(this.isDestroyed),
-      map(([v1Team, v2Team]: [Team, Team]) => {
-        return this.isIAMv2 ? v2Team : v1Team;
-      }),
-      filter(identity)
-    ).subscribe((team: Team) => {
-        this.team = team;
-        this.updateNameForm.controls.name.setValue(this.team.name);
-        this.store.dispatch(new GetTeamUsers({ id: this.teamId }));
-        this.store.dispatch(new GetUsers());
-      if (this.isIAMv2) {
-          this.store.dispatch(new GetProjects());
+      filter(([isV2, _v1TeamFromRoute, _v2TeamFromRoute]) => isV2 !== null),
+      map(([isV2, v1Team, v2Team]) => {
+        if (isV2) {
+          return v2Team;
+        } else {
+          return v1Team;
         }
-      });
+      }));
+
+    combineLatest([this.isIAMv2$, team$]).pipe(
+      takeUntil(this.isDestroyed),
+      filter(([_isV2, team]) => team !== undefined),
+      distinctUntilChanged(([isV2, team]) => isV2 === isV2 && team === team)
+    ).subscribe(([isV2, team]) => {
+      if (isV2) {
+        this.teamId = team.id;
+      } else {
+        this.teamId = team.guid;
+      }
+      this.team = team;
+      this.updateNameForm.controls.name.setValue(this.team.name);
+      this.store.dispatch(new GetTeamUsers({ id: this.teamId }));
+      if (isV2) {
+        this.store.dispatch(new GetProjects());
+      }
+    });
 
     combineLatest([
       this.store.select(allProjects),
-      this.store.select(getAllProjectStatus)
+      this.store.select(getAllProjectStatus),
+      team$
     ]).pipe(
       takeUntil(this.isDestroyed),
-      filter(([_, pStatus]: [Project[], EntityStatus]) => pStatus !== EntityStatus.loading),
-      filter(() => !!this.team)
-    ).subscribe(([allowedProjects, _]) => {
+      filter(([_, pStatus, _team]) =>
+      pStatus !== EntityStatus.loading)
+    ).subscribe(([allowedProjects, _, team]) => {
         this.projects = {};
         allowedProjects
           .forEach(p => {
-            this.projects[p.id] = { ...p, checked: this.team.projects.includes(p.id)
+            this.projects[p.id] = { ...p, checked: team.projects.includes(p.id)
             };
           });
       });
@@ -175,21 +182,18 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
       this.store.select(teamUsers),
       this.store.select(getUsersStatus)]).pipe(
         takeUntil(this.isDestroyed),
-        filter(([_allUsers, uStatus, _teamUsers, tuStatus]:
-          [User[], EntityStatus, string[], EntityStatus]) =>
+        filter(([_allUsers, uStatus, _teamUsers, tuStatus]) =>
             uStatus === EntityStatus.loadingSuccess &&
             tuStatus === EntityStatus.loadingSuccess),
-        filter(() => !!this.team),
         // Map UUID membership to user records and remove any entries that don't
         // map to user records.
-        map(([users, _uStatus, teamUserIds, _tuStatus]:
-          [User[], EntityStatus, string[], EntityStatus]) => {
+        map(([users, _uStatus, teamUserIds, _tuStatus]) => {
             return at(teamUserIds, keyBy('membership_id', users))
               .filter(userRecord => userRecord !== undefined);
-        })).subscribe((users: User[]) => {
-          // Sort naturally first by name, then by id
-          this.users = ChefSorters.naturalSort(users, ['name', 'id']);
-        });
+      })).subscribe((users: User[]) => {
+        // Sort naturally first by name, then by id
+        this.users = ChefSorters.naturalSort(users, ['name', 'id']);
+      });
 
     // If, however, the user browses directly to /settings/teams/ID, the store
     // will not contain the team data, so we fetch it.

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -131,7 +131,6 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
       this.store.select(v1TeamFromRoute),
       this.store.select(v2TeamFromRoute)
     ]).pipe(
-      takeUntil(this.isDestroyed),
       filter(([isV2, _v1TeamFromRoute, _v2TeamFromRoute]) => isV2 !== null),
       map(([isV2, v1Team, v2Team]) => {
         if (isV2) {

--- a/components/automate-ui/src/app/pages/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/pages/team-details/team-details.component.ts
@@ -8,7 +8,7 @@ import { filter, map, takeUntil, distinctUntilChanged } from 'rxjs/operators';
 
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { routeParams, routeURL } from 'app/route.selectors';
+import { routeURL, routeState } from 'app/route.selectors';
 import { EntityStatus, loading } from 'app/entities/entities';
 import { User } from 'app/entities/users/user.model';
 import { Regex } from 'app/helpers/auth/regex';
@@ -199,12 +199,9 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     // TODO: This also fires when teamFromRoute fires; should inhibit that since
     // we already have the team details, as noted above.
     // Triggered every time the route changes (including on initial load).
-    combineLatest([
-      this.store.select(routeParams),
-      this.store.select(routeURL)
-    ]).pipe(
+    this.store.select(routeState).pipe(
       takeUntil(this.isDestroyed),
-      map(([params, url]) => [params.id as string, url]),
+      map(state => [state.params.id as string, state.url]),
       // Only fetch if we are on the team details route, otherwise
       // we'll trigger GetTeam with the wrong input on any route
       // away to a page that also uses the :id param.

--- a/components/automate-ui/src/app/route.selectors.ts
+++ b/components/automate-ui/src/app/route.selectors.ts
@@ -2,19 +2,24 @@ import { createSelector, createFeatureSelector } from '@ngrx/store';
 
 import { RouterReducerState } from './ngrx.reducers';
 
-export const routerState = createFeatureSelector<RouterReducerState>('router');
+export const routerReducerState = createFeatureSelector<RouterReducerState>('router');
 
 export const routeParams = createSelector(
-  routerState,
+  routerReducerState,
   ({state}) => state.params
 );
 
 export const previousRoute = createSelector(
-  routerState,
+  routerReducerState,
   (state) => state.previousRoute
 );
 
 export const routeURL = createSelector(
-  routerState,
+  routerReducerState,
   ({state}) => state.url
+);
+
+export const routeState = createSelector(
+  routerReducerState,
+  ({state}) => state
 );


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Removing duplicate API requests from the policy and team pages. When loading the pages the observable subscribe functions were being called multiple times for with the same data. This caused the page's data to be requested each time.

### :chains: Related Resources

#2104

### :+1: Definition of Done
All of the auth pages do not perform multiple requests for page data. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui && start_all_services`
1. Open the Teams detail page for the admin https://a2-dev.test/settings/teams/admins
1. Open the Chrome inspect tool then select the network tab. 
1. Ensure each API request is only called once.
1. Do the same thing for the team add user page, policy details page, and policy add member page. 

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable