### PR TITLE
Point to older docs for use with static installs

### DIFF
--- a/components/automate-chef-io/content/docs/data-lifecycle.md
+++ b/components/automate-chef-io/content/docs/data-lifecycle.md
@@ -27,10 +27,10 @@ The `data-lifecycle` API allows configuring and running lifecycle jobs by data t
 
 Different jobs are available depending on the data type you wish to configure or run.
 
-In order to see the data lifecycle job statuses, configure jobs, or run jobs, you will need an [admin token]({{< relref "api-tokens.md#creating-an-admin-api-token" >}}) or a token for a user with `dataLifecycle:*` IAM access.
+You need an [admin token]({{< relref "api-tokens.md#creating-an-admin-api-token" >}}) or a token for a user with `dataLifecycle:*` IAM access to see the data lifecycle job statuses, configure jobs, or run jobs.
 
 {{% warning %}}
-Note: Chef Automate releases earlier than 20191129172405 handled data retention differently. The [upgrade documentation]({{< ref "install/#upgrades" >}}) covers configuring your system to install new Chef Automate versions, or contact your customer support agent for guidance. You can also use the [previous data retention documentation](https://github.com/chef/automate/blob/20191104205453/components/automate-chef-io/content/docs/configuration.md#data-retention) for help with configuring data retention on older Chef Automate installations.
+Note: Chef Automate data retention processes changed in 20191129172405. The [upgrade documentation]({{< ref "install/#upgrades" >}}) covers configuring your system to install new Chef Automate versions. For questions or help, contact your customer support agent for guidance. You can also use the [previous data retention documentation](https://github.com/chef/automate/blob/20191104205453/components/automate-chef-io/content/docs/configuration.md#data-retention) for help with configuring data retention on older Chef Automate installations.
 {{% /warning %}}
 
 ## Status

--- a/components/automate-chef-io/content/docs/data-lifecycle.md
+++ b/components/automate-chef-io/content/docs/data-lifecycle.md
@@ -30,7 +30,7 @@ Different jobs are available depending on the data type you wish to configure or
 In order to see the data lifecycle job statuses, configure jobs, or run jobs, you will need an [admin token]({{< relref "api-tokens.md#creating-an-admin-api-token" >}}) or a token for a user with `dataLifecycle:*` IAM access.
 
 {{% warning %}}
-Note: Chef Automate releases earlier than 20191129172405 handled data retention differently. The [upgrade documentation]({{< ref "install/#upgrades" >}}) covers configuring your system to install new Chef Automate versions, or contact your customer support agent for guidance. You can also use the [previous documentation](https://github.com/chef/automate/blob/20191104205453/components/automate-chef-io/content/docs/configuration.md#data-retention) for help with configuring data retention on older Chef Automate installations.
+Note: Chef Automate releases earlier than 20191129172405 handled data retention differently. The [upgrade documentation]({{< ref "install/#upgrades" >}}) covers configuring your system to install new Chef Automate versions, or contact your customer support agent for guidance. You can also use the [previous data retention documentation](https://github.com/chef/automate/blob/20191104205453/components/automate-chef-io/content/docs/configuration.md#data-retention) for help with configuring data retention on older Chef Automate installations.
 {{% /warning %}}
 
 ## Status

--- a/components/automate-chef-io/content/docs/data-lifecycle.md
+++ b/components/automate-chef-io/content/docs/data-lifecycle.md
@@ -30,7 +30,7 @@ Different jobs are available depending on the data type you wish to configure or
 You need an [admin token]({{< relref "api-tokens.md#creating-an-admin-api-token" >}}) or a token for a user with `dataLifecycle:*` IAM access to see the data lifecycle job statuses, configure jobs, or run jobs.
 
 {{% warning %}}
-Note: Chef Automate data retention processes changed in 20191129172405. The [upgrade documentation]({{< ref "install/#upgrades" >}}) covers configuring your system to install new Chef Automate versions. For questions or help, contact your customer support agent for guidance. You can also use the [previous data retention documentation](https://github.com/chef/automate/blob/20191104205453/components/automate-chef-io/content/docs/configuration.md#data-retention) for help with configuring data retention on older Chef Automate installations.
+Note: Chef Automate data retention processes changed in 20191129172405. The [upgrade documentation]({{< ref "install/#upgrades" >}}) covers configuring your system to install new Chef Automate versions. For guidance, contact your customer support agent. You can also use the [previous data retention documentation](https://github.com/chef/automate/blob/20191104205453/components/automate-chef-io/content/docs/configuration.md#data-retention) for help with configuring data retention on older Chef Automate installations.
 {{% /warning %}}
 
 ## Status

--- a/components/automate-chef-io/content/docs/data-lifecycle.md
+++ b/components/automate-chef-io/content/docs/data-lifecycle.md
@@ -31,6 +31,10 @@ In order to see the data lifecycle job statuses, configure jobs, or run jobs, yo
 an [admin token]({{< relref "api-tokens.md#creating-an-admin-api-token" >}}) or a token
 for a user with `dataLifecycle:*` IAM access.
 
+For Automate 2 versions < 20191129172405, see [older docs](https://github.com/chef/automate/blob/20191104205453/components/automate-chef-io/content/docs/configuration.md#data-retention)
+
+For Automate 2 versions higher than the level mentioned above, use the following
+
 ## Status
 
 To see the combined status and configuration for all data lifecycle jobs you can use the global status endpoint

--- a/components/automate-chef-io/content/docs/data-lifecycle.md
+++ b/components/automate-chef-io/content/docs/data-lifecycle.md
@@ -27,13 +27,11 @@ The `data-lifecycle` API allows configuring and running lifecycle jobs by data t
 
 Different jobs are available depending on the data type you wish to configure or run.
 
-In order to see the data lifecycle job statuses, configure jobs, or run jobs, you will need
-an [admin token]({{< relref "api-tokens.md#creating-an-admin-api-token" >}}) or a token
-for a user with `dataLifecycle:*` IAM access.
+In order to see the data lifecycle job statuses, configure jobs, or run jobs, you will need an [admin token]({{< relref "api-tokens.md#creating-an-admin-api-token" >}}) or a token for a user with `dataLifecycle:*` IAM access.
 
-For Automate 2 versions < 20191129172405, see [older docs](https://github.com/chef/automate/blob/20191104205453/components/automate-chef-io/content/docs/configuration.md#data-retention)
-
-For Automate 2 versions higher than the level mentioned above, use the following
+{{% warning %}}
+Note: Chef Automate releases earlier than 20191129172405 handled data retention differently. The [upgrade documentation]({{< ref "install/#upgrades" >}}) covers configuring your system to install new Chef Automate versions, or contact your customer support agent for guidance. You can also use the [previous documentation](https://github.com/chef/automate/blob/20191104205453/components/automate-chef-io/content/docs/configuration.md#data-retention) for help with configuring data retention on older Chef Automate installations.
+{{% /warning %}}
 
 ## Status
 


### PR DESCRIPTION
This info would be valuable for the two following scenarios

* Non auto-updating installs
* Airgap installs

In the same vein as these issues

https://github.com/chef/automate/issues/2141

https://github.com/chef/automate/issues/2136

The data retention docs need to be versioned, so that customers can find the old docs to use with old installs.

A completely different set of commands are used for Automate 2
versions < 20191129172405 compared to versions afterward.

These include the status command, the configs for setting retention
length and job schedule, showing the config, and a command to manually run the retention process outside of the schedule using the retention level currently set.

Maybe make a link to the old docs from the new, like this.

Signed-off-by: Sean Horn <sean_horn@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
