### PR TITLE
Fix client-runs export breaking on page barrier

### DIFF
--- a/components/config-mgmt-service/grpcserver/node_export.go
+++ b/components/config-mgmt-service/grpcserver/node_export.go
@@ -157,12 +157,15 @@ func (s *CfgMgmtServer) nodePager(ctx context.Context, request *pRequest.NodeExp
 func jsonExport(stream service.CfgMgmt_NodeExportServer) exportHandler {
 	initialRun := true
 	return func(nodes []backend.Node) error {
+		// If this is the first set of nodes to export, prepend "[" to start a JSON document.
 		if initialRun {
 			err := stream.Send(&response.ExportData{Content: []byte("[")})
 			if err != nil {
 				return err
 			}
 			initialRun = false
+			// If this is not the first set of nodes and the collection has elements,
+			// prepend the "," that couldn't get added in the previous call to this function.
 		} else if len(nodes) != 0 {
 			err := stream.Send(&response.ExportData{Content: []byte(",")})
 			if err != nil {
@@ -170,6 +173,7 @@ func jsonExport(stream service.CfgMgmt_NodeExportServer) exportHandler {
 			}
 		}
 
+		// If the collection has no elements, append "]" to close the JSON document and stop.
 		if len(nodes) == 0 {
 			err := stream.Send(&response.ExportData{Content: []byte("]")})
 			if err != nil {
@@ -189,7 +193,10 @@ func jsonExport(stream service.CfgMgmt_NodeExportServer) exportHandler {
 				return fmt.Errorf("Failed to marshal JSON export data: %+v", err)
 			}
 
-			if i != len(nodes) - 1 {
+			// If this is the last element of the collection passed to this function call,
+			// there is not enough information to know if this is the last element overall.
+			// So, only append "," if it can be determined that there are more elements.
+			if i != len(nodes)-1 {
 				raw = append(raw, ',')
 			}
 

--- a/components/config-mgmt-service/grpcserver/node_export.go
+++ b/components/config-mgmt-service/grpcserver/node_export.go
@@ -102,7 +102,9 @@ func (s *CfgMgmtServer) NodeExport(request *pRequest.NodeExport, stream service.
 	// even after the node no longer exists
 	nodeFilters["exists"] = []string{"true"}
 
-	nodePager := s.nodePager(ctx, request, nodeFilters)
+	sortField, sortAsc := request.Sorting.GetParameters()
+
+	nodePager := s.nodePager(ctx, sortField, sortAsc, nodeFilters)
 
 	for {
 		nodes, err := nodePager()
@@ -123,13 +125,12 @@ func (s *CfgMgmtServer) NodeExport(request *pRequest.NodeExport, stream service.
 	return nil
 }
 
-func (s *CfgMgmtServer) nodePager(ctx context.Context, request *pRequest.NodeExport, nodeFilters map[string][]string) func() ([]backend.Node, error) {
+func (s *CfgMgmtServer) nodePager(ctx context.Context, sortField string, sortAsc bool, nodeFilters map[string][]string) func() ([]backend.Node, error) {
 	pageSize := 100
 	start := time.Time{}
 	end := time.Time{}
 	var cursorValue interface{}
 	cursorID := ""
-	sortField, sortAsc := request.Sorting.GetParameters()
 	actualSortField := params.ConvertParamToNodeStateBackendLowerFilter(sortField)
 
 	return func() ([]backend.Node, error) {

--- a/components/config-mgmt-service/grpcserver/node_export.go
+++ b/components/config-mgmt-service/grpcserver/node_export.go
@@ -160,7 +160,7 @@ func jsonExport(stream service.CfgMgmt_NodeExportServer) exportHandler {
 	return func(nodes []backend.Node) error {
 		// If this is the first set of nodes to export, prepend "[" to start a JSON document.
 		if initialRun {
-			err := stream.Send(&response.ExportData{Content: []byte("[")})
+			err := stream.Send(&response.ExportData{Content: []byte{'['}})
 			if err != nil {
 				return err
 			}
@@ -168,7 +168,7 @@ func jsonExport(stream service.CfgMgmt_NodeExportServer) exportHandler {
 			// If this is not the first set of nodes and the collection has elements,
 			// prepend the "," that couldn't get added in the previous call to this function.
 		} else if len(nodes) != 0 {
-			err := stream.Send(&response.ExportData{Content: []byte(",")})
+			err := stream.Send(&response.ExportData{Content: []byte{','}})
 			if err != nil {
 				return err
 			}
@@ -176,7 +176,7 @@ func jsonExport(stream service.CfgMgmt_NodeExportServer) exportHandler {
 
 		// If the collection has no elements, append "]" to close the JSON document and stop.
 		if len(nodes) == 0 {
-			err := stream.Send(&response.ExportData{Content: []byte("]")})
+			err := stream.Send(&response.ExportData{Content: []byte{']'}})
 			if err != nil {
 				return err
 			}

--- a/components/config-mgmt-service/integration_test/node_export_test.go
+++ b/components/config-mgmt-service/integration_test/node_export_test.go
@@ -759,17 +759,12 @@ func TestNodeExportPagingJSON(t *testing.T) {
 		data = append(data, tdata.GetContent()...)
 	}
 
-	actualNumberOfNodes := 0
-	dec := json.NewDecoder(bytes.NewReader(data))
-	for dec.More() {
-		var nodes []interface{}
-		err := dec.Decode(&nodes)
-		require.NoError(t, err)
+	var outputNodes []interface{}
+	err = json.Unmarshal(data, &outputNodes)
 
-		actualNumberOfNodes += len(nodes)
-	}
+	require.NoError(t, err)
 
-	assert.Equal(t, numberOfNodes, actualNumberOfNodes)
+	assert.Equal(t, numberOfNodes, len(outputNodes))
 }
 
 func TestNodeExportPagingCSV(t *testing.T) {

--- a/components/config-mgmt-service/integration_test/node_export_test.go
+++ b/components/config-mgmt-service/integration_test/node_export_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"bytes"
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"github.com/buger/jsonparser"
@@ -690,7 +691,7 @@ func TestNodeExportLoopBug(t *testing.T) {
 	}
 }
 
-func TestNodeExportPaging(t *testing.T) {
+func TestNodeExportPagingJSON(t *testing.T) {
 	esClient := elastic.New(elasticsearchUrl)
 	c := config.New(esClient)
 	server := grpcserver.NewCfgMgmtServer(c)
@@ -769,4 +770,80 @@ func TestNodeExportPaging(t *testing.T) {
 	}
 
 	assert.Equal(t, numberOfNodes, actualNumberOfNodes)
+}
+
+func TestNodeExportPagingCSV(t *testing.T) {
+	esClient := elastic.New(elasticsearchUrl)
+	c := config.New(esClient)
+	server := grpcserver.NewCfgMgmtServer(c)
+
+	lis := bufconn.Listen(1024 * 1024)
+	s := grpc.NewServer()
+	api.RegisterCfgMgmtServer(s, server)
+
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			t.Fatalf("Server exited with error: %v", err)
+		}
+	}()
+
+	dialer := func(string, time.Duration) (net.Conn, error) { return lis.Dial() }
+
+	conn, err := grpc.DialContext(context.Background(), "bufnet", grpc.WithDialer(dialer), grpc.WithInsecure())
+	defer conn.Close()
+	require.NoError(t, err)
+
+	client := api.NewCfgMgmtClient(conn)
+
+	names := []string{
+		"Taco Bell",
+		"taco bell",
+		"TACO BELL",
+		"tACO bELL",
+		"TACO bell",
+	}
+
+	// page size is hardcoded to 100, so to test the pagination code we need more than that.
+	numberOfNodes := 150
+	nodes := make([]iBackend.Node, numberOfNodes)
+	for i := 0; i < numberOfNodes; i++ {
+		nodes[i].Exists = true
+		nodes[i].NodeInfo = iBackend.NodeInfo{
+			NodeName:   names[i%len(names)],
+			EntityUuid: newUUID(),
+		}
+	}
+
+	// Add nodes with projects
+	suite.IngestNodes(nodes)
+	defer suite.DeleteAllDocuments()
+
+	response, err := client.NodeExport(context.Background(), &request.NodeExport{
+		OutputType: "csv",
+		Sorting: &request.Sorting{
+			Field: backend.Name,
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	data := make([]byte, 0)
+	for {
+		tdata, err := response.Recv()
+		if err != nil && err == io.EOF {
+			data = append(data, tdata.GetContent()...)
+			break
+		}
+
+		require.NoError(t, err)
+		data = append(data, tdata.GetContent()...)
+	}
+
+	reader := csv.NewReader(bytes.NewReader(data))
+	outputNodes, err := reader.ReadAll()
+
+	require.NoError(t, err)
+	// Add 1 for the CSV header
+	assert.Equal(t, numberOfNodes+1, len(outputNodes))
 }


### PR DESCRIPTION
Fix for https://github.com/chef/customer-bugs/issues/70.

The problem with the exported JSON was that each page of results from elasticsearch was being streamed as a fully formed document. The go stdlib's json streaming parser is apparently lenient enough to interpret this as one big collection of objects, but the document parser is not. the solution ended up being changing the existing integration test to be more strict in the output allowed, then adding `[`, `]`, and `,` in the appropriate places to create one big document.