### PR TITLE
roll back diagnostics test change

### DIFF
--- a/components/automate-cli/pkg/diagnostics/integration/iam_v2.go
+++ b/components/automate-cli/pkg/diagnostics/integration/iam_v2.go
@@ -61,7 +61,7 @@ func CreateIAMV2Diagnostic() diagnostics.Diagnostic {
 			vsn := struct {
 				Version struct{ Major, Minor string }
 			}{}
-			err := MustJSONDecodeSuccess(tstCtx.DoLBRequest("/apis/iam/v2/policy_version")).WithValue(&vsn)
+			err := MustJSONDecodeSuccess(tstCtx.DoLBRequest("/apis/iam/v2beta/policy_version")).WithValue(&vsn)
 			if err != nil {
 				return false, "", err
 			}

--- a/integration/tests/airgap_ow_upgrade.sh
+++ b/integration/tests/airgap_ow_upgrade.sh
@@ -4,7 +4,6 @@
 test_name="airgap_ow_upgrade"
 test_upgrades=true
 test_diagnostics_filters="~purge"
-test_diagnostics_pre_upgrade_filters="~skip-for-deep-upgrade"
 
 CURRENT_OLDEST_VERSION=20190501153509
 OLD_MANIFEST_DIR="${A2_ROOT_DIR}/components/automate-deployment/testdata/old_manifests/"

--- a/integration/tests/ha_data_services_migrate.sh
+++ b/integration/tests/ha_data_services_migrate.sh
@@ -5,7 +5,6 @@ test_name="ha_data_services_migrate"
 test_external_services=(ha_backend)
 test_diagnostics_filters="~purge"
 test_upgrades=true
-test_diagnostics_pre_upgrade_filters="~skip-for-deep-upgrade"
 
 CURRENT_OLDEST_VERSION=20190501153509
 OLD_MANIFEST_DIR="${A2_ROOT_DIR}/components/automate-deployment/testdata/old_manifests/"

--- a/integration/tests/manual_upgrade.sh
+++ b/integration/tests/manual_upgrade.sh
@@ -6,7 +6,6 @@ test_upgrades=true
 test_upgrade_strategy="none"
 test_loadbalancer_url="https://localhost:4443"
 upgrade_scaffold_pid_file="/tmp/upgrade-scaffold-pid"
-test_diagnostics_pre_upgrade_filters="~skip-for-deep-upgrade"
 
 do_setup() {
     hab pkg install core/jq-static

--- a/integration/tests/reset_admin_access_v1.sh
+++ b/integration/tests/reset_admin_access_v1.sh
@@ -36,10 +36,8 @@ do_test_deploy() {
     remove_admin_from_admins_team # just an example of how to screw A2 IAM up
 
     log_info "Restoring default admin access"
-    # Use the installed version of chef/automate-cli to ensure we use
-    # the current version of chef-automate, not the next version we're upgrading
-    # to.
-    hab pkg exec chef/automate-cli chef-automate iam admin-access restore $AUTOMATE_API_DEFAULT_PASSWORD
+
+    chef-automate iam admin-access restore $AUTOMATE_API_DEFAULT_PASSWORD
 
     do_test_deploy_default
 }

--- a/integration/tests/upgrade_current_master.sh
+++ b/integration/tests/upgrade_current_master.sh
@@ -5,4 +5,3 @@ test_name="upgrade_current_master"
 test_upgrades=true
 test_upgrade_inspec_profiles=()
 test_upgrade_begin_manifest="current.json"
-test_diagnostics_pre_upgrade_filters="~skip-for-deep-upgrade"

--- a/integration/tests/upgrade_current_master_habdev.sh
+++ b/integration/tests/upgrade_current_master_habdev.sh
@@ -5,7 +5,6 @@ test_name="upgrade_current_master_habdev"
 test_upgrades=true
 test_upgrade_inspec_profiles=()
 test_upgrade_begin_manifest="current.json"
-test_diagnostics_pre_upgrade_filters="~skip-for-deep-upgrade"
 
 do_prepare_deploy() {
     do_prepare_deploy_default


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Follow-up to https://github.com/chef/automate/pull/2564, rolls back diagnostic test change.

We cannot update the diagnostic test path to the non-beta path `iam/v2/policy_version` yet because these diagnostics always starts on an older version of Automate (20190501), as a way to ensure any instance that old can still upgrade to latest.

Depending on the outcome of our discussion on v1 backwards compatibility, we may want to leave these tests as is and leave the beta path in place or change these diagnostic tests. 

### :+1: Definition of Done
- [x] buildkite passes

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).