### PR TITLE
Clarify when Automate respects proxy environment variables.

### DIFF
--- a/components/automate-chef-io/content/docs/configuration.md
+++ b/components/automate-chef-io/content/docs/configuration.md
@@ -123,16 +123,17 @@ Currently you cannot apply a license after your initial deployment by patching t
 
 You can configure Chef Automate to use a proxy either by setting environment variables, or by setting configuration options.
 
-Chef Automate respects the proxy environment variables:
+The command `chef-automate deploy` without a configuration file will respect the proxy environment variables:
 
 * `HTTPS_PROXY`/`https_proxy`
 * `HTTP_PROXY`/`http_proxy`
 * `NO_PROXY`/`no_proxy` (See [Required Sites and Domains]({{< relref "#required-sites-and-domains" >}}).)
 
 Setting these environment variables prior to initial deployment of Chef Automate
-adds them to the configuration.
+adds them to the configuration that Chef Automate generates.
 
-To set a proxy by editing a configuration file, create a TOML file that contains the partial configuration:
+If you provide a configuration file during deployment (`chef-automate deploy
+/path/to/config.toml`), you must specify any proxy settings in that configuration file.
 
 ```toml
 [global.v1.proxy]
@@ -143,6 +144,8 @@ no_proxy = ["0.0.0.0", "127.0.0.1"]
 # password = "<your proxy password>"
 ```
 
+To patch the proxy settings, create a TOML file that contains the `[global.v1.proxy]`
+section and settings.
 Then run `chef-automate config patch </path/to/your-file.toml>` to deploy your change.
 
 ##### Required Sites and Domains

--- a/components/automate-chef-io/content/docs/migrate.md
+++ b/components/automate-chef-io/content/docs/migrate.md
@@ -1,6 +1,9 @@
 +++
-title = "Upgrade from Chef Automate 1"
-description = "Upgrade an existing Chef Automate 1 installation"
+title = "Migrate from Chef Automate 1"
+aliases = [
+  "/docs/upgrade/"
+]
+description = "Migrate an existing Chef Automate 1 installation"
 draft = false
 bref = ""
 toc = true
@@ -10,16 +13,16 @@ toc = true
     weight = 60
 +++
 
-This guide shows you how to upgrade your existing Chef Automate 1 installation to Chef Automate 2.
+This guide shows you how to migrate your existing Chef Automate 1 installation to Chef Automate 2.
 
 ## Overview
 
-The Chef Automate upgrade process performs the following steps, in order:
+The Chef Automate migration process performs the following steps, in order:
 
-1. Runs preflight checks to ensure the system is suitable for Chef Automate 2, your Chef Automate 1 installation can be upgraded safely, and that the upgrade process will be able to migrate your data.
-1. Analyzes your Chef Automate 1 configuration files and migrates the relevant settings to a configuration file for Chef Automate 2. If incompatibilities are detected, the upgrade process fails and emits a description of the problem. You will have an opportunity to make any necessary changes to the generated Chef Automate 2 configuration.
-1. Downloads Automate 2. Chef Automate 2 is distributed via [Habitat](https://www.habitat.sh/) packages that are installed early in the process to minimize the downtime required for the upgrade.
-1. Puts your Chef Automate 1 installation into maintenance mode, waits for queued data to be processed, and then backs up all Chef Automate 1 data. This ensures that data will not be lost in the upgrade process and that you will be able to recover to a working state should an unforeseen error occur.
+1. Runs preflight checks to ensure the system is suitable for Chef Automate 2, your Chef Automate 1 installation can be migrated safely, and that the upgrade process will be able to migrate your data.
+1. Analyzes your Chef Automate 1 configuration files and migrates the relevant settings to a configuration file for Chef Automate 2. If incompatibilities are detected, the migration process fails and emits a description of the problem. You will have an opportunity to make any necessary changes to the generated Chef Automate 2 configuration.
+1. Downloads Automate 2. Chef Automate 2 is distributed via [Habitat](https://www.habitat.sh/) packages that are installed early in the process to minimize the downtime required for the migration.
+1. Puts your Chef Automate 1 installation into maintenance mode, waits for queued data to be processed, and then backs up all Chef Automate 1 data. This ensures that data will not be lost in the migration process and that you will be able to recover to a working state should an unforeseen error occur.
 1. Creates a local snapshot of Chef Automate 1 data for import into Chef Automate 2.
 1. Shuts down Chef Automate 1.
 1. Imports the Chef Automate 1 snapshot into Chef Automate 2.
@@ -33,7 +36,7 @@ SAML configuration is not migrated.
 
 ## Prerequisites
 
-Before you start the upgrade process, fulfill the requirements detailed in this section.
+Before you start the migration process, fulfill the requirements detailed in this section.
 
 ### Command Line Tool
 
@@ -78,27 +81,27 @@ The Chef Automate 2 installer respects the following environment variables:
 * `HTTP_PROXY`/`http_proxy`
 * `NO_PROXY`/`no_proxy`
 
-If you use a proxy to manage outbound HTTP(S) connections, ensure these variables are set when running the upgrade.
+If you use a proxy to manage outbound HTTP(S) connections, ensure these variables are set when running the migration.
 
 ### Chef Automate 1 Version
 
-Recent versions of Chef Automate 1 contain enhancements that the upgrade process relies upon to ensure your data is safely migrated. Currently, Chef Automate 1.8.38 or greater is required.
+Recent versions of Chef Automate 1 contain enhancements that the migration process relies upon to ensure your data is safely migrated. Currently, Chef Automate 1.8.38 or greater is required.
 
 ### Systemd
 
-Chef Automate 2 requires the systemd init system. If you're currently using Chef Automate 1 on an operating system that makes use of a different init system, we recommend consulting support for the appropriate upgrade strategy.
+Chef Automate 2 requires the systemd init system. If you're currently using Chef Automate 1 on an operating system that makes use of a different init system, we recommend consulting Customer Support for the appropriate migration strategy.
 
 ## Considerations
 
-While we've taken care to make the upgrade process as smooth as possible, this section outlines some caveats to consider before you proceed.
+While we've taken care to make the migration process as smooth as possible, this section outlines some caveats to consider before you proceed.
 
 ### Plan for Downtime
 
-The Chef Automate 2 upgrade process puts your Chef Automate 1 installation into maintenance mode, shuts it down, and starts Chef Automate 2. During the downtime, the upgrade process takes a backup of your Chef Automate 1 data and exports some of its data to a local snapshot, which is imported into Chef Automate 2.
+The Chef Automate 2 migration process puts your Chef Automate 1 installation into maintenance mode, shuts it down, and starts Chef Automate 2. During the downtime, the migration process takes a backup of your Chef Automate 1 data and exports some of its data to a local snapshot, which is imported into Chef Automate 2.
 
 To minimize this downtime, we recommended that you take an online backup of Chef Automate 1 just prior to the upgrade. Historical information such as Chef Client run data and compliance scan data is backed up incrementally, which means that the upgrade only needs to transfer data that has been added since the last backup.
 
-By default, the Chef Automate 2 upgrade process will not proceed if your Chef Automate 1 installation does not have backups configured. Invoke the upgrade using the `--skip-backup-check` flag to avoid this check.
+By default, the Chef Automate 2 upgrade process will not proceed if your Chef Automate 1 installation does not have backups configured. Invoke the migration using the `--skip-backup-check` flag to avoid this check.
 
 To configure Chef Automate 1 backups, see the [Chef Automate 1 Documentation](https://docs.chef.io/delivery_server_backup.html).
 
@@ -115,19 +118,19 @@ For more information, please contact your Chef account representative.
 * **Custom Kibana dashboards:** Chef Automate 2 does not include Kibana in its technology stack
 * **SAML config migration:** Chef Automate 2 supports SAML integration, however due to configuration incompatibilities Chef Automate 2 cannot migrate Chef Automate 1 SAML settings to Chef Automate 2 as part of the upgrade. After the upgrade is completed, you may follow [these configuration instructions]({{< relref "configuration.md#saml" >}}) to set up SAML.
 
-Should you wish to upgrade to Chef Automate 2 without these features, invoke the upgrade with the appropriate flags:
+Should you wish to migrate to Chef Automate 2 without these features, invoke the migration with the appropriate flags:
 
 * `--skip-fips-check`
 * `--skip-disaster-recovery-check`
 * `--skip-saml-check`
 
-These flags enable you to upgrade by skipping preflight checks for unsupported features.
+These flags enable you to migrate by skipping preflight checks for unsupported features.
 
 ### External Elasticsearch cluster
 
-The Chef Automate 2 upgrade process requires manual intervention to upgrade a Chef Automate 1 installation that uses external Elasticsearch.
+The Chef Automate 2 migration process requires manual intervention to migrate a Chef Automate 1 installation that uses external Elasticsearch.
 
-To upgrade an external Elasticsearch cluster, please reach out to a Customer Success or Customer Support representative for assistance.
+To migrate an external Elasticsearch cluster, please reach out to a Customer Success or Customer Support representative for assistance.
 
 ### New Data Paths
 
@@ -141,18 +144,18 @@ If you use dedicated disks or partitions for either of these applications in Che
 ### Workflow
 
 Follow the instructions in [Upgrade Workflow]{{< relref "workflow_install.md" >}}
-The upgrade process will stop if it detects that you used the Workflow component of Chef Automate 1.
+The migration process will stop if it detects that you used the Workflow component of Chef Automate 1.
 To use Workflow with Chef Automate 2 specify the `--enable-workflow` option to enable the Workflow component. You can enable the Workflow component after upgrading with `chef-automate deploy --enable-workflow`.
 
 ### Chef Automate 2 License
 
-Login to Chef Automate to start a 60-day trial. The trial provides you with a 60-day license.
+Login to Chef Automate to start a trial. The trial provides you with a 60-day license.
 Requesting a trial license requires internet connectivity in your Chef Automate 2 instance (only at the time of the license request).
 
-If you are upgrading an [airgapped Chef Automate installation](https://docs.chef.io/install_chef_air_gap.html#chef-automate),
+If you are migrating an [airgapped Chef Automate installation](https://docs.chef.io/install_chef_air_gap.html#chef-automate),
 contact your Chef account representative for a Chef Automate 2 license.
 
-## Upgrade
+## Migrate
 
 1. Create a backup your Chef Automate 1 installation:
 
@@ -160,7 +163,7 @@ contact your Chef account representative for a Chef Automate 2 license.
     automate-ctl create-backup
     ```
 
-2. Once the backup has completed, initiate the upgrade process. If your host is internet-connected,
+2. Once the backup has completed, initiate the migration process. If your host is internet-connected,
    run the command:
 
     ```shell
@@ -173,13 +176,12 @@ contact your Chef account representative for a Chef Automate 2 license.
     ./chef-automate migrate-from-v1 --airgap-bundle </path/to/bundle>
     ```
 
-After the upgrade runs the preflight checks and analyzes your Chef Automate 1 configuration, it asks for confirmation to continue. Review the generated configuration file and if it is correct, type `yes` to continue.
+After the migration runs the preflight checks and analyzes your Chef Automate 1 configuration, it asks for confirmation to continue. Review the generated configuration file and if it is correct, type `yes` to continue.
 
-The upgrade process backs up your Chef Automate 1 data, shuts down Chef Automate 1, imports your data to Chef Automate 2, then starts Chef Automate 2.
+The migration process backs up your Chef Automate 1 data, shuts down Chef Automate 1, imports your data to Chef Automate 2, then starts Chef Automate 2.
 At this point, you can use your existing Chef Automate 1 user credentials to login to Chef Automate 2.
 If you've been using LDAP for authenticating users, that configuration will have been migrated as well, and you can use your LDAP credentials to login.
 Historical data will be migrated in the background.
 
-### Upgrading an airgapped installation between versions of Chef Automate 2
-
-See the [Airgapped Installation]({{< relref "airgapped-installation.md#upgrade" >}}) documentation.
+### Upgrades
+Chef Automate 2 handles upgrades differently than Chef Automate 1 did. The [Installation]({{< relref "install.md#upgrade" >}}) documentation and [Airgapped Installation]({{< relref "airgapped-installation.md#upgrade" >}}) documentation provide further detail.

--- a/components/automate-chef-io/content/docs/upgrade.md
+++ b/components/automate-chef-io/content/docs/upgrade.md
@@ -180,6 +180,6 @@ At this point, you can use your existing Chef Automate 1 user credentials to log
 If you've been using LDAP for authenticating users, that configuration will have been migrated as well, and you can use your LDAP credentials to login.
 Historical data will be migrated in the background.
 
-### Upgrading an Airgapped Installation
+### Upgrading an airgapped installation between versions of Chef Automate 2
 
-To upgrade your airgapped installation, see the [Airgapped Installation]({{< relref "airgapped-installation.md#upgrade" >}}) documentation.
+See the [Airgapped Installation]({{< relref "airgapped-installation.md#upgrade" >}}) documentation.


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When a user provides a config file to Automate during deployment, they must specify any proxy settings needed within that config file. `chef-automate deploy config.toml` will *not* respect proxy environment variables.

Fixes #2688.
### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
