### PR TITLE
added contact link to airgapped install docs

### DIFF
--- a/components/automate-chef-io/content/docs/airgapped-installation.md
+++ b/components/automate-chef-io/content/docs/airgapped-installation.md
@@ -19,9 +19,7 @@ Bundle and the `chef-automate` binary used to create it to the airgapped host fo
 
 ## Obtain a License
 
-Contact your Chef account representative to obtain a license for Chef Automate; Chef
-Automate's trial license feature requires internet connectivity and cannot be used on an
-airgapped host.
+To obtain a trial license for an airgapped host [contact Chef](https://www.chef.io/contact-us/).
 
 ## Create an Airgap Installation Bundle
 


### PR DESCRIPTION
## Overview
Recently, in an [internal slack convo](https://chefio.slack.com/archives/CARK1CBNX/p1579826191009200) it came up that the wording in the license information for an air-gapped install was a bit confusing, and that it might be helpful to include a contact link. This pr addresses these things.