### PR TITLE
Fix backwards timewizard message in apps tab

### DIFF
--- a/components/automate-ui/src/app/entities/service-groups/service-groups.facade.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.facade.ts
@@ -88,7 +88,7 @@ export class ServiceGroupsFacadeService {
       previousHealth = previousHealth.toLowerCase();
     }
 
-    return 'Changed from ' + currentHealth + ' to ' + previousHealth;
+    return 'Changed from ' + previousHealth + ' to ' + currentHealth;
   }
 
   public updatePageNumber(pageNumber: number, total: number, pageSize: number, trackEvent: string) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The apps tab gets current and previous status switched when generating timewizard messages. This PR flips them to the correct order.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :camera: Screenshots, if applicable

Chef software employees can see a customer screenshot of the bug in action in the a2-eas-beta channel.