### PR TITLE
ci: temporarily disable "backups repo permissions" test

### DIFF
--- a/.expeditor/nightly.pipeline.yml
+++ b/.expeditor/nightly.pipeline.yml
@@ -96,15 +96,19 @@ steps:
           single-use: true
           privileged: true
 
-  - label: "[integration] backups repo permissions"
-    command:
-      - integration/run_test integration/tests/backup_repo_permissions.sh
-    timeout_in_minutes: 30 # it restores twice so we'll give it a while
-    expeditor:
-      executor:
-        linux:
-          single-use: true
-          privileged: true
+  # TODO(ssd) 2019-12-13: This test is broken given the current design
+  # of config patch and backup/restore.  We are working on fixes for
+  # the various problems that make this test incorrect.
+  #
+  # - label: "[integration] backups repo permissions"
+  #   command:
+  #     - integration/run_test integration/tests/backup_repo_permissions.sh
+  #   timeout_in_minutes: 30 # it restores twice so we'll give it a while
+  #   expeditor:
+  #     executor:
+  #       linux:
+  #         single-use: true
+  #         privileged: true
 
   - label: "[integration] product mitm"
     command:


### PR DESCRIPTION
This test is broken in multiple ways. The most egregious are:

- backups are taken before the modified configuration is applied

- the backup location is incorrectly deteremined by the restore
  command

We are working on a series of changes to address this.  For now, this
unblocks the nightlies.

Signed-off-by: Steven Danna <steve@chef.io>