### PR TITLE
Change position of chef-page to fixed on policy add members component

### DIFF
--- a/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.scss
+++ b/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.scss
@@ -1,6 +1,8 @@
 @import "~styles/variables";
 
 chef-page {
+  position: fixed;
+
   chef-modal {
     #{--modal-width}: 777px;
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
on the policy-add-members page, when a user chooses to add a member to a policy, a full screen modal is opened.  With the modal open, it appeared that the buttons near the bottom of the screen were not rendering.  After scrolling down we could see the buttons were rendered properly but they were hiding behind a footer.

To fix, changed the position of the chef-page that held this content to fixed, so that it show above the rest of the contnet.

### :chains: Related Resources
fixes #2253

### :+1: Definition of Done
Policy add members renders as intended, full screen with access to all content it contains.

### :athletic_shoe: How to Build and Test the Change

1. build components/automate-ui-devproxy && start_all_services
2. navigate to https://a2-dev.test/settings/policies/administrator-access#members, click `add members` -> see full screen modal
3. navigate to directly https://a2-dev.test/settings/policies/administrator-access/add-members -> see full screen modal

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
before:
<img width="930" alt="Before" src="https://user-images.githubusercontent.com/16737484/69365458-3801a800-0c49-11ea-9f1f-7171a1d42ce9.png">

after:
<img width="926" alt="after" src="https://user-images.githubusercontent.com/16737484/69365468-3f28b600-0c49-11ea-9285-38a8792fea12.png">

