### PR TITLE
Applying license should immediately be reflected in license notification banner

### DIFF
--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.spec.ts
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.spec.ts
@@ -40,7 +40,7 @@ function genLicenseResp(licenseEndDate: moment.Moment): LicenseStatus {
 }
 
 describe('LicenseApplyComponent', () => {
-  let component;
+  let component: LicenseApplyComponent;
 
   it('should be created', () => {
     setup(genLicenseApplyReducer());

--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.spec.ts
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.spec.ts
@@ -11,7 +11,7 @@ import { TelemetryService } from 'app/services/telemetry/telemetry.service';
 import { MockChefSessionService } from 'app/testing/mock-chef-session.service';
 import { EntityStatus } from 'app/entities/entities';
 import { runtimeChecks } from 'app/ngrx.reducers';
-import { ApplyStatus, LicenseStatus } from 'app/entities/license/license.model';
+import { ApplyStatus, LicenseStatus, FetchStatus } from 'app/entities/license/license.model';
 import { LicenseApplyComponent } from './license-apply.component';
 
 function genErrorResp(status: number, msg: string): any /* HttpErrorResponse */ {
@@ -65,6 +65,16 @@ describe('LicenseApplyComponent', () => {
       expect(component.applyLicenseInternalError).toBeFalsy();
       expect(component.badRequestReason).toBe('');
       expect(component.expirationDate).toEqual(futureDate.format(DateTime.RFC2822));
+    });
+
+    it('check "current license status" after the successfully license applied.', () => {
+      const futureDate = moment().utc().add(2, 'months');
+      setup(genLicenseFetchReducer(futureDate));
+
+      expect(component.permissionDenied).toBeFalsy();
+      expect(component.applyLicenseInternalError).toBeFalsy();
+      expect(component.badRequestReason).toBe('');
+      expect(component.licenseExpired).toBeFalsy();
     });
 
     it('reflects permission denied', () => {
@@ -173,6 +183,17 @@ describe('LicenseApplyComponent', () => {
     spyOn(store, 'dispatch').and.callThrough();
     return { state: reducer(), store };
   }
+
+  function genLicenseFetchReducer(licenseEndDate: moment.Moment): () => { fetch: FetchStatus } {
+    return () => ({
+       fetch: {
+         license: genLicenseResp(licenseEndDate || moment().utc().add(2, 'months')),
+         status: EntityStatus.loadingSuccess,
+         expiryMessage: '',
+         errorResp: null
+       }
+     });
+   }
 
   function genLicenseApplyReducer(expiry?: moment.Moment): () => { apply: ApplyStatus } {
     return () => ({

--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.ts
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.ts
@@ -47,7 +47,7 @@ export class LicenseApplyComponent implements AfterViewInit {
   }
 
   constructor(
-    private licenseFacade: LicenseFacadeService,
+    public licenseFacade: LicenseFacadeService,
     fb: FormBuilder) {
       this.licenseFacade.licenseApplyReason$.subscribe((reason) => {
         this.licenseApplyReason = reason;

--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.ts
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.ts
@@ -89,7 +89,7 @@ export class LicenseApplyComponent implements AfterViewInit {
         this.setExpirationDate(fetchStatus.license);
         this.unlockModal();
       });
-
+      this.licenseFacade.getLicenseStatus();
       return;
     }
 

--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.ts
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.ts
@@ -89,6 +89,7 @@ export class LicenseApplyComponent implements AfterViewInit {
         this.setExpirationDate(fetchStatus.license);
         this.unlockModal();
       });
+      this.licenseFacade.getLicenseStatus();
       return;
     }
 

--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.ts
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.ts
@@ -89,7 +89,6 @@ export class LicenseApplyComponent implements AfterViewInit {
         this.setExpirationDate(fetchStatus.license);
         this.unlockModal();
       });
-      this.licenseFacade.getLicenseStatus();
       return;
     }
 

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.spec.ts
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.spec.ts
@@ -52,7 +52,7 @@ function genLicenseResp(licenseEndDate: moment.Moment): LicenseStatus {
 }
 
 describe('LicenseLockoutComponent', () => {
-  let component;
+  let component: LicenseLockoutComponent;
   // Tests on this action make use of the inherent state updating
   // of the underlying component.
   describe('GetLicenseStatus Action', () => {

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.spec.ts
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.spec.ts
@@ -52,8 +52,7 @@ function genLicenseResp(licenseEndDate: moment.Moment): LicenseStatus {
 }
 
 describe('LicenseLockoutComponent', () => {
-  let component: LicenseLockoutComponent;
-
+  let component;
   // Tests on this action make use of the inherent state updating
   // of the underlying component.
   describe('GetLicenseStatus Action', () => {
@@ -147,16 +146,6 @@ describe('LicenseLockoutComponent', () => {
       expect(component.trialRequestInternalError).toBeFalsy();
     });
 
-    it('check "current license status" after the successfully register.', () => {
-      const futureDate = moment().utc().add(2, 'months');
-      setup(genLicenseFetchReducer(futureDate));
-
-      expect(component.licenseExpired).toBeFalsy();
-      expect(component.fetchStatusInternalError).toBeFalsy();
-      expect(component.expirationDate).toEqual(futureDate
-                                      .format(DateTime.RFC2822));
-    });
-
     it('reflects other error as a generic request error', () => {
       // any other HTTP code not mentioned above will do
       const { state } = setup(genErrorRequestReducer(HttpStatus.NOT_FOUND));
@@ -180,6 +169,16 @@ describe('LicenseLockoutComponent', () => {
         component.handleLicenseRequest(state.request);
         expect(store.dispatch).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('GetLicenseStatus() Service', () => {
+    it('check "license status" after the successfully requested license.', () => {
+      const { state } = setup(genLicenseRequestReducer());
+      component.requestingLicense = true;
+      spyOn(component.licenseFacade, 'getLicenseStatus');
+      component.handleLicenseRequest(state.request);
+      expect(component.licenseFacade.getLicenseStatus).toHaveBeenCalled();
     });
   });
 

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.spec.ts
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.spec.ts
@@ -147,6 +147,16 @@ describe('LicenseLockoutComponent', () => {
       expect(component.trialRequestInternalError).toBeFalsy();
     });
 
+    it('check "current license status" after the successfully register.', () => {
+      const futureDate = moment().utc().add(2, 'months');
+      setup(genLicenseFetchReducer(futureDate));
+
+      expect(component.licenseExpired).toBeFalsy();
+      expect(component.fetchStatusInternalError).toBeFalsy();
+      expect(component.expirationDate).toEqual(futureDate
+                                      .format(DateTime.RFC2822));
+    });
+
     it('reflects other error as a generic request error', () => {
       // any other HTTP code not mentioned above will do
       const { state } = setup(genErrorRequestReducer(HttpStatus.NOT_FOUND));

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.ts
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.ts
@@ -159,6 +159,7 @@ export class LicenseLockoutComponent implements AfterViewInit {
       this.licenseExpired = moment().isAfter(state.license.licensed_period.end);
       licenseCurrentlyExpired = this.licenseExpired;
       this.setExpirationDate(state.license);
+      this.licenseFacade.getLicenseStatus();
     } else { // loadingFailure
       this.trialLicenseApplied = false;
 

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.ts
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.ts
@@ -159,7 +159,6 @@ export class LicenseLockoutComponent implements AfterViewInit {
       this.licenseExpired = moment().isAfter(state.license.licensed_period.end);
       licenseCurrentlyExpired = this.licenseExpired;
       this.setExpirationDate(state.license);
-      this.licenseFacade.getLicenseStatus();
     } else { // loadingFailure
       this.trialLicenseApplied = false;
 
@@ -189,6 +188,7 @@ export class LicenseLockoutComponent implements AfterViewInit {
     if (state.status === EntityStatus.loadingSuccess) {
       this.trialLicenseApplied = true;
       this.unlockModal();
+      this.licenseFacade.getLicenseStatus();
       return;
     }
 

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.ts
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.ts
@@ -83,7 +83,7 @@ export class LicenseLockoutComponent implements AfterViewInit {
   }
 
   constructor(
-    private licenseFacade: LicenseFacadeService,
+    public licenseFacade: LicenseFacadeService,
     private chefSessionService: ChefSessionService,
     private sessionStorage: SessionStorageService,
     public fb: FormBuilder


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description: 
Whether getting a new trial license (in which case a license notification banner should appear) or applying a full license (in which case the banner should disappear), that banner change should occur immediately, not at the next polling interval.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
fixes #1509
### :+1: Definition of Done
I have added some changes to reflect the license notification banner immediately. 
### :athletic_shoe: How to Build and Test the Change
build components/automate-ui
### :camera: Screenshots
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/12297653/73248531-21dc0f00-41d9-11ea-8f25-95a7eb03344b.gif)

