### PR TITLE
automate-2281 automate-2278

### DIFF
--- a/components/automate-ui/src/app/components/authorized/authorized.component.ts
+++ b/components/automate-ui/src/app/components/authorized/authorized.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, EventEmitter, OnInit, OnDestroy, ChangeDetectorRef, Output } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { isEmpty, isArray, pipe } from 'lodash/fp';
 import { takeUntil, filter, debounceTime } from 'rxjs/operators';
@@ -30,12 +30,12 @@ export class AuthorizedComponent implements OnInit, OnDestroy {
 
   @Input()
   set allOf(val: Check[] | Check) {
-    this._allOf = this.normalizeInput(val);
+    this._allOf = val ? this.normalizeInput(val) : undefined;
   }
 
   @Input()
   set anyOf(val: Check[] | Check) {
-    this._anyOf = this.normalizeInput(val);
+    this._anyOf = val ? this.normalizeInput(val) : undefined;
   }
 
   // Include the bare `not` attribute in your HTML element to negate the check.
@@ -45,6 +45,9 @@ export class AuthorizedComponent implements OnInit, OnDestroy {
   // Defaults to false. Useful when trying to generalize components that contain
   // this component.
   @Input() overrideVisible = false;
+
+  // if you wish to output visible
+  @Output() isAuthorized: EventEmitter<boolean> = new EventEmitter();
 
   public visible = false;
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
@@ -68,6 +71,7 @@ export class AuthorizedComponent implements OnInit, OnDestroy {
         const oldVisible = this.visible;
         const newVisible = this.authorizedChecker.evalPerms(perms);
         this.visible = this.not === undefined ? newVisible : !newVisible;
+        this.isAuthorized.emit(this.visible);
 
         // Allow this component to receive updates on pages with "OnPush" strategy.
         if (oldVisible !== this.visible) {

--- a/components/automate-ui/src/app/components/authorized/authorized.component.ts
+++ b/components/automate-ui/src/app/components/authorized/authorized.component.ts
@@ -30,12 +30,12 @@ export class AuthorizedComponent implements OnInit, OnDestroy {
 
   @Input()
   set allOf(val: Check[] | Check) {
-    this._allOf = val ? this.normalizeInput(val) : undefined;
+    this._allOf = val ? this.normalizeInput(val) : [];
   }
 
   @Input()
   set anyOf(val: Check[] | Check) {
-    this._anyOf = val ? this.normalizeInput(val) : undefined;
+    this._anyOf = val ? this.normalizeInput(val) : [];
   }
 
   // Include the bare `not` attribute in your HTML element to negate the check.

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.html
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.html
@@ -6,34 +6,23 @@
     <div class="nav-items">
       <span *ngFor="let menuGroup of menuGroups$ | async">
         <div
-          *ngIf="isGroupVisible(menuGroup)"
+          *ngIf="(menuGroup.visible | async) || hasAuthroizedMenuItems(menuGroup)"
           class="menu-item-groups"
         >
           <div class="group">{{ menuGroup.name }}</div>
           <span *ngFor="let menuItem of menuGroup.items">
-            <span *ngIf="menuItem.visible && !menuItem.authorized">
+            <span *ngIf="!menuItem.authorized && (menuItem.visible | async)">
               <chef-sidebar-entry
                 [route]="menuItem.route"
                 [icon]="menuItem.icon"
                 [openInNewPage]="menuItem.openInNewPage"
               >{{ menuItem.name }}</chef-sidebar-entry>
             </span>
-            <span *ngIf="menuItem.visible && menuItem.authorized && menuItem.authorized.anyOf">
-              <app-authorized
-                [menuItem.authorized.name]
-                [anyOf]="menuItem.authorized.anyOf"
-              >
-                <chef-sidebar-entry
-                  [route]="menuItem.route"
-                  [icon]="menuItem.icon"
-                  [openInNewPage]="menuItem.openInNewPage"
-                >{{ menuItem.name }}</chef-sidebar-entry>
-              </app-authorized>
-            </span>
-            <span *ngIf="menuItem.visible && menuItem.authorized && menuItem.authorized.allOf">
+            <span *ngIf="menuItem.authorized && (menuItem.visible | async)">
                 <app-authorized
-                  [menuItem.authorized.name]
+                  [anyOf]="menuItem.authorized.anyOf"
                   [allOf]="menuItem.authorized.allOf"
+                  (isAuthorized)="isAuthorized($event, menuItem)"
                 >
                   <chef-sidebar-entry
                     [route]="menuItem.route"

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.html
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.html
@@ -6,19 +6,19 @@
     <div class="nav-items">
       <span *ngFor="let menuGroup of menuGroups$ | async">
         <div
-          *ngIf="isVisible(menuGroup.visible) | async"
+          *ngIf="isGroupVisible(menuGroup)"
           class="menu-item-groups"
         >
           <div class="group">{{ menuGroup.name }}</div>
           <span *ngFor="let menuItem of menuGroup.items">
-            <span *ngIf="(isVisible(menuItem.visible) | async) && !menuItem.authorized">
+            <span *ngIf="menuItem.visible && !menuItem.authorized">
               <chef-sidebar-entry
                 [route]="menuItem.route"
                 [icon]="menuItem.icon"
                 [openInNewPage]="menuItem.openInNewPage"
               >{{ menuItem.name }}</chef-sidebar-entry>
             </span>
-            <span *ngIf="(isVisible(menuItem.visible) | async) && menuItem.authorized && menuItem.authorized.anyOf">
+            <span *ngIf="menuItem.visible && menuItem.authorized && menuItem.authorized.anyOf">
               <app-authorized
                 [menuItem.authorized.name]
                 [anyOf]="menuItem.authorized.anyOf"
@@ -30,7 +30,7 @@
                 >{{ menuItem.name }}</chef-sidebar-entry>
               </app-authorized>
             </span>
-            <span *ngIf="(isVisible(menuItem.visible) | async) && menuItem.authorized && menuItem.authorized.allOf">
+            <span *ngIf="menuItem.visible && menuItem.authorized && menuItem.authorized.allOf">
                 <app-authorized
                   [menuItem.authorized.name]
                   [allOf]="menuItem.authorized.allOf"

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.html
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.html
@@ -6,7 +6,7 @@
     <div class="nav-items">
       <span *ngFor="let menuGroup of menuGroups$ | async">
         <div
-          [hidden]="!((menuGroup.visible$ | async) && menuGroup.hasAuthroizedMenuItems)"
+          [hidden]="!((menuGroup.visible$ | async) && menuGroup.hasAuthorizedMenuItems)"
           class="menu-item-groups"
         >
           <div class="group">{{ menuGroup.name }}</div>

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.html
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.html
@@ -6,7 +6,7 @@
     <div class="nav-items">
       <span *ngFor="let menuGroup of menuGroups$ | async">
         <div
-          [hidden]="!((menuGroup.visible$ | async) && menuGroup.hasAuthorizedMenuItems)"
+          [hidden]="!((menuGroup.visible$ | async) && menuGroup.hasVisibleMenuItems)"
           class="menu-item-groups"
         >
           <div class="group">{{ menuGroup.name }}</div>

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.html
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.html
@@ -6,23 +6,23 @@
     <div class="nav-items">
       <span *ngFor="let menuGroup of menuGroups$ | async">
         <div
-          *ngIf="(menuGroup.visible | async) || hasAuthroizedMenuItems(menuGroup)"
+          [hidden]="!((menuGroup.visible$ | async) && menuGroup.hasAuthroizedMenuItems)"
           class="menu-item-groups"
         >
           <div class="group">{{ menuGroup.name }}</div>
           <span *ngFor="let menuItem of menuGroup.items">
-            <span *ngIf="!menuItem.authorized && (menuItem.visible | async)">
+            <span *ngIf="!menuItem.authorized && (menuItem.visible$ | async)">
               <chef-sidebar-entry
                 [route]="menuItem.route"
                 [icon]="menuItem.icon"
                 [openInNewPage]="menuItem.openInNewPage"
               >{{ menuItem.name }}</chef-sidebar-entry>
             </span>
-            <span *ngIf="menuItem.authorized && (menuItem.visible | async)">
+            <span *ngIf="menuItem.authorized && (menuItem.visible$ | async)">
                 <app-authorized
                   [anyOf]="menuItem.authorized.anyOf"
                   [allOf]="menuItem.authorized.allOf"
-                  (isAuthorized)="isAuthorized($event, menuItem)"
+                  (isAuthorized)="isAuthorized($event, menuItem, menuGroup)"
                 >
                   <chef-sidebar-entry
                     [route]="menuItem.route"

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject } from '@angular/core';
-import { Observable, BehaviorSubject } from 'rxjs';
+import { Observable } from 'rxjs';
+import { find } from 'lodash';
 
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 import { MenuItemGroup } from 'app/entities/layout/layout.model';
@@ -18,9 +19,7 @@ export class SidebarComponent {
     this.menuGroups$ = layoutFacade.sidebar$;
   }
 
-  public isVisible(item: any) {
-    return item.subscribe
-      ? item
-      : new BehaviorSubject(item);
+  public isGroupVisible(menuGroup: MenuItemGroup) {
+    return menuGroup.visible && menuGroup.items && find(menuGroup.items, ['visible', true]);
   }
 }

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 import { find } from 'lodash';
 
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
-import { MenuItemGroup } from 'app/entities/layout/layout.model';
+import { MenuItemGroup, MenuItem } from 'app/entities/layout/layout.model';
 
 @Component({
   selector: 'chef-sidebar',
@@ -19,7 +19,7 @@ export class SidebarComponent {
     this.menuGroups$ = layoutFacade.sidebar$;
   }
 
-  public isGroupVisible(menuGroup: MenuItemGroup) {
+  public isGroupVisible(menuGroup: MenuItemGroup): MenuItem {
     return menuGroup.visible && menuGroup.items && find(menuGroup.items, ['visible', true]);
   }
 }

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
@@ -15,7 +15,7 @@ export class SidebarComponent {
   constructor(
     @Inject(LayoutFacadeService) public layoutFacade: LayoutFacadeService
   ) {
-    this.menuGroups$ = layoutFacade.menuGroups$;
+    this.menuGroups$ = layoutFacade.sidebar$;
   }
 
   public isVisible(item: any) {

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
@@ -1,9 +1,9 @@
 import { Component, Inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { find } from 'lodash';
+import { find } from 'lodash/fp';
 
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
-import { MenuItemGroup, MenuItem } from 'app/entities/layout/layout.model';
+import { MenuItemGroup } from 'app/entities/layout/layout.model';
 
 @Component({
   selector: 'chef-sidebar',
@@ -19,7 +19,14 @@ export class SidebarComponent {
     this.menuGroups$ = layoutFacade.sidebar$;
   }
 
-  public isGroupVisible(menuGroup: MenuItemGroup): MenuItem {
-    return menuGroup.visible && menuGroup.items && find(menuGroup.items, ['visible', true]);
+  public hasAuthroizedMenuItems(menuItemGroup: any): boolean {
+    const authorizedItem = find(menuItemGroup.items, (menuItem) => {
+      return menuItem.authorized && menuItem.authorized.isAuthorized;
+    });
+    return authorizedItem !== undefined;
+  }
+
+  public isAuthorized($event, menuItem) {
+    menuItem.authorized.isAuthorized = $event;
   }
 }

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
@@ -19,32 +19,32 @@ export class SidebarComponent {
     this.updateMenuGroupVisibility();
   }
 
-  public updateMenuGroupVisibility(): void {
+  public isAuthorized($event, menuItem, menuGroup) {
+    menuItem.authorized.isAuthorized = $event;
+    this.setGroupVisibility(menuGroup);
+  }
+
+  public hasMenuItemsNotRequiringAuthorization(menuItemGroup: any): boolean {
+    return menuItemGroup.items.some(menuItem =>
+      menuItem.authorized === undefined);
+  }
+
+  private updateMenuGroupVisibility(): void {
     this.menuGroups$.subscribe((menuGroups: MenuItemGroup[]) => {
       if (menuGroups) {
-        menuGroups.forEach(menuItemGroup => this.hasVisibleMenuItems(menuItemGroup));
+        menuGroups.forEach(menuItemGroup => this.setGroupVisibility(menuItemGroup));
       }
     });
   }
 
-  public hasVisibleMenuItems(menuItemGroup: any): void {
-    menuItemGroup.hasAuthorizedMenuItems =
-      this.hasAuthorizedMenuItems(menuItemGroup) ||
-      this.hasNoAuthorizedMenuItems(menuItemGroup);
+  private setGroupVisibility(menuItemGroup: MenuItemGroup): void {
+    menuItemGroup.hasVisibleMenuItems =
+      this.hasVisibleMenuItems(menuItemGroup) ||
+      this.hasMenuItemsNotRequiringAuthorization(menuItemGroup);
   }
 
-  public hasAuthorizedMenuItems(menuItemGroup: any): boolean {
-    return menuItemGroup.items.filter(menuItem =>
-        menuItem.authorized && menuItem.authorized.isAuthorized).length > 0;
-  }
-
-  public hasNoAuthorizedMenuItems(menuItemGroup: any): boolean {
-    return menuItemGroup.items.filter(menuItem =>
-        menuItem.authorized === undefined).length > 0;
-  }
-
-  public isAuthorized($event, menuItem, menuGroup) {
-    menuItem.authorized.isAuthorized = $event;
-    this.hasVisibleMenuItems(menuGroup);
+  private hasVisibleMenuItems(menuItemGroup: any): boolean {
+    return  menuItemGroup.items.some(menuItem =>
+          menuItem.authorized && menuItem.authorized.isAuthorized);
   }
 }

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
@@ -16,16 +16,35 @@ export class SidebarComponent {
     @Inject(LayoutFacadeService) public layoutFacade: LayoutFacadeService
   ) {
     this.menuGroups$ = layoutFacade.sidebar$;
+    this.updateMenuGroupVisibility();
   }
 
-  public hasAuthroizedMenuItems(menuItemGroup: any): void {
+  public updateMenuGroupVisibility(): void {
+    this.menuGroups$.subscribe((menuGroups: MenuItemGroup[]) => {
+      if (menuGroups) {
+        menuGroups.forEach(menuItemGroup => this.hasVisibleMenuItems(menuItemGroup));
+      }
+    });
+  }
+
+  public hasVisibleMenuItems(menuItemGroup: any): void {
     menuItemGroup.hasAuthroizedMenuItems =
-      menuItemGroup.items.filter(menuItem =>
+      this.hasAuthroizedMenuItems(menuItemGroup) ||
+      this.hasNoAuthroizedMenuItems(menuItemGroup);
+  }
+
+  public hasAuthroizedMenuItems(menuItemGroup: any): boolean {
+    return menuItemGroup.items.filter(menuItem =>
         menuItem.authorized && menuItem.authorized.isAuthorized).length > 0;
+  }
+
+  public hasNoAuthroizedMenuItems(menuItemGroup: any): boolean {
+    return menuItemGroup.items.filter(menuItem =>
+        menuItem.authorized === undefined).length > 0;
   }
 
   public isAuthorized($event, menuItem, menuGroup) {
     menuItem.authorized.isAuthorized = $event;
-    this.hasAuthroizedMenuItems(menuGroup);
+    this.hasVisibleMenuItems(menuGroup);
   }
 }

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
@@ -28,17 +28,17 @@ export class SidebarComponent {
   }
 
   public hasVisibleMenuItems(menuItemGroup: any): void {
-    menuItemGroup.hasAuthroizedMenuItems =
-      this.hasAuthroizedMenuItems(menuItemGroup) ||
-      this.hasNoAuthroizedMenuItems(menuItemGroup);
+    menuItemGroup.hasAuthorizedMenuItems =
+      this.hasAuthorizedMenuItems(menuItemGroup) ||
+      this.hasNoAuthorizedMenuItems(menuItemGroup);
   }
 
-  public hasAuthroizedMenuItems(menuItemGroup: any): boolean {
+  public hasAuthorizedMenuItems(menuItemGroup: any): boolean {
     return menuItemGroup.items.filter(menuItem =>
         menuItem.authorized && menuItem.authorized.isAuthorized).length > 0;
   }
 
-  public hasNoAuthroizedMenuItems(menuItemGroup: any): boolean {
+  public hasNoAuthorizedMenuItems(menuItemGroup: any): boolean {
     return menuItemGroup.items.filter(menuItem =>
         menuItem.authorized === undefined).length > 0;
   }

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
@@ -1,6 +1,5 @@
 import { Component, Inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { find } from 'lodash/fp';
 
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 import { MenuItemGroup } from 'app/entities/layout/layout.model';
@@ -19,14 +18,14 @@ export class SidebarComponent {
     this.menuGroups$ = layoutFacade.sidebar$;
   }
 
-  public hasAuthroizedMenuItems(menuItemGroup: any): boolean {
-    const authorizedItem = find(menuItemGroup.items, (menuItem) => {
-      return menuItem.authorized && menuItem.authorized.isAuthorized;
-    });
-    return authorizedItem !== undefined;
+  public hasAuthroizedMenuItems(menuItemGroup: any): void {
+    menuItemGroup.hasAuthroizedMenuItems =
+      menuItemGroup.items.filter(menuItem =>
+        menuItem.authorized && menuItem.authorized.isAuthorized).length > 0;
   }
 
-  public isAuthorized($event, menuItem) {
+  public isAuthorized($event, menuItem, menuGroup) {
     menuItem.authorized.isAuthorized = $event;
+    this.hasAuthroizedMenuItems(menuGroup);
   }
 }

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.ts
@@ -39,11 +39,11 @@ export class SidebarComponent {
 
   private setGroupVisibility(menuItemGroup: MenuItemGroup): void {
     menuItemGroup.hasVisibleMenuItems =
-      this.hasVisibleMenuItems(menuItemGroup) ||
+      this.hasAuthorizedMenuItems(menuItemGroup) ||
       this.hasMenuItemsNotRequiringAuthorization(menuItemGroup);
   }
 
-  private hasVisibleMenuItems(menuItemGroup: any): boolean {
+  private hasAuthorizedMenuItems(menuItemGroup: any): boolean {
     return  menuItemGroup.items.some(menuItem =>
           menuItem.authorized && menuItem.authorized.isAuthorized);
   }

--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { BehaviorSubject } from 'rxjs';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { isProductDeployed } from 'app/staticConfig';
@@ -8,24 +9,19 @@ import { isIAMv2 } from 'app/entities/policies/policy.selectors';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { clientRunsWorkflowEnabled } from 'app/entities/client-runs/client-runs.selectors';
 import * as fromClientRuns from 'app/entities/client-runs/client-runs.reducer';
-
-import { Sidebars } from './layout.model';
-
-import {
-    UpdateSidebars
-} from './layout.actions';
+import { UpdateSidebars } from './layout.actions';
 
 @Injectable({
     providedIn: 'root'
 })
 export class LayoutSidebarService implements OnInit, OnDestroy {
-    public sidebars = new BehaviorSubject<Sidebars>({});
     public applicationsFeatureFlagOn: boolean;
     public chefInfraServerViewsFeatureFlagOn: boolean;
     public isIAMv2: boolean;
-    public ServiceNowfeatureFlagOn: boolean;
+    public ServiceNowFeatureFlagOn: boolean;
     private activeSidebar: string;
     private workflowEnabled: boolean;
+    private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
     constructor(
         private store: Store<NgrxStateAtom>,
@@ -34,8 +30,10 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
     ) {
         this.chefInfraServerViewsFeatureFlagOn = this.featureFlagsService.getFeatureStatus('chefInfraServerViews');
         this.applicationsFeatureFlagOn = this.featureFlagsService.getFeatureStatus('applications');
-        this.ServiceNowfeatureFlagOn = this.featureFlagsService.getFeatureStatus('servicenow_cmdb');
-        this.store.select(isIAMv2).subscribe(
+        this.ServiceNowFeatureFlagOn = this.featureFlagsService.getFeatureStatus('servicenow_cmdb');
+        this.store.select(isIAMv2).pipe(
+          takeUntil(this.isDestroyed)
+        ).subscribe(
             (IAMv2) => {
                 this.isIAMv2 = IAMv2;
                 this.updateSidebars();
@@ -50,256 +48,256 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        this.updateSidebars();
+      this.updateSidebars();
     }
 
     ngOnDestroy() {
-        this.sidebars.next({});
-        this.sidebars.complete();
+      this.isDestroyed.next(true);
+      this.isDestroyed.complete();
     }
 
     public updateSidebars(sidebarName?: string): void {
-        this.activeSidebar = sidebarName || this.activeSidebar;
-        this.store.dispatch(new UpdateSidebars({
-            active: this.activeSidebar,
-            dashboards: [{
-                name: 'Dashboards',
-                items: [
-                  {
-                    name: 'Event Feed',
-                    icon: 'today',
-                    route: '/dashboards/event-feed',
-                    visible: true
-                  }
-                ],
-                visible: true
-            }],
-            applications: [{
-                name: 'Applications',
-                items: [
-                    {
-                        name: 'Service Groups',
-                        icon: 'group_work',
-                        route: '/applications/service-groups',
-                        visible: true
-                    },
-                    {
-                      name: 'Habitat Builder',
-                      icon: 'build',
-                      route: isProductDeployed('builder') ? '/bldr' : 'https://bldr.habitat.sh',
-                      visible: true,
-                      openInNewPage: true
-                  }
-                ],
-                visible: this.applicationsFeatureFlagOn
-            }],
-            infrastructure: [{
-                name: 'Infrastructure',
-                items: [
-                    {
-                        name: 'Client Runs',
-                        icon: 'storage',
-                        route: '/infrastructure/client-runs',
-                        visible: true
-                    },
-                    {
-                      name: 'Chef Servers',
-                      icon: 'storage',
-                      route: '/infrastructure/chef-servers',
-                      visible: this.chefInfraServerViewsFeatureFlagOn
-                    },
-                    {
-                        name: 'Workflow',
-                        icon: 'local_shipping',
-                        route: '/workflow',
-                        visible: this.workflowEnabled
-                    }
-                ],
-                visible: true
-            }],
-            compliance: [{
-                name: 'Compliance',
-                items: [
-                    {
-                        name: 'Reports',
-                        icon: 'equalizer',
-                        route: '/compliance/reports',
-                        authorized: {
-                            name: 'reports',
-                            allOf: [['/compliance/reporting/stats/summary', 'post'],
-                            ['/compliance/reporting/stats/failures', 'post'],
-                            ['/compliance/reporting/stats/trend', 'post']]
-                        },
-                        visible: true
-                    },
-                    {
-                        name: 'Scan Jobs',
-                        icon: 'wifi_tethering',
-                        route: '/compliance/scan-jobs',
-                        authorized: {
-                            name: 'reports',
-                            allOf: [['/compliance/scanner/jobs', 'post'],
-                            ['/compliance/scanner/jobs/search', 'post']]
-                        },
-                        visible: true
-                    },
-                    {
-                        name: 'Profiles',
-                        icon: 'library_books',
-                        route: '/compliance/compliance-profiles',
-                        authorized: {
-                            name: 'profiles',
-                            allOf: [['/compliance/profiles/search', 'post']]
-                        },
-                        visible: true
-                    }
-                ],
-                visible: true
-            }],
-            settings: [
-                {
-                    name: 'Node Management',
-                    items: [
-                        {
-                            name: 'Notifications',
-                            icon: 'notifications',
-                            route: '/settings/notifications',
-                            authorized: {
-                                name: 'notifications',
-                                anyOf: ['/notifications/rules', 'get']
-                            },
-                            visible: true
-                        },
-                        {
-                            name: 'Data Feeds',
-                            icon: 'assignment',
-                            route: '/settings/data-feed',
-                            authorized: {
-                                name: 'data_feed',
-                                anyOf: ['/datafeed/destinations', 'post']
-                            },
-                            visible: this.ServiceNowfeatureFlagOn
-                        },
-                        {
-                            name: 'Node Integrations',
-                            icon: 'settings_input_component',
-                            route: '/settings/node-integrations',
-                            authorized: {
-                                name: 'integrations',
-                                anyOf: ['/nodemanagers/search', 'post']
-                            },
-                            visible: true
-                        },
-                        {
-                            name: 'Node Credentials',
-                            icon: 'vpn_key',
-                            iconRotation: 90,
-                            route: '/settings/node-credentials',
-                            authorized: {
-                                name: 'credentials',
-                                anyOf: ['/secrets/search', 'post']
-                            },
-                            visible: true
-                        },
-                        {
-                            name: 'Node Lifecycle',
-                            icon: 'storage',
-                            route: '/settings/node-lifecycle',
-                            authorized: {
-                                name: 'lifecycle',
-                                anyOf: ['/retention/nodes/status', 'get']
-                            },
-                            visible: true
-                        }
-                    ],
-                    visible: true
+      this.activeSidebar = sidebarName || this.activeSidebar;
+      this.store.dispatch(new UpdateSidebars({
+        active: this.activeSidebar,
+        dashboards: [{
+          name: 'Dashboards',
+          items: [
+            {
+              name: 'Event Feed',
+              icon: 'today',
+              route: '/dashboards/event-feed',
+              visible: true
+            }
+          ],
+          visible: true
+        }],
+        applications: [{
+          name: 'Applications',
+          items: [
+            {
+              name: 'Service Groups',
+              icon: 'group_work',
+              route: '/applications/service-groups',
+              visible: true
+            },
+            {
+              name: 'Habitat Builder',
+              icon: 'build',
+              route: isProductDeployed('builder') ? '/bldr' : 'https://bldr.habitat.sh',
+              visible: true,
+              openInNewPage: true
+            }
+          ],
+          visible: this.applicationsFeatureFlagOn
+        }],
+        infrastructure: [{
+          name: 'Infrastructure',
+          items: [
+            {
+              name: 'Client Runs',
+              icon: 'storage',
+              route: '/infrastructure/client-runs',
+              visible: true
+            },
+            {
+              name: 'Chef Servers',
+              icon: 'storage',
+              route: '/infrastructure/chef-servers',
+              visible: this.chefInfraServerViewsFeatureFlagOn
+            },
+            {
+              name: 'Workflow',
+              icon: 'local_shipping',
+              route: '/workflow',
+              visible: this.workflowEnabled
+            }
+          ],
+          visible: true
+        }],
+        compliance: [{
+          name: 'Compliance',
+          items: [
+            {
+              name: 'Reports',
+              icon: 'equalizer',
+              route: '/compliance/reports',
+              authorized: {
+                name: 'reports',
+                allOf: [['/compliance/reporting/stats/summary', 'post'],
+                ['/compliance/reporting/stats/failures', 'post'],
+                ['/compliance/reporting/stats/trend', 'post']]
+              },
+              visible: true
+            },
+            {
+              name: 'Scan Jobs',
+              icon: 'wifi_tethering',
+              route: '/compliance/scan-jobs',
+              authorized: {
+                name: 'reports',
+                allOf: [['/compliance/scanner/jobs', 'post'],
+                ['/compliance/scanner/jobs/search', 'post']]
+              },
+              visible: true
+            },
+            {
+              name: 'Profiles',
+              icon: 'library_books',
+              route: '/compliance/compliance-profiles',
+              authorized: {
+                name: 'profiles',
+                allOf: [['/compliance/profiles/search', 'post']]
+              },
+              visible: true
+            }
+          ],
+          visible: true
+        }],
+        settings: [
+          {
+            name: 'Node Management',
+            items: [
+              {
+                name: 'Notifications',
+                icon: 'notifications',
+                route: '/settings/notifications',
+                authorized: {
+                  name: 'notifications',
+                  anyOf: ['/notifications/rules', 'get']
                 },
-                {
-                    name: 'Identity',
-                    items: [
-                        {
-                            name: 'Users',
-                            icon: 'person',
-                            route: '/settings/users',
-                            authorized: {
-                                name: 'users',
-                                allOf: ['/auth/users', 'get']
-                            },
-                            visible: true
-                        },
-                        {
-                            name: 'Teams',
-                            icon: 'people',
-                            route: '/settings/teams',
-                            authorized: {
-                                name: 'teams',
-                                allOf: ['/auth/teams', 'get']
-                            },
-                            visible: true
-                        },
-                        {
-                            name: 'API Tokens',
-                            icon: 'vpn_key',
-                            route: '/settings/tokens',
-                            authorized: {
-                                name: 'tokens',
-                                anyOf: [['/auth/tokens', 'get'],
-                                    ['/iam/v2/tokens', 'get']]
-                            },
-                            visible: true
-                        }
-                    ],
-                    visible: true
+                visible: true
+              },
+              {
+                name: 'Data Feeds',
+                icon: 'assignment',
+                route: '/settings/data-feed',
+                authorized: {
+                  name: 'data_feed',
+                  anyOf: ['/datafeed/destinations', 'post']
                 },
-                {
-                    name: 'Access Management',
-                    items: [
-                        {
-                            name: 'Policies',
-                            icon: 'security',
-                            route: '/settings/policies',
-                            authorized: {
-                                name: 'policies',
-                                allOf: ['/iam/v2/policies', 'get']
-                            },
-                            visible: true
-                        },
-                        {
-                            name: 'Roles',
-                            icon: 'assignment_ind',
-                            route: '/settings/roles',
-                            authorized: {
-                                name: 'roles',
-                                allOf: ['/iam/v2/roles', 'get']
-                            },
-                            visible: true
-                        },
-                        {
-                            name: 'Projects',
-                            icon: 'work',
-                            route: '/settings/projects',
-                            authorized: {
-                                name: 'projects',
-                                allOf: ['/iam/v2/projects', 'get']
-                            },
-                            visible: true
-                        }
-                    ],
-                    visible: this.isIAMv2
-                }
+                visible: this.ServiceNowFeatureFlagOn
+              },
+              {
+                name: 'Node Integrations',
+                icon: 'settings_input_component',
+                route: '/settings/node-integrations',
+                authorized: {
+                  name: 'integrations',
+                  anyOf: ['/nodemanagers/search', 'post']
+                },
+                visible: true
+              },
+              {
+                name: 'Node Credentials',
+                icon: 'vpn_key',
+                iconRotation: 90,
+                route: '/settings/node-credentials',
+                authorized: {
+                  name: 'credentials',
+                  anyOf: ['/secrets/search', 'post']
+                },
+                visible: true
+              },
+              {
+                name: 'Node Lifecycle',
+                icon: 'storage',
+                route: '/settings/node-lifecycle',
+                authorized: {
+                  name: 'lifecycle',
+                  anyOf: ['/retention/nodes/status', 'get']
+                },
+                visible: true
+              }
             ],
-            profile: [{
-                name: 'User Menu',
-                items: [
-                  {
-                    name: 'Profile',
-                    icon: 'person',
-                    route: '.',
-                    visible: true
-                  }
-                ],
+            visible: true
+          },
+          {
+            name: 'Identity',
+            items: [
+              {
+                name: 'Users',
+                icon: 'person',
+                route: '/settings/users',
+                authorized: {
+                  name: 'users',
+                  allOf: ['/auth/users', 'get']
+                },
                 visible: true
-            }]
-        }));
+              },
+              {
+                name: 'Teams',
+                icon: 'people',
+                route: '/settings/teams',
+                authorized: {
+                  name: 'teams',
+                  allOf: ['/auth/teams', 'get']
+                },
+                visible: true
+              },
+              {
+                name: 'API Tokens',
+                icon: 'vpn_key',
+                route: '/settings/tokens',
+                authorized: {
+                  name: 'tokens',
+                  anyOf: [['/auth/tokens', 'get'],
+                  ['/iam/v2/tokens', 'get']]
+                },
+                visible: true
+              }
+            ],
+            visible: true
+          },
+          {
+            name: 'Access Management',
+            items: [
+              {
+                name: 'Policies',
+                icon: 'security',
+                route: '/settings/policies',
+                authorized: {
+                  name: 'policies',
+                  allOf: ['/iam/v2/policies', 'get']
+                },
+                visible: true
+              },
+              {
+                name: 'Roles',
+                icon: 'assignment_ind',
+                route: '/settings/roles',
+                authorized: {
+                  name: 'roles',
+                  allOf: ['/iam/v2/roles', 'get']
+                },
+                visible: true
+              },
+              {
+                name: 'Projects',
+                icon: 'work',
+                route: '/settings/projects',
+                authorized: {
+                  name: 'projects',
+                  allOf: ['/iam/v2/projects', 'get']
+                },
+                visible: true
+              }
+            ],
+            visible: this.isIAMv2
+          }
+        ],
+        profile: [{
+          name: 'User Profile',
+          items: [
+            {
+              name: 'Profile',
+              icon: 'person',
+              route: '.',
+              visible: true
+            }
+          ],
+          visible: true
+        }]
+      }));
     }
 }

--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { Observable } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { isProductDeployed } from 'app/staticConfig';
@@ -9,286 +9,297 @@ import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.se
 import { clientRunsWorkflowEnabled } from 'app/entities/client-runs/client-runs.selectors';
 import * as fromClientRuns from 'app/entities/client-runs/client-runs.reducer';
 
-import { MenuItemGroup } from './layout.model';
+import { Sidebars } from './layout.model';
+
+import {
+    UpdateSidebars
+} from './layout.actions';
 
 @Injectable({
     providedIn: 'root'
 })
-export class LayoutSidebarService {
+export class LayoutSidebarService implements OnInit, OnDestroy {
+    public sidebars = new BehaviorSubject<Sidebars>({});
     public applicationsFeatureFlagOn: boolean;
     public chefInfraServerViewsFeatureFlagOn: boolean;
-    public isIAMv2$: Observable<boolean>;
+    public isIAMv2: boolean;
     public ServiceNowfeatureFlagOn: boolean;
+    private activeSidebar: string;
     private workflowEnabled: boolean;
-
 
     constructor(
         private store: Store<NgrxStateAtom>,
         private clientRunsStore: Store<fromClientRuns.ClientRunsEntityState>,
         private featureFlagsService: FeatureFlagsService
     ) {
-        this.isIAMv2$ = this.store.select(isIAMv2);
         this.chefInfraServerViewsFeatureFlagOn = this.featureFlagsService.getFeatureStatus('chefInfraServerViews');
         this.applicationsFeatureFlagOn = this.featureFlagsService.getFeatureStatus('applications');
         this.ServiceNowfeatureFlagOn = this.featureFlagsService.getFeatureStatus('servicenow_cmdb');
+        this.store.select(isIAMv2).subscribe(
+            (IAMv2) => {
+                this.isIAMv2 = IAMv2;
+                this.updateSidebars();
+            }
+        );
         this.clientRunsStore.select(clientRunsWorkflowEnabled).subscribe(
-            (workflowEnabled) => this.workflowEnabled = workflowEnabled
+            (workflowEnabled) => {
+                this.workflowEnabled = workflowEnabled;
+                this.updateSidebars();
+            }
         );
     }
 
-    public getDashboardsSidebar(): MenuItemGroup[] {
-        return [{
-            name: 'Dashboards',
-            items: [
-                {
+    ngOnInit() {
+        this.updateSidebars();
+    }
+
+    ngOnDestroy() {
+        this.sidebars.next({});
+        this.sidebars.complete();
+    }
+
+    public updateSidebars(sidebarName?: string): void {
+        this.activeSidebar = sidebarName || this.activeSidebar;
+        this.store.dispatch(new UpdateSidebars({
+            active: this.activeSidebar,
+            dashboards: [{
+                name: 'Dashboards',
+                items: [
+                  {
                     name: 'Event Feed',
                     icon: 'today',
                     route: '/dashboards/event-feed',
                     visible: true
-                }
-            ],
-            visible: true
-        }];
-    }
-
-    public getApplicationsSidebar(): MenuItemGroup[] {
-        return [{
-            name: 'Applications',
-            items: [
-                {
-                    name: 'Service Groups',
-                    icon: 'group_work',
-                    route: '/applications/service-groups',
-                    visible: true
-                },
-                {
-                    name: 'Habitat Builder',
-                    icon: 'build',
-                    route: isProductDeployed('builder') ? '/bldr' : 'https://bldr.habitat.sh',
-                    visible: true,
-                    openInNewPage: true
-                }
-            ],
-            visible: true
-        }];
-    }
-
-    public getInfrastructureSidebar(): MenuItemGroup[] {
-        return [{
-            name: 'Infrastructure',
-            items: [
-                {
-                    name: 'Client Runs',
-                    icon: 'storage',
-                    route: '/infrastructure/client-runs',
-                    visible: true
-                },
-                {
-                    name: 'Chef Servers',
-                    icon: 'storage',
-                    route: '/infrastructure/chef-servers',
-                    visible: this.chefInfraServerViewsFeatureFlagOn
-                },
-                {
-                    name: 'Workflow',
-                    icon: 'local_shipping',
-                    route: '/workflow',
-                    visible: this.workflowEnabled
-                }
-            ],
-            visible: true
-        }];
-    }
-
-    public getComplianceSidebar(): MenuItemGroup[] {
-        return [{
-            name: 'Compliance',
-            items: [
-                {
-                    name: 'Reports',
-                    icon: 'equalizer',
-                    route: '/compliance/reports',
-                    authorized: {
-                        name: 'reports',
-                        allOf: [['/compliance/reporting/stats/summary', 'post'],
-                        ['/compliance/reporting/stats/failures', 'post'],
-                        ['/compliance/reporting/stats/trend', 'post']]
-                    },
-                    visible: true
-                },
-                {
-                    name: 'Scan Jobs',
-                    icon: 'wifi_tethering',
-                    route: '/compliance/scan-jobs',
-                    authorized: {
-                        name: 'reports',
-                        allOf: [['/compliance/scanner/jobs', 'post'],
-                        ['/compliance/scanner/jobs/search', 'post']]
-                    },
-                    visible: true
-                },
-                {
-                    name: 'Profiles',
-                    icon: 'library_books',
-                    route: '/compliance/compliance-profiles',
-                    authorized: {
-                        name: 'profiles',
-                        allOf: [['/compliance/profiles/search', 'post']]
-                    },
-                    visible: true
-                }
-            ],
-            visible: true
-        }];
-    }
-
-    public getSettingsSidebar(): MenuItemGroup[] {
-        return [
-            {
-                name: 'Node Management',
+                  }
+                ],
+                visible: true
+            }],
+            applications: [{
+                name: 'Applications',
                 items: [
                     {
-                        name: 'Notifications',
-                        icon: 'notifications',
-                        route: '/settings/notifications',
-                        authorized: {
-                            name: 'notifications',
-                            anyOf: ['/notifications/rules', 'get']
-                        },
+                        name: 'Service Groups',
+                        icon: 'group_work',
+                        route: '/applications/service-groups',
                         visible: true
                     },
                     {
-                        name: 'Data Feeds',
-                        icon: 'assignment',
-                        route: '/settings/data-feed',
-                        authorized: {
-                            name: 'data_feed',
-                            anyOf: ['/datafeed/destinations', 'post']
-                        },
-                        visible: this.ServiceNowfeatureFlagOn
-                    },
+                      name: 'Habitat Builder',
+                      icon: 'build',
+                      route: isProductDeployed('builder') ? '/bldr' : 'https://bldr.habitat.sh',
+                      visible: true,
+                      openInNewPage: true
+                  }
+                ],
+                visible: this.applicationsFeatureFlagOn
+            }],
+            infrastructure: [{
+                name: 'Infrastructure',
+                items: [
                     {
-                        name: 'Node Integrations',
-                        icon: 'settings_input_component',
-                        route: '/settings/node-integrations',
-                        authorized: {
-                            name: 'integrations',
-                            anyOf: ['/nodemanagers/search', 'post']
-                        },
-                        visible: true
-                    },
-                    {
-                        name: 'Node Credentials',
-                        icon: 'vpn_key',
-                        iconRotation: 90,
-                        route: '/settings/node-credentials',
-                        authorized: {
-                            name: 'credentials',
-                            anyOf: ['/secrets/search', 'post']
-                        },
-                        visible: true
-                    },
-                    {
-                        name: 'Node Lifecycle',
+                        name: 'Client Runs',
                         icon: 'storage',
-                        route: '/settings/node-lifecycle',
+                        route: '/infrastructure/client-runs',
+                        visible: true
+                    },
+                    {
+                      name: 'Chef Servers',
+                      icon: 'storage',
+                      route: '/infrastructure/chef-servers',
+                      visible: this.chefInfraServerViewsFeatureFlagOn
+                    },
+                    {
+                        name: 'Workflow',
+                        icon: 'local_shipping',
+                        route: '/workflow',
+                        visible: this.workflowEnabled
+                    }
+                ],
+                visible: true
+            }],
+            compliance: [{
+                name: 'Compliance',
+                items: [
+                    {
+                        name: 'Reports',
+                        icon: 'equalizer',
+                        route: '/compliance/reports',
                         authorized: {
-                            name: 'lifecycle',
-                            anyOf: ['/retention/nodes/status', 'get']
+                            name: 'reports',
+                            allOf: [['/compliance/reporting/stats/summary', 'post'],
+                            ['/compliance/reporting/stats/failures', 'post'],
+                            ['/compliance/reporting/stats/trend', 'post']]
+                        },
+                        visible: true
+                    },
+                    {
+                        name: 'Scan Jobs',
+                        icon: 'wifi_tethering',
+                        route: '/compliance/scan-jobs',
+                        authorized: {
+                            name: 'reports',
+                            allOf: [['/compliance/scanner/jobs', 'post'],
+                            ['/compliance/scanner/jobs/search', 'post']]
+                        },
+                        visible: true
+                    },
+                    {
+                        name: 'Profiles',
+                        icon: 'library_books',
+                        route: '/compliance/compliance-profiles',
+                        authorized: {
+                            name: 'profiles',
+                            allOf: [['/compliance/profiles/search', 'post']]
                         },
                         visible: true
                     }
                 ],
                 visible: true
-            },
-            {
-                name: 'Identity',
-                items: [
-                    {
-                        name: 'Users',
-                        icon: 'person',
-                        route: '/settings/users',
-                        authorized: {
-                            name: 'users',
-                            allOf: ['/auth/users', 'get']
-                        },
-                        visible: true
-                    },
-                    {
-                        name: 'Teams',
-                        icon: 'people',
-                        route: '/settings/teams',
-                        authorized: {
-                            name: 'teams',
-                            allOf: ['/auth/teams', 'get']
-                        },
-                        visible: true
-                    },
-                    {
-                        name: 'API Tokens',
-                        icon: 'vpn_key',
-                        route: '/settings/tokens',
-                        authorized: {
-                            name: 'tokens',
-                            anyOf: [['/auth/tokens', 'get'],
-                            ['/iam/v2/tokens', 'get']]
-                        },
-                        visible: true
-                    }
-                ],
-                visible: true
-            },
-            {
-                name: 'Access Management',
-                items: [
-                    {
-                        name: 'Policies',
-                        icon: 'security',
-                        route: '/settings/policies',
-                        authorized: {
-                            name: 'policies',
-                            allOf: ['/iam/v2/policies', 'get']
-                        },
-                        visible: true
-                    },
-                    {
-                        name: 'Roles',
-                        icon: 'assignment_ind',
-                        route: '/settings/roles',
-                        authorized: {
-                            name: 'roles',
-                            allOf: ['/iam/v2/roles', 'get']
-                        },
-                        visible: true
-                    },
-                    {
-                        name: 'Projects',
-                        icon: 'work',
-                        route: '/settings/projects',
-                        authorized: {
-                            name: 'projects',
-                            allOf: ['/iam/v2/projects', 'get']
-                        },
-                        visible: true
-                    }
-                ],
-                visible: this.isIAMv2$
-            }
-        ];
-    }
-
-    public getUserProfileSidebar(): MenuItemGroup[] {
-        return [{
-            name: 'User Menu',
-            items: [
+            }],
+            settings: [
                 {
+                    name: 'Node Management',
+                    items: [
+                        {
+                            name: 'Notifications',
+                            icon: 'notifications',
+                            route: '/settings/notifications',
+                            authorized: {
+                                name: 'notifications',
+                                anyOf: ['/notifications/rules', 'get']
+                            },
+                            visible: true
+                        },
+                        {
+                            name: 'Data Feeds',
+                            icon: 'assignment',
+                            route: '/settings/data-feed',
+                            authorized: {
+                                name: 'data_feed',
+                                anyOf: ['/datafeed/destinations', 'post']
+                            },
+                            visible: this.ServiceNowfeatureFlagOn
+                        },
+                        {
+                            name: 'Node Integrations',
+                            icon: 'settings_input_component',
+                            route: '/settings/node-integrations',
+                            authorized: {
+                                name: 'integrations',
+                                anyOf: ['/nodemanagers/search', 'post']
+                            },
+                            visible: true
+                        },
+                        {
+                            name: 'Node Credentials',
+                            icon: 'vpn_key',
+                            iconRotation: 90,
+                            route: '/settings/node-credentials',
+                            authorized: {
+                                name: 'credentials',
+                                anyOf: ['/secrets/search', 'post']
+                            },
+                            visible: true
+                        },
+                        {
+                            name: 'Node Lifecycle',
+                            icon: 'storage',
+                            route: '/settings/node-lifecycle',
+                            authorized: {
+                                name: 'lifecycle',
+                                anyOf: ['/retention/nodes/status', 'get']
+                            },
+                            visible: true
+                        }
+                    ],
+                    visible: true
+                },
+                {
+                    name: 'Identity',
+                    items: [
+                        {
+                            name: 'Users',
+                            icon: 'person',
+                            route: '/settings/users',
+                            authorized: {
+                                name: 'users',
+                                allOf: ['/auth/users', 'get']
+                            },
+                            visible: true
+                        },
+                        {
+                            name: 'Teams',
+                            icon: 'people',
+                            route: '/settings/teams',
+                            authorized: {
+                                name: 'teams',
+                                allOf: ['/auth/teams', 'get']
+                            },
+                            visible: true
+                        },
+                        {
+                            name: 'API Tokens',
+                            icon: 'vpn_key',
+                            route: '/settings/tokens',
+                            authorized: {
+                                name: 'tokens',
+                                anyOf: [['/auth/tokens', 'get'],
+                                    ['/iam/v2/tokens', 'get']]
+                            },
+                            visible: true
+                        }
+                    ],
+                    visible: true
+                },
+                {
+                    name: 'Access Management',
+                    items: [
+                        {
+                            name: 'Policies',
+                            icon: 'security',
+                            route: '/settings/policies',
+                            authorized: {
+                                name: 'policies',
+                                allOf: ['/iam/v2/policies', 'get']
+                            },
+                            visible: true
+                        },
+                        {
+                            name: 'Roles',
+                            icon: 'assignment_ind',
+                            route: '/settings/roles',
+                            authorized: {
+                                name: 'roles',
+                                allOf: ['/iam/v2/roles', 'get']
+                            },
+                            visible: true
+                        },
+                        {
+                            name: 'Projects',
+                            icon: 'work',
+                            route: '/settings/projects',
+                            authorized: {
+                                name: 'projects',
+                                allOf: ['/iam/v2/projects', 'get']
+                            },
+                            visible: true
+                        }
+                    ],
+                    visible: this.isIAMv2
+                }
+            ],
+            profile: [{
+                name: 'User Menu',
+                items: [
+                  {
                     name: 'Profile',
                     icon: 'person',
                     route: '.',
                     visible: true
-                }
-            ],
-            visible: true
-        }];
+                  }
+                ],
+                visible: true
+            }]
+        }));
     }
 }

--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -21,14 +21,254 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
     public ServiceNowFeatureFlagOn: boolean;
     private activeSidebar: string;
     private workflowEnabled: boolean;
-    private isDestroyed: Subject<boolean> = new Subject<boolean>();
+    private isDestroyed = new Subject<boolean>();
+    private sidebar = {
+      active: '',
+      dashboards: [{
+        name: 'Dashboards',
+        items: [
+          {
+            name: 'Event Feed',
+            icon: 'today',
+            route: '/dashboards/event-feed',
+            visible: true
+          }
+        ],
+        visible: true
+      }],
+      applications: [{
+        name: 'Applications',
+        items: [
+          {
+            name: 'Service Groups',
+            icon: 'group_work',
+            route: '/applications/service-groups',
+            visible: true
+          },
+          {
+            name: 'Habitat Builder',
+            icon: 'build',
+            route: isProductDeployed('builder') ? '/bldr' : 'https://bldr.habitat.sh',
+            visible: true,
+            openInNewPage: true
+          }
+        ],
+        visible: this.applicationsFeatureFlagOn
+      }],
+      infrastructure: [{
+        name: 'Infrastructure',
+        items: [
+          {
+            name: 'Client Runs',
+            icon: 'storage',
+            route: '/infrastructure/client-runs',
+            visible: true
+          },
+          {
+            name: 'Chef Servers',
+            icon: 'storage',
+            route: '/infrastructure/chef-servers',
+            visible: this.chefInfraServerViewsFeatureFlagOn
+          },
+          {
+            name: 'Workflow',
+            icon: 'local_shipping',
+            route: '/workflow',
+            visible: this.workflowEnabled
+          }
+        ],
+        visible: true
+      }],
+      compliance: [{
+        name: 'Compliance',
+        items: [
+          {
+            name: 'Reports',
+            icon: 'equalizer',
+            route: '/compliance/reports',
+            authorized: {
+              name: 'reports',
+              allOf: [['/compliance/reporting/stats/summary', 'post'],
+              ['/compliance/reporting/stats/failures', 'post'],
+              ['/compliance/reporting/stats/trend', 'post']]
+            },
+            visible: true
+          },
+          {
+            name: 'Scan Jobs',
+            icon: 'wifi_tethering',
+            route: '/compliance/scan-jobs',
+            authorized: {
+              name: 'reports',
+              allOf: [['/compliance/scanner/jobs', 'post'],
+              ['/compliance/scanner/jobs/search', 'post']]
+            },
+            visible: true
+          },
+          {
+            name: 'Profiles',
+            icon: 'library_books',
+            route: '/compliance/compliance-profiles',
+            authorized: {
+              name: 'profiles',
+              allOf: [['/compliance/profiles/search', 'post']]
+            },
+            visible: true
+          }
+        ],
+        visible: true
+      }],
+      settings: [
+        {
+          name: 'Node Management',
+          items: [
+            {
+              name: 'Notifications',
+              icon: 'notifications',
+              route: '/settings/notifications',
+              authorized: {
+                name: 'notifications',
+                anyOf: ['/notifications/rules', 'get']
+              },
+              visible: true
+            },
+            {
+              name: 'Data Feeds',
+              icon: 'assignment',
+              route: '/settings/data-feed',
+              authorized: {
+                name: 'data_feed',
+                anyOf: ['/datafeed/destinations', 'post']
+              },
+              visible: this.ServiceNowFeatureFlagOn
+            },
+            {
+              name: 'Node Integrations',
+              icon: 'settings_input_component',
+              route: '/settings/node-integrations',
+              authorized: {
+                name: 'integrations',
+                anyOf: ['/nodemanagers/search', 'post']
+              },
+              visible: true
+            },
+            {
+              name: 'Node Credentials',
+              icon: 'vpn_key',
+              iconRotation: 90,
+              route: '/settings/node-credentials',
+              authorized: {
+                name: 'credentials',
+                anyOf: ['/secrets/search', 'post']
+              },
+              visible: true
+            },
+            {
+              name: 'Node Lifecycle',
+              icon: 'storage',
+              route: '/settings/node-lifecycle',
+              authorized: {
+                name: 'lifecycle',
+                anyOf: ['/retention/nodes/status', 'get']
+              },
+              visible: true
+            }
+          ],
+          visible: true
+        },
+        {
+          name: 'Identity',
+          items: [
+            {
+              name: 'Users',
+              icon: 'person',
+              route: '/settings/users',
+              authorized: {
+                name: 'users',
+                allOf: ['/auth/users', 'get']
+              },
+              visible: true
+            },
+            {
+              name: 'Teams',
+              icon: 'people',
+              route: '/settings/teams',
+              authorized: {
+                name: 'teams',
+                allOf: ['/auth/teams', 'get']
+              },
+              visible: true
+            },
+            {
+              name: 'API Tokens',
+              icon: 'vpn_key',
+              route: '/settings/tokens',
+              authorized: {
+                name: 'tokens',
+                anyOf: [['/auth/tokens', 'get'],
+                ['/iam/v2/tokens', 'get']]
+              },
+              visible: true
+            }
+          ],
+          visible: true
+        },
+        {
+          name: 'Access Management',
+          items: [
+            {
+              name: 'Policies',
+              icon: 'security',
+              route: '/settings/policies',
+              authorized: {
+                name: 'policies',
+                allOf: ['/iam/v2/policies', 'get']
+              },
+              visible: true
+            },
+            {
+              name: 'Roles',
+              icon: 'assignment_ind',
+              route: '/settings/roles',
+              authorized: {
+                name: 'roles',
+                allOf: ['/iam/v2/roles', 'get']
+              },
+              visible: true
+            },
+            {
+              name: 'Projects',
+              icon: 'work',
+              route: '/settings/projects',
+              authorized: {
+                name: 'projects',
+                allOf: ['/iam/v2/projects', 'get']
+              },
+              visible: true
+            }
+          ],
+          visible: this.isIAMv2
+        }
+      ],
+      profile: [{
+        name: 'User Menu',
+        items: [
+          {
+            name: 'Profile',
+            icon: 'person',
+            route: '.',
+            visible: true
+          }
+        ],
+        visible: true
+      }]
+    };
 
     constructor(
         private store: Store<NgrxStateAtom>,
         private clientRunsStore: Store<fromClientRuns.ClientRunsEntityState>,
         private featureFlagsService: FeatureFlagsService
     ) {
-        this.chefInfraServerViewsFeatureFlagOn = this.featureFlagsService.getFeatureStatus('chefInfraServerViews');
         this.applicationsFeatureFlagOn = this.featureFlagsService.getFeatureStatus('applications');
         this.ServiceNowFeatureFlagOn = this.featureFlagsService.getFeatureStatus('servicenow_cmdb');
         this.store.select(isIAMv2).pipe(
@@ -39,7 +279,9 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
                 this.updateSidebars();
             }
         );
-        this.clientRunsStore.select(clientRunsWorkflowEnabled).subscribe(
+        this.clientRunsStore.select(clientRunsWorkflowEnabled).pipe(
+          takeUntil(this.isDestroyed)
+        ).subscribe(
             (workflowEnabled) => {
                 this.workflowEnabled = workflowEnabled;
                 this.updateSidebars();
@@ -56,248 +298,13 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
       this.isDestroyed.complete();
     }
 
+    // For sidebars, we are constraining <app-authorized> attributes:
+    // 1. You can use `anyOf` or `allOf` but not both.
+    // 2. You cannot use `not`.
+
     public updateSidebars(sidebarName?: string): void {
       this.activeSidebar = sidebarName || this.activeSidebar;
-      this.store.dispatch(new UpdateSidebars({
-        active: this.activeSidebar,
-        dashboards: [{
-          name: 'Dashboards',
-          items: [
-            {
-              name: 'Event Feed',
-              icon: 'today',
-              route: '/dashboards/event-feed',
-              visible: true
-            }
-          ],
-          visible: true
-        }],
-        applications: [{
-          name: 'Applications',
-          items: [
-            {
-              name: 'Service Groups',
-              icon: 'group_work',
-              route: '/applications/service-groups',
-              visible: true
-            },
-            {
-              name: 'Habitat Builder',
-              icon: 'build',
-              route: isProductDeployed('builder') ? '/bldr' : 'https://bldr.habitat.sh',
-              visible: true,
-              openInNewPage: true
-            }
-          ],
-          visible: this.applicationsFeatureFlagOn
-        }],
-        infrastructure: [{
-          name: 'Infrastructure',
-          items: [
-            {
-              name: 'Client Runs',
-              icon: 'storage',
-              route: '/infrastructure/client-runs',
-              visible: true
-            },
-            {
-              name: 'Chef Servers',
-              icon: 'storage',
-              route: '/infrastructure/chef-servers',
-              visible: this.chefInfraServerViewsFeatureFlagOn
-            },
-            {
-              name: 'Workflow',
-              icon: 'local_shipping',
-              route: '/workflow',
-              visible: this.workflowEnabled
-            }
-          ],
-          visible: true
-        }],
-        compliance: [{
-          name: 'Compliance',
-          items: [
-            {
-              name: 'Reports',
-              icon: 'equalizer',
-              route: '/compliance/reports',
-              authorized: {
-                name: 'reports',
-                allOf: [['/compliance/reporting/stats/summary', 'post'],
-                ['/compliance/reporting/stats/failures', 'post'],
-                ['/compliance/reporting/stats/trend', 'post']]
-              },
-              visible: true
-            },
-            {
-              name: 'Scan Jobs',
-              icon: 'wifi_tethering',
-              route: '/compliance/scan-jobs',
-              authorized: {
-                name: 'reports',
-                allOf: [['/compliance/scanner/jobs', 'post'],
-                ['/compliance/scanner/jobs/search', 'post']]
-              },
-              visible: true
-            },
-            {
-              name: 'Profiles',
-              icon: 'library_books',
-              route: '/compliance/compliance-profiles',
-              authorized: {
-                name: 'profiles',
-                allOf: [['/compliance/profiles/search', 'post']]
-              },
-              visible: true
-            }
-          ],
-          visible: true
-        }],
-        settings: [
-          {
-            name: 'Node Management',
-            items: [
-              {
-                name: 'Notifications',
-                icon: 'notifications',
-                route: '/settings/notifications',
-                authorized: {
-                  name: 'notifications',
-                  anyOf: ['/notifications/rules', 'get']
-                },
-                visible: true
-              },
-              {
-                name: 'Data Feeds',
-                icon: 'assignment',
-                route: '/settings/data-feed',
-                authorized: {
-                  name: 'data_feed',
-                  anyOf: ['/datafeed/destinations', 'post']
-                },
-                visible: this.ServiceNowFeatureFlagOn
-              },
-              {
-                name: 'Node Integrations',
-                icon: 'settings_input_component',
-                route: '/settings/node-integrations',
-                authorized: {
-                  name: 'integrations',
-                  anyOf: ['/nodemanagers/search', 'post']
-                },
-                visible: true
-              },
-              {
-                name: 'Node Credentials',
-                icon: 'vpn_key',
-                iconRotation: 90,
-                route: '/settings/node-credentials',
-                authorized: {
-                  name: 'credentials',
-                  anyOf: ['/secrets/search', 'post']
-                },
-                visible: true
-              },
-              {
-                name: 'Node Lifecycle',
-                icon: 'storage',
-                route: '/settings/node-lifecycle',
-                authorized: {
-                  name: 'lifecycle',
-                  anyOf: ['/retention/nodes/status', 'get']
-                },
-                visible: true
-              }
-            ],
-            visible: true
-          },
-          {
-            name: 'Identity',
-            items: [
-              {
-                name: 'Users',
-                icon: 'person',
-                route: '/settings/users',
-                authorized: {
-                  name: 'users',
-                  allOf: ['/auth/users', 'get']
-                },
-                visible: true
-              },
-              {
-                name: 'Teams',
-                icon: 'people',
-                route: '/settings/teams',
-                authorized: {
-                  name: 'teams',
-                  allOf: ['/auth/teams', 'get']
-                },
-                visible: true
-              },
-              {
-                name: 'API Tokens',
-                icon: 'vpn_key',
-                route: '/settings/tokens',
-                authorized: {
-                  name: 'tokens',
-                  anyOf: [['/auth/tokens', 'get'],
-                  ['/iam/v2/tokens', 'get']]
-                },
-                visible: true
-              }
-            ],
-            visible: true
-          },
-          {
-            name: 'Access Management',
-            items: [
-              {
-                name: 'Policies',
-                icon: 'security',
-                route: '/settings/policies',
-                authorized: {
-                  name: 'policies',
-                  allOf: ['/iam/v2/policies', 'get']
-                },
-                visible: true
-              },
-              {
-                name: 'Roles',
-                icon: 'assignment_ind',
-                route: '/settings/roles',
-                authorized: {
-                  name: 'roles',
-                  allOf: ['/iam/v2/roles', 'get']
-                },
-                visible: true
-              },
-              {
-                name: 'Projects',
-                icon: 'work',
-                route: '/settings/projects',
-                authorized: {
-                  name: 'projects',
-                  allOf: ['/iam/v2/projects', 'get']
-                },
-                visible: true
-              }
-            ],
-            visible: this.isIAMv2
-          }
-        ],
-        profile: [{
-          name: 'User Profile',
-          items: [
-            {
-              name: 'Profile',
-              icon: 'person',
-              route: '.',
-              visible: true
-            }
-          ],
-          visible: true
-        }]
-      }));
+      this.sidebar.active = this.activeSidebar;
+      this.store.dispatch(new UpdateSidebars(this.sidebar));
     }
 }

--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -37,7 +37,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
     }
 
     populateSidebar() {
-      const sidebars = {
+      const sidebars: Sidebars = {
         active: '',
         dashboards: [{
           name: 'Dashboards',
@@ -64,7 +64,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
               openInNewPage: true
             }
           ],
-          visible$: this.applicationsFeatureFlagOn
+          visible$: new BehaviorSubject(this.applicationsFeatureFlagOn)
         }],
         infrastructure: [{
           name: 'Infrastructure',
@@ -78,7 +78,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
               name: 'Chef Servers',
               icon: 'storage',
               route: '/infrastructure/chef-servers',
-              visible$: this.chefInfraServerViewsFeatureFlagOn
+              visible$: new BehaviorSubject(this.chefInfraServerViewsFeatureFlagOn)
             },
             {
               name: 'Workflow',
@@ -139,7 +139,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
                 authorized: {
                   anyOf: ['/datafeed/destinations', 'post']
                 },
-                visible$: this.ServiceNowFeatureFlagOn
+                visible$: new BehaviorSubject(this.ServiceNowFeatureFlagOn)
               },
               {
                 name: 'Node Integrations',
@@ -252,7 +252,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
       this.isDestroyed.complete();
     }
 
-    private updateVisibleValues(sidebars: any): Sidebars {
+    private updateVisibleValues(sidebars: Sidebars): Sidebars {
       forEach(sidebars, (_value, key) => {
         const menuGroups = sidebars[key];
         forEach(menuGroups, (menuGroup) => {

--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -2,7 +2,6 @@ import { Injectable, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Subject, Observable, BehaviorSubject } from 'rxjs';
 import { forEach } from 'lodash';
-// import { takeUntil } from 'rxjs/operators';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { isProductDeployed } from 'app/staticConfig';
@@ -24,7 +23,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
     private activeSidebar: string;
     private workflowEnabled$: Observable<boolean>;
     private isDestroyed = new Subject<boolean>();
-    private sidebar: Sidebars;
+    private sidebars: Sidebars;
 
     constructor(
         private store: Store<NgrxStateAtom>,
@@ -35,26 +34,10 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
         this.ServiceNowFeatureFlagOn = this.featureFlagsService.getFeatureStatus('servicenow_cmdb');
         this.isIAMv2$ = this.store.select(isIAMv2);
         this.workflowEnabled$ = this.clientRunsStore.select(clientRunsWorkflowEnabled);
-        // this.store.select(isIAMv2).pipe(
-        //   takeUntil(this.isDestroyed)
-        // ).subscribe(
-        //     (IAMv2) => {
-        //         this.isIAMv2 = IAMv2;
-        //         this.updateSidebars();
-        //     }
-        // );
-        // this.clientRunsStore.select(clientRunsWorkflowEnabled).pipe(
-        //   takeUntil(this.isDestroyed)
-        // ).subscribe(
-        //     (workflowEnabled) => {
-        //         this.workflowEnabled$ = workflowEnabled;
-        //         this.updateSidebars();
-        //     }
-        // );
     }
 
     populateSidebar() {
-      const sidebar = {
+      const sidebars = {
         active: '',
         dashboards: [{
           name: 'Dashboards',
@@ -257,7 +240,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
           ]
         }]
       };
-      this.sidebar = this.updateVisibleValues(sidebar);
+      this.sidebars = this.updateVisibleValues(sidebars);
     }
 
     ngOnInit() {
@@ -269,9 +252,9 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
       this.isDestroyed.complete();
     }
 
-    private updateVisibleValues(sidebar): Sidebars {
-      forEach(sidebar, (_value, key) => {
-        const menuGroups = sidebar[key];
+    private updateVisibleValues(sidebars: any): Sidebars {
+      forEach(sidebars, (_value, key) => {
+        const menuGroups = sidebars[key];
         forEach(menuGroups, (menuGroup) => {
           if (menuGroup && menuGroup.name) {
             this.setVisibleValuesToObservables(menuGroup);
@@ -284,7 +267,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
           }
         });
       });
-      return sidebar;
+      return sidebars;
     }
 
     private setVisibleValuesToObservables(item: any): void {
@@ -315,7 +298,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
     public updateSidebars(sidebarName?: string): void {
       this.populateSidebar();
       this.activeSidebar = sidebarName || this.activeSidebar;
-      this.sidebar.active = this.activeSidebar;
-      this.store.dispatch(new UpdateSidebars(this.sidebar));
+      this.sidebars.active = this.activeSidebar;
+      this.store.dispatch(new UpdateSidebars(this.sidebars));
     }
 }

--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -19,10 +19,10 @@ import { Sidebars } from './layout.model';
 export class LayoutSidebarService implements OnInit, OnDestroy {
     public applicationsFeatureFlagOn: boolean;
     public chefInfraServerViewsFeatureFlagOn: boolean;
-    public isIAMv2: Observable<boolean>;
+    public isIAMv2$: Observable<boolean>;
     public ServiceNowFeatureFlagOn: boolean;
     private activeSidebar: string;
-    private workflowEnabled: Observable<boolean>;
+    private workflowEnabled$: Observable<boolean>;
     private isDestroyed = new Subject<boolean>();
     private sidebar: Sidebars;
 
@@ -33,8 +33,8 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
     ) {
         this.applicationsFeatureFlagOn = this.featureFlagsService.getFeatureStatus('applications');
         this.ServiceNowFeatureFlagOn = this.featureFlagsService.getFeatureStatus('servicenow_cmdb');
-        this.isIAMv2 = this.store.select(isIAMv2);
-        this.workflowEnabled = this.clientRunsStore.select(clientRunsWorkflowEnabled);
+        this.isIAMv2$ = this.store.select(isIAMv2);
+        this.workflowEnabled$ = this.clientRunsStore.select(clientRunsWorkflowEnabled);
         // this.store.select(isIAMv2).pipe(
         //   takeUntil(this.isDestroyed)
         // ).subscribe(
@@ -47,7 +47,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
         //   takeUntil(this.isDestroyed)
         // ).subscribe(
         //     (workflowEnabled) => {
-        //         this.workflowEnabled = workflowEnabled;
+        //         this.workflowEnabled$ = workflowEnabled;
         //         this.updateSidebars();
         //     }
         // );
@@ -81,7 +81,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
               openInNewPage: true
             }
           ],
-          visible: this.applicationsFeatureFlagOn
+          visible$: this.applicationsFeatureFlagOn
         }],
         infrastructure: [{
           name: 'Infrastructure',
@@ -95,13 +95,13 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
               name: 'Chef Servers',
               icon: 'storage',
               route: '/infrastructure/chef-servers',
-              visible: this.chefInfraServerViewsFeatureFlagOn
+              visible$: this.chefInfraServerViewsFeatureFlagOn
             },
             {
               name: 'Workflow',
               icon: 'local_shipping',
               route: '/workflow',
-              visible: this.workflowEnabled
+              visible$: this.workflowEnabled$
             }
           ]
         }],
@@ -156,7 +156,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
                 authorized: {
                   anyOf: ['/datafeed/destinations', 'post']
                 },
-                visible: this.ServiceNowFeatureFlagOn
+                visible$: this.ServiceNowFeatureFlagOn
               },
               {
                 name: 'Node Integrations',
@@ -243,7 +243,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
                 }
               }
             ],
-            visible: this.isIAMv2
+            visible$: this.isIAMv2$
           }
         ],
         profile: [{
@@ -280,7 +280,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
                 this.setVisibleValuesToObservables(menuItem);
               });
             }
-            menuGroup.visible = this.setMenuGroupVisibility(menuGroup);
+            menuGroup.visible$ = this.setMenuGroupVisibility(menuGroup);
           }
         });
       });
@@ -288,20 +288,20 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
     }
 
     private setVisibleValuesToObservables(item: any): void {
-      if (item.visible === undefined) {
-        item.visible = new BehaviorSubject(true);
-      } else if (!item.visible.subscribe) {
-        item.visible = new BehaviorSubject(item.visible);
+      if (item.visible$ === undefined) {
+        item.visible$ = new BehaviorSubject(true);
+      } else if (!item.visible$.subscribe) {
+        item.visible$ = new BehaviorSubject(item.visible$);
       }
     }
 
     private setMenuGroupVisibility(menuGroup: any): any {
       let anyMenuItemsVisible = false;
       forEach(menuGroup.items, (menuItem) => {
-        if (menuItem.visible === undefined) {
+        if (menuItem.visible$ === undefined) {
           anyMenuItemsVisible = true;
-        } else if (menuItem.visible.subscribe) {
-          menuItem.visible.subscribe((value) => {
+        } else if (menuItem.visible$.subscribe) {
+          menuItem.visible$.subscribe((value) => {
             anyMenuItemsVisible = value ? true : anyMenuItemsVisible;
           });
         }

--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Subject, Observable, BehaviorSubject } from 'rxjs';
-import { forEach } from 'lodash';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { isProductDeployed } from 'app/staticConfig';

--- a/components/automate-ui/src/app/entities/layout/layout.actions.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.actions.ts
@@ -1,9 +1,10 @@
 import { Action } from '@ngrx/store';
-import { MenuItemGroup } from './layout.model';
+import { Sidebars } from './layout.model';
 
 export enum LayoutActionTypes {
   SHOW_PAGE_LOADING = 'Layout::SHOW_PAGE_LOADING',
-  UPDATE_SIDEBAR_MENU_GROUPS = 'LAYOUT::UPDATE'
+  GET_SIDEBAR = 'LAYOUT::GET_SIDEBAR',
+  UPDATE_SIDEBARS = 'LAYOUT::UPDATE_SIDEBARS'
 }
 
 export class ShowPageLoading implements Action {
@@ -11,12 +12,18 @@ export class ShowPageLoading implements Action {
   constructor(public payload: boolean) {}
 }
 
-export class UpdateSidebarMenuGroups implements Action {
-  readonly type = LayoutActionTypes.UPDATE_SIDEBAR_MENU_GROUPS;
+export class GetSidebar implements Action {
+  readonly type = LayoutActionTypes.GET_SIDEBAR;
+  constructor() {}
+}
 
-  constructor(public payload: MenuItemGroup[] ) {}
+export class UpdateSidebars implements Action {
+  readonly type = LayoutActionTypes.UPDATE_SIDEBARS;
+
+  constructor(public payload: Sidebars ) {}
 }
 
 export type LayoutActions =
   | ShowPageLoading
-  | UpdateSidebarMenuGroups;
+  | GetSidebar
+  | UpdateSidebars;

--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -8,7 +8,7 @@ import { isIAMv2 } from 'app/entities/policies/policy.selectors';
 import { LayoutSidebarService } from './layout-sidebar.service';
 import * as fromLayout from './layout.reducer';
 import { MenuItemGroup } from './layout.model';
-import { sidebar, showPageLoading } from './layout.selectors';
+import { sidebar,  showPageLoading } from './layout.selectors';
 import { ShowPageLoading } from './layout.actions';
 
 import { GetProjects } from 'app/entities/projects/project.actions';

--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -8,8 +8,8 @@ import { isIAMv2 } from 'app/entities/policies/policy.selectors';
 import { LayoutSidebarService } from './layout-sidebar.service';
 import * as fromLayout from './layout.reducer';
 import { MenuItemGroup } from './layout.model';
-import { sidebarMenuGroups, showPageLoading } from './layout.selectors';
-import { ShowPageLoading, UpdateSidebarMenuGroups } from './layout.actions';
+import { sidebar, showPageLoading } from './layout.selectors';
+import { ShowPageLoading } from './layout.actions';
 
 import { GetProjects } from 'app/entities/projects/project.actions';
 
@@ -43,6 +43,7 @@ export class LayoutFacadeService implements OnInit, OnDestroy {
   };
   public contentHeight = `calc(100% - ${Height.Navigation}px)`;
   public menuGroups$: Observable<MenuItemGroup[]>;
+  public sidebar$: Observable<MenuItemGroup[]>;
   public showPageLoading$: Observable<boolean>;
   private isDestroyed = new Subject<boolean>();
 
@@ -51,6 +52,7 @@ export class LayoutFacadeService implements OnInit, OnDestroy {
     private layoutSidebarService: LayoutSidebarService
   ) {
     this.menuGroups$ = store.select(sidebarMenuGroups);
+    this.sidebar$ = store.select(sidebar);
     this.showPageLoading$ = store.select(showPageLoading);
     this.updateDisplay();
   }
@@ -95,8 +97,8 @@ export class LayoutFacadeService implements OnInit, OnDestroy {
     return this.layout.sidebar.navigation = true;
   }
 
-  ShowPageLoading(showLoading: boolean): void {
-    this.store.dispatch(new ShowPageLoading(showLoading));
+  ShowPageLoading(showLoading: boolean) {
+    this.store.dispatch( new ShowPageLoading(showLoading));
   }
 
   showFullPage(): void {
@@ -113,39 +115,7 @@ export class LayoutFacadeService implements OnInit, OnDestroy {
     this.layout.userNotifications.display = true;
   }
 
-  showDashboardsSidebar(): void {
-    this.store.dispatch(new UpdateSidebarMenuGroups(
-      this.layoutSidebarService.getDashboardsSidebar()
-    ));
-  }
-
-  showApplicationsSidebar(): void {
-    this.store.dispatch(new UpdateSidebarMenuGroups(
-      this.layoutSidebarService.getApplicationsSidebar()
-    ));
-  }
-
-  showInfrastructureSidebar(): void {
-    this.store.dispatch(new UpdateSidebarMenuGroups(
-      this.layoutSidebarService.getInfrastructureSidebar()
-    ));
-  }
-
-  showComplianceSidebar(): void {
-    this.store.dispatch(new UpdateSidebarMenuGroups(
-      this.layoutSidebarService.getComplianceSidebar()
-    ));
-  }
-
-  showSettingsSidebar(): void {
-    this.store.dispatch(new UpdateSidebarMenuGroups(
-      this.layoutSidebarService.getSettingsSidebar()
-    ));
-  }
-
-  showUserProfileSidebar(): void {
-    this.store.dispatch(new UpdateSidebarMenuGroups(
-      this.layoutSidebarService.getUserProfileSidebar()
-    ));
+  showSidebar(sidebarName: string) {
+    this.layoutSidebarService.updateSidebars(sidebarName);
   }
 }

--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -51,7 +51,6 @@ export class LayoutFacadeService implements OnInit, OnDestroy {
     }
   };
   public contentHeight = `calc(100% - ${Height.Navigation}px)`;
-  public menuGroups$: Observable<MenuItemGroup[]>;
   public sidebar$: Observable<MenuItemGroup[]>;
   public showPageLoading$: Observable<boolean>;
   private isDestroyed = new Subject<boolean>();
@@ -60,7 +59,7 @@ export class LayoutFacadeService implements OnInit, OnDestroy {
     private store: Store<fromLayout.LayoutEntityState>,
     private layoutSidebarService: LayoutSidebarService
   ) {
-    this.menuGroups$ = store.select(sidebarMenuGroups);
+    this.store.dispatch(new GetProjects());
     this.sidebar$ = store.select(sidebar);
     this.showPageLoading$ = store.select(showPageLoading);
     this.updateDisplay();

--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -80,11 +80,11 @@ export class LayoutFacadeService implements OnInit, OnDestroy {
     this.isDestroyed.complete();
   }
 
-  getContentStyle() {
+  getContentStyle(): any {
     return { 'height': this.contentHeight };
   }
 
-  updateDisplay() {
+  updateDisplay(): void {
     let combinedHeights = 0;
     if (this.layout.header.navigation) {
       combinedHeights += Height.Navigation;
@@ -105,7 +105,7 @@ export class LayoutFacadeService implements OnInit, OnDestroy {
     return this.layout.sidebar.navigation = true;
   }
 
-  ShowPageLoading(showLoading: boolean) {
+  ShowPageLoading(showLoading: boolean): void {
     this.store.dispatch( new ShowPageLoading(showLoading));
   }
 

--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -21,6 +21,15 @@ enum Height {
   PendingEditsBar = 52
 }
 
+export enum Sidebar {
+  Dashboards = 'dashboards',
+  Applications = 'applications',
+  Infrastructure = 'infrastructure',
+  Compliance = 'compliance',
+  Settings = 'settings',
+  Profile = 'profile'
+}
+
 @Injectable({
   providedIn: 'root'
 })

--- a/components/automate-ui/src/app/entities/layout/layout.model.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.model.ts
@@ -22,7 +22,7 @@ export interface Sidebars {
 export interface MenuItemGroup {
   name: string;
   items: MenuItem[];
-  visible: any; // boolean or observable
+  visible: boolean;
 }
 
 // MenuItem {

--- a/components/automate-ui/src/app/entities/layout/layout.model.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.model.ts
@@ -1,3 +1,5 @@
+import { Observable } from 'rxjs';
+
 // Sidebar {
 //   active: "dashboards",
 //   dashboards: []
@@ -16,13 +18,13 @@ export interface Sidebars {
 // MenuItemGroup {
 //   name: "Node Management",
 //   items: [],
-//   visible: true
+//   visible: Observable
 // }
 
 export interface MenuItemGroup {
   name: string;
   items: MenuItem[];
-  visible: boolean;
+  visible?: any;
 }
 
 // MenuItem {
@@ -30,7 +32,7 @@ export interface MenuItemGroup {
 //   icon: "notifications",
 //   route: "/settings/data-feed",
 //   authorized: {},
-//   visible: true
+//   visible: Observable
 // }
 
 export interface MenuItem {
@@ -39,17 +41,18 @@ export interface MenuItem {
   iconRotation?: number;
   route: string;
   authorized?: Authorized;
-  visible: boolean;
+  visible?: Observable<any>;
   openInNewPage?: boolean;
 }
 
 // Authorized {
+//   isAuthorized: false,
 //   type: "notifications",
 //   permissions: "['/notifications/rules', 'get']"
 // }
 
 export interface Authorized {
-  name: string;
+  isAuthorized?: boolean;
   allOf?: any[];
   anyOf?: any[];
 }

--- a/components/automate-ui/src/app/entities/layout/layout.model.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.model.ts
@@ -1,3 +1,18 @@
+// Sidebar {
+//   active: "dashboards",
+//   dashboards: []
+// }
+
+export interface Sidebars {
+  active?: string;
+  dashboards?: MenuItemGroup[];
+  applications?: MenuItemGroup[];
+  infrastructure?: MenuItemGroup[];
+  compliance?: MenuItemGroup[];
+  settings?: MenuItemGroup[];
+  profile?: MenuItemGroup[];
+}
+
 // MenuItemGroup {
 //   name: "Node Management",
 //   items: [],

--- a/components/automate-ui/src/app/entities/layout/layout.model.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.model.ts
@@ -24,7 +24,7 @@ export interface Sidebars {
 export interface MenuItemGroup {
   name: string;
   items: MenuItem[];
-  visible?: any;
+  visible$?: Observable<boolean>;
 }
 
 // MenuItem {
@@ -41,7 +41,7 @@ export interface MenuItem {
   iconRotation?: number;
   route: string;
   authorized?: Authorized;
-  visible?: Observable<any>;
+  visible$?: Observable<boolean>;
   openInNewPage?: boolean;
 }
 

--- a/components/automate-ui/src/app/entities/layout/layout.model.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.model.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 
-// Sidebar {
+// Sidebars {
 //   active: "dashboards",
 //   dashboards: []
 // }
@@ -18,7 +18,7 @@ export interface Sidebars {
 // MenuItemGroup {
 //   name: "Node Management",
 //   items: [],
-//   visible: Observable
+//   visible$: Observable<boolean>
 // }
 
 export interface MenuItemGroup {
@@ -32,7 +32,7 @@ export interface MenuItemGroup {
 //   icon: "notifications",
 //   route: "/settings/data-feed",
 //   authorized: {},
-//   visible: Observable
+//   visible$: Observable<boolean>
 // }
 
 export interface MenuItem {

--- a/components/automate-ui/src/app/entities/layout/layout.model.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.model.ts
@@ -49,8 +49,8 @@ export interface MenuItem {
 
 // Authorized {
 //   isAuthorized: false,
-//   type: "notifications",
-//   permissions: "['/notifications/rules', 'get']"
+//   allOf: "['/notifications/rules', 'get']"
+//   anyOf: "['/notifications/rules', 'get']"
 // }
 
 export interface Authorized {

--- a/components/automate-ui/src/app/entities/layout/layout.model.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.model.ts
@@ -18,12 +18,14 @@ export interface Sidebars {
 // MenuItemGroup {
 //   name: "Node Management",
 //   items: [],
+//   hasVisibleMenuItems: true,
 //   visible$: Observable<boolean>
 // }
 
 export interface MenuItemGroup {
   name: string;
   items: MenuItem[];
+  hasVisibleMenuItems?: boolean;
   visible$?: Observable<boolean>;
 }
 

--- a/components/automate-ui/src/app/entities/layout/layout.reducer.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.reducer.ts
@@ -1,15 +1,15 @@
 import { set } from 'lodash/fp';
-import { MenuItemGroup } from './layout.model';
+import { Sidebars } from './layout.model';
 import { LayoutActions, LayoutActionTypes } from './layout.actions';
 
 export interface LayoutEntityState {
   showPageLoading: boolean;
-  menuGroups: MenuItemGroup[];
+  sidebars: Sidebars;
 }
 
 export const InitialState: LayoutEntityState = {
   showPageLoading: false,
-  menuGroups: []
+  sidebars: {}
 };
 
 export function layoutEntityReducer(
@@ -22,8 +22,8 @@ export function layoutEntityReducer(
       return set('showPageLoading', action.payload)(state);
     }
 
-    case LayoutActionTypes.UPDATE_SIDEBAR_MENU_GROUPS: {
-      return set('menuGroups', action.payload)(state);
+    case LayoutActionTypes.UPDATE_SIDEBARS: {
+      return set('sidebars', action.payload)(state);
     }
 
     default:

--- a/components/automate-ui/src/app/entities/layout/layout.selectors.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.selectors.ts
@@ -4,12 +4,14 @@ import { LayoutEntityState } from './layout.reducer';
 
 export const layoutState = createFeatureSelector<LayoutEntityState>('layout');
 
-export const sidebarMenuGroups = createSelector(
-    layoutState,
-    (layout) => layout.menuGroups
-  );
+export const sidebar = createSelector(
+  layoutState,
+  (layout) => {
+    return layout.sidebars[layout.sidebars.active];
+  }
+);
 
-  export const showPageLoading = createSelector(
+export const showPageLoading = createSelector(
     layoutState,
     (layout) => layout.showPageLoading
   );

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
@@ -9,7 +9,7 @@ import { identity, isNil } from 'lodash/fp';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams, routeURL } from 'app/route.selectors';
 import { Regex } from 'app/helpers/auth/regex';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 
 import { pending, EntityStatus, allLoaded } from 'app/entities/entities';
 import {
@@ -73,7 +73,7 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.layoutFacade.showInfrastructureSidebar();
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
     // Populate our tabValue from the fragment.
     this.store.select(routeURL).pipe(takeUntil(this.isDestroyed))
     .subscribe((url: string) => {

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
@@ -8,7 +8,7 @@ import { isNil } from 'lodash/fp';
 import { HttpStatus } from 'app/types/types';
 import { ChefKeyboardEvent } from 'app/types/material-types';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { loading, EntityStatus, pending } from 'app/entities/entities';
 import { Server } from 'app/entities/servers/server.model';
 import {
@@ -58,7 +58,7 @@ export class ChefServersListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.layoutFacade.showInfrastructureSidebar();
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
     this.store.dispatch(new GetServers());
     this.store.pipe(
       select(saveStatus),

--- a/components/automate-ui/src/app/modules/policy/details/policy-details.component.ts
+++ b/components/automate-ui/src/app/modules/policy/details/policy-details.component.ts
@@ -45,7 +45,7 @@ export class PolicyDetailsComponent implements OnInit, OnDestroy {
   ) {  }
 
   ngOnInit(): void {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     // Populate our tabValue from the fragment.
     this.store.select(routeURL).pipe(takeUntil(this.isDestroyed))
       .subscribe((url: string) => {

--- a/components/automate-ui/src/app/modules/policy/details/policy-details.component.ts
+++ b/components/automate-ui/src/app/modules/policy/details/policy-details.component.ts
@@ -6,7 +6,7 @@ import { isNil } from 'lodash/fp';
 import { Subject, combineLatest } from 'rxjs';
 
 import { EntityStatus } from 'app/entities/entities';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeURL, routeState } from 'app/route.selectors';
 import { GetPolicy } from 'app/entities/policies/policy.actions';
@@ -45,7 +45,7 @@ export class PolicyDetailsComponent implements OnInit, OnDestroy {
   ) {  }
 
   ngOnInit(): void {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     // Populate our tabValue from the fragment.
     this.store.select(routeURL).pipe(takeUntil(this.isDestroyed))
       .subscribe((url: string) => {

--- a/components/automate-ui/src/app/modules/policy/list/policy-list.component.ts
+++ b/components/automate-ui/src/app/modules/policy/list/policy-list.component.ts
@@ -9,7 +9,7 @@ import { loading } from 'app/entities/entities';
 import { DeletePolicy, GetPolicies } from 'app/entities/policies/policy.actions';
 import { allPolicies, getAllStatus, isIAMv2 } from 'app/entities/policies/policy.selectors';
 import { Policy } from 'app/entities/policies/policy.model';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { ChefKeyboardEvent } from 'app/types/material-types';
 
 @Component({
@@ -44,7 +44,7 @@ export class PolicyListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.store.dispatch(new GetPolicies());
   }
 

--- a/components/automate-ui/src/app/modules/policy/list/policy-list.component.ts
+++ b/components/automate-ui/src/app/modules/policy/list/policy-list.component.ts
@@ -44,7 +44,7 @@ export class PolicyListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.store.dispatch(new GetPolicies());
   }
 

--- a/components/automate-ui/src/app/modules/roles/details/role-details.component.ts
+++ b/components/automate-ui/src/app/modules/roles/details/role-details.component.ts
@@ -28,7 +28,7 @@ export class RoleDetailsComponent implements OnInit, OnDestroy {
   ) {  }
 
   ngOnInit(): void {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.store.select(roleFromRoute).pipe(
       filter(identity),
       takeUntil(this.isDestroyed))

--- a/components/automate-ui/src/app/modules/roles/details/role-details.component.ts
+++ b/components/automate-ui/src/app/modules/roles/details/role-details.component.ts
@@ -5,7 +5,7 @@ import { Subject, combineLatest } from 'rxjs';
 import { filter, pluck, takeUntil } from 'rxjs/operators';
 
 import { EntityStatus } from 'app/entities/entities';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams } from 'app/route.selectors';
 import { GetRole } from 'app/entities/roles/role.actions';
@@ -28,7 +28,7 @@ export class RoleDetailsComponent implements OnInit, OnDestroy {
   ) {  }
 
   ngOnInit(): void {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.store.select(roleFromRoute).pipe(
       filter(identity),
       takeUntil(this.isDestroyed))

--- a/components/automate-ui/src/app/modules/roles/list/roles-list.component.ts
+++ b/components/automate-ui/src/app/modules/roles/list/roles-list.component.ts
@@ -3,7 +3,7 @@ import { Store } from '@ngrx/store';
 import { Observable, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { loading } from 'app/entities/entities';
@@ -40,7 +40,7 @@ export class RolesListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.store.dispatch(new GetRoles());
   }
 

--- a/components/automate-ui/src/app/modules/roles/list/roles-list.component.ts
+++ b/components/automate-ui/src/app/modules/roles/list/roles-list.component.ts
@@ -40,7 +40,7 @@ export class RolesListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.store.dispatch(new GetRoles());
   }
 

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
@@ -94,7 +94,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
 
     this.isIAMv2$ = this.store.select(isIAMv2);
 

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
@@ -6,7 +6,7 @@ import { isEmpty, keyBy, at, xor, isNil } from 'lodash/fp';
 import { combineLatest, Subject, Observable } from 'rxjs';
 import { filter, map, takeUntil, distinctUntilChanged } from 'rxjs/operators';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeURL, routeState } from 'app/route.selectors';
@@ -94,7 +94,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
 
     this.isIAMv2$ = this.store.select(isIAMv2);
 

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
@@ -81,7 +81,7 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.store.dispatch(new GetTeams());
 
     this.store.pipe(

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.ts
@@ -5,7 +5,7 @@ import { Observable, Subject, combineLatest } from 'rxjs';
 import { map, filter, takeUntil } from 'rxjs/operators';
 import { isNil } from 'lodash/fp';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { loading, EntityStatus, pending } from 'app/entities/entities';
@@ -81,7 +81,7 @@ export class TeamManagementComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.store.dispatch(new GetTeams());
 
     this.store.pipe(

--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
@@ -5,7 +5,7 @@ import { isEmpty, identity, xor, isNil } from 'lodash/fp';
 import { combineLatest, Subject } from 'rxjs';
 import { filter, pluck, takeUntil } from 'rxjs/operators';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams } from 'app/route.selectors';
 import { Regex } from 'app/helpers/auth/regex';
@@ -61,7 +61,7 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
 
     this.store.pipe(
       select(isIAMv2),

--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
@@ -61,7 +61,7 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
 
     this.store.pipe(
       select(isIAMv2),

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
@@ -5,7 +5,7 @@ import { Observable, Subject, combineLatest } from 'rxjs';
 import { filter, takeUntil, map } from 'rxjs/operators';
 import { isNil } from 'lodash/fp';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { DateTime } from 'app/helpers/datetime/datetime';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Regex } from 'app/helpers/auth/regex';
@@ -80,7 +80,7 @@ export class ApiTokenListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.store.dispatch(new GetAllTokens());
 
     this.store.select(assignableProjects)

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
@@ -80,7 +80,7 @@ export class ApiTokenListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.store.dispatch(new GetAllTokens());
 
     this.store.select(assignableProjects)

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
@@ -62,10 +62,12 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
       // undefined for admin view
       // true for profile view
       if (data.isNonAdmin) {
+        this.layoutFacade.showSidebar('settings');
         this.userDetails = new UserProfileDetails(
           this.store, this.layoutFacade, this.isDestroyed, this.fb);
         this.loading = false;
       } else {
+        this.layoutFacade.showSidebar('profile');
         // Is this user the logged-in user?
         combineLatest([
           // Get the user ID from the URL

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
@@ -8,7 +8,7 @@ import { filter, pluck, takeUntil, first, map } from 'rxjs/operators';
 
 import { identity, isNil } from 'lodash/fp';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { ChefValidators } from 'app/helpers/auth/validator';
 import { routeURL, routeParams } from 'app/route.selectors';
@@ -62,12 +62,12 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
       // undefined for admin view
       // true for profile view
       if (data.isNonAdmin) {
-        this.layoutFacade.showSidebar('settings');
+        this.layoutFacade.showSidebar(Sidebar.Settings);
         this.userDetails = new UserProfileDetails(
           this.store, this.layoutFacade, this.isDestroyed, this.fb);
         this.loading = false;
       } else {
-        this.layoutFacade.showSidebar('profile');
+        this.layoutFacade.showSidebar(Sidebar.Profile);
         // Is this user the logged-in user?
         combineLatest([
           // Get the user ID from the URL
@@ -178,8 +178,7 @@ class UserAdminDetails extends UserDetails {
       super(store);
 
       store.dispatch(new GetUser({ id: userId }));
-
-      layoutFacade.showSettingsSidebar();
+      layoutFacade.showSidebar(Sidebar.Settings);
       this.createForms(fb);
       this.resetForms();
 
@@ -247,8 +246,7 @@ class UserAdminSelfDetails extends UserDetails {
       super(store);
 
       store.dispatch(new GetUserSelf());
-
-      layoutFacade.showSettingsSidebar();
+      layoutFacade.showSidebar(Sidebar.Settings);
 
       this.createForms(fb);
       this.resetForms();
@@ -327,8 +325,7 @@ class UserProfileDetails extends UserDetails {
       super(store);
 
       store.dispatch(new GetUserSelf());
-
-      layoutFacade.showUserProfileSidebar();
+      layoutFacade.showSidebar(Sidebar.Profile);
 
       this.createForms(fb);
       this.resetForms();

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
@@ -37,7 +37,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
  }
 
   ngOnInit() {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.store.dispatch(new GetUsers());
     this.layoutFacade.ShowPageLoading(true);
     combineLatest([

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
@@ -3,10 +3,10 @@ import { Store } from '@ngrx/store';
 import { Subject, combineLatest } from 'rxjs';
 import { takeUntil, filter } from 'rxjs/operators';
 
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { EntityStatus } from 'app/entities/entities';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 import { allUsers, getStatus } from 'app/entities/users/user.selectors';
 import { DeleteUser, GetUsers } from 'app/entities/users/user.actions';
 import { User } from 'app/entities/users/user.model';
@@ -37,7 +37,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
  }
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.store.dispatch(new GetUsers());
     this.layoutFacade.ShowPageLoading(true);
     combineLatest([

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/containers/credentials-add-edit-screen.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/containers/credentials-add-edit-screen.ts
@@ -6,7 +6,7 @@ import { HttpClient } from '@angular/common/http';
 import { Credential, CredentialTypes } from '../credentials.state';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { CredentialsLogic } from '../credentials.logic';
 import { environment } from '../../../../../environments/environment';
 const SECRETS_URL = environment.secrets_url;
@@ -34,7 +34,7 @@ export class CredentialsAddEditScreenComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.route.paramMap
       .subscribe(params => {
         this.credential$ = params.get('id') ?

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/containers/credentials-add-edit-screen.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/containers/credentials-add-edit-screen.ts
@@ -34,7 +34,7 @@ export class CredentialsAddEditScreenComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.route.paramMap
       .subscribe(params => {
         this.credential$ = params.get('id') ?

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/containers/credentials-list-screen.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/containers/credentials-list-screen.ts
@@ -33,7 +33,7 @@ export class CredentialsListScreenComponent {
     private router: Router,
     private route: ActivatedRoute
   ) {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.credentialsList$ = store.select(selectors.credentialsList);
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/containers/credentials-list-screen.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/containers/credentials-list-screen.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { Credential,
          CredentialsList,
          CredentialsActions,
@@ -33,7 +33,7 @@ export class CredentialsListScreenComponent {
     private router: Router,
     private route: ActivatedRoute
   ) {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.credentialsList$ = store.select(selectors.credentialsList);
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.ts
@@ -42,7 +42,7 @@ export class ProfileDetailsComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showComplianceSidebar();
+    this.layoutFacade.showSidebar('compliance');
     this.layoutFacade.ShowPageLoading(false);
     this.route.queryParams.pipe(
       takeUntil(this.isDestroyed))

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.ts
@@ -5,7 +5,7 @@ import { Subject } from 'rxjs';
 import { ProfilesService } from 'app/services/profiles/profiles.service';
 import { AvailableProfilesService } from 'app/services/profiles/available-profiles.service';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 
 import { saveAs } from 'file-saver';
 
@@ -42,7 +42,7 @@ export class ProfileDetailsComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('compliance');
+    this.layoutFacade.showSidebar(Sidebar.Compliance);
     this.layoutFacade.ShowPageLoading(false);
     this.route.queryParams.pipe(
       takeUntil(this.isDestroyed))

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
@@ -12,7 +12,7 @@ import {
   ElementRef,
   ViewChild
 } from '@angular/core';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { ProfilesService } from 'app/services/profiles/profiles.service';
 import { UploadService } from 'app/services/profiles/upload.service';
 import { AvailableProfilesService } from 'app/services/profiles/available-profiles.service';
@@ -83,7 +83,7 @@ export class ProfileOverviewComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('compliance');
+    this.layoutFacade.showSidebar(Sidebar.Compliance);
     this.layoutFacade.ShowPageLoading(true);
     this.user = this.chefSessionService.username;
 

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
@@ -83,7 +83,7 @@ export class ProfileOverviewComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showComplianceSidebar();
+    this.layoutFacade.showSidebar('compliance');
     this.layoutFacade.ShowPageLoading(true);
     this.user = this.chefSessionService.username;
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -5,7 +5,7 @@ import { Subject } from 'rxjs';
 import { ReportQueryService } from '../../shared/reporting/report-query.service';
 import * as moment from 'moment';
 import { DateTime } from 'app/helpers/datetime/datetime';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 
 @Component({
   selector: 'app-reporting-node',
@@ -35,7 +35,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('compliance');
+    this.layoutFacade.showSidebar(Sidebar.Compliance);
     this.reportLoading = true;
     this.layoutFacade.ShowPageLoading(true);
     const id: string = this.route.snapshot.params['id'];

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -35,7 +35,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.layoutFacade.showComplianceSidebar();
+    this.layoutFacade.showSidebar('compliance');
     this.reportLoading = true;
     this.layoutFacade.ShowPageLoading(true);
     const id: string = this.route.snapshot.params['id'];

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
@@ -39,7 +39,7 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showComplianceSidebar();
+    this.layoutFacade.showSidebar('compliance');
     this.showLoadingIcon = true;
     this.layoutFacade.ShowPageLoading(true);
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.ts
@@ -12,7 +12,7 @@ import { ScanResultsService } from '../../shared/reporting/scan-results.service'
 import { paginationOverride } from '../shared';
 import * as moment from 'moment';
 import { FilterC } from '../../+reporting/types';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 
 @Component({
   selector: 'app-reporting-profile',
@@ -39,7 +39,7 @@ export class ReportingProfileComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('compliance');
+    this.layoutFacade.showSidebar(Sidebar.Compliance);
     this.showLoadingIcon = true;
     this.layoutFacade.ShowPageLoading(true);
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -22,7 +22,7 @@ import {
   ReportQueryService,
   ReportQuery
 } from '../shared/reporting';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { saveAs } from 'file-saver';
 import {
   Chicklet
@@ -199,7 +199,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('compliance');
+    this.layoutFacade.showSidebar(Sidebar.Compliance);
     const allUrlParameters$ = this.getAllUrlParameters();
 
     this.endDate$ = this.reportQuery.state.pipe(map((reportQuery: ReportQuery) =>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -199,7 +199,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.layoutFacade.showComplianceSidebar();
+    this.layoutFacade.showSidebar('compliance');
     const allUrlParameters$ = this.getAllUrlParameters();
 
     this.endDate$ = this.reportQuery.state.pipe(map((reportQuery: ReportQuery) =>

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/job-scans-list/job-scans-list.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/job-scans-list/job-scans-list.component.ts
@@ -33,7 +33,7 @@ export class JobScansListComponent implements OnInit, OnDestroy {
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
   ngOnInit(): void {
-    this.layoutFacade.showComplianceSidebar();
+    this.layoutFacade.showSidebar('compliance');
     this.store.select(selectors.jobScansList).pipe(
       takeUntil(this.isDestroyed))
       .subscribe(jobScansList => this.jobScansList = jobScansList);

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/job-scans-list/job-scans-list.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/job-scans-list/job-scans-list.component.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from '../../../../../ngrx.reducers';
 import * as moment from 'moment';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import * as selectors from '../../state/scanner.selectors';
 import * as actions from '../../state/scanner.actions';
 
@@ -33,7 +33,7 @@ export class JobScansListComponent implements OnInit, OnDestroy {
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
   ngOnInit(): void {
-    this.layoutFacade.showSidebar('compliance');
+    this.layoutFacade.showSidebar(Sidebar.Compliance);
     this.store.select(selectors.jobScansList).pipe(
       takeUntil(this.isDestroyed))
       .subscribe(jobScansList => this.jobScansList = jobScansList);

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-add/nodes-add.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-add/nodes-add.component.ts
@@ -37,7 +37,7 @@ export class NodesAddComponent implements OnInit {
   nodesToAdd$: BehaviorSubject<any[]> = new BehaviorSubject([]);
 
   ngOnInit() {
-    this.layoutFacade.showComplianceSidebar();
+    this.layoutFacade.showSidebar('compliance');
     this.form = this.createForm();
 
     // Populate nodesToAdd$ with serialized form body

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-add/nodes-add.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-add/nodes-add.component.ts
@@ -5,7 +5,7 @@ import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { FormArray, FormBuilder, FormGroup, FormControl, Validators } from '@angular/forms';
 import { environment as env } from '../../../../../../environments/environment';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 
 @Component({
   templateUrl: './nodes-add.component.html',
@@ -37,7 +37,7 @@ export class NodesAddComponent implements OnInit {
   nodesToAdd$: BehaviorSubject<any[]> = new BehaviorSubject([]);
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('compliance');
+    this.layoutFacade.showSidebar(Sidebar.Compliance);
     this.form = this.createForm();
 
     // Populate nodesToAdd$ with serialized form body

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-edit/nodes-edit.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-edit/nodes-edit.component.ts
@@ -5,7 +5,7 @@ import { FormArray, FormBuilder, FormGroup, FormControl, Validators } from '@ang
 import { Observable, combineLatest  } from 'rxjs';
 import { startWith, switchMap, map } from 'rxjs/operators';
 import { environment as env } from 'environments/environment';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 
 @Component({
   templateUrl: './nodes-edit.component.html',
@@ -30,7 +30,7 @@ export class NodesEditComponent implements OnInit {
   secrets$: Observable<any[]>;
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('compliance');
+    this.layoutFacade.showSidebar(Sidebar.Compliance);
     this.route.paramMap.pipe(
       switchMap(params => this.fetchNode(params.get('id'))))
       .subscribe(node => {

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-edit/nodes-edit.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-edit/nodes-edit.component.ts
@@ -30,7 +30,7 @@ export class NodesEditComponent implements OnInit {
   secrets$: Observable<any[]>;
 
   ngOnInit() {
-    this.layoutFacade.showComplianceSidebar();
+    this.layoutFacade.showSidebar('compliance');
     this.route.paramMap.pipe(
       switchMap(params => this.fetchNode(params.get('id'))))
       .subscribe(node => {

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/scanner/scanner.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/scanner/scanner.component.ts
@@ -23,7 +23,7 @@ export class ScannerComponent implements OnInit {
 
   ngOnInit() {
     this.layoutFacade.ShowPageLoading(true);
-    this.layoutFacade.showComplianceSidebar();
+    this.layoutFacade.showSidebar('compliance');
     this.jobsCount$ = this.store.select(selectors.jobsList)
       .pipe(map(jobsList => jobsList.total));
     this.jobsCountLoaded = true;

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/scanner/scanner.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/scanner/scanner.component.ts
@@ -2,7 +2,7 @@ import { map } from 'rxjs/operators';
 import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Store } from '@ngrx/store';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import * as selectors from '../../state/scanner.selectors';
 
 @Component({
@@ -23,7 +23,7 @@ export class ScannerComponent implements OnInit {
 
   ngOnInit() {
     this.layoutFacade.ShowPageLoading(true);
-    this.layoutFacade.showSidebar('compliance');
+    this.layoutFacade.showSidebar(Sidebar.Compliance);
     this.jobsCount$ = this.store.select(selectors.jobsList)
       .pipe(map(jobsList => jobsList.total));
     this.jobsCountLoaded = true;

--- a/components/automate-ui/src/app/pages/applications/applications.component.ts
+++ b/components/automate-ui/src/app/pages/applications/applications.component.ts
@@ -14,6 +14,7 @@ export class ApplicationsComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showApplicationsSidebar();
+    this.layoutFacade.showSidebar('applications');
+    this.applicationsFeatureFlagOn = this.featureFlagsService.getFeatureStatus('applications');
   }
 }

--- a/components/automate-ui/src/app/pages/applications/applications.component.ts
+++ b/components/automate-ui/src/app/pages/applications/applications.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 
 @Component({
   selector: 'app-applications-dashboard',
@@ -14,7 +14,6 @@ export class ApplicationsComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('applications');
-    this.applicationsFeatureFlagOn = this.featureFlagsService.getFeatureStatus('applications');
+    this.layoutFacade.showSidebar(Sidebar.Applications);
   }
 }

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
@@ -90,7 +90,7 @@ export class AutomateSettingsComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.store.dispatch(new GetSettings({}));
     this.store.select(automateSettingsState)
       .subscribe((automateSettingsSelector) => {

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
@@ -3,7 +3,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { FormGroup, FormBuilder } from '@angular/forms';
 import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from '../../ngrx.reducers';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import {
   automateSettingsState,
   changeConfiguration
@@ -90,7 +90,7 @@ export class AutomateSettingsComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.store.dispatch(new GetSettings({}));
     this.store.select(automateSettingsState)
       .subscribe((automateSettingsSelector) => {

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -33,7 +33,7 @@ import {
   ColumnsPreference
 } from '../../entities/client-runs/client-runs.model';
 import {
-  UpdateNodeFilters, GetWorkflowEnabled, GetNodeSuggestions, DeleteNodes, UpdateColumns
+  UpdateNodeFilters, GetNodeSuggestions, DeleteNodes, UpdateColumns
 } from '../../entities/client-runs/client-runs.actions';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
 import * as moment from 'moment';
@@ -252,10 +252,9 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit() {
-    this.layoutFacade.showInfrastructureSidebar();
     // Only load when first opening the /chef-runs page
     this.store.dispatch(new GetWorkflowEnabled());
-
+    this.layoutFacade.showSidebar('infrastructure');
     const allUrlParameters$ = this.getAllUrlParameters();
 
     this.searchBarFilters$ = allUrlParameters$.pipe(map((chicklets: Chicklet[]) =>

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -33,7 +33,7 @@ import {
   ColumnsPreference
 } from '../../entities/client-runs/client-runs.model';
 import {
-  UpdateNodeFilters, GetNodeSuggestions, DeleteNodes, UpdateColumns
+  UpdateNodeFilters, GetWorkflowEnabled, GetNodeSuggestions, DeleteNodes, UpdateColumns
 } from '../../entities/client-runs/client-runs.actions';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
 import * as moment from 'moment';
@@ -255,6 +255,9 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
     // Only load when first opening the /chef-runs page
     this.store.dispatch(new GetWorkflowEnabled());
     this.layoutFacade.showSidebar('infrastructure');
+    // Only load when first opening the /chef-runs page
+    this.store.dispatch(new GetWorkflowEnabled());
+
     const allUrlParameters$ = this.getAllUrlParameters();
 
     this.searchBarFilters$ = allUrlParameters$.pipe(map((chicklets: Chicklet[]) =>

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -43,7 +43,7 @@ import {
   ClientRunsRequests
 } from '../../entities/client-runs/client-runs.requests';
 import { EntityStatus } from '../../entities/entities';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 
 @Component({
   selector: 'app-client-runs',
@@ -252,9 +252,7 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit() {
-    // Only load when first opening the /chef-runs page
-    this.store.dispatch(new GetWorkflowEnabled());
-    this.layoutFacade.showSidebar('infrastructure');
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
     // Only load when first opening the /chef-runs page
     this.store.dispatch(new GetWorkflowEnabled());
 

--- a/components/automate-ui/src/app/pages/data-feed-form/data-feed-form.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed-form/data-feed-form.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { Destination } from 'app/pages/data-feed/destination';
 import { DatafeedService } from 'app/services/data-feed/data-feed.service';
 
@@ -53,7 +53,7 @@ export class DatafeedFormComponent {
     private datafeedService: DatafeedService,
     private route: ActivatedRoute
   ) {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.model = new Model(new Destination(undefined, '', '', ''), '', '');
     this.id = this.route.snapshot.params['id'];
     this.isEditDestination = this.id ? true : false;

--- a/components/automate-ui/src/app/pages/data-feed-form/data-feed-form.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed-form/data-feed-form.component.ts
@@ -53,7 +53,7 @@ export class DatafeedFormComponent {
     private datafeedService: DatafeedService,
     private route: ActivatedRoute
   ) {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.model = new Model(new Destination(undefined, '', '', ''), '', '');
     this.id = this.route.snapshot.params['id'];
     this.isEditDestination = this.id ? true : false;

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.ts
@@ -41,7 +41,7 @@ export class DatafeedComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.destinations$ = this.service.fetchDestinations();
     this.destinations$.subscribe(destinations => {
         this.sendCountToTelemetry(destinations);

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.ts
@@ -4,7 +4,7 @@ import { map, filter } from 'rxjs/operators';
 import { Component, OnInit } from '@angular/core';
 import { MatDialog, MatSnackBar } from '@angular/material';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { SortDirection } from '../../types/types';
 import { DatafeedService } from '../../services/data-feed/data-feed.service';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
@@ -41,7 +41,7 @@ export class DatafeedComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.destinations$ = this.service.fetchDestinations();
     this.destinations$.subscribe(destinations => {
         this.sendCountToTelemetry(destinations);

--- a/components/automate-ui/src/app/pages/event-feed/event-feed.component.ts
+++ b/components/automate-ui/src/app/pages/event-feed/event-feed.component.ts
@@ -155,7 +155,7 @@ export class EventFeedComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showDashboardsSidebar();
+    this.layoutFacade.showSidebar('dashboards');
     this.store.select(eventFeedSelectors.loadedEvents).pipe(
     takeUntil(this.isDestroyed))
     .subscribe((loadedEvents: ChefEvent[]) => {

--- a/components/automate-ui/src/app/pages/event-feed/event-feed.component.ts
+++ b/components/automate-ui/src/app/pages/event-feed/event-feed.component.ts
@@ -23,7 +23,7 @@ import { some, pickBy } from 'lodash/fp';
 import {
   eventFeedState
 } from '../../services/event-feed/event-feed.selectors';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 
 @Component({
   selector: 'app-event-feed',
@@ -155,7 +155,7 @@ export class EventFeedComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('dashboards');
+    this.layoutFacade.showSidebar(Sidebar.Dashboards);
     this.store.select(eventFeedSelectors.loadedEvents).pipe(
     takeUntil(this.isDestroyed))
     .subscribe((loadedEvents: ChefEvent[]) => {

--- a/components/automate-ui/src/app/pages/integrations/add/integrations-add.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/add/integrations-add.component.ts
@@ -12,7 +12,7 @@ import {
   toPairs,
   toUpper
 } from 'lodash/fp';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { NgrxStateAtom } from '../../../ngrx.reducers';
 import { CreateManager } from '../../../entities/managers/manager.actions';
 import { integrationsAddState } from './integrations-add.selectors';
@@ -35,7 +35,7 @@ export class IntegrationsAddComponent implements OnDestroy {
     location: Location,
     fb: FormBuilder
   ) {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.sub = store.select(integrationsAddState).subscribe(({status}) => {
       this.status = status;
       if (status === Status.success) {

--- a/components/automate-ui/src/app/pages/integrations/add/integrations-add.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/add/integrations-add.component.ts
@@ -35,7 +35,7 @@ export class IntegrationsAddComponent implements OnDestroy {
     location: Location,
     fb: FormBuilder
   ) {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.sub = store.select(integrationsAddState).subscribe(({status}) => {
       this.status = status;
       if (status === Status.success) {

--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.ts
@@ -25,7 +25,7 @@ export class IntegrationsDetailComponent {
     private store: Store<NgrxStateAtom>,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.managerDetail$ = this.store.select(integrationsDetail);
   }
 

--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.component.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { NgrxStateAtom } from '../../../ngrx.reducers';
 import { IntegrationsDetailState } from './integrations-detail.reducer';
 import { integrationsDetail } from './integrations-detail.selectors';
@@ -25,7 +25,7 @@ export class IntegrationsDetailComponent {
     private store: Store<NgrxStateAtom>,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.managerDetail$ = this.store.select(integrationsDetail);
   }
 

--- a/components/automate-ui/src/app/pages/integrations/edit/integrations-edit.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/edit/integrations-edit.component.ts
@@ -17,7 +17,7 @@ import {
   map
 } from 'lodash/fp';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { NgrxStateAtom } from '../../../ngrx.reducers';
 import { managerFromRoute } from '../../../entities/managers/manager.selectors';
 import { UpdateManager } from '../../../entities/managers/manager.actions';
@@ -43,7 +43,7 @@ export class IntegrationsEditComponent implements OnDestroy {
     fb: FormBuilder,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.createForm(fb);
 
     this.subs = [

--- a/components/automate-ui/src/app/pages/integrations/edit/integrations-edit.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/edit/integrations-edit.component.ts
@@ -43,7 +43,7 @@ export class IntegrationsEditComponent implements OnDestroy {
     fb: FormBuilder,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.createForm(fb);
 
     this.subs = [

--- a/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.ts
@@ -34,7 +34,7 @@ export class IntegrationsListComponent {
     private router: Router,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.managers$ = store.select(cloudManagers);
     this.managerStatus$ = store.select(managerStatus);
     this.automateManager$ = store.select(automateManager);

--- a/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.ts
+++ b/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Store } from '@ngrx/store';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { DateTime } from '../../../helpers/datetime/datetime';
 import { NgrxStateAtom } from '../../../ngrx.reducers';
 import { EntityStatus } from '../../../entities/entities';
@@ -34,7 +34,7 @@ export class IntegrationsListComponent {
     private router: Router,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.managers$ = store.select(cloudManagers);
     this.managerStatus$ = store.select(managerStatus);
     this.automateManager$ = store.select(automateManager);

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -63,7 +63,7 @@ export class JobAddComponent implements OnDestroy {
     private chefSession: ChefSessionService,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.layoutFacade.showComplianceSidebar();
+    this.layoutFacade.showSidebar('compliance');
     this.managers$ = this.store.select(allManagers);
     this.profiles$ = this.store.select(allProfiles);
     this.status$ = this.store.select(jobAddStatus);

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -10,7 +10,7 @@ import * as moment from 'moment';
 
 import { NgrxStateAtom } from '../../ngrx.reducers';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { ChefSessionService } from '../../services/chef-session/chef-session.service';
 import { Manager } from '../../entities/managers/manager.model';
 import { Profile } from '../../entities/profiles/profile.model';
@@ -63,7 +63,7 @@ export class JobAddComponent implements OnDestroy {
     private chefSession: ChefSessionService,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.layoutFacade.showSidebar('compliance');
+    this.layoutFacade.showSidebar(Sidebar.Compliance);
     this.managers$ = this.store.select(allManagers);
     this.profiles$ = this.store.select(allProfiles);
     this.status$ = this.store.select(jobAddStatus);

--- a/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
+++ b/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
@@ -11,7 +11,7 @@ import * as moment from 'moment';
 
 import { NgrxStateAtom } from '../../ngrx.reducers';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { ChefSessionService } from '../../services/chef-session/chef-session.service';
 import { Job } from '../../entities/jobs/job.model';
 import { Manager } from '../../entities/managers/manager.model';
@@ -67,7 +67,7 @@ export class JobEditComponent implements OnDestroy {
     private chefSession: ChefSessionService,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.layoutFacade.showSidebar('compliance');
+    this.layoutFacade.showSidebar(Sidebar.Compliance);
     this.managers$ = this.store.select(allManagers);
     this.profiles$ = this.store.select(allProfiles);
     this.status$ = this.store.select(jobEditStatus);

--- a/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
+++ b/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
@@ -67,7 +67,7 @@ export class JobEditComponent implements OnDestroy {
     private chefSession: ChefSessionService,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.layoutFacade.showComplianceSidebar();
+    this.layoutFacade.showSidebar('compliance');
     this.managers$ = this.store.select(allManagers);
     this.profiles$ = this.store.select(allProfiles);
     this.status$ = this.store.select(jobEditStatus);

--- a/components/automate-ui/src/app/pages/node-details/node-details.component.ts
+++ b/components/automate-ui/src/app/pages/node-details/node-details.component.ts
@@ -7,7 +7,7 @@ import { NodeDetailsService } from '../../services/node-details/node-details.ser
 import { NodeRun, RunInfo } from '../../types/types';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
 import { previousRoute } from '../../route.selectors';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 
 @Component({
   selector: 'app-node-details',
@@ -38,7 +38,7 @@ export class NodeDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('infrastructure');
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
     // Scroll to the top of the view
     window.scrollTo(0, 0);
     this.nodeId = this.getRouteParam('node-id');

--- a/components/automate-ui/src/app/pages/node-details/node-details.component.ts
+++ b/components/automate-ui/src/app/pages/node-details/node-details.component.ts
@@ -38,7 +38,7 @@ export class NodeDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.layoutFacade.showInfrastructureSidebar();
+    this.layoutFacade.showSidebar('infrastructure');
     // Scroll to the top of the view
     window.scrollTo(0, 0);
     this.nodeId = this.getRouteParam('node-id');

--- a/components/automate-ui/src/app/pages/node-noruns-details/node-noruns-details.component.ts
+++ b/components/automate-ui/src/app/pages/node-noruns-details/node-noruns-details.component.ts
@@ -20,7 +20,7 @@ export class NodeNoRunsDetailsComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showInfrastructureSidebar();
+    this.layoutFacade.showSidebar('infrastructure');
     this.nodeId = this.getRouteParam('node-id');
     this.route.data.subscribe((data: { node: Node }) => {
         this.node = data.node;

--- a/components/automate-ui/src/app/pages/node-noruns-details/node-noruns-details.component.ts
+++ b/components/automate-ui/src/app/pages/node-noruns-details/node-noruns-details.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import {
   Node
 } from '../../entities/client-runs/client-runs.model';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 
 @Component({
   selector: 'app-node-noruns-details',
@@ -20,7 +20,7 @@ export class NodeNoRunsDetailsComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('infrastructure');
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
     this.nodeId = this.getRouteParam('node-id');
     this.route.data.subscribe((data: { node: Node }) => {
         this.node = data.node;

--- a/components/automate-ui/src/app/pages/notification-form/notification-form.component.ts
+++ b/components/automate-ui/src/app/pages/notification-form/notification-form.component.ts
@@ -1,10 +1,9 @@
 import { Component, OnInit } from '@angular/core';
-import { Rule, ServiceActionType } from 'app/pages/notifications/rule';
-import { RulesService } from 'app/services/rules/rules.service';
-
 import { ActivatedRoute } from '@angular/router';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
+import { Rule, ServiceActionType } from 'app/pages/notifications/rule';
+import { RulesService } from 'app/services/rules/rules.service';
 
 enum UrlTestState {
   Inactive,
@@ -76,7 +75,7 @@ export class NotificationFormComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     const alertKeys = this.getAlertTypeKeys();
     this.alertOptions = alertKeys.map(key => {
       const opt = { value: key, viewValue: key };

--- a/components/automate-ui/src/app/pages/notification-form/notification-form.component.ts
+++ b/components/automate-ui/src/app/pages/notification-form/notification-form.component.ts
@@ -76,7 +76,7 @@ export class NotificationFormComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     const alertKeys = this.getAlertTypeKeys();
     this.alertOptions = alertKeys.map(key => {
       const opt = { value: key, viewValue: key };

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.ts
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.ts
@@ -44,7 +44,7 @@ export class NotificationsComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.rules$ = this.service.fetchRules();
     this.rules$.subscribe(rules => {
         this.sendCountToTelemetry(rules);

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.ts
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.ts
@@ -5,7 +5,7 @@ import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { Rule, ServiceActionType } from './rule';
 import { SortDirection } from '../../types/types';
 import { RulesService } from '../../services/rules/rules.service';
@@ -44,7 +44,7 @@ export class NotificationsComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.rules$ = this.service.fetchRules();
     this.rules$.subscribe(rules => {
         this.sendCountToTelemetry(rules);

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -6,7 +6,7 @@ import { Subject, combineLatest } from 'rxjs';
 import { filter, pluck, takeUntil } from 'rxjs/operators';
 import { identity, isNil } from 'lodash/fp';
 
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams, routeURL } from 'app/route.selectors';
 import { Regex } from 'app/helpers/auth/regex';
@@ -58,7 +58,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     // Populate our tabValue from the fragment.
     this.store.select(routeURL).pipe(takeUntil(this.isDestroyed))
       .subscribe((url: string) => {

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -58,7 +58,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     // Populate our tabValue from the fragment.
     this.store.select(routeURL).pipe(takeUntil(this.isDestroyed))
       .subscribe((url: string) => {

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -10,7 +10,7 @@ import { Regex } from 'app/helpers/auth/regex';
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { HttpStatus } from 'app/types/types';
 import { loading, EntityStatus } from 'app/entities/entities';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { ProjectStatus } from 'app/entities/rules/rule.model';
 import { isIAMv2 } from 'app/entities/policies/policy.selectors';
 import { ProjectService } from 'app/entities/projects/project.service';
@@ -61,7 +61,7 @@ export class ProjectListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.layoutFacade.showSidebar('settings');
+    this.layoutFacade.showSidebar(Sidebar.Settings);
     this.projects.getApplyRulesStatus();
     this.store.dispatch(new GetProjects());
     this.store.pipe(

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -61,7 +61,7 @@ export class ProjectListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.layoutFacade.showSettingsSidebar();
+    this.layoutFacade.showSidebar('settings');
     this.projects.getApplyRulesStatus();
     this.store.dispatch(new GetProjects());
     this.store.pipe(

--- a/components/automate-ui/src/app/staticConfig.ts
+++ b/components/automate-ui/src/app/staticConfig.ts
@@ -4,5 +4,5 @@ interface StaticConfig {
 const staticConfig: StaticConfig = window['staticAutomateConfig'] || {};
 
 export function isProductDeployed(productName: string): boolean {
-  return staticConfig.products.includes(productName);
+  return staticConfig.products && staticConfig.products.includes(productName);
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Automate-2281 - Workflow nav item is missing
Previously, on the infrastructure left nav there was a workflow nav item, its gone now.
missing in dev: https://a2-workflow-local-fresh-install-dev.cd.chef.co/infrastructure/client-runs
there in acceptance: https://a2-workflow-local-fresh-install-acceptance.cd.chef.co/infrastructure/client-runs

Automate-2278 - setting sidebar no longer reacts to IAM version change without refresh
Previously, the settings sidebar was subscribed to the IAM Version on the store and would instantly react to IAM version changes, displaying the correct menu items for each version.
Since the layout update, a refresh is required to display the correct sidebar.

### :chains: Related Resources
fixes #2281

fixes #2278

### :+1: Definition of Done
Workflow nav shows when clientRunsWorkflowEnabled is enabled.

Settings sidebar menu items show correct links in IAMVersion.

### :athletic_shoe: How to Build and Test the Change
chef-automate iam reset-to-v1
chef-automate iam upgrade-to-v2
start_workflow_service

### :camera: Screenshots, if applicable
![Screen Shot 2019-12-09 at 2 22 27 PM](https://user-images.githubusercontent.com/4108100/70469998-bd7db880-1a8f-11ea-85ba-7faa8c696733.png)
![Screen Shot 2019-12-09 at 2 21 53 PM](https://user-images.githubusercontent.com/4108100/70470012-c53d5d00-1a8f-11ea-9734-3d8829f91a87.png)
![Screen Shot 2019-12-09 at 2 32 20 PM](https://user-images.githubusercontent.com/4108100/70470500-c0c57400-1a90-11ea-8fb4-8bfb85497203.png)
