### PR TITLE
Remove bintray from preflight checks

### DIFF
--- a/components/automate-deployment/pkg/a1upgrade/a1upgrade_compat.go
+++ b/components/automate-deployment/pkg/a1upgrade/a1upgrade_compat.go
@@ -89,8 +89,7 @@ const proxyEnabledMsg = `
          # Uncomment the following lines and set the parameters as necessary.
          # user = "<your proxy user>"
          # password = "<your proxy password>"
-         # no_proxy = ["whitelist", "should", "include", "packages.chef.io","raw.githubusercontent.com",
-                       "api.bintray.com","bldr.habitat.sh","akamai.bintray.com","dl.bintray.com","bintray.com"]
+         # no_proxy = ["whitelist", "should", "include", "packages.chef.io","raw.githubusercontent.com", "bldr.habitat.sh"]
 `
 
 const disasterRecoveryEnabledMsg = `

--- a/components/automate-deployment/pkg/preflight/checks.go
+++ b/components/automate-deployment/pkg/preflight/checks.go
@@ -341,12 +341,8 @@ func DefaultSysctlCheck() Check {
 var externalURLs = []string{
 	"https://licensing.chef.io/status",
 	"https://bldr.habitat.sh",
-	"https://api.bintray.com",
 	"https://raw.githubusercontent.com",
 	"https://packages.chef.io",
-	"https://akamai.bintray.com",
-	"https://dl.bintray.com",
-	"https://bintray.com",
 	"https://github.com",
 	"https://downloads.chef.io",
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

habitat is now fetched from packages.chef.io in most cases

Testing for bintray now exposes us to false positives in the preflight checker.
