### PR TITLE
a1upgrade: set HAB_LICENSE when calling hab commands

### DIFF
--- a/lib/platform/pg/exporter.go
+++ b/lib/platform/pg/exporter.go
@@ -135,6 +135,7 @@ func (db DatabaseExporter) Export() error {
 	err := db.CmdExecutor.Run(
 		cmd[0],
 		append(db.ConnInfo.PsqlCmdOptions(),
+			command.Envvar("HAB_LICENSE", "accept-no-persist"),
 			command.Args(cmd[1:]...),
 			command.Timeout(db.Timeout),
 			command.Stdout(db.Stdout))...)
@@ -222,6 +223,7 @@ func (db DatabaseExporter) restoreSQLFile(exitOnError bool) error {
 	err := db.CmdExecutor.Run(
 		psqlCmd[0],
 		append(db.ConnInfo.PsqlCmdOptions(),
+			command.Envvar("HAB_LICENSE", "accept-no-persist"),
 			command.Args(psqlCmd[1:]...),
 			command.Stderr(stderrBuff),
 			command.Timeout(db.Timeout),
@@ -276,6 +278,7 @@ func (db DatabaseExporter) buildSQLTOC(pgBackupFile string, filters []string) (f
 	defer cancel()
 	waitFunc, err := db.CmdExecutor.Start(
 		pgListCmd[0],
+		command.Envvar("HAB_LICENSE", "accept-no-persist"),
 		command.Args(pgListCmd[1:]...),
 		command.Stderr(stderrListBuff),
 		command.Stdout(writer),
@@ -366,6 +369,7 @@ func (db DatabaseExporter) restoreCustomFile(exitOnError bool) error {
 	err = db.CmdExecutor.Run(
 		pgRestoreCmd[0],
 		append(db.ConnInfo.PsqlCmdOptions(),
+			command.Envvar("HAB_LICENSE", "accept-no-persist"),
 			command.Args(pgRestoreCmd[1:]...),
 			command.Stderr(stderrBuff),
 			command.Timeout(db.Timeout))...)

--- a/lib/platform/pg/exporter_test.go
+++ b/lib/platform/pg/exporter_test.go
@@ -39,7 +39,9 @@ var testExpectedEnv = []string{
 	"PGSSLKEY=/hab/svc/automate-postgresql/config/server.key",
 	"PGSSLCERT=/hab/svc/automate-postgresql/config/server.crt",
 	"PGSSLROOTCERT=/hab/svc/automate-postgresql/config/root.crt",
-	"PGTZ=UTC"}
+	"PGTZ=UTC",
+	"HAB_LICENSE=accept-no-persist",
+}
 
 var connInfo = &pg.A2ConnInfo{
 	Host:  "test-db.example.com",


### PR DESCRIPTION
We do not currently globally accept the license for `hab` and have
rather opted to pass the HAB_LICENSE environment variable in various
locations. We forgot to pass the variable here.

We should consider calling `hab license accept` for the user somewhere
to avoid this game of wack-a-mole.

Signed-off-by: Steven Danna <steve@chef.io>