### PR TITLE
for ec2 Vagrantfile, pull out just the hab version from manifest

### DIFF
--- a/ec2/Vagrantfile
+++ b/ec2/Vagrantfile
@@ -19,7 +19,7 @@ es_ebs_snapshot = ''
 
 def extract_from_manifest(manifest, build)
   manifest_json = JSON.parse(open(manifest).read)
-  hab_version = manifest_json["hab"].find {|x| x.start_with?("core/hab/") }.gsub("core/hab/", "")
+  hab_version = manifest_json["hab"].find {|x| x.start_with?("core/hab/") }.split("/")[2]
   git_sha = 'HEAD'
   git_sha = manifest_json["git_sha"] if build != 'latest'
   return hab_version, git_sha


### PR DESCRIPTION
This is the same fix that was put into the Vagrantfile at root of this repo in pr #2431.
This same sort of change needed to also be in ec2 Vagrantfile

The new install.sh doesn't support passing the release, so now we pull out just the version.

Signed-off-by: Rick Marry <rmarry@chef.io>

