### PR TITLE
Rebuild CLI docs when generator script changes

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -111,6 +111,7 @@ subscriptions:
           only_if_modified:
             - components/automate-cli/cmd/*
             - components/automate-cli/pkg/status/error_codes.go
+            - .expeditor/generate-automate-cli-docs.sh
       - bash:.expeditor/generate-automate-api-docs.sh:
           post_commit: false
           only_if_modified:


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

We recently made some fixes to the script that generates CLI docs but this did not trigger a rebuild of the CLI docs so the docs content got stale and we had to manually update it.

### :chains: Related Resources

https://github.com/chef/automate/pull/2683
https://github.com/chef/automate/pull/2632
