### PR TITLE
workflow-web: remove /status/console calls

### DIFF
--- a/components/automate-workflow-web/src/components/navbar/navbar.js
+++ b/components/automate-workflow-web/src/components/navbar/navbar.js
@@ -9,10 +9,6 @@ navbarComponent.$inject = ['$state', '$http', 'featureFlags'];
 function navbarComponent($state, $http, featureFlags) {
   function link(scope) {
     scope.isOn = featureFlags.isOn;
-    // check if there's a "back to console" link we need to display
-    $http.get('/workflow/status/console')
-      .then((resp) => scope.console = resp.data);
-
     scope.isParentActive = (parent) => $state.includes(parent);
   }
 

--- a/components/automate-workflow-web/test/e2e/specs/navbar.spec.js
+++ b/components/automate-workflow-web/test/e2e/specs/navbar.spec.js
@@ -48,15 +48,6 @@ describe('navbar', () => {
             }
           }
         },
-        {
-          request: {
-            url: '/workflow/status/console',
-            method: 'GET'
-          },
-          response: {
-            status: 404
-          }
-        }
       ]);
     });
 
@@ -118,72 +109,6 @@ describe('navbar', () => {
 
     it('does not show any link next to Admin', () => {
       expect(navbar.consoleLink).not.toBePresent();
-    });
-  });
-
-  describe('navigation with a console link', () => {
-
-    beforeEach(() => {
-      navbar = new Navbar();
-
-      mockApi([
-        authorizedLogin,
-        {
-          request: {
-            url: '/api/v0/e/Chef/users$',
-            method: 'GET'
-          },
-          response: {
-            status: 200,
-            body: {
-              users: []
-            }
-          }
-        },
-        {
-          request: {
-            url: '/api/v0/e/Chef/orgs$',
-            method: 'GET'
-          },
-          response: {
-            status: 200,
-            body: {
-              orgs: []
-            }
-          }
-        },
-        {
-          request: {
-            url: '/workflow/status/console',
-            method: 'GET'
-          },
-          response: {
-            status: 200,
-            body: {
-              name: 'chefworks console',
-              url: 'https://chef.io'
-            }
-          }
-        }
-      ]);
-    });
-
-    // See comment above
-    beforeEach(() => {
-      browser.ignoreSynchronization = true;
-      browser.get('#/dashboard');
-      browser.wait(presenceOf('.navbar'));
-    });
-
-    it('shows the console link next to Admin', () => {
-      expect(navbar.consoleLink).toBePresent();
-      navbar.consoleLink.getAttribute('target').then((attr) => {
-        expect(attr).toBe('_blank');
-      });
-      navbar.consoleLink.getAttribute('href').then((attr) => {
-        expect(attr).toBe('https://chef.io/')
-      });
-      expect(navbar.consoleLink.getText()).toBe('chefworks console');
     });
   });
 });

--- a/components/automate-workflow-web/test/unit/specs/components/navbar.spec.js
+++ b/components/automate-workflow-web/test/unit/specs/components/navbar.spec.js
@@ -30,13 +30,6 @@ describe('navbarComponent', () => {
   }
 
   describe('isParentActive()', () => {
-
-    // we're not interested in the back-to-console link here
-    beforeEach(inject(($httpBackend) => {
-      $httpBackend.when('GET', '/workflow/status/console').respond(404);
-      $httpBackend.when('GET', '/workflow/status/version').respond('delivery 0.6.47\n');
-    }));
-
     beforeEach(() => {
       inject(createDirective());
       $httpBackend.flush();


### PR DESCRIPTION
I don't know what this is for. But, I do know that we always return
404 to this endpoint as it is hard-coded into the nginx
configuration. Thus, all this ever does is produce an extra request
that gets rejected.

Signed-off-by: Steven Danna <steve@chef.io>