### PR TITLE
Add instructions for creating and restoring airgapped offline backups

### DIFF
--- a/components/automate-chef-io/content/docs/backup.md
+++ b/components/automate-chef-io/content/docs/backup.md
@@ -131,7 +131,12 @@ Success: Created backup 20180518010336
 
 ## Storing Backups in a Single-file Archive for Airgapped Installations
 
-The backup directory (`/var/opt/chef-automate/backups` by default) contains both the timestamp-based directory (ie. `20180518010336`) for the configuration and the reporting data stored in the `automate-elasticsearch-data` directory. You will need to archive both of these in any offline backups you create.
+The backup directory contains both the timestamp-based directory for the configuration, and the reporting data stored in the `automate-elasticsearch-data` directory. 
+You will need to archive both of these directory types in any offline backups you create.
+
+By default, the backup directory will be located at `/var/opt/chef-automate/backups`. 
+A timestamp-based directory can be distinguished from the `automate-elasticsearch-data` directory by its file name format, such as `20180518010336`.
+
 
 ## Listing Backups
 
@@ -187,7 +192,7 @@ If backups are stored in S3:
 chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID
 ```
 
-To restore a backup of an [airgapped installation]({{< relref "airgapped-installation.md" >}}), you must extract your single-file backup archive into the default backup directory (`/var/opt/chef-automate/backups`) and specify the [Airgap Installation Bundle]({{< relref "airgapped-installation.md#create-an-airgap-installation-bundle" >}}) the installation is using:
+To restore a backup of an [airgapped installation]({{< relref "airgapped-installation.md" >}}), you must extract your single-file backup archive into the default backup directory of `/var/opt/chef-automate/backups`, and specify the [Airgap Installation Bundle]({{< relref "airgapped-installation.md#create-an-airgap-installation-bundle" >}}) being used by the installation:
 
 ```shell
 chef-automate backup restore --airgap-bundle </path/to/bundle> /var/opt/chef-automate/backups/BACKUP_ID

--- a/components/automate-chef-io/content/docs/backup.md
+++ b/components/automate-chef-io/content/docs/backup.md
@@ -129,6 +129,10 @@ The command will show the backup progress for each service. If the backup is suc
 Success: Created backup 20180518010336
 ```
 
+## Storing Backups Offline for Airgapped Installations
+
+The backup directory (`/var/opt/chef-automate/backups` by default) contains both the timestamp-based directory (ie. `20180518010336`) for the configuration and the reporting data stored in the `automate-elasticsearch-data` directory. You will need to archive both of these in any offline backups you create.
+
 ## Listing Backups
 
 You can list existing backups with the `backup list` command:
@@ -183,10 +187,10 @@ If backups are stored in S3:
 chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID
 ```
 
-To restore a backup of an [airgapped installation]({{< relref "airgapped-installation.md" >}}), you must specify the [Airgap Installation Bundle]({{< relref "airgapped-installation.md#create-an-airgap-installation-bundle" >}}) the installation is using:
+To restore a backup of an [airgapped installation]({{< relref "airgapped-installation.md" >}}), you must extract your backup archive into the default backup directory (`/var/opt/chef-automate/backups`) and specify the [Airgap Installation Bundle]({{< relref "airgapped-installation.md#create-an-airgap-installation-bundle" >}}) the installation is using:
 
 ```shell
-chef-automate backup restore /path/to/backups/BACKUP_ID --airgap-bundle </path/to/bundle>
+chef-automate backup restore --airgap-bundle </path/to/bundle> /var/opt/chef-automate/backups/BACKUP_ID
 ```
 
 If the restore is successful, you will see the following message at the end of the status output:

--- a/components/automate-chef-io/content/docs/backup.md
+++ b/components/automate-chef-io/content/docs/backup.md
@@ -129,7 +129,7 @@ The command will show the backup progress for each service. If the backup is suc
 Success: Created backup 20180518010336
 ```
 
-## Storing Backups Offline for Airgapped Installations
+## Storing Backups in a Single-file Archive for Airgapped Installations
 
 The backup directory (`/var/opt/chef-automate/backups` by default) contains both the timestamp-based directory (ie. `20180518010336`) for the configuration and the reporting data stored in the `automate-elasticsearch-data` directory. You will need to archive both of these in any offline backups you create.
 
@@ -187,7 +187,7 @@ If backups are stored in S3:
 chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID
 ```
 
-To restore a backup of an [airgapped installation]({{< relref "airgapped-installation.md" >}}), you must extract your backup archive into the default backup directory (`/var/opt/chef-automate/backups`) and specify the [Airgap Installation Bundle]({{< relref "airgapped-installation.md#create-an-airgap-installation-bundle" >}}) the installation is using:
+To restore a backup of an [airgapped installation]({{< relref "airgapped-installation.md" >}}), you must extract your single-file backup archive into the default backup directory (`/var/opt/chef-automate/backups`) and specify the [Airgap Installation Bundle]({{< relref "airgapped-installation.md#create-an-airgap-installation-bundle" >}}) the installation is using:
 
 ```shell
 chef-automate backup restore --airgap-bundle </path/to/bundle> /var/opt/chef-automate/backups/BACKUP_ID


### PR DESCRIPTION
The instructions did not include what to backup if you're not using S3
and the 'automate-elasticsearch-data' was a crucial component. Restoring
appears to currently require being in the default backup directory.

Signed-off-by: Matt Ray <matthewhray@gmail.com>

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [x] Docs added/updated?

### :camera: Screenshots, if applicable