### PR TITLE
[AUTOMATE-2143] Throw error if all cypress environment variables are not set

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -412,7 +412,7 @@ steps:
   #
   - label: ":cypress: (flaky included) IAMv1"
     command:
-      - IAM=v1 integration/run_test integration/tests/cypress_e2e.sh
+      - FLAKY=yes IAM=v1 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
     soft_fail: true
     expeditor:
@@ -432,12 +432,10 @@ steps:
       executor:
         linux:
           privileged: true
-          environment:
-            - CYPRESS_RUN_FLAKY=true
 
   - label: ":cypress: (flaky included) IAMv2"
     command:
-      - IAM=v2.1 integration/run_test integration/tests/cypress_e2e.sh
+      - FLAKY=yes IAM=v2.1 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
     soft_fail: true
     expeditor:
@@ -445,12 +443,10 @@ steps:
       executor:
         linux:
           privileged: true
-          environment:
-            - CYPRESS_RUN_FLAKY=true
 
   - label: ":cypress: IAMv1"
     command:
-      - IAM=v1 integration/run_test integration/tests/cypress_e2e.sh
+      - FLAKY=no IAM=v1 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 20
     expeditor:
       secrets: &cypress_secrets
@@ -472,7 +468,7 @@ steps:
 
   - label: ":cypress: IAMv2"
     command:
-      - IAM=v2.1 integration/run_test integration/tests/cypress_e2e.sh
+      - FLAKY=no IAM=v2.1 integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 25
     expeditor:
       secrets: *cypress_secrets

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -46,11 +46,11 @@ dev or acceptance; typically start with your local box with this:
 export CYPRESS_BASE_URL=https://a2-dev.test
 ```
 
-Most Cypress tests also expect the following IAM-related environment variables. Set them
-according to your targeted Automate instance's IAM version.
+You must also set the IAM version, whether or not run run the flaky tests, and optionally the admin token:
 
 ```bash
 export CYPRESS_IAM_VERSION=v1 || v2.1
+export CYPRESS_RUN_FLAKY=yes || no
 export CYPRESS_ADMIN_TOKEN=<admin token value> # optional
 ```
 
@@ -112,10 +112,10 @@ Your dev environment's IAM version MUST match the value of CYPRESS_IAM_VERSION f
 
 ### Running Flaky Tests
 
-There are some known flaky tests we are trying to debug. By default, they do not run. If you wish to run them:
+There are some known flaky tests we are trying to debug. You must set whether or not you wish for them to run:
 
 ```bash
-CYPRESS_RUN_FLAKY=true npm run cypress:run
+CYPRESS_RUN_FLAKY=yes npm run cypress:run
 ```
 
 The tests are marked as flaky by the `itFlaky` descriptor instead of the `it` descriptor.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -21,6 +21,19 @@ cd automate/e2e
 npm install
 ```
 
+There are four different helpers you can run, depending on what version of IAM you are on
+and whether or not you want to run the tests marked as flaky:
+
+```
+npm run cypress:local:v1
+npm run cypress:local:v1:flaky
+npm run cypress:local:v2
+npm run cypress:local:v2:flaky
+```
+
+These commands are simply setting the correct environment variables to run cypress locally.
+See below for more details.
+
 ### Environment Variables
 
 Next set your environment variables. See "Working with Secrets" in
@@ -46,7 +59,7 @@ dev or acceptance; typically start with your local box with this:
 export CYPRESS_BASE_URL=https://a2-dev.test
 ```
 
-You must also set the IAM version, whether or not run run the flaky tests, and optionally the admin token:
+You must also set the IAM version, whether or not to run the flaky tests, and optionally the admin token:
 
 ```bash
 export CYPRESS_IAM_VERSION=v1 || v2.1

--- a/e2e/cypress/integration/constants.ts
+++ b/e2e/cypress/integration/constants.ts
@@ -1,6 +1,7 @@
 export type IAMVersion = 'v1' | 'v2.1';
-export const iamVersion: IAMVersion = Cypress.env('IAM_VERSION') || 'v2.1';
+export type FlakyResponse = 'yes' | 'no';
+export const iamVersion: IAMVersion = Cypress.env('IAM_VERSION');
 export function isV1() { return iamVersion === 'v1'; }
 export const describeIfIAMV2p1 = iamVersion === 'v2.1' ? describe : describe.skip;
-export const runFlaky: boolean = Cypress.env('RUN_FLAKY') || false;
-export const itFlaky = runFlaky ? it : it.skip;
+export const runFlaky: FlakyResponse = Cypress.env('RUN_FLAKY');
+export const itFlaky = runFlaky === 'yes' ? it : it.skip;

--- a/e2e/cypress/support/index.ts
+++ b/e2e/cypress/support/index.ts
@@ -26,26 +26,26 @@ const IAMV1 = 'v1';
 before(function () {
   if (!Cypress.env('IAM_VERSION')) {
     // tslint:disable-next-line:no-string-throw
-    throw('MISSING ENVIRONMENT VARIABLE: ' +
+    throw new Error('MISSING ENVIRONMENT VARIABLE: ' +
       `You must pass CYPRESS_IAM_VERSION. Must be one of: "${IAMV2}", "${IAMV1}".`);
   }
 
   if (Cypress.env('IAM_VERSION') !== IAMV2 && Cypress.env('IAM_VERSION') !== IAMV1) {
     // tslint:disable-next-line:no-string-throw
-    throw('INCORRECT ENVIRONMENT VARIABLE: ' +
+    throw new Error('INCORRECT ENVIRONMENT VARIABLE: ' +
       `You must pass CYPRESS_IAM_VERSION. Must be one of: "${IAMV2}", "${IAMV1}". ` +
       `You passed: ${Cypress.env('IAM_VERSION')}`);
   }
 
   if (!Cypress.env('RUN_FLAKY')) {
     // tslint:disable-next-line:no-string-throw
-    throw('MISSING ENVIRONMENT VARIABLE: You must pass CYPRESS_RUN_FLAKY.' +
+    throw new Error('MISSING ENVIRONMENT VARIABLE: You must pass CYPRESS_RUN_FLAKY.' +
       'Must be one of: "yes", "no".');
   }
 
   if (Cypress.env('RUN_FLAKY') !== 'yes' && Cypress.env('RUN_FLAKY') !== 'no') {
     // tslint:disable-next-line:no-string-throw
-    throw('INCORRECT ENVIRONMENT VARIABLE: You must pass CYPRESS_RUN_FLAKY. ' +
+    throw new Error('INCORRECT ENVIRONMENT VARIABLE: You must pass CYPRESS_RUN_FLAKY. ' +
       'Must be one of: "yes", "no".' +
       `You passed: ${Cypress.env('RUN_FLAKY')}`);
   }

--- a/e2e/cypress/support/index.ts
+++ b/e2e/cypress/support/index.ts
@@ -15,19 +15,64 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands';
+import '../integration/constants';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
+const IAMV2 = 'v2.1';
+const IAMV1 = 'v1';
+
 before(function () {
-  if (!Cypress.env('ADMIN_TOKEN')) {
+  if (!Cypress.env('IAM_VERSION')) {
+    // tslint:disable-next-line:no-string-throw
+    throw('MISSING ENVIRONMENT VARIABLE: ' +
+      `You must pass CYPRESS_IAM_VERSION. Must be one of: "${IAMV2}", "${IAMV1}".`);
+  }
+
+  if (Cypress.env('IAM_VERSION') !== IAMV2 && Cypress.env('IAM_VERSION') !== IAMV1) {
+    // tslint:disable-next-line:no-string-throw
+    throw('INCORRECT ENVIRONMENT VARIABLE: ' +
+      `You must pass CYPRESS_IAM_VERSION. Must be one of: "${IAMV2}", "${IAMV1}". ` +
+      `You passed: ${Cypress.env('IAM_VERSION')}`);
+  }
+
+  if (!Cypress.env('RUN_FLAKY')) {
+    // tslint:disable-next-line:no-string-throw
+    throw('MISSING ENVIRONMENT VARIABLE: You must pass CYPRESS_RUN_FLAKY.' +
+      'Must be one of: "yes", "no".');
+  }
+
+  if (Cypress.env('RUN_FLAKY') !== 'yes' && Cypress.env('RUN_FLAKY') !== 'no') {
+    // tslint:disable-next-line:no-string-throw
+    throw('INCORRECT ENVIRONMENT VARIABLE: You must pass CYPRESS_RUN_FLAKY. ' +
+      'Must be one of: "yes", "no".' +
+      `You passed: ${Cypress.env('RUN_FLAKY')}`);
+  }
+
     cy.adminLogin('/').then(() => {
       const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
-      cy.generateAdminToken(admin.id_token);
+
+      // this needs to use the id_token because generateAdminToken will
+      // throw a confusing error if you are on the wrong version of IAM so we need
+      // to do this first.
+      cy.request({
+        auth: { bearer: admin.id_token },
+        url: '/apis/iam/v2beta/policy_version'
+      }).then((response) => {
+        if (Cypress.env('IAM_VERSION') === IAMV2) {
+          expect(response.body.version.major).to.equal('V2');
+        } else {
+          expect(response.body.version.major).to.equal('V1');
+        }
+      });
+
+      if (!Cypress.env('ADMIN_TOKEN')) {
+        cy.generateAdminToken(admin.id_token);
+      }
     });
 
     // reset test state
     // each UI test logs in at the beginning, so we don't want any session data lying around
     cy.clearLocalStorage();
-  }
 });

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,6 +5,10 @@
   "main": "index.js",
   "scripts": {
     "cypress:open": "cypress open",
+    "cypress:local:v1": "CYPRESS_BASE_URL=https://a2-dev.test CYPRESS_IAM_VERSION=v1 CYPRESS_RUN_FLAKY=no cypress open",
+    "cypress:local:v1:flaky": "CYPRESS_BASE_URL=https://a2-dev.test CYPRESS_IAM_VERSION=v2.1 CYPRESS_RUN_FLAKY=yes cypress open",
+    "cypress:local:v2": "CYPRESS_BASE_URL=https://a2-dev.test CYPRESS_IAM_VERSION=v2.1 CYPRESS_RUN_FLAKY=no cypress open",
+    "cypress:local:v2:flaky": "CYPRESS_BASE_URL=https://a2-dev.test CYPRESS_IAM_VERSION=v2.1 CYPRESS_RUN_FLAKY=yes cypress open",
     "cypress:run": "cypress run",
     "cypress:record": "cypress run --record",
     "lint": "tslint -p tsconfig.json"

--- a/integration/run_test
+++ b/integration/run_test
@@ -24,7 +24,7 @@ test_commandline() {
 
     # Reproduce a select set of environment variables that influence
     # the tests.
-    env_vars=$(set +o pipefail; env | grep -E '^(IAM)=' | tr '\n' ' ')
+    env_vars=$(set +o pipefail; env | grep -E '^(FLAKY|IAM)=' | tr '\n' ' ')
     echo "    $env_vars $complete_commandline"
 }
 
@@ -91,6 +91,7 @@ docker_run_args=(
         "--env" "CONTAINER_HOSTNAME=${test_container_name}"
         "--env" "test_notifications_endpoint=${test_notifications_endpoint}"
         "--env" "IAM"
+        "--env" "FLAKY"
         "--env" "A2_LICENSE"
         "--env" "CYPRESS_AUTOMATE_ACCEPTANCE_TARGET_HOST"
         "--env" "CYPRESS_AUTOMATE_ACCEPTANCE_TARGET_USER"

--- a/integration/tests/cypress_e2e.sh
+++ b/integration/tests/cypress_e2e.sh
@@ -44,6 +44,7 @@ do_deploy() {
 
     export CYPRESS_IAM_VERSION=$IAM
     export CYPRESS_ADMIN_TOKEN=$token
+    export CYPRESS_RUN_FLAKY=$FLAKY
 
     log_info "fixing dns resolution for '${CONTAINER_HOSTNAME}'"
     echo "127.0.0.1 ${CONTAINER_HOSTNAME}" >> /etc/hosts


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

- Changed CYPRESS_RUN_FLAKY to 'yes', 'no', from a boolean, because there is no way to tell the difference between false being passed and the env var not being passed at all
- Added a test to assert that the IAM version returned via the API matches what you passed in via CYPRESS_IAM_VERSION
- Also fixes bug where the flaky tests weren't actually running in the flaky pipelines 😓 

I did not do `CYPRESS_BASE_URL` because cypress itself will throw a fit if that isn't set to a valid address.

### :athletic_shoe: How to Build and Test the Change

```
CYPRESS_IAM_VERSION="x" CYPRESS_RUN_FLAKY="x" npm run cypress:open
```

with various missing and incorrect values for the env vars.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?
