### PR TITLE
[authz-service] update get_admin_token in README.md

### DIFF
--- a/components/authz-service/README.md
+++ b/components/authz-service/README.md
@@ -617,7 +617,7 @@ and access to all _administrative_ tasks to all users in the local admins group
 (`team:local:admins`).
 This allows you to explore the user interface immediately,
 unencumbered with policy roadblocks limiting what you can see.
-The set of default policies is described [here](../../components/automate-chef-io/content/docs/iam-v2-overview.md).
+The set of default policies is described in the [iam v2 overview](../../components/automate-chef-io/content/docs/iam-v2-overview.md).
 
 That set of default policies may even be fine for certain organizations.
 For others, it will be necessary to add and remove policies

--- a/components/authz-service/README.md
+++ b/components/authz-service/README.md
@@ -617,8 +617,7 @@ and access to all _administrative_ tasks to all users in the local admins group
 (`team:local:admins`).
 This allows you to explore the user interface immediately,
 unencumbered with policy roadblocks limiting what you can see.
-<!-- TODO: link is broken any reference? -->
-The set of default policies is [here](../../docs/default_policies.md).
+The set of default policies is described [here](../../components/automate-chef-io/content/docs/iam-v2-overview.md).
 
 That set of default policies may even be fine for certain organizations.
 For others, it will be necessary to add and remove policies

--- a/components/authz-service/README.md
+++ b/components/authz-service/README.md
@@ -643,9 +643,7 @@ To add a new default policy, the following is needed:
 
 ### Policy API
 
-<!-- TODO: Can we update it with Open API Doc? -->
-Documentation of the complete Policy API are available [here](TBD).
-**Link to the swagger docs, or should the content be inline here??**
+[Policy API Documentation](https://automate.chef.io/docs/api/#tag/policies)
 
 Managing policies is done via the command line.
 These setup steps will make the process as productive as possible for you.

--- a/components/authz-service/README.md
+++ b/components/authz-service/README.md
@@ -617,6 +617,7 @@ and access to all _administrative_ tasks to all users in the local admins group
 (`team:local:admins`).
 This allows you to explore the user interface immediately,
 unencumbered with policy roadblocks limiting what you can see.
+<!-- TODO: link is broken any reference? -->
 The set of default policies is [here](../../docs/default_policies.md).
 
 That set of default policies may even be fine for certain organizations.
@@ -643,6 +644,7 @@ To add a new default policy, the following is needed:
 
 ### Policy API
 
+<!-- TODO: Can we update it with Open API Doc? -->
 Documentation of the complete Policy API are available [here](TBD).
 **Link to the swagger docs, or should the content be inline here??**
 

--- a/components/authz-service/README.md
+++ b/components/authz-service/README.md
@@ -651,7 +651,7 @@ These setup steps will make the process as productive as possible for you.
 
 1. Install the `jq` JSON formatter to be able to get pretty-printed output (`brew install jq`).
 1. Install the `jo` JSON generator to be able to type JSON concisely (`brew install jo`).
-1. In habitat studio, generate a non-expiring token (`generate_supertoken`).
+1. In habitat studio, generate a non-expiring token (`get_admin_token`).
 1. Copy that token into the `TOK` value in the following snippet and
   then execute to define these shell variables:
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
`generate_supertoken` used earlier in order to generate admin token for dev env, which was replaced with `get_admin_token` but still we have documented in authz-service README.md need to updated.

### :chains: Related Resources
NA
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
NA
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable

Signed-off-by: Vivek Singh <vsingh@chef.io>