### PR TITLE
Add three-dot-column class to any columns using control menu

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.html
@@ -42,7 +42,7 @@
             <span>{{ summary.skipped.total | number }}</span>
           </span>
         </chef-td>
-        <chef-td class="actions-cell">
+        <chef-td class="actions-cell three-dot-column">
           <mat-select panelClass="chef-control-menu">
             <mat-option *ngIf="!hasFilter(control)" (onSelectionChange)="addFilter(control)">Add Filter</mat-option>
             <mat-option *ngIf="hasFilter(control)" (onSelectionChange)="removeFilter(control)">Remove Filter</mat-option>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
@@ -94,7 +94,7 @@
             {{ statusControlsSeverity(node.latest_report.controls, node.latest_report.status) | uppercase }}
           </span>
         </chef-td>
-        <chef-td>
+        <chef-td class="three-dot-column">
           <mat-select panelClass="chef-control-menu">
             <mat-option *ngIf="!hasFilter(node)" (onSelectionChange)="addFilter(node)">Add Filter</mat-option>
             <mat-option *ngIf="hasFilter(node)" (onSelectionChange)="removeFilter(node)">Remove Filter</mat-option>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
@@ -29,7 +29,7 @@
         </chef-td>
         <chef-td class="version-cell">{{ profile.version }}</chef-td>
         <chef-td class="identifier-cell">{{ user }}/{{ profile.name }}</chef-td>
-        <chef-td class="actions-cell">
+        <chef-td class="actions-cell three-dot-column">
           <mat-select panelClass="chef-control-menu">
             <mat-option *ngIf="!hasFilter(profile)" (onSelectionChange)="addFilter(profile)">Add Filter</mat-option>
             <mat-option *ngIf="hasFilter(profile)" (onSelectionChange)="removeFilter(profile)">Remove Filter</mat-option>

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.html
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.html
@@ -41,7 +41,7 @@
               <chef-td>
                   <a [routerLink]="['/settings/data-feed/form', destination.id]">{{ destination.name }}</a>
                 </chef-td>
-              <chef-td class="actions">
+              <chef-td class="actions three-dot-column">
                 <mat-select panelClass="chef-control-menu">
                   <mat-option (onSelectionChange)="deleteDestination(destination)">Delete Destination</mat-option>
                 </mat-select>

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.html
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.html
@@ -45,7 +45,7 @@
               <chef-td>
                 {{rule.AlertTypeLabels[rule.ruleType]}}
               </chef-td>
-              <chef-td class="actions">
+              <chef-td class="actions three-dot-column">
                 <mat-select panelClass="chef-control-menu">
                   <mat-option (onSelectionChange)="deleteRule(rule)">Delete Notification</mat-option>
                 </mat-select>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
All tables that use the control menu need to add three-dot-column to last column (which is the one containing our new control menu).  Some of those were initially missed.  This branch adds those classes where needed.

### :chains: Related Resources
https://github.com/chef/automate/pull/2283

### :+1: Definition of Done
All control menus are right aligned within their column

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
make serve

All control menus should now be right aligned within their containing column

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
