### PR TITLE
gateway: quick fix for mockgen Make targets

### DIFF
--- a/components/automate-gateway/gateway/datacollector_bench_test.go
+++ b/components/automate-gateway/gateway/datacollector_bench_test.go
@@ -1,3 +1,5 @@
+// +build !mockgen
+
 package gateway
 
 import (

--- a/components/automate-gateway/gateway/datacollector_internal_test.go
+++ b/components/automate-gateway/gateway/datacollector_internal_test.go
@@ -1,3 +1,5 @@
+// +build !mockgen
+
 //
 //  Author:: Salim Afiune <afiune@chef.io>
 //  Copyright:: Copyright 2018, Chef Software Inc.

--- a/components/automate-gateway/gateway/datacollector_test.go
+++ b/components/automate-gateway/gateway/datacollector_test.go
@@ -1,3 +1,5 @@
+// +build !mockgen
+
 //
 //  Author:: Salim Afiune <afiune@chef.io>
 //  Copyright:: Copyright 2018, Chef Software Inc.
@@ -9,11 +11,12 @@ import (
 	"io/ioutil"
 	"testing"
 
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/stretchr/testify/assert"
+
 	ingestProto "github.com/chef/automate/api/external/ingest/request"
 	subject "github.com/chef/automate/components/automate-gateway/gateway"
 	inspecEvent "github.com/chef/automate/components/compliance-service/ingest/events/inspec"
-	structpb "github.com/golang/protobuf/ptypes/struct"
-	"github.com/stretchr/testify/assert"
 )
 
 func readExample(path string) []byte {

--- a/components/automate-gateway/gateway/helpers_internal_test.go
+++ b/components/automate-gateway/gateway/helpers_internal_test.go
@@ -1,3 +1,5 @@
+// +build !mockgen
+
 //
 //  Author:: Salim Afiune <afiune@chef.io>
 //  Copyright:: Copyright 2018, Chef Software Inc.

--- a/components/automate-gateway/gateway_mocks/Makefile
+++ b/components/automate-gateway/gateway_mocks/Makefile
@@ -1,6 +1,14 @@
+# NOTE(ssd) 2019-11-13: The mockgen tag is used to exclude files in
+# the gateway package that require the mocked client package to
+# build. According to the documenation of mockgen, we should be in
+# "source" mode which doesn't require compiling the module; however,
+# in practice it appears to be compiling the module anyway, leading to
+# a chicken-and-egg problem.
+
+export GOFLAGS = -mod=vendor -tags=mockgen
+
 all: mock_compliance_events/compliance_events_mock.go \
 	mock_compliance_ingest/compliance_ingest_mock.go \
-	mock_feed/feed_mock.go \
 	mock_gateway/clients_mock.go \
 	mock_notifier/notifier_mock.go
 
@@ -9,9 +17,6 @@ mock_compliance_events/compliance_events_mock.go: ../../compliance-service/inges
 
 mock_compliance_ingest/compliance_ingest_mock.go: ../../compliance-service/ingest/ingest/compliance.pb.go
 	mockgen -source $< -destination $@ -package mock_compliance_ingest
-
-mock_feed/feed_mock.go: ../../compliance-service/api/automate-feed/feed.pb.go
-	mockgen -source $< -destination $@
 
 mock_gateway/clients_mock.go: ../gateway/clients.go
 	mockgen -source $< -destination $@

--- a/components/automate-gateway/gateway_mocks/mock_gateway/clients_mock.go
+++ b/components/automate-gateway/gateway_mocks/mock_gateway/clients_mock.go
@@ -326,22 +326,6 @@ func (mr *MockClientsFactoryMockRecorder) SecretClient() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretClient", reflect.TypeOf((*MockClientsFactory)(nil).SecretClient))
 }
 
-// DatafeedClient mocks base method
-func (m *MockClientsFactory) DatafeedClient() (data_feed.DatafeedServiceClient, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DatafeedClient")
-	ret0, _ := ret[0].(data_feed.DatafeedServiceClient)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DatafeedClient indicates an expected call of DatafeedClient
-func (mr *MockClientsFactoryMockRecorder) DatafeedClient() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatafeedClient", reflect.TypeOf((*MockClientsFactory)(nil).DatafeedClient))
-}
-
-
 // NodesClient mocks base method
 func (m *MockClientsFactory) NodesClient() (nodes.NodesServiceClient, error) {
 	m.ctrl.T.Helper()
@@ -490,4 +474,19 @@ func (m *MockClientsFactory) DeploymentServiceClient() (deployment.DeploymentCli
 func (mr *MockClientsFactoryMockRecorder) DeploymentServiceClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeploymentServiceClient", reflect.TypeOf((*MockClientsFactory)(nil).DeploymentServiceClient))
+}
+
+// DatafeedClient mocks base method
+func (m *MockClientsFactory) DatafeedClient() (data_feed.DatafeedServiceClient, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DatafeedClient")
+	ret0, _ := ret[0].(data_feed.DatafeedServiceClient)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DatafeedClient indicates an expected call of DatafeedClient
+func (mr *MockClientsFactoryMockRecorder) DatafeedClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatafeedClient", reflect.TypeOf((*MockClientsFactory)(nil).DatafeedClient))
 }


### PR DESCRIPTION
This fixes a chicken-and-egg problem that we hit when trying to add a
service since the package the code-generator reflects on also requires
that the generated code is already correctly generated.

Note the change in clients_mock.go is likely from the fact that this
file was hand-edited in the past.

I've also removed a Make target which simply didn't work because the
relevant files didn't exist.

Further, I noticed that running `make` produces files in

    mock_compliance_events/

which are not currently in source control. I haven't added them here
as as I wasn't sure if this was intentional.

In short, mock generation is a big mess still and needs to be cleaned
up, but at least now `make` works again.

Signed-off-by: Steven Danna <steve@chef.io>
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>