### PR TITLE
do not allow users to update name or tags of ingested nodes

### DIFF
--- a/components/compliance-service/api/tests/test_ingest_to_mgr_conn.rb
+++ b/components/compliance-service/api/tests/test_ingest_to_mgr_conn.rb
@@ -48,4 +48,27 @@ describe File.basename(__FILE__) do
         node["scan_data"].end_time != nil
     }, "Nodes did not have necessary scan_data: #{nodes_list["nodes"]}"
   end
+
+  it "not allowed to update name or tags of ingested node" do
+    nodes = Nodes::NodesService
+    nodes_list = MANAGER_GRPC nodes, :list, Nodes::Query.new()
+
+    assert_grpc_error("invalid option. unable to update name of ingested node", 3) do
+      MANAGER_GRPC nodes, :update, Nodes::Node.new(
+        id: nodes_list['nodes'][0].id,
+        name: "new name"
+      )
+    end
+
+    assert_grpc_error("invalid option. unable to update tags of ingested node", 3) do
+      node = nodes_list['nodes'][0]
+      MANAGER_GRPC nodes, :update, Nodes::Node.new(
+        id: node.id,
+        name: node.name,
+        tags: [
+          Common::Kv.new(key: "blablabla", value: "hahaha")
+        ]
+      )
+    end
+  end
 end

--- a/components/nodemanager-service/tests/aws_ec2_nodes_integration_test.go
+++ b/components/nodemanager-service/tests/aws_ec2_nodes_integration_test.go
@@ -73,11 +73,7 @@ func TestAWSEC2Nodes(t *testing.T) {
 	readNode.TargetConfig.Host = "localhost"
 	readNode.TargetConfig.Port = 22
 	_, err = nodesClient.Update(ctx, readNode)
-	require.NoError(t, err)
-	readNodeAfterUpdate, err := nodesClient.Read(ctx, &nodes.Id{Id: readNode.GetId()})
-	require.NoError(t, err)
-	assert.NotEqual(t, "new name", readNodeAfterUpdate.GetName())
-	assert.NotEqual(t, "localhost", readNodeAfterUpdate.GetTargetConfig().GetHost())
+	assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = invalid option. unable to update name of aws-ec2 node")
 }
 
 func TestAWSEC2SearchNodeFields(t *testing.T) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

this change prevents users from updating the name or tags on ingested nodes (nodes with no manager)

users may update other fields, such as the credential id for the node or backend, port, host information.
the name and tags are collected at ingestion time from the chef-client and inspec reports.

also made the inability to update aws-ec2 or azure-vm node names, tags, and host more obvious.

### :chains: Related Resources
n/a

### :+1: Definition of Done
user not allowed to update name or tags on ingested node

### :athletic_shoe: How to Build and Test the Change
rebuild nodemanager
ingest some nodes
try to update name of ingested node

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [n/a] Docs added/updated?
