### PR TITLE
Turn off client cert checking at the load balancer

### DIFF
--- a/components/automate-load-balancer/habitat/config/nginx.conf
+++ b/components/automate-load-balancer/habitat/config/nginx.conf
@@ -116,9 +116,6 @@ http {
     ssl_certificate {{../pkg.svc_data_path}}/{{tls.server_name}}.cert;
     ssl_certificate_key {{../pkg.svc_data_path}}/{{tls.server_name}}.key;
 
-    ssl_client_certificate {{../pkg.svc_config_path}}/root_ca.crt;
-    ssl_verify_client optional;
-
     proxy_ssl_trusted_certificate {{../pkg.svc_config_path}}/root_ca.crt;
     proxy_ssl_certificate {{../pkg.svc_config_path}}/service.crt;
     proxy_ssl_certificate_key {{../pkg.svc_config_path}}/service.key;

--- a/integration/helpers/cert_auth_tests.sh
+++ b/integration/helpers/cert_auth_tests.sh
@@ -3,6 +3,13 @@
 # who possess the key for a certificate part of the a2 deployment
 # can use the certificate to authenticate either through the
 # automate-load-balancer or automate-gateway
+
+# (YZL, 2.28.2020) Since we have turned off client certificate auth at the load balancer,
+# sending a request with a client cert to the load balancer results in a request with an
+# empty X-Client-Cert header being made to the gateway via nginx. The empty header causes
+# the gateway to expect token auth. If no token has been specified, as in these tests, the
+# gateway returns a 401.
+
 cert_auth_tests() {
     log_info "Starting the Certificate Authentication test suite"
     hab pkg install core/curl
@@ -57,10 +64,10 @@ EOF
 invalid_cert_test_load_balancer() {
     local result
     result=$(hab_curl -sS --insecure --cert "$(invalid_cert_path)" --key "$(invalid_key_path)" "https://localhost/data-collector/v0")
-    if ! echo "$result" | grep -q "SSL certificate error"; then
+    if ! echo "$result" | grep -q "request not authenticated"; then
         cat <<EOF
         ...Failed
-        Expected response to contain "SSL certificate error"
+        Expected response to contain "request not authenticated"
 
         Got:
         ${result}
@@ -101,20 +108,22 @@ test_authorized_cert() {
     accepted
 EOF
 
-    authorized_cert_test "https://localhost/data-collector/v0"
-    authorized_cert_test "https://localhost:2000/events/data-collector"
+    authorized_cert_test "https://localhost/data-collector/v0" "401"
+    authorized_cert_test "https://localhost:2000/events/data-collector" "200"
 }
 
 authorized_cert_test() {
     local endpoint="$1"
     echo "...Checking ${endpoint}"
 
+    local expected_result="$2"
+
     local result
     result=$(hab_curl -o /dev/null -w "%{http_code}" -sS --insecure --cert "$(authorized_cert_path)" --key "$(authorized_key_path)" "${endpoint}" )
-    if [ "$result" != "200" ]; then
+    if [ "$result" != "$expected_result" ]; then
         cat <<EOF
         ...Failed
-        Expected http code 200
+        Expected http code $expected_result
 
         Got:
         ${result}
@@ -169,23 +178,25 @@ test_authorized_cert_in_header_authenticated() {
     scenario, we will authenticate with a valid cert, and pass a cert that
     is authorized to hit the endpoint. The authenticated cert is not authorized
 EOF
-    authorized_cert_in_header_authenticated_test "https://localhost/data-collector/v0"
-    authorized_cert_in_header_authenticated_test "https://localhost:2000/events/data-collector"
+    authorized_cert_in_header_authenticated_test "https://localhost/data-collector/v0" "401"
+    authorized_cert_in_header_authenticated_test "https://localhost:2000/events/data-collector" "403"
 }
 
 authorized_cert_in_header_authenticated_test() {
     local endpoint="$1"
     echo "...Checking ${endpoint}"
 
+    local expected_result="$2"
+
     local result
     result=$(hab_curl -o /dev/null -w "%{http_code}" -sS --insecure \
         --cert "$(authenticated_cert_path)" --key "$(authenticated_key_path)" \
         -H "X-Client-Cert: $(urlencode "$(cat "$(authorized_cert_path)")")"  \
         "${endpoint}" )
-    if [ "$result" != "403" ]; then
+    if [ "$result" != "$2" ]; then
         cat <<EOF
         ...Failed
-        Expected http code 403
+        Expected http code $expected_result
 
         Got:
         ${result}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
We had originally set up *client* cert checking at the load balancer as part of a research spike for service auth for the automate-deployed Chef Infra server. This was not user-configurable, and since we went in a different direction for service auth, has not been used. We are taking it out now because it's causing ssl handshake issues for some libressl users.

Replaces #2979.
Fixes #2968 

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
