### PR TITLE
Deactivate modifyObstructiveCode cypress flag

### DIFF
--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,4 +1,5 @@
 {
+  "modifyObstructiveCode": false,
   "projectId": "yvg8zo",
   "defaultCommandTimeout": 25000,
   "pageLoadTimeout": 80000,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Cypress started failing recently on every test--
but only on some local machines (Brenna and Michael)
and not others (Tyler) and not buildkite.

<img width="448" alt="image" src="https://user-images.githubusercontent.com/6817500/72386493-54b0de00-36d6-11ea-85ea-00090f906543.png">

Isolated it to this line of code:
https://github.com/chef/automate/blob/04edc6fc9930ab6d2d0c2b9fabb3842a5dc4a8ef/e2e/cypress/support/index.ts#L53

Trials by all auth team members could not conclusively isolate what environmental settings caused it to fail or not, but this at least seems to fix it on those having problems.

Let's see if this holds muster for everyone and buildkite.

### :chains: Related Resources

 - Fix came from [this StackOverflow post](https://stackoverflow.com/a/57933501)
 - Documentation for [modifyObstructiveCode](https://docs.cypress.io/guides/references/configuration.html#modifyObstructiveCode)
 - A related [story of pain](https://github.com/cypress-io/cypress/issues/4889)

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

Setup Cypress per e2e/readme.md.
Run Cypress tests (e.g. `npm run cypress:open`).
Run any test and see that the above error does not occur.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](../CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
