### PR TITLE
[automate-2105] Replace Stencil table with Angular table in tok…

### DIFF
--- a/components/automate-ui/src/app/components/chef-components.module.ts
+++ b/components/automate-ui/src/app/components/chef-components.module.ts
@@ -1,4 +1,5 @@
 // Modules
+import { ChefPipesModule } from '../pipes/chef-pipes.module';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
@@ -7,7 +8,6 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 // Components
-import { SettingsSidebarComponent } from './settings-sidebar/settings-sidebar.component';
 import { AuthorizedComponent } from './authorized/authorized.component';
 import { BreadcrumbsComponent } from './breadcrumbs/breadcrumbs.component';
 import { BreadcrumbComponent } from './breadcrumb/breadcrumb.component';
@@ -33,20 +33,26 @@ import { InputDirective } from './input/input.directive';
 import { LandingComponent } from './landing/landing.component';
 import { PagePickerComponent } from './page-picker/page-picker.component';
 import { ProjectsDropdownComponent } from './projects-dropdown/projects-dropdown.component';
+import { SettingsSidebarComponent } from './settings-sidebar/settings-sidebar.component';
 import { SidebarComponent } from './sidebar/sidebar.component';
 import { SidebarNoShadeComponent } from './sidebar-no-shade/sidebar-no-shade.component';
 import { SidebarEntryComponent } from './sidebar-entry/sidebar-entry.component';
 import { TabComponent } from './tab/tab.component';
 import { TabsComponent } from './tabs/tabs.component';
-import { ChefPipesModule } from '../pipes/chef-pipes.module';
+import { TableBodyComponent } from './table/table-body/table-body.component';
+import { TableComponent } from './table/table.component';
+import { TableCellComponent } from './table/table-cell/table-cell.component';
+import { TableRowComponent } from './table/table-row/table-row.component';
+import { TableHeaderCellComponent } from './table/table-header-cell/table-header-cell.component';
+import { TableHeaderComponent } from './table/table-header/table-header.component';
 
 @NgModule({
   imports: [
+    ChefPipesModule,
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
     RouterModule,
-    ChefPipesModule,
 
     // Angular Material
     MatDialogModule,
@@ -58,7 +64,6 @@ import { ChefPipesModule } from '../pipes/chef-pipes.module';
     MatSnackBarModule,
 
     // Components
-    SettingsSidebarComponent,
     AuthorizedComponent,
     BreadcrumbsComponent,
     BreadcrumbComponent,
@@ -73,11 +78,18 @@ import { ChefPipesModule } from '../pipes/chef-pipes.module';
     LandingComponent,
     PagePickerComponent,
     ProjectsDropdownComponent,
+    SettingsSidebarComponent,
     SidebarComponent,
     SidebarNoShadeComponent,
     SidebarEntryComponent,
     TabComponent,
     TabsComponent,
+    TableBodyComponent,
+    TableComponent,
+    TableCellComponent,
+    TableRowComponent,
+    TableHeaderCellComponent,
+    TableHeaderComponent,
 
     // Directives
     ErrorDirective,
@@ -85,7 +97,6 @@ import { ChefPipesModule } from '../pipes/chef-pipes.module';
     InputDirective
   ],
   declarations: [
-    SettingsSidebarComponent,
     AuthorizedComponent,
     BreadcrumbsComponent,
     BreadcrumbComponent,
@@ -103,11 +114,18 @@ import { ChefPipesModule } from '../pipes/chef-pipes.module';
     LandingComponent,
     PagePickerComponent,
     ProjectsDropdownComponent,
+    SettingsSidebarComponent,
     SidebarComponent,
     SidebarNoShadeComponent,
     SidebarEntryComponent,
     TabComponent,
-    TabsComponent
+    TabsComponent,
+    TableBodyComponent,
+    TableComponent,
+    TableCellComponent,
+    TableRowComponent,
+    TableHeaderCellComponent,
+    TableHeaderComponent
   ],
   schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
 })

--- a/components/automate-ui/src/app/components/table/table-body/table-body.component.html
+++ b/components/automate-ui/src/app/components/table/table-body/table-body.component.html
@@ -1,0 +1,3 @@
+<tr>
+  <ng-content select="chef-table-row"></ng-content>
+</tr>

--- a/components/automate-ui/src/app/components/table/table-body/table-body.component.html
+++ b/components/automate-ui/src/app/components/table/table-body/table-body.component.html
@@ -1,3 +1,1 @@
-<tr>
-  <ng-content select="chef-table-row"></ng-content>
-</tr>
+<ng-content select="chef-table-row"></ng-content>

--- a/components/automate-ui/src/app/components/table/table-body/table-body.component.scss
+++ b/components/automate-ui/src/app/components/table/table-body/table-body.component.scss
@@ -1,0 +1,5 @@
+@import '../table.component';
+
+:host {
+  display: table-row-group;
+}

--- a/components/automate-ui/src/app/components/table/table-body/table-body.component.spec.ts
+++ b/components/automate-ui/src/app/components/table/table-body/table-body.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TableBodyComponent } from './table-body.component';
+
+describe('TableBodyComponent', () => {
+  let component: TableBodyComponent;
+  let fixture: ComponentFixture<TableBodyComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TableBodyComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TableBodyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/components/table/table-body/table-body.component.ts
+++ b/components/automate-ui/src/app/components/table/table-body/table-body.component.ts
@@ -1,15 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 
 @Component({
   selector: 'chef-table-body',
   templateUrl: './table-body.component.html',
   styleUrls: ['./table-body.component.scss']
 })
-export class TableBodyComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+export class TableBodyComponent {
+  @HostBinding('attr.role') role = 'rowgroup';
 }

--- a/components/automate-ui/src/app/components/table/table-body/table-body.component.ts
+++ b/components/automate-ui/src/app/components/table/table-body/table-body.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'chef-table-body',
+  templateUrl: './table-body.component.html',
+  styleUrls: ['./table-body.component.scss']
+})
+export class TableBodyComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/components/automate-ui/src/app/components/table/table-cell/table-cell.component.html
+++ b/components/automate-ui/src/app/components/table/table-cell/table-cell.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/components/automate-ui/src/app/components/table/table-cell/table-cell.component.scss
+++ b/components/automate-ui/src/app/components/table/table-cell/table-cell.component.scss
@@ -1,0 +1,21 @@
+@import '../table.component';
+
+:host {
+  display: table-cell;
+  padding: $size_16;
+  vertical-align: middle;
+  text-align: left;
+  font-size: 14px;
+  border-bottom: 1px solid $chef-light-grey;
+  border-top: 1px solid $chef-light-grey;
+}
+
+:host:first-child {
+  border-left: 1px solid $chef-light-grey;
+  border-radius: $global-radius 0 0 $global-radius;
+}
+
+:host:last-child {
+  border-right: 1px solid $chef-light-grey;
+  border-radius: 0 $global-radius $global-radius 0;
+}

--- a/components/automate-ui/src/app/components/table/table-cell/table-cell.component.scss
+++ b/components/automate-ui/src/app/components/table/table-cell/table-cell.component.scss
@@ -6,16 +6,16 @@
   vertical-align: middle;
   text-align: left;
   font-size: 14px;
-  border-bottom: 1px solid $chef-light-grey;
-  border-top: 1px solid $chef-light-grey;
+  border-bottom: 1px solid $chef-grey;
+  border-top: 1px solid $chef-grey;
 }
 
 :host:first-child {
-  border-left: 1px solid $chef-light-grey;
+  border-left: 1px solid $chef-grey;
   border-radius: $global-radius 0 0 $global-radius;
 }
 
 :host:last-child {
-  border-right: 1px solid $chef-light-grey;
+  border-right: 1px solid $chef-grey;
   border-radius: 0 $global-radius $global-radius 0;
 }

--- a/components/automate-ui/src/app/components/table/table-cell/table-cell.component.spec.ts
+++ b/components/automate-ui/src/app/components/table/table-cell/table-cell.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TableCellComponent } from './table-cell.component';
+
+describe('TableCellComponent', () => {
+  let component: TableCellComponent;
+  let fixture: ComponentFixture<TableCellComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TableCellComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TableCellComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/components/table/table-cell/table-cell.component.ts
+++ b/components/automate-ui/src/app/components/table/table-cell/table-cell.component.ts
@@ -1,0 +1,10 @@
+import { Component, HostBinding } from '@angular/core';
+
+@Component({
+  selector: 'chef-table-cell',
+  templateUrl: './table-cell.component.html',
+  styleUrls: ['./table-cell.component.scss']
+})
+export class TableCellComponent {
+  @HostBinding('attr.role') role = 'cell';
+}

--- a/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.html
+++ b/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.html
@@ -1,0 +1,2 @@
+<ng-content></ng-content>
+

--- a/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.scss
+++ b/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.scss
@@ -6,7 +6,7 @@
   vertical-align: middle;
   text-align: left;
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 700;
   background-color: $chef-lightest-grey;
   border-bottom: 1px solid $chef-light-grey;
   border-top: 1px solid $chef-light-grey;

--- a/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.scss
+++ b/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.scss
@@ -1,0 +1,23 @@
+@import '../table.component';
+
+:host {
+  display: table-cell;
+  padding: $size_16;
+  vertical-align: middle;
+  text-align: left;
+  font-size: 14px;
+  font-weight: 500;
+  background-color: $chef-lightest-grey;
+  border-bottom: 1px solid $chef-light-grey;
+  border-top: 1px solid $chef-light-grey;
+}
+
+:host:first-child {
+  border-left: 1px solid $chef-light-grey;
+  border-radius: $global-radius 0 0 $global-radius;
+}
+
+:host:last-child {
+  border-right: 1px solid $chef-light-grey;
+  border-radius: 0 $global-radius $global-radius 0;
+}

--- a/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.scss
+++ b/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.scss
@@ -8,16 +8,16 @@
   font-size: 14px;
   font-weight: 700;
   background-color: $chef-lightest-grey;
-  border-bottom: 1px solid $chef-light-grey;
-  border-top: 1px solid $chef-light-grey;
+  border-bottom: 1px solid $chef-grey;
+  border-top: 1px solid $chef-grey;
 }
 
 :host:first-child {
-  border-left: 1px solid $chef-light-grey;
+  border-left: 1px solid $chef-grey;
   border-radius: $global-radius 0 0 $global-radius;
 }
 
 :host:last-child {
-  border-right: 1px solid $chef-light-grey;
+  border-right: 1px solid $chef-grey;
   border-radius: 0 $global-radius $global-radius 0;
 }

--- a/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.spec.ts
+++ b/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TableHeaderCellComponent } from './table-header-cell.component';
+
+describe('TableHeaderCellComponent', () => {
+  let component: TableHeaderCellComponent;
+  let fixture: ComponentFixture<TableHeaderCellComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TableHeaderCellComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TableHeaderCellComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.ts
+++ b/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.ts
@@ -6,5 +6,5 @@ import { Component, HostBinding } from '@angular/core';
   styleUrls: ['./table-header-cell.component.scss']
 })
 export class TableHeaderCellComponent {
-  @HostBinding('attr.role') role = 'rowheader';
+  @HostBinding('attr.role') role = 'columnheader';
 }

--- a/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.ts
+++ b/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.ts
@@ -1,0 +1,10 @@
+import { Component, HostBinding } from '@angular/core';
+
+@Component({
+  selector: 'chef-table-header-cell',
+  templateUrl: './table-header-cell.component.html',
+  styleUrls: ['./table-header-cell.component.scss']
+})
+export class TableHeaderCellComponent {
+  @HostBinding('attr.role') role = 'rowheader';
+}

--- a/components/automate-ui/src/app/components/table/table-header/table-header.component.html
+++ b/components/automate-ui/src/app/components/table/table-header/table-header.component.html
@@ -1,0 +1,3 @@
+<tr>
+  <ng-content select="chef-table-row"></ng-content>
+</tr>

--- a/components/automate-ui/src/app/components/table/table-header/table-header.component.html
+++ b/components/automate-ui/src/app/components/table/table-header/table-header.component.html
@@ -1,3 +1,1 @@
-<tr>
-  <ng-content select="chef-table-row"></ng-content>
-</tr>
+<ng-content select="chef-table-row"></ng-content>

--- a/components/automate-ui/src/app/components/table/table-header/table-header.component.scss
+++ b/components/automate-ui/src/app/components/table/table-header/table-header.component.scss
@@ -2,9 +2,4 @@
 
 :host {
   display: table-header-group;
-
-  & > tr {
-    background-color: $chef-lightest-grey;
-    box-shadow: 0 0 $size_16 0 $chef-light-grey;
-  }
 }

--- a/components/automate-ui/src/app/components/table/table-header/table-header.component.scss
+++ b/components/automate-ui/src/app/components/table/table-header/table-header.component.scss
@@ -1,0 +1,10 @@
+@import '../table.component';
+
+:host {
+  display: table-header-group;
+
+  & > tr {
+    background-color: $chef-lightest-grey;
+    box-shadow: 0 0 $size_16 0 $chef-light-grey;
+  }
+}

--- a/components/automate-ui/src/app/components/table/table-header/table-header.component.spec.ts
+++ b/components/automate-ui/src/app/components/table/table-header/table-header.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TableHeaderComponent } from './table-header.component';
+
+describe('TableHeaderComponent', () => {
+  let component: TableHeaderComponent;
+  let fixture: ComponentFixture<TableHeaderComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TableHeaderComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TableHeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/components/table/table-header/table-header.component.ts
+++ b/components/automate-ui/src/app/components/table/table-header/table-header.component.ts
@@ -1,0 +1,10 @@
+import { Component, HostBinding } from '@angular/core';
+
+@Component({
+  selector: 'chef-table-header',
+  templateUrl: './table-header.component.html',
+  styleUrls: ['./table-header.component.scss']
+})
+export class TableHeaderComponent {
+  @HostBinding('attr.role') role = 'rowgroup';
+}

--- a/components/automate-ui/src/app/components/table/table-row/table-row.component.html
+++ b/components/automate-ui/src/app/components/table/table-row/table-row.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/components/automate-ui/src/app/components/table/table-row/table-row.component.scss
+++ b/components/automate-ui/src/app/components/table/table-row/table-row.component.scss
@@ -1,0 +1,8 @@
+@import '../table.component';
+
+:host {
+  display: table-row;
+  padding: $size_16;
+  background-color: $white;
+  box-shadow: 0 0 $size_16 0 $chef-light-grey;
+}

--- a/components/automate-ui/src/app/components/table/table-row/table-row.component.scss
+++ b/components/automate-ui/src/app/components/table/table-row/table-row.component.scss
@@ -4,5 +4,4 @@
   display: table-row;
   padding: $size_16;
   background-color: $white;
-  box-shadow: 0 0 $size_16 0 $chef-light-grey;
 }

--- a/components/automate-ui/src/app/components/table/table-row/table-row.component.spec.ts
+++ b/components/automate-ui/src/app/components/table/table-row/table-row.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TableRowComponent } from './table-row.component';
+
+describe('TableRowComponent', () => {
+  let component: TableRowComponent;
+  let fixture: ComponentFixture<TableRowComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TableRowComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TableRowComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/components/table/table-row/table-row.component.ts
+++ b/components/automate-ui/src/app/components/table/table-row/table-row.component.ts
@@ -6,5 +6,5 @@ import { Component, HostBinding } from '@angular/core';
   styleUrls: ['./table-row.component.scss']
 })
 export class TableRowComponent {
-  @HostBinding('attr.role') role = 'rowgroup';
+  @HostBinding('attr.role') role = 'row';
 }

--- a/components/automate-ui/src/app/components/table/table-row/table-row.component.ts
+++ b/components/automate-ui/src/app/components/table/table-row/table-row.component.ts
@@ -1,0 +1,10 @@
+import { Component, HostBinding } from '@angular/core';
+
+@Component({
+  selector: 'chef-table-row',
+  templateUrl: './table-row.component.html',
+  styleUrls: ['./table-row.component.scss']
+})
+export class TableRowComponent {
+  @HostBinding('attr.role') role = 'rowgroup';
+}

--- a/components/automate-ui/src/app/components/table/table.component.html
+++ b/components/automate-ui/src/app/components/table/table.component.html
@@ -1,0 +1,2 @@
+<ng-content select="chef-table-header"></ng-content>
+<ng-content select="chef-table-body"></ng-content>

--- a/components/automate-ui/src/app/components/table/table.component.scss
+++ b/components/automate-ui/src/app/components/table/table.component.scss
@@ -1,0 +1,9 @@
+@import "~styles/variables";
+
+:host {
+  display: table;
+  table-layout: fixed;
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0 8px;
+}

--- a/components/automate-ui/src/app/components/table/table.component.spec.ts
+++ b/components/automate-ui/src/app/components/table/table.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TableComponent } from './table.component';
+
+describe('TableComponent', () => {
+  let component: TableComponent;
+  let fixture: ComponentFixture<TableComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TableComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/components/table/table.component.ts
+++ b/components/automate-ui/src/app/components/table/table.component.ts
@@ -1,0 +1,10 @@
+import { Component, HostBinding } from '@angular/core';
+
+@Component({
+  selector: 'chef-table-new',
+  templateUrl: './table.component.html',
+  styleUrls: ['./table.component.scss']
+})
+export class TableComponent {
+  @HostBinding('attr.role') role = 'table';
+}

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html
@@ -41,34 +41,34 @@
         </app-authorized>
       </chef-toolbar>
       <app-authorized [anyOf]="[['/iam/v2beta/tokens', 'get'], ['/auth/tokens', 'get']]">
-        <chef-table *ngIf="(apiTokenCount$ | async) > 0">
-          <chef-thead>
-            <chef-tr>
-              <chef-th>Name</chef-th>
-              <chef-th *ngIf="isIAMv2$ | async">ID</chef-th>
-              <chef-th *ngIf="isIAMv2$ | async">Projects</chef-th>
-              <chef-th>Created Date</chef-th>
-              <chef-th>Status</chef-th>
-              <chef-th class="controls"></chef-th>
-            </chef-tr>
-          </chef-thead>
-          <chef-tbody>
-            <chef-tr *ngFor="let token of sortedApiTokens$ | async">
-              <chef-td>
+        <chef-table-new *ngIf="(apiTokenCount$ | async) > 0">
+          <chef-table-header>
+            <chef-table-row>
+              <chef-table-header-cell>Name</chef-table-header-cell>
+              <chef-table-header-cell *ngIf="isIAMv2$ | async">ID</chef-table-header-cell>
+              <chef-table-header-cell *ngIf="isIAMv2$ | async">Projects</chef-table-header-cell>
+              <chef-table-header-cell>Created Date</chef-table-header-cell>
+              <chef-table-header-cell>Status</chef-table-header-cell>
+              <chef-table-header-cell class="controls"></chef-table-header-cell>
+            </chef-table-row>
+          </chef-table-header>
+          <chef-table-body>
+            <chef-table-row *ngFor="let token of sortedApiTokens$ | async">
+              <chef-table-cell>
                 <a [routerLink]="['/settings/tokens', token.id]">{{ token.name }}</a>
-              </chef-td>
-              <chef-td *ngIf="isIAMv2$ | async">{{ token.id }}</chef-td>
-              <chef-td *ngIf="isIAMv2$ | async" class="projects-column">
+              </chef-table-cell>
+              <chef-table-cell *ngIf="isIAMv2$ | async">{{ token.id }}</chef-table-cell>
+              <chef-table-cell *ngIf="isIAMv2$ | async" class="projects-column">
                 <span *ngIf="token.projects.length === 0">{{ unassigned }}</span>
                 <span *ngIf="token.projects.length === 1">{{ token.projects[0] }}</span>
                 <span *ngIf="token.projects.length > 1">{{ token.projects.length }} projects</span>
-              </chef-td>
-              <chef-td>{{ token.created_at | datetime: RFC2822 }}</chef-td>
-              <chef-td>
+              </chef-table-cell>
+              <chef-table-cell>{{ token.created_at | datetime: RFC2822 }}</chef-table-cell>
+              <chef-table-cell>
                 <ng-container *ngIf="token.active">Active</ng-container>
                 <ng-container *ngIf="!token.active">Inactive</ng-container>
-              </chef-td>
-              <chef-td class="controls">
+              </chef-table-cell>
+              <chef-table-cell class="controls">
                 <chef-control-menu id="menu-{{token.id}}" data-cy="token-control">
                   <chef-option (click)="notifyCopy()" data-cy="copy-token">
                     <chef-clipboard plain value={{token.value}} label="Copy Token" icon=""></chef-clipboard>
@@ -76,10 +76,10 @@
                   <chef-option (click)="toggleActive(token)">Toggle Status</chef-option>
                   <chef-option (click)="startTokenDelete(token)" data-cy="delete">Delete Token</chef-option>
                 </chef-control-menu>
-              </chef-td>
-           </chef-tr>
-          </chef-tbody>
-        </chef-table>
+             </chef-table-cell>
+            </chef-table-row>
+          </chef-table-body>
+        </chef-table-new>
       </app-authorized>
     </div>
   </main>

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.scss
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.scss
@@ -1,9 +1,7 @@
 @import "~styles/variables";
 
-chef-table {
-  .controls {
-    justify-content: flex-end;
-  }
+.controls {
+  text-align: right;
 }
 
 .empty-state {

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.scss
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.scss
@@ -4,6 +4,10 @@
   text-align: right;
 }
 
+#create-button {
+  margin: 0;
+}
+
 .empty-state {
   text-align: center;
 

--- a/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/api-token/list/api-token-list.component.spec.ts
@@ -59,7 +59,13 @@ describe('ApiTokenListComponent', () => {
         MockComponent({ selector: 'chef-tbody' }),
         MockComponent({ selector: 'chef-tr' }),
         MockComponent({ selector: 'chef-th' }),
-        MockComponent({ selector: 'chef-td' })
+        MockComponent({ selector: 'chef-td' }),
+        MockComponent({ selector: 'chef-table-new' }),
+        MockComponent({ selector: 'chef-table-header' }),
+        MockComponent({ selector: 'chef-table-body' }),
+        MockComponent({ selector: 'chef-table-row' }),
+        MockComponent({ selector: 'chef-table-header-cell' }),
+        MockComponent({ selector: 'chef-table-cell' })
       ]
     })
     .compileComponents();

--- a/e2e/cypress/integration/ui/settings/06_token_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/06_token_mgmt.spec.ts
@@ -10,7 +10,7 @@ describe('token management', () => {
   const tokenID1 = `${cypressPrefix}-id-1-${now}`;
   const tokenID2 = `${cypressPrefix}-id-2-${now}`;
   const tokenID3 = `${cypressPrefix}-token-3-${now}`;
-  const tokensTable = 'app-api-tokens chef-table';
+  const tokensTable = 'app-api-tokens chef-table-new';
 
   before(() => {
     cy.adminLogin('/settings/tokens').then(() => {
@@ -68,18 +68,18 @@ describe('token management', () => {
   });
 
   it('displays the returned tokens info', () => {
-    cy.get(`${tokensTable} chef-td`).contains(tokenName1);
-    cy.get(`${tokensTable} chef-td`).contains(tokenName2);
+    cy.get(`${tokensTable} chef-table-cell`).contains(tokenName1);
+    cy.get(`${tokensTable} chef-table-cell`).contains(tokenName2);
 
-    cy.get('chef-table chef-td').contains(tokenName1).parent()
-      .get('chef-td').contains('Active');
-    cy.get('chef-table chef-td').contains(tokenName2).parent()
-      .get('chef-td').contains('Inactive');
+    cy.get('chef-table-new chef-table-cell').contains(tokenName1).parent()
+      .get('chef-table-cell').contains('Active');
+    cy.get('chef-table-new chef-table-cell').contains(tokenName2).parent()
+      .get('chef-table-cell').contains('Inactive');
   });
 
   it('control menu has all options', () => {
     ['Copy Token', 'Toggle Status', 'Delete Token'].forEach((item, _) => {
-      cy.get('chef-tbody').contains(tokenName1).parent().parent()
+      cy.get('chef-table-body').contains(tokenName1).parent().parent()
         .find('[data-cy=token-control]').as('controlMenu');
       cy.get('@controlMenu').should('be.visible').click({ force: true });
       cy.get('@controlMenu').contains(item);
@@ -87,7 +87,7 @@ describe('token management', () => {
   });
 
   it('can copy token', () => {
-    cy.get('chef-tbody').contains(tokenName1).parent().parent()
+    cy.get('chef-table-body').contains(tokenName1).parent().parent()
     .find('[data-cy=token-control]').as('controlMenu');
     cy.get('@controlMenu').should('be.visible')
       .click({ force: true }).then(() =>
@@ -99,13 +99,13 @@ describe('token management', () => {
   });
 
   it('can delete token', () => {
-    cy.get('chef-tbody').contains(tokenName1).parent().parent()
+    cy.get('chef-table-body').contains(tokenName1).parent().parent()
       .find('[data-cy=token-control]').as('controlMenu');
     cy.get('@controlMenu').should('be.visible').click();
     cy.get('@controlMenu').find('[data-cy=delete]').click({ force: true });
     cy.get('app-delete-object-modal').find('button').contains('Delete Token')
       .click({force: true});
-    cy.get('chef-tbody').contains(tokenName1).should('not.exist');
+    cy.get('chef-table-body').contains(tokenName1).should('not.exist');
   });
 
   it('can create a new token', () => {
@@ -127,7 +127,7 @@ describe('token management', () => {
   });
 
   it('opens token details', () => {
-    cy.get('chef-tbody').contains(tokenName2).click();
+    cy.get('chef-table-body').contains(tokenName2).click();
     cy.url().should('include', `/settings/tokens/${tokenID2}`);
     cy.contains(tokenName2).should('exist');
     cy.get('h1.page-title').contains(tokenName2);


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This is the first step of replacing the StencilJS table component -- `<chef-table>`, aka chef-table.tsx -- with an equivalent Angular component. Ultimately this new Angular component will also be called `<chef-table>` but for the interim -- which should be on the order of a couple weeks -- it is `<chef-table-new>`, as introduced in this PR.

Just as that top-level `<chef-table>` element is temporarily renamed--while the StencilJS and the Angular components co-exist--so are the child elements:

StencilJS  | Angular
-----------|--------
chef-table | chef-table-new
chef-thead | chef-table-header
chef-tbody | chef-table-body
chef-tr    | chef-table-row
chef-th    | chef-table-header-cell
chef-td    | chef-table-cell

We (the Auth team) felt a need to get the token table patched quickly because the rendering is unacceptably slow once you have over 500 or so tokens. At 1000 tokens, for example, it takes 20 to 30 seconds, so it looks like the application has frozen. Coordinating with the UI team, they will manage the changeover to this new Angular component for all other places it is used, confirming that there are no idiosyncrasies popping up.

Here is the outline of that process:
1. Remove the StencilJS component and rebuild the chef-ui-lib.
2. Rename the six Angular elements above back to the names used by StencilJS, which means just update the `selector` decorator in each of those 6 component files--neither the file nor class names need change.
3. Revert the tag names in `components/automate-ui/src/app/pages/api-token/list/api-token-list.component.html`. 
4. Revert the corresponding changes to the test file `e2e/cypress/integration/ui/settings/06_token_mgmt.spec.ts`.
4. All other pages in the application should then just work; each should be reviewed in the running app for any idiosyncrasies.

Note that the control menu (the ellipsis at the end of each row) is still using a StencilJS component, so that is still experiencing the dramatic rendering delay. Work is currently underway to replace that with an Angular component so that will be taken care of very soon.

What changed? Timing diagram 1 shows the "before" -- both table and control menus appeared an interminably long time after the spinner went away.
Diagrams 2 and 3 show "after"--there is a slight difference between a page refresh (where the browser cache is empty) vs. just navigating back to the table once seen before in the data/spinner behavior, but both are quite acceptable. Note that long tail showing that the control menu still lags, though.

![image](https://user-images.githubusercontent.com/6817500/68415380-18e22100-0147-11ea-8e81-35d7426cc9b0.png)

Finally, here is the what the token list looks like with the StencilJS component (before) and the Angular component (after):
![image](https://user-images.githubusercontent.com/6817500/68412083-7cb51b80-0140-11ea-972d-18e6e7fd2a49.png)


### :chains: Related Resources
NA

### :+1: Definition of Done
Token table looks just as it did before.

### :athletic_shoe: How to Build and Test the Change

1. Rebuild angular-ui
2. Load lots of tokens. (The example command here will generate 1000 tokens with indicies in the range 1001 to 2000.)
```
. scripts/auth_collections.sh
export TOK=your-admin-token-here
export TARGET_HOST=https://a2-dev.test
authGen tokens create 1000 1001
```
