### PR TITLE
[automate-2140] API Documentation: Auth Security Definitions

### DIFF
--- a/components/automate-chef-io/data/docs/api-static/02-meta-description.yaml
+++ b/components/automate-chef-io/data/docs/api-static/02-meta-description.yaml
@@ -36,6 +36,6 @@ info:
     ```
 
     The Chef Automate documentation covers policies, authentication, and authorization in greater detail.
-    * **[Permission for An API Client](https://automate.chef.io/docs/authorization-overview/#permission-for-an-api-client)** walks through how to limit access to the Chef Automate API by writing a policy for a standard token.
+    * **[Permission for An API Client](https://automate.chef.io/docs/iam-v1-overview/#permission-for-an-api-client)** walks through how to limit access to the Chef Automate API by writing a policy for a standard token.
     * **[API Tokens](https://automate.chef.io/docs/api-tokens/)** explains authentication in Chef Automate.
-    * **[Authorization Overview](https://automate.chef.io/docs/authorization-overview/#overview)** explains authorization in Chef Automate.
+    * **[Authorization Overview](https://automate.chef.io/docs/iam-v1-overview/#overview)** explains authorization in Chef Automate.

--- a/components/automate-chef-io/data/docs/api-static/02-meta-description.yaml
+++ b/components/automate-chef-io/data/docs/api-static/02-meta-description.yaml
@@ -3,12 +3,46 @@ info:
     # Authentication
     The standard way of authenticating for the Automate API is to generate an
     API token and pass that with your API requests with the `api-token` header.
-    An example request using curl looks like this:
+
+    An administrative token can be created and set to a variable using the following CLI helper:
+
+    ```
+    export TOKEN=`chef-automate admin-token`
+    ```
+
+    With an administrative token you can access the entire Chef Automate API – including administrative 
+    tasks such as managing local users and managing local teams and managing authorization policies.
+    Using the token above, an example request using curl looks like this:
 
     ```
     curl -s -H "api-token: $TOKEN" https://automate.example.com/api/v0/auth/policies -v
     ```
+    
+    With the administrative token, it is possible to create standard tokens with more limited permissions.
+    The following curl returns a new token object whose value can be set to a new variable:
+
+    ```
+    curl -s -H "api-token: $TOKEN" -d '{"description":"New Token"}' https://automate.example.com/api/v0/auth/tokens
+    {
+      "id": "9d7ae605-5b6a-4850-a12f-b5cb7fa732f5",
+      "description": "New Token",
+      "value": "bww8EEpr39_eYMnQ2zybtrP9uzk=",
+      "active": false,
+      "created": "2019-12-03T00:15:10Z",
+      "updated": "2019-12-03T00:15:10Z"
+    }
+
+    export TOKEN2=bww8EEpr39_eYMnQ2zybtrP9uzk=
+    ```
+
+    You can grant a standard token access to specific parts of the Chef Automate API 
+    if you write a policy. 
+    The [Permission for An API Client](https://automate.chef.io/docs/authorization-overview/#permission-for-an-api-client)
+    section of the Automate documentation walks through how to grant a token access to all Compliance API endpoints.
 
     For more information about authentication, refer to the
     [API Tokens](https://automate.chef.io/docs/api-tokens/)
+    section of the Automate documentation. 
+    For more information about authorization, refer to the 
+    [Authorization Overview](https://automate.chef.io/docs/authorization-overview/#overview) 
     section of the Automate documentation.

--- a/components/automate-chef-io/data/docs/api-static/02-meta-description.yaml
+++ b/components/automate-chef-io/data/docs/api-static/02-meta-description.yaml
@@ -1,25 +1,25 @@
 info:
   description: |
     # Authentication
-    The standard way of authenticating for the Automate API is to generate an
-    API token and pass that with your API requests with the `api-token` header.
+    The Chef Automate API typically uses am API token and passed in the header of  your API request.
 
-    An admin token can be created and set to a variable using the following CLI helper:
+    To create admin token can and set it as an environment variable use the following command:
 
     ```
     export TOKEN=`chef-automate admin-token`
     ```
 
-    With an admin token you can access the entire Chef Automate API – including administrative
-    tasks such as managing local users, managing local teams, and managing authorization policies.
-    Using the token, an example curl request looks like this:
+    An admin token has unlimited access the entire Chef Automate API.
+
+    Pass the token as part of the API call. For example:
 
     ```
     curl -s -H "api-token: $TOKEN" https://automate.example.com/api/v0/auth/policies -v
     ```
 
-    With the admin token, it is possible to create standard tokens with more limited permissions.
-    The following curl returns a new token object whose value can be set to a new variable:
+    To create api tokens with limited permissions, use your admin token to create a standard token. You can then write a policy that exactly defines the API access for the standard token.
+
+    In this example, the `curl` command creates the new token and the `export` command saves as an environment variable with the name "TOKEN2".
 
     ```
     curl -s -H "api-token: $TOKEN" -d '{"description":"New Token"}' https://automate.example.com/api/v0/auth/tokens

--- a/components/automate-chef-io/data/docs/api-static/02-meta-description.yaml
+++ b/components/automate-chef-io/data/docs/api-static/02-meta-description.yaml
@@ -4,21 +4,21 @@ info:
     The standard way of authenticating for the Automate API is to generate an
     API token and pass that with your API requests with the `api-token` header.
 
-    An administrative token can be created and set to a variable using the following CLI helper:
+    An admin token can be created and set to a variable using the following CLI helper:
 
     ```
     export TOKEN=`chef-automate admin-token`
     ```
 
-    With an administrative token you can access the entire Chef Automate API – including administrative 
-    tasks such as managing local users and managing local teams and managing authorization policies.
-    Using the token above, an example request using curl looks like this:
+    With an admin token you can access the entire Chef Automate API – including administrative
+    tasks such as managing local users, managing local teams, and managing authorization policies.
+    Using the token, an example curl request looks like this:
 
     ```
     curl -s -H "api-token: $TOKEN" https://automate.example.com/api/v0/auth/policies -v
     ```
     
-    With the administrative token, it is possible to create standard tokens with more limited permissions.
+    With the admin token, it is possible to create standard tokens with more limited permissions.
     The following curl returns a new token object whose value can be set to a new variable:
 
     ```

--- a/components/automate-chef-io/data/docs/api-static/02-meta-description.yaml
+++ b/components/automate-chef-io/data/docs/api-static/02-meta-description.yaml
@@ -17,7 +17,7 @@ info:
     ```
     curl -s -H "api-token: $TOKEN" https://automate.example.com/api/v0/auth/policies -v
     ```
-    
+
     With the admin token, it is possible to create standard tokens with more limited permissions.
     The following curl returns a new token object whose value can be set to a new variable:
 
@@ -35,14 +35,7 @@ info:
     export TOKEN2=bww8EEpr39_eYMnQ2zybtrP9uzk=
     ```
 
-    You can grant a standard token access to specific parts of the Chef Automate API 
-    if you write a policy. 
-    The [Permission for An API Client](https://automate.chef.io/docs/authorization-overview/#permission-for-an-api-client)
-    section of the Automate documentation walks through how to grant a token access to all Compliance API endpoints.
-
-    For more information about authentication, refer to the
-    [API Tokens](https://automate.chef.io/docs/api-tokens/)
-    section of the Automate documentation. 
-    For more information about authorization, refer to the 
-    [Authorization Overview](https://automate.chef.io/docs/authorization-overview/#overview) 
-    section of the Automate documentation.
+    The Chef Automate documentation covers policies, authentication, and authorization in greater detail.
+    * **[Permission for An API Client](https://automate.chef.io/docs/authorization-overview/#permission-for-an-api-client)** walks through how to limit access to the Chef Automate API by writing a policy for a standard token.
+    * **[API Tokens](https://automate.chef.io/docs/api-tokens/)** explains authentication in Chef Automate.
+    * **[Authorization Overview](https://automate.chef.io/docs/authorization-overview/#overview)** explains authorization in Chef Automate.

--- a/components/automate-chef-io/data/docs/api-static/04-meta-auth.json
+++ b/components/automate-chef-io/data/docs/api-static/04-meta-auth.json
@@ -1,7 +1,7 @@
 {
   "securityDefinitions": {
     "APIToken": {
-      "description": "The Automate API can most easily be authenticated using an API Token.",
+      "description": "Authenticate with the Automate API using an API Token.",
       "type": "apiKey",
       "name": "api-token",
       "in": "header"

--- a/components/automate-chef-io/data/docs/api-static/04-meta-auth.json
+++ b/components/automate-chef-io/data/docs/api-static/04-meta-auth.json
@@ -1,0 +1,10 @@
+{
+  "securityDefinitions": {
+    "APIToken": {
+      "description": "The Automate API can most easily be authenticated using an API Token.",
+      "type": "apiKey",
+      "name": "api-token",
+      "in": "header"
+    }
+  }
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

In order for consumers of the OpenAPI documentation to easily authenticate with our API, we have documented the authentication header according to the [OpenAPI specs for security definitions objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#security-definitions-object). 

### Resources
- fixes #2140

### :+1: Definition of Done
- [x] the Authentication section of the API docs contains all the information needed to exercise the Chef Automate API
- [x] the Authentication section of the API docs includes an API Token [security definition object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#security-definitions-object)

### :athletic_shoe: How to Build and Test the Change
```
cd components/automate-chef-io
make serve
```
navigate to http://localhost:1313/docs/api/#section/Authentication

### :white_check_mark: Checklist

- [x] Docs added/updated?