### PR TITLE
adjusting toolbar button margins

### DIFF
--- a/components/chef-ui-library/src/molecules/chef-toolbar/chef-toolbar.scss
+++ b/components/chef-ui-library/src/molecules/chef-toolbar/chef-toolbar.scss
@@ -1,10 +1,5 @@
 chef-toolbar {
   chef-button {
-    margin-top: 0;
-
-    &:first-child {
-      margin-top: 0;
-      margin-left: 0;
-    }
+    margin: 0 8px 0 0;
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When we switched the angular table component we started using border-spacing which added 8px to the top of our tables, which also pushed the buttons 8px farther away from the tables. This is fixing it by setting the bottom margin of the toolbar buttons to 0 as well. We could also just stop using border-spacing.. but this seemed like a smaller change.

### :chains: Related Resources
#2717

### :+1: Definition of Done
tables and toolbar buttons are 8px away from each other

### :athletic_shoe: How to Build and Test the Change
`make update-ui-lib` from `components/automate-ui`
`rebuild components/automate-ui-devproxy`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
#### before
<img width="253" alt="before" src="https://user-images.githubusercontent.com/5489125/73520491-9caf5080-43b8-11ea-98bf-93ca6bf51987.png">

#### after
<img width="365" alt="after" src="https://user-images.githubusercontent.com/5489125/73520503-a2a53180-43b8-11ea-88a4-6b70230a25aa.png">
