### PR TITLE
Fix broken patch config during restore

### DIFF
--- a/api/interservice/deployment/override_config.go
+++ b/api/interservice/deployment/override_config.go
@@ -73,61 +73,56 @@ func MergeAndValidateNewUserOverrideConfig(existing *api.AutomateConfig, req *Ba
 
 	// Merge the restore task options into the config
 	reqS3 := req.GetS3BackupLocation()
-	if reqS3.GetBucketName() == "" {
-		// Return the defaults because we're in filesystem mode and the request
-		// caries no meaningful backup info in that mode.
-		// NOTE: It would be nice to carry the endpoint type in the backup req
-		return nil
-	}
+	if reqS3.GetBucketName() != "" {
+		// We're in S3 mode so we need to populate the config with any options
+		// that are in the req.
+		if cfg.GetGlobal().GetV1() == nil {
+			cfg.Global = config.NewGlobalConfig()
+		}
 
-	// We're in S3 mode so we need to populate the config with any options
-	// that are in the req.
-	if cfg.GetGlobal().GetV1() == nil {
-		cfg.Global = config.NewGlobalConfig()
-	}
+		if cfg.Global.V1.Backups == nil {
+			cfg.Global.V1.Backups = &config.Backups{}
+		}
 
-	if cfg.Global.V1.Backups == nil {
-		cfg.Global.V1.Backups = &config.Backups{}
-	}
+		if cfg.Global.V1.Backups.GetS3() != nil {
+			// We can't use the config from the override config because it might
+			// be different than where you told us the backup lives. We need to
+			// configure automate to use the backup location where the backup lives
+			// in order to restore (mostly because of the way ES works)
+			logrus.Warn("Ignoring s3 config from restore override config in favor of user-specified backup location")
+		}
 
-	if cfg.Global.V1.Backups.GetS3() != nil {
-		// We can't use the config from the override config because it might
-		// be different than where you told us the backup lives. We need to
-		// configure automate to use the backup location where the backup lives
-		// in order to restore (mostly because of the way ES works)
-		logrus.Warn("Ignoring s3 config from restore override config in favor of user-specified backup location")
-	}
+		cfg.Global.V1.Backups.S3 = &config.Backups_S3{
+			Credentials: &config.Backups_S3_AWSCredentials{},
+			Bucket:      &config.Backups_S3_Bucket{},
+		}
 
-	cfg.Global.V1.Backups.S3 = &config.Backups_S3{
-		Credentials: &config.Backups_S3_AWSCredentials{},
-		Bucket:      &config.Backups_S3_Bucket{},
-	}
+		creds := cfg.GetGlobal().GetV1().GetBackups().GetS3().GetCredentials()
+		bucket := cfg.GetGlobal().GetV1().GetBackups().GetS3().GetBucket()
 
-	creds := cfg.GetGlobal().GetV1().GetBackups().GetS3().GetCredentials()
-	bucket := cfg.GetGlobal().GetV1().GetBackups().GetS3().GetBucket()
+		if bName := reqS3.GetBucketName(); bName != "" {
+			bucket.Name = w.String(bName)
+		}
 
-	if bName := reqS3.GetBucketName(); bName != "" {
-		bucket.Name = w.String(bName)
-	}
+		if endpoint := reqS3.GetEndpoint(); endpoint != "" {
+			bucket.Endpoint = w.String(endpoint)
+		}
 
-	if endpoint := reqS3.GetEndpoint(); endpoint != "" {
-		bucket.Endpoint = w.String(endpoint)
-	}
+		if basePath := reqS3.GetBasePath(); basePath != "" {
+			bucket.BasePath = w.String(basePath)
+		}
 
-	if basePath := reqS3.GetBasePath(); basePath != "" {
-		bucket.BasePath = w.String(basePath)
-	}
+		if accessKey := reqS3.GetAccessKey(); accessKey != "" {
+			creds.AccessKey = w.String(accessKey)
+		}
 
-	if accessKey := reqS3.GetAccessKey(); accessKey != "" {
-		creds.AccessKey = w.String(accessKey)
-	}
+		if secretKey := reqS3.GetSecretKey(); secretKey != "" {
+			creds.SecretKey = w.String(secretKey)
+		}
 
-	if secretKey := reqS3.GetSecretKey(); secretKey != "" {
-		creds.SecretKey = w.String(secretKey)
-	}
-
-	if sessionToken := reqS3.GetSessionToken(); sessionToken != "" {
-		creds.SessionToken = w.String(sessionToken)
+		if sessionToken := reqS3.GetSessionToken(); sessionToken != "" {
+			creds.SessionToken = w.String(sessionToken)
+		}
 	}
 
 	if patchConfig != nil {

--- a/api/interservice/deployment/override_config_test.go
+++ b/api/interservice/deployment/override_config_test.go
@@ -107,7 +107,7 @@ func TestMergeAndValidateNewUserOverrideConfig(t *testing.T) {
 		require.Equal(t, expectedCfg, cfg)
 	})
 
-	t.Run("config patch", func(t *testing.T) {
+	t.Run("config patch 1", func(t *testing.T) {
 		cfg := newValidOverrideConfig()
 		rt := NewBackupRestoreTask()
 		rt.S3BackupLocation = &S3BackupLocation{
@@ -156,6 +156,29 @@ func TestMergeAndValidateNewUserOverrideConfig(t *testing.T) {
 				},
 			},
 		}
+		expectedCfg.Global.V1.Log = &config.Log{
+			Level: w.String("debug"),
+		}
+		err := MergeAndValidateNewUserOverrideConfig(cfg, rt)
+		require.NoError(t, err)
+		require.Equal(t, expectedCfg, cfg)
+	})
+
+	t.Run("config patch 2", func(t *testing.T) {
+		cfg := newValidOverrideConfig()
+		rt := NewBackupRestoreTask()
+
+		rt.PatchConfig = &dc.AutomateConfig{
+			Global: config.NewGlobalConfig(),
+		}
+		rt.PatchConfig.Global.V1.Log = &config.Log{
+			Level: w.String("debug"),
+		}
+
+		// Make sure the patch config overrides the default backup config
+		// from the restore task
+		expectedCfg := newValidOverrideConfig()
+
 		expectedCfg.Global.V1.Log = &config.Log{
 			Level: w.String("debug"),
 		}

--- a/integration/tests/ha_data_services_migrate.sh
+++ b/integration/tests/ha_data_services_migrate.sh
@@ -65,3 +65,11 @@ do_upgrade() {
         "$test_backup_id"
 }
 
+do_test_upgrade() {
+    do_test_upgrade_default
+    # doing the patch again shouldn't change anything because
+    # the restore should have patched the config
+    log_info "Making sure patch config doesn't change anything"
+    chef-automate config patch /services/ha_backend.toml
+    do_test_upgrade_default
+}


### PR DESCRIPTION
It seems to have broken in #2344
Basically, in most cases, the code ends up discarding the requested
patch config because it returns early. The only case when this doesn't
happen is if you're doing backups to S3
