### PR TITLE
Two notifications received when removing a user from a team

### DIFF
--- a/components/automate-ui/src/app/modules/user/user-table/user-table.component.html
+++ b/components/automate-ui/src/app/modules/user/user-table/user-table.component.html
@@ -33,7 +33,7 @@
             <!-- TODO: Need to account for v1 / v2 in the app-authorized path -->
             <!-- <app-authorized [allOf]="['/iam/v2/users/{id}', 'delete', user.id]"> -->
             <mat-select panelClass="chef-control-menu" data-cy="select">
-              <mat-option data-cy="delete" (onSelectionChange)="removeClicked.emit(user)">{{ removeText }}</mat-option>
+              <mat-option data-cy="delete" (onSelectionChange)="deleteUser($event, user)">{{ removeText }}</mat-option>
             </mat-select>
             <!-- </app-authorized> -->
           </chef-table-cell>

--- a/components/automate-ui/src/app/modules/user/user-table/user-table.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-table/user-table.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, Output, OnInit, EventEmitter } from '@angular/core';
+import { ChefKeyboardEvent } from 'app/types/material-types';
 import { User } from 'app/entities/users/user.model';
 
 @Component({
@@ -29,5 +30,11 @@ export class UserTableComponent implements OnInit {
   ngOnInit(): void {
     this.getPermissionsPath = [this.baseUrl, 'get'];
     this.createPermissionsPath = [this.baseUrl, 'post'];
+  }
+
+  deleteUser($event: ChefKeyboardEvent, user: User) {
+    if ($event.isUserInput) {
+      this.removeClicked.emit(user);
+    }
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Upon removing a user, we were getting two notifications in the UI:
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/6817500/73045321-483d2b80-3e22-11ea-987a-d635f046e403.png">

This is due to the fact that the actual delete operation was dispatched twice, not that the response was posted twice.

Technical details:
The problem here with "onSelectionChange" is that when you select a new option, it both selects the new option and then deselects the old one. So you get one event with the new option and a second event with the old option.
The fix: Check for the new option selection only, the one with `isUserInput` being true.

### :chains: Related Resources
Reference: https://github.com/angular/components/issues/4094

### :+1: Definition of Done
Only one dispatch, and thus one notification in the UI.

### :athletic_shoe: How to Build and Test the Change

Rebuild automate-ui
Navigate to Users
Using the control menu for any user in the list, select <kbd>Remove User</kbd>.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
