### PR TITLE
Welcome modal fixes

### DIFF
--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -44,6 +44,7 @@ import { UIComponent } from 'app/ui.component';
 
 // Services
 import { ChefSessionService } from './services/chef-session/chef-session.service';
+import { TelemetryService } from './services/telemetry/telemetry.service';
 import { NodeDetailsResolverService } from './services/node-details/node-details-resolver.service';
 import {
   NodeNoRunsDetailsResolverService
@@ -57,7 +58,7 @@ const routes: Routes = [
   {
     path: '',
     component: UIComponent,
-    canActivate: [ChefSessionService],
+    canActivate: [ChefSessionService, TelemetryService],
     children: [{
       path: '',
       redirectTo: 'dashboards/event-feed',

--- a/components/automate-ui/src/app/page-components/welcome-modal/welcome-modal.component.ts
+++ b/components/automate-ui/src/app/page-components/welcome-modal/welcome-modal.component.ts
@@ -90,8 +90,7 @@ export class WelcomeModalComponent {
         break;
       case null:
         // If the user has not set a preference this is their first visit
-        // with this browser. So we show them the modal and store the default pref.
-        this.localStorage.putBoolean(SHOW_AT_START_PREF_KEY, this.showAtStartPref);
+        // with this browser. So we show them the modal.
         this.showModal();
         break;
     }
@@ -114,9 +113,10 @@ export class WelcomeModalComponent {
     }
   }
 
-  // Shows the modal and sets the has_been_seen flag to true.
+  // Shows the modal and sets the showAtStart and hasSeen flags.
   public showModal(): void {
     this.isVisible = true;
+    this.localStorage.putBoolean(SHOW_AT_START_PREF_KEY, this.showAtStartPref);
     this.sessionStorage.putBoolean(this.chefSessionService.userWelcomeModalSeenKey(), true);
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

These commits fix issues where
- welcome modal would display again on page refresh after dismissing it on first viewing
- telemetry checkbox toggle would not display on first viewing of welcome modal

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://github.com/chef/automate/issues/1655

### :+1: Definition of Done

- Welcome modal only automatically displays on first login (unless option to always display is selected)
- Welcome modal provides option to toggle telemetry on first login

### :athletic_shoe: How to Build and Test the Change

- Start new, empty browser instance (incognito)
- Log in
- See welcome modal is displayed w/ correct content and checkbox options
- Dismiss modal and refresh page
- See modal doesn't reappear (unless option to always show on startup is selected)

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?