### PR TITLE
removed here link text on release dashboards

### DIFF
--- a/components/release-mgmt-dashboard/src/app/app.component.html
+++ b/components/release-mgmt-dashboard/src/app/app.component.html
@@ -9,7 +9,7 @@
 </header>
 <main>
   <div class="notification" *ngIf="deploy_in_progress">
-    <span class="deploy-in-progress">There is an automated deployment in progress. Some environments may be impacted as they are upgraded. You can follow the <a href="{{deploy_logs_url}}" target="_blank">logs</a>.</span>
+    <span class="deploy-in-progress">There is an automated deployment in progress. Some environments may be impacted as they are upgraded. You can follow the <a href="{{deploy_logs_url}}" target="_blank" rel="noopener">logs</a>.</span>
   </div>
   <div *ngFor="let server of servers" id="{{server.id}}" class="server">
     <div class="server-header">

--- a/components/release-mgmt-dashboard/src/app/app.component.html
+++ b/components/release-mgmt-dashboard/src/app/app.component.html
@@ -9,7 +9,7 @@
 </header>
 <main>
   <div class="notification" *ngIf="deploy_in_progress">
-    <span class="deploy-in-progress">There is an automated deployment in progress. Some environments may be impacted as they are upgraded.  You can follow the logs <a href="{{deploy_logs_url}}" target="_blank">here</a>.</span>
+    <span class="deploy-in-progress">There is an automated deployment in progress. Some environments may be impacted as they are upgraded. You can follow the <a href="{{deploy_logs_url}}" target="_blank">logs</a>.</span>
   </div>
   <div *ngFor="let server of servers" id="{{server.id}}" class="server">
     <div class="server-header">


### PR DESCRIPTION
## Overview
`here` links are a poor experience
this removes the here link from our release dashboards
[accessibility and link text](https://webaim.org/techniques/hypertext/link_text)
