### PR TITLE
Correcting disposition of ListProjects for IAM v1

### DIFF
--- a/components/authz-service/server/v2/system.go
+++ b/components/authz-service/server/v2/system.go
@@ -66,6 +66,12 @@ func SystemPolicies() []*storage.Policy {
 				Resources: []string{"iam:rules"},
 				Projects:  []string{constants.AllProjectsID},
 			},
+			{
+				Effect:    storage.Allow,
+				Actions:   []string{"iam:projects:list"},
+				Resources: []string{"iam:projects"},
+				Projects:  []string{constants.AllProjectsID},
+			},
 		},
 	}
 

--- a/components/authz-service/server/v2/system.go
+++ b/components/authz-service/server/v2/system.go
@@ -66,12 +66,6 @@ func SystemPolicies() []*storage.Policy {
 				Resources: []string{"iam:rules"},
 				Projects:  []string{constants.AllProjectsID},
 			},
-			{
-				Effect:    storage.Allow,
-				Actions:   []string{"iam:projects:list"},
-				Resources: []string{"iam:projects"},
-				Projects:  []string{constants.AllProjectsID},
-			},
 		},
 	}
 

--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -1,7 +1,10 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable, Subject } from 'rxjs';
+import { first, filter } from 'rxjs/operators';
+import { identity } from 'lodash/fp';
 
+import { isIAMv2 } from 'app/entities/policies/policy.selectors';
 import { LayoutSidebarService } from './layout-sidebar.service';
 import * as fromLayout from './layout.reducer';
 import { MenuItemGroup } from './layout.model';
@@ -21,7 +24,7 @@ enum Height {
 @Injectable({
   providedIn: 'root'
 })
-export class LayoutFacadeService implements OnDestroy {
+export class LayoutFacadeService implements OnInit, OnDestroy {
   public layout = {
     header: {
       display: true,
@@ -47,10 +50,19 @@ export class LayoutFacadeService implements OnDestroy {
     private store: Store<fromLayout.LayoutEntityState>,
     private layoutSidebarService: LayoutSidebarService
   ) {
-    this.store.dispatch(new GetProjects());
     this.menuGroups$ = store.select(sidebarMenuGroups);
     this.showPageLoading$ = store.select(showPageLoading);
     this.updateDisplay();
+  }
+
+  ngOnInit(): void {
+    this.store.select(isIAMv2)
+      .pipe(filter(identity), first())
+      .subscribe(isV2 => {
+        if (isV2) {
+          this.store.dispatch(new GetProjects());
+        }
+      });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

### UPDATED DESCRIPTION

Just treating v1 as a problem; V2 behavior is sufficient as is--without this commit, to wit:
viewer, editor, or better will not see an error, and will see projects status banner
user with no permissions will see an error--but that's OK. It is not a real use case (at most, a user is just in the process of being set up)

<img width="1339" alt="image" src="https://user-images.githubusercontent.com/6817500/74207089-eb6bae80-4c32-11ea-9d6a-20bdc67f6e97.png">

### ORIGINAL DESCRIPTION
Initially, this surfaced as a v1 issue but it turns out it affects both v1 and v2, though differently.

#### v2 (now obsolete)
_Actual (prior to this PR):_
Only admin users (or users explicitly given permission) could access `ListProjects`; other users would see an error banner.

_Desired (with this PR):_
All users need to see the projects status bar when projects are not up to date (though only folks with permission to update should see the <kbd>update projects</kbd> and <kbd>stop update</kbd> buttons).

#### v1
_Actual (prior to this PR):_
The system attempts to invoke `ListProjects` for all users; an error banner ensues for non-admin users.

_Desired (with this PR):_
The system no longer attempts to invoke `ListProjects` for any user.

#### Trade-Off (now obsolete)
This PR is the lesser of two evils. It fixes the issue as outlined above, but this quick-fix requires giving the user permission to view the projects list page, which is not desirable.
A better fix would be to introduce a new endpoint (called perhaps `AnyProjectsPending`) that returns a simple boolean, as that is all the front-end actually needs. Though fairly straightforward, this requires some team discussion and a bit more thought, so I deemed it not appropriate when trying to get acceptance unblocked.

#### Details

- Scope: affects all non-admin users, IAM v1
- In dev? 2020-02-06
- In acceptance? 2020-02-10
- In current? no

### :chains: Related Resources

- PR of origin: "Automate-835 bottom user notifications" (https://github.com/chef/automate/pull/2691)
- Commit of origin: a02150a5d

### :+1: Definition of Done
v1: No error and no project update bar.

### :athletic_shoe: How to Build and Test the Change

rebuild automate-ui (e.g. make serve)

Create a non-admin user. No need to add any particular policies.
Run the system in v1 (`chef-automate iam reset-to-v1`) mode logged in as the non-admin user.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
