### PR TITLE
Show Services' Health Check Messages

### DIFF
--- a/.studio/applications-service
+++ b/.studio/applications-service
@@ -410,11 +410,42 @@ function applications_populate_database() {
   # Service groups with a larger set of health statuses. This excercises some
   # filtering cases, such as whether a service group with 1 service in critical
   # and 1 warning shows up when filtering for warning.
+
+  ##
+  # We use the east/central/mountain/west variants of the pos-terminal service
+  # to exercise some variations in how the UI displays health check output.
+
   for health_code in $(seq 0 3); do
     applications_publish_supervisor_message --name "pos-terminal" --group "default" \
       --origin custom --version "2.3.4" --release "20190115181111" --health "$health_code" \
       --sup-id "$(uuidgen)" \
-      --application "pos" --environment "production-us-east" --site "ny-123"
+      --application "pos" --environment "production-us-east" --site "ny-123" \
+      --hc-stderr "rm: cannot remove 'results/': Is a directory" \
+      --hc-stdout "rm: cannot remove 'results/': Is a directory" --hc-exit "$health_code"
+  done
+
+  for health_code in $(seq 0 3); do
+    applications_publish_supervisor_message --name "pos-terminal" --group "default" \
+      --origin custom --version "2.3.4" --release "20190115181111" --health "$health_code" \
+      --sup-id "$(uuidgen)" \
+      --application "pos" --environment "production-us-central" --site "chi-123" \
+      --hc-stderr "rm: cannot remove 'results/': Is a directory" \
+      --hc-exit "$health_code"
+  done
+
+  for health_code in $(seq 0 3); do
+    applications_publish_supervisor_message --name "pos-terminal" --group "default" \
+      --origin custom --version "2.3.4" --release "20190115181111" --health "$health_code" \
+      --sup-id "$(uuidgen)" \
+      --application "pos" --environment "production-us-mountain" --site "den-123" \
+      --hc-stdout "rm: cannot remove 'results/': Is a directory" --hc-exit "$health_code"
+  done
+
+  for health_code in $(seq 0 3); do
+    applications_publish_supervisor_message --name "pos-terminal" --group "default" \
+      --origin custom --version "2.3.4" --release "20190115181111" --health "$health_code" \
+      --sup-id "$(uuidgen)" \
+      --application "pos" --environment "production-us-west" --site "sea-123"
   done
 
   for health_code in 0 1 3 ; do

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.facade.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.facade.ts
@@ -107,7 +107,7 @@ export class ServiceGroupsFacadeService {
   public healthCheckStatus(health: string): string {
     switch (health) {
       case 'OK':
-        return 'Ok';
+        return 'OK';
       case 'CRITICAL':
         return 'Critical';
       case 'WARNING':

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.model.ts
@@ -72,6 +72,13 @@ export interface GroupService {
   previous_health_check: string;
   current_health_since: string;
   health_updated_at: Date;
+  health_check_result: HealthCheckResult;
+}
+
+export interface HealthCheckResult {
+  stdout: string;
+  stderr: string;
+  exit_status: number;
 }
 
 export interface GroupServicesFilters {

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -80,7 +80,7 @@
             <div class ="health-line">
                 <chef-icon class="health-icon {{ service.health_check }}">{{ service.health_check | serviceStatusIcon }}</chef-icon>
               <span>
-                {{ healthCheckStatus(service.health_check) }}: 
+                {{ healthCheckStatus(service.health_check) }}:
                 {{ timewizardMessage(service.health_check, service.previous_health_check) }}
                 <a [id]="'health-timestamp-' + i"> {{ service.current_health_since }} ago</a>
               </span>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -57,14 +57,6 @@
           <div class ="site-line"><b>Site:</b> {{ service.site  || "--"}}</div>
         </div>
         <div class="body">
-          <div class="disconnect-notice" *ngIf="service.disconnected">
-            <img class="disconnect-icon" src="assets/img/icon-disconnected.svg" alt="" aria-hidden />
-            <div>
-              <span>Disconnected service: Last health check received </span>
-              <span class="disconnect-time" [attr.id]="'disconnect-time-' + i">{{ service.last_event_since }} ago.</span>
-            </div>
-            <chef-tooltip [attr.for]="'disconnect-time-' + i">{{ service.last_event_occurred_at | datetime: RFC2822 }}</chef-tooltip>
-          </div>
           <div class ="release-line"><chef-icon>grain</chef-icon>{{ service.release || "--"}}</div>
           <div class ="channel-line">
             <chef-badge *ngIf="service.update_strategy !== 'NONE'">
@@ -75,14 +67,42 @@
               [tooltip]="tooltipMessageFor('channel')"
               *ngIf="service.update_strategy === 'NONE'">NO CHANNEL: NONE</chef-badge>
           </div>
-          <div class ="health-line">
-            <chef-icon class="{{ service.health_check }}">{{ service.health_check | serviceStatusIcon }}</chef-icon>
-            {{ healthCheckStatus(service.health_check) }}
+          <div class="disconnect-notice" *ngIf="service.disconnected">
+            <img class="disconnect-icon" src="assets/img/icon-disconnected.svg" alt="" aria-hidden />
+            <div>
+              <span>Disconnected service: Last health check received </span>
+              <span class="disconnect-time" [attr.id]="'disconnect-time-' + i">{{ service.last_event_since }} ago.</span>
+            </div>
+            <chef-tooltip [attr.for]="'disconnect-time-' + i">{{ service.last_event_occurred_at | datetime: RFC2822 }}</chef-tooltip>
           </div>
-          <chef-tooltip [attr.for]="'health-timestamp-' + i">{{ formatTimestamp(service.health_updated_at) }}</chef-tooltip>
-          <div class="timewizard-line">
-            {{ timewizardMessage(service.health_check, service.previous_health_check) }}
-            <a [id]="'health-timestamp-' + i"> {{ service.current_health_since }} ago</a>
+          <div class="health-info-panel {{service.health_check}}">
+            <chef-tooltip [attr.for]="'health-timestamp-' + i">{{ formatTimestamp(service.health_updated_at) }}</chef-tooltip>
+            <div class ="health-line">
+                <chef-icon class="health-icon {{ service.health_check }}">{{ service.health_check | serviceStatusIcon }}</chef-icon>
+              <span>
+                {{ healthCheckStatus(service.health_check) }}: 
+                {{ timewizardMessage(service.health_check, service.previous_health_check) }}
+                <a [id]="'health-timestamp-' + i"> {{ service.current_health_since }} ago</a>
+              </span>
+            </div>
+            <div class="healthcheck-message-collection"  *ngIf="service.health_check !== 'OK'">
+              <div class="healthcheck-message">
+                <div class="healthcheck-header {{service.health_check}}">
+                  Health Check Error Message
+                </div>
+                <div class="healthcheck-content">
+                  {{service.health_check_result.stderr}}
+                </div>
+              </div>
+              <div class="healthcheck-message">
+                <div class="healthcheck-header {{service.health_check}}">
+                  Health Check Output Message
+                </div>
+                <div class="healthcheck-content">
+                  {{service.health_check_result.stdout}}
+                </div>
+               </div>
+            </div>
           </div>
         </div>
       </li>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -75,6 +75,7 @@
             </div>
             <chef-tooltip [attr.for]="'disconnect-time-' + i">{{ service.last_event_occurred_at | datetime: RFC2822 }}</chef-tooltip>
           </div>
+          <hr class="health-info-divider" />
           <div class="health-info-panel {{service.health_check}}">
             <chef-tooltip [attr.for]="'health-timestamp-' + i">{{ formatTimestamp(service.health_updated_at) }}</chef-tooltip>
             <div class ="health-line">

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -85,8 +85,11 @@
                 <a [id]="'health-timestamp-' + i"> {{ service.current_health_since }} ago</a>
               </span>
             </div>
-            <div class="healthcheck-message-collection"  *ngIf="service.health_check !== 'OK'">
-              <div class="healthcheck-message">
+            <div class="healthcheck-message-collection" *ngIf="service.health_check !== 'OK'">
+              <div class="no-healthcheck-messages {{ service.health_check }}" *ngIf="service.health_check_result.stderr === '' && service.health_check_result.stdout === ''" >
+                Health check messages not available. When services specify a health-check hook, the hook's output will be shown here. <a href="https://www.habitat.sh/docs/reference/#sts=health-check">Learn more about writing health-check hooks.</a>
+              </div>
+              <div class="healthcheck-message" *ngIf="service.health_check_result.stderr !== ''">
                 <div class="healthcheck-header {{service.health_check}}">
                   Health Check Error Message
                 </div>
@@ -94,7 +97,7 @@
                   {{service.health_check_result.stderr}}
                 </div>
               </div>
-              <div class="healthcheck-message">
+              <div class="healthcheck-message" *ngIf="service.health_check_result.stdout !== ''">
                 <div class="healthcheck-header {{service.health_check}}">
                   Health Check Output Message
                 </div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -67,6 +67,7 @@
               [tooltip]="tooltipMessageFor('channel')"
               *ngIf="service.update_strategy === 'NONE'">NO CHANNEL: NONE</chef-badge>
           </div>
+          <hr class="health-info-divider" />
           <div class="disconnect-notice" *ngIf="service.disconnected">
             <img class="disconnect-icon" src="assets/img/icon-disconnected.svg" alt="" aria-hidden />
             <div>
@@ -75,7 +76,6 @@
             </div>
             <chef-tooltip [attr.for]="'disconnect-time-' + i">{{ service.last_event_occurred_at | datetime: RFC2822 }}</chef-tooltip>
           </div>
-          <hr class="health-info-divider" />
           <div class="health-info-panel {{service.health_check}}">
             <chef-tooltip [attr.for]="'health-timestamp-' + i">{{ formatTimestamp(service.health_updated_at) }}</chef-tooltip>
             <div class ="health-line">
@@ -88,7 +88,7 @@
             </div>
             <div class="healthcheck-message-collection" *ngIf="service.health_check !== 'OK'">
               <div class="no-healthcheck-messages {{ service.health_check }}" *ngIf="service.health_check_result.stderr === '' && service.health_check_result.stdout === ''" >
-                Health check messages not available. When services specify a health-check hook, the hook's output will be shown here. <a href="https://www.habitat.sh/docs/reference/#sts=health-check">Learn more about writing health-check hooks.</a>
+                Health check messages not available. When services specify a health-check hook, the hook's output will be shown here. Learn more about <a href="https://www.habitat.sh/docs/reference/#sts=health-check">writing health-check hooks.</a>
               </div>
               <div class="healthcheck-message" *ngIf="service.health_check_result.stderr !== ''">
                 <div class="healthcheck-header {{service.health_check}}">

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -57,6 +57,7 @@ chef-alert {
     display: block;
     background-color: $chef-white;
     border-top: 1px solid $gray-pale;
+    // if changed then hr.health-info-divider needs to be adjusted also
     padding: 1em;
     position: relative;
     width: 100%;
@@ -104,6 +105,11 @@ chef-alert {
     align-items: center;
     margin-bottom: 8px;
     font-size: 14px;
+  }
+
+  hr.health-info-divider {
+    margin: 16px -1em 16px -1em;
+    background-color: $gray-pale;
   }
 
   .health-info-panel {

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -160,8 +160,8 @@ chef-alert {
   }
 
   .no-healthcheck-messages {
-    border: 1px solid;
     margin: 1px;
+    border: 1px solid;
     border-radius: $global-radius;
     padding: 3px 8px 3px 8px;
 

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -113,7 +113,7 @@ chef-alert {
   }
 
   .health-info-panel {
-    border-radius: $global-radius;
+    border-radius: 2px;
     align-items: center;
     padding: 8px;
     font-size: 12px;
@@ -145,7 +145,7 @@ chef-alert {
     align-items: flex-start;
     background: $chef-info-alert-light;
     color: $chef-info-alert;
-    border-radius: $global-radius;
+    border-radius: 2px;
     padding: 8px;
     margin-bottom: 8px;
     font-size: 12px;
@@ -168,7 +168,7 @@ chef-alert {
   .no-healthcheck-messages {
     margin: 1px;
     border: 1px solid;
-    border-radius: $global-radius;
+    border-radius: 2px;
     padding: 3px 8px 3px 8px;
 
     a {
@@ -181,8 +181,14 @@ chef-alert {
     padding: 2px;
   }
 
+  // desired space between adjacent healthcheck-message divs is 8px, we have
+  // 2 * 2px == 4px from the padding above which means we need 4px more:
+  .healthcheck-message + .healthcheck-message {
+    margin-top: 4px;
+  }
+
   .healthcheck-header {
-    border-radius: $global-radius $global-radius 0 0;
+    border-radius: 2px 2px 0 0;
     padding: 3px 8px 3px 8px;
 
     &.CRITICAL {
@@ -204,7 +210,7 @@ chef-alert {
   }
 
   .healthcheck-content {
-    border-radius: 0 0 $global-radius $global-radius;
+    border-radius: 0 0 2px 2px;
     background-color: var(--chef-primary-dark);
     color: var(--chef-white);
     padding: 8px;

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -106,24 +106,100 @@ chef-alert {
     font-size: 14px;
   }
 
+  .health-info-panel {
+    border-radius: $global-radius;
+    align-items: center;
+    padding: 8px;
+    font-size: 12px;
+
+    &.CRITICAL {
+      background-color: #F9DBEA; // TODO: variables (piggy pink lol)
+      color: #BA1E6A; // TODO: variables (maroon)
+    }
+
+    &.WARNING {
+      // TODO variables
+      background-color: #FFE5D4;
+      color: #B74500;
+    }
+
+    &.UNKNOWN {
+      // TODO variables
+      background-color: #F3F6F8;
+      color: #222435;
+    }
+
+    &.OK {
+      background-color: #CFE8FF;
+      color: #005BAB;
+    }
+
+  }
+
+  .disconnect-notice {
+    display: flex;
+    align-items: flex-start;
+    background: $chef-info-alert-light;
+    color: $chef-info-alert;
+    border-radius: $global-radius;
+    padding: 8px;
+    margin-bottom: 8px;
+    font-size: 12px;
+
+    .disconnect-icon {
+      display: block;
+      margin-right: 6px;
+      height: 16px;
+      width: 16px;
+      transform: translateY(2px);
+      flex: none;
+    }
+
+    .disconnect-time:hover {
+      color: $chef-info-alert-dark;
+    }
+
+  }
+
+  .healthcheck-message {
+    padding: 2px;
+  }
+
+  .healthcheck-header {
+    border-radius: $global-radius $global-radius 0 0;
+    padding: 3px 8px 3px 8px;
+
+    &.CRITICAL {
+      // TODO: variables!
+      background-color: #961856;
+      color: #FFFFFF;
+    }
+
+    &.WARNING {
+      background-color: #B74500;
+      color: #FFFFFF;
+    }
+
+    &.UNKNOWN {
+      background-color: #424848;
+      color: #FFFFFF;
+    }
+
+
+  }
+
+  .healthcheck-content {
+    border-radius: 0 0 $global-radius $global-radius;
+    background-color: #222435;
+    color: #FFFFFF;
+    padding: 8px;
+  }
+
   .health-line {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     font-size: 12px;
     margin-bottom: 6px;
-  }
-
-  .channel-line {
-    padding-left: 18px;
-    margin-bottom: 8px;
-  }
-
-  .timewizard-line {
-    padding-left: 24px;
-    font-size: 12px;
-    color: $chef-dark-grey;
-    letter-spacing: 0.1px;
-    line-height: 18px;
 
     a {
       color: inherit;
@@ -132,6 +208,18 @@ chef-alert {
     a:hover {
       color: $chef-primary-dark;
     }
+
+    .health-icon {
+      display: block;
+      margin-right: 6px;
+      height: 16px;
+      width: 16px;
+    }
+  }
+
+  .channel-line {
+    padding-left: 18px;
+    margin-bottom: 8px;
   }
 
   chef-icon {
@@ -168,28 +256,3 @@ chef-alert {
   padding-right: 35px;
 }
 
-.disconnect-notice {
-  display: flex;
-  align-items: flex-start;
-  background: $chef-info-alert-light;
-  color: $chef-info-alert;
-  border-radius: $global-radius;
-  padding: 8px;
-  margin-bottom: 8px;
-
-  .disconnect-icon {
-    display: block;
-    margin-right: 6px;
-    height: 14px;
-    width: 14px;
-    transform: translateY(5px);
-  }
-
-  .disconnect-time:hover {
-    color: $chef-info-alert-dark;
-  }
-
-  span:first-child {
-    display: block;
-  }
-}

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -44,7 +44,7 @@ chef-alert {
   @include modal-box();
   display: block;
   box-shadow: none;
-  background-color: #F2F5F7;
+  background-color: #F2F5F7; // unique color
   margin-bottom: 1em;
   margin-right: 35px;
   margin-left: -5px;
@@ -113,25 +113,23 @@ chef-alert {
     font-size: 12px;
 
     &.CRITICAL {
-      background-color: #F9DBEA; // TODO: variables (piggy pink lol)
-      color: #BA1E6A; // TODO: variables (maroon)
+      background-color: var(--chef-badge-critical-background);
+      color: var(--chef-badge-critical-color);
     }
 
     &.WARNING {
-      // TODO variables
-      background-color: #FFE5D4;
-      color: #B74500;
+      background-color: var(--chef-badge-warning-background);
+      color: var(--chef-badge-warning-color);
     }
 
     &.UNKNOWN {
-      // TODO variables
-      background-color: #F3F6F8;
-      color: #222435;
+      background-color: var(--chef-lightest-grey);
+      color: var(--chef-primary-dark);
     }
 
     &.OK {
-      background-color: #CFE8FF;
-      color: #005BAB;
+      background-color: var(--chef-badge-success-background);
+      color: var(--chef-badge-success-color);
     }
 
   }
@@ -162,7 +160,6 @@ chef-alert {
   }
 
   .no-healthcheck-messages {
-    // TODO variables
     border: 1px solid;
     margin: 1px;
     border-radius: $global-radius;
@@ -183,19 +180,18 @@ chef-alert {
     padding: 3px 8px 3px 8px;
 
     &.CRITICAL {
-      // TODO: variables!
-      background-color: #961856;
-      color: #FFFFFF;
+      background-color: #961856; // unique color
+      color: var(--chef-white);
     }
 
     &.WARNING {
-      background-color: #B74500;
-      color: #FFFFFF;
+      background-color: var(--chef-badge-warning-color);
+      color: var(--chef-white);
     }
 
     &.UNKNOWN {
-      background-color: #424848;
-      color: #FFFFFF;
+      background-color: #424848; // unique color
+      color: var(--chef-white);
     }
 
 
@@ -203,8 +199,8 @@ chef-alert {
 
   .healthcheck-content {
     border-radius: 0 0 $global-radius $global-radius;
-    background-color: #222435;
-    color: #FFFFFF;
+    background-color: var(--chef-primary-dark);
+    color: var(--chef-white);
     padding: 8px;
     overflow-wrap: break-word;
   }

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -161,6 +161,19 @@ chef-alert {
 
   }
 
+  .no-healthcheck-messages {
+    // TODO variables
+    border: 1px solid;
+    margin: 1px;
+    border-radius: $global-radius;
+    padding: 3px 8px 3px 8px;
+
+    a {
+      color: inherit;
+    }
+
+  }
+
   .healthcheck-message {
     padding: 2px;
   }
@@ -193,6 +206,7 @@ chef-alert {
     background-color: #222435;
     color: #FFFFFF;
     padding: 8px;
+    overflow-wrap: break-word;
   }
 
   .health-line {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Display services' health check messages in the applications tab UI. This enables expedited troubleshooting of problems when users emit helpful information from their health check scripts.

### :chains: Related Resources

#2554

NOTE: this doesn't include the show more/show less accordion for long messages. That will be done later.

### :athletic_shoe: How to Build and Test the Change

Build:
* `build components/automate-ui`

Test data:
There are some improvements to the sample data to show all of the different UI cases. Either restart the studio or `source .studio/applications-service`. Then `applications_populate_database`.

Verify Behavior:
* Filter for service name `pos-terminal`
* The four `pos-terminal.default` service groups show each of the following cases:
  * (production-us-west environment) no health check messages at all: shows informational message with link to documentation
  * (production-us-central environment)  stderr only: shows the stderr and no empty chrome for stdout
  * (production-us-mountain environment) stdout only: shows the stdout and no empty chrome for stderr
  * (production-us-east environment) stdout and stderr are both shown.
* filter for service name `nginx`
  * the bldr cache app in qa env shows messages of the maximum size. They wrap even without word breaks
  * the demo/demo one shows what we think a typical message might be.

### :camera: Screenshots, if applicable

Full page:
![Screen Shot 2019-12-20 at 1 58 51 PM](https://user-images.githubusercontent.com/37162/71295490-e2481a80-2330-11ea-966e-03f3bacc8897.png)

Different health statuses (critical/warning/unknown/ok) with stdout, stderr, both, neither:
![Screen Shot 2019-12-20 at 1 36 20 PM](https://user-images.githubusercontent.com/37162/71294556-b7a89280-232d-11ea-8dcf-3dc2edd77569.png)
![Screen Shot 2019-12-20 at 1 36 34 PM](https://user-images.githubusercontent.com/37162/71294565-c131fa80-232d-11ea-8eab-1a461fb915b1.png)
![Screen Shot 2019-12-20 at 1 36 49 PM](https://user-images.githubusercontent.com/37162/71294574-c8f19f00-232d-11ea-89c1-5aba025dad18.png)
![Screen Shot 2019-12-20 at 2 00 58 PM](https://user-images.githubusercontent.com/37162/71295553-318e4b00-2331-11ea-9442-74573b911649.png)

![Screen Shot 2019-12-20 at 1 37 23 PM](https://user-images.githubusercontent.com/37162/71294605-dc9d0580-232d-11ea-8f90-ac97e1675060.png)
![Screen Shot 2019-12-20 at 1 37 45 PM](https://user-images.githubusercontent.com/37162/71294623-e9b9f480-232d-11ea-94c0-7c26f6f439be.png)
![Screen Shot 2019-12-20 at 1 38 00 PM](https://user-images.githubusercontent.com/37162/71294634-f2aac600-232d-11ea-8477-6f82cf2d6092.png)
![Screen Shot 2019-12-20 at 1 38 11 PM](https://user-images.githubusercontent.com/37162/71294646-f8a0a700-232d-11ea-8df2-bd536ee25d73.png)
![Screen Shot 2019-12-20 at 1 38 24 PM](https://user-images.githubusercontent.com/37162/71294658-00604b80-232e-11ea-8a10-fcabb738a1ab.png)
