### PR TITLE
fix bug new years too many indices bug

### DIFF
--- a/components/compliance-service/reporting/relaxting/indices.go
+++ b/components/compliance-service/reporting/relaxting/indices.go
@@ -115,7 +115,7 @@ func wholeCalendarYears(prefix string, startTime time.Time, endTime time.Time) (
 		err = errors.New(StartDateGreaterThanEndDateErrMsg)
 		return indices, straddle, err
 	}
-	endOfStartYear := time.Date(startTime.Year(), time.December, 31, 0, 0, 0, 0, time.UTC)
+	endOfStartYear := time.Date(startTime.Year(), time.December, 31, 23, 59, 59, 0, time.UTC)
 
 	firstWholeCalYear := startTime.Year()
 	if !(startTime.Day() == 1 && startTime.Month() == 1 && (endTime.Equal(endOfStartYear) || endTime.After(endOfStartYear))) {

--- a/components/compliance-service/reporting/relaxting/indices_test.go
+++ b/components/compliance-service/reporting/relaxting/indices_test.go
@@ -197,6 +197,32 @@ func TestIndexDatesEndDateIsEndOfTensRange(t *testing.T) {
 	}
 }
 
+func TestIndexDatesDayBeforeEndDateIsEndOfYear(t *testing.T) {
+	startTime := "2006-12-21T15:04:05Z"
+	endTime := "2006-12-30T23:59:59Z"
+
+	esIndex, err := relaxting.IndexDates(relaxting.CompDailySumIndexPrefix, startTime, endTime)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, fmt.Sprintf("%[1]s2006.12.21*,%[1]s2006.12.22*,%[1]s2006.12.23*,%[1]s2006.12.24*,"+
+			"%[1]s2006.12.25*,%[1]s2006.12.26*,%[1]s2006.12.27*,%[1]s2006.12.28*,%[1]s2006.12.29*,%[1]s2006.12.30*",
+			relaxting.CompDailySumIndexPrefix), esIndex)
+	}
+}
+
+func TestIndexDatesEndDateIsEndOfYear(t *testing.T) {
+	startTime := "2006-12-21T15:04:05Z"
+	endTime := "2006-12-31T23:59:59Z"
+
+	esIndex, err := relaxting.IndexDates(relaxting.CompDailySumIndexPrefix, startTime, endTime)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, fmt.Sprintf("%[1]s2006.12.21*,%[1]s2006.12.22*,%[1]s2006.12.23*,%[1]s2006.12.24*,"+
+			"%[1]s2006.12.25*,%[1]s2006.12.26*,%[1]s2006.12.27*,%[1]s2006.12.28*,%[1]s2006.12.29*,%[1]s2006.12.3*",
+			relaxting.CompDailySumIndexPrefix), esIndex)
+	}
+}
+
 func TestIndexDatesStartDateIsAfterStartOfTensRangeAndEndDateIsEndOfTensRange(t *testing.T) {
 	startTime := "2006-01-18T15:04:05Z"
 	endTime := "2006-01-19T15:04:05Z"


### PR DESCRIPTION
Signed-off-by: Rick Marry <rmarry@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
This change fixes a bug that occurs when selecting Dec 31 as end_time for api calls on compliance reporting

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] Tests added/updated?
- [ ] Docs added/updated?

### :camera: Screenshots, if applicable