### PR TITLE
Add button for back to docs

### DIFF
--- a/components/automate-chef-io/layouts/_default/data-api.html
+++ b/components/automate-chef-io/layouts/_default/data-api.html
@@ -18,6 +18,18 @@
     </style>
   </head>
   <body>
+    <a style="
+          background: #EF9600;
+          display: block;
+          text-align: center;
+          width: 228px;
+          margin: 1rem 0 1.5rem 16px;
+          padding: 8px 0;
+          color: white;
+          text-decoration: none;
+          font-family: montserrat;
+          font-size: 14px;
+        " href='https://automate.chef.io/docs'>Return to Docs</a>
     <ReDoc spec-url="/api-docs/all-apis.swagger.json"></ReDoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"></script>
   </body>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The API docs are on an outside site and getting back to docs was a pretty bad experience. I added a "return to docs" button on the API page. 

There are limitations to styling the API pages. Even so, this button could be prettier. 

![Screen Shot 2020-02-18 at 1 04 53 PM](https://user-images.githubusercontent.com/16737484/74777879-49aa1a00-524f-11ea-8d6c-a1aa4afe9b50.png)


### :chains: Related Resources
https://github.com/chef/automate/pull/2890

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

Checkout this branch
Build the API docs by running the following all-in-one command from the top-level automate directory:

```
hab studio run "source .studiorc && compile_all_protobuf_components" && pushd components/automate-chef-io/ && make sync_swagger_files generate_swagger && make serve || popd
```
Review the API docs in your browser:

http://localhost:1313/docs/api

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

