### PR TITLE
backup: Remove async operations

### DIFF
--- a/components/automate-deployment/pkg/backup/event_handler.go
+++ b/components/automate-deployment/pkg/backup/event_handler.go
@@ -113,16 +113,12 @@ func (eh *EventHandler) formatMessage(ops []*api.DeployEvent_Backup_Operation) s
 		}
 	}
 	padding := maxOpLen + maxOpTypeLen
-	fmtStr := fmt.Sprintf("%%-%ds %%s %%-%ds \n", padding, padding+16)
+	fmtStr := fmt.Sprintf("%%-%ds %%%d.2f%%%%\n", padding, 6)
 
 	m := strings.Builder{}
 	m.WriteString(fmt.Sprintf("%s in progress\n\n", strings.Title(eh.opTypeToString(ops[0].Type))))
 	for _, o := range eh.sortOps(ops) {
-		m.WriteString(fmt.Sprintf(fmtStr,
-			o.Name,
-			fmt.Sprintf("(sync %.2f%%)", o.SyncProgress),
-			fmt.Sprintf("(async %.2f%%)", o.AsyncProgress),
-		))
+		m.WriteString(fmt.Sprintf(fmtStr, o.Name, o.SyncProgress))
 	}
 
 	return m.String()

--- a/components/automate-deployment/pkg/backup/event_handler_test.go
+++ b/components/automate-deployment/pkg/backup/event_handler_test.go
@@ -22,10 +22,9 @@ func TestBackupHandler(t *testing.T) {
 			api.DeployEvent_COMPLETE_OK,
 			[]*api.DeployEvent_Backup_Operation{
 				{
-					Status:        api.DeployEvent_COMPLETE_OK,
-					Name:          "service-a",
-					SyncProgress:  100,
-					AsyncProgress: 100,
+					Status:       api.DeployEvent_COMPLETE_OK,
+					Name:         "service-a",
+					SyncProgress: 100,
 				},
 			},
 		)
@@ -43,17 +42,15 @@ func TestBackupHandler(t *testing.T) {
 			api.DeployEvent_COMPLETE_FAIL,
 			[]*api.DeployEvent_Backup_Operation{
 				{
-					Status:        api.DeployEvent_COMPLETE_OK,
-					Name:          "service-a",
-					SyncProgress:  100,
-					AsyncProgress: 100,
+					Status:       api.DeployEvent_COMPLETE_OK,
+					Name:         "service-a",
+					SyncProgress: 100,
 				},
 				{
-					Status:        api.DeployEvent_COMPLETE_FAIL,
-					Name:          "service-b",
-					SyncProgress:  100,
-					AsyncProgress: 51,
-					Error:         "sub-operation failed",
+					Status:       api.DeployEvent_COMPLETE_FAIL,
+					Name:         "service-b",
+					SyncProgress: 100,
+					Error:        "sub-operation failed",
 				},
 			},
 		)
@@ -71,16 +68,14 @@ func TestBackupHandler(t *testing.T) {
 			api.DeployEvent_COMPLETE_FAIL,
 			[]*api.DeployEvent_Backup_Operation{
 				{
-					Status:        api.DeployEvent_COMPLETE_OK,
-					Name:          "service-a",
-					SyncProgress:  100,
-					AsyncProgress: 100,
+					Status:       api.DeployEvent_COMPLETE_OK,
+					Name:         "service-a",
+					SyncProgress: 100,
 				},
 				{
-					Status:        api.DeployEvent_COMPLETE_FAIL,
-					Name:          "service-b",
-					SyncProgress:  100,
-					AsyncProgress: 51,
+					Status:       api.DeployEvent_COMPLETE_FAIL,
+					Name:         "service-b",
+					SyncProgress: 100,
 				},
 			},
 		)
@@ -98,16 +93,14 @@ func TestBackupHandler(t *testing.T) {
 			api.DeployEvent_RUNNING,
 			[]*api.DeployEvent_Backup_Operation{
 				{
-					Status:        api.DeployEvent_COMPLETE_OK,
-					Name:          "service-a",
-					SyncProgress:  100,
-					AsyncProgress: 100,
+					Status:       api.DeployEvent_COMPLETE_OK,
+					Name:         "service-a",
+					SyncProgress: 100,
 				},
 				{
-					Status:        api.DeployEvent_RUNNING,
-					Name:          "service-b",
-					SyncProgress:  66,
-					AsyncProgress: 0,
+					Status:       api.DeployEvent_RUNNING,
+					Name:         "service-b",
+					SyncProgress: 66,
 				},
 			},
 		)

--- a/components/automate-deployment/pkg/backup/executor.go
+++ b/components/automate-deployment/pkg/backup/executor.go
@@ -8,11 +8,9 @@ import (
 	api "github.com/chef/automate/api/interservice/deployment"
 )
 
-// Executor executes synchronous and asynchronous backup operations. It
-// listens for the operation events, annotates them, and publishes them to the
-// status and publishing the backup status to event sender.
-// It breaks backup execution into two phases: sync and async. All synchronous
-// operations will be executed first, followed by asynchronous operations.
+// Executor executes backup operations. It listens for the operation
+// events, annotates them, and publishes them to the status and
+// publishing the backup status to event sender.
 type Executor struct {
 	// BackupTask event operations channel to publish backup events to
 	opEventChan chan api.DeployEvent_Backup_Operation
@@ -27,16 +25,15 @@ type Executor struct {
 	// an operation failure.
 	cancel func()
 
-	// Operation progress calculators. These are used to aggregate the overall
-	// progress of all operation that are to be executed.
-	syncProgress  *ProgressCalculator
-	asyncProgress *ProgressCalculator
+	// Operation progress calculator. Thit is used to aggregate
+	// the overall progress of all operation that are to be
+	// executed.
+	progress *ProgressCalculator
 
 	// Operation progress channel. This is a channel for each operation to
 	// publish progress events.
-	syncProgressChan  chan OperationProgress
-	asyncProgressChan chan OperationProgress
-	progressExitChan  chan struct{}
+	progressChan     chan OperationProgress
+	progressExitChan chan struct{}
 
 	// What backup operation type were executing
 	execType api.DeployEvent_Backup_Operation_Type
@@ -57,14 +54,11 @@ type ExecutorOpt func(*Executor)
 // NewExecutor returns a new instance of a backup job executor
 func NewExecutor(opts ...ExecutorOpt) *Executor {
 	executor := &Executor{
-		// Operation progress calculators
-		syncProgress:  NewProgressCalculator(),
-		asyncProgress: NewProgressCalculator(),
+		progress: NewProgressCalculator(),
 
 		// Operation progress channel
-		syncProgressChan:  make(chan OperationProgress),
-		asyncProgressChan: make(chan OperationProgress),
-		progressExitChan:  make(chan struct{}),
+		progressChan:     make(chan OperationProgress),
+		progressExitChan: make(chan struct{}),
 
 		// TODO(jaym) 05-07-2018: Remove the lock
 		// The purpose of the lock is to make sure only 1 backup executor runs at a time.
@@ -120,8 +114,8 @@ func WithLock(lock *sync.Mutex) ExecutorOpt {
 	}
 }
 
-// Backup runs the sync and async operations and waits for them to complete.
-// When completed or failed it publishes notifications to the event channel
+// Backup runs the operations and waits for them to complete.  When
+// completed or failed it publishes notifications to the event channel
 // and notifies that runner that the operations have completed.
 func (b *Executor) Backup(backupCtx Context) error {
 	defer b.stopProgressCalculator()
@@ -132,11 +126,7 @@ func (b *Executor) Backup(backupCtx Context) error {
 	b.locky.Lock()
 	defer b.locky.Unlock()
 
-	if err := b.runSyncBackupOperations(backupCtx); err != nil {
-		return err
-	}
-
-	if err := b.runAsyncBackupOperations(backupCtx); err != nil {
+	if err := b.runBackupOperations(backupCtx); err != nil {
 		return err
 	}
 
@@ -145,11 +135,10 @@ func (b *Executor) Backup(backupCtx Context) error {
 	}
 
 	b.opEventChan <- api.DeployEvent_Backup_Operation{
-		Status:        api.DeployEvent_COMPLETE_OK,
-		Type:          b.execType,
-		Name:          b.spec.Name,
-		AsyncProgress: 100,
-		SyncProgress:  100,
+		Status:       api.DeployEvent_COMPLETE_OK,
+		Type:         b.execType,
+		Name:         b.spec.Name,
+		SyncProgress: 100,
 	}
 
 	return nil
@@ -165,12 +154,6 @@ func (b *Executor) DeleteBackup(backupCtx Context) error {
 		}
 	}
 
-	for _, op := range b.spec.AsyncOps() {
-		if err := op.Delete(backupCtx); err != nil {
-			b.cancel()
-			return err
-		}
-	}
 	for _, op := range b.spec.FinalizingOps() {
 		if _, ok := op.(*MetadataWriterOperation); ok {
 			// our metadata operations should be the last that are
@@ -204,27 +187,23 @@ func (b *Executor) Restore(backupCtx Context, metadata *Metadata) error {
 	b.startProgressCalculator()
 
 	b.opEventChan <- api.DeployEvent_Backup_Operation{
-		Status:        api.DeployEvent_RUNNING,
-		Type:          b.execType,
-		Name:          b.spec.Name,
-		AsyncProgress: 0,
-		SyncProgress:  0,
+		Status:       api.DeployEvent_RUNNING,
+		Type:         b.execType,
+		Name:         b.spec.Name,
+		SyncProgress: 0,
 	}
 
 	if err := b.runRestoreSync(backupCtx, metadata, b.spec.SyncOps()); err != nil {
 		return err
 	}
 
-	b.syncProgress.Done()
-
-	b.asyncProgress.Done()
+	b.progress.Done()
 
 	b.opEventChan <- api.DeployEvent_Backup_Operation{
-		Status:        api.DeployEvent_COMPLETE_OK,
-		Type:          b.execType,
-		Name:          b.spec.Name,
-		AsyncProgress: 100,
-		SyncProgress:  100,
+		Status:       api.DeployEvent_COMPLETE_OK,
+		Type:         b.execType,
+		Name:         b.spec.Name,
+		SyncProgress: 100,
 	}
 
 	return nil
@@ -244,13 +223,12 @@ func (b *Executor) runRestoreSync(backupCtx Context, metadata *Metadata, ops []O
 
 		verifier := metadata.Verifier()
 
-		if err := op.Restore(backupCtx, b.spec.Name, verifier, b.syncProgressChan); err != nil {
+		if err := op.Restore(backupCtx, b.spec.Name, verifier, b.progressChan); err != nil {
 			b.opEventChan <- api.DeployEvent_Backup_Operation{
-				Status:        api.DeployEvent_COMPLETE_FAIL,
-				Type:          b.execType,
-				Name:          b.spec.Name,
-				AsyncProgress: b.asyncProgress.Percent(),
-				SyncProgress:  b.syncProgress.Percent(),
+				Status:       api.DeployEvent_COMPLETE_FAIL,
+				Type:         b.execType,
+				Name:         b.spec.Name,
+				SyncProgress: b.progress.Percent(),
 			}
 
 			// Do a non-blocking publish to the error channel
@@ -308,25 +286,14 @@ func (b *Executor) startProgressCalculator() {
 	go func() {
 		for {
 			select {
-			case u := <-b.syncProgressChan:
-				b.syncProgress.Update(u)
+			case u := <-b.progressChan:
+				b.progress.Update(u)
 
 				b.opEventChan <- api.DeployEvent_Backup_Operation{
-					Status:        api.DeployEvent_RUNNING,
-					Type:          b.execType,
-					Name:          b.spec.Name,
-					SyncProgress:  b.syncProgress.Percent(),
-					AsyncProgress: b.asyncProgress.Percent(),
-				}
-			case u := <-b.asyncProgressChan:
-				b.asyncProgress.Update(u)
-
-				b.opEventChan <- api.DeployEvent_Backup_Operation{
-					Status:        api.DeployEvent_RUNNING,
-					Type:          b.execType,
-					Name:          b.spec.Name,
-					SyncProgress:  b.syncProgress.Percent(),
-					AsyncProgress: b.asyncProgress.Percent(),
+					Status:       api.DeployEvent_RUNNING,
+					Type:         b.execType,
+					Name:         b.spec.Name,
+					SyncProgress: b.progress.Percent(),
 				}
 			case <-b.progressExitChan:
 				return
@@ -343,21 +310,16 @@ func (b *Executor) stopProgressCalculator() {
 // resetProgress resets progress to zero for all operations.
 func (b *Executor) resetProgress() {
 	b.progressExitChan = make(chan struct{})
-	b.syncProgress = NewProgressCalculator()
-	b.asyncProgress = NewProgressCalculator()
+	b.progress = NewProgressCalculator()
 
 	for _, o := range b.spec.SyncOps() {
 		op := o
-		b.syncProgress.Update(OperationProgress{Name: op.String(), Progress: 0})
-	}
-	for _, o := range b.spec.AsyncOps() {
-		op := o
-		b.asyncProgress.Update(OperationProgress{Name: op.String(), Progress: 0})
+		b.progress.Update(OperationProgress{Name: op.String(), Progress: 0})
 	}
 }
 
-// runSyncBackupOperations runs synchronous operations
-func (b *Executor) runSyncBackupOperations(backupCtx Context) error {
+// runBackupOperations runs the backup operations
+func (b *Executor) runBackupOperations(backupCtx Context) error {
 	for _, o := range b.spec.SyncOps() {
 		op := o
 		// Make sure another op hasn't already failed before we start more.
@@ -373,13 +335,12 @@ func (b *Executor) runSyncBackupOperations(backupCtx Context) error {
 			"op_name": op.String(),
 		}).Debug("Starting backup operation")
 
-		if err := op.Backup(backupCtx, b.objectManifest, b.syncProgressChan); err != nil {
+		if err := op.Backup(backupCtx, b.objectManifest, b.progressChan); err != nil {
 			b.opEventChan <- api.DeployEvent_Backup_Operation{
-				Status:        api.DeployEvent_COMPLETE_FAIL,
-				Type:          b.execType,
-				Name:          b.spec.Name,
-				AsyncProgress: b.asyncProgress.Percent(),
-				SyncProgress:  b.syncProgress.Percent(),
+				Status:       api.DeployEvent_COMPLETE_FAIL,
+				Type:         b.execType,
+				Name:         b.spec.Name,
+				SyncProgress: b.progress.Percent(),
 			}
 
 			// Do a non-blocking publish to the error channel
@@ -395,92 +356,12 @@ func (b *Executor) runSyncBackupOperations(backupCtx Context) error {
 		}
 	}
 
-	b.syncProgress.Done()
+	b.progress.Done()
 	b.opEventChan <- api.DeployEvent_Backup_Operation{
-		Status:        api.DeployEvent_COMPLETE_OK,
-		Type:          b.execType,
-		Name:          b.spec.Name,
-		AsyncProgress: b.asyncProgress.Percent(),
-		SyncProgress:  b.syncProgress.Percent(),
-	}
-
-	return nil
-}
-
-// runAsyncBackupOperations runs asynchronous operations
-func (b *Executor) runAsyncBackupOperations(backupCtx Context) error {
-	wg := sync.WaitGroup{}
-	// If an operation fails it should publish it's error message to the asyncErrChan
-	// We only care about the first error we'll buffer the first write only.
-	asyncErrChan := make(chan error, 1)
-
-	// Start all async operations in their own goroutines
-	for _, aop := range b.spec.AsyncOps() {
-		wg.Add(1)
-		op := aop // copy because golang range
-
-		go func() {
-			defer wg.Done()
-
-			logrus.WithFields(logrus.Fields{
-				"task_id": backupCtx.backupTask.TaskID(),
-				"mode":    "async",
-				"op_name": op.String(),
-			}).Debug("Starting backup operation")
-
-			if err := op.Backup(backupCtx, b.objectManifest, b.asyncProgressChan); err != nil {
-				b.opEventChan <- api.DeployEvent_Backup_Operation{
-					Status:        api.DeployEvent_COMPLETE_FAIL,
-					Type:          b.execType,
-					Name:          b.spec.Name,
-					AsyncProgress: b.asyncProgress.Percent(),
-					SyncProgress:  b.syncProgress.Percent(),
-				}
-
-				// Do a non-blocking publish to the error channels. These channels
-				// are buffered to a single message because the first error
-				// is the only one we care about. This helps us to avoid
-				// publishing cascading errors because the context has been
-				// cancelled.
-				select {
-				case b.opErrChan <- err:
-				default:
-				}
-				select {
-				case asyncErrChan <- err:
-				default:
-				}
-
-				// Cancel our context to signal other operations and specification
-				// to terminate.
-				b.cancel()
-			}
-		}()
-	}
-
-	// wait for them to finish
-	wg.Wait()
-
-	select {
-	case err := <-asyncErrChan:
-		b.opEventChan <- api.DeployEvent_Backup_Operation{
-			Status:        api.DeployEvent_COMPLETE_FAIL,
-			Type:          b.execType,
-			Name:          b.spec.Name,
-			AsyncProgress: b.asyncProgress.Percent(),
-			SyncProgress:  b.syncProgress.Percent(),
-		}
-		return err
-	default:
-	}
-
-	b.asyncProgress.Done()
-	b.opEventChan <- api.DeployEvent_Backup_Operation{
-		Status:        api.DeployEvent_COMPLETE_OK,
-		Type:          b.execType,
-		Name:          b.spec.Name,
-		AsyncProgress: b.asyncProgress.Percent(),
-		SyncProgress:  b.syncProgress.Percent(),
+		Status:       api.DeployEvent_COMPLETE_OK,
+		Type:         b.execType,
+		Name:         b.spec.Name,
+		SyncProgress: b.progress.Percent(),
 	}
 
 	return nil
@@ -502,13 +383,12 @@ func (b *Executor) runFinalizingOperations(backupCtx Context) error {
 			"op_name": op.String(),
 		}).Debug("Starting backup operation")
 
-		if err := op.Backup(backupCtx, b.objectManifest, b.syncProgressChan); err != nil {
+		if err := op.Backup(backupCtx, b.objectManifest, b.progressChan); err != nil {
 			b.opEventChan <- api.DeployEvent_Backup_Operation{
-				Status:        api.DeployEvent_COMPLETE_FAIL,
-				Type:          b.execType,
-				Name:          b.spec.Name,
-				AsyncProgress: b.asyncProgress.Percent(),
-				SyncProgress:  b.syncProgress.Percent(),
+				Status:       api.DeployEvent_COMPLETE_FAIL,
+				Type:         b.execType,
+				Name:         b.spec.Name,
+				SyncProgress: b.progress.Percent(),
 			}
 
 			// Do a non-blocking publish to the error channel

--- a/components/automate-deployment/pkg/backup/executor.go
+++ b/components/automate-deployment/pkg/backup/executor.go
@@ -25,7 +25,7 @@ type Executor struct {
 	// an operation failure.
 	cancel func()
 
-	// Operation progress calculator. Thit is used to aggregate
+	// Operation progress calculator. This is used to aggregate
 	// the overall progress of all operation that are to be
 	// executed.
 	progress *ProgressCalculator

--- a/components/automate-deployment/pkg/backup/runner.go
+++ b/components/automate-deployment/pkg/backup/runner.go
@@ -712,8 +712,6 @@ func (r *Runner) restoreServices(ctx context.Context, desiredServices []*deploym
 			r.failf(err, "Timed out waiting for service %s to start", svc.Name())
 			return err
 		}
-
-		// TODO: Restore async operations
 	}
 
 	return nil

--- a/components/automate-deployment/pkg/backup/runner_test.go
+++ b/components/automate-deployment/pkg/backup/runner_test.go
@@ -58,16 +58,14 @@ func TestCreateBackupEvent(t *testing.T) {
 
 		// Add some running operations
 		r.updateOperationStatus(task.TaskID(), api.DeployEvent_Backup_Operation{
-			Status:        api.DeployEvent_RUNNING,
-			Name:          "service-a",
-			SyncProgress:  float64(100),
-			AsyncProgress: 76,
+			Status:       api.DeployEvent_RUNNING,
+			Name:         "service-a",
+			SyncProgress: float64(100),
 		})
 		r.updateOperationStatus(task.TaskID(), api.DeployEvent_Backup_Operation{
-			Status:        api.DeployEvent_COMPLETE_OK,
-			Name:          "service-b",
-			SyncProgress:  100,
-			AsyncProgress: 100,
+			Status:       api.DeployEvent_COMPLETE_OK,
+			Name:         "service-b",
+			SyncProgress: 100,
 		})
 
 		e := r.createBackupEvent(task.TaskID(), api.DeployEvent_RUNNING)
@@ -80,14 +78,12 @@ func TestCreateBackupEvent(t *testing.T) {
 		assert.Equal(t, "service-a", op.Name)
 		assert.Equal(t, api.DeployEvent_RUNNING, op.Status)
 		assert.Equal(t, float64(100), op.SyncProgress)
-		assert.Equal(t, float64(76), op.AsyncProgress)
 
 		op = operationByName("service-b", e.Operations)
 		assert.NotNil(t, op)
 		assert.Equal(t, "service-b", op.Name)
 		assert.Equal(t, api.DeployEvent_COMPLETE_OK, op.Status)
 		assert.Equal(t, float64(100), op.SyncProgress)
-		assert.Equal(t, float64(100), op.AsyncProgress)
 	})
 }
 
@@ -236,13 +232,11 @@ func testDefaultSpecs() []Spec {
 			Name:          "config-mgmt",
 			WriteMetadata: true,
 			testSyncOps:   []testOperation{{name: "cfg-mgmt-sync"}},
-			testAsyncOps:  []testOperation{{name: "cfg-mgmt-async"}},
 		},
 		{
 			Name:          "deployment-service",
 			WriteMetadata: true,
 			testSyncOps:   []testOperation{{name: "deployment-sync"}},
-			testAsyncOps:  []testOperation{{name: "deployment-async"}},
 		},
 	}
 }

--- a/components/automate-deployment/pkg/backup/spec.go
+++ b/components/automate-deployment/pkg/backup/spec.go
@@ -21,31 +21,25 @@ type Spec struct {
 
 	// Paths to back up. Broken down into which phase of the backup they
 	// should run.
-	SyncPaths  []PathCopyOperation `json:"sync_paths"`
-	AsyncPaths []PathCopyOperation `json:"async_paths"`
+	SyncPaths []PathCopyOperation `json:"sync_paths"`
 
 	// Backup commands to run. Broken down into which phase of the backup they
 	// should run.
-	SyncCmds  []CommandExecuteOperation `json:"sync_cmds"`
-	AsyncCmds []CommandExecuteOperation `json:"async_cmds"`
+	SyncCmds []CommandExecuteOperation `json:"sync_cmds"`
 
 	// Databases to dump. Broken down into which phase the database dumps should
 	// occur. When DB operations have been implemented they should be used here.
-	SyncDbsV2  []DatabaseDumpOperationV2 `json:"sync_dbs_v2"`
-	AsyncDbsV2 []DatabaseDumpOperationV2 `json:"async_dbs_v2"`
+	SyncDbsV2 []DatabaseDumpOperationV2 `json:"sync_dbs_v2"`
 
-	SyncEsIndices  []ElasticsearchOperation `json:"sync_es"`
-	AsyncEsIndices []ElasticsearchOperation `json:"async_es"`
+	SyncEsIndices []ElasticsearchOperation `json:"sync_es"`
 
 	SyncBuilderMinio []BuilderMinioDumpOperation `json:"sync_builder_minio"`
 
 	// Test operations
-	testSyncOps  []testOperation
-	testAsyncOps []testOperation
+	testSyncOps []testOperation
 
 	// DEPRECATED
-	SyncDbs  []DatabaseDumpOperation `json:"sync_dbs"`
-	AsyncDbs []DatabaseDumpOperation `json:"async_dbs"`
+	SyncDbs []DatabaseDumpOperation `json:"sync_dbs"`
 }
 
 // SyncOps returns a slice of Operations that should be run synchronously
@@ -90,47 +84,10 @@ func (s *Spec) SyncOps() []Operation {
 	return ops
 }
 
-// AsyncOps returns a slice of Operations that should be run asynchronously
-func (s *Spec) AsyncOps() []Operation {
-	ops := []Operation{}
-
-	for _, ap := range s.AsyncPaths {
-		p := ap
-		ops = append(ops, &p)
-	}
-
-	for _, ac := range s.AsyncCmds {
-		c := ac
-		ops = append(ops, &c)
-	}
-
-	for _, sc := range s.AsyncDbs {
-		c := sc
-		ops = append(ops, &c)
-	}
-
-	for _, sc := range s.AsyncDbsV2 {
-		c := sc
-		ops = append(ops, &c)
-	}
-
-	for _, ae := range s.AsyncEsIndices {
-		c := ae
-		ops = append(ops, &c)
-	}
-
-	for _, ts := range s.testAsyncOps {
-		t := ts
-		ops = append(ops, &t)
-	}
-
-	return ops
-}
-
-// FinalizingOps returns a slice of Operations that should be run after the
-// synchronous and asynchronous data backup operations have completed.
-// Currently this includes only the MetadataWriterOperation, if the relevant
-// service supports it.
+// FinalizingOps returns a slice of Operations that should be run
+// after the data backup operations have completed.  Currently this
+// includes only the MetadataWriterOperation, if the relevant service
+// supports it.
 func (s *Spec) FinalizingOps() []Operation {
 	ops := []Operation{}
 
@@ -578,35 +535,19 @@ func setDefaults(spec Spec) {
 	for i := range spec.SyncPaths {
 		spec.SyncPaths[i].ObjectName = []string{spec.Name, spec.SyncPaths[i].Name}
 	}
-	for i := range spec.AsyncPaths {
-		spec.AsyncPaths[i].ObjectName = []string{spec.Name, spec.AsyncPaths[i].Name}
-	}
+
 	for i := range spec.SyncCmds {
 		spec.SyncCmds[i].ObjectName = []string{spec.Name, spec.SyncCmds[i].Name}
 		spec.SyncCmds[i].PkgOrigin = "chef"
 		spec.SyncCmds[i].PkgName = spec.Name
 	}
 
-	for i := range spec.AsyncCmds {
-		spec.AsyncCmds[i].ObjectName = []string{spec.Name, spec.AsyncCmds[i].Name}
-		spec.AsyncCmds[i].PkgOrigin = "chef"
-		spec.AsyncCmds[i].PkgName = spec.Name
-	}
-
 	for i := range spec.SyncDbs {
 		spec.SyncDbs[i].ObjectName = []string{spec.Name, "pg_data"}
 	}
 
-	for i := range spec.AsyncDbs {
-		spec.AsyncDbs[i].ObjectName = []string{spec.Name, "pg_data"}
-	}
-
 	for i := range spec.SyncDbsV2 {
 		spec.SyncDbsV2[i].ObjectName = []string{spec.Name, "pg_data"}
-	}
-
-	for i := range spec.AsyncDbsV2 {
-		spec.AsyncDbsV2[i].ObjectName = []string{spec.Name, "pg_data"}
 	}
 
 	for i := range spec.SyncBuilderMinio {
@@ -619,30 +560,16 @@ func SetCommandExecutor(spec Spec, exec command.Executor) {
 	for i := range spec.SyncPaths {
 		spec.SyncPaths[i].cmdExecutor = exec
 	}
-	for i := range spec.AsyncPaths {
-		spec.AsyncPaths[i].cmdExecutor = exec
-	}
+
 	for i := range spec.SyncCmds {
 		spec.SyncCmds[i].cmdExecutor = exec
-	}
-
-	for i := range spec.AsyncCmds {
-		spec.AsyncCmds[i].cmdExecutor = exec
 	}
 
 	for i := range spec.SyncDbs {
 		spec.SyncDbs[i].cmdExecutor = exec
 	}
 
-	for i := range spec.AsyncDbs {
-		spec.AsyncDbs[i].cmdExecutor = exec
-	}
-
 	for i := range spec.SyncDbsV2 {
 		spec.SyncDbsV2[i].cmdExecutor = exec
-	}
-
-	for i := range spec.AsyncDbsV2 {
-		spec.AsyncDbsV2[i].cmdExecutor = exec
 	}
 }

--- a/components/automate-deployment/pkg/backup/spec_test.go
+++ b/components/automate-deployment/pkg/backup/spec_test.go
@@ -17,17 +17,17 @@ func TestDefaultSpecs(t *testing.T) {
 	t.Run("authn-service", func(t *testing.T) {
 		spec := testSpecFor(t, "authn-service")
 		testRequireMetadata(t, spec)
-		testRequireDb(t, spec, "sync", "chef_authn_service", "authn")
+		testRequireDb(t, spec, "chef_authn_service", "authn")
 	})
 	t.Run("authz-service", func(t *testing.T) {
 		spec := testSpecFor(t, "authz-service")
 		testRequireMetadata(t, spec)
-		testRequireDb(t, spec, "sync", "chef_authz_service", "authz")
+		testRequireDb(t, spec, "chef_authz_service", "authz")
 	})
 	t.Run("automate-dex", func(t *testing.T) {
 		spec := testSpecFor(t, "automate-dex")
 		testRequireMetadata(t, spec)
-		testRequireDb(t, spec, "sync", "dex", "dex")
+		testRequireDb(t, spec, "dex", "dex")
 	})
 	t.Run("automate-elasticsearch", func(t *testing.T) {
 		testSpecFor(t, "automate-elasticsearch")
@@ -47,8 +47,8 @@ func TestDefaultSpecs(t *testing.T) {
 	t.Run("compliance-service", func(t *testing.T) {
 		spec := testSpecFor(t, "compliance-service")
 		testRequireMetadata(t, spec)
-		testRequireDb(t, spec, "sync", "chef_compliance_service", "compliance")
-		testRequireEs(t, spec, "sync", "compliance-service", "comp-*")
+		testRequireDb(t, spec, "chef_compliance_service", "compliance")
+		testRequireEs(t, spec, "compliance-service", "comp-*")
 	})
 	t.Run("config-mgmt-service", func(t *testing.T) {
 		testSpecFor(t, "config-mgmt-service")
@@ -56,9 +56,9 @@ func TestDefaultSpecs(t *testing.T) {
 	t.Run("deployment-service", func(t *testing.T) {
 		spec := testSpecFor(t, "deployment-service")
 		testRequireMetadata(t, spec)
-		testRequirePath(t, spec, "sync", "/hab/user/deployment-service/config")
-		testRequirePath(t, spec, "sync", "/hab/svc/deployment-service/data", Exclude("bolt.db"))
-		testRequireCmd(t, spec, "sync", "deployment-service dumpdb", "deployment-service restoredb")
+		testRequirePath(t, spec, "/hab/user/deployment-service/config")
+		testRequirePath(t, spec, "/hab/svc/deployment-service/data", Exclude("bolt.db"))
+		testRequireCmd(t, spec, "deployment-service dumpdb", "deployment-service restoredb")
 	})
 	t.Run("es-sidecar-service", func(t *testing.T) {
 		testSpecFor(t, "es-sidecar-service")
@@ -66,14 +66,14 @@ func TestDefaultSpecs(t *testing.T) {
 	t.Run("ingest-service", func(t *testing.T) {
 		spec := testSpecFor(t, "ingest-service")
 		testRequireMetadata(t, spec)
-		testRequirePath(t, spec, "sync", "/hab/svc/ingest-service/data")
-		testRequireEs(t, spec, "sync", "ingest-service", "node-state-7,node-attribute,converge-history-*,actions-*")
+		testRequirePath(t, spec, "/hab/svc/ingest-service/data")
+		testRequireEs(t, spec, "ingest-service", "node-state-7,node-attribute,converge-history-*,actions-*")
 	})
 	t.Run("license-control-service", func(t *testing.T) {
 		spec := testSpecFor(t, "license-control-service")
 		testRequireMetadata(t, spec)
-		testRequirePath(t, spec, "sync", "/hab/svc/license-control-service/data")
-		testRequirePath(t, spec, "sync", "/hab/svc/license-control-service/config", Include("opt_out"), Exclude("*"))
+		testRequirePath(t, spec, "/hab/svc/license-control-service/data")
+		testRequirePath(t, spec, "/hab/svc/license-control-service/config", Include("opt_out"), Exclude("*"))
 	})
 	t.Run("local-user-service", func(t *testing.T) {
 		testSpecFor(t, "local-user-service")
@@ -81,38 +81,38 @@ func TestDefaultSpecs(t *testing.T) {
 	t.Run("notifications-service", func(t *testing.T) {
 		spec := testSpecFor(t, "notifications-service")
 		testRequireMetadata(t, spec)
-		testRequireDb(t, spec, "sync", "notifications_service", "notifications")
+		testRequireDb(t, spec, "notifications_service", "notifications")
 	})
 	t.Run("teams-service", func(t *testing.T) {
 		spec := testSpecFor(t, "teams-service")
 		testRequireMetadata(t, spec)
-		testRequireDb(t, spec, "sync", "chef_teams_service", "teams")
+		testRequireDb(t, spec, "chef_teams_service", "teams")
 	})
 	t.Run("session-service", func(t *testing.T) {
 		spec := testSpecFor(t, "session-service")
 		testRequireMetadata(t, spec)
-		testRequireDb(t, spec, "sync", "chef_session_service", "session")
+		testRequireDb(t, spec, "chef_session_service", "session")
 	})
 	t.Run("automate-cs-bookshelf", func(t *testing.T) {
 		spec := testSpecFor(t, "automate-cs-bookshelf")
 		testRequireMetadata(t, spec)
-		testRequireDb(t, spec, "sync", "automate-cs-bookshelf", "automate-cs-bookshelf")
+		testRequireDb(t, spec, "automate-cs-bookshelf", "automate-cs-bookshelf")
 	})
 	t.Run("automate-cs-oc-bifrost", func(t *testing.T) {
 		spec := testSpecFor(t, "automate-cs-oc-bifrost")
 		testRequireMetadata(t, spec)
-		testRequireDb(t, spec, "sync", "automate-cs-oc-bifrost", "automate-cs-oc-bifrost")
+		testRequireDb(t, spec, "automate-cs-oc-bifrost", "automate-cs-oc-bifrost")
 	})
 	t.Run("automate-cs-oc-erchef", func(t *testing.T) {
 		spec := testSpecFor(t, "automate-cs-oc-erchef")
 		testRequireMetadata(t, spec)
-		testRequireDb(t, spec, "sync", "automate-cs-oc-erchef", "automate-cs-oc-erchef")
-		testRequireEs(t, spec, "sync", "automate-cs-oc-erchef", "chef")
+		testRequireDb(t, spec, "automate-cs-oc-erchef", "automate-cs-oc-erchef")
+		testRequireEs(t, spec, "automate-cs-oc-erchef", "chef")
 	})
 	t.Run("nodemanager-service", func(t *testing.T) {
 		spec := testSpecFor(t, "nodemanager-service")
 		testRequireMetadata(t, spec)
-		testRequireDb(t, spec, "sync", "nodemanager_service", "nodemanager")
+		testRequireDb(t, spec, "nodemanager_service", "nodemanager")
 	})
 }
 
@@ -143,17 +143,6 @@ func TestDeduplication(t *testing.T) {
 
 func TestSetCommandExecutor(t *testing.T) {
 	testCmdExec := command.NewMockExecutor(t)
-
-	t.Run("sets async path defaults", func(t *testing.T) {
-		s := Spec{Name: "test",
-			AsyncPaths: []PathCopyOperation{
-				{Name: "sync", SrcPath: "/tmp/test"},
-			},
-		}
-		SetCommandExecutor(s, testCmdExec)
-
-		require.Equal(t, testCmdExec, s.AsyncPaths[0].cmdExecutor, "command executor must match")
-	})
 	t.Run("sets sync path defaults", func(t *testing.T) {
 		s := Spec{Name: "test",
 			SyncPaths: []PathCopyOperation{
@@ -163,16 +152,6 @@ func TestSetCommandExecutor(t *testing.T) {
 		SetCommandExecutor(s, testCmdExec)
 
 		require.Equal(t, testCmdExec, s.SyncPaths[0].cmdExecutor, "command executor must match")
-	})
-	t.Run("sets async cmd defaults", func(t *testing.T) {
-		s := Spec{Name: "postgres", AsyncCmds: []CommandExecuteOperation{
-			{Name: "async-pgdump", Cmd: Cmd{
-				Name: "async", Dump: []string{"pgdump"},
-			}},
-		}}
-		SetCommandExecutor(s, testCmdExec)
-
-		require.Equal(t, testCmdExec, s.AsyncCmds[0].cmdExecutor, "command executor must match")
 	})
 	t.Run("sets sync cmd defaults", func(t *testing.T) {
 		s := Spec{Name: "postgres", SyncCmds: []CommandExecuteOperation{
@@ -187,16 +166,6 @@ func TestSetCommandExecutor(t *testing.T) {
 }
 
 func TestSetDefaults(t *testing.T) {
-	t.Run("sets async path defaults", func(t *testing.T) {
-		s := Spec{Name: "test",
-			AsyncPaths: []PathCopyOperation{
-				{Name: "sync", SrcPath: "/tmp/test"},
-			},
-		}
-		setDefaults(s)
-
-		require.Equal(t, []string{"test", "sync"}, s.AsyncPaths[0].ObjectName)
-	})
 	t.Run("sets sync path defaults", func(t *testing.T) {
 		s := Spec{Name: "test",
 			SyncPaths: []PathCopyOperation{
@@ -206,18 +175,6 @@ func TestSetDefaults(t *testing.T) {
 		setDefaults(s)
 
 		require.Equal(t, []string{"test", "foo"}, s.SyncPaths[0].ObjectName)
-	})
-	t.Run("sets async cmd defaults", func(t *testing.T) {
-		s := Spec{Name: "postgres", AsyncCmds: []CommandExecuteOperation{
-			{Name: "async-pgdump", Cmd: Cmd{
-				Name: "async", Dump: []string{"pgdump"},
-			}},
-		}}
-		setDefaults(s)
-
-		require.Equal(t, []string{"postgres", "async-pgdump"}, s.AsyncCmds[0].ObjectName)
-		require.Equal(t, "chef", s.AsyncCmds[0].PkgOrigin)
-		require.Equal(t, "postgres", s.AsyncCmds[0].PkgName)
 	})
 	t.Run("sets sync cmd defaults", func(t *testing.T) {
 		s := Spec{Name: "postgres", SyncCmds: []CommandExecuteOperation{
@@ -233,29 +190,11 @@ func TestSetDefaults(t *testing.T) {
 	})
 }
 
-func testRequirePath(t *testing.T, spec Spec, mode, path string, matchers ...RsyncMatcher) {
-	validMode := false
-	if mode == "sync" || mode == "async" {
-		validMode = true
-	}
-	require.Truef(t, validMode,
-		"%s in not a valid mode for path %s. must be one of 'sync' or 'async'",
-		mode, path,
-	)
-
+func testRequirePath(t *testing.T, spec Spec, path string, matchers ...RsyncMatcher) {
 	var p PathCopyOperation
-	if mode == "sync" {
-		for _, sp := range spec.SyncPaths {
-			if sp.SrcPath == path {
-				p = sp
-			}
-		}
-	}
-	if mode == "async" {
-		for _, asp := range spec.AsyncPaths {
-			if asp.SrcPath == path {
-				p = asp
-			}
+	for _, sp := range spec.SyncPaths {
+		if sp.SrcPath == path {
+			p = sp
 		}
 	}
 	require.Equal(t, path, p.SrcPath, "could not find path matching %s", path)
@@ -285,51 +224,20 @@ func findDbByName(name string, dbs []DatabaseDumpOperationV2) DatabaseDumpOperat
 	return DatabaseDumpOperationV2{}
 }
 
-func testRequireDb(t *testing.T, spec Spec, mode, name string, user string) {
-	validMode := mode == "sync" || mode == "async"
-	require.Truef(t, validMode,
-		"%s in not a valid mode for DB %s. must be one of 'sync' or 'async'",
-		mode, name,
-	)
-
-	var p DatabaseDumpOperationV2
-	if mode == "sync" {
-		p = findDbByName(name, spec.SyncDbsV2)
-	}
-	if mode == "async" {
-		p = findDbByName(name, spec.AsyncDbsV2)
-	}
-
+func testRequireDb(t *testing.T, spec Spec, name string, user string) {
+	p := findDbByName(name, spec.SyncDbsV2)
 	assert.Equal(t, name, p.Name, "could not find database matching %s", name)
 	assert.Equal(t, user, p.User, "username for database %s doesn't match %s", name, user)
 }
 
-func testRequireCmd(t *testing.T, spec Spec, mode, dumpCmd, restoreCmd string) {
-	validMode := false
-	if mode == "sync" || mode == "async" {
-		validMode = true
-	}
-	require.Truef(t, validMode,
-		"%s in not a valid mode for dumpcmd %s. must be one of 'sync' or 'async'",
-		mode, dumpCmd,
-	)
-
+func testRequireCmd(t *testing.T, spec Spec, dumpCmd, restoreCmd string) {
 	dc := strings.Split(dumpCmd, " ")
 	rc := strings.Split(restoreCmd, " ")
 
 	var c CommandExecuteOperation
-	if mode == "sync" {
-		for _, sc := range spec.SyncCmds {
-			if reflect.DeepEqual(sc.Cmd.Dump, dc) && reflect.DeepEqual(sc.Cmd.Restore, rc) {
-				c = sc
-			}
-		}
-	}
-	if mode == "async" {
-		for _, ac := range spec.AsyncCmds {
-			if reflect.DeepEqual(ac.Cmd.Dump, dc) && reflect.DeepEqual(ac.Cmd.Restore, rc) {
-				c = ac
-			}
+	for _, sc := range spec.SyncCmds {
+		if reflect.DeepEqual(sc.Cmd.Dump, dc) && reflect.DeepEqual(sc.Cmd.Restore, rc) {
+			c = sc
 		}
 	}
 	require.Truef(t, reflect.DeepEqual(dc, c.Cmd.Dump),
@@ -352,21 +260,8 @@ func findEsByName(name string, esops []ElasticsearchOperation) ElasticsearchOper
 	return ElasticsearchOperation{}
 }
 
-func testRequireEs(t *testing.T, spec Spec, mode, serviceName string, multiIndexSpec string) {
-	validMode := mode == "sync" || mode == "async"
-	require.Truef(t, validMode,
-		"%s in not a valid mode for DB %s. must be one of 'sync' or 'async'",
-		mode, serviceName,
-	)
-
-	var op ElasticsearchOperation
-	if mode == "sync" {
-		op = findEsByName(serviceName, spec.SyncEsIndices)
-	}
-	if mode == "async" {
-		op = findEsByName(serviceName, spec.AsyncEsIndices)
-	}
-
+func testRequireEs(t *testing.T, spec Spec, serviceName string, multiIndexSpec string) {
+	op := findEsByName(serviceName, spec.SyncEsIndices)
 	assert.Equal(t, serviceName, op.ServiceName, "could not find es operation for %s", serviceName)
 	assert.Equal(t, multiIndexSpec, op.MultiIndexSpec, "incorrect index spec for %s", serviceName)
 }


### PR DESCRIPTION
Currently, we do not use any async operations so these should be safe
to remove. This is one in a number of steps we want to take to reduce
the scope of the backup/restore code.

Signed-off-by: Steven Danna <steve@chef.io>