### PR TITLE
changing angular table component to use flex

### DIFF
--- a/components/automate-ui/src/app/components/table/table-body/table-body.component.scss
+++ b/components/automate-ui/src/app/components/table/table-body/table-body.component.scss
@@ -1,5 +1,3 @@
 @import '../table.component';
 
-:host {
-  display: table-row-group;
-}
+:host {}

--- a/components/automate-ui/src/app/components/table/table-body/table-body.component.scss
+++ b/components/automate-ui/src/app/components/table/table-body/table-body.component.scss
@@ -1,3 +1,0 @@
-@import '../table.component';
-
-:host {}

--- a/components/automate-ui/src/app/components/table/table-body/table-body.component.ts
+++ b/components/automate-ui/src/app/components/table/table-body/table-body.component.ts
@@ -2,8 +2,7 @@ import { Component, HostBinding } from '@angular/core';
 
 @Component({
   selector: 'chef-table-body',
-  templateUrl: './table-body.component.html',
-  styleUrls: ['./table-body.component.scss']
+  templateUrl: './table-body.component.html'
 })
 export class TableBodyComponent {
   @HostBinding('attr.role') role = 'rowgroup';

--- a/components/automate-ui/src/app/components/table/table-cell/table-cell.component.scss
+++ b/components/automate-ui/src/app/components/table/table-cell/table-cell.component.scss
@@ -1,7 +1,6 @@
 @import '../table.component';
 
 :host {
-  display: table-cell;
   padding: $size_16;
   vertical-align: middle;
   text-align: left;

--- a/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.scss
+++ b/components/automate-ui/src/app/components/table/table-header-cell/table-header-cell.component.scss
@@ -1,7 +1,6 @@
 @import '../table.component';
 
 :host {
-  display: table-cell;
   padding: $size_16;
   vertical-align: middle;
   text-align: left;

--- a/components/automate-ui/src/app/components/table/table-header/table-header.component.scss
+++ b/components/automate-ui/src/app/components/table/table-header/table-header.component.scss
@@ -1,5 +1,3 @@
 @import '../table.component';
 
-:host {
-  display: table-header-group;
-}
+:host {}

--- a/components/automate-ui/src/app/components/table/table-header/table-header.component.scss
+++ b/components/automate-ui/src/app/components/table/table-header/table-header.component.scss
@@ -1,3 +1,0 @@
-@import '../table.component';
-
-:host {}

--- a/components/automate-ui/src/app/components/table/table-header/table-header.component.ts
+++ b/components/automate-ui/src/app/components/table/table-header/table-header.component.ts
@@ -2,8 +2,7 @@ import { Component, HostBinding } from '@angular/core';
 
 @Component({
   selector: 'chef-table-header',
-  templateUrl: './table-header.component.html',
-  styleUrls: ['./table-header.component.scss']
+  templateUrl: './table-header.component.html'
 })
 export class TableHeaderComponent {
   @HostBinding('attr.role') role = 'rowgroup';

--- a/components/automate-ui/src/app/components/table/table-row/table-row.component.scss
+++ b/components/automate-ui/src/app/components/table/table-row/table-row.component.scss
@@ -1,7 +1,8 @@
 @import '../table.component';
 
 :host {
-  display: table-row;
-  padding: $size_16;
+  display: flex;
+  flex-flow: row nowrap;
+  margin-bottom: .5em;
   background-color: $white;
 }

--- a/components/automate-ui/src/app/components/table/table.component.scss
+++ b/components/automate-ui/src/app/components/table/table.component.scss
@@ -1,9 +1,7 @@
 @import "~styles/variables";
 
 :host {
-  display: table;
-  table-layout: fixed;
+  display: flex;
+  flex-flow: column nowrap;
   width: 100%;
-  border-collapse: separate;
-  border-spacing: 0 8px;
 }

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.scss
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.scss
@@ -1,9 +1,5 @@
 @import "~styles/variables";
 
-#create-button {
-  margin: 0;
-}
-
 .empty-state {
   text-align: center;
 

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.scss
@@ -70,7 +70,7 @@ chef-loading-spinner {
     chef-table-cell:last-child {
       chef-button {
         margin: -0.5em 0;
-        float: right;
+        margin-left: auto;
       }
     }
   }

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -57,7 +57,7 @@
         <ng-container *ngIf="showRulesTable()">
           <chef-toolbar>
             <app-authorized [allOf]="['/iam/v2/projects', 'post']">
-              <chef-button [routerLink]="['/settings', 'projects', project?.id, 'rules']" id="create-button" primary>Create Rule</chef-button>
+              <chef-button [routerLink]="['/settings', 'projects', project?.id, 'rules']" primary>Create Rule</chef-button>
             </app-authorized>
             <small *ngIf="project?.status === 'EDITS_PENDING'">Edits are pending: update <a [routerLink]="['/settings/projects']">projects</a> to apply edits.</small>
           </chef-toolbar>

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.scss
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.scss
@@ -7,7 +7,6 @@ chef-page-header {
 chef-toolbar {
   display: block;
   position: relative;
-  margin-bottom: 5px;
 
   small {
     bottom: 2px;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Recently, we started using a new table component on the auth tables. The styles on this new table used border-spacing which is pretty inflexible and caused an additional 8px to be added to the top of the table. To address this, I changed the component to use flex instead.

I also considered removing the bottom margin from the buttons in the toolbar but since this new table component has not replaced all tables yet that would cause the pages with the chef ui library table component to have zero space between the toolbar buttons and the table.

### :chains: Related Resources
#2717

### :+1: Definition of Done
tables and toolbar buttons are 8px away from each other

### :athletic_shoe: How to Build and Test the Change
rebuild components/automate-ui-devproxy

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
#### before
<img width="253" alt="before" src="https://user-images.githubusercontent.com/5489125/73520491-9caf5080-43b8-11ea-98bf-93ca6bf51987.png">

#### after
<img width="365" alt="after" src="https://user-images.githubusercontent.com/5489125/73520503-a2a53180-43b8-11ea-88a4-6b70230a25aa.png">