### PR TITLE
terraform: accept hab license

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
+++ b/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
@@ -5,6 +5,7 @@ set -e
 # are not shell variables.
 export HAB_NONINTERACTIVE="true"
 export HAB_NOCOLORING="true"
+export HAB_LICENSE=accept-no-persist
 
 automate_deployed() {
     [[ -f /hab/user/deployment-service/config/user.toml ]]


### PR DESCRIPTION
We've upgraded Hab to a version that requires license acceptance.

Signed-off-by: Steven Danna <steve@chef.io>