### PR TITLE
studio: fail immediately if mockgen fails

### DIFF
--- a/.studio/common
+++ b/.studio/common
@@ -78,28 +78,32 @@ function compile_go_protobuf_component() {
 # Adding auto tab complete
 complete -F _component_auto_complete compile_go_protobuf_component
 
+function mockgen_debug() {
+    echo "mockgen $*"
+    mockgen "$@"
+}
 
 function compile_client_mocks() {
   install_gomock
   (
-    cd "/src/api/interservice" || exit 1
-    mockgen -source event/event.pb.go -destination event/event.pb.client_mock.go -package event -self_package github.com/chef/automate/api/interservice/event
-    mockgen -source authz/v2/project.pb.go -destination authz/v2/project.pb.client_mock.go -package v2 -self_package github.com/chef/automate/api/interservice/authz/v2
-    mockgen -source authz/authz.pb.go -destination authz/authz.pb.client_mock.go -package authz -self_package github.com/chef/automate/api/interservice/authz
-    mockgen -source authn/authenticate.pb.go -destination authn/authenticate.pb.client_mock.go -package authn -self_package github.com/chef/automate/api/interservice/authn
+    set -e
+    cd "/src/api/interservice"
+    mockgen_debug -source event/event.pb.go -destination event/event.pb.client_mock.go -package event -self_package github.com/chef/automate/api/interservice/event
+    mockgen_debug -source authz/v2/project.pb.go -destination authz/v2/project.pb.client_mock.go -package v2 -self_package github.com/chef/automate/api/interservice/authz/v2
+    mockgen_debug -source authz/authz.pb.go -destination authz/authz.pb.client_mock.go -package authz -self_package github.com/chef/automate/api/interservice/authz
+    mockgen_debug -source authn/authenticate.pb.go -destination authn/authenticate.pb.client_mock.go -package authn -self_package github.com/chef/automate/api/interservice/authn
     # NOTE(ssd) 2020-02-17: Use "reflect-mode" for cfgmgmt because of
     # an issue with source-mode's ability to parse interfaces from the
     # grpc package. Details here:
     #
     # https://github.com/golang/mock/issues/156#issuecomment-586213812
     #
-    mockgen -destination cfgmgmt/service/cfgmgmt.pb.client_mock.go -package service -self_package github.com/chef/automate/api/interservice/cfgmgmt/service github.com/chef/automate/api/interservice/cfgmgmt/service CfgMgmtClient,CfgMgmt_NodeExportClient,CfgMgmt_ReportExportClient,CfgMgmtServer,CfgMgmt_NodeExportServer,CfgMgmt_ReportExportServer
-    mockgen -source ingest/chef.pb.go -destination ingest/chef.pb.client_mock.go -package ingest -self_package github.com/chef/automate/api/interservice/ingest
-    mockgen -source event_feed/event_feed.pb.go -destination event_feed/event_feed.pb.client_mock.go -package event_feed -self_package github.com/chef/automate/api/interservice/event_feed
-    mockgen -source nodemanager/manager/manager.pb.go -destination nodemanager/manager/manager.pb.client_mock.go -package manager -self_package github.com/chef/automate/api/interservice/nodemanager/manager
+    mockgen_debug -destination cfgmgmt/service/cfgmgmt.pb.client_mock.go -package service -self_package github.com/chef/automate/api/interservice/cfgmgmt/service github.com/chef/automate/api/interservice/cfgmgmt/service CfgMgmtClient,CfgMgmt_NodeExportClient,CfgMgmt_ReportExportClient,CfgMgmtServer,CfgMgmt_NodeExportServer,CfgMgmt_ReportExportServer
+    mockgen_debug -source ingest/chef.pb.go -destination ingest/chef.pb.client_mock.go -package ingest -self_package github.com/chef/automate/api/interservice/ingest
+    mockgen_debug -source event_feed/event_feed.pb.go -destination event_feed/event_feed.pb.client_mock.go -package event_feed -self_package github.com/chef/automate/api/interservice/event_feed
+    mockgen_debug -source nodemanager/manager/manager.pb.go -destination nodemanager/manager/manager.pb.client_mock.go -package manager -self_package github.com/chef/automate/api/interservice/nodemanager/manager
   )
 }
-
 
 document "compile_all_protobuf_components" <<DOC
   Compile every protobuf file for every component in A2.


### PR DESCRIPTION
Occasionally we hit problems with mockgen either caused by an outdated
mockgen binary in the go binary cache or other problems. Often, these
problems are made more confusing by the fact that the failure does not
halt the generation process.

Signed-off-by: Steven Danna <steve@chef.io>