### PR TITLE
CSS changes to display dropdown on top of loading overlay

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.scss
@@ -21,6 +21,10 @@
   }
 }
 
+chef-loading-spinner {
+  z-index: 199;
+}
+
 .profiles-table {
   chef-loading-spinner {
     display: block;


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
Currently, both the global projects filter rand the user dropdowns display behind the loading overlay

Repro
chef-automate iam upgrade-to-v2 --beta2.1 note: after the 2.1 release you should not need the beta flag
visit compliance/profiles
open the project's dropdown and user menu and notice they display behind the overlay.

### :chains: Related Resources
fixes #2012

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui

### :camera: Screenshots
![Screenshot from 2019-11-15 15-28-29](https://user-images.githubusercontent.com/12297653/68934688-263d8200-07bd-11ea-8e3b-397141fb4215.png)
![Screenshot from 2019-11-15 15-28-40](https://user-images.githubusercontent.com/12297653/68934696-29d10900-07bd-11ea-98a2-dc59d647f981.png)

