### PR TITLE
Change terraform environments to use product config

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/main.tf
+++ b/terraform/test-environments/modules/chef_automate_install/main.tf
@@ -241,8 +241,11 @@ EOF
   deployment_type = "${var.deployment_type}"
   upgrade_strategy = "${var.upgrade == "true" ? "at-once" : "none"}"
   manifest_cache_expiry = "0s"
-  enable_chef_server = ${var.enable_chef_server}
-  enable_workflow = ${var.enable_workflow}
+  products = ${jsonencode(compact(list(
+      "automate",
+      var.enable_chef_server ? "chef-server" : "",
+      var.enable_workflow_server ? "workflow" : "",
+      var.enable_builder ? "builder" : "")))}
 
 [gateway.v1.sys.service]
   trial_license_url = "https://licensing-${var.channel}.chef.io/create-trial"

--- a/terraform/test-environments/modules/chef_automate_install/variables.tf
+++ b/terraform/test-environments/modules/chef_automate_install/variables.tf
@@ -130,3 +130,8 @@ variable "workflow_enterprise" {
   default     = "demo"
   description = "A2 Workflow enterprise name."
 }
+
+variable "enable_builder" {
+  default     = "false"
+  description = "Enables A2 Builder feature."
+}


### PR DESCRIPTION
we are no longer using the `enable_*` things, so to enable builder we will need to go through the products array

a step towards finishing #1792 