### PR TITLE
Fix for incompatible profiles breaking A1 to A2 migration

### DIFF
--- a/components/compliance-service/api/profiles/server/migrate.go
+++ b/components/compliance-service/api/profiles/server/migrate.go
@@ -67,7 +67,7 @@ func (srv *PGProfileServer) migrateDiskProfiles() error {
 
 			_, err = srv.storeProfile(namespace, tmpFile)
 			if err != nil {
-				logrus.WithError(err).Errorf("Could not store profile %q", tmpFile)
+				logrus.WithError(err).Errorf("Could not store profile %q", profile)
 				finalError = multierr.Combine(finalError, err)
 			} else {
 				// archive profile, so that we do not import it during next bootup

--- a/components/compliance-service/api/profiles/server/migrate.go
+++ b/components/compliance-service/api/profiles/server/migrate.go
@@ -68,7 +68,6 @@ func (srv *PGProfileServer) migrateDiskProfiles() error {
 			_, err = srv.storeProfile(namespace, tmpFile)
 			if err != nil {
 				logrus.WithError(err).Errorf("Could not store profile %q", profile)
-				finalError = multierr.Combine(finalError, err)
 			} else {
 				// archive profile, so that we do not import it during next bootup
 				err := market.Archive(srv.profiles.ProfilesPath, namespace, profile)

--- a/components/compliance-service/profiles/market/market.go
+++ b/components/compliance-service/profiles/market/market.go
@@ -88,11 +88,5 @@ func TempUpload(body io.ReadCloser, suffix string) (string, error) {
 func CheckProfile(tmpWithSuffix string) (inspec.CheckResult, error) {
 	defer util.TimeTrack(time.Now(), "CheckProfile")
 
-	checkResult, err := inspec.Check(tmpWithSuffix)
-	if err != nil {
-		logrus.Error("CheckProfile InSpec Check failed for " + tmpWithSuffix)
-		return checkResult, err
-	}
-
-	return checkResult, nil
+	return inspec.Check(tmpWithSuffix)
 }


### PR DESCRIPTION
Fix for #2615. 

Steps to reproduce:
* Download the bad profile into the `automate/` directory so it is visible in the studio.
* Enter the hab studio.
* Make the legacy profile store directory: `[8][default:/src:130]# mkdir -p /hab/svc/compliance-service/data/profiles/admin`
* Copy the bad profile into the profile store: `[8][default:/src:130]# cp crashing_profile-0.1.0.tar.gz /hab/svc/compliance-service/data/profiles/admin/`
* Start automate and view the logs.

Before this PR, the logs looked like this:

```
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (4/41) Profiles: Migrating profiles from disk, if any..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Connecting to Elasticsearch Sidecar" address="172.17.0.2:10123"
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrate all profiles from Automate 1"
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrate namespace admin to new profile store"
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrate profile /hab/svc/compliance-service/data/profiles/admin/crashing_profile-0.1.0.tar.gz to new profile store"
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Starting GRPC server on 0.0.0.0:10121"
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (5/41) ElasticSearch_A1: Post feeds migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (6/41) ElasticSearch_A1: Migrating the profiles index..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (7/41) ElasticSearch_A1: Post profiles migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (8/41) ElasticSearch_A1: Calculating TimeSeries migration range..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (9/41) ElasticSearch_A1: ElasticSearch_A1 ended with status COMPLETED"
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (10/41) ElasticSearch_A2_v1: Post feeds migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (11/41) ElasticSearch_A2_v1: Migrating the profiles index..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (12/41) ElasticSearch_A2_v1: Post profiles migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (13/41) ElasticSearch_A2_v1: Calculating TimeSeries migration range..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (14/41) ElasticSearch_A2_v1: ElasticSearch_A2_v1 ended with status COMPLETED"
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (15/41) ElasticSearch_A2_v2: Post feeds migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (16/41) ElasticSearch_A2_v2: Migrating the profiles index..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (17/41) ElasticSearch_A2_v2: Post profiles migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (18/41) ElasticSearch_A2_v2: Calculating TimeSeries migration range..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (19/41) ElasticSearch_A2_v2: ElasticSearch_A2_v2 ended with status COMPLETED"
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (20/41) ElasticSearch_A2_v3: Post feeds migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (21/41) ElasticSearch_A2_v3: Migrating the profiles index..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (22/41) ElasticSearch_A2_v3: Post profiles migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (23/41) ElasticSearch_A2_v3: Calculating TimeSeries migration range..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (24/41) ElasticSearch_A2_v3: ElasticSearch_A2_v3 ended with status COMPLETED"
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (25/41) ElasticSearch_A2_v4: Post feeds migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (26/41) ElasticSearch_A2_v4: Migrating the profiles index..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (27/41) ElasticSearch_A2_v4: Post profiles migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (28/41) ElasticSearch_A2_v4: Calculating TimeSeries migration range..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (29/41) ElasticSearch_A2_v4: ElasticSearch_A2_v4 ended with status COMPLETED"
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (30/41) ElasticSearch_A2_v5: Post feeds migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (31/41) ElasticSearch_A2_v5: Migrating the profiles index..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (32/41) ElasticSearch_A2_v5: Post profiles migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (33/41) ElasticSearch_A2_v5: Calculating TimeSeries migration range..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (34/41) ElasticSearch_A2_v5: ElasticSearch_A2_v5 ended with status COMPLETED"
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (35/41) ElasticSearch_A2_v6: Post feeds migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (36/41) ElasticSearch_A2_v6: Migrating the profiles index..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (37/41) ElasticSearch_A2_v6: Post profiles migration cleanup..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (38/41) ElasticSearch_A2_v6: Calculating TimeSeries migration range..."
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Migrations running (39/41) ElasticSearch_A2_v6: ElasticSearch_A2_v6 ended with status COMPLETED"
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Starting task poller" poll_interval="10s with up to 1s of jitter" task_name=scan-job
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Starting task poller" poll_interval="10s with up to 1s of jitter" task_name=purge
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Starting task poller" poll_interval="10s with up to 1s of jitter" task_name=resolve-job
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Starting task poller" poll_interval="10s with up to 1s of jitter" task_name=create-child
[2020-02-07T21:24:06+00:00] compliance-service.default(O): time="2020-02-07T21:24:06Z" level=info msg="Starting task poller" poll_interval="10s with up to 1s of jitter" task_name=scan-job-summary
[2020-02-07T21:24:09+00:00] compliance-service.default(O): time="2020-02-07T21:24:09Z" level=error msg="CheckProfile InSpec Check failed for /hab/svc/compliance-service/var/tmp/inspec-upload278283377.tar.gz"
[2020-02-07T21:24:09+00:00] compliance-service.default(O): time="2020-02-07T21:24:09Z" level=error msg="Create CheckProfile error: Check InSpec check failed for /hab/svc/compliance-service/var/tmp/inspec-upload278283377.tar.gz with message: exit status 1\ncontrols/example.rb:1:in `load_with_context': lol (RuntimeError)\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:161:in `instance_eval'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:161:in `load_with_context'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:145:in `load_control_file'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:208:in `block in collect_tests'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:204:in `each'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:204:in `collect_tests'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:605:in `load_checks_params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:598:in `load_params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:195:in `params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:452:in `controls_count'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:422:in `check'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/cli.rb:118:in `check'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/base_cli.rb:35:in `start'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-bin-4.18.51/bin/inspec:11:in `<main>'\n"
[2020-02-07T21:24:09+00:00] compliance-service.default(O): time="2020-02-07T21:24:09Z" level=error msg="Could not store profile \"/hab/svc/compliance-service/var/tmp/inspec-upload278283377.tar.gz\"" error="rpc error: code = InvalidArgument desc = Check InSpec check failed for /hab/svc/compliance-service/var/tmp/inspec-upload278283377.tar.gz with message: exit status 1\ncontrols/example.rb:1:in `load_with_context': lol (RuntimeError)\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:161:in `instance_eval'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:161:in `load_with_context'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:145:in `load_control_file'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:208:in `block in collect_tests'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:204:in `each'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:204:in `collect_tests'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:605:in `load_checks_params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:598:in `load_params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:195:in `params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:452:in `controls_count'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:422:in `check'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/cli.rb:118:in `check'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/base_cli.rb:35:in `start'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-bin-4.18.51/bin/inspec:11:in `<main>'\n"
[2020-02-07T21:24:09+00:00] compliance-service.default(O): time="2020-02-07T21:24:09Z" level=error msg="could not migrate disk profiles: rpc error: code = InvalidArgument desc = Check InSpec check failed for /hab/svc/compliance-service/var/tmp/inspec-upload278283377.tar.gz with message: exit status 1\ncontrols/example.rb:1:in `load_with_context': lol (RuntimeError)\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:161:in `instance_eval'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:161:in `load_with_context'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:145:in `load_control_file'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:208:in `block in collect_tests'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:204:in `each'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:204:in `collect_tests'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:605:in `load_checks_params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:598:in `load_params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:195:in `params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:452:in `controls_count'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:422:in `check'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/cli.rb:118:in `check'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/base_cli.rb:35:in `start'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-bin-4.18.51/bin/inspec:11:in `<main>'\n"
[2020-02-07T21:24:09+00:00] compliance-service.default(O): time="2020-02-07T21:24:09Z" level=info msg="Migrations running (40/41) Profiles: Profiles ended with status FAILED"
[2020-02-07T21:24:09+00:00] compliance-service.default(O): time="2020-02-07T21:24:09Z" level=info msg="Migrations failed"
```

After this PR the logs look like this:
```
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (4/41) Profiles: Migrating profiles from disk, if any..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrate all profiles from Automate 1"
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrate namespace admin to new profile store"
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrate profile /hab/svc/compliance-service/data/profiles/admin/crashing_profile-0.1.0.tar.gz to new profile store"
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Starting GRPC server on 0.0.0.0:10121"
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (5/41) ElasticSearch_A1: Post feeds migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (6/41) ElasticSearch_A1: Migrating the profiles index..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (7/41) ElasticSearch_A1: Post profiles migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (8/41) ElasticSearch_A1: Calculating TimeSeries migration range..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (9/41) ElasticSearch_A1: ElasticSearch_A1 ended with status COMPLETED"
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (10/41) ElasticSearch_A2_v1: Post feeds migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (11/41) ElasticSearch_A2_v1: Migrating the profiles index..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (12/41) ElasticSearch_A2_v1: Post profiles migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (13/41) ElasticSearch_A2_v1: Calculating TimeSeries migration range..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (14/41) ElasticSearch_A2_v1: ElasticSearch_A2_v1 ended with status COMPLETED"
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (15/41) ElasticSearch_A2_v2: Post feeds migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (16/41) ElasticSearch_A2_v2: Migrating the profiles index..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (17/41) ElasticSearch_A2_v2: Post profiles migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (18/41) ElasticSearch_A2_v2: Calculating TimeSeries migration range..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (19/41) ElasticSearch_A2_v2: ElasticSearch_A2_v2 ended with status COMPLETED"
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (20/41) ElasticSearch_A2_v3: Post feeds migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (21/41) ElasticSearch_A2_v3: Migrating the profiles index..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (22/41) ElasticSearch_A2_v3: Post profiles migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (23/41) ElasticSearch_A2_v3: Calculating TimeSeries migration range..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (24/41) ElasticSearch_A2_v3: ElasticSearch_A2_v3 ended with status COMPLETED"
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (25/41) ElasticSearch_A2_v4: Post feeds migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (26/41) ElasticSearch_A2_v4: Migrating the profiles index..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (27/41) ElasticSearch_A2_v4: Post profiles migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (28/41) ElasticSearch_A2_v4: Calculating TimeSeries migration range..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (29/41) ElasticSearch_A2_v4: ElasticSearch_A2_v4 ended with status COMPLETED"
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (30/41) ElasticSearch_A2_v5: Post feeds migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (31/41) ElasticSearch_A2_v5: Migrating the profiles index..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (32/41) ElasticSearch_A2_v5: Post profiles migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (33/41) ElasticSearch_A2_v5: Calculating TimeSeries migration range..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (34/41) ElasticSearch_A2_v5: ElasticSearch_A2_v5 ended with status COMPLETED"
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (35/41) ElasticSearch_A2_v6: Post feeds migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (36/41) ElasticSearch_A2_v6: Migrating the profiles index..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (37/41) ElasticSearch_A2_v6: Post profiles migration cleanup..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (38/41) ElasticSearch_A2_v6: Calculating TimeSeries migration range..."
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Migrations running (39/41) ElasticSearch_A2_v6: ElasticSearch_A2_v6 ended with status COMPLETED"
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Starting task poller" poll_interval="10s with up to 1s of jitter" task_name=purge
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Starting task poller" poll_interval="10s with up to 1s of jitter" task_name=create-child
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Starting task poller" poll_interval="10s with up to 1s of jitter" task_name=resolve-job
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Starting task poller" poll_interval="10s with up to 1s of jitter" task_name=scan-job
[2020-02-08T00:52:39+00:00] compliance-service.default(O): time="2020-02-08T00:52:39Z" level=info msg="Starting task poller" poll_interval="10s with up to 1s of jitter" task_name=scan-job-summary
[2020-02-08T00:52:41+00:00] compliance-service.default(O): time="2020-02-08T00:52:41Z" level=error msg="Create CheckProfile error: Check InSpec check failed for /hab/svc/compliance-service/var/tmp/inspec-upload042172283.tar.gz with message: exit status 1\ncontrols/example.rb:1:in `load_with_context': lol (RuntimeError)\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:161:in `instance_eval'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:161:in `load_with_context'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:145:in `load_control_file'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:208:in `block in collect_tests'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:204:in `each'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:204:in `collect_tests'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:605:in `load_checks_params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:598:in `load_params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:195:in `params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:452:in `controls_count'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:422:in `check'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/cli.rb:118:in `check'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/base_cli.rb:35:in `start'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-bin-4.18.51/bin/inspec:11:in `<main>'\n"
[2020-02-08T00:52:41+00:00] compliance-service.default(O): time="2020-02-08T00:52:41Z" level=error msg="Could not store profile \"/hab/svc/compliance-service/data/profiles/admin/crashing_profile-0.1.0.tar.gz\"" error="rpc error: code = InvalidArgument desc = Check InSpec check failed for /hab/svc/compliance-service/var/tmp/inspec-upload042172283.tar.gz with message: exit status 1\ncontrols/example.rb:1:in `load_with_context': lol (RuntimeError)\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:161:in `instance_eval'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:161:in `load_with_context'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile_context.rb:145:in `load_control_file'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:208:in `block in collect_tests'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:204:in `each'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:204:in `collect_tests'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:605:in `load_checks_params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:598:in `load_params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:195:in `params'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:452:in `controls_count'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/profile.rb:422:in `check'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/cli.rb:118:in `check'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-4.18.51/lib/inspec/base_cli.rb:35:in `start'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/inspec-bin-4.18.51/bin/inspec:11:in `<main>'\n"
[2020-02-08T00:52:41+00:00] compliance-service.default(O): time="2020-02-08T00:52:41Z" level=info msg="Migrations running (40/41) Profiles: Profiles ended with status COMPLETED"
[2020-02-08T00:52:41+00:00] compliance-service.default(O): time="2020-02-08T00:52:41Z" level=info msg="Migrations complete"
```