### PR TITLE
Can see hidden Scan Jobs panel when scrolling right

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -176,7 +176,7 @@
           <chef-scroll-top></chef-scroll-top>
         </ng-container>
     
-        <chef-side-panel class="reporting-profile-side-panel" [visible]="showScanHistory">
+        <chef-side-panel class="reporting-profile-side-panel" [hidden]="!showScanHistory" [visible]="showScanHistory">
           <div class="side-panel-header">
             <chef-icon class="header-icon">restore</chef-icon>
             <div class="header-text">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
@@ -89,7 +89,7 @@
         <chef-scroll-top></chef-scroll-top>
       </ng-container>
 
-      <chef-side-panel class="reporting-profile-side-panel" [visible]="scanResults.opened">
+      <chef-side-panel class="reporting-profile-side-panel" [hidden]="!scanResults.opened" [visible]="scanResults.opened">
         <div class="side-panel-header">
           <chef-icon class="header-icon">equalizer</chef-icon>
           <div class="header-text">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
@@ -52,7 +52,7 @@
   <chef-scroll-top></chef-scroll-top>
 </ng-container>
 
-<chef-side-panel class="reporting-profiles-side-panel" [visible]="displayScanResultsSidebar">
+<chef-side-panel class="reporting-profiles-side-panel" [hidden]="!displayScanResultsSidebar" [visible]="displayScanResultsSidebar">
   <div class="side-panel-header">
     <chef-icon class="header-icon">equalizer</chef-icon>
     <div class="header-text">

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
@@ -73,7 +73,7 @@
 
 <chef-scroll-top></chef-scroll-top>
 
-<chef-side-panel class="side-panel" [visible]="showJobResults">
+<chef-side-panel class="side-panel" [hidden]="!showJobResults" [visible]="showJobResults">
   <div class="side-panel-header">
     <chef-icon class="header-icon">equalizer</chef-icon>
     <div class="header-text">

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.html
@@ -102,7 +102,7 @@
 
 <chef-scroll-top></chef-scroll-top>
 
-<chef-side-panel class="side-panel" [visible]="showNodeResults">
+<chef-side-panel class="side-panel" [hidden]="!showNodeResults" [visible]="showNodeResults">
   <div class="side-panel-header">
     <chef-icon class="header-icon">equalizer</chef-icon>
     <div class="header-text">


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
I can scroll right on the Scan Jobs page to see a hidden panel

### :chains: Related Resources
https://app.zenhub.com/workspaces/ui-team-5cba23a3b14fdc05970c8f87/issues/chef/automate/2264

fixes #2264

### :+1: Definition of Done
Can't scroll to right and see right panel

### :athletic_shoe: How to Build and Test the Change
navigate to /compliance/scan-jobs/jobs
try to scroll to the right of the page

### :camera: Screenshots, if applicable
![Screen Shot 2019-11-21 at 9 22 45 AM (3)](https://user-images.githubusercontent.com/4108100/69351193-82325b80-0c40-11ea-9b14-e64859d2af2d.png)
