### PR TITLE
Jamie/control tag filtering no values

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
@@ -88,7 +88,7 @@
     primary
     *ngFor="let filter of filters"
     (click)="onRemoveFilterClick(filter)">
-    <span>{{ filter.type.name }}: {{ filter.value.text }}</span>
+    <span>{{ filter.type.name }}: {{ displayText(filter.value.text) }}</span>
     <chef-icon>close</chef-icon>
   </chef-button>
 </div>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.spec.ts
@@ -51,4 +51,18 @@ describe('ReportingSearchbarComponent', () => {
       });
     });
   });
+
+  describe('displayText()', () => {
+    using([
+      ['', 'no value'],
+      ['scoop', 'scoop'],
+      ['something', 'something'],
+      ['9684', '9684'],
+      ['TEST-123', 'TEST-123']
+    ], function(input: string, output: string) {
+      it(`returns string reading '${output}' when passed ${input}`, () => {
+        expect(component.displayText(input)).toEqual(output);
+      })
+    })
+  });
 });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.spec.ts
@@ -62,7 +62,7 @@ describe('ReportingSearchbarComponent', () => {
     ], function(input: string, output: string) {
       it(`returns string reading '${output}' when passed ${input}`, () => {
         expect(component.displayText(input)).toEqual(output);
-      })
-    })
+      });
+    });
   });
 });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
@@ -472,7 +472,7 @@ export class ReportingSearchbarComponent implements OnInit {
     return type.search('control_tag:') === 0 ? 'control_tag_value' : type;
   }
 
-  public displayText(text: string) {
+  public displayText(text: string): string {
     return text === '' ? 'no value' : text;
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
@@ -472,6 +472,10 @@ export class ReportingSearchbarComponent implements OnInit {
     return type.search('control_tag:') === 0 ? 'control_tag_value' : type;
   }
 
+  public displayText(text: string) {
+    return text === '' ? 'no value' : text;
+  }
+
   // When value is clicked for the control tag key
   onControlTagKeyValueClick(value: any) {
     const reportQuery = this.reportQuery.getReportQuery();

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -235,7 +235,6 @@ export class ReportingComponent implements OnInit, OnDestroy {
             filter.value.text = name;
           }
         }
-
         return filter;
       })));
   }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -181,7 +181,15 @@ export class ReportingComponent implements OnInit, OnDestroy {
     return this.route.queryParamMap.pipe(map((params: ParamMap) => {
       return params.keys.reduce((list, key) => {
         const paramValues = params.getAll(key);
-        return list.concat(paramValues.map(value => ({type: key, text: value})));
+
+        // Necessary check to remove text from api call for no values
+        const mappedParam = paramValues.map(value => {
+          console.log(value)
+          const _value = value === 'no value' ? 'no value' : value;
+          return { type: key, text: _value };
+        });
+
+        return list.concat(mappedParam);
       }, []);
     }));
   }
@@ -217,7 +225,6 @@ export class ReportingComponent implements OnInit, OnDestroy {
       }),
       takeUntil(this.isDestroyed)
     ).subscribe(suggestions => this.availableFilterValues = suggestions.filter(e => e.text));
-    // ).subscribe(suggestions => console.log(suggestions));
 
     this.filters$ = this.reportQuery.state.pipe(map((reportQuery: ReportQuery) =>
       reportQuery.filters.filter((filter) => filter.value.text !== undefined).map(filter => {
@@ -229,6 +236,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
             filter.value.text = name;
           }
         }
+        console.log(filter)
         return filter;
       })));
   }
@@ -417,11 +425,13 @@ export class ReportingComponent implements OnInit, OnDestroy {
     return this.suggestionsService.getSuggestions(type.replace('_id', ''), text, reportQuery).pipe(
       map(data => {
 
+        data.map(item => Object.assign(item, { title: item.text }));
+
         if (type === 'control_tag_value') {
-          data.unshift({id: '', score: 1, text: 'no value', title: 'no value', version: ''});
+          data.unshift({id: '', score: 1, text: '', title: 'no value', version: ''});
         }
 
-        return data.map(item => Object.assign(item, { title: item.text }));
+        return data;
       }),
       takeUntil(this.isDestroyed)
     );

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -145,6 +145,14 @@ export class ReportingComponent implements OnInit, OnDestroy {
     }
   ];
 
+  private noValuesControlTagFilter = {
+    id: '',
+    score: 1,
+    text: 'no value',
+    title: 'no value',
+    version: ''
+  };
+
   availableFilterValues = [];
   defaultFilterInputPlaceholder = 'Filter by...';
   inputSelectedFilter: {};
@@ -229,6 +237,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
             filter.value.text = name;
           }
         }
+
         return filter;
       })));
   }
@@ -313,7 +322,6 @@ export class ReportingComponent implements OnInit, OnDestroy {
 
   onFilterAdded(event) {
     const {type, value} = event.detail;
-    console.log(event.detail);
 
     let filterValue = value.text;
     let typeName = type.name;
@@ -342,7 +350,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
       } else {
         typeName = 'control_name';
       }
-    } else if (type.name.split(':')[0] === 'control_tag') {
+    } else if (this.isTypeControlTag(type.name)) {
       if (value.title === 'no value') {
         typeName = type.name;
         filterValue = value.id;
@@ -424,18 +432,12 @@ export class ReportingComponent implements OnInit, OnDestroy {
     return this.suggestionsService.getSuggestions(type.replace('_id', ''), text, reportQuery).pipe(
       map(data => {
 
-        data.map(item => Object.assign(item, { title: item.text }));
-
+        // Adding the option of 'no value' only to the control tag third level suggestions
         if (type === 'control_tag_value') {
-          data.unshift({
-            id: '',
-            score: 1,
-            text: 'no value',
-            title: 'no value',
-            version: ''});
+          data.unshift(this.noValuesControlTagFilter);
         }
 
-        return data;
+        return data.map(item => Object.assign(item, { title: item.text }));
       }),
       takeUntil(this.isDestroyed)
     );

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -217,11 +217,13 @@ export class ReportingComponent implements OnInit, OnDestroy {
       }),
       takeUntil(this.isDestroyed)
     ).subscribe(suggestions => this.availableFilterValues = suggestions.filter(e => e.text));
+    // ).subscribe(suggestions => console.log(suggestions));
 
     this.filters$ = this.reportQuery.state.pipe(map((reportQuery: ReportQuery) =>
       reportQuery.filters.filter((filter) => filter.value.text !== undefined).map(filter => {
         filter.value.id = filter.value.text;
         if (['profile_id', 'node_id', 'control_id'].indexOf(filter.type.name) >= 0) {
+
           const name = this.reportQuery.getFilterTitle(filter.type.name, filter.value.id);
           if (name !== undefined) {
             filter.value.text = name;
@@ -414,6 +416,11 @@ export class ReportingComponent implements OnInit, OnDestroy {
   getSuggestions(type: string, text: string, reportQuery: ReportQuery) {
     return this.suggestionsService.getSuggestions(type.replace('_id', ''), text, reportQuery).pipe(
       map(data => {
+
+        if (type === 'control_tag_value') {
+          data.unshift({id: '', score: 1, text: 'no value', title: 'no value', version: ''});
+        }
+
         return data.map(item => Object.assign(item, { title: item.text }));
       }),
       takeUntil(this.isDestroyed)

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -145,10 +145,11 @@ export class ReportingComponent implements OnInit, OnDestroy {
     }
   ];
 
+  private NO_VALUE = 'no value';
   private noValuesControlTagFilter = {
     id: '',
     score: 1,
-    text: 'no value',
+    text: this.NO_VALUE,
     title: 'no value',
     version: ''
   };

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -345,6 +345,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
       if ( value.id ) {
         typeName = 'control_id';
         filterValue = value.id;
+        // console.log(filterValue);
         this.reportQuery.setFilterTitle(typeName, value.id, value.title);
       } else {
         typeName = 'control_name';

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -189,7 +189,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
     return this.route.queryParamMap.pipe(map((params: ParamMap) => {
       return params.keys.reduce((list, key) => {
         const paramValues = params.getAll(key);
-        return list.concat(paramValues.map(value => ({ type: key, text: value })));
+        return list.concat(paramValues.map(value => ({type: key, text: value})));
       }, []);
     }));
   }
@@ -228,9 +228,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
 
     this.filters$ = this.reportQuery.state.pipe(map((reportQuery: ReportQuery) =>
       reportQuery.filters.filter((filter) => filter.value.text !== undefined).map(filter => {
-
         filter.value.id = filter.value.text;
-
         if (['profile_id', 'node_id', 'control_id'].indexOf(filter.type.name) >= 0) {
           const name = this.reportQuery.getFilterTitle(filter.type.name, filter.value.id);
           if (name !== undefined) {

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -101,6 +101,7 @@ export class StatsService {
 
     const formatted = this.formatFilters(reportQuery);
     let body = { filters: formatted };
+    console.log('stats service')
     console.log(body);
 
     const {page, perPage} = listParams;

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -101,8 +101,6 @@ export class StatsService {
 
     const formatted = this.formatFilters(reportQuery);
     let body = { filters: formatted };
-    console.log('stats service')
-    console.log(body);
 
     const {page, perPage} = listParams;
     if (page && perPage) {

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -101,6 +101,7 @@ export class StatsService {
 
     const formatted = this.formatFilters(reportQuery);
     let body = { filters: formatted };
+    console.log(body);
 
     const {page, perPage} = listParams;
     if (page && perPage) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
On the compliance reports page, this branch will provide the ability to filter by `no values` when on the 3rd level suggestions of Control Tags.

This involves adding a 'no values' option to the suggestions dropdown at the 3rd level, and a small function to the search-bar component for displaying the `no values` text.

### :chains: Related Resources
https://github.com/chef/automate/pull/1989

### :+1: Definition of Done
Users are now able to select a "no value" option when filtering at the 3rd level of control tags.

### :athletic_shoe: How to Build and Test the Change
1. build components/automate_ui_devproxy && start_all_services
2. in hab studio, make sure you have latest master and run `load_compliance_reports`
3. navigate to https://a2-dev.test/compliance/reports/nodes
    - Click in search bar
    - filter by control tag
    - filter by your choice
    - see 'no value' listed at top of third suggestion dropdown
    - filter by 'no value'

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
<img width="1355" alt="Screen Shot 2019-11-08 at 2 42 30 PM" src="https://user-images.githubusercontent.com/16737484/68515503-0eeb1b80-0236-11ea-96c0-50fe21e93685.png">
