### PR TITLE
Apps tab: don't focus new service group when clicking a service filter that filters all the services

### DIFF
--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -28,8 +28,8 @@ import {
   serviceGroupsState,
   serviceGroupsHealth,
   serviceGroupsError,
-  selectedServiceGroupList,
-  selectedServiceGroupStatus
+  selectedServiceGroupStatus,
+  selectedServiceGroupHealth
 } from '../../entities/service-groups/service-groups.selector';
 import { find, filter as fpFilter, pickBy, some, includes, get } from 'lodash/fp';
 import { TelemetryService } from 'app/services/telemetry/telemetry.service';
@@ -233,17 +233,23 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
       }
     });
 
-    // If selected service group sidebar is null when
-    // filter is applied, select the first service group
-    // This is temp, file will be refactored in story PR 1292
+
+    // If the user applies a filter via the filter bar or the *service group*
+    // status filters that filters out all of the services in the
+    // selected service group, then we want to pick a new service to become the
+    // selected service group. However, this logic does not apply to the
+    // *service* status filters (in the services sidebar); when all services
+    // are filtered out via those status filters we have a special state that
+    // says, e.g., "none of the services reuturned warning" that we want to
+    // show.
     this.store.select(serviceGroupsStatus).subscribe((sgStatus) => {
       if (sgStatus === 'loadingSuccess') {
         this.store.select(selectedServiceGroupStatus).subscribe((sSgStatus) => {
           if (sSgStatus === 'loadingSuccess') {
             this.serviceGroupsList$.subscribe((serviceGroups) => {
               if (serviceGroups.length > 0) {
-                this.store.select(selectedServiceGroupList).subscribe((list) => {
-                  if (list.length === 0) {
+                this.store.select(selectedServiceGroupHealth).subscribe((sgHealth) => {
+                  if (sgHealth.total === 0) {
                     this.onServiceGroupSelect(null, serviceGroups[0].id);
                   }
                 });


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Fixes a bug in the Apps tab UI where selecting a service filter with zero services would cause a new service group to be selected. I think the logic that caused this was intended only be triggered when the user applied a filter via the textual filter bar that filtered all the services in the selected service group; that behavior has been maintained.

### :chains: Related Resources

#2073 

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

With automate running and data populated in the apps tab:
* select a service group that has zero services in one of the health statuses (e.g., a service group with all services critical works)
* click one of the filters on the right side services panel for which there are zero services (e.g., if all services are critical then click the "warning," "OK," or "unknown" filters.
  * without this patch the UI will pick the first service group in the list to become the selected one and reload the services panel (the buggy behavior)
  * with this patch you will see zero services in the services panel, and you will see text like  "None of the services returned warning" there.
* in both cases if you filter out all of the services with a query in the filter bar, it will still pick a new service group as the selected one.

### :camera: Screenshots, if applicable
![Screen Shot 2019-12-05 at 12 33 06 PM](https://user-images.githubusercontent.com/37162/70271561-7e7ff800-175b-11ea-9533-cb4b757eec85.png)
