### PR TITLE
Right panel positioning issue

### DIFF
--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -44,6 +44,10 @@ export class LayoutFacadeService {
         });
     }
 
+    hasGlobalNotifications(): boolean {
+        return this.headerHeight === '110px';
+    }
+
     ShowPageLoading(showLoading: boolean) {
         this.store.dispatch( new ShowPageLoading(showLoading));
     }

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.html
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.html
@@ -34,7 +34,7 @@
 </ul>
 
 <chef-click-outside omit="event-group-button" (clickOutside)="clickedOutsidePanel()">
-  <chef-side-panel #groupSidePanel [hidden]="!showEventGroupPanel" [visible]="showEventGroupPanel" tabindex="0" role="dialog">
+  <chef-side-panel #groupSidePanel [visible]="showEventGroupPanel" tabindex="0" role="dialog">
     <chef-button secondary label="close" (click)="hideGroupedEvents()"><chef-icon>close</chef-icon></chef-button>
 
     <ul class="event-group-list" *ngIf="groupedEvent">

--- a/components/automate-ui/src/app/page-components/resources/resources.component.html
+++ b/components/automate-ui/src/app/page-components/resources/resources.component.html
@@ -44,11 +44,13 @@
     <div class="cookbook">Cookbook</div>
     <div class="view-action">View</div>
   </div>
-  <app-resource-item
-    [resource]="resourcesData"
-    *ngFor="let resourcesData of (resourcesDataCollection | selectedStatus:active) |
-      slice:(pageSize * (currentPage - 1)):(pageSize * (currentPage - 1)) + pageSize">
-  </app-resource-item>
+  <div id="resource-item-list">
+    <app-resource-item
+      [resource]="resourcesData"
+      *ngFor="let resourcesData of (resourcesDataCollection | selectedStatus:active) |
+        slice:(pageSize * (currentPage - 1)):(pageSize * (currentPage - 1)) + pageSize">
+    </app-resource-item>
+  </div>
 </div>
 <div class="no-resources" *ngIf="resourcesTotal === 0">
   <span>No resources ran.</span>

--- a/components/automate-ui/src/app/page-components/resources/resources.component.scss
+++ b/components/automate-ui/src/app/page-components/resources/resources.component.scss
@@ -1,6 +1,11 @@
 @import "~styles/variables";
 @import "~styles/mixins";
 
+#resource-item-list {
+  height: 20vh;
+  overflow-y: scroll;
+}
+
 .rollup-item {
   display: inline-block;
   width: 15%;

--- a/components/automate-ui/src/app/page-components/resources/resources.component.scss
+++ b/components/automate-ui/src/app/page-components/resources/resources.component.scss
@@ -1,11 +1,6 @@
 @import "~styles/variables";
 @import "~styles/mixins";
 
-#resource-item-list {
-  height: 20vh;
-  overflow-y: scroll;
-}
-
 .rollup-item {
   display: inline-block;
   width: 15%;

--- a/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
+++ b/components/automate-ui/src/app/page-components/run-history/run-history.component.scss
@@ -175,8 +175,3 @@ app-date-selector {
   margin-bottom: 1em;
   justify-content: center;
 }
-
-#run-history-panel {
-  position: absolute;
-  top: 0;
-}

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -176,7 +176,7 @@
           <chef-scroll-top></chef-scroll-top>
         </ng-container>
     
-        <chef-side-panel class="reporting-profile-side-panel" [hidden]="!showScanHistory" [visible]="showScanHistory">
+        <chef-side-panel class="reporting-profile-side-panel" [visible]="showScanHistory">
           <div class="side-panel-header">
             <chef-icon class="header-icon">restore</chef-icon>
             <div class="header-text">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
@@ -89,7 +89,7 @@
         <chef-scroll-top></chef-scroll-top>
       </ng-container>
 
-      <chef-side-panel class="reporting-profile-side-panel" [hidden]="!scanResults.opened" [visible]="scanResults.opened">
+      <chef-side-panel class="reporting-profile-side-panel" [visible]="scanResults.opened">
         <div class="side-panel-header">
           <chef-icon class="header-icon">equalizer</chef-icon>
           <div class="header-text">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
@@ -52,7 +52,7 @@
   <chef-scroll-top></chef-scroll-top>
 </ng-container>
 
-<chef-side-panel class="reporting-profiles-side-panel" [hidden]="!displayScanResultsSidebar" [visible]="displayScanResultsSidebar">
+<chef-side-panel class="reporting-profiles-side-panel" [visible]="displayScanResultsSidebar">
   <div class="side-panel-header">
     <chef-icon class="header-icon">equalizer</chef-icon>
     <div class="header-text">

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
@@ -73,7 +73,7 @@
 
 <chef-scroll-top></chef-scroll-top>
 
-<chef-side-panel class="side-panel" [hidden]="!showJobResults" [visible]="showJobResults">
+<chef-side-panel class="side-panel" [visible]="showJobResults">
   <div class="side-panel-header">
     <chef-icon class="header-icon">equalizer</chef-icon>
     <div class="header-text">

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.html
@@ -102,7 +102,7 @@
 
 <chef-scroll-top></chef-scroll-top>
 
-<chef-side-panel class="side-panel" [hidden]="!showNodeResults" [visible]="showNodeResults">
+<chef-side-panel class="side-panel" [visible]="showNodeResults">
   <div class="side-panel-header">
     <chef-icon class="header-icon">equalizer</chef-icon>
     <div class="header-text">

--- a/components/automate-ui/src/app/pages/node-details/node-details.component.html
+++ b/components/automate-ui/src/app/pages/node-details/node-details.component.html
@@ -38,7 +38,7 @@
       </div>
       <app-logs-modal [isVisible]="modalIsVisible" [nodeRun]="nodeRun"></app-logs-modal>
       <app-run-history
-        *ngIf="runHistoryVisible"
+        [hidden]="!runHistoryVisible"
         [visible]="runHistoryVisible"
         class="run-history-container"
         [nodeId]="nodeId"

--- a/components/automate-ui/src/app/pages/node-details/node-details.component.html
+++ b/components/automate-ui/src/app/pages/node-details/node-details.component.html
@@ -38,7 +38,6 @@
       </div>
       <app-logs-modal [isVisible]="modalIsVisible" [nodeRun]="nodeRun"></app-logs-modal>
       <app-run-history
-        [hidden]="!runHistoryVisible"
         [visible]="runHistoryVisible"
         class="run-history-container"
         [nodeId]="nodeId"

--- a/components/automate-ui/src/app/ui.component.html
+++ b/components/automate-ui/src/app/ui.component.html
@@ -24,7 +24,7 @@
   </div>
 
   <!-- App Content -->
-  <div id="app-content-wrapper" [ngStyle]="{'height' : layoutFacade.contentHeight}">
+  <div id="app-content-wrapper" [attr.hasNotifications]="layoutFacade.hasGlobalNotifications() ? true : null" [ngStyle]="{'height' : layoutFacade.contentHeight}">
     <div id="main-content-wrapper">
       <div id="notifications-wrapper">
         <app-chef-notifications></app-chef-notifications>

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -4,6 +4,19 @@
 @import "assets/chef-ui-library/collection/styles/variables.example.css";
 @import "styles/chef-theme";
 
+
+#app-content-wrapper {
+  chef-side-panel {
+    top: 68px;
+  }
+
+  &[hasNotifications] {
+    chef-side-panel {
+      top: 107px;
+    }
+  }
+}
+
 .content-container {
   height: 100%;
   position: relative;
@@ -12,11 +25,6 @@
     height: inherit;
     position: relative;
   }
-}
-
-chef-side-panel {
-  position: absolute;
-  top: 0;
 }
 
 .container {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The run history panel, compliance/scan-job error panel, and compliance/reports scan results panel are not positioned correctly. They seem to not correctly take up the right space vertically.

### :chains: Related Resources
https://app.zenhub.com/workspaces/ui-team-5cba23a3b14fdc05970c8f87/issues/chef/automate/2238

fixes #2238

### :+1: Definition of Done
Run history panel is not cut off on top and does extend to the bottom of page.

### :athletic_shoe: How to Build and Test the Change
navigate to infrastructure/client-runs and go to a node detail page
scroll down
then open the run history panel
notice that the top is cut off

### :camera: Screenshots, if applicable
![Screen Shot 2019-11-21 at 11 48 22 AM (3)](https://user-images.githubusercontent.com/4108100/69362804-d7786800-0c54-11ea-8923-92d9ad96065e.png)
