### PR TITLE
moving authentication docs to their own section

### DIFF
--- a/components/automate-chef-io/config.toml
+++ b/components/automate-chef-io/config.toml
@@ -58,6 +58,11 @@ weight = 20
 identifier = "configuring_automate"
 
 [[menu.docs]]
+name = "Authentication"
+weight = 30
+identifier = "authentication"
+
+[[menu.docs]]
 name = "Event Feed"
 weight = 40
 identifier = "event_feed"

--- a/components/automate-chef-io/content/docs/OAuth.md
+++ b/components/automate-chef-io/content/docs/OAuth.md
@@ -7,8 +7,8 @@ bref = ""
 toc = true
 [menu]
   [menu.docs]
-    parent = "configuring_automate"
-    weight = 40
+    parent = "authentication"
+    weight = 20
 +++
 
 ## Alpha: Setting up Automate as an OAuth Provider for Habitat Builder

--- a/components/automate-chef-io/content/docs/ldap.md
+++ b/components/automate-chef-io/content/docs/ldap.md
@@ -7,8 +7,8 @@ bref = ""
 toc = true
 [menu]
   [menu.docs]
-    parent = "configuring_automate"
-    weight = 30
+    parent = "authentication"
+    weight = 10
 +++
 
 ## Authentication via Existing Identity Management Systems

--- a/components/automate-chef-io/content/docs/saml.md
+++ b/components/automate-chef-io/content/docs/saml.md
@@ -7,8 +7,8 @@ bref = ""
 toc = true
 [menu]
   [menu.docs]
-    parent = "configuring_automate"
-    weight = 50
+    parent = "authentication"
+    weight = 30
 +++
 
 ## Authentication via Existing Identity Management Systems


### PR DESCRIPTION
Signed-off-by: susanev <susan.ra.evans@gmail.com>

### :nut_and_bolt: Description: What code changed, and why?
The config menu item is getting kinda big so I was thinking it might be helpful to users to have an authentication specific section.

### :athletic_shoe: How to Build and Test the Change
`make serve` from `components/automate-chef-io`

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [x] Docs added/updated?
