### PR TITLE
[Automate-2593] fix unit test ngrx setup

### DIFF
--- a/components/automate-ui/src/app/components/settings-sidebar/settings-sidebar.component.spec.ts
+++ b/components/automate-ui/src/app/components/settings-sidebar/settings-sidebar.component.spec.ts
@@ -22,7 +22,7 @@ describe('SettingsSidebarComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule,
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
       ],
       declarations: [
         SettingsSidebarComponent,

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.spec.ts
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.spec.ts
@@ -22,7 +22,7 @@ describe('SidebarComponent', () => {
         FeatureFlagsService
       ],
       imports: [
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
       ]
     }).compileComponents();
     store = TestBed.get(Store);

--- a/components/automate-ui/src/app/modules/license/license-notifications/license-notifications.component.spec.ts
+++ b/components/automate-ui/src/app/modules/license/license-notifications/license-notifications.component.spec.ts
@@ -20,7 +20,7 @@ describe('LicenseNotificationsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
       ],
       declarations: [
         MockComponent({ selector: 'chef-notification', inputs: ['type', 'timeout'] }),

--- a/components/automate-ui/src/app/modules/policy/list/policy-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/policy/list/policy-list.component.spec.ts
@@ -44,7 +44,7 @@ describe('PolicyListComponent', () => {
       ],
       imports: [
         ChefPipesModule,
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
       ]
     }).compileComponents();
       store = TestBed.get(Store);

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -133,8 +133,10 @@ export function routerReducer(state = defaultRouterState, action) {
   }
 }
 
+// Note: this is used ONLY for unit tests, but better to be defined here since
+// it needs to mirror the ngrxReducers.
 export const defaultInitialState = {
-  ...defaultRouterState,
+  router: defaultRouterState,
   credentials: credentials.initialState,
   event_feed: eventFeed.initialState,
   scanner: scanner.initialState,
@@ -166,7 +168,7 @@ export const defaultInitialState = {
   serviceGroups: serviceGroups.ServiceGroupEntityInitialState,
   teams: teamEntity.TeamEntityInitialState,
   userperms: permEntity.initialState,
-  users: userEntity.userEntityAdapter.getInitialState
+  users: userEntity.UserEntityInitialState
 };
 
 export const ngrxReducers = {

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -9,7 +9,7 @@ import * as projectsFilter from './services/projects-filter/projects-filter.redu
 import * as apiToken from './entities/api-tokens/api-token.reducer';
 import * as automateSettings from './entities/automate-settings/automate-settings.reducer';
 import * as clientRuns from './entities/client-runs/client-runs.reducer';
-import * as integationsAdd from './pages/integrations/add/integration-add.reducer';
+import * as integrationsAdd from './pages/integrations/add/integration-add.reducer';
 import * as integrationsDetail from './pages/integrations/detail/integrations-detail.reducer';
 import * as integrationsEdit from './pages/integrations/edit/integrations-edit.reducer';
 import * as license from './entities/license/license.reducer';
@@ -43,7 +43,7 @@ export interface NgrxStateAtom {
   projectsFilter: projectsFilter.ProjectsFilterState;
 
   // UI State
-  integrations_add: integationsAdd.IntegrationsAddState;
+  integrations_add: integrationsAdd.IntegrationsAddState;
   integrations_detail: integrationsDetail.IntegrationsDetailState;
   integrations_edit: integrationsEdit.IntegrationsEditState;
   job_add: jobAdd.JobAddState;
@@ -145,7 +145,7 @@ export const defaultInitialState = {
   projectsFilter: projectsFilter.projectsFilterInitialState,
 
   // UI State
-  integrations_add: integationsAdd.IntegrationsAddInitialState,
+  integrations_add: integrationsAdd.IntegrationsAddInitialState,
   integrations_detail: integrationsDetail.IntegrationsDetailInitialState,
   integrations_edit: integrationsEdit.IntegrationsEditInitialState,
   job_add: jobAdd.JobAddInitialState,
@@ -185,7 +185,7 @@ export const ngrxReducers = {
   job_add: jobAdd.jobAddReducer,
   job_edit: jobEdit.jobEditReducer,
   job_list: jobList.jobListReducer,
-  integrations_add: integationsAdd.integrationsAddReducer,
+  integrations_add: integrationsAdd.integrationsAddReducer,
   integrations_detail: integrationsDetail.integrationsDetailReducer,
   integrations_edit: integrationsEdit.integrationsEditReducer,
 

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.spec.ts
@@ -21,7 +21,7 @@ describe('JobsListComponent', () => {
       imports: [
         RouterTestingModule,
         HttpClientTestingModule,
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
       ],
       declarations: [
         JobsListComponent

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.spec.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.spec.ts
@@ -37,7 +37,7 @@ describe('JobAddComponent', () => {
       imports: [
         ReactiveFormsModule,
         RouterTestingModule,
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
       ],
       declarations: [
         JobAddComponent

--- a/components/automate-ui/src/app/pages/job-edit/job-edit.component.spec.ts
+++ b/components/automate-ui/src/app/pages/job-edit/job-edit.component.spec.ts
@@ -48,7 +48,7 @@ describe('JobEditComponent', () => {
       imports: [
         ReactiveFormsModule,
         RouterTestingModule,
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
       ],
       declarations: [
         JobEditComponent

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.spec.ts
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.spec.ts
@@ -65,7 +65,7 @@ describe('NotificationsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
       ],
       declarations: [
         NotificationsComponent,

--- a/cspell.json
+++ b/cspell.json
@@ -464,6 +464,7 @@
         "searchbar",
         "segmentio",
         "selectable",
+        "serializability",
         "serveropts",
         "Setresgid",
         "Setresuid",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Trying to resolve a lot of noise being generated by UI unit tests (see #2486)
was causing compilation errors. It turns out that the new work of #2486 (automate unit test noise) was exposing a hidden bug in the unit test setup that had been recently introduced from #1485 (moving the license banner)--some calls to `StoreModule.forRoot` were passing incorrect arguments.  That bug in turn was masking one more bug: two properties in the `defaultInitialState` used by ngrx store were defined incorrectly.

This PR corrects both of those issues.

#### First bug: calls to `forRoot` using `defaultInitialState`

Here's the signature for [forRoot](https://ngrx.io/api/store/StoreModule):
<img width="751" alt="image" src="https://user-images.githubusercontent.com/6817500/71628948-98bcc280-2baf-11ea-9fb9-af87fd6f9858.png">

And here is the [RootStoreConfig](https://ngrx.io/api/store/RootStoreConfig) interface:
<img width="511" alt="image" src="https://user-images.githubusercontent.com/6817500/71629027-f7823c00-2baf-11ea-8910-401e2395c33a.png">

Notice that `RootStoreConfig` has an `initialState` property, which is where the `defaultInitialState` object needs to reside, rather than flatten its properties with the spread operator. Since all properties of `RootStoreConfig` are optional (!), this did not cause any errors (though it did cause me some grief 😁 ).

In a nutshell, then, needed to remove the spread operator and add the `initialState` property:
```
-        StoreModule.forRoot(ngrxReducers, { ...defaultInitialState, runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
```

#### Second bug: Incorrect `defaultInitialState` definition

With the above fixed, I was then seeing compilation errors:
```
Type '{ router: { state: { url: string; params: { id: string; }; queryParams: {}; fragment: string; path: any[]; }; navigationId: number; }; policies: PolicyEntityState & { iamMajorVersion: string; }; ... 26 more ...; users: { ...; }; }' is not assignable to type 'InitialState<{ credentials: CredentialsState; scanner: ScannerState; router: RouterReducerState<{ url: string; queryParams: {}; params: {}; fragment: string; path: string[]; }>; ... 26 more ...; users: UserEntityState; }>'.
Type '{ router: { state: { url: string; params: { id: string; }; queryParams: {}; fragment: string; path: any[]; }; navigationId: number; }; policies: PolicyEntityState & { iamMajorVersion: string; }; ... 26 more ...; users: { ...; }; }' is not assignable to type 'Partial<{ credentials: CredentialsState; scanner: ScannerState; router: RouterReducerState<{ url: string; queryParams: {}; params: {}; fragment: string; path: string[]; }>; ... 26 more ...; users: UserEntityState; }>'.
Types of property 'users' are incompatible.
Type '{ (): EntityState<User>; <S extends object>(state: S): EntityState<User> & S; }' is missing the following properties from type 'UserEntityState': getStatus, updateStatus, deleteStatus, createStatus, and 2 more.
```

Should probably call those compilation warnings rather than errors, as they did **not** fail the build nor did they affect test results--_all tests passed_!

But the error displays on the console when running `make unit` or `npm run test`.

There were actually two problems:
1. The `router` section was missing the "router" key.
2. The `users` section was given a method name (not a method call), when it should have been given a constant.

The incorrect `router` section did not manifest, showing only that no test relied upon it.

The incorrect `users` value caused the error shown above once the `forRoot` bug was patched.

Here are the crucial changes:

```
-  ...defaultRouterState,
+  router: defaultRouterState,

-  users: userEntity.userEntityAdapter.getInitialState
+  users: userEntity.UserEntityInitialState

```

### :chains: Related Resources
See above

### :+1: Definition of Done
All tests pass and none of the errors of the type shown above appear.
You will, however, still see many, many occurrences of console warnings that will be fixed in #2486.

### :athletic_shoe: How to Build and Test the Change
```
cd components/automate-ui
make unit
```
