### PR TITLE
studio: pull out just the hab version from manifest

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ SCRIPT
 def hab_version_from_manifest
   manifest = JSON.parse(open("https://packages.chef.io/manifests/dev/automate/latest.json").read)
   hab = manifest["hab"]
-  hab.find {|x| x.start_with?("core/hab/") }.gsub("core/hab/", "")
+  hab.find {|x| x.start_with?("core/hab/") }.split("/")[2]
 end
 
 $install_hab = <<SCRIPT


### PR DESCRIPTION
The new install.sh doesn't support passing the release, so now we pull
out just the version.

Signed-off-by: Steven Danna <steve@chef.io>