### PR TITLE
Filter service groups and services by disconnected status

### DIFF
--- a/components/automate-ui/src/app/entities/service-groups/service-groups.facade.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.facade.ts
@@ -45,7 +45,7 @@ export class ServiceGroupsFacadeService {
   public currentServicesFilters$: Observable<GroupServicesFilters>;
 
   // The collection of allowable status
-  public allowedStatus = ['ok', 'critical', 'warning', 'unknown'];
+  public allowedStatus = ['ok', 'critical', 'warning', 'unknown', 'disconnected'];
 
   constructor(
       private store: Store<fromServiceGroups.ServiceGroupsEntityState>,

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -32,6 +32,11 @@
           <div class="filter-label">Warning</div>
           <div class="filter-total">{{ serviceGroupsHealthSummary.warning }}</div>
         </chef-option>
+        <chef-option class="filter disconnected" value='disconnected' (click)="updateHealthFilter('disconnected')">
+          <chef-icon class="filter-icon"></chef-icon>
+          <div class="filter-label">Disconnected</div>
+          <div class="filter-total">{{ serviceGroupsHealthSummary.disconnected }}</div>
+        </chef-option>
         <chef-option class="filter success" value='ok' (click)="updateHealthFilter('ok')">
           <chef-icon class="filter-icon">check_circle</chef-icon>
           <div class="filter-label">OK</div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -34,6 +34,12 @@ chef-alert {
   justify-content: left;
 }
 
+.filter.disconnected chef-icon {
+  // This is set in chef-ui-library but automate-ui's copy is in a slightly
+  // different path:
+  background: url(/assets/img/icon-disconnected.svg);
+}
+
 .service-item {
   @include modal-box();
   display: block;

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -53,6 +53,11 @@
       <div class="filter-label">Warning</div>
       <div class="filter-total">{{ sgHealthSummary["warning"] }}</div>
     </chef-option>
+    <chef-option class="filter disconnected" value='disconnected' (click)="statusFilter('disconnected')">
+      <chef-icon class="filter-icon"></chef-icon>
+      <div class="filter-label">Disconnected</div>
+      <div class="filter-total">{{ sgHealthSummary["disconnected"] }}</div>
+    </chef-option>
     <chef-option class="filter success" value='ok' (click)="statusFilter('ok')">
       <chef-icon class="filter-icon">check_circle</chef-icon>
       <div class="filter-label">OK</div>

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
@@ -63,6 +63,12 @@ app-search-bar {
   }
 }
 
+.filter.disconnected chef-icon {
+  // This is set in chef-ui-library but automate-ui's copy is in a slightly
+  // different path:
+  background: url(/assets/img/icon-disconnected.svg);
+}
+
 chef-alert {
   align-items: left;
   justify-content: left;

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -66,7 +66,7 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
   private selectedStatus$: Observable<string>;
 
   // The collection of allowable status
-  private allowedStatus = ['ok', 'critical', 'warning', 'unknown'];
+  private allowedStatus = ['ok', 'critical', 'warning', 'unknown', 'disconnected'];
 
   // Has this component been destroyed
   private isDestroyed: Subject<boolean> = new Subject();
@@ -429,15 +429,15 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
 
   public statusFilter(status: string): void {
     const queryParams = {...this.route.snapshot.queryParams};
+
+    delete queryParams['status'];
+    delete queryParams['page'];
+
     if ( includes(status, this.allowedStatus) ) {
       queryParams['status'] = [status];
       this.telemetryService.track('applicationsStatusFilter',
         { entity: 'serviceGroup', statusFilter: status});
-    } else {
-      delete queryParams['status'];
     }
-
-    delete queryParams['page'];
 
     this.router.navigate([], {queryParams});
   }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Users want to know which services are disconnected from automate so they can remediate problems. We currently have badges for disconnected services but no way to filter for them.

### :chains: Related Resources

#1780 

### :athletic_shoe: How to Build and Test the Change

Build:
* `build components/automate-ui`
* `start_all_services`

Sample Data:
Generating the sample data is time-sensitive since the data generator doesn't create health check messages with timestamps in the past. What I did was:
* run `applications_populate_database`
* Wait 5m
* run it again

Then within the next 5 minutes:
* Filter for `environment: production`, this reduces the data down to 5 service groups
* Click the service groups disconnected status filter, there should be only 4 matching service groups (the group `wizrd.default` should be filtered out and not visible)
* All the service groups visible on the page should have 1/2 of the services disconnected. Select one of the service groups, then click the services disconnected status filter, the services list should be refreshed with only the disconnected service(s) visible.

### :camera: Screenshots, if applicable

not-selected:
![Screen Shot 2019-12-19 at 3 04 49 PM](https://user-images.githubusercontent.com/37162/71216930-ead91c00-2270-11ea-94cf-215c6b4ce2f6.png)

hover:
![Screen Shot 2019-12-19 at 3 05 13 PM](https://user-images.githubusercontent.com/37162/71216950-fa586500-2270-11ea-93a4-6dce0bb71e6a.png)

selected:
![Screen Shot 2019-12-19 at 3 05 52 PM](https://user-images.githubusercontent.com/37162/71216980-0f34f880-2271-11ea-8dab-2e4479752c19.png)

lean version in the side panel:
![Screen Shot 2019-12-19 at 3 06 15 PM](https://user-images.githubusercontent.com/37162/71217002-207e0500-2271-11ea-955a-95d8ef2f8e8a.png)
