### PR TITLE
studio: don't bind mount /

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -205,7 +205,6 @@ generate_netrc_config
 # Prepare the environment to run our services
 prepare_system() {
   # These are needed for elasticsearch
-  mount --bind / / > /dev/null
   install_if_missing core/busybox-static sysctl > /dev/null
   sysctl -w net.ipv6.conf.all.disable_ipv6=1 > /dev/null
   sysctl -w vm.max_map_count=262144 > /dev/null
@@ -238,7 +237,6 @@ history -r /src/.bash_history
 
 cleanup() {
     save_history
-    umount /
 }
 
 # When exiting the studio save the bash history to a file


### PR DESCRIPTION
We believe this was put in place to get around various checks in ES
that explicitly look for / in the mount table.

However, this was inserted a while ago, recently made some debugging
more complicated, and may no longer be required.

If CI passes, I think we should remove it, if it becomes an issue in
everyday studio use, we can bring it back.

Signed-off-by: Steven Danna <steve@chef.io>