### PR TITLE
Connect chef-load hab sup to automate EAS apps

### DIFF
--- a/terraform/test-environments/modules/chef_load_instance/templates/hab-sup-exec-start.conf.tpl
+++ b/terraform/test-environments/modules/chef_load_instance/templates/hab-sup-exec-start.conf.tpl
@@ -1,0 +1,9 @@
+[Service]
+ExecStart=
+ExecStart=/bin/hab sup run \
+  --event-stream-application="load-generation" \
+  --event-stream-environment="pipeline" \
+  --event-stream-site="chef-cd-pipeline" \
+  --event-stream-url="${automate_server_fqdn}:4222" \
+  --event-stream-token="${automate_server_token}"
+


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Adds end-to-end coverage of real habitat supervisor connecting to Automate applications feature.
