### PR TITLE
Correcting a Command on the IAMv1 Docs

### DIFF
--- a/components/automate-chef-io/content/docs/iam-v1-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v1-overview.md
@@ -81,7 +81,7 @@ Here is a concrete example, granting `read` permission for the user `user@exampl
 and for the members of `team:ldap:ops` on resource `cfgmgmt:nodes:*`:
 
 ```bash
-curl -s -H "api-token: $TOKEN" -H "Content-Type: application/json" -d '{"subjects":["user:local:user@example.com"], "action":"read", "resource":"cfgmgmt:nodes:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies?pretty
+curl -s -H "api-token: $TOKEN" -H "Content-Type: application/json" -d '{"subjects":["user:local:user@example.com", "team:ldap:ops"], "action":"read", "resource":"cfgmgmt:nodes:*"}' https://{{< example_fqdn "automate" >}}/api/v0/auth/policies?pretty
 ```
 
 ### Action


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The below command was missing the "team:ldap:ops" from the subjects. 
`curl -s -H "api-token: $TOKEN" -H "Content-Type: application/json" -d '{"subjects":["user:local:user@example.com"], "action":"read", "resource":"cfgmgmt:nodes:*"}' https://automate.example.com/api/v0/auth/policies?pretty`

https://automate.chef.io/docs/iam-v1-overview/#structure

### :camera: Screenshots, if applicable
Below is what the docs look like after the correction. 
![image](https://user-images.githubusercontent.com/1679247/72299264-27e8c200-3615-11ea-9bd2-68b4cdb9713a.png)

