### PR TITLE
Add applications load generation to chef-load machines

### DIFF
--- a/terraform/test-environments/modules/chef_load_instance/main.tf
+++ b/terraform/test-environments/modules/chef_load_instance/main.tf
@@ -27,6 +27,18 @@ data "template_file" "chef_load_toml" {
   }
 }
 
+data "template_file" "applications_load_gen_toml" {
+  count = "${var.instance_count}"
+
+  template = "${file("${path.module}/templates/applications_load_gen.toml.tpl")}"
+
+  vars {
+    automate_server_fqdn  = "${var.automate_server_fqdn}"
+    automate_server_token = "${var.automate_server_token}"
+    num_svcs              = "${var.chef_load_nodes}"
+  }
+}
+
 module "chef_load_cd_base" {
   source = "github.com/chef/es-terraform//modules/cd_base"
 
@@ -130,6 +142,11 @@ CONF
   }
 
   provisioner "file" {
+    content     = "${element(data.template_file.applications_load_gen_toml.*.rendered, count.index)}"
+    destination = "/tmp/applications-load-gen_user.toml"
+  }
+
+  provisioner "file" {
     content     = "${var.chef_server_client_key}"
     destination = "/tmp/chef-server-client-key.txt"
   }
@@ -144,7 +161,9 @@ CONF
       "sudo mv /tmp/chef_load_sample_data /opt",
       "sudo mv /tmp/chef-server-client-key.txt /opt",
       "sudo mkdir -p /hab/user/chef-load/config",
+      "sudo mkdir -p /hab/user/applications-load-gen/config",
       "sudo mv /tmp/chef-load_user.toml /hab/user/chef-load/config/user.toml",
+      "sudo mv /tmp/applications_load_gen_user.toml /hab/user/applications-load-gen/config/user.toml",
       "sudo mv /tmp/group-node-names /etc/cron.hourly/group-node-names",
       "sudo chown root:root /etc/cron.hourly/group-node-names",
       "sudo chmod a+x /etc/cron.hourly/group-node-names",
@@ -152,6 +171,7 @@ CONF
       "sudo mkdir -p /var/log/chef-load",
       "sudo chown hab /var/log/chef-load",
       "sudo hab svc load chef/chef-load --channel ${var.chef_load_channel} --strategy at-once",
+      "sudo hab svc load chef/applications-load-gen --channel dev --strategy at-once",
     ]
   }
 }

--- a/terraform/test-environments/modules/chef_load_instance/templates/applications_load_gen.toml.tpl
+++ b/terraform/test-environments/modules/chef_load_instance/templates/applications_load_gen.toml.tpl
@@ -1,0 +1,7 @@
+[mlsa]
+accept = true
+
+[target]
+host = "${automate_server_fqdn}"
+auth_token = "${automate_server_token}"
+svc_count = ${num_svcs}

--- a/terraform/test-environments/modules/chef_load_instance/variables.tf
+++ b/terraform/test-environments/modules/chef_load_instance/variables.tf
@@ -110,3 +110,8 @@ variable "chef_load_actions" {
   default     = "1000"
   description = "The number of Chef Actions that chef-load will simulate."
 }
+
+variable "apps_load_svcs" {
+  default     = "20000"
+  description = "The number of services that applications-load-gen will simulate."
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

In https://github.com/chef/automate/pull/2776 we created the applications-load-gen service. Now we want to run it against the automate instances in the pipeline. The primary goal is to make the acceptance environments useful for UI testing/demonstration but having a baseline load test will be welcome also.
