### PR TITLE
Bumping expeditor to go 1.13

### DIFF
--- a/.expeditor/generate-automate-cli-docs.sh
+++ b/.expeditor/generate-automate-cli-docs.sh
@@ -5,6 +5,9 @@ set -eou pipefail
 mkdir -p /go/src/github.com/chef
 ln -s /workspace /go/src/github.com/chef/automate
 
+# bumping expeditor to go 1.13
+hab pkg install --binlink core/go/1.13.5
+
 pushd /go/src/github.com/chef/automate/components/automate-cli
   make docs
 popd


### PR DESCRIPTION
Expeditor needs to be bumped go 1.13 for building the automate-cli. 
