### PR TITLE
specifying multiple control filters on export returns only those controls

### DIFF
--- a/components/automate-chef-io/data/docs/api-static/01-reporting-export.swagger.json
+++ b/components/automate-chef-io/data/docs/api-static/01-reporting-export.swagger.json
@@ -3,7 +3,7 @@
     "/compliance/reporting/export": {
       "post": {
         "summary": "Export reports",
-        "description": "Stream reports in JSON (default) or CSV format.\n\nSupports filtering, but not pagination or sorting.\n\nInclude the value `csv` for the `type` parameter in the request to receive CSV formatted data.\nIncluding more than one value for `control`, `profile_id`, or `profile_name` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\n\n Example: \n\n ```'{'type':'csv','filters':[{'type':'start_time','values':['2019-09-16T00:00:00Z']},{'type':'end_time','values':['2019-09-18T23:59:59Z']}, {'type':'environment','values':['_default']}]}'```",
+        "description": "Stream reports in JSON (default) or CSV format.\n\nSupports filtering, but not pagination or sorting.\n\nInclude the value `csv` for the `type` parameter in the request to receive CSV formatted data.\nIncluding more than one value for `profile_id`, or `profile_name` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\n\n Example: \n\n ```'{'type':'csv','filters':[{'type':'start_time','values':['2019-09-16T00:00:00Z']},{'type':'end_time','values':['2019-09-18T23:59:59Z']}, {'type':'environment','values':['_default']}]}'```",
         "tags": [
           "ReportingService"
         ],
@@ -35,7 +35,7 @@
     "/compliance/reporting/node/export": {
       "post": {
         "summary": "Export node reports",
-        "description": "Stream historical reports for a single node in JSON (default) or CSV format.\n\nSupports filtering, but not pagination or sorting.\nRequires one `node_id` filter.\n\nInclude the value `csv` for the `type` parameter in the request to receive CSV formatted data.\nIncluding more than one value for `control`, `profile_id`, `profile_name`, or `node_id` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\nLimited to 9999 results.\n\nExample: \n\n ```'{'type':'csv','filters':[{'type':'start_time','values':['2019-09-16T00:00:00Z']},{'type':'end_time','values':['2019-09-18T23:59:59Z']}, {'type':'node_id','values':['9b9f4e51-b049-4b10-9555-10578916e149']}]}'```",
+        "description": "Stream historical reports for a single node in JSON (default) or CSV format.\n\nSupports filtering, but not pagination or sorting.\nRequires one `node_id` filter.\n\nInclude the value `csv` for the `type` parameter in the request to receive CSV formatted data.\nIncluding more than one value for `profile_id`, `profile_name`, or `node_id` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\nLimited to 9999 results.\n\nExample: \n\n ```'{'type':'csv','filters':[{'type':'start_time','values':['2019-09-16T00:00:00Z']},{'type':'end_time','values':['2019-09-18T23:59:59Z']}, {'type':'node_id','values':['9b9f4e51-b049-4b10-9555-10578916e149']}]}'```",
         "tags": [
           "ReportingService"
         ],

--- a/components/automate-gateway/api/compliance/reporting/reporting.pb.go
+++ b/components/automate-gateway/api/compliance/reporting/reporting.pb.go
@@ -2946,7 +2946,7 @@ type ReportingServiceClient interface {
 	//
 	//List all IDs for the latest report for each node, with optional filtering.
 	//Supports filtering, but not pagination or sorting.
-	//Including more than one value for `control`, `profile_id`, or `profile_name` is not allowed.
+	//Including more than one value for `profile_id`, or `profile_name` is not allowed.
 	//Including values for both `profile_id` and `profile_name` in one request is not allowed.
 	//Not limited to 10k results.
 	ListReportIds(ctx context.Context, in *Query, opts ...grpc.CallOption) (*ReportIds, error)
@@ -2961,7 +2961,8 @@ type ReportingServiceClient interface {
 	//Fetch a report
 	//
 	//Fetch a specific report by ID. Supports filtering, but not pagination or sorting.
-	//Including more than one value for `profile_id` is not allowed.
+	//Including more than one value for `profile_id`, or `profile_name` is not allowed.
+	//Including values for both `profile_id` and `profile_name` in one request is not allowed.
 	ReadReport(ctx context.Context, in *Query, opts ...grpc.CallOption) (*Report, error)
 	//
 	//List suggestions
@@ -3243,7 +3244,7 @@ type ReportingServiceServer interface {
 	//
 	//List all IDs for the latest report for each node, with optional filtering.
 	//Supports filtering, but not pagination or sorting.
-	//Including more than one value for `control`, `profile_id`, or `profile_name` is not allowed.
+	//Including more than one value for `profile_id`, or `profile_name` is not allowed.
 	//Including values for both `profile_id` and `profile_name` in one request is not allowed.
 	//Not limited to 10k results.
 	ListReportIds(context.Context, *Query) (*ReportIds, error)
@@ -3258,7 +3259,8 @@ type ReportingServiceServer interface {
 	//Fetch a report
 	//
 	//Fetch a specific report by ID. Supports filtering, but not pagination or sorting.
-	//Including more than one value for `profile_id` is not allowed.
+	//Including more than one value for `profile_id`, or `profile_name` is not allowed.
+	//Including values for both `profile_id` and `profile_name` in one request is not allowed.
 	ReadReport(context.Context, *Query) (*Report, error)
 	//
 	//List suggestions

--- a/components/automate-gateway/api/compliance/reporting/reporting.proto
+++ b/components/automate-gateway/api/compliance/reporting/reporting.proto
@@ -58,7 +58,7 @@ service ReportingService {
 
 	List all IDs for the latest report for each node, with optional filtering. 
 	Supports filtering, but not pagination or sorting.
-	Including more than one value for `control`, `profile_id`, or `profile_name` is not allowed.
+	Including more than one value for `profile_id`, or `profile_name` is not allowed.
 	Including values for both `profile_id` and `profile_name` in one request is not allowed.
 	Not limited to 10k results.
 	*/
@@ -103,7 +103,8 @@ service ReportingService {
 	Fetch a report
 
 	Fetch a specific report by ID. Supports filtering, but not pagination or sorting.
-	Including more than one value for `profile_id` is not allowed.
+	Including more than one value for `profile_id`, or `profile_name` is not allowed.
+	Including values for both `profile_id` and `profile_name` in one request is not allowed.	
 	*/
 	rpc ReadReport(Query) returns (Report) {
 		option (google.api.http) = {

--- a/components/automate-gateway/api/compliance/reporting/reporting.swagger.json
+++ b/components/automate-gateway/api/compliance/reporting/reporting.swagger.json
@@ -125,7 +125,7 @@
     "/compliance/reporting/report-ids": {
       "post": {
         "summary": "List report IDs",
-        "description": "List all IDs for the latest report for each node, with optional filtering. \nSupports filtering, but not pagination or sorting.\nIncluding more than one value for `control`, `profile_id`, or `profile_name` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\nNot limited to 10k results.",
+        "description": "List all IDs for the latest report for each node, with optional filtering. \nSupports filtering, but not pagination or sorting.\nIncluding more than one value for `profile_id`, or `profile_name` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\nNot limited to 10k results.",
         "operationId": "ListReportIds",
         "responses": {
           "200": {
@@ -181,7 +181,7 @@
     "/compliance/reporting/reports/id/{id}": {
       "post": {
         "summary": "Fetch a report",
-        "description": "Fetch a specific report by ID. Supports filtering, but not pagination or sorting.\nIncluding more than one value for `profile_id` is not allowed.",
+        "description": "Fetch a specific report by ID. Supports filtering, but not pagination or sorting.\nIncluding more than one value for `profile_id`, or `profile_name` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.",
         "operationId": "ReadReport",
         "responses": {
           "200": {

--- a/components/automate-gateway/api/compliance_reporting_reporting.pb.swagger.go
+++ b/components/automate-gateway/api/compliance_reporting_reporting.pb.swagger.go
@@ -128,7 +128,7 @@ func init() {
     "/compliance/reporting/report-ids": {
       "post": {
         "summary": "List report IDs",
-        "description": "List all IDs for the latest report for each node, with optional filtering. \nSupports filtering, but not pagination or sorting.\nIncluding more than one value for ` + "`" + `control` + "`" + `, ` + "`" + `profile_id` + "`" + `, or ` + "`" + `profile_name` + "`" + ` is not allowed.\nIncluding values for both ` + "`" + `profile_id` + "`" + ` and ` + "`" + `profile_name` + "`" + ` in one request is not allowed.\nNot limited to 10k results.",
+        "description": "List all IDs for the latest report for each node, with optional filtering. \nSupports filtering, but not pagination or sorting.\nIncluding more than one value for ` + "`" + `profile_id` + "`" + `, or ` + "`" + `profile_name` + "`" + ` is not allowed.\nIncluding values for both ` + "`" + `profile_id` + "`" + ` and ` + "`" + `profile_name` + "`" + ` in one request is not allowed.\nNot limited to 10k results.",
         "operationId": "ListReportIds",
         "responses": {
           "200": {
@@ -184,7 +184,7 @@ func init() {
     "/compliance/reporting/reports/id/{id}": {
       "post": {
         "summary": "Fetch a report",
-        "description": "Fetch a specific report by ID. Supports filtering, but not pagination or sorting.\nIncluding more than one value for ` + "`" + `profile_id` + "`" + ` is not allowed.",
+        "description": "Fetch a specific report by ID. Supports filtering, but not pagination or sorting.\nIncluding more than one value for ` + "`" + `profile_id` + "`" + `, or ` + "`" + `profile_name` + "`" + ` is not allowed.\nIncluding values for both ` + "`" + `profile_id` + "`" + ` and ` + "`" + `profile_name` + "`" + ` in one request is not allowed.",
         "operationId": "ReadReport",
         "responses": {
           "200": {

--- a/components/compliance-service/api/reporting/server/server.go
+++ b/components/compliance-service/api/reporting/server/server.go
@@ -74,20 +74,9 @@ func (srv *Server) ListReportIds(ctx context.Context, in *reporting.Query) (*rep
 		return nil, err
 	}
 
-	if len(formattedFilters["profile_name"]) > 0 && len(formattedFilters["profile_id"]) > 0 {
-		return nil, status.Error(codes.InvalidArgument, "Invalid: Cannot specify both 'profile_name' and 'profile_id' filters")
-	}
-
-	if len(formattedFilters["profile_name"]) > 1 {
-		return nil, status.Error(codes.InvalidArgument, "Invalid: Only one 'profile_name' filter is allowed")
-	}
-
-	if len(formattedFilters["profile_id"]) > 1 {
-		return nil, status.Error(codes.InvalidArgument, "Invalid: Only one 'profile_id' filter is allowed")
-	}
-
-	if len(formattedFilters["control"]) > 1 {
-		return nil, status.Error(codes.InvalidArgument, "Invalid: Only one 'control' filter is allowed")
+	err = validateReportQueryParams(formattedFilters)
+	if err != nil {
+		return nil, err
 	}
 
 	// Step 1: Retrieving the latest report ID for each node based on the provided filters
@@ -204,7 +193,7 @@ func (srv *Server) Export(in *reporting.Query, stream reporting.ReportingService
 		return err
 	}
 
-	err = validateExportQueryParams(formattedFilters)
+	err = validateReportQueryParams(formattedFilters)
 	if err != nil {
 		return err
 	}
@@ -241,7 +230,7 @@ func (srv *Server) Export(in *reporting.Query, stream reporting.ReportingService
 	return nil
 }
 
-func validateExportQueryParams(formattedFilters map[string][]string) error {
+func validateReportQueryParams(formattedFilters map[string][]string) error {
 	if len(formattedFilters["profile_name"]) > 0 && len(formattedFilters["profile_id"]) > 0 {
 		return status.Error(codes.InvalidArgument, "Invalid: Cannot specify both 'profile_name' and 'profile_id' filters")
 	}
@@ -253,10 +242,6 @@ func validateExportQueryParams(formattedFilters map[string][]string) error {
 	if len(formattedFilters["profile_id"]) > 1 {
 		return status.Error(codes.InvalidArgument, "Invalid: Only one 'profile_id' filter is allowed")
 	}
-
-	if len(formattedFilters["control"]) > 1 {
-		return status.Error(codes.InvalidArgument, "Invalid: Only one 'control' filter is allowed")
-	}
 	return nil
 }
 
@@ -267,7 +252,7 @@ func (srv *Server) ExportNode(in *reporting.Query, stream reporting.ReportingSer
 		return err
 	}
 
-	err = validateExportQueryParams(formattedFilters)
+	err = validateReportQueryParams(formattedFilters)
 	if err != nil {
 		return err
 	}

--- a/components/compliance-service/api/tests/export_test.go
+++ b/components/compliance-service/api/tests/export_test.go
@@ -309,12 +309,14 @@ func TestJSONExportWithTwoControlsOnlyReturnsThoseTwoControls(t *testing.T) {
 	reports, err := getJSONReportsFromStream(stream)
 	require.NoError(t, err)
 
+	require.Len(t, reports, 1)
 	report := reports[0]
 	assert.Equal(t, "bb93e1b2-36d6-439e-ac70-cccccccccc04", report.GetId())
-	assert.Equal(t, 3, len(report.GetProfiles()))
+
+	require.Len(t, report.GetProfiles(), 3)
 	assert.Equal(t, "09adcbb3b9b3233d5de63cd98a5ba3e155b3aaeb66b5abed379f5fb1ff143988", report.GetProfiles()[0].GetSha256())
 
-	assert.Equal(t, 2, len(report.GetProfiles()[0].GetControls()))
+	require.Len(t, report.GetProfiles()[0].GetControls(), 2)
 	assert.Equal(t, "nginx-01", report.GetProfiles()[0].GetControls()[0].GetId())
 	assert.Equal(t, "nginx-02", report.GetProfiles()[0].GetControls()[1].GetId())
 }

--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -507,11 +507,26 @@ func (backend *ES2Backend) GetReport(esIndex string, reportId string,
 	return report, errorutils.ProcessNotFound(nil, reportId)
 }
 
+func arrayIncludes(a []string, matchString string) bool {
+	for _, itemInArray := range a {
+		if itemInArray == matchString {
+			return true
+		}
+	}
+	return false
+}
+
 func convertControl(profileControlsMap map[string]*reportingapi.Control, reportControlMin ESInSpecReportControl, filters map[string][]string) *reportingapi.Control {
 	profileControl := profileControlsMap[reportControlMin.ID]
 
 	if profileControl == nil {
 		return nil
+	}
+
+	if len(filters["control"]) > 0 {
+		if !arrayIncludes(filters["control"], profileControl.Id) {
+			return nil
+		}
 	}
 
 	profileControl.Results = make([]*reportingapi.Result, 0)

--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -507,15 +507,6 @@ func (backend *ES2Backend) GetReport(esIndex string, reportId string,
 	return report, errorutils.ProcessNotFound(nil, reportId)
 }
 
-func arrayIncludes(a []string, matchString string) bool {
-	for _, itemInArray := range a {
-		if itemInArray == matchString {
-			return true
-		}
-	}
-	return false
-}
-
 func convertControl(profileControlsMap map[string]*reportingapi.Control, reportControlMin ESInSpecReportControl, filters map[string][]string) *reportingapi.Control {
 	profileControl := profileControlsMap[reportControlMin.ID]
 
@@ -524,7 +515,7 @@ func convertControl(profileControlsMap map[string]*reportingapi.Control, reportC
 	}
 
 	if len(filters["control"]) > 0 {
-		if !arrayIncludes(filters["control"], profileControl.Id) {
+		if !stringutils.SliceContains(filters["control"], profileControl.Id) {
 			return nil
 		}
 	}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This code change addresses two issues:
- when a single control filter is applied on export (and no profile filter is included), the report should be filtered by that control (only that control is returned)
- allow filtering by multiple controls

### :chains: Related Resources
https://github.com/chef/automate/issues/2255

### :+1: Definition of Done
filtering by a single control filter returns a report with only that control
filtering by multiple control filters returns reports with only those controls included

### :athletic_shoe: How to Build and Test the Change
rebuild compliance
filter by a single control, no profile
expect exported report/viewed report to only include that one control
filter by a multiple controls, no profile
expect exported report/viewed report to only include specified controls

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [x] Docs added/updated?

