### PR TITLE
Delete functionality for custom created roles

### DIFF
--- a/components/automate-ui/e2e/admin.e2e-spec.ts
+++ b/components/automate-ui/e2e/admin.e2e-spec.ts
@@ -670,7 +670,7 @@ describe('Admin pages', () => {
         const name = $('app-roles-list chef-table-new chef-table-row:nth-child(1) chef-table-cell:first-child a');
         browser.wait(EC.textToBePresentInElement(name, 'Owner'));
 
-        const policyType = $('chef-table-new chef-table-row:nth-child(1) chef-table-cell:nth-child(2)');
+        const policyType = $('chef-table-new chef-table-row:nth-child(1) chef-table-cell:nth-child(3)');
         browser.wait(EC.textToBePresentInElement(policyType, 'Chef-managed'));
       });
 
@@ -679,7 +679,7 @@ describe('Admin pages', () => {
         browser.wait(EC.textToBePresentInElement(name,
           'Some role whose name does not start with A'));
 
-        const policyType = $('chef-table-new chef-table-row:nth-child(2) chef-table-cell:nth-child(2)');
+        const policyType = $('chef-table-new chef-table-row:nth-child(2) chef-table-cell:nth-child(3)');
         browser.wait(EC.textToBePresentInElement(policyType, 'Custom'));
       });
     });

--- a/components/automate-ui/src/app/entities/roles/role.actions.ts
+++ b/components/automate-ui/src/app/entities/roles/role.actions.ts
@@ -4,6 +4,9 @@ import { Action } from '@ngrx/store';
 import { Role } from './role.model';
 
 export enum RoleActionTypes {
+  DELETE          = 'ROLE::DELETE',
+  DELETE_SUCCESS  = 'ROLE::DELETE::SUCCESS',
+  DELETE_FAILURE  = 'ROLE::DELETE::FAILURE',
   GET_ALL         = 'ROLE::GET_ALL',
   GET_ALL_SUCCESS = 'ROLE::GET_ALL::SUCCESS',
   GET_ALL_FAILURE = 'ROLE::GET_ALL::FAILURE',
@@ -49,7 +52,25 @@ export class GetRoleFailure implements Action {
   constructor(public payload: HttpErrorResponse, public id: string) { }
 }
 
+export class DeleteRole implements Action {
+  readonly type = RoleActionTypes.DELETE;
+  constructor(public payload: { id: string }) { }
+}
+
+export class DeleteRoleSuccess implements Action {
+  readonly type = RoleActionTypes.DELETE_SUCCESS;
+  constructor(public payload: { id: string }) { }
+}
+
+export class DeleteRoleFailure implements Action {
+  readonly type = RoleActionTypes.DELETE_FAILURE;
+  constructor(public payload: HttpErrorResponse) { }
+}
+
 export type RoleActions =
+  | DeleteRole
+  | DeleteRoleSuccess
+  | DeleteRoleFailure
   | GetRoles
   | GetRolesSuccess
   | GetRolesFailure

--- a/components/automate-ui/src/app/entities/roles/role.effects.ts
+++ b/components/automate-ui/src/app/entities/roles/role.effects.ts
@@ -3,7 +3,6 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of as observableOf } from 'rxjs';
 import { catchError, mergeMap, map } from 'rxjs/operators';
-
 import { CreateNotification } from 'app/entities/notifications/notification.actions';
 import { Type } from 'app/entities/notifications/notification.model';
 
@@ -14,7 +13,10 @@ import {
   RoleActionTypes,
   GetRole,
   GetRoleSuccess,
-  GetRoleFailure
+  GetRoleFailure,
+  DeleteRole,
+  DeleteRoleSuccess,
+  DeleteRoleFailure
 } from './role.actions';
 
 import {
@@ -66,4 +68,34 @@ export class RoleEffects {
           message: `Could not get role ${id}: ${msg || payload.error}`
         });
       }));
+  
+  @Effect()
+  deleteRole$ = this.actions$.pipe(
+    ofType(RoleActionTypes.DELETE),
+    mergeMap(({ payload: { id} }: DeleteRole) =>
+      this.requests.deleteRole(id).pipe(
+        map(() => new DeleteRoleSuccess({id})),
+        catchError((error: HttpErrorResponse) =>
+          observableOf(new DeleteRoleFailure(error))))));
+
+  @Effect()
+  deleteProjectSuccess$ = this.actions$.pipe(
+      ofType(RoleActionTypes.DELETE_SUCCESS),
+      map(({ payload: { id } }: DeleteRoleSuccess) => {
+        return new CreateNotification({
+          type: Type.info,
+          message: `Successfully deleted role ${id}.`
+        });
+      }));
+
+  @Effect()
+  deleteRoleFailure$ = this.actions$.pipe(
+    ofType(RoleActionTypes.DELETE_FAILURE),
+    map(({ payload: { error } }: DeleteRoleFailure) => {
+      const msg = error.error;
+      return new CreateNotification({
+        type: Type.error,
+        message: `Could not delete role: ${msg || error}`
+      });
+    }));
 }

--- a/components/automate-ui/src/app/entities/roles/role.effects.ts
+++ b/components/automate-ui/src/app/entities/roles/role.effects.ts
@@ -68,7 +68,7 @@ export class RoleEffects {
           message: `Could not get role ${id}: ${msg || payload.error}`
         });
       }));
-  
+
   @Effect()
   deleteRole$ = this.actions$.pipe(
     ofType(RoleActionTypes.DELETE),

--- a/components/automate-ui/src/app/entities/roles/role.effects.ts
+++ b/components/automate-ui/src/app/entities/roles/role.effects.ts
@@ -79,12 +79,12 @@ export class RoleEffects {
           observableOf(new DeleteRoleFailure(error))))));
 
   @Effect()
-  deleteProjectSuccess$ = this.actions$.pipe(
+  deleteRoleSuccess$ = this.actions$.pipe(
       ofType(RoleActionTypes.DELETE_SUCCESS),
       map(({ payload: { id } }: DeleteRoleSuccess) => {
         return new CreateNotification({
           type: Type.info,
-          message: `Successfully deleted role ${id}.`
+          message: `Deleted role ${id}.`
         });
       }));
 

--- a/components/automate-ui/src/app/entities/roles/role.reducer.ts
+++ b/components/automate-ui/src/app/entities/roles/role.reducer.ts
@@ -8,13 +8,15 @@ import { Role } from './role.model';
 export interface RoleEntityState extends EntityState<Role> {
   getAllStatus: EntityStatus;
   getStatus: EntityStatus;
+  deleteStatus: EntityStatus;
 }
 
 export const roleEntityAdapter: EntityAdapter<Role> = createEntityAdapter<Role>();
 
 export const RoleEntityInitialState: RoleEntityState = roleEntityAdapter.getInitialState({
   getAllStatus: EntityStatus.notLoaded,
-  getStatus: EntityStatus.notLoaded
+  getStatus: EntityStatus.notLoaded,
+  deleteStatus: EntityStatus.notLoaded
 });
 
 export function roleEntityReducer(state: RoleEntityState = RoleEntityInitialState,
@@ -23,6 +25,7 @@ export function roleEntityReducer(state: RoleEntityState = RoleEntityInitialStat
   switch (action.type) {
     case RoleActionTypes.GET_ALL:
       return set('getAllStatus', EntityStatus.loading, roleEntityAdapter.removeAll(state));
+
     case RoleActionTypes.GET_ALL_SUCCESS:
       return set('getAllStatus', EntityStatus.loadingSuccess,
         roleEntityAdapter.addAll(action.payload.roles, state));
@@ -37,8 +40,18 @@ export function roleEntityReducer(state: RoleEntityState = RoleEntityInitialStat
       return set('getStatus', EntityStatus.loadingSuccess,
         roleEntityAdapter.addOne(action.payload, state));
 
-    case RoleActionTypes.GET_ALL_FAILURE:
+    case RoleActionTypes.GET_FAILURE:
       return set('getStatus', EntityStatus.loadingFailure, state);
+
+    case RoleActionTypes.DELETE:
+      return set('deleteStatus', EntityStatus.loading, state);
+
+    case RoleActionTypes.DELETE_SUCCESS:
+      return set('deleteStatus', EntityStatus.loadingSuccess,
+        roleEntityAdapter.removeOne(action.payload.id, state));
+
+    case RoleActionTypes.DELETE_FAILURE:
+      return set('deleteStatus', EntityStatus.loadingFailure, state);
 
     default:
       return state;

--- a/components/automate-ui/src/app/entities/roles/role.requests.ts
+++ b/components/automate-ui/src/app/entities/roles/role.requests.ts
@@ -25,4 +25,8 @@ export class RoleRequests {
   public getRole(id: string): Observable<RoleResponse> {
     return this.http.get<RoleResponse>(`${env.auth_v2_url}/roles/${id}`);
   }
+
+  public deleteRole(id: string): Observable<RoleResponse> {
+    return this.http.delete<RoleResponse>(`${env.auth_v2_url}/roles/${id}`);
+  }
 }

--- a/components/automate-ui/src/app/entities/roles/role.selectors.ts
+++ b/components/automate-ui/src/app/entities/roles/role.selectors.ts
@@ -21,6 +21,11 @@ export const getStatus = createSelector(
   (state) => state.getStatus
 );
 
+export const deleteStatus = createSelector(
+  roleState,
+  (state) => state.deleteStatus
+);
+
 export const roleFromRoute = createSelector(
   roleEntities,
   routeParams,

--- a/components/automate-ui/src/app/modules/roles/list/roles-list.component.html
+++ b/components/automate-ui/src/app/modules/roles/list/roles-list.component.html
@@ -1,6 +1,15 @@
 <div class="content-container">
   <div class="container">
     <main>
+      <chef-loading-spinner *ngIf="loading$ | async" size='50' fixed></chef-loading-spinner>
+      <app-delete-object-modal
+        [visible]="deleteModalVisible"
+        objectNoun="role"
+        [objectName]="roleToDelete?.name"
+        (close)="closeDeleteModal()"
+        (deleteClicked)="deleteRole()"
+        objectAction="Delete">
+      </app-delete-object-modal>
       <chef-page-header>
         <chef-heading>Roles</chef-heading>
         <chef-subheading>
@@ -16,7 +25,9 @@
             <chef-table-header>
               <chef-table-row>
                 <chef-table-header-cell>Name</chef-table-header-cell>
+                <chef-table-header-cell></chef-table-header-cell>
                 <chef-table-header-cell>Type</chef-table-header-cell>
+                <chef-table-header-cell class="three-dot-column"></chef-table-header-cell>
               </chef-table-row>
             </chef-table-header>
             <chef-table-body>
@@ -24,7 +35,13 @@
                   <chef-table-cell>
                     <a [routerLink]="['/settings/roles', role.id]">{{ role.name }}</a>
                   </chef-table-cell>
+                  <chef-table-cell></chef-table-cell>
                   <chef-table-cell>{{ role.type | iamType }}</chef-table-cell>
+                  <chef-table-cell class="three-dot-column">
+                    <chef-control-menu *ngIf="(role.type | iamType).toLowerCase() === 'custom'">
+                      <chef-option data-cy="delete" (click)="startRoleDelete(role)">Delete Role</chef-option>
+                    </chef-control-menu>
+                  </chef-table-cell>
               </chef-table-row>
             </chef-table-body>
           </chef-table-new>

--- a/components/automate-ui/src/app/modules/roles/list/roles-list.component.scss
+++ b/components/automate-ui/src/app/modules/roles/list/roles-list.component.scss
@@ -1,3 +1,3 @@
 .three-dot-column {
-    text-align: right;
+  text-align: right;
 }

--- a/components/automate-ui/src/app/modules/roles/list/roles-list.component.scss
+++ b/components/automate-ui/src/app/modules/roles/list/roles-list.component.scss
@@ -1,0 +1,3 @@
+.three-dot-column {
+    text-align: right;
+}

--- a/components/automate-ui/src/app/modules/roles/list/roles-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/roles/list/roles-list.component.spec.ts
@@ -20,6 +20,9 @@ describe('RolesListComponent', () => {
         MockComponent({ selector: 'app-authorized',
                         inputs: ['allOf'],
                         template: '<ng-content></ng-content>' }),
+        MockComponent({ selector: 'app-delete-object-modal',
+                        inputs: ['visible', 'objectNoun', 'objectName'],
+                        outputs: ['close', 'deleteClicked']}),
         MockComponent({ selector: 'chef-loading-spinner' }),
         MockComponent({ selector: 'chef-page-header' }),
         MockComponent({ selector: 'chef-heading' }),
@@ -30,6 +33,8 @@ describe('RolesListComponent', () => {
         MockComponent({ selector: 'chef-table-header-cell' }),
         MockComponent({ selector: 'chef-table-header' }),
         MockComponent({ selector: 'chef-table-row' }),
+        MockComponent({ selector: 'chef-option' }),
+        MockComponent({ selector: 'chef-control-menu' }),
         MockComponent({ selector: 'a', inputs: ['routerLink']}),
         RolesListComponent
       ],

--- a/components/automate-ui/src/app/modules/roles/list/roles-list.component.ts
+++ b/components/automate-ui/src/app/modules/roles/list/roles-list.component.ts
@@ -1,13 +1,13 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { loading } from 'app/entities/entities';
-import { GetRoles } from 'app/entities/roles/role.actions';
+import { GetRoles, DeleteRole } from 'app/entities/roles/role.actions';
 import { isIAMv2 } from 'app/entities/policies/policy.selectors';
 import { allRoles, getAllStatus } from 'app/entities/roles/role.selectors';
 import { Role } from 'app/entities/roles/role.model';
@@ -17,10 +17,14 @@ import { Role } from 'app/entities/roles/role.model';
   templateUrl: './roles-list.component.html',
   styleUrls: ['./roles-list.component.scss']
 })
-export class RolesListComponent implements OnInit {
+
+export class RolesListComponent implements OnInit, OnDestroy {
+  public loading$: Observable<boolean>;
   public sortedRoles$: Observable<Role[]>;
   public isIAMv2$: Observable<boolean>;
-
+  public roleToDelete: Role;
+  public deleteModalVisible = false;
+  private isDestroyed = new Subject<boolean>();
   constructor(
     private store: Store<NgrxStateAtom>,
     private layoutFacade: LayoutFacadeService
@@ -37,5 +41,24 @@ export class RolesListComponent implements OnInit {
   ngOnInit(): void {
     this.layoutFacade.showSettingsSidebar();
     this.store.dispatch(new GetRoles());
+  }
+
+  ngOnDestroy(): void {
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
+  }
+
+  public startRoleDelete(role: Role): void {
+    this.roleToDelete = role;
+    this.deleteModalVisible = true;
+  }
+
+  public deleteRole(): void {
+    this.closeDeleteModal();
+    this.store.dispatch(new DeleteRole(this.roleToDelete));
+  }
+
+  public closeDeleteModal(): void {
+    this.deleteModalVisible = false;
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
**Overview**
In the roles list view in the UI, all custom roles should have the control menu with a delete option. On delete, a confirmation modal should be displayed.

**Design Details**
Add control (3-dot) menu to the roles list view on custom roles
Add confirmation modal
I have added new changes to delete the custom created roles using the delete confirmation modal popup.

### :chains: Related Resources
fixes #1692

### :+1: Definition of Done
Previously delete functionality is not available from UI side to delete the custom created roles, I have added new changes for this functionality.

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui`
1. add a custom role `curl -XPOST -d '{"name": "Test", "id": "test", "actions": ["infra:*","compliance:*","teams:*","users:*"],"projects": []}' -H "api-token: $token" https://a2-dev.test/apis/iam/v2beta/roles?pretty --insecure`
1. naviagate to `settings/roles`
1. use the 3-dot control menu to delete the custom role.

### :camera: Screenshots
![custom_role1](https://user-images.githubusercontent.com/12297653/69321115-84101500-0c68-11ea-93a7-bad0c6a28f11.png)
![custom_role2](https://user-images.githubusercontent.com/12297653/69321116-84a8ab80-0c68-11ea-9e93-f743bf68aaaa.png)
![custom_role3](https://user-images.githubusercontent.com/12297653/69321117-84a8ab80-0c68-11ea-8bd6-1b8f7c76d156.png)
