### PR TITLE
Add 404 page to automate-chef-io

### DIFF
--- a/components/automate-chef-io/layouts/404.html
+++ b/components/automate-chef-io/layouts/404.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+{{ partial "automate/head" . }}
+
+<body>
+  <div class="off-canvas-wrapper has-sidebar">
+    <div class="off-canvas-content" data-off-canvas-content>
+      <div id="menu" class="cell small-12" data-sticky-container>
+        {{ partial "automate/header" . }}
+      </div>
+      <div class="cell small-12" style="z-index: 10;">
+        {{ partial "mini-hero" . }}
+      </div>
+      <div id="main-content" class="cell small-12" data-sticky-container>
+        <div id="main-content-col" class="col-content">
+          <h1>404</h1>
+          <div class="prose">
+            <p>The page you were looking for is not here. If you think it's our fault,
+            <a href="https://docs.chef.io/feedback.html">please let us know</a>.</p>
+          </div>
+        </div>
+      </div>
+      <div id="footer" class="cell small-12">
+        <nav>
+          {{ partial "automate/footer" . }}
+        </nav>
+      </div>
+    </div>
+  </div>
+  <script src="{{ "js/scripts-all.js" | relURL }}"></script>
+</body>
+
+</html>

--- a/components/automate-chef-io/layouts/404.html
+++ b/components/automate-chef-io/layouts/404.html
@@ -15,8 +15,9 @@
         <div id="main-content-col" class="col-content">
           <h1>404</h1>
           <div class="prose">
-            <p>The page you were looking for is not here. If you think it's our fault,
-            <a href="https://docs.chef.io/feedback.html">please let us know</a>.</p>
+            <p>We did something wrong!</p>
+            <p>If a page has gone missing,</p>
+            <p><a href="https://docs.chef.io/feedback.html">contact us</a> for help.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

This adds a 404 page to automate.chef.io. 

### :chains: Related Resources

n/a

### :+1: Definition of Done

Users see a proper 404 page if they navigate to a page that doesn't exist.

### :athletic_shoe: How to Build and Test the Change

`make serve` then navigate to `localhost:1313/404.html`
Unfortunately you [can't test](https://discourse.gohugo.io/t/how-to-test-404-html-on-local-server/681) if the 404 page works locally.

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable