### PR TITLE
add retention to make searching the docs easier

### DIFF
--- a/components/automate-chef-io/content/docs/data-lifecycle.md
+++ b/components/automate-chef-io/content/docs/data-lifecycle.md
@@ -13,6 +13,7 @@ toc = true
 
 # Overview
 
+Data Lifecycle manages the retention of events, service groups, Chef Client runs, compliance reports and scans in Chef Automate.
 Chef Automate stores data from the `ingest-service`, `event-feed-service`,
 `compliance-service` and `applications-service` in ElasticSearch or PostgreSQL.
 Over time users may wish to prune data from Chef Automate by creating data

--- a/components/automate-chef-io/content/docs/node-lifecycle.md
+++ b/components/automate-chef-io/content/docs/node-lifecycle.md
@@ -14,7 +14,7 @@ toc = true
 
 ## Overview
 
-From the **Settings** tab, navigate to the _Node Lifecycle_ page in the sidebar.
+Node Lifecycle manages the retention of Chef Client runs in Chef Automate. From the **Settings** tab, navigate to the _Node Lifecycle_ page in the sidebar.
 
 ### Missing Nodes
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Today in the feedback session @teknofire mentioned that he had some customers struggle to find the retention related documentation using search. This attempts to add the word `retention` to both related docs pages so they are easier to find.

### :athletic_shoe: How to Build and Test the Change
`make serve` from `components/automate-chef-io`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
