### PR TITLE
Reduce base load for applications service

### DIFF
--- a/terraform/test-environments/modules/chef_load_instance/variables.tf
+++ b/terraform/test-environments/modules/chef_load_instance/variables.tf
@@ -112,6 +112,6 @@ variable "chef_load_actions" {
 }
 
 variable "apps_load_svcs" {
-  default     = "20000"
+  default     = "10000"
   description = "The number of services that applications-load-gen will simulate."
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

20k services plus compliance and infra is too much for the dev perf test machines
