### PR TITLE
Update remaining v2beta stragglers

### DIFF
--- a/e2e/cypress/integration/ui/settings/06_token_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/06_token_mgmt.spec.ts
@@ -52,7 +52,7 @@ describe('token management', () => {
   });
 
   after(() => {
-    // can still use v2beta APIs while on v1
+    // can still use v2 APIs while on v1
     cy.cleanupV2IAMObjectsByIDPrefixes(cypressPrefix, ['tokens']);
   });
 

--- a/scripts/auth_collections.sh
+++ b/scripts/auth_collections.sh
@@ -28,7 +28,7 @@
 # Options:
 #    -o or --one-line     output each entity on one-line
 #    -s or --show         show the executed curl command
-#    -2 or --v2           use IAM V2 endpoints
+#    -1 or --v1           use IAM V1 endpoints (default is V2)
 #    -p or --projects     project filter; a comma-separate list as a single argument
 #
 # Examples:
@@ -36,7 +36,7 @@
 #     a2 --one users
 #     a2 -s users name bob
 #     a2 -o --show users name bob
-#     a2 --v2 -o --show -p proj1,proj2 roles
+#     a2 --v1 -o --show -p proj1,proj2 roles
 #
 # To run on a different environment you can adjust the env vars for a single invocation. Example:
 # TARGET_HOST=https://fresh-install-dev.cd.chef.co TOK=stVpD9I23OFn_U2OME= a2 -s policies
@@ -53,13 +53,13 @@ authQuery () {
   # process options
   jq_option=
   show_cmd=
-  auth_path="api/v0/auth"
+  auth_path="apis/iam/v2"
   projects=""
   while [[ "$1" =~ ^- ]]; do
     case "$1" in
       -o|--one-line) jq_option="-c"; shift;;
       -s|--show) show_cmd=1; shift;;
-      -2|--v2) auth_path="apis/iam/v2beta"; shift;;
+      -1|--v1) auth_path="api/v0/auth"; shift;;
       -p|--projects) projects="projects: $2"; shift 2;;
       -*) echo "'$1' unknown"; return 1;;
     esac
@@ -93,7 +93,7 @@ authQuery () {
 # Options:
 #    -s or --show         show the executed curl commands
 #    -d or --dry-run      show the curl commands but do not execute them
-#    -2 or --v2           use IAM V2 endpoints
+#    -1 or --v1           use IAM V1 endpoints (default is V2)
 #
 # Example:
 #    authLoad teams captured/teams-from-acceptance.txt
@@ -102,12 +102,12 @@ authLoad() {
   # process options
   dry_run=
   show_cmd=
-  auth_path="api/v0/auth"
+  auth_path="apis/iam/v2"
   while [[ "$1" =~ ^- ]]; do
     case "$1" in
       -s|--show) show_cmd=1; shift;;
       -d|--dry-run) dry_run=1; shift;;
-      -2|--v2) auth_path="apis/iam/v2beta"; shift;;
+      -1|--v1) auth_path="api/v0/auth"; shift;;
       -*) echo "'$1' unknown"; return 1;;
     esac
   done
@@ -163,16 +163,16 @@ authLoad() {
 #         $ authGen policies delete 100 501
 #
 # Options:
-#    -2 or --v2           use IAM V2 endpoints
+#    -1 or --v1           use IAM V1 endpoints (default is V2)
 #
 # TODO: Except for common things (e.g. teams) this supports only IAM v1 so far.
 #
 authGen() {
   # process options
-  auth_path="api/v0/auth"
+  auth_path="apis/iam/v2"
   while [[ "$1" =~ ^- ]]; do
     case "$1" in
-      -2|--v2) auth_path="apis/iam/v2beta"; shift;;
+      -1|--v1) auth_path="api/v0/auth"; shift;;
       -*) echo "'$1' unknown"; return 1;;
     esac
   done


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Follow-on to https://github.com/chef/automate/pull/2533/; found a couple stragglers of "v2beta".
Also switches defaults in auth_collections to v2 instead of v1.

### :chains: Related Resources

### :+1: Definition of Done

```
$ authQuery -s users
..."https://a2-iamv2p1-local-inplace-upgrade-acceptance.cd.chef.co/apis/iam/v2/users"
$ authQuery -s -1 users
..."https://a2-iamv2p1-local-inplace-upgrade-acceptance.cd.chef.co/api/v0/auth/users" 
```

### :athletic_shoe: How to Build and Test the Change
Source the scripts/auth_collections.sh script and execute `authQuery` as above (need to provide `$TOK` and `$TARGET_HOST` shell variables).

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).