### PR TITLE
update binlinks when upgrading go in expeditor environment

### DIFF
--- a/.expeditor/generate-automate-cli-docs.sh
+++ b/.expeditor/generate-automate-cli-docs.sh
@@ -6,7 +6,7 @@ mkdir -p /go/src/github.com/chef
 ln -s /workspace /go/src/github.com/chef/automate
 
 # bumping expeditor to go 1.13
-hab pkg install --binlink core/go/1.13.5
+hab pkg install --binlink core/go/1.13.5 --force
 
 pushd /go/src/github.com/chef/automate/components/automate-cli
   make docs


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

In 3cc632ce6fab8aa346de7b83e0177b27811c804a we modified the script that builds the CLI docs so it upgrades go to 1.13 in the expeditor environment. However, we didn't use `--force` to overwrite existing binlinks. We are now seeing builds fail where `.expeditor/generate-automate-cli-docs.sh` is stuck with a too-old version of go, and in the logs for those builds, we see 

```
Â» Binlinking go from core/go/1.13.5/20191212163200 into /bin
Â» Binlinking gofmt from core/go/1.13.5/20191212163200 into /bin
Ã˜ Skipping binlink because go already exists at /bin/go. Use --force to overwrite
Ã˜ Skipping binlink because gofmt already exists at /bin/gofmt. Use --force to overwrite
```

Here we add `--force` so that we get the desired effect of upgrading go.

### :chains: Related Resources

Chef employees can log into the VPN to see https://logs.cd.chef.co/raw/chef-automate-master-staged_workload_released-chef-automate-master-post_merge-2020-01-14t22-15-19-00-00

