### PR TITLE
[auth-2624] user modal update

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -12,7 +12,7 @@
               Name is required.
             </chef-error>
           </chef-form-field>
-          <span class="detail">Don't worry, {{ objectNoun }} names can be changed later.</span>
+          <span class="detail light">Don't worry, {{ objectNoun }} names can be changed later.</span>
         </div>
         <div *ngIf="modifyID" class="id-margin">
           <chef-form-field>
@@ -33,7 +33,7 @@
               {{ objectNoun | titlecase }} ID "{{createForm.get('id').value}}" already exists.
             </chef-error>
           </chef-form-field>
-          <span class="detail">{{ objectNoun | titlecase }} IDs are unique, permanent, and cannot be changed later.</span>
+          <span class="detail light">{{ objectNoun | titlecase }} IDs are unique, permanent, and cannot be changed later.</span>
         </div>
         <div *ngIf="!modifyID" class="id-margin">
           <div id="id-fields">

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, EventEmitter, Input, Output, OnInit, OnChanges, SimpleChanges
+  Component, EventEmitter, Input, Output, OnInit, OnDestroy, OnChanges, SimpleChanges
 } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
@@ -9,13 +9,15 @@ import {
   ProjectChecked,
   ProjectCheckedMap
 } from 'app/components/projects-dropdown/projects-dropdown.component';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-create-object-modal',
   templateUrl: './create-object-modal.component.html',
   styleUrls: ['./create-object-modal.component.scss']
 })
-export class CreateObjectModalComponent implements OnInit, OnChanges {
+export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges {
   @Input() visible = false;
   @Input() creating = false;
   @Input() objectNoun: string;
@@ -33,12 +35,20 @@ export class CreateObjectModalComponent implements OnInit, OnChanges {
   public conflictError = false;
   public projectsUpdatedEvent = new EventEmitter();
 
+  private isDestroyed = new Subject<boolean>();
+
   ngOnInit(): void {
-    this.conflictErrorEvent.subscribe((isConflict: boolean) => {
+    this.conflictErrorEvent.pipe(takeUntil(this.isDestroyed))
+    .subscribe((isConflict: boolean) => {
       this.conflictError = isConflict;
       // Open the ID input on conflict so user can resolve it.
       this.modifyID = isConflict;
     });
+  }
+
+  ngOnDestroy() {
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/components/automate-ui/src/app/entities/users/user.effects.ts
+++ b/components/automate-ui/src/app/entities/users/user.effects.ts
@@ -6,6 +6,7 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of, combineLatest } from 'rxjs';
 import { identity } from 'lodash/fp';
 
+import { HttpStatus } from 'app/types/types';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { CreateNotification } from 'app/entities/notifications/notification.actions';
 import { Type } from 'app/entities/notifications/notification.model';
@@ -184,12 +185,13 @@ export class UserEffects {
 
   @Effect()
   createUserFailure$ = this.actions$.pipe(
-    ofType(UserActionTypes.CREATE_FAILURE),
-    map(({ payload }: CreateUserFailure) => {
-      const msg = payload.error.error;
-      return new CreateNotification({
-        type: Type.error,
-        message: `Could not create user: ${msg || payload.error}`
-      });
-    }));
+    ofType<CreateUserFailure>(UserActionTypes.CREATE_FAILURE),
+    // username conflict and bad password handled in the modal, see user-management.component.ts
+    filter(({ payload: { status } }) => {
+      return status !== HttpStatus.CONFLICT && status !== HttpStatus.BAD_REQUEST;
+    }),
+    map(({ payload: { error } }) => new CreateNotification({
+      type: Type.error,
+      message: `Could not create user: ${error.error || error}.`
+    })));
 }

--- a/components/automate-ui/src/app/entities/users/user.reducer.spec.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.spec.ts
@@ -125,7 +125,10 @@ describe('userStatusEntityReducer', () => {
 
       it('sets status to loadingFailure', () => {
         const { createStatus } = userEntityReducer(initialState, action);
+        const { createError } = userEntityReducer(initialState, action);
+
         expect(createStatus).toEqual(EntityStatus.loadingFailure);
+        expect(createError).toEqual(action.payload);
       });
     });
 
@@ -263,14 +266,10 @@ function userState(action: string, ...us: User[]): UserEntityState {
     entities[u.id] = u;
     ids.push(u.id);
   }
-
+  const createError = null;
   return ['get', 'create', 'update', 'delete']
     .reduce((state, a) => {
       state[a + 'Status'] = a === action ? EntityStatus.loadingSuccess : EntityStatus.notLoaded;
       return state;
-    }, { entities, ids }) as UserEntityState;
+    }, { entities, ids, createError }) as UserEntityState;
 }
-
-
-
-

--- a/components/automate-ui/src/app/entities/users/user.reducer.spec.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.spec.ts
@@ -124,8 +124,7 @@ describe('userStatusEntityReducer', () => {
       const action = new CreateUserFailure(payload);
 
       it('sets status to loadingFailure', () => {
-        const { createStatus } = userEntityReducer(initialState, action);
-        const { createError } = userEntityReducer(initialState, action);
+        const { createStatus, createError } = userEntityReducer(initialState, action);
 
         expect(createStatus).toEqual(EntityStatus.loadingFailure);
         expect(createError).toEqual(action.payload);
@@ -266,10 +265,9 @@ function userState(action: string, ...us: User[]): UserEntityState {
     entities[u.id] = u;
     ids.push(u.id);
   }
-  const createError = null;
   return ['get', 'create', 'update', 'delete']
     .reduce((state, a) => {
       state[a + 'Status'] = a === action ? EntityStatus.loadingSuccess : EntityStatus.notLoaded;
       return state;
-    }, { entities, ids, createError }) as UserEntityState;
+    }, { entities, ids, createError: null }) as UserEntityState;
 }

--- a/components/automate-ui/src/app/entities/users/user.reducer.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.ts
@@ -1,10 +1,10 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
 import { set, pipe } from 'lodash/fp';
 
 import { EntityStatus } from '../entities';
 import { UserActionTypes, UserActions } from './user.actions';
 import { User } from './user.model';
-import { HttpErrorResponse } from '@angular/common/http';
 
 export interface UserEntityState extends EntityState<User> {
   getStatus: EntityStatus;

--- a/components/automate-ui/src/app/entities/users/user.reducer.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.ts
@@ -1,5 +1,5 @@
 import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
-import { set, pipe, unset } from 'lodash/fp';
+import { set, pipe } from 'lodash/fp';
 
 import { EntityStatus } from '../entities';
 import { UserActionTypes, UserActions } from './user.actions';
@@ -92,13 +92,13 @@ export function userEntityReducer(state: UserEntityState = UserEntityInitialStat
 
     case UserActionTypes.CREATE:
       return pipe(
-        unset('createError'),
+        set('createError', null),
         set('createStatus', EntityStatus.loading)
       )(state) as UserEntityState;
 
     case UserActionTypes.CREATE_SUCCESS:
       return pipe(
-        unset('createError'),
+        set('createError', null),
         set('createStatus', EntityStatus.loadingSuccess)
       )(userEntityAdapter.addOne(action.payload, state)) as UserEntityState;
 

--- a/components/automate-ui/src/app/entities/users/user.reducer.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.ts
@@ -1,15 +1,17 @@
 import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
-import { set } from 'lodash/fp';
+import { set, pipe, unset } from 'lodash/fp';
 
 import { EntityStatus } from '../entities';
 import { UserActionTypes, UserActions } from './user.actions';
 import { User } from './user.model';
+import { HttpErrorResponse } from '@angular/common/http';
 
 export interface UserEntityState extends EntityState<User> {
   getStatus: EntityStatus;
   updateStatus: EntityStatus;
   deleteStatus: EntityStatus;
   createStatus: EntityStatus;
+  createError: HttpErrorResponse;
 }
 
 export const userEntityAdapter: EntityAdapter<User> = createEntityAdapter<User>();
@@ -18,7 +20,8 @@ export const UserEntityInitialState: UserEntityState = userEntityAdapter.getInit
   getStatus: EntityStatus.notLoaded,
   updateStatus: EntityStatus.notLoaded,
   deleteStatus: EntityStatus.notLoaded,
-  createStatus: EntityStatus.notLoaded
+  createStatus: EntityStatus.notLoaded,
+  createError: null
 });
 
 export function userEntityReducer(state: UserEntityState = UserEntityInitialState,
@@ -88,14 +91,22 @@ export function userEntityReducer(state: UserEntityState = UserEntityInitialStat
       return set('deleteStatus', EntityStatus.loadingFailure, state);
 
     case UserActionTypes.CREATE:
-      return set('createStatus', EntityStatus.loading, state);
+      return pipe(
+        unset('createError'),
+        set('createStatus', EntityStatus.loading)
+      )(state) as UserEntityState;
 
     case UserActionTypes.CREATE_SUCCESS:
-      return set('createStatus', EntityStatus.loadingSuccess,
-                  userEntityAdapter.addOne(action.payload, state));
+      return pipe(
+        unset('createError'),
+        set('createStatus', EntityStatus.loadingSuccess)
+      )(userEntityAdapter.addOne(action.payload, state)) as UserEntityState;
 
     case UserActionTypes.CREATE_FAILURE:
-      return set('createStatus', EntityStatus.loadingFailure, state);
+      return pipe(
+        set('createError', action.payload),
+        set('createStatus', EntityStatus.loadingFailure)
+      )(state) as UserEntityState;
 
     default:
       return state;

--- a/components/automate-ui/src/app/entities/users/user.selectors.ts
+++ b/components/automate-ui/src/app/entities/users/user.selectors.ts
@@ -31,6 +31,11 @@ export const createStatus = createSelector(
   (state) => state.createStatus
 );
 
+export const createError = createSelector(
+  userState,
+  (state) => state.createError
+);
+
 export const userFromRoute = createSelector(
   userEntities,
   routeParams,

--- a/components/automate-ui/src/app/helpers/auth/username-mapper.spec.ts
+++ b/components/automate-ui/src/app/helpers/auth/username-mapper.spec.ts
@@ -4,8 +4,9 @@ import { UsernameMapper } from './username-mapper';
 describe('UsernameMapper', () => {
 
     using([
-      ['-0a5l9z@-', '-0a5l9z@-', 'preserves numbers, lowercase letters, hyphens, @ symbol'],
+      ['-0a5l9z-', '-0a5l9z-', 'preserves numbers, lowercase letters, hyphens, @ symbol'],
       ['my_name__', 'my_name__', 'preserves underscores'],
+      ['my.name+last_name@email.com', 'my.name+last_name@email.com', 'preserves email symbols'],
       ['my-name!', 'my-name-', 'replaces trailing unsupported single char with hyphen'],
       ['my-name$/', 'my-name--', 'replaces trailing unsupported multiple chars with hyphen'],
       ['my^%<>name', 'my----name', 'replaces middle unsupported chars with hyphen'],

--- a/components/automate-ui/src/app/helpers/auth/username-mapper.spec.ts
+++ b/components/automate-ui/src/app/helpers/auth/username-mapper.spec.ts
@@ -11,7 +11,7 @@ describe('UsernameMapper', () => {
       ['my-name$/', 'my-name--', 'replaces trailing unsupported multiple chars with hyphen'],
       ['my^%<>name', 'my----name', 'replaces middle unsupported chars with hyphen'],
       ['#my-name', '-my-name', 'replaces leading unsupported single char with hyphens'],
-      [';=@my-name', '---my-name', 'replaces leading unsupported multiple chars with hyphens'],
+      [';=&my-name', '---my-name', 'replaces leading unsupported multiple chars with hyphens'],
       [' my_name  ', '-my_name--', 'replaces leading/trailing spaces with hyphens'],
       ['my   name', 'my---name', 'replaces middle spaces with hyphens'],
       ['My-Name', 'my-name', 'maps upper case to lower case']

--- a/components/automate-ui/src/app/helpers/auth/username-mapper.spec.ts
+++ b/components/automate-ui/src/app/helpers/auth/username-mapper.spec.ts
@@ -4,7 +4,7 @@ import { UsernameMapper } from './username-mapper';
 describe('UsernameMapper', () => {
 
     using([
-      ['-0a5l9z-', '-0a5l9z-', 'preserves numbers, lowercase letters, hyphens, @ symbol'],
+      ['-0a5l9z-', '-0a5l9z-', 'preserves numbers, lowercase letters, hyphens'],
       ['my_name__', 'my_name__', 'preserves underscores'],
       ['my.name+last_name@email.com', 'my.name+last_name@email.com', 'preserves email symbols'],
       ['my-name!', 'my-name-', 'replaces trailing unsupported single char with hyphen'],

--- a/components/automate-ui/src/app/helpers/auth/username-mapper.spec.ts
+++ b/components/automate-ui/src/app/helpers/auth/username-mapper.spec.ts
@@ -1,0 +1,24 @@
+import { using } from 'app/testing/spec-helpers';
+import { UsernameMapper } from './username-mapper';
+
+describe('UsernameMapper', () => {
+
+    using([
+      ['-0a5l9z@-', '-0a5l9z@-', 'preserves numbers, lowercase letters, hyphens, @ symbol'],
+      ['my_name__', 'my_name__', 'preserves underscores'],
+      ['my-name!', 'my-name-', 'replaces trailing unsupported single char with hyphen'],
+      ['my-name$/', 'my-name--', 'replaces trailing unsupported multiple chars with hyphen'],
+      ['my^%<>name', 'my----name', 'replaces middle unsupported chars with hyphen'],
+      ['#my-name', '-my-name', 'replaces leading unsupported single char with hyphens'],
+      [';=@my-name', '---my-name', 'replaces leading unsupported multiple chars with hyphens'],
+      [' my_name  ', '-my_name--', 'replaces leading/trailing spaces with hyphens'],
+      ['my   name', 'my---name', 'replaces middle spaces with hyphens'],
+      ['My-Name', 'my-name', 'maps upper case to lower case']
+    ], function (inputVal: string, outputVal: string, desc: string) {
+
+      it('transform ' + desc, () => {
+        expect(UsernameMapper.transform(inputVal)).toBe(outputVal);
+      });
+    });
+
+});

--- a/components/automate-ui/src/app/helpers/auth/username-mapper.ts
+++ b/components/automate-ui/src/app/helpers/auth/username-mapper.ts
@@ -1,0 +1,6 @@
+export class UsernameMapper {
+
+  public static transform(input: string): string {
+    return input.toLowerCase().replace(/[^a-z0-9_@]/g, '-');
+  }
+}

--- a/components/automate-ui/src/app/helpers/auth/username-mapper.ts
+++ b/components/automate-ui/src/app/helpers/auth/username-mapper.ts
@@ -1,6 +1,6 @@
 export class UsernameMapper {
 
   public static transform(input: string): string {
-    return input.toLowerCase().replace(/[^a-z0-9_@]/g, '-');
+    return input.toLowerCase().replace(/[^a-z0-9_@+\.]/g, '-');
   }
 }

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
@@ -1,64 +1,72 @@
-<form [formGroup]="createUserForm">
-  <chef-form-field>
-    <label>
-      <span class="label">Display Name <span aria-hidden="true">*</span></span>
-      <input chefInput formControlName="displayname" type="text" (keyup)="handleNameInput($event)" autocomplete="off"/>
-    </label>
-    <chef-error *ngIf="(createUserForm.get('displayname').hasError('required') && createUserForm.get('displayname').touched) || (createUserForm.get('displayname').hasError('pattern') && createUserForm.get('displayname').dirty)">
-      Display name is required.
-    </chef-error>
-  </chef-form-field>
-  <span class="detail">Don't worry, display names can be changed later.</span>
-  <div *ngIf="modifyUsername">
-    <chef-form-field>
-      <label>
-        <span class="label">Username <span aria-hidden="true">*</span></span>
-        <input chefInput formControlName="username" type="text" (keyup)="handleUsernameInput($event)" autocomplete="off"/>
-      </label>
-      <chef-error *ngIf="createUserForm.get('username').hasError('required') && createUserForm.get('username').dirty">
-        Username is required.
-      </chef-error>
-      <chef-error *ngIf="createUserForm.get('username').hasError('pattern') && createUserForm.get('username').dirty">
-        Only letters, numbers, and these characters (<strong>_@.+-</strong>) allowed.
-      </chef-error>
-      <chef-error *ngIf="conflictError">
-        Username "{{createUserForm.get('username').value}}" already exists.
-      </chef-error>
-    </chef-form-field>
-  </div>
-  <div *ngIf="!modifyUsername">
-    <div id="username-fields">
-      <span class="key-label">Username:&nbsp;</span>
-      <span>{{ this.createUserForm?.value.username }}</span>
+<div class="flex-container">
+  <form [formGroup]="createUserForm">
+    <div class="field-margin">
+      <chef-form-field>
+        <label>
+          <span>Display Name <span aria-hidden="true">*</span></span>
+          <input chefInput formControlName="displayname" type="text" (keyup)="handleNameInput($event)" autocomplete="off"/>
+        </label>
+        <chef-error *ngIf="(createUserForm.get('displayname').hasError('required') && createUserForm.get('displayname').touched) || (createUserForm.get('displayname').hasError('pattern') && createUserForm.get('displayname').dirty)">
+          Display name is required.
+        </chef-error>
+      </chef-form-field>
+      <span class="detail">Don't worry, display names can be changed later.</span>
     </div>
-    <chef-toolbar>
-      <chef-button tertiary (click)="modifyUsername = true" id="edit-button-object-modal">Edit Username</chef-button>
-    </chef-toolbar>
-  </div>
-  <chef-form-field>
-    <label>
-      <span class="label">Password <span aria-hidden="true">*</span></span>
-      <input chefInput formControlName="password" type="password"/>
-    </label>
-    <chef-error *ngIf="(createUserForm.get('password').hasError('required') || createUserForm.get('password').hasError('pattern')) && createUserForm.get('password').dirty && createUserForm.get('password').touched">
-      Password is required.
-    </chef-error>
-    <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && createUserForm.get('password').dirty && createUserForm.get('password').touched">
-      Password must be at least 8 characters.
-    </chef-error>
-    <chef-error *ngIf="passwordError">
-      Password must contain at least 3 distinct characters.
-    </chef-error>
-  </chef-form-field>
-  <span class="detail">Must be a minimum of 8 total characters with at least 3 distinct characters.<br>
-    May include both upper and lower case letters, punctuation marks, and symbols.</span>
-  <chef-form-field>
-    <label>
-      <span class="label">Confirm Password <span aria-hidden="true">*</span></span>
-      <input chefInput formControlName="confirmPassword" type="password"/>
-    </label>
-    <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && createUserForm.get('confirmPassword').dirty && createUserForm.get('confirmPassword').touched">
-      Passwords must match.
-    </chef-error>
-  </chef-form-field>
-</form>
+    <div class="field-margin" *ngIf="modifyUsername">
+      <chef-form-field>
+        <label>
+          <span>Username <span aria-hidden="true">*</span></span>
+          <input chefInput formControlName="username" type="text" (keyup)="handleUsernameInput($event)" autocomplete="off"/>
+        </label>
+        <chef-error *ngIf="createUserForm.get('username').hasError('required') && createUserForm.get('username').dirty">
+          Username is required.
+        </chef-error>
+        <chef-error *ngIf="createUserForm.get('username').hasError('pattern') && createUserForm.get('username').dirty">
+          Only letters, numbers, and these characters (<strong>_@.+-</strong>) allowed.
+        </chef-error>
+        <chef-error *ngIf="conflictError">
+          Username "{{createUserForm.get('username').value}}" already exists.
+        </chef-error>
+      </chef-form-field>
+    </div>
+    <div class="field-margin" *ngIf="!modifyUsername">
+      <div id="username-fields">
+        <span class="key-label">Username:&nbsp;</span>
+        <span>{{ this.createUserForm?.value.username }}</span>
+      </div>
+      <chef-toolbar>
+        <chef-button tertiary (click)="modifyUsername = true" id="edit-button-object-modal">Edit Username</chef-button>
+      </chef-toolbar>
+    </div>
+    <div class="field-margin">
+      <chef-form-field>
+        <label>
+          <span>Password <span aria-hidden="true">*</span></span>
+          <input chefInput formControlName="password" type="password"/>
+        </label>
+        <chef-error *ngIf="(createUserForm.get('password').hasError('required') || createUserForm.get('password').hasError('pattern')) && createUserForm.get('password').dirty && createUserForm.get('password').touched">
+          Password is required.
+        </chef-error>
+        <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && createUserForm.get('password').dirty && createUserForm.get('password').touched">
+          Password must be at least 8 characters.
+        </chef-error>
+        <chef-error *ngIf="passwordError">
+          Password must contain at least 3 distinct characters.
+        </chef-error>
+      </chef-form-field>
+      <span class="detail">Must be a minimum of 8 total characters with at least 3 distinct characters.<br>
+        May include both upper and lower case letters, punctuation marks, and symbols.</span>
+    </div>
+    <div class="field-margin">
+      <chef-form-field>
+        <label>
+          <span>Confirm Password <span aria-hidden="true">*</span></span>
+          <input chefInput formControlName="confirmPassword" type="password"/>
+        </label>
+        <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && createUserForm.get('confirmPassword').dirty && createUserForm.get('confirmPassword').touched">
+          Passwords must match.
+        </chef-error>
+      </chef-form-field>
+    </div>
+  </form>
+</div>

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
@@ -4,9 +4,9 @@
       <chef-form-field>
         <label>
           <span>Display Name <span aria-hidden="true">*</span></span>
-          <input chefInput formControlName="displayname" type="text" (keyup)="handleNameInput($event)" autocomplete="off"/>
+          <input chefInput formControlName="displayName" type="text" (keyup)="handleNameInput($event)" autocomplete="off"/>
         </label>
-        <chef-error *ngIf="(createUserForm.get('displayname').hasError('required') && createUserForm.get('displayname').touched) || (createUserForm.get('displayname').hasError('pattern') && createUserForm.get('displayname').dirty)">
+        <chef-error *ngIf="leftInputEmpty('displayName')">
           Display name is required.
         </chef-error>
       </chef-form-field>
@@ -18,10 +18,10 @@
           <span>Username <span aria-hidden="true">*</span></span>
           <input chefInput formControlName="username" type="text" (keyup)="handleUsernameInput($event)" autocomplete="off"/>
         </label>
-        <chef-error *ngIf="createUserForm.get('username').hasError('required') && createUserForm.get('username').dirty">
+        <chef-error *ngIf="leftInputEmpty('username')">
           Username is required.
         </chef-error>
-        <chef-error *ngIf="createUserForm.get('username').hasError('pattern') && createUserForm.get('username').dirty">
+        <chef-error *ngIf="createUserForm.get('username').hasError('pattern') && hasAttemptedInput('username')">
           Only letters, numbers, and these characters (<strong>_@.+-</strong>) allowed.
         </chef-error>
         <chef-error *ngIf="conflictError">
@@ -44,10 +44,10 @@
           <span>Password <span aria-hidden="true">*</span></span>
           <input chefInput formControlName="password" type="password"/>
         </label>
-        <chef-error *ngIf="(createUserForm.get('password').hasError('required') || createUserForm.get('password').hasError('pattern')) && createUserForm.get('password').dirty && createUserForm.get('password').touched">
+        <chef-error *ngIf="leftInputEmpty('password')">
           Password is required.
         </chef-error>
-        <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && createUserForm.get('password').dirty && createUserForm.get('password').touched">
+        <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && hasAttemptedInput('password')">
           Password must be at least 8 characters.
         </chef-error>
         <chef-error *ngIf="passwordError">
@@ -63,7 +63,10 @@
           <span>Confirm Password <span aria-hidden="true">*</span></span>
           <input chefInput formControlName="confirmPassword" type="password"/>
         </label>
-        <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && createUserForm.get('confirmPassword').dirty && createUserForm.get('confirmPassword').touched">
+        <chef-error *ngIf="leftInputEmpty('confirmPassword')">
+          Confirm Password is required.
+        </chef-error>
+        <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && hasAttemptedInput('confirmPassword')">
           Passwords must match.
         </chef-error>
       </chef-form-field>

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
@@ -10,7 +10,7 @@
           Display name is required.
         </chef-error>
       </chef-form-field>
-      <span class="detail">Don't worry, display names can be changed later.</span>
+      <span class="detail light">Don't worry, display names can be changed later.</span>
     </div>
     <div class="field-margin" *ngIf="modifyUsername">
       <chef-form-field>
@@ -54,7 +54,7 @@
           Password must contain at least 3 distinct characters.
         </chef-error>
       </chef-form-field>
-      <span class="detail">Must be a minimum of 8 total characters with at least 3 distinct characters.<br>
+      <span class="detail light">Must be a minimum of 8 total characters with at least 3 distinct characters.<br>
         May include both upper and lower case letters, punctuation marks, and symbols.</span>
     </div>
     <div class="field-margin">

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
@@ -12,13 +12,16 @@
   <chef-form-field>
     <label>
       <span class="label">Username <span aria-hidden="true">*</span></span>
-      <input chefInput formControlName="username" type="text" autocomplete="off"/>
+      <input chefInput formControlName="username" type="text" autocomplete="off" (keyup)="handleUsernameInput($event)" />
     </label>
     <chef-error *ngIf="createUserForm.get('username').hasError('required') && createUserForm.get('username').dirty">
       Username is required.
     </chef-error>
     <chef-error *ngIf="createUserForm.get('username').hasError('pattern') && createUserForm.get('username').dirty">
       Only letters, numbers, and these characters (<strong>_@.+-</strong>) allowed.
+    </chef-error>
+    <chef-error *ngIf="conflictError">
+      Username "{{createUserForm.get('username').value}}" already exists.
     </chef-error>
   </chef-form-field>
   <chef-form-field>
@@ -31,6 +34,9 @@
     </chef-error>
     <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && createUserForm.get('password').dirty && createUserForm.get('password').touched">
       Password must be at least 8 characters.
+    </chef-error>
+    <chef-error *ngIf="passwordError">
+      Password must contain at least 3 distinct characters.
     </chef-error>
   </chef-form-field>
   <span class="detail">Must be a minimum of 8 total characters with at least 3 distinct characters.<br>

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
@@ -2,28 +2,39 @@
   <chef-form-field>
     <label>
       <span class="label">Display Name <span aria-hidden="true">*</span></span>
-      <input chefInput formControlName="displayname" type="text" autocomplete="off"/>
+      <input chefInput formControlName="displayname" type="text" (keyup)="handleNameInput($event)" autocomplete="off"/>
     </label>
     <chef-error *ngIf="(createUserForm.get('displayname').hasError('required') && createUserForm.get('displayname').touched) || (createUserForm.get('displayname').hasError('pattern') && createUserForm.get('displayname').dirty)">
       Display name is required.
     </chef-error>
   </chef-form-field>
   <span class="detail">Don't worry, display names can be changed later.</span>
-  <chef-form-field>
-    <label>
-      <span class="label">Username <span aria-hidden="true">*</span></span>
-      <input chefInput formControlName="username" type="text" autocomplete="off" (keyup)="handleUsernameInput($event)" />
-    </label>
-    <chef-error *ngIf="createUserForm.get('username').hasError('required') && createUserForm.get('username').dirty">
-      Username is required.
-    </chef-error>
-    <chef-error *ngIf="createUserForm.get('username').hasError('pattern') && createUserForm.get('username').dirty">
-      Only letters, numbers, and these characters (<strong>_@.+-</strong>) allowed.
-    </chef-error>
-    <chef-error *ngIf="conflictError">
-      Username "{{createUserForm.get('username').value}}" already exists.
-    </chef-error>
-  </chef-form-field>
+  <div *ngIf="modifyUsername">
+    <chef-form-field>
+      <label>
+        <span class="label">Username <span aria-hidden="true">*</span></span>
+        <input chefInput formControlName="username" type="text" (keyup)="handleUsernameInput($event)" autocomplete="off"/>
+      </label>
+      <chef-error *ngIf="createUserForm.get('username').hasError('required') && createUserForm.get('username').dirty">
+        Username is required.
+      </chef-error>
+      <chef-error *ngIf="createUserForm.get('username').hasError('pattern') && createUserForm.get('username').dirty">
+        Only letters, numbers, and these characters (<strong>_@.+-</strong>) allowed.
+      </chef-error>
+      <chef-error *ngIf="conflictError">
+        Username "{{createUserForm.get('username').value}}" already exists.
+      </chef-error>
+    </chef-form-field>
+  </div>
+  <div *ngIf="!modifyUsername">
+    <div id="username-fields">
+      <span class="key-label">Username:&nbsp;</span>
+      <span>{{ this.createUserForm?.value.username }}</span>
+    </div>
+    <chef-toolbar>
+      <chef-button tertiary (click)="modifyUsername = true" id="edit-button-object-modal">Edit Username</chef-button>
+    </chef-toolbar>
+  </div>
   <chef-form-field>
     <label>
       <span class="label">Password <span aria-hidden="true">*</span></span>

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
@@ -28,6 +28,7 @@
           Username "{{createUserForm.get('username').value}}" already exists.
         </chef-error>
       </chef-form-field>
+      <span class="detail light">Usernames are unique, permanent, and cannot be changed later.</span>
     </div>
     <div class="field-margin" *ngIf="!modifyUsername">
       <div id="username-fields">

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
@@ -3,7 +3,7 @@
     <div class="field-margin">
       <chef-form-field>
         <label>
-          <span>Display Name <span aria-hidden="true">*</span></span>
+          Display Name <span aria-hidden="true">*</span>
           <input chefInput formControlName="displayName" type="text" (keyup)="handleNameInput($event)" autocomplete="off"/>
         </label>
         <chef-error *ngIf="leftInputEmpty('displayName')">
@@ -15,7 +15,7 @@
     <div class="field-margin" *ngIf="modifyUsername">
       <chef-form-field>
         <label>
-          <span>Username <span aria-hidden="true">*</span></span>
+          Username <span aria-hidden="true">*</span>
           <input chefInput formControlName="username" type="text" (keyup)="handleUsernameInput($event)" autocomplete="off"/>
         </label>
         <chef-error *ngIf="leftInputEmpty('username')">
@@ -35,13 +35,13 @@
         <span>{{ this.createUserForm?.value.username }}</span>
       </div>
       <chef-toolbar>
-        <chef-button tertiary (click)="modifyUsername = true" id="edit-button-object-modal">Edit Username</chef-button>
+        <chef-button tertiary (click)="modifyUsername = true" data-cy="edit-username">Edit Username</chef-button>
       </chef-toolbar>
     </div>
     <div class="field-margin">
       <chef-form-field>
         <label>
-          <span>Password <span aria-hidden="true">*</span></span>
+          Password <span aria-hidden="true">*</span>
           <input chefInput formControlName="password" type="password"/>
         </label>
         <chef-error *ngIf="leftInputEmpty('password')">
@@ -60,7 +60,7 @@
     <div class="field-margin">
       <chef-form-field>
         <label>
-          <span>Confirm Password <span aria-hidden="true">*</span></span>
+          Confirm Password <span aria-hidden="true">*</span>
           <input chefInput formControlName="confirmPassword" type="password"/>
         </label>
         <chef-error *ngIf="leftInputEmpty('confirmPassword')">

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
@@ -6,7 +6,7 @@
           Display Name <span aria-hidden="true">*</span>
           <input chefInput formControlName="displayName" type="text" (keyup)="handleNameInput($event)" autocomplete="off"/>
         </label>
-        <chef-error *ngIf="leftInputEmpty('displayName')">
+        <chef-error *ngIf="hasAttemptedInputWithError('displayName')">
           Display name is required.
         </chef-error>
       </chef-form-field>
@@ -18,7 +18,7 @@
           Username <span aria-hidden="true">*</span>
           <input chefInput formControlName="username" type="text" (keyup)="handleUsernameInput($event)" autocomplete="off"/>
         </label>
-        <chef-error *ngIf="leftInputEmpty('username')">
+        <chef-error *ngIf="hasAttemptedInputWithError('username')">
           Username is required.
         </chef-error>
         <chef-error *ngIf="createUserForm.get('username').hasError('pattern') && hasAttemptedInput('username')">
@@ -45,7 +45,7 @@
           Password <span aria-hidden="true">*</span>
           <input chefInput formControlName="password" type="password"/>
         </label>
-        <chef-error *ngIf="leftInputEmpty('password')">
+        <chef-error *ngIf="hasAttemptedInputWithError('password')">
           Password is required.
         </chef-error>
         <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && hasAttemptedInput('password')">
@@ -64,7 +64,7 @@
           Confirm Password <span aria-hidden="true">*</span>
           <input chefInput formControlName="confirmPassword" type="password"/>
         </label>
-        <chef-error *ngIf="leftInputEmpty('confirmPassword')">
+        <chef-error *ngIf="hasAttemptedInputWithError('confirmPassword')">
           Confirm Password is required.
         </chef-error>
         <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && hasAttemptedInput('confirmPassword')">

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
@@ -4,7 +4,7 @@
       <span class="label">Display Name <span aria-hidden="true">*</span></span>
       <input chefInput formControlName="displayname" type="text" autocomplete="off"/>
     </label>
-    <chef-error *ngIf="(createUserForm.get('displayname').hasError('required') || createUserForm.get('displayname').hasError('pattern')) && createUserForm.get('displayname').dirty">
+    <chef-error *ngIf="(createUserForm.get('displayname').hasError('required') && createUserForm.get('displayname').touched) || (createUserForm.get('displayname').hasError('pattern') && createUserForm.get('displayname').dirty)">
       Display name is required.
     </chef-error>
   </chef-form-field>
@@ -26,19 +26,21 @@
       <span class="label">Password <span aria-hidden="true">*</span></span>
       <input chefInput formControlName="password" type="password"/>
     </label>
-    <chef-error *ngIf="(createUserForm.get('password').hasError('required') || createUserForm.get('password').hasError('pattern')) && createUserForm.get('password').dirty">
+    <chef-error *ngIf="(createUserForm.get('password').hasError('required') || createUserForm.get('password').hasError('pattern')) && createUserForm.get('password').dirty && createUserForm.get('password').touched">
       Password is required.
     </chef-error>
-    <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && createUserForm.get('password').dirty">
+    <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && createUserForm.get('password').dirty && createUserForm.get('password').touched">
       Password must be at least 8 characters.
     </chef-error>
   </chef-form-field>
+  <span class="detail">Must be a minimum of 8 total characters with at least 3 distinct characters.<br>
+    May include both upper and lower case letters, punctuation marks, and symbols.</span>
   <chef-form-field>
     <label>
       <span class="label">Confirm Password <span aria-hidden="true">*</span></span>
       <input chefInput formControlName="confirmPassword" type="password"/>
     </label>
-    <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && createUserForm.get('confirmPassword').dirty">
+    <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && createUserForm.get('confirmPassword').dirty && createUserForm.get('confirmPassword').touched">
       Passwords must match.
     </chef-error>
   </chef-form-field>

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.html
@@ -1,13 +1,14 @@
 <form [formGroup]="createUserForm">
   <chef-form-field>
     <label>
-      <span class="label">User's Full Name <span aria-hidden="true">*</span></span>
-      <input chefInput formControlName="fullname" type="text" autocomplete="off"/>
+      <span class="label">Display Name <span aria-hidden="true">*</span></span>
+      <input chefInput formControlName="displayname" type="text" autocomplete="off"/>
     </label>
-    <chef-error *ngIf="(createUserForm.get('fullname').hasError('required') || createUserForm.get('fullname').hasError('pattern')) && createUserForm.get('fullname').dirty">
-      User's Full Name is required.
+    <chef-error *ngIf="(createUserForm.get('displayname').hasError('required') || createUserForm.get('displayname').hasError('pattern')) && createUserForm.get('displayname').dirty">
+      Display name is required.
     </chef-error>
   </chef-form-field>
+  <span class="detail">Don't worry, display names can be changed later.</span>
   <chef-form-field>
     <label>
       <span class="label">Username <span aria-hidden="true">*</span></span>

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.scss
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.scss
@@ -1,27 +1,35 @@
 @import "~styles/variables";
 
-form {
-  margin-top: 8px;
-  padding: 1em 10em 1em 10em;
+.flex-container {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
 
-  chef-form-field {
-    padding-bottom: .5em;
-  }
-
-  input {
-    font-size: 1em;
-  }
-
-  .detail {
-    color: $chef-primary-dark;
-    font-size: 12px;
-  }
-
-  #username-fields {
-    font-size: 0.75em;
-
-    .key-label {
-      font-weight: bold;
+  form {
+    width: 71%;
+  
+    .field-margin {
+      margin-bottom: 30px;
+    }
+  
+    input {
+      font-size: 1em;
+    }
+  
+    .detail {
+      width: 100%;
+      color: $chef-primary-dark;
+      font-size: 12px;
+      white-space: nowrap;
+    }
+  
+    #username-fields {
+      font-size: 0.75em;
+  
+      .key-label {
+        font-weight: bold;
+      }
     }
   }
 }
+

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.scss
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.scss
@@ -16,4 +16,12 @@ form {
     color: $chef-primary-dark;
     font-size: 12px;
   }
+
+  #username-fields {
+    font-size: 0.75em;
+
+    .key-label {
+      font-weight: bold;
+    }
+  }
 }

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.scss
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.scss
@@ -7,25 +7,25 @@
 
   form {
     width: 71%;
-  
+
     .field-margin {
       margin-bottom: 30px;
     }
-  
+
     input {
       font-size: 1em;
     }
-  
+
     .detail {
       width: 100%;
       color: $chef-primary-dark;
       font-size: 12px;
       white-space: nowrap;
     }
-  
+
     #username-fields {
       font-size: 0.75em;
-  
+
       .key-label {
         font-weight: bold;
       }

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.scss
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.scss
@@ -3,12 +3,17 @@
 form {
   margin-top: 8px;
   padding: 1em 10em 1em 10em;
-}
 
-chef-form-field {
-  padding-bottom: .5em;
-}
+  chef-form-field {
+    padding-bottom: .5em;
+  }
 
-input {
-  font-size: 1em;
+  input {
+    font-size: 1em;
+  }
+
+  .detail {
+    color: $chef-primary-dark;
+    font-size: 12px;
+  }
 }

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.spec.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.spec.ts
@@ -1,0 +1,62 @@
+import { EventEmitter } from '@angular/core';
+import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { MockComponent } from 'ng2-mock-component';
+
+import { using } from 'app/testing/spec-helpers';
+import { UserFormComponent } from './user-form.component';
+
+describe('UserFormComponent', () => {
+  let fixture: ComponentFixture<UserFormComponent>;
+  let component: UserFormComponent;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      declarations: [
+        UserFormComponent,
+        MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),
+        MockComponent({ selector: 'chef-form-field' }),
+        MockComponent({ selector: 'chef-error' }),
+        MockComponent({ selector: 'chef-toolbar' })
+      ],
+     imports: [
+        ReactiveFormsModule
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserFormComponent);
+    component = fixture.componentInstance;
+    component.conflictErrorEvent = new EventEmitter();
+    component.passwordErrorEvent = new EventEmitter();
+    component.closeEvent = new EventEmitter();
+    component.createUserForm = new FormBuilder().group({
+      displayName: ['', null],
+      username: ['', null],
+      password: ['', null],
+      confirmPassword: ['', null]
+    });
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  using([
+    ['my-name', 'my-name', 'mirrors input with no leading/trailing whitespace'],
+    ['  my-name  ', 'my-name', 'trims leading whitespace'],
+    ['my-name  ', 'my-name', 'trims trailing whitespace']
+  ], function (inputVal: string, outputVal: string, desc: string) {
+
+    it('handleNameInput ' + desc, () => {
+      component.createUserForm.controls['displayName'].setValue(inputVal);
+      component.handleNameInput(new KeyboardEvent('keyup',
+        // Typescript bug requires us to work around with <any>
+        // https://github.com/Microsoft/TypeScript/issues/15228
+        <any>{bubbles : true, cancelable : true, key : inputVal, char : inputVal, shiftKey : true
+      }));
+      expect(component.createUserForm.controls['username'].value).toBe(outputVal);
+    });
+  });
+});

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.ts
@@ -26,17 +26,17 @@ export class UserFormComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.conflictErrorEvent.pipe(takeUntil(this.isDestroyed))
       .subscribe((isConflict: boolean) => {
-      this.conflictError = isConflict;
-      // Open the ID input on conflict so user can resolve it.
-      this.modifyUsername = isConflict;
-    });
+        this.conflictError = isConflict;
+        // Open the ID input on conflict so user can resolve it.
+        this.modifyUsername = isConflict;
+      });
 
     this.passwordErrorEvent.pipe(takeUntil(this.isDestroyed))
-    .subscribe((badPassword: boolean) => {
-      this.passwordError = badPassword;
-      this.createUserForm.get('password').reset();
-      this.createUserForm.get('confirmPassword').reset();
-    });
+      .subscribe((badPassword: boolean) => {
+        this.passwordError = badPassword;
+        this.createUserForm.get('password').reset();
+        this.createUserForm.get('confirmPassword').reset();
+      });
   }
 
   ngOnDestroy() {
@@ -55,13 +55,24 @@ export class UserFormComponent implements OnInit, OnDestroy {
     if (!this.modifyUsername && !this.isNavigationKey(event)) {
       this.conflictError = false;
       this.createUserForm.controls.username.setValue(
-        UsernameMapper.transform(this.createUserForm.controls.displayname.value.trim()));
+        UsernameMapper.transform(this.createUserForm.controls.displayName.value.trim()));
     }
   }
 
   handleClose(): void {
     this.modifyUsername = false;
-    this.close.emit();
+  }
+
+  hasAttemptedInput(field: string): boolean {
+    return (this.createUserForm.get(field).touched &&
+      this.createUserForm.get(field).dirty);
+  }
+
+  leftInputEmpty(field: string): boolean {
+    return ((this.createUserForm.get(field).hasError('required') &&
+      this.createUserForm.get(field).touched) ||
+      (this.createUserForm.get(field).hasError('pattern') &&
+        this.createUserForm.get(field).dirty));
   }
 
   private isNavigationKey(event: KeyboardEvent): boolean {

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit, EventEmitter } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
 @Component({
@@ -6,6 +6,33 @@ import { FormGroup } from '@angular/forms';
   templateUrl: './user-form.component.html',
   styleUrls: ['./user-form.component.scss']
 })
-export class UserFormComponent {
+export class UserFormComponent implements OnInit {
   @Input() createUserForm: FormGroup;
+  @Input() conflictErrorEvent: EventEmitter<boolean>;
+  @Input() passwordErrorEvent: EventEmitter<boolean>;
+
+  public conflictError = false;
+  public passwordError = false;
+
+  ngOnInit(): void {
+    this.conflictErrorEvent.subscribe((isConflict: boolean) => {
+      this.conflictError = isConflict;
+    });
+    // TODO add takeUntil(this.isDestroyed) to unsubscribe
+
+    this.passwordErrorEvent.subscribe((badPassword: boolean) => {
+      this.passwordError = badPassword;
+      this.createUserForm.get('password').reset();
+      this.createUserForm.get('confirmPassword').reset();
+    });
+    // TODO add takeUntil(this.isDestroyed) to unsubscribe
+  }
+
+  handleUsernameInput(event: KeyboardEvent): void {
+    // no change if navigation key entered
+    if (event.key === 'Shift' || event.key === 'Tab') {
+      return;
+    }
+    this.conflictError = false;
+  }
 }

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.ts
@@ -68,7 +68,7 @@ export class UserFormComponent implements OnInit, OnDestroy {
       this.createUserForm.get(field).dirty);
   }
 
-  leftInputEmpty(field: string): boolean {
+  hasAttemptedInputWithError(field: string): boolean {
     return ((this.createUserForm.get(field).hasError('required') &&
       this.createUserForm.get(field).touched) ||
       (this.createUserForm.get(field).hasError('pattern') &&

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit, EventEmitter } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { IdMapper } from 'app/helpers/auth/id-mapper';
+import { UsernameMapper } from 'app/helpers/auth/username-mapper';
 
 @Component({
   selector: 'app-user-form',
@@ -41,11 +41,9 @@ export class UserFormComponent implements OnInit {
 
   handleNameInput(event: KeyboardEvent): void {
     if (!this.modifyUsername && !this.isNavigationKey(event)) {
-      console.log('in the handleName here is username' + this.createUserForm.controls.username.value);
       this.conflictError = false;
       this.createUserForm.controls.username.setValue(
-        IdMapper.transform(this.createUserForm.controls.displayname.value.trim()));
-        console.log('in the transformation here is username' + this.createUserForm.controls.username.value);
+        UsernameMapper.transform(this.createUserForm.controls.displayname.value.trim()));
     }
   }
 

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, EventEmitter } from '@angular/core';
+import { Component, Input, OnInit, EventEmitter, Output } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { UsernameMapper } from 'app/helpers/auth/username-mapper';
 
@@ -11,6 +11,9 @@ export class UserFormComponent implements OnInit {
   @Input() createUserForm: FormGroup;
   @Input() conflictErrorEvent: EventEmitter<boolean>;
   @Input() passwordErrorEvent: EventEmitter<boolean>;
+  @Input() closeEvent: EventEmitter<any>;
+
+  @Output() close = new EventEmitter();
 
   public conflictError = false;
   public passwordError = false;
@@ -45,6 +48,11 @@ export class UserFormComponent implements OnInit {
       this.createUserForm.controls.username.setValue(
         UsernameMapper.transform(this.createUserForm.controls.displayname.value.trim()));
     }
+  }
+
+  handleClose(): void {
+    this.modifyUsername = false;
+    this.close.emit();
   }
 
   private isNavigationKey(event: KeyboardEvent): boolean {

--- a/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-form/user-form.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit, EventEmitter } from '@angular/core';
 import { FormGroup } from '@angular/forms';
+import { IdMapper } from 'app/helpers/auth/id-mapper';
 
 @Component({
   selector: 'app-user-form',
@@ -13,10 +14,13 @@ export class UserFormComponent implements OnInit {
 
   public conflictError = false;
   public passwordError = false;
+  public modifyUsername = false; // Whether the edit Username form is open or not.
 
   ngOnInit(): void {
     this.conflictErrorEvent.subscribe((isConflict: boolean) => {
       this.conflictError = isConflict;
+      // Open the ID input on conflict so user can resolve it.
+      this.modifyUsername = isConflict;
     });
     // TODO add takeUntil(this.isDestroyed) to unsubscribe
 
@@ -29,10 +33,23 @@ export class UserFormComponent implements OnInit {
   }
 
   handleUsernameInput(event: KeyboardEvent): void {
-    // no change if navigation key entered
-    if (event.key === 'Shift' || event.key === 'Tab') {
+    if (this.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
+  }
+
+  handleNameInput(event: KeyboardEvent): void {
+    if (!this.modifyUsername && !this.isNavigationKey(event)) {
+      console.log('in the handleName here is username' + this.createUserForm.controls.username.value);
+      this.conflictError = false;
+      this.createUserForm.controls.username.setValue(
+        IdMapper.transform(this.createUserForm.controls.displayname.value.trim()));
+        console.log('in the transformation here is username' + this.createUserForm.controls.username.value);
+    }
+  }
+
+  private isNavigationKey(event: KeyboardEvent): boolean {
+    return event.key === 'Shift' || event.key === 'Tab';
   }
 }

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.html
@@ -23,7 +23,7 @@
           <app-user-form [createUserForm]="createUserForm"></app-user-form>
           <div class="line"></div>
           <div class="options">
-            <chef-button primary class="create" (click)="handleCreateUser()" [disabled]="!createUserForm.valid"
+            <chef-button primary class="create" (click)="createUser()" [disabled]="!createUserForm.valid"
               tabindex="2" data-cy="save-user">
               <ng-container *ngIf="!creatingUser">
                 <chef-icon>save</chef-icon>
@@ -40,7 +40,7 @@
       </chef-modal>
   
       <section class="page-body">
-                <app-user-table
+        <app-user-table
           [addButtonText]="addButtonText"
           [removeText]="removeText"
           [users]="users"

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.html
@@ -20,7 +20,11 @@
           Create User
         </h2>
         <div>
-          <app-user-form [createUserForm]="createUserForm"></app-user-form>
+          <app-user-form 
+            [createUserForm]="createUserForm"
+            [conflictErrorEvent]="conflictErrorEvent"
+            [passwordErrorEvent]="passwordErrorEvent">
+          </app-user-form>
           <div class="line"></div>
           <div class="options">
             <chef-button primary class="create" (click)="createUser()" [disabled]="!createUserForm.valid"

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.html
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.html
@@ -14,31 +14,27 @@
         <chef-subheading>Chef Automate only displays local users.</chef-subheading>
       </chef-page-header>
   
-      <chef-modal label="create-user-label" class="user-modal" [visible]="createModalVisible"
+      <chef-modal [visible]="createModalVisible"
         (closeModal)="closeCreateModal()">
-        <h2 id="create-user-label" class="title" slot="title">
-          Create User
-        </h2>
-        <div>
+        <h2 slot="title"> Create User </h2>
+        <div class="flex-container">
           <app-user-form 
             [createUserForm]="createUserForm"
             [conflictErrorEvent]="conflictErrorEvent"
             [passwordErrorEvent]="passwordErrorEvent">
           </app-user-form>
-          <div class="line"></div>
-          <div class="options">
-            <chef-button primary class="create" (click)="createUser()" [disabled]="!createUserForm.valid"
+          <div>
+            <chef-button primary (click)="createUser()" [disabled]="!createUserForm.valid"
               tabindex="2" data-cy="save-user">
               <ng-container *ngIf="!creatingUser">
-                <chef-icon>save</chef-icon>
-                <span>Save and Close </span>
+                Create User
               </ng-container>
               <ng-container *ngIf="creatingUser">
                 <chef-loading-spinner></chef-loading-spinner>
-                <span>Saving...</span>
+                <span>Creating...</span>
               </ng-container>
             </chef-button>
-            <chef-button type="reset" tertiary id="cancel" (click)="closeCreateModal()" tabindex="-1">Cancel</chef-button>
+            <chef-button type="reset" tertiary (click)="closeCreateModal()" tabindex="-1">Cancel</chef-button>
           </div>
         </div>
       </chef-modal>

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.scss
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.scss
@@ -5,29 +5,17 @@
 }
 
 chef-modal {
-  .errors {
-    margin: 8px 85px 8px 85px;
-  }
-
-  .title {
-    font-size: 18px;
+  [slot=title] {
+    text-align: center;
     font-weight: bold;
-    color: $chef-primary-dark;
-    text-align: center;
-    margin-top: 10px;
-    margin-bottom: 20px;
+    margin-top: 1em;
+    padding-bottom: 12px;
   }
 
-  .line {
-    margin: 1.5em 2em 1.5em 1em;
-    box-sizing: border-box;
-    height: 3px;
-    width: 95%;
-    border: 1px solid $chef-light-grey;
-  }
-
-  .options {
-    text-align: center;
+  .flex-container {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
   }
 }
 

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.spec.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.spec.ts
@@ -15,7 +15,12 @@ describe('UserManagementComponent', () => {
 
     TestBed.configureTestingModule({
       declarations: [
-        MockComponent({ selector: 'app-user-form', inputs: ['createUserForm'] }),
+        MockComponent({ selector: 'app-user-form',
+            inputs: [
+              'createUserForm',
+              'conflictErrorEvent',
+              'passwordErrorEvent'
+            ] }),
         MockComponent({ selector: 'app-user-table',
             inputs: [
               'addButtonText',
@@ -66,7 +71,7 @@ describe('UserManagementComponent', () => {
     });
 
      it('should be valid when all fields are filled out and passwords match', () => {
-      component.createUserForm.controls['fullname'].setValue('Sam');
+      component.createUserForm.controls['displayName'].setValue('Sam');
       component.createUserForm.controls['username'].setValue('Mary');
       component.createUserForm.controls['password'].setValue('imawitch');
       component.createUserForm.controls['confirmPassword'].setValue('imawitch');

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
@@ -126,7 +126,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
   public closeCreateModal(): void {
     this.createUserForm.reset();
     this.createModalVisible = false;
-    // do we need to manually reset the errors or is reset enough?
+    // TODO reset errors(conflict, pswd)/modifyUsername on close
     // this.conflictErrorEvent.emit(false);
   }
 

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
@@ -49,7 +49,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
   ) {
     this.createUserForm = fb.group({
       // Must stay in sync with error checks in user-form.component.html
-      fullname: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      displayname: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       username: ['', [Validators.required, Validators.pattern(USERNAME_PATTERN)]],
       // length validator must be consistent with
       // backend password rules in local-user-service/password/password.go
@@ -88,6 +88,10 @@ export class UserManagementComponent implements OnInit, OnDestroy {
           this.closeCreateModal();
         }
       });
+
+      // TODO
+      // handle userCreate errors
+      // emit conflictErrorEvent;
   }
 
   ngOnDestroy() {
@@ -119,12 +123,12 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     this.store.dispatch(new DeleteUser(this.userToDelete));
   }
 
-  public handleCreateUser(): void {
+  public createUser(): void {
     this.creatingUser = true;
     const formValues = this.createUserForm.value;
 
     const userCreateReq = <CreateUserPayload>{
-      name: formValues.fullname.trim(),
+      name: formValues.displayname.trim(),
       id: formValues.username,
       password: formValues.password
     };

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
@@ -38,6 +38,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
   // TODO maybe combine these into one smarter emitter?
   public conflictErrorEvent = new EventEmitter<boolean>();
   public passwordErrorEvent = new EventEmitter<boolean>();
+  public closeEvent = new EventEmitter();
 
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
@@ -126,8 +127,9 @@ export class UserManagementComponent implements OnInit, OnDestroy {
   public closeCreateModal(): void {
     this.createUserForm.reset();
     this.createModalVisible = false;
-    // TODO reset errors(conflict, pswd)/modifyUsername on close
-    // this.conflictErrorEvent.emit(false);
+    this.conflictErrorEvent.emit(false);
+    this.passwordErrorEvent.emit(false);
+    this.closeEvent.emit();
   }
 
   public closeDeleteModal(): void {

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
@@ -75,8 +75,8 @@ export class UserManagementComponent implements OnInit, OnDestroy {
       this.store.select(allUsers),
       this.store.select(getStatus)
     ]).pipe(
-      takeUntil(this.isDestroyed),
-      filter(([_, uStatus]) => uStatus !== EntityStatus.loading)
+      filter(([_, uStatus]) => uStatus !== EntityStatus.loading),
+      takeUntil(this.isDestroyed)
       ).subscribe(([users, _]: [User[], EntityStatus]) => {
         this.isLoading = false;
         this.layoutFacade.ShowPageLoading(false);
@@ -86,8 +86,8 @@ export class UserManagementComponent implements OnInit, OnDestroy {
 
     this.store.pipe(
       select(createStatus),
-      takeUntil(this.isDestroyed),
-      filter(state => this.createModalVisible && !pending(state)))
+      filter(state => this.createModalVisible && !pending(state)),
+      takeUntil(this.isDestroyed))
       .subscribe(state => {
         this.creatingUser = false;
         if (state === EntityStatus.loadingSuccess) {
@@ -99,9 +99,9 @@ export class UserManagementComponent implements OnInit, OnDestroy {
       this.store.select(createStatus),
       this.store.select(createError)
     ]).pipe(
-      takeUntil(this.isDestroyed),
       filter(() => this.createModalVisible),
-      filter(([state, error]) => state === EntityStatus.loadingFailure && !isNil(error)))
+      filter(([state, error]) => state === EntityStatus.loadingFailure && !isNil(error)),
+      takeUntil(this.isDestroyed))
       .subscribe(([_, error]) => {
         if (error.status === HttpStatus.CONFLICT) {
           this.conflictErrorEvent.emit(true);

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
@@ -150,7 +150,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     this.creatingUser = true;
     const formValues = this.createUserForm.value;
 
-    const userCreateReq = <CreateUserPayload>{
+    const userCreateReq: CreateUserPayload = {
       name: formValues.displayName.trim(),
       id: formValues.username,
       password: formValues.password

--- a/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-management/user-management.component.ts
@@ -55,7 +55,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
   ) {
     this.createUserForm = fb.group({
       // Must stay in sync with error checks in user-form.component.html
-      displayname: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      displayName: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       username: ['', [Validators.required, Validators.pattern(USERNAME_PATTERN)]],
       // length validator must be consistent with
       // backend password rules in local-user-service/password/password.go
@@ -151,7 +151,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     const formValues = this.createUserForm.value;
 
     const userCreateReq = <CreateUserPayload>{
-      name: formValues.displayname.trim(),
+      name: formValues.displayName.trim(),
       id: formValues.username,
       password: formValues.password
     };

--- a/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/01_user_mgmt.spec.ts
@@ -30,10 +30,15 @@ describe('user management', () => {
     // we increase the default delay to mimic the average human's typing speed
     // only need this for input values upon which later test assertions depend
     // ref: https://github.com/cypress-io/cypress/issues/534
-    cy.get('[formcontrolname=fullname]').focus()
+    cy.get('[formcontrolname=displayName]').focus()
       .type(name, { delay: typeDelay }).should('have.value', name);
 
-    cy.get('[formcontrolname=username]').focus()
+    // username is auto-generated from the display name
+    cy.get('#username-fields span').contains(`cypress-test-user-${now}`).should('exist');
+
+    // we can also edit the username directly
+    cy.get('[data-cy=edit-username]').click();
+    cy.get('[formcontrolname=username]').focus().clear()
       .type(username, { delay: typeDelay }).should('have.value', username);
 
     cy.get('[formcontrolname=password]').focus()
@@ -68,8 +73,8 @@ describe('user management', () => {
     cy.get('app-user-details chef-form-field').contains('Confirm New Password').should('exist');
 
     cy.get('app-user-details chef-button.edit-button').click();
-    cy.get('[formcontrolname=fullName]').find('input').should('not.be.disabled')
-      .focus().clear().type(updated_name);
+    cy.get('[formcontrolname=fullName]').should('not.be.disabled')
+      .clear().type(updated_name);
 
     cy.get('app-user-details chef-button.save-button').click();
     cy.wait('@updateUser');
@@ -78,9 +83,9 @@ describe('user management', () => {
     // so we test that some change was made to the name, not the exact new name
     cy.get('app-user-details div.name-column').contains('updated').should('exist');
 
-    cy.get('[formcontrolname=newPassword]').find('input')
+    cy.get('[formcontrolname=newPassword]')
       .focus().type(updated_password, { delay: typeDelay }).should('have.value', updated_password);
-    cy.get('[formcontrolname=confirmPassword]').find('input')
+    cy.get('[formcontrolname=confirmPassword]')
       .focus().type(updated_password, { delay: typeDelay }).should('have.value', updated_password);
     cy.get('app-user-details chef-button').contains('Update Password').click({ force: true });
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When did this...
![image](https://user-images.githubusercontent.com/21015366/72644673-6e486480-3926-11ea-97d5-eeea646d43c0.png)

Become hotter than this???
<img width="1081" alt="Screen Shot 2020-01-17 at 12 39 59 PM" src="https://user-images.githubusercontent.com/21015366/72644699-861fe880-3926-11ea-8f9e-95a29a21eb3b.png">


This PR updates the user creation modal to be consistent with the token/team/project creation modals.

Instead of making the `create-object-modal` fit with the special case of users, we decided to keep the user modal a part of the `user-management` component. We decided it would over-complicate the `create-object-modal` to add special casing for the user modal (extra password fields, rename Name and ID fields to Display Name and Username). This decision resulted in some duplicated code which we should probably extract into a common helper library once we add another creation modal.

There is some potential to refactor the `create-object-modal` so that we can slot any form we need into it. We might consider this when we get to adding a role creation modal (which will need a dropdown for actions). Then we could revisit using the `create-object-modal` on the user page.

### :+1: Definition of Done
- [x] modal styles match [zeplin mock](https://zpl.io/25JAppn)
- [x] conflict and bad password errors are handled inside the modal (fixes https://github.com/chef/automate/issues/2401)
- [x] the Display Name is used to auto-generate the Username

### :athletic_shoe: How to Build and Test the Change
- start up the UI however you like to
- navigate to https://a2-dev.test/settings/users
- select `Create User` and try creating some users with the snazzy new modal
- create a user with the same username as another user (like `editor` or `admin`) and see the error in the modal
- create a user with the password `aaaaaaaa` and see the error in the modal
- create a user with an auto-generated username
- create a user with a custom username

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).