### PR TITLE
fix revendor target and ignore EINVAL in atomic writer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,31 +2,6 @@
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-grpcGatewayVendorPath=./vendor/github.com/grpc-ecosystem/grpc-gateway/
-
 .PHONY: revendor
 revendor: ## revendor dependencies in vendor/ and update .bldr.toml with deps
-	# Revendor
-	@go mod tidy
-	@go mod vendor
-	@go mod verify
-
-	# Some of our tests and proto generators require files that go doesn't
-	# believe in vendoring so we copy them from the module cache to the vendor
-	# directory ourselves when we revendor.
-	#
-	# See https://github.com/golang/go/issues/26366
-	$(eval grpcGatewayModPath=$(shell bash -c 'GOFLAGS="" go list -f {{.Dir}} -m "github.com/grpc-ecosystem/grpc-gateway"'))
-
-	# Add files that go mod won't vendor that we need
-	@mkdir -p $(grpcGatewayVendorPath)
-	@cp -rf --no-preserve=mode $(grpcGatewayModPath)/* $(grpcGatewayVendorPath)
-
-	# Clean up files that go mod will vendor that we don't need
-	@find ./vendor -type f \( -name .gitignore -o -name .travis.yml -o -name package.json -o -name Makefile -o -name Dockerfile -o -name MAINTAINERS -o -name \*.md -o -name \*.vim -o -name \*.yml \) -delete
-
-	# Explicitly clean out grpc-gateway example folder
-	rm -rf ./vendor/github.com/grpc-ecosystem/grpc-gateway/examples/
-
-	# Update .bldr with new dep information
-	@go run tools/bldr-config-gen/main.go
+	@scripts/revendor.sh

--- a/scripts/revendor.sh
+++ b/scripts/revendor.sh
@@ -5,6 +5,7 @@
 #
 grpcGatewayVendorPath=./vendor/github.com/grpc-ecosystem/grpc-gateway/
 
+echo "Vendoring dependencies in vendor/"
 go mod tidy
 go mod vendor
 go mod verify
@@ -26,6 +27,7 @@ else
     exit 1
 fi
 
+echo "Cleaning up unnecessary files from vendor/"
 # Clean up files that go mod will vendor that we don't need
 find ./vendor -type f \( -name .gitignore -o -name .travis.yml -o -name package.json -o -name Makefile -o -name Dockerfile -o -name MAINTAINERS -o -name \*.md -o -name \*.vim -o -name \*.yml \) -delete
 
@@ -33,4 +35,5 @@ find ./vendor -type f \( -name .gitignore -o -name .travis.yml -o -name package.
 rm -rf ./vendor/github.com/grpc-ecosystem/grpc-gateway/examples/
 
 # Update .bldr with new dep information
+echo "Regenerating .bldr configuration file"
 go run tools/bldr-config-gen/main.go

--- a/scripts/revendor.sh
+++ b/scripts/revendor.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Creates the vendor/ directory in this repository. Should be run from
+# the root of the repository.
+#
+grpcGatewayVendorPath=./vendor/github.com/grpc-ecosystem/grpc-gateway/
+
+go mod tidy
+go mod vendor
+go mod verify
+
+# Some of our tests and proto generators require files that go doesn't
+# believe in vendoring so we copy them from the module cache to the
+# vendor directory ourselves when we revendor.
+#
+# See https://github.com/golang/go/issues/26366
+grpcGatewayModPath=$(GOFLAGS="" go list -f "{{.Dir}}" -m "github.com/grpc-ecosystem/grpc-gateway")
+
+# Add files that go mod won't vendor that we need
+mkdir -p $grpcGatewayVendorPath
+
+if [[ -n "$grpcGatewayModPath" ]]; then
+    cp -rf --no-preserve=mode "$grpcGatewayModPath/"* $grpcGatewayVendorPath
+else
+    echo "Could not find github.com/grpc-ecosystem/grpc-gateway module path"
+    exit 1
+fi
+
+# Clean up files that go mod will vendor that we don't need
+find ./vendor -type f \( -name .gitignore -o -name .travis.yml -o -name package.json -o -name Makefile -o -name Dockerfile -o -name MAINTAINERS -o -name \*.md -o -name \*.vim -o -name \*.yml \) -delete
+
+# Explicitly clean out grpc-gateway example folder
+rm -rf ./vendor/github.com/grpc-ecosystem/grpc-gateway/examples/
+
+# Update .bldr with new dep information
+go run tools/bldr-config-gen/main.go


### PR DESCRIPTION
This fixes two problems that led to `revendor` not working correctly.

Previously, we were copying files from grpc-ecosystem/grpc-gateway
manually into our vendor directory. However, to determine the path to
copy from, we needed to look up the the path after installation. But,
because of some confusion about how `$(eval)` works, this did not work
on systems where that go module was not already installed.

To fix this, I've moved this logic to a shell script since I think
more people will be able to reason about the behavior of the shell
script.

Additionally, we now ignore EINVAL from directory syncs in the atomic
writer. Vboxfs and potentially other filesystems don't support calling
sync on a directory, returning EINVAL. This has been a recurring
source of confusion. Other bits of code turn of sync'ing completely to
avoid this issue, but that is a bit overkill.

Signed-off-by: Steven Danna <steve@chef.io>