### PR TITLE
Auth 2184/project limit config docs

### DIFF
--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -243,12 +243,16 @@ so they are not relevant when assigning IAM resources such as teams or roles.
 
 By default, Chef Automate is currently limited to six projects. If you would like to increase that limit, you will need to do so using the Chef Automate CLI:
 
+First, write the file with your new project limit:
+
 ```
 cat << EOF > authz.toml
 [auth_z.v1.sys.service]
 project_limit = <desired-max-projects>
 EOF
 ```
+
+Then, update the existing Chef Automate configuration:
 
 `chef-automate config patch authz.toml`
 

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -241,7 +241,7 @@ so they are not relevant when assigning IAM resources such as teams or roles.
 
 #### Configuring Project Limit
 
-By default, Chef Automate is currently limited to six projects. If you would like to increase that limit, you will need to do so using the Chef Automate cli:
+By default, Chef Automate is currently limited to six projects. If you would like to increase that limit, you will need to do so using the Chef Automate CLI:
 
 ```
 cat << EOF > autht.toml

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -239,6 +239,21 @@ Projects can be managed via the Projects list under the **Settings** tab and con
 [assigning ingested resources to projects]({{< relref "iam-v2-guide#assigning-ingested-resources-to-projects" >}}),
 so they are not relevant when assigning IAM resources such as teams or roles.
 
+#### Configuring Project Limit
+
+By default, Chef Automate is currently limited to six projects. If you would like to increase that limit, you will need to do so using the Chef Automate cli:
+
+```
+cat << EOF > autht.toml
+[auth_z.v1.sys.service]
+project_limit = <desired-max-projects>
+EOF`
+```
+
+`chef-automate config patch authz.toml`
+
+Note: As a consequence of increasing the project limit, you may see slower loading times in the UI.
+
 #### Creating a Project
 
 To create a project, navigate to the Projects list under the **Settings** tab and select **Create Project**. You will need to provide a name and can optionally edit the ID. You must create a project before you can assign any resources to it.

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -244,10 +244,10 @@ so they are not relevant when assigning IAM resources such as teams or roles.
 By default, Chef Automate is currently limited to six projects. If you would like to increase that limit, you will need to do so using the Chef Automate CLI:
 
 ```
-cat << EOF > autht.toml
+cat << EOF > authz.toml
 [auth_z.v1.sys.service]
 project_limit = <desired-max-projects>
-EOF`
+EOF
 ```
 
 `chef-automate config patch authz.toml`

--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -138,6 +138,7 @@ Projects are used in a policy to reduce the scope of that policy's permissions t
 
 {{< info >}}
 Chef Automate is currently limited to six projects while we continue to refine the user experience during this beta period.
+See [Configuring Project Limit]({{< relref "iam-v2-guide.md#configuring-project-limit" >}}) for configuration instructions.
 {{< /info >}}
 
 ### Setting Up Projects


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

We now allow customers to modify the maximum number of projects that can be created. This documents the steps to do so.
