### PR TITLE
Track latest redoc release in API docs

### DIFF
--- a/components/automate-chef-io/layouts/_default/data-api.html
+++ b/components/automate-chef-io/layouts/_default/data-api.html
@@ -19,7 +19,7 @@
   </head>
   <body>
     <ReDoc spec-url="/api-docs/all-apis.swagger.json"></ReDoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"></script>
   </body>
 </html>
 


### PR DESCRIPTION
To fix problems with the API docs not behaving properly with Chrome 80 we need to track the latest release of redoc. The problem is described in #2828.

We were already attempting to track the latest release but for some reason were one behind so this is not really a change in the desired behavior. We should probably be more explicit about the version of redoc used but that is another discussion.