### PR TITLE
Fetch ReDoc js file when building hab package rather than rely on CDN.

### DIFF
--- a/components/automate-chef-io/.gitignore
+++ b/components/automate-chef-io/.gitignore
@@ -8,3 +8,4 @@ package.json
 public/
 themes/
 static/api-docs
+static/redoc.standalone.js

--- a/components/automate-chef-io/Makefile
+++ b/components/automate-chef-io/Makefile
@@ -6,10 +6,14 @@ SWAGGER_DIR=data/docs/api_chef_automate
 SWAGGER_FILES=$(shell find $(SWAGGER_DIR) -name '*.swagger.json')
 STATIC_SWAGGER_FILES=$(shell find data/docs/api-static/ -type f | sort -n)
 
+REDOC_FILE=static/redoc.standalone.js
+REDOC_VERSION=2.0.0-rc.23
+
 themes/chef:
 	scripts/clone_hugo.sh
 
 clean:
+	rm -f $(REDOC_FILE)
 	rm -f $(SWAGGER_RESULT_FILE)
 	rm -rf themes/
 	rm -rf public/
@@ -44,13 +48,13 @@ generate_swagger: $(SWAGGER_RESULT_FILE)
 		jq -es 'if . == [] then null else .[] | .paths = (.paths | with_entries( select( all( .value[].tags[]; . != "hidden") ) ) ) end' \
 		> $(SWAGGER_RESULT_FILE)
 
-serve: sync generate_swagger
+serve: sync generate_swagger $(REDOC_FILE)
 	hugo server --buildDrafts --noHTTPCache
 
 lint: themes/chef
 	hugo -D
 
-build: themes/chef generate_swagger
+build: themes/chef generate_swagger $(REDOC_FILE)
 	hugo
 
 # Consult scripts/spellcheck.sh in the root Automate directory for notes on using cspell.
@@ -66,3 +70,6 @@ spellcheck:
 		; EXIT_CODE=$$?; \
 		popd > /dev/null; \
 		exit $$EXIT_CODE
+
+$(REDOC_FILE):
+	curl -s -f -o $(REDOC_FILE) https://cdn.jsdelivr.net/npm/redoc@$(REDOC_VERSION)/bundles/redoc.standalone.js

--- a/components/automate-chef-io/habitat/plan.sh
+++ b/components/automate-chef-io/habitat/plan.sh
@@ -6,6 +6,7 @@ pkg_license=('Chef-MLSA')
 pkg_description="HTML for automate.chef.io"
 pkg_upstream_url="https://www.chef.io/automate"
 pkg_build_deps=(
+  core/curl
   core/git
   core/hugo
   core/jq-static

--- a/components/automate-chef-io/layouts/_default/data-api.html
+++ b/components/automate-chef-io/layouts/_default/data-api.html
@@ -31,7 +31,7 @@
           font-size: 14px;
         " href='https://automate.chef.io/docs'>Return to Docs</a>
     <ReDoc spec-url="/api-docs/all-apis.swagger.json"></ReDoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"></script>
+    <script src="/redoc.standalone.js"></script>
   </body>
 </html>
 


### PR DESCRIPTION
Fix for #2855.

I had originally planned to use [redoc-cli](https://github.com/Redocly/redoc/blob/master/cli/README.md) to package the docs, but that had a few downsides:
* The combined HTML + js file didn't work with hugo the way we're doing things currently, and I don't understand hugo enough to rework things to get this to work.
* This would have added npm to the docs development process and package building, which seems a bit onerous.
* While trying to get this going there was work done that would have conflicted and needed to be redone (#2902).
* Some other smaller concerns that can basically be summed up as redoc-cli doesn't do much to justify depending on it.

This still relies on the CDN, but would move potential failures to package build time rather than when a customer views the docs, which seems like a much better trade off.