### PR TITLE
automate-builder-memcached: remove extra ssl_key flag

### DIFF
--- a/components/automate-builder-memcached/habitat/hooks/run
+++ b/components/automate-builder-memcached/habitat/hooks/run
@@ -13,9 +13,8 @@ exec 2>&1
 # - ssl_ciphers:         specify cipher list to be used
 # - ssl_ca_cert:         PEM format file of acceptable client CA's
 #
-ssl_options="ssl_key={{pkg.svc_config_path}}/service.crt"
+ssl_options="ssl_key={{pkg.svc_config_path}}/service.key"
 ssl_options="${ssl_options},ssl_chain_cert={{pkg.svc_config_path}}/service.crt"
-ssl_options="${ssl_options},ssl_key={{pkg.svc_config_path}}/service.key"
 ssl_options="${ssl_options},ssl_ca_cert={{pkg.svc_config_path}}/root_ca.crt"
 ssl_options="${ssl_options},ssl_verify_mode=2"
 ssl_options="${ssl_options},ssl_ciphers=ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:!aNULL:!eNULL:!EXPORT"


### PR DESCRIPTION
This was being set twice, once to an incorrect value

Signed-off-by: Steven Danna <steve@chef.io>