### PR TITLE
control and profile level waivers for nodes

### DIFF
--- a/components/compliance-service/api/tests/02_deep_nodes_spec.rb
+++ b/components/compliance-service/api/tests/02_deep_nodes_spec.rb
@@ -257,51 +257,52 @@ describe File.basename(__FILE__) do
     assert_equal_json_sorted(expected_nodes, actual_nodes.to_json)
 
     # Test filter by profile_id and waived control
-    # actual_nodes = GRPC reporting, :list_nodes, Reporting::Query.new(filters: [
-    #     Reporting::ListFilter.new(type: 'profile_id', values: ['447542ecfb8a8800ed0146039da3af8fed047f575f6037cfba75f3b664a97ea4']),
-    #     Reporting::ListFilter.new(type: "control", values: ["pro1-con1"]),
-    #     Reporting::ListFilter.new(type: 'end_time', values: ['2018-04-01T23:59:59Z'])
-    # ])
-    # expected_nodes = {"nodes" => [
-    #           {
-    #             "environment"=>"DevSec Prod Omega",
-    #             "id"=>"34cbbb4c-c502-4971-1111-888888888888",
-    #             "latestReport"=>{
-    #               "controls"=>{
-    #                 "failed"=>{},
-    #                 "passed"=>{},
-    #                 "skipped"=>{},
-    #                 "total"=>1,
-    #                 "waived"=>{"total"=>1}
-    #               },
-    #               "endTime"=>"2018-04-01T10:18:41Z",
-    #               "id"=>"44024b50-2e0d-42fa-cccc-yyyyyyyyyyyy",
-    #               "status"=>"waived"
-    #             },
-    #             "name"=>"osx(2)-omega-pro1(f)-pro2(w)-failed",
-    #             "platform"=>{"full"=>"mac_os_x 17.7.0", "name"=>"mac_os_x", "release"=>"17.7.0"},
-    #             "profiles"=>[
-    #               {
-    #                 "full"=>"My Profile 1 title, v1.0.1",
-    #                 "id"=>"447542ecfb8a8800ed0146039da3af8fed047f575f6037cfba75f3b664a97ea4",
-    #                 "name"=>"myprofile1",
-    #                 "status"=>"failed",
-    #                 "version"=>"1.0.1"
-    #               },
-    #               {
-    #                 "full"=>"My Profile 2 title, v1.0.5",
-    #                 "id"=>"447542ecfb8a8800ed0146039da3af8fed047f575f6037cfba75f3b664a97ea5",
-    #                 "name"=>"myprofile2",
-    #                 "status"=>"waived",
-    #                 "version"=>"1.0.5"
-    #               }
-    #             ]
-    #           }
-    #         ],
-    #         "total"=>1,
-    #         "totalWaived"=>1
-    #       }.to_json
-    # assert_equal_json_sorted(expected_nodes, actual_nodes.to_json)
+    # TODO: CONFIRM WITH THE TEAM BECAUSE AT THE MOMENT latestReport and node status is deep, where profiles array(inc status) is shallow
+    actual_nodes = GRPC reporting, :list_nodes, Reporting::Query.new(filters: [
+        Reporting::ListFilter.new(type: 'profile_id', values: ['447542ecfb8a8800ed0146039da3af8fed047f575f6037cfba75f3b664a97ea4']),
+        Reporting::ListFilter.new(type: "control", values: ["pro1-con1"]),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-04-01T23:59:59Z'])
+    ])
+    expected_nodes = {"nodes" => [
+              {
+                "environment"=>"DevSec Prod Omega",
+                "id"=>"34cbbb4c-c502-4971-1111-888888888888",
+                "latestReport"=>{
+                  "controls"=>{
+                    "failed"=>{},
+                    "passed"=>{},
+                    "skipped"=>{},
+                    "total"=>1,
+                    "waived"=>{"total"=>1}
+                  },
+                  "endTime"=>"2018-04-01T10:18:41Z",
+                  "id"=>"44024b50-2e0d-42fa-cccc-yyyyyyyyyyyy",
+                  "status"=>"waived"
+                },
+                "name"=>"osx(2)-omega-pro1(f)-pro2(w)-failed",
+                "platform"=>{"full"=>"mac_os_x 17.7.0", "name"=>"mac_os_x", "release"=>"17.7.0"},
+                "profiles"=>[
+                  {
+                    "full"=>"My Profile 1 title, v1.0.1",
+                    "id"=>"447542ecfb8a8800ed0146039da3af8fed047f575f6037cfba75f3b664a97ea4",
+                    "name"=>"myprofile1",
+                    "status"=>"failed",
+                    "version"=>"1.0.1"
+                  },
+                  {
+                    "full"=>"My Profile 2 title, v1.0.5",
+                    "id"=>"447542ecfb8a8800ed0146039da3af8fed047f575f6037cfba75f3b664a97ea5",
+                    "name"=>"myprofile2",
+                    "status"=>"waived",
+                    "version"=>"1.0.5"
+                  }
+                ]
+              }
+            ],
+            "total"=>1,
+            "totalWaived"=>1
+          }.to_json
+    assert_equal_json_sorted(expected_nodes, actual_nodes.to_json)
 
     actual = GRPC reporting, :list_nodes, Reporting::Query.new(filters: [
         Reporting::ListFilter.new(type: 'profile_id', values: ['non-existent'])

--- a/components/compliance-service/reporting/relaxting/depth.go
+++ b/components/compliance-service/reporting/relaxting/depth.go
@@ -9,6 +9,7 @@ import (
 
 	reportingapi "github.com/chef/automate/components/compliance-service/api/reporting"
 	"github.com/chef/automate/components/compliance-service/api/stats"
+	"github.com/chef/automate/components/compliance-service/ingest/events/inspec"
 	"github.com/chef/automate/components/compliance-service/reporting"
 )
 
@@ -140,7 +141,10 @@ func getControlLevelControlSums(hit *elastic.SearchHit) (nodeControlSummary repo
 						if err == nil {
 							// this is for one node and since this control should only be in this profile once, it's
 							// reasonable to list it with a cardinality of 1
-							if control.Status == "failed" {
+							if control.WaivedStr == inspec.ControlWaivedStrYes || control.WaivedStr == inspec.ControlWaivedStrYesRun {
+								nodeControlSummary.Waived.Total = 1
+								control.Status = "waived"
+							} else if control.Status == "failed" {
 								nodeControlSummary.Failed.Total = 1
 								if control.Impact < 0.4 {
 									nodeControlSummary.Failed.Minor = 1

--- a/components/compliance-service/reporting/relaxting/nodes.go
+++ b/components/compliance-service/reporting/relaxting/nodes.go
@@ -25,9 +25,10 @@ type ProfileSource struct {
 }
 
 type ControlSource struct {
-	ID     string  `json:"id"`
-	Impact float32 `json:"impact"`
-	Status string  `json:"status"`
+	ID        string  `json:"id"`
+	Impact    float32 `json:"impact"`
+	Status    string  `json:"status"`
+	WaivedStr string  `json:"waived_str"`
 }
 
 type TotalNodeCounts struct {
@@ -174,7 +175,7 @@ func (backend *ES2Backend) GetNodes(from int32, size int32, filters map[string][
 			}
 
 		}
-		// get node counts of passed/failed/skipped nodes to append to totals response
+		// get node counts of passed/failed/skipped/waived nodes to append to totals response
 		nodeSummary, err := backend.GetStatsSummaryNodes(filters)
 		if err != nil {
 			return nil, emptyTotals, errors.Wrapf(err, "%s error retrieving node count totals: ", myName)

--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -896,7 +896,7 @@ func (backend ES2Backend) getFiltersQuery(filters map[string][]string, latestOnl
 		profileBaseFscIncludes := []string{"profiles.name", "profiles.sha256", "profiles.version"}
 		profileLevelFscIncludes := []string{"profiles.controls_sums", "profiles.status"}
 		controlLevelFscIncludes := []string{"profiles.controls.id", "profiles.controls.status",
-			"profiles.controls.impact"}
+			"profiles.controls.impact", "profiles.controls.waived_str"}
 
 		profileAndControlQuery := getProfileAndControlQuery(filters, profileBaseFscIncludes,
 			profileLevelFscIncludes, controlLevelFscIncludes)

--- a/components/compliance-service/reporting/relaxting/stats_control_level.go
+++ b/components/compliance-service/reporting/relaxting/stats_control_level.go
@@ -445,11 +445,13 @@ func (depth *ControlDepth) getStatsSummaryNodesAggs() map[string]elastic.Aggrega
 		Must(elastic.NewTermQuery("profiles.controls.status", "skipped")).
 		MustNot(waivedQuery))
 
+	waivedFilter := elastic.NewFilterAggregation().Filter(waivedQuery)
+
 	impactTerms := elastic.NewTermsAggregation().Field("profiles.controls.impact").Size(1).
 		SubAggregation("compliant", passedFilter).
 		SubAggregation("noncompliant", failedFilter).
 		SubAggregation("skipped", skippedFilter).
-		SubAggregation("waived", waivedQuery)
+		SubAggregation("waived", waivedFilter)
 
 	aggs := make(map[string]elastic.Aggregation)
 	aggs["impact"] = impactTerms

--- a/components/compliance-service/reporting/relaxting/stats_profile_level.go
+++ b/components/compliance-service/reporting/relaxting/stats_profile_level.go
@@ -450,9 +450,6 @@ func (depth *ProfileDepth) getStatsSummaryNodesAggs() map[string]elastic.Aggrega
 	aggHighRisk := elastic.NewFilterAggregation().
 		Filter(elastic.NewRangeQuery("profiles.controls_sums.failed.critical").Gt(0))
 
-	// TODO: This needs some other query type that takes two paths
-	// RDM- I think that this term query fixes this TODO
-	// basically if total waived controls == total controls, we have a waived node
 	aggWaived := elastic.NewFilterAggregation().
 		Filter(elastic.NewTermQuery("profiles.status", "waived"))
 

--- a/components/compliance-service/reporting/relaxting/stats_profile_level.go
+++ b/components/compliance-service/reporting/relaxting/stats_profile_level.go
@@ -451,9 +451,10 @@ func (depth *ProfileDepth) getStatsSummaryNodesAggs() map[string]elastic.Aggrega
 		Filter(elastic.NewRangeQuery("profiles.controls_sums.failed.critical").Gt(0))
 
 	// TODO: This needs some other query type that takes two paths
+	// RDM- I think that this term query fixes this TODO
 	// basically if total waived controls == total controls, we have a waived node
 	aggWaived := elastic.NewFilterAggregation().
-		Filter(elastic.NewTermQuery("profiles.controls_sums.total", "profiles.controls_sums.waived.total"))
+		Filter(elastic.NewTermQuery("profiles.status", "waived"))
 
 	aggMediumRisk := elastic.NewFilterAggregation().
 		Filter(elastic.NewBoolQuery().


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This change sets waiver sums for control as well as profile level depths for support of deep filtering in stats node api