### PR TITLE
Apps Tab: don't reset service group selection and related state until service group no longer listed

### DIFF
--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -226,8 +226,24 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
     )
     .subscribe(([serviceGroups, queryParams]) => {
       if (serviceGroups.length > 0) {
-        const sgId = queryParams.get('sgId') || serviceGroups[0]['id'];
-        this.router.navigate([], { queryParams: { sgId }, queryParamsHandling: 'merge' });
+        // if we do not have an sgId parameter, pick the first sgId from the
+        // service group list and load it:
+        const sgId = queryParams.get('sgId');
+        if ( !sgId ) {
+          this.router.navigate(
+            [],
+            { queryParams: { sgId: serviceGroups[0]['id'] }, queryParamsHandling: 'merge' }
+          );
+        }
+
+        // if the selected service group is not visible on the page, then pick
+        // the first service group from the list and navigate to it. this lets
+        // us maintain a service group selection regardless of other navigation
+        // as long as the service group is still in the list.
+        const selectedSGVisibleOnPage = serviceGroups.find(sg => sg.id === sgId);
+        if ( !selectedSGVisibleOnPage ) {
+          this.onServiceGroupSelect(null, serviceGroups[0].id);
+        }
       } else {
         this.selectedServiceGroupId = null;
       }
@@ -433,9 +449,6 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
     }
 
     delete queryParams['page'];
-    delete queryParams['sgId'];
-    delete queryParams['sgPage'];
-    delete queryParams['sgStatus'];
 
     this.router.navigate([], {queryParams});
   }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

On the apps tab, when a status filter is selected, the user's selection for current service group, status filter for services, and current page on the services list are reset. These should only be reset if the selected filter excludes the selected service group. For example, if the selected service group contains services in the critical state and the user selects the critical health filter, the currently selected service group matches so we shouldn't reset these selections. If the user clicks the warning filter, then the selected service group doesn't match so we _should_ reset the selection. To get this behavior fully correct with pagination would be really complicated so I've implemented a compromise where the service group selection gets reset when the service group content loads and doesn't contain the selected service group.

### :chains: Related Resources

addresses #2262

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

Build: automate-ui

Repro/demo:

* create sample data in the studio with `applications_populate_database`
* select the `nginx.default` service group in the _demo_ app and environment (this is one with 40 services)
* in the services panel on the right, select the critical filter and navigate to page 2 of the services list.
* click the "Critical" service groups filter above the main table
  * without the fix applied, you will have a different service group selected and your services health filter and page state are reset
  * with the fix applied, the selected service group, services health filter, and services pagination state are all maintained.
* click the warning service groups filter and the selected service group will be reset since the previously selected service group isn't visible in the table any longer. 
