### PR TITLE
Streamline notifications (cosmetic)

### DIFF
--- a/components/automate-ui/src/app/components/notifications/notifications.component.html
+++ b/components/automate-ui/src/app/components/notifications/notifications.component.html
@@ -1,14 +1,7 @@
 <div class="notifications">
   <ng-container *ngFor="let notification of notifications">
-    <chef-notification *ngIf="notification.type === 'error'"
-      [type]="notification.type === 'license' ? 'error' : notification.type"
-      [timeout]="notification.timeout" (dismissed)="handleNotificationDismissal(notification.id)">
-      {{ notification.message }}
-    </chef-notification>
-  </ng-container>
-  <ng-container *ngFor="let notification of notifications">
-    <chef-notification *ngIf="notification.type === 'info'"
-      [type]="notification.type === 'license' ? 'error' : notification.type"
+    <chef-notification *ngIf="notification.type !== 'license'"
+      [type]="notification.type"
       [timeout]="notification.timeout" (dismissed)="handleNotificationDismissal(notification.id)">
       {{ notification.message }}
     </chef-notification>

--- a/components/automate-ui/src/app/entities/notifications/notification.model.ts
+++ b/components/automate-ui/src/app/entities/notifications/notification.model.ts
@@ -1,9 +1,6 @@
 export enum Type {
   error = 'error',
   info = 'info',
-  /* TODO (tc) This is a stopgap because product decided it was
-     too risky to ship the full experience of a license banner.
-     This code will be removed first thing after ChefConf. */
   license = 'license'
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Noticed some redundancy while investigating a related issue.

### :chains: Related Resources

### :+1: Definition of Done
Info and error notifications still work the same way (directly affected by this change).
License notifications still work the same way (not affected by this change)

### :athletic_shoe: How to Build and Test the Change

Logged in as admin, create a new user, e.g.. "bob".
Upon successful creation you should see a "created user" message lasting for 8 seconds.
<img width="1014" alt="image" src="https://user-images.githubusercontent.com/6817500/74857091-0788e300-52f8-11ea-9875-3b74175aa2cd.png">

Logout and login as "bob".
Attempt to visit the policies page via URL (https://a2-dev.test/settings/policies). You should see an error lasting for 30 seconds:
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/6817500/74857299-533b8c80-52f8-11ea-8866-e0f685713846.png">

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
