### PR TITLE
Update config on automate-chef-io for Hugo 0.61 and Goldmark

### DIFF
--- a/components/automate-chef-io/config.toml
+++ b/components/automate-chef-io/config.toml
@@ -10,8 +10,54 @@ theme = "chef"
 # chef-hugo-theme repository
 # themesDir = "../../../hugo-themes"
 
-pygmentsStyle = "emacs"
-pygmentsCodefences = true
+[markup]
+  defaultMarkdownHandler = "goldmark"
+  [markup.blackFriday]
+    angledQuotes = false
+    footnoteAnchorPrefix = ""
+    footnoteReturnLinkContents = ""
+    fractions = true
+    hrefTargetBlank = false
+    latexDashes = true
+    nofollowLinks = false
+    noreferrerLinks = false
+    plainIDAnchors = true
+    skipHTML = false
+    smartDashes = true
+    smartypants = true
+    smartypantsQuotesNBSP = false
+    taskLists = true
+  [markup.goldmark]
+    [markup.goldmark.extensions]
+      definitionList = true
+      footnote = true
+      linkify = true
+      strikethrough = true
+      table = true
+      taskList = true
+      typographer = true
+    [markup.goldmark.parser]
+      attribute = true
+      autoHeadingID = true
+      autoHeadingIDType = "github"
+    [markup.goldmark.renderer]
+      hardWraps = false
+      unsafe = false
+      xHTML = false
+  [markup.highlight]
+    codeFences = true
+    guessSyntax = false
+    hl_Lines = ""
+    lineNoStart = 1
+    lineNos = false
+    lineNumbersInTable = true
+    noClasses = true
+    style = "emacs"
+    tabWidth = 4
+  [markup.tableOfContents]
+    endLevel = 3
+    ordered = false
+    startLevel = 1
 
 [params]
   enable_search = true  # set to true to show search bar


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

This updates the config so that Hugo will generate the automate site using Goldmark instead of Blackfriday. See [here](https://gohugo.io/news/0.60.0-relnotes/) and [here](https://gohugo.io/getting-started/configuration-markup#goldmark) for more info.

All of these are Hugo's defaults except for `style = "emacs"`.

Things to be aware of:
-  `autoHeadingIDType = "github"` could change heading IDs after the version of Hugo is bumped to 0.62 which could break links. See **autoHeadingIDType** below [here](https://gohugo.io/getting-started/configuration-markup#goldmark).
- `unsafe = false` will prevent Goldmark from rendering any HTML elements inside markdown pages. As far as I can tell there aren't any so it shouldn't be a problem.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

`make serve`

### :white_check_mark: Checklist

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [X] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
