### PR TITLE
[AUTOMATE-2408] If projects update is in progress, do not allow project deletion to occur

### DIFF
--- a/components/automate-ui/src/app/pages/project/confirm-apply-start-modal/confirm-apply-start-modal.component.html
+++ b/components/automate-ui/src/app/pages/project/confirm-apply-start-modal/confirm-apply-start-modal.component.html
@@ -1,7 +1,10 @@
 <chef-modal id="confirm-apply-start-modal" [visible]="visible" (closeModal)="cancel.emit()">
   <h2 id="title" slot="title">Update Projects?</h2>
   <div class="modal-content">
-    <p>Updating projects will apply all pending edits and move ingested resources into the correct projects. This background process can take up to <strong>12 hours</strong> to complete.</p>
+    <p>
+      Updating projects will apply all pending edits by moving ingested resources into the correct projects.
+      During this background process you will be unable to delete projects and it can take up to
+      <strong>12 hours</strong> to complete.</p>
     <div class="options">
       <chef-button id="confirm-button" primary (click)="confirm.emit()">
         Update Projects

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -272,6 +272,20 @@ describeIfIAMV2p1('projects API', () => {
         method: 'POST',
         url: '/apis/iam/v2beta/apply-rules'
       });
+
+      // Project cannot be deleted while apply-rules is in flight
+      for (const project of [avengersProject, xmenProject]) {
+        cy.request({
+          headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+          method: 'DELETE',
+          url: `/apis/iam/v2beta/projects/${project.id}`,
+          failOnStatusCode: false
+        }).then((response) => {
+          expect(response.status).to.equal(400);
+          expect(response.body.error).to.contain('while projects update is in progress');
+        });
+      }
+
       cy.waitUntilApplyRulesNotRunning(500);
 
       // confirm rules are applied


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When project update is in progress, we will return a 400 on any attempt to delete a project. Also updated some of the project update modal language to reflect this.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :athletic_shoe: How to Build and Test the Change

```
start_all_services
rebuild components/automate-ui-devproxy
rebuild components/authz-service
```

Kick off a project update in UI. Try to delete a project and see the error from the screenshot below. After project update is finished, successfully delete project.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable

![Screen Shot 2019-12-05 at 1 01 50 PM](https://user-images.githubusercontent.com/1899715/70280177-b9d6f280-176c-11ea-939a-bbbfd1c5019e.png)

![Screen Shot 2019-12-05 at 1 04 53 PM](https://user-images.githubusercontent.com/1899715/70280189-bd6a7980-176c-11ea-9b2b-4712de215464.png)
