### PR TITLE
Add some logging around forced migration

### DIFF
--- a/components/authz-service/storage/v1/postgres/postgres.go
+++ b/components/authz-service/storage/v1/postgres/postgres.go
@@ -67,7 +67,7 @@ func (m *policyMap) Scan(src interface{}) error {
 
 // New instantiates the postgres IAM v1 storage backend.
 func New(ctx context.Context, l logger.Logger, migConf migration.Config, dataMigConf datamigration.Config) (storage.Storage, error) {
-	l.Infof("applying database migrations from %s", migConf.Path)
+	l.Infof("[v1] applying database migrations from %s", migConf.Path)
 
 	db, err := postgres.New(ctx, migConf, dataMigConf)
 	if err != nil {

--- a/components/authz-service/storage/v2/postgres/postgres.go
+++ b/components/authz-service/storage/v2/postgres/postgres.go
@@ -44,7 +44,7 @@ func GetInstance() *pg {
 	return singletonInstance
 }
 
-// New instantiates the singleton postgres storage backend.
+// Initialize instantiates the singleton postgres storage backend.
 // Will only initialize once. Will simply return nil if already initialized.
 func Initialize(ctx context.Context, e engine.Engine, l logger.Logger, migConf migration.Config,
 	dataMigConf datamigration.Config, projectLimit int) error {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Additional logging could prove useful in the event of
(a) customer issues once the force upgrade is released, and 
(b) helping us to make sure it is working as expected before release

### :chains: Related Resources
PR #2793 Forced migration upgrade

### :+1: Definition of Done

Supervisor log shows something like the output below.


#### REVISED PER REVIEW FEEDBACK

Got rid of the "bracketing" notion; not enough value added.

```
"applying database migrations from /hab/pkgs/msorens/authz-service/0.1.0/20200224202924/migrations"
"Initializing DB migrations..."
"Current schema version: 73"
"Migrating schema from version 73 to 74"
"Setting up IAM data basics..."
"Checking for data migrations..."
"Checking for remaining schema migrations..."
"DB initialization complete at version 74"
```

#### OUTDATED
Notice that the logging is instrumented as brackets. The "open bracket" has the form `x...` and the "close bracket" has the form `x -- complete`. That covers the eventuality of failures in the middle.
```
"applying database migrations from /hab/pkgs/msorens/authz-service/0.1.0/20200221033251/migrations"
"Running db migrations..."
"Current schema version: 73"
"Migrating schema from version 73 to 74"
"Migrating schema from version 73 to 74 -- complete"
"Migrating from IAM v1 to v2..."
"Migrating from IAM v1 to v2 -- complete"
"Migrating data if needed"
"Migrating data if needed -- complete"
"Migrating schema post-version 74..."
"Migrating schema post-version 74 -- no changes necessary"
"Running db migrations -- complete"
```

### :athletic_shoe: How to Build and Test the Change (maybe?)

```
rebuild components/automate-deployment
rebuild components/automate-gateway
rebuild components/automate-cli
rebuild components/authz-service && sl | grep authz-service
```

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
