### PR TITLE
Remove services view state from URL and update service groups URL

### DIFF
--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -224,7 +224,7 @@ const routes: Routes = [
       ]
     },
     {
-      path: 'applications',
+      path: 'applications/service-groups',
       children: [
         {
           path: '',

--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -56,7 +56,7 @@ export class LayoutSidebarService {
                 {
                     name: 'Service Groups',
                     icon: 'group_work',
-                    route: '/applications',
+                    route: '/applications/service-groups',
                     visible: true
                 },
                 {

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.facade.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.facade.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
-import { Action, Store } from '@ngrx/store';
+import { Store } from '@ngrx/store';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { includes } from 'lodash/fp';
@@ -50,7 +49,6 @@ export class ServiceGroupsFacadeService {
 
   constructor(
       private store: Store<fromServiceGroups.ServiceGroupsEntityState>,
-      private router: Router,
       private telemetryService: TelemetryService
     ) {
     // this.allBooks$ = store.pipe(select(fromBooks.getAllBooks));
@@ -60,18 +58,6 @@ export class ServiceGroupsFacadeService {
     this.serviceGroupsName$ = store.select(selectedServiceGroupName);
     this.svcHealthSummary$ = this.store.select(selectedServiceGroupHealth);
     this.currentServicesFilters$ = this.store.select(selectedServiceGroupFilters);
-  }
-
-  dispatch(action: Action) {
-    this.store.dispatch(action);
-  }
-
-  public updateServicesFilters(selectedHealth, currentPage): void {
-    const queryParams = {
-      'sgStatus': selectedHealth,
-      'sgPage': currentPage
-    };
-    this.router.navigate([], { queryParams, queryParamsHandling: 'merge' });
   }
 
   // returns a timewizard message for the provided current and previous health checks

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
@@ -75,7 +75,7 @@ export interface GroupService {
 }
 
 export interface GroupServicesFilters {
-  service_group_id?: string;
+  service_group_id: string;
   health?: string;
   page?: number;
   pageSize?: number;

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
@@ -79,7 +79,7 @@ export interface GroupServicesFilters {
   health?: string;
   page?: number;
   pageSize?: number;
-  searchBar?: Array<Chicklet>;
+  searchBar: Array<Chicklet>;
 }
 
 export interface GroupServicesPayload {

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
@@ -97,8 +97,6 @@ export function serviceGroupsEntityReducer(
         set('error', action.payload))(state);
 
     case ServiceGroupsActionTypes.UPDATE_SELECTED_SERVICE_GROUP:
-      console.log(`reducin' UPDATE_SELECTED_SERVICE_GROUP`);
-      console.log(action.payload);
       return set('selectedGroup.services.filters', action.payload, state);
 
     case ServiceGroupsActionTypes.GET_SERVICES_BY_SERVICE_GROUP:

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
@@ -38,6 +38,7 @@ export const ServiceGroupEntityInitialState: ServiceGroupsEntityState = {
       error: null,
       filters: {
         service_group_id: undefined,
+        searchBar: [],
         page: 1,
         health: 'total'
       },

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
@@ -37,6 +37,7 @@ export const ServiceGroupEntityInitialState: ServiceGroupsEntityState = {
     services: {
       error: null,
       filters: {
+        service_group_id: undefined,
         page: 1,
         health: 'total'
       },
@@ -96,6 +97,8 @@ export function serviceGroupsEntityReducer(
         set('error', action.payload))(state);
 
     case ServiceGroupsActionTypes.UPDATE_SELECTED_SERVICE_GROUP:
+      console.log(`reducin' UPDATE_SELECTED_SERVICE_GROUP`);
+      console.log(action.payload);
       return set('selectedGroup.services.filters', action.payload, state);
 
     case ServiceGroupsActionTypes.GET_SERVICES_BY_SERVICE_GROUP:

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -7,7 +7,7 @@
       <div class="navigation-menu">
         <div role="menuitem" class="nav-link"><a routerLink="/dashboards/event-feed" routerLinkActive="active" tabindex="0">Dashboards</a></div>
 
-        <div *ngIf="applicationsFeatureFlagOn" role="menuitem" class="nav-link"><a routerLink="/applications" routerLinkActive="active" tabindex="0">Applications</a></div>
+        <div *ngIf="applicationsFeatureFlagOn" role="menuitem" class="nav-link"><a routerLink="/applications/service-groups" routerLinkActive="active" tabindex="0">Applications</a></div>
 
         <app-authorized [allOf]="[['/cfgmgmt/nodes', 'get'], ['/cfgmgmt/stats/node_counts', 'get']]">
           <div role="menuitem" class="nav-link"><a routerLink="/infrastructure/client-runs" routerLinkActive="active" tabindex="0">Infrastructure</a></div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -63,30 +63,13 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   public timewizardMessage = this.serviceGroupsFacade.timewizardMessage;
 
   ngOnInit() {
-    console.log('oninit for a new ServicesSidebarComponent')
-
-    // FIXME: need to reset status filter and pagination state when the service group id changes
-    // FIXME: pagination controls borked, probably need to fix app-page-picker 
-
-    // this.services$.pipe(takeUntil(this.isDestroyed))
-    //   .subscribe( () => {
-    //   });
-
     this.svcHealthSummary$.pipe(takeUntil(this.isDestroyed))
         .subscribe((serviceGroupsHealthSummary) => {
-          // this.selectedHealth = 'total';
-          // this.currentPage = 1;
-          // this.pageSize = 25;
-
           this.serviceGroupsHealthSummary = serviceGroupsHealthSummary;
           this.totalServices = getOr(0, this.selectedHealth, this.serviceGroupsHealthSummary);
         });
 
     this.currentServicesFilters$.pipe(takeUntil(this.isDestroyed)).subscribe((servicesFilters) => {
-      console.log(`currentServicesFilters$ servicesFilters:`)
-      console.log(servicesFilters)
-
-
       this.selectedHealth = getOr('total', 'health', servicesFilters);
       this.currentPage    = getOr(1, 'page', servicesFilters);
       this.totalServices  = getOr(0, this.selectedHealth, this.serviceGroupsHealthSummary);
@@ -96,9 +79,6 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
          totalServices: this.totalServices,
          statusFilter: this.selectedHealth
       });
-
-      console.log(`currentServicesFilters$ this:`)
-      console.log(this);
     });
   }
 
@@ -108,7 +88,6 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   }
 
   public updateHealthFilter(health: string) {
-    console.log(`updateHealthFilter to ${health}`)
     this.currentPage = 1;
     this.selectedHealth = this.serviceGroupsFacade
       .updateHealthFilter(health, 'applicationsStatusFilter');
@@ -124,7 +103,6 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
 
   refresh() {
     if (this.serviceGroupsId) {
-      console.log(`doing dat refresh>>>`)
 
       const paramsForDispatch = {
           service_group_id: this.serviceGroupsId,

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnDestroy, OnInit, Input } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
+import { Store } from '@ngrx/store';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { takeUntil } from 'rxjs/operators';
 import { getOr } from 'lodash/fp';
 
@@ -11,6 +13,7 @@ import {
   GroupService,
   GroupServicesFilters
 } from '../../entities/service-groups/service-groups.model';
+import { UpdateSelectedSG } from 'app/entities/service-groups/service-groups.actions';
 import { TelemetryService } from 'app/services/telemetry/telemetry.service';
 import { DateTime } from 'app/helpers/datetime/datetime';
 
@@ -29,6 +32,7 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   public pageSize = 25;
   public totalServices = 0;
   public RFC2822 = DateTime.RFC2822;
+  public selectedSearchBarFilters = [];
 
   public services$: Observable<GroupService[]>;
   public serviceGroupsStatus$: Observable<EntityStatus>;
@@ -42,7 +46,8 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
 
   constructor(
     private serviceGroupsFacade: ServiceGroupsFacadeService,
-    private telemetryService: TelemetryService
+    private telemetryService: TelemetryService,
+    public store: Store<NgrxStateAtom>
   ) {
     this.services$ = this.serviceGroupsFacade.services$;
     this.serviceGroupsStatus$ = this.serviceGroupsFacade.serviceGroupsStatus$;
@@ -58,21 +63,44 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   public timewizardMessage = this.serviceGroupsFacade.timewizardMessage;
 
   ngOnInit() {
+    console.log('oninit for a new ServicesSidebarComponent')
+
+    // FIXME: need to reset status filter and pagination state when the service group id changes
+    // FIXME: pagination controls borked, probably need to fix app-page-picker 
+
+    // this.services$.pipe(takeUntil(this.isDestroyed))
+    //   .subscribe( () => {
+    //   });
+
     this.svcHealthSummary$.pipe(takeUntil(this.isDestroyed))
         .subscribe((serviceGroupsHealthSummary) => {
+          // this.selectedHealth = 'total';
+          // this.currentPage = 1;
+          // this.pageSize = 25;
+
           this.serviceGroupsHealthSummary = serviceGroupsHealthSummary;
           this.totalServices = getOr(0, this.selectedHealth, this.serviceGroupsHealthSummary);
         });
 
     this.currentServicesFilters$.pipe(takeUntil(this.isDestroyed)).subscribe((servicesFilters) => {
-      this.selectedHealth = getOr('total', 'health', servicesFilters);
-      this.currentPage    = getOr(1, 'page', servicesFilters);
-      this.totalServices  = getOr(0, this.selectedHealth, this.serviceGroupsHealthSummary);
+      console.log(`currentServicesFilters$ servicesFilters:`)
+      console.log(servicesFilters)
+
+
+      // not working, it's always _undefined_
+      // this.selectedHealth = getOr('total', 'health', servicesFilters);
+      //this.currentPage    = getOr(1, 'page', servicesFilters);
+      // not working, it's always _undefined_
+      //this.totalServices  = getOr(0, this.selectedHealth, this.serviceGroupsHealthSummary);
+      this.selectedSearchBarFilters = getOr([], 'searchBar', servicesFilters);
       this.telemetryService.track('applicationsServiceCount', {
          serviceGroupsId: this.serviceGroupsId,
          totalServices: this.totalServices,
          statusFilter: this.selectedHealth
       });
+
+      console.log(`currentServicesFilters$ this:`)
+      console.log(this);
     });
   }
 
@@ -82,18 +110,35 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   }
 
   public updateHealthFilter(health: string) {
+    console.log(`updateHealthFilter to ${health}`)
     this.currentPage = 1;
     this.selectedHealth = this.serviceGroupsFacade
       .updateHealthFilter(health, 'applicationsStatusFilter');
-    this.serviceGroupsFacade
-      .updateServicesFilters(health, this.currentPage);
+    this.refresh();
   }
 
   public updatePageNumber(pageNumber: number) {
     this.currentPage = pageNumber;
     this.serviceGroupsFacade
       .updatePageNumber(pageNumber, this.totalServices, this.currentPage, 'applicationsPageChange');
-    this.serviceGroupsFacade
-      .updateServicesFilters(this.selectedHealth, this.currentPage);
+    this.refresh();
   }
+
+  refresh() {
+    if (this.serviceGroupsId) {
+      console.log(`doing dat refresh>>>`)
+
+      const paramsForDispatch = {
+          service_group_id: this.serviceGroupsId,
+          page: this.currentPage,
+          pageSize: this.pageSize,
+          health: this.selectedHealth,
+          searchBar: this.selectedSearchBarFilters
+      };
+
+      this.store.dispatch(new UpdateSelectedSG(paramsForDispatch));
+      document.querySelector<HTMLElement>('app-services-sidebar').focus();
+    }
+  }
+
 }

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -104,7 +104,7 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   refresh() {
     if (this.serviceGroupsId) {
 
-      const paramsForDispatch = {
+      const paramsForDispatch: GroupServicesFilters = {
           service_group_id: this.serviceGroupsId,
           page: this.currentPage,
           pageSize: this.pageSize,

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -87,11 +87,9 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
       console.log(servicesFilters)
 
 
-      // not working, it's always _undefined_
-      // this.selectedHealth = getOr('total', 'health', servicesFilters);
-      //this.currentPage    = getOr(1, 'page', servicesFilters);
-      // not working, it's always _undefined_
-      //this.totalServices  = getOr(0, this.selectedHealth, this.serviceGroupsHealthSummary);
+      this.selectedHealth = getOr('total', 'health', servicesFilters);
+      this.currentPage    = getOr(1, 'page', servicesFilters);
+      this.totalServices  = getOr(0, this.selectedHealth, this.serviceGroupsHealthSummary);
       this.selectedSearchBarFilters = getOr([], 'searchBar', servicesFilters);
       this.telemetryService.track('applicationsServiceCount', {
          serviceGroupsId: this.serviceGroupsId,

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -212,16 +212,16 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
     )
     .subscribe(([serviceGroups]) => {
       if (serviceGroups.length > 0) {
-        // if we do not have an sgId parameter, pick the first sgId from the
-        // service group list
+        // if we do not have a selected service group, pick the first sgId from
+        // the service group list
         if ( !this.selectedServiceGroupId ) {
           this.selectedServiceGroupId = serviceGroups[0]['id'];
         }
 
         // if the selected service group is not visible on the page, then pick
-        // the first service group from the list and navigate to it. this lets
-        // us maintain a service group selection regardless of other navigation
-        // as long as the service group is still in the list.
+        // the first service group from the list. this lets us maintain a
+        // service group selection regardless of other navigation as long as
+        // the service group is still in the list.
         const selectedSGVisibleOnPage = serviceGroups.find(sg => sg.id === this.selectedServiceGroupId);
         if ( !selectedSGVisibleOnPage ) {
           this.selectedServiceGroupId = serviceGroups[0]['id'];
@@ -235,8 +235,6 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
         this.selectedServiceGroupId = null;
       }
     });
-
-    // TODO: status filters and pagination in the services sidebar are broken :(
 
     // If the user applies a filter via the filter bar or the *service group*
     // status filters that filters out all of the services in the

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -13,14 +13,13 @@ import {
 } from 'app/types/types';
 import { EntityStatus } from 'app/entities/entities';
 import {
-  GetServiceGroupsSuggestions, UpdateServiceGroupsFilters, UpdateSelectedSG
+  GetServiceGroupsSuggestions, UpdateServiceGroupsFilters
 } from 'app/entities/service-groups/service-groups.actions';
 import {
   ServiceGroup,
   ServiceGroupsFilters,
   FieldDirection,
-  ServiceGroupsHealthSummary,
-  GroupServicesFilters
+  ServiceGroupsHealthSummary
 } from '../../entities/service-groups/service-groups.model';
 import {
   serviceGroupsStatus,
@@ -77,15 +76,6 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
 
   // Sort field by default
   readonly defaultSortField = 'percent_ok';
-
-  // Services sidebar page
-  public sgPage = 1;
-
-  // Services sidebar pagination sizing
-  public sgPageSize = 25;
-
-  // Services sidebar status filter
-  public selectedSgStatus = 'total';
 
   // Should the URL share dropdown be displayed
   shareDropdownVisible = false;
@@ -240,7 +230,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
         // The sidebar content needs to be rendered on the initial page load
         // and also when filters are applied that change the service groups
         // content.
-        this.refreshServicesSidebar(this.currentSidebarParams());
+        this.refreshServicesSidebar();
       } else {
         this.selectedServiceGroupId = null;
       }
@@ -349,29 +339,8 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
     }, []);
   }
 
-  refreshServicesSidebar(queryParams) {
-    if (this.selectedServiceGroupId) {
-      const servicesFilters: GroupServicesFilters = {
-        service_group_id: this.selectedServiceGroupId,
-        page: queryParams['sgPage'],
-        pageSize: queryParams['sgPageSize'],
-        health: queryParams['sgStatus'],
-        searchBar: queryParams['searchBar']
-      };
-
-      this.store.dispatch(new UpdateSelectedSG(servicesFilters));
-      document.querySelector<HTMLElement>('app-services-sidebar').focus();
-    }
-  }
-
-  currentSidebarParams() {
-    const params = this.route.snapshot.queryParamMap;
-    return {
-        page: this.sgPage,
-        pageSize: this.sgPageSize,
-        health: params.get('sgStatus') || 'total',
-        searchBar: this.selectedSearchBarFilters
-    }
+  refreshServicesSidebar() {
+    // TODO!!
   }
 
   public updateAllFilters(allParameters: Chicklet[]): void {
@@ -472,11 +441,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
 
     this.selectedServiceGroupId = id;
 
-    const queryParams = this.currentSidebarParams();
-    delete queryParams['sgPage'];
-    delete queryParams['sgStatus'];
-
-    this.refreshServicesSidebar(queryParams)
+    this.refreshServicesSidebar()
   }
 
   // TODO @afiune: Add links when they work
@@ -511,10 +476,6 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
       delete queryParams['page'];
     }
 
-    delete queryParams['sgId'];
-    delete queryParams['sgPage'];
-    delete queryParams['sgStatus'];
-
     this.router.navigate([], { queryParams });
   }
 
@@ -537,10 +498,6 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
         sortField: [field], sortDirection: [fieldDirection]};
 
       delete queryParams['page'];
-      delete queryParams['sgId'];
-      delete queryParams['sgPage'];
-      delete queryParams['sgStatus'];
-
       this.router.navigate([], {queryParams});
     }
   }

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -13,7 +13,7 @@ import {
 } from 'app/types/types';
 import { EntityStatus } from 'app/entities/entities';
 import {
-  GetServiceGroupsSuggestions, UpdateServiceGroupsFilters
+  GetServiceGroupsSuggestions, UpdateServiceGroupsFilters, UpdateSelectedSG
 } from 'app/entities/service-groups/service-groups.actions';
 import {
   ServiceGroup,
@@ -340,7 +340,12 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   }
 
   refreshServicesSidebar() {
-    // TODO!!
+    if (this.selectedServiceGroupId) {
+      this.store.dispatch(new UpdateSelectedSG({
+        service_group_id: this.selectedServiceGroupId
+      }));
+      document.querySelector<HTMLElement>('app-services-sidebar').focus();
+    }
   }
 
   public updateAllFilters(allParameters: Chicklet[]): void {

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -340,7 +340,8 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   refreshServicesSidebar() {
     if (this.selectedServiceGroupId) {
       this.store.dispatch(new UpdateSelectedSG({
-        service_group_id: this.selectedServiceGroupId
+        service_group_id: this.selectedServiceGroupId,
+        searchBar: this.selectedSearchBarFilters
       }));
       document.querySelector<HTMLElement>('app-services-sidebar').focus();
     }

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -222,7 +222,9 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
         // the first service group from the list. this lets us maintain a
         // service group selection regardless of other navigation as long as
         // the service group is still in the list.
-        const selectedSGVisibleOnPage = serviceGroups.find(sg => sg.id === this.selectedServiceGroupId);
+        const selectedSGVisibleOnPage = serviceGroups.find(sg => {
+          return sg.id === this.selectedServiceGroupId;
+        });
         if ( !selectedSGVisibleOnPage ) {
           this.selectedServiceGroupId = serviceGroups[0]['id'];
         }
@@ -445,7 +447,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
 
     this.selectedServiceGroupId = id;
 
-    this.refreshServicesSidebar()
+    this.refreshServicesSidebar();
   }
 
   // TODO @afiune: Add links when they work

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -210,12 +210,12 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
       withLatestFrom(this.route.queryParamMap),
       takeUntil(this.isDestroyed)
     )
-    .subscribe(([serviceGroups]) => {
+    .subscribe(([serviceGroups, _]) => {
       if (serviceGroups.length > 0) {
         // if we do not have a selected service group, pick the first sgId from
         // the service group list
         if ( !this.selectedServiceGroupId ) {
-          this.selectedServiceGroupId = serviceGroups[0]['id'];
+          this.selectedServiceGroupId = serviceGroups[0].id;
         }
 
         // if the selected service group is not visible on the page, then pick
@@ -226,7 +226,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
           return sg.id === this.selectedServiceGroupId;
         });
         if ( !selectedSGVisibleOnPage ) {
-          this.selectedServiceGroupId = serviceGroups[0]['id'];
+          this.selectedServiceGroupId = serviceGroups[0].id;
         }
 
         // The sidebar content needs to be rendered on the initial page load


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Updates the URLs in the apps tab as specified in #1884

Removes services view state from the URL; instead it is managed in the application memory. This makes sense architecturally because a particular service group can come and go from a set of service group filters over time. For example, if the critical status filter is selected, and the services within a service group all change status to `OK`, then the URL `/applications/service-groups?status=critical&sgId=<the id>` no longer refers to the same content in the same way.

This change means that when users share URLs they won't have the same service group selection state, though if a user wishes to construct a URL that shows just a particular service group, they can still do so with the filtering functionality we have.

Making this change means that changes to service group view state will no longer trigger events from observables that watch the query parameters, which solves a bug where the service group list was being re-rendered for changes to the services view state and would lose the user's scroll position after flickering the content (#2149)

### :chains: Related Resources

Addresses #1884 and #2149

### :athletic_shoe: How to Build and Test the Change

*To Build:*
* build components/automate-ui
* start_all_services
* create the sample data with `applications_populate_database`

*Verify No Regressions:*
* Start at the event feed: `https://a2-dev.test/dashboards/event-feed`
* Click on "Applications" in the nav bar, the URL should not be wrong
* Click on "Service Groups" on the left nav, the URL should not be wrong (nothing should happen since it should be a link to the page you are on)
* Service groups state should all save to the URL:
  * use the 'OK' health filter
  * Sort by env or app or any non-default field
  * go to page 2
  * refresh and you should have the same service groups list on the left side list
* search bar filters filter the services in the sidebar
  * search for `Site` = `aaa`, should show the "multisite.default" service group, only the two services with site = aaa should show in the sidebar.
* services status filters in the sidebar work as expected
 * Select a filter with more than zero services in the sidebar, it should work; select a filter with zero services and you should see the "None of the services" message
* pagination in the sidebar works:
  * select the `redis.default` service group
  * filter for critical status
  * page 2 of services should have different IDs than those on page 1 and the "OK" services should not be shown.
* services status filter and pagination state is reset when a new service group is selected
  * with the critical filter active and viewing page 2 of `redis.default`, select a service group that will have multiple pages, like `mobile-api-frontend.default`. The health filter should reset to "total" and you should be on page 1.

While doing the above, you should only see the service groups list be refreshed when taking an action that affects the service groups content (service groups health filter, search bar filter, service groups sort, service groups pagination).
