### PR TITLE
[purge] always log purge actions

### DIFF
--- a/components/es-sidecar-service/pkg/server/purge.go
+++ b/components/es-sidecar-service/pkg/server/purge.go
@@ -15,20 +15,23 @@ import (
 
 // PurgeTimeSeriesIndicesByAge deletes indexes in the form basename-YYYY-mm-dd older than the requested number of days.
 func (server *EsSidecarServer) PurgeTimeSeriesIndicesByAge(ctx context.Context, in *api.PurgeRequest) (*api.PurgeResponse, error) {
-	log.WithFields(log.Fields{
+	logctx := log.WithFields(log.Fields{
 		"id":                     in.GetId(),
 		"index-base-name":        in.GetIndex(),
 		"delete-older-than-days": in.GetOlderThanDays(),
-	}).Debug("purge of time-series index")
+	})
 
 	err := server.es.DeleteTimeSeriesIndicesByAge(ctx, in.GetIndex(), int(in.GetOlderThanDays()))
 	if err != nil {
+		logctx.WithError(err).Error("failed to purge time series indices by age")
 		errStr := err.Error()
 		return &api.PurgeResponse{
 			Success: false,
 			Message: errStr,
 		}, status.Error(codes.Internal, errStr)
 	}
+
+	logctx.Info("successfully purged time series indices by age")
 
 	return &api.PurgeResponse{
 		Success: true,
@@ -39,34 +42,33 @@ func (server *EsSidecarServer) PurgeTimeSeriesIndicesByAge(ctx context.Context, 
 // PurgeDocumentsFromIndexByAge deletes all documents containing a date-mapped field "end_time" older than
 // in.OlderThanDays from in.Index.
 func (server *EsSidecarServer) PurgeDocumentsFromIndexByAge(ctx context.Context, in *api.PurgeRequest) (*api.PurgeResponse, error) {
-	logFields := log.Fields{
+	logctx := log.WithFields(log.Fields{
 		"id":                     in.GetId(),
 		"index":                  in.GetIndex(),
 		"delete-older-than-days": in.GetOlderThanDays(),
 		"custom-purge-field":     in.GetCustomPurgeField(),
-	}
+	})
 
-	log.WithFields(logFields).Debug("Initiating document purge from index")
+	logctx.Debug("Initiating document purge from index")
 	err := server.es.DeleteDocumentsFromIndexByAge(ctx, in.GetIndex(), int(in.GetOlderThanDays()), in.GetCustomPurgeField())
-	if err == nil {
-		log.WithFields(logFields).Info("Document purge completed successfully")
-		return &api.PurgeResponse{Success: true}, nil
-	} else {
+	if err != nil {
+		res := &api.PurgeResponse{Success: false, Message: err.Error()}
+
 		deleteErr, isDeleteError := err.(elastic.DeleteError)
 		if isDeleteError {
 			failures := make([]*api.PurgeResponse_Failure, 0, len(deleteErr.Failures))
 			for _, failed := range deleteErr.Failures {
 				failures = append(failures, &api.PurgeResponse_Failure{Id: failed.ID, Type: failed.Type})
 			}
-			errStr := err.Error()
-			return &api.PurgeResponse{
-				Success:  false,
-				Message:  errStr,
-				Failures: failures,
-			}, status.Error(codes.Internal, errStr)
+			logctx.WithError(err).WithField("failures", failures).Error("failed to purge document from index by age")
+			res.Failures = failures
 		}
+
+		return res, status.Error(codes.Internal, err.Error())
 	}
-	return nil, status.Error(codes.Internal, err.Error())
+
+	logctx.Info("successfully purged documents from index by age")
+	return &api.PurgeResponse{Success: true}, nil
 }
 
 // Version returns the Version of the ES Sidecar Service

--- a/lib/datalifecycle/purge/policies.go
+++ b/lib/datalifecycle/purge/policies.go
@@ -43,6 +43,7 @@ func (p EsPolicy) Purge(ctx context.Context, esSidecarClient es.EsSidecarClient)
 		res    *es.PurgeResponse
 		req    = &es.PurgeRequest{}
 		logctx = log.WithFields(log.Fields{
+			"policy_type":     "elasticsearch",
 			"id":              id,
 			"older_than_days": p.OlderThanDays,
 			"index_name":      p.IndexName,
@@ -50,7 +51,7 @@ func (p EsPolicy) Purge(ctx context.Context, esSidecarClient es.EsSidecarClient)
 	)
 
 	if p.Disabled {
-		logctx.Debug("Skipping purge because policy is disabled")
+		logctx.Info("Skipping purge because policy is disabled")
 		return nil
 	}
 
@@ -63,7 +64,7 @@ func (p EsPolicy) Purge(ctx context.Context, esSidecarClient es.EsSidecarClient)
 		req.CustomPurgeField = p.CustomPurgeField
 	}
 
-	logctx.Debug("Purging")
+	logctx.Info("Purging")
 	if req.CustomPurgeField == "" {
 		// We add 1 one here because otherwise we would delete an
 		// index that included documents newer than olderThanDays.


### PR DESCRIPTION
Always log purge workflows and ElasticSearch sidecar purge operations.

Signed-off-by: Ryan Cragun <ryan@chef.io>