### PR TITLE
Make footer on chef-page fixed

### DIFF
--- a/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.scss
+++ b/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.scss
@@ -1,7 +1,6 @@
 @import "~styles/variables";
 
 chef-page {
-  position: fixed;
 
   chef-modal {
     #{--modal-width}: 777px;

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -1,6 +1,7 @@
 @import "~styles/variables";
 
 chef-page {
+  position: fixed;
 
   small {
     color: $chef-dark-grey;

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -1,7 +1,6 @@
 @import "~styles/variables";
 
 chef-page {
-  position: fixed;
 
   small {
     color: $chef-dark-grey;

--- a/components/chef-ui-library/src/templates/chef-page/chef-page.scss
+++ b/components/chef-ui-library/src/templates/chef-page/chef-page.scss
@@ -5,7 +5,7 @@ chef-page {
   min-height: 450px;
   overflow: hidden;
   padding: 64px;
-  position: relative;
+  position: fixed;
   width: 100vw;
 
   &.example-page-width {

--- a/components/chef-ui-library/src/templates/chef-page/chef-page.scss
+++ b/components/chef-ui-library/src/templates/chef-page/chef-page.scss
@@ -29,7 +29,7 @@ chef-page {
   }
 
   #page-footer {
-    position: absolute;
+    position: fixed;
     left: 0;
     bottom: 0;
     margin: 64px;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Notifications left around from previous actions at the top of the screen were forcing the footer of chef-page off page.  Realized that since chef-pages are all full screen, we can make the footer of chef-page fixed so that content can never force it off screen.

### :chains: Related Resources
fixes #2374

### :+1: Definition of Done
Notifications do not affect our ability to see the save or cancel buttons on chef-page components

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
_you may also need to run make update-ui-lib from automate-ui folder_
Create a project
Quickly click Create Rule
You will see the full screen create rule modal correctly display the notification for a bit with the rest of the modal rendered properly
After the notification times out or is removed, the buttons rendered in the bottom of the modal will remain in the same place with the modal full screen.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable