### PR TITLE
Increase project limit default to 300

### DIFF
--- a/api/config/authz/config_request.go
+++ b/api/config/authz/config_request.go
@@ -48,9 +48,11 @@ func (c *ConfigRequest) Validate() error {
 
 	if projectLimit != nil {
 		if limit := projectLimit.GetValue(); limit < constants_v2.MinConfigurableProjects {
-			// MinConfigurableProjects supports customers who previously increased
-			// their limit, but not as high as the new limit. Can be removed when
-			// we no longer limit projects.
+			// Previously, users could not configure their project_limit to be below the
+			// default.
+			// MinConfigurableProjects supports customers who previously
+			// increased their limit to a number that is lower than the new default.
+			// Can be removed when we no longer limit projects.
 			e := errors.Errorf("project limit must be at least %v", constants_v2.MinConfigurableProjects)
 			cfgErr.AddInvalidValue("auth_z.v1.sys.service.project_limit", e.Error())
 		}

--- a/api/config/authz/config_request.go
+++ b/api/config/authz/config_request.go
@@ -47,8 +47,11 @@ func (c *ConfigRequest) Validate() error {
 	projectLimit := c.GetV1().GetSys().GetService().GetProjectLimit()
 
 	if projectLimit != nil {
-		if limit := projectLimit.GetValue(); limit < constants_v2.MaxProjects {
-			e := errors.Errorf("project limit must be at least %v", constants_v2.MaxProjects)
+		if limit := projectLimit.GetValue(); limit < constants_v2.MinConfigurableProjects {
+			// MinConfigurableProjects supports customers who previously increased
+			// their limit, but not as high as the new limit. Can be removed when
+			// we no longer limit projects.
+			e := errors.Errorf("project limit must be at least %v", constants_v2.MinConfigurableProjects)
 			cfgErr.AddInvalidValue("auth_z.v1.sys.service.project_limit", e.Error())
 		}
 	}

--- a/api/config/authz/config_request.go
+++ b/api/config/authz/config_request.go
@@ -29,7 +29,7 @@ func DefaultConfigRequest() *ConfigRequest {
 
 	c.V1.Sys.Service.Host = w.String("0.0.0.0")
 	c.V1.Sys.Service.Port = w.Int32(10130)
-	c.V1.Sys.Service.ProjectLimit = w.Int32(constants_v2.MaxProjects)
+	c.V1.Sys.Service.ProjectLimit = w.Int32(constants_v2.DefaultProjectLimit)
 	c.V1.Sys.Logger.Level = w.String("info")
 	c.V1.Sys.Logger.Format = w.String("text")
 	c.V1.Sys.Storage.Database = w.String("chef_authz_service")

--- a/api/config/authz/config_request.go
+++ b/api/config/authz/config_request.go
@@ -1,10 +1,11 @@
 package authz
 
 import (
+	fmt "fmt"
+
 	config "github.com/chef/automate/api/config/shared"
 	w "github.com/chef/automate/api/config/shared/wrappers"
 	constants_v2 "github.com/chef/automate/components/authz-service/constants/v2"
-	"github.com/pkg/errors"
 )
 
 // NewConfigRequest returns a new instance of ConfigRequest with zero values.
@@ -52,9 +53,9 @@ func (c *ConfigRequest) Validate() error {
 			// default.
 			// MinConfigurableProjects supports customers who previously
 			// increased their limit to a number that is lower than the new default.
-			// Can be removed when we no longer limit projects.
-			e := errors.Errorf("project limit must be at least %v", constants_v2.MinConfigurableProjects)
-			cfgErr.AddInvalidValue("auth_z.v1.sys.service.project_limit", e.Error())
+			// It should be removed when we no longer limit projects.
+			failureStr := fmt.Sprintf("project limit must be at least %d", constants_v2.MinConfigurableProjects)
+			cfgErr.AddInvalidValue("auth_z.v1.sys.service.project_limit", failureStr)
 		}
 	}
 

--- a/authz.toml
+++ b/authz.toml
@@ -1,0 +1,2 @@
+[auth_z.v1.sys.service]
+project_limit = 10

--- a/components/authz-service/constants/v2/constants.go
+++ b/components/authz-service/constants/v2/constants.go
@@ -50,4 +50,10 @@ const (
 // Business logic constants
 const (
 	DefaultProjectLimit = 300
+	// MinConfigurableProjects is based on our original default for customers who have
+	// previously set their project_limit to greater than 6, but less than the
+	// new default of 300.
+	// This exists only due to our current state where users can configure the
+	// limit and should be removed when the limit itself is removed.
+	MinConfigurableProjects = 6
 )

--- a/components/authz-service/constants/v2/constants.go
+++ b/components/authz-service/constants/v2/constants.go
@@ -54,6 +54,6 @@ const (
 	// default.
 	// MinConfigurableProjects supports customers who previously
 	// increased their limit to a number that is lower than the new default.
-	// It should removed when we no longer limit projects.
+	// It should be removed when we no longer limit projects.
 	MinConfigurableProjects = 6
 )

--- a/components/authz-service/constants/v2/constants.go
+++ b/components/authz-service/constants/v2/constants.go
@@ -49,5 +49,5 @@ const (
 
 // Business logic constants
 const (
-	MaxProjects = 6
+	MaxProjects = 300
 )

--- a/components/authz-service/constants/v2/constants.go
+++ b/components/authz-service/constants/v2/constants.go
@@ -50,10 +50,10 @@ const (
 // Business logic constants
 const (
 	DefaultProjectLimit = 300
-	// MinConfigurableProjects is based on our original default for customers who have
-	// previously set their project_limit to greater than 6, but less than the
-	// new default of 300.
-	// This exists only due to our current state where users can configure the
-	// limit and should be removed when the limit itself is removed.
+	// Previously, users could not configure their project_limit to be below the
+	// default.
+	// MinConfigurableProjects supports customers who previously
+	// increased their limit to a number that is lower than the new default.
+	// It should removed when we no longer limit projects.
 	MinConfigurableProjects = 6
 )

--- a/components/authz-service/constants/v2/constants.go
+++ b/components/authz-service/constants/v2/constants.go
@@ -49,5 +49,5 @@ const (
 
 // Business logic constants
 const (
-	MaxProjects = 300
+	DefaultProjectLimit = 300
 )

--- a/components/authz-service/server/v2/project_test.go
+++ b/components/authz-service/server/v2/project_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/chef/automate/lib/tls/test/helpers"
 )
 
+const projectLimitForTesting = 10 // DefaultProjectLimit is 300
+
 func TestUpdateProject(t *testing.T) {
 	ctx := context.Background()
 
@@ -132,8 +134,8 @@ func TestCreateProject(t *testing.T) {
 			grpctest.AssertCode(t, codes.AlreadyExists, err)
 			assert.Nil(t, resp)
 		}},
-		{"does not create project if max projects surpassed", func(t *testing.T) {
-			for i := 1; i <= constants.MaxProjects; i++ {
+		{"does not create project if project limit surpassed", func(t *testing.T) {
+			for i := 1; i <= projectLimitForTesting; i++ {
 				projectID := "my-id-" + strconv.Itoa(i)
 				project := &api.CreateProjectReq{
 					Id:   projectID,
@@ -144,8 +146,8 @@ func TestCreateProject(t *testing.T) {
 			}
 
 			oneProjectTooMany := &api.CreateProjectReq{
-				Id:   "my-id-" + strconv.Itoa(constants.MaxProjects+1),
-				Name: "name-" + strconv.Itoa(constants.MaxProjects+1),
+				Id:   "my-id-" + strconv.Itoa(projectLimitForTesting+1),
+				Name: "name-" + strconv.Itoa(projectLimitForTesting+1),
 			}
 			resp, err := cl.CreateProject(ctx, oneProjectTooMany)
 			assert.Nil(t, resp)
@@ -490,7 +492,7 @@ func setupProjectsAndRules(t *testing.T) (api.ProjectsClient, *cache.Cache, *cac
 	require.NoError(t, err, "init logger for storage")
 
 	mem_v2 := memstore_v2.New()
-	pg, testDb, _, _, _ := testhelpers.SetupTestDB(t)
+	pg, testDb, _, _, _ := testhelpers.SetupTestDBWithLimit(t, projectLimitForTesting)
 	manager, err := cereal.NewManager(postgres.NewPostgresBackend(testDb.ConnURI))
 	require.NoError(t, err)
 	domainServices := []string{"testdomain"}

--- a/components/authz-service/server/v2/project_test.go
+++ b/components/authz-service/server/v2/project_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/chef/automate/lib/tls/test/helpers"
 )
 
-const projectLimitForTesting = 10 // DefaultProjectLimit is 300
+const projectLimitForTesting = 10 // DefaultProjectLimit is higher
 
 func TestUpdateProject(t *testing.T) {
 	ctx := context.Background()

--- a/components/authz-service/server/v2/project_test.go
+++ b/components/authz-service/server/v2/project_test.go
@@ -491,7 +491,8 @@ func setupProjectsAndRules(t *testing.T) (api.ProjectsClient, *cache.Cache, *cac
 	l, err := logger.NewLogger("text", "error")
 	require.NoError(t, err, "init logger for storage")
 
-	mem_v2 := memstore_v2.New()
+	mem_v2 := memstore_v2.NewWithProjectLimit(projectLimitForTesting)
+	// TODO: we should be able to optionally use PG. We're only using memstore
 	pg, testDb, _, _, _ := testhelpers.SetupTestDBWithLimit(t, projectLimitForTesting)
 	manager, err := cereal.NewManager(postgres.NewPostgresBackend(testDb.ConnURI))
 	require.NoError(t, err)

--- a/components/authz-service/server/v2/rules_property_test.go
+++ b/components/authz-service/server/v2/rules_property_test.go
@@ -24,7 +24,7 @@ import (
 const (
 	idRegex          = "^[a-z0-9-_]{1,64}$"
 	conditionLimit   = 10 // help avoid the grpc limit of 4194304
-	projectLimit     = 6  // system limitation
+	projectLimit     = 6  // system limitation is 300
 	SuperuserSubject = "tls:service:deployment-service:internal"
 )
 

--- a/components/authz-service/server/v2/rules_property_test.go
+++ b/components/authz-service/server/v2/rules_property_test.go
@@ -24,7 +24,7 @@ import (
 const (
 	idRegex          = "^[a-z0-9-_]{1,64}$"
 	conditionLimit   = 10 // help avoid the grpc limit of 4194304
-	projectLimit     = 6  // system limitation is 300
+	projectLimit     = 6  // system limitation is higher
 	SuperuserSubject = "tls:service:deployment-service:internal"
 )
 

--- a/components/authz-service/storage/v2/memstore/memstore.go
+++ b/components/authz-service/storage/v2/memstore/memstore.go
@@ -26,16 +26,19 @@ type State struct {
 var ErrTypeAssertionFailed = errors.New("type assertion failed: could not convert interface{} to *storage.Policy")
 
 func New() *State {
-	s := &State{
+	return NewWithProjectLimit(constants_v2.DefaultProjectLimit)
+}
+
+func NewWithProjectLimit(projectLimit int) *State {
+	return &State{
 		policies:       cache.New(cache.NoExpiration, -1 /* never run cleanup */),
 		roles:          cache.New(cache.NoExpiration, -1),
 		projects:       cache.New(cache.NoExpiration, -1),
 		rules:          cache.New(cache.NoExpiration, -1),
 		policyChangeID: 0,
 		changeManager:  newPolicyChangeNotifierManager(),
-		projectLimit:   constants_v2.DefaultProjectLimit,
+		projectLimit:   projectLimit,
 	}
-	return s
 }
 
 func (s *State) bumpPolicyVersion() {

--- a/components/authz-service/storage/v2/memstore/memstore.go
+++ b/components/authz-service/storage/v2/memstore/memstore.go
@@ -33,7 +33,7 @@ func New() *State {
 		rules:          cache.New(cache.NoExpiration, -1),
 		policyChangeID: 0,
 		changeManager:  newPolicyChangeNotifierManager(),
-		projectLimit:   constants_v2.MaxProjects,
+		projectLimit:   constants_v2.DefaultProjectLimit,
 	}
 	return s
 }

--- a/components/authz-service/testhelpers/testhelpers.go
+++ b/components/authz-service/testhelpers/testhelpers.go
@@ -122,7 +122,7 @@ func SetupProjectsAndRulesWithDB(t *testing.T) (
 }
 
 func SetupTestDB(t *testing.T) (storage.Storage, *TestDB, *opa.State, *prng.Prng, *migration.Config) {
-	return SetupTestDBWithLimit(t, constants_v2.MaxProjects)
+	return SetupTestDBWithLimit(t, constants_v2.DefaultProjectLimit)
 }
 
 func SetupTestDBWithLimit(t *testing.T, projectLimit int) (storage.Storage, *TestDB, *opa.State, *prng.Prng, *migration.Config) {

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -241,7 +241,7 @@ so they are not relevant when assigning IAM resources such as teams or roles.
 
 #### Configuring Project Limit
 
-By default, Chef Automate limits you to six projects. You can increase the project limit using the command line.
+By default, Chef Automate is currently limited to 300 projects. If you would like to increase that limit, you will need to do so using the Chef Automate CLI:
 
 First, write the file with your new project limit:
 

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -241,7 +241,7 @@ so they are not relevant when assigning IAM resources such as teams or roles.
 
 #### Configuring Project Limit
 
-By default, Chef Automate is currently limited to 300 projects. If you would like to increase that limit, you will need to do so using the Chef Automate CLI:
+By default, Chef Automate limits you to 300 projects. You can increase the project limit using the command line.
 
 First, write the file with your new project limit:
 

--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -133,7 +133,7 @@ IAM v2 projects are collections of resources either created in Chef Automate, or
 Projects are used in a policy to reduce the scope of that policy's permissions to only the resources assigned to the given projects.
 
 {{< info >}}
-Chef Automate limits you to six projects while we continue to refine the user experience.
+Chef Automate limits you to 300 projects while we continue to refine the user experience.
 See [Configuring Project Limit]({{< relref "iam-v2-guide.md#configuring-project-limit" >}}) for configuration instructions.
 {{< /info >}}
 

--- a/integration/tests/cypress_e2e.sh
+++ b/integration/tests/cypress_e2e.sh
@@ -6,16 +6,6 @@ test_name=":cypress: e2e tests"
 test_deploy_inspec_profiles=()
 test_skip_diagnostics=true
 
-do_create_config() {
-    do_create_config_default
-
-    #shellcheck disable=SC2154
-    cat <<EOF >> "$test_config_path"
-[auth_z.v1.sys.service]
-  project_limit = 50
-EOF
-}
-
 # Note: these tests use the UI, so a valid license needs to be set up.
 # Alternatively, the UI tests could also _apply the license_ and thus
 # give us some test coverage for the license apply modal etc; but we

--- a/scripts/auth_collections.sh
+++ b/scripts/auth_collections.sh
@@ -191,8 +191,8 @@ authGen() {
   SEED=$4
   ID_PREFIX=test-$RESOURCE
   if [[ ! $MODE =~ ^(create|delete)$ ]]; then echo "mode must be 'create' or 'delete'"; return; fi
-  if [[ ! $RESOURCE =~ ^(tokens|users|teams|team-members|policies|rules)$ ]]; then
-    echo "resource must be in: tokens, users, teams, team-members, policies, rules"
+  if [[ ! $RESOURCE =~ ^(projects|tokens|users|teams|team-members|policies|rules)$ ]]; then
+    echo "resource must be in: projects, tokens, users, teams, team-members, policies, rules"
     return
   fi
 
@@ -213,6 +213,9 @@ function create_resource {
   local json
   local resource
   case "$RESOURCE" in
+    projects)
+      json=$(jo -p id="$id" name="$name")
+      resource=$RESOURCE ;;
     tokens)
       json=$(jo -p id="$id" name="$name" description="test token for $name" active=true)
       resource=$RESOURCE ;;
@@ -246,6 +249,7 @@ function delete_resource {
   local id=$ID_PREFIX-$id_index
   local name="$ID_PREFIX $id_index"
   case "$RESOURCE" in
+    projects)  ;;
     tokens)  ;;
     users)  ;;
     teams) 

--- a/terraform/test-environments/modules/chef_automate_install/main.tf
+++ b/terraform/test-environments/modules/chef_automate_install/main.tf
@@ -234,9 +234,6 @@ EOF
 [global.v1]
   fqdn = "${var.alb_fqdn == "" ? element(var.instance_fqdn, count.index) : var.alb_fqdn}"
 
-[auth_z.v1.sys.service]
-  project_limit = 50
-
 [deployment.v1.svc]
   channel = "${var.channel}"
   deployment_type = "${var.deployment_type}"


### PR DESCRIPTION
Signed-off-by: Blake Johnson <bstier@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

With the IAM release, we are now supporting up to 300 projects. 

Customers using the default limit of 6 will have their limit automatically increased. Customers who have increased their limit will still have that limit applied.

### :athletic_shoe: How to Build and Test the Change

`cat /hab/svc/authz-service/config/config.yml` will show you the current limit of 6

`rebuild components/automate-deployment
  rebuild components/authz-service`

`cat /hab/svc/authz-service/config/config.yml` will show you the new limit of 300

Try creating 301 projects-- you should get an error on the 301st.

per @msorens on quick project creation:

> 
> You can easily generate (or remove) hundreds of projects from the command-line with these commands:
> 
> ### Generate 500 starting with id 101
> authGen projects create 500 101
> ### Remove them after testing
> authGen projects delete 500 101
> That will work inside or outside hab studio with a couple prerequisites:
> 1. Point at your A2 instance and authorize it:
> 
> export TOK=`chef-automate iam token create TEST --admin`
> export TARGET_HOST=https://a2-dev.test
> Cherry-pick commit 0784ca05 into your PR that tweaks the existing script.
> Source the script (. ./scripts/auth_collections.sh)
> 

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).