### PR TITLE
Adding run message validation to the ingest pipeline

### DIFF
--- a/components/ingest-service/pipeline/chef_run.go
+++ b/components/ingest-service/pipeline/chef_run.go
@@ -31,6 +31,7 @@ func NewChefRunPipeline(client backend.Client, authzClient iam_v2.ProjectsClient
 	)
 
 	chefRunPipeline(in,
+		processor.MessageValidator,
 		processor.BuildTransmogrify(chefIngestRunPipelineConfig.NumberOfMsgsTransformers),
 		processor.ChefRunCorrections,
 		processor.BuildRunProjectTagger(authzClient),

--- a/components/ingest-service/pipeline/processor/corrections_run.go
+++ b/components/ingest-service/pipeline/processor/corrections_run.go
@@ -1,0 +1,37 @@
+package processor
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/chef/automate/components/ingest-service/pipeline/message"
+)
+
+// ChefRunCorrections - This processor makes updates and corrections to the raw data from the chef run message.
+func ChefRunCorrections(in <-chan message.ChefRun) <-chan message.ChefRun {
+	out := make(chan message.ChefRun, 100)
+	go func() {
+		for msg := range in {
+			log.WithFields(log.Fields{
+				"message_id":  msg.ID,
+				"buffer_size": len(out),
+			}).Debug("Corrections ChefRun")
+
+			cleanUpErrorTitle(&msg)
+
+			out <- msg
+		}
+		close(out)
+	}()
+
+	return out
+}
+
+// This method cleans up an error message coming from chef server.
+// Because 412 "Precondition Failed" is not user friendly, the message
+// was changed to "Error Resolving Cookbooks for Run List."
+func cleanUpErrorTitle(chefRun *message.ChefRun) {
+	if chefRun.NodeRun.Error.Description.Title == "412 \"Precondition Failed\"" ||
+		chefRun.NodeRun.Error.Description.Title == "Error Resolving Cookbooks for Run List:" {
+		chefRun.NodeRun.Error.Description.Title = "Error Resolving Cookbooks for Run List."
+	}
+}

--- a/components/ingest-service/pipeline/processor/transmogrify_run.go
+++ b/components/ingest-service/pipeline/processor/transmogrify_run.go
@@ -80,33 +80,3 @@ func ChefRunTransmogrify(in <-chan message.ChefRun, out chan<- message.ChefRun, 
 		close(out)
 	}()
 }
-
-// ChefRunCorrections - This processor makes updates and corrections to the raw data from the chef run message.
-func ChefRunCorrections(in <-chan message.ChefRun) <-chan message.ChefRun {
-	out := make(chan message.ChefRun, 100)
-	go func() {
-		for msg := range in {
-			log.WithFields(log.Fields{
-				"message_id":  msg.ID,
-				"buffer_size": len(out),
-			}).Debug("Corrections ChefRun")
-
-			cleanUpErrorTitle(&msg)
-
-			out <- msg
-		}
-		close(out)
-	}()
-
-	return out
-}
-
-// This method cleans up an error message coming from chef server.
-// Because 412 "Precondition Failed" is not user friendly, the message
-// was changed to "Error Resolving Cookbooks for Run List."
-func cleanUpErrorTitle(chefRun *message.ChefRun) {
-	if chefRun.NodeRun.Error.Description.Title == "412 \"Precondition Failed\"" ||
-		chefRun.NodeRun.Error.Description.Title == "Error Resolving Cookbooks for Run List:" {
-		chefRun.NodeRun.Error.Description.Title = "Error Resolving Cookbooks for Run List."
-	}
-}

--- a/components/ingest-service/pipeline/processor/validator_run.go
+++ b/components/ingest-service/pipeline/processor/validator_run.go
@@ -1,0 +1,37 @@
+package processor
+
+import (
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/chef/automate/components/ingest-service/pipeline/message"
+)
+
+// MessageValidator - Validate the message before it moves further in the pipeline.
+func MessageValidator(in <-chan message.ChefRun) <-chan message.ChefRun {
+	out := make(chan message.ChefRun, 100)
+	go func() {
+		for msg := range in {
+			log.WithFields(log.Fields{
+				"message_id":  msg.ID,
+				"buffer_size": len(out),
+			}).Debug("MessageValidator ChefRun")
+
+			if msg.Run.EntityUuid == "" {
+				msg.FinishProcessing(status.Errorf(codes.InvalidArgument, "the entity_uuid is missing from the message"))
+				continue
+			}
+
+			if msg.Run.RunId == "" {
+				msg.FinishProcessing(status.Errorf(codes.InvalidArgument, "the run_id is missing from the message"))
+				continue
+			}
+
+			out <- msg
+		}
+		close(out)
+	}()
+
+	return out
+}

--- a/components/ingest-service/pipeline/processor/validator_run_internal_test.go
+++ b/components/ingest-service/pipeline/processor/validator_run_internal_test.go
@@ -1,0 +1,70 @@
+package processor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	chef "github.com/chef/automate/api/external/ingest/request"
+	"github.com/chef/automate/components/ingest-service/pipeline/message"
+)
+
+// The message should pass through the pipe
+func TestMessageValidator(t *testing.T) {
+	inbox := make(chan message.ChefRun, 100)
+
+	errc := make(chan error)
+
+	run := &chef.Run{
+		EntityUuid: "node_id",
+		RunId:      "run_id",
+	}
+
+	inbox <- message.NewChefRun(context.Background(), run, errc)
+	close(inbox)
+
+	out := MessageValidator(inbox)
+
+	<-out
+}
+
+func TestMessageValidatorMissingEntityUUID(t *testing.T) {
+	inbox := make(chan message.ChefRun, 100)
+
+	errc := make(chan error)
+
+	run := &chef.Run{
+		EntityUuid: "", // missing
+		RunId:      "run_id",
+	}
+
+	inbox <- message.NewChefRun(context.Background(), run, errc)
+	close(inbox)
+
+	MessageValidator(inbox)
+
+	err := <-errc
+
+	assert.Error(t, err)
+}
+
+func TestMessageValidatorMissingRunId(t *testing.T) {
+	inbox := make(chan message.ChefRun, 100)
+
+	errc := make(chan error)
+
+	run := &chef.Run{
+		EntityUuid: "node_id",
+		RunId:      "", // missing
+	}
+
+	inbox <- message.NewChefRun(context.Background(), run, errc)
+	close(inbox)
+
+	MessageValidator(inbox)
+
+	err := <-errc
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Validating the CCR message at the beginning of the ingestion pipeline. Users were seeing that if the CCR was missing the "entity_uuid" it could fail other CCR requests from successfully ingesting because of the bundling of messages. 

### :chains: Related Resources

https://github.com/chef/automate/issues/2309

### :+1: Definition of Done
Fail a CCR request that is missing a value for "entity_uuid" before bundling the message with other requests. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/ingest-service && start_all_services`
1. Add debug level logging to the ingest service `chef-automate debug set-log-level ingest-service debug`
1. Follow the logs with `sl | grep "ingest-service.default" | grep -v "Worker" &`
1. Open the components/ingest-service/examples/converge-success-report.json file and remove the "entity_uuid" field.
1. Send the CCR to the data collector. `curl -f --insecure -H "api-token: $(get_admin_token)" --data "@/src/components/ingest-service/examples/converge-success-report.json" https://localhost/data-collector/v0`
1. Ensure the message "ingest-service.default(O): time="2020-02-08T00:13:15Z" level=error msg="Message failure" error="the entity_uuid is missing from the message"" is displayed. 
1. Again, open the components/ingest-service/examples/converge-success-report.json file, add back the "entity_uuid" field, and remove the "rule_id" filed. 
1. Send the CCR to the data collector. `curl -f --insecure -H "api-token: $(get_admin_token)" --data "@/src/components/ingest-service/examples/converge-success-report.json" https://localhost/data-collector/v0`
1. Ensure the message "ingest-service.default(O): time="2020-02-08T00:15:09Z" level=error msg="Message failure" error="the run_id is missing from the message"" is displayed. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).