### PR TITLE
Show a docs link when apps tab is empty

### DIFF
--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.html
@@ -191,7 +191,7 @@
   -->
   <div class="empty-status" *ngIf="(serviceGroupsStatus$ | async) === 'loadingSuccess' && sgHealthSummary.total === 0">
     <h3>Add service groups</h3>
-    <p>Contact your account representative to find out more about adding service groups.</p>
+    <p>Find out more about <a href="https://automate.chef.io/docs/applications-setup/" target="_blank">adding service groups.</a></p>
   </div>
   <div class="empty-status" *ngIf="(serviceGroupsStatus$ | async) === 'loadingSuccess' && sgHealthSummary.total !== 0 && (serviceGroupsList$ | async).length === 0">
     <h3>None of the service groups returned {{ selectedStatus$ | async }}</h3>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The message that appears when a user visits the applications tab but has no applications data is updated to link to the getting started documentation for the apps tab.

### :chains: Related Resources

#2677 

### :athletic_shoe: How to Build and Test the Change

Build automate-ui, start all services and then visit the apps tab. The link is not expected to work until the next time we promote acceptance to current. Chef Software employees can view the acceptance version of the page over VPN at https://a2-docs-acceptance.cd.chef.co/docs/applications-setup/

### :camera: Screenshots, if applicable

<img width="1007" alt="Screen Shot 2020-01-22 at 1 41 30 PM" src="https://user-images.githubusercontent.com/37162/72936901-fced2500-3d1c-11ea-9b61-6530e0002415.png">
