### PR TITLE
[Automate-2889] Suppress pending banner if progress banner active

### DIFF
--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.html
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.html
@@ -1,4 +1,4 @@
-<div id="pending-edits-bar" [hidden]="!layoutFacade.layout.userNotifications.pendingEdits">
+<div id="pending-edits-bar" [hidden]="hideBar">
   <span class="info">Project edits pending, update <a [routerLink]="['/settings/projects']">projects</a> to apply changes.</span>
   <app-authorized [allOf]="['/iam/v2/apply-rules', 'post']">
     <button mat-button (click)="openConfirmUpdateStartModal()">Update Projects</button>

--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.html
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.html
@@ -1,4 +1,4 @@
-<div id="pending-edits-bar" [hidden]="hideBar">
+<div id="pending-edits-bar" [hidden]="isBarHidden">
   <span class="info">Project edits pending, update <a [routerLink]="['/settings/projects']">projects</a> to apply changes.</span>
   <app-authorized [allOf]="['/iam/v2/apply-rules', 'post']">
     <button mat-button (click)="openConfirmUpdateStartModal()">Update Projects</button>

--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.spec.ts
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.spec.ts
@@ -137,7 +137,7 @@ describe('PendingEditsBarComponent', () => {
       const uneditedProject2 = genProject('uuid-112', 'RULES_APPLIED');
       store.dispatch(new GetProjectsSuccess({ projects: [uneditedProject1, uneditedProject2] }));
       component.updateDisplay();
-      expect(component.layoutFacade.layout.userNotifications.pendingEdits).toEqual(false);
+      expect(component.hideBar).toEqual(true);
     });
 
     it('is visible if some project has changes', () => {
@@ -145,7 +145,18 @@ describe('PendingEditsBarComponent', () => {
       const uneditedProject = genProject('uuid-111', 'RULES_APPLIED');
       store.dispatch(new GetProjectsSuccess({ projects: [uneditedProject, editedProject] }));
       component.updateDisplay();
-      expect(component.layoutFacade.layout.userNotifications.pendingEdits).toEqual(true);
+      expect(component.hideBar).toEqual(false);
+    });
+
+    it('is visible if some project has changes... UNLESS progress bar is active', () => {
+      const editedProject = genProject('uuid-99', 'EDITS_PENDING');
+      const uneditedProject = genProject('uuid-111', 'RULES_APPLIED');
+      store.dispatch(new GetProjectsSuccess({ projects: [uneditedProject, editedProject] }));
+      component.updateDisplay();
+
+      component.layoutFacade.layout.userNotifications.updatesProcessing = true;
+
+      expect(component.hideBar).toEqual(true);
     });
 
     it('is visible if rules are not being applied', () => {
@@ -157,7 +168,7 @@ describe('PendingEditsBarComponent', () => {
       store.dispatch(new GetApplyRulesStatusSuccess( // update finished
           genState(ApplyRulesStatusState.NotRunning)));
       component.updateDisplay();
-      expect(component.layoutFacade.layout.userNotifications.pendingEdits).toEqual(true);
+      expect(component.hideBar).toEqual(false);
     });
 
     it('is visible if update fails', () => {
@@ -167,7 +178,7 @@ describe('PendingEditsBarComponent', () => {
       store.dispatch(new GetApplyRulesStatusSuccess(
         genState(ApplyRulesStatusState.NotRunning, true, false)));
       component.updateDisplay();
-      expect(component.layoutFacade.layout.userNotifications.pendingEdits).toEqual(true);
+      expect(component.hideBar).toEqual(false);
     });
 
     it('is visible if update is cancelled', () => {
@@ -177,7 +188,7 @@ describe('PendingEditsBarComponent', () => {
       store.dispatch(new GetApplyRulesStatusSuccess(
         genState(ApplyRulesStatusState.NotRunning, false, true)));
       component.updateDisplay();
-      expect(component.layoutFacade.layout.userNotifications.pendingEdits).toEqual(true);
+      expect(component.hideBar).toEqual(false);
     });
 
     it('is displayed if update is cancelled but update is still running', () => {
@@ -187,7 +198,7 @@ describe('PendingEditsBarComponent', () => {
       store.dispatch(new GetApplyRulesStatusSuccess(
         genState(ApplyRulesStatusState.Running, false, true)));
       component.updateDisplay();
-      expect(component.layoutFacade.layout.userNotifications.pendingEdits).toEqual(true);
+      expect(component.hideBar).toEqual(false);
     });
   });
 

--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.spec.ts
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.spec.ts
@@ -137,7 +137,7 @@ describe('PendingEditsBarComponent', () => {
       const uneditedProject2 = genProject('uuid-112', 'RULES_APPLIED');
       store.dispatch(new GetProjectsSuccess({ projects: [uneditedProject1, uneditedProject2] }));
       component.updateDisplay();
-      expect(component.hideBar).toEqual(true);
+      expect(component.isBarHidden).toEqual(true);
     });
 
     it('is visible if some project has changes', () => {
@@ -145,7 +145,7 @@ describe('PendingEditsBarComponent', () => {
       const uneditedProject = genProject('uuid-111', 'RULES_APPLIED');
       store.dispatch(new GetProjectsSuccess({ projects: [uneditedProject, editedProject] }));
       component.updateDisplay();
-      expect(component.hideBar).toEqual(false);
+      expect(component.isBarHidden).toEqual(false);
     });
 
     it('is visible if some project has changes... UNLESS progress bar is active', () => {
@@ -156,7 +156,7 @@ describe('PendingEditsBarComponent', () => {
 
       component.layoutFacade.layout.userNotifications.updatesProcessing = true;
 
-      expect(component.hideBar).toEqual(true);
+      expect(component.isBarHidden).toEqual(true);
     });
 
     it('is visible if rules are not being applied', () => {
@@ -168,7 +168,7 @@ describe('PendingEditsBarComponent', () => {
       store.dispatch(new GetApplyRulesStatusSuccess( // update finished
           genState(ApplyRulesStatusState.NotRunning)));
       component.updateDisplay();
-      expect(component.hideBar).toEqual(false);
+      expect(component.isBarHidden).toEqual(false);
     });
 
     it('is visible if update fails', () => {
@@ -178,7 +178,7 @@ describe('PendingEditsBarComponent', () => {
       store.dispatch(new GetApplyRulesStatusSuccess(
         genState(ApplyRulesStatusState.NotRunning, true, false)));
       component.updateDisplay();
-      expect(component.hideBar).toEqual(false);
+      expect(component.isBarHidden).toEqual(false);
     });
 
     it('is visible if update is cancelled', () => {
@@ -188,7 +188,7 @@ describe('PendingEditsBarComponent', () => {
       store.dispatch(new GetApplyRulesStatusSuccess(
         genState(ApplyRulesStatusState.NotRunning, false, true)));
       component.updateDisplay();
-      expect(component.hideBar).toEqual(false);
+      expect(component.isBarHidden).toEqual(false);
     });
 
     it('is displayed if update is cancelled but update is still running', () => {
@@ -198,7 +198,7 @@ describe('PendingEditsBarComponent', () => {
       store.dispatch(new GetApplyRulesStatusSuccess(
         genState(ApplyRulesStatusState.Running, false, true)));
       component.updateDisplay();
-      expect(component.hideBar).toEqual(false);
+      expect(component.isBarHidden).toEqual(false);
     });
   });
 

--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.ts
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.ts
@@ -85,7 +85,7 @@ export class PendingEditsBarComponent implements OnDestroy {
     this.closeConfirmApplyStartModal();
   }
 
-  get hideBar() {
+  get isBarHidden() {
     return !this.layoutFacade.layout.userNotifications.pendingEdits
       || this.layoutFacade.layout.userNotifications.updatesProcessing;
   }

--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.ts
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.ts
@@ -84,4 +84,9 @@ export class PendingEditsBarComponent implements OnDestroy {
   public cancelApplyStart(): void {
     this.closeConfirmApplyStartModal();
   }
+
+  get hideBar() {
+    return !this.layoutFacade.layout.userNotifications.pendingEdits
+      || this.layoutFacade.layout.userNotifications.updatesProcessing;
+  }
 }

--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -82,13 +82,13 @@ export class LayoutFacadeService implements OnInit, OnDestroy {
     if (this.layout.header.license) {
       combinedHeights += Height.License;
     }
-    if (this.layout.userNotifications.pendingEdits) {
-      combinedHeights += Height.PendingEditsBar;
-    }
+    // order matters for these two: pending is suppressed if processing
     if (this.layout.userNotifications.updatesProcessing) {
       combinedHeights += Height.ProcessProgressBar;
+    } else if (this.layout.userNotifications.pendingEdits) {
+      combinedHeights += Height.PendingEditsBar;
     }
-    this.contentHeight = `calc(100vh - ${combinedHeights}px)`;
+   this.contentHeight = `calc(100vh - ${combinedHeights}px)`;
   }
 
   hasGlobalNotifications(): boolean {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Images are still broken in github (along with some other github issues): This is a picture showing both the pending edits bar and the project update progress bar. It should only ever show one, so when the project update progress bar is present the pending edits bar should not be.

<img width="969" alt="image" src="https://user-images.githubusercontent.com/6817500/74801579-f0141080-528b-11ea-9ef2-d5fe6305be0f.png">

### :chains: Related Resources
NA

### :+1: Definition of Done
When there are pending edits, the pending edits bar will appear.
An admin or other designated user will then at some point begin a project update,
causing the project update progress bar to appear and the pending edits bar to disappear.
While that is running, users are free to make further project changes that will be pending for the next cycle.
However, while the project update progress bar is active, the pending edits bar will stay hidden.
As soon as the project update completes, the pending edits bar will appear.
(If no further edits were made, of course, the pending edits bar will not appear.)

### :athletic_shoe: How to Build and Test the Change

rebuild automate-ui

#### Case 1
1. create some projects and some rules.
2. ➡️ observe the pending edits bar.
3. begin a project update from the pending edits bar ("update projects").
4. ➡️ pending edits bar disappears at the same time progress bar appears--they do not appear together.
5. ➡️ sometime later update completes and progress bar disappears.

#### Case 2
1. create some projects and some rules.
2. ➡️ observe the pending edits bar.
3. begin a project update from the pending edits bar ("update projects").
4. ➡️ pending edits bar disappears; progress bar appears.
5. while update is in progress, edit a rule (same or different user, same or different rule).
6. ➡️ observe no banner changes; progress bar remains displayed; pending edits bar remains hidden.
7. ➡️ sometime later update completes: progress bar disappears at the same time pending edits bar appears--they do not appear together.

#### Case 3
1. create some projects and some rules.
2. ➡️ observe the pending edits bar.
3. begin a project update from the pending edits bar ("update projects")
4. ➡️ pending edits bar disappears at the same time progress bar appears--they do not appear together.
5. stop the project update.
6. ➡️ shortly the progress bar disappears at the same time the pending edits bar appears--they do not appear together.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
