### PR TITLE
Only show auto create msg for project modal

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -44,7 +44,7 @@
             <chef-button tertiary (click)="modifyID = true" id="edit-button-object-modal" data-cy="edit-button">Edit ID</chef-button>
           </chef-toolbar>
         </div>
-        <div class="checkbox-margin" *ngIf="!showProjectsDropdown">
+        <div class="checkbox-margin" *ngIf="createProjectModal">
           <chef-checkbox checked="true" disabled="true">
             Also create owner, editor, and viewer policies for this project.
           </chef-checkbox>

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -20,6 +20,7 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
   @Input() creating = false;
   @Input() objectNoun: string;
   @Input() showProjectsDropdown = false;
+  @Input() createProjectModal = false;
   @Input() assignableProjects: Project[] = [];
   @Input() createForm: FormGroup; // NB: The form must contain 'name' and 'id' fields
   @Input() conflictErrorEvent: EventEmitter<boolean>; // TC: This element assumes 'id' is the

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.html
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.html
@@ -67,18 +67,19 @@
           </app-authorized>
           <app-authorized not [allOf]="['/iam/v2beta/projects', 'post']">
             <div class="empty-case-container">
-              <p>It looks like no one has created any projects yet and you<br/>
-                don't have permission to create them.<br/><br/>
+              <p>It looks like no one has created any projects yet or you<br/>
+                don't have permission to view them.<br/><br/>
                 If this is a mistake, then reach out to your administrator.
               </p>
             </div>
           </app-authorized>
         </ng-container>
       </section>
-  
+
       <app-create-object-modal
         [visible]="createModalVisible"
         [showProjectsDropdown]="false"
+        [createProjectModal]="true"
         [creating]="creatingProject"
         [conflictErrorEvent]="conflictErrorEvent"
         objectNoun="project"
@@ -86,7 +87,7 @@
         (close)="closeCreateModal()"
         (createClicked)="createProject()">
       </app-create-object-modal>
-  
+
       <app-delete-object-modal
         [visible]="deleteModalVisible"
         objectNoun="project"
@@ -96,13 +97,13 @@
         (deleteClicked)="deleteProject()"
         objectAction="Delete">
       </app-delete-object-modal>
-  
+
       <app-confirm-apply-start-modal
         [visible]="confirmApplyStartModalVisible"
         (confirm)="confirmApplyStart()"
         (cancel)="cancelApplyStart()">
       </app-confirm-apply-start-modal>
-  
+
       <app-confirm-apply-stop-modal
         [visible]="confirmApplyStopModalVisible"
         [applyRulesStatus]="projects.applyRulesStatus$ | async"

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
@@ -64,7 +64,7 @@ describe('ProjectListComponent', () => {
         }),
         MockComponent({
           selector: 'app-create-object-modal',
-          inputs: ['creating', 'createForm', 'visible', 'showProjectsDropdown', 'objectNoun', 'conflictErrorEvent'],
+          inputs: ['creating', 'createForm', 'visible', 'showProjectsDropdown', 'objectNoun', 'conflictErrorEvent', 'createProjectModal'],
           outputs: ['close', 'deleteClicked']
         }),
         MockComponent({


### PR DESCRIPTION
Signed-off-by: Blake Johnson <bstier@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Need to only show the "Create policies for project" when creating project. Should never show in v1.

Before:


![image](https://user-images.githubusercontent.com/24259050/68903582-77cc0b00-06f0-11ea-8ad3-dfd63b51a8a7.png)

After:

<img width="706" alt="Screen Shot 2019-11-14 at 3 07 49 PM" src="https://user-images.githubusercontent.com/24259050/68903618-90d4bc00-06f0-11ea-8725-956159ce161b.png">

