### PR TITLE
Refactor latestVersion to avoid calling heavyweight codepath.

### DIFF
--- a/components/compliance-service/profiles/db/store.go
+++ b/components/compliance-service/profiles/db/store.go
@@ -285,6 +285,10 @@ func (s *Store) latestVersion(namespace string, name string) (string, error) {
 		return "", err
 	}
 
+	if len(versions) == 0 {
+		return "", nil
+	}
+
 	semver.Sort(versions)
 	latest := versions[len(versions)-1]
 


### PR DESCRIPTION
* I'm changing the behavior and signature of ListProfilesMetadata for #2258 so I wanted to avoid calling it here.
* This code was pulling a bunch of stuff from the database, parsing json, etc when it didn't need to.