### PR TITLE
[automate-2181] Fix token subscriptions

### DIFF
--- a/components/automate-ui/src/app/entities/entities.ts
+++ b/components/automate-ui/src/app/entities/entities.ts
@@ -38,6 +38,10 @@ export function pendingState(state: StateWithStatus): boolean {
   );
 }
 
+export function pending(status: EntityStatus): boolean {
+  return status === EntityStatus.notLoaded || status === EntityStatus.loading;
+}
+
 export function loading(status: EntityStatus): boolean {
   return status === EntityStatus.loading;
 }

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
@@ -167,7 +167,7 @@ export class ApiTokenListComponent implements OnInit, OnDestroy {
     }));
   }
 
-  resetCreateModal(): void {
+  private resetCreateModal(): void {
     this.creatingToken = false;
     this.createTokenForm.reset();
   }

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
@@ -1,16 +1,16 @@
-import { Component, EventEmitter, OnInit } from '@angular/core';
+import { Component, EventEmitter, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Store, select } from '@ngrx/store';
-import { Observable, Subject } from 'rxjs';
+import { Observable, Subject, combineLatest } from 'rxjs';
 import { filter, takeUntil, map } from 'rxjs/operators';
-import { identity } from 'lodash/fp';
+import { isNil } from 'lodash/fp';
 
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 import { DateTime } from 'app/helpers/datetime/datetime';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Regex } from 'app/helpers/auth/regex';
 import { HttpStatus } from 'app/types/types';
-import { loading, EntityStatus } from 'app/entities/entities';
+import { loading, EntityStatus, pending } from 'app/entities/entities';
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { Type } from 'app/entities/notifications/notification.model';
 import { CreateNotification } from 'app/entities/notifications/notification.actions';
@@ -33,7 +33,7 @@ import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filt
   templateUrl: './api-token-list.component.html',
   styleUrls: ['./api-token-list.component.scss']
 })
-export class ApiTokenListComponent implements OnInit {
+export class ApiTokenListComponent implements OnInit, OnDestroy {
   public loading$: Observable<boolean>;
   public sortedApiTokens$: Observable<ApiToken[]>;
   public apiTokenCount$: Observable<number>;
@@ -43,6 +43,7 @@ export class ApiTokenListComponent implements OnInit {
   public createTokenForm: FormGroup;
   public creatingToken = false;
   public conflictErrorEvent = new EventEmitter<boolean>();
+  private isDestroyed = new Subject<boolean>();
 
   public isIAMv2$: Observable<boolean>;
   public dropdownProjects: Project[] = [];
@@ -85,6 +86,38 @@ export class ApiTokenListComponent implements OnInit {
           };
         });
       });
+
+    this.store.pipe(
+      select(saveStatus),
+      takeUntil(this.isDestroyed),
+      filter(state => this.createModalVisible && !pending(state)))
+      .subscribe(state => {
+        this.creatingToken = false;
+        if (state === EntityStatus.loadingSuccess) {
+          this.closeCreateModal();
+        }
+      });
+
+    combineLatest([
+      this.store.select(saveStatus),
+      this.store.select(saveError)
+    ]).pipe(
+      takeUntil(this.isDestroyed),
+      filter(() => this.createModalVisible),
+      filter(([state, error]) => state === EntityStatus.loadingFailure && !isNil(error)))
+      .subscribe(([_, error]) => {
+        if (error.status === HttpStatus.CONFLICT) {
+          this.conflictErrorEvent.emit(true);
+        } else {
+          // Close the modal on any error other than conflict and display in banner.
+          this.closeCreateModal();
+        }
+      });
+  }
+
+  ngOnDestroy() {
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
   }
 
   public closeDeleteModal(): void {
@@ -110,38 +143,6 @@ export class ApiTokenListComponent implements OnInit {
     };
     this.store.dispatch(new CreateToken(tok));
 
-    const pendingCreate = new Subject<boolean>();
-    this.store.pipe(
-      select(saveStatus),
-      filter(identity),
-      takeUntil(pendingCreate))
-      .subscribe((state) => {
-        if (!loading(state)) {
-          pendingCreate.next(true);
-          pendingCreate.complete();
-          this.creatingToken = false;
-          if (state === EntityStatus.loadingSuccess) {
-            this.closeCreateModal();
-          }
-          if (state === EntityStatus.loadingFailure) {
-            const pendingCreateError = new Subject<boolean>();
-            this.store.pipe(
-              select(saveError),
-              filter(identity),
-              takeUntil(pendingCreateError))
-              .subscribe((error) => {
-                pendingCreateError.next(true);
-                pendingCreateError.complete();
-                if (error.status === HttpStatus.CONFLICT) {
-                  this.conflictErrorEvent.emit(true);
-                // Close the modal on any error other than conflict and display in banner.
-                } else {
-                  this.closeCreateModal();
-                }
-            });
-          }
-        }
-      });
   }
 
   public toggleActive(token: ApiToken): void {

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
@@ -77,6 +77,7 @@ export class ApiTokenListComponent implements OnInit, OnDestroy {
     this.store.dispatch(new GetAllTokens());
 
     this.store.select(assignableProjects)
+      .pipe(takeUntil(this.isDestroyed))
       .subscribe((assignable: ProjectsFilterOption[]) => {
         this.dropdownProjects = assignable.map(p => {
           return <Project>{


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Per the items noted in the [spreadsheet for subscription fixes](https://docs.google.com/spreadsheets/d/17n8G693ChnCjz9pfie5Gmj6q6hfs-0v-T7R557tYgzU/edit#gid=0) this PR cleans up subscriptions for tokens (token list and token details):
-- adds missing Observable completion
-- removes nested subscriptions
-- removes conditional completion on several Observables

### :chains: Related Resources
#2162 (Find Nested Subs and Subs Not Completed)

### :+1: Definition of Done
Creating a token from the token list page and editing a token from the token details page function as before. In the case of creating a token, this includes either successfully creating a new token or failing to create one due to id conflicts.

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui

#### Token-list page
Navigate to Settings >> API Tokens >> Create Token
Attempt to create a token with an already used ID. Error pop-up within the modal should appear indicating a conflict and modal should remain open.
Attempt to create a token with a unique ID. Modal should close and info banner indicating token created show appear.

#### Token-details page
Navigate to Settings >> API Tokens >> [some token]
Add a character to the token name; observe that the Save button becomes enabled.
Remove the character and the Save button becomes disabled again, because there is no change to save.
Do it again, but this time press Save to register the name change.
Now repeat the exercise, noting that the Save button is disabled according to the newly saved name, not the original name.

### :camera: Screenshots, if applicable

![image](https://user-images.githubusercontent.com/6817500/68733320-19394c80-058b-11ea-8aa8-79cf43010730.png)

![image](https://user-images.githubusercontent.com/6817500/68733365-4be34500-058b-11ea-9d2b-35eddd4cffe8.png)
