### PR TITLE
makefile: ensure the db tests for nodemanager actually run

### DIFF
--- a/components/nodemanager-service/Makefile
+++ b/components/nodemanager-service/Makefile
@@ -180,7 +180,7 @@ test-integration:
 
 run-db-tests:
 	@POSTGRES_URI="$(POSTGRES_URI)" CGO_ENABLED=0 \
-		go test -v -cover -database ./pgdb/...
+		go test -v ./pgdb/... -cover -database -parallel=1 -p 1 -failfast
 
 run-one-db-test:
 	@POSTGRES_URI="$(POSTGRES_URI)" \


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
noticed while working on a thing locally that a test i expected to fail was not failing.
started looking into it and noticed a "no test files" msg being printed.
checked on buildkite and saw the same:
```
 * NodeManager Service is running, moving on...
make[1]: Leaving directory `/var/lib/buildkite-agent/builds/single-use-privileged-i-0ec9b0c7d6c74c73c-1/chef-oss/.golang/chef-automate-master-verify/src/github.com/chef/automate/components/nodemanager-service'
===> Running db integration tests with PG6
make[1]: Entering directory `/var/lib/buildkite-agent/builds/single-use-privileged-i-0ec9b0c7d6c74c73c-1/chef-oss/.golang/chef-automate-master-verify/src/github.com/chef/automate/components/nodemanager-service'
?   	github.com/chef/automate/components/nodemanager-service	[no test files]
make[1]: Leaving directory `/var/lib/buildkite-agent/builds/single-use-privileged-i-0ec9b0c7d6c74c73c-1/chef-oss/.golang/chef-automate-master-verify/src/github.com/chef/automate/components/nodemanager-service'
===> Tests passed, you are the boss!!!
make[1]: Entering directory `/var/lib/buildkite-agent/builds/single-use-privileged-i-0ec9b0c7d6c74c73c-1/chef-oss/.golang/chef-automate-master-verify/src/github.com/chef/automate/components/nodemanager-service'
```

i grabbed the db testing command from the compliance service makefile and just adjusted the folder name to be correct for nodemanager, now i'm seeing test files being executed.

### :chains: Related Resources
n/a

### :+1: Definition of Done
nodemanager db tests run in buildkite

