### PR TITLE
removing beta section from release notes template

### DIFF
--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -28,9 +28,6 @@ pushd ./automate.wiki
 -
 
 ## Backward Incompatibilities
-
-## Beta Features
-### Identity and Access Management v2
 -
 
 EOH


### PR DESCRIPTION
## Overview
We are about to make iam v2 generally available so we no longer need the beta section.