### PR TITLE
Remove unneeded `id` attribute

### DIFF
--- a/components/automate-ui/src/app/page-components/create-v1-team-modal/create-v1-team-modal.component.html
+++ b/components/automate-ui/src/app/page-components/create-v1-team-modal/create-v1-team-modal.component.html
@@ -6,7 +6,7 @@
           <chef-form-field>
             <label>
               <span class="label">Name <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="name" type="text" (keyup)="handleNameInput($event)" id="name-input" autocomplete="off"/>
+              <input chefInput formControlName="name" type="text" (keyup)="handleNameInput($event)" autocomplete="off"/>
             </label>
             <chef-error *ngIf="(createForm.get('name').hasError('required') || createForm.get('name').hasError('pattern')) && createForm.get('name').dirty">
               Name is required.


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The changed component creates a modal dialog on the teams list page, specifically for v1. But there is also a modal dialog for v2, and both use the same `name-input` id. That is a violation of HTML so the simplest solution is just to delete the V1 `id` as it is not used.

Here's the violation as it appears in the browser console when you load the teams list page:
<img width="449" alt="image" src="https://user-images.githubusercontent.com/6817500/72477581-b2136080-37a4-11ea-8cc5-b0b62153469a.png">

### :chains: Related Resources

### :+1: Definition of Done
No browser warning

### :athletic_shoe: How to Build and Test the Change
rebuild automate-ui; navigate to teams list page

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

