### PR TITLE
buildkite: accept the hab license in another place

### DIFF
--- a/.expeditor/buildkite/inspec.sh
+++ b/.expeditor/buildkite/inspec.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 echo -e "$CHEF_CI_SSH_PRIVATE_KEY" > chef-ci-ad-ssh
 
+export HAB_LICENSE=accept-no-persist
+
 instances_to_test=$(curl --silent "https://a2-${CHANNEL}.cd.chef.co/assets/data.json" |\
   jq --raw-output '.[] | select(.tags | any(. == "chef-automate-cli")) | .fqdn')
 


### PR DESCRIPTION
This script requires us to accept the hab license because we are
calling `hab` from inside the tests.

Signed-off-by: Steven Danna <steve@chef.io>