### PR TITLE
scaffolding: make proxy.sh work under `set -u`

### DIFF
--- a/lib/scaffolding/support/proxy.sh
+++ b/lib/scaffolding/support/proxy.sh
@@ -28,5 +28,5 @@ appendToStringIfMissing() {
 # addNoProxy adds the given argument to
 # the no_proxy environment variable.
 addNoProxy() {
-    export no_proxy="$(appendToStringIfMissing "$no_proxy" "$1" ",")"
+    export no_proxy="$(appendToStringIfMissing "${no_proxy:-}" "$1" ",")"
 }


### PR DESCRIPTION
`no_proxy` might be undefined, causing this to fail if the calling
hook is running with `set -u`.

Signed-off-by: Steven Danna <steve@chef.io>