### PR TITLE
add backupRunning state to converger 

### DIFF
--- a/api/interservice/deployment/errors.go
+++ b/api/interservice/deployment/errors.go
@@ -2,12 +2,16 @@ package deployment
 
 import (
 	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
 	upgradePendingMessage     = "deployment-service upgrade pending"
 	reconfigurePendingMessage = "deployment-service reconfiguration pending"
 	restartPendingMessage     = "deployment-service is waiting to shut down"
+	backupInProgressMessage   = "deployment-service backup is running"
 )
 
 var (
@@ -22,16 +26,39 @@ var (
 	// expects to be stopped by some external process (hab-sup or
 	// systemd)
 	ErrRestartPending = errors.New(restartPendingMessage)
+
+	// ErrBackupInProgress is returned when the requested action
+	// is not possible because a backup is currently being taken.
+	ErrBackupInProgress = errors.New(backupInProgressMessage)
 )
 
 func IsDeploymentServicePendingError(err error) bool {
 	return err == ErrSelfReconfigurePending ||
 		err == ErrSelfUpgradePending ||
-		err == ErrRestartPending
+		err == ErrRestartPending ||
+		err == ErrBackupInProgress
 }
 
-func IsDeploymentServicePendingMessage(msg string) bool {
+func isDeploymentServicePendingMessage(msg string) bool {
 	return msg == reconfigurePendingMessage ||
 		msg == upgradePendingMessage ||
-		msg == restartPendingMessage
+		msg == restartPendingMessage ||
+		msg == backupInProgressMessage
+}
+
+func IsRetriableGRPCStatus(err error) bool {
+	if grpcStatus, ok := status.FromError(err); ok {
+		// first test for grpc codes:
+		// codes.Unavailable means that we can retry
+		if grpcStatus.Code() == codes.Unavailable {
+			return true
+		}
+
+		// back-compat: old versions of the server don't return a code so we
+		// should check the message
+		if grpcStatus.Code() == codes.Unknown {
+			return isDeploymentServicePendingMessage(grpcStatus.Message())
+		}
+	}
+	return false
 }

--- a/components/automate-deployment/pkg/converge/converger.go
+++ b/components/automate-deployment/pkg/converge/converger.go
@@ -460,7 +460,7 @@ func (w *waitingForReconfigure) ProcessMessage(c *converger, msg message) (state
 func (w *waitingForReconfigure) String() string { return "waiting for reconfigure" }
 
 // backupRunning running is a converger state that we enter when we've
-// recieved a user-signal indicating that a backup is about to begin.
+// received a user-signal indicating that a backup is about to begin.
 //
 // This state can be removed when the converger itself handles taking
 // a backup.


### PR DESCRIPTION
The new backupRunning state represents the fact that we do not want to
run most operations while the backup is running. The converger enters
this state when then backup code runs StartBackup.  The motivation for this
change is recently observed test failures caused by attempts to start a backup
when a previously configuration change was still waiting to be applied.

Right now, the backup code remains outside of the compiler, so we've
also added a BackupComplete() call to signal when we should leave this
state.

Attempts to StartBackup() when we are waiting for a restart or a
reconfigure will fail. The client then retries these failures.

Signed-off-by: Steven Danna <steve@chef.io>