### PR TITLE
Data feeds page UI changes - general with empty state

### DIFF
--- a/components/automate-ui/src/app/components/settings-sidebar/settings-sidebar.component.html
+++ b/components/automate-ui/src/app/components/settings-sidebar/settings-sidebar.component.html
@@ -5,7 +5,7 @@
       <chef-sidebar-entry route="/settings/notifications" icon="notifications">Notifications</chef-sidebar-entry>
     </app-authorized>
     <app-authorized #data_feed [anyOf]="['/datafeed/destinations', 'post']">
-      <chef-sidebar-entry *ngIf="featureFlagOn" route="/settings/data-feed" icon="notifications">Data Feeds</chef-sidebar-entry>
+      <chef-sidebar-entry *ngIf="featureFlagOn" route="/settings/data-feed" icon="assignment">Data Feeds</chef-sidebar-entry>
     </app-authorized>
     <app-authorized #integrations [anyOf]="['/nodemanagers/search', 'post']">
       <chef-sidebar-entry route="/settings/node-integrations" icon="settings_input_component">Node Integrations</chef-sidebar-entry>

--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -149,7 +149,7 @@ export class LayoutSidebarService {
                     },
                     {
                         name: 'Data Feeds',
-                        icon: 'notifications',
+                        icon: 'assignment',
                         route: '/settings/data-feed',
                         authorized: {
                             name: 'data_feed',

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.html
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.html
@@ -31,7 +31,7 @@
             <chef-tr>
               <chef-th class="sort" (click)="toggleSort('name')">
                 <div class="text-and-sort-icons">
-                  <span>Endpoint Name</span>
+                  <span>Name</span>
                   <chef-icon aria-hidden="true" id="{{sortIcon('name')}}" class="sort-icon">arrow_drop_up</chef-icon>
                 </div>
               </chef-th>

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.html
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.html
@@ -6,8 +6,8 @@
   <div class="container">
     <main>
       <chef-page-header [contrasting-background]="false">
-        <chef-heading>Data Feed Destinations</chef-heading>
-        <chef-subheading>Data Feed Destinations for bulk client data and compliance reports.</chef-subheading>
+        <chef-heading>Data Feeds</chef-heading>
+        <chef-subheading>Data Feed for bulk client data and compliance reports.</chef-subheading>
       </chef-page-header>
 
       <div class="page-body">
@@ -17,10 +17,10 @@
 
         <app-authorized [anyOf]="['/datafeed/destination', 'post']">
           <div *ngIf="(destinations$ | async)?.length === 0" class="empty-state">
-            <p>Create the first datafeed endpoint to get started!</p>
+            <p>Create a data feed to get started!</p>
           </div>
           <div [ngClass]="(destinations$ | async)?.length === 0 ? 'empty-state' : ''">
-            <chef-button primary [routerLink]="['/settings/data-feed/form']">Create Destination</chef-button>
+            <chef-button primary [routerLink]="['/settings/data-feed/form']">Create Data Feed</chef-button>
           </div>
         </app-authorized>
 


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description
The new data feed page needs to be updated to be consistent with the rest of Automate.
**Design Details**: 
 **Empty state**

- change data feeds left-nav icon to assignment
- change h1 to Data Feeds
- change empty message to Create a data feed to get started!
- change the primary button to Create Data Feed
- change only column header to Name

### :chains: Related Resources
fixes #2745
### :+1: Definition of Done
I have added some UI changes for the data feeds page.
### :athletic_shoe: How to Build and Test the Change
youll need to turn on the service now CMDB feature flag to see the left nav item, type `feat` anywhere in the ui
build components/automate-ui
### :camera: Screenshots
![Chef Automate](https://user-images.githubusercontent.com/12297653/72444282-c3289580-37d5-11ea-85ec-e60f819f6014.png)