### PR TITLE
[automate-2366] Remove introspection from individual projects on list page

### DIFF
--- a/components/automate-ui/src/app/modules/policy/list/policy-list.component.html
+++ b/components/automate-ui/src/app/modules/policy/list/policy-list.component.html
@@ -29,7 +29,7 @@
                       <chef-table-cell class="type-column">{{ policy.type | iamType }}</chef-table-cell>
                       <chef-table-cell class="status-column">{{ status(policy) | capitalize }}</chef-table-cell>
                       <chef-table-cell class="three-dot-column">
-                      <!-- <app-authorized [allOf]="['/policies/{policy}', 'delete', policy]"> -->
+                      <!-- <app-authorized [allOf]="[`/iam/v2beta/policies/{id}`, 'delete', policy.id]"> -->
                         <chef-control-menu *ngIf="policy.type !== 'CHEF_MANAGED'">
                           <chef-option (click)="startPolicyDelete(policy)">Delete Policy</chef-option>
                         </chef-control-menu>
@@ -40,7 +40,7 @@
               </chef-table-new>
             </app-authorized>
           </section>
-      
+
           <app-delete-object-modal
             [visible]="deleteModalVisible"
             objectNoun="policy"

--- a/components/automate-ui/src/app/modules/roles/list/roles-list.component.html
+++ b/components/automate-ui/src/app/modules/roles/list/roles-list.component.html
@@ -38,9 +38,11 @@
                   <chef-table-cell></chef-table-cell>
                   <chef-table-cell>{{ role.type | iamType }}</chef-table-cell>
                   <chef-table-cell class="three-dot-column">
+                    <!-- <app-authorized [allOf]="[`/iam/v2beta/roles/{id}`, 'delete', role.id]"> -->
                     <chef-control-menu *ngIf="(role.type | iamType).toLowerCase() === 'custom'">
                       <chef-option data-cy="delete" (click)="startRoleDelete(role)">Delete Role</chef-option>
                     </chef-control-menu>
+                    <!-- </app-authorized> -->
                   </chef-table-cell>
               </chef-table-row>
             </chef-table-body>

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.html
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.html
@@ -5,7 +5,7 @@
           <chef-heading>Teams</chef-heading>
           <chef-subheading>Chef Automate only displays local teams.</chef-subheading>
         </chef-page-header>
-    
+
       <app-create-v1-team-modal
         [visible]="createV1TeamModalVisible"
         [creating]="creatingTeam"
@@ -14,7 +14,7 @@
         (close)="closeCreateModal()"
         (createClicked)="createV1Team()">
       </app-create-v1-team-modal>
-  
+
       <app-create-object-modal
         [visible]="createModalVisible"
         [creating]="creatingTeam"
@@ -26,7 +26,7 @@
         (close)="closeCreateModal()"
         (createClicked)="createV2Team()">
       </app-create-object-modal>
-  
+
       <app-delete-object-modal
         [visible]="deleteModalVisible"
         objectNoun="team"
@@ -35,7 +35,7 @@
         (deleteClicked)="deleteTeam()"
         objectAction="Delete">
       </app-delete-object-modal>
-  
+
       <div class="page-body">
         <ng-container *ngIf="(sortedTeams$ | async)?.length > 0">
           <section>
@@ -78,7 +78,8 @@
                       <span *ngIf="team.projects.length > 1">{{ team.projects.length }} projects</span>
                     </chef-table-cell>
                     <chef-table-cell class="three-dot-column">
-                      <!-- <app-authorized [allOf]="[`/auth/teams/${team.id}`, 'delete']"> -->
+                      <!-- TODO: Need to account for v1 / v2 in the app-authorized path -->
+                      <!-- <app-authorized [allOf]="['/iam/v2beta/teams/{id}', 'delete', team.id]"> -->
                       <chef-control-menu>
                         <chef-option (click)="startTeamDelete(team)">Delete Team</chef-option>
                       </chef-control-menu>

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.html
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.html
@@ -71,8 +71,12 @@
                   <chef-option (click)="notifyCopy()" data-cy="copy-token">
                     <chef-clipboard plain value={{token.value}} label="Copy Token" icon=""></chef-clipboard>
                   </chef-option>
+                  <!-- <app-authorized [allOf]="[`/iam/v2beta/tokens/{id}`, 'put', token.id]"> -->
                   <chef-option (click)="toggleActive(token)">Toggle Status</chef-option>
+                  <!-- </app-authorized> -->
+                  <!-- <app-authorized [allOf]="[`/iam/v2beta/tokens/{id}`, 'delete', token.id]"> -->
                   <chef-option (click)="startTokenDelete(token)" data-cy="delete">Delete Token</chef-option>
+                  <!-- </app-authorized> -->
                 </chef-control-menu>
              </chef-table-cell>
             </chef-table-row>

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.html
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.html
@@ -47,7 +47,7 @@
               <chef-table-header-cell *ngIf="isIAMv2$ | async">Projects</chef-table-header-cell>
               <chef-table-header-cell>Created Date</chef-table-header-cell>
               <chef-table-header-cell>Status</chef-table-header-cell>
-              <chef-table-header-cell class="controls"></chef-table-header-cell>
+              <chef-table-header-cell class="three-dot-column"></chef-table-header-cell>
             </chef-table-row>
           </chef-table-header>
           <chef-table-body>
@@ -66,7 +66,7 @@
                 <ng-container *ngIf="token.active">Active</ng-container>
                 <ng-container *ngIf="!token.active">Inactive</ng-container>
               </chef-table-cell>
-              <chef-table-cell class="controls">
+              <chef-table-cell class="three-dot-column">
                 <chef-control-menu id="menu-{{token.id}}" data-cy="token-control">
                   <chef-option (click)="notifyCopy()" data-cy="copy-token">
                     <chef-clipboard plain value={{token.value}} label="Copy Token" icon=""></chef-clipboard>

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.scss
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.scss
@@ -1,6 +1,6 @@
 @import "~styles/variables";
 
-.controls {
+.three-dot-column {
   text-align: right;
 }
 

--- a/components/automate-ui/src/app/modules/user/user-table/user-table.component.html
+++ b/components/automate-ui/src/app/modules/user/user-table/user-table.component.html
@@ -30,12 +30,8 @@
             {{ user.id }}
           </chef-table-cell>
           <chef-table-cell class="three-dot-column">
-            <!-- TODO (tc) We do not yet have a way of checking permissions on a specific object.
-            Also the shape of the team membership API isn't restful so we'll have to figure
-            out something else here anyway -->
-            <!-- <app-authorized
-              [allOf]="generateDeletePermissionsPath(user)"
-              [overrideVisible]="overridePermissionsCheck"> -->
+            <!-- TODO: Need to account for v1 / v2 in the app-authorized path -->
+            <!-- <app-authorized [allOf]="['/iam/v2beta/users/{id}', 'delete', user.id]"> -->
             <chef-control-menu>
               <chef-option data-cy="delete" (click)="removeClicked.emit(user)">{{ removeText }}</chef-option>
             </chef-control-menu>

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.html
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.html
@@ -10,7 +10,7 @@
       <section *ngIf="!(isIAMv2$ | async)" class="page-body">
         Currently, you are using IAM v1. Projects are only available with IAM v2.
       </section>
-  
+
       <section *ngIf="isIAMv2$ | async" class="page-body">
         <ng-container *ngIf="(sortedProjects$ | async)?.length > 0">
           <chef-toolbar>
@@ -45,11 +45,11 @@
                   <chef-table-cell>{{ project.id }}</chef-table-cell>
                   <chef-table-cell>{{ getRulesStatus(project) }}</chef-table-cell>
                   <chef-table-cell class="three-dot-column">
-                    <app-authorized [allOf]="['/iam/v2beta/projects/{id}', 'delete', project.id]">
+                    <!-- <app-authorized [allOf]="['/iam/v2beta/projects/{id}', 'delete', project.id]"> -->
                       <chef-control-menu>
                         <chef-option (click)="startProjectDelete(project)" data-cy="delete-project">Delete Project</chef-option>
                       </chef-control-menu>
-                    </app-authorized>
+                    <!-- </app-authorized> -->
                   </chef-table-cell>
                 </chef-table-row>
               </chef-table-body>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This PR removes introspection around the control menu on each project for the time being due to two issues.
1. Parameterized introspection is not yet set up for projects.
2. A back-end call for each resource is too much overhead.

### :chains: Related Resources
N/A

### :+1: Definition of Done
Network calls to the introspect endpoint do not occur for each project in the projects list.

### :athletic_shoe: How to Build and Test the Change

Rebuild automate-ui.
Watch in the network tab when you reload the projects page that introspect calls on each specific project do not occur.
