### PR TITLE
Add indexes for profile list queries

### DIFF
--- a/components/compliance-service/api/tests/01_market_spec.rb
+++ b/components/compliance-service/api/tests/01_market_spec.rb
@@ -16,7 +16,7 @@ describe File.basename(__FILE__) do
   end
 
   it "errors out when an invalid sort field is specified" do
-    assert_grpc_error(/sort field 'bogus' is invalid. Use either 'name', 'title' or 'maintainer'/, 3) do
+    assert_grpc_error(/sort field 'bogus' is invalid. Use either 'name' or 'title'/, 3) do
       GRPC profiles, :list, Profiles::Query.new(
         sort: 'bogus',
         order: 1

--- a/components/compliance-service/dao/pgdb/migration/sql/40_denormalize_profiles_columns.down.sql
+++ b/components/compliance-service/dao/pgdb/migration/sql/40_denormalize_profiles_columns.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS store_profiles_info_name_version;
+DROP INDEX IF EXISTS store_profiles_info_title_version;

--- a/components/compliance-service/dao/pgdb/migration/sql/40_denormalize_profiles_columns.up.sql
+++ b/components/compliance-service/dao/pgdb/migration/sql/40_denormalize_profiles_columns.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS store_profiles_info_name_version ON store_profiles ((info->>'name'), (info->>'version'));
+CREATE INDEX IF NOT EXISTS store_profiles_info_title_version ON store_profiles ((info->>'title'), (info->>'version'));

--- a/components/compliance-service/profiles/db/store.go
+++ b/components/compliance-service/profiles/db/store.go
@@ -424,8 +424,8 @@ func (s *Store) ListProfilesMetadata(req ProfilesListRequest) ([]inspec.Metadata
 		return nil, 0, status.Errorf(codes.InvalidArgument, "order field '%s' is invalid. Use either 'ASC' or 'DESC'", req.Order)
 	}
 
-	if req.Sort != "name" && req.Sort != "title" && req.Sort != "maintainer" {
-		return nil, 0, status.Errorf(codes.InvalidArgument, "sort field '%s' is invalid. Use either 'name', 'title' or 'maintainer'", req.Sort)
+	if req.Sort != "name" && req.Sort != "title" {
+		return nil, 0, status.Errorf(codes.InvalidArgument, "sort field '%s' is invalid. Use either 'name' or 'title'", req.Sort)
 	}
 
 	sql := squirrel.


### PR DESCRIPTION
While working on #2367 I noticed that despite the profiles database table having indexes on it, they weren't being used.

```
chef_compliance_service=# \d store_profiles
          Table "public.store_profiles"
 Column | Type  | Collation | Nullable | Default
--------+-------+-----------+----------+---------
 sha256 | text  |           | not null |
 tar    | bytea |           | not null |
 info   | jsonb |           | not null |
Indexes:
    "store_profiles_pkey" PRIMARY KEY, btree (sha256)
    "idxprofileinfoname" btree ((info ->> 'name'::text))
    "idxprofileinfoversion" btree ((info ->> 'version'::text))
Check constraints:
    "store_profiles_sha256_check" CHECK (sha256 <> ''::text)
Referenced by:
    TABLE "store_market" CONSTRAINT "store_market_sha256_fkey" FOREIGN KEY (sha256) REFERENCES store_profiles(sha256)
    TABLE "store_namespace" CONSTRAINT "store_namespace_sha256_fkey" FOREIGN KEY (sha256) REFERENCES store_profiles(sha256)
```

Once the UI for the profiles page implements pagination, the query for listing all available profiles will be something like this:
```
chef_compliance_service=# explain analyze select sha256, info, count(*) over () as total from store_profiles where exists (select 1 from store_market where store_profiles.sha256 = store_market.sha256) order by info->>'name', info->>'version' offset 0 limit 50 ;
                                                               QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=43.58..43.71 rows=50 width=161) (actual time=955.177..956.206 rows=50 loops=1)
   ->  Sort  (cost=43.58..44.42 rows=336 width=161) (actual time=955.156..955.492 rows=50 loops=1)
         Sort Key: ((store_profiles.info ->> 'name'::text)), ((store_profiles.info ->> 'version'::text))
         Sort Method: top-N heapsort  Memory: 38kB
         ->  WindowAgg  (cost=12.56..32.42 rows=336 width=161) (actual time=14.813..951.637 rows=336 loops=1)
               ->  Hash Semi Join  (cost=12.56..26.54 rows=336 width=89) (actual time=4.968..12.018 rows=336 loops=1)
                     Hash Cond: (store_profiles.sha256 = store_market.sha256)
                     ->  Seq Scan on store_profiles  (cost=0.00..9.36 rows=336 width=89) (actual time=0.013..2.353 rows=336 loops=1)
                     ->  Hash  (cost=8.36..8.36 rows=336 width=65) (actual time=4.926..4.942 rows=336 loops=1)
                           Buckets: 1024  Batches: 1  Memory Usage: 40kB
                           ->  Seq Scan on store_market  (cost=0.00..8.36 rows=336 width=65) (actual time=0.011..2.382 rows=336 loops=1)
 Planning time: 1.166 ms
 Execution time: 956.746 ms
(13 rows)
```

I noticed that if I removed one of the fields in the order clause the query uses an index and is much faster:
```
chef_compliance_service=# explain analyze select sha256, info, count(*) over () as total from store_profiles where exists (select 1 from store_market where store_profiles.sha256 = store_market.sha256) order by info->>'name' offset 0 limit 50 ;
                                                                        QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.55..28.46 rows=50 width=129) (actual time=21.380..69.676 rows=50 loops=1)
   ->  WindowAgg  (cost=0.55..188.15 rows=336 width=129) (actual time=21.363..68.866 rows=50 loops=1)
         ->  Nested Loop Semi Join  (cost=0.55..183.11 rows=336 width=89) (actual time=0.093..18.032 rows=336 loops=1)
               ->  Index Scan using idxprofileinfoname on store_profiles  (cost=0.27..34.31 rows=336 width=89) (actual time=0.022..3.551 rows=336 loops=1)
               ->  Index Only Scan using store_market_pkey on store_market  (cost=0.27..0.43 rows=1 width=65) (actual time=0.016..0.016 rows=1 loops=336)
                     Index Cond: (sha256 = store_profiles.sha256)
                     Heap Fetches: 336
 Planning time: 0.612 ms
 Execution time: 70.204 ms
(9 rows)
```

When I created an index on both fields used in the order clause I saw a similar speedup:
```
chef_compliance_service=# create index on store_profiles ((info->>'name'), (info->>'version')) ;
CREATE INDEX
chef_compliance_service=# explain analyze select sha256, info, count(*) over () as total from store_profiles where exists (select 1 from store_market where store_profiles.sha256 = store_market.sha256) order by info->>'name', info->>'version' offset 0 limit 50 ;
                                                                              QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.55..31.42 rows=50 width=161) (actual time=20.159..116.343 rows=50 loops=1)
   ->  WindowAgg  (cost=0.55..207.99 rows=336 width=161) (actual time=20.139..115.556 rows=50 loops=1)
         ->  Nested Loop Semi Join  (cost=0.55..202.11 rows=336 width=89) (actual time=0.342..16.830 rows=336 loops=1)
               ->  Index Scan using store_profiles_expr_expr1_idx on store_profiles  (cost=0.27..53.31 rows=336 width=89) (actual time=0.286..3.676 rows=336 loops=1)
               ->  Index Only Scan using store_market_pkey on store_market  (cost=0.27..0.43 rows=1 width=65) (actual time=0.014..0.014 rows=1 loops=336)
                     Index Cond: (sha256 = store_profiles.sha256)
                     Heap Fetches: 336
 Planning time: 2.073 ms
 Execution time: 117.005 ms
(9 rows)
```

This won't affect the query speeds of the page as it is now, because I think we're running into to edge cases of postgres:
* If you have a table with a json column, if those json documents are over some threshold they are stored seperately from the rest of the table's data and lookups are relatively expensive. How do you solve this? Use indexes.
* If you query a table with a small number of rows, postgres will avoid using an index because a sequential scan of the entire table is faster for very small tables. 

So because the `store_profiles` table is small (~300 rows), postgres will not use indexes as aggressively so we always pay the cost of expensive json document lookups.