### PR TITLE
updates to feature flag text + styles

### DIFF
--- a/components/automate-ui/src/app/components/sidebar-no-shade/sidebar-no-shade.component.scss
+++ b/components/automate-ui/src/app/components/sidebar-no-shade/sidebar-no-shade.component.scss
@@ -7,7 +7,7 @@
   overflow-y: auto;
   width: $sidebar-width;
   height: 100vh;
-  background-color: #FFF;
+  background-color: $chef-white;
   border-right: 1px solid #DFE3E5;
 
   .sidebar-selector {

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.scss
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.scss
@@ -7,7 +7,7 @@
   overflow-y: auto;
   width: $sidebar-width;
   height: 100%;
-  background-color: #FFF;
+  background-color: $chef-white;
   border-right: 1px solid #DFE3E5;
 
   .sidebar-selector {

--- a/components/automate-ui/src/app/modules/license/license-notifications/license-notifications.component.scss
+++ b/components/automate-ui/src/app/modules/license/license-notifications/license-notifications.component.scss
@@ -9,7 +9,7 @@
   button.link {
     background: none;
     border: 0;
-    color: #FFF;
+    color: $chef-white;
     cursor: pointer;
     padding: 0;
     text-decoration: underline;

--- a/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.html
+++ b/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.html
@@ -30,7 +30,7 @@
     </div>
     <div *ngIf="features.length === 0"><b>There are currently no {{ flagType }} features to select.</b></div>
     <div class="buttons">
-      <chef-button (click)="closeModal()" primary>Close</chef-button>
+      <chef-button id="cancel-button" (click)="closeModal()" primary>Close</chef-button>
     </div>
   </div>
 </div>

--- a/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.html
+++ b/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.html
@@ -1,14 +1,14 @@
 <div class="feature-flags" [class.active]="isVisible">
   <div class="modal-content">
+    <chef-button class="close" (click)="closeModal()" secondary>
+      <chef-icon>close</chef-icon>
+    </chef-button>
     <div>
       <div class="header">
-        <chef-icon class="icon">flag</chef-icon>
-        <span class="text">Feature Flags</span>
-        <chef-button class="close" (click)="closeModal()" secondary>
-          <chef-icon>close</chef-icon>
-        </chef-button>
+        <h1>Feature Flags</h1>
       </div>
-      <p class="warning"> {{ warning }} </p>    </div>
+      <p class="warning"> {{ warning }} </p>
+    </div>
     <div class="features" *ngIf="features.length > 0">
       <div class="feature" *ngFor="let feature of features">
         <div (click)="updateFlag(feature)" class="title-desc">
@@ -30,7 +30,7 @@
     </div>
     <div *ngIf="features.length === 0"><b>There are currently no {{ flagType }} features to select.</b></div>
     <div class="buttons">
-      <chef-button id="cancel-button" (click)="closeModal()" secondary>CLOSE</chef-button>
+      <chef-button (click)="closeModal()" primary>Close</chef-button>
     </div>
   </div>
 </div>

--- a/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.scss
+++ b/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.scss
@@ -18,7 +18,7 @@
 
   .modal-content {
     margin: 15% auto;
-    background-color: #FFF;
+    background-color: $chef-white;
     padding: 30px;
     position: relative;
     width: 50%;

--- a/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.scss
+++ b/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.scss
@@ -18,38 +18,38 @@
 
   .modal-content {
     margin: 15% auto;
-    background-color: $gray-pale;
-    padding: 20px;
-    border: 1px solid $gray7;
+    background-color: #fff;
+    padding: 30px;
+    position: relative;
     width: 50%;
 
     .header {
       position: relative;
-      padding: 10px 0 20px;
 
-      .icon {
-        font-size: 22px;
+      h1 {
+        font-size: 24px;
+        font-weight: 700;
+        text-align: center;
+        margin-top: 24px;
+        padding-bottom: 4px;
       }
+    }
 
-      .text {
-        margin-left: 5px;
-        font-size: 20px;
-      }
-
-      .close {
-        position: absolute;
-        right: 0;
-        top: 0;
-      }
+    .close {
+      position: absolute;
+      right: 5px;
+      top: 5px;
     }
 
     .warning {
-      font-size: 16px;
-      padding-bottom: 14px;
-      margin-bottom: 0px;
+      color: var(--chef-dark-grey);
+      font-size: 13px;
+      padding-bottom: 16px;
+      margin-bottom: 8px;
     }
 
     .features {
+      margin-bottom: 20px;
 
       .feature {
         overflow: hidden;
@@ -67,7 +67,7 @@
 
           .title {
             font-size: 16px;
-            font-weight: bold;
+            font-weight: 400;
             margin-top: 12px;
             margin-bottom: 12px;
           }
@@ -84,8 +84,9 @@
       }
     }
 
-    #cancel-button {
-      margin: 20px 0 0;
+    .buttons {
+      display: flex;
+      justify-content: center;
     }
 
     .onoffswitch {

--- a/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.scss
+++ b/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.scss
@@ -18,7 +18,7 @@
 
   .modal-content {
     margin: 15% auto;
-    background-color: #fff;
+    background-color: #FFF;
     padding: 30px;
     position: relative;
     width: 50%;

--- a/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.ts
+++ b/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.ts
@@ -40,15 +40,8 @@ export class FeatureFlagsComponent implements OnInit {
   public warning: string;
   public flagType: FlagTypes;
 
-  betaWarning = 'The flagged features below have not yet been made generally available. If you ' +
-                'choose to turn them on, be aware that they may contain bugs that could reduce ' +
-                'performance, make the experience poor, or break everything. The warranties in ' +
-                'your license agreement do not apply to the flagged features – they are ' +
-                'provided "as is" with no warranties of any kind, whether express or implied, ' +
-                'and Chef will have no liability to you for any problems in or caused by the ' +
-                'flagged features or any related documentation, whether direct, indirect, ' +
-                'special or consequential, including lost profits or data (our lawyer made us ' +
-                'add the last part).';
+  betaWarning = 'The warranties and indemnities in your license agreement do not apply ' + 
+                'to experimental features. Experimental features are provided "as is" ' + 'with no warranties of any kind, express or implied. Chef disclaims any ' + 'and all liability related in any way to the experimental features or ' + 'any related documentation.';
 
   legacyWarning = 'The flagged features below are in legacy status, meaning they have been ' +
                   'replaced with new functionality in the product.  Legacy features will be ' +

--- a/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.ts
+++ b/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.ts
@@ -40,8 +40,11 @@ export class FeatureFlagsComponent implements OnInit {
   public warning: string;
   public flagType: FlagTypes;
 
-  betaWarning = 'The warranties and indemnities in your license agreement do not apply ' + 
-                'to experimental features. Experimental features are provided "as is" ' + 'with no warranties of any kind, express or implied. Chef disclaims any ' + 'and all liability related in any way to the experimental features or ' + 'any related documentation.';
+  betaWarning = 'The warranties and indemnities in your license agreement do not apply ' +
+                'to experimental features. Experimental features are provided "as is" ' +
+                'with no warranties of any kind, express or implied. Chef disclaims any ' +
+                'and all liability related in any way to the experimental features or ' +
+                'any related documentation.';
 
   legacyWarning = 'The flagged features below are in legacy status, meaning they have been ' +
                   'replaced with new functionality in the product.  Legacy features will be ' +

--- a/components/automate-ui/src/app/page-components/json-tree/json-tree.component.scss
+++ b/components/automate-ui/src/app/page-components/json-tree/json-tree.component.scss
@@ -66,7 +66,7 @@
 }
 
 ::ng-deep .jsontree_bg {
-  background: #FFF;
+  background: $chef-white;
 }
 
 /* Styles for the container of the tree (e.g. fonts, margins etc.) */
@@ -149,7 +149,7 @@
 }
 
 ::ng-deep .jsontree_node_expanded > .jsontree_label-wrapper > .jsontree_label > .jsontree_expand-button {
-  background: #FFF;
+  background: $chef-white;
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAJCAIAAABv85FHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3gUBFAwe2SlGKQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAARUlEQVQI132PwQ3AMAwCjdWd8QhMbfrIo1Ga5D4IYYEM21UVPyQFSe8gmfOt7dlmnHmGLJOSvmyY7s7MfSeA496S4fLfC/74Ll1MLvV+AAAAAElFTkSuQmCC");
 }
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.scss
@@ -25,7 +25,7 @@ chef-page {
 
   chef-error {
     background-color: #DC267F;
-    color: #FFFFFF;
+    color: $chef-white;
     border-radius: 0 0 4px 4px;
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
@jyan-chef recently worked with legal to refine the feature flag text for Workstation; this pr updates that text to match in Automate too.. yay for consistency! i also made a few style changes to get this modal a bit closer to the rest of the modals in Automate. Note: those toggles prolly need to be updated too, to the angular material component, but will leave those as-is for now.

### :chains: Related Resources
#### Feature Flag Text
(from legal)
"The warranties and indemnities in your license agreement do not apply to experimental features. Experimental features are provided "as is" with no warranties of any kind, express or implied. Chef disclaims any and all liability related in any way to the experimental features or any related documentation."

### :+1: Definition of Done
Feature flag text is refined and the feature flag modal still works as before.

### :athletic_shoe: How to Build and Test the Change

1. `rebuild components/automate-ui-devproxy`
1. type `feat` from any page in the automate ui

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](../CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
#### before
<img width="1229" alt="feature-flag-modal-before" src="https://user-images.githubusercontent.com/5489125/72308774-f6caba80-3631-11ea-8159-cca5bef92731.png">

#### after
<img width="1227" alt="feature-flag-modal" src="https://user-images.githubusercontent.com/5489125/72307910-ae5ecd00-3630-11ea-8051-1c2d00a04a13.png">
