### PR TITLE
[automate-2388] Deleting project tags from Compliance resources

### DIFF
--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -233,6 +233,7 @@ func (backend *ESClient) DeleteReportProjectTag(ctx context.Context, projectTagT
 		Index(index).
 		Type(docType).
 		Script(elastic.NewScript(deleteProjectTagScript).Params(params)).
+		Refresh("true").
 		WaitForCompletion(false).
 		ProceedOnVersionConflict().
 		DoAsync(ctx)
@@ -255,6 +256,7 @@ func (backend *ESClient) DeleteSummaryProjectTag(ctx context.Context, projectTag
 		Index(index).
 		Type(docType).
 		Script(elastic.NewScript(deleteProjectTagScript).Params(params)).
+		Refresh("true").
 		WaitForCompletion(false).
 		ProceedOnVersionConflict().
 		DoAsync(ctx)

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -192,9 +192,30 @@ func (backend *ESClient) setDailyLatestToFalse(ctx context.Context, nodeId strin
 }
 
 func (backend *ESClient) DeleteProjectTag(ctx context.Context,
-	projectTagToBeDelete string) ([]string, error) {
-	// TODO implement
-	return []string{}, nil
+	projectTagToDelete string) ([]string, error) {
+	logrus.Debugf("starting project delete project %q", projectTagToDelete)
+
+	esReportJobID, err := backend.DeleteReportProjectTag(ctx, projectTagToDelete)
+	if err != nil {
+		return []string{}, errors.Wrap(err, "Failed to start Elasticsearch Node project tags delete")
+	}
+
+	esSummaryJobID, err := backend.DeleteSummaryProjectTag(ctx, projectTagToDelete)
+	if err != nil {
+		return []string{}, errors.Wrap(err, "Failed to start Elasticsearch Action project tags delete")
+	}
+
+	logrus.Debugf("Started Project delete with report job ID: %q, summary job ID %q", esReportJobID, esSummaryJobID)
+
+	return []string{esReportJobID, esSummaryJobID}, nil
+}
+
+func (backend *ESClient) DeleteReportProjectTag(ctx context.Context, projectTagToDelete string) (string, error) {
+	return "", nil
+}
+
+func (backend *ESClient) DeleteSummaryProjectTag(ctx context.Context, projectTagToDelete string) (string, error) {
+	return "", nil
 }
 
 func (backend *ESClient) UpdateProjectTags(ctx context.Context, projectTaggingRules map[string]*iam_v2.ProjectRules) ([]string, error) {

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -211,7 +211,34 @@ func (backend *ESClient) DeleteProjectTag(ctx context.Context,
 }
 
 func (backend *ESClient) DeleteReportProjectTag(ctx context.Context, projectTagToDelete string) (string, error) {
-	return "", nil
+	script := `
+		if (ctx._source['projects'] != null) {
+			def foundIndex = ctx._source.projects.indexOf(params.project);
+
+			if (foundIndex != -1) {
+				ctx._source.projects.remove(foundIndex);
+			}
+		}
+	`
+
+	params := map[string]interface{}{"project": projectTagToDelete}
+	docType := mappings.DocType
+	mapping := mappings.ComplianceRepDate
+	index := fmt.Sprintf("%s-%s", mapping.Index, "*")
+
+	startTaskResult, err := elastic.NewUpdateByQueryService(backend.client).
+		Index(index).
+		Type(docType).
+		Script(elastic.NewScript(script).Params(params)).
+		WaitForCompletion(false).
+		ProceedOnVersionConflict().
+		DoAsync(ctx)
+
+	if err != nil {
+		return "", err
+	}
+
+	return startTaskResult.TaskId, nil
 }
 
 func (backend *ESClient) DeleteSummaryProjectTag(ctx context.Context, projectTagToDelete string) (string, error) {

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -209,12 +209,12 @@ func (backend *ESClient) DeleteProjectTag(ctx context.Context,
 
 	esReportJobID, err := backend.DeleteReportProjectTag(ctx, projectTagToDelete)
 	if err != nil {
-		return []string{}, errors.Wrap(err, "Failed to start Elasticsearch Node project tags delete")
+		return []string{}, errors.Wrap(err, "Failed to start Elasticsearch Report project tags delete")
 	}
 
 	esSummaryJobID, err := backend.DeleteSummaryProjectTag(ctx, projectTagToDelete)
 	if err != nil {
-		return []string{}, errors.Wrap(err, "Failed to start Elasticsearch Action project tags delete")
+		return []string{}, errors.Wrap(err, "Failed to start Elasticsearch Summary project tags delete")
 	}
 
 	logrus.Debugf("Started Project delete with report job ID: %q, summary job ID %q", esReportJobID, esSummaryJobID)

--- a/components/compliance-service/integration_test/project_delete_test.go
+++ b/components/compliance-service/integration_test/project_delete_test.go
@@ -1,0 +1,148 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/chef/automate/components/compliance-service/reporting/relaxting"
+)
+
+func TestReportProjectDelete(t *testing.T) {
+	var (
+		ctx               = context.Background()
+		projectIDToDelete = "target_project"
+	)
+
+	cases := []struct {
+		description        string
+		existingProjectIDs []string
+		projectIDToDelete  string
+		expectedProjectIDs []string
+	}{
+		{
+			description:        "Deleting the last project tag",
+			existingProjectIDs: []string{"target_project"},
+			expectedProjectIDs: []string{},
+		},
+		{
+			description:        "Deleting a project that does not exist",
+			existingProjectIDs: []string{},
+			expectedProjectIDs: []string{},
+		},
+		{
+			description:        "Deleting a project on a report with multiple projects",
+			existingProjectIDs: []string{"project3", "target_project", "project9"},
+			expectedProjectIDs: []string{"project3", "project9"},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.description, func(t *testing.T) {
+
+			report := &relaxting.ESInSpecReport{
+				Projects: test.existingProjectIDs,
+			}
+
+			_, err := suite.InsertInspecReports([]*relaxting.ESInSpecReport{report})
+			require.NoError(t, err)
+
+			defer suite.DeleteAllDocuments()
+
+			esJobID, err := suite.ingesticESClient.DeleteReportProjectTag(ctx, projectIDToDelete)
+			require.NoError(t, err)
+
+			suite.WaitForESJobToComplete(esJobID)
+
+			suite.RefreshComplianceReportIndex()
+
+			// get the reports
+			reports, err := suite.GetAllReportsESInSpecReport()
+			require.NoError(t, err)
+			require.Equal(t, 1, len(reports))
+
+			updatedReport := reports[0]
+
+			assert.ElementsMatch(t, test.expectedProjectIDs, updatedReport.Projects)
+		})
+	}
+}
+
+func TestReportProjectDeleteNoReports(t *testing.T) {
+	t.Run("Deleting a project when there are no reports", func(t *testing.T) {
+		// Send a project rules update event
+
+		// wait
+
+		// refresh
+	})
+}
+
+func TestSummaryProjectDelete(t *testing.T) {
+
+	// cases := []struct {
+	// 	description        string
+	// summary             *relaxting.ESInSpecSummary
+	// 	projectIDToDelete  string
+	// 	expectedProjectIDs []string
+	// }{
+	// 	{
+	// 		description: "Deleting the last project tag",
+	// 		report: &relaxting.ESInSpecSummary{
+	// 			Projects: []string{"target_project"},
+	// 		},
+	// 		expectedProjectIDs: []string{},
+	// 	},
+	// 	{
+	// 		description: "Deleting a project that does not exist",
+	// 		report: &relaxting.ESInSpecSummary{
+	// 			Projects: []string{},
+	// 		},
+	// 		expectedProjectIDs: []string{},
+	// 	},
+	// 	{
+	// 		description: "Deleting a project on a report with multiple projects",
+	// 		report: &relaxting.ESInSpecSummary{
+	// 			Projects: []string{"project3", "target_project", "project9"},
+	// 		},
+	// 		expectedProjectIDs: []string{"project3", "project9"},
+	// 	},
+	// }
+
+	// ingest summary
+
+	// call DeleteSummaryProjectTag(ctx, projectToDelete)
+	// require no error
+
+	// wait
+
+	// refresh
+
+	// assert no nodes
+}
+
+func TestSummaryProjectDeleteNoSummaries(t *testing.T) {
+	t.Run("Deleting a project when there are no summaries", func(t *testing.T) {
+		// Send a project rules update event
+
+		// wait
+
+		// refresh
+	})
+}
+
+func TestProjectDelete(t *testing.T) {
+	t.Run("Deleting a project from summaries and reports", func(t *testing.T) {
+		// ingest both summary and report
+
+		// call DeleteProjectTag(ctx, projectToDelete)
+
+		// wait
+
+		// refresh
+
+		// assert project is removed from both summary and report
+	})
+}

--- a/components/compliance-service/integration_test/project_delete_test.go
+++ b/components/compliance-service/integration_test/project_delete_test.go
@@ -87,55 +87,72 @@ func TestReportProjectDeleteNoReports(t *testing.T) {
 }
 
 func TestSummaryProjectDelete(t *testing.T) {
+	cases := []struct {
+		description        string
+		existingProjectIDs []string
+		projectIDToDelete  string
+		expectedProjectIDs []string
+	}{
+		{
+			description:        "Deleting the last project tag",
+			existingProjectIDs: []string{"target_project"},
+			expectedProjectIDs: []string{},
+		},
+		{
+			description:        "Deleting a project that does not exist",
+			existingProjectIDs: []string{},
+			expectedProjectIDs: []string{},
+		},
+		{
+			description:        "Deleting a project on a summary with multiple projects",
+			existingProjectIDs: []string{"project3", "target_project", "project9"},
+			expectedProjectIDs: []string{"project3", "project9"},
+		},
+	}
 
-	// cases := []struct {
-	// 	description        string
-	// summary             *relaxting.ESInSpecSummary
-	// 	projectIDToDelete  string
-	// 	expectedProjectIDs []string
-	// }{
-	// 	{
-	// 		description: "Deleting the last project tag",
-	// 		report: &relaxting.ESInSpecSummary{
-	// 			Projects: []string{"target_project"},
-	// 		},
-	// 		expectedProjectIDs: []string{},
-	// 	},
-	// 	{
-	// 		description: "Deleting a project that does not exist",
-	// 		report: &relaxting.ESInSpecSummary{
-	// 			Projects: []string{},
-	// 		},
-	// 		expectedProjectIDs: []string{},
-	// 	},
-	// 	{
-	// 		description: "Deleting a project on a report with multiple projects",
-	// 		report: &relaxting.ESInSpecSummary{
-	// 			Projects: []string{"project3", "target_project", "project9"},
-	// 		},
-	// 		expectedProjectIDs: []string{"project3", "project9"},
-	// 	},
-	// }
+	for _, test := range cases {
+		t.Run(test.description, func(t *testing.T) {
 
-	// ingest summary
+			summary := &relaxting.ESInSpecSummary{
+				Projects: test.existingProjectIDs,
+			}
 
-	// call DeleteSummaryProjectTag(ctx, projectToDelete)
-	// require no error
+			_, err := suite.InsertInspecSummaries([]*relaxting.ESInSpecSummary{summary})
+			require.NoError(t, err)
 
-	// wait
+			defer suite.DeleteAllDocuments()
 
-	// refresh
+			esJobID, err := suite.ingesticESClient.DeleteSummaryProjectTag(ctx, projectIDToDelete)
+			require.NoError(t, err)
 
-	// assert no nodes
+			suite.WaitForESJobToComplete(esJobID)
+
+			suite.RefreshComplianceSummaryIndex()
+
+			// get the summaries
+			summaries, err := suite.GetAllSummaryESInSpecSummary()
+			require.NoError(t, err)
+			require.Equal(t, 1, len(summaries))
+
+			updatedSummary := summaries[0]
+
+			assert.ElementsMatch(t, test.expectedProjectIDs, updatedSummary.Projects)
+		})
+	}
 }
 
 func TestSummaryProjectDeleteNoSummaries(t *testing.T) {
 	t.Run("Deleting a project when there are no summaries", func(t *testing.T) {
-		// Send a project rules update event
+		esJobID, err := suite.ingesticESClient.DeleteSummaryProjectTag(ctx, projectIDToDelete)
+		assert.NoError(t, err)
 
-		// wait
+		suite.WaitForESJobToComplete(esJobID)
 
-		// refresh
+		suite.RefreshComplianceSummaryIndex()
+
+		summaries, err := suite.GetAllSummaryESInSpecSummary()
+		require.NoError(t, err)
+		require.Equal(t, 0, len(summaries))
 	})
 }
 

--- a/components/compliance-service/integration_test/project_delete_test.go
+++ b/components/compliance-service/integration_test/project_delete_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/chef/automate/components/compliance-service/reporting/relaxting"
 )
 
+var (
+	ctx               = context.Background()
+	projectIDToDelete = "target_project"
+)
+
 func TestReportProjectDelete(t *testing.T) {
-	var (
-		ctx               = context.Background()
-		projectIDToDelete = "target_project"
-	)
 
 	cases := []struct {
 		description        string
@@ -72,11 +73,16 @@ func TestReportProjectDelete(t *testing.T) {
 
 func TestReportProjectDeleteNoReports(t *testing.T) {
 	t.Run("Deleting a project when there are no reports", func(t *testing.T) {
-		// Send a project rules update event
+		esJobID, err := suite.ingesticESClient.DeleteReportProjectTag(ctx, projectIDToDelete)
+		assert.NoError(t, err)
 
-		// wait
+		suite.WaitForESJobToComplete(esJobID)
 
-		// refresh
+		suite.RefreshComplianceReportIndex()
+
+		reports, err := suite.GetAllReportsESInSpecReport()
+		require.NoError(t, err)
+		require.Equal(t, 0, len(reports))
 	})
 }
 

--- a/components/compliance-service/integration_test/project_delete_test.go
+++ b/components/compliance-service/integration_test/project_delete_test.go
@@ -147,15 +147,88 @@ func TestSummaryProjectDeleteNoSummaries(t *testing.T) {
 }
 
 func TestProjectDelete(t *testing.T) {
-	t.Run("Deleting a project from summaries and reports", func(t *testing.T) {
-		// ingest both summary and report
+	t.Run("Deleting a project from multiple summaries and reports with different projects", func(t *testing.T) {
+		oneProjectReportNode := "one-proj-rep"
+		multiProjectReportNode := "multi-proj-rep"
+		noProjectReportNode := "no-proj-rep"
 
-		// call DeleteProjectTag(ctx, projectToDelete)
+		reports := []*relaxting.ESInSpecReport{
+			{
+				NodeID:   oneProjectReportNode,
+				Projects: []string{projectIDToDelete},
+			},
+			{
+				NodeID:   multiProjectReportNode,
+				Projects: []string{"project3", projectIDToDelete, "project9"},
+			},
+			{
+				NodeID:   noProjectReportNode,
+				Projects: []string{},
+			},
+		}
 
-		// wait
+		oneProjectSummaryNode := "one-proj-sum"
+		multiProjectSummaryNode := "multi-proj-sum"
+		noProjectSummaryNode := "no-proj-sum"
 
-		// refresh
+		summaries := []*relaxting.ESInSpecSummary{
+			{
+				NodeID:   oneProjectSummaryNode,
+				Projects: []string{projectIDToDelete},
+			},
+			{
+				NodeID:   multiProjectSummaryNode,
+				Projects: []string{"project4", projectIDToDelete, "project8"},
+			},
+			{
+				NodeID:   noProjectSummaryNode,
+				Projects: []string{},
+			},
+		}
 
-		// assert project is removed from both summary and report
+		_, err := suite.InsertInspecReports(reports)
+		require.NoError(t, err)
+		_, err = suite.InsertInspecSummaries(summaries)
+		require.NoError(t, err)
+
+		esJobIDs, err := suite.ingesticESClient.DeleteProjectTag(ctx, projectIDToDelete)
+		require.NoError(t, err)
+
+		waitForESJobsToComplete(esJobIDs)
+		suite.RefreshComplianceReportIndex()
+		suite.RefreshComplianceSummaryIndex()
+
+		updatedReports, err := suite.GetAllReportsESInSpecReport()
+		require.NoError(t, err)
+		require.Equal(t, 3, len(updatedReports))
+
+		reportMap := make(map[string]*relaxting.ESInSpecReport, len(updatedReports))
+		for _, report := range updatedReports {
+			reportMap[report.NodeID] = report
+		}
+
+		updatedSummaries, err := suite.GetAllSummaryESInSpecSummary()
+		require.NoError(t, err)
+		require.Equal(t, 3, len(updatedSummaries))
+
+		summaryMap := make(map[string]*relaxting.ESInSpecSummary, len(updatedSummaries))
+		for _, summary := range updatedSummaries {
+			summaryMap[summary.NodeID] = summary
+		}
+
+		assert.Equal(t, []string{}, reportMap[noProjectReportNode].Projects)
+		assert.Equal(t, []string{}, reportMap[oneProjectReportNode].Projects)
+		assert.Equal(t, []string{}, summaryMap[noProjectSummaryNode].Projects)
+		assert.Equal(t, []string{}, summaryMap[oneProjectSummaryNode].Projects)
+
+		assert.ElementsMatch(t, []string{"project3", "project9"}, reportMap[multiProjectReportNode].Projects)
+		assert.ElementsMatch(t, []string{"project4", "project8"}, summaryMap[multiProjectSummaryNode].Projects)
 	})
+	suite.DeleteAllDocuments()
+}
+
+func waitForESJobsToComplete(jobs []string) {
+	for _, job := range jobs {
+		suite.WaitForESJobToComplete(job)
+	}
 }

--- a/components/compliance-service/integration_test/project_delete_test.go
+++ b/components/compliance-service/integration_test/project_delete_test.go
@@ -16,7 +16,6 @@ var (
 )
 
 func TestReportProjectDelete(t *testing.T) {
-
 	cases := []struct {
 		description        string
 		existingProjectIDs []string
@@ -25,7 +24,7 @@ func TestReportProjectDelete(t *testing.T) {
 	}{
 		{
 			description:        "Deleting the last project tag",
-			existingProjectIDs: []string{"target_project"},
+			existingProjectIDs: []string{projectIDToDelete},
 			expectedProjectIDs: []string{},
 		},
 		{
@@ -35,7 +34,7 @@ func TestReportProjectDelete(t *testing.T) {
 		},
 		{
 			description:        "Deleting a project on a report with multiple projects",
-			existingProjectIDs: []string{"project3", "target_project", "project9"},
+			existingProjectIDs: []string{"project3", projectIDToDelete, "project9"},
 			expectedProjectIDs: []string{"project3", "project9"},
 		},
 	}
@@ -50,13 +49,10 @@ func TestReportProjectDelete(t *testing.T) {
 			_, err := suite.InsertInspecReports([]*relaxting.ESInSpecReport{report})
 			require.NoError(t, err)
 
-			defer suite.DeleteAllDocuments()
-
 			esJobID, err := suite.ingesticESClient.DeleteReportProjectTag(ctx, projectIDToDelete)
 			require.NoError(t, err)
 
 			suite.WaitForESJobToComplete(esJobID)
-
 			suite.RefreshComplianceReportIndex()
 
 			// get the reports
@@ -65,9 +61,9 @@ func TestReportProjectDelete(t *testing.T) {
 			require.Equal(t, 1, len(reports))
 
 			updatedReport := reports[0]
-
 			assert.ElementsMatch(t, test.expectedProjectIDs, updatedReport.Projects)
 		})
+		suite.DeleteAllDocuments()
 	}
 }
 
@@ -77,7 +73,6 @@ func TestReportProjectDeleteNoReports(t *testing.T) {
 		assert.NoError(t, err)
 
 		suite.WaitForESJobToComplete(esJobID)
-
 		suite.RefreshComplianceReportIndex()
 
 		reports, err := suite.GetAllReportsESInSpecReport()
@@ -95,7 +90,7 @@ func TestSummaryProjectDelete(t *testing.T) {
 	}{
 		{
 			description:        "Deleting the last project tag",
-			existingProjectIDs: []string{"target_project"},
+			existingProjectIDs: []string{projectIDToDelete},
 			expectedProjectIDs: []string{},
 		},
 		{
@@ -105,14 +100,13 @@ func TestSummaryProjectDelete(t *testing.T) {
 		},
 		{
 			description:        "Deleting a project on a summary with multiple projects",
-			existingProjectIDs: []string{"project3", "target_project", "project9"},
+			existingProjectIDs: []string{"project3", projectIDToDelete, "project9"},
 			expectedProjectIDs: []string{"project3", "project9"},
 		},
 	}
 
 	for _, test := range cases {
 		t.Run(test.description, func(t *testing.T) {
-
 			summary := &relaxting.ESInSpecSummary{
 				Projects: test.existingProjectIDs,
 			}
@@ -120,13 +114,10 @@ func TestSummaryProjectDelete(t *testing.T) {
 			_, err := suite.InsertInspecSummaries([]*relaxting.ESInSpecSummary{summary})
 			require.NoError(t, err)
 
-			defer suite.DeleteAllDocuments()
-
 			esJobID, err := suite.ingesticESClient.DeleteSummaryProjectTag(ctx, projectIDToDelete)
 			require.NoError(t, err)
 
 			suite.WaitForESJobToComplete(esJobID)
-
 			suite.RefreshComplianceSummaryIndex()
 
 			// get the summaries
@@ -135,9 +126,9 @@ func TestSummaryProjectDelete(t *testing.T) {
 			require.Equal(t, 1, len(summaries))
 
 			updatedSummary := summaries[0]
-
 			assert.ElementsMatch(t, test.expectedProjectIDs, updatedSummary.Projects)
 		})
+		suite.DeleteAllDocuments()
 	}
 }
 
@@ -147,7 +138,6 @@ func TestSummaryProjectDeleteNoSummaries(t *testing.T) {
 		assert.NoError(t, err)
 
 		suite.WaitForESJobToComplete(esJobID)
-
 		suite.RefreshComplianceSummaryIndex()
 
 		summaries, err := suite.GetAllSummaryESInSpecSummary()


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Adds a function to delete a project from Compliance reports and summaries.

### :chains: Related Resources
branched off: https://github.com/chef/automate/pull/2394

### :+1: Definition of Done
- a deleted project can be removed from Compliance reports and summaries (without having to go through a whole project update)

### :athletic_shoe: How to Build and Test the Change
- depends on https://github.com/chef/automate/issues/2389 to exercise
- until that's ready, we can just run tests locally:
```
# in the studio, with all services up
hab pkg install -b core/go
export ELASTICSEARCH_URL="http://localhost:10141"

# reports only
go test -v -p 1 --parallel=1 -count=1 github.com/chef/automate/components/compliance-service/integration_test -run TestReportProjectDelete

# summaries only
go test -v -p 1 --parallel=1 -count=1 github.com/chef/automate/components/compliance-service/integration_test -run TestSummaryProjectDelete

# both reports and summaries
go test -v -p 1 --parallel=1 -count=1 github.com/chef/automate/components/compliance-service/integration_test -run TestProjectDelete
```

### :white_check_mark: Checklist

- [x] Tests added/updated?