### PR TITLE
[automate-2177] clean up team pages subscriptions

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -36,7 +36,7 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
     this.conflictErrorEvent.subscribe((isConflict: boolean) => {
       this.conflictError = isConflict;
       // Open the ID input on conflict so user can resolve it.
-      this.modifyID = true;
+      this.modifyID = isConflict;
     });
   }
 

--- a/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.ts
@@ -116,8 +116,8 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
       takeUntil(this.isDestroyed),
       filter(state => this.addingUsers && !pending(state)))
       .subscribe((state) => {
-        this.addingUsers = false;
         if (state === EntityStatus.loadingSuccess) {
+          this.addingUsers = false;
           this.closePage();
         }
     });
@@ -128,17 +128,16 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
       this.store.select(addTeamUsersStatusError)
     ]).pipe(
       takeUntil(this.isDestroyed),
-      filter(([state, error]) => {
-        return this.addingUsers && state === EntityStatus.loadingFailure && !isNil(error);
-      }))
-      .subscribe(([_, error]) => {
-        if (error.message === undefined) {
+      filter(() => this.addingUsers),
+      filter(([state, resp]) => state === EntityStatus.loadingFailure && !isNil(resp)))
+      .subscribe(([_, resp]) => {
+        this.addingUsers = false;
+        if (resp.error.message === undefined) {
           this.addUsersFailed = 'An error occurred while attempting ' +
           'to add users. Please try again.';
         } else {
-          this.addUsersFailed = `Failed to add users: ${error.message}`;
+          this.addUsersFailed = `Failed to add users: ${resp.error.message}`;
         }
-        this.addingUsers = false;
       });
   }
 

--- a/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.ts
@@ -111,6 +111,7 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
       this.mapOfUsersToFilter = userArrayToHash(membershipUsers);
     });
 
+    // handle user addition success response
     this.store.pipe(
       select(addUsersStatus),
       takeUntil(this.isDestroyed),
@@ -123,6 +124,7 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
         }
     });
 
+    // handle user addition failure response
     combineLatest([
       this.store.select(addUsersStatus),
       this.store.select(addTeamUsersStatusError)

--- a/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.ts
@@ -43,7 +43,6 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
   public isIAMv2$: Observable<boolean>;
   private isDestroyed = new Subject<boolean>();
   public addingUsers = false;
-  public addUsersSuccessful = false;
   private usersToAdd: { [id: string]: User } = {};
   public showSecondary = false;
   public addUsersFailed = '';
@@ -118,8 +117,7 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
       filter(state => this.addingUsers && !pending(state)))
       .subscribe((state) => {
         this.addingUsers = false;
-        this.addUsersSuccessful = (state === EntityStatus.loadingSuccess);
-        if (this.addUsersSuccessful) {
+        if (state === EntityStatus.loadingSuccess) {
           this.closePage();
         }
     });
@@ -130,7 +128,9 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
       this.store.select(addTeamUsersStatusError)
     ]).pipe(
       takeUntil(this.isDestroyed),
-      filter(([state, error]) => state === EntityStatus.loadingFailure && !isNil(error)))
+      filter(([state, error]) => {
+        return this.addingUsers && state === EntityStatus.loadingFailure && !isNil(error);
+      }))
       .subscribe(([_, error]) => {
         if (error.message === undefined) {
           this.addUsersFailed = 'An error occurred while attempting ' +

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
@@ -203,6 +203,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
         this.users = ChefSorters.naturalSort(users, ['name', 'id']);
       });
 
+    // handle team update response
     this.store.pipe(
       select(updateStatus),
       takeUntil(this.isDestroyed),

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, FormControl, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
-import { isEmpty, identity, keyBy, at, xor } from 'lodash/fp';
+import { isEmpty, keyBy, at, xor } from 'lodash/fp';
 import { combineLatest, Subject, Observable } from 'rxjs';
 import { filter, map, takeUntil, distinctUntilChanged } from 'rxjs/operators';
 
@@ -10,7 +10,7 @@ import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeURL, routeState } from 'app/route.selectors';
-import { EntityStatus, loading } from 'app/entities/entities';
+import { EntityStatus, pending } from 'app/entities/entities';
 import { User } from 'app/entities/users/user.model';
 import { Regex } from 'app/helpers/auth/regex';
 import { allUsers, getStatus as getAllUsersStatus } from 'app/entities/users/user.selectors';
@@ -57,7 +57,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   public updateNameForm: FormGroup;
   // isLoadingTeam represents the initial team load as well as subsequent updates in progress.
   public isLoadingTeam = true;
-  public saving = false;
+  public saveInProgress = false;
   public saveSuccessful = false;
   public tabValue: TeamTabName = 'users';
   private url: string;
@@ -202,6 +202,18 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
         // Sort naturally first by name, then by id
         this.users = ChefSorters.naturalSort(users, ['name', 'id']);
       });
+
+    this.store.pipe(
+      select(updateStatus),
+      takeUntil(this.isDestroyed),
+      filter(state => this.saveInProgress && !pending(state)))
+      .subscribe((state) => {
+        this.saveInProgress = false;
+        this.saveSuccessful = (state === EntityStatus.loadingSuccess);
+        if (this.saveSuccessful) {
+          this.updateNameForm.markAsPristine();
+        }
+      });
  }
 
   ngOnDestroy(): void {
@@ -230,29 +242,11 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
 
   saveTeam(): void {
     this.saveSuccessful = false;
-    this.saving = true;
+    this.saveInProgress = true;
     this.updateNameForm.controls['name'].disable();
     const name: string = this.updateNameForm.controls.name.value.trim();
     const projects = Object.keys(this.projects).filter(id => this.projects[id].checked);
     this.store.dispatch(new UpdateTeam({ ...this.team, name, projects }));
-
-    const pendingSave = new Subject<boolean>();
-    this.store.pipe(
-      select(updateStatus),
-      filter(identity),
-      takeUntil(pendingSave))
-      .subscribe((state) => {
-        if (!loading(state)) {
-          pendingSave.next(true);
-          pendingSave.complete();
-          this.saving = false;
-          this.updateNameForm.controls['name'].enable();
-          this.saveSuccessful = (state === EntityStatus.loadingSuccess);
-          if (this.saveSuccessful) {
-            this.updateNameForm.markAsPristine();
-          }
-        }
-      });
   }
 
   onSelectedTab(event: { target: { value: TeamTabName } }): void {
@@ -283,6 +277,6 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   }
 
   dropdownDisabled(): boolean {
-    return isEmpty(this.projects) || this.saving;
+    return isEmpty(this.projects) || this.saveInProgress;
   }
 }

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.spec.ts
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.spec.ts
@@ -168,7 +168,7 @@ describe('TeamManagementComponent', () => {
       store.dispatch(new CreateTeamFailure(error));
 
       expect(component.createV1TeamModalVisible).toBe(false);
-      expect(component.conflictErrorEvent.emit).not.toHaveBeenCalled();
+      expect(component.conflictErrorEvent.emit).toHaveBeenCalledWith(false);
     });
   });
 

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
@@ -99,7 +99,9 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
     this.store.pipe(
       select(createStatus),
       takeUntil(this.isDestroyed),
-      filter(state => this.createModalVisible && !pending(state)))
+      filter(state => {
+        return (this.createModalVisible || this.createV1TeamModalVisible) && !pending(state);
+      }))
       .subscribe(state => {
         this.creatingTeam = false;
         if (state === EntityStatus.loadingSuccess) {
@@ -113,7 +115,7 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
       this.store.select(createError)
     ]).pipe(
       takeUntil(this.isDestroyed),
-      filter(() => this.createModalVisible),
+      filter(() => (this.createModalVisible || this.createV1TeamModalVisible)),
       filter (([state, error]) => state === EntityStatus.loadingFailure && !isNil(error)))
       .subscribe(([_, error]) => {
         if (error.status === HttpStatus.CONFLICT) {
@@ -186,5 +188,6 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
     this.creatingTeam = false;
     this.createTeamForm.reset();
     this.createV1TeamForm.reset();
+    this.conflictErrorEvent.emit(false);
   }
 }

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
@@ -95,6 +95,7 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
         });
       });
 
+    // handle team creation success response
     this.store.pipe(
       select(createStatus),
       takeUntil(this.isDestroyed),
@@ -106,6 +107,7 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
         }
       });
 
+    // handle team creation failure response
     combineLatest([
       this.store.select(createStatus),
       this.store.select(createError)

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
@@ -1,14 +1,14 @@
 import { Component, OnInit, OnDestroy, EventEmitter } from '@angular/core';
 import { Validators, FormGroup, FormBuilder } from '@angular/forms';
 import { Store, select } from '@ngrx/store';
-import { Observable, Subject } from 'rxjs';
+import { Observable, Subject, combineLatest } from 'rxjs';
 import { map, filter, takeUntil } from 'rxjs/operators';
-import { identity } from 'lodash/fp';
+import { isNil } from 'lodash/fp';
 
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { loading, EntityStatus } from 'app/entities/entities';
+import { loading, EntityStatus, pending } from 'app/entities/entities';
 import { isIAMv2 } from 'app/entities/policies/policy.selectors';
 import {
   createError,
@@ -76,12 +76,14 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.layoutFacade.showSettingsSidebar();
     this.store.dispatch(new GetTeams());
+
     this.store.pipe(
       select(isIAMv2),
       takeUntil(this.isDestroyed))
       .subscribe(latest => {
         this.isIAMv2 = latest;
     });
+
     this.store.select(assignableProjects)
       .subscribe((assignable: ProjectsFilterOption[]) => {
         this.dropdownProjects = assignable.map(p => {
@@ -91,6 +93,33 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
             type: p.type
           };
         });
+      });
+
+    this.store.pipe(
+      select(createStatus),
+      takeUntil(this.isDestroyed),
+      filter(state => this.createModalVisible && !pending(state)))
+      .subscribe(state => {
+        this.creatingTeam = false;
+        if (state === EntityStatus.loadingSuccess) {
+          this.closeCreateModal();
+        }
+      });
+
+    combineLatest([
+      this.store.select(createStatus),
+      this.store.select(createError)
+    ]).pipe(
+      takeUntil(this.isDestroyed),
+      filter(() => this.createModalVisible),
+      filter (([state, error]) => state === EntityStatus.loadingFailure && !isNil(error)))
+      .subscribe(([_, error]) => {
+        if (error.status === HttpStatus.CONFLICT) {
+          this.conflictErrorEvent.emit(true);
+        } else {
+          // close modal on any error other than conflict and display in banner
+          this.closeCreateModal();
+        }
       });
   }
 
@@ -134,38 +163,6 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
   public createTeamCommon(team: Team): void {
     this.creatingTeam = true;
     this.store.dispatch(new CreateTeam(team));
-
-    const pendingCreate = new Subject<boolean>();
-    this.store.pipe(
-      select(createStatus),
-      filter(identity),
-      takeUntil(pendingCreate))
-      .subscribe((state) => {
-        if (!loading(state)) {
-          pendingCreate.next(true);
-          pendingCreate.complete();
-          this.creatingTeam = false;
-          if (state === EntityStatus.loadingSuccess) {
-            this.closeCreateModal();
-          }
-          if (state === EntityStatus.loadingFailure) {
-            const pendingCreateError = new Subject<boolean>();
-            this.store.pipe(
-              select(createError),
-              filter(identity),
-              takeUntil(pendingCreateError))
-              .subscribe((error) => {
-                pendingCreateError.next(true);
-                pendingCreateError.complete();
-                if (error.status === HttpStatus.CONFLICT) {
-                  this.conflictErrorEvent.emit(true);
-                } else { // Close the modal on any error other than conflict and display in banner.
-                  this.closeCreateModal();
-                }
-            });
-          }
-        }
-      });
   }
 
   public openCreateModal(): void {

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
@@ -170,5 +170,6 @@ export class ApiTokenListComponent implements OnInit, OnDestroy {
   private resetCreateModal(): void {
     this.creatingToken = false;
     this.createTokenForm.reset();
+    this.conflictErrorEvent.emit(false);
   }
 }

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -184,6 +184,7 @@ export class ProjectListComponent implements OnInit, OnDestroy {
   resetCreateModal(): void {
     this.creatingProject = false;
     this.createProjectForm.reset();
+    this.conflictErrorEvent.emit(false);
   }
 
   public openConfirmUpdateStartModal(): void {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
In the interest of improving performance across auth pages, we're auditing how we're handling subscriptions to ensure the following: 
1. all subscriptions are destroyed when the user moves away from the page
2. no nested subscriptions exist 

This PR cleans up the teams pages:
- team-details.component.ts
- team-management.component.ts
- team-add-users.component.ts

### :chains: Related Resources
sub-task of https://github.com/chef/automate/issues/2162
depends on: https://github.com/chef/automate/pull/2188 **(this must be merged first)**

### :+1: Definition of Done
- refactored pages work as they did before (modal closes when appropriate, errors display as expected)

### :athletic_shoe: How to Build and Test the Change

- start the UI and navigate to https://a2-dev.test/settings/teams
- create a team and see the team table update with that team
- create a team with the same id and see a conflict error in the creation modal
- navigate to your new team, select the `Details` tab
- update the team name
- select the `Users` tab and click `Add Users`
- add some users and save
- click `Add Users` again - this time, run `chef-automate dev remove-some components/teams-service/` in the studio before saving your additions
- this time you should stay on the add users page and see an error above the save button (note: CSS styling needs fixing)
- `chef-automate dev deploy-some components/teams-service/` will restore automate to healthy status

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable