### PR TITLE
Adding project delete integration tests

### DIFF
--- a/e2e/cypress/index.d.ts
+++ b/e2e/cypress/index.d.ts
@@ -11,7 +11,7 @@ declare namespace Cypress {
     cleanupV2IAMObjectsByIDPrefixes(idPrefix: string, objectPlurals: string[]): void
     cleanupUsersByNamePrefix(namePrefix: string): void
     cleanupTeamsByDescriptionPrefix(namePrefix: string): void
-    waitUntilApplyRulesNotRunning(attempts: number): void
+    applyRulesAndWait(attempts: number): void
     waitForNodemanagerNode(nodeId: string, maxRetries: number): void
     waitForClientRunsNode(nodeId: string, maxRetries: number): void
     waitForComplianceNode(nodeId: string, start: string, end: string,

--- a/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/01_projects_api.spec.ts
@@ -267,12 +267,7 @@ describeIfIAMV2p1('projects API', () => {
           .forEach(({ status }) => expect(status).to.equal(editsPendingStr));
       });
 
-      cy.request({
-        headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
-        method: 'POST',
-        url: '/apis/iam/v2beta/apply-rules'
-      });
-      cy.waitUntilApplyRulesNotRunning(500);
+      cy.applyRulesAndWait(500);
 
       // confirm rules are applied
       for (const project of [avengersProject, xmenProject]) {
@@ -386,12 +381,7 @@ describeIfIAMV2p1('projects API', () => {
           .forEach(({ status }) => expect(status).to.equal(editsPendingStr));
       });
 
-      cy.request({
-        headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
-        method: 'POST',
-        url: '/apis/iam/v2beta/apply-rules'
-      });
-      cy.waitUntilApplyRulesNotRunning(100);
+      cy.applyRulesAndWait(100);
 
       cy.request({
         headers: {
@@ -467,12 +457,7 @@ describeIfIAMV2p1('projects API', () => {
           .forEach(({ status }) => expect(status).to.equal(editsPendingStr));
       });
 
-      cy.request({
-        headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
-        method: 'POST',
-        url: '/apis/iam/v2beta/apply-rules'
-      });
-      cy.waitUntilApplyRulesNotRunning(100);
+      cy.applyRulesAndWait(100);
 
       cy.request({
         headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },

--- a/e2e/cypress/integration/api/iam/10_projects_api_action_update.spec.ts
+++ b/e2e/cypress/integration/api/iam/10_projects_api_action_update.spec.ts
@@ -87,14 +87,7 @@ describeIfIAMV2p1('Action project update tagging', () => {
       });
     });
 
-    // apply rules
-    cy.request({
-      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
-      method: 'POST',
-      url: '/apis/iam/v2beta/apply-rules'
-    });
-
-    cy.waitUntilApplyRulesNotRunning(100);
+    cy.applyRulesAndWait(100);
   });
 
   after(() => cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['projects', 'policies']));

--- a/e2e/cypress/integration/api/iam/11_projects_api_action_ingestion.spec.ts
+++ b/e2e/cypress/integration/api/iam/11_projects_api_action_ingestion.spec.ts
@@ -69,14 +69,7 @@ describeIfIAMV2p1('Action project tagging on ingestion', () => {
       });
     });
 
-    // apply rules
-    cy.request({
-      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
-      method: 'POST',
-      url: '/apis/iam/v2beta/apply-rules'
-    });
-
-    cy.waitUntilApplyRulesNotRunning(100);
+    cy.applyRulesAndWait(100);
 
     // Ingest an action with attributes that match all the projects
     cy.fixture('action/environment_create.json').then((action) => {

--- a/e2e/cypress/integration/api/iam/12_projects_api_node_ingestion.spec.ts
+++ b/e2e/cypress/integration/api/iam/12_projects_api_node_ingestion.spec.ts
@@ -168,14 +168,7 @@ describeIfIAMV2p1('Ingestion project tagging', () => {
       });
     });
 
-    // apply rules
-    cy.request({
-      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
-      method: 'POST',
-      url: '/apis/iam/v2beta/apply-rules'
-    });
-
-    cy.waitUntilApplyRulesNotRunning(100);
+    cy.applyRulesAndWait(100);
 
     // Ingest a InSpec report with attributes that match all the projects
     cy.fixture('compliance/inspec-report.json').then((report) => {

--- a/e2e/cypress/integration/api/iam/13_projects_api_node_update.spec.ts
+++ b/e2e/cypress/integration/api/iam/13_projects_api_node_update.spec.ts
@@ -214,14 +214,7 @@ describeIfIAMV2p1('project update re-tagging', () => {
       });
     });
 
-    // apply rules
-    cy.request({
-      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
-      method: 'POST',
-      url: '/apis/iam/v2beta/apply-rules'
-    });
-
-    cy.waitUntilApplyRulesNotRunning(100);
+    cy.applyRulesAndWait(100);
   });
 
   after(() => cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['projects', 'policies']));

--- a/e2e/cypress/integration/api/iam/14_projects_delete_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/14_projects_delete_api.spec.ts
@@ -46,7 +46,7 @@ describeIfIAMV2p1('Project delete', () => {
       body: rule
     });
 
-    // Try to delete the project
+    // Try to delete the project with a stagged rule
     cy.request({
       headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
       method: 'DELETE',
@@ -57,7 +57,7 @@ describeIfIAMV2p1('Project delete', () => {
         'Did not fail deleting a project with a stagged rule').to.be.oneOf([400]);
     });
 
-    // Ensure the project exists
+    // Ensure the project was not deleted
     cy.request({
       headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
       method: 'GET',
@@ -67,9 +67,10 @@ describeIfIAMV2p1('Project delete', () => {
         resp.body.projects.some((p: any) => p.id === project.id)).to.be.true;
     });
 
-    applyRules();
+    // Apply the rules to make the rule applied
+    cy.applyRulesAndWait(100);
 
-    // Try to delete the project
+    // Try to delete the project with the applied rule
     cy.request({
       headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
       method: 'DELETE',
@@ -80,7 +81,7 @@ describeIfIAMV2p1('Project delete', () => {
         'Did not fail deleting a project with a applied rule').to.be.oneOf([400]);
     });
 
-    // Ensure the project exists
+    // Ensure the project was not removed
     cy.request({
       headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
       method: 'GET',
@@ -99,7 +100,7 @@ describeIfIAMV2p1('Project delete', () => {
       expect(deleteResp.status).to.be.oneOf([200]);
     });
 
-    // Try to delete the project
+    // Try to delete the project with a non applied deleted rule
     cy.request({
       headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
       method: 'DELETE',
@@ -110,7 +111,7 @@ describeIfIAMV2p1('Project delete', () => {
         'Did not fail deleting a project with a deleted applied rule').to.be.oneOf([400]);
     });
 
-    // Ensure the project exists
+    // Ensure the project was not removed
     cy.request({
       headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
       method: 'GET',
@@ -120,9 +121,10 @@ describeIfIAMV2p1('Project delete', () => {
         resp.body.projects.some((p: any) => p.id === project.id)).to.be.true;
     });
 
-    applyRules();
+    // Apply the rules to remove the rule
+    cy.applyRulesAndWait(100);
 
-    // Delete the project
+    // Now deleting the project should work
     cy.request({
       headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
       method: 'DELETE',
@@ -142,13 +144,3 @@ describeIfIAMV2p1('Project delete', () => {
     });
   });
 });
-
-function applyRules() {
-  cy.request({
-    headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
-    method: 'POST',
-    url: '/apis/iam/v2beta/apply-rules'
-  });
-
-  cy.waitUntilApplyRulesNotRunning(100);
-}

--- a/e2e/cypress/integration/api/iam/14_projects_delete_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/14_projects_delete_api.spec.ts
@@ -1,0 +1,154 @@
+import { describeIfIAMV2p1 } from '../../../support/constants';
+import { uuidv4 } from '../../../support/helpers';
+
+describeIfIAMV2p1('Project delete', () => {
+  const cypressPrefix = 'test-project-delete';
+
+  const project =  {
+    id: `${cypressPrefix}-project-delete-applied-rule${Cypress.moment().format('MMDDYYhhmm')}`,
+    name: 'project delete'
+  };
+
+  const rule = {
+    id: 'rule-applied',
+    name: 'rule',
+    type: 'NODE',
+    project_id: project.id,
+    conditions: [
+      {
+        attribute: 'CHEF_SERVER',
+        operator: 'EQUALS',
+        values: ['example.org']
+      }
+    ]
+  };
+
+  before(() => {
+    cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['projects', 'policies']);
+  });
+
+  after(() => cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['projects', 'policies']));
+
+  it('deleting a project', () => {
+    // Create a project
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'POST',
+      url: '/apis/iam/v2beta/projects',
+      body: project
+    });
+
+    // Add a rule to the project
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'POST',
+      url: `/apis/iam/v2beta/projects/${project.id}/rules`,
+      body: rule
+    });
+
+    // Try to delete the project
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'DELETE',
+      url: `/apis/iam/v2beta/projects/${project.id}`,
+      failOnStatusCode: false
+    }).then((deleteResp) => {
+      expect(deleteResp.status,
+        'Did not fail deleting a project with a stagged rule').to.be.oneOf([400]);
+    });
+
+    // Ensure the project exists
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'GET',
+      url: '/apis/iam/v2beta/projects'
+    }).then((resp: Cypress.ObjectLike) => {
+      expect(resp.body.projects && resp.body.projects.length > 0 &&
+        resp.body.projects.some((p: any) => p.id === project.id)).to.be.true;
+    });
+
+    applyRules();
+
+    // Try to delete the project
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'DELETE',
+      url: `/apis/iam/v2beta/projects/${project.id}`,
+      failOnStatusCode: false
+    }).then((deleteResp) => {
+      expect(deleteResp.status,
+        'Did not fail deleting a project with a applied rule').to.be.oneOf([400]);
+    });
+
+    // Ensure the project exists
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'GET',
+      url: '/apis/iam/v2beta/projects'
+    }).then((resp: Cypress.ObjectLike) => {
+      expect(resp.body.projects && resp.body.projects.length > 0 &&
+        resp.body.projects.some((p: any) => p.id === project.id)).to.be.true;
+    });
+
+    // Delete the rule
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'DELETE',
+      url: `/apis/iam/v2beta/projects/${project.id}/rules/${rule.id}`
+    }).then((deleteResp) => {
+      expect(deleteResp.status).to.be.oneOf([200]);
+    });
+
+    // Try to delete the project
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'DELETE',
+      url: `/apis/iam/v2beta/projects/${project.id}`,
+      failOnStatusCode: false
+    }).then((deleteResp) => {
+      expect(deleteResp.status,
+        'Did not fail deleting a project with a deleted applied rule').to.be.oneOf([400]);
+    });
+
+    // Ensure the project exists
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'GET',
+      url: '/apis/iam/v2beta/projects'
+    }).then((resp: Cypress.ObjectLike) => {
+      expect(resp.body.projects && resp.body.projects.length > 0 &&
+        resp.body.projects.some((p: any) => p.id === project.id)).to.be.true;
+    });
+
+    applyRules();
+
+    // Delete the project
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'DELETE',
+      url: `/apis/iam/v2beta/projects/${project.id}`
+    }).then((deleteResp) => {
+      expect(deleteResp.status).to.be.oneOf([200]);
+    });
+
+    // Ensure the project is removed
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'GET',
+      url: '/apis/iam/v2beta/projects'
+    }).then((resp: Cypress.ObjectLike) => {
+      expect(resp.body.projects && (resp.body.projects.length === 0 ||
+        !resp.body.projects.some((p: any) => p.id === project.id))).to.be.true;
+    });
+  });
+});
+
+function applyRules() {
+  cy.request({
+    headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+    method: 'POST',
+    url: '/apis/iam/v2beta/apply-rules'
+  });
+
+  cy.waitUntilApplyRulesNotRunning(100);
+}

--- a/e2e/cypress/integration/api/iam/14_projects_delete_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/14_projects_delete_api.spec.ts
@@ -64,7 +64,7 @@ describeIfIAMV2p1('Project delete', () => {
       url: '/apis/iam/v2beta/projects'
     }).then((resp: Cypress.ObjectLike) => {
       expect(resp.body.projects && resp.body.projects.length > 0 &&
-        resp.body.projects.some((p: any) => p.id === project.id)).to.be.true;
+        resp.body.projects.some((p: any) => p.id === project.id)).to.be.equal(true);
     });
 
     // Apply the rules to make the rule applied
@@ -88,7 +88,7 @@ describeIfIAMV2p1('Project delete', () => {
       url: '/apis/iam/v2beta/projects'
     }).then((resp: Cypress.ObjectLike) => {
       expect(resp.body.projects && resp.body.projects.length > 0 &&
-        resp.body.projects.some((p: any) => p.id === project.id)).to.be.true;
+        resp.body.projects.some((p: any) => p.id === project.id)).to.be.equal(true);
     });
 
     // Delete the rule
@@ -118,7 +118,7 @@ describeIfIAMV2p1('Project delete', () => {
       url: '/apis/iam/v2beta/projects'
     }).then((resp: Cypress.ObjectLike) => {
       expect(resp.body.projects && resp.body.projects.length > 0 &&
-        resp.body.projects.some((p: any) => p.id === project.id)).to.be.true;
+        resp.body.projects.some((p: any) => p.id === project.id)).to.be.equal(true);
     });
 
     // Apply the rules to remove the rule
@@ -140,7 +140,7 @@ describeIfIAMV2p1('Project delete', () => {
       url: '/apis/iam/v2beta/projects'
     }).then((resp: Cypress.ObjectLike) => {
       expect(resp.body.projects && (resp.body.projects.length === 0 ||
-        !resp.body.projects.some((p: any) => p.id === project.id))).to.be.true;
+        !resp.body.projects.some((p: any) => p.id === project.id))).to.be.equal(true);
     });
   });
 });

--- a/e2e/cypress/integration/api/iam/14_projects_delete_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/14_projects_delete_api.spec.ts
@@ -46,7 +46,7 @@ describeIfIAMV2p1('Project delete', () => {
       body: rule
     });
 
-    // Try to delete the project with a stagged rule
+    // Try to delete the project with a staged rule
     cy.request({
       headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
       method: 'DELETE',
@@ -54,7 +54,7 @@ describeIfIAMV2p1('Project delete', () => {
       failOnStatusCode: false
     }).then((deleteResp) => {
       expect(deleteResp.status,
-        'Did not fail deleting a project with a stagged rule').to.be.oneOf([400]);
+        'Did not fail deleting a project with a staged rule').to.equal(400);
     });
 
     // Ensure the project was not deleted
@@ -63,8 +63,7 @@ describeIfIAMV2p1('Project delete', () => {
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((resp: Cypress.ObjectLike) => {
-      expect(resp.body.projects && resp.body.projects.length > 0 &&
-        resp.body.projects.some((p: any) => p.id === project.id)).to.be.equal(true);
+      expect(responseContainsProject(resp.body.projects, project.id)).to.be.equal(true);
     });
 
     // Apply the rules to make the rule applied
@@ -78,7 +77,7 @@ describeIfIAMV2p1('Project delete', () => {
       failOnStatusCode: false
     }).then((deleteResp) => {
       expect(deleteResp.status,
-        'Did not fail deleting a project with a applied rule').to.be.oneOf([400]);
+        'Did not fail deleting a project with a applied rule').to.be.equal(400);
     });
 
     // Ensure the project was not removed
@@ -87,8 +86,7 @@ describeIfIAMV2p1('Project delete', () => {
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((resp: Cypress.ObjectLike) => {
-      expect(resp.body.projects && resp.body.projects.length > 0 &&
-        resp.body.projects.some((p: any) => p.id === project.id)).to.be.equal(true);
+      expect(responseContainsProject(resp.body.projects, project.id)).to.be.equal(true);
     });
 
     // Delete the rule
@@ -97,7 +95,7 @@ describeIfIAMV2p1('Project delete', () => {
       method: 'DELETE',
       url: `/apis/iam/v2beta/projects/${project.id}/rules/${rule.id}`
     }).then((deleteResp) => {
-      expect(deleteResp.status).to.be.oneOf([200]);
+      expect(deleteResp.status).to.be.equal(200);
     });
 
     // Try to delete the project with a non applied deleted rule
@@ -108,7 +106,7 @@ describeIfIAMV2p1('Project delete', () => {
       failOnStatusCode: false
     }).then((deleteResp) => {
       expect(deleteResp.status,
-        'Did not fail deleting a project with a deleted applied rule').to.be.oneOf([400]);
+        'Did not fail deleting a project with a deleted applied rule').to.be.equal(400);
     });
 
     // Ensure the project was not removed
@@ -117,8 +115,7 @@ describeIfIAMV2p1('Project delete', () => {
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((resp: Cypress.ObjectLike) => {
-      expect(resp.body.projects && resp.body.projects.length > 0 &&
-        resp.body.projects.some((p: any) => p.id === project.id)).to.be.equal(true);
+      expect(responseContainsProject(resp.body.projects, project.id)).to.be.equal(true);
     });
 
     // Apply the rules to remove the rule
@@ -130,7 +127,7 @@ describeIfIAMV2p1('Project delete', () => {
       method: 'DELETE',
       url: `/apis/iam/v2beta/projects/${project.id}`
     }).then((deleteResp) => {
-      expect(deleteResp.status).to.be.oneOf([200]);
+      expect(deleteResp.status).to.be.equal(200);
     });
 
     // Ensure the project is removed
@@ -139,8 +136,13 @@ describeIfIAMV2p1('Project delete', () => {
       method: 'GET',
       url: '/apis/iam/v2beta/projects'
     }).then((resp: Cypress.ObjectLike) => {
-      expect(resp.body.projects && (resp.body.projects.length === 0 ||
-        !resp.body.projects.some((p: any) => p.id === project.id))).to.be.equal(true);
+      expect(responseContainsProject(resp.body.projects, project.id)).to.be.equal(false);
     });
   });
 });
+
+function responseContainsProject(projectsResponse: any, projectId: string): boolean {
+  return projectsResponse &&
+    projectsResponse.length > 0 &&
+    projectsResponse.some((p: any) => p.id === projectId);
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Add integration tests for the cases preventing project delete. 

A user can not delete a project when:
* The project has applied rules
* The project has staged rules
* The project has deleted applied rules

### :chains: Related Resources

#2449 

### :athletic_shoe: How to Build and Test the Change
Look at the cypress test in buildkite