### PR TITLE
Update display formats for event feed datetimes

### DIFF
--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -16,6 +16,24 @@ export class DateTime {
   // Format for filenames of report downloads
   // 2019-09-24-09:59:59
   public static readonly REPORT_DATE_TIME: string = 'YYYY-MM-DD-HHmmss';
+
+  // Format for short date display
   // 25 Oct 2019
   public static readonly CHEF_SHORT_DATE: string = 'DD MMM YYYY';
+
+  // Format for date labels in event feed graph
+  // Tue, 24 Sept
+  public static readonly EVENT_GRAPH_DATE_LABEL: string = 'ddd, DD MMM';
+
+  // Format for time labels in event feed table
+  // 09:59
+  public static readonly EVENT_TABLE_TIME_LABEL: string = 'HH:mm';
+
+  // Format for day labels in event feed table
+  // Tuesday
+  public static readonly EVENT_TABLE_DAY_LABEL: string = 'dddd';
+
+  // Format for date labels in event feed table
+  // 24 September
+  public static readonly EVENT_TABLE_DATE_LABEL: string = 'D MMMM';
 }

--- a/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.html
+++ b/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.html
@@ -8,12 +8,12 @@
           [attr.x]="zoomButtonPosition(i)"
           y="0"
           tabindex="0"
-          [attr.aria-label]="date | date: 'EEE, MMM d'"
+          [attr.aria-label]="date | datetime: DateTime.EVENT_GRAPH_DATE_LABEL"
           (click)="dateSelected(date, i)"
           (keydown.enter)="dateSelected(date, i)"/>
         <text class="guitar-string-zoom-date"
           [attr.x]="zoomTextPosition(i)" y="18">
-            {{date | date: 'EEE, MMM d'}}
+            {{date | datetime: DateTime.EVENT_GRAPH_DATE_LABEL}}
         </text>
       </ng-container>
       <rect class="slider-overlay start" x="0" y="0" width="0" height="100%"/>
@@ -73,7 +73,7 @@
       [width]="graphicProportions.sectionWidth"
       [index]="i"
       *ngFor="let date of guitarStringDataContainer.sectionDates; let i = index">
-      {{date | date: 'EEE, MMM d'}}
+      {{date | datetime: DateTime.EVENT_GRAPH_DATE_LABEL}}
     </svg:g>
 
   </chef-guitar-string-collection>
@@ -93,8 +93,8 @@
           </app-event-icon>
           <span class="guitar-tooltip-text">
             <span class="guitar-tooltip-date">
-                {{item.start | date:'EE' }}, {{item.start | date:'MMM d yyyy' }}
-                from {{item.start | date:'h:mm a' }} - {{item.end | date:'h:mm a' }}
+              {{ item.start | datetime: DateTime.CHEF_DATE_TIME }}
+              {{ item.start | datetime: DateTime.CHEF_HOURS_MINS }} - {{ item.end | datetime: DateTime.CHEF_HOURS_MINS }} UTC
             </span>
             <span [innerHTML]="getTooltipText(item, item.isMultiple(), guitarString)"></span>
           </span>

--- a/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.spec.ts
@@ -20,6 +20,7 @@ import {
 import * as moment from 'moment';
 import { find } from 'lodash';
 import { initialState } from '../../services/event-feed/event-feed.reducer';
+import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 
 function create_changes(
   previousValue: GuitarStringCollection,
@@ -47,6 +48,7 @@ describe('EventFeedGuitarStringsComponent', () => {
         EventFeedService
       ],
       imports: [
+        ChefPipesModule,
         StoreModule.forRoot({
           'event_feed': combineReducers(eventFeed.eventFeedReducer)
         }, { runtimeChecks })

--- a/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.ts
@@ -21,7 +21,7 @@ import { initialState } from '../../services/event-feed/event-feed.reducer';
 import { Subject } from 'rxjs';
 import { reduce } from 'lodash/fp';
 import * as d3 from 'd3';
-
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 export class GuitarStringDataContainer {
   dynamicallyBucketedGuitarStrings: GuitarString[] = [];
@@ -279,6 +279,9 @@ export class EventFeedGuitarStringsComponent implements OnInit, OnDestroy, OnCha
   endSliderPosition = 100;
   sliderGrid = 100 / this.buttonDates.length;
   sliderWidth: number;
+
+  DateTime = DateTime;
+
   @ViewChild('startSlider', { static: true }) startSlider: ElementRef;
   @ViewChild('endSlider', { static: true }) endSlider: ElementRef;
 

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.html
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.html
@@ -2,9 +2,9 @@
   <caption class="visually-hidden">Event Feed Table</caption>
   <li *ngFor="let event of events; index as i" class="event-row">
     <div class="event-date-time">
-      <div class="event-time">{{event.startTime | date:'h:mm a' }}</div>
-      <div class="event-day">{{event.startTime | date:'EEEE' }},</div>
-      <div class="event-date">{{event.startTime | date:'LLLL d' }}</div>
+      <div class="event-time">{{ event.startTime | datetime: DateTime.EVENT_TABLE_TIME_LABEL }}</div>
+      <div class="event-day">{{ event.startTime | datetime: DateTime.EVENT_TABLE_DAY_LABEL }},</div>
+      <div class="event-date">{{ event.startTime | datetime: DateTime.EVENT_TABLE_DATE_LABEL }}</div>
     </div>
     <div class="event-info">
       <div class="event-chat-bubble">
@@ -62,7 +62,7 @@
         </div>
         <p class="event-group-text">
           <strong>{{getEventGroupText(event)}}</strong>
-          {{event.startTime | date:'EE' }}, {{event.startTime | date:'MMM d yyyy' }} at {{event.startTime | date:'h:mm a' }}
+          {{ event.startTime | datetime: DateTime.RFC2822 }}
         </p>
       </li>
     </ul>

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { EventFeedTableComponent } from './event-feed-table.component';
 import { MockComponent } from 'ng2-mock-component';
-import { CapitalizePipe } from '../../pipes/capitalize.pipe';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { EventFeedService } from '../../services/event-feed/event-feed.service';
 import { Observable, of as observableOf } from 'rxjs';
@@ -11,6 +10,7 @@ import {
   ChefEvent
 } from '../../types/types';
 import * as moment from 'moment';
+import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 
 class MockEventFeedService {
   lastRequestedGetEventFeedFilters: EventFeedFilter;
@@ -21,21 +21,23 @@ class MockEventFeedService {
   }
 }
 
-describe('SearchBarComponent', () => {
+describe('EventFeedTableComponent', () => {
   let component: EventFeedTableComponent;
   let fixture;
   const mockEventFeedService = new MockEventFeedService();
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [
+        ChefPipesModule
+      ],
       declarations: [
         EventFeedTableComponent,
         MockComponent({ selector: 'chef-icon' }),
         MockComponent({ selector: 'chef-button' }),
         MockComponent({ selector: 'app-event-icon', inputs: ['group', 'type', 'task'] }),
         MockComponent({ selector: 'chef-click-outside'}),
-        MockComponent({ selector: 'chef-side-panel', inputs: ['visible']}),
-        CapitalizePipe
+        MockComponent({ selector: 'chef-side-panel', inputs: ['visible']})
       ],
       providers: [
         { provide: EventFeedService, useValue: mockEventFeedService }

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.ts
@@ -5,6 +5,7 @@ import { map } from 'rxjs/operators';
 import { ChefEvent, ChefEventCollection, EventFeedFilter, Chicklet } from '../../types/types';
 import { EventFeedService } from '../../services/event-feed/event-feed.service';
 import * as moment from 'moment';
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 const ENTITY_TYPE_TAG = 'event-type';
 @Component({
@@ -21,6 +22,9 @@ export class EventFeedTableComponent implements OnDestroy, OnInit {
   groupedEvent: ChefEvent;
   groupedEvents: ChefEvent[];
   groupedEventsButton;
+
+  DateTime = DateTime;
+
   @ViewChild('groupSidePanel', { static: true }) sidepanel: ElementRef;
   private subscription: Subscription;
   private isDestroyed = new Subject<boolean>();


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This commit updates the displayed datetimes within event-feed graph and table to use datetime formats specified in fixes #1977

**Before**
![](https://user-images.githubusercontent.com/479121/68819149-747b4580-0644-11ea-8854-a53767ea232b.png)

**After**
![](https://user-images.githubusercontent.com/479121/68819163-80670780-0644-11ea-9eca-f483e69f9f75.png)
