### PR TITLE
[automate-elasticsearch] Remove stale keystore file when starting service

### DIFF
--- a/components/automate-elasticsearch/habitat/config/init_keystore
+++ b/components/automate-elasticsearch/habitat/config/init_keystore
@@ -2,6 +2,11 @@
 
 exec 2>&1
 
+if [[ -f {{pkg.svc_config_path}}/elasticsearch.keystore.tmp ]]; then
+  echo "Removing stale keystore temporary file"
+  rm {{pkg.svc_config_path}}/elasticsearch.keystore.tmp
+fi
+
 if [[ -f {{pkg.svc_config_path}}/elasticsearch.keystore ]]; then
   elasticsearch-keystore upgrade
 else


### PR DESCRIPTION
It's possible that ElasticSearch will leave a temporary keystore file
around when the service is stopped. Upon restart the temporary keyfile
will prevent the service from starting:

automate-elasticsearch.default(O): Exception in thread "main"
org.elasticsearch.bootstrap.BootstrapException:
java.nio.file.FileAlreadyExistsException:
/hab/svc/automate-elasticsearch/config/elasticsearch.keystore.tmp

Here, we automatically detect and remove the old temporary file when
initializing the keystore during startup.

Signed-off-by: Ryan Cragun <ryan@chef.io>