### PR TITLE
Add more defensive hab license accepting

### DIFF
--- a/terraform/test-environments/modules/chef_load_instance/main.tf
+++ b/terraform/test-environments/modules/chef_load_instance/main.tf
@@ -172,8 +172,8 @@ CONF
   provisioner "remote-exec" {
     inline = [
       "set -e",
-      "sudo hab svc unload chef/chef-load || true",
-      "sudo hab svc unload chef/applications-load-gen || true",
+      "sudo HAB_LICENSE=accept hab svc unload chef/chef-load || true",
+      "sudo HAB_LICENSE=accept hab svc unload chef/applications-load-gen || true",
       "for _ in {1..5} ; do if sudo hab sup status | grep -q chef-load; then echo \"waiting for chef-load to unload\" && sleep 5; fi; done",
       "for _ in {1..5} ; do if sudo hab sup status | grep -q applications-load-gen; then echo \"waiting for applications-load-gen to unload\" && sleep 5; fi; done",
       "sudo mv /bin/hab /bin/hab.old",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

terraform: If a hab upgrade doesn't complete all the way we can end up with newer hab but without having accepted the license. Add the license accepting env VAR in more places to catch this case.
