### PR TITLE
[automate-2520] support S3 snapshots when using external elasticsearch

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -634,7 +634,7 @@ steps:
   - label: "backup to s3"
     command:
       - integration/run_test integration/tests/backup_s3.sh
-    timeout_in_minutes: 25
+    timeout_in_minutes: 30
     expeditor:
       accounts:
         - aws/chef-cd
@@ -665,6 +665,22 @@ steps:
         linux:
           single-use: true
           privileged: true
+
+  - label: "backup w external es to s3"
+    command:
+      - integration/run_test integration/tests/backup_external_es_s3.sh
+    timeout_in_minutes: 30
+    expeditor:
+      accounts:
+        - aws/chef-cd
+      executor:
+        linux:
+          single-use: true
+          privileged: true
+      secrets:
+        A2_LICENSE:
+          path: secret/a2/license
+          field: license
 
   - label: "upgrade dev -> master"
     command:

--- a/api/config/es_sidecar/config_request.go
+++ b/api/config/es_sidecar/config_request.go
@@ -26,6 +26,7 @@ func NewConfigRequest() *ConfigRequest {
 }
 
 // DefaultConfigRequest returns a new instance of ConfigRequest with default values.
+// nolint: gomnd
 func DefaultConfigRequest() *ConfigRequest {
 	c := NewConfigRequest()
 	c.V1.Sys.Service.Host = w.String("0.0.0.0")
@@ -34,7 +35,7 @@ func DefaultConfigRequest() *ConfigRequest {
 	c.V1.Sys.Log.Level = w.String("info")
 	c.V1.Sys.Log.Format = w.String("text")
 
-	c.V1.Sys.Backups.Backend = w.String("fs")
+	c.V1.Sys.Backups.Backend = w.String("s3")
 	c.V1.Sys.Backups.S3.Es.Compress = w.Bool(true)
 	return c
 }
@@ -58,81 +59,6 @@ func (c *ConfigRequest) PrepareSystemConfig(creds *ac.TLSCredentials) (ac.Prepar
 // SetGlobalConfig imports settings from the global configuration
 func (c *ConfigRequest) SetGlobalConfig(g *ac.GlobalConfig) {
 	c.V1.Sys.Mlsa = g.V1.Mlsa
-	if externalCfg := g.GetV1().GetExternal().GetElasticsearch(); externalCfg.GetEnable().GetValue() {
-		if externalCfg.GetBackup().GetEnable().GetValue() {
-			switch externalCfg.GetBackup().GetLocation().GetValue() {
-			case "s3":
-				s3cfg := externalCfg.GetBackup().GetS3()
-				c.V1.Sys.Backups = &ConfigRequest_V1_System_Backups{
-					Backend: w.String("s3"),
-					S3: &ConfigRequest_V1_System_Backups_S3Settings{
-						Bucket:   s3cfg.GetBasePath(),
-						BasePath: s3cfg.GetBasePath(),
-						Client:   s3cfg.GetClient(),
-						Es:       s3cfg.GetSettings(),
-					},
-				}
-			case "fs":
-				fsCfg := externalCfg.GetBackup().GetFs()
-				c.V1.Sys.Backups = &ConfigRequest_V1_System_Backups{
-					Backend: w.String("fs"),
-					Fs: &ConfigRequest_V1_System_Backups_FsSettings{
-						RootLocation:           fsCfg.GetPath(),
-						MaxRestoreBytesPerSec:  fsCfg.GetSettings().GetMaxRestoreBytesPerSec(),
-						MaxSnapshotBytesPerSec: fsCfg.GetSettings().GetMaxSnapshotBytesPerSec(),
-					},
-				}
-			default:
-				c.V1.Sys.Backups = &ConfigRequest_V1_System_Backups{
-					Backend: w.String("disable"),
-				}
-			}
-		} else {
-			c.V1.Sys.Backups = &ConfigRequest_V1_System_Backups{
-				Backend: w.String("disable"),
-			}
-		}
-	} else {
-		if b := g.GetV1().GetBackups(); b != nil {
-			switch b.GetLocation().GetValue() {
-			case "s3":
-				globalS3 := b.GetS3()
-				c.V1.Sys.Backups.Backend = w.String("s3")
-				c.V1.Sys.Backups.S3 = &ConfigRequest_V1_System_Backups_S3Settings{
-					Bucket:   globalS3.GetBucket().GetName(),
-					BasePath: globalS3.GetBucket().GetBasePath(),
-					Es:       globalS3.GetEs(),
-				}
-			default:
-				// We continue to provide the FS config. This will be used if elasticsearch
-				// is external
-				c.V1.Sys.Backups.Backend = w.String("fs")
-
-				if g.V1.Backups.Filesystem.Path != nil {
-					c.V1.Sys.Backups.Fs.RootLocation = g.V1.Backups.Filesystem.Path
-				}
-				if g.V1.Backups.Filesystem.EsMaxSnapshotBytesPerSec != nil {
-					c.V1.Sys.Backups.Fs.MaxSnapshotBytesPerSec = g.V1.Backups.Filesystem.EsMaxSnapshotBytesPerSec
-				}
-				if g.V1.Backups.Filesystem.EsMaxRestoreBytesPerSec != nil {
-					c.V1.Sys.Backups.Fs.MaxRestoreBytesPerSec = g.V1.Backups.Filesystem.EsMaxRestoreBytesPerSec
-				}
-
-				// Here we're going to catch our default setting of "fs", which
-				// now uses the backup-gateway in S3 mode. So we'll configure our
-				// backend to the backup-gateway with the filesystem path base name
-				// as our bucket.
-				c.V1.Sys.Backups.Backend = w.String("s3")
-				c.V1.Sys.Backups.S3 = &ConfigRequest_V1_System_Backups_S3Settings{
-					Bucket: w.String("backups"),
-					Es: &ac.Backups_S3_Elasticsearch{
-						MaxSnapshotBytesPerSec: b.GetFilesystem().GetEsMaxSnapshotBytesPerSec(),
-						MaxRestoreBytesPerSec:  b.GetFilesystem().GetEsMaxRestoreBytesPerSec(),
-					},
-				}
-			}
-		}
-	}
 
 	if logLevel := g.GetV1().GetLog().GetLevel().GetValue(); logLevel != "" {
 		c.V1.Sys.Log.Level.Value = logLevel
@@ -141,4 +67,173 @@ func (c *ConfigRequest) SetGlobalConfig(g *ac.GlobalConfig) {
 	if logFormat := g.GetV1().GetLog().GetFormat().GetValue(); logFormat != "" {
 		c.V1.Sys.Log.Format.Value = logFormat
 	}
+
+	//
+	// Users can configure the ElasticSearch backup configuration the at es-sidecar
+	// level, the global backups level, and in some cases the global external
+	// level. Precedence for configuration is as follows in order of priority
+	//
+	// * External configuration (if using external ElasticSearch)
+	// * Global configuration
+	// * User defined es-sidecar configuration
+	// * es-sidecar default configuration
+	//
+	externalCfg := g.GetV1().GetExternal().GetElasticsearch()
+
+	backupsCfg := c.GetV1().GetSys().GetBackups()
+	if backupsCfg == nil {
+		backupsCfg = &ConfigRequest_V1_System_Backups{}
+	}
+
+	// If we're in external mode, apply and global and external config
+	if externalCfg.GetEnable().GetValue() {
+		c.applyGlobalBackupConfig(backupsCfg, g.GetV1().GetBackups())
+		c.applyExternalConfig(backupsCfg, externalCfg.GetBackup())
+		return
+	}
+
+	// If we're in internal mode, apply global config and then ensure that old
+	// internal fs config is migrated to use the backup gateway in S3 mode.
+	c.applyGlobalBackupConfig(backupsCfg, g.GetV1().GetBackups())
+	c.migrateToBackupGateway(backupsCfg)
+
+	return
+}
+
+// Given a backup config and an external configuration, merge any external values
+// into the backup config
+func (c *ConfigRequest) applyExternalConfig(
+	cfg *ConfigRequest_V1_System_Backups,
+	override *ac.External_Elasticsearch_Backup) {
+
+	// If backups are disabled we don't need to worry about applying any other
+	// config.
+	if !override.GetEnable().GetValue() {
+		cfg.Backend = w.String("disable")
+		return
+	}
+
+	backend := override.GetLocation().GetValue()
+	switch backend {
+	case "s3":
+		cfg.Backend = w.String(backend)
+		if cfg.S3 == nil {
+			cfg.S3 = &ConfigRequest_V1_System_Backups_S3Settings{}
+		}
+
+		extS3cfg := override.GetS3()
+		if b := extS3cfg.GetBucket(); b != nil {
+			cfg.S3.Bucket = b
+		}
+
+		if bp := extS3cfg.GetBasePath(); bp != nil {
+			cfg.S3.BasePath = bp
+		}
+
+		if c := extS3cfg.GetClient(); c != nil {
+			cfg.S3.Client = c
+		}
+
+		if s := extS3cfg.GetSettings(); s != nil {
+			cfg.S3.Es = s
+		}
+	case "fs":
+		cfg.Backend = w.String(backend)
+		if cfg.Fs == nil {
+			cfg.Fs = &ConfigRequest_V1_System_Backups_FsSettings{}
+		}
+
+		fsCfg := override.GetFs()
+		if p := fsCfg.GetPath(); p != nil {
+			cfg.Fs.RootLocation = p
+		}
+
+		if rb := fsCfg.GetSettings().GetMaxRestoreBytesPerSec(); rb != nil {
+			cfg.Fs.MaxRestoreBytesPerSec = rb
+		}
+
+		if sb := fsCfg.GetSettings().GetMaxSnapshotBytesPerSec(); sb != nil {
+			cfg.Fs.MaxSnapshotBytesPerSec = sb
+		}
+	default:
+		// Disable external backups by default
+		cfg.Backend = w.String("disabled")
+	}
+
+	return
+}
+
+// Given a backup config and the global backup config, merge any global values
+// into the backup config
+func (c *ConfigRequest) applyGlobalBackupConfig(
+	cfg *ConfigRequest_V1_System_Backups,
+	global *ac.Backups) {
+
+	if global == nil {
+		return
+	}
+
+	if backend := global.GetLocation(); backend != nil {
+		cfg.Backend = backend
+	}
+
+	if globalS3 := global.GetS3(); globalS3 != nil {
+		if cfg.GetS3() == nil {
+			cfg.S3 = &ConfigRequest_V1_System_Backups_S3Settings{}
+		}
+
+		if name := globalS3.GetBucket().GetName(); name != nil {
+			cfg.S3.Bucket = name
+		}
+
+		if bp := globalS3.GetBucket().GetBasePath(); bp != nil {
+			cfg.S3.BasePath = bp
+		}
+
+		if es := globalS3.GetEs(); es != nil {
+			newEs := &ac.Backups_S3_Elasticsearch{}
+			_ = ac.Merge(cfg.S3.GetEs(), es, newEs)
+
+			cfg.S3.Es = newEs
+		}
+	}
+
+	if globalFs := global.GetFilesystem(); globalFs != nil {
+		if p := globalFs.GetPath(); p != nil {
+			cfg.Fs.RootLocation = p
+		}
+
+		if sb := globalFs.GetEsMaxSnapshotBytesPerSec(); sb != nil {
+			cfg.Fs.MaxSnapshotBytesPerSec = sb
+		}
+
+		if rb := globalFs.GetEsMaxRestoreBytesPerSec(); rb != nil {
+			cfg.Fs.MaxRestoreBytesPerSec = rb
+		}
+	}
+
+	return
+}
+
+// Given a backup config that is not using external elasticsearch, migrate
+// old fs backend to the s3 compatible backup-gateway
+func (c *ConfigRequest) migrateToBackupGateway(cfg *ConfigRequest_V1_System_Backups) {
+	// If the backend is configured to use S3 then we need not worry about fallback
+	if cfg.GetBackend().GetValue() == "s3" {
+		return
+	}
+
+	// Here we're going to catch our default setting of "fs", which
+	// now uses the backup-gateway in S3 mode. So we'll configure our
+	// backend to the backup-gateway with "backups" as the default bucket
+	cfg.Backend = w.String("s3")
+	cfg.S3 = &ConfigRequest_V1_System_Backups_S3Settings{
+		Bucket: w.String("backups"),
+		Es: &ac.Backups_S3_Elasticsearch{
+			MaxSnapshotBytesPerSec: cfg.GetFs().GetMaxSnapshotBytesPerSec(),
+			MaxRestoreBytesPerSec:  cfg.GetFs().GetMaxRestoreBytesPerSec(),
+		},
+	}
+
+	return
 }

--- a/api/config/es_sidecar/config_request_test.go
+++ b/api/config/es_sidecar/config_request_test.go
@@ -3,6 +3,7 @@ package es_sidecar
 import (
 	"testing"
 
+	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
 
 	shared "github.com/chef/automate/api/config/shared"
@@ -10,22 +11,265 @@ import (
 )
 
 func TestValidateConfigRequestValid(t *testing.T) {
-	c := NewConfigRequest()
+	c := DefaultConfigRequest()
 	err := c.Validate()
 	assert.Nil(t, err)
 }
 
 func TestSetGlobalConfig(t *testing.T) {
-	t.Run("it configures the MLSA",
-		func(t *testing.T) {
-			c := NewConfigRequest()
-			c.V1.Sys.Mlsa.Accept = w.Bool(false)
-			g := shared.DefaultGlobalConfig()
-			g.V1.Mlsa.Accept = w.Bool(true)
+	t.Run("it configures the MLSA", func(t *testing.T) {
+		c := DefaultConfigRequest()
+		c.V1.Sys.Mlsa.Accept = w.Bool(false)
+		g := shared.DefaultGlobalConfig()
+		g.V1.Mlsa.Accept = w.Bool(true)
 
-			c.SetGlobalConfig(g)
+		c.SetGlobalConfig(g)
 
-			assert.Equal(t, c.V1.Sys.Mlsa.Accept.Value, true)
-		},
-	)
+		assert.Equal(t, true, c.V1.Sys.Mlsa.Accept.Value)
+	})
+
+	t.Run("with external s3 backup config", func(t *testing.T) {
+		c := DefaultConfigRequest()
+		c.V1.Sys.Backups.S3.Bucket = w.String("internal-bucket")
+		c.V1.Sys.Backups.S3.Client = w.String("internal-client")
+		c.V1.Sys.Backups.S3.BasePath = w.String("internal-base-path")
+		c.V1.Sys.Backups.S3.Es.Compress = w.Bool(false)
+
+		g := shared.DefaultGlobalConfig()
+		g.V1.External = &shared.External{
+			Elasticsearch: &shared.External_Elasticsearch{
+				Enable: w.Bool(true),
+				Backup: &shared.External_Elasticsearch_Backup{
+					Enable:   w.Bool(true),
+					Location: w.String("s3"),
+					S3: &shared.External_Elasticsearch_Backup_S3Settings{
+						Bucket:   w.String("external-bucket"),
+						Client:   w.String("external-client"),
+						BasePath: w.String("external-base-path"),
+						Settings: &shared.Backups_S3_Elasticsearch{
+							Compress: w.Bool(true),
+						},
+					},
+				},
+			},
+		}
+		c.SetGlobalConfig(g)
+
+		assert.Equal(t, "s3", c.V1.Sys.Backups.Backend.Value)
+		assert.Equal(t, "external-bucket", c.V1.Sys.Backups.S3.Bucket.Value)
+		assert.Equal(t, "external-client", c.V1.Sys.Backups.S3.Client.Value)
+		assert.Equal(t, "external-base-path", c.V1.Sys.Backups.S3.BasePath.Value)
+		assert.Equal(t, true, c.V1.Sys.Backups.S3.Es.Compress.Value)
+	})
+
+	t.Run("with external fs backup config", func(t *testing.T) {
+		c := DefaultConfigRequest()
+		c.V1.Sys.Backups.Fs.RootLocation = w.String("internal-root")
+		c.V1.Sys.Backups.Fs.MaxRestoreBytesPerSec = w.String("internal-restore-bytes")
+		c.V1.Sys.Backups.Fs.MaxSnapshotBytesPerSec = w.String("internal-snapshot-bytes")
+
+		g := shared.DefaultGlobalConfig()
+		g.V1.External = &shared.External{
+			Elasticsearch: &shared.External_Elasticsearch{
+				Enable: w.Bool(true),
+				Backup: &shared.External_Elasticsearch_Backup{
+					Enable:   w.Bool(true),
+					Location: w.String("fs"),
+					Fs: &shared.External_Elasticsearch_Backup_FsSettings{
+						Path: w.String("external-root"),
+						Settings: &shared.External_Elasticsearch_Backup_FsSettings_OptionalSettings{
+							MaxRestoreBytesPerSec:  w.String("external-restore-bytes"),
+							MaxSnapshotBytesPerSec: w.String("external-snapshot-bytes"),
+						},
+					},
+				},
+			},
+		}
+		c.SetGlobalConfig(g)
+
+		assert.Equal(t, "fs", c.V1.Sys.Backups.Backend.Value)
+		assert.Equal(t, "external-root", c.V1.Sys.Backups.Fs.RootLocation.Value)
+		assert.Equal(t, "external-restore-bytes", c.V1.Sys.Backups.Fs.MaxRestoreBytesPerSec.Value)
+		assert.Equal(t, "external-snapshot-bytes", c.V1.Sys.Backups.Fs.MaxSnapshotBytesPerSec.Value)
+	})
+
+	t.Run("with external no backup config", func(t *testing.T) {
+		c := DefaultConfigRequest()
+
+		g := shared.DefaultGlobalConfig()
+		g.V1.External = &shared.External{
+			Elasticsearch: &shared.External_Elasticsearch{
+				Enable: w.Bool(true),
+				Backup: &shared.External_Elasticsearch_Backup{
+					Enable: w.Bool(false),
+				},
+			},
+		}
+		c.SetGlobalConfig(g)
+
+		assert.Equal(t, "disable", c.V1.Sys.Backups.Backend.Value)
+	})
+
+	t.Run("with internal global s3 backup config with user config", func(t *testing.T) {
+		c := DefaultConfigRequest()
+		c.V1.Sys.Backups.S3.Bucket = w.String("user-bucket")
+		c.V1.Sys.Backups.S3.Client = w.String("user-client")
+		c.V1.Sys.Backups.S3.BasePath = w.String("user-base-path")
+		c.V1.Sys.Backups.S3.Es.Compress = w.Bool(false)
+
+		g := shared.DefaultGlobalConfig()
+		g.V1.Backups = &shared.Backups{
+			Location: w.String("s3"),
+			S3: &shared.Backups_S3{
+				Bucket: &shared.Backups_S3_Bucket{
+					Name:     w.String("global-bucket"),
+					BasePath: w.String("global-base-path"),
+				},
+				Es: &shared.Backups_S3_Elasticsearch{
+					Compress: w.Bool(true),
+				},
+			},
+		}
+
+		c.SetGlobalConfig(g)
+		assert.Equal(t, "s3", c.V1.Sys.Backups.Backend.Value)
+		assert.Equal(t, "global-bucket", c.V1.Sys.Backups.S3.Bucket.Value)
+		assert.Equal(t, "user-client", c.V1.Sys.Backups.S3.Client.Value)
+		assert.Equal(t, "global-base-path", c.V1.Sys.Backups.S3.BasePath.Value)
+		assert.Equal(t, true, c.V1.Sys.Backups.S3.Es.Compress.Value)
+	})
+
+	t.Run("with internal global fs backup config with user config", func(t *testing.T) {
+		c := DefaultConfigRequest()
+		c.V1.Sys.Backups.Fs.RootLocation = w.String("user-root")
+		c.V1.Sys.Backups.Fs.MaxSnapshotBytesPerSec = w.String("user-snapshot-bytes")
+		c.V1.Sys.Backups.Fs.MaxRestoreBytesPerSec = w.String("user-restore-bytes")
+
+		g := shared.DefaultGlobalConfig()
+		g.V1.Backups = &shared.Backups{
+			Location: w.String("fs"),
+			Filesystem: &shared.Backups_Filesystem{
+				Path:                     w.String("global-root"),
+				EsMaxSnapshotBytesPerSec: w.String("global-snapshot-bytes"),
+				EsMaxRestoreBytesPerSec:  w.String("global-restore-bytes"),
+			},
+		}
+
+		c.SetGlobalConfig(g)
+
+		// NOTE: This is bit tricky. Why we set the location to fs in the global
+		// config, we actually don't want to do that anymore. Instead of want
+		// to use the s3 backup-gateway.
+		assert.Equal(t, "s3", c.V1.Sys.Backups.Backend.Value)
+		assert.Equal(t, "global-root", c.V1.Sys.Backups.Fs.RootLocation.Value)
+		assert.Equal(t, "global-snapshot-bytes", c.V1.Sys.Backups.Fs.MaxSnapshotBytesPerSec.Value)
+		assert.Equal(t, "global-restore-bytes", c.V1.Sys.Backups.Fs.MaxRestoreBytesPerSec.Value)
+	})
+
+	t.Run("with internal global s3 backup config without user config", func(t *testing.T) {
+		c := DefaultConfigRequest()
+
+		g := shared.DefaultGlobalConfig()
+		g.V1.Backups = &shared.Backups{
+			Location: w.String("s3"),
+			S3: &shared.Backups_S3{
+				Bucket: &shared.Backups_S3_Bucket{
+					Name:     w.String("global-bucket"),
+					BasePath: w.String("global-base-path"),
+				},
+				Es: &shared.Backups_S3_Elasticsearch{
+					Compress: w.Bool(true),
+				},
+			},
+		}
+
+		c.SetGlobalConfig(g)
+
+		assert.Equal(t, "s3", c.V1.Sys.Backups.Backend.Value)
+		assert.Equal(t, "global-bucket", c.V1.Sys.Backups.S3.Bucket.Value)
+		assert.Equal(t, "global-base-path", c.V1.Sys.Backups.S3.BasePath.Value)
+		assert.Equal(t, true, c.V1.Sys.Backups.S3.Es.Compress.Value)
+	})
+
+	t.Run("with internal global fs backup config without user config", func(t *testing.T) {
+		c := DefaultConfigRequest()
+		c.V1.Sys.Backups.Fs = &ConfigRequest_V1_System_Backups_FsSettings{}
+
+		g := shared.DefaultGlobalConfig()
+		g.V1.Backups = &shared.Backups{
+			Location: w.String("fs"),
+			Filesystem: &shared.Backups_Filesystem{
+				Path:                     w.String("global-root"),
+				EsMaxSnapshotBytesPerSec: w.String("global-snapshot-bytes"),
+				EsMaxRestoreBytesPerSec:  w.String("global-restore-bytes"),
+			},
+		}
+
+		c.SetGlobalConfig(g)
+
+		// NOTE: This is bit tricky. Why we set the location to fs in the global
+		// config, we actually don't want to do that anymore. Instead of want
+		// to use the s3 backup-gateway.
+		assert.Equal(t, "s3", c.V1.Sys.Backups.Backend.Value)
+		assert.Equal(t, "global-root", c.V1.Sys.Backups.Fs.RootLocation.Value)
+		assert.Equal(t, "global-snapshot-bytes", c.V1.Sys.Backups.Fs.MaxSnapshotBytesPerSec.Value)
+		assert.Equal(t, "global-restore-bytes", c.V1.Sys.Backups.Fs.MaxRestoreBytesPerSec.Value)
+	})
+
+	t.Run("with no backup config", func(t *testing.T) {
+		c := DefaultConfigRequest()
+		g := shared.DefaultGlobalConfig()
+
+		c.SetGlobalConfig(g)
+
+		// Default to the "backups" bucket on the backup-gateway
+		assert.Equal(t, "s3", c.V1.Sys.Backups.Backend.Value)
+		assert.Equal(t, "backups", c.V1.Sys.Backups.S3.Bucket.Value)
+	})
+
+	t.Run("automate issue 2520, external es with global s3", func(t *testing.T) {
+		/*
+			Given the following TOML config we should properly generate the correct
+			es-sidecar config with the correct backend, bucket and base path.
+
+			[global.v1.backups]
+			  location = "s3"
+			[global.v1.backups.s3.bucket]
+			  name = "external-bucket"
+			  base_path = "external-base-path"
+			  endpoint = "my.aws.com"
+			[global.v1.external.elasticsearch]
+			  enable = true
+			  nodes = ["http://127.0.0.1:59200"]
+			[global.v1.external.elasticsearch.backup]
+			  enable = true
+			  location = "s3"
+		*/
+
+		c := DefaultConfigRequest()
+		g := shared.DefaultGlobalConfig()
+		g.V1.Backups.Location = w.String("s3")
+		g.V1.Backups.S3 = &shared.Backups_S3{
+			Bucket: &shared.Backups_S3_Bucket{
+				Name:     w.String("external-bucket"),
+				BasePath: w.String("external-base-path"),
+				Endpoint: w.String("my.aws.com"),
+			},
+		}
+		g.V1.External = &shared.External{
+			Elasticsearch: &shared.External_Elasticsearch{
+				Enable: w.Bool(true),
+				Nodes:  []*wrappers.StringValue{w.String("http://127.0.0.1:59200")},
+				Backup: &shared.External_Elasticsearch_Backup{
+					Enable:   w.Bool(true),
+					Location: w.String("s3"),
+				},
+			},
+		}
+		c.SetGlobalConfig(g)
+
+		assert.Equal(t, "s3", c.V1.Sys.Backups.Backend.Value)
+		assert.Equal(t, "external-bucket", c.V1.Sys.Backups.S3.Bucket.Value)
+		assert.Equal(t, "external-base-path", c.V1.Sys.Backups.S3.BasePath.Value)
+	})
 }

--- a/integration/base.sh
+++ b/integration/base.sh
@@ -373,8 +373,6 @@ export A2_ROOT_DIR="$source_dir/../"
 # Load the shared code
 # shellcheck source=./helpers/log.sh
 source "${source_dir}/helpers/log.sh"
-# shellcheck source=./helpers/s3.sh
-source "${source_dir}/helpers/s3.sh"
 # shellcheck source=./helpers/setup.sh
 source "${source_dir}/helpers/setup.sh"
 # shellcheck source=./helpers/build.sh

--- a/integration/base.sh
+++ b/integration/base.sh
@@ -373,6 +373,8 @@ export A2_ROOT_DIR="$source_dir/../"
 # Load the shared code
 # shellcheck source=./helpers/log.sh
 source "${source_dir}/helpers/log.sh"
+# shellcheck source=./helpers/s3.sh
+source "${source_dir}/helpers/s3.sh"
 # shellcheck source=./helpers/setup.sh
 source "${source_dir}/helpers/setup.sh"
 # shellcheck source=./helpers/build.sh

--- a/integration/helpers/s3.sh
+++ b/integration/helpers/s3.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+#shellcheck disable=SC2034
+
+__bucket_base_path() {
+    head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13
+    return 0
+}
+
+s3_bucket_name="a2-backup-restore-test"
+
+s3_bucket_base_path="$(__bucket_base_path)"
+
+# deployment-service currently requires the regional endpoint
+s3_endpoint="https://s3.us-west-2.amazonaws.com"
+
+do_deploy_s3_default() {
+    #shellcheck disable=SC2154
+    chef-automate deploy config.toml \
+        --product automate \
+        --product builder \
+        --hartifacts "$test_hartifacts_path" \
+        --override-origin "$HAB_ORIGIN" \
+        --manifest-dir "$test_manifest_path" \
+        --admin-password chefautomate \
+        --accept-terms-and-mlsa
+
+    log_info "applying dev license"
+    chef-automate license apply "$A2_LICENSE"
+}
+
+do_test_deploy_s3_default() {
+    #shellcheck disable=SC2154
+    #shellcheck source=integration/helpers/bldr_tests.sh
+    source "${source_dir}/helpers/bldr_tests.sh"
+
+    do_test_deploy_default
+    bldr_smoke_test
+}
+
+do_backup_s3_default() {
+  echo "Backing up to S3"
+  echo "  bucket: ${s3_bucket_name}/${s3_bucket_base_path}"
+  echo "  endpoint: ${s3_endpoint}"
+  do_backup_default
+}
+
+do_prepare_restore_s3_default() {
+  do_prepare_restore_default
+
+  # Remove the default backup directory
+  [[ -d /var/opt/chef-automate/backups ]] && rm -r /var/opt/chef-automate/backups
+
+  # make sure we can list the backups, and it contains
+  # our backup
+  #shellcheck disable=SC2154
+  chef-automate backup list \
+      --debug \
+      "s3://${s3_bucket_name}/${s3_bucket_base_path}" | awk -v s="${test_backup_id}" 'BEGIN{r=1}; $0~s{r=0} 1; END{exit(r)}'
+}
+
+do_restore_s3_default() {
+  #shellcheck disable=SC2154
+  chef-automate backup restore \
+      --debug \
+      --override-origin "$HAB_ORIGIN" \
+      "s3://${s3_bucket_name}/${s3_bucket_base_path}/${test_backup_id}"
+}
+
+do_test_restore_s3_default() {
+  do_test_restore_default || return 1
+  delete_backup_and_assert_idempotent
+  verify_packages
+
+  hab pkg install core/hab
+  artifacts_dir=$(mktemp -d --suffix="bldr_smoke")
+  # TODO(jaym): remove when we upgrade hab to a version
+  # that supports hab pkg download
+  SSL_CERT_FILE="/hab/svc/automate-load-balancer/data/$CONTAINER_HOSTNAME.cert" \
+      hab pkg exec core/hab \
+      hab pkg download \
+      -u "https://$CONTAINER_HOSTNAME/bldr/v1" \
+      -c "unstable" \
+      --download-directory "$artifacts_dir" \
+      "${TEST_ORIGIN}/${TEST_PKG}"
+
+  rm -r "$artifacts_dir"
+}

--- a/integration/run_test
+++ b/integration/run_test
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 set -Eeo pipefail
 
 CI=${CI:-false}
@@ -76,9 +75,14 @@ if [[ "$CI" = "true" ]]; then
     echo "uptime"
     uptime
     echo "======================================="
+else
+    # In CI we expect the images to have already pulled the latest docker
+    # layers, but we can't rely on that for local machines. Here we'll make sure
+    # we start containers with the latest images.
+    docker pull chefes/centos-systemd:latest
+    docker pull chefes/a2-integration:latest
 fi
 
-docker pull chefes/centos-systemd:latest
 workdir="/go/src/github.com/chef/automate"
 
 docker_run_args=(
@@ -191,11 +195,11 @@ echo "${docker_run_args[*]}"
 docker run "${docker_run_args[@]}" chefes/a2-integration:latest
 
 if [ $CI != "true" ]; then
-    secret_origin_key=$(hab origin key export --type secret $HAB_ORIGIN)
-    docker exec -e SEC_KEY="$secret_origin_key" "$test_container_name" bash -c 'echo "$SEC_KEY" | hab origin key import'
+    secret_origin_key=$(HAB_LICENSE=accept-no-persist hab origin key export --type secret "$HAB_ORIGIN")
+    docker exec -e SEC_KEY="$secret_origin_key" -e HAB_LICENSE="accept-no-persist" "$test_container_name" bash -c 'echo "$SEC_KEY" | hab origin key import'
 
-    public_origin_key=$(hab origin key export --type public $HAB_ORIGIN)
-    docker exec -e SEC_KEY="$public_origin_key" "$test_container_name" bash -c 'echo "$SEC_KEY" | hab origin key import'
+    public_origin_key=$(HAB_LICENSE=accept-no-persist hab origin key export --type public "$HAB_ORIGIN")
+    docker exec -e SEC_KEY="$public_origin_key" -e HAB_LICENSE="accept-no-persist" "$test_container_name" bash -c 'echo "$SEC_KEY" | hab origin key import'
 fi
 
 echo "Running the docker. Will timeout after $TIMEOUT mins"

--- a/integration/tests/backup_external_es_s3.sh
+++ b/integration/tests/backup_external_es_s3.sh
@@ -1,15 +1,34 @@
 #!/bin/bash
 
 #shellcheck disable=SC2034
-test_name="backup-s3"
+#shellcheck disable=SC2154
+
+test_name="backup-external-es-s3"
 test_backup_restore=true
+
+do_setup() {
+  do_setup_default
+
+  local previous_umask
+  previous_umask=$(umask)
+  umask 022
+
+  start_external_elasticsearch "${s3_endpoint}"
+
+  umask "$previous_umask"
+}
 
 do_create_config() {
   do_create_config_default
 
-  #shellcheck disable=SC2154
   cat <<EOF >> "$test_config_path"
 [global.v1.backups]
+  location = "s3"
+[global.v1.external.elasticsearch]
+  enable = true
+  nodes = ["http://127.0.0.1:59200"]
+[global.v1.external.elasticsearch.backup]
+  enable = true
   location = "s3"
 [global.v1.backups.s3.bucket]
   name = "${s3_bucket_name}"

--- a/integration/tests/backup_external_es_s3.sh
+++ b/integration/tests/backup_external_es_s3.sh
@@ -3,6 +3,9 @@
 #shellcheck disable=SC2034
 #shellcheck disable=SC2154
 
+# shellcheck source=integration/helpers/s3.sh
+source "${source_dir}/helpers/s3.sh"
+
 test_name="backup-external-es-s3"
 test_backup_restore=true
 

--- a/integration/tests/backup_s3.sh
+++ b/integration/tests/backup_s3.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 #shellcheck disable=SC2034
+#shellcheck disable=SC2154
+
+# shellcheck source=integration/helpers/s3.sh
+source "${source_dir}/helpers/s3.sh"
+
 test_name="backup-s3"
 test_backup_restore=true
 


### PR DESCRIPTION
* Add new external es with s3 integration test
* Rewrite SetGlobalConfig() for the es-sidecar-service
* Add unit tests for the various external, global and es-sidecar level
  configuration combinations
* Extract common s3 integration test functions into helpers
* Update the external Es to 6.8.3 to match what is currently deployed
* Add and configure repository-s3 for external es integration tests

Fixes #2520

Signed-off-by: Ryan Cragun <ryan@chef.io>