### PR TITLE
adding more sign in details to dev docs

### DIFF
--- a/dev-docs/ui-development.md
+++ b/dev-docs/ui-development.md
@@ -68,10 +68,13 @@ instead of using the `start_automate_ui_background` helper method._
 
 1. Run `npm run serve:hab` to start up the webserver.
 
-1. Open <https://a2-dev.test/> in your browser. Log in with an email and password of `admin`
-   and `chefautomate`, respectively. If you have issues with login, please clear all site data (local
+1. Open <https://a2-dev.test/> in your browser. If you have issues with sign in, please clear all site data (local
    and session storage and cookies) for `https://a2-dev.test` and re-navigate back to the root of
    <https://a2-dev.test/>.
+    - Sign in as `admin`, `viewer`, or `editor` all with the same password of `chefautomate`.
+      - `admin` gives access to everything.
+      - `editor` is what most users expereince which gives them access to everything except for `Node Credentials`, `Notifications`, Identity pages, Roles, and Policies.
+      - `viewer` gives access to the same pages as `editor`, but users cannot take any action.
 
 1. Optional step: Turn on client-side feature flags by typing the letter sequence on any page in the UI. After toggling a feature flag, a browser refresh is required.
     * Type `beta` to open the beta features modal


### PR DESCRIPTION
## Overview
Today in ui team meeting it was mentioned that this wasn't documented yet, so adding details around signing in as a `editor` or `viewer`.