### PR TITLE
Request legal exception for LGPL nss-myhostname

### DIFF
--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -257,6 +257,8 @@ exceptions:
       reason: (sd) Binary use only. Already shipped in chef-server. Exception made by Chef Legal
     - name: chef/automate-openjdk
       reason: Exception made by Chef Legal
+    - name: core/nss-myhostname
+      reason: (dan) Plugin for nss/glibc, doesn't link to our software.
 
   ruby:
     - name: highline

--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -258,7 +258,7 @@ exceptions:
     - name: chef/automate-openjdk
       reason: Exception made by Chef Legal
     - name: core/nss-myhostname
-      reason: (dan) Plugin for nss/glibc, doesn't link to our software.
+      reason: Exception made by Chef Legal
 
   ruby:
     - name: highline

--- a/components/automate-workflow-ctl/habitat/plan.sh
+++ b/components/automate-workflow-ctl/habitat/plan.sh
@@ -7,9 +7,8 @@ vendor_origin=${vendor_origin:-"chef"}
 
 pkg_deps=(
   core/coreutils
-  # https://github.com/chef/automate/issues/2733
-  core/ruby/2.5.7/20191025133938
-  core/bundler/1.17.3/20191025140337 # also pinned bc of 2733
+  core/ruby
+  core/bundler
   # NOTE(ssd) 2019-04-03: This dependency isn't needed, but we want to
   # make sure that this package always gets built whenever
   # automate-workflow-server gets built so we have to share all

--- a/components/automate-workflow-server/habitat/plan.sh
+++ b/components/automate-workflow-server/habitat/plan.sh
@@ -28,9 +28,8 @@ pkg_deps=(
   # packages.
   ${local_platform_tools_origin:-chef}/automate-platform-tools
 
-  # https://github.com/chef/automate/issues/2733
-  core/bundler/1.17.3/20191025140337
-  core/ruby/2.5.7/20191025133938
+  core/bundler
+  core/ruby
   "${vendor_origin}/automate-workflow-ctl"
 )
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The core/ruby package depends on nss-myhostname at runtime. This library is LGPL 2.1+ and fails license scout checks. This patch adds an exception for the library. DO NOT MERGE unless/until approved by legal.

The library in question is described in it's documentation this way:

> nss-myhostname is a plugin for the GNU Name Service Switch (NSS)
> functionality of the GNU C Library (glibc) providing host name
> resolution for the locally configured system hostname as returned by
> gethostname(2).

Therefore the "work that uses the library" (which is subject to LGPL requirements) in this case is glibc, which is already packaged with Automate and excepted by legal.

### :chains: Related Resources

* https://github.com/chef/automate/issues/2733
* https://github.com/chef/automate/pull/2734
* https://github.com/nomeata/libnss-myhostname

