### PR TITLE
Update the create user notification banner

### DIFF
--- a/components/automate-ui/src/app/entities/users/user.effects.ts
+++ b/components/automate-ui/src/app/entities/users/user.effects.ts
@@ -178,7 +178,7 @@ export class UserEffects {
     map(( { payload: user }: CreateUserSuccess)  =>
       new CreateNotification({
         type: Type.info,
-        message: `Created user: ${user.id}`
+        message: `Created user: ${user.id}.`
       })
     ));
 

--- a/components/automate-ui/src/app/entities/users/user.effects.ts
+++ b/components/automate-ui/src/app/entities/users/user.effects.ts
@@ -175,10 +175,12 @@ export class UserEffects {
   @Effect()
   createUserSuccess$ = this.actions$.pipe(
     ofType(UserActionTypes.CREATE_SUCCESS),
-    map(() => new CreateNotification({
-      type: Type.info,
-      message: 'Successfully created a new user'
-    })));
+    map(( { payload: user }: CreateUserSuccess)  =>
+      new CreateNotification({
+        type: Type.info,
+        message: `Created user: ${user.id}`
+      })
+    ));
 
   @Effect()
   createUserFailure$ = this.actions$.pipe(

--- a/components/automate-ui/src/app/modules/user/user-table/user-table.component.html
+++ b/components/automate-ui/src/app/modules/user/user-table/user-table.component.html
@@ -16,7 +16,7 @@
     <chef-table-new>
       <chef-table-header>
         <chef-table-row>
-          <chef-table-header-cell class="name-column">Name</chef-table-header-cell>
+          <chef-table-header-cell class="name-column">Display Name</chef-table-header-cell>
           <chef-table-header-cell class="username-column">Username</chef-table-header-cell>
           <chef-table-header-cell class="three-dot-column"></chef-table-header-cell>
         </chef-table-row>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Change user notification on the creation of user to display "Created user: <user's username>." Where <user's username> is the user's ID.  Also, update the column header to "Display Name". 

### :chains: Related Resources
https://github.com/chef/automate/issues/2623

### :+1: Definition of Done
The notification banner displays the user's ID after a user is created. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/autoate-ui && start_all_services`
1. Open https://a2-dev.test/settings/users
1. Ensure the column header is "Display Name" and not "Name"
1. Create a new user. 
1. Ensure after the user is created ensure the notification banner displays "Created user: <user's username>." like the image below. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![new_user](https://user-images.githubusercontent.com/1679247/72392511-271f6100-36e5-11ea-8ad5-0b53f629eb69.png)
