### PR TITLE
studio: use vendor-state specific directory for GOBIN

### DIFF
--- a/.studio/deployment-service
+++ b/.studio/deployment-service
@@ -91,9 +91,9 @@ document "upgrade_from_v1_self_test" <<DOC
 DOC
 function upgrade_from_v1_self_test {
   # Ensure that self-test mode shims are compiled and in the path
-  [[ -f /src/bin/pg_dump ]] || go_build_pkg components/automate-deployment/cmd/pg_dump
-  [[ -f /src/bin/automate-ctl ]] || go_build_pkg components/automate-deployment/cmd/automate-ctl
-  [[ -f /src/bin/chef-server-ctl ]] || go_build_pkg components/automate-deployment/cmd/chef-server-ctl
+  [[ -f "$GOBIN/pg_dump" ]] || go_build_pkg components/automate-deployment/cmd/pg_dump
+  [[ -f "$GOBIN/automate-ctl" ]] || go_build_pkg components/automate-deployment/cmd/automate-ctl
+  [[ -f "$GOBIN/chef-server-ctl" ]] || go_build_pkg components/automate-deployment/cmd/chef-server-ctl
 
   local failure_code=$FAILURE
   if [ -n "$1" ]; then
@@ -107,7 +107,7 @@ function upgrade_from_v1_self_test {
 
   install_chef_automate_cli
 
-  PATH=/src/bin:$PATH CHEF_AUTOMATE_SKIP_SYSTEMD=true FAILURE=$failure_code \
+  PATH=$GOBIN:$PATH CHEF_AUTOMATE_SKIP_SYSTEMD=true FAILURE=$failure_code \
     chef-automate upgrade-from-v1 /src/dev/config.toml \
       --hartifacts /src/results \
       --override-origin "$HAB_ORIGIN" \

--- a/.studio/golang
+++ b/.studio/golang
@@ -113,7 +113,7 @@ complete -F _component_auto_complete go_build_component
 document "reload_component_binary" <<DOC
   Reloads the component binary from the '/src' directory. (Build a binary with 'go_build')
 
-  This helper will force load a binary located at '/src/bin/\$component' into your already installed
+  This helper will force load a binary located at '$GOBIN/\$component' into your already installed
   habitat package. If no package have been installed, it will try to install one.
 DOC
 function reload_component_binary() {
@@ -131,16 +131,16 @@ function reload_component_binary() {
     fi
   fi
 
-  [ ! -f /src/bin/${component} ] && go_build_component $component
+  [ ! -f "$GOBIN/${component}" ] && go_build_component "$component"
 
   # TODO: (@afiune) This is a bit too extreme but what we are trying to avoid is to
   # be polling to the depot for newer packages, since we disable that functionality
   # we have to force load the binary like this. Maybe I'll revisit this latter.
   log_line " Reloading $component binary"
   # we need to unlink the old one so that the new one my be updated and then relinked
-  unlink ${component_path}/bin/${component}
-  kill_running_service $component
-  cp /src/bin/${component} ${component_path}/bin/${component}
+  unlink "${component_path}/bin/${component}"
+  kill_running_service "$component"
+  cp "$GOBIN/${component}" "${component_path}/bin/${component}"
   if [[ $? != 0 ]]; then
     error "There was a problem trying to reload the $component binary."
     error "Run 'go_build_component $component' and try again."

--- a/.studio/tooling
+++ b/.studio/tooling
@@ -147,4 +147,5 @@ function revendor() {
   pushd /src || return 1
     make revendor
   popd || return 1
+  setup_gobin
 }

--- a/.studiorc
+++ b/.studiorc
@@ -53,10 +53,19 @@ export CGO_ENABLED=0
 export GO111MODULE=on
 
 # Specify where to put 'go installed' binaries
-export GOBIN=/src/bin
+setup_gobin() {
+    local vendor_hash
+    vendor_hash=$(sha256sum /src/vendor/modules.txt | cut -c1-16)
+    export GOBIN_BASE="/src/bin"
+    GOBIN="${GOBIN_BASE}/${vendor_hash}"
+    export GOBIN
+    mkdir -p "$GOBIN"
+}
+
+setup_gobin
 
 # Make 'go installed' binaries available in the PATH
-export PATH=$PATH:/src/bin
+export PATH=$PATH:$GOBIN
 
 # Enable vendor mode by default
 export GOFLAGS=-mod=vendor
@@ -126,8 +135,11 @@ GETTING_STARTED
 # Memory check. Because we all always forget to change the docker preferences
 # when we re-install it
 total_memory_kb=$(grep MemTotal /proc/meminfo | grep -o -E '[[:digit:]]+')
-# 8 gigs == 8164340kb, subtract a few kb so we can just do a less than comp
-if (( total_memory_kb < 8164000 )); then
+# 8 gigs == 8164340kb, subtract a few MB so we can just do a less than
+# comp and to account for the fact that MemTotal is the physical ram
+# reported by the BIOS less the kernel binary code and some other
+# reserved regions.
+if (( total_memory_kb < 8000000 )); then
   warn "!!!"
   warn "This system has less than 8Gb of RAM. You will not be able to run a full Automate deployment."
   warn "!!!"
@@ -221,6 +233,18 @@ prepare_system() {
 }
 
 prepare_system
+
+log_old_bindirs() {
+  readarray -t old_bindirs < <(find "$GOBIN_BASE" -maxdepth 1 -mindepth 1 -type d -not -path "$GOBIN")
+  if [ ${#old_bindirs[@]} -gt 0 ]; then
+    warn "The following bin directories are out-dated and can be cleaned up:"
+    for old_dir in "${old_bindirs[@]}"; do
+      warn "  $old_dir"
+    done
+  fi
+}
+
+log_old_bindirs
 
 # Saves the in memory bash history to a file
 save_history() {


### PR DESCRIPTION
The binaries we build and put in /src/bin are typically dependent on
the state of our vendored modules. This sets up GOBIN to be based on
the hash of `vendor/modules.txt` to help ensure we don't see errors
caused by old binaries.

We don't clean up the old bin directories by default, but we do warn
devs as they enter the studio.

Signed-off-by: Steven Danna <steve@chef.io>