### PR TITLE
[automate-2179] clean up project subscriptions

### DIFF
--- a/components/automate-ui/src/app/modules/policy/details/policy-details.component.scss
+++ b/components/automate-ui/src/app/modules/policy/details/policy-details.component.scss
@@ -20,35 +20,35 @@ chef-tab-selector {
 
 thead {
   font-size: 14px;
-  letter-spacing: 0.2px;	
-  color: $chef-primary-dark;	
-}	
+  letter-spacing: 0.2px;
+  color: $chef-primary-dark;
+}
 
-th {	
-  text-align: left;	
-  padding: 0px;	
-}	
+th {
+  text-align: left;
+  padding: 0px;
+}
 
-tbody > .detail-row {	
-  padding-top: 0px;	
-  padding-bottom: 15px;	
-}	
+tbody > .detail-row {
+  padding-top: 0px;
+  padding-bottom: 15px;
+}
 
-.detail-row {	
-  display: flex;	
-  color: $chef-primary-dark;	
-}	
+.detail-row {
+  display: flex;
+  color: $chef-primary-dark;
+}
 
-.id-column {	
-  width: 33%;	
-  padding-top: 0px;	
-  padding-left: 0px;	
-}	
+.id-column {
+  width: 33%;
+  padding-top: 0px;
+  padding-left: 0px;
+}
 
-.type-column {	
-  width: 66%;	
-  padding-top: 0px;	
-  padding-left: 0px;	
+.type-column {
+  width: 66%;
+  padding-top: 0px;
+  padding-left: 0px;
 }
 
 .three-dot-column {

--- a/components/automate-ui/src/app/modules/policy/details/policy-details.component.scss
+++ b/components/automate-ui/src/app/modules/policy/details/policy-details.component.scss
@@ -18,6 +18,39 @@ chef-tab-selector {
   }
 }
 
+thead {
+  font-size: 14px;
+  letter-spacing: 0.2px;	
+  color: $chef-primary-dark;	
+}	
+
+th {	
+  text-align: left;	
+  padding: 0px;	
+}	
+
+tbody > .detail-row {	
+  padding-top: 0px;	
+  padding-bottom: 15px;	
+}	
+
+.detail-row {	
+  display: flex;	
+  color: $chef-primary-dark;	
+}	
+
+.id-column {	
+  width: 33%;	
+  padding-top: 0px;	
+  padding-left: 0px;	
+}	
+
+.type-column {	
+  width: 66%;	
+  padding-top: 0px;	
+  padding-left: 0px;	
+}
+
 .three-dot-column {
   text-align: right;
 }

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.scss
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.scss
@@ -69,29 +69,29 @@ form {
 
 thead {
   font-size: 14px;
-  letter-spacing: 0.2px;	
+  letter-spacing: 0.2px;
   color: $chef-primary-dark;
 }
 
-th {	
-  text-align: left;	
-  padding: 0px;	
-}	
+th {
+  text-align: left;
+  padding: 0px;
+}
 
-tbody > .detail-row {	
-  padding-top: 0px;	
-  padding-bottom: 15px;	
-}	
+tbody > .detail-row {
+  padding-top: 0px;
+  padding-bottom: 15px;
+}
 
-.detail-row {	
-  display: flex;	
-  color: $chef-primary-dark;	
-}	
+.detail-row {
+  display: flex;
+  color: $chef-primary-dark;
+}
 
-.id-column {	
-  width: 33%;	
-  padding-top: 0px;	
-  padding-left: 0px;	
+.id-column {
+  width: 33%;
+  padding-top: 0px;
+  padding-left: 0px;
 }
 
 .three-dot-column {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.scss
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.scss
@@ -67,6 +67,33 @@ form {
   }
 }
 
+thead {
+  font-size: 14px;
+  letter-spacing: 0.2px;	
+  color: $chef-primary-dark;
+}
+
+th {	
+  text-align: left;	
+  padding: 0px;	
+}	
+
+tbody > .detail-row {	
+  padding-top: 0px;	
+  padding-bottom: 15px;	
+}	
+
+.detail-row {	
+  display: flex;	
+  color: $chef-primary-dark;	
+}	
+
+.id-column {	
+  width: 33%;	
+  padding-top: 0px;	
+  padding-left: 0px;	
+}
+
 .three-dot-column {
   text-align: right;
 }

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
@@ -2,7 +2,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule, Store } from '@ngrx/store';
-import { of as observableOf } from 'rxjs';
 import { MockComponent } from 'ng2-mock-component';
 
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
@@ -18,6 +17,9 @@ import { projectEntityReducer, ApplyRulesStatusState } from 'app/entities/projec
 import { Project } from 'app/entities/projects/project.model';
 import { ProjectStatus } from 'app/entities/rules/rule.model';
 import { ProjectListComponent } from './project-list.component';
+import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
+import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
+import { GetIamVersionSuccess } from 'app/entities/policies/policy.actions';
 
 describe('ProjectListComponent', () => {
   let component: ProjectListComponent;
@@ -96,9 +98,13 @@ describe('ProjectListComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         ChefPipesModule,
-        StoreModule.forRoot({
+        StoreModule.forRoot(
+          {
           policies: policyEntityReducer,
-          projects: projectEntityReducer
+          projects: projectEntityReducer,
+          // not used directly in this component, needed to suppress unit test warnings
+          notifications: notificationEntityReducer,
+          clientRunsEntity: clientRunsEntityReducer
         }, { runtimeChecks })
       ],
       providers: [
@@ -116,7 +122,7 @@ describe('ProjectListComponent', () => {
     element = fixture.debugElement.nativeElement;
     store = TestBed.get(Store);
 
-    component.isIAMv2$ = observableOf(true);
+    store.dispatch(new GetIamVersionSuccess({ version: { major: 'v2' } }));
     fixture.detectChanges();
   });
 
@@ -143,7 +149,7 @@ describe('ProjectListComponent', () => {
     });
 
     it('does not display project data for v1', () => {
-      component.isIAMv2$ = observableOf(false);
+      store.dispatch(new GetIamVersionSuccess({ version: { major: 'v1' } }));
       store.dispatch(new GetProjectsSuccess({ projects: projectList }));
       expect(element).not.toContainPath('chef-table-new');
     });

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -3,11 +3,11 @@
   [attr.confirm-btn-text]=" saving ? 'Saving Rule...' : 'Save Rule' "
   [attr.heading]="getHeading()"
   [attr.disable-confirm]="!ruleForm.valid || !ruleForm.dirty"
-  [attr.page-loading]="isLoading"
+  [attr.page-loading]="(isLoading$ | async)"
   [attr.confirm-loading]="saving"
   (confirm)="saveRule()"
   (close)="closePage()">
-  <div *ngIf="!isLoading">
+  <div *ngIf="!(isLoading$ | async)">
     <ng-container>
       <form id="ruleForm" [formGroup]="ruleForm" (ngSubmit)="saveRule()">
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -13,6 +13,7 @@ import { Rule, Condition, ConditionOperator, RuleType } from 'app/entities/rules
 import { ruleEntityReducer } from 'app/entities/rules/rule.reducer';
 import { Project } from 'app/entities/projects/project.model';
 import { ProjectRulesComponent } from './project-rules.component';
+import { of as observableOf } from 'rxjs';
 
 describe('ProjectRulesComponent', () => {
   let component: ProjectRulesComponent;
@@ -113,7 +114,7 @@ describe('ProjectRulesComponent', () => {
     beforeEach(() => {
       component.project = project;
       component.rule = <Rule>{};
-      component.isLoading = false;
+      component.isLoading$ = observableOf(false);
       fixture.detectChanges();
     });
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

In the interest of improving performance across auth pages, we're auditing how we're handling subscriptions to ensure the following:

1. all subscriptions are destroyed when the user moves away from the page
2. no nested subscriptions exist

This PR cleans up the project pages:

- project-details.component.ts
- project-list.component.ts
- project-rules.component.ts

### :chains: Related Resources

### :+1: Definition of Done

- refactored pages work as they did before (modal closes when appropriate, errors display as expected)
- each page subscribes to each data stream only once and closes the subscription when the component is destroyed

### :athletic_shoe: How to Build and Test the Change
1. start the UI and navigate to https://a2-dev.test/settings/projects
2. create a project and see the project table update with that project
3. navigate to your new project, select the Details tab
4. update the project name
5. add some project rules

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable