### PR TITLE
Use 1 for the first page of paginated profile results.

### DIFF
--- a/components/compliance-service/api/tests/01_market_spec.rb
+++ b/components/compliance-service/api/tests/01_market_spec.rb
@@ -181,7 +181,7 @@ describe File.basename(__FILE__) do
 
   it "limits list results when per_page parameter is present" do
     actual_data = GRPC profiles, :list, Profiles::Query.new(
-      page: 0,
+      page: 1,
       per_page: 1
     )
     expected_data = {
@@ -206,7 +206,7 @@ describe File.basename(__FILE__) do
 
   it "limits list results when requesting a higher page number" do
     actual_data = GRPC profiles, :list, Profiles::Query.new(
-      page: 1,
+      page: 2,
       per_page: 1
     )
     expected_data = {

--- a/components/compliance-service/profiles/db/store.go
+++ b/components/compliance-service/profiles/db/store.go
@@ -455,10 +455,18 @@ func (s *Store) ListProfilesMetadata(req ProfilesListRequest) ([]inspec.Metadata
 		sql = sql.Where(terms)
 	}
 
-	// For backwards compatibility, pagination needs to be optional. Including a value for PerPage is how a caller can opt-in to pagination.
-	if req.PerPage > 0 {
+	// For backwards compatibility, pagination needs to be optional, so only paginate when either parameter has been set.
+	if req.Page > 0 || req.PerPage > 0 {
 		perPage := uint64(req.PerPage)
-		page := uint64(req.Page)
+		page := uint64(req.Page) - 1
+
+		if req.Page < 1 {
+			page = 0
+		}
+
+		if req.PerPage < 1 {
+			perPage = 100
+		}
 
 		sql = sql.
 			Limit(perPage).


### PR DESCRIPTION
As we discovered in #2616, using 0 to represent the first page of paginated results is not necessarily as intuitive as I had originally thought. Given that using 1 for the first page is [somewhat of a convention in automate](https://github.com/chef/automate/blob/d8f6e7482050126e83906d242f56c6c69dbdc7c9/components/applications-service/pkg/params/pagination.go#L10) and is [also used in popular pagination libraries](https://github.com/kaminari/kaminari/blob/master/README.md#the-page-scope), it seems like a good idea to change this.