### PR TITLE
Prevent duplicate data from aggregated data when fetching nodes

### DIFF
--- a/components/compliance-service/api/tests/25_nodes_spec.rb
+++ b/components/compliance-service/api/tests/25_nodes_spec.rb
@@ -570,7 +570,7 @@ describe File.basename(__FILE__) do
       ),
       field: "tags"
     )
-    assert_equal(["department", "boss"], tag_keys["fields"])
+    assert_same_elements(["department", "boss"], tag_keys["fields"])
 
     names = MANAGER_GRPC manager, :search_node_fields, Manager::FieldQuery.new(
       node_manager_id: "e69dc612-7e67-43f2-9b19-256afd385820",

--- a/components/compliance-service/api/tests/26_bulk_nodes_spec.rb
+++ b/components/compliance-service/api/tests/26_bulk_nodes_spec.rb
@@ -89,7 +89,7 @@ describe File.basename(__FILE__) do
     assert_equal("winrm", node_read.target_config.backend)
 
     second_node = actual_nodes['nodes'].find {|n| n.name == "my-ssh-node-127.0.0.1" }
-    assert_equal([Common::Kv.new( key:"test-node", value:"is-amazing" ), Common::Kv.new( key:"compliance-service", value:"rockin-like-whoa" )], second_node.tags)
+    assert_same_elements([Common::Kv.new( key:"test-node", value:"is-amazing" ), Common::Kv.new( key:"compliance-service", value:"rockin-like-whoa" )], second_node.tags)
     # read node to evaluate target config info
     node_read = MANAGER_GRPC nodes, :read, Nodes::Id.new(id: second_node.id)
     assert_equal(22, node_read.target_config.port)
@@ -97,7 +97,7 @@ describe File.basename(__FILE__) do
     assert_equal("ssh", node_read.target_config.backend)
 
     third_node = actual_nodes['nodes'].find {|n| n.name == "my-ssh-node-localhost" }
-    assert_equal([Common::Kv.new( key:"test-node", value:"is-amazing" ), Common::Kv.new( key:"compliance-service", value:"rockin-like-whoa" )], third_node.tags)
+    assert_same_elements([Common::Kv.new( key:"test-node", value:"is-amazing" ), Common::Kv.new( key:"compliance-service", value:"rockin-like-whoa" )], third_node.tags)
     # read node to evaluate target config info
     node_read = MANAGER_GRPC nodes, :read, Nodes::Id.new(id: third_node.id)
     assert_equal(22, node_read.target_config.port)

--- a/components/compliance-service/api/tests/run.rb
+++ b/components/compliance-service/api/tests/run.rb
@@ -16,6 +16,7 @@ require 'json'
 require 'pry'
 require 'grpc'
 require 'deepsort'
+require 'set'
 
 module VulcanoTest
 
@@ -109,6 +110,10 @@ module VulcanoTest
 
   def assert_equal_json_sorted(expected, actual)
     assert_equal JSON.parse(expected).deep_sort, JSON.parse(actual).deep_sort
+  end
+
+  def assert_same_elements(expected, actual)
+    assert_equal(expected.to_set, actual.to_set)
   end
 end
 

--- a/components/nodemanager-service/pgdb/nodes.go
+++ b/components/nodemanager-service/pgdb/nodes.go
@@ -57,9 +57,9 @@ SELECT
   COALESCE(n.source_id, '') AS source_id,
   COALESCE(n.source_region, '') AS source_region,
   COALESCE(n.source_account_id, '') AS source_account_id,
-  COALESCE(('[' || string_agg('{"key":"' || t.key || '"' || ',"value": "' || t.value || '"}', ',') || ']'), '[]') :: JSON AS tags,
+  COALESCE(('[' || string_agg(DISTINCT '{"key":"' || t.key || '"' || ',"value": "' || t.value || '"}', ',') || ']'), '[]') :: JSON AS tags,
   COALESCE(array_to_json(array_remove(array_agg(DISTINCT m.manager_id), NULL)), '[]') AS manager_ids,
-  COALESCE(array_to_json(array_remove(array_agg(p.project_id), NULL)), '[]') AS projects,
+  COALESCE(array_to_json(array_remove(array_agg(DISTINCT p.project_id), NULL)), '[]') AS projects,
   COUNT(*) OVER () AS total_count
 FROM nodes n
   LEFT JOIN nodes_tags nt ON n.id = nt.node_id


### PR DESCRIPTION
Fix for #2348.

As far as I can tell, this bug was caused by the [sql query that fetches nodes](https://github.com/chef/automate/blob/master/components/nodemanager-service/pgdb/nodes.go#L40-L76) doing multiple joins and aggregations at once. I initially solved this by changing the query to do each aggregation separately and joining against teh result, but some of the code we use for filtering depends on the query doing the joins how it is currently done, and redoing that did not seem like a great use of time.

Using `DISTINCT` like I did in this PR solves the immediate issue, but from what I've gathered this is sort of a big hammer that only papers over the original problem. Using `DISTINCT` like this has the following downsides:

* The query is bigger and more complicated than it needs to be. The sql is kind of straigtforward to read, but results in complicated behavior for postgres because it builds up a big data set before anything is done to whittle it down. In other words, if these tables were big this query might not work very well.
* There might be other behavior or side effects that are obscured. For example, for the aggregations this query does, grouping manager ids, project ids, and tags, unique values are desired, but it wouldn't be possible to add an aggregation where repeated values were the correct behavior.

