### PR TITLE
fix project update progress percentage

### DIFF
--- a/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.spec.ts
+++ b/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.spec.ts
@@ -138,7 +138,7 @@ describe('ProcessProgressBarComponent', () => {
       component.projects.applyRulesStart(); // start the update
       store.dispatch(new GetApplyRulesStatusSuccess( // side effect of the update
         genState(ApplyRulesStatusState.Running)));
-      expect(component.percentageComplete).toEqual(0.5);
+      expect(component.percentageComplete).toEqual(50);
     });
   });
 

--- a/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.ts
+++ b/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.ts
@@ -38,7 +38,7 @@ export class ProcessProgressBarComponent implements OnInit {
         }
         this.applyRulesInProgress = state === ApplyRulesStatusState.Running;
         if (!this.cancelRulesInProgress && state === ApplyRulesStatusState.Running) {
-          this.percentageComplete = percentageComplete;
+          this.percentageComplete = Math.floor(percentageComplete * 100);
         }
         this.layoutFacade.layout.userNotifications.updatesProcessing = this.applyRulesInProgress;
         this.layoutFacade.updateDisplay();

--- a/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.ts
+++ b/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.ts
@@ -38,7 +38,7 @@ export class ProcessProgressBarComponent implements OnInit {
         }
         this.applyRulesInProgress = state === ApplyRulesStatusState.Running;
         if (!this.cancelRulesInProgress && state === ApplyRulesStatusState.Running) {
-          this.percentageComplete = Math.floor(percentageComplete * 100);
+          this.percentageComplete = Math.floor(percentageComplete);
         }
         this.layoutFacade.layout.userNotifications.updatesProcessing = this.applyRulesInProgress;
         this.layoutFacade.updateDisplay();

--- a/components/automate-ui/src/app/entities/projects/project.reducer.ts
+++ b/components/automate-ui/src/app/entities/projects/project.reducer.ts
@@ -126,7 +126,14 @@ export function projectEntityReducer(
       return set(UPDATE_STATUS, EntityStatus.loadingFailure, state);
 
     case ProjectActionTypes.GET_APPLY_RULES_STATUS_SUCCESS:
-      return set(APPLY_RULES_STATUS, mapKeys(key => camelCase(key), action.payload), state);
+      return set(
+        APPLY_RULES_STATUS,
+        mapKeys(key => camelCase(key),
+          {
+            ...action.payload,
+            percentage_complete: action.payload.percentage_complete * 100
+          }),
+        state);
 
     default:
       return state;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
We were displaying a fractional percentage, this fixes it.

### :+1: Definition of Done
The percentage format that is displayed in stop modal matches the one displayed in the banner.

### :athletic_shoe: How to Build and Test the Change
- `rebuild components/automate-ui-devproxy`
- load 500 nodes with either `chef_load_nodes 500` or `chef_load_compliance_nodes 500`
- create a project
- add an ingest rule to it, it doesnt matter the content of the ingest rule
- run a project update
    - note: if you only ever see 0% or 100% youll need to add more nodes

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
#### before
<img width="420" alt="incorrect-percentage" src="https://user-images.githubusercontent.com/5489125/74703616-9b589300-51c2-11ea-9785-18eb9af8abe8.png">

#### after
<img width="349" alt="correct-percentage" src="https://user-images.githubusercontent.com/5489125/74703477-26855900-51c2-11ea-868e-f476382974c5.png">
