### PR TITLE
[automate-2486] quell unit test noise

### DIFF
--- a/components/automate-ui/src/app/components/landing/landing.component.spec.ts
+++ b/components/automate-ui/src/app/components/landing/landing.component.spec.ts
@@ -154,8 +154,9 @@ describe('LandingComponent', () => {
       providers: [
         { provide: Router, useValue: router }
       ],
-
-      declarations: [LandingComponent]
+      declarations: [
+        LandingComponent
+      ]
     })
       .compileComponents();
   }

--- a/components/automate-ui/src/app/components/notifications/notifications.component.spec.ts
+++ b/components/automate-ui/src/app/components/notifications/notifications.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent } from 'ng2-mock-component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { StoreModule, Store } from '@ngrx/store';
-import { NgrxStateAtom, ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 
 import { ChefNotificationsComponent } from './notifications.component';
 
@@ -18,7 +18,7 @@ describe('ChefNotificationsComponent', () => {
         ChefNotificationsComponent
       ],
       imports: [
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       schemas: [
         NO_ERRORS_SCHEMA

--- a/components/automate-ui/src/app/components/settings-sidebar/settings-sidebar.component.spec.ts
+++ b/components/automate-ui/src/app/components/settings-sidebar/settings-sidebar.component.spec.ts
@@ -21,7 +21,8 @@ describe('SettingsSidebarComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule,
+      imports: [
+        RouterTestingModule,
         StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
       ],
       declarations: [

--- a/components/automate-ui/src/app/modules/roles/list/roles-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/roles/list/roles-list.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
-import { ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
+import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { RolesListComponent } from './roles-list.component';
@@ -38,7 +38,7 @@ describe('RolesListComponent', () => {
       ],
       imports: [
         ChefPipesModule,
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       providers: [
         FeatureFlagsService

--- a/components/automate-ui/src/app/modules/roles/list/roles-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/roles/list/roles-list.component.spec.ts
@@ -2,11 +2,9 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
-import { runtimeChecks } from 'app/ngrx.reducers';
+import { ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { roleEntityReducer } from 'app/entities/roles/role.reducer';
-import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
 import { RolesListComponent } from './roles-list.component';
 
 describe('RolesListComponent', () => {
@@ -40,10 +38,7 @@ describe('RolesListComponent', () => {
       ],
       imports: [
         ChefPipesModule,
-        StoreModule.forRoot({
-          policies: policyEntityReducer,
-          roles: roleEntityReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
       ],
       providers: [
         FeatureFlagsService

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.spec.ts
@@ -2,33 +2,15 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { routerReducer } from '@ngrx/router-store';
-import { MockComponent } from 'ng2-mock-component';
 import { StoreModule, Store, Action } from '@ngrx/store';
-
 import * as routerStore from '@ngrx/router-store';
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
-import {
-  projectsFilterReducer,
-  projectsFilterInitialState
-} from 'app/services/projects-filter/projects-filter.reducer';
-import {
-  policyEntityReducer, PolicyEntityInitialState
-} from 'app/entities/policies/policy.reducer';
-import {
-  projectEntityReducer,
-  ProjectEntityInitialState
-} from 'app/entities/projects/project.reducer';
+import { MockComponent } from 'ng2-mock-component';
+
+import { NgrxStateAtom, ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+import { PolicyEntityInitialState } from 'app/entities/policies/policy.reducer';
 import { Project } from 'app/entities/projects/project.model';
 import { GetProjectsSuccess, GetProjects } from 'app/entities/projects/project.actions';
-import {
-  userEntityReducer,
-  UserEntityInitialState
-} from 'app/entities/users/user.reducer';
-import {
-  teamEntityReducer,
-  TeamEntityInitialState
-} from 'app/entities/teams/team.reducer';
 import {
   GetTeamSuccess,
   GetTeamUsersSuccess,
@@ -37,7 +19,6 @@ import {
 } from 'app/entities/teams/team.actions';
 import { Team } from 'app/entities/teams/team.model';
 import { TeamDetailsComponent } from './team-details.component';
-import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 
 const declarations: any[] = [
   MockComponent({ selector: 'app-user-table',
@@ -87,20 +68,18 @@ describe('TeamDetailsComponent v2', () => {
   const v2PolicyEntityInitialState = Object.assign({}, PolicyEntityInitialState,
     {iamMajorVersion: 'v2'});
   const initialState = {
+    ...defaultInitialState,
     router: {
       state: {
         url: `/settings/teams/${targetId}`,
         params: { id: targetId },
         queryParams: {},
-        fragment: ''
+        fragment: '',
+        path: []
       },
       navigationId: 0 // what's that zero?
     },
-    users: UserEntityInitialState,
-    teams: TeamEntityInitialState,
-    policies: v2PolicyEntityInitialState,
-    projects: ProjectEntityInitialState,
-    projectsFilter: projectsFilterInitialState
+    policies: v2PolicyEntityInitialState
   };
 
   beforeEach(async(() => {
@@ -112,14 +91,7 @@ describe('TeamDetailsComponent v2', () => {
       imports: [
         ReactiveFormsModule,
         RouterTestingModule,
-        StoreModule.forRoot({
-          router: routerReducer,
-          teams: teamEntityReducer,
-          users: userEntityReducer,
-          policies: policyEntityReducer,
-          projects: projectEntityReducer,
-          projectsFilter: projectsFilterReducer
-        }, { initialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { initialState, runtimeChecks })
       ]
     }).compileComponents();
   }));
@@ -217,20 +189,18 @@ describe('TeamDetailsComponent v1', () => {
   const v1PolicyEntityInitialState = Object.assign({}, PolicyEntityInitialState,
     {iamMajorVersion: 'v1'});
   const initialState = {
+    ...defaultInitialState,
     router: {
       state: {
         url: `/settings/teams/${targetId}`,
         params: { id: targetId },
         queryParams: {},
-        fragment: ''
+        fragment: '',
+        path: []
       },
       navigationId: 0 // what's that zero?
     },
-    users: UserEntityInitialState,
-    teams: TeamEntityInitialState,
-    policies: v1PolicyEntityInitialState,
-    projects: ProjectEntityInitialState,
-    projectsFilter: projectsFilterInitialState
+    policies: v1PolicyEntityInitialState
   };
 
   beforeEach(async(() => {
@@ -242,14 +212,7 @@ describe('TeamDetailsComponent v1', () => {
       imports: [
         ReactiveFormsModule,
         RouterTestingModule,
-        StoreModule.forRoot({
-          router: routerReducer,
-          teams: teamEntityReducer,
-          users: userEntityReducer,
-          policies: policyEntityReducer,
-          projects: projectEntityReducer,
-          projectsFilter: projectsFilterReducer
-        }, { initialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { initialState, runtimeChecks })
       ]
     }).compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.spec.ts
@@ -6,7 +6,14 @@ import { StoreModule, Store, Action } from '@ngrx/store';
 import * as routerStore from '@ngrx/router-store';
 import { MockComponent } from 'ng2-mock-component';
 
-import { NgrxStateAtom, ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
+import {
+  NgrxStateAtom,
+  ngrxReducers,
+  defaultInitialState,
+  runtimeChecks,
+  defaultRouterState,
+  defaultRouterRouterState
+} from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { PolicyEntityInitialState } from 'app/entities/policies/policy.reducer';
 import { Project } from 'app/entities/projects/project.model';
@@ -19,6 +26,7 @@ import {
 } from 'app/entities/teams/team.actions';
 import { Team } from 'app/entities/teams/team.model';
 import { TeamDetailsComponent } from './team-details.component';
+import { IAMMajorVersion } from 'app/entities/policies/policy.model';
 
 const declarations: any[] = [
   MockComponent({ selector: 'app-user-table',
@@ -65,21 +73,19 @@ describe('TeamDetailsComponent v2', () => {
   let router: Router;
   let store: Store<NgrxStateAtom>;
 
-  const v2PolicyEntityInitialState = Object.assign({}, PolicyEntityInitialState,
-    {iamMajorVersion: 'v2'});
   const initialState = {
     ...defaultInitialState,
     router: {
+      ...defaultRouterState,
       state: {
+        ...defaultRouterRouterState,
         url: `/settings/teams/${targetId}`,
-        params: { id: targetId },
-        queryParams: {},
-        fragment: '',
-        path: []
-      },
-      navigationId: 0 // what's that zero?
+        params: { id: targetId }
+      }
     },
-    policies: v2PolicyEntityInitialState
+    policies: {
+      ...PolicyEntityInitialState, iamMajorVersion: 'v2' as IAMMajorVersion
+    }
   };
 
   beforeEach(async(() => {
@@ -186,21 +192,19 @@ describe('TeamDetailsComponent v1', () => {
   let router: Router;
   let store: Store<NgrxStateAtom>;
 
-  const v1PolicyEntityInitialState = Object.assign({}, PolicyEntityInitialState,
-    {iamMajorVersion: 'v1'});
   const initialState = {
     ...defaultInitialState,
     router: {
+      ...defaultRouterState,
       state: {
+        ...defaultRouterRouterState,
         url: `/settings/teams/${targetId}`,
-        params: { id: targetId },
-        queryParams: {},
-        fragment: '',
-        path: []
-      },
-      navigationId: 0 // what's that zero?
+        params: { id: targetId }
+      }
     },
-    policies: v1PolicyEntityInitialState
+    policies: {
+      ...PolicyEntityInitialState, iamMajorVersion: 'v1' as IAMMajorVersion
+    }
   };
 
   beforeEach(async(() => {

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.spec.ts
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.spec.ts
@@ -6,7 +6,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MockComponent } from 'ng2-mock-component';
 import { StoreModule, Store } from '@ngrx/store';
 
-import { NgrxStateAtom, ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { HttpStatus } from 'app/types/types';
 import { Team } from 'app/entities/teams/team.model';
 import {
@@ -71,7 +71,7 @@ describe('TeamManagementComponent', () => {
         FormsModule,
         ReactiveFormsModule,
         RouterTestingModule,
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.spec.ts
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.spec.ts
@@ -6,11 +6,8 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MockComponent } from 'ng2-mock-component';
 import { StoreModule, Store } from '@ngrx/store';
 
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
 import { HttpStatus } from 'app/types/types';
-import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
-import { projectsFilterReducer } from 'app/services/projects-filter/projects-filter.reducer';
-import { teamEntityReducer } from 'app/entities/teams/team.reducer';
 import { Team } from 'app/entities/teams/team.model';
 import {
   GetTeamsSuccess,
@@ -74,11 +71,7 @@ describe('TeamManagementComponent', () => {
         FormsModule,
         ReactiveFormsModule,
         RouterTestingModule,
-        StoreModule.forRoot({
-          teams: teamEntityReducer,
-          policies: policyEntityReducer,
-          projectsFilter: projectsFilterReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
       ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })

--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.spec.ts
@@ -5,7 +5,14 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule, Store } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
-import { NgrxStateAtom, runtimeChecks, ngrxReducers, defaultInitialState } from 'app/ngrx.reducers';
+import {
+  NgrxStateAtom,
+  ngrxReducers,
+  defaultInitialState,
+  runtimeChecks,
+  defaultRouterState,
+  defaultRouterRouterState
+} from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { Project } from 'app/entities/projects/project.model';
@@ -26,14 +33,12 @@ describe('ApiTokenDetailsComponent', () => {
   const initialState = {
     ...defaultInitialState,
     router: {
+      ...defaultRouterState,
       state: {
+        ...defaultRouterRouterState,
         url: `/settings/tokens/${targetId}`,
-        params: { id: targetId },
-        queryParams: {},
-        fragment: '',
-        path: []
-      },
-      navigationId: 0
+        params: { id: targetId }
+      }
     }
   };
 

--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.spec.ts
@@ -2,38 +2,19 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { routerReducer } from '@ngrx/router-store';
-import { MockComponent } from 'ng2-mock-component';
 import { StoreModule, Store } from '@ngrx/store';
+import { MockComponent } from 'ng2-mock-component';
 
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, ngrxReducers, defaultInitialState } from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import {
-  ApiTokenEntityInitialState,
-  apiTokenEntityReducer
-} from 'app/entities/api-tokens/api-token.reducer';
-import {
-  GetTokenSuccess
-} from 'app/entities/api-tokens/api-token.actions';
-import { ApiToken } from 'app/entities/api-tokens/api-token.model';
-import { ApiTokenDetailsComponent } from './api-token-details.component';
-import {
-  policyEntityReducer,
-  PolicyEntityInitialState
-} from 'app/entities/policies/policy.reducer';
-import {
-  projectEntityReducer,
-  ProjectEntityInitialState
-} from 'app/entities/projects/project.reducer';
-import {
-  projectsFilterReducer,
-  projectsFilterInitialState
-} from 'app/services/projects-filter/projects-filter.reducer';
 import { Project } from 'app/entities/projects/project.model';
 import { GetProjectsSuccess, GetProjects } from 'app/entities/projects/project.actions';
 import { IamVersionResponse } from 'app/entities/policies/policy.requests';
 import { GetIamVersionSuccess } from 'app/entities/policies/policy.actions';
+import { GetTokenSuccess } from 'app/entities/api-tokens/api-token.actions';
+import { ApiToken } from 'app/entities/api-tokens/api-token.model';
+import { ApiTokenDetailsComponent } from './api-token-details.component';
 
 describe('ApiTokenDetailsComponent', () => {
   let component: ApiTokenDetailsComponent;
@@ -43,19 +24,17 @@ describe('ApiTokenDetailsComponent', () => {
 
   const targetId = 'a-token-01';
   const initialState = {
+    ...defaultInitialState,
     router: {
       state: {
         url: `/settings/tokens/${targetId}`,
         params: { id: targetId },
         queryParams: {},
-        fragment: ''
+        fragment: '',
+        path: []
       },
       navigationId: 0
-    },
-    apiTokens: ApiTokenEntityInitialState,
-    policies: PolicyEntityInitialState,
-    projects: ProjectEntityInitialState,
-    projectsFilter: projectsFilterInitialState
+    }
   };
 
   beforeEach(async(() => {
@@ -89,13 +68,7 @@ describe('ApiTokenDetailsComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         ChefPipesModule,
-        StoreModule.forRoot({
-          router: routerReducer,
-          apiTokens: apiTokenEntityReducer,
-          policies: policyEntityReducer,
-          projects: projectEntityReducer,
-          projectsFilter: projectsFilterReducer
-        }, { initialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { initialState, runtimeChecks })
       ]
     }).compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.spec.ts
@@ -8,6 +8,8 @@ import { runtimeChecks } from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { apiTokenEntityReducer } from 'app/entities/api-tokens/api-token.reducer';
+import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
+import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
 import { ApiTokenListComponent } from './api-token-list.component';
 import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
 import { projectsFilterReducer } from 'app/services/projects-filter/projects-filter.reducer';
@@ -26,7 +28,9 @@ describe('ApiTokenListComponent', () => {
         StoreModule.forRoot({
           apiTokens: apiTokenEntityReducer,
           policies: policyEntityReducer,
-          projectsFilter: projectsFilterReducer
+          projectsFilter: projectsFilterReducer,
+          notifications: notificationEntityReducer, // not used here but needed to suppress warnings
+          clientRunsEntity: clientRunsEntityReducer // not used here but needed to suppress warnings
         }, { runtimeChecks })
       ],
       providers: [

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.spec.ts
@@ -6,7 +6,14 @@ import { StoreModule, Store } from '@ngrx/store';
 import { Subject } from 'rxjs';
 import { MockComponent } from 'ng2-mock-component';
 
-import { NgrxStateAtom, runtimeChecks, defaultInitialState, ngrxReducers } from 'app/ngrx.reducers';
+import {
+  NgrxStateAtom,
+  ngrxReducers,
+  defaultInitialState,
+  runtimeChecks,
+  defaultRouterState,
+  defaultRouterRouterState
+} from 'app/ngrx.reducers';
 import { customMatchers } from 'app/testing/custom-matchers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { UserEntityInitialState } from 'app/entities/users/user.reducer';
@@ -36,14 +43,12 @@ describe('UserDetailsComponent', () => {
   const initialState = {
     ...defaultInitialState,
     router: {
+      ...defaultRouterState,
       state: {
+        ...defaultRouterRouterState,
         url: '/settings/users/alice',
-        params: { id: 'alice' },
-        queryParams: {},
-        fragment: '',
-        path: []
-      },
-      navigationId: 0 // what's that zero?
+        params: { id: 'alice' }
+      }
     },
     users: UserEntityInitialState
   };

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.spec.ts
@@ -3,16 +3,13 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { StoreModule, Store } from '@ngrx/store';
-import { routerReducer } from '@ngrx/router-store';
 import { Subject } from 'rxjs';
 import { MockComponent } from 'ng2-mock-component';
 
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, defaultInitialState, ngrxReducers } from 'app/ngrx.reducers';
 import { customMatchers } from 'app/testing/custom-matchers';
-import {
-  userEntityReducer,
-  UserEntityInitialState
-} from 'app/entities/users/user.reducer';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+import { UserEntityInitialState } from 'app/entities/users/user.reducer';
 import { User } from 'app/entities/users/user.model';
 import {
   GetUser,
@@ -21,8 +18,6 @@ import {
   DeleteUserSuccess
 } from 'app/entities/users/user.actions';
 import { UserDetailsComponent } from './user-details.component';
-
-import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 
 describe('UserDetailsComponent', () => {
   let component: UserDetailsComponent;
@@ -39,12 +34,14 @@ describe('UserDetailsComponent', () => {
   };
 
   const initialState = {
+    ...defaultInitialState,
     router: {
       state: {
         url: '/settings/users/alice',
         params: { id: 'alice' },
         queryParams: {},
-        fragment: ''
+        fragment: '',
+        path: []
       },
       navigationId: 0 // what's that zero?
     },
@@ -57,10 +54,7 @@ describe('UserDetailsComponent', () => {
         RouterTestingModule,
         FormsModule,
         ReactiveFormsModule,
-        StoreModule.forRoot({
-          router: routerReducer,
-          users: userEntityReducer
-        }, { initialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { initialState, runtimeChecks })
       ],
       declarations: [
         MockComponent({ selector: 'chef-breadcrumbs' }),

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.spec.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.spec.ts
@@ -3,8 +3,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MockComponent } from 'ng2-mock-component';
 import { StoreModule } from '@ngrx/store';
 
-import { runtimeChecks } from 'app/ngrx.reducers';
-import { userEntityReducer } from 'app/entities/users/user.reducer';
+import { ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { UserManagementComponent } from './user-management.component';
 
@@ -45,9 +44,7 @@ describe('UserManagementComponent', () => {
       ],
       imports: [
         ReactiveFormsModule,
-        StoreModule.forRoot({
-          users: userEntityReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
       ]
     }).compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.spec.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.spec.ts
@@ -3,7 +3,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MockComponent } from 'ng2-mock-component';
 import { StoreModule } from '@ngrx/store';
 
-import { ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
+import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { UserManagementComponent } from './user-management.component';
 
@@ -44,7 +44,7 @@ describe('UserManagementComponent', () => {
       ],
       imports: [
         ReactiveFormsModule,
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ]
     }).compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/user/user-profile-sidebar/user-profile-sidebar.component.spec.ts
+++ b/components/automate-ui/src/app/modules/user/user-profile-sidebar/user-profile-sidebar.component.spec.ts
@@ -9,7 +9,8 @@ describe('UserProfileSidebarComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule
+      imports: [
+        RouterTestingModule
       ],
       declarations: [
         UserProfileSidebarComponent,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -110,14 +110,16 @@ export const runtimeChecks = {
   strictActionSerializability: false
 };
 
+export const defaultRouterRouterState = {
+  url: '/',
+  queryParams: {},
+  params: {},
+  fragment: '',
+  path: ['/']
+};
+
 export const defaultRouterState = {
-  state: {
-    url: '/',
-    queryParams: {},
-    params: {},
-    fragment: '',
-    path: ['/']
-  },
+  state: defaultRouterRouterState,
   previousRoute: {},
   navigationId: 0
 };

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.spec.ts
@@ -9,8 +9,8 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { Observable, throwError, of as observableOf } from 'rxjs';
 import { ProfilesService } from 'app/services/profiles/profiles.service';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
-import * as fromClientRuns from 'app/entities/client-runs/client-runs.reducer';
-import * as fromNotifications from 'app/entities/notifications/notification.reducer';
+import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
+import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
 import * as fromLayout from 'app/entities/layout/layout.reducer';
 
 class MockProfilesService {
@@ -30,30 +30,16 @@ describe('ProfileDetailsComponent', () => {
     username: 'TestUser'
   };
 
-  const initialState = {
-    router: {
-      state: {
-        url: '/',
-        params: {},
-        queryParams: {},
-        fragment: ''
-      }
-    },
-    clientRunsEntity: fromClientRuns.ClientRunsEntityInitialState,
-    notifications: fromNotifications.InitialState,
-    layout: fromLayout.InitialState
-  };
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
         HttpClientTestingModule,
         StoreModule.forRoot({
-          clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
-          notifications: fromNotifications.notificationEntityReducer,
+          clientRunsEntity: clientRunsEntityReducer, // not used but needed to suppress warnings
+          notifications: notificationEntityReducer, // not used but needed to suppress warnings
           layout: fromLayout.layoutEntityReducer
-        }, { initialState, runtimeChecks })
+        }, { runtimeChecks })
       ],
       declarations: [
         ProfileDetailsComponent

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
@@ -38,20 +38,6 @@ describe('ProfilesOverviewComponent', () => {
     token: 'TestToken'
   };
 
-  const initialState = {
-    router: {
-      state: {
-        url: '/',
-        params: {},
-        queryParams: {},
-        fragment: ''
-      }
-    },
-    clientRunsEntity: fromClientRuns.ClientRunsEntityInitialState,
-    notifications: fromNotifications.InitialState,
-    layout: fromLayout.InitialState
-  };
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -61,7 +47,7 @@ describe('ProfilesOverviewComponent', () => {
           clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
           notifications: fromNotifications.notificationEntityReducer,
           layout: fromLayout.layoutEntityReducer
-        }, { initialState, runtimeChecks })
+        }, { runtimeChecks })
       ],
       declarations: [
         ProfileOverviewComponent

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.spec.ts
@@ -22,20 +22,6 @@ describe('ReportingNodeComponent', () => {
   let element: DebugElement;
   let statsService: StatsService;
 
-  const initialState = {
-    router: {
-      state: {
-        url: '/',
-        params: {},
-        queryParams: {},
-        fragment: ''
-      }
-    },
-    clientRunsEntity: fromClientRuns.ClientRunsEntityInitialState,
-    notifications: fromNotifications.InitialState,
-    layout: fromLayout.InitialState
-  };
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -46,7 +32,7 @@ describe('ReportingNodeComponent', () => {
           clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
           notifications: fromNotifications.notificationEntityReducer,
           layout: fromLayout.layoutEntityReducer
-        }, { initialState, runtimeChecks })
+        }, { runtimeChecks })
       ],
       declarations: [
         ReportingNodeComponent,

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.spec.ts
@@ -21,20 +21,6 @@ describe('ReportingProfileComponent', () => {
   let store: Store<NgrxStateAtom>;
   let fixture, component, element, statsService;
 
-  const initialState = {
-    router: {
-      state: {
-        url: '/',
-        params: {},
-        queryParams: {},
-        fragment: ''
-      }
-    },
-    clientRunsEntity: fromClientRuns.ClientRunsEntityInitialState,
-    notifications: fromNotifications.InitialState,
-    layout: fromLayout.InitialState
-  };
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -45,7 +31,7 @@ describe('ReportingProfileComponent', () => {
           clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
           notifications: fromNotifications.notificationEntityReducer,
           layout: fromLayout.layoutEntityReducer
-        }, { initialState, runtimeChecks })
+        }, { runtimeChecks })
       ],
       declarations: [
         ReportingProfileComponent

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -41,20 +41,6 @@ describe('ReportingComponent', () => {
   let router: Router;
   let route: ActivatedRoute;
 
-  const initialState = {
-    router: {
-      state: {
-        url: '/',
-        params: {},
-        queryParams: {},
-        fragment: ''
-      }
-    },
-    clientRunsEntity: fromClientRuns.ClientRunsEntityInitialState,
-    notifications: fromNotifications.InitialState,
-    layout: fromLayout.InitialState
-  };
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -65,7 +51,7 @@ describe('ReportingComponent', () => {
           clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
           notifications: fromNotifications.notificationEntityReducer,
           layout: fromLayout.layoutEntityReducer
-        }, { initialState, runtimeChecks })
+        }, { runtimeChecks })
       ],
       declarations: [
         ReportingComponent,

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.spec.ts
@@ -4,7 +4,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 import { Store, StoreModule } from '@ngrx/store';
-import { NgrxStateAtom, ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import * as moment from 'moment';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
 import { MockChefSessionService } from 'app/testing/mock-chef-session.service';
@@ -21,7 +21,7 @@ describe('JobsListComponent', () => {
       imports: [
         RouterTestingModule,
         HttpClientTestingModule,
-        StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       declarations: [
         JobsListComponent

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-add/nodes-add.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-add/nodes-add.component.spec.ts
@@ -19,20 +19,6 @@ describe('NodesAddComponent', () => {
   let fixture: ComponentFixture<NodesAddComponent>;
   let component: NodesAddComponent;
 
-  const initialState = {
-    router: {
-      state: {
-        url: '/',
-        params: {},
-        queryParams: {},
-        fragment: ''
-      }
-    },
-    clientRunsEntity: fromClientRuns.ClientRunsEntityInitialState,
-    notifications: fromNotifications.InitialState,
-    layout: fromLayout.InitialState
-  };
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -45,7 +31,7 @@ describe('NodesAddComponent', () => {
           clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
           notifications: fromNotifications.notificationEntityReducer,
           layout: fromLayout.layoutEntityReducer
-        }, { initialState, runtimeChecks })
+        }, { runtimeChecks })
       ],
       declarations: [
         NodesAddComponent

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
@@ -4,7 +4,7 @@ import { StoreModule } from '@ngrx/store';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormGroup, FormBuilder } from '@angular/forms';
 
-import { ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
+import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import {
   IngestJob,
   IngestJobs,
@@ -29,7 +29,7 @@ describe('AutomateSettingsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       declarations: [
         AutomateSettingsComponent

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
@@ -1,13 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { AutomateSettingsComponent } from './automate-settings.component';
 import { StoreModule } from '@ngrx/store';
-import { runtimeChecks } from 'app/ngrx.reducers';
-import {
-  automateSettingsEntityReducer
-} from 'app/entities/automate-settings/automate-settings.reducer';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormGroup, FormBuilder } from '@angular/forms';
+
+import { ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
 import {
   IngestJob,
   IngestJobs,
@@ -16,6 +13,7 @@ import {
 
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
+import { AutomateSettingsComponent } from './automate-settings.component';
 
 let mockJobSchedulerStatus: JobSchedulerStatus = null;
 
@@ -31,9 +29,7 @@ describe('AutomateSettingsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
-        StoreModule.forRoot({
-          automateSettings: automateSettingsEntityReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
       ],
       declarations: [
         AutomateSettingsComponent

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.spec.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.spec.ts
@@ -7,11 +7,13 @@ import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
 import { runtimeChecks } from 'app/ngrx.reducers';
-import * as sidebar from '../../services/sidebar/sidebar.reducer';
+import { EntityStatus } from '../../entities/entities';
+import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
+import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
 import { UpdateNodeFilters } from '../../entities/client-runs/client-runs.actions';
+import * as sidebar from '../../services/sidebar/sidebar.reducer';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { EntityStatus } from '../../entities/entities';
 import { ClientRunsComponent } from './client-runs.component';
 
 class MockTelemetryService {
@@ -47,7 +49,9 @@ describe('ClientRunsComponent', () => {
         RouterTestingModule,
         HttpClientTestingModule,
         StoreModule.forRoot({
-          sidebar: sidebar.sidebarReducer
+          sidebar: sidebar.sidebarReducer,
+          notifications: notificationEntityReducer, // not used here but needed to suppress warnings
+          clientRunsEntity: clientRunsEntityReducer // not used here but needed to suppress warnings
         }, { runtimeChecks })
       ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]

--- a/components/automate-ui/src/app/pages/data-feed-form/data-feed-form.component.spec.ts
+++ b/components/automate-ui/src/app/pages/data-feed-form/data-feed-form.component.spec.ts
@@ -22,20 +22,6 @@ describe('DatafeedFormComponent', () => {
   let datafeedService: DatafeedService;
   const snapshot = { params: { name: 'name' }};
 
-  const initialState = {
-    router: {
-      state: {
-        url: '/',
-        params: {},
-        queryParams: {},
-        fragment: ''
-      }
-    },
-    clientRunsEntity: fromClientRuns.ClientRunsEntityInitialState,
-    notifications: fromNotifications.InitialState,
-    layout: fromLayout.InitialState
-  };
-
   class MockDatafeedService {
     fetchDestinations(): Observable<Destination[]> { return observableOf([]); }
     fetchDestination(destination) { return observableOf(destination); }
@@ -71,7 +57,7 @@ describe('DatafeedFormComponent', () => {
           clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
           notifications: fromNotifications.notificationEntityReducer,
           layout: fromLayout.layoutEntityReducer
-        }, { initialState, runtimeChecks })
+        }, { runtimeChecks })
       ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     }).compileComponents();

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.spec.ts
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.spec.ts
@@ -28,20 +28,6 @@ describe('DatafeedComponent', () => {
   const cardId = '#destinations-cards';
   const listId = '#destinations-list';
 
-  const initialState = {
-    router: {
-      state: {
-        url: '/',
-        params: {},
-        queryParams: {},
-        fragment: ''
-      }
-    },
-    clientRunsEntity: fromClientRuns.ClientRunsEntityInitialState,
-    notifications: fromNotifications.InitialState,
-    layout: fromLayout.InitialState
-  };
-
   class MockTelemetryService {
     track() { }
   }
@@ -83,7 +69,7 @@ describe('DatafeedComponent', () => {
           clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
           notifications: fromNotifications.notificationEntityReducer,
           layout: fromLayout.layoutEntityReducer
-        }, { initialState, runtimeChecks })
+        }, { runtimeChecks })
       ],
       declarations: [
         DatafeedComponent

--- a/components/automate-ui/src/app/pages/integrations/add/integrations-add.component.spec.ts
+++ b/components/automate-ui/src/app/pages/integrations/add/integrations-add.component.spec.ts
@@ -1,13 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { StoreModule } from '@ngrx/store';
 import { ReactiveFormsModule } from '@angular/forms';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
+import { StoreModule } from '@ngrx/store';
+
+import { ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { IntegrationsAddComponent } from './integrations-add.component';
-import { runtimeChecks } from 'app/ngrx.reducers';
-import { managerEntityReducer } from '../../../entities/managers/manager.reducer';
-import { integrationsAddReducer } from './integration-add.reducer';
 
 describe('IntegrationsAddComponent', () => {
   let component: IntegrationsAddComponent;
@@ -18,10 +17,7 @@ describe('IntegrationsAddComponent', () => {
       imports: [
         RouterTestingModule,
         ReactiveFormsModule,
-        StoreModule.forRoot({
-          managers: managerEntityReducer,
-          integrations_add: integrationsAddReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
       ],
       providers: [
         FeatureFlagsService

--- a/components/automate-ui/src/app/pages/integrations/add/integrations-add.component.spec.ts
+++ b/components/automate-ui/src/app/pages/integrations/add/integrations-add.component.spec.ts
@@ -4,7 +4,7 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule } from '@ngrx/store';
 
-import { ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
+import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { IntegrationsAddComponent } from './integrations-add.component';
 
@@ -17,7 +17,7 @@ describe('IntegrationsAddComponent', () => {
       imports: [
         RouterTestingModule,
         ReactiveFormsModule,
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       providers: [
         FeatureFlagsService

--- a/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.spec.ts
@@ -1,12 +1,15 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { StoreModule } from '@ngrx/store';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
-import { IntegrationsListComponent } from './integrations-list.component';
+import { StoreModule } from '@ngrx/store';
+
 import { runtimeChecks } from 'app/ngrx.reducers';
+import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
+import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
 import { managerEntityReducer } from '../../../entities/managers/manager.reducer';
 import { ChefPipesModule } from '../../../pipes/chef-pipes.module';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+import { IntegrationsListComponent } from './integrations-list.component';
 
 describe('IntegrationsListComponent', () => {
   let component: IntegrationsListComponent;
@@ -29,7 +32,9 @@ describe('IntegrationsListComponent', () => {
             previousRoute: {},
             navigationId: 0
           }),
-          managers: managerEntityReducer
+          managers: managerEntityReducer,
+          notifications: notificationEntityReducer, // not used here but needed to suppress warnings
+          clientRunsEntity: clientRunsEntityReducer // not used here but needed to suppress warnings
         }, { runtimeChecks })
       ],
       declarations: [

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.spec.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.spec.ts
@@ -5,7 +5,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule, Store } from '@ngrx/store';
 import { ROUTER_NAVIGATION } from '@ngrx/router-store';
-import { NgrxStateAtom, ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { ChefSessionService } from '../../services/chef-session/chef-session.service';
 import { JobAddComponent, Step } from './job-add.component';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
@@ -37,7 +37,7 @@ describe('JobAddComponent', () => {
       imports: [
         ReactiveFormsModule,
         RouterTestingModule,
-        StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       declarations: [
         JobAddComponent

--- a/components/automate-ui/src/app/pages/job-edit/job-edit.component.spec.ts
+++ b/components/automate-ui/src/app/pages/job-edit/job-edit.component.spec.ts
@@ -7,7 +7,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule, Store } from '@ngrx/store';
 import { ROUTER_NAVIGATION } from '@ngrx/router-store';
-import { NgrxStateAtom, ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { ChefSessionService } from '../../services/chef-session/chef-session.service';
 import { JobEditComponent, Step } from './job-edit.component';
 import { Job } from '../../entities/jobs/job.model';
@@ -48,7 +48,7 @@ describe('JobEditComponent', () => {
       imports: [
         ReactiveFormsModule,
         RouterTestingModule,
-        StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       declarations: [
         JobEditComponent

--- a/components/automate-ui/src/app/pages/node-details/node-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/node-details/node-details.component.spec.ts
@@ -1,18 +1,21 @@
+import { NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed, ComponentFixtureAutoDetect, ComponentFixture } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute } from '@angular/router';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { runtimeChecks } from 'app/ngrx.reducers';
-import { NodeDetailsComponent  } from './node-details.component';
-import { NodeDetailsService } from '../../services/node-details/node-details.service';
-import { MockComponent } from 'ng2-mock-component';
-import { AttributesService } from '../../services/attributes/attributes.service';
-import { NodeRun } from '../../types/types';
-import { NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { TelemetryService } from '../../services/telemetry/telemetry.service';
-import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { StoreModule } from '@ngrx/store';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { MockComponent } from 'ng2-mock-component';
+
+import { runtimeChecks } from 'app/ngrx.reducers';
+import { NodeRun } from 'app/types/types';
+import { NodeDetailsService } from 'app/services/node-details/node-details.service';
+import { AttributesService } from 'app/services/attributes/attributes.service';
+import { TelemetryService } from 'app/services/telemetry/telemetry.service';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
+import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
+import { NodeDetailsComponent  } from './node-details.component';
 
 class MockTelemetryService {
   track() { }
@@ -81,6 +84,8 @@ function createTestFixture(
       FormsModule,
       RouterTestingModule,
       StoreModule.forRoot({
+        notifications: notificationEntityReducer, // not used here but needed to suppress warnings
+        clientRunsEntity: clientRunsEntityReducer, // not used here but needed to suppress warnings
         router: () => ({
           state: {
             url: '/',

--- a/components/automate-ui/src/app/pages/notification-form/notification-form.component.spec.ts
+++ b/components/automate-ui/src/app/pages/notification-form/notification-form.component.spec.ts
@@ -25,20 +25,6 @@ describe('NotificationFormComponent', () => {
   let ruleService: RulesService;
   const snapshot = { params: { id: 'id' }};
 
-  const initialState = {
-    router: {
-      state: {
-        url: '/',
-        params: {},
-        queryParams: {},
-        fragment: ''
-      }
-    },
-    clientRunsEntity: fromClientRuns.ClientRunsEntityInitialState,
-    notifications: fromNotifications.InitialState,
-    layout: fromLayout.InitialState
-  };
-
   class MockRulesService {
     fetchRules(): Observable<Rule[]> { return observableOf([]); }
     fetchRule(rule) { return observableOf(rule); }
@@ -74,7 +60,7 @@ describe('NotificationFormComponent', () => {
           clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
           notifications: fromNotifications.notificationEntityReducer,
           layout: fromLayout.layoutEntityReducer
-        }, { initialState, runtimeChecks })
+        }, { runtimeChecks })
       ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     }).compileComponents();

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.spec.ts
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.spec.ts
@@ -5,7 +5,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { By } from '@angular/platform-browser';
 import { Observable, of as observableOf } from 'rxjs';
 import { Store, StoreModule } from '@ngrx/store';
-import { NgrxStateAtom, ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { MockComponent } from 'ng2-mock-component';
 
 import { Rule, ServiceActionType } from './rule';
@@ -65,7 +65,7 @@ describe('NotificationsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
-        StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       declarations: [
         NotificationsComponent,

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -5,11 +5,13 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule, Store } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
+import { runtimeChecks } from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
+import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
 import { GetProjectSuccess } from 'app/entities/projects/project.actions';
-import { runtimeChecks } from 'app/ngrx.reducers';
 import { projectEntityReducer } from 'app/entities/projects/project.reducer';
 import { Project } from 'app/entities/projects/project.model';
 import { Rule } from 'app/entities/rules/rule.model';
@@ -115,7 +117,9 @@ describe('ProjectDetailsComponent', () => {
             navigationId: 0
           }),
           projects: projectEntityReducer,
-          rules: ruleEntityReducer
+          rules: ruleEntityReducer,
+          notifications: notificationEntityReducer, // not used here but needed to suppress warnings
+          clientRunsEntity: clientRunsEntityReducer // not used here but needed to suppress warnings
         }, { runtimeChecks })
       ],
       providers: [

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
@@ -110,9 +110,8 @@ describe('ProjectListComponent', () => {
           {
           policies: policyEntityReducer,
           projects: projectEntityReducer,
-          // not used directly in this component, needed to suppress unit test warnings
-          notifications: notificationEntityReducer,
-          clientRunsEntity: clientRunsEntityReducer
+          notifications: notificationEntityReducer, // not used here but needed to suppress warnings
+          clientRunsEntity: clientRunsEntityReducer // not used here but needed to suppress warnings
         }, { runtimeChecks })
       ],
       providers: [


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

There are a lot of extraneous console messages (over 1000!!) when you run `make unit` for automate-ui. 
```
WARN: 'The feature name "clientRunsEntity" does not exist in the state, therefore createFeatureSelector cannot access it.  Be sure it is imported in a loaded module using StoreModule.forRoot('clientRunsEntity', ...) or StoreModule.forFeature('clientRunsEntity', ...).  If the default state is intended to be undefined, as is the case with router state, this development-only warning message can be ignored.'
WARN: 'The feature name "notifications" does not exist in the state, therefore createFeatureSelector cannot access it.  Be sure it is imported in a loaded module using StoreModule.forRoot('notifications', ...) or StoreModule.forFeature('notifications', ...).  If the default state is intended to be undefined, as is the case with router state, this development-only warning message can be ignored.'
WARN: 'The feature name "notifications" does not exist in the state, therefore createFeatureSelector cannot access it.  Be sure it is imported in a loaded module using StoreModule.forRoot('notifications', ...) or StoreModule.forFeature('notifications', ...).  If the default state is intended to be undefined, as is the case with router state, this development-only warning message can be ignored.'
WARN: 'The feature name "clientRunsEntity" does not exist in the state, therefore createFeatureSelector cannot access it.  Be sure it is imported in a loaded module using StoreModule.forRoot('clientRunsEntity', ...) or StoreModule.forFeature('clientRunsEntity', ...).  If the default state is intended to be undefined, as is the case with router state, this development-only warning message can be ignored.'
. . .
```
This PR quashes those.

Notes: 
Those warnings are completely non-specific in terms of where they came from. The bulk of the work was identifying the problem files.
I did that by first starting the tests in watch-mode:
```
npm run test:watch
```
Then, start by subdividing the set of *.spec.ts files: switched to a subdirectory (e.g. `entities`) then used this to enable just those tests:
```
sed -i '' 's/^describe/fdescribe/' $(find . -name '*.spec.ts' -print)
```
If any failures in that group, subdivide again.
If all clean, revert the `fdescribe`:
```
sed -i '' 's/fdescribe/describe/' $(find . -name '*.spec.ts' -print)
```

The second challenge was figuring out what the fix was.
Comparing and contrasting files that were working with those that were not led me to the appropriate ngrx/store setup lines.
I readily addressed the issue in 10 of the 14 problem files.
The remaining four files required I get sidetracked for awhile--see PR #2595--and then returning here, I could finish up those last 4 files.

I then went through all uses of the `StoreModule.forRoot`, slicing it this way and that, and shook out a few more files that needed the same fix from PR #2595. Also identified another handful that enumerated state bits for setup yet were not even needed, so I removed all those. Follow the commits to see the logical groupings.

### :chains: Related Resources
NA

### :+1: Definition of Done
Test output is just this, with no console warnings, and all tests pass:
```
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
...............................................................................
Chrome 79.0.3945 (Mac OS X 10.14.6): Executed 1359 of 1393 (skipped 34) SUCCESS (35.647 secs / 32.769 secs)
```
### :athletic_shoe: How to Build and Test the Change

```
cd automate-ui
make unit
```