### PR TITLE
deployment: don't pass release to install.sh

### DIFF
--- a/components/automate-deployment/pkg/target/local_target.go
+++ b/components/automate-deployment/pkg/target/local_target.go
@@ -1344,9 +1344,26 @@ func (t *LocalTarget) installHabViaInstallScript(ctx context.Context, requiredVe
 		return err
 	}
 
+	// TODO(ssd) 2019-12-03: HACK until we remove the use of install.sh
+	lastBintrayVersion := "0.89.0"
+	targetVersion, err := habpkg.ParseSemverishVersion(requiredVersion.Version())
+	if err != nil {
+		return err
+	}
+
+	switchoverVersion, err := habpkg.ParseSemverishVersion(lastBintrayVersion)
+	if err != nil {
+		return err
+	}
+
+	version := requiredVersion.Version()
+	if habpkg.CompareSemverish(targetVersion, switchoverVersion) != habpkg.SemverishGreater {
+		version = habpkg.VersionString(requiredVersion)
+	}
+
 	output, execErr := t.Executor.CombinedOutput(
 		"bash",
-		command.Args(script.Name(), "-v", habpkg.VersionString(requiredVersion)),
+		command.Args(script.Name(), "-v", version),
 		command.Envvar("TMPDIR", t.habTmpDir()),
 		command.Context(ctx),
 	)


### PR DESCRIPTION
The newest version of install.sh doesn't support passing the release,
only the version.

This is a quick-fix for the problem, but we will follow up by
completely removing the need for install.sh.

Signed-off-by: Steven Danna <steve@chef.io>