### PR TITLE
Add chef-automate external-cert show command to automate-cli

### DIFF
--- a/components/automate-cli/cmd/chef-automate/cert.go
+++ b/components/automate-cli/cmd/chef-automate/cert.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/chef/automate/components/automate-deployment/pkg/client"
+)
+
+type certCmdFlagSet struct {
+	hostname string
+	filepath string
+}
+
+var certCmdFlags = certCmdFlagSet{}
+
+func init() {
+
+	certCmd := certCmd()
+
+	certCmd.PersistentFlags().StringVarP(
+		&certCmdFlags.hostname,
+		"hostname",
+		"n",
+		"",
+		"Hostname for the automate TLS certificate",
+	)
+	certCmd.PersistentFlags().StringVarP(
+		&certCmdFlags.filepath,
+		"file",
+		"f",
+		"",
+		"File path to save automate TLS certifcate to.",
+	)
+	RootCmd.AddCommand(certCmd)
+}
+
+func certCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "external-cert COMMAND",
+		Short: "Manage Chef Automate's external certificate",
+		Long:  "Manage Chef Automate's external certificate authority. Used for establishing TLS/SSL communication with automate.",
+	}
+
+	certShow := &cobra.Command{
+		Use:   "show",
+		Short: "Show the external TLS/SSL certificates in Automate. Optionally, save the certificates to a file in the specified path.",
+		RunE:  runCertShowCmd,
+		Args:  cobra.MaximumNArgs(2),
+	}
+
+	cmd.AddCommand(certShow)
+
+	return cmd
+}
+
+func runCertShowCmd(*cobra.Command, []string) error {
+	res, err := client.GetAutomateConfig(int64(client.DefaultClientTimeout))
+	if err != nil {
+		return status.Wrap(
+			err,
+			status.DeploymentServiceUnreachableError,
+			"Connecting to deployment-service failed",
+		)
+	}
+	tlsCreds := res.Config.GetGlobal().GetV1().GetFrontendTls()
+
+	if certCmdFlags.hostname != "" && certCmdFlags.filepath != "" {
+		for _, tlsCred := range tlsCreds {
+			if tlsCred.GetServerName() == certCmdFlags.hostname {
+				return writeToFile(tlsCred.GetCert())
+			}
+		}
+		// Error no matching hostname found in the automate frontend_tls cert configuration
+		return status.Wrap(
+			err,
+			status.CommandExecutionError,
+			fmt.Sprintf("Unable to find matching certificate configuration for hostname %s", certCmdFlags.filepath),
+		)
+	} else if certCmdFlags.hostname != "" {
+		found := false
+		for _, tlsCred := range tlsCreds {
+			if tlsCred.GetServerName() == certCmdFlags.hostname {
+				found = true
+				writer.Printf("Hostname: %s\nCert: %s\n", tlsCred.GetServerName(), tlsCred.GetCert())
+				return nil
+			}
+		}
+		if !found {
+			// Error no matching hostname found in the automate frontend_tls cert configuration
+			return status.Wrap(
+				err,
+				status.CommandExecutionError,
+				fmt.Sprintf("Unable to find matching certificate configuration for hostname %s", certCmdFlags.filepath),
+			)
+		}
+	} else if certCmdFlags.filepath != "" {
+		if len(tlsCreds) > 1 {
+			// There is more than one cert and it is unclear which one to save to the cert file
+			return status.Wrap(
+				err,
+				status.CommandExecutionError,
+				fmt.Sprintf("Found more than one host certificate configured, please specify a hostname using the -hostname flag"),
+			)
+		}
+		return writeToFile(tlsCreds[0].GetCert())
+
+	} // Print all certs to stdout
+	for _, tlsCred := range tlsCreds {
+		if tlsCred.GetServerName() != "" {
+			writer.Printf("Hostname: %s\nCertificate:\n %s\n", tlsCred.GetServerName(), tlsCred.GetCert())
+		} else {
+			// Don't print the hostname if it isn't there
+			// It is most likely not set, so let's keep it simple
+			writer.Printf("Certificate:\n %s\n", tlsCred.GetCert())
+		}
+	}
+	return nil
+}
+
+func writeToFile(cert string) error {
+	err := ioutil.WriteFile(certCmdFlags.filepath, []byte(cert), 0644)
+	if err != nil {
+		return status.Wrap(
+			err,
+			status.FileAccessError,
+			fmt.Sprintf("Unable to write to file %s", certCmdFlags.filepath),
+		)
+	}
+	return nil
+}


### PR DESCRIPTION
Command takes --file and --hostname as args
Supports multiple certificates if there is more than one
This command makes it easier for a user to retrieve the frontend_tls certificate that
is configured for automate, which will make it easier to set up encrypted comms with habitat

Signed-off-by: kmacgugan <kmacgugan@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Added a new automate cli command 'external-cert show'

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
start_all_services
build components/automate-cli

`chef-automate external-cert show -h` to see help information
`chef-automate external-cert show` should print out the certifcate
`chef-automate external-cert show -f automate.crt` should save the cert to automate.crt file with 0644 permissions. 
Testing hostname arguments: 
Hostname is not set by default in the frontend_tls block. It can be added under the key `server_name`. Get your current cert by doing `chef-automate config show` and copying the section for frontend_tls. Make a config.toml file that contains the cert and looks like: 
```
[global]
  [global.v1]
    fqdn = "a2-dev.test"

    [[global.v1.frontend_tls]]
      server_name = "a2-dev.test"
      cert = "<cert here>"
      key = "<key here>"
   ```
`chef-automate config patch config.toml` to apply this config with the added `server_name` section.
Now you can test 
`chef-automate external-cert show -n a2-dev.test` and will see that it prints the hostname and the cert. 

You can also test out multiple certs by making another global.v1.frontend_tls section with another server_name. 
This has been tested, as well as all error cases. 

For more deets on frontend_tls docs:
https://automate.chef.io/docs/configuration/#load-balancer-certificate-and-private-key


### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable