### PR TITLE
Jamie/10-filters-ngrx-conversion

### DIFF
--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -21,8 +21,7 @@
           <input 
             chefInput
             type="text"
-            [(ngModel)]="filterValue"
-            (keyup)="handleFilterKeyUp()"
+            (keyup)="handleFilterKeyUp($event.target.value)"
             placeholder="Filter projects..." />
         </div>
 

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { cloneDeep } from 'lodash/fp';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
 import { ProjectsFilterService } from 'app/services/projects-filter/projects-filter.service';
@@ -11,7 +11,7 @@ const { ALL_PROJECTS_LABEL } = ProjectConstants;
   templateUrl: './projects-filter-dropdown.component.html',
   styleUrls: [ './projects-filter-dropdown.component.scss' ]
 })
-export class ProjectsFilterDropdownComponent {
+export class ProjectsFilterDropdownComponent implements OnInit {
 
   constructor(public projectsFilterService: ProjectsFilterService) { }
 
@@ -37,11 +37,16 @@ export class ProjectsFilterDropdownComponent {
   // so they can be filtered while maintaining the actual options.
   filteredOptions: ProjectsFilterOption[] = [];
 
-  filterValue = '';
-
   optionsEdited = false;
 
   dropdownActive = false;
+
+
+  ngOnInit() {
+    this.projectsFilterService.filterValue$.subscribe((filterValue) => {
+      this.filteredOptions = this.filterOptions(filterValue);
+    });
+  }
 
   resetOptions() {
     if (!this.optionsEdited) {
@@ -50,13 +55,16 @@ export class ProjectsFilterDropdownComponent {
   }
 
   handleFilterKeyUp(filterValue: string): void {
-    // this.filteredOptions = this.filterOptions(this.filterValue);
     this.projectsFilterService.updateFilterValue(filterValue);
   }
 
   filterOptions(value: string): ProjectsFilterOption[] {
     return this.editableOptions.filter(option =>
       option.label.toLowerCase().indexOf(value.toLowerCase()) > -1);
+  }
+
+  clearFilterValue(): void {
+    this.projectsFilterService.updateFilterValue('');
   }
 
   handleLabelClick() {
@@ -69,8 +77,8 @@ export class ProjectsFilterDropdownComponent {
   handleEscape(): void {
     this.optionsEdited = false;
     this.resetOptions();
-    this.filterValue = '';
     this.dropdownActive = false;
+    this.clearFilterValue();
     this.onOptionChange.emit(this.editableOptions);
   }
 

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { cloneDeep } from 'lodash/fp';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
+import { ProjectsFilterService } from 'app/services/projects-filter/projects-filter.service';
 import { ProjectConstants } from 'app/entities/projects/project.model';
 
 const { ALL_PROJECTS_LABEL } = ProjectConstants;
@@ -11,6 +12,9 @@ const { ALL_PROJECTS_LABEL } = ProjectConstants;
   styleUrls: [ './projects-filter-dropdown.component.scss' ]
 })
 export class ProjectsFilterDropdownComponent {
+
+  constructor(public projectsFilterService: ProjectsFilterService) { }
+
   @Input() options: ProjectsFilterOption[] = [];
 
   @Input() selectionLabel = ALL_PROJECTS_LABEL;
@@ -45,8 +49,9 @@ export class ProjectsFilterDropdownComponent {
     }
   }
 
-  handleFilterKeyUp(): void {
-    this.filteredOptions = this.filterOptions(this.filterValue);
+  handleFilterKeyUp(filterValue: string): void {
+    // this.filteredOptions = this.filterOptions(this.filterValue);
+    this.projectsFilterService.updateFilterValue(filterValue);
   }
 
   filterOptions(value: string): ProjectsFilterOption[] {

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -6,6 +6,12 @@ import { StoreModule } from '@ngrx/store';
 import { ProjectsFilterDropdownComponent } from './projects-filter-dropdown.component';
 import { ProjectsFilterService } from 'app/services/projects-filter/projects-filter.service';
 
+import { runtimeChecks } from 'app/ngrx.reducers';
+import {
+  projectsFilterInitialState,
+  projectsFilterReducer
+} from 'app/services/projects-filter/projects-filter.reducer';
+
 
 describe('ProjectsFilterDropdownComponent', () => {
   let component: ProjectsFilterDropdownComponent;
@@ -22,7 +28,12 @@ describe('ProjectsFilterDropdownComponent', () => {
       ],
       imports: [
         RouterTestingModule,
-        StoreModule.forRoot([])
+        StoreModule.forRoot({
+          projectsFilter: projectsFilterReducer
+        }, {
+          initialState: { projectsFilter: projectsFilterInitialState },
+          runtimeChecks
+        })
       ]
     })
     .compileComponents();

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -2,15 +2,9 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule } from '@ngrx/store';
-// import { runtimeChecks } from 'app/ngrx.reducers';
 
 import { ProjectsFilterDropdownComponent } from './projects-filter-dropdown.component';
 import { ProjectsFilterService } from 'app/services/projects-filter/projects-filter.service';
-// import {
-//   projectsFilterInitialState,
-//   projectsFilterReducer
-// } from 'app/services/projects-filter/projects-filter.reducer';
-
 
 
 describe('ProjectsFilterDropdownComponent', () => {

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -1,7 +1,17 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { StoreModule } from '@ngrx/store';
+// import { runtimeChecks } from 'app/ngrx.reducers';
+
 import { ProjectsFilterDropdownComponent } from './projects-filter-dropdown.component';
+import { ProjectsFilterService } from 'app/services/projects-filter/projects-filter.service';
+// import {
+//   projectsFilterInitialState,
+//   projectsFilterReducer
+// } from 'app/services/projects-filter/projects-filter.reducer';
+
+
 
 describe('ProjectsFilterDropdownComponent', () => {
   let component: ProjectsFilterDropdownComponent;
@@ -13,8 +23,12 @@ describe('ProjectsFilterDropdownComponent', () => {
       declarations: [
         ProjectsFilterDropdownComponent
       ],
+      providers: [
+        ProjectsFilterService
+      ],
       imports: [
-        FormsModule
+        RouterTestingModule,
+        StoreModule.forRoot([])
       ]
     })
     .compileComponents();

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.actions.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.actions.ts
@@ -7,7 +7,8 @@ export enum ProjectsFilterActionTypes {
   LOAD_OPTIONS_SUCCESS   = 'PROJECTS_FILTER::LOAD_OPTIONS::SUCCESS',
   LOAD_OPTIONS_FAILURE   = 'PROJECTS_FILTER::LOAD_OPTIONS::FAILURE',
   SAVE_OPTIONS           = 'PROJECTS_FILTER::SAVE_OPTIONS',
-  UPDATE_SELECTION_COUNT = 'PROJECTS_FILTER::UPDATE_SELECTION_COUNT'
+  UPDATE_SELECTION_COUNT = 'PROJECTS_FILTER::UPDATE_SELECTION_COUNT',
+  UPDATE_FILTER_VALUE    = 'PROJECTS_FILTER::UPDATE_FILTER_VALUE'
 }
 
 export class LoadOptions implements Action {
@@ -34,9 +35,17 @@ export class UpdateSelectionCount implements Action {
   constructor(public payload: ProjectsFilterOption[]) { }
 }
 
+export class UpdateFilterValue implements Action {
+  readonly type = ProjectsFilterActionTypes.UPDATE_FILTER_VALUE;
+  constructor(public payload: string) { }
+}
+
+
+
 export type ProjectsFilterActions =
   | LoadOptions
   | LoadOptionsSuccess
   | LoadOptionsFailure
   | SaveOptions
-  | UpdateSelectionCount;
+  | UpdateSelectionCount
+  | UpdateFilterValue;

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -35,6 +35,7 @@ export interface ProjectsFilterState {
   selectionCountActive: boolean;
   dropdownCaretVisible: boolean;
   filterVisible: boolean;
+  filterValue: string;
 }
 
 export const projectsFilterInitialState: ProjectsFilterState = {
@@ -45,7 +46,8 @@ export const projectsFilterInitialState: ProjectsFilterState = {
   selectionCountVisible: false,
   selectionCountActive: false,
   dropdownCaretVisible: false,
-  filterVisible: false
+  filterVisible: false,
+  filterValue: ''
 };
 
 export function projectsFilterReducer(
@@ -101,6 +103,10 @@ export function projectsFilterReducer(
         set('selectionCountVisible', selectionCountVisible(sortedOptions)),
         set('selectionCountActive', selectionCountActive(sortedOptions))
       )(state) as ProjectsFilterState;
+    }
+
+    case ProjectsFilterActionTypes.UPDATE_FILTER_VALUE: {
+      return set('filterValue', action.payload, state);
     }
   }
 

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.selectors.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.selectors.ts
@@ -41,3 +41,5 @@ export const dropdownCaretVisible = createSelector(projectsFilterState,
 
 export const filterVisible = createSelector(projectsFilterState,
   state => state.filterVisible);
+
+export const filterValue = createSelector(projectsFilterState, state => state.filterValue);

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -26,6 +26,8 @@ export class ProjectsFilterService {
 
   filterVisible$ = <Observable<boolean>>this.store.select(selectors.filterVisible);
 
+  filterValue$ = <Observable<string>>this.store.select(selectors.filterValue);
+
   constructor(private store: Store<NgrxStateAtom>, private router: Router) { }
 
   loadOptions() {

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -40,6 +40,10 @@ export class ProjectsFilterService {
     this.store.dispatch(new UpdateSelectionCount(options));
   }
 
+  updateFilterValue(filterValue: string) {
+    this.store.dispatch(new this.updateFilterValue(filterValue));
+  }
+
   storeOptions(options: ProjectsFilterOption[]) {
     localStorage.setItem(STORE_OPTIONS_KEY, JSON.stringify(options));
 

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { ProjectsFilterOption } from './projects-filter.reducer';
 import * as selectors from './projects-filter.selectors';
-import { LoadOptions, SaveOptions, UpdateSelectionCount } from './projects-filter.actions';
+import { LoadOptions, SaveOptions, UpdateSelectionCount, UpdateFilterValue } from './projects-filter.actions';
 
 const STORE_OPTIONS_KEY = 'projectsFilter.options';
 
@@ -41,7 +41,7 @@ export class ProjectsFilterService {
   }
 
   updateFilterValue(filterValue: string) {
-    this.store.dispatch(new this.updateFilterValue(filterValue));
+    this.store.dispatch(new UpdateFilterValue(filterValue));
   }
 
   storeOptions(options: ProjectsFilterOption[]) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The Global Projects Dropdown filter was built using a two way binding, ngModel pattern, however we would prefer a one way binding, ngrx pattern.  This branch modifies the Global project filter dropdown to use a one way binding ngrx pattern.

### :chains: Related Resources
https://github.com/chef/automate/pull/2671

### :+1: Definition of Done
ngModel is gone from the global project dropdown and and ngrx pattern takes its place

### :athletic_shoe: How to Build and Test the Change
To build:
1. build components/automate-ui-devproxy && start_all_services
2. make serve

To test:
1. if you do not have projects, go to https://a2-dev.test/settings/projects and create several projects
2. Click on the top right dropdown that will read something like "All Projects"
3.  In the dropdown, type some letters and watch your projects filter.


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
