### PR TITLE
Global filter refresh on project delete

### DIFF
--- a/components/automate-ui/src/app/entities/projects/project.effects.spec.ts
+++ b/components/automate-ui/src/app/entities/projects/project.effects.spec.ts
@@ -1,0 +1,75 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Observable, of } from 'rxjs';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { StoreModule } from '@ngrx/store';
+import {
+    ngrxReducers,
+    runtimeChecks
+} from 'app/ngrx.reducers';
+
+import { ProjectEffects } from './project.effects';
+import { DeleteProjectSuccess } from './project.actions';
+import { LoadOptions } from 'app/services/projects-filter/projects-filter.actions';
+import { Type } from 'app/entities/notifications/notification.model';
+import { CreateNotification } from 'app/entities/notifications/notification.actions';
+import { ProjectRequests } from './project.requests';
+
+describe('ProjectEffects', () => {
+  let effects: ProjectEffects;
+  let actions: Observable<any>;
+  const initialState = { };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        StoreModule.forRoot(ngrxReducers, { initialState, runtimeChecks })
+      ],
+      providers: [
+        ProjectEffects,
+        ProjectRequests,
+        provideMockActions(() => actions)
+      ]
+    });
+
+    effects = TestBed.get(ProjectEffects);
+  });
+
+  it('DeleteProjectSuccess ensuring the loadOption and CreateNotification are both created',
+    done => {
+    const id = 'project3';
+    const loadOption = new LoadOptions();
+    const createNotification = new CreateNotification({
+      type: Type.info,
+      message: `Deleted project ${id}.`
+    });
+
+    actions = of(new DeleteProjectSuccess({id}));
+
+    let loadOptionSeen = false;
+    let createNotificationSeen = false;
+    let numberOfActionsSeen = 0;
+
+    // The subscribe should be called with two actions of loadOption and CreateNotification
+    effects.deleteProjectSuccess$.subscribe(result => {
+      numberOfActionsSeen += 1;
+      if (result.type === loadOption.type ) {
+        loadOptionSeen = true;
+      } else if (result.type === createNotification.type &&
+        result.payload.message === createNotification.payload.message) {
+        createNotificationSeen = true;
+      } else {
+        fail('The action returned was not correct. action: ' + JSON.stringify(result));
+      }
+
+      if (numberOfActionsSeen > 2) {
+        fail('Only two actions should be returned');
+      } else if ( numberOfActionsSeen === 2 ) {
+        expect(loadOptionSeen).toEqual(true);
+        expect(createNotificationSeen).toEqual(true);
+        done();
+      }
+    });
+  });
+});

--- a/components/automate-ui/src/app/entities/projects/project.effects.ts
+++ b/components/automate-ui/src/app/entities/projects/project.effects.ts
@@ -42,6 +42,9 @@ import {
   ProjectActionTypes,
   ProjectActions
 } from './project.actions';
+import {
+  LoadOptions
+} from 'app/services/projects-filter/projects-filter.actions';
 import { applyRulesStatus } from './project.selectors';
 import { ApplyRulesStatusState } from './project.reducer';
 
@@ -131,12 +134,13 @@ export class ProjectEffects {
   @Effect()
   deleteProjectSuccess$ = this.actions$.pipe(
       ofType(ProjectActionTypes.DELETE_SUCCESS),
-      map(({ payload: { id } }: DeleteProjectSuccess) => {
-        return new CreateNotification({
+      switchMap(({ payload: { id } }: DeleteProjectSuccess) => [
+        new LoadOptions(),
+        new CreateNotification({
           type: Type.info,
           message: `Deleted project ${id}.`
-        });
-      }));
+        })
+      ]));
 
   @Effect()
   deleteProjectFailure$ = this.actions$.pipe(


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Adding a new action to the project delete effect to refresh the global filter. 

### :chains: Related Resources
https://github.com/chef/automate/issues/1756

### :+1: Definition of Done

Global project filter updates immediately upon adding and deleting projects.

### :athletic_shoe: How to Build and Test the Change
1. Start the UI. 
1. Create a project
1. Ensure the new project is in the global filter
1. Delete the project
1. Ensure the project is removed from the global filter. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
