### PR TITLE
Run compliance scanner tests against inspec master

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -587,6 +587,34 @@ steps:
       - gopath-checkout#v1.0.1:
           import: github.com/chef/automate
 
+  - label: "compliance-service scanner with inspec master"
+    command:
+      - sudo sysctl -w vm.max_map_count=262144 # Needed for ElasticSearch 6
+      - export PATH=\$PATH:/usr/local/go/bin:\$HOME/.local/bin:\$HOME/bin
+      - sudo scripts/install_inspec_master.sh
+      - sudo scripts/install_golang.sh
+      - sudo scripts/install_grpcurl.sh
+      - cd components/compliance-service
+      - sudo -E  PATH=\$(hab pkg path core/ruby)/bin:\$PATH make test-integration-scanner
+      - cd ../.. && sudo git clean -fxd
+    artifact_paths:
+      - /tmp/secrets-service.log
+      - /tmp/event-service.log
+      - /tmp/compliance.log
+      - /tmp/nodemanager-service.log
+    env:
+      ES_VER: 6
+      LANG: en_US.UTF-8
+    timeout_in_minutes: 20
+    expeditor:
+      executor:
+        linux:
+          single-use: true
+          privileged: true
+    plugins:
+      - gopath-checkout#v1.0.1:
+          import: github.com/chef/automate
+
   - label: "compliance-service reporting"
     command:
       - sudo sysctl -w vm.max_map_count=262144 # Needed for ElasticSearch 6

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -606,6 +606,7 @@ steps:
       ES_VER: 6
       LANG: en_US.UTF-8
     timeout_in_minutes: 20
+    soft_fail: true
     expeditor:
       executor:
         linux:

--- a/components/compliance-service/Makefile
+++ b/components/compliance-service/Makefile
@@ -464,7 +464,7 @@ test: generate-ruby-grpc wait-for-compliance-service
 test-prep: $(MARKET_PATH) $(PROFILES_PATH) start-ssh-node download-sample-market-profiles install-inspec start-es-pg
 
 install-inspec:
-	@inspec --version | grep -q $(shell cat ../../INSPEC_VERSION) || gem install inspec-bin --no-document --version $(shell cat ../../INSPEC_VERSION)
+	@inspec --version 2> /dev/null | grep -q $(shell cat ../../INSPEC_VERSION) || gem install inspec-bin --no-document --version $(shell cat ../../INSPEC_VERSION)
 
 test-examples:
 	@printf "===> REQUIRES RUNNING SERVICE\n"

--- a/scripts/install_inspec_master.sh
+++ b/scripts/install_inspec_master.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+export HAB_NONINTERACTIVE=true
+export HAB_NOCOLORING=true
+export HAB_LICENSE="accept-no-persist"
+
+install_inspec() {
+  hab pkg install core/gcc --binlink --force
+  hab pkg install core/ruby --binlink --force
+
+  tmp_dir=$(mktemp -d)
+  git clone --depth=1 https://github.com/inspec/inspec "$tmp_dir"
+  cd "$tmp_dir"
+  bundle
+  bundle exec rake install
+}
+
+install_inspec


### PR DESCRIPTION
In order to have better awareness of breaking changes in the integration of automate and inspec, this PR adds a buildkite task to build the latest inspec from master and use that to run the inspec focused tests.