### PR TITLE
Fix client runs export incomplete data bug

### DIFF
--- a/components/config-mgmt-service/backend/client.go
+++ b/components/config-mgmt-service/backend/client.go
@@ -55,12 +55,12 @@ type Client interface {
 		string, int, string, bool) ([]InventoryNode, error)
 	// @params (ctx, start, end, filters, cursorField, cursorID, pageSize, sortField, ascending)
 	// returns (Node, error)
-	GetNodesPageByCurser(context.Context, time.Time,
+	GetNodesPageByCursor(context.Context, time.Time,
 		time.Time, map[string][]string, interface{},
 		string, int, string, bool) ([]Node, error)
 	// @params (ctx, nodeID, start, end, filters, cursorEndTime, cursorID, pageSize, ascending)
 	// returns (Runs, error)
-	GetRunsPageByCurser(context.Context, string, time.Time, time.Time, map[string][]string, time.Time,
+	GetRunsPageByCursor(context.Context, string, time.Time, time.Time, map[string][]string, time.Time,
 		string, int, bool) ([]Run, error)
 }
 

--- a/components/config-mgmt-service/backend/elastic/elastic.go
+++ b/components/config-mgmt-service/backend/elastic/elastic.go
@@ -31,7 +31,6 @@ const (
 	// Elasticsearch fields we use within this package
 	RunFieldTimestamp    = "start_time"
 	RunFieldEndTimestamp = "end_time"
-	CheckinTimestamp     = "checkin"
 	ActionFieldTimestamp = "recorded_at"
 	ActionFieldID        = "id"
 	NodeFieldID          = "entity_uuid"

--- a/components/config-mgmt-service/backend/elastic/nodes.go
+++ b/components/config-mgmt-service/backend/elastic/nodes.go
@@ -100,7 +100,7 @@ func (es Backend) GetInventoryNodes(ctx context.Context, start time.Time,
 	return nodes, nil
 }
 
-func (es Backend) GetNodesPageByCurser(ctx context.Context, start time.Time,
+func (es Backend) GetNodesPageByCursor(ctx context.Context, start time.Time,
 	end time.Time, filters map[string][]string, cursorField interface{},
 	cursorID string, pageSize int, sortField string,
 	ascending bool) ([]backend.Node, error) {

--- a/components/config-mgmt-service/backend/elastic/nodes.go
+++ b/components/config-mgmt-service/backend/elastic/nodes.go
@@ -55,7 +55,7 @@ func (es Backend) GetInventoryNodes(ctx context.Context, start time.Time,
 
 	mainQuery := newBoolQueryFromFilters(filters)
 
-	rangeQuery, ok := newRangeQueryTime(start, end, CheckinTimestamp)
+	rangeQuery, ok := newRangeQueryTime(start, end, backend.CheckIn)
 
 	if ok {
 		mainQuery = mainQuery.Must(rangeQuery)
@@ -67,7 +67,7 @@ func (es Backend) GetInventoryNodes(ctx context.Context, start time.Time,
 		Query(mainQuery).
 		Index(IndexNodeState).
 		Size(pageSize).
-		Sort(CheckinTimestamp, ascending).
+		Sort(backend.CheckIn, ascending).
 		Sort(NodeFieldID, ascending).
 		FetchSourceContext(fetchSource)
 
@@ -108,10 +108,10 @@ func (es Backend) GetNodesPageByCursor(ctx context.Context, start time.Time,
 	mainQuery := newBoolQueryFromFilters(filters)
 
 	if sortField == "" {
-		sortField = CheckinTimestamp
+		sortField = backend.CheckIn
 	}
 
-	rangeQuery, ok := newRangeQueryTime(start, end, CheckinTimestamp)
+	rangeQuery, ok := newRangeQueryTime(start, end, backend.CheckIn)
 
 	if ok {
 		mainQuery = mainQuery.Must(rangeQuery)

--- a/components/config-mgmt-service/backend/elastic/nodes.go
+++ b/components/config-mgmt-service/backend/elastic/nodes.go
@@ -101,7 +101,7 @@ func (es Backend) GetInventoryNodes(ctx context.Context, start time.Time,
 }
 
 func (es Backend) GetNodesPageByCursor(ctx context.Context, start time.Time,
-	end time.Time, filters map[string][]string, cursorField interface{},
+	end time.Time, filters map[string][]string, cursorValue interface{},
 	cursorID string, pageSize int, sortField string,
 	ascending bool) ([]backend.Node, error) {
 
@@ -124,8 +124,8 @@ func (es Backend) GetNodesPageByCursor(ctx context.Context, start time.Time,
 		Sort(sortField, ascending).
 		Sort(NodeFieldID, ascending)
 
-	if cursorField != nil && cursorID != "" {
-		switch v := cursorField.(type) {
+	if cursorValue != nil && cursorID != "" {
+		switch v := cursorValue.(type) {
 		case time.Time:
 			// the date has to be in milliseconds
 			milliseconds := v.UnixNano() / int64(time.Millisecond)
@@ -135,7 +135,7 @@ func (es Backend) GetNodesPageByCursor(ctx context.Context, start time.Time,
 			lower := strings.ToLower(v)
 			searchService = searchService.SearchAfter(lower, cursorID)
 		default:
-			searchService = searchService.SearchAfter(cursorField, cursorID)
+			searchService = searchService.SearchAfter(cursorValue, cursorID)
 		}
 	}
 

--- a/components/config-mgmt-service/backend/elastic/runs.go
+++ b/components/config-mgmt-service/backend/elastic/runs.go
@@ -158,7 +158,7 @@ func (es Backend) GetRuns(nodeID string, page int, perPage int, filters map[stri
 	return runs, nil
 }
 
-func (es Backend) GetRunsPageByCurser(ctx context.Context, nodeID string, start time.Time,
+func (es Backend) GetRunsPageByCursor(ctx context.Context, nodeID string, start time.Time,
 	end time.Time, filters map[string][]string, cursorEndTime time.Time,
 	cursorID string, pageSize int, ascending bool) ([]backend.Run, error) {
 

--- a/components/config-mgmt-service/backend/mock/mock.go
+++ b/components/config-mgmt-service/backend/mock/mock.go
@@ -155,7 +155,7 @@ func (m Backend) GetInventoryNodes(ctx context.Context, start time.Time,
 	return nodes, nil
 }
 
-func (m Backend) GetNodesPageByCurser(context.Context, time.Time,
+func (m Backend) GetNodesPageByCursor(context.Context, time.Time,
 	time.Time, map[string][]string, interface{},
 	string, int, string, bool) ([]backend.Node, error) {
 	var nodes []backend.Node
@@ -165,7 +165,7 @@ func (m Backend) GetNodesPageByCurser(context.Context, time.Time,
 	return nodes, nil
 }
 
-func (m Backend) GetRunsPageByCurser(context.Context, string, time.Time,
+func (m Backend) GetRunsPageByCursor(context.Context, string, time.Time,
 	time.Time, map[string][]string, time.Time,
 	string, int, bool) ([]backend.Run, error) {
 	var runs []backend.Run

--- a/components/config-mgmt-service/grpcserver/cfg_mgmt.go
+++ b/components/config-mgmt-service/grpcserver/cfg_mgmt.go
@@ -373,7 +373,7 @@ func (s *CfgMgmtServer) getNodeAsync(ctx context.Context, nodeID string, project
 	})
 	go func() {
 		projectFilters["entity_uuid"] = []string{nodeID}
-		nodes, err := s.client.GetNodesPageByCurser(ctx, time.Time{}, time.Time{},
+		nodes, err := s.client.GetNodesPageByCursor(ctx, time.Time{}, time.Time{},
 			projectFilters, nil, "", 1, "", true)
 		nodesChan <- struct {
 			nodes []backend.Node

--- a/components/config-mgmt-service/grpcserver/node_export.go
+++ b/components/config-mgmt-service/grpcserver/node_export.go
@@ -98,7 +98,7 @@ func (s *CfgMgmtServer) exportNodes(ctx context.Context, request *pRequest.NodeE
 	pageSize := 100
 	start := time.Time{}
 	end := time.Time{}
-	var cursorField interface{}
+	var cursorValue interface{}
 	cursorID := ""
 	sortField, sortAsc := request.Sorting.GetParameters()
 	nodeFilters, err := stringutils.FormatFiltersWithKeyConverter(request.Filter,
@@ -118,7 +118,7 @@ func (s *CfgMgmtServer) exportNodes(ctx context.Context, request *pRequest.NodeE
 	nodeFilters["exists"] = []string{"true"}
 
 	nodes, err := s.client.GetNodesPageByCursor(ctx, start, end,
-		nodeFilters, cursorField, cursorID, pageSize, sortField, sortAsc)
+		nodeFilters, cursorValue, cursorID, pageSize, sortField, sortAsc)
 	if err != nil {
 		return status.Errorf(codes.Internal, err.Error())
 	}
@@ -131,13 +131,13 @@ func (s *CfgMgmtServer) exportNodes(ctx context.Context, request *pRequest.NodeE
 
 		lastNode := nodes[len(nodes)-1]
 		cursorID = lastNode.EntityUuid
-		cursorField, err = backend.GetSortableFieldValue(sortField, lastNode)
+		cursorValue, err = backend.GetSortableFieldValue(sortField, lastNode)
 		if err != nil {
 			return err
 		}
 
 		nodes, err = s.client.GetNodesPageByCursor(ctx, start, end,
-			nodeFilters, cursorField, cursorID, pageSize, sortField, sortAsc)
+			nodeFilters, cursorValue, cursorID, pageSize, sortField, sortAsc)
 		if err != nil {
 			return status.Errorf(codes.Internal, err.Error())
 		}

--- a/components/config-mgmt-service/grpcserver/node_export.go
+++ b/components/config-mgmt-service/grpcserver/node_export.go
@@ -121,9 +121,8 @@ func (s *CfgMgmtServer) exportNodes(ctx context.Context, request *pRequest.NodeE
 		sortField = backend.CheckIn
 	} else {
 		sortField = params.ConvertParamToNodeRunBackend(sortField)
-	}
 
-	nodes, err := s.client.GetNodesPageByCurser(ctx, start, end,
+	nodes, err := s.client.GetNodesPageByCursor(ctx, start, end,
 		nodeFilters, cursorField, cursorID, pageSize, sortField, sortAsc)
 	if err != nil {
 		return status.Errorf(codes.Internal, err.Error())
@@ -142,7 +141,7 @@ func (s *CfgMgmtServer) exportNodes(ctx context.Context, request *pRequest.NodeE
 			return err
 		}
 
-		nodes, err = s.client.GetNodesPageByCurser(ctx, start, end,
+		nodes, err = s.client.GetNodesPageByCursor(ctx, start, end,
 			nodeFilters, cursorField, cursorID, pageSize, sortField, sortAsc)
 		if err != nil {
 			return status.Errorf(codes.Internal, err.Error())

--- a/components/config-mgmt-service/grpcserver/node_export.go
+++ b/components/config-mgmt-service/grpcserver/node_export.go
@@ -117,8 +117,10 @@ func (s *CfgMgmtServer) exportNodes(ctx context.Context, request *pRequest.NodeE
 	// even after the node no longer exists
 	nodeFilters["exists"] = []string{"true"}
 
+	actualSortField := params.ConvertParamToNodeStateBackendLowerFilter(sortField)
+
 	nodes, err := s.client.GetNodesPageByCursor(ctx, start, end,
-		nodeFilters, cursorValue, cursorID, pageSize, sortField, sortAsc)
+		nodeFilters, cursorValue, cursorID, pageSize, actualSortField, sortAsc)
 	if err != nil {
 		return status.Errorf(codes.Internal, err.Error())
 	}
@@ -137,7 +139,7 @@ func (s *CfgMgmtServer) exportNodes(ctx context.Context, request *pRequest.NodeE
 		}
 
 		nodes, err = s.client.GetNodesPageByCursor(ctx, start, end,
-			nodeFilters, cursorValue, cursorID, pageSize, sortField, sortAsc)
+			nodeFilters, cursorValue, cursorID, pageSize, actualSortField, sortAsc)
 		if err != nil {
 			return status.Errorf(codes.Internal, err.Error())
 		}

--- a/components/config-mgmt-service/grpcserver/node_export.go
+++ b/components/config-mgmt-service/grpcserver/node_export.go
@@ -117,11 +117,6 @@ func (s *CfgMgmtServer) exportNodes(ctx context.Context, request *pRequest.NodeE
 	// even after the node no longer exists
 	nodeFilters["exists"] = []string{"true"}
 
-	if sortField == "" {
-		sortField = backend.CheckIn
-	} else {
-		sortField = params.ConvertParamToNodeRunBackend(sortField)
-
 	nodes, err := s.client.GetNodesPageByCursor(ctx, start, end,
 		nodeFilters, cursorField, cursorID, pageSize, sortField, sortAsc)
 	if err != nil {

--- a/components/config-mgmt-service/grpcserver/report_export.go
+++ b/components/config-mgmt-service/grpcserver/report_export.go
@@ -115,7 +115,7 @@ func (s *CfgMgmtServer) exportReports(ctx context.Context, request *pRequest.Rep
 		return status.Errorf(codes.InvalidArgument, err.Error())
 	}
 
-	runs, err := s.client.GetRunsPageByCurser(ctx, request.NodeId, start, end,
+	runs, err := s.client.GetRunsPageByCursor(ctx, request.NodeId, start, end,
 		runFilters, cursorEndTime, cursorID, pageSize, sortAsc)
 	if err != nil {
 		return status.Errorf(codes.Internal, err.Error())
@@ -142,7 +142,7 @@ func (s *CfgMgmtServer) exportReports(ctx context.Context, request *pRequest.Rep
 		cursorID = lastRun.RunID
 		cursorEndTime = lastRun.EndTime
 
-		runs, err = s.client.GetRunsPageByCurser(ctx, request.NodeId, start, end,
+		runs, err = s.client.GetRunsPageByCursor(ctx, request.NodeId, start, end,
 			runFilters, cursorEndTime, cursorID, pageSize, sortAsc)
 		if err != nil {
 			return status.Errorf(codes.Internal, err.Error())

--- a/components/config-mgmt-service/integration_test/node_export_test.go
+++ b/components/config-mgmt-service/integration_test/node_export_test.go
@@ -1,9 +1,9 @@
 package integration_test
 
 import (
-	// "bytes"
+	"bytes"
 	"context"
-	// "encoding/json"
+	"encoding/json"
 	"fmt"
 	"github.com/buger/jsonparser"
 	"github.com/chef/automate/api/interservice/cfgmgmt/request"
@@ -688,4 +688,85 @@ func TestNodeExportLoopBug(t *testing.T) {
 			assert.Equal(t, numberOfNodes, actualNumberOfNodes)
 		})
 	}
+}
+
+func TestNodeExportPaging(t *testing.T) {
+	esClient := elastic.New(elasticsearchUrl)
+	c := config.New(esClient)
+	server := grpcserver.NewCfgMgmtServer(c)
+
+	lis := bufconn.Listen(1024 * 1024)
+	s := grpc.NewServer()
+	api.RegisterCfgMgmtServer(s, server)
+
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			t.Fatalf("Server exited with error: %v", err)
+		}
+	}()
+
+	dialer := func(string, time.Duration) (net.Conn, error) { return lis.Dial() }
+
+	conn, err := grpc.DialContext(context.Background(), "bufnet", grpc.WithDialer(dialer), grpc.WithInsecure())
+	defer conn.Close()
+	require.NoError(t, err)
+
+	client := api.NewCfgMgmtClient(conn)
+
+	names := []string{
+		"Taco Bell",
+		"taco bell",
+		"TACO BELL",
+		"tACO bELL",
+		"TACO bell",
+	}
+
+	// page size is hardcoded to 100, so to test the pagination code we need more than that.
+	numberOfNodes := 150
+	nodes := make([]iBackend.Node, numberOfNodes)
+	for i := 0; i < numberOfNodes; i++ {
+		nodes[i].Exists = true
+		nodes[i].NodeInfo = iBackend.NodeInfo{
+			NodeName:   names[i%len(names)],
+			EntityUuid: newUUID(),
+		}
+	}
+
+	// Add nodes with projects
+	suite.IngestNodes(nodes)
+	defer suite.DeleteAllDocuments()
+
+	response, err := client.NodeExport(context.Background(), &request.NodeExport{
+		OutputType: "json",
+		Sorting: &request.Sorting{
+			Field: backend.Name,
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	data := make([]byte, 0)
+	for {
+		tdata, err := response.Recv()
+		if err != nil && err == io.EOF {
+			data = append(data, tdata.GetContent()...)
+			break
+		}
+
+		require.NoError(t, err)
+		data = append(data, tdata.GetContent()...)
+	}
+
+	actualNumberOfNodes := 0
+	dec := json.NewDecoder(bytes.NewReader(data))
+	for dec.More() {
+		var nodes []interface{}
+		err := dec.Decode(&nodes)
+		require.NoError(t, err)
+
+		actualNumberOfNodes += len(nodes)
+	}
+
+	assert.Equal(t, numberOfNodes, actualNumberOfNodes)
 }

--- a/components/config-mgmt-service/params/parameters.go
+++ b/components/config-mgmt-service/params/parameters.go
@@ -68,39 +68,39 @@ func ConvertParamToNodeRunBackend(parameter string) string {
 // This is using the ".lower" values to match on fields case-insensitively
 func ConvertParamToNodeStateBackendLowerFilter(parameter string) string {
 	switch parameter {
-	case "id", "node_id":
+	case "id", "node_id", backend.Id:
 		return backend.Id
-	case "name":
+	case "name", backend.Name:
 		return backend.Name + ".lower"
-	case "cookbook":
+	case "cookbook", backend.Cookbook:
 		return backend.Cookbook + ".lower"
-	case "attribute":
+	case "attribute", backend.Attribute:
 		return backend.Attribute + ".lower"
-	case "resource_name", "resource_names":
+	case "resource_name", "resource_names", backend.ResourceName:
 		return backend.ResourceName + ".lower"
-	case "recipe":
+	case "recipe", backend.Recipe:
 		return backend.Recipe + ".lower"
-	case "organization":
+	case "organization", backend.Organization:
 		return backend.Organization + ".lower"
-	case "role":
+	case "role", backend.Role:
 		return backend.Role + ".lower"
-	case "chef_version":
+	case "chef_version", backend.ChefVersion:
 		return backend.ChefVersion + ".lower"
-	case "chef_tags":
+	case "chef_tags", backend.ChefTags:
 		return backend.ChefTags + ".lower"
-	case "error":
+	case "error", backend.ErrorMessage:
 		return backend.ErrorMessage + ".lower"
-	case "chef_server", "source_fqdn":
+	case "chef_server", "source_fqdn", backend.ChefServer:
 		return backend.ChefServer + ".lower"
-	case "environment":
+	case "environment", backend.Environment:
 		return backend.Environment + ".lower"
-	case "platform":
+	case "platform", backend.Platform:
 		return backend.Platform + ".lower"
-	case "policy_group":
+	case "policy_group", backend.PolicyGroup:
 		return backend.PolicyGroup + ".lower"
-	case "policy_name":
+	case "policy_name", backend.PolicyName:
 		return backend.PolicyName + ".lower"
-	case "policy_revision":
+	case "policy_revision", backend.PolicyRevision:
 		return backend.PolicyRevision + ".lower"
 	default:
 		return parameter

--- a/components/config-mgmt-service/params/parameters_test.go
+++ b/components/config-mgmt-service/params/parameters_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/chef/automate/components/config-mgmt-service/backend"
 	subject "github.com/chef/automate/components/config-mgmt-service/params"
 	"github.com/stretchr/testify/assert"
 )
@@ -86,6 +87,32 @@ func TestValidateDateRangeWithInvalidDatesReturnFalse(t *testing.T) {
 			} else {
 				assert.False(t, subject.ValidateDateRange(test.start, test.end))
 			}
+		})
+	}
+}
+
+func TestConverParamToNodeStateBackendLowerFilter(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		// Does this function add `.lower` to string field values?
+		{input: "name", expected: "node_name.lower"},
+		{input: backend.Name, expected: "node_name.lower"},
+
+		// Does this function leave the odd one out?
+		{input: "id", expected: backend.Id},
+		{input: "node_id", expected: backend.Id},
+		{input: backend.Id, expected: backend.Id},
+
+		// Does this function transform unexpected values?
+		{input: "watlololol", expected: "watlololol"},
+	}
+
+	for _, test := range cases {
+		t.Run(fmt.Sprintf("with input \"%s\" it should return \"%s\"", test.input, test.expected), func(t *testing.T) {
+			actual := subject.ConvertParamToNodeStateBackendLowerFilter(test.input)
+			assert.Equal(t, actual, test.expected)
 		})
 	}
 }


### PR DESCRIPTION
Attempted fix for #2284.

Sorting on the client runs export endpoint was being done case sensitively, and this made it so that the paginated could be incomplete with a large number of similarly named nodes. I believe this happened because the pagination for this endpoint works by remembering that last position in the list and searching for matching elements after that one; when lots of the nodes had similar names differing in case, this made it so finding the last element when fetching the next page was unreliable. This PR contains a fix for the incomplete data issue, but it necessarily includes a behavior change because it's unclear whether we can support a case sensitive sort with the way pagination is implemented.

Before the sorting changes in this PR, the test would reliably fail with a message like this:

```
=== RUN   TestNodeExportPaging
--- FAIL: TestNodeExportPaging (0.48s)
    node_export_test.go:771:
                Error Trace:    node_export_test.go:771
                Error:          Not equal:
                                expected: 150
                                actual  : 118
                Test:           TestNodeExportPaging
FAIL
coverage: [no statements]
FAIL    github.com/chef/automate/components/config-mgmt-service/integration_test        1.776s
FAIL
```

```
=== RUN   TestNodeExportPaging
--- FAIL: TestNodeExportPaging (0.47s)
    node_export_test.go:771:
                Error Trace:    node_export_test.go:771
                Error:          Not equal:
                                expected: 150
                                actual  : 120
                Test:           TestNodeExportPaging
FAIL
coverage: [no statements]
FAIL    github.com/chef/automate/components/config-mgmt-service/integration_test        1.987s
FAIL
```

There is a small amount of randomness to the results because random UUIDs are generated in the tests and the UUID is used as the secondary, tie-breaker sort.