### PR TITLE
Auth 2304/hide unassigned if only one allowed

### DIFF
--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -4,7 +4,7 @@
   [attr.title]="selectionLabel"
   [disabled]="!dropdownCaretVisible"
   (click)="handleLabelClick()"
-  *ngIf="filterVisible()">
+  *ngIf="filterVisible">
   <span class="selection-label">{{ selectionLabel }}</span>
   <span class="selection-count"
     *ngIf="selectionCountVisible"

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -23,6 +23,8 @@ export class ProjectsFilterDropdownComponent implements OnChanges {
 
   @Input() dropdownCaretVisible = false;
 
+  @Input() filterVisible = false;
+
   @Output() onSelection = new EventEmitter<ProjectsFilterOption[]>();
 
   editableOptions: ProjectsFilterOption[] = [];
@@ -81,9 +83,5 @@ export class ProjectsFilterDropdownComponent implements OnChanges {
     if (element) {
       (element as HTMLElement).focus();
     }
-  }
-
-  filterVisible() {
-    return this.selectionCount > 0;
   }
 }

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -30,6 +30,7 @@ describe('ProjectsFilterDropdownComponent', () => {
       component.selectionCount = 3;
       component.selectionCountVisible = true;
       component.selectionCountActive = true;
+      component.filterVisible = true;
       fixture.detectChanges();
     });
 

--- a/components/automate-ui/src/app/page-components/projects-filter/projects-filter.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter/projects-filter.component.html
@@ -5,5 +5,6 @@
   [selectionCountVisible]="projectsFilter.selectionCountVisible$ | async"
   [selectionCountActive]="projectsFilter.selectionCountActive$ | async"
   [dropdownCaretVisible]="projectsFilter.dropdownCaretVisible$ | async"
+  [filterVisible]="projectsFilter.filterVisible$ | async"
   (onSelection)="projectsFilter.saveOptions($event)">
 </app-projects-filter-dropdown>

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.spec.ts
@@ -218,6 +218,11 @@ describe('projectsFilterReducer', () => {
         genProject('zz-proj')
       );
 
+      it('displays filter', () => {
+        const { filterVisible } = projectsFilterReducer(initialState, action);
+        expect(filterVisible).toEqual(true);
+      });
+
       it('displays project name', () => {
         const { selectionLabel } = projectsFilterReducer(initialState, action);
         expect(selectionLabel).toEqual('zz-proj');
@@ -239,9 +244,9 @@ describe('projectsFilterReducer', () => {
         genUnassignedProject()
       );
 
-      it('displays "(unassigned)"', () => {
-        const { selectionLabel } = projectsFilterReducer(initialState, action);
-        expect(selectionLabel).toEqual(UNASSIGNED_PROJECT_LABEL);
+      it('does not display filter', () => {
+        const { filterVisible } = projectsFilterReducer(initialState, action);
+        expect(filterVisible).toEqual(false);
       });
 
       it('displays no count badge', () => {
@@ -262,6 +267,11 @@ describe('projectsFilterReducer', () => {
           genUnassignedProject(),
           genProject('zz-proj')
         );
+
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
 
         it('displays "All projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
@@ -285,6 +295,11 @@ describe('projectsFilterReducer', () => {
           genProject('zz-proj', true)
         );
 
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
+
         it('displays that project', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
           expect(selectionLabel).toEqual('zz-proj');
@@ -307,6 +322,11 @@ describe('projectsFilterReducer', () => {
           genProject('zz-proj')
         );
 
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
+
         it('displays "(unassigned)"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
           expect(selectionLabel).toEqual(UNASSIGNED_PROJECT_LABEL);
@@ -327,6 +347,11 @@ describe('projectsFilterReducer', () => {
           genUnassignedProject(true),
           genProject('zz-proj', true)
         );
+
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
 
         it('displays "All projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
@@ -357,6 +382,11 @@ describe('projectsFilterReducer', () => {
           genProject('b-proj')
         );
 
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
+
         it('displays "All projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
           expect(selectionLabel).toEqual(ALL_PROJECTS_LABEL);
@@ -381,6 +411,11 @@ describe('projectsFilterReducer', () => {
           genProject('a-proj', true),
           genProject('b-proj')
         );
+
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
 
         it('displays that project', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
@@ -407,6 +442,11 @@ describe('projectsFilterReducer', () => {
           genProject('b-proj')
         );
 
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
+
         it('displays "(unassigned)"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
           expect(selectionLabel).toEqual(UNASSIGNED_PROJECT_LABEL);
@@ -430,6 +470,11 @@ describe('projectsFilterReducer', () => {
           genProject('a-proj'),
           genProject('b-proj')
         );
+
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
 
         it('displays selected project', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
@@ -455,10 +500,16 @@ describe('projectsFilterReducer', () => {
           genProject('b-proj')
         );
 
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
+
         it('displays "Multiple projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
           expect(selectionLabel).toEqual(MULTIPLE_PROJECTS_LABEL);
         });
+
         it('displays blue count badge with count of checked projects', () => {
           const { selectionCount, selectionCountActive, selectionCountVisible }
             = projectsFilterReducer(initialState, action);
@@ -481,6 +532,11 @@ describe('projectsFilterReducer', () => {
           genProject('a-proj', true),
           genProject('b-proj')
         );
+
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
 
         it('displays "Multiple projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
@@ -509,10 +565,16 @@ describe('projectsFilterReducer', () => {
           genProject('b-proj', true)
         );
 
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
+
         it('displays "All projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
           expect(selectionLabel).toEqual(ALL_PROJECTS_LABEL);
         });
+
         it('displays blue count badge with count of checked projects', () => {
           const { selectionCount, selectionCountActive, selectionCountVisible }
             = projectsFilterReducer(initialState, action);
@@ -536,6 +598,11 @@ describe('projectsFilterReducer', () => {
           genProject('b-proj', true)
         );
 
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
+
         it('displays "All projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
           expect(selectionLabel).toEqual(ALL_PROJECTS_LABEL);
@@ -553,9 +620,7 @@ describe('projectsFilterReducer', () => {
     });
 
     describe('with at least 2 projects allowed but not unassigned', () => {
-
       // Also check that every case displays the caret to open dropdown
-
       describe('when nothing is selected', () => {
         const action = genAction(
           genProject('zz-proj'),
@@ -563,6 +628,11 @@ describe('projectsFilterReducer', () => {
           genProject('a-proj'),
           genProject('b-proj')
         );
+
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
 
         it('displays "All projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
@@ -591,6 +661,11 @@ describe('projectsFilterReducer', () => {
           genProject('b-proj')
         );
 
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
+
         it('displays that project', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
           expect(selectionLabel).toEqual('a-proj');
@@ -615,10 +690,16 @@ describe('projectsFilterReducer', () => {
           genProject('b-proj')
         );
 
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
+
         it('displays "Multiple projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
           expect(selectionLabel).toEqual(MULTIPLE_PROJECTS_LABEL);
         });
+
         it('displays blue count badge with count of checked projects', () => {
           const { selectionCount, selectionCountActive, selectionCountVisible }
             = projectsFilterReducer(initialState, action);
@@ -641,10 +722,16 @@ describe('projectsFilterReducer', () => {
           genProject('b-proj', true)
         );
 
+        it('displays filter', () => {
+          const { filterVisible } = projectsFilterReducer(initialState, action);
+          expect(filterVisible).toEqual(true);
+        });
+
         it('displays "All projects"', () => {
           const { selectionLabel } = projectsFilterReducer(initialState, action);
           expect(selectionLabel).toEqual(ALL_PROJECTS_LABEL);
         });
+
         it('displays blue count badge with count of checked projects', () => {
           const { selectionCount, selectionCountActive, selectionCountVisible }
             = projectsFilterReducer(initialState, action);

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -164,9 +164,10 @@ function dropdownCaretVisible(options: ProjectsFilterOption[]): boolean {
 }
 
 function filterVisible(options: ProjectsFilterOption[]): boolean {
+  const hasSomePermissions = options.length > 0;
   const hasOnlyUnassignedPermission = options.length === 1 &&
     options[0].value === UNASSIGNED_PROJECT_ID;
-  return !hasOnlyUnassignedPermission;
+  return hasSomePermissions && !hasOnlyUnassignedPermission;
 }
 
 function mergeOptions(

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -34,6 +34,7 @@ export interface ProjectsFilterState {
   selectionCountVisible: boolean;
   selectionCountActive: boolean;
   dropdownCaretVisible: boolean;
+  filterVisible: boolean;
 }
 
 export const projectsFilterInitialState: ProjectsFilterState = {
@@ -43,7 +44,8 @@ export const projectsFilterInitialState: ProjectsFilterState = {
   selectionCount: 0,
   selectionCountVisible: false,
   selectionCountActive: false,
-  dropdownCaretVisible: false
+  dropdownCaretVisible: false,
+  filterVisible: false
 };
 
 export function projectsFilterReducer(
@@ -66,7 +68,8 @@ export function projectsFilterReducer(
         set('selectionCount', selectionCount(sortedOptions)),
         set('selectionCountVisible', selectionCountVisible(sortedOptions)),
         set('selectionCountActive', selectionCountActive(sortedOptions)),
-        set('dropdownCaretVisible', dropdownCaretVisible(sortedOptions))
+        set('dropdownCaretVisible', dropdownCaretVisible(sortedOptions)),
+        set('filterVisible', filterVisible(sortedOptions))
       )(state) as ProjectsFilterState;
     }
 
@@ -158,6 +161,12 @@ function selectionCountActive(options: ProjectsFilterOption[]): boolean {
 function dropdownCaretVisible(options: ProjectsFilterOption[]): boolean {
   const hasOnlyOneOption = options.length === 1;
   return !hasOnlyOneOption;
+}
+
+function filterVisible(options: ProjectsFilterOption[]): boolean {
+  const hasOnlyUnassignedPermission = options.length === 1 &&
+    options[0].value === UNASSIGNED_PROJECT_ID;
+  return !hasOnlyUnassignedPermission;
 }
 
 function mergeOptions(

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.selectors.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.selectors.ts
@@ -38,3 +38,6 @@ export const selectionCountActive = createSelector(projectsFilterState,
 
 export const dropdownCaretVisible = createSelector(projectsFilterState,
   state => state.dropdownCaretVisible);
+
+export const filterVisible = createSelector(projectsFilterState,
+  state => state.filterVisible);

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -24,6 +24,8 @@ export class ProjectsFilterService {
 
   dropdownCaretVisible$ = <Observable<boolean>>this.store.select(selectors.dropdownCaretVisible);
 
+  filterVisible$ = <Observable<boolean>>this.store.select(selectors.filterVisible);
+
   constructor(private store: Store<NgrxStateAtom>, private router: Router) { }
 
   loadOptions() {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Users were confused by the `(unassigned)` label in the dropdown when it was the only "project" to which they had access.

### :+1: Definition of Done

All these scenarios are true:

- [x] Hide the (unassigned) label from the top-right if that's the only thing a user has access to
- [x] If they have access to only 1 project, that projects name should still appear in the top-right
- [x] If a user has access to unassigned and another project, unassigned should still show up in the top-right if the user filters to view only unassigned resources

### :athletic_shoe: How to Build and Test the Change

Bring up the UI and sign in as users with varying project permissions (one project, one project + unassigned, only unassigned, no projects) and ensure that the above scenarios render correctly.

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?
