### PR TITLE
compliance-service: fix nil pointer dereference

### DIFF
--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -349,7 +349,7 @@ func (backend *ESClient) UpdateReportProjectsTags(ctx context.Context, projectTa
 	if err != nil {
 		return "", err
 	}
-	return startTaskResult.TaskId, err
+	return startTaskResult.TaskId, nil
 }
 
 func (backend *ESClient) UpdateSummaryProjectsTags(ctx context.Context, projectTaggingRules map[string]*iam_v2.ProjectRules) (string, error) {
@@ -488,8 +488,10 @@ func (backend *ESClient) UpdateSummaryProjectsTags(ctx context.Context, projectT
 		WaitForCompletion(false).
 		ProceedOnVersionConflict().
 		DoAsync(ctx)
-
-	return startTaskResult.TaskId, err
+	if err != nil {
+		return "", err
+	}
+	return startTaskResult.TaskId, nil
 }
 
 func (backend *ESClient) JobCancel(ctx context.Context, jobID string) error {

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -346,7 +346,9 @@ func (backend *ESClient) UpdateReportProjectsTags(ctx context.Context, projectTa
 		WaitForCompletion(false).
 		ProceedOnVersionConflict().
 		DoAsync(ctx)
-
+	if err != nil {
+		return "", err
+	}
 	return startTaskResult.TaskId, err
 }
 

--- a/components/event-feed-service/pkg/persistence/feed-elastic.go
+++ b/components/event-feed-service/pkg/persistence/feed-elastic.go
@@ -57,7 +57,10 @@ func (efs ElasticFeedStore) ReindexFeedsToLatest(ctx context.Context, previousIn
 	src := olivere.NewReindexSource().Index(previousIndex)
 	dst := olivere.NewReindexDestination().Index(IndexNameFeeds)
 	startTaskResult, err := efs.client.Reindex().Source(src).Destination(dst).DoAsync(ctx)
-	return startTaskResult.TaskId, err
+	if err != nil {
+		return "", err
+	}
+	return startTaskResult.TaskId, nil
 }
 
 // DeleteIndex - delete index with name 'index'

--- a/components/ingest-service/backend/elastic/actions.go
+++ b/components/ingest-service/backend/elastic/actions.go
@@ -9,10 +9,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/olivere/elastic"
+
 	iam_v2 "github.com/chef/automate/api/interservice/authz/v2"
 	"github.com/chef/automate/components/ingest-service/backend"
 	"github.com/chef/automate/components/ingest-service/backend/elastic/mappings"
-	"github.com/olivere/elastic"
 )
 
 // InsertAction inserts a Chef Client Action into action-YYYY.MM.DD index
@@ -84,6 +85,9 @@ func (es *Backend) UpdateActionProjectTags(ctx context.Context,
 		WaitForCompletion(false).
 		ProceedOnVersionConflict().
 		DoAsync(ctx)
+	if err != nil {
+		return "", err
+	}
 
-	return startTaskResult.TaskId, err
+	return startTaskResult.TaskId, nil
 }

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -1,18 +1,18 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"time"
 
-	"context"
+	"github.com/olivere/elastic"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	iam_v2 "github.com/chef/automate/api/interservice/authz/v2"
 	"github.com/chef/automate/components/ingest-service/backend"
 	"github.com/chef/automate/components/ingest-service/backend/elastic/mappings"
 	project_update_lib "github.com/chef/automate/lib/authz"
-	"github.com/olivere/elastic"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -343,7 +343,10 @@ func (es *Backend) ReindexNodeStateToLatest(ctx context.Context, previousIndex s
 	src := elastic.NewReindexSource().Index(previousIndex)
 	dst := elastic.NewReindexDestination().Index(mappings.NodeState.Index)
 	startTaskResult, err := es.client.Reindex().Source(src).Destination(dst).DoAsync(ctx)
-	return startTaskResult.TaskId, err
+	if err != nil {
+		return "", err
+	}
+	return startTaskResult.TaskId, nil
 }
 
 func (es *Backend) storeExists(ctx context.Context, indexName string) bool {

--- a/components/ingest-service/backend/elastic/nodes.go
+++ b/components/ingest-service/backend/elastic/nodes.go
@@ -226,8 +226,10 @@ func (es *Backend) UpdateNodeProjectTags(ctx context.Context, projectTaggingRule
 		WaitForCompletion(false).
 		ProceedOnVersionConflict().
 		DoAsync(ctx)
-
-	return startTaskResult.TaskId, err
+	if err != nil {
+		return "", err
+	}
+	return startTaskResult.TaskId, nil
 }
 
 // DeleteNodeByFields deletes a node from node state but it's org name, node name and source_fqdn


### PR DESCRIPTION
We recently observed the following panic during a CI failure:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xffaeab]

    goroutine 2840 [running]:
    github.com/chef/automate/components/compliance-service/ingest/ingestic.(*ESClient).UpdateReportProjectsTags(0xc0000b3cf0, 0x161b660, 0xc0096e22c0, 0xc00b3f8180, 0x1, 0x161b660, 0xc0096e22c0, 0x141ef5e)
            /src/components/compliance-service/ingest/ingestic/ingestic.go:350 +0x4ab
    github.com/chef/automate/components/compliance-service/ingest/ingestic.(*ESClient).UpdateProjectTags(0xc0000b3cf0, 0x161b660, 0xc0096e22c0, 0xc00b3f8180, 0x0, 0x0, 0x0, 0xc00b40e420, 0x0)
            /src/components/compliance-service/ingest/ingestic/ingestic.go:197 +0xbb
    github.com/chef/automate/lib/authz.(*ESStartProjectTagUpdaterTask).startProjectTagUpdater(0xc0002b4520, 0x161b660, 0xc0096e22c0, 0xccf9070573, 0x282f66e9, 0x282f66e900000000, 0x5dd50328, 0xc00b4b7560)
            /src/lib/authz/project_rules_update_workflow.go:221 +0x138
    github.com/chef/automate/lib/authz.(*ESStartProjectTagUpdaterTask).Run(0xc0002b4520, 0x161b660, 0xc0096e22c0, 0x15f5220, 0xc00b40e300, 0x3c, 0xc003e38a40, 0x1f, 0xd0)
            /src/lib/authz/project_rules_update_workflow.go:202 +0x46
    github.com/chef/automate/lib/cereal.(*registeredExecutor).runTask(0xc0000d9380, 0x161b660, 0xc0096e22c0, 0xc00b40e300, 0x1612c20, 0xc00b40e2d0, 0x1, 0xc00b40e2d0)
            /src/lib/cereal/cereal.go:911 +0xaa
    github.com/chef/automate/lib/cereal.(*registeredExecutor).startTaskWorker.func1(0xc0003e4000, 0x15f5240, 0xc000510230, 0x161b660, 0xc0000ae780, 0xc0000d9380, 0xc0001a4060)
            /src/lib/cereal/cereal.go:902 +0xdb
    created by github.com/chef/automate/lib/cereal.(*registeredExecutor).startTaskWorker
            /src/lib/cereal/cereal.go:873 +0x298

Unfortunately, the logs don't indicate what the underlying error was,
but this change hopefully fixes the most proximate cause of the panic:
on error, the result from the elastic library may be nil.

Signed-off-by: Steven Danna <steve@chef.io>