### PR TITLE
[automate-2930] Fix NATS gateway test errors related to v2 force upgrade

### DIFF
--- a/components/event-gateway/integration_test/suite_test.go
+++ b/components/event-gateway/integration_test/suite_test.go
@@ -9,7 +9,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/chef/automate/api/interservice/authz"
+	policies "github.com/chef/automate/api/interservice/authz/v2"
 	"github.com/chef/automate/lib/grpc/secureconn"
 	"github.com/chef/automate/lib/tls/certs"
 )
@@ -27,8 +27,8 @@ var (
 
 type Suite struct {
 	connFactory           *secureconn.Factory
-	AuthPoliciesToRestore []*authz.Policy
-	AuthzClient           authz.AuthorizationClient
+	AuthPoliciesToRestore []*policies.Policy
+	AuthzClient           policies.PoliciesClient
 	authzConn             *grpc.ClientConn
 }
 

--- a/components/event-gateway/integration_test/suite_test.go
+++ b/components/event-gateway/integration_test/suite_test.go
@@ -26,10 +26,9 @@ var (
 )
 
 type Suite struct {
-	connFactory           *secureconn.Factory
-	AuthPoliciesToRestore []*policies.Policy
-	AuthzClient           policies.PoliciesClient
-	authzConn             *grpc.ClientConn
+	connFactory *secureconn.Factory
+	AuthzClient policies.PoliciesClient
+	authzConn   *grpc.ClientConn
 }
 
 func NewSuite() *Suite {


### PR DESCRIPTION
Event gateway now green:

https://buildkite.com/chef/chef-automate-master-verify-private/builds/9622#8b9e70e0-b2d8-4705-aef9-186c32e33c98

### :athletic_shoe: How to Build and Test the Change

```
start_all_services
rebuild components/authz-service/ && rebuild components/automate-gateway/ && rebuild components/automate-cli/
event_gateway_integration
```

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
