### PR TITLE
adding filtering to project assignment dropdown

### DIFF
--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
@@ -14,8 +14,18 @@
   </button>
   <chef-click-outside (clickOutside)="closeDropdown()">
     <chef-dropdown [attr.visible]="active">
+
+      <div id="filter-container">
+        <input 
+          chefInput
+          type="text"
+          placeholder="Filter projects..." 
+
+          />
+      </div>
+
       <chef-checkbox
-        *ngFor="let project of projectsArray"
+        *ngFor="let project of filteredProjects"
         [checked]="project.checked"
         [attr.title]="project.name"
         (change)="projectChecked($event.detail, project)"
@@ -23,6 +33,12 @@
         (keydown.esc)="closeDropdown()"
         (keydown.arrowup)="moveFocus($event)"
         (keydown.arrowdown)="moveFocus($event)">{{ project['name'] }}</chef-checkbox>
+
+      <div class="no-projects" *ngIf="projectsArray.length < 1">
+        <p>No projects found.</p>
+        <p>You don't have access to any projects that match your search.</p>
+      </div>
+
     </chef-dropdown>
   </chef-click-outside>
 </div>

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
@@ -25,15 +25,17 @@
           />
       </div>
 
-      <chef-checkbox
-        *ngFor="let project of filteredProjects"
-        [checked]="project.checked"
-        [attr.title]="project.name"
-        (change)="projectChecked($event.detail, project)"
-        (keydown.enter)="closeDropdown()"
-        (keydown.esc)="closeDropdown()"
-        (keydown.arrowup)="moveFocus($event)"
-        (keydown.arrowdown)="moveFocus($event)">{{ project['name'] }}</chef-checkbox>
+      <div id="project-container">
+        <chef-checkbox
+          *ngFor="let project of filteredProjects"
+          [checked]="project.checked"
+          [attr.title]="project.name"
+          (change)="projectChecked($event.detail, project)"
+          (keydown.enter)="closeDropdown()"
+          (keydown.esc)="closeDropdown()"
+          (keydown.arrowup)="moveFocus($event)"
+          (keydown.arrowdown)="moveFocus($event)">{{ project['name'] }}</chef-checkbox>
+      </div>
 
       <div class="no-projects" *ngIf="filteredProjects.length === 0">
         <p>No projects found.</p>

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
@@ -34,7 +34,7 @@
           (keydown.enter)="closeDropdown()"
           (keydown.esc)="closeDropdown()"
           (keydown.arrowup)="moveFocus($event)"
-          (keydown.arrowdown)="moveFocus($event)">{{ project['name'] }}</chef-checkbox>
+          (keydown.arrowdown)="moveFocus($event)">{{ project.name }}</chef-checkbox>
       </div>
 
       <div class="no-projects" *ngIf="filteredProjects.length === 0">

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
@@ -25,7 +25,7 @@
       </div>
 
       <chef-checkbox
-        *ngFor="let project of filteredProjects"
+        *ngFor="let project of projectsArray"
         [checked]="project.checked"
         [attr.title]="project.name"
         (change)="projectChecked($event.detail, project)"
@@ -34,7 +34,7 @@
         (keydown.arrowup)="moveFocus($event)"
         (keydown.arrowdown)="moveFocus($event)">{{ project['name'] }}</chef-checkbox>
 
-      <div class="no-projects" *ngIf="projectsArray.length < 1">
+      <div class="no-projects" *ngIf="projectsArray.length === 0">
         <p>No projects found.</p>
         <p>You don't have access to any projects that match your search.</p>
       </div>

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.html
@@ -19,13 +19,14 @@
         <input 
           chefInput
           type="text"
+          [(ngModel)]="filterValue"
           placeholder="Filter projects..." 
-
+          (keyup)="handleFilterKeyUp()"
           />
       </div>
 
       <chef-checkbox
-        *ngFor="let project of projectsArray"
+        *ngFor="let project of filteredProjects"
         [checked]="project.checked"
         [attr.title]="project.name"
         (change)="projectChecked($event.detail, project)"
@@ -34,7 +35,7 @@
         (keydown.arrowup)="moveFocus($event)"
         (keydown.arrowdown)="moveFocus($event)">{{ project['name'] }}</chef-checkbox>
 
-      <div class="no-projects" *ngIf="projectsArray.length === 0">
+      <div class="no-projects" *ngIf="filteredProjects.length === 0">
         <p>No projects found.</p>
         <p>You don't have access to any projects that match your search.</p>
       </div>

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
@@ -68,12 +68,12 @@ chef-dropdown {
   border-top: none;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
-  
+
   #filter-container {
     padding: 14px 18px;
     border-bottom: 1px solid $chef-grey;
   }
-  
+
   #project-container {
     max-height: 210px;
     overflow-y: scroll;

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
@@ -35,7 +35,6 @@
     z-index: 4;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-    border-color: $chef-dark-grey;
   }
 
   &[disabled] {

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
@@ -68,7 +68,7 @@ chef-dropdown {
   border-top: none;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
-  overflow-y: auto;
+  overflow-y: scroll;
   max-height: 325px;
 
   #filter-container {

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
@@ -68,12 +68,20 @@ chef-dropdown {
   border-top: none;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
-  overflow-y: scroll;
-  max-height: 325px;
-
+  
   #filter-container {
-    padding: 14px;
+    padding: 14px 18px;
     border-bottom: 1px solid $chef-grey;
+  }
+  
+  #project-container {
+    max-height: 210px;
+    overflow-y: scroll;
+  }
+
+  .no-projects {
+    padding: 14px 18px 0px;
+    font-style: italic;
   }
 }
 

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.scss
@@ -48,7 +48,7 @@
 
   &:focus {
     outline: none;
-    border-color: $chef-dark-grey;
+    border-color: $chef-grey;
   }
 
   > chef-icon {
@@ -65,12 +65,17 @@ chef-dropdown {
   width: 100%;
   font-size: 14px;
   z-index: 3;
-  border: 1px solid $chef-dark-grey;
+  border: 1px solid $chef-grey;
   border-top: none;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   overflow-y: auto;
-  max-height: 125px;
+  max-height: 325px;
+
+  #filter-container {
+    padding: 14px;
+    border-bottom: 1px solid $chef-grey;
+  }
 }
 
 chef-checkbox {

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -27,4 +27,38 @@ describe('ProjectsDropdownComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('dropdown', () => {
+    beforeEach(() => {
+      component.active = true;
+      component.filteredProjects = [
+        {
+          name: 'Project 1',
+          id: 'project-1',
+          type: 'CUSTOM',
+          status: 'NO_RULES',
+          checked: false
+        },
+        {
+          name: 'Project 2',
+          id: 'project-2',
+          type: 'CUSTOM',
+          status: 'NO_RULES',
+          checked: true
+        }
+      ];
+      fixture.detectChanges();
+    });
+
+    it('displays a list of checkbox options', () => {
+      const options = Array.from(fixture.nativeElement.querySelectorAll('chef-checkbox'));
+      expect(options.length).toEqual(2);
+      options.forEach((option: HTMLInputElement, index: number) => {
+        const { name, checked } = component.filteredProjects[index];
+        expect(option.textContent).toEqual(name);
+        expect(option.checked).toEqual(checked);
+      });
+    });
+
+  });
 });

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -1,4 +1,5 @@
 import { CUSTOM_ELEMENTS_SCHEMA, EventEmitter } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProjectsDropdownComponent } from './projects-dropdown.component';
@@ -10,6 +11,7 @@ describe('ProjectsDropdownComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ ProjectsDropdownComponent ],
+      imports: [ FormsModule ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -40,7 +40,7 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
 
   // filteredProjects is merely a container to hold the projectsArray
   // that can be altered
-  public filteredProjects: ProjectChecked[];
+  public filteredProjects: ProjectChecked[] = [];
   public active = false;
   public label = UNASSIGNED_PROJECT_ID;
   public filterValue = '';

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -70,10 +70,12 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
     if (this.disabled) {
       return;
     }
+    if (!this.active) {
+      this.filterValue = '';
+      this.filteredProjects = this.projectsArray;
+    }
 
     this.active = !this.active;
-    this.filterValue = '';
-    this.filteredProjects = this.projectsArray;
   }
 
   projectChecked(checked: boolean, project: ProjectChecked): void {

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -38,6 +38,9 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
   // Emits a project that changed as a result of a check or uncheck.
   @Output() onProjectChecked = new EventEmitter<ProjectChecked>();
 
+  // filteredProjects is merely a container to hold the projectsArray
+  // that can be altered
+  public filteredProjects: ProjectChecked[];
   public active = false;
   public label = UNASSIGNED_PROJECT_ID;
 
@@ -77,6 +80,13 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
       this.active = false;
     }
   }
+
+  // handleFilterKeyUp() {
+  //   this.filteredProjects = this.projectsArray.filter(project => {
+  //     // project.label.toLowerCase().indexOf(this.filterValue.toLowerCase()) > -1
+  //     console.log(project);
+  //   });
+  // }
 
   moveFocus(event: KeyboardEvent): void {
     event.preventDefault();

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -69,6 +69,7 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
     }
 
     this.active = !this.active;
+    this.filterValue = '';
   }
 
   projectChecked(checked: boolean, project: ProjectChecked): void {

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -53,9 +53,12 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
     }
   }
 
-  ngOnChanges(): void {
-    this.filteredProjects = this.projectsArray;
+  ngOnChanges(changes): void {
     this.updateLabel();
+    // only update the projects list on initialization/the first change
+    if (changes.projects && changes.projects.firstChange) {
+      this.filteredProjects = this.projectsArray;
+    }
   }
 
   get projectsArray(): ProjectChecked[] {

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -43,6 +43,7 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
   public filteredProjects: ProjectChecked[];
   public active = false;
   public label = UNASSIGNED_PROJECT_ID;
+  public filterValue = '';
 
   ngOnInit(): void {
     if (this.projectsUpdated) { // an optional setting
@@ -53,6 +54,7 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(): void {
+    this.filteredProjects = this.projectsArray;
     this.updateLabel();
   }
 
@@ -81,12 +83,15 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
     }
   }
 
-  // handleFilterKeyUp() {
-  //   this.filteredProjects = this.projectsArray.filter(project => {
-  //     // project.label.toLowerCase().indexOf(this.filterValue.toLowerCase()) > -1
-  //     console.log(project);
-  //   });
-  // }
+  handleFilterKeyUp(): void {
+    this.filteredProjects = this.filterProjects(this.filterValue);
+  }
+
+  filterProjects(value: string): ProjectChecked[]  {
+    return this.projectsArray.filter(project =>
+      project.id.toLowerCase().indexOf(value.toLowerCase()) > -1
+    );
+  }
 
   moveFocus(event: KeyboardEvent): void {
     event.preventDefault();

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -70,6 +70,7 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
 
     this.active = !this.active;
     this.filterValue = '';
+    this.filteredProjects = this.projectsArray;
   }
 
   projectChecked(checked: boolean, project: ProjectChecked): void {

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, OnChanges, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { ProjectConstants, Project } from 'app/entities/projects/project.model';
@@ -53,7 +53,7 @@ export class ProjectsDropdownComponent implements OnInit, OnChanges {
     }
   }
 
-  ngOnChanges(changes): void {
+  ngOnChanges(changes: SimpleChanges): void {
     this.updateLabel();
     // only update the projects list on initialization/the first change
     if (changes.projects && changes.projects.firstChange) {

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -11,7 +11,7 @@
     [ngClass]="{'active': selectionCountActive }">{{ selectionCount }}</span>
   <chef-icon *ngIf="dropdownCaretVisible" aria-hidden>keyboard_arrow_down</chef-icon>
 </button>
-<chef-click-outside omit="dropdown-label" (clickOutside)="handleEscape()">
+<chef-click-outside omit="dropdown-label" (clickOutside)="handleEscape()" *ngIf="dropdownActive">
   <chef-dropdown class="dropdown" id="projects-filter-dropdown" [attr.visible]="dropdownActive" (keydown.esc)="handleEscape()">
 
       <div class="dropdown-body">

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -146,7 +146,7 @@ describe('ProjectsFilterDropdownComponent', () => {
 
       it('the dropdown is hidden', () => {
         const dropdown = fixture.nativeElement.querySelector('.dropdown');
-        expect(dropdown.getAttribute('visible')).toEqual('false');
+        expect(dropdown).toBeNull();
       });
     });
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This branch adds the capability to filter projects in the dropdown list that sits inside Settings > Teams > Details where a user can be assigned projects.

Note: In the interest of time, this branch does not use a redux pattern and should be updated after release.

### :chains: Related Resources
fixes #1842

### :+1: Definition of Done
A user can click on the project dropdown, and type to filter their projects

### :athletic_shoe: How to Build and Test the Change
To Build:
build components/automate-ui-devproxy && start_all_services
make serve

To Test:
Navigate to https://a2-dev.test/settings/teams/admins#details
please note, it is necessary to have several projects created
click on the projects dropdown
type in the input to filter the project selection

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable