### PR TITLE
Remove all applied search query filters when user clicks `clear all` button

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -386,13 +386,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
   }
 
   onFiltersClear(_event) {
-    const queryParams = {...this.route.snapshot.queryParams};
-
-    const filteredParams = pickBy((_value, key) => {
-        return this.allowedURLFilterTypes.indexOf(key) < 0;
-      }, queryParams);
-
-    this.router.navigate([], {queryParams: filteredParams});
+    this.router.navigate([], {queryParams: {} });
   }
 
   getData(reportQuery: ReportQuery) {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -386,7 +386,20 @@ export class ReportingComponent implements OnInit, OnDestroy {
   }
 
   onFiltersClear(_event) {
-    this.router.navigate([], {queryParams: {} });
+    const queryParams = {...this.route.snapshot.queryParams};
+
+    const filteredParams = pickBy((_value, key) => {
+
+      // Only handles control_tag filters
+      if (key.includes('control_tag')) {
+        return false;
+      }
+
+        return this.allowedURLFilterTypes.indexOf(key) < 0;
+      }, queryParams);
+
+
+    this.router.navigate([], {queryParams: filteredParams});
   }
 
   getData(reportQuery: ReportQuery) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When attempting to remove all filters using the `clear all` button on the Compliance page, the function would not remove filters that include the `control_tag` filter.  This is because `control_tag`s have 3rd level filter available to them which incorporates a `:` delimiter and the initial function doesn't know how to handle them.

Since we are clearing all filters, it would make sense to use an empty object, instead of looping through all the filters.

### :chains: Related Resources

### :+1: Definition of Done
the `clear all` button now removes all filters applied on compliance pages.

### :athletic_shoe: How to Build and Test the Change

1. build components/automate-ui-devproxy && start_all_services
2. you may need to run `load_compliance_reports` in hab studio to have reports to filter by
3. Navigate to https://a2-dev.test/compliance/reports/overview
4. filter by anything involving `control tag`
5. filter by anything else other than `control tag`
6. click `clear all`
7. see them both go away and URL query should be clear;

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable