### PR TITLE
instructions for adding sample data to the infra views

### DIFF
--- a/.studio/infra-proxy-service
+++ b/.studio/infra-proxy-service
@@ -66,7 +66,7 @@ function infra_service_load_sample_data() {
    "${server_prefix}-${timestamp}.com" \
    "${org_prefix}-${timestamp}" \
    "${org_prefix}-${timestamp}-user" \
-   "-----BEGIN RSA PRIVATE KEY-----\n${org_prefix}=${timestamp}-key"
+   "--ORG_ADMIN_KEY--"
   done  
   log_line "Sample data loaded..."
 }

--- a/.studio/infra-proxy-service
+++ b/.studio/infra-proxy-service
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# Helper methods specific for the infra-proxy-service
+
+document "start_infra_proxy_service" <<DOC
+  Build and start the local infra-proxy-service
+DOC
+function start_infra_proxy_service() {
+  build components/infra-proxy-service/
+  start_deployment_service
+  chef-automate dev deploy-some $HAB_ORIGIN/infra-proxy-service --with-deps
+}
+
+document "infra_service_load_sample_data" <<DOC
+  Before running this command make sure either run `start_infra_proxy_service` or `start_all_services`
+  Hits the create server & org endpoint inside the infra-proxy-service. (CreateServer & CreateOrg)
+
+  1. -N No of records Default: 50
+  2. -S Chef server name's prefix Default: chef-server
+  3. -O Chef server org's name prefix Default: chef-org
+
+  Example:
+  -----------------------------
+  infra_service_load_sample_data -N 100 -S chef-server -O chef-org
+DOC
+
+function infra_service_load_sample_data() {
+  install_if_missing core/jq-static jq
+  install_if_missing core/grpcurl grpcurl
+
+  local OPTIND opt 
+  local records=50
+  local server_prefix="chef-server"
+  local org_prefix="chef-org"
+  while getopts ":N:S:O:" opt; do
+    case $opt in
+      N) records="$OPTARG"
+      ;;
+      S) server_prefix="$OPTARG"
+      ;;
+      O) org_prefix="$OPTARG"
+      ;;
+      \?) echo "Invalid option -$OPTARG" >&2
+      ;;
+      : )
+      echo "Invalid option: $OPTARG requires an argument" 1>&2
+      ;;
+    esac
+  done
+  shift $((OPTIND -1))
+  
+  log_line "Started Loading sample data..."
+  log_line "Total number of records: $records"
+  log_line "Chef server's name prefix: $server_prefix"
+  log_line "Chef server org's name prefix: $org_prefix"
+
+  for _ in $(seq 1 ${records}); do
+   local ip_address=$(printf "%d.%d.%d.%d" "$((RANDOM % 256))" "$((RANDOM % 256))" "$((RANDOM % 256))" "$((RANDOM % 256))")
+   local timestamp=$(date +%s%N)
+
+   infra_service_create_servers_orgs "${server_prefix}-${timestamp}" \
+   "${server_prefix}-${timestamp}" \
+   "${ip_address}" \
+   "${server_prefix}-${timestamp}.com" \
+   "${org_prefix}-${timestamp}" \
+   "${org_prefix}-${timestamp}-user" \
+   "-----BEGIN RSA PRIVATE KEY-----\n${org_prefix}=${timestamp}-key"
+  done  
+  log_line "Sample data loaded..."
+}
+
+function infra_service_create_servers_orgs() {
+  local server_id=$(chef-automate dev grpcurl infra-proxy-service -- -d \
+  "$(cat << EOF
+    {"name": "$1", "description": "$2", "ip_address": "$3", "fqdn": "$4"}
+EOF
+  )" chef.automate.domain.infra_proxy.service.InfraProxy.CreateServer | jq .server.id)
+
+  chef-automate dev grpcurl infra-proxy-service -- -d \
+  "$(cat << EOF
+    {"name": "$5", "admin_user": "$6", "admin_key": "$7", "server_id": $server_id}
+EOF
+  )" chef.automate.domain.infra_proxy.service.InfraProxy.CreateOrg >/dev/null 2>&1
+}
+
+document "infra_service_psql" <<DOC
+   Enter psql with the infra proxy service database
+DOC
+function infra_service_psql() {
+  chef-automate dev psql chef_infra_proxy
+}

--- a/.studio/infra-proxy-service
+++ b/.studio/infra-proxy-service
@@ -54,9 +54,11 @@ function infra_service_load_sample_data() {
   log_line "Chef server's name prefix: $server_prefix"
   log_line "Chef server org's name prefix: $org_prefix"
 
+  local ip_address
+  local timestamp
   for _ in $(seq 1 ${records}); do
-   local ip_address=$(printf "%d.%d.%d.%d" "$((RANDOM % 256))" "$((RANDOM % 256))" "$((RANDOM % 256))" "$((RANDOM % 256))")
-   local timestamp=$(date +%s%N)
+   ip_address=$(printf "%d.%d.%d.%d" "$((RANDOM % 256))" "$((RANDOM % 256))" "$((RANDOM % 256))" "$((RANDOM % 256))")
+   timestamp=$(date +%s%N)
 
    infra_service_create_servers_orgs "${server_prefix}-${timestamp}" \
    "${server_prefix}-${timestamp}" \
@@ -70,7 +72,8 @@ function infra_service_load_sample_data() {
 }
 
 function infra_service_create_servers_orgs() {
-  local server_id=$(chef-automate dev grpcurl infra-proxy-service -- -d \
+  local server_id
+  server_id=$(chef-automate dev grpcurl infra-proxy-service -- -d \
   "$(cat << EOF
     {"name": "$1", "description": "$2", "ip_address": "$3", "fqdn": "$4"}
 EOF

--- a/.studio/infra-proxy-service
+++ b/.studio/infra-proxy-service
@@ -12,7 +12,7 @@ function start_infra_proxy_service() {
 }
 
 document "infra_service_load_sample_data" <<DOC
-  Before running this command make sure either run `start_infra_proxy_service` or `start_all_services`
+  Before running this command make sure either run 'start_infra_proxy_service' or 'start_all_services'
   Hits the create server & org endpoint inside the infra-proxy-service. (CreateServer & CreateOrg)
 
   1. -N No of records Default: 50

--- a/dev-docs/adding-data/adding_test_data.md
+++ b/dev-docs/adding-data/adding_test_data.md
@@ -66,6 +66,18 @@ _Note: to add an ec2 integration for aws, change type from "aws-api" to "aws-ec2
 
 If testing in an instance running in AWS, you can use the "read creds from cloud env" option to make things easier.
 
+# Adding data to infra views
+
+from hab studio:
+
+ensure you have `jq` installed
+
+option one: `infra_service_load_sample_data`
+By default, 50 records of the infra servers and orgs will be added with the prefix `chef-server` and `chef-org` respectively.
+
+option one: `infra_service_load_sample_data -N 100 -S infra-server -O infra-org`
+100 records of the infra servers and orgs will be added, modify the numbers on each of those options to meet your needs.
+
 # Deleting data
 
 to delete the postgres data:

--- a/dev-docs/adding-data/adding_test_data.md
+++ b/dev-docs/adding-data/adding_test_data.md
@@ -75,7 +75,7 @@ ensure you have `jq` installed
 option one: `infra_service_load_sample_data`
 By default, 50 records of the infra servers and orgs will be added with the prefix `chef-server` and `chef-org` respectively.
 
-option one: `infra_service_load_sample_data -N 100 -S infra-server -O infra-org`
+option two: `infra_service_load_sample_data -N 100 -S infra-server -O infra-org`
 100 records of the infra servers and orgs will be added, modify the numbers on each of those options to meet your needs.
 
 # Deleting data


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

- Infra views feature has been added recently, so it would nice to populate sample data.
- Add hab studio script to populate the dummy data for the infra servers & orgs.
- In order to fetch dummy data for the cookbooks, roles, etc required mocking which we will decide further.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
[MSYS-1251](https://chefio.atlassian.net/browse/MSYS-1251)
### :+1: Definition of Done
Ease to add sample data for the infra views testing.

### :athletic_shoe: How to Build and Test the Change
 - From hab studio `source .studio/infra-proxy-service` file to load the script.
-  Start `infra-proxy-service` service by running `start_infra_proxy_service` or `start_all_services`
 - Hit `infra_service_load_sample_data` will populate 50 records by default.
 - For more detail ref `dev-docs/adding-data/adding_test_data.md`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>