### PR TITLE
Limit database connections in applications service

### DIFF
--- a/components/applications-service/habitat/default.toml
+++ b/components/applications-service/habitat/default.toml
@@ -9,6 +9,8 @@ metrics_port = 20133
 [storage]
 database = "chef_applications_service"
 user = "applications"
+max_open_conns = 10
+max_idle_conns = 10
 
 [tls]
 key_contents = ""

--- a/components/applications-service/pkg/config/service.go
+++ b/components/applications-service/pkg/config/service.go
@@ -37,9 +37,11 @@ type Events struct {
 }
 
 type Postgres struct {
-	URI        string `mapstructure:"uri"`
-	Database   string `mapstructure:"database"`
-	SchemaPath string `mapstructure:"schema_path"`
+	URI          string `mapstructure:"uri"`
+	Database     string `mapstructure:"database"`
+	SchemaPath   string `mapstructure:"schema_path"`
+	MaxOpenConns int    `mapstructure:"max_open_conns"`
+	MaxIdleConns int    `mapstructure:"max_idle_conns"`
 }
 
 type Jobs struct {

--- a/components/applications-service/pkg/storage/postgres/db.go
+++ b/components/applications-service/pkg/storage/postgres/db.go
@@ -55,6 +55,12 @@ func (db *Postgres) connect() error {
 		return errors.Wrapf(err, "Failed to open database with uri: %s", db.URI)
 	}
 
+	if db.MaxIdleConns > 0 {
+		dbMap.SetMaxIdleConns(db.MaxIdleConns)
+	}
+	if db.MaxOpenConns > 0 {
+		dbMap.SetMaxOpenConns(db.MaxOpenConns)
+	}
 	// Configure the database mapping object
 	db.DbMap = &gorp.DbMap{Db: dbMap, Dialect: gorp.PostgresDialect{}}
 


### PR DESCRIPTION
We're seing the applications create and destroy a lot
of db connections in the perf environment. This should
hopefully fix it
