### PR TITLE
Remove "applications" from beta features list in release notes

### DIFF
--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -30,9 +30,6 @@ pushd ./automate.wiki
 ## Backward Incompatibilities
 
 ## Beta Features
-### Applications
--
-
 ### Identity and Access Management v2
 -
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The applications tab is going GA whenever the next dev->acceptance->current promotion cycle is completed (by default next Monday the 27th). Removing it from the "Beta Features" section of the default release notes.

