### PR TITLE
Make missing go-swagger command an explicit error when building API docs

### DIFF
--- a/components/automate-chef-io/Makefile
+++ b/components/automate-chef-io/Makefile
@@ -38,9 +38,11 @@ sync_swagger_files: clean_swagger_files
 
 $(SWAGGER_RESULT_FILE): $(SWAGGER_FILES)
 
+# This jq script is more complicated than it needs to be to workaround an issue where jq treats empty input as valid input:
+# https://github.com/stedolan/jq/issues/1142
 generate_swagger: $(SWAGGER_RESULT_FILE)
 	swagger mixin -c=0 $(STATIC_SWAGGER_FILES) $(SWAGGER_FILES) | \
-		jq '.paths = (.paths | with_entries( select( all( .value[].tags[]; . != "hidden") ) ) )' \
+		jq -es 'if . == [] then null else .[] | .paths = (.paths | with_entries( select( all( .value[].tags[]; . != "hidden") ) ) ) end' \
 		> $(SWAGGER_RESULT_FILE)
 
 serve: sync generate_swagger


### PR DESCRIPTION
Previously, not having go-swagger installed would prevent the API docs from being built but it was not always obvious that this was an error:

```
Petes-MacBook-Pro:automate-chef-io pete$ make generate_swagger ; echo $?
swagger mixin -c=0 data/docs/api-static//00-meta.swagger.json data/docs/api-static//01-reporting-export.swagger.json data/docs/api-static//02-meta-description.yaml data/docs/api-static//03-tags.swagger.json data/docs/api_chef_automate/license/license.swagger.json data/docs/api_chef_automate/event_feed/response/event.swagger.json data/docs/api_chef_automate/event_feed/response/eventstrings.swagger.json data/docs/api_chef_automate/event_feed/event_feed.swagger.json data/docs/api_chef_automate/event_feed/request/event.swagger.json data/docs/api_chef_automate/event_feed/request/eventstrings.swagger.json data/docs/api_chef_automate/nodes/nodes.swagger.json data/docs/api_chef_automate/nodes/manager/manager.swagger.json data/docs/api_chef_automate/auth/users/users.swagger.json data/docs/api_chef_automate/auth/users/response/users.swagger.json data/docs/api_chef_automate/auth/users/request/users.swagger.json data/docs/api_chef_automate/auth/teams/response/teams.swagger.json data/docs/api_chef_automate/auth/teams/request/teams.swagger.json data/docs/api_chef_automate/auth/teams/teams.swagger.json data/docs/api_chef_automate/auth/tokens/response/tokens.swagger.json data/docs/api_chef_automate/auth/tokens/tokens.swagger.json data/docs/api_chef_automate/auth/tokens/request/tokens.swagger.json data/docs/api_chef_automate/secrets/secrets.swagger.json data/docs/api_chef_automate/ingest/chef.swagger.json data/docs/api_chef_automate/ingest/job_scheduler.swagger.json data/docs/api_chef_automate/legacy/legacy.swagger.json data/docs/api_chef_automate/compliance/reporting/reporting.swagger.json data/docs/api_chef_automate/compliance/reporting/stats/stats.swagger.json data/docs/api_chef_automate/compliance/profiles/profiles.swagger.json data/docs/api_chef_automate/compliance/scanner/jobs/jobs.swagger.json data/docs/api_chef_automate/data_lifecycle/data_lifecycle.swagger.json data/docs/api_chef_automate/iam/v2beta/users.swagger.json data/docs/api_chef_automate/iam/v2beta/response/users.swagger.json data/docs/api_chef_automate/iam/v2beta/response/rules.swagger.json data/docs/api_chef_automate/iam/v2beta/response/tokens.swagger.json data/docs/api_chef_automate/iam/v2beta/response/teams.swagger.json data/docs/api_chef_automate/iam/v2beta/response/policy.swagger.json data/docs/api_chef_automate/iam/v2beta/rules.swagger.json data/docs/api_chef_automate/iam/v2beta/common/users.swagger.json data/docs/api_chef_automate/iam/v2beta/common/rules.swagger.json data/docs/api_chef_automate/iam/v2beta/common/tokens.swagger.json data/docs/api_chef_automate/iam/v2beta/common/teams.swagger.json data/docs/api_chef_automate/iam/v2beta/common/policy.swagger.json data/docs/api_chef_automate/iam/v2beta/tokens.swagger.json data/docs/api_chef_automate/iam/v2beta/request/users.swagger.json data/docs/api_chef_automate/iam/v2beta/request/rules.swagger.json data/docs/api_chef_automate/iam/v2beta/request/tokens.swagger.json data/docs/api_chef_automate/iam/v2beta/request/teams.swagger.json data/docs/api_chef_automate/iam/v2beta/request/policy.swagger.json data/docs/api_chef_automate/iam/v2beta/teams.swagger.json data/docs/api_chef_automate/iam/v2beta/policy.swagger.json data/docs/api_chef_automate/deployment/deployment.swagger.json data/docs/api_chef_automate/applications/applications.swagger.json data/docs/api_chef_automate/cfgmgmt/cfgmgmt.swagger.json data/docs/api_chef_automate/data_feed/data_feed.swagger.json data/docs/api_chef_automate/authz/response/authz.swagger.json data/docs/api_chef_automate/authz/request/authz.swagger.json data/docs/api_chef_automate/authz/authz.swagger.json data/docs/api_chef_automate/telemetry/telemetry.swagger.json data/docs/api_chef_automate/notifications/notifications.swagger.json data/docs/api_chef_automate/gateway/gateway.swagger.json | \
                jq '.paths = (.paths | with_entries( select( all( .value[].tags[]; . != "hidden") ) ) )' \
                > static/api-docs/all-apis.swagger.json
bash: swagger: command not found
0
```

This is because jq by default treats an empty json input as valid input (an empty string is a valid json document, after all). Here's an example with a small jq script to change one value of the document:

```
Petes-MacBook-Pro:automate-chef-io pete$ echo '{"foo": "bar"}' | jq '.foo = "tacos"' ; echo $?
{
  "foo": "tacos"
}
0
Petes-MacBook-Pro:automate-chef-io pete$ echo | jq '.foo = "tacos"' ; echo $?
0
```

For our use case, we want the second case to fail. This has been fixed on jq master, but jq has not had a new release in over a year: https://github.com/stedolan/jq/issues/1142

This PR applies a workaround in the above issue to get the behavior we want:

```
Petes-MacBook-Pro:automate-chef-io pete$ echo '{"foo": "bar"}' | jq -es 'if . == [] then null else .[] | .foo = "tacos" end' ; echo $?
{
  "foo": "tacos"
}
0

Petes-MacBook-Pro:automate-chef-io pete$ echo | jq -es 'if . == [] then null else .[] | .foo = "tacos" end' ; echo $?
null
1
```

After this change, not having go-swagger installed should be more obvious of a failure:

```
Petes-MacBook-Pro:automate-chef-io pete$ make generate_swagger ; echo $?
swagger mixin -c=0 data/docs/api-static//00-meta.swagger.json data/docs/api-static//01-reporting-export.swagger.json data/docs/api-static//02-meta-description.yaml data/docs/api-static//03-tags.swagger.json data/docs/api_chef_automate/license/license.swagger.json data/docs/api_chef_automate/event_feed/response/event.swagger.json data/docs/api_chef_automate/event_feed/response/eventstrings.swagger.json data/docs/api_chef_automate/event_feed/event_feed.swagger.json data/docs/api_chef_automate/event_feed/request/event.swagger.json data/docs/api_chef_automate/event_feed/request/eventstrings.swagger.json data/docs/api_chef_automate/nodes/nodes.swagger.json data/docs/api_chef_automate/nodes/manager/manager.swagger.json data/docs/api_chef_automate/auth/users/users.swagger.json data/docs/api_chef_automate/auth/users/response/users.swagger.json data/docs/api_chef_automate/auth/users/request/users.swagger.json data/docs/api_chef_automate/auth/teams/response/teams.swagger.json data/docs/api_chef_automate/auth/teams/request/teams.swagger.json data/docs/api_chef_automate/auth/teams/teams.swagger.json data/docs/api_chef_automate/auth/tokens/response/tokens.swagger.json data/docs/api_chef_automate/auth/tokens/tokens.swagger.json data/docs/api_chef_automate/auth/tokens/request/tokens.swagger.json data/docs/api_chef_automate/secrets/secrets.swagger.json data/docs/api_chef_automate/ingest/chef.swagger.json data/docs/api_chef_automate/ingest/job_scheduler.swagger.json data/docs/api_chef_automate/legacy/legacy.swagger.json data/docs/api_chef_automate/compliance/reporting/reporting.swagger.json data/docs/api_chef_automate/compliance/reporting/stats/stats.swagger.json data/docs/api_chef_automate/compliance/profiles/profiles.swagger.json data/docs/api_chef_automate/compliance/scanner/jobs/jobs.swagger.json data/docs/api_chef_automate/data_lifecycle/data_lifecycle.swagger.json data/docs/api_chef_automate/iam/v2beta/users.swagger.json data/docs/api_chef_automate/iam/v2beta/response/users.swagger.json data/docs/api_chef_automate/iam/v2beta/response/rules.swagger.json data/docs/api_chef_automate/iam/v2beta/response/tokens.swagger.json data/docs/api_chef_automate/iam/v2beta/response/teams.swagger.json data/docs/api_chef_automate/iam/v2beta/response/policy.swagger.json data/docs/api_chef_automate/iam/v2beta/rules.swagger.json data/docs/api_chef_automate/iam/v2beta/common/users.swagger.json data/docs/api_chef_automate/iam/v2beta/common/rules.swagger.json data/docs/api_chef_automate/iam/v2beta/common/tokens.swagger.json data/docs/api_chef_automate/iam/v2beta/common/teams.swagger.json data/docs/api_chef_automate/iam/v2beta/common/policy.swagger.json data/docs/api_chef_automate/iam/v2beta/tokens.swagger.json data/docs/api_chef_automate/iam/v2beta/request/users.swagger.json data/docs/api_chef_automate/iam/v2beta/request/rules.swagger.json data/docs/api_chef_automate/iam/v2beta/request/tokens.swagger.json data/docs/api_chef_automate/iam/v2beta/request/teams.swagger.json data/docs/api_chef_automate/iam/v2beta/request/policy.swagger.json data/docs/api_chef_automate/iam/v2beta/teams.swagger.json data/docs/api_chef_automate/iam/v2beta/policy.swagger.json data/docs/api_chef_automate/deployment/deployment.swagger.json data/docs/api_chef_automate/applications/applications.swagger.json data/docs/api_chef_automate/cfgmgmt/cfgmgmt.swagger.json data/docs/api_chef_automate/data_feed/data_feed.swagger.json data/docs/api_chef_automate/authz/response/authz.swagger.json data/docs/api_chef_automate/authz/request/authz.swagger.json data/docs/api_chef_automate/authz/authz.swagger.json data/docs/api_chef_automate/telemetry/telemetry.swagger.json data/docs/api_chef_automate/notifications/notifications.swagger.json data/docs/api_chef_automate/gateway/gateway.swagger.json | \
                jq -es 'if . == [] then null else .[] | .paths = (.paths | with_entries( select( all( .value[].tags[]; . != "hidden") ) ) ) end' \
                > static/api-docs/all-apis.swagger.json
bash: swagger: command not found
make: *** [generate_swagger] Error 1
2
```
