### PR TITLE
[automate-2587] Exclude non-working ts files

### DIFF
--- a/components/automate-ui/tsconfig.json
+++ b/components/automate-ui/tsconfig.json
@@ -22,5 +22,10 @@
     "module": "esnext",
     "noUnusedLocals": true,
     "noUnusedParameters": true
-  }
+  },
+  "exclude": [
+    "**/node_modules/*",
+    "dist/*",
+    "src/assets/*"
+  ]
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Lately, every time opening TS files in the automate-ui project in VSCode, one gets a balloon warning:

<img width="394" alt="image" src="https://user-images.githubusercontent.com/6817500/71549925-cd940400-297a-11ea-9cb1-d053dd727f21.png">

Besides that warning I have also been seeing a lot of **false** TypeScript errors showing up upon opening TypeScript files for editing, starting with calling out many of the import statements and "could not find...". Those, of course, cascaded many other errors in the files. This seemed to occur randomly--no particular files for any particular reason, and not all the time.
Anecdotally, this patch seems to have resolved that as well. 🤞 

Per [this post](https://github.com/Microsoft/vscode/issues/31188#issuecomment-317588447) I enabled TypeScript server logging to identify large directories that are generated files rather than working code: the `dist` and `assets` dirs. So those are being added to the exclusion list in the root `tsconfig.json` file.

I am also including `node_modules` per [a related post](https://github.com/Microsoft/vscode/issues/31188#issuecomment-317611881) in the same issue.

### :chains: Related Resources
NA

### :+1: Definition of Done
Warning no longer appears in VSCode.

### :athletic_shoe: How to Build and Test the Change

1. Restart VSCode and let it initialize--wait until status bar info stablizes and looks something like this:
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/6817500/71549998-c5889400-297b-11ea-9ae0-84554acc8760.png">


2. Open any TypeScript file for editing from the automate-ui project (e.g. components/automate-ui/src/app/modules/team/team-details/team-details.component.ts). You should see this initialization:
<img width="680" alt="image" src="https://user-images.githubusercontent.com/6817500/71549991-bdc8ef80-297b-11ea-82e4-638ce5acee9b.png">

3. Without this patch in place, you would then see within 10 seconds or so the warning box shown at top. With this patch in place, you should not see that warning box.
