### PR TITLE
nodemanager Read RPC project filtering

### DIFF
--- a/components/nodemanager-service/tests/project_filtering_test.go
+++ b/components/nodemanager-service/tests/project_filtering_test.go
@@ -47,106 +47,137 @@ func TestReadProjectFilteringIngestedNodes(t *testing.T) {
 	manualNodeID := manualNodeIds[0]
 
 	cases := []struct {
-		description  string
-		ctx          context.Context
-		ingestedNode *manager.NodeMetadata
-		isError      bool
+		description     string
+		requestProjects []string
+		nodeProjects    []string
+		isError         bool
 	}{
 		{
-			description: "Allowed project is requested with matching node project",
-			ctx:         contextWithProjects([]string{"target_project"}),
-			ingestedNode: &manager.NodeMetadata{
-				Uuid:     "node1",
-				Projects: []string{"target_project"},
-			},
-			isError: false,
+			description:     "Node project matching request's projects",
+			requestProjects: []string{"target_project"},
+			nodeProjects:    []string{"target_project"},
+			isError:         false,
 		},
 		{
-			description: "Not allowed project is requested with node with different project",
-			ctx:         contextWithProjects([]string{"missed_target_project"}),
-			ingestedNode: &manager.NodeMetadata{
-				Uuid:     "node1",
-				Projects: []string{"target_project"},
-			},
-			isError: true,
+			description:     "Node project not matching request's projects",
+			requestProjects: []string{"missed_target_project"},
+			nodeProjects:    []string{"target_project"},
+			isError:         true,
 		},
 		{
-			description: "Allowed unassigned project is requested with node unassigned",
-			ctx:         contextWithProjects([]string{authzConstants.UnassignedProjectID}),
-			ingestedNode: &manager.NodeMetadata{
-				Uuid:     "node1",
-				Projects: []string{},
-			},
-			isError: false,
+			description:     "Node has no projects; request's project has unassigned project",
+			requestProjects: []string{authzConstants.UnassignedProjectID},
+			nodeProjects:    []string{},
+			isError:         false,
 		},
 		{
-			description: "Allowed unassigned and target project is requested with matching node project",
-			ctx:         contextWithProjects([]string{authzConstants.UnassignedProjectID, "target_project"}),
-			ingestedNode: &manager.NodeMetadata{
-				Uuid:     "node1",
-				Projects: []string{"target_project"},
-			},
-			isError: false,
+			description:     "Node has a project assigned; request's project has unassigned and the matching project",
+			requestProjects: []string{authzConstants.UnassignedProjectID, "target_project"},
+			nodeProjects:    []string{"target_project"},
+			isError:         false,
 		},
 		{
-			description: "Not allowed unassigned project is requested with node with project tagged",
-			ctx:         contextWithProjects([]string{authzConstants.UnassignedProjectID}),
-			ingestedNode: &manager.NodeMetadata{
-				Uuid:     "node1",
-				Projects: []string{"target_project"},
-			},
-			isError: true,
+			description:     "Node has a project assigned; request's projects has only the unassigned project",
+			requestProjects: []string{authzConstants.UnassignedProjectID},
+			nodeProjects:    []string{"target_project"},
+			isError:         true,
 		},
 		{
-			description: "Allowed all project is requested with node with target_project",
-			ctx:         contextWithProjects([]string{authzConstants.AllProjectsExternalID}),
-			ingestedNode: &manager.NodeMetadata{
-				Uuid:     "node1",
-				Projects: []string{"target_project"},
-			},
-			isError: false,
+			description:     "Node is assigned a project; request for all projects",
+			requestProjects: []string{authzConstants.AllProjectsExternalID},
+			nodeProjects:    []string{"target_project"},
+			isError:         false,
 		},
 		{
-			description: "Allowed all project is requested with node unassigned",
-			ctx:         contextWithProjects([]string{authzConstants.AllProjectsExternalID}),
-			ingestedNode: &manager.NodeMetadata{
-				Uuid:     "node1",
-				Projects: []string{},
-			},
-			isError: false,
+			description:     "Node has no projects; requested for all projects",
+			requestProjects: []string{authzConstants.AllProjectsExternalID},
+			nodeProjects:    []string{},
+			isError:         false,
+		},
+		{
+			description:     "Node has no projects; requested projects is empty",
+			requestProjects: []string{},
+			nodeProjects:    []string{},
+			isError:         false,
+		},
+		{
+			description:     "Node has one project not matching any of several requested projects",
+			requestProjects: []string{"project3", "project4", "project7", "project6"},
+			nodeProjects:    []string{"project9"},
+			isError:         true,
+		},
+		{
+			description:     "Node has one project matching one of several requested projects",
+			requestProjects: []string{"project3", "project4", "project7", "project6"},
+			nodeProjects:    []string{"project7"},
+			isError:         false,
+		},
+		{
+			description:     "Node with several projects where one matches a single requested project",
+			requestProjects: []string{"project3"},
+			nodeProjects:    []string{"project3", "project4", "project7", "project6"},
+			isError:         false,
+		},
+		{
+			description:     "Node with several projects where one matches one of several requested projects",
+			requestProjects: []string{"project3", "project10", "project12", "project13"},
+			nodeProjects:    []string{"project3", "project4", "project7", "project6"},
+			isError:         false,
+		},
+		{
+			description:     "Node with several projects that do not matche several requested projects",
+			requestProjects: []string{"project14", "project10", "project12", "project13"},
+			nodeProjects:    []string{"project3", "project4", "project7", "project6"},
+			isError:         true,
+		},
+		{
+			description:     "Node with several projects where two match two of several requested projects",
+			requestProjects: []string{"project3", "project10", "project12", "project13"},
+			nodeProjects:    []string{"project3", "project10", "project7", "project6"},
+			isError:         false,
 		},
 	}
 
 	for _, test := range cases {
 		t.Run(fmt.Sprintf("Project filter: %s", test.description),
 			func(t *testing.T) {
-				// Ingest node
-				test.ingestedNode.LastContact = timestamp
-				test.ingestedNode.RunData = &nodes.LastContactData{
-					Id:      createUUID(),
-					EndTime: timestamp,
-					Status:  nodes.LastContactData_PASSED,
+
+				// Create the context with projects added
+				ctx := contextWithProjects(test.requestProjects)
+
+				// Create Ingest node
+				node := &manager.NodeMetadata{
+					Uuid:        "node1",
+					Projects:    test.nodeProjects,
+					LastContact: timestamp,
+					RunData: &nodes.LastContactData{
+						Id:      createUUID(),
+						EndTime: timestamp,
+						Status:  nodes.LastContactData_PASSED,
+					},
 				}
 
-				err = db.ProcessIncomingNode(test.ingestedNode)
+				// ingest node
+				err = db.ProcessIncomingNode(node)
 				require.NoError(t, err)
 
 				// Delete created node after the test is complete
-				defer db.DeleteNode(test.ingestedNode.Uuid)
+				defer db.DeleteNode(node.Uuid)
 
 				// Call Read to get the ingested node with project filtering context.
-				nodeResponse, err := nodeManager.Read(test.ctx, &nodes.Id{
-					Id: test.ingestedNode.Uuid,
+				nodeResponse, err := nodeManager.Read(ctx, &nodes.Id{
+					Id: node.Uuid,
 				})
 
 				if test.isError {
 					assert.Error(t, err)
 				} else {
 					require.NoError(t, err)
-					assert.Equal(t, test.ingestedNode.Uuid, nodeResponse.Id)
+					assert.Equal(t, node.Uuid, nodeResponse.Id)
 				}
 
-				manualNodeResponse, err := nodeManager.Read(test.ctx, &nodes.Id{Id: manualNodeID})
+				// Test that we can read the manually added node for all cases.
+				manualNodeResponse, err := nodeManager.Read(ctx, &nodes.Id{Id: manualNodeID})
 				require.NoError(t, err)
 				assert.Equal(t, manualNodeID, manualNodeResponse.Id)
 			})


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Adding project filtering to the "api/v0/nodes/<id>"/Read RPC function. This is needed because the nodemanager stores both ingested nodes and manually added nodes. These changes filter the ingested nodes only. The manually added nodes will not be filtered by the project tags in the context object.

If the ingested node is not allowed by the passed in projects in the request a 404 will be returned. 

### :chains: Related Resources
#2350

### :+1: Definition of Done

All ingested client runs and compliance nodes are filtered by projects on the Read RPC. 

### :athletic_shoe: How to Build and Test the Change

1. `build components/nodemanager-service && start_all_services`
1. Ingest some client run nodes with `send_chef_run_example`
1. Go to https://a2-dev.test/infrastructure/client-runs and copy the node ID for the new node created. 
1. Ensure the node can be retrieved with unassigned by running this command `curl -X GET -f --insecure -H "api-token: $(get_admin_token)" -H "projects: (unassigned)" https://localhost/api/v0/nodes/id/<node ID>`
1. Create a project with the name "project9" with one rule that matches environment = B
1. Apply the rules
1. Ensure the node can be retrieved with project9 with this command `curl -X GET -f --insecure -H "api-token: $(get_admin_token)" -H "projects: project9" https://localhost/api/v0/nodes/id/<node ID>`
1. Ensure the node can not be retrieved with unassigned by running this command again `curl -X GET -f --insecure -H "api-token: $(get_admin_token)" -H "projects: (unassigned)" https://localhost/api/v0/nodes/id/<node ID>`. You should see a 404. 

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable