### PR TITLE
Assorted ui display bug fixes

### DIFF
--- a/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.ts
@@ -65,7 +65,9 @@ export class TeamAddUsersComponent implements OnInit, OnDestroy {
     ]).pipe(
         takeUntil(this.isDestroyed),
         filter(([isV2, _v2TeamFromRoute, _v1TeamFromRoute]) => isV2 !== null),
-        map(([isV2, v2Team, v1Team]) => isV2 ? [v2Team, v2Team.id] : [v1Team, v1Team.guid]),
+        map(([isV2, v2Team, v1Team]) =>
+          isV2 ? [v2Team, v2Team ? v2Team.id : null] : [v1Team, v1Team ? v1Team.guid : null]),
+        filter(([team, _teamId]) => team != null),
         distinctUntilChanged(
           ([_teamA, teamIdA]: [Team, string], [_teamB, teamIdB]: [Team, string]) =>
           teamIdA === teamIdB)

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.html
@@ -6,7 +6,7 @@
         <span *ngIf="!(isIAMv2$ | async)">{{ team?.id }}</span>
         <span *ngIf="isIAMv2$ | async">{{ team?.name }}</span>
       </chef-breadcrumbs>
-  
+
       <chef-page-header>
         <chef-heading *ngIf="!(isIAMv2$ | async)">{{ team?.id }}</chef-heading>
         <chef-heading *ngIf="isIAMv2$ | async">{{ team?.name }}</chef-heading>
@@ -40,7 +40,7 @@
             </tr>
           </tbody>
         </table>
-  
+
         <chef-tab-selector (change)="onSelectedTab($event)" [value]="tabValue">
           <chef-option value='users'>Users</chef-option>
           <chef-option value='details' data-cy="team-details-tab-details">Details</chef-option>
@@ -52,7 +52,7 @@
             <!-- TODO remove [overridePermissionsCheck]=true once the UI is able to check specific objects
             since the path to permission on here is /auth/teams/:id/users we'll have to show everything for now. -->
             <app-user-table [addButtonText]="addButtonText" [removeText]="removeText" [users]="users"
-              [baseUrl]="'/auth/users/' + team.id" [overridePermissionsCheck]=true [showTable]="showUsersTable()"
+              [baseUrl]="'/auth/users/' + team?.id" [overridePermissionsCheck]=true [showTable]="showUsersTable()"
               [showEmptyMessage]="showEmptyStateMessage()" (addClicked)="toggleUserMembershipView()"
               (removeClicked)="removeUser($event)">
             </app-user-table>

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.html
@@ -22,7 +22,7 @@
           </thead>
           <tbody>
             <tr class="detail-row">
-              <td *ngIf="!(isIAMv2$ | async)" class="id-column">{{ team.name }}</td>
+              <td *ngIf="!(isIAMv2$ | async)" class="id-column">{{ team?.name }}</td>
               <ng-container *ngIf="isIAMv2$ | async">
                 <td class="id-column">{{ team?.id }}</td>
                 <td class="projects-column" data-cy="team-details-projects">

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, FormControl, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
-import { isEmpty, keyBy, at, xor } from 'lodash/fp';
+import { isEmpty, keyBy, at, xor, isNil } from 'lodash/fp';
 import { combineLatest, Subject, Observable } from 'rxjs';
 import { filter, map, takeUntil, distinctUntilChanged } from 'rxjs/operators';
 
@@ -174,8 +174,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
       team$
     ]).pipe(
       takeUntil(this.isDestroyed),
-      filter(([_, pStatus, _team]) =>
-      pStatus !== EntityStatus.loading)
+      filter(([_, pStatus, team]) => !pending(pStatus) && !isNil(team))
     ).subscribe(([allowedProjects, _, team]) => {
         this.projects = {};
         allowedProjects


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This includes fixes for 3 browser console errors:

#### 1. Cannot read property 'id' of undefined

Repro steps:
Teams > (team) > users > add users

#### 2. Cannot read property 'projects' of undefined

Note this issue surfaced after (1) was fixed, so you will not see it on master.

Repro steps:
Teams > (team) > users > add users > (close)

#### 3. Cannot read property 'name' of undefined

Repro steps:
Teams > (team) > (browser refresh)

### :chains: Related Resources
N/A

### :+1: Definition of Done
None of the errors above appear in the browser console log.

### :athletic_shoe: How to Build and Test the Change

 - Rebuild automate-ui
 - Open dev tools (<kbd>cmd</kbd> + <kbd>opt</kbd> + <kbd>i</kbd>)
 - Follow the repro steps noted above.