### PR TITLE
Set default log level to error for builder-api

### DIFF
--- a/components/automate-builder-api/habitat/default.toml
+++ b/components/automate-builder-api/habitat/default.toml
@@ -6,7 +6,7 @@ port   = 10103
 ttl = 15
 
 [log]
-level = "debug"
+level = "error"
 scoped_levels = ["tokio_core=error","tokio_reactor=error","zmq=error","hyper=error"]
 
 [datastore]


### PR DESCRIPTION
This shouldn't get used in general, but that matches
what automate will set it as