### PR TITLE
Remove references to Asset from ServiceNow notifications UI

### DIFF
--- a/components/automate-ui/src/app/pages/notification-form/notification-form.component.ts
+++ b/components/automate-ui/src/app/pages/notification-form/notification-form.component.ts
@@ -5,7 +5,6 @@ import { RulesService } from 'app/services/rules/rules.service';
 import { ActivatedRoute } from '@angular/router';
 
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
-import { FeatureFlagsService } from '../../services/feature-flags/feature-flags.service';
 
 enum UrlTestState {
   Inactive,
@@ -52,19 +51,16 @@ export class NotificationFormComponent implements OnInit {
   SLACK = ServiceActionType.SLACK;
   WEBHOOK = ServiceActionType.WEBHOOK;
   SERVICENOW = ServiceActionType.SERVICENOW;
-  showAsset: boolean;
 
   constructor(
     private rulesService: RulesService,
     private route: ActivatedRoute,
-    private layoutFacade: LayoutFacadeService,
-    private featureFlags: FeatureFlagsService
+    private layoutFacade: LayoutFacadeService
   ) {
     this.model = new Model(new Rule('', '', null, '', null, '', false), '', '');
     this.notificationId = this.route.snapshot.params['id'];
     this.isEditRule = this.notificationId ? true : false;
     this.showLoading = this.isEditRule;
-    this.showAsset = this.featureFlags.getFeatureStatus('servicenow_cmdb');
 
     if (this.isEditRule) {
       this.rulesService.fetchRule(this.notificationId)
@@ -89,14 +85,7 @@ export class NotificationFormComponent implements OnInit {
   }
 
   getAlertTypeKeys() {
-    const alertKeys = this.model.rule.getAlertTypeKeys();
-    if (!this.showAsset) {
-      const index = alertKeys.indexOf('Assets');
-      if (index > -1) {
-        alertKeys.splice(index, 1);
-      }
-    }
-    return alertKeys;
+    return this.model.rule.getAlertTypeKeys();
   }
 
   updateCriticalControlsOnly(event) {

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.ts
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.ts
@@ -135,8 +135,6 @@ export class NotificationsComponent implements OnInit {
           acc['ccrRuleCount'] += 1;
         } else if (rule.ruleType === 'ComplianceFailure') {
           acc['complianceRuleCount'] += 1;
-        } else if (rule.ruleType === 'Assets') {
-          acc['assetsRuleCount'] += 1;
         }
 
         if (rule.targetType === ServiceActionType.SLACK) {

--- a/components/automate-ui/src/app/pages/notifications/rule.ts
+++ b/components/automate-ui/src/app/pages/notifications/rule.ts
@@ -1,4 +1,4 @@
-export type RuleType = 'CCRFailure' | 'ComplianceFailure' | 'Assets';
+export type RuleType = 'CCRFailure' | 'ComplianceFailure';
 
 // The target type used by the service
 export enum ServiceActionType {
@@ -20,8 +20,7 @@ export class Rule implements RuleInterface {
 
   AlertTypeLabels = {
     CCRFailure: 'Chef client run failures',
-    ComplianceFailure: 'InSpec scan failures',
-    Assets: 'Assets'
+    ComplianceFailure: 'InSpec scan failures'
   };
 
   constructor(

--- a/components/data-feed-service/service/data-feed-aggregate-task.go
+++ b/components/data-feed-service/service/data-feed-aggregate-task.go
@@ -85,7 +85,6 @@ func (d *DataFeedAggregateTask) Run(ctx context.Context, task cereal.Task) (inte
 
 		if err != nil {
 			log.Errorf("Error retrieving credentials, cannot send asset notification: %v", err)
-			// TODO error handling - need some form of report in automate that indicates when data was sent and if it was successful
 		} else {
 			// build and send notification for this rule
 			notification := datafeedNotification{username: username, password: password, url: destinations[destination].URL, data: buffer}

--- a/components/data-feed-service/service/data-feed-service.go
+++ b/components/data-feed-service/service/data-feed-service.go
@@ -128,7 +128,6 @@ func Start(dataFeedConfig *config.DataFeedConfig, connFactory *secureconn.Factor
 
 func handleSendErr(notification datafeedNotification, startTime time.Time, endTime time.Time, err error) {
 	log.Errorf("Failed to send notification to %v. Start: %v, End: %v. %v", notification.url, startTime, endTime, err)
-	// TODO report this failure to the UI with the time window and notification details
 }
 
 func GetCredentials(ctx context.Context, client secrets.SecretsServiceClient, secretID string) (string, string, error) {
@@ -331,7 +330,6 @@ func buildWindowsJson(windowsJson map[string]interface{}) map[string]interface{}
 	windowsJson["os_service_pack"] = servicePack
 
 	//delete(windowsJson, "kernel")
-	// TODO we could get the chassis from the kernel attributes
 
 	return windowsJson
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The 'Assets' notification type was to support the early development of the datafeed service. Notifications are no longer needed for the datafeed service and the Assets type is no longer relevant.

This PR removes the Assets type from the dropdown on the UI, reverting back to the previous notifications functionality.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated? 


- [ ] Docs added/updated?
- [X] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable

![Screenshot 2020-01-28 at 15 38 38](https://user-images.githubusercontent.com/34461777/73278976-4db0c200-41e4-11ea-9f57-6860bcdcaff8.png)
![Screenshot 2020-01-28 at 15 35 35](https://user-images.githubusercontent.com/34461777/73278994-530e0c80-41e4-11ea-842a-6bc49a9d3507.png)