### PR TITLE
Retry all 5xx in diagnostics

### DIFF
--- a/components/automate-cli/pkg/diagnostics/context.go
+++ b/components/automate-cli/pkg/diagnostics/context.go
@@ -193,8 +193,8 @@ func (c *testContext) DoLBRequest(path string, opts ...lbrequest.Opts) (*http.Re
 			lastErr = err
 			continue
 		}
-		if resp.StatusCode == 503 {
-			lastErr = errors.Errorf("503 Service Unavailable: %s", path)
+		if resp.StatusCode >= 500 {
+			lastErr = errors.Errorf("Got 5xx. %d %s: %s", resp.StatusCode, resp.Status, path)
 			resp.Body.Close() // nolint: errcheck
 			continue
 		}


### PR DESCRIPTION
Some endpoints return various levels of 500 when they're not completely ready. These should all be retryable 