### PR TITLE
[automate-2176] clean up user pages subscriptions

### DIFF
--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.html
@@ -13,14 +13,14 @@
         <chef-breadcrumb [link]="['/settings/users']">Users</chef-breadcrumb>
         {{ user?.name }}
       </chef-breadcrumbs>
-
+  
       <chef-page-header>
         <div class="detail-row">
           <div class="name-column">
-            <ng-container *ngIf="!editMode">
+            <ng-container *ngIf="!updatingUser">
               <div class="display3">{{ user?.name }}</div>
             </ng-container>
-            <ng-container *ngIf="editMode">
+            <ng-container *ngIf="updatingUser">
               <form [formGroup]="editForm">
                 <chef-form-field class="display3">
                   <label>
@@ -39,10 +39,10 @@
             </div>
           </div>
           <div class="button-column">
-            <ng-container *ngIf="!editMode">
+            <ng-container *ngIf="!updatingUser">
               <app-authorized [allOf]="[['/auth/users/{username}', 'put', user?.id], ['/iam/v2beta/users/{username}', 'put', user?.id],
                 ['/auth/users/{username}', 'get', user?.id], ['/iam/v2beta/users/{username}', 'get', user?.id]]">
-                <chef-button secondary class="edit-button" (click)="setEditMode(true)">
+                <chef-button secondary class="edit-button" (click)="setUpdatingUser(true)">
                   <chef-icon>mode_edit</chef-icon>
                   <span>Edit</span>
                 </chef-button>
@@ -56,12 +56,12 @@
                 </chef-button>
               </app-authorized>
             </ng-container>
-            <ng-container *ngIf="editMode">
+            <ng-container *ngIf="updatingUser">
               <chef-button primary class="save-button" [disabled]="!editForm.valid || !editForm.dirty"
                 (click)="saveFullName()">
                 <span>Save</span>
               </chef-button>
-              <chef-button tertiary (click)="setEditMode(false)">Cancel</chef-button>
+              <chef-button tertiary (click)="setUpdatingUser(false)">Cancel</chef-button>
             </ng-container>
           </div>
         </div>

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.html
@@ -2,7 +2,7 @@
   <div class="container">
     <main>
       <chef-loading-spinner *ngIf="isLoading" size='50' fixed></chef-loading-spinner>
-      
+  
       <app-delete-object-modal
         [visible]="deleteModalVisible"
         objectNoun="user"
@@ -11,13 +11,13 @@
         (deleteClicked)="deleteUser()"
         objectAction="Delete">
       </app-delete-object-modal>
-      
       <chef-page-header>
         <chef-heading>Users</chef-heading>
         <chef-subheading>Chef Automate only displays local users.</chef-subheading>
       </chef-page-header>
-
-      <chef-modal label="create-user-label" class="user-modal" [visible]="createModalVisible" (closeModal)="closeCreateModal()">
+  
+      <chef-modal label="create-user-label" class="user-modal" [visible]="createModalVisible"
+        (closeModal)="closeCreateModal()">
         <h2 id="create-user-label" class="title" slot="title">
           Create User
         </h2>
@@ -25,20 +25,24 @@
           <app-user-form [createUserForm]="createUserForm"></app-user-form>
           <div class="line"></div>
           <div class="options">
-            <chef-button primary class="create" (click)="handleCreateUser()"
-              [disabled]="!createUserForm.valid" tabindex="2" data-cy="save-user">
-              <chef-icon *ngIf="!isLoading">save</chef-icon>
-              <span *ngIf="!isLoading">Save and Close </span>
-              <chef-loading-spinner *ngIf="isLoading"></chef-loading-spinner>
-              <span *ngIf="isLoading">Saving...</span>
+            <chef-button primary class="create" (click)="handleCreateUser()" [disabled]="!createUserForm.valid"
+              tabindex="2" data-cy="save-user">
+              <ng-container *ngIf="!creatingUser">
+                <chef-icon>save</chef-icon>
+                <span>Save and Close </span>
+              </ng-container>
+              <ng-container *ngIf="creatingUser">
+                <chef-loading-spinner></chef-loading-spinner>
+                <span>Saving...</span>
+              </ng-container>
             </chef-button>
             <chef-button type="reset" tertiary id="cancel" (click)="closeCreateModal()" tabindex="-1">Cancel</chef-button>
           </div>
         </div>
       </chef-modal>
-
+  
       <section class="page-body">
-        <app-user-table
+                <app-user-table
           [addButtonText]="addButtonText"
           [removeText]="removeText"
           [users]="users"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

In the interest of improving performance across auth pages, we're auditing how we're handling subscriptions to ensure the following:

1. all subscriptions are destroyed when the user moves away from the page
2. no nested subscriptions exist

This PR cleans up the users pages:

- user-details.component.ts
- user-management.component.ts

### :chains: Related Resources
- depends on https://github.com/chef/automate/pull/2130
and https://github.com/chef/automate/pull/2188

### :+1: Definition of Done

- refactored pages work as they did before (modal closes when appropriate, errors display as expected)
- each page subscribes to each data stream only once and closes the subscription when the component is destroyed

### :athletic_shoe: How to Build and Test the Change

1. start the UI and navigate to https://a2-dev.test/settings/users
2. create a user and see the user table update with that user
3. navigate to your new user, select the Edit button
4. update the user name
5. delete the user and you should be navigated back to the user list page
6. make another user and go to their details - this time, run chef-automate dev remove-some components/local-user-service/ in the studio before editing
7. try to edit: edit mode will close and an error alert will display
8. try to delete the user, you'll stay on the user page and see an error alert


### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?
