### PR TITLE
[automate-2904] Remove state-clearing upon initiating "get all"

### DIFF
--- a/components/automate-ui/src/app/entities/api-tokens/api-token.reducer.ts
+++ b/components/automate-ui/src/app/entities/api-tokens/api-token.reducer.ts
@@ -45,13 +45,8 @@ export function apiTokenEntityReducer(
   switch (action.type) {
 
     case ApiTokenActionTypes.GET_ALL: {
-      return set(
-        STATUS,
-        EntityStatus.loading,
-        // clear token state to ensure we fetch the latest data
-        apiTokenEntityAdapter.removeAll(state)
-      ) as ApiTokenEntityState;
-    }
+      return set(STATUS, EntityStatus.loading, state);
+   }
 
     case ApiTokenActionTypes.GET_ALL_SUCCESS: {
       return set(

--- a/components/automate-ui/src/app/entities/orgs/org.reducer.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.reducer.ts
@@ -40,7 +40,7 @@ export function orgEntityReducer(
 
   switch (action.type) {
     case OrgActionTypes.GET_ALL:
-      return set(GET_ALL_STATUS, EntityStatus.loading, orgEntityAdapter.removeAll(state));
+      return set(GET_ALL_STATUS, EntityStatus.loading, state);
 
     case OrgActionTypes.GET_ALL_SUCCESS:
       return pipe(

--- a/components/automate-ui/src/app/entities/policies/policy.reducer.ts
+++ b/components/automate-ui/src/app/entities/policies/policy.reducer.ts
@@ -42,8 +42,7 @@ export function policyEntityReducer(state: PolicyEntityState = PolicyEntityIniti
       )(state) as PolicyEntityState;
 
     case PolicyActionTypes.GET_ALL:
-      return set('getAllStatus',
-        EntityStatus.loading, policyEntityAdapter.removeAll(state)) as PolicyEntityState;
+      return set('getAllStatus', EntityStatus.loading, state);
 
     case PolicyActionTypes.GET_ALL_SUCCESS:
     return set('getAllStatus', EntityStatus.loadingSuccess,

--- a/components/automate-ui/src/app/entities/projects/project.reducer.ts
+++ b/components/automate-ui/src/app/entities/projects/project.reducer.ts
@@ -65,7 +65,7 @@ export function projectEntityReducer(
 
   switch (action.type) {
     case ProjectActionTypes.GET_ALL:
-      return set(GET_ALL_STATUS, EntityStatus.loading, projectEntityAdapter.removeAll(state));
+      return set(GET_ALL_STATUS, EntityStatus.loading, state);
 
     case ProjectActionTypes.GET_ALL_SUCCESS:
       return set(GET_ALL_STATUS, EntityStatus.loadingSuccess,

--- a/components/automate-ui/src/app/entities/roles/role.reducer.ts
+++ b/components/automate-ui/src/app/entities/roles/role.reducer.ts
@@ -24,7 +24,7 @@ export function roleEntityReducer(state: RoleEntityState = RoleEntityInitialStat
 
   switch (action.type) {
     case RoleActionTypes.GET_ALL:
-      return set('getAllStatus', EntityStatus.loading, roleEntityAdapter.removeAll(state));
+      return set('getAllStatus', EntityStatus.loading, state);
 
     case RoleActionTypes.GET_ALL_SUCCESS:
       return set('getAllStatus', EntityStatus.loadingSuccess,

--- a/components/automate-ui/src/app/entities/rules/rule.reducer.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.reducer.ts
@@ -89,7 +89,7 @@ export function ruleEntityReducer(
 
   switch (action.type) {
     case RuleActionTypes.GET_ALL:
-      return set(GET_ALL_STATUS, EntityStatus.loading, ruleEntityAdapter.removeAll(state));
+      return set(GET_ALL_STATUS, EntityStatus.loading, state);
 
     case RuleActionTypes.GET_ALL_SUCCESS:
       return pipe(

--- a/components/automate-ui/src/app/entities/servers/server.reducer.ts
+++ b/components/automate-ui/src/app/entities/servers/server.reducer.ts
@@ -40,11 +40,7 @@ export function serverEntityReducer(
   switch (action.type) {
 
     case ServerActionTypes.GET_ALL: {
-      return set(
-        GET_ALL_STATUS,
-        EntityStatus.loading,
-        serverEntityAdapter.removeAll(state)
-      ) as ServerEntityState;
+      return set(GET_ALL_STATUS, EntityStatus.loading, state);
     }
 
     case ServerActionTypes.GET_ALL_SUCCESS: {

--- a/components/automate-ui/src/app/entities/teams/team.reducer.ts
+++ b/components/automate-ui/src/app/entities/teams/team.reducer.ts
@@ -42,12 +42,7 @@ export function teamEntityReducer(state: TeamEntityState = TeamEntityInitialStat
   switch (action.type) {
 
     case TeamActionTypes.GET_ALL: {
-      return set(
-        'getAllStatus',
-        EntityStatus.loading,
-        // clear team state to ensure we fetch the latest data
-        teamEntityAdapter.removeAll(state)
-      ) as TeamEntityState;
+      return set('getAllStatus', EntityStatus.loading, state);
     }
 
     case TeamActionTypes.GET_ALL_SUCCESS: {

--- a/components/automate-ui/src/app/entities/users/user.reducer.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.ts
@@ -30,12 +30,7 @@ export function userEntityReducer(state: UserEntityState = UserEntityInitialStat
   switch (action.type) {
 
     case UserActionTypes.GET_ALL:
-      return set(
-        'getStatus',
-        EntityStatus.loading,
-        // clear user state to ensure we fetch the latest data
-        userEntityAdapter.removeAll(state)
-      ) as UserEntityState;
+      return set('getStatus', EntityStatus.loading, state);
 
     case UserActionTypes.GET_ALL_SUCCESS:
       return set('getStatus', EntityStatus.loadingSuccess,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Closely tied to #2703, during that project update--if you were on the projects list page, notice that the background behind the spinner shows there are no projects.

(Weird! Unable to load the image here.)

That is due to the list of projects being erased at the start of the project fetch that is coincident with a Project Update.

That list should not have actually been erased--we may have been a bit over-eager in state clearing in a couple
earlier PRs, notably https://github.com/chef/automate/pull/2158.
I think it still makes sense for individual "get" calls to do some state clearning,
but "get all" does not need it; when the result is returned and
added to the state with an `addAll` call, that completely replaces
the section of state at hand.

Reference: https://ngrx.io/guide/entity/adapter#adapter-collection-methods

Technically, there is only one page affected--the projects list, because a `GetAllProjects` is done with a Project Update. Which means only the project reducer needs to be fixed. However, if it is a legitimate fix for that file, then it should be done across the board (as I have done), to keep consistent in what we consider best practices.

### :chains: Related Resources
See above

### :+1: Definition of Done
Project list remains behind the spinner during project update

### :athletic_shoe: How to Build and Test the Change

rebuild automate-ui
create some projects and rules that need updated
(not sure if it is technically needed, but issue seems to occur more when there are nodes in the system, e.g. `chef_load_nodes 1000` in hab studio).
Set your brower to a slow connection ("Slow 3G"), then start a project update.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).