### PR TITLE
Don't strip applications service binary

### DIFF
--- a/components/applications-service/habitat/plan.sh
+++ b/components/applications-service/habitat/plan.sh
@@ -44,3 +44,7 @@ do_install() {
   mkdir "${pkg_prefix}/schema"
   cp -r pkg/storage/postgres/schema/sql/* "${pkg_prefix}/schema"
 }
+
+do_strip() {
+  return 0
+}


### PR DESCRIPTION
This will make it possible for us to debug in the perf test environment.
That environment is showing 7k and growing goroutines, but we cannot
analyze the core dump with debug symbols

