### PR TITLE
[automate-2216] Supply missing field caption for team details

### DIFF
--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.scss
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.scss
@@ -55,6 +55,7 @@ section {
 
   #projects-container {
     display: flex;
+    margin-top: 30px;
     margin-bottom: 38px;
 
     chef-loading-spinner {

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
@@ -103,6 +103,10 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     this.store.dispatch(new GetUsers());
     this.isIAMv2$ = this.store.select(isIAMv2);
     this.layoutFacade.showSettingsSidebar();
+
+    this.isIAMv2$.pipe(takeUntil(this.isDestroyed))
+      .subscribe((isV2) => this.descriptionOrName = isV2 ? 'name' : 'description');
+
     this.store.select(routeURL).pipe(takeUntil(this.isDestroyed))
       .subscribe((url: string) => {
         this.url = url;
@@ -135,13 +139,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
       this.store.select(v2TeamFromRoute)
     ]).pipe(
       filter(([isV2, _v1TeamFromRoute, _v2TeamFromRoute]) => isV2 !== null),
-      map(([isV2, v1Team, v2Team]) => {
-        if (isV2) {
-          return v2Team;
-        } else {
-          return v1Team;
-        }
-      }));
+      map(([isV2, v1Team, v2Team]) => isV2 ? v2Team : v1Team ));
 
     combineLatest([this.isIAMv2$, team$]).pipe(
       takeUntil(this.isDestroyed),


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

A bug was recently introduced that caused a field caption for team details
to disappear:
 
![image](https://user-images.githubusercontent.com/6817500/68901404-b959b780-06ea-11ea-86aa-268ea9998be4.png)

### :+1: Definition of Done

Caption now appears on V2:
![image](https://user-images.githubusercontent.com/6817500/68902225-903a2680-06ec-11ea-9d7b-1b8ea8a9d3ca.png)

Caption now appears on V1:
![image](https://user-images.githubusercontent.com/6817500/68902234-94feda80-06ec-11ea-9f41-35030ae674a5.png)

### :athletic_shoe: How to Build and Test the Change

rebuild automate-ui
Navigate to Settings >> Teams >> [team] >> Details
Try on both v1 and v2