### PR TITLE
[automate-2180] Fix policy subscriptions

### DIFF
--- a/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.ts
@@ -1,17 +1,16 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
 import { trigger, transition, style, animate, state, keyframes } from '@angular/animations';
-import { HttpErrorResponse } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { identity } from 'lodash/fp';
+import { identity, isNil } from 'lodash/fp';
 import { filter, pluck, takeUntil, distinctUntilChanged, map } from 'rxjs/operators';
 import { combineLatest, Subject, Observable } from 'rxjs';
 
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams } from 'app/route.selectors';
-import { EntityStatus, allLoadedSuccessfully } from 'app/entities/entities';
+import { EntityStatus, allLoadedSuccessfully, pending } from 'app/entities/entities';
 import {
   GetPolicy, AddPolicyMembers, PolicyMembersMgmtPayload
 } from 'app/entities/policies/policy.actions';
@@ -152,6 +151,33 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
           // Now that the membersAvailableMap is correct, refresh.
           this.refreshSortedMembersAvailable();
       });
+
+    this.store.select(addPolicyMembersStatus).pipe(
+      takeUntil(this.isDestroyed),
+      filter(addState => this.addingMembers && !pending(addState)))
+      .subscribe((addPolicyState) => {
+        if (addPolicyState === EntityStatus.loadingSuccess) {
+          this.addingMembers = false;
+          this.router.navigate(this.backRoute(), { fragment: 'members' });
+        }
+      });
+
+    combineLatest([
+      this.store.select(addPolicyMembersStatus),
+      this.store.select(addPolicyMembersHTTPError)
+    ]).pipe(
+      takeUntil(this.isDestroyed),
+      filter(() => this.addingMembers),
+      filter(([addState, error]) => addState === EntityStatus.loadingFailure && !isNil(error)))
+      .subscribe(([_, error]) => {
+        this.addingMembers = false;
+        if (error.message === undefined) {
+          this.addMembersFailed = 'An error occurred while attempting ' +
+            'to add members. Please try again.';
+        } else {
+          this.addMembersFailed = `Failed to add members: ${error.message}`;
+        }
+      });
   }
 
   addAvailableMember(member: Member, refresh: boolean): void {
@@ -179,32 +205,6 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
       id: this.policy.id,
       members: this.membersToAddValues()
     }));
-
-    const pendingAdd = new Subject<boolean>();
-    this.store.select(addPolicyMembersStatus).pipe(
-      filter(identity),
-      takeUntil(pendingAdd))
-      .subscribe((addPolicyState) => {
-        if (addPolicyState === EntityStatus.loadingSuccess) {
-          pendingAdd.next(true);
-          pendingAdd.complete();
-          this.addingMembers = false;
-          this.router.navigate(this.backRoute(), { fragment: 'members' });
-        }
-        if (addPolicyState === EntityStatus.loadingFailure) {
-          this.store.select(addPolicyMembersHTTPError).pipe(
-            filter(identity),
-            takeUntil(pendingAdd)).subscribe((error: HttpErrorResponse) => {
-              if (error.message === undefined) {
-                this.addMembersFailed = 'An error occurred while attempting ' +
-                'to add members. Please try again.';
-              } else {
-                this.addMembersFailed = `Failed to add members: ${error.message}`;
-              }
-              this.addingMembers = false;
-          });
-        }
-      });
   }
 
   ngOnDestroy() {

--- a/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.ts
+++ b/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.ts
@@ -169,13 +169,13 @@ export class PolicyAddMembersComponent implements OnInit, OnDestroy {
       takeUntil(this.isDestroyed),
       filter(() => this.addingMembers),
       filter(([addState, error]) => addState === EntityStatus.loadingFailure && !isNil(error)))
-      .subscribe(([_, error]) => {
+      .subscribe(([_, resp]) => {
         this.addingMembers = false;
-        if (error.message === undefined) {
+        if (resp.error.message === undefined) {
           this.addMembersFailed = 'An error occurred while attempting ' +
             'to add members. Please try again.';
         } else {
-          this.addMembersFailed = `Failed to add members: ${error.message}`;
+          this.addMembersFailed = `Failed to add members: ${resp.error.message}`;
         }
       });
   }


### PR DESCRIPTION
Per the items noted in the [spreadsheet for subscription fixes](https://docs.google.com/spreadsheets/d/17n8G693ChnCjz9pfie5Gmj6q6hfs-0v-T7R557tYgzU/edit#gid=0) this PR cleans up subscriptions for policies:
-- removes nested subscription
-- removes conditional completion on an Observable

### :chains: Related Resources
#2162 (Find Nested Subs and Subs Not Completed)

### :+1: Definition of Done
Adding members successfully or not successfully does the right thing, as indicated below.

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui

Navigate to `Settings >> Policies >> [policy] >> Add Members`

Add a member successfully and the view should auto-navigate back to the members tab of the policy details page.

Add a member unsuccessfully and the add-members should remain open with an error (note the formatting of that error is being reviewed by UX).

One way to force the add-member failure is to add this to components/authz-service/server/v2/policy.go::AddPolicyMembers just after the test for not nil (L329).
```
if err == nil {
		return nil, status.Errorf(codes.InvalidArgument, "parse member: %s", "hello")
	}
```
Then `go_update_component authz-service` in hab studio to compile that change.

### :camera: Screenshots, if applicable