### PR TITLE
Update builder

### DIFF
--- a/components/automate-builder-api/habitat/plan.sh
+++ b/components/automate-builder-api/habitat/plan.sh
@@ -14,8 +14,8 @@ pkg_deps=(
   core/bash
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # We need to pin here to get a build from unstable
-  "core/curl/7.65.3/20190826035620"
-  "habitat/builder-api/8559/20191114222102"
+  "core/curl/7.67.0/20191203153051"
+  "habitat/builder-api/8637/20200115221726"
 )
 
 pkg_binds=(


### PR DESCRIPTION
The latest build fixes a bug where certain pacakges would cause
builder to hang when configured to use SSL + memcached