### PR TITLE
[AUTOMATE-1654] Reset the project update state on update and properly render state

### DIFF
--- a/components/automate-ui/src/app/entities/projects/project.reducer.ts
+++ b/components/automate-ui/src/app/entities/projects/project.reducer.ts
@@ -110,7 +110,10 @@ export function projectEntityReducer(
       return set(DELETE_STATUS, EntityStatus.loadingFailure, state);
 
     case ProjectActionTypes.UPDATE:
-      return set(UPDATE_STATUS, EntityStatus.loading, state);
+      return pipe(
+          set(UPDATE_STATUS, EntityStatus.loading),
+          set(APPLY_RULES_STATUS, initialApplyRulesStatus)
+        )(state) as ProjectEntityState;
 
     case ProjectActionTypes.UPDATE_SUCCESS:
       return set(UPDATE_STATUS, EntityStatus.loadingSuccess,

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -92,12 +92,13 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       .subscribe(({ state, failed, cancelled, percentageComplete }: ApplyRulesStatus) => {
         if (this.applyRulesInProgress && state === ApplyRulesStatusState.NotRunning) {
           this.cancelRulesInProgress = false;
+          this.percentageComplete = 0;
           this.closeConfirmApplyStopModal();
         }
         this.applyRulesInProgress = state === ApplyRulesStatusState.Running;
         this.updateProjectsFailed = failed;
         this.updateProjectsCancelled = cancelled;
-        if (!this.cancelRulesInProgress) {
+        if (!this.cancelRulesInProgress && state === ApplyRulesStatusState.Running) {
           this.percentageComplete = percentageComplete;
         }
       });


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Reset the project update status state in the store when we kick off the project update and also fix some small issues with the update logic.

### :athletic_shoe: How to Build and Test the Change

Boot up the UI and run some project updates. You should no longer briefly see 100% get returned. This was because it was getting back 100% complete due to race condition between project update kickoff API request and status endpoint.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?
