### PR TITLE
Chef Manage A2 SAML auth caveat

### DIFF
--- a/components/automate-chef-io/content/docs/migrate.md
+++ b/components/automate-chef-io/content/docs/migrate.md
@@ -113,7 +113,7 @@ If you rely on any of the capabilities listed below, we recommend you continue t
 Chef continues support of Chef Automate 1 while we develop upgrade paths for these capabilities on the new platform.
 For more information, please contact your Chef account representative.
 
-* **Chef Manage:** Chef Automate 2, unlike Automate 1 cannot serve as a SAML auth proxy
+* **Chef Manage:** Chef Automate 2, unlike Automate 1, cannot serve as a SAML auth proxy
 * **FIPS:** Chef Automate 2 cannot currently operate in FIPS mode
 * **Disaster Recovery:** Chef Automate 2 cannot currently operate in a primary/standby mode
 * **Custom Kibana dashboards:** Chef Automate 2 does not include Kibana in its technology stack

--- a/components/automate-chef-io/content/docs/migrate.md
+++ b/components/automate-chef-io/content/docs/migrate.md
@@ -113,6 +113,7 @@ If you rely on any of the capabilities listed below, we recommend you continue t
 Chef continues support of Chef Automate 1 while we develop upgrade paths for these capabilities on the new platform.
 For more information, please contact your Chef account representative.
 
+* **Chef Manage:** Chef Automate 2, unlike Automate 1 cannot serve as a SAML auth proxy
 * **FIPS:** Chef Automate 2 cannot currently operate in FIPS mode
 * **Disaster Recovery:** Chef Automate 2 cannot currently operate in a primary/standby mode
 * **Custom Kibana dashboards:** Chef Automate 2 does not include Kibana in its technology stack


### PR DESCRIPTION
Note that A2 cannot function as an A2 SAML proxy for Chef Manage

Signed-off-by: Sean Horn <sean_horn@chef.io>

### :white_check_mark: Checklist

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [X] Docs added/updated?
- [X] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).