### PR TITLE
Progress bar fix

### DIFF
--- a/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.html
+++ b/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.html
@@ -3,7 +3,7 @@
   <div class="modal-content">
     <chef-progress-bar
       [value]="progressValue"
-      [valueMax]="1"
+      [valueMax]="100"
       [prefixText]="progressPrefixText"
       [suffixText]="progressSuffixText">
     </chef-progress-bar>

--- a/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.spec.ts
+++ b/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.spec.ts
@@ -50,11 +50,11 @@ describe('ConfirmApplyStopModalComponent', () => {
   describe('progress bar', () => {
     using([
       [0,     '0% complete'],
-      [0.1,   '10% complete'],
-      [0.5,   '50% complete'],
-      [0.919, '91% complete'],
-      [0.92,  '92% complete'],
-      [1,     '100% complete']
+      [0.75,  '0% complete'],
+      [10,   '10% complete'],
+      [91.9, '91% complete'],
+      [92,   '92% complete'],
+      [100, '100% complete']
     ], (percentageComplete, progressPrefixText) => {
       it('displays correct percentage', () => {
         component.updateProgress({ ...component.applyRulesStatus, percentageComplete });
@@ -88,14 +88,14 @@ describe('ConfirmApplyStopModalComponent', () => {
     });
 
     it('does not update percentage once update is cancelled', () => {
-      component.updateProgress({ ...component.applyRulesStatus, percentageComplete: 0.1 });
+      component.updateProgress({ ...component.applyRulesStatus, percentageComplete: 10.0201 });
       expect(component.progressPrefixText).toContain('10%');
-      component.updateProgress({ ...component.applyRulesStatus, percentageComplete: 0.2 });
+      component.updateProgress({ ...component.applyRulesStatus, percentageComplete: 20.5 });
       expect(component.progressPrefixText).toContain('20%');
 
       component.stopRulesInProgress = true;
 
-      component.updateProgress({ ...component.applyRulesStatus, percentageComplete: 0.3 });
+      component.updateProgress({ ...component.applyRulesStatus, percentageComplete: 30.111 });
       expect(component.progressPrefixText).toContain('20%');
     });
 

--- a/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.ts
+++ b/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.ts
@@ -46,7 +46,7 @@ export class ConfirmApplyStopModalComponent implements OnChanges {
     const durCountdown = etc.diff(now) < 0 ? '00:00:00' : `${durHours}:${durMins}:${durSecs}`;
 
     this.progressValue = percentageComplete;
-    this.progressPrefixText = `${Math.floor(percentageComplete * 100)}% complete`;
+    this.progressPrefixText = `${percentageComplete}% complete`;
     this.progressSuffixText = `${durCountdown} until finished`;
   }
 }

--- a/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.ts
+++ b/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.ts
@@ -46,7 +46,7 @@ export class ConfirmApplyStopModalComponent implements OnChanges {
     const durCountdown = etc.diff(now) < 0 ? '00:00:00' : `${durHours}:${durMins}:${durSecs}`;
 
     this.progressValue = percentageComplete;
-    this.progressPrefixText = `${percentageComplete}% complete`;
+    this.progressPrefixText = `${Math.floor(percentageComplete)}% complete`;
     this.progressSuffixText = `${durCountdown} until finished`;
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Changes from PR #2891 caused a couple rendering issues:
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/6817500/74884169-66b21c00-5327-11ea-8a7a-ea8d56bea7b5.png">

This PR remedies those: key points are indicated.
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/6817500/74884115-4b471100-5327-11ea-88be-9af723f3d106.png">

### :chains: Related Resources
PR #2891 fix project update progress percentage

### :+1: Definition of Done
1. Stop Update bar characteristics match progress update banner
2. Percentages are shown in whole numbers
3. Bar coloration reflects percentages

### :athletic_shoe: How to Build and Test the Change

(rebuild automate-ui if needed; should be automatic)

- load lots of nodes, e.g. `chef_load_nodes 500` or `chef_load_compliance_nodes 500`
- create one or more projects
- create one or more rules
- run a project update
    - note: if you only ever see 0% or 100% try again or add more nodes!

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).