### PR TITLE
Document Apps API filter parameters

### DIFF
--- a/api/external/applications/applications.pb.go
+++ b/api/external/applications/applications.pb.go
@@ -76,6 +76,28 @@ func (HealthStatus) EnumDescriptor() ([]byte, []int) {
 // Request message for listing services.
 type ServicesReq struct {
 	// Applies search filters, in the format of `fieldname:value`.
+	// Valid filter fieldnames are:
+	// * `origin`: origin component of the service's package identifier
+	// * `service`: the name component of the service's package identifier
+	// * `version`: the version number component of the service's package identifier
+	// * `buildstamp`: the build timestamp (also called "release") of the service's package identifier
+	// * `channel`: the package channel to which the service subscribes for updates
+	// * `application`: the application field of the service's event-stream metadata
+	// * `environment`: the environment field of the service's event-stream metadata
+	// * `site`: the site field of the service's event-stream metadata
+	// * `group`: the suffix of the service group name
+	// Services may also be filtered by `status`, which refers to a service's
+	// connected/disconnected state or it's most recent healthcheck result. Valid
+	// status filter parameters are:
+	// * `status:disconnected`: only return services in the disconnected state
+	// * `status:critical`: only return services that are returning a "critical"
+	//   healthcheck result
+	// * `status:unknown`: only return services that are returning an "unknown"
+	//   healthcheck result
+	// * `status:warning`: only return services that are returning a "warning"
+	//   healthcheck result
+	// * `status:ok`: only return services that are returning "ok" health check
+	//   results
 	Filter []string `protobuf:"bytes,1,rep,name=filter,proto3" json:"filter,omitempty"`
 	// Applies pagination parameters.
 	Pagination *query.Pagination `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
@@ -139,6 +161,7 @@ type ServicesDistinctValuesReq struct {
 	// Query value, supports wildcards (* and ?).
 	QueryFragment string `protobuf:"bytes,2,opt,name=query_fragment,json=queryFragment,proto3" json:"query_fragment,omitempty"`
 	// Applies filters, in the format of `fieldname:value`.
+	// See documentation for ServicesReq for valid filter parameters
 	Filter               []string `protobuf:"bytes,3,rep,name=filter,proto3" json:"filter,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -200,6 +223,7 @@ type ServicesBySGReq struct {
 	// Applies sorting parameters.
 	Sorting *query.Sorting `protobuf:"bytes,3,opt,name=sorting,proto3" json:"sorting,omitempty"`
 	// Applies filters, in the format of `fieldname:value`.
+	// See documentation for ServicesReq for valid filter parameters
 	Filter               []string `protobuf:"bytes,5,rep,name=filter,proto3" json:"filter,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -1001,6 +1025,7 @@ func (m *Service) GetId() string {
 // Request message for GetServiceGroupsHealthCounts
 type ServiceGroupsHealthCountsReq struct {
 	// Applies search filters, in the format of `fieldname:value`.
+	// See the documentation for ServiceGroupsReq for valid filter parameters.
 	Filter               []string `protobuf:"bytes,1,rep,name=filter,proto3" json:"filter,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -1042,6 +1067,33 @@ func (m *ServiceGroupsHealthCountsReq) GetFilter() []string {
 // Request message for GetServiceGroups
 type ServiceGroupsReq struct {
 	// Applies search and status filters, in the format of `fieldname:value` or `status:value`.
+	// Valid filter fieldnames are:
+	// * `origin`: origin component of the service's package identifier
+	// * `service`: the name component of the service's package identifier
+	// * `version`: the version number component of the service's package identifier
+	// * `buildstamp`: the build timestamp (also called "release") of the service's package identifier
+	// * `channel`: the package channel to which the service subscribes for updates
+	// * `application`: the application field of the service's event-stream metadata
+	// * `environment`: the environment field of the service's event-stream metadata
+	// * `site`: the site field of the service's event-stream metadata
+	// * `group`: the suffix of the service group name
+	// Service groups may also be filtered by `status`, which refers to a service's
+	// connected/disconnected state or it's most recent healthcheck result. Valid
+	// status filter parameters are:
+	// * `status:disconnected`: only return service groups that contain at least
+	//   one service in the disconnected state
+	// * `status:critical`: only return service groups that contain at least one
+	//   service that is returning a "critical" healthcheck result
+	// * `status:critical`: only return service groups that contain at least one
+	//   service that is returning a "critical" healthcheck result
+	// * `status:unknown`: only return service groups that contain at least one
+	//   service that is returning an "unknown" healthcheck result and no
+	//   services returning "critical" results
+	// * `status:warning`: only return service groups that contain at least one
+	//   service that is returning a "warning" healthcheck result and have no
+	//   services returning "critical" or "unknown" results
+	// * `status:ok`: only return service groups where all services are returning
+	//   "ok" health check results
 	Filter []string `protobuf:"bytes,1,rep,name=filter,proto3" json:"filter,omitempty"`
 	// Pagination parameters for service groups list.
 	Pagination *query.Pagination `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`

--- a/api/external/applications/applications.proto
+++ b/api/external/applications/applications.proto
@@ -307,6 +307,28 @@ service ApplicationsService {
 // Request message for listing services.
 message ServicesReq {
   // Applies search filters, in the format of `fieldname:value`.
+  // Valid filter fieldnames are:
+  // * `origin`: origin component of the service's package identifier
+  // * `service`: the name component of the service's package identifier
+  // * `version`: the version number component of the service's package identifier
+  // * `buildstamp`: the build timestamp (also called "release") of the service's package identifier
+  // * `channel`: the package channel to which the service subscribes for updates
+  // * `application`: the application field of the service's event-stream metadata
+  // * `environment`: the environment field of the service's event-stream metadata
+  // * `site`: the site field of the service's event-stream metadata
+  // * `group`: the suffix of the service group name
+  // Services may also be filtered by `status`, which refers to a service's
+  // connected/disconnected state or it's most recent healthcheck result. Valid
+  // status filter parameters are:
+  // * `status:disconnected`: only return services in the disconnected state
+  // * `status:critical`: only return services that are returning a "critical"
+  //   healthcheck result
+  // * `status:unknown`: only return services that are returning an "unknown"
+  //   healthcheck result
+  // * `status:warning`: only return services that are returning a "warning"
+  //   healthcheck result
+  // * `status:ok`: only return services that are returning "ok" health check
+  //   results
   repeated string filter = 1;
   // Applies pagination parameters.
   common.query.Pagination pagination = 2;
@@ -321,6 +343,7 @@ message ServicesDistinctValuesReq {
   // Query value, supports wildcards (* and ?).
   string query_fragment = 2;
   // Applies filters, in the format of `fieldname:value`.
+  // See documentation for ServicesReq for valid filter parameters
   repeated string filter = 3;
 }
 
@@ -333,6 +356,7 @@ message ServicesBySGReq {
   // Applies sorting parameters.
   common.query.Sorting sorting = 3;
   // Applies filters, in the format of `fieldname:value`.
+  // See documentation for ServicesReq for valid filter parameters
   repeated string filter = 5;
 }
 
@@ -455,12 +479,40 @@ message Service {
 // Request message for GetServiceGroupsHealthCounts
 message ServiceGroupsHealthCountsReq {
   // Applies search filters, in the format of `fieldname:value`.
+  // See the documentation for ServiceGroupsReq for valid filter parameters.
   repeated string filter = 1;
 }
 
 // Request message for GetServiceGroups
 message ServiceGroupsReq {
   // Applies search and status filters, in the format of `fieldname:value` or `status:value`.
+  // Valid filter fieldnames are:
+  // * `origin`: origin component of the service's package identifier
+  // * `service`: the name component of the service's package identifier
+  // * `version`: the version number component of the service's package identifier
+  // * `buildstamp`: the build timestamp (also called "release") of the service's package identifier
+  // * `channel`: the package channel to which the service subscribes for updates
+  // * `application`: the application field of the service's event-stream metadata
+  // * `environment`: the environment field of the service's event-stream metadata
+  // * `site`: the site field of the service's event-stream metadata
+  // * `group`: the suffix of the service group name
+  // Service groups may also be filtered by `status`, which refers to a service's
+  // connected/disconnected state or it's most recent healthcheck result. Valid
+  // status filter parameters are:
+  // * `status:disconnected`: only return service groups that contain at least
+  //   one service in the disconnected state
+  // * `status:critical`: only return service groups that contain at least one
+  //   service that is returning a "critical" healthcheck result
+  // * `status:critical`: only return service groups that contain at least one
+  //   service that is returning a "critical" healthcheck result
+  // * `status:unknown`: only return service groups that contain at least one
+  //   service that is returning an "unknown" healthcheck result and no
+  //   services returning "critical" results
+  // * `status:warning`: only return service groups that contain at least one
+  //   service that is returning a "warning" healthcheck result and have no
+  //   services returning "critical" or "unknown" results
+  // * `status:ok`: only return service groups where all services are returning
+  //   "ok" health check results
   repeated string filter = 1;
   // Pagination parameters for service groups list.
   common.query.Pagination pagination = 2;

--- a/api/external/applications/applications.swagger.json
+++ b/api/external/applications/applications.swagger.json
@@ -110,7 +110,7 @@
         "parameters": [
           {
             "name": "filter",
-            "description": "Applies search and status filters, in the format of `fieldname:value` or `status:value`.",
+            "description": "Applies search and status filters, in the format of `fieldname:value` or `status:value`.\nValid filter fieldnames are:\n* `origin`: origin component of the service's package identifier\n* `service`: the name component of the service's package identifier\n* `version`: the version number component of the service's package identifier\n* `buildstamp`: the build timestamp (also called \"release\") of the service's package identifier\n* `channel`: the package channel to which the service subscribes for updates\n* `application`: the application field of the service's event-stream metadata\n* `environment`: the environment field of the service's event-stream metadata\n* `site`: the site field of the service's event-stream metadata\n* `group`: the suffix of the service group name\nService groups may also be filtered by `status`, which refers to a service's\nconnected/disconnected state or it's most recent healthcheck result. Valid\nstatus filter parameters are:\n* `status:disconnected`: only return service groups that contain at least\n  one service in the disconnected state\n* `status:critical`: only return service groups that contain at least one\n  service that is returning a \"critical\" healthcheck result\n* `status:critical`: only return service groups that contain at least one\n  service that is returning a \"critical\" healthcheck result\n* `status:unknown`: only return service groups that contain at least one\n  service that is returning an \"unknown\" healthcheck result and no\n  services returning \"critical\" results\n* `status:warning`: only return service groups that contain at least one\n  service that is returning a \"warning\" healthcheck result and have no\n  services returning \"critical\" or \"unknown\" results\n* `status:ok`: only return service groups where all services are returning\n  \"ok\" health check results.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -218,7 +218,7 @@
           },
           {
             "name": "filter",
-            "description": "Applies filters, in the format of `fieldname:value`.",
+            "description": "Applies filters, in the format of `fieldname:value`.\nSee documentation for ServicesReq for valid filter parameters.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -249,7 +249,7 @@
         "parameters": [
           {
             "name": "filter",
-            "description": "Applies search filters, in the format of `fieldname:value`.",
+            "description": "Applies search filters, in the format of `fieldname:value`.\nSee the documentation for ServiceGroupsReq for valid filter parameters.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -280,7 +280,7 @@
         "parameters": [
           {
             "name": "filter",
-            "description": "Applies search filters, in the format of `fieldname:value`.",
+            "description": "Applies search filters, in the format of `fieldname:value`.\nValid filter fieldnames are:\n* `origin`: origin component of the service's package identifier\n* `service`: the name component of the service's package identifier\n* `version`: the version number component of the service's package identifier\n* `buildstamp`: the build timestamp (also called \"release\") of the service's package identifier\n* `channel`: the package channel to which the service subscribes for updates\n* `application`: the application field of the service's event-stream metadata\n* `environment`: the environment field of the service's event-stream metadata\n* `site`: the site field of the service's event-stream metadata\n* `group`: the suffix of the service group name\nServices may also be filtered by `status`, which refers to a service's\nconnected/disconnected state or it's most recent healthcheck result. Valid\nstatus filter parameters are:\n* `status:disconnected`: only return services in the disconnected state\n* `status:critical`: only return services that are returning a \"critical\"\n  healthcheck result\n* `status:unknown`: only return services that are returning an \"unknown\"\n  healthcheck result\n* `status:warning`: only return services that are returning a \"warning\"\n  healthcheck result\n* `status:ok`: only return services that are returning \"ok\" health check\n  results.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -360,7 +360,7 @@
           },
           {
             "name": "filter",
-            "description": "Applies filters, in the format of `fieldname:value`.",
+            "description": "Applies filters, in the format of `fieldname:value`.\nSee documentation for ServicesReq for valid filter parameters.",
             "in": "query",
             "required": false,
             "type": "array",

--- a/components/automate-gateway/api/applications.pb.swagger.go
+++ b/components/automate-gateway/api/applications.pb.swagger.go
@@ -113,7 +113,7 @@ func init() {
         "parameters": [
           {
             "name": "filter",
-            "description": "Applies search and status filters, in the format of ` + "`" + `fieldname:value` + "`" + ` or ` + "`" + `status:value` + "`" + `.",
+            "description": "Applies search and status filters, in the format of ` + "`" + `fieldname:value` + "`" + ` or ` + "`" + `status:value` + "`" + `.\nValid filter fieldnames are:\n* ` + "`" + `origin` + "`" + `: origin component of the service's package identifier\n* ` + "`" + `service` + "`" + `: the name component of the service's package identifier\n* ` + "`" + `version` + "`" + `: the version number component of the service's package identifier\n* ` + "`" + `buildstamp` + "`" + `: the build timestamp (also called \"release\") of the service's package identifier\n* ` + "`" + `channel` + "`" + `: the package channel to which the service subscribes for updates\n* ` + "`" + `application` + "`" + `: the application field of the service's event-stream metadata\n* ` + "`" + `environment` + "`" + `: the environment field of the service's event-stream metadata\n* ` + "`" + `site` + "`" + `: the site field of the service's event-stream metadata\n* ` + "`" + `group` + "`" + `: the suffix of the service group name\nService groups may also be filtered by ` + "`" + `status` + "`" + `, which refers to a service's\nconnected/disconnected state or it's most recent healthcheck result. Valid\nstatus filter parameters are:\n* ` + "`" + `status:disconnected` + "`" + `: only return service groups that contain at least\n  one service in the disconnected state\n* ` + "`" + `status:critical` + "`" + `: only return service groups that contain at least one\n  service that is returning a \"critical\" healthcheck result\n* ` + "`" + `status:critical` + "`" + `: only return service groups that contain at least one\n  service that is returning a \"critical\" healthcheck result\n* ` + "`" + `status:unknown` + "`" + `: only return service groups that contain at least one\n  service that is returning an \"unknown\" healthcheck result and no\n  services returning \"critical\" results\n* ` + "`" + `status:warning` + "`" + `: only return service groups that contain at least one\n  service that is returning a \"warning\" healthcheck result and have no\n  services returning \"critical\" or \"unknown\" results\n* ` + "`" + `status:ok` + "`" + `: only return service groups where all services are returning\n  \"ok\" health check results.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -221,7 +221,7 @@ func init() {
           },
           {
             "name": "filter",
-            "description": "Applies filters, in the format of ` + "`" + `fieldname:value` + "`" + `.",
+            "description": "Applies filters, in the format of ` + "`" + `fieldname:value` + "`" + `.\nSee documentation for ServicesReq for valid filter parameters.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -252,7 +252,7 @@ func init() {
         "parameters": [
           {
             "name": "filter",
-            "description": "Applies search filters, in the format of ` + "`" + `fieldname:value` + "`" + `.",
+            "description": "Applies search filters, in the format of ` + "`" + `fieldname:value` + "`" + `.\nSee the documentation for ServiceGroupsReq for valid filter parameters.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -283,7 +283,7 @@ func init() {
         "parameters": [
           {
             "name": "filter",
-            "description": "Applies search filters, in the format of ` + "`" + `fieldname:value` + "`" + `.",
+            "description": "Applies search filters, in the format of ` + "`" + `fieldname:value` + "`" + `.\nValid filter fieldnames are:\n* ` + "`" + `origin` + "`" + `: origin component of the service's package identifier\n* ` + "`" + `service` + "`" + `: the name component of the service's package identifier\n* ` + "`" + `version` + "`" + `: the version number component of the service's package identifier\n* ` + "`" + `buildstamp` + "`" + `: the build timestamp (also called \"release\") of the service's package identifier\n* ` + "`" + `channel` + "`" + `: the package channel to which the service subscribes for updates\n* ` + "`" + `application` + "`" + `: the application field of the service's event-stream metadata\n* ` + "`" + `environment` + "`" + `: the environment field of the service's event-stream metadata\n* ` + "`" + `site` + "`" + `: the site field of the service's event-stream metadata\n* ` + "`" + `group` + "`" + `: the suffix of the service group name\nServices may also be filtered by ` + "`" + `status` + "`" + `, which refers to a service's\nconnected/disconnected state or it's most recent healthcheck result. Valid\nstatus filter parameters are:\n* ` + "`" + `status:disconnected` + "`" + `: only return services in the disconnected state\n* ` + "`" + `status:critical` + "`" + `: only return services that are returning a \"critical\"\n  healthcheck result\n* ` + "`" + `status:unknown` + "`" + `: only return services that are returning an \"unknown\"\n  healthcheck result\n* ` + "`" + `status:warning` + "`" + `: only return services that are returning a \"warning\"\n  healthcheck result\n* ` + "`" + `status:ok` + "`" + `: only return services that are returning \"ok\" health check\n  results.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -363,7 +363,7 @@ func init() {
           },
           {
             "name": "filter",
-            "description": "Applies filters, in the format of ` + "`" + `fieldname:value` + "`" + `.",
+            "description": "Applies filters, in the format of ` + "`" + `fieldname:value` + "`" + `.\nSee documentation for ServicesReq for valid filter parameters.",
             "in": "query",
             "required": false,
             "type": "array",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The `filters` fields in the Applications API are free-form text at the protobuf level but then are validated like an enum inside the applications service. We need to tell users what the valid values are and what they mean so they can use the API without having to reverse engineer it from the browser.

### :chains: Related Resources

#2635
#2622

