### PR TITLE
Make date user-friendly in licensing error message

### DIFF
--- a/components/license-control-service/pkg/server/server.go
+++ b/components/license-control-service/pkg/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
@@ -155,8 +156,9 @@ func (s *LicenseControlServer) Update(ctx context.Context, req *lc.UpdateRequest
 	)
 
 	if !req.Force && ptypes.TimestampNow().GetSeconds() > licensedPeriod.end.GetSeconds() {
-		msg := fmt.Sprintf("Rejecting license ID %v, expired at %v; set force=true to override",
-			license.Id, licensedPeriod.end)
+		msg := fmt.Sprintf("Rejecting license ID %v, expired at %s; set force=true to override",
+			license.Id,
+			time.Unix(licensedPeriod.end.GetSeconds(), 0).UTC().Format(time.RFC3339))
 		logctx.Warn(msg)
 		return nil, status.Errorf(codes.InvalidArgument, msg)
 	}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Wanted to change this error message when applying an expired license--notice the reported date on the last line:
```
root@a2-iamv2p1-local-fresh-install-acceptance:~# chef-automate license apply temp.txt 
Reading token data from file: temp.txt
DeploymentServiceCallError: A request to the deployment-service failed:
Request to apply license failed: rpc error: code = InvalidArgument
desc = Rejecting license ID 9121bf7b-c10b-47db-aa65-faba6bc126b8,
expired at seconds:1525219199 ; set force=true to override
```

to this:
```
root@a2-iamv2p1-local-fresh-install-acceptance:~# chef-automate license apply temp.txt 
Reading token data from file: temp.txt
DeploymentServiceCallError: A request to the deployment-service failed:
Request to apply license failed: rpc error: code = InvalidArgument
desc = Rejecting license ID 9121bf7b-c10b-47db-aa65-faba6bc126b8,
expired at 2018-05-01T23:59:59Z; set force=true to override
```

### :chains: Related Resources
NA

### :+1: Definition of Done
Date outputs in a user-friendly manner when applying an expired license.

### :athletic_shoe: How to Build and Test the Change

1. rebuild component/license-control-service
2. get an expired license (this assumes it is in temp.txt)
3. `chef-automate license apply temp.txt`


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
