### PR TITLE
[automate-2570] preserve underscores in auto-generated IAM ids

### DIFF
--- a/components/automate-ui/src/app/helpers/auth/id-mapper.spec.ts
+++ b/components/automate-ui/src/app/helpers/auth/id-mapper.spec.ts
@@ -4,11 +4,15 @@ import { IdMapper } from './id-mapper';
 describe('IdMapper', () => {
 
     using([
-      ['my-name', 'my-name', 'mirrors nominal input'],
-      ['-0a5l9z-', '-0a5l9z-', 'supports numbers, letters, and hyphens'],
-      ['my-name!', 'my-name-', 'replaces trailing out-of-range char with hyphen'],
-      ['#$my-name', '--my-name', 'replaces leading out-of-range chars with hyphens'],
-      ['my name', 'my-name', 'replaces space char with hyphen'],
+      ['-0a5l9z-', '-0a5l9z-', 'preserves numbers, lowercase letters, and hyphens'],
+      ['my_name__', 'my_name__', 'preserves underscores'],
+      ['my-name!', 'my-name-', 'replaces trailing unsupported single char with hyphen'],
+      ['my-name$/', 'my-name--', 'replaces trailing unsupported multiple chars with hyphen'],
+      ['my^%<>name', 'my----name', 'replaces middle unsupported chars with hyphen'],
+      ['#my-name', '-my-name', 'replaces leading unsupported single char with hyphens'],
+      [';=@my-name', '---my-name', 'replaces leading unsupported multiple chars with hyphens'],
+      [' my_name  ', '-my_name--', 'replaces leading/trailing spaces with hyphens'],
+      ['my   name', 'my---name', 'replaces middle spaces with hyphens'],
       ['My-Name', 'my-name', 'maps upper case to lower case']
     ], function (inputVal: string, outputVal: string, desc: string) {
 

--- a/components/automate-ui/src/app/helpers/auth/id-mapper.ts
+++ b/components/automate-ui/src/app/helpers/auth/id-mapper.ts
@@ -1,6 +1,6 @@
 export class IdMapper {
 
   public static transform(input: string): string {
-    return input.toLowerCase().replace(/[^a-z0-9]/g, '-');
+    return input.toLowerCase().replace(/[^a-z0-9_]/g, '-');
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

**Note: I was so tempted to make this the smallest PR on record -- a single character -- but I would not be able to face myself in the morning if I did not apply TDD and do the tests first. Sigh.**

Back in PR #1172 (allow underscore IDs in IAM resources) we expanded the allowable character set for IAM IDs to include an underscore character. However, one spot that was missed was the auto-generated IDs in the UI, specifically in the `CreateObjectModalComponent` that is (at present) used for creating new teams, tokens, and projects.

### :chains: Related Resources
PR #1172 (allow underscore IDs in IAM resources)

### :+1: Definition of Done
When entering a name for a team, token, or project in the UI, the auto-generated ID that appears preserves any underscores that are typed (along with hyphens, digits, and alphabetic characters).

### :athletic_shoe: How to Build and Test the Change

Rebuild automate-ui.
Navigate to `Settings >> Teams >> Create Team`.

Type a value for the name. As you type the ID is auto-generated, character for character, with non-supported characters being replaced by hyphens. But now underscores will be preserved.

<img width="790" alt="image" src="https://user-images.githubusercontent.com/6817500/71501706-c0fb9880-2820-11ea-8f2f-36d1794c75be.png">

Similar fix works for tokens and projects as well.