### PR TITLE
[Automate-2823] chrome 80 workaround

### DIFF
--- a/components/automate-ui/src/main.ts
+++ b/components/automate-ui/src/main.ts
@@ -34,6 +34,7 @@ applyPolyfills().then(() => {
       if (typeof callback !== 'function') {
         throw new TypeError(callback + ' is not a function');
       }
+      // tslint:disable-next-line
       let t = Object(this), len = t.length >>> 0, k = 0, value;
       if (arguments.length === 2) {
         value = arguments[1];

--- a/components/automate-ui/src/main.ts
+++ b/components/automate-ui/src/main.ts
@@ -15,3 +15,43 @@ platformBrowserDynamic().bootstrapModule(AppModule, { preserveWhitespaces: true 
 applyPolyfills().then(() => {
   defineCustomElements(window);
 });
+
+// Temporary fix from https://github.com/angular/angular/issues/35219#issuecomment-583455039
+(function () {
+  function getChromeVersion() {
+    const raw = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+
+    return raw ? parseInt(raw[2], 10) : false;
+  }
+
+  const chromeVersion = getChromeVersion();
+  if (chromeVersion && chromeVersion >= 80) {
+    Array.prototype.reduce = function (callback /*, initialValue*/) {
+      'use strict';
+      if (this == null) {
+        throw new TypeError('Array.prototype.reduce called on null or undefined');
+      }
+      if (typeof callback !== 'function') {
+        throw new TypeError(callback + ' is not a function');
+      }
+      let t = Object(this), len = t.length >>> 0, k = 0, value;
+      if (arguments.length === 2) {
+        value = arguments[1];
+      } else {
+        while (k < len && !(k in t)) {
+          k++;
+        }
+        if (k >= len) {
+          throw new TypeError('Reduce of empty array with no initial value');
+        }
+        value = t[k++];
+      }
+      for (; k < len; k++) {
+        if (k in t) {
+          value = callback(value, t[k], k, t);
+        }
+      }
+      return value;
+    };
+  }
+})();


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

With an update to Chrome version 80, we started getting browser console errors on many pages with modals--here is just one example from the Users list page:
```
CreateUserModalComponent.html:4 ERROR Error: Cannot find control with name: 'displayName'
    at _throwError (forms.js:3357)
    at setUpControl (forms.js:3181)
    at FormGroupDirective.addControl (forms.js:7345)
    at FormControlName._setUpControl (forms.js:8070)
    at FormControlName.ngOnChanges (forms.js:7993)
    at checkAndUpdateDirectiveInline (core.js:31906)
    at checkAndUpdateNodeInline (core.js:44367)
    at checkAndUpdateNode (core.js:44306)
    at debugCheckAndUpdateNode (core.js:45328)
    at debugCheckDirectivesFn (core.js:45271)
CreateUserModalComponent.html:9 ERROR TypeError: Cannot read property 'pipe' of null
    at FormControlDirective.ngOnInit (form-control.directive.ts:70)
    at checkAndUpdateDirectiveInline (core.js:31910)
    at checkAndUpdateNodeInline (core.js:44367)
    at checkAndUpdateNode (core.js:44306)
    at debugCheckAndUpdateNode (core.js:45328)
    at debugCheckDirectivesFn (core.js:45271)
    at Object.eval [as updateDirectives] (CreateUserModalComponent.html:9)
    at Object.debugUpdateDirectives [as updateDirectives] (core.js:45259)
```

**This PR provides a temporary patch until the angular team fixes the root cause.**

### :chains: Related Resources
https://github.com/angular/angular/issues/35219
https://github.com/angular/angular/issues/35214

### :+1: Definition of Done
No more browser errors

### :athletic_shoe: How to Build and Test the Change
 * Rebuild automate-ui.
 * Navigate to various auth pages in the browser.

Note that the problem mostly occurred right after a browser refresh.
That is, if you went from Event Feed to Users, you would see the error.
But if you then went elsewhere and came back to Users, this time you would not.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
