### PR TITLE
adding viewer and editor to sign in docs 

### DIFF
--- a/dev-docs/DEV_ENVIRONMENT.md
+++ b/dev-docs/DEV_ENVIRONMENT.md
@@ -75,9 +75,9 @@ If you want to develop against the UI:
 
 Open <https://a2-dev.test/> in your browser.
 
-Sign in as `admin`, `viewer`, or `editor` all with the same password of `chefautomate`.
+Sign in as `admin`, `viewer`, or `editor`, each using the same password of `chefautomate`.
   - `admin` gives access to everything.
-  - `editor` is what most users expereince which gives them access to everything except for `Node Credentials`, `Notifications`, Identity pages, Roles, and Policies.
+  - `editor` defines the permissions most users will have. It gives them access to everything except for `Node Credentials`, `Notifications`, Identity pages, Roles, and Policies.
   - `viewer` gives access to the same pages as `editor`, but users cannot take any action.
 
 ## Setup

--- a/dev-docs/DEV_ENVIRONMENT.md
+++ b/dev-docs/DEV_ENVIRONMENT.md
@@ -73,8 +73,12 @@ If you want to develop against the UI:
 # start_all_services
 ```
 
-Open <https://a2-dev.test> in your browser. Log in with `admin` and `chefautomate` as username and
-password, respectively.
+Open <https://a2-dev.test/> in your browser.
+
+Sign in as `admin`, `viewer`, or `editor` all with the same password of `chefautomate`.
+  - `admin` gives access to everything.
+  - `editor` is what most users expereince which gives them access to everything except for `Node Credentials`, `Notifications`, Identity pages, Roles, and Policies.
+  - `viewer` gives access to the same pages as `editor`, but users cannot take any action.
 
 ## Setup
 

--- a/dev-docs/ui-development.md
+++ b/dev-docs/ui-development.md
@@ -71,10 +71,10 @@ instead of using the `start_automate_ui_background` helper method._
 1. Open <https://a2-dev.test/> in your browser. If you have issues with sign in, please clear all site data (local
    and session storage and cookies) for `https://a2-dev.test` and re-navigate back to the root of
    <https://a2-dev.test/>.
-    - Sign in as `admin`, `viewer`, or `editor` all with the same password of `chefautomate`.
-      - `admin` gives access to everything.
-      - `editor` is what most users expereince which gives them access to everything except for `Node Credentials`, `Notifications`, Identity pages, Roles, and Policies.
-      - `viewer` gives access to the same pages as `editor`, but users cannot take any action.
+   - Sign in as `admin`, `viewer`, or `editor`, each using the same password of `chefautomate`.
+     - `admin` gives access to everything.
+     - `editor` defines the permissions most users will have. It gives them access to everything except for `Node Credentials`, `Notifications`, Identity pages, Roles, and Policies.
+     - `viewer` gives access to the same pages as `editor`, but users cannot take any action.
 
 1. Optional step: Turn on client-side feature flags by typing the letter sequence on any page in the UI. After toggling a feature flag, a browser refresh is required.
     * Type `beta` to open the beta features modal


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Recently, added this to the ui dev docs, but noticed that this page mentions signing in as well so adding details for how to sign in as viewer or editor.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
