### PR TITLE
Jamie/2285 v1 create team modal bug

### DIFF
--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -103,9 +103,6 @@ import {
 import {
   ConvergeRadialGraphComponent
 } from './page-components/converge-radial-graph/converge-radial-graph.component';
-import {
-  CreateV1TeamModalComponent
-} from './page-components/create-v1-team-modal/create-v1-team-modal.component';
 import { DatafeedFormComponent } from './pages/data-feed-form/data-feed-form.component';
 import { DatafeedComponent } from './pages/data-feed/data-feed.component';
 import { DateSelectorComponent } from './page-components/date-selector/date-selector.component';
@@ -206,7 +203,6 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     ClientRunsSidebarComponent,
     ClientRunsTableComponent,
     ConvergeRadialGraphComponent,
-    CreateV1TeamModalComponent,
     DatafeedComponent,
     DatafeedFormComponent,
     DateSelectorComponent,

--- a/components/automate-ui/src/app/components/chef-components.module.ts
+++ b/components/automate-ui/src/app/components/chef-components.module.ts
@@ -12,6 +12,7 @@ import { AuthorizedComponent } from './authorized/authorized.component';
 import { BreadcrumbsComponent } from './breadcrumbs/breadcrumbs.component';
 import { BreadcrumbComponent } from './breadcrumb/breadcrumb.component';
 import { CalendarComponent } from './calendar/calendar.component';
+import { CreateV1TeamModalComponent } from '../page-components/create-v1-team-modal/create-v1-team-modal.component';
 import { CreateObjectModalComponent } from './create-object-modal/create-object-modal.component';
 import { DeleteObjectModalComponent } from './delete-object-modal/delete-object-modal.component';
 import { ErrorDirective } from './error/error.directive';
@@ -69,6 +70,7 @@ import { TableHeaderComponent } from './table/table-header/table-header.componen
     BreadcrumbsComponent,
     BreadcrumbComponent,
     CalendarComponent,
+    CreateV1TeamModalComponent,
     CreateObjectModalComponent,
     DeleteObjectModalComponent,
     FormFieldComponent,
@@ -103,6 +105,7 @@ import { TableHeaderComponent } from './table/table-header/table-header.componen
     BreadcrumbsComponent,
     BreadcrumbComponent,
     CalendarComponent,
+    CreateV1TeamModalComponent,
     CreateObjectModalComponent,
     DeleteObjectModalComponent,
     ErrorDirective,

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
@@ -174,7 +174,6 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
       this.createModalVisible = true;
     } else {
       this.createV1TeamModalVisible = true;
-      console.log(this.createV1TeamModalVisible);
     }
     this.resetCreateModal();
   }

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
@@ -174,6 +174,7 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
       this.createModalVisible = true;
     } else {
       this.createV1TeamModalVisible = true;
+      console.log(this.createV1TeamModalVisible);
     }
     this.resetCreateModal();
   }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When on iam v1 at `settings/teams` and attempting to create a team.  When a user clicked on the `create team` button, nothing would happen.

I moved the `CreateV1TeamModalComponent` from the appModule over to the `ChefComponentsModule` because that is where the `CreateObjectModalComponent` and `DeleteObjectModalComponent` are living.

### :chains: Related Resources
fixes #2285

### :+1: Definition of Done
`Create Team` button displays modal on both v1 and v2

### :athletic_shoe: How to Build and Test the Change

1. build components/automate-ui-devproxy && start_all_services
2. chef-automate iam reset-to-v1
3. navigate to https://a2-dev.test/settings/teams
4. click Create Team
5. See the v1 create team modal pop up.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable