### PR TITLE
Jamie/2573 accordions for long service messages

### DIFF
--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -96,11 +96,13 @@
                 </div>
                 <div class="healthcheck-content" [class.active]="activeErrorAccordions.includes(i)">
                   {{service.health_check_result.stderr}}
+                  <div class="show-more-container">
+                    <button 
+                    *ngIf="service.health_check_result.stderr.length > 138"
+                    class="show-more-button"
+                    (click)="toggleMoreErrorMsg(i)">Show {{ activeErrorAccordions.includes(i) ? "Less" : "More"}}</button>
+                  </div>
                 </div>
-                <button 
-                *ngIf="service.health_check_result.stderr.length > 138"
-                class="show-more-button"
-                (click)="toggleMoreErrorMsg(i)">Show {{ activeErrorAccordions.includes(i) ? "Less" : "More"}}</button>
               </div>
               <div class="healthcheck-message" *ngIf="service.health_check_result.stdout !== ''">
                 <div class="healthcheck-header {{service.health_check}}">
@@ -108,11 +110,13 @@
                 </div>
                 <div class="healthcheck-content" [class.active]="activeHealthAccordions.includes(i)">
                   {{service.health_check_result.stdout}}
+                  <div class="show-more-container">
+                    <button 
+                    *ngIf="service.health_check_result.stdout.length > 138"
+                    class="show-more-button"
+                    (click)="toggleMoreHealthMsg(i)">Show {{ activeHealthAccordions.includes(i) ? "Less" : "More"}}</button>
+                  </div>
                 </div>
-                <button 
-                *ngIf="service.health_check_result.stdout.length > 138"
-                class="show-more-button"
-                (click)="toggleMoreHealthMsg(i)">Show {{ activeHealthAccordions.includes(i) ? "Less" : "More"}}</button>
               </div>
             </div>
           </div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -99,8 +99,10 @@
                   <div class="show-more-container">
                     <button 
                     *ngIf="service.health_check_result.stderr.length > 138"
-                    class="show-more-button"
-                    (click)="toggleMoreErrorMsg(i)">Show {{ activeErrorAccordions.includes(i) ? "Less" : "More"}}</button>
+                    (click)="toggleMoreErrorMsg(i)"
+                    class="show-more-button">
+                    <chef-icon class="unfold">{{ activeErrorAccordions.includes(i) ? "unfold_less" : "unfold_more"}}</chef-icon>
+                    Show {{ activeErrorAccordions.includes(i) ? "Less" : "More"}}</button>
                   </div>
                 </div>
               </div>
@@ -114,7 +116,9 @@
                     <button 
                     *ngIf="service.health_check_result.stdout.length > 138"
                     class="show-more-button"
-                    (click)="toggleMoreHealthMsg(i)">Show {{ activeHealthAccordions.includes(i) ? "Less" : "More"}}</button>
+                    (click)="toggleMoreHealthMsg(i)">
+                    <chef-icon class="unfold">{{ activeErrorAccordions.includes(i) ? "unfold_less" : "unfold_more"}}</chef-icon>
+                    Show {{ activeErrorAccordions.includes(i) ? "Less" : "More"}}</button>
                   </div>
                 </div>
               </div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -98,7 +98,8 @@
                   {{service.health_check_result.stderr}}
                 </div>
                 <button 
-                *ngIf="service.health_check_result.stderr.length > 184"
+                *ngIf="service.health_check_result.stderr.length > 138"
+                class="show-more-button"
                 (click)="toggleMoreErrorMsg(i)">Show {{ activeErrorAccordions.includes(i) ? "Less" : "More"}}</button>
               </div>
               <div class="healthcheck-message" *ngIf="service.health_check_result.stdout !== ''">
@@ -109,7 +110,8 @@
                   {{service.health_check_result.stdout}}
                 </div>
                 <button 
-                *ngIf="service.health_check_result.stdout.length > 184" 
+                *ngIf="service.health_check_result.stdout.length > 138"
+                class="show-more-button"
                 (click)="toggleMoreHealthMsg(i)">Show {{ activeHealthAccordions.includes(i) ? "Less" : "More"}}</button>
               </div>
             </div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -117,8 +117,8 @@
                     *ngIf="service.health_check_result.stdout.length > 138"
                     class="show-more-button"
                     (click)="toggleMoreHealthMsg(i)">
-                    <chef-icon class="unfold">{{ activeErrorAccordions.includes(i) ? "unfold_less" : "unfold_more"}}</chef-icon>
-                    Show {{ activeErrorAccordions.includes(i) ? "Less" : "More"}}</button>
+                    <chef-icon class="unfold">{{ activeHealthAccordions.includes(i) ? "unfold_less" : "unfold_more"}}</chef-icon>
+                    Show {{ activeHealthAccordions.includes(i) ? "Less" : "More"}}</button>
                   </div>
                 </div>
               </div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -98,7 +98,7 @@
                   {{service.health_check_result.stderr}}
                   <div class="show-more-container">
                     <button 
-                    *ngIf="service.health_check_result.stderr.length > 138"
+                    *ngIf="service.health_check_result.stderr.length > LINES_OUTPUT_3"
                     (click)="toggleMoreErrorMsg(i)"
                     class="show-more-button">
                     <chef-icon class="unfold">{{ activeErrorAccordions.includes(i) ? "unfold_less" : "unfold_more"}}</chef-icon>
@@ -114,7 +114,7 @@
                   {{service.health_check_result.stdout}}
                   <div class="show-more-container">
                     <button 
-                    *ngIf="service.health_check_result.stdout.length > 138"
+                    *ngIf="service.health_check_result.stdout.length > LINES_OUTPUT_3"
                     class="show-more-button"
                     (click)="toggleMoreHealthMsg(i)">
                     <chef-icon class="unfold">{{ activeHealthAccordions.includes(i) ? "unfold_less" : "unfold_more"}}</chef-icon>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -94,9 +94,12 @@
                 <div class="healthcheck-header {{service.health_check}}">
                   Health Check Error Message
                 </div>
-                <div class="healthcheck-content">
+                <div class="healthcheck-content" [class.active]="activeAccordions.includes(i)">
                   {{service.health_check_result.stderr}}
                 </div>
+                <button 
+                *ngIf="service.health_check_result.stderr.length > 184"
+                (click)="toggleMore(i)">Show {{ activeAccordions.includes(i) ? "Less" : "More"}}</button>
               </div>
               <div class="healthcheck-message" *ngIf="service.health_check_result.stdout !== ''">
                 <div class="healthcheck-header {{service.health_check}}">

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -94,21 +94,24 @@
                 <div class="healthcheck-header {{service.health_check}}">
                   Health Check Error Message
                 </div>
-                <div class="healthcheck-content" [class.active]="activeAccordions.includes(i)">
+                <div class="healthcheck-content" [class.active]="activeErrorAccordions.includes(i)">
                   {{service.health_check_result.stderr}}
                 </div>
                 <button 
                 *ngIf="service.health_check_result.stderr.length > 184"
-                (click)="toggleMore(i)">Show {{ activeAccordions.includes(i) ? "Less" : "More"}}</button>
+                (click)="toggleMoreErrorMsg(i)">Show {{ activeErrorAccordions.includes(i) ? "Less" : "More"}}</button>
               </div>
               <div class="healthcheck-message" *ngIf="service.health_check_result.stdout !== ''">
                 <div class="healthcheck-header {{service.health_check}}">
                   Health Check Output Message
                 </div>
-                <div class="healthcheck-content">
+                <div class="healthcheck-content" [class.active]="activeHealthAccordions.includes(i)">
                   {{service.health_check_result.stdout}}
                 </div>
-               </div>
+                <button 
+                *ngIf="service.health_check_result.stdout.length > 184" 
+                (click)="toggleMoreHealthMsg(i)">Show {{ activeHealthAccordions.includes(i) ? "Less" : "More"}}</button>
+              </div>
             </div>
           </div>
         </div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -218,6 +218,7 @@ chef-alert {
     max-height: 74px;
     overflow: hidden;
     transition: .35s max-height;
+
     &.active {
       max-height: 1000px; // temp placeholder
     }

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -215,6 +215,11 @@ chef-alert {
     color: var(--chef-white);
     padding: 8px;
     overflow-wrap: break-word;
+    max-height: 90px;
+    overflow: hidden;
+    &.active {
+      max-height: unset;
+    }
   }
 
   .health-line {

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -220,7 +220,7 @@ chef-alert {
     transition: .35s max-height;
 
     &.active {
-      max-height: 1000px; // temp placeholder
+      max-height: 500px; // temp placeholder
     }
   }
 

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -218,7 +218,7 @@ chef-alert {
     overflow-wrap: break-word;
     max-height: 94px;
     overflow: hidden;
-    transition: .35s max-height;
+    transition: .25s max-height;
 
     &.active {
       max-height: 540px; // temp placeholder
@@ -233,11 +233,18 @@ chef-alert {
     background: var(--chef-primary-dark);
 
     .show-more-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
       background: transparent;
       border: none;
       color: #9CB2F9; // need to snag varibale from list
       padding: 8px;
       cursor: pointer;
+    }
+
+    .unfold {
+      margin-right: 4px;
     }
   }
 

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -221,7 +221,7 @@ chef-alert {
     transition: .25s max-height;
 
     &.active {
-      max-height: 540px; // temp placeholder
+      max-height: 540px; // need enough space for max 1024 characters
     }
   }
 
@@ -238,7 +238,7 @@ chef-alert {
       justify-content: center;
       background: transparent;
       border: none;
-      color: #9CB2F9; // need to snag varibale from list
+      color: #9CB2F9; // from extended palette
       padding: 8px;
       cursor: pointer;
     }

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -215,11 +215,18 @@ chef-alert {
     color: var(--chef-white);
     padding: 8px;
     overflow-wrap: break-word;
-    max-height: 90px;
+    max-height: 74px;
     overflow: hidden;
+    transition: .35s max-height;
     &.active {
-      max-height: unset;
+      max-height: 1000px; // temp placeholder
     }
+  }
+
+  .show-more-button {
+    background: transparent;
+    border: none;
+    cursor: pointer;
   }
 
   .health-line {

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -210,24 +210,35 @@ chef-alert {
   }
 
   .healthcheck-content {
+    position: relative;
     border-radius: 0 0 2px 2px;
     background-color: var(--chef-primary-dark);
     color: var(--chef-white);
-    padding: 8px;
+    padding: 8px 8px 40px 8px;
     overflow-wrap: break-word;
-    max-height: 74px;
+    max-height: 94px;
     overflow: hidden;
     transition: .35s max-height;
 
     &.active {
-      max-height: 500px; // temp placeholder
+      max-height: 540px; // temp placeholder
     }
   }
 
-  .show-more-button {
-    background: transparent;
-    border: none;
-    cursor: pointer;
+  .show-more-container {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background: var(--chef-primary-dark);
+
+    .show-more-button {
+      background: transparent;
+      border: none;
+      color: #9CB2F9; // need to snag varibale from list
+      padding: 8px;
+      cursor: pointer;
+    }
   }
 
   .health-line {

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -221,7 +221,10 @@ chef-alert {
     transition: .25s max-height;
 
     &.active {
-      max-height: 540px; // need enough space for max 1024 characters
+      // we need enough space for 1024 characters which is the maximum length
+      // of a health message.  540px maps to enough height for a full message
+      // plus room for the button.
+      max-height: 540px;
     }
   }
 

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -33,6 +33,7 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   public totalServices = 0;
   public RFC2822 = DateTime.RFC2822;
   public selectedSearchBarFilters = [];
+  public activeAccordions = []; // change to array of numbers
 
   public services$: Observable<GroupService[]>;
   public serviceGroupsStatus$: Observable<EntityStatus>;
@@ -114,6 +115,14 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
 
       this.store.dispatch(new UpdateSelectedSG(paramsForDispatch));
       document.querySelector<HTMLElement>('app-services-sidebar').focus();
+    }
+  }
+
+  public toggleMore(index: number) {
+    if (this.activeAccordions.includes(index)) {
+      this.activeAccordions = this.activeAccordions.filter(e => e !== index);
+    } else {
+      this.activeAccordions.push(index);
     }
   }
 

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -33,7 +33,8 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   public totalServices = 0;
   public RFC2822 = DateTime.RFC2822;
   public selectedSearchBarFilters = [];
-  public activeAccordions = []; // change to array of numbers
+  public activeErrorAccordions = []; // change to array of numbers
+  public activeHealthAccordions = []; // change to array of numbers
 
   public services$: Observable<GroupService[]>;
   public serviceGroupsStatus$: Observable<EntityStatus>;
@@ -118,11 +119,19 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
     }
   }
 
-  public toggleMore(index: number) {
-    if (this.activeAccordions.includes(index)) {
-      this.activeAccordions = this.activeAccordions.filter(e => e !== index);
+  public toggleMoreErrorMsg(index: number) {
+    if (this.activeErrorAccordions.includes(index)) {
+      this.activeErrorAccordions = this.activeErrorAccordions.filter(n => n !== index);
     } else {
-      this.activeAccordions.push(index);
+      this.activeErrorAccordions.push(index);
+    }
+  }
+
+  public toggleMoreHealthMsg(index: number) {
+    if (this.activeHealthAccordions.includes(index)) {
+      this.activeHealthAccordions = this.activeHealthAccordions.filter(n => n !== index);
+    } else {
+      this.activeHealthAccordions.push(index);
     }
   }
 

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -33,8 +33,8 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   public totalServices = 0;
   public RFC2822 = DateTime.RFC2822;
   public selectedSearchBarFilters = [];
-  public activeErrorAccordions = []; // change to array of numbers
-  public activeHealthAccordions = []; // change to array of numbers
+  public activeErrorAccordions: number[] = [];
+  public activeHealthAccordions: number[] = [];
 
   public services$: Observable<GroupService[]>;
   public serviceGroupsStatus$: Observable<EntityStatus>;

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -33,6 +33,9 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
   public totalServices = 0;
   public RFC2822 = DateTime.RFC2822;
   public selectedSearchBarFilters = [];
+
+  // Health Check Accordions
+  public LINES_OUTPUT_3 = 138;  // provides max of 3 lines of output visible by default;
   public activeErrorAccordions: number[] = [];
   public activeHealthAccordions: number[] = [];
 

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.ts
@@ -124,17 +124,17 @@ export class ServicesSidebarComponent implements OnInit, OnDestroy {
 
   public toggleMoreErrorMsg(index: number) {
     if (this.activeErrorAccordions.includes(index)) {
-      this.activeErrorAccordions = this.activeErrorAccordions.filter(n => n !== index);
+      this.activeErrorAccordions = this.activeErrorAccordions.filter(n => n !== index); // close
     } else {
-      this.activeErrorAccordions.push(index);
+      this.activeErrorAccordions.push(index); // open accordion
     }
   }
 
   public toggleMoreHealthMsg(index: number) {
     if (this.activeHealthAccordions.includes(index)) {
-      this.activeHealthAccordions = this.activeHealthAccordions.filter(n => n !== index);
+      this.activeHealthAccordions = this.activeHealthAccordions.filter(n => n !== index); // close
     } else {
-      this.activeHealthAccordions.push(index);
+      this.activeHealthAccordions.push(index); // open accordion
     }
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
We are attempting to make the outputs from health checks more scannable, so text should be sitting in an accordion if longer than around 140 characters.  This branch adds show more buttons to long health messages that can expand and collapse

### :chains: Related Resources
https://github.com/chef/automate/pull/2572
https://github.com/chef/automate/issues/2554

### :+1: Definition of Done
show more buttons are in place and toggling properly

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
source .studio/applications-service
applications_populate_database

make serve

navigate to https://a2-dev.test/applications/service-groups
toggle open various health messages on the right side of the screen

Verify Behavior:
Filter for service name: pos-terminal
There should be no "show more" buttons shown in any of the production environments

Filter for service name: nginx
the bldr-cache app in qa env shows messages of the maximum size. They wrap even without word breaks

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable

![Accordions](https://user-images.githubusercontent.com/16737484/74276971-90d26100-4ccb-11ea-9a9e-26bbe355c65a.gif)