### PR TITLE
Remove ngmodel without ngrx

### DIFF
--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -21,8 +21,7 @@
           <input 
             chefInput
             type="text"
-            [(ngModel)]="filterValue"
-            (keyup)="handleFilterKeyUp()"
+            (keyup)="handleFilterKeyUp($event.target.value)"
             placeholder="Filter projects..." />
         </div>
 

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -33,8 +33,6 @@ export class ProjectsFilterDropdownComponent {
   // so they can be filtered while maintaining the actual options.
   filteredOptions: ProjectsFilterOption[] = [];
 
-  filterValue = '';
-
   optionsEdited = false;
 
   dropdownActive = false;
@@ -45,8 +43,8 @@ export class ProjectsFilterDropdownComponent {
     }
   }
 
-  handleFilterKeyUp(): void {
-    this.filteredOptions = this.filterOptions(this.filterValue);
+  handleFilterKeyUp(filterValue: string): void {
+    this.filteredOptions = this.filterOptions(filterValue);
   }
 
   filterOptions(value: string): ProjectsFilterOption[] {
@@ -64,7 +62,6 @@ export class ProjectsFilterDropdownComponent {
   handleEscape(): void {
     this.optionsEdited = false;
     this.resetOptions();
-    this.filterValue = '';
     this.dropdownActive = false;
     this.onOptionChange.emit(this.editableOptions);
   }

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -1,5 +1,4 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ProjectsFilterDropdownComponent } from './projects-filter-dropdown.component';
 
@@ -12,9 +11,6 @@ describe('ProjectsFilterDropdownComponent', () => {
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
       declarations: [
         ProjectsFilterDropdownComponent
-      ],
-      imports: [
-        FormsModule
       ]
     })
     .compileComponents();


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The Global Projects Dropdown filter was built using a two way binding, ngModel pattern, however we would prefer to not use ngModel.  This branch removes the use of ngModel.

### :chains: Related Resources
https://github.com/chef/automate/pull/2671

### :+1: Definition of Done
ngModel is gone from the global project dropdown

### :athletic_shoe: How to Build and Test the Change
To build:
1. build components/automate-ui-devproxy && start_all_services
2. make serve

To test:
1. if you do not have projects, go to https://a2-dev.test/settings/projects and create several projects
2. Click on the top right dropdown that will read something like "All Projects"
3.  In the dropdown, type some letters and watch your projects filter.


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
