### PR TITLE
Back z-index down a notch

### DIFF
--- a/components/chef-ui-library/src/atoms/chef-loading-spinner/chef-loading-spinner.scss
+++ b/components/chef-ui-library/src/atoms/chef-loading-spinner/chef-loading-spinner.scss
@@ -32,5 +32,5 @@ chef-loading-spinner[fixed] {
   right: 0;
   bottom: 0;
   background: var(--chef-loading-bg-color);
-  z-index: 200;
+  z-index: 190;
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The Project and Profile dropdowns were hidden behind the chef-loading-spinner.  The simplest adjustments was to back the z-index of the chef-loading-spinner down a little.

### :chains: Related Resources
https://github.com/chef/automate/pull/2227
https://github.com/chef/automate/issues/2012

### :+1: Definition of Done
Overlay no longer hiding dropdowns

### :athletic_shoe: How to Build and Test the Change

1. build components/automate-ui-devproxy
2. navigate to https://a2-dev.test/compliance/compliance-profiles
3. while profiles are loading, click on the projects and/or user dropdowns, they should sit over the top of the overlay.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable
Before
<img width="979" alt="Screen Shot 2019-12-04 at 11 26 54 AM" src="https://user-images.githubusercontent.com/16737484/70174046-021ce480-1689-11ea-90f1-ffd0a62b7fe9.png">
<img width="974" alt="Screen Shot 2019-12-04 at 11 26 47 AM" src="https://user-images.githubusercontent.com/16737484/70174048-021ce480-1689-11ea-81a8-3f4aed4d661a.png">


After
<img width="983" alt="Screen Shot 2019-12-04 at 11 23 48 AM" src="https://user-images.githubusercontent.com/16737484/70173862-9cc8f380-1688-11ea-80e2-9aaba578f8f0.png">
<img width="979" alt="Screen Shot 2019-12-04 at 11 24 02 AM" src="https://user-images.githubusercontent.com/16737484/70173863-9cc8f380-1688-11ea-92e1-d941297cb89e.png">
