### PR TITLE
Updating wording from old password to previous password

### DIFF
--- a/components/automate-gateway/handler/iam/v2/users/users.go
+++ b/components/automate-gateway/handler/iam/v2/users/users.go
@@ -93,7 +93,7 @@ func (p *Server) UpdateUser(
 }
 
 // UpdateSelf allows a user to update their own info,
-// requiring the old password if they want to change password.
+// requiring the previous password if they want to change password.
 func (p *Server) UpdateSelf(
 	ctx context.Context, req *pb_req.UpdateSelfReq) (*pb_resp.UpdateSelfResp, error) {
 	resp, err := p.users.UpdateSelf(ctx, &local_user.UpdateSelfReq{

--- a/components/automate-gateway/handler/users.go
+++ b/components/automate-gateway/handler/users.go
@@ -61,7 +61,7 @@ func (a *UsersServer) UpdateUser(ctx context.Context, r *localUserReq.UpdateUser
 }
 
 // UpdateSelf allows a user to update their own info,
-// requiring the old password if they want to change password.
+// requiring the previous password if they want to change password.
 func (a *UsersServer) UpdateSelf(ctx context.Context, r *localUserReq.UpdateSelf) (*localUserRes.User, error) {
 	req := &local_user.UpdateSelfReq{
 		Id:               r.Id,

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.html
@@ -43,16 +43,16 @@
         <form [formGroup]="passwordForm">
           <chef-form-field *ngIf="!isAdminView" class="password">
             <label>
-              <span class="label">Old Password <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="oldPassword" type="password"/>
+              <span class="label">Previous Password <span aria-hidden="true">*</span></span>
+              <input chefInput formControlName="previousPassword" type="password"/>
             </label>
             <chef-error
-              *ngIf="passwordForm.get('oldPassword').hasError('required') && passwordForm.get('oldPassword').dirty">
-              Old Password is required.
+              *ngIf="passwordForm.get('previousPassword').hasError('required') && passwordForm.get('previousPassword').dirty">
+              Previous Password is required.
             </chef-error>
             <chef-error
-              *ngIf="passwordForm.get('oldPassword').hasError('minlength') && passwordForm.get('oldPassword').dirty">
-              Old Password must be at least 8 characters.
+              *ngIf="passwordForm.get('previousPassword').hasError('minlength') && passwordForm.get('previousPassword').dirty">
+              Previous Password must be at least 8 characters.
             </chef-error>
           </chef-form-field>
           <chef-form-field class="password">

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
@@ -126,7 +126,7 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
       displayName: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
     this.passwordForm = fb.group({
-      oldPassword: ['', [ChefValidators.nonAdminLengthValidator(this.isAdminView, 8)]],
+      previousPassword: ['', [ChefValidators.nonAdminLengthValidator(this.isAdminView, 8)]],
       newPassword: ['',
         [Validators.required,
         Validators.pattern(Regex.patterns.NON_BLANK),
@@ -161,7 +161,7 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
 
   private savePasswordForSelf(): void {
     const password = this.passwordForm.get('newPassword').value;
-    const previous_password = this.passwordForm.get('oldPassword').value;
+    const previous_password = this.passwordForm.get('previousPassword').value;
     this.store.dispatch(new UpdatePasswordSelf({
       id: this.user.id,
       name: this.user.name,

--- a/components/local-user-service/server/grpc.go
+++ b/components/local-user-service/server/grpc.go
@@ -193,21 +193,21 @@ func (s *Server) UpdateSelf(ctx context.Context, req *local_user.UpdateSelfReq) 
 	if req.Password != "" {
 		if req.PreviousPassword == "" {
 			return nil, status.Error(codes.InvalidArgument,
-				"to update existing password, provide old password")
+				"to update existing password, provide previous password")
 		}
 
-		// check if old password is OK
+		// check if previous password is OK
 		s.logger.Info(fmt.Sprintf("attempting to validate user %s by logging in so we can update their password", req.Email))
 		ok, err := s.users.ValidatePassword(ctx, req.Email, req.PreviousPassword)
 		if err != nil {
-			return nil, status.Error(codes.Internal, "could not validate old password")
+			return nil, status.Error(codes.Internal, "could not validate previous password")
 		}
 		if !ok {
 			// Note: this could be used for guessing passwords; however, to guess a
 			// password using this API, the sender needs some kind of authentication
 			// already. You can also guess passwords completely unauthenticated by
 			// just querying dex.
-			return nil, status.Error(codes.InvalidArgument, "old password does not match")
+			return nil, status.Error(codes.InvalidArgument, "previous password does not match")
 		}
 
 		// If successful, we are set to update using the new hashed password.

--- a/components/local-user-service/server/grpc_test.go
+++ b/components/local-user-service/server/grpc_test.go
@@ -86,7 +86,7 @@ func TestUsersGRPC(t *testing.T) {
 		},
 	},
 		Validate: func(email string) bool {
-			return email == "alice@email.com" // only alice's old password will be valid
+			return email == "alice@email.com" // only alice's previous password will be valid
 		},
 	}
 
@@ -311,7 +311,7 @@ func TestUsersGRPC(t *testing.T) {
 			assert.Equal(t, us.Name, req.Name)
 		})
 
-		t.Run("when user wants to update their password but do not pass the correct old password", func(t *testing.T) {
+		t.Run("when user wants to update their password but do not pass the correct previous password", func(t *testing.T) {
 			req := api.UpdateSelfReq{
 				Id:               "bob",
 				Name:             "ChangeAgain",
@@ -325,7 +325,7 @@ func TestUsersGRPC(t *testing.T) {
 			assert.Nil(t, resp)
 		})
 
-		t.Run("when user wants to update their password but does not pass a old password", func(t *testing.T) {
+		t.Run("when user wants to update their password but does not pass a previous password", func(t *testing.T) {
 			req := api.UpdateSelfReq{
 				Id:       "alice",
 				Name:     "ChangeAgain",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

To prevent problems with API users we have decided to use the word "previous" instead of "old" for the user current password. This is used when a user changes their password. This PR is reverting some of the changes from this PR https://github.com/chef/automate/pull/2652. 

### :chains: Related Resources

https://github.com/chef/automate/pull/2652

### :+1: Definition of Done
* The API reverts back to using the error message of "previous password does not match". 
* The user's profile page is changed to have the "Previous Password" label instead of "Old Password". 

### :athletic_shoe: How to Build and Test the Change
1. Start the UI and go to https://a2-dev.test/user-details/admin#password
1. Ensure the first text field has the label of "Previous Password". 
1. Update the password with the incorrect previous password and ensure the error message in the banner displays "Could not update user: previous password does not match". 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
This is how it currently looks. 
![old_password](https://user-images.githubusercontent.com/1679247/72922281-9d355080-3d01-11ea-9da1-12bb61020c13.png)

This is how it looks after this change. 
![previous_password](https://user-images.githubusercontent.com/1679247/72922010-20a27200-3d01-11ea-9965-4752ab4ebb79.png)


