### PR TITLE
Fix error related to timewizard formatting.

### DIFF
--- a/components/automate-ui/src/app/entities/service-groups/service-groups.facade.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.facade.ts
@@ -78,16 +78,15 @@ export class ServiceGroupsFacadeService {
       return 'Since the service was loaded,';
     }
 
-    return 'Changed from ' + this.formatHealthStatusForTimewizard(previousHealth) +
-      ' to ' + this.formatHealthStatusForTimewizard(currentHealth);
-  }
-
-  // display all health check status in lower case, except for 'OK' (upper case)
-  private formatHealthStatusForTimewizard(health: string): string {
-    if (health !== 'OK') {
-      return health.toLowerCase();
+    if (currentHealth !== 'OK') {
+      currentHealth = currentHealth.toLowerCase();
     }
-    return health;
+
+    if (previousHealth !== 'OK') {
+      previousHealth = previousHealth.toLowerCase();
+    }
+
+    return 'Changed from ' + currentHealth + ' to ' + previousHealth;
   }
 
   public updatePageNumber(pageNumber: number, total: number, pageSize: number, trackEvent: string) {


### PR DESCRIPTION
Effect: 
numbers on sidebar were missing because an error was occuring.
services cards appeared blank if they were rendered after a service that had switched health statuses.

The error was due to scoping of `this` when calling another function in the class. `this` was not in the scope when the function was called from the html page, so it couldn't find the function also in the class. 

Fix: 
Removed the function by pulling in simple logic into the same method. 
There is probably a better way to do this if you are a level 8+ javascript wizard. 

The error that occured was
ServicesSidebarComponent.html:74 ERROR TypeError: this.formatHealthStatusForTimewizard is not a function
    at ServicesSidebarComponent.timewizardMessage (service-groups.facade.ts:92)


### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
This error occurred after a service switched health statuses. I was able to do this by manually publishing a service and editing the health status. 
example: 
`    applications_publish_supervisor_message --name "pos-terminal" --group "default" \
      --origin custom --version "2.3.4" --release "20190115181111" --health "1" \
      --sup-id "3802df84-14e4-42f7-8e15-07865a49b033" \
      --application "pos" --environment "production-us-east" --site "ny-123"`
and then 
    `applications_publish_supervisor_message --name "pos-terminal" --group "default" \
      --origin custom --version "2.3.4" --release "20190115181111" --health "0" \
      --sup-id "3802df84-14e4-42f7-8e15-07865a49b033" \
      --application "pos" --environment "production-us-east" --site "ny-123"`
### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable