### PR TITLE
Refactor profile list code

### DIFF
--- a/components/compliance-service/api/profiles/server/pgserver.go
+++ b/components/compliance-service/api/profiles/server/pgserver.go
@@ -282,21 +282,21 @@ func (srv *PGProfileServer) Delete(ctx context.Context, in *profiles.ProfileDeta
 }
 
 func (srv *PGProfileServer) List(ctx context.Context, in *profiles.Query) (*profiles.Profiles, error) {
-	var metadata []inspec.Metadata
-	var err error
 	sortOrder := in.Order.String()
-	if in.Sort == "" {
-		in.Sort = "title"
-	}
-	logrus.Infof("Listing profiles by %s %s", in.Sort, sortOrder)
-	if len(in.Owner) == 0 {
-		// list market profiles
-		metadata, err = srv.store.ListMarketProfilesMetadata(in.Name, in.Sort, sortOrder)
-	} else {
-		// list all profiles by owner
-		metadata, err = srv.store.ListProfilesMetadata(in.Owner, in.Name, in.Sort, sortOrder)
+
+	sortField := in.Sort
+	if sortField == "" {
+		sortField = "title"
 	}
 
+	logrus.WithFields(logrus.Fields{
+		"sortOrder": sortOrder,
+		"sortField": sortField,
+		"namespace": in.Owner,
+		"name":      in.Name,
+	}).Infof("Listing profiles")
+
+	metadata, err := srv.store.ListProfilesMetadata(in.Owner, in.Name, sortField, sortOrder)
 	if err != nil {
 		return nil, err
 	}

--- a/components/compliance-service/profiles/db/store.go
+++ b/components/compliance-service/profiles/db/store.go
@@ -437,11 +437,10 @@ func (s *Store) ListProfilesMetadata(namespace string, name string, sort string,
 
 		rows, err = s.DB.Query(query, namespace, name)
 	}
-	defer rows.Close() // nolint: errcheck
-
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close() // nolint: errcheck
 
 	return s.parseList(rows)
 }

--- a/components/compliance-service/profiles/db/store.go
+++ b/components/compliance-service/profiles/db/store.go
@@ -367,111 +367,31 @@ func (s *Store) parseList(rows *sql.Rows) ([]inspec.Metadata, error) {
 		logrus.Debug("iterate over row")
 		err := rows.Scan(&sha256, &metadataBlob)
 		if err != nil {
-			logrus.Error(err)
-			return entries, err
+			return nil, err
 		}
 		logrus.Debug("parse metadata")
 		metadata := inspec.Metadata{}
 		err = metadata.ParseJSON(metadataBlob)
 		if err != nil {
-			logrus.Error(err)
-			return entries, err
+			return nil, err
 		}
 		metadata.Sha256 = sha256
 		entries = append(entries, metadata)
 	}
 	err := rows.Err()
 	if err != nil {
-		logrus.Error(err)
-		return entries, err
+		return nil, err
 	}
 	return entries, nil
 }
 
-func validateSortOrder(sort string, order string) error {
+func (s *Store) ListProfilesMetadata(namespace string, name string, sort string, order string) ([]inspec.Metadata, error) {
 	if order != "ASC" && order != "DESC" {
-		return status.Errorf(codes.InvalidArgument, "order field '%s' is invalid. Use either 'ASC' or 'DESC'", sort)
+		return nil, status.Errorf(codes.InvalidArgument, "order field '%s' is invalid. Use either 'ASC' or 'DESC'", order)
 	}
 
 	if sort != "name" && sort != "title" && sort != "maintainer" {
-		return status.Errorf(codes.InvalidArgument, "sort field '%s' is invalid. Use either 'name', 'title' or 'maintainer'", sort)
-	}
-	return nil
-}
-
-func (s *Store) marketProfilesAll(sort string, order string) (*sql.Rows, error) {
-	selectMarketSQL := fmt.Sprintf(`
-		SELECT sha256, info
-		FROM store_profiles WHERE sha256 IN
-		(SELECT sha256 FROM store_market)
-		ORDER BY store_profiles.info #>> '{%s}' %s, store_profiles.info #>> '{version}' DESC;
-	`, sort, order)
-
-	selectMarketStmt, err := s.DB.Prepare(selectMarketSQL)
-	if err != nil {
-		logrus.Error(err)
-		return nil, err
-	}
-
-	return selectMarketStmt.Query()
-}
-
-func (s *Store) marketProfilesByName(name string, sort string, order string) (*sql.Rows, error) {
-	selectMarketSQL := fmt.Sprintf(`
-		SELECT sha256, info
-		FROM store_profiles WHERE sha256 IN
-		(SELECT sha256 FROM store_market)
-		AND info->>'name' = $1
-		ORDER BY store_profiles.info #>> '{%s}' %s, store_profiles.info #>> '{version}' DESC;
-	`, sort, order)
-
-	selectMarketStmt, err := s.DB.Prepare(selectMarketSQL)
-	if err != nil {
-		logrus.Error(err)
-		return nil, err
-	}
-
-	return selectMarketStmt.Query(name)
-}
-
-// returns array of profiles with info
-func (s *Store) namespaceProfilesAll(namespace string, sort string, order string) (*sql.Rows, error) {
-	selectProfilesSQL := fmt.Sprintf(`
-		SELECT sha256, info
-		FROM store_profiles WHERE
-		sha256 IN (SELECT sha256 FROM store_namespace WHERE owner=$1)
-		ORDER BY store_profiles.info #>> '{%s}' %s, store_profiles.info #>> '{version}' DESC;
-	`, sort, order)
-
-	selectProfilesStmt, err := s.DB.Prepare(selectProfilesSQL)
-	if err != nil {
-		return nil, err
-	}
-
-	return selectProfilesStmt.Query(namespace)
-}
-
-func (s *Store) namespaceProfilesByName(namespace string, name string, sort string, order string) (*sql.Rows, error) {
-	selectProfilesSQL := fmt.Sprintf(`
-		SELECT sha256, info
-		FROM store_profiles WHERE
-		sha256 IN (SELECT sha256 FROM store_namespace WHERE owner=$1)
-		AND info->>'name' = $2
-		ORDER BY store_profiles.info #>> '{%s}' %s, store_profiles.info #>> '{version}' DESC;
-	`, sort, order)
-
-	selectProfilesStmt, err := s.DB.Prepare(selectProfilesSQL)
-	if err != nil {
-		return nil, err
-	}
-
-	return selectProfilesStmt.Query(namespace, name)
-}
-
-func (s *Store) ListProfilesMetadata(namespace string, name string, sort string, order string) ([]inspec.Metadata, error) {
-	err := validateSortOrder(sort, order)
-	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "sort field '%s' is invalid. Use either 'name', 'title' or 'maintainer'", sort)
 	}
 
 	var rows *sql.Rows
@@ -479,21 +399,50 @@ func (s *Store) ListProfilesMetadata(namespace string, name string, sort string,
 
 	switch {
 	case len(namespace) == 0 && len(name) == 0:
-		rows, err = s.marketProfilesAll(sort, order)
+		query := fmt.Sprintf(`
+			SELECT sha256, info
+			FROM store_profiles WHERE sha256 IN
+			(SELECT sha256 FROM store_market)
+			ORDER BY store_profiles.info #>> '{%s}' %s, store_profiles.info #>> '{version}' DESC;
+		`, sort, order)
+
+		rows, err = s.DB.Query(query)
 	case len(namespace) == 0:
-		rows, err = s.marketProfilesByName(name, sort, order)
+		query := fmt.Sprintf(`
+			SELECT sha256, info
+			FROM store_profiles WHERE sha256 IN
+			(SELECT sha256 FROM store_market)
+			AND info->>'name' = $1
+			ORDER BY store_profiles.info #>> '{%s}' %s, store_profiles.info #>> '{version}' DESC;
+		`, sort, order)
+
+		rows, err = s.DB.Query(query, name)
 	case len(name) == 0:
-		rows, err = s.namespaceProfilesAll(namespace, sort, order)
+		query := fmt.Sprintf(`
+			SELECT sha256, info
+			FROM store_profiles WHERE
+			sha256 IN (SELECT sha256 FROM store_namespace WHERE owner=$1)
+			ORDER BY store_profiles.info #>> '{%s}' %s, store_profiles.info #>> '{version}' DESC;
+		`, sort, order)
+
+		rows, err = s.DB.Query(query, namespace)
 	default:
-		rows, err = s.namespaceProfilesByName(namespace, name, sort, order)
+		query := fmt.Sprintf(`
+			SELECT sha256, info
+			FROM store_profiles WHERE
+			sha256 IN (SELECT sha256 FROM store_namespace WHERE owner=$1)
+			AND info->>'name' = $2
+			ORDER BY store_profiles.info #>> '{%s}' %s, store_profiles.info #>> '{version}' DESC;
+		`, sort, order)
+
+		rows, err = s.DB.Query(query, namespace, name)
 	}
+	defer rows.Close() // nolint: errcheck
 
 	if err != nil {
-		logrus.Error(err)
 		return nil, err
 	}
 
-	defer rows.Close() // nolint: errcheck
 	return s.parseList(rows)
 }
 


### PR DESCRIPTION
This code is extracted from another branch I had going with experiments to speed up the available profile list page in the app. The logic to decide which SQL query to run was spread across many functions that felt redundant and convoluted, so I consolidated from 8 functions to 2. This also removes a few redundant log messages.