### PR TITLE
ci: use ruby26 in inspec-from-master tests

### DIFF
--- a/scripts/install_inspec_master.sh
+++ b/scripts/install_inspec_master.sh
@@ -7,7 +7,7 @@ export HAB_LICENSE="accept-no-persist"
 
 install_inspec() {
   hab pkg install core/gcc --binlink --force
-  hab pkg install core/ruby --binlink --force
+  hab pkg install core/ruby26 --binlink --force
 
   tmp_dir=$(mktemp -d)
   git clone --depth=1 https://github.com/inspec/inspec "$tmp_dir"


### PR DESCRIPTION
This is to address the following error:

```
Gem::RuntimeRequirementNotMetError: chef-zero requires Ruby version >= 2.6. The
current ruby version is 2.5.0.
An error occurred while installing chef-zero (15.0.0), and Bundler
cannot continue.
Make sure that `gem install chef-zero -v '15.0.0' --source
'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  berkshelf was resolved to 7.0.9, which depends on
    chef was resolved to 14.14.29, which depends on
      chef-zero
```

We might also consider not installing all of the bundle groups in
these tests.

Signed-off-by: Steven Danna <steve@chef.io>