### PR TITLE
automate-cs-nginx: pin curl to address build failure

### DIFF
--- a/components/automate-cs-nginx/habitat/plan.sh
+++ b/components/automate-cs-nginx/habitat/plan.sh
@@ -10,7 +10,10 @@ pkg_license=('Chef-MLSA')
 pkg_version="13.0.47"
 pkg_deps=(
   chef/mlsa
-  core/curl
+  # TODO: REMOVE PINS
+  # The following pins match those in the chef-server-* packages below
+  # and can be removed once we unblock upgrades of chef-server.
+  core/curl/7.65.3/20190826035620
   core/bundler/1.17.3/20191007210608
   core/ruby/2.5.7/20191007205439
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh


### PR DESCRIPTION
We are still pinned to an older version of automate-cs until we finish
up an investigation of why we are seeing test failures on the latest
build.  To avoid dependency conflicts, this means that any deps that
are shared with the automate-cs-* packages need to be pinned.

Signed-off-by: Steven Danna <steve@chef.io>