### PR TITLE
allow user to include region when creating aws mgr

### DIFF
--- a/components/automate-chef-io/content/docs/node-integrations.md
+++ b/components/automate-chef-io/content/docs/node-integrations.md
@@ -63,12 +63,15 @@ The service makes calls to these API:
 * `STS-GetCallerIdentity`
 * `SEC2-DescribeRegions`
 * `IAM-ListAccountAliases`
+* `IAM-GetAccountSummary`
+* `IAM-ListUsers`
 
 Permissions: You'll need at least a global read permission; `arn:aws:iam::aws:policy/ReadOnlyAccess`
 
 ## AWS Credential-less Scanning with Chef Automate
 
 For users running Chef Automate 2 in EC2, we invite you to try out our "AWS-EC2 Credential-less Scanning"!
+Please note that credential-less scanning is not supported for AWS govcloud.
 
 ### Ensure Minimum Permissions
 
@@ -86,7 +89,9 @@ Ensure the policy attached to the role used by the instance you have Chef Automa
                 "ec2:DescribeRegions",
                 "sts:GetCallerIdentity",
                 "ec2:DescribeInstanceStatus",
-                "iam:ListAccountAliases"
+                "iam:ListAccountAliases",
+                "iam:GetAccountSummary",
+                "iam:ListUsers",
             ],
             "Resource": "*"
         }
@@ -138,6 +143,7 @@ The service makes these API calls:
 ## Azure VM Scanning with Chef Automate
 
 Set up Chef Automate to detect and scan the nodes in your Azure account by providing your Azure Credentials and creating an _Azure VM Node Manager_. To add an Azure VM Node Manager, navigate to the [_Node Integrations_]({{< relref "node-integrations.md" >}}) page in the Settings tab, select `Create Integration`, and you should see _Azure_ as one of your node management service options.
+Please note we do not support Azure govcloud.
 
 ### Adding an Azure VM Node Manager
 

--- a/components/automate-chef-io/content/docs/node-integrations.md
+++ b/components/automate-chef-io/content/docs/node-integrations.md
@@ -28,6 +28,7 @@ To create an AWS EC2 Node Manager, you need the following information:
 
 1. A name for your manager
 2. Your AWS credentials (access key ID and secret access key)
+3. The default region to target (if `us-east-1` is not desired)
 
 ![Chef Automate Create AWS-EC2 Manager](/images/docs/node-integrations-full.png)
 
@@ -71,7 +72,7 @@ Permissions: You'll need at least a global read permission; `arn:aws:iam::aws:po
 ## AWS Credential-less Scanning with Chef Automate
 
 For users running Chef Automate 2 in EC2, we invite you to try out our "AWS-EC2 Credential-less Scanning"!
-Please note that credential-less scanning is not supported for AWS govcloud.
+Please note that credential-less scanning is not supported for AWS GovCloud.
 
 ### Ensure Minimum Permissions
 
@@ -143,7 +144,7 @@ The service makes these API calls:
 ## Azure VM Scanning with Chef Automate
 
 Set up Chef Automate to detect and scan the nodes in your Azure account by providing your Azure Credentials and creating an _Azure VM Node Manager_. To add an Azure VM Node Manager, navigate to the [_Node Integrations_]({{< relref "node-integrations.md" >}}) page in the Settings tab, select `Create Integration`, and you should see _Azure_ as one of your node management service options.
-Please note we do not support Azure govcloud.
+Please note we do not support Azure Government Cloud.
 
 ### Adding an Azure VM Node Manager
 

--- a/components/automate-ui/src/app/pages/integrations/add/integrations-add.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/add/integrations-add.component.ts
@@ -51,7 +51,8 @@ export class IntegrationsAddComponent implements OnDestroy {
         no_creds: false,
         credentials: fb.group({
           aws_access_key_id: '',
-          aws_secret_access_key: ''
+          aws_secret_access_key: '',
+          aws_region: ''
         })
       }),
       azure: fb.group({

--- a/components/automate-ui/src/app/pages/integrations/aws-form/aws-form.component.html
+++ b/components/automate-ui/src/app/pages/integrations/aws-form/aws-form.component.html
@@ -23,6 +23,11 @@
       <span class="label">Enter your AWS secret access key</span>
       <chef-input ngDefaultControl type="password" formControlName="aws_secret_access_key"></chef-input>
     </label>
+
+    <label class="form-field">
+      <span class="label">Specify a default region to target</span>
+      <chef-input ngDefaultControl type="text" placeholder="us-east-1" formControlName="aws_region"></chef-input>
+    </label>
   </ng-container>
 
 </ng-container>

--- a/components/nodemanager-service/api/manager/server/server.go
+++ b/components/nodemanager-service/api/manager/server/server.go
@@ -645,7 +645,6 @@ func (srv *Server) addNodeForEachEc2Instance(ctx context.Context, managerId stri
 }
 
 func (srv *Server) addNodeForAccount(ctx context.Context, managerId string, managerName string, managerAcctId string, credential string) ([]string, error) {
-	logrus.Infof("Getting regions for node manager: %+v", managerId)
 	myaws, _, err := managers.GetAWSManagerFromID(ctx, managerId, srv.DB, srv.secretsClient)
 	if err != nil {
 		return nil, fmt.Errorf("addNodeForAccount; error getting connection %s %s", managerName, err.Error())

--- a/components/nodemanager-service/managers/awsec2/awsec2_test.go
+++ b/components/nodemanager-service/managers/awsec2/awsec2_test.go
@@ -1,6 +1,7 @@
 package awsec2
 
 import (
+	"os"
 	"testing"
 
 	"github.com/chef/automate/components/compliance-service/api/common"
@@ -10,6 +11,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewSetsRegionCorrectly(t *testing.T) {
+	creds := New(AwsCreds{
+		Region: "us-gov-west-1",
+	})
+	assert.Equal(t, "us-gov-west-1", creds.Region)
+
+	creds = New(AwsCreds{
+		Region: "",
+	})
+	assert.Equal(t, "us-east-1", creds.Region)
+
+	os.Setenv("AWS_REGION", "test-env")
+	creds = New(AwsCreds{
+		Region: "",
+	})
+	assert.Equal(t, "test-env", creds.Region)
+}
 
 func TestFormatRegionFilters(t *testing.T) {
 	region := "*us-west*"


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?
When accessing the AWS api, a region value is required. We've been defaulting to the value of env var "AWS_REGION" and using "us-east-1" when the env var is not set.
This change modifies the code to also accept (and prefer) a region value by credential.
That means that a user can now add an integration with the following api body:
```
'{"name":"test (fake) aws-api integration","type":"aws-api","credential_data":[{"key":"AWS_ACCESS_KEY_ID","value":"test"},{"key":"AWS_SECRET_ACCESS_KEY","value":"test"},{"key":"AWS_REGION","value":"us-gov-west-1"}],"instance_credentials":[]}'
```
If the region is included in the api call, we use that value. If it is not specified, we go back to the original code path of looking for the env var and then falling back to us-east-1 as a default.

### :chains: Related Resources
https://github.com/chef/automate/issues/2358

### :+1: Definition of Done
when creating an aws integration, the region value specified in the api is passed through to all aws api calls. 

### :athletic_shoe: How to Build and Test the Change
- rebuild nodemanager service, compliance service, and ui
- create an IAM user in govcloud with the following perms:
```
                "ec2:DescribeInstances",
                "ssm:*",
                "ec2:DescribeRegions",
                "sts:GetCallerIdentity",
                "ec2:DescribeInstanceStatus",
                "iam:ListAccountAliases",
                "iam:GetAccountSummary",
                "iam:ListUsers",
```
- add an api integration and specify the region needed for gov cloud (`us-gov-west-1`)
- run a scan job with the AWS profile, take a look at the results
- add a node in the govcloud account
- add an ec2 integration and specify the region needed for gov cloud (`us-gov-west-1`)
- ensure the node was added and has all the correct info (public ip, tags, name)

**note: ssm scanning is not currently supported with govcloud**

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [x] Docs added/updated?

### :camera: Screenshots, if applicable
<img width="585" alt="Screen Shot 2019-11-26 at 05 54 39" src="https://user-images.githubusercontent.com/10341541/69635282-4cf78600-1011-11ea-8a15-18ddf702c1cb.png">
