### PR TITLE
[automate-1523] fix password match error

### DIFF
--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.html
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.html
@@ -58,7 +58,7 @@
           <chef-form-field class="password">
             <label>
               <span class="label">New Password <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="newPassword" type="password"/>
+              <input chefInput formControlName="newPassword" type="password" (keyup)="handlePasswordInput($event)" />
             </label>
             <chef-error
               *ngIf="(passwordForm.get('newPassword').hasError('required') || passwordForm.get('newPassword').hasError('pattern')) && passwordForm.get('newPassword').dirty">

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.ts
@@ -154,6 +154,10 @@ export class UserDetailsComponent implements OnInit, OnDestroy {
     }
   }
 
+  public handlePasswordInput(): void {
+    this.passwordForm.get('confirmPassword').updateValueAndValidity();
+  }
+
   private savePasswordForUser(): void {
     const password = this.passwordForm.get('newPassword').value;
     this.store.dispatch(new UpdatePasswordUser({ ...this.user, password }));

--- a/components/automate-ui/src/app/page-components/create-user-modal/create-user-modal.component.html
+++ b/components/automate-ui/src/app/page-components/create-user-modal/create-user-modal.component.html
@@ -45,7 +45,7 @@
         <chef-form-field>
           <label>
             Password <span aria-hidden="true">*</span>
-            <input chefInput formControlName="password" type="password" />
+            <input chefInput formControlName="password" type="password" (keyup)="handlePasswordInput($event)"/>
           </label>
           <chef-error *ngIf="hasAttemptedInputWithError('password')">
             Password is required.

--- a/components/automate-ui/src/app/page-components/create-user-modal/create-user-modal.component.html
+++ b/components/automate-ui/src/app/page-components/create-user-modal/create-user-modal.component.html
@@ -8,7 +8,8 @@
             Display Name <span aria-hidden="true">*</span>
             <input chefInput formControlName="displayName" type="text" (keyup)="handleNameInput($event)" autocomplete="off" />
           </label>
-          <chef-error *ngIf="hasAttemptedInputWithError('displayName')">
+          <chef-error *ngIf="hasAttemptedInputWithRequiredError('displayName') || 
+            (createUserForm.get('displayName').hasError('pattern') && hasAttemptedInput('displayName'))">
             Display name is required.
           </chef-error>
         </chef-form-field>
@@ -20,7 +21,7 @@
             Username <span aria-hidden="true">*</span>
             <input chefInput formControlName="username" type="text" (keyup)="handleUsernameInput($event)" autocomplete="off" />
           </label>
-          <chef-error *ngIf="hasAttemptedInputWithError('username')">
+          <chef-error *ngIf="hasAttemptedInputWithRequiredError('username')">
             Username is required.
           </chef-error>
           <chef-error *ngIf="createUserForm.get('username').hasError('pattern') && hasAttemptedInput('username')">
@@ -47,7 +48,8 @@
             Password <span aria-hidden="true">*</span>
             <input chefInput formControlName="password" type="password" (keyup)="handlePasswordInput($event)"/>
           </label>
-          <chef-error *ngIf="hasAttemptedInputWithError('password')">
+          <chef-error *ngIf="hasAttemptedInputWithRequiredError('password') || 
+            (createUserForm.get('password').hasError('pattern') && hasAttemptedInput('password'))">
             Password is required.
           </chef-error>
           <chef-error *ngIf="createUserForm.get('password').hasError('minlength') && hasAttemptedInput('password')">
@@ -66,7 +68,7 @@
             Confirm Password <span aria-hidden="true">*</span>
             <input chefInput formControlName="confirmPassword" type="password" />
           </label>
-          <chef-error *ngIf="hasAttemptedInputWithError('confirmPassword')">
+          <chef-error *ngIf="hasAttemptedInputWithRequiredError('confirmPassword')">
             Confirm Password is required.
           </chef-error>
           <chef-error *ngIf="createUserForm.get('confirmPassword').hasError('noMatch') && hasAttemptedInput('confirmPassword')">

--- a/components/automate-ui/src/app/page-components/create-user-modal/create-user-modal.component.ts
+++ b/components/automate-ui/src/app/page-components/create-user-modal/create-user-modal.component.ts
@@ -39,7 +39,7 @@ export class CreateUserModalComponent implements OnInit, OnDestroy {
     fb: FormBuilder
   ) {
     this.createUserForm = fb.group({
-      // Must stay in sync with error checks in user-form.component.html
+      // Must stay in sync with error checks in create-user-modal.component.html
       displayName: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       username: ['', [Validators.required, Validators.pattern(USERNAME_PATTERN)]],
       // length validator must be consistent with
@@ -126,6 +126,10 @@ export class CreateUserModalComponent implements OnInit, OnDestroy {
   }
 
   handlePasswordInput(event: KeyboardEvent): void {
+    // This handles the case where a user first enters the password and confirmPassword
+    // then goes back and changes the original password.
+    // Since the match validator is only activated by changes to confirmPassword,
+    // we have to manually revalidate confirmPassword here
     this.createUserForm.get('confirmPassword').updateValueAndValidity();
     if (!this.isNavigationKey(event)) {
       this.passwordError = false;
@@ -141,7 +145,7 @@ export class CreateUserModalComponent implements OnInit, OnDestroy {
       this.createUserForm.get(field).dirty);
   }
 
-  hasAttemptedInputWithError(field: string): boolean {
+  hasAttemptedInputWithRequiredError(field: string): boolean {
     return (this.createUserForm.get(field).hasError('required') &&
       (this.createUserForm.get(field).touched || this.createUserForm.get(field).dirty));
   }

--- a/components/automate-ui/src/app/page-components/create-user-modal/create-user-modal.component.ts
+++ b/components/automate-ui/src/app/page-components/create-user-modal/create-user-modal.component.ts
@@ -125,6 +125,13 @@ export class CreateUserModalComponent implements OnInit, OnDestroy {
     }
   }
 
+  handlePasswordInput(event: KeyboardEvent): void {
+    this.createUserForm.get('confirmPassword').updateValueAndValidity();
+    if (!this.isNavigationKey(event)) {
+      this.passwordError = false;
+    }
+  }
+
   handleClose(): void {
     this.modifyUsername = false;
   }

--- a/components/automate-ui/src/app/page-components/create-user-modal/create-user-modal.component.ts
+++ b/components/automate-ui/src/app/page-components/create-user-modal/create-user-modal.component.ts
@@ -142,10 +142,8 @@ export class CreateUserModalComponent implements OnInit, OnDestroy {
   }
 
   hasAttemptedInputWithError(field: string): boolean {
-    return ((this.createUserForm.get(field).hasError('required') &&
-      this.createUserForm.get(field).touched) ||
-      (this.createUserForm.get(field).hasError('pattern') &&
-        this.createUserForm.get(field).dirty));
+    return (this.createUserForm.get(field).hasError('required') &&
+      (this.createUserForm.get(field).touched || this.createUserForm.get(field).dirty));
   }
 
   private isNavigationKey(event: KeyboardEvent): boolean {

--- a/e2e/cypress/integration/ui/settings/user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/user_mgmt.spec.ts
@@ -22,7 +22,7 @@ describe('user management', () => {
     cy.get('app-user-table').should('exist');
 
     // open modal
-    cy.get('[data-cy=app-user-table-add-button]').contains('Create User').click();
+    cy.get('[data-cy=app-user-table-add-button]').click();
     cy.get('app-user-management chef-modal').should('exist');
 
     // we increase the default delay to mimic the average human's typing speed

--- a/e2e/cypress/integration/ui/settings/user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/user_mgmt.spec.ts
@@ -63,7 +63,7 @@ describe('user management', () => {
     cy.get('[data-cy=save-user]').click();
     cy.get('app-user-management chef-modal').should('not.be.visible');
     cy.get('#main-content-wrapper').scrollTo('top');
-    cy.get('chef-notification.info').should('be.visible');
+    cy.get('chef-notification.info').contains(`Created user: ${username}`);
 
     cy.get('app-user-table chef-table-cell').contains(username).should('exist');
     cy.get('app-user-table chef-table-cell').contains(name).should('exist');
@@ -107,7 +107,6 @@ describe('user management', () => {
 
     cy.get('.update-password-button').click();
     cy.get('#main-content-wrapper').scrollTo('top');
-    cy.get('chef-notification.info').contains(`Reset password for user: ${username}`)
-      .should('be.visible');
+    cy.get('chef-notification.info').contains(`Reset password for user: ${username}`);
   });
 });

--- a/e2e/cypress/integration/ui/settings/user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/user_mgmt.spec.ts
@@ -64,6 +64,8 @@ describe('user management', () => {
     cy.get('app-user-management chef-modal').should('not.be.visible');
     cy.get('#main-content-wrapper').scrollTo('top');
     cy.get('chef-notification.info').contains(`Created user: ${username}`);
+    // close notification banner so we can assert the password success notification later
+    cy.get('chef-notification.info chef-icon').click();
 
     cy.get('app-user-table chef-table-cell').contains(username).should('exist');
     cy.get('app-user-table chef-table-cell').contains(name).should('exist');
@@ -107,6 +109,8 @@ describe('user management', () => {
 
     cy.get('.update-password-button').click();
     cy.get('#main-content-wrapper').scrollTo('top');
+
+    cy.wait('@updateUser');
     cy.get('chef-notification.info').contains(`Reset password for user: ${username}`);
   });
 });


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Fixes when the `password must match` error shows up

### :chains: Related Resources
branched off: https://github.com/chef/automate/pull/2704 (merged and rebased)

### :+1: Definition of Done
on both the user create modal and user details page:
- [x] Whenever the two password fields do not match an error should be presented to the user.
- [x] When they match (whether the first is corrected to match the second or the reverse), the error should go away and the save button should be enabled.
- [x] bonus: each field throws a Required error if the user enters all spaces then leaves the input

### :athletic_shoe: How to Build and Test the Change

Create User Modal
1. Sign in as admin
2. Navigate to Settings > Users
3. Use the Create User button
4. Enter a password, and a matching password in the confirm password box
5. Now go back to the first password box and add/delete a letter
6. Keep changing the password and confirm password fields until they match and the save button is enabled

User Details/User Profile Page

1. Click on a user to view their details page and click on the Reset Pasword tab (or click on the Profile link in the top right)
2. Enter in a password
3. Enter the identical password with one extra character on the end
4. You will see the "Passwords must match" error and the save is disabled
5. Add the additional character to the above password field
6. Now they match and the save button is enabled

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).