### PR TITLE
Force deployment of automate with builder

### DIFF
--- a/components/automate-deployment/pkg/services/internal/generated/gen.go
+++ b/components/automate-deployment/pkg/services/internal/generated/gen.go
@@ -546,7 +546,8 @@ var ProductMetadataJSON = `
       "dependencies": [
         "core",
         "postgresql",
-        "auth"
+        "auth",
+        "automate"
       ],
       "hidden": false
     },

--- a/products.meta
+++ b/products.meta
@@ -149,7 +149,7 @@
       "name": "builder",
       "type": "product",
       "aliases": ["depot"],
-      "dependencies": ["core", "postgresql", "auth"],
+      "dependencies": ["core", "postgresql", "auth", "automate"],
       "services": [
         "chef/automate-minio",
         "chef/automate-builder-memcached",


### PR DESCRIPTION
Currently, builder users will need access to the automate-ui to manage users.
We'll temporarily force people to deploy automate when deploying builder
to get access to those management features.

Helps with #2248 