### PR TITLE
license lockout modal design changes and add sign out functionality

### DIFF
--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.html
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.html
@@ -4,7 +4,7 @@
     <ng-container *ngIf="!fetchStatusInternalError">
       <ng-container *ngIf="!trialLicenseApplied">
         <h2 id="license-lockout-label" class="title">Welcome to Chef Automate!</h2>
-        <div class="subtitle">Register to get started with a 60-day trial or <a href="https://www.chef.io/contact-us/" target="_blank">contact us</a></div>
+        <div class="subtitle">Register to get started with a 60-day trial or <a href="https://www.chef.io/contact-us/" target="_blank" rel="noopener">contact Chef</a>.</div>
         <div class="error-container">
           <chef-alert type="error" *ngIf="fetchStatusInternalError">
             <span>
@@ -71,8 +71,8 @@
           <chef-loading-spinner *ngIf="requestingLicense" size="30"></chef-loading-spinner>
         </div>
         <div class="footer">
-          <a (click)="backToLicenseApply(); false" class="active">Apply Non-Trial License</a>
-          <a (click)="logout()" class="active">Sign Out</a>
+          <chef-button tertiary (click)="backToLicenseApply(); false">Apply Non-Trial License</chef-button>
+          <chef-button tertiary (click)="logout()">Sign Out</chef-button>
         </div>
       </ng-container>
 

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.html
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.html
@@ -4,7 +4,7 @@
     <ng-container *ngIf="!fetchStatusInternalError">
       <ng-container *ngIf="!trialLicenseApplied">
         <h2 id="license-lockout-label" class="title">Welcome to Chef Automate!</h2>
-        <div class="subtitle">Sign up to get started with a 60-day trial.</div>
+        <div class="subtitle">Register to get started with a 60-day trial or <a href="https://www.chef.io/contact-us/" target="_blank">contact us</a></div>
         <div class="error-container">
           <chef-alert type="error" *ngIf="fetchStatusInternalError">
             <span>
@@ -30,20 +30,19 @@
           </chef-alert>
         </div>
 
-        <div class="note">Required fields are marked with an asterisk (*).</div>
         <form class="trial" [formGroup]="trialForm" (ngSubmit)="onTrialLicenseFormSubmit()" novalidate>
           <div class="name-container">
             <chef-form-field>
               <label for="firstName">First Name *</label>
               <div class="suggester-input-wrapper">
-                <input chefInput name="firstName" id="firstName" formControlName="firstName" type="text" autofocus placeholder="First Name">
+                <input chefInput name="firstName" id="firstName" formControlName="firstName" type="text" autofocus>
               </div>
               <chef-error *ngIf="trialForm.get('firstName').hasError('required') && trialForm.get('firstName').dirty">First name required.</chef-error>
             </chef-form-field>
             <chef-form-field>
               <label for="firstName">Last Name *</label>
               <div class="suggester-input-wrapper">
-                <input chefInput name="lastName" id="lastName" formControlName="lastName" type="text" placeholder="Last Name">
+                <input chefInput name="lastName" id="lastName" formControlName="lastName" type="text">
               </div>
                 <chef-error *ngIf="trialForm.get('lastName').hasError('required') && trialForm.get('lastName').dirty">Last name required.</chef-error>
             </chef-form-field>
@@ -52,7 +51,7 @@
             <chef-form-field>
               <label for="email">Email *</label>
               <div class="suggester-input-wrapper">
-                <input chefInput name="email" id="email" formControlName="email" type="text" placeholder="Email">
+                <input chefInput name="email" id="email" formControlName="email" type="text">
               </div>
               <chef-error *ngIf="trialForm.get('email').hasError('email') && trialForm.get('email').dirty">Valid email required.</chef-error>
             </chef-form-field>
@@ -65,16 +64,15 @@
             <a href="https://www.chef.io/online-master-agreement" target="_blank">Master License and Services Agreement</a>
           </chef-checkbox>
           <div class="button">
-            <chef-button primary type="submit" [disabled]="!(trialForm.valid && mlsaAgree) || requestingLicense">Sign Up</chef-button>
+            <chef-button primary type="submit" [disabled]="!(trialForm.valid && mlsaAgree) || requestingLicense">Register</chef-button>
           </div>
         </form>
         <div class="spinner-container">
           <chef-loading-spinner *ngIf="requestingLicense" size="30"></chef-loading-spinner>
         </div>
         <div class="footer">
-          <a href="" (click)="backToLicenseApply(); false" class="active">Already have a license?</a>
-          Or
-          <a href="https://www.chef.io/contact-us/" target="_blank">contact us</a> to get a license.
+          <a (click)="backToLicenseApply(); false" class="active">Apply Non-Trial License</a>
+          <a (click)="logout()" class="active">Sign Out</a>
         </div>
       </ng-container>
 

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.scss
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.scss
@@ -143,11 +143,7 @@
     text-align: center;
     width: 100%;
 
-    .active {
-      cursor: pointer;
-    }
-
-    a:first-of-type {
+    button:first-of-type {
       margin-right: 60px;
     }
   }

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.scss
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.scss
@@ -34,7 +34,6 @@
   .title {
     font-size: 24px;
     font-weight: bold;
-    color: $chef-primary-bright;
     margin-bottom: 1em;
     margin-top: 20px;
 
@@ -142,17 +141,14 @@
     margin-top: 10px;
     font-size: 14px;
     text-align: center;
+    width: 100%;
 
     .active {
       cursor: pointer;
     }
 
     a:first-of-type {
-      display: block;
-      font-size: 18px;
-      font-weight: 600;
-      text-decoration: underline;
-      padding-bottom: 20px;
+      margin-right: 60px;
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Sachin Bachhav <sbachhav@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
If a user signs in as a non-admin user before a license is applied, they will get a license popup that they can't get past as only the admin can apply a license. They also can't get to the log out button to re-login as admin.
The current workaround is opening an incognito window or using the CLI to set a license key.
so as fix added sign out functionality along with some design changes.
### :chains: Related Resources
fixes #1484 

### :+1: Definition of Done
Added Sign out functionality in license lockout modal
### :athletic_shoe: How to Build and Test the Change
`build components/automate-ui`

1. Set up environment
2. Log in as admin user
3. Create a non-admin user
4. Log out as admin user
5. Remove license in studio using remove_dev_license
6. Log in as non-admin user

### :camera: Screenshots
![licence_lock_modal](https://user-images.githubusercontent.com/54940695/69050794-c1865f80-0a28-11ea-8a77-75663f7c9b7f.png)
