### PR TITLE
Event feed right panel does not open

### DIFF
--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.html
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.html
@@ -34,7 +34,7 @@
 </ul>
 
 <chef-click-outside omit="event-group-button" (clickOutside)="clickedOutsidePanel()">
-  <chef-side-panel *ngIf="showEventGroupPanel" #groupSidePanel [visible]="showEventGroupPanel" tabindex="0" role="dialog">
+  <chef-side-panel #groupSidePanel [hidden]="!showEventGroupPanel" [visible]="showEventGroupPanel" tabindex="0" role="dialog">
     <chef-button secondary label="close" (click)="hideGroupedEvents()"><chef-icon>close</chef-icon></chef-button>
 
     <ul class="event-group-list" *ngIf="groupedEvent">

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, ViewChild, ElementRef, OnDestroy, OnInit } from '@angular/core';
 import { capitalize, getOr, endsWith, replace, concat } from 'lodash/fp';
-import { Subject, Subscription, Observable } from 'rxjs';
+import { Subject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ChefEvent, ChefEventCollection, EventFeedFilter, Chicklet } from '../../types/types';
 import { EventFeedService } from '../../services/event-feed/event-feed.service';
@@ -26,7 +26,6 @@ export class EventFeedTableComponent implements OnDestroy, OnInit {
   DateTime = DateTime;
 
   @ViewChild('groupSidePanel', { static: true }) sidepanel: ElementRef;
-  private subscription: Subscription;
   private isDestroyed = new Subject<boolean>();
 
   constructor(
@@ -80,7 +79,6 @@ export class EventFeedTableComponent implements OnDestroy, OnInit {
 
   hideGroupedEvents() {
     this.showEventGroupPanel = false;
-    this.subscription.unsubscribe();
     this.groupedEventsButton.focus();
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When using the buttons that look like links on the event feed the panel on the right does not open.

### :chains: Related Resources
https://app.zenhub.com/workspaces/ui-team-5cba23a3b14fdc05970c8f87/issues/chef/automate/2237

fixes #2237

### :+1: Definition of Done
Event feeds side panel opens

### :athletic_shoe: How to Build and Test the Change
Create some events (get a few profiles, or something else)
Navigate to the event feed
Use a button that looks like a link
Notice the right panel does not open

### :camera: Screenshots, if applicable
![Screen Shot 2019-11-21 at 10 49 47 AM (3)](https://user-images.githubusercontent.com/4108100/69358556-a98f2580-0c4c-11ea-88d1-de67c96a7b5b.png)
