### PR TITLE
airgap: download new hab binary from packages.chef.io

### DIFF
--- a/components/automate-deployment/pkg/airgap/bundle_creator_test.go
+++ b/components/automate-deployment/pkg/airgap/bundle_creator_test.go
@@ -10,9 +10,14 @@ import (
 )
 
 func TestHabBinaryDownload(t *testing.T) {
-	dl := bintrayHabDownloader{}
+	dl := netHabDownloader{}
 	buf := sha256.New()
 	err := dl.DownloadHabBinary("0.56.0", "20180530234036", buf)
 	require.NoError(t, err)
 	assert.Equal(t, "d829ee385a7ca3cca980f5c52671643df2ee4f80104f2336884d3c565f9a2e13", hex.EncodeToString(buf.Sum(nil)))
+
+	buf = sha256.New()
+	err = dl.DownloadHabBinary("0.90.6", "20191112141314", buf)
+	require.NoError(t, err)
+	assert.Equal(t, "1d4cdb2165e967e7421b671512c6588cdfeb7b218f18a594bcfaf52325f8a934", hex.EncodeToString(buf.Sum(nil)))
 }

--- a/components/automate-deployment/pkg/habpkg/semverish.go
+++ b/components/automate-deployment/pkg/habpkg/semverish.go
@@ -79,38 +79,44 @@ func getInt(s string) (int, string, error) {
 	return ret, s[end:], err
 }
 
+const (
+	SemverishGreater = 1
+	SemverishEqual   = 0
+	SemverishLess    = -1
+)
+
 func CompareSemverish(a SemverishVersion, b SemverishVersion) int {
 	for i := 0; i < len(a.parts); i++ {
 		if len(b.parts) > i {
 			if a.parts[i] < b.parts[i] {
-				return -1
+				return SemverishLess
 			} else if a.parts[i] > b.parts[i] {
-				return 1
+				return SemverishGreater
 			}
 		} else {
-			return 1
+			return SemverishGreater
 		}
 	}
 	if len(b.parts) > len(a.parts) {
-		return -1
+		return SemverishLess
 	}
 
 	// No-prerelease always wins
 	if a.prerelease == "" && b.prerelease != "" {
-		return 1
+		return SemverishGreater
 	} else if a.prerelease != "" && b.prerelease == "" {
-		return -1
+		return SemverishLess
 	}
 
 	// Otherwise, just lexigraphically sort the pre-release, this
 	// is not what the spec says to do.
 	if a.prerelease < b.prerelease {
-		return -1
+		return SemverishLess
 	} else if a.prerelease > b.prerelease {
-		return 1
+		return SemverishGreater
 	}
 
-	return 0
+	return SemverishEqual
 }
 
 // GreaterOrEqual returns true if a is greater or equal to b, assuming
@@ -127,11 +133,11 @@ func SemverishGreaterOrEqual(a VersionedArtifact, b VersionedArtifact) (bool, er
 	}
 
 	switch CompareSemverish(semverA, semverB) {
-	case 1: // greater
+	case SemverishGreater:
 		return true, nil
-	case -1: // less than
+	case SemverishLess:
 		return false, nil
-	case 0: // equal
+	case SemverishEqual:
 		return a.Release() >= b.Release(), nil
 	default:
 		return false, nil

--- a/components/automate-deployment/tools/upgrade-test-scaffold/upgrade-test-scaffold.go
+++ b/components/automate-deployment/tools/upgrade-test-scaffold/upgrade-test-scaffold.go
@@ -254,7 +254,7 @@ func InstallChefAutomate(manifestPath string) error {
 	}
 
 	logrus.Infof("Downloading temporary habitat binary (%s)", habpkg.Ident(&habPkg))
-	dl := airgap.NewBintrayHabDownloader()
+	dl := airgap.NewNetHabDownloader()
 	err = dl.DownloadHabBinary(habPkg.Version(), habPkg.Release(), tmpHabBin)
 	if err != nil {
 		return errors.Wrap(err, "downloading temporary hab")


### PR DESCRIPTION
The tarballs of the hab binary is now hosted on packages.chef.io
rather than bintray.

NB: Once we update to the newest version of hab, we can potentially
remove bintray from our preflight checks and documentation.

Signed-off-by: Steven Danna <steve@chef.io>