### PR TITLE
[automate-2389] cereal connections for project deletion

### DIFF
--- a/components/authn-service/tokens/pg/adapter.go
+++ b/components/authn-service/tokens/pg/adapter.go
@@ -55,6 +55,7 @@ func (a *adapter) CreateLegacyTokenWithValue(ctx context.Context, value string) 
 
 // PurgeProject removes a project from every token it exists in
 func (a *adapter) PurgeProject(ctx context.Context, projectID string) error {
+	a.logger.Info("starting project delete for id " + projectID)
 	_, err := a.db.ExecContext(ctx, "UPDATE chef_authn_tokens SET project_ids=array_remove(project_ids, $1)", projectID)
 	if err != nil {
 		return err

--- a/components/authz-service/server/v2/project_purger_workflow/project_purger.go
+++ b/components/authz-service/server/v2/project_purger_workflow/project_purger.go
@@ -38,6 +38,7 @@ var projectPurgeDomainServices = []string{
 	"authn",
 	"ingest",
 	"compliance",
+	"nodemanager",
 }
 
 type cerealProjectPurger struct {

--- a/components/authz-service/server/v2/project_purger_workflow/project_purger.go
+++ b/components/authz-service/server/v2/project_purger_workflow/project_purger.go
@@ -32,10 +32,11 @@ type ProjectPurger interface {
 
 // Map of every domain service that performs project purging.
 // Any future domain that has non-rule based project data
-// needs to be added here and RegisterTaskExecutors with the same string.
+// needs to be added here and RegisterTaskExecutor *in the domain* with the same string.
 var projectPurgeDomainServices = []string{
 	"teams",
 	"authn",
+	"ingest",
 }
 
 type cerealProjectPurger struct {

--- a/components/authz-service/server/v2/project_purger_workflow/project_purger.go
+++ b/components/authz-service/server/v2/project_purger_workflow/project_purger.go
@@ -37,6 +37,7 @@ var projectPurgeDomainServices = []string{
 	"teams",
 	"authn",
 	"ingest",
+	"compliance",
 }
 
 type cerealProjectPurger struct {

--- a/components/compliance-service/compliance.go
+++ b/components/compliance-service/compliance.go
@@ -56,6 +56,7 @@ import (
 	notifications "github.com/chef/automate/components/notifications-client/api"
 	"github.com/chef/automate/components/notifications-client/notifier"
 	project_update_lib "github.com/chef/automate/lib/authz"
+	"github.com/chef/automate/lib/authz/project_purge"
 	"github.com/chef/automate/lib/cereal"
 	"github.com/chef/automate/lib/cereal/postgres"
 	"github.com/chef/automate/lib/datalifecycle/purge"
@@ -176,6 +177,10 @@ func serveGrpc(ctx context.Context, db *pgdb.DB, connFactory *secureconn.Factory
 		err = project_update_lib.RegisterTaskExecutors(cerealProjectUpdateManager, "compliance", ingesticESClient, authzProjectsClient)
 		if err != nil {
 			logrus.WithError(err).Fatal("could not register project update task executors")
+		}
+		err = project_purge.RegisterTaskExecutors(cerealProjectUpdateManager, "compliance", ingesticESClient)
+		if err != nil {
+			logrus.WithError(err).Fatal("could not register project purge task executors")
 		}
 		if err := cerealProjectUpdateManager.Start(ctx); err != nil {
 			logrus.WithError(err).Fatal("could not start cereal manager")

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -192,6 +192,7 @@ func (backend *ESClient) setDailyLatestToFalse(ctx context.Context, nodeId strin
 }
 
 func (backend *ESClient) PurgeProject(ctx context.Context, projectTagToBeDelete string) error {
+	logrus.Infof("starting project delete for id %q", projectTagToBeDelete)
 	// TODO implement
 	return nil
 }

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -191,10 +191,9 @@ func (backend *ESClient) setDailyLatestToFalse(ctx context.Context, nodeId strin
 	return errors.Wrap(err, "setDailyLatestToFalse")
 }
 
-func (backend *ESClient) DeleteProjectTag(ctx context.Context,
-	projectTagToBeDelete string) ([]string, error) {
+func (backend *ESClient) PurgeProject(ctx context.Context, projectTagToBeDelete string) error {
 	// TODO implement
-	return []string{}, nil
+	return nil
 }
 
 func (backend *ESClient) UpdateProjectTags(ctx context.Context, projectTaggingRules map[string]*iam_v2.ProjectRules) ([]string, error) {

--- a/components/ingest-service/backend/client.go
+++ b/components/ingest-service/backend/client.go
@@ -81,7 +81,7 @@ type Client interface {
 	// @param (context, projectRules)
 	UpdateProjectTags(context.Context, map[string]*iam_v2.ProjectRules) ([]string, error)
 	// @param (context, projectTagToDelete)
-	DeleteProjectTag(context.Context, string) ([]string, error)
+	PurgeProject(context.Context, string) error
 
 	// Migration contracts
 	ReindexInsightstoConvergeHistory(context.Context, string, string) error

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -42,22 +42,22 @@ func (es *Backend) Initializing() bool {
 	return !es.initialized
 }
 
-func (es *Backend) DeleteProjectTag(ctx context.Context, projectTagToBeDeleted string) ([]string, error) {
+func (es *Backend) PurgeProject(ctx context.Context, projectTagToBeDeleted string) error {
 	log.Debugf("starting project delete project %q", projectTagToBeDeleted)
 
 	esNodeJobID, err := es.DeleteNodeProjectTag(ctx, projectTagToBeDeleted)
 	if err != nil {
-		return []string{}, errors.Wrap(err, "Failed to start Elasticsearch Node project tags delete")
+		return errors.Wrap(err, "Failed to start Elasticsearch Node project tags delete")
 	}
 
 	esActionJobID, err := es.DeleteActionProjectTag(ctx, projectTagToBeDeleted)
 	if err != nil {
-		return []string{}, errors.Wrap(err, "Failed to start Elasticsearch Action project tags delete")
+		return errors.Wrap(err, "Failed to start Elasticsearch Action project tags delete")
 	}
 
 	log.Debugf("Started Project delete with node job ID: %q action job ID %q", esNodeJobID, esActionJobID)
 
-	return []string{esNodeJobID, esActionJobID}, nil
+	return nil
 }
 
 func (es *Backend) UpdateProjectTags(ctx context.Context, projectTaggingRules map[string]*iam_v2.ProjectRules) ([]string, error) {

--- a/components/ingest-service/grpc/grpc.go
+++ b/components/ingest-service/grpc/grpc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/chef/automate/components/ingest-service/serveropts"
 	"github.com/chef/automate/components/nodemanager-service/api/manager"
 	project_update_lib "github.com/chef/automate/lib/authz"
+	"github.com/chef/automate/lib/authz/project_purge"
 	"github.com/chef/automate/lib/cereal"
 	"github.com/chef/automate/lib/cereal/postgres"
 	"github.com/chef/automate/lib/datalifecycle/purge"
@@ -206,6 +207,11 @@ func Spawn(opts *serveropts.Opts) error {
 	}
 
 	err = project_update_lib.RegisterTaskExecutors(projectUpdateManager, "ingest", client, authzProjectsClient)
+	if err != nil {
+		return err
+	}
+
+	err = project_purge.RegisterTaskExecutors(projectUpdateManager, "ingest", client)
 	if err != nil {
 		return err
 	}

--- a/components/nodemanager-service/nodemanager.go
+++ b/components/nodemanager-service/nodemanager.go
@@ -34,6 +34,7 @@ import (
 
 	iam_v2 "github.com/chef/automate/api/interservice/authz/v2"
 	project_update_lib "github.com/chef/automate/lib/authz"
+	"github.com/chef/automate/lib/authz/project_purge"
 	"github.com/chef/automate/lib/tracing"
 )
 
@@ -254,6 +255,10 @@ func serve(ctx context.Context, config *config.Nodemanager, connFactory *securec
 
 		err = project_update_lib.RegisterTaskExecutors(projectUpdateManager, "nodemanager",
 			db, authzProjectsClient)
+		if err != nil {
+			return err
+		}
+		err = project_purge.RegisterTaskExecutors(projectUpdateManager, "nodemanager", db)
 		if err != nil {
 			return err
 		}

--- a/components/nodemanager-service/pgdb/project_update.go
+++ b/components/nodemanager-service/pgdb/project_update.go
@@ -96,6 +96,7 @@ func (projectUpdate *ProjectUpdate) updateFail(err error) {
 }
 
 func (db *DB) PurgeProject(ctx context.Context, projectTagToBeDelete string) error {
+	log.Infof("starting project delete for id %q", projectTagToBeDelete)
 	// TODO implement
 	return nil
 }

--- a/components/nodemanager-service/pgdb/project_update.go
+++ b/components/nodemanager-service/pgdb/project_update.go
@@ -95,10 +95,9 @@ func (projectUpdate *ProjectUpdate) updateFail(err error) {
 	projectUpdate.running = false
 }
 
-func (db *DB) DeleteProjectTag(ctx context.Context,
-	projectTagToBeDelete string) ([]string, error) {
+func (db *DB) PurgeProject(ctx context.Context, projectTagToBeDelete string) error {
 	// TODO implement
-	return []string{}, nil
+	return nil
 }
 
 // JobCancel - cancel the a currently running project update

--- a/components/teams-service/storage/postgres/postgres.go
+++ b/components/teams-service/storage/postgres/postgres.go
@@ -498,6 +498,7 @@ func (p *postgres) GetTeamsForUser(ctx context.Context, userID string) ([]storag
 
 // PurgeProject removes a project from every team it exists in
 func (p *postgres) PurgeProject(ctx context.Context, projectID string) error {
+	p.logger.Infof("starting project delete for id %q", projectID)
 	_, err := p.db.ExecContext(ctx, "UPDATE teams SET projects=array_remove(projects, $1)", projectID)
 	if err != nil {
 		return p.processError(err)

--- a/lib/authz/project_update_manager.go
+++ b/lib/authz/project_update_manager.go
@@ -19,7 +19,7 @@ type ProjectTaggedDomainService interface {
 	JobCancel(context.Context, string) error
 	UpdateProjectTags(context.Context, map[string]*iam_v2.ProjectRules) ([]string, error)
 	JobStatus(context.Context, string) (JobStatus, error)
-	DeleteProjectTag(context.Context, string) ([]string, error)
+	PurgeProject(context.Context, string) error
 }
 
 // ProjectUpdateBackend takes a connection to cereal-service and returns a cereal backend


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This sub-task adds appropriate wiring for the ingest, compliance, and node-manager services for project deletion.

Note that this PR puts the infrastructure in place for all three services. However, as only the ingest service sub-task has been merged to master, that is the only one that really works at the time of writing.

### :chains: Related Resources
N/A

### :+1: Definition of Done

Upon deleting a project from the UI or the API, the `PurgeProject` method in ingest, compliance, and node-manager services is called, as evinced via the supervisor log:
```
[5][default:/src:0]# sl | grep "starting project"
[2019-12-04T22:27:42+00:00] authz-service.default(O): time="2019-12-04T22:27:42Z" level=info msg="starting project move to graveyard for id \"p1\""
[2019-12-04T22:27:43+00:00] nodemanager-service.default(O): time="2019-12-04T22:27:43Z" level=info msg="starting project purges"
[2019-12-04T22:27:43+00:00] nodemanager-service.default(O): time="2019-12-04T22:27:43Z" level=info msg="starting project delete for id \"p1\""
[2019-12-04T22:27:44+00:00] teams-service.default(O): time="2019-12-04T22:27:44Z" level=info msg="starting project purges"
[2019-12-04T22:27:44+00:00] teams-service.default(O): time="2019-12-04T22:27:44Z" level=info msg="starting project delete project \"p1\""
[2019-12-04T22:27:45+00:00] ingest-service.default(O): time="2019-12-04T22:27:45Z" level=info msg="starting project purges"
[2019-12-04T22:27:45+00:00] ingest-service.default(O): time="2019-12-04T22:27:45Z" level=info msg="starting project delete project \"p1\""
[2019-12-04T22:27:45+00:00] authn-service.default(O): time="2019-12-04T22:27:45Z" level=info msg="starting project purges"
[2019-12-04T22:27:45+00:00] authn-service.default(O): 2019-12-04T22:27:45.823Z  info    pg/adapter.go:58        starting project delete project p1
[2019-12-04T22:27:50+00:00] compliance-service.default(O): time="2019-12-04T22:27:50Z" level=info msg="starting project purges"
[2019-12-04T22:27:50+00:00] compliance-service.default(O): time="2019-12-04T22:27:50Z" level=info msg="starting project delete for id \"p1\""
[2019-12-04T22:27:50+00:00] authz-service.default(O): time="2019-12-04T22:27:50Z" level=info msg="starting project delete from graveyard for id \"p1\""
```

### :athletic_shoe: How to Build and Test the Change
Rebuild the following components:
 - authn-service
 - authz-service
 - compliance-service
 - ingest-service
 - nodemanager-service
 - teams-service

Tip: you can generate such a list automatically with this in your .bash_profile:
```
export A2PATH="$GOPATH/src/github.com/chef/automate"
alias rebuild_what='git diff `git merge-base master HEAD` HEAD --name-only "$A2PATH/components/" | awk -F/ "{print \$2}" | sort | uniq'
```
