### PR TITLE
Pin ruby to avoid LGPL dep for now

### DIFF
--- a/components/automate-workflow-ctl/habitat/plan.sh
+++ b/components/automate-workflow-ctl/habitat/plan.sh
@@ -7,8 +7,9 @@ vendor_origin=${vendor_origin:-"chef"}
 
 pkg_deps=(
   core/coreutils
-  core/ruby
-  core/bundler
+  # https://github.com/chef/automate/issues/2733
+  core/ruby/2.5.7/20191025133938
+  core/bundler/1.17.3/20191025140337 # also pinned bc of 2733
   # NOTE(ssd) 2019-04-03: This dependency isn't needed, but we want to
   # make sure that this package always gets built whenever
   # automate-workflow-server gets built so we have to share all

--- a/components/automate-workflow-server/habitat/plan.sh
+++ b/components/automate-workflow-server/habitat/plan.sh
@@ -28,8 +28,9 @@ pkg_deps=(
   # packages.
   ${local_platform_tools_origin:-chef}/automate-platform-tools
 
-  core/bundler
-  core/ruby
+  # https://github.com/chef/automate/issues/2733
+  core/bundler/1.17.3/20191025140337
+  core/ruby/2.5.7/20191025133938
   "${vendor_origin}/automate-workflow-ctl"
 )
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Pin ruby debs to a version that avoids LGPL dep.

### :chains: Related Resources

Workaround (but not a fix!) for #2733

### :+1: Definition of Done

License scout passes.

### :athletic_shoe: How to Build and Test the Change

watch Ci

