### PR TITLE
Loading Overlay Size Issue

### DIFF
--- a/components/automate-ui/e2e/helpers/browser_expectations.ts
+++ b/components/automate-ui/e2e/helpers/browser_expectations.ts
@@ -20,6 +20,6 @@ export function waitForElement(selector) {
 
 export function waitForSpinners() {
   return browser.wait(() => {
-    return $$('chef-loading-spinner').count().then(c => c === 0);
+    return $$('chef-loading-spinner').filter(s => s.hidden === false).count().then(c => c === 0);
   }, 5000);
 }

--- a/components/automate-ui/src/app/entities/layout/layout.actions.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.actions.ts
@@ -2,8 +2,14 @@ import { Action } from '@ngrx/store';
 import { MenuItemGroup } from './layout.model';
 
 export enum LayoutActionTypes {
+  SHOW_PAGE_LOADING = 'Layout::SHOW_PAGE_LOADING',
   GET_SIDEBAR_MENU_GROUPS = 'LAYOUT::GET',
   UPDATE_SIDEBAR_MENU_GROUPS = 'LAYOUT::UPDATE'
+}
+
+export class ShowPageLoading implements Action {
+  readonly type = LayoutActionTypes.SHOW_PAGE_LOADING;
+  constructor(public payload: boolean) {}
 }
 
 export class GetSidebarMenuGroups implements Action {
@@ -18,5 +24,6 @@ export class UpdateSidebarMenuGroups implements Action {
 }
 
 export type LayoutActions =
+  | ShowPageLoading
   | GetSidebarMenuGroups
   | UpdateSidebarMenuGroups;

--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -8,8 +8,9 @@ import { notificationState } from 'app/entities/notifications/notification.selec
 
 import * as fromLayout from './layout.reducer';
 import { MenuItemGroup } from './layout.model';
-import { sidebarMenuGroups } from './layout.selectors';
+import { sidebarMenuGroups, showPageLoading } from './layout.selectors';
 import {
+    ShowPageLoading,
     GetSidebarMenuGroups,
     UpdateSidebarMenuGroups
 } from './layout.actions';
@@ -21,6 +22,7 @@ export class LayoutFacadeService {
     headerHeight = '70px';
     contentHeight = `calc(100% - ${this.headerHeight})`;
     menuGroups$: Observable<MenuItemGroup[]>;
+    showPageLoading$: Observable<boolean>;
     showLicenseNotification = false;
     showHeader = true;
     showSidebar = true;
@@ -30,6 +32,7 @@ export class LayoutFacadeService {
         private layoutSidebarService: LayoutSidebarService
     ) {
         this.menuGroups$ = store.select(sidebarMenuGroups);
+        this.showPageLoading$ = store.select(showPageLoading);
         store.select(notificationState).subscribe((notifications) => {
             this.showLicenseNotification = filter((n) =>
                 n.type === 'license', notifications).length > 0;
@@ -39,6 +42,10 @@ export class LayoutFacadeService {
                 this.updateContentHeight('70px');
             }
         });
+    }
+
+    ShowPageLoading(showLoading: boolean) {
+        this.store.dispatch( new ShowPageLoading(showLoading));
     }
 
     showFullPage() {

--- a/components/automate-ui/src/app/entities/layout/layout.reducer.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.reducer.ts
@@ -3,10 +3,12 @@ import { MenuItemGroup } from './layout.model';
 import { LayoutActions, LayoutActionTypes } from './layout.actions';
 
 export interface LayoutEntityState {
+  showPageLoading: boolean;
   menuGroups: MenuItemGroup[];
 }
 
 export const InitialState: LayoutEntityState = {
+  showPageLoading: false,
   menuGroups: []
 };
 
@@ -15,6 +17,10 @@ export function layoutEntityReducer(
   action: LayoutActions): LayoutEntityState {
 
   switch (action.type) {
+
+    case LayoutActionTypes.SHOW_PAGE_LOADING: {
+      return set('showPageLoading', action.payload)(state);
+    }
 
     case LayoutActionTypes.GET_SIDEBAR_MENU_GROUPS:
       return state;

--- a/components/automate-ui/src/app/entities/layout/layout.selectors.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.selectors.ts
@@ -8,3 +8,8 @@ export const sidebarMenuGroups = createSelector(
     layoutState,
     (layout) => layout.menuGroups
   );
+
+  export const showPageLoading = createSelector(
+    layoutState,
+    (layout) => layout.showPageLoading
+  );

--- a/components/automate-ui/src/app/modules/policy/list/policy-list.component.html
+++ b/components/automate-ui/src/app/modules/policy/list/policy-list.component.html
@@ -1,6 +1,4 @@
 <div class="content-container">
-    <chef-loading-spinner *ngIf="loading$ | async" size='50' fixed></chef-loading-spinner>
-
     <div class="container">
       <main>
           <chef-page-header>

--- a/components/automate-ui/src/app/modules/policy/list/policy-list.component.ts
+++ b/components/automate-ui/src/app/modules/policy/list/policy-list.component.ts
@@ -17,7 +17,6 @@ import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
   styleUrls: ['./policy-list.component.scss']
 })
 export class PolicyListComponent implements OnInit {
-  public loading$: Observable<boolean>;
   public sortedPolicies$: Observable<Policy[]>;
   public isIAMv2$: Observable<boolean>;
   public policyToDelete: Policy;
@@ -27,7 +26,9 @@ export class PolicyListComponent implements OnInit {
     private store: Store<NgrxStateAtom>,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.loading$ = store.pipe(select(getAllStatus), map(loading));
+    store.pipe(select(getAllStatus), map(loading)).subscribe((isloading) =>
+      this.layoutFacade.ShowPageLoading(isloading));
+
     this.sortedPolicies$ = store.pipe(
       select(allPolicies),
       map(policies => ChefSorters.naturalSort(policies, 'name')));

--- a/components/automate-ui/src/app/modules/roles/list/roles-list.component.html
+++ b/components/automate-ui/src/app/modules/roles/list/roles-list.component.html
@@ -1,7 +1,6 @@
 <div class="content-container">
   <div class="container">
     <main>
-      <chef-loading-spinner *ngIf="loading$ | async" size='50' fixed></chef-loading-spinner>
       <chef-page-header>
         <chef-heading>Roles</chef-heading>
         <chef-subheading>

--- a/components/automate-ui/src/app/modules/roles/list/roles-list.component.ts
+++ b/components/automate-ui/src/app/modules/roles/list/roles-list.component.ts
@@ -18,7 +18,6 @@ import { Role } from 'app/entities/roles/role.model';
   styleUrls: ['./roles-list.component.scss']
 })
 export class RolesListComponent implements OnInit {
-  public loading$: Observable<boolean>;
   public sortedRoles$: Observable<Role[]>;
   public isIAMv2$: Observable<boolean>;
 
@@ -26,7 +25,9 @@ export class RolesListComponent implements OnInit {
     private store: Store<NgrxStateAtom>,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.loading$ = store.select(getAllStatus).pipe(map(loading));
+    store.select(getAllStatus).pipe(map(loading)).subscribe((isloading) =>
+      this.layoutFacade.ShowPageLoading(isloading));
+
     this.sortedRoles$ = store.select(allRoles).pipe(
       map((roles: Role[]) => ChefSorters.naturalSort(roles, 'name')));
 

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.html
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.html
@@ -1,7 +1,6 @@
 <div class="content-container">
   <div class="container">
     <main>
-      <chef-loading-spinner *ngIf="loading$ | async" size='50' fixed></chef-loading-spinner>
         <chef-page-header>
           <chef-heading>Teams</chef-heading>
           <chef-subheading>Chef Automate only displays local teams.</chef-subheading>

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
@@ -49,8 +49,13 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
     fb: FormBuilder,
     private layoutFacade: LayoutFacadeService
     ) {
-    store.select(getAllStatus).pipe(map(loading)).subscribe((isloading) =>
-      this.layoutFacade.ShowPageLoading(isloading));
+      store.pipe(
+        select(getAllStatus),
+        takeUntil(this.isDestroyed),
+        map(loading)
+      ).subscribe((isLoading) =>
+        this.layoutFacade.ShowPageLoading(isLoading)
+      );
 
     this.sortedTeams$ = store.select(allTeams).pipe(
       map((teams: Team[]) => ChefSorters.naturalSort(teams, 'id')),

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
@@ -30,7 +30,6 @@ import { Project, ProjectConstants } from 'app/entities/projects/project.model';
 })
 export class TeamManagementComponent implements OnInit, OnDestroy {
   public sortedTeams$: Observable<Team[]>;
-  public loading$: Observable<boolean>;
   public teamToDelete: Team;
   public deleteModalVisible = false;
   public createModalVisible = false;
@@ -50,7 +49,9 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
     fb: FormBuilder,
     private layoutFacade: LayoutFacadeService
     ) {
-    this.loading$ = store.select(getAllStatus).pipe(map(loading));
+    store.select(getAllStatus).pipe(map(loading)).subscribe((isloading) =>
+      this.layoutFacade.ShowPageLoading(isloading));
+
     this.sortedTeams$ = store.select(allTeams).pipe(
       map((teams: Team[]) => ChefSorters.naturalSort(teams, 'id')),
       takeUntil(this.isDestroyed));

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.html
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.html
@@ -1,6 +1,4 @@
 <div class="content-container">
-  <chef-loading-spinner *ngIf="loading$ | async" size='50' fixed></chef-loading-spinner>
-
   <div class="container token-container">
     <main>
       <chef-page-header contrastingBackground>

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
@@ -34,7 +34,6 @@ import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filt
   styleUrls: ['./api-token-list.component.scss']
 })
 export class ApiTokenListComponent implements OnInit, OnDestroy {
-  public loading$: Observable<boolean>;
   public sortedApiTokens$: Observable<ApiToken[]>;
   public apiTokenCount$: Observable<number>;
   public deleteModalVisible = false;
@@ -55,7 +54,8 @@ export class ApiTokenListComponent implements OnInit, OnDestroy {
     fb: FormBuilder,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.loading$ = store.pipe(select(apiTokenStatus), map(loading));
+    store.select(apiTokenStatus).pipe(map(loading)).subscribe((isloading) =>
+      this.layoutFacade.ShowPageLoading(isloading));
     this.isIAMv2$ = store.select(isIAMv2);
     this.apiTokenCount$ = store.select(totalApiTokens);
 

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
@@ -54,8 +54,14 @@ export class ApiTokenListComponent implements OnInit, OnDestroy {
     fb: FormBuilder,
     private layoutFacade: LayoutFacadeService
   ) {
-    store.select(apiTokenStatus).pipe(map(loading)).subscribe((isloading) =>
-      this.layoutFacade.ShowPageLoading(isloading));
+    store.pipe(
+      select(apiTokenStatus),
+      takeUntil(this.isDestroyed),
+      map(loading)
+    ).subscribe((isLoading) =>
+      this.layoutFacade.ShowPageLoading(isLoading)
+    );
+
     this.isIAMv2$ = store.select(isIAMv2);
     this.apiTokenCount$ = store.select(totalApiTokens);
 

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.html
@@ -1,8 +1,6 @@
 <div class="content-container">
   <div class="container">
     <main>
-      <chef-loading-spinner *ngIf="isLoading" size='50' fixed></chef-loading-spinner>
-  
       <app-delete-object-modal
         [visible]="deleteModalVisible"
         objectNoun="user"

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
@@ -64,6 +64,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.layoutFacade.showSettingsSidebar();
     this.store.dispatch(new GetUsers());
+    this.layoutFacade.ShowPageLoading(true);
     combineLatest([
       this.store.select(allUsers),
       this.store.select(getStatus)
@@ -72,6 +73,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
       filter(([_, uStatus]) => uStatus !== EntityStatus.loading)
       ).subscribe(([users, _]: [User[], EntityStatus]) => {
         this.isLoading = false;
+        this.layoutFacade.ShowPageLoading(false);
         // Sort naturally first by name, then by id
         this.users = ChefSorters.naturalSort(users, ['name', 'id']);
       });

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.html
@@ -142,8 +142,6 @@
         <chef-button tertiary (click)="hideDeleteModal()">Cancel</chef-button>
       </div>
     </chef-modal>
-
-      <chef-loading-spinner *ngIf="showLoadingIcon" size="100"></chef-loading-spinner>
     </main>
   </div>
 </div>

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.ts
@@ -43,6 +43,7 @@ export class ProfileDetailsComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.layoutFacade.showComplianceSidebar();
+    this.layoutFacade.ShowPageLoading(false);
     this.route.queryParams.pipe(
       takeUntil(this.isDestroyed))
       .subscribe(({owner, name, version}) => {
@@ -110,6 +111,7 @@ export class ProfileDetailsComponent implements OnInit, OnDestroy {
 
   fetchProfile(owner, name, version) {
     this.showLoadingIcon = true;
+    this.layoutFacade.ShowPageLoading(true);
     if (!owner || !owner.length) {
     // if we receive undefined for owner, we know this
     // profile is a 'premium' (available) profile
@@ -120,6 +122,7 @@ export class ProfileDetailsComponent implements OnInit, OnDestroy {
             this.profile = availProfile;
             this.isAvailable = true;
             this.showLoadingIcon = false;
+            this.layoutFacade.ShowPageLoading(false);
           });
     } else {
       this.profilesService.getProfile(owner, name, version).pipe(
@@ -128,6 +131,7 @@ export class ProfileDetailsComponent implements OnInit, OnDestroy {
           (installedProfile) => {
             this.profile = installedProfile;
             this.showLoadingIcon = false;
+            this.layoutFacade.ShowPageLoading(false);
           });
     }
   }

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
@@ -1,7 +1,6 @@
 <div class="app-main-container">
   <div class="container">
     <main>
-      <chef-loading-spinner *ngIf="ProfilesDataLoading" size='50' fixed></chef-loading-spinner>
       <chef-notification
         *ngIf="downloadErrorVisible"
         type="error"

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
@@ -61,8 +61,6 @@ export class ProfileOverviewComponent implements OnInit, OnDestroy {
   // notification data
   downloadErrorVisible = false;
 
-  // show spinner before loading data
-  ProfilesDataLoading = true;
   userProfilesDataLoaded = false;
   availableProfilesDataLoaded = false;
 
@@ -86,6 +84,7 @@ export class ProfileOverviewComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.layoutFacade.showComplianceSidebar();
+    this.layoutFacade.ShowPageLoading(true);
     this.user = this.chefSessionService.username;
 
     observableForkJoin([
@@ -158,7 +157,7 @@ export class ProfileOverviewComponent implements OnInit, OnDestroy {
 
   stopSpinnerAfterDataLoad() {
     if (this.userProfilesDataLoaded && this.availableProfilesDataLoaded) {
-      this.ProfilesDataLoading = false;
+      this.layoutFacade.ShowPageLoading(false);
     }
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -212,8 +212,6 @@
             </ul>
           </div>
         </chef-side-panel>
-    
-        <chef-loading-spinner *ngIf="reportLoading" size="100"></chef-loading-spinner>
       </main>
   </div>
 </div>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -37,6 +37,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.layoutFacade.showComplianceSidebar();
     this.reportLoading = true;
+    this.layoutFacade.ShowPageLoading(true);
     const id: string = this.route.snapshot.params['id'];
     const reportQuery = this.reportQuery.getReportQuery();
     reportQuery.filters = reportQuery.filters.concat([{type: {name: 'node_id'}, value: {id}}]);
@@ -47,6 +48,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
         this.statsService.getSingleReport(reports[0].id, reportQuery)
           .subscribe(data => {
             this.reportLoading = false;
+            this.layoutFacade.ShowPageLoading(false);
             this.activeReport = Object.assign(reports[0], data);
           });
       });
@@ -59,9 +61,11 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
 
   onReportItemClick(_event, report) {
     this.reportLoading = true;
+    this.layoutFacade.ShowPageLoading(true);
     this.statsService.getSingleReport(report.id, this.reportQuery.getReportQuery())
       .subscribe(data => {
         this.reportLoading = false;
+        this.layoutFacade.ShowPageLoading(false);
         this.activeReport = Object.assign(report, data);
       });
   }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
@@ -156,10 +156,6 @@
           </ul>
         </div>
       </chef-side-panel>
-
-      <div *ngIf="showLoadingIcon">
-        <chef-loading-spinner size="100"></chef-loading-spinner>
-      </div>
     </main>
   </div>
 </div>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
@@ -41,6 +41,7 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.layoutFacade.showComplianceSidebar();
     this.showLoadingIcon = true;
+    this.layoutFacade.ShowPageLoading(true);
 
     const id = this.route.snapshot.params['id'];
     this.fetchProfile(id, this.reportQuery.getReportQuery()).pipe(
@@ -77,6 +78,7 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
     this.controls = controls;
     this.scanResults.profile = profile;
     this.showLoadingIcon = false;
+    this.layoutFacade.ShowPageLoading(false);
   }
 
   onFilterParamsChange(reportQuery: ReportQuery, params: any) {

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/scanner/scanner.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/scanner/scanner.component.html
@@ -1,7 +1,6 @@
 <div class="content-container">
   <div class="container">
     <main>
-      <chef-loading-spinner *ngIf="countsLoading" size='50' fixed></chef-loading-spinner>
       <chef-page-header>
         <chef-heading>Scan Jobs</chef-heading>
         <chef-subheading>Compliance scan jobs run inspec exec on a set of nodes.</chef-subheading>

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/scanner/scanner.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/scanner/scanner.component.ts
@@ -13,9 +13,6 @@ export class ScannerComponent implements OnInit {
 
   jobsCount$: Observable<number>;
   nodesCount$: Observable<number>;
-
-  // show spinner before loading data
-  countsLoading = true;
   jobsCountLoaded = false;
   nodesCountLoaded = false;
 
@@ -25,6 +22,7 @@ export class ScannerComponent implements OnInit {
   ) {}
 
   ngOnInit() {
+    this.layoutFacade.ShowPageLoading(true);
     this.layoutFacade.showComplianceSidebar();
     this.jobsCount$ = this.store.select(selectors.jobsList)
       .pipe(map(jobsList => jobsList.total));
@@ -33,7 +31,6 @@ export class ScannerComponent implements OnInit {
     this.nodesCount$ = this.store.select(selectors.nodeTotals)
       .pipe(map(nodeTotals => nodeTotals.all));
     this.nodesCountLoaded = true;
-
-    this.countsLoading = false;
+    this.layoutFacade.ShowPageLoading(false);
   }
 }

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -75,8 +75,13 @@ export class ProjectListComponent implements OnInit, OnDestroy {
     this.layoutFacade.showSettingsSidebar();
     this.projects.getApplyRulesStatus();
     this.store.dispatch(new GetProjects());
-    this.store.select(getAllStatus).pipe(map(loading)).subscribe((isloading) =>
-      this.layoutFacade.ShowPageLoading(isloading));
+    this.store.pipe(
+      select(getAllStatus),
+      takeUntil(this.isDestroyed),
+      map(loading)
+    ).subscribe((isLoading) =>
+      this.layoutFacade.ShowPageLoading(isLoading)
+    );
     this.sortedProjects$ = this.store.select(allProjects).pipe(
       map((unsorted: Project[]) => ChefSorters.naturalSort(unsorted, 'name')));
 

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -27,7 +27,6 @@ import { LoadOptions } from 'app/services/projects-filter/projects-filter.action
   styleUrls: ['./project-list.component.scss']
 })
 export class ProjectListComponent implements OnInit, OnDestroy {
-  public loading$: Observable<boolean>;
   public isIAMv2$: Observable<boolean>;
   public sortedProjects$: Observable<Project[]>;
   public projectToDelete: Project;
@@ -76,8 +75,8 @@ export class ProjectListComponent implements OnInit, OnDestroy {
     this.layoutFacade.showSettingsSidebar();
     this.projects.getApplyRulesStatus();
     this.store.dispatch(new GetProjects());
-
-    this.loading$ = this.store.select(getAllStatus).pipe(map(loading));
+    this.store.select(getAllStatus).pipe(map(loading)).subscribe((isloading) =>
+      this.layoutFacade.ShowPageLoading(isloading));
     this.sortedProjects$ = this.store.select(allProjects).pipe(
       map((unsorted: Project[]) => ChefSorters.naturalSort(unsorted, 'name')));
 

--- a/components/automate-ui/src/app/ui.component.html
+++ b/components/automate-ui/src/app/ui.component.html
@@ -29,6 +29,7 @@
       <div id="notifications-wrapper">
         <app-chef-notifications></app-chef-notifications>
       </div>
+      <chef-loading-spinner [hidden]="!(layoutFacade.showPageLoading$ | async)" size='50' fixed></chef-loading-spinner>
       <router-outlet></router-outlet>
     </div>
     <!-- App Sidebar -->

--- a/components/automate-ui/src/app/ui.component.scss
+++ b/components/automate-ui/src/app/ui.component.scss
@@ -26,5 +26,10 @@
     order: 2;
     height: 100%;
     overflow-x: scroll;
+    position: relative;
   }
+}
+
+[hidden] {
+  display: none !important; // sass-lint:disable-line no-important
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Loading overlay should be over the full page content (excluding top and left navigation). It seems to not be extending to the bottom of the page. Note: many pages use the loading overlay.

### :chains: Related Resources
https://app.zenhub.com/workspaces/ui-team-5cba23a3b14fdc05970c8f87/issues/chef/automate/2263

fixes #2263

### :+1: Definition of Done
Loading overlay should extend to the bottom of the page.

### :athletic_shoe: How to Build and Test the Change
navigate to compliance/compliance-profiles (only cause its the slowest loading page)
notice the loading overlay stops short and does not extend to the bottom of the page

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
![Screen Shot 2019-11-21 at 9 08 06 AM (3)](https://user-images.githubusercontent.com/4108100/69350079-8493b600-0c3e-11ea-996e-2034b7d8e00a.png)
