### PR TITLE
add docs aliases

### DIFF
--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -1,5 +1,8 @@
 +++
 title = "IAM v2 Overview"
+aliases = [
+    "/docs/authorization/"
+]
 description = "IAM v2 Overview"
 draft = false
 bref = ""

--- a/components/automate-chef-io/content/docs/node-credentials.md
+++ b/components/automate-chef-io/content/docs/node-credentials.md
@@ -1,5 +1,8 @@
 +++
 title = "Node Credentials"
+aliases = [
+    "/docs/credentials/"
+]
 description = "SSH, WinRM, and sudo credentials to remotely access nodes."
 date = 2018-05-22T17:23:24-07:00
 weight = 20

--- a/components/automate-chef-io/content/docs/node-integrations.md
+++ b/components/automate-chef-io/content/docs/node-integrations.md
@@ -1,5 +1,9 @@
 +++
 title = "Node Integrations"
+aliases = [
+    "/docs/integrations/",
+    "/docs/integrations-ui/"
+]
 description = "Connect Chef Automate to cloud services."
 date = 2018-05-22T18:01:36-07:00
 weight = 20

--- a/components/automate-chef-io/content/docs/profiles.md
+++ b/components/automate-chef-io/content/docs/profiles.md
@@ -1,5 +1,8 @@
 +++
 title = "Profiles"
+aliases = [
+    "/docs/asset-store/"
+]
 description = "Select and Install Compliance Profiles"
 date = 2018-03-26T16:02:53-07:00
 draft = false

--- a/components/automate-chef-io/content/docs/users.md
+++ b/components/automate-chef-io/content/docs/users.md
@@ -1,5 +1,9 @@
 +++
 title = "Users"
+aliases = [
+    "/docs/users-and-teams/",
+    "/docs/admin/"
+]
 description = "Manage Chef Automate Users."
 date = 2018-05-16T16:03:13-07:00
 draft = false


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Recently, I noticed the [automate section on docs.chef.io](https://docs.chef.io/#chef-automate) which listed a number of pages that 404'd, so this is adding the aliases for those pages that had their names changed at some point in the past.

### :+1: Definition of Done
less 404s

### :athletic_shoe: How to Build and Test the Change
`make serve` from `components/automate-chef-io`... but i dont think we can really test this until it merges.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
