### PR TITLE
copy correct file in chef load setup

### DIFF
--- a/terraform/test-environments/modules/chef_load_instance/main.tf
+++ b/terraform/test-environments/modules/chef_load_instance/main.tf
@@ -100,7 +100,7 @@ EOF
       "sudo chown root:root /tmp/limits.conf",
       "sudo chown root:root /tmp/hab-sup-exec-start.conf",
       "sudo mv /tmp/limits.conf /etc/systemd/system/hab-supervisor.service.d/limits.conf",
-      "sudo mv /tmp/limits.conf /etc/systemd/system/hab-supervisor.service.d/hab-sup-exec-start.conf",
+      "sudo mv /tmp/hab-sup-exec-start.conf /etc/systemd/system/hab-supervisor.service.d/hab-sup-exec-start.conf",
     ]
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Copied the wrong file when setting up systemd overrides
