### PR TITLE
updating a link in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 ### :white_check_mark: Checklist
 
-- [ ] I have read the [CONTRIBUTING document](../CONTRIBUTING.md).
+- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
 - [ ] Tests added/updated?
 - [ ] Docs added/updated?
 - [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Updating this PR template to fix the "CONTRIBUTING document" link to point to https://github.com/chef/automate/blob/master/CONTRIBUTING.md. 

### :athletic_shoe: How to Build and Test the Change
Create a new PR after this one is merged then ensure the link to the CONTRIBUTING document is correct. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](../CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
