### PR TITLE
Fix notifications license display logic

### DIFF
--- a/components/automate-ui/src/app/components/notifications/notifications.component.ts
+++ b/components/automate-ui/src/app/components/notifications/notifications.component.ts
@@ -24,13 +24,7 @@ export class ChefNotificationsComponent {
         this.notifications = notifications;
         this.layoutFacade.layout.header.license =
           notifications &&  notifications.some(n => n.type === Type.license);
-          if (this.layoutFacade.layout.header.license) {
-            this.layoutFacade.layout.header.license = true;
-            this.layoutFacade.updateDisplay();
-          } else {
-            this.layoutFacade.layout.header.license = false;
-            this.layoutFacade.updateDisplay();
-          }
+        this.layoutFacade.updateDisplay();
       });
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Small fix for notifications logic on displaying license banner.

### :chains: Related Resources
https://app.zenhub.com/workspaces/ui-team-5cba23a3b14fdc05970c8f87/issues/chef/automate/835

### :+1: Definition of Done
License banner only shows when there's a license notification

### :athletic_shoe: How to Build and Test the Change
hab studio enter 
export DEVPROXY_URL=localhost
build components/automate-ui-devproxy
start_automate_ui_background |  stop_automate_ui_background
start_all_services
chef-automate dev psql chef_license_control_service -- -c "UPDATE licenses SET active=NULL"
