### PR TITLE
deployment/automate-cli: set HAB_LICENSE at startup

### DIFF
--- a/components/automate-cli/cmd/chef-automate/chef-automate.go
+++ b/components/automate-cli/cmd/chef-automate/chef-automate.go
@@ -123,6 +123,13 @@ func newRootCmd() *cobra.Command {
 				}
 			}
 
+			// Set HAB_LICENSE to ensure any hab commands
+			// we call get this variable by default.
+			err := os.Setenv("HAB_LICENSE", "accept-no-persist")
+			if err != nil {
+				logrus.WithError(err).Warn("Could not set HAB_LICENSE=accept-no-persist")
+			}
+
 			if _, found := cmd.Annotations[NoCheckVersionAnnotation]; found || globalOpts.noCheckVersion || disableAutoUpdate() {
 				logrus.Debug("Not checking version")
 			} else {

--- a/components/automate-deployment/cmd/deployment-service/deployment-service.go
+++ b/components/automate-deployment/cmd/deployment-service/deployment-service.go
@@ -14,6 +14,11 @@ var RootCmd = &cobra.Command{
 }
 
 func main() {
+	if err := os.Setenv("HAB_LICENSE", "accept-no-persist"); err != nil {
+		fmt.Fprintf(os.Stderr, "could not set HAB_LICENSE=accept-no-persist: %s\n", err.Error())
+		os.Exit(1)
+	}
+
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error()) // nolint: gas
 		os.Exit(1)

--- a/components/automate-deployment/pkg/a1upgrade/filemover.go
+++ b/components/automate-deployment/pkg/a1upgrade/filemover.go
@@ -273,7 +273,10 @@ func (f *FileMover) doRsyncMove() error {
 		args = append([]string{"pkg", "exec", "core/rsync", "rsync"}, args...)
 	}
 
-	_, err = f.c.Output(f.RsyncCmd, command.Args(args...), command.Timeout(f.Timeout))
+	_, err = f.c.Output(f.RsyncCmd,
+		command.Args(args...),
+		command.Envvar("HAB_LICENSE", "accept-no-persist"),
+		command.Timeout(f.Timeout))
 	if err != nil {
 		return errors.Wrapf(err, "rsync failed: %s", command.StderrFromError(err))
 	}


### PR DESCRIPTION
We now set HAB_LICENSE=accept-no-persist at the startup of
deployment-service and automate-cli. This will hopefully help end the
wack-a-mole.

Signed-off-by: Steven Danna <steve@chef.io>