### PR TITLE
[automate-2861] Update authn service to teams v2 client

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -103,7 +103,6 @@ paths = [
   "components/authn-service/*",
   "api/config/platform/*",
   "api/config/shared/*",
-  "api/external/common/*",
   "api/interservice/authn/*",
   "api/interservice/authz/*",
   "api/interservice/cereal/*",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This PR switches the authn-service to use a teams V2 client instead of a teams V1 client.

### :chains: Related Resources
NA

### :+1: Definition of Done
Everything still works

### :athletic_shoe: How to Build and Test the Change

rebuild components/authn-service/

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
