### PR TITLE
Make proxy_ssl_verify_depth configurable for external autoamte

### DIFF
--- a/components/automate-cs-nginx/habitat/config/chef_https.conf
+++ b/components/automate-cs-nginx/habitat/config/chef_https.conf
@@ -42,6 +42,7 @@
     proxy_read_timeout      300;
     proxy_ssl_trusted_certificate {{pkg.svc_config_path}}/root_ca.crt;
     proxy_ssl_verify        on;
+    proxy_ssl_verify_depth {{ cfg.ngx.http.ssl_verify_depth }};
 
 
     error_page 404 =404 /404.html;
@@ -73,7 +74,6 @@
       proxy_ssl_trusted_certificate {{pkg.svc_config_path}}/root_ca.crt;
       proxy_ssl_protocols           TLSv1.2 TLSv1.3;
       proxy_ssl_verify              on;
-      proxy_ssl_verify_depth        2;
       proxy_ssl_session_reuse       on;
     }
 
@@ -142,7 +142,6 @@
       proxy_ssl_trusted_certificate {{pkg.svc_config_path}}/root_ca.crt;
       proxy_ssl_protocols           TLSv1.2 TLSv1.3;
       proxy_ssl_verify              on;
-      proxy_ssl_verify_depth        2;
       proxy_ssl_session_reuse       on;
 
       proxy_pass https://automate-gateway;
@@ -164,7 +163,6 @@
       proxy_ssl_trusted_certificate {{pkg.svc_config_path}}/root_ca.crt;
       proxy_ssl_protocols           TLSv1.2 TLSv1.3;
       proxy_ssl_verify              on;
-      proxy_ssl_verify_depth        2;
       proxy_ssl_session_reuse       on;
 
       proxy_pass https://automate-gateway;
@@ -201,7 +199,6 @@
       proxy_ssl_trusted_certificate {{pkg.svc_config_path}}/root_ca.crt;
       proxy_ssl_protocols           TLSv1.2 TLSv1.3;
       proxy_ssl_verify              on;
-      proxy_ssl_verify_depth        2;
       proxy_ssl_session_reuse       on;
     }
 
@@ -216,7 +213,6 @@
       proxy_ssl_trusted_certificate {{pkg.svc_config_path}}/root_ca.crt;
       proxy_ssl_protocols           TLSv1.2 TLSv1.3;
       proxy_ssl_verify              on;
-      proxy_ssl_verify_depth        2;
       proxy_ssl_session_reuse       on;
     }
 
@@ -234,7 +230,6 @@
       proxy_ssl_trusted_certificate {{pkg.svc_config_path}}/root_ca.crt;
       proxy_ssl_protocols           TLSv1.2 TLSv1.3;
       proxy_ssl_verify              on;
-      proxy_ssl_verify_depth        2;
       proxy_ssl_session_reuse       on;
     }
 
@@ -269,7 +264,6 @@
       proxy_ssl_trusted_certificate {{pkg.svc_config_path}}/root_ca.crt;
       proxy_ssl_protocols           TLSv1.2 TLSv1.3;
       proxy_ssl_verify              on;
-      proxy_ssl_verify_depth        2;
       proxy_ssl_session_reuse       on;
     }
   }


### PR DESCRIPTION
When automate is used to deploy chef-server, its possible to configure
an automate data collector endpoint for it to talk to. This change
allows you to configure the proxy_ssl_verify_depth for such cases.

Fixes #2243

Signed-off-by: Jay Mundrawala <jmundrawala@chef.io>