### PR TITLE
Vinay/automate infra proxy org ui

### DIFF
--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -26,6 +26,7 @@ import { SigninComponent } from './pages/signin/signin.component';
 // Components
 import { AutomateSettingsComponent } from './pages/automate-settings/automate-settings.component';
 import { ChefServersListComponent } from './modules/infra-proxy/chef-servers-list/chef-servers-list.component';
+import { ChefServerDetailsComponent } from './modules/infra-proxy/chef-server-details/chef-server-details.component';
 import { NodeDetailsComponent } from './pages/node-details/node-details.component';
 import {
   NodeNoRunsDetailsComponent
@@ -238,6 +239,10 @@ const routes: Routes = [
             {
               path: '',
               component: ChefServersListComponent
+            },
+            {
+              path: ':id',
+              component: ChefServerDetailsComponent
             }
           ]
         }

--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -79,6 +79,7 @@ import { ProjectRequests } from './entities/projects/project.requests';
 import { RoleRequests } from './entities/roles/role.requests';
 import { RuleRequests } from './entities/rules/rule.requests';
 import { ServerRequests } from './entities/servers/server.requests';
+import { OrgRequests } from './entities/orgs/org.requests';
 import { ServiceGroupsRequests } from './entities/service-groups/service-groups.requests';
 import { TeamRequests } from './entities/teams/team.requests';
 import { UserPermsRequests } from './entities/userperms/userperms.requests';
@@ -321,6 +322,7 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     RulesService,
     RunHistoryStore,
     ServerRequests,
+    OrgRequests,
     ServiceGroupsRequests,
     SessionStorageService,
     SidebarService,

--- a/components/automate-ui/src/app/entities/orgs/org.actions.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.actions.ts
@@ -25,7 +25,7 @@ export interface OrgSuccessPayload {
   org: Org;
 }
 
-export class GetOrgsForServer implements Action {
+export class GetOrgs implements Action {
   readonly type = OrgActionTypes.GET_ALL;
 
   constructor(public payload: { server_id: string }) { }
@@ -124,7 +124,7 @@ export class UpdateOrgFailure implements Action {
 }
 
 export type OrgActions =
-  | GetOrgsForServer
+  | GetOrgs
   | GetOrgsSuccess
   | GetOrgsFailure
   | GetOrg

--- a/components/automate-ui/src/app/entities/orgs/org.actions.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.actions.ts
@@ -1,0 +1,141 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Action } from '@ngrx/store';
+
+import { Org } from './org.model';
+
+export enum OrgActionTypes {
+  GET_ALL = 'ORGS::GET_ALL',
+  GET_ALL_SUCCESS = 'ORGS::GET_ALL::SUCCESS',
+  GET_ALL_FAILURE = 'ORGS::GET_ALL::FAILURE',
+  GET = 'ORGS::GET',
+  GET_SUCCESS = 'ORGS::GET::SUCCESS',
+  GET_FAILURE = 'ORGS::GET::FAILURE',
+  CREATE = 'ORGS::CREATE',
+  CREATE_SUCCESS = 'ORGS::CREATE::SUCCESS',
+  CREATE_FAILURE = 'ORGS::CREATE::FAILURE',
+  DELETE = 'ORGS::DELETE',
+  DELETE_SUCCESS = 'ORGS::DELETE::SUCCESS',
+  DELETE_FAILURE = 'ORGS::DELETE::FAILURE',
+  UPDATE = 'ORGS::UPDATE',
+  UPDATE_SUCCESS = 'ORGS::UPDATE::SUCCESS',
+  UPDATE_FAILURE = 'ORGS::UPDATE::FAILURE'
+}
+
+export interface OrgSuccessPayload {
+  org: Org;
+}
+
+export class GetOrgsForServer implements Action {
+  readonly type = OrgActionTypes.GET_ALL;
+
+  constructor(public payload: { server_id: string }) { }
+}
+
+export interface OrgsSuccessPayload {
+  orgs: Org[];
+}
+
+export class GetOrgsSuccess implements Action {
+  readonly type = OrgActionTypes.GET_ALL_SUCCESS;
+
+  constructor(public payload: OrgsSuccessPayload) { }
+}
+
+export class GetOrgsFailure implements Action {
+  readonly type = OrgActionTypes.GET_ALL_FAILURE;
+
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export class GetOrg implements Action {
+  readonly type = OrgActionTypes.GET;
+
+  constructor(public payload: { server_id: string, id: string }) { }
+}
+
+export class GetOrgSuccess implements Action {
+  readonly type = OrgActionTypes.GET_SUCCESS;
+
+  constructor(public payload: OrgSuccessPayload) { }
+}
+
+export class GetOrgFailure implements Action {
+  readonly type = OrgActionTypes.GET_FAILURE;
+
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export interface CreateOrgPayload {
+  server_id: string;
+  name: string;
+  admin_user: string;
+  admin_key: string;
+}
+
+export class CreateOrg implements Action {
+  readonly type = OrgActionTypes.CREATE;
+  constructor(public payload:  CreateOrgPayload ) { }
+}
+
+export class CreateOrgSuccess implements Action {
+  readonly type = OrgActionTypes.CREATE_SUCCESS;
+  constructor(public payload: OrgSuccessPayload) { }
+}
+
+export class CreateOrgFailure implements Action {
+  readonly type = OrgActionTypes.CREATE_FAILURE;
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export class DeleteOrg implements Action {
+  readonly type = OrgActionTypes.DELETE;
+
+  constructor(public payload: { server_id: string, id: string, name: string }) { }
+}
+
+export class DeleteOrgSuccess implements Action {
+  readonly type = OrgActionTypes.DELETE_SUCCESS;
+
+  constructor(public payload: { id: string, name: string }) { }
+}
+
+export class DeleteOrgFailure implements Action {
+  readonly type = OrgActionTypes.DELETE_FAILURE;
+
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export class UpdateOrg implements Action {
+  readonly type = OrgActionTypes.UPDATE;
+
+  constructor(public payload: { org: Org }) { }
+}
+
+export class UpdateOrgSuccess implements Action {
+  readonly type = OrgActionTypes.UPDATE_SUCCESS;
+
+  constructor(public payload: OrgSuccessPayload) { }
+}
+
+export class UpdateOrgFailure implements Action {
+  readonly type = OrgActionTypes.UPDATE_FAILURE;
+
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export type OrgActions =
+  | GetOrgsForServer
+  | GetOrgsSuccess
+  | GetOrgsFailure
+  | GetOrg
+  | GetOrgSuccess
+  | GetOrgFailure
+  | CreateOrg
+  | CreateOrgSuccess
+  | CreateOrgFailure
+  | DeleteOrg
+  | DeleteOrgSuccess
+  | DeleteOrgFailure
+  | UpdateOrg
+  | UpdateOrgSuccess
+  | UpdateOrgFailure;

--- a/components/automate-ui/src/app/entities/orgs/org.effects.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.effects.ts
@@ -1,0 +1,163 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { of as observableOf } from 'rxjs';
+import { catchError, mergeMap, map, filter } from 'rxjs/operators';
+
+import { HttpStatus } from 'app/types/types';
+import { CreateNotification } from 'app/entities/notifications/notification.actions';
+import { Type } from 'app/entities/notifications/notification.model';
+
+import {
+  GetOrgsForServer,
+  GetOrgsSuccess,
+  OrgsSuccessPayload,
+  GetOrgsFailure,
+  GetOrg,
+  GetOrgSuccess,
+  GetOrgFailure,
+  CreateOrg,
+  CreateOrgSuccess,
+  CreateOrgFailure,
+  DeleteOrg,
+  DeleteOrgSuccess,
+  DeleteOrgFailure,
+  UpdateOrg,
+  UpdateOrgFailure,
+  UpdateOrgSuccess,
+  OrgSuccessPayload,
+  OrgActionTypes
+} from './org.actions';
+
+import {
+  OrgRequests
+} from './org.requests';
+
+@Injectable()
+export class OrgEffects {
+  constructor(
+    private actions$: Actions,
+    private requests: OrgRequests
+  ) { }
+
+  @Effect()
+  getOrgsForProject$ = this.actions$.pipe(
+      ofType(OrgActionTypes.GET_ALL),
+      mergeMap(({ payload: { server_id } }: GetOrgsForServer) =>
+        this.requests.getOrgsForServer(server_id).pipe(
+          map((resp: OrgsSuccessPayload) => new GetOrgsSuccess(resp)),
+          catchError((error: HttpErrorResponse) => observableOf(new GetOrgsFailure(error))))));
+
+  @Effect()
+  getOrgsFailure$ = this.actions$.pipe(
+      ofType(OrgActionTypes.GET_ALL_FAILURE),
+      map(({ payload }: GetOrgsFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not get orgs: ${msg || payload.error}`
+        });
+      }));
+
+  @Effect()
+  getOrg$ = this.actions$.pipe(
+      ofType(OrgActionTypes.GET),
+      mergeMap(({ payload: { server_id, id } }: GetOrg) =>
+        this.requests.getOrg(server_id, id).pipe(
+          map((resp: OrgSuccessPayload) => new GetOrgSuccess(resp)),
+          catchError((error: HttpErrorResponse) => observableOf(new GetOrgFailure(error))))));
+
+ @Effect()
+  getOrgFailure$ = this.actions$.pipe(
+      ofType(OrgActionTypes.GET_FAILURE),
+      map(({ payload }: GetOrgFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not get org: ${msg || payload.error}`
+        });
+      }));
+
+  @Effect()
+  createOrg$ = this.actions$.pipe(
+      ofType(OrgActionTypes.CREATE),
+      mergeMap(({ payload }: CreateOrg) =>
+      this.requests.createOrg( payload ).pipe(
+        map((resp: OrgSuccessPayload) => new CreateOrgSuccess(resp)),
+        catchError((error: HttpErrorResponse) => observableOf(new GetOrgFailure(error))))));
+
+  @Effect()
+  createOrgSuccess$ = this.actions$.pipe(
+      ofType(OrgActionTypes.CREATE_SUCCESS),
+      map(({ payload: { org } }: CreateOrgSuccess) => new CreateNotification({
+      type: Type.info,
+      message: `Created org ${org.name}.`
+    })));
+
+  @Effect()
+  createOrgFailure$ = this.actions$.pipe(
+    ofType(OrgActionTypes.CREATE_FAILURE),
+    filter(({ payload }: CreateOrgFailure) => payload.status !== HttpStatus.CONFLICT),
+    map(({ payload }: CreateOrgFailure) => new CreateNotification({
+        type: Type.error,
+        message: `Could not create org: ${payload.error.error || payload}`
+      })));
+
+  @Effect()
+  deleteOrg$ = this.actions$.pipe(
+      ofType(OrgActionTypes.DELETE),
+      mergeMap(({ payload: { server_id, id, name } }: DeleteOrg) =>
+        this.requests.deleteOrg(server_id, id).pipe(
+          map(() => new DeleteOrgSuccess({id, name})),
+          catchError((error: HttpErrorResponse) =>
+            observableOf(new DeleteOrgFailure(error))))));
+
+  @Effect()
+  deleteOrgSuccess$ = this.actions$.pipe(
+      ofType(OrgActionTypes.DELETE_SUCCESS),
+      map(({ payload: { name } }: DeleteOrgSuccess) => {
+        return new CreateNotification({
+          type: Type.info,
+          message: `Deleted org ${name}.`
+        });
+      }));
+
+  @Effect()
+  deleteOrgFailure$ = this.actions$.pipe(
+      ofType(OrgActionTypes.DELETE_FAILURE),
+      map(({ payload }: DeleteOrgFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not delete org: ${msg || payload.error}`
+        });
+      }));
+
+  @Effect()
+  updateOrg$ = this.actions$.pipe(
+      ofType(OrgActionTypes.UPDATE),
+      mergeMap(({ payload: { org } }: UpdateOrg) =>
+        this.requests.updateOrg(org).pipe(
+          map((resp: OrgSuccessPayload) => new UpdateOrgSuccess(resp)),
+          catchError((error: HttpErrorResponse) =>
+            observableOf(new UpdateOrgFailure(error))))));
+  @Effect()
+  updateOrgSuccess$ = this.actions$.pipe(
+      ofType(OrgActionTypes.UPDATE_SUCCESS),
+      map(({ payload: { org } }: UpdateOrgSuccess) => new CreateNotification({
+      type: Type.info,
+      message: `Updated org ${org.name}.`
+    })));
+
+  @Effect()
+  updateOrgFailure$ = this.actions$.pipe(
+      ofType(OrgActionTypes.UPDATE_FAILURE),
+      map(({ payload }: UpdateOrgFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not update org: ${msg || payload.error}`
+        });
+      }));
+}
+

--- a/components/automate-ui/src/app/entities/orgs/org.effects.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.effects.ts
@@ -9,7 +9,7 @@ import { CreateNotification } from 'app/entities/notifications/notification.acti
 import { Type } from 'app/entities/notifications/notification.model';
 
 import {
-  GetOrgsForServer,
+  GetOrgs,
   GetOrgsSuccess,
   OrgsSuccessPayload,
   GetOrgsFailure,
@@ -43,8 +43,8 @@ export class OrgEffects {
   @Effect()
   getOrgsForProject$ = this.actions$.pipe(
       ofType(OrgActionTypes.GET_ALL),
-      mergeMap(({ payload: { server_id } }: GetOrgsForServer) =>
-        this.requests.getOrgsForServer(server_id).pipe(
+      mergeMap(({ payload: { server_id } }: GetOrgs) =>
+        this.requests.getOrgs(server_id).pipe(
           map((resp: OrgsSuccessPayload) => new GetOrgsSuccess(resp)),
           catchError((error: HttpErrorResponse) => observableOf(new GetOrgsFailure(error))))));
 
@@ -141,6 +141,7 @@ export class OrgEffects {
           map((resp: OrgSuccessPayload) => new UpdateOrgSuccess(resp)),
           catchError((error: HttpErrorResponse) =>
             observableOf(new UpdateOrgFailure(error))))));
+
   @Effect()
   updateOrgSuccess$ = this.actions$.pipe(
       ofType(OrgActionTypes.UPDATE_SUCCESS),

--- a/components/automate-ui/src/app/entities/orgs/org.model.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.model.ts
@@ -1,0 +1,7 @@
+export interface Org {
+  id: string;
+  server_id: string;
+  name: string;
+  admin_user: string;
+  admin_key: string;
+}

--- a/components/automate-ui/src/app/entities/orgs/org.reducer.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.reducer.ts
@@ -1,0 +1,104 @@
+import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
+import { HttpErrorResponse } from '@angular/common/http';
+import { set, pipe, unset } from 'lodash/fp';
+
+import { EntityStatus } from 'app/entities/entities';
+import { OrgActionTypes, OrgActions } from './org.actions';
+import { Org } from './org.model';
+
+export interface OrgEntityState extends EntityState<Org> {
+  getAllStatus: EntityStatus;
+  getStatus: EntityStatus;
+  createStatus: EntityStatus;
+  createError: HttpErrorResponse;
+  updateStatus: EntityStatus;
+  deleteStatus: EntityStatus;
+}
+
+const GET_ALL_STATUS = 'getAllStatus';
+const GET_STATUS = 'getStatus';
+const CREATE_STATUS = 'createStatus';
+const CREATE_ERROR = 'createError';
+const DELETE_STATUS = 'deleteStatus';
+const UPDATE_STATUS = 'updateStatus';
+
+export const orgEntityAdapter: EntityAdapter<Org> = createEntityAdapter<Org>();
+
+export const OrgEntityInitialState: OrgEntityState =
+  orgEntityAdapter.getInitialState(<OrgEntityState>{
+    getAllStatus: EntityStatus.notLoaded,
+    getStatus: EntityStatus.notLoaded,
+    createStatus: EntityStatus.notLoaded,
+    createError: null,
+    deleteStatus: EntityStatus.notLoaded,
+    updateStatus: EntityStatus.notLoaded
+  });
+
+export function orgEntityReducer(
+  state: OrgEntityState = OrgEntityInitialState,
+  action: OrgActions): OrgEntityState {
+
+  switch (action.type) {
+    case OrgActionTypes.GET_ALL:
+      return set(GET_ALL_STATUS, EntityStatus.loading, orgEntityAdapter.removeAll(state));
+
+    case OrgActionTypes.GET_ALL_SUCCESS:
+      return pipe(
+        set(GET_ALL_STATUS, EntityStatus.loadingSuccess))
+        (orgEntityAdapter.addAll(action.payload.orgs, state)) as OrgEntityState;
+
+    case OrgActionTypes.GET_ALL_FAILURE:
+      return set(GET_ALL_STATUS, EntityStatus.loadingFailure, state);
+
+    case OrgActionTypes.GET:
+      return set(GET_STATUS, EntityStatus.loading, orgEntityAdapter.removeAll(state));
+
+    case OrgActionTypes.GET_SUCCESS:
+      return set(GET_STATUS, EntityStatus.loadingSuccess,
+        orgEntityAdapter.addOne(action.payload.org, state));
+
+    case OrgActionTypes.GET_FAILURE:
+      return set(GET_STATUS, EntityStatus.loadingFailure, state);
+
+    case OrgActionTypes.CREATE:
+      return set(CREATE_STATUS, EntityStatus.loading, state);
+
+    case OrgActionTypes.CREATE_SUCCESS:
+      return pipe(
+        set(CREATE_STATUS, EntityStatus.loadingSuccess),
+        unset(CREATE_ERROR)
+      )(orgEntityAdapter.addOne(action.payload.org, state)) as OrgEntityState;
+
+    case OrgActionTypes.CREATE_FAILURE:
+      return pipe(
+        set(CREATE_STATUS, EntityStatus.loadingFailure),
+        set(CREATE_ERROR, action.payload)
+      )(state) as OrgEntityState;
+
+    case OrgActionTypes.DELETE:
+      return set(DELETE_STATUS, EntityStatus.loading, state);
+
+    case OrgActionTypes.DELETE_SUCCESS:
+      return set(DELETE_STATUS, EntityStatus.loadingSuccess,
+        orgEntityAdapter.removeOne(action.payload.id, state));
+
+    case OrgActionTypes.DELETE_FAILURE:
+      return set(DELETE_STATUS, EntityStatus.loadingFailure, state);
+
+    case OrgActionTypes.UPDATE:
+      return set(UPDATE_STATUS, EntityStatus.loading, state);
+
+    case OrgActionTypes.UPDATE_SUCCESS:
+      return set(UPDATE_STATUS, EntityStatus.loadingSuccess,
+        orgEntityAdapter.updateOne({
+          id: action.payload.org.id,
+          changes: action.payload.org
+        }, state));
+
+    case OrgActionTypes.UPDATE_FAILURE:
+      return set(UPDATE_STATUS, EntityStatus.loadingFailure, state);
+
+    default:
+      return state;
+  }
+}

--- a/components/automate-ui/src/app/entities/orgs/org.requests.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.requests.ts
@@ -15,25 +15,25 @@ export class OrgRequests {
 
   public getOrgs(server_id: string): Observable<OrgsSuccessPayload> {
     return this.http.get<OrgsSuccessPayload>(
-      `${env.gateway_url}/infra_proxy/servers/${server_id}/orgs`);
+      `${env.infra_proxy_url}/servers/${server_id}/orgs`);
   }
 
   public getOrg(server_id: string, id: string): Observable<OrgSuccessPayload> {
     return this.http.get<OrgSuccessPayload>(
-      `${env.gateway_url}/infra_proxy/servers/${server_id}/orgs/${id}`);
+      `${env.infra_proxy_url}/servers/${server_id}/orgs/${id}`);
   }
 
   public createOrg(org: CreateOrgPayload): Observable<OrgSuccessPayload> {
     return this.http.post<OrgSuccessPayload>(
-      `${env.gateway_url}/infra_proxy/servers/${org.server_id}/orgs`, org);
+      `${env.infra_proxy_url}/servers/${org.server_id}/orgs`, org);
   }
 
   public deleteOrg(server_id: string, id: string): Observable<{}> {
-    return this.http.delete(`${env.gateway_url}/infra_proxy/servers/${server_id}/orgs/${id}`);
+    return this.http.delete(`${env.infra_proxy_url}/servers/${server_id}/orgs/${id}`);
   }
 
   public updateOrg(org: Org): Observable<OrgSuccessPayload> {
     return this.http.put<OrgSuccessPayload>(
-      `${env.gateway_url}/infra_proxy/servers/${org.server_id}/orgs/${org.id}`, org);
+      `${env.infra_proxy_url}/servers/${org.server_id}/orgs/${org.id}`, org);
   }
 }

--- a/components/automate-ui/src/app/entities/orgs/org.requests.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.requests.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment as env } from 'environments/environment';
+import { Org } from './org.model';
+
+import {
+  OrgsSuccessPayload, OrgSuccessPayload, CreateOrgPayload
+} from './org.actions';
+
+@Injectable()
+export class OrgRequests {
+
+  constructor(private http: HttpClient) { }
+
+  public getOrgsForServer(server_id: string): Observable<OrgsSuccessPayload> {
+    return this.http.get<OrgsSuccessPayload>(
+      `${env.gateway_url}/infra_proxy/servers/${server_id}/orgs`);
+  }
+
+  public getOrg(server_id: string, id: string): Observable<OrgSuccessPayload> {
+    return this.http.get<OrgSuccessPayload>(
+      `${env.gateway_url}/infra_proxy/servers/${server_id}/orgs/${id}`);
+  }
+
+  public createOrg(org: CreateOrgPayload): Observable<OrgSuccessPayload> {
+    return this.http.post<OrgSuccessPayload>(
+      `${env.gateway_url}/infra_proxy/servers/${org.server_id}/orgs`, org);
+  }
+
+  public deleteOrg(server_id: string, id: string): Observable<{}> {
+    return this.http.delete(`${env.gateway_url}/infra_proxy/servers/${server_id}/orgs/${id}`);
+  }
+
+  public updateOrg(org: Org): Observable<OrgSuccessPayload> {
+    return this.http.put<OrgSuccessPayload>(
+      `${env.gateway_url}/infra_proxy/servers/${org.server_id}/orgs/${org.id}`, org);
+  }
+}

--- a/components/automate-ui/src/app/entities/orgs/org.requests.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.requests.ts
@@ -13,7 +13,7 @@ export class OrgRequests {
 
   constructor(private http: HttpClient) { }
 
-  public getOrgsForServer(server_id: string): Observable<OrgsSuccessPayload> {
+  public getOrgs(server_id: string): Observable<OrgsSuccessPayload> {
     return this.http.get<OrgsSuccessPayload>(
       `${env.gateway_url}/infra_proxy/servers/${server_id}/orgs`);
   }

--- a/components/automate-ui/src/app/entities/orgs/org.selectors.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.selectors.ts
@@ -1,0 +1,47 @@
+import { createSelector, createFeatureSelector } from '@ngrx/store';
+
+import { routeParams } from 'app/route.selectors';
+import { OrgEntityState, orgEntityAdapter } from './org.reducer';
+
+export const orgState = createFeatureSelector<OrgEntityState>('orgs');
+
+export const {
+  selectAll: allOrgs,
+  selectEntities: orgEntities
+} = orgEntityAdapter.getSelectors(orgState);
+
+export const getAllStatus = createSelector(
+  orgState,
+  (state) => state.getAllStatus
+);
+
+export const getStatus = createSelector(
+  orgState,
+  (state) => state.getStatus
+);
+
+export const createStatus = createSelector(
+  orgState,
+  (state) => state.createStatus
+);
+
+export const createError = createSelector(
+  orgState,
+  (state) => state.createError
+);
+
+export const updateStatus = createSelector(
+  orgState,
+  (state) => state.updateStatus
+);
+
+export const deleteStatus = createSelector(
+  orgState,
+  (state) => state.deleteStatus
+);
+
+export const orgFromRoute = createSelector(
+  orgEntities,
+  routeParams,
+  (state, { orgid }) => state[orgid]
+);

--- a/components/automate-ui/src/app/entities/orgs/org.selectors.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.selectors.ts
@@ -43,5 +43,5 @@ export const deleteStatus = createSelector(
 export const orgFromRoute = createSelector(
   orgEntities,
   routeParams,
-  (state, { orgid }) => state[orgid]
+  (state, { orgId }) => state[orgId]
 );

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -112,14 +112,14 @@
         </ng-container>
       </section>
 
-      <app-org-create-edit-modal
+      <app-create-org-modal
         [visible]="createModalVisible"
         [creating]="creatingServerOrg"
         [createForm]="orgForm"
         (close)="closeCreateModal()"
         [conflictErrorEvent]="conflictErrorEvent"
         (createClicked)="createServerOrg()">
-      </app-org-create-edit-modal>
+      </app-create-org-modal>
       <app-delete-object-modal
         [visible]="deleteModalVisible"
         objectNoun="org"

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -108,7 +108,7 @@
               <chef-table-row>
                 <chef-table-header-cell>Org Name</chef-table-header-cell>
                 <chef-table-header-cell>Admin</chef-table-header-cell>
-                <chef-table-header-cell class="controls"></chef-table-header-cell>
+                <chef-table-header-cell class="three-dot-column"></chef-table-header-cell>
               </chef-table-row>
             </chef-table-header>
             <chef-table-body>
@@ -117,10 +117,10 @@
                   <a [routerLink]="['/infrastructure','chef-servers', server?.id, 'orgs', org.id, 'cookbooks']">{{ org.name }}</a>
                 </chef-table-cell>
                 <chef-table-cell>{{ org.admin_user }}</chef-table-cell>
-                <chef-table-cell class="controls">
-                  <chef-control-menu>
+                <chef-table-cell class="three-dot-column">
+                  <mat-select>
                     <chef-option data-cy="delete" (click)="startOrgDelete(org)">Delete Org</chef-option>
-                  </chef-control-menu>
+                  </mat-select>
                 </chef-table-cell>
               </chef-table-row>
             </chef-table-body>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -30,18 +30,18 @@
         <form [formGroup]="updateServerForm">
           <chef-form-field id="update-name">
             <label>
-              <span class="label">Chef Server Name <span aria-hidden="true">*</span></span>
+              Chef Server Name <span aria-hidden="true">*</span>
               <input chefInput formControlName="name" type="text" autocomplete="off"
                 data-cy="update-chefServer-name">
             </label>
             <chef-error
               *ngIf="(updateServerForm.get('name').hasError('required') || updateServerForm.get('name').hasError('pattern')) && updateServerForm.get('name').dirty">
-              Display Name is required.
+              Name is required.
             </chef-error>
           </chef-form-field>
           <chef-form-field id="update-description">
             <label>
-              <span class="label">Chef Server Description <span aria-hidden="true">*</span></span>
+              Description <span aria-hidden="true">*</span>
               <input chefInput formControlName="description" type="text" autocomplete="off"
                 data-cy="update-chefServer-description">
             </label>
@@ -52,7 +52,7 @@
           </chef-form-field>
           <chef-form-field id="update-fqdn">
             <label>
-              <span class="label">FQDN <span aria-hidden="true">*</span></span>
+              FQDN <span aria-hidden="true">*</span>
               <input chefInput formControlName="fqdn" type="text" autocomplete="off"
                 data-cy="update-chefServer-fqdn">
             </label>
@@ -63,13 +63,13 @@
           </chef-form-field>
           <chef-form-field id="update-ip_address">    
             <label>
-              <span class="label">IP Address <span aria-hidden="true">*</span></span>
+              IP Address <span aria-hidden="true">*</span>
               <input chefInput formControlName="ip_address" type="text" autocomplete="off"
                 data-cy="update-chefServer-ip_address">
             </label>
             <chef-error
               *ngIf="(updateServerForm.get('ip_address').hasError('required') || updateServerForm.get('ip_address').hasError('pattern')) && updateServerForm.get('ip_address').dirty">
-              FQDN is required.
+              IP Address is required.
             </chef-error>
           </chef-form-field>  
           <div id="button-bar">

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -46,7 +46,7 @@
         <form [formGroup]="updateServerForm">
           <chef-form-field id="update-name">
             <label>
-              Chef Server Name <span aria-hidden="true">*</span>
+                <span class="label">Chef Server Name <span aria-hidden="true">*</span></span>
               <input chefInput formControlName="name" type="text" autocomplete="off"
                 data-cy="update-chefServer-name">
             </label>
@@ -57,7 +57,7 @@
           </chef-form-field>
           <chef-form-field id="update-description">
             <label>
-              Description <span aria-hidden="true">*</span>
+              <span class="label">Description <span aria-hidden="true">*</span></span>
               <input chefInput formControlName="description" type="text" autocomplete="off"
                 data-cy="update-chefServer-description">
             </label>
@@ -68,7 +68,7 @@
           </chef-form-field>
           <chef-form-field id="update-fqdn">
             <label>
-              FQDN <span aria-hidden="true">*</span>
+              <span class="label">FQDN <span aria-hidden="true">*</span></span>
               <input chefInput formControlName="fqdn" type="text" autocomplete="off"
                 data-cy="update-chefServer-fqdn">
             </label>
@@ -79,7 +79,7 @@
           </chef-form-field>
           <chef-form-field id="update-ip_address">    
             <label>
-              IP Address <span aria-hidden="true">*</span>
+              <span class="label">IP Address <span aria-hidden="true">*</span></span>
               <input chefInput formControlName="ip_address" type="text" autocomplete="off"
                 data-cy="update-chefServer-ip_address">
             </label>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -1,0 +1,133 @@
+<div class="content-container">
+  <div class="container">
+    <main>
+      <chef-breadcrumbs>
+        <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Server</chef-breadcrumb>
+        {{ server?.name }}
+      </chef-breadcrumbs>
+      <chef-page-header>
+        <chef-heading>{{ server?.name }}</chef-heading>
+        <table>
+          <thead>
+            <tr class="detail-row">
+              <th class="id-column">FQDN</th>
+              <th class="id-column">IP Address</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="detail-row">
+              <td class="id-column">{{ server?.fqdn }}</td>
+              <td class="id-column">{{ server?.ip_address }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <chef-tab-selector [value]="tabValue" (change)="onSelectedTab($event)">
+          <chef-option value='orgs' data-cy="orgs-tab">Orgs</chef-option>
+          <chef-option value='details' data-cy="details-tab">Details</chef-option>
+        </chef-tab-selector>
+      </chef-page-header>
+      <section class="page-body" *ngIf="tabValue === 'details'">
+        <form [formGroup]="updateServerForm">
+          <chef-form-field id="update-name">
+            <label>
+              <span class="label">Chef Server Name <span aria-hidden="true">*</span></span>
+              <input chefInput formControlName="name" type="text" autocomplete="off"
+                data-cy="update-chefServer-name">
+            </label>
+            <chef-error
+              *ngIf="(updateServerForm.get('name').hasError('required') || updateServerForm.get('name').hasError('pattern')) && updateServerForm.get('name').dirty">
+              Display Name is required.
+            </chef-error>
+          </chef-form-field>
+          <chef-form-field id="update-description">
+            <label>
+              <span class="label">Chef Server Description <span aria-hidden="true">*</span></span>
+              <input chefInput formControlName="description" type="text" autocomplete="off"
+                data-cy="update-chefServer-description">
+            </label>
+            <chef-error
+              *ngIf="(updateServerForm.get('description').hasError('required') || updateServerForm.get('description').hasError('pattern')) && updateServerForm.get('description').dirty">
+              Description is required.
+            </chef-error>
+          </chef-form-field>
+          <chef-form-field id="update-fqdn">
+            <label>
+              <span class="label">FQDN <span aria-hidden="true">*</span></span>
+              <input chefInput formControlName="fqdn" type="text" autocomplete="off"
+                data-cy="update-chefServer-fqdn">
+            </label>
+            <chef-error
+              *ngIf="(updateServerForm.get('fqdn').hasError('required') || updateServerForm.get('fqdn').hasError('pattern')) && updateServerForm.get('fqdn').dirty">
+              FQDN is required.
+            </chef-error>
+          </chef-form-field>
+          <chef-form-field id="update-ip_address">    
+            <label>
+              <span class="label">IP Address <span aria-hidden="true">*</span></span>
+              <input chefInput formControlName="ip_address" type="text" autocomplete="off"
+                data-cy="update-chefServer-ip_address">
+            </label>
+            <chef-error
+              *ngIf="(updateServerForm.get('ip_address').hasError('required') || updateServerForm.get('ip_address').hasError('pattern')) && updateServerForm.get('ip_address').dirty">
+              FQDN is required.
+            </chef-error>
+          </chef-form-field>  
+          <div id="button-bar">
+            <chef-button [disabled]="isLoading || !updateServerForm.valid || !updateServerForm.dirty"
+              primary inline (click)="saveServer()">                
+            <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
+            <span *ngIf="saving">Saving...</span>
+            <span *ngIf="!saving">Save</span></chef-button>
+            <span id="saved-note" *ngIf="saveSuccessful && !updateServerForm.dirty">All changes saved.</span>
+          </div>
+        </form>
+      </section>
+      <section class="page-body" *ngIf="tabValue === 'orgs'">
+        <ng-container>
+          <chef-toolbar>
+            <chef-button id="create-button" primary (click)="openCreateModal('create')">Create Org</chef-button>
+          </chef-toolbar>
+          <chef-table-new>
+            <chef-table-header>
+              <chef-table-row>
+                <chef-table-header-cell>Org Name</chef-table-header-cell>
+                <chef-table-header-cell>Admin</chef-table-header-cell>
+                <chef-table-header-cell class="controls"></chef-table-header-cell>
+              </chef-table-row>
+            </chef-table-header>
+            <chef-table-body>
+              <chef-table-row *ngFor="let org of orgs">
+                <chef-table-cell>
+                  <a [routerLink]="['/infrastructure','chef-servers', server?.id, 'orgs', org.id, 'cookbooks']">{{ org.name }}</a>
+                </chef-table-cell>
+                <chef-table-cell>{{ org.admin_user }}</chef-table-cell>
+                <chef-table-cell class="controls">
+                  <chef-control-menu>
+                    <chef-option data-cy="delete" (click)="startOrgDelete(org)">Delete Org</chef-option>
+                  </chef-control-menu>
+                </chef-table-cell>
+              </chef-table-row>
+            </chef-table-body>
+          </chef-table-new>
+        </ng-container>
+      </section>
+
+      <app-org-create-edit-modal
+        [visible]="createModalVisible"
+        [creating]="creatingServerOrg"
+        [createForm]="orgForm"
+        (close)="closeCreateModal()"
+        [conflictErrorEvent]="conflictErrorEvent"
+        (createClicked)="createServerOrg()">
+      </app-org-create-edit-modal>
+      <app-delete-object-modal
+        [visible]="deleteModalVisible"
+        objectNoun="org"
+        [objectName]="orgToDelete?.name"
+        (close)="closeDeleteModal()"
+        (deleteClicked)="deleteOrg()"
+        objectAction="Delete">
+      </app-delete-object-modal>
+    </main>
+  </div>
+</div>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -26,6 +26,22 @@
           <chef-option value='details' data-cy="details-tab">Details</chef-option>
         </chef-tab-selector>
       </chef-page-header>
+      <app-create-org-modal
+        [visible]="createModalVisible"
+        [creating]="creatingServerOrg"
+        [createForm]="orgForm"
+        (close)="closeCreateModal()"
+        [conflictErrorEvent]="conflictErrorEvent"
+        (createClicked)="createServerOrg()">
+      </app-create-org-modal>
+      <app-delete-object-modal
+        [visible]="deleteModalVisible"
+        objectNoun="org"
+        [objectName]="orgToDelete?.name"
+        (close)="closeDeleteModal()"
+        (deleteClicked)="deleteOrg()"
+        objectAction="Delete">
+      </app-delete-object-modal>
       <section class="page-body" *ngIf="tabValue === 'details'">
         <form [formGroup]="updateServerForm">
           <chef-form-field id="update-name">
@@ -111,23 +127,6 @@
           </chef-table-new>
         </ng-container>
       </section>
-
-      <app-create-org-modal
-        [visible]="createModalVisible"
-        [creating]="creatingServerOrg"
-        [createForm]="orgForm"
-        (close)="closeCreateModal()"
-        [conflictErrorEvent]="conflictErrorEvent"
-        (createClicked)="createServerOrg()">
-      </app-create-org-modal>
-      <app-delete-object-modal
-        [visible]="deleteModalVisible"
-        objectNoun="org"
-        [objectName]="orgToDelete?.name"
-        (close)="closeDeleteModal()"
-        (deleteClicked)="deleteOrg()"
-        objectAction="Delete">
-      </app-delete-object-modal>
     </main>
   </div>
 </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -119,7 +119,7 @@
                 <chef-table-cell>{{ org.admin_user }}</chef-table-cell>
                 <chef-table-cell class="three-dot-column">
                   <mat-select>
-                    <chef-option data-cy="delete" (click)="startOrgDelete(org)">Delete Org</chef-option>
+                    <mat-option data-cy="delete" (click)="startOrgDelete(org)">Delete Org</mat-option>
                   </mat-select>
                 </chef-table-cell>
               </chef-table-row>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
@@ -1,0 +1,129 @@
+@import "~styles/variables";
+
+chef-page-header {
+  padding-bottom: 0;
+}
+
+chef-toolbar {
+  display: block;
+  position: relative;
+  margin-bottom: 5px;
+
+  small {
+    bottom: 2px;
+    color: $chef-dark-grey;
+    position: absolute;
+    right: 0;
+  }
+}
+
+chef-tab-selector {
+  chef-option {
+    margin-right: 16px;
+    color: $chef-primary-dark;
+  }
+}
+
+form {
+
+  #update-name {
+    width: 240px;
+  }
+
+  input {
+    font-size: 1em;
+    width: 240px;
+  }
+
+  input[type="text"]:disabled {
+    opacity: 0.5;
+    background-color: $chef-grey;
+    border: none;
+  }
+
+  #changes-not-allowed {
+    font-size: 12px;
+  }
+
+  #button-bar {
+    margin-top: 15px;
+
+    span#saved-note {
+      display: inline-block;
+      margin-top: 5px;
+      font-size: 12px;
+    }
+
+    chef-button {
+      margin-top: 0;
+      margin-left: 0;
+
+      chef-loading-spinner {
+        position: relative;
+        top: 2px;
+        margin-right: 5px;
+      }
+    }
+  }
+}
+
+thead {
+  font-size: 14px;
+  letter-spacing: 0.2px;
+  color: $chef-primary-dark;
+}
+
+th {
+  text-align: left;
+  padding: 0px;
+}
+
+tbody > .detail-row {
+  padding-top: 0px;
+  padding-bottom: 15px;
+}
+
+.detail-row {
+  display: flex;
+  color: $chef-primary-dark;
+}
+
+.id-column {
+  width: 33%;
+  padding-top: 0px;
+  padding-left: 0px;
+}
+
+.type-column {
+  width: 66%;
+  padding-top: 0px;
+  padding-left: 0px;
+}
+
+chef-table-new {
+  .controls {
+    text-align: right;
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+}
+
+.empty-case-container {
+  margin-top: 42px;
+  //display: flex;
+  justify-content: center;
+  //flex-direction: column;
+  text-align: center;
+
+  .empty-case-entry {
+    margin-top: 18px;
+    margin-bottom: 0;
+  }
+
+  p {
+    font-size: 18px;
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.spec.ts
@@ -3,13 +3,12 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ChefServerDetailsComponent } from './chef-server-details.component';
 import { HttpErrorResponse } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
-import { CommonModule }  from '@angular/common';
-import { BrowserModule } from '@angular/platform-browser';
-import { ReactiveFormsModule, FormsModule, FormBuilder } from '@angular/forms';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { MockComponent } from 'ng2-mock-component';
 import { StoreModule, Store } from '@ngrx/store';
+
 import { Org } from 'app/entities/orgs/org.model';
-import { CreateOrgSuccess, CreateOrgFailure } from 'app/entities/orgs/org.actions';
+import { CreateOrgFailure } from 'app/entities/orgs/org.actions';
 import { NgrxStateAtom, ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { HttpStatus } from 'app/types/types';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
@@ -20,15 +19,14 @@ describe('ChefServerDetailsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [
-        CommonModule,
-        BrowserModule,
-        ReactiveFormsModule,
-        FormsModule,
-        RouterTestingModule,
-        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ],
       declarations: [
+        MockComponent({
+          selector: 'app-create-org-modal',
+          inputs: ['visible', 'creating', 'conflictErrorEvent', 'createForm'],
+          outputs: ['close', 'createClicked']
+          }),
+        MockComponent({ selector: 'chef-button',
+          inputs: ['disabled', 'routerLink'] }),
         MockComponent({ selector: 'chef-control-menu' }),
         MockComponent({ selector: 'chef-th' }),
         MockComponent({ selector: 'chef-td' }),
@@ -53,6 +51,12 @@ describe('ChefServerDetailsComponent', () => {
       providers: [
         FeatureFlagsService
       ],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+      ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();
@@ -62,18 +66,6 @@ describe('ChefServerDetailsComponent', () => {
     fixture = TestBed.createComponent(ChefServerDetailsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-    component.updateServerForm = new FormBuilder().group({
-      name: ['', null],
-      description: ['', null],
-      fqdn: ['', null],
-      ip_address: ['', null]
-    });
-
-    component.orgForm = new FormBuilder().group({
-      name: ['', null],
-      admin_user: ['', null],
-      admin_key: ['', null]
-    });
   });
 
   it('should create', () => {
@@ -101,22 +93,9 @@ describe('ChefServerDetailsComponent', () => {
 
     it('opening create modal resets name, description, fqdn and ip_address to empty string', () => {
       component.openCreateModal('create');
-      expect(component.orgForm.controls['name'].value).toEqual('');
-      expect(component.orgForm.controls['admin_user'].value).toEqual('')
-      expect(component.orgForm.controls['admin_key'].value).toEqual('')
-    });
-
-    it('on success, closes modal and adds new server', () => {
-      component.orgForm.controls['name'].setValue(org.name);
-      component.orgForm.controls['admin_user'].setValue(org.admin_user);
-      component.orgForm.controls['admin_key'].setValue(org.admin_key);
-      component.createServerOrg();
-
-      store.dispatch(new CreateOrgSuccess({'org': org}));
-
-      component.orgs.map(orgs => {
-        expect(orgs).toContain(org);
-      });
+      expect(component.orgForm.controls['name'].value).toBe('');
+      expect(component.orgForm.controls['admin_user'].value).toBe('');
+      expect(component.orgForm.controls['admin_key'].value).toBe('');
     });
 
     it('on conflict error, modal is open with conflict error', () => {

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.spec.ts
@@ -1,15 +1,58 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { ChefServerDetailsComponent } from './chef-server-details.component';
+import { HttpErrorResponse } from '@angular/common/http';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CommonModule }  from '@angular/common';
+import { BrowserModule } from '@angular/platform-browser';
+import { ReactiveFormsModule, FormsModule, FormBuilder } from '@angular/forms';
+import { MockComponent } from 'ng2-mock-component';
+import { StoreModule, Store } from '@ngrx/store';
+import { Org } from 'app/entities/orgs/org.model';
+import { CreateOrgSuccess, CreateOrgFailure } from 'app/entities/orgs/org.actions';
+import { NgrxStateAtom, ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
+import { HttpStatus } from 'app/types/types';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 
-xdescribe('ChefServerDetailsComponent', () => {
+describe('ChefServerDetailsComponent', () => {
   let component: ChefServerDetailsComponent;
   let fixture: ComponentFixture<ChefServerDetailsComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ChefServerDetailsComponent ],
+      imports: [
+        CommonModule,
+        BrowserModule,
+        ReactiveFormsModule,
+        FormsModule,
+        RouterTestingModule,
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+      ],
+      declarations: [
+        MockComponent({ selector: 'chef-control-menu' }),
+        MockComponent({ selector: 'chef-th' }),
+        MockComponent({ selector: 'chef-td' }),
+        MockComponent({ selector: 'chef-error' }),
+        MockComponent({ selector: 'chef-form-field' }),
+        MockComponent({ selector: 'chef-heading' }),
+        MockComponent({ selector: 'chef-icon' }),
+        MockComponent({ selector: 'chef-loading-spinner' }),
+        MockComponent({ selector: 'chef-option' }),
+        MockComponent({ selector: 'chef-page-header' }),
+        MockComponent({ selector: 'chef-subheading' }),
+        MockComponent({ selector: 'chef-toolbar' }),
+        MockComponent({ selector: 'chef-table-new' }),
+        MockComponent({ selector: 'chef-table-header' }),
+        MockComponent({ selector: 'chef-table-body' }),
+        MockComponent({ selector: 'chef-table-row' }),
+        MockComponent({ selector: 'chef-table-header-cell' }),
+        MockComponent({ selector: 'chef-table-cell' }),
+        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
+        ChefServerDetailsComponent
+      ],
+      providers: [
+        FeatureFlagsService
+      ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();
@@ -19,9 +62,96 @@ xdescribe('ChefServerDetailsComponent', () => {
     fixture = TestBed.createComponent(ChefServerDetailsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    component.updateServerForm = new FormBuilder().group({
+      name: ['', null],
+      description: ['', null],
+      fqdn: ['', null],
+      ip_address: ['', null]
+    });
+
+    component.orgForm = new FormBuilder().group({
+      name: ['', null],
+      admin_user: ['', null],
+      admin_key: ['', null]
+    });
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('create org', () => {
+    let store: Store<NgrxStateAtom>;
+    const org = <Org> {
+        id: '1',
+        name: 'new org',
+        admin_user: 'new org user',
+        admin_key: 'new admin key'
+      };
+
+    beforeEach(() => {
+      store = TestBed.get(Store);
+    });
+
+    it('openCreateModal opens modal', () => {
+      expect(component.createModalVisible).toBe(false);
+      component.openCreateModal('create');
+      expect(component.createModalVisible).toBe(true);
+    });
+
+    it('opening create modal resets name, description, fqdn and ip_address to empty string', () => {
+      component.openCreateModal('create');
+      expect(component.orgForm.controls['name'].value).toEqual('');
+      expect(component.orgForm.controls['admin_user'].value).toEqual('')
+      expect(component.orgForm.controls['admin_key'].value).toEqual('')
+    });
+
+    it('on success, closes modal and adds new server', () => {
+      component.orgForm.controls['name'].setValue(org.name);
+      component.orgForm.controls['admin_user'].setValue(org.admin_user);
+      component.orgForm.controls['admin_key'].setValue(org.admin_key);
+      component.createServerOrg();
+
+      store.dispatch(new CreateOrgSuccess({'org': org}));
+
+      component.orgs.map(orgs => {
+        expect(orgs).toContain(org);
+      });
+    });
+
+    it('on conflict error, modal is open with conflict error', () => {
+      spyOn(component.conflictErrorEvent, 'emit');
+      component.openCreateModal('create');
+      component.orgForm.controls['name'].setValue(org.name);
+      component.orgForm.controls['admin_user'].setValue(org.admin_user);
+      component.orgForm.controls['admin_key'].setValue(org.admin_key);
+      component.createServerOrg();
+
+      const conflict = <HttpErrorResponse>{
+        status: HttpStatus.CONFLICT,
+        ok: false
+      };
+      store.dispatch(new CreateOrgFailure(conflict));
+
+      expect(component.createModalVisible).toBe(true);
+    });
+
+    it('on create error, modal is closed with failure banner', () => {
+      spyOn(component.conflictErrorEvent, 'emit');
+      component.openCreateModal('create');
+      component.orgForm.controls['name'].setValue(org.name);
+      component.orgForm.controls['admin_user'].setValue(org.admin_user);
+      component.orgForm.controls['admin_key'].setValue(org.admin_key);
+      component.createServerOrg();
+
+      const error = <HttpErrorResponse>{
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
+        ok: false
+      };
+      store.dispatch(new CreateOrgFailure(error));
+
+      expect(component.createModalVisible).toBe(true);
+    });
+
   });
 });

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.spec.ts
@@ -1,0 +1,27 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChefServerDetailsComponent } from './chef-server-details.component';
+
+xdescribe('ChefServerDetailsComponent', () => {
+  let component: ChefServerDetailsComponent;
+  let fixture: ComponentFixture<ChefServerDetailsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ChefServerDetailsComponent ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChefServerDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
@@ -1,0 +1,221 @@
+import { Component, OnInit, OnDestroy, EventEmitter } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { Subject, combineLatest } from 'rxjs';
+import { filter, pluck, takeUntil } from 'rxjs/operators';
+import { identity, isNil } from 'lodash/fp';
+
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { routeParams, routeURL } from 'app/route.selectors';
+import { Regex } from 'app/helpers/auth/regex';
+import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+
+import { EntityStatus, allLoaded, loading } from 'app/entities/entities';
+import {
+  getStatus, serverFromRoute, updateStatus
+} from 'app/entities/servers/server.selectors';
+
+import { Server } from 'app/entities/servers/server.model';
+import { GetServer, UpdateServer } from 'app/entities/servers/server.actions';
+import { GetOrgsForServer, CreateOrg, DeleteOrg } from 'app/entities/orgs/org.actions';
+import { Org } from 'app/entities/orgs/org.model';
+import {
+  allOrgs,
+  getAllStatus as getAllOrgsForServerStatus,
+  deleteStatus as deleteOrgStatus
+} from 'app/entities/orgs/org.selectors';
+
+export type ChefServerTabName = 'orgs' | 'details';
+
+
+
+@Component({
+  selector: 'app-chef-server-details',
+  templateUrl: './chef-server-details.component.html',
+  styleUrls: ['./chef-server-details.component.scss']
+})
+export class ChefServerDetailsComponent implements OnInit, OnDestroy {
+  public server: Server;
+  public orgs: Org[] = [];
+  public tabValue: ChefServerTabName = 'orgs';
+  public url: string;
+  public updateServerForm: FormGroup;
+  public orgForm: FormGroup;
+  public createModalVisible = false;
+  public creatingServerOrg = false;
+  public conflictErrorEvent = new EventEmitter<boolean>();
+  public orgToDelete: Org;
+  public deleteModalVisible = false;
+  public modalType: string;
+  private id: string;
+  public saveSuccessful = false;
+
+  // isLoading represents the initial load as well as subsequent updates in progress.
+  public isLoading = true;
+  public saving = false;
+  private isDestroyed = new Subject<boolean>();
+
+  constructor(
+    private fb: FormBuilder,
+    private store: Store<NgrxStateAtom>,
+    private router: Router,
+    private layoutFacade: LayoutFacadeService
+
+  ) { 
+    
+    this.orgForm = fb.group({
+      name: ['', [Validators.required]],
+      admin_user: ['', [Validators.required]],
+      admin_key: ['', [Validators.required]]
+    });
+  }
+
+  ngOnInit() {
+    this.layoutFacade.showInfastructureSidebar();
+    // Populate our tabValue from the fragment.
+    this.store.select(routeURL).pipe(takeUntil(this.isDestroyed))
+    .subscribe((url: string) => {
+      this.url = url;
+      const [, fragment] = url.split('#');
+      this.tabValue = (fragment === 'details') ? 'details' : 'orgs';
+    });
+
+    this.updateServerForm = this.fb.group({
+      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      description: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      fqdn: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      ip_address: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
+    });
+
+    this.store.select(routeParams).pipe(
+      pluck('id'),
+      filter(identity),
+      takeUntil(this.isDestroyed))
+      .subscribe((id: string) => {
+        this.id = id;
+        this.store.dispatch(new GetServer({ id }));
+        this.store.dispatch(new GetOrgsForServer({ server_id: id }));
+      });
+
+      combineLatest([
+        this.store.select(getStatus),
+        this.store.select(getAllOrgsForServerStatus)
+      ]).pipe(
+        takeUntil(this.isDestroyed)
+      ).subscribe(([getServerSt, getOrgsSt]) => {
+          this.isLoading =
+            !allLoaded([getServerSt, getOrgsSt]);
+        });
+
+      combineLatest([
+        this.store.select(getStatus),
+        this.store.select(getAllOrgsForServerStatus),
+        this.store.select(serverFromRoute),
+        this.store.select(allOrgs)
+      ]).pipe(
+          filter(([getServerSt, getOrgsSt, _serverState, _allOrgsState]) =>
+            getServerSt === EntityStatus.loadingSuccess &&
+            getOrgsSt === EntityStatus.loadingSuccess),
+          filter(([_getServerSt, _getOrgsSt, serverState, allOrgsState]) =>
+            !isNil(serverState) && !isNil(allOrgsState)),
+          takeUntil(this.isDestroyed)
+        ).subscribe(([_getServerSt, _getOrgsSt, ServerState, allOrgsState]) => {
+          this.server = { ...ServerState };
+          this.orgs = allOrgsState;
+          this.updateServerForm.controls['name'].setValue(this.server.name);
+          this.updateServerForm.controls['description'].setValue(this.server.description);
+          this.updateServerForm.controls['fqdn'].setValue(this.server.fqdn);
+          this.updateServerForm.controls['ip_address'].setValue(this.server.ip_address);
+          this.creatingServerOrg = false;
+          this.closeCreateModal();
+        });
+
+        this.store.select(deleteOrgStatus).pipe(
+          filter(status => this.id !== undefined && status === EntityStatus.loadingSuccess),
+          takeUntil(this.isDestroyed))
+          .subscribe(() => {
+            this.store.dispatch(new GetServer({ id: this.id }));
+          });
+  }
+
+  ngOnDestroy(): void {
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
+  }
+
+  onSelectedTab(event: { target: { value: ChefServerTabName } }) {
+    this.tabValue = event.target.value;
+    this.router.navigate([this.url.split('#')[0]], { fragment: event.target.value });
+  }
+
+  public openCreateModal(type: string): void {
+    this.createModalVisible = true;
+    this.modalType = type;
+  }
+
+  public closeCreateModal(): void {
+    this.createModalVisible = false;
+    this.resetCreateModal();
+  }
+
+  public createServerOrg(): void {
+    this.creatingServerOrg = true;
+    const serverOrg = {
+      server_id: this.id,
+      name: this.orgForm.controls['name'].value.trim(),
+      admin_user: this.orgForm.controls['admin_user'].value.trim(),
+      admin_key: this.orgForm.controls['admin_key'].value.trim()
+    };
+    this.store.dispatch(new CreateOrg( serverOrg ));
+  }
+
+  private resetCreateModal(): void {
+    this.creatingServerOrg = false;
+    this.orgForm.reset();
+    this.conflictErrorEvent.emit(false);
+  }
+
+  public startOrgDelete(org: Org): void {
+    this.orgToDelete = org;
+    this.deleteModalVisible = true;
+  }
+
+  public deleteOrg(): void {
+    this.closeDeleteModal();
+    this.store.dispatch(new DeleteOrg(this.orgToDelete));
+  }
+
+  public closeDeleteModal(): void {
+    this.deleteModalVisible = false;
+  }
+
+  saveServer(): void {
+    this.saveSuccessful = false;
+    this.saving = true;
+    const updatedServer = {
+      id: this.server.id,
+      name: this.updateServerForm.controls.name.value.trim(),
+      description: this.updateServerForm.controls.description.value.trim(),
+      fqdn: this.updateServerForm.controls.fqdn.value.trim(),
+      ip_address: this.updateServerForm.controls.ip_address.value.trim()
+    };
+    this.store.dispatch(new UpdateServer({server: updatedServer}));
+    const pendingSave = new Subject<boolean>();
+    this.store.select(updateStatus).pipe(
+      filter(identity),
+      takeUntil(pendingSave))
+      .subscribe((state) => {
+        if (!loading(state)) {
+          pendingSave.next(true);
+          pendingSave.complete();
+          this.saving = false;
+          this.saveSuccessful = (state === EntityStatus.loadingSuccess);
+          if (this.saveSuccessful) {
+            this.updateServerForm.markAsPristine();
+          }
+        }
+      });
+  }
+
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
@@ -18,7 +18,7 @@ import {
 
 import { Server } from 'app/entities/servers/server.model';
 import { GetServer, UpdateServer } from 'app/entities/servers/server.actions';
-import { GetOrgsForServer, CreateOrg, DeleteOrg } from 'app/entities/orgs/org.actions';
+import { GetOrgs, CreateOrg, DeleteOrg } from 'app/entities/orgs/org.actions';
 import { Org } from 'app/entities/orgs/org.model';
 import {
   allOrgs,
@@ -72,7 +72,7 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.layoutFacade.showInfastructureSidebar();
+    this.layoutFacade.showInfrastructureSidebar();
     // Populate our tabValue from the fragment.
     this.store.select(routeURL).pipe(takeUntil(this.isDestroyed))
     .subscribe((url: string) => {
@@ -95,7 +95,7 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
       .subscribe((id: string) => {
         this.id = id;
         this.store.dispatch(new GetServer({ id }));
-        this.store.dispatch(new GetOrgsForServer({ server_id: id }));
+        this.store.dispatch(new GetOrgs({ server_id: id }));
       });
 
     combineLatest([

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
@@ -62,8 +62,8 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
     private router: Router,
     private layoutFacade: LayoutFacadeService
 
-  ) { 
-    
+  ) {
+
     this.orgForm = fb.group({
       name: ['', [Validators.required]],
       admin_user: ['', [Validators.required]],

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
@@ -39,8 +39,7 @@
           <chef-table-body>
             <chef-table-row *ngFor= "let server of sortedChefServers$ | async">
               <chef-table-cell>
-                <!-- TODO : Change router link Once Infra Proxy Orgs Introduced -->
-                <a [routerLink]="['/infrastructure/chef-servers']">{{ server.name }}</a>
+                <a [routerLink]="['/infrastructure/chef-servers', server.id]">{{ server.name }}</a>
               </chef-table-cell>
               <chef-table-cell>{{ server.fqdn }}</chef-table-cell>
               <chef-table-cell>{{ server.ip_address }}</chef-table-cell>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
@@ -5,7 +5,7 @@
       <div class="name-margin"> 
         <chef-form-field>
           <label>
-            <span class="label">Org Name <span aria-hidden="true">*</span></span>
+            Org Name <span aria-hidden="true">*</span>
             <input chefInput name="name" formControlName="name" type="text" data-cy="org-name" autocomplete="off">
           </label>
           <chef-error
@@ -15,7 +15,7 @@
         </chef-form-field>
         <chef-form-field>
           <label>
-            <span class="label">Admin User <span aria-hidden="true">*</span></span>
+            Admin User <span aria-hidden="true">*</span>
             <input chefInput name="admin_user" formControlName="admin_user" type="text" id="admin-input" data-cy="admin-user" autocomplete="off">
           </label>
           <chef-error
@@ -25,7 +25,7 @@
         </chef-form-field>
         <chef-form-field>
           <label>
-            <span class="label">Admin Key <span aria-hidden="true">*</span></span>
+            Admin Key <span aria-hidden="true">*</span>
             <textarea chefInput name="admin_key" id="admin_key" formControlName="admin_key" cols="54" rows="10" placeholder="-----BEGIN RSA PRIVATE KEY -----" autofocus></textarea>
           </label>
           <chef-error
@@ -37,7 +37,7 @@
       <chef-button [disabled]="!createForm?.valid || creating || conflictError"  primary id="create-org-modal-btn" (click)="createServerOrg()">
         <chef-loading-spinner *ngIf="creating"></chef-loading-spinner>
         <span *ngIf="!creating">Create Org</span>
-        <span *ngIf="creating">Creating Org ...</span>
+        <span *ngIf="creating">Creating Org...</span>
       </chef-button>
     </form>
   </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
@@ -1,0 +1,44 @@
+<chef-modal [visible]="visible" (closeModal)="closeEvent()">
+  <h2 slot="title">Create New Org</h2>
+  <div class="flex-container">
+    <form [formGroup]="createForm">
+      <div class="name-margin"> 
+        <chef-form-field>
+          <label>
+            <span class="label">Org Name <span aria-hidden="true">*</span></span>
+            <input chefInput name="name" formControlName="name" type="text" data-cy="org-name" autocomplete="off">
+          </label>
+          <chef-error
+            *ngIf="(createForm.get('name').hasError('required') || createForm.get('name').hasError('pattern')) && createForm.get('name').dirty">
+            Display Name is required.
+          </chef-error>
+        </chef-form-field>
+        <chef-form-field>
+          <label>
+            <span class="label">Admin User <span aria-hidden="true">*</span></span>
+            <input chefInput name="admin_user" formControlName="admin_user" type="text" id="admin-input" data-cy="admin-user" autocomplete="off">
+          </label>
+          <chef-error
+            *ngIf="(createForm.get('admin_user').hasError('required') || createForm.get('admin_user').hasError('pattern')) && createForm.get('admin_user').dirty">
+            Admin user is required.
+          </chef-error>
+        </chef-form-field>
+        <chef-form-field>
+          <label>
+            <span class="label">Admin Key <span aria-hidden="true">*</span></span>
+            <textarea chefInput name="admin_key" id="admin_key" formControlName="admin_key" cols="54" rows="10" placeholder="-----BEGIN RSA PRIVATE KEY -----" autofocus></textarea>
+          </label>
+          <chef-error
+            *ngIf="(createForm.get('admin_key').hasError('required') || createForm.get('admin_key').hasError('pattern')) && createForm.get('admin_key').dirty">
+            Admin key is required.
+          </chef-error>
+        </chef-form-field>
+      </div>
+      <chef-button [disabled]="!createForm?.valid || creating || conflictError"  primary id="create-org-modal-btn" (click)="createServerOrg()">
+        <chef-loading-spinner *ngIf="creating"></chef-loading-spinner>
+        <span *ngIf="!creating">Create Org</span>
+        <span *ngIf="creating">Creating Org ...</span>
+      </chef-button>
+    </form>
+  </div>
+</chef-modal>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
@@ -38,5 +38,8 @@ chef-modal {
         margin-right: 5px;
       }
     }
+    #admin_key {
+      height: 200px !important;
+    }
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
@@ -38,8 +38,9 @@ chef-modal {
         margin-right: 5px;
       }
     }
+
     #admin_key {
-      height: 200px !important;
+      height: 200px;
     }
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
@@ -1,0 +1,42 @@
+@import "~styles/variables";
+
+chef-modal {
+
+  [slot=title] {
+    text-align: center;
+    font-weight: bold;
+    margin-top: 1em;
+    padding-bottom: 12px;
+  }
+
+  .flex-container {
+    display: flex;
+    justify-content: center;
+
+    .margin {
+      margin-bottom: 30px;
+    }
+
+    form {
+      flex-basis: 60%;
+
+      input {
+        font-size: 1em;
+      }
+
+      label {
+        padding-bottom: 0;
+      }
+    }
+
+    #button-bar {
+      text-align: center;
+
+      chef-loading-spinner {
+        position: relative;
+        top: 2px;
+        margin-right: 5px;
+      }
+    }
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.spec.ts
@@ -4,7 +4,7 @@ import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
 import { CreateOrgModalComponent } from './create-org-modal.component';
 import { MockComponent } from 'ng2-mock-component';
 import { RouterTestingModule } from '@angular/router/testing';
-import { CommonModule }  from '@angular/common';
+import { CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
 
 describe('CreateOrgModalComponent', () => {
@@ -21,7 +21,7 @@ describe('CreateOrgModalComponent', () => {
         MockComponent({ selector: 'chef-checkbox' }),
         MockComponent({ selector: 'chef-error' }),
         MockComponent({ selector: 'chef-toolbar' }),
-        MockComponent({ selector: 'chef-modal', inputs: ['visible'] }),
+        MockComponent({ selector: 'chef-modal', inputs: ['visible'] })
       ],
       imports: [
         CommonModule,

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.spec.ts
@@ -1,0 +1,27 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateOrgModalComponent } from './create-org-modal.component';
+
+describe('CreateOrgModalComponent', () => {
+  let component: CreateOrgModalComponent;
+  let fixture: ComponentFixture<CreateOrgModalComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CreateOrgModalComponent ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CreateOrgModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.spec.ts
@@ -1,7 +1,11 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
 import { CreateOrgModalComponent } from './create-org-modal.component';
+import { MockComponent } from 'ng2-mock-component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CommonModule }  from '@angular/common';
+import { BrowserModule } from '@angular/platform-browser';
 
 describe('CreateOrgModalComponent', () => {
   let component: CreateOrgModalComponent;
@@ -9,7 +13,22 @@ describe('CreateOrgModalComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ CreateOrgModalComponent ],
+      declarations: [
+        CreateOrgModalComponent,
+        MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),
+        MockComponent({ selector: 'chef-loading-spinner' }),
+        MockComponent({ selector: 'chef-form-field' }),
+        MockComponent({ selector: 'chef-checkbox' }),
+        MockComponent({ selector: 'chef-error' }),
+        MockComponent({ selector: 'chef-toolbar' }),
+        MockComponent({ selector: 'chef-modal', inputs: ['visible'] }),
+      ],
+      imports: [
+        CommonModule,
+        BrowserModule,
+        ReactiveFormsModule,
+        RouterTestingModule
+      ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();
@@ -18,7 +37,11 @@ describe('CreateOrgModalComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CreateOrgModalComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.createForm = new FormBuilder().group({
+      name: ['', null],
+      admin_user: ['', null],
+      admin_key: ['', null]
+    });
   });
 
   it('should create', () => {

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.ts
@@ -1,0 +1,33 @@
+import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'app-create-org-modal',
+  templateUrl: './create-org-modal.component.html',
+  styleUrls: ['./create-org-modal.component.scss']
+})
+export class CreateOrgModalComponent implements OnInit {
+  // @Input() type: string;
+  @Input() visible = false;
+  @Input() creating = false;
+  @Input() conflictErrorEvent: EventEmitter<boolean>;
+  @Output() close = new EventEmitter();
+  @Output() createClicked = new EventEmitter();
+  @Input() createForm: FormGroup;
+
+  public conflictError = false;
+
+  ngOnInit() {
+    this.conflictErrorEvent.subscribe((isConflict: boolean) => {
+      this.conflictError = isConflict;
+    });
+  }
+
+  closeEvent(): void {
+    this.close.emit();
+  }
+
+  createServerOrg(): void {
+    this.createClicked.emit();
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.ts
@@ -7,7 +7,6 @@ import { FormGroup } from '@angular/forms';
   styleUrls: ['./create-org-modal.component.scss']
 })
 export class CreateOrgModalComponent implements OnInit {
-  // @Input() type: string;
   @Input() visible = false;
   @Input() creating = false;
   @Input() conflictErrorEvent: EventEmitter<boolean>;

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
@@ -7,11 +7,15 @@ import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { ChefComponentsModule } from 'app/components/chef-components.module';
 import { ChefServersListComponent } from './chef-servers-list/chef-servers-list.component';
 import { CreateChefServerModalComponent } from './create-chef-server-modal/create-chef-server-modal.component';
+import { ChefServerDetailsComponent } from './chef-server-details/chef-server-details.component';
+import { CreateOrgModalComponent } from './create-org-modal/create-org-modal.component';
 
 @NgModule({
   declarations: [
     ChefServersListComponent,
-    CreateChefServerModalComponent
+    CreateChefServerModalComponent,
+    ChefServerDetailsComponent,
+    CreateOrgModalComponent
   ],
   imports: [
     CommonModule,

--- a/components/automate-ui/src/app/ngrx.effects.ts
+++ b/components/automate-ui/src/app/ngrx.effects.ts
@@ -19,6 +19,7 @@ import { ProjectsFilterEffects } from './services/projects-filter/projects-filte
 import { RoleEffects } from './entities/roles/role.effects';
 import { RuleEffects } from './entities/rules/rule.effects';
 import { ServerEffects } from './entities/servers/server.effects';
+import { OrgEffects } from './entities/orgs/org.effects';
 import { ServiceGroupsEffects } from './entities/service-groups/service-groups.effects';
 import { ScannerEffects } from './pages/+compliance/+scanner/state/scanner.effects';
 import { SidebarEffects } from './services/sidebar/sidebar.effects';
@@ -45,6 +46,7 @@ import { UserPermEffects } from './entities/userperms/userperms.effects';
       RoleEffects,
       RuleEffects,
       ServerEffects,
+      OrgEffects,
       ServiceGroupsEffects,
       ScannerEffects,
       SidebarEffects,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -28,6 +28,7 @@ import * as projectEntity from './entities/projects/project.reducer';
 import * as roleEntity from './entities/roles/role.reducer';
 import * as ruleEntity from './entities/rules/rule.reducer';
 import * as serverEntity from './entities/servers/server.reducer';
+import * as orgEntity from './entities/orgs/org.reducer';
 import * as serviceGroups from './entities/service-groups/service-groups.reducer';
 import * as teamEntity from './entities/teams/team.reducer';
 import * as userEntity from './entities/users/user.reducer';
@@ -65,6 +66,7 @@ export interface NgrxStateAtom {
   roles: roleEntity.RoleEntityState;
   rules: ruleEntity.RuleEntityState;
   servers: serverEntity.ServerEntityState;
+  orgs: orgEntity.OrgEntityState;
   serviceGroups: serviceGroups.ServiceGroupsEntityState;
   teams: teamEntity.TeamEntityState;
   userperms: permEntity.PermEntityState;
@@ -170,6 +172,7 @@ export const defaultInitialState = {
   roles: roleEntity.RoleEntityInitialState,
   rules: ruleEntity.RuleEntityInitialState,
   servers: serverEntity.ServerEntityInitialState,
+  orgs: orgEntity.orgEntityAdapter.getInitialState,
   serviceGroups: serviceGroups.ServiceGroupEntityInitialState,
   teams: teamEntity.TeamEntityInitialState,
   userperms: permEntity.initialState,
@@ -209,6 +212,7 @@ export const ngrxReducers = {
   roles: roleEntity.roleEntityReducer,
   rules: ruleEntity.ruleEntityReducer,
   servers: serverEntity.serverEntityReducer,
+  org: orgEntity.orgEntityReducer,
   serviceGroups: serviceGroups.serviceGroupsEntityReducer,
   teams: teamEntity.teamEntityReducer,
   userperms: permEntity.permEntityReducer,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -212,7 +212,7 @@ export const ngrxReducers = {
   roles: roleEntity.roleEntityReducer,
   rules: ruleEntity.ruleEntityReducer,
   servers: serverEntity.serverEntityReducer,
-  org: orgEntity.orgEntityReducer,
+  orgs: orgEntity.orgEntityReducer,
   serviceGroups: serviceGroups.serviceGroupsEntityReducer,
   teams: teamEntity.teamEntityReducer,
   userperms: permEntity.permEntityReducer,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -172,7 +172,7 @@ export const defaultInitialState = {
   roles: roleEntity.RoleEntityInitialState,
   rules: ruleEntity.RuleEntityInitialState,
   servers: serverEntity.ServerEntityInitialState,
-  orgs: orgEntity.orgEntityAdapter.getInitialState,
+  orgs: orgEntity.OrgEntityInitialState,
   serviceGroups: serviceGroups.ServiceGroupEntityInitialState,
   teams: teamEntity.TeamEntityInitialState,
   userperms: permEntity.initialState,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Code changes for the introduction of infra proxy module in automate-ui In order to make a single source of truth for chef infra org data here

In this PR following points we have covered:

Created infra-proxy module in automate-ui to keep all infra-proxy related component separate
Designed infra proxy UI flows and used Infra-proxy-service

### :chains: Related Resources
Refered Wireframes: https://chef.invisionapp.com/share/PZSLN5TJ8B9#/screens/369724921
For feature, description refer: #1544
### :+1: Definition of Done
I have added infra proxy module and UI new pages

1. chef server details page 
   - Orgs (List of orgs)
   - Details (see the server details and the user can also update the server details )

2. create org popup modal
### :athletic_shoe: How to Build 

 - build components/infra-proxy-service
 - rebuild components/automate-gateway
 - rebuild components/automate-deployment
 - build components/automate-ui

### :information_source: Note
NOTE: This PR is dependent on PR https://github.com/chef/automate/pull/2581 so build steps are depending on the same for Infra-proxy-service 

### :camera: Screenshots
![server_details](https://user-images.githubusercontent.com/12297653/71721677-fcfbb280-2e4b-11ea-9234-0503cf0e1cd6.png)
![server_details1](https://user-images.githubusercontent.com/12297653/71721681-0422c080-2e4c-11ea-9b43-df1a68d9c0f5.png)
![create_org_modal](https://user-images.githubusercontent.com/12297653/71721685-0ab13800-2e4c-11ea-9d66-d360d2327c03.png)

