### PR TITLE
Update config-mgmt integration test instructions

### DIFF
--- a/components/config-mgmt-service/integration_test/README.md
+++ b/components/config-mgmt-service/integration_test/README.md
@@ -6,7 +6,7 @@ Below is the steps to run the tests:
 ```
 $ hab studio enter
 [1][default:/src:0]# start_deployment_service
-[2][default:/src:0]# chef-automate dev deploy-some chef/automate-elasticsearch
+[2][default:/src:0]# chef-automate dev deploy-some chef/automate-elasticsearch --with-deps
 [3][default:/src:0]# config_mgmt_integration
 ```
 
@@ -14,7 +14,7 @@ This will run the integration tests by leveraging the helper `go_test`
 
 # How do I run a single test
 
-Before running any test manually, make sure you bring up elasticsearch by running `start_deployment_service` then `chef-automate dev deploy-some chef/automate-elasticsearch`,
+Before running any test manually, make sure you bring up elasticsearch by running `start_deployment_service` then `chef-automate dev deploy-some chef/automate-elasticsearch --with-deps`,
 otherwise you will see the following error when running any of them:
 ```
 Could not create elasticsearch client from 'http://elasticsearch:9200': health check timeout: no Elasticsearch node available

--- a/components/config-mgmt-service/integration_test/README.md
+++ b/components/config-mgmt-service/integration_test/README.md
@@ -13,22 +13,6 @@ $ hab studio enter
 This will run the integration tests by leveraging the helper `go_test`
 
 # How do I run a single test
-To run a single test you have to step into the Go Workspace inside your habitat studio, you can use the
-helper method `enter_go_workspace`
-```
-$ hab studio enter
-[1][default:/src:0]# enter_go_workspace
-=> Configuring Go Workspace. [please wait]
-=> Available scaffolding variables:
-$scaffolding_go_gopath        - /hab/cache/src/go
-$scaffolding_go_workspace_src - /hab/cache/src/go/src
-$scaffolding_go_pkg_path      - /hab/cache/src/go/src/github.com/chef/automate/components/config-mgmt-service
-[3][default:/hab/cache/src/go/src/github.com/chef/automate/components/config-mgmt-service:0]#
-```
-
-This helper will automatically configure the Go workspace (by leveraging the `scaffolding-go` hooks) and it
-will also position yourself inside the config-mgmt-service directory where you can run any command like `go`,
-`dep`, etc. natively.
 
 Before running any test manually, make sure you bring up elasticsearch by running `start_deployment_service` then `chef-automate dev deploy-some chef/automate-elasticsearch`,
 otherwise you will see the following error when running any of them:
@@ -48,8 +32,6 @@ can execute:
 PASS
 ok  	github.com/chef/automate/components/config-mgmt-service/integration_test	2.904s
 ```
-
-_NOTE: Remember that you have to enter the go workspace to run these commands. (use `egw` alias to do so)_
 
 Now lets imagine that you continue writing more test cases for the same new functionality you just added (called
 `Foo()` remember) so you add the following test functions:


### PR DESCRIPTION
* `enter_go_workspace` is apparently no longer necessary. If I try to do that in my local env I see this error, but all the other commands work fine without it:

```
[1][default:/src:0]# enter_go_workspace
  ERROR: Unable to setup Go Workspace.
  ERROR: setup_go_workspace: requires the 'pkg_scaffolding' variable to exist in your plan.sh
```

* Starting elasticsearch without appending `--with-deps` to the command will make it so the command doesn't start and the service health check will fail.