### PR TITLE
ci: more fallout of moving to ruby26

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -597,7 +597,7 @@ steps:
       - sudo scripts/install_golang.sh
       - sudo scripts/install_grpcurl.sh
       - cd components/compliance-service
-      - sudo -E  PATH=\$(hab pkg path core/ruby)/bin:\$PATH make test-integration-scanner
+      - sudo -E  PATH=\$(hab pkg path core/ruby26)/bin:\$PATH make test-integration-scanner
       - cd ../.. && sudo git clean -fxd
     artifact_paths:
       - /tmp/secrets-service.log


### PR DESCRIPTION
This test is an `soft_fail: true` test so I missed that this was
failing during my last PR.

Hopefully this gets us passing again.

Signed-off-by: Steven Danna <steve@chef.io>