### PR TITLE
Add app-authorized to applications nav link

### DIFF
--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -7,7 +7,7 @@
       <div class="navigation-menu">
         <div role="menuitem" class="nav-link"><a routerLink="/dashboards/event-feed" routerLinkActive="active" tabindex="0">Dashboards</a></div>
 
-        <app-authorized [anyOf]="[['/applications/services', 'get'], ['/applications/service-groups', 'get']]">
+        <app-authorized [allOf]="[['/applications/services', 'get'], ['/applications/service-groups', 'get']]">
           <div role="menuitem" class="nav-link"><a routerLink="/applications/service-groups" routerLinkActive="active" tabindex="0">Applications</a></div>
         </app-authorized>
 

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -7,7 +7,9 @@
       <div class="navigation-menu">
         <div role="menuitem" class="nav-link"><a routerLink="/dashboards/event-feed" routerLinkActive="active" tabindex="0">Dashboards</a></div>
 
-        <div role="menuitem" class="nav-link"><a routerLink="/applications/service-groups" routerLinkActive="active" tabindex="0">Applications</a></div>
+        <app-authorized [anyOf]="['/auth/introspect', 'get']">
+          <div role="menuitem" class="nav-link"><a routerLink="/applications/service-groups" routerLinkActive="active" tabindex="0">Applications</a></div>
+        </app-authorized>
 
         <app-authorized [allOf]="[['/cfgmgmt/nodes', 'get'], ['/cfgmgmt/stats/node_counts', 'get']]">
           <div role="menuitem" class="nav-link"><a routerLink="/infrastructure" routerLinkActive="active" tabindex="0">Infrastructure</a></div>

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -7,7 +7,7 @@
       <div class="navigation-menu">
         <div role="menuitem" class="nav-link"><a routerLink="/dashboards/event-feed" routerLinkActive="active" tabindex="0">Dashboards</a></div>
 
-        <app-authorized [anyOf]="['/auth/introspect', 'get']">
+        <app-authorized [anyOf]="['/applications/service-groups', 'get']">
           <div role="menuitem" class="nav-link"><a routerLink="/applications/service-groups" routerLinkActive="active" tabindex="0">Applications</a></div>
         </app-authorized>
 

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -7,7 +7,7 @@
       <div class="navigation-menu">
         <div role="menuitem" class="nav-link"><a routerLink="/dashboards/event-feed" routerLinkActive="active" tabindex="0">Dashboards</a></div>
 
-        <app-authorized [anyOf]="['/applications/service-groups', 'get']">
+        <app-authorized [anyOf]="[['/applications/services', 'get'], ['/applications/service-groups', 'get']]">
           <div role="menuitem" class="nav-link"><a routerLink="/applications/service-groups" routerLinkActive="active" tabindex="0">Applications</a></div>
         </app-authorized>
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
We need to remove the Applications link from navigation when the user does not have permissions to see the applications tab.  This branch adds an app authorized container around Applications using introspection to check if the user has permission or not.

### :chains: Related Resources

### :+1: Definition of Done
When a user does not have permission to use the Applications tab, it is not accessible

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy
make serve

In order to test this properly, you'll need to:
1. log in as admin
2. create a new user
3. create a policy that does not allow a user to view applications
4. assign your new user that policy
5. log out of admin
6. log in as the user you created.

If you're testing this, please let me know if you see the applications tab when you expect not to. - thank you!

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
