### PR TITLE
[AUTOMATE-2138] Always refetch latest data in UI for projects, policies, and roles

### DIFF
--- a/components/automate-ui/src/app/entities/entities.ts
+++ b/components/automate-ui/src/app/entities/entities.ts
@@ -45,3 +45,8 @@ export function loading(status: EntityStatus): boolean {
 export function allLoadedSuccessfully(statuses: EntityStatus[]): boolean {
   return statuses.every(status => status === EntityStatus.loadingSuccess);
 }
+
+export function allLoaded(statuses: EntityStatus[]): boolean {
+  return statuses.every(status =>
+    status === EntityStatus.loadingSuccess || status === EntityStatus.loadingFailure);
+}

--- a/components/automate-ui/src/app/entities/policies/policy.reducer.ts
+++ b/components/automate-ui/src/app/entities/policies/policy.reducer.ts
@@ -42,7 +42,8 @@ export function policyEntityReducer(state: PolicyEntityState = PolicyEntityIniti
       )(state) as PolicyEntityState;
 
     case PolicyActionTypes.GET_ALL:
-      return set('getAllStatus', EntityStatus.loading, state) as PolicyEntityState;
+      return set('getAllStatus',
+        EntityStatus.loading, policyEntityAdapter.removeAll(state)) as PolicyEntityState;
 
     case PolicyActionTypes.GET_ALL_SUCCESS:
     return set('getAllStatus', EntityStatus.loadingSuccess,
@@ -52,7 +53,8 @@ export function policyEntityReducer(state: PolicyEntityState = PolicyEntityIniti
       return set('getAllStatus', EntityStatus.loadingFailure, state) as PolicyEntityState;
 
     case PolicyActionTypes.GET:
-      return set('getStatus', EntityStatus.loading, state) as PolicyEntityState;
+      return set('getStatus',
+        EntityStatus.loading, policyEntityAdapter.removeAll(state)) as PolicyEntityState;
 
     case PolicyActionTypes.GET_SUCCESS:
       return set('getStatus', EntityStatus.loadingSuccess,

--- a/components/automate-ui/src/app/entities/projects/project.reducer.ts
+++ b/components/automate-ui/src/app/entities/projects/project.reducer.ts
@@ -65,7 +65,7 @@ export function projectEntityReducer(
 
   switch (action.type) {
     case ProjectActionTypes.GET_ALL:
-      return set(GET_ALL_STATUS, EntityStatus.loading, state);
+      return set(GET_ALL_STATUS, EntityStatus.loading, projectEntityAdapter.removeAll(state));
 
     case ProjectActionTypes.GET_ALL_SUCCESS:
       return set(GET_ALL_STATUS, EntityStatus.loadingSuccess,
@@ -75,7 +75,7 @@ export function projectEntityReducer(
       return set(GET_ALL_STATUS, EntityStatus.loadingFailure, state);
 
     case ProjectActionTypes.GET:
-      return set(GET_STATUS, EntityStatus.loading, state);
+      return set(GET_STATUS, EntityStatus.loading, projectEntityAdapter.removeAll(state));
 
     case ProjectActionTypes.GET_SUCCESS:
       return set(GET_STATUS, EntityStatus.loadingSuccess,

--- a/components/automate-ui/src/app/entities/roles/role.reducer.ts
+++ b/components/automate-ui/src/app/entities/roles/role.reducer.ts
@@ -22,8 +22,7 @@ export function roleEntityReducer(state: RoleEntityState = RoleEntityInitialStat
 
   switch (action.type) {
     case RoleActionTypes.GET_ALL:
-      return set('getAllStatus', EntityStatus.loading, state);
-
+      return set('getAllStatus', EntityStatus.loading, roleEntityAdapter.removeAll(state));
     case RoleActionTypes.GET_ALL_SUCCESS:
       return set('getAllStatus', EntityStatus.loadingSuccess,
         roleEntityAdapter.addAll(action.payload.roles, state));
@@ -32,7 +31,7 @@ export function roleEntityReducer(state: RoleEntityState = RoleEntityInitialStat
       return set('getAllStatus', EntityStatus.loadingFailure, state);
 
     case RoleActionTypes.GET:
-      return set('getStatus', EntityStatus.loading, state);
+      return set('getStatus', EntityStatus.loading, roleEntityAdapter.removeAll(state));
 
     case RoleActionTypes.GET_SUCCESS:
       return set('getStatus', EntityStatus.loadingSuccess,

--- a/components/automate-ui/src/app/entities/rules/rule.reducer.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.reducer.ts
@@ -89,7 +89,7 @@ export function ruleEntityReducer(
 
   switch (action.type) {
     case RuleActionTypes.GET_ALL:
-      return set(GET_ALL_STATUS, EntityStatus.loading, state);
+      return set(GET_ALL_STATUS, EntityStatus.loading, ruleEntityAdapter.removeAll(state));
 
     case RuleActionTypes.GET_ALL_SUCCESS:
       return pipe(
@@ -101,7 +101,7 @@ export function ruleEntityReducer(
       return set(GET_ALL_STATUS, EntityStatus.loadingFailure, state);
 
     case RuleActionTypes.GET:
-      return set(GET_STATUS, EntityStatus.loading, state);
+      return set(GET_STATUS, EntityStatus.loading, ruleEntityAdapter.removeAll(state));
 
     case RuleActionTypes.GET_SUCCESS:
       return set(GET_STATUS, EntityStatus.loadingSuccess,

--- a/components/automate-ui/src/app/pages/policy/details/policy-details.component.html
+++ b/components/automate-ui/src/app/pages/policy/details/policy-details.component.html
@@ -36,15 +36,15 @@
       </section>
     </section>
     <section class="page-body" *ngIf="tabValue === 'members'">
-      <div *ngIf="(members$ | async)?.length === 0" class="empty-state">
+      <div *ngIf="members.length === 0" class="empty-state">
         <p>Add some members to get started!</p>
       </div>
       <chef-toolbar>
-        <div [ngClass]="(members$ | async)?.length === 0 ? 'empty-state' : ''">
+        <div [ngClass]="members.length === 0 ? 'empty-state' : ''">
           <chef-button primary [routerLink]="['/settings', 'policies', policy?.id, 'add-members']">Add Members</chef-button>
         </div>
       </chef-toolbar>
-      <chef-table *ngIf="(members$ | async)?.length > 0">
+      <chef-table *ngIf="members.length > 0">
         <chef-thead>
           <chef-tr>
             <chef-th>ID</chef-th>
@@ -53,7 +53,7 @@
           </chef-tr>
         </chef-thead>
         <chef-tbody>
-          <chef-tr *ngFor="let member of members$ | async">
+          <chef-tr *ngFor="let member of members">
             <chef-td>
               <a *ngIf="memberURLs.hasOwnProperty(member.name)" [routerLink]="memberURLs[member.name]">
                 {{ member.displayName }}

--- a/components/automate-ui/src/app/pages/roles/details/role-details.component.ts
+++ b/components/automate-ui/src/app/pages/roles/details/role-details.component.ts
@@ -1,13 +1,14 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { identity } from 'lodash/fp';
-import { Subject } from 'rxjs';
+import { identity, isNil } from 'lodash/fp';
+import { Subject, combineLatest } from 'rxjs';
 import { filter, pluck, takeUntil } from 'rxjs/operators';
 
+import { EntityStatus } from 'app/entities/entities';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams } from 'app/route.selectors';
 import { GetRole } from 'app/entities/roles/role.actions';
-import { roleFromRoute } from 'app/entities/roles/role.selectors';
+import { roleFromRoute, getStatus } from 'app/entities/roles/role.selectors';
 import { Role } from 'app/entities/roles/role.model';
 
 @Component({
@@ -23,19 +24,23 @@ export class RoleDetailsComponent implements OnInit, OnDestroy {
   constructor(private store: Store<NgrxStateAtom>) {  }
 
   ngOnInit(): void {
-    this.store.select(roleFromRoute).pipe(
-      filter(identity),
-      takeUntil(this.isDestroyed))
-      .subscribe((state) => {
-        this.role = <Role>Object.assign({}, state);
-      });
-
     this.store.select(routeParams).pipe(
       pluck('id'),
       filter(identity),
       takeUntil(this.isDestroyed))
       .subscribe((id: string) => {
         this.store.dispatch(new GetRole({ id }));
+      });
+
+    combineLatest([
+      this.store.select(getStatus),
+      this.store.select(roleFromRoute)
+    ]).pipe(
+      filter(([status, _]) => status === EntityStatus.loadingSuccess),
+      filter(([_, roleState]) => !isNil(roleState)),
+      takeUntil(this.isDestroyed))
+      .subscribe(([_, roleState]) => {
+        this.role = <Role>Object.assign({}, roleState);
       });
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When calls to `GET` and `GET_ALL` happen in the store, clear the store of the object in question and refetch so that we always have the latest data.

Also updated all the subscriptions to filter until the fetch is completed to avoid flickering and other undesirable side effects of hitting the subscribe code multiple times.

### :athletic_shoe: How to Build and Test the Change

Spin up UI. Go to a role, policy, and project from both the list view and by refreshing from the details page. Everything should function correctly.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?
