### PR TITLE
ci: update automation of habitat version bumping

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -165,7 +165,7 @@ subscriptions:
       - bash:.expeditor/update-inspec-version.sh:
           post_commit: false
   # Update Habitat when it is released
-  - workload: artifact_published:stable:habitat:*
+  - workload: habitat-sh/habitat:master_completed:project_promoted:habitat-sh/habitat:master:current:*
     actions:
       - bash:.expeditor/update_habitat.sh:
           post_commit: false

--- a/.expeditor/update_habitat.sh
+++ b/.expeditor/update_habitat.sh
@@ -3,27 +3,30 @@
 set -eou pipefail
 
 NO_GIT=${NO_GIT:-false}
-
 if [[ "$NO_GIT" != "true" ]]; then
     branch="expeditor/bump-hab"
     git checkout -b "$branch"
 fi
 
-HAB_SUP_VERSION=$EXPEDITOR_VERSION
-HAB_SUP_RELEASE=$(curl "https://bldr.habitat.sh/v1/depot/channels/core/stable/pkgs/hab-sup/$HAB_SUP_VERSION/latest" | jq -r .ident.release)
+# Get latest version by retrieving and parsing the manifest for the
+# target version.
+TARGET_VERSION=${TARGET_VERSION:-"latest"}
+MANIFEST_URL="http://packages.chef.io/files/stable/habitat/$TARGET_VERSION/manifest.json"
 
-# Habitat promotes hab-sup last. We trigger on hab-sup and then query
-# the version of the other two packages.
-HAB_VERSION=$HAB_SUP_VERSION
-HAB_RELEASE=$(curl "https://bldr.habitat.sh/v1/depot/channels/core/stable/pkgs/hab/$HAB_VERSION/latest" | jq -r .ident.release)
+MANIFEST=$(curl --silent "$MANIFEST_URL")
+PACKAGES=$(jq -r '.packages | ."x86_64-linux"[]' <<< "$MANIFEST")
 
-HAB_LAUNCH_IDENT_JSON=$(curl "https://bldr.habitat.sh/v1/depot/channels/core/stable/pkgs/hab-launcher/latest" | jq -r .ident)
-HAB_LAUNCH_VERSION=$(echo "$HAB_LAUNCH_IDENT_JSON" | jq -r .version)
-HAB_LAUNCH_RELEASE=$(echo "$HAB_LAUNCH_IDENT_JSON" | jq -r .release)
+HAB_SUP_VERSION=$(awk -F/ '/core\/hab-sup\// { print $3 }' <<< "$PACKAGES")
+HAB_SUP_RELEASE=$(awk -F/ '/core\/hab-sup\// { print $4 }' <<< "$PACKAGES")
+HAB_VERSION=$(awk -F/ '/core\/hab\// { print $3 }' <<< "$PACKAGES")
+HAB_RELEASE=$(awk -F/ '/core\/hab\// { print $4 }' <<< "$PACKAGES")
+HAB_LAUNCH_VERSION=$(awk -F/ '/core\/hab-launcher\// { print $3 }' <<< "$PACKAGES")
+HAB_LAUNCH_RELEASE=$(awk -F/ '/core\/hab-launcher\// { print $4 }' <<< "$PACKAGES")
 
-sed -i -r "s|pins\[\"hab\"\].*\"version\" =>.*|pins[\"hab\"]          = { \"origin\" => \"core\", \"name\" => \"hab\",          \"version\" => \"$HAB_VERSION\", \"release\" => \"$HAB_RELEASE\"},|" .expeditor/create-manifest.rb
-sed -i -r "s|pins\[\"hab-sup\"\].*\"version\" =>.*|pins[\"hab-sup\"]      = { \"origin\" => \"core\", \"name\" => \"hab-sup\",      \"version\" => \"$HAB_SUP_VERSION\", \"release\" => \"$HAB_SUP_RELEASE\"},|" .expeditor/create-manifest.rb
-sed -i -r "s|pins\[\"hab-launcher\"\].*\"version\" =>.*|pins[\"hab-launcher\"] = { \"origin\" => \"core\", \"name\" => \"hab-launcher\", \"version\" => \"$HAB_LAUNCH_VERSION\",   \"release\" => \"$HAB_LAUNCH_RELEASE\"}|" .expeditor/create-manifest.rb
+# Modify relevant source files with the new version.
+sed -i -r "s|pins\[\"hab\"\].*\"version\" =>.*|pins[\"hab\"]          = { \"origin\" => \"core\", \"name\" => \"hab\",          \"version\" => \"$HAB_VERSION\", \"release\" => \"$HAB_RELEASE\"}|" .expeditor/create-manifest.rb
+sed -i -r "s|pins\[\"hab-sup\"\].*\"version\" =>.*|pins[\"hab-sup\"]      = { \"origin\" => \"core\", \"name\" => \"hab-sup\",      \"version\" => \"$HAB_SUP_VERSION\", \"release\" => \"$HAB_SUP_RELEASE\"}|" .expeditor/create-manifest.rb
+sed -i -r "s|pins\[\"hab-launcher\"\].*\"version\" =>.*|pins[\"hab-launcher\"] = { \"origin\" => \"core\", \"name\" => \"hab-launcher\", \"version\" => \"$HAB_LAUNCH_VERSION\",  \"release\" => \"$HAB_LAUNCH_RELEASE\"}|" .expeditor/create-manifest.rb
 
 sed -i -r "s|core/hab/[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]{14}|core/hab/$HAB_VERSION/$HAB_RELEASE|" components/automate-deployment/habitat/plan.sh
 sed -i -r "s|RECOMMENDED_HAB_VERSION=\".*\"|RECOMMENDED_HAB_VERSION=\"$HAB_VERSION\"|" .studiorc


### PR DESCRIPTION
The Habitat release process has changed. They now publish a manifest
with all relevant package versions.

By default the script will pull from the latest stable release, but
TARGET_VERSION can be set to an exact version for local testing or
manually setting the pin.

The workload I've subscribed to was taken from:

  https://github.com/habitat-sh/homebrew-habitat/pull/28

The script has been testing locally, but unfortunately we don't have a
great way to confirm that it will work in the context of expeditor.

Signed-off-by: Steven Danna <steve@chef.io>