### PR TITLE
Update member expression regex to include special characters

### DIFF
--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -15,7 +15,7 @@ export class Regex {
     // Only allows wildcard alone or words and numbers, but not combined
     // Legal Values: *, chef, _state, etc.
     // Illegal Values: abc*, *chef, c*h*e*f, **
-    NO_MIXED_WILDCARD: '^(\\*|[-\\w]+)$'
+    NO_MIXED_WILDCARD: '^(\\*|[-!\\[\\]@#$%^&()+=/?><.,~\\w]+)$'
   };
 
 }

--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -15,7 +15,12 @@ export class Regex {
     // Only allows wildcard alone or words and numbers, but not combined
     // Legal Values: *, chef, _state, etc.
     // Illegal Values: abc*, *chef, c*h*e*f, **
-    NO_MIXED_WILDCARD: '^(\\*|[-!\\[\\]@#$%^&()+=/?><.,~\\w]+)$'
+
+    // Allows no special characters except hyphen
+    NO_MIXED_WILDCARD_ALLOW_HYPHEN: '^(\\*|[-\\w]+)$',
+
+    // Allows all special characters except colon :
+    NO_MIXED_WILDCARD_ALLOW_SPECIAL: '^(\\*|[^:*]+)$'
   };
 
 }

--- a/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.html
@@ -76,8 +76,11 @@
                 <chef-error *ngIf="expressionForm.get('name').hasError('required') && expressionForm.get('name').touched">
                   {{ nameOrId }} is a required field.
                 </chef-error>
-                <chef-error *ngIf="expressionForm.get('name').hasError('pattern') && expressionForm.get('name').dirty">
-                  {{ nameOrId }} must be text or a wildcard but not both.
+                <chef-error *ngIf="ldapOrSaml && expressionForm.get('name').hasError('pattern') && expressionForm.get('name').dirty">
+                  {{ nameOrId }} may contain a single wildcard or a {{ nameOrId }} without colons or wildcards.
+                </chef-error>
+                <chef-error *ngIf="!ldapOrSaml && expressionForm.get('name').hasError('pattern') && expressionForm.get('name').dirty">
+                  {{ nameOrId }} may contain text and hyphens or a wildcard but not both.
                 </chef-error>
               </chef-form-field>
 

--- a/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.ts
@@ -334,15 +334,14 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
         if (formValues.type === 'user' || formValues.type === 'team') {
           this.addIdentityControl();
         } else if (formValues.type === 'token') {
-          this.addNameControl();
+          this.addNameControl(formValues.identityProvider);
         }
         break;
       case 'identityProvider':
         this.resetErrors();
+        this.expressionForm.removeControl('name');
         if (formValues.identityProvider !== matchAllWildCard) {
-          this.addNameControl();
-        } else {
-          this.expressionForm.removeControl('name');
+          this.addNameControl(formValues.identityProvider);
         }
         break;
       case 'name': // fallthrough
@@ -376,15 +375,28 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
     this.expressionForm.addControl('identityProvider', new FormControl('', Validators.required));
   }
 
-  private addNameControl(): void {
-    this.expressionForm.addControl('name', new FormControl('',
-      [
-        Validators.required,
-        Validators.pattern(Regex.patterns.NO_MIXED_WILDCARD)
-      ]
-    )
-    );
+  private addNameControl(identityProvider): void {
+    if (identityProvider === 'ldap' || identityProvider === 'saml' ) {
+      console.log('set name to all')
+        this.expressionForm.addControl('name', new FormControl('',
+          [
+            Validators.required,
+            Validators.pattern(Regex.patterns.NO_MIXED_WILDCARD_ALLOW_SPECIAL)
+          ]
+        )
+      );
+    } else {
+      console.log('set name to hyphen only')
+        this.expressionForm.addControl('name', new FormControl('',
+          [
+            Validators.required,
+            Validators.pattern(Regex.patterns.NO_MIXED_WILDCARD_ALLOW_HYPHEN)
+          ]
+        )
+      );
+    }
   }
+
 
   private setExpressionOutput(): void {
     this.expressionOutput =

--- a/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.ts
@@ -377,7 +377,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
   private addNameControl(identityProvider): void {
     if (identityProvider === 'ldap' || identityProvider === 'saml' ) {
-      console.log('set name to all')
         this.expressionForm.addControl('name', new FormControl('',
           [
             Validators.required,
@@ -386,7 +385,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
         )
       );
     } else {
-      console.log('set name to hyphen only')
         this.expressionForm.addControl('name', new FormControl('',
           [
             Validators.required,

--- a/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.ts
@@ -88,6 +88,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
   public expressionOutput: string;
   public allIdentity: string;
   public nameOrId: string;
+  public ldapOrSaml = false;
 
 
   constructor(
@@ -334,7 +335,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
         if (formValues.type === 'user' || formValues.type === 'team') {
           this.addIdentityControl();
         } else if (formValues.type === 'token') {
-          this.addNameControl(formValues.identityProvider);
+          this.addNameControl(null);
         }
         break;
       case 'identityProvider':
@@ -377,6 +378,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
 
   private addNameControl(identityProvider): void {
     if (identityProvider === 'ldap' || identityProvider === 'saml' ) {
+        this.ldapOrSaml = true;
         this.expressionForm.addControl('name', new FormControl('',
           [
             Validators.required,
@@ -385,6 +387,7 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
         )
       );
     } else {
+        this.ldapOrSaml = false;
         this.expressionForm.addControl('name', new FormControl('',
           [
             Validators.required,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This branch updates the regex validation used in the member expression modal so that users can use whatever characters they use, with the exception of `:` and `;`

### :chains: Related Resources

### :+1: Definition of Done
Users can now use special characters.  The use of `*` along with other characters is still disallowed.

### :athletic_shoe: How to Build and Test the Change

1. build components/automate-ui-devproxy && start_all_services
2. navigate to https://a2-dev.test/settings/policies/administrator-access/add-members
3. click on `Add Member Expression` on the bottom left
4. set Type => Team, Identity Provider => LDAP
5. in Name => type special characters and see them allowed
6. in Name => add a `*` to any text, see that it is disallowed.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
<img width="945" alt="Screen Shot 2019-11-13 at 3 16 53 PM" src="https://user-images.githubusercontent.com/16737484/68812732-a41c5480-0628-11ea-8ee3-7fc10633ea20.png">