### PR TITLE
Add styles to labels in scan jobs form

### DIFF
--- a/components/automate-ui/src/app/page-components/job-nodes-form/job-nodes-form.component.scss
+++ b/components/automate-ui/src/app/page-components/job-nodes-form/job-nodes-form.component.scss
@@ -83,6 +83,14 @@
   }
 }
 
+label {
+  display: block;
+  color: #222435;
+  font-size: .75em;
+  font-weight: 700;
+  padding-bottom: .5em;
+}
+
 chef-form-field {
   width: auto;
   min-width: 230px;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The styling in https://a2-local-inplace-upgrade-dev.cd.chef.co/jobs/add is out of wack in the `Add Nodes` portion of the form.  Specifically elements are laid out inline.  Turned out that the styling for the labels was missing.  I've replaced the label styling and now they are back to normal.

### :chains: Related Resources
fixes #2240

### :+1: Definition of Done
Form elements are stacking on top of each other, as they are in acceptance.

### :athletic_shoe: How to Build and Test the Change

1. build components/automate-ui-devproxy && start_all_services
2. navigate to https://a2-dev.test/jobs/add#add-nodes, see that the form elements match the acceptance image below or here https://a2-local-inplace-upgrade-acceptance.cd.chef.co/jobs/add

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
Dev - broken
<img width="1117" alt="dev" src="https://user-images.githubusercontent.com/16737484/69386717-3bf8ee80-0c78-11ea-80d8-3718833ea26f.png">

Acceptance - correct
<img width="1116" alt="acceptance" src="https://user-images.githubusercontent.com/16737484/69386734-461aed00-0c78-11ea-85a2-4409e44a29fe.png">

This Branch
<img width="997" alt="branch" src="https://user-images.githubusercontent.com/16737484/69386739-49ae7400-0c78-11ea-8918-de88293dd931.png">
