### PR TITLE
On-Prem Bldr Docs: remove in-development warnings

### DIFF
--- a/components/automate-chef-io/content/docs/on-prem-builder.md
+++ b/components/automate-chef-io/content/docs/on-prem-builder.md
@@ -14,10 +14,6 @@ toc = true
 
 This guide details how to install Chef Automate and deploy Chef Habitat Builder on-prem together. Enterprise customers may wish to set up an on-premises Chef Habitat Builder depot to store Chef Habitat packages for use by their own Chef Habitat Studios and Supervisors.
 
-{{< warning >}}
-Automate-deployed Chef Habitat Builder is a new feature that is in active development. Please contact your Chef representative before using this implementation in production.
-{{< /warning >}}
-
 This guide covers setting up Chef Automate and Chef Habitat Builder on-prem, and bootstrapping Chef Habitat Builder on-prem with curated core seed lists from the Chef Habitat public Builder.
 
 The Chef installer includes everything necessary to get started with Chef Automate and Chef Habitat Builder on-prem.


### PR DESCRIPTION
With the completion of incremental backup and restore, on-prem Bldr is
mature to roll out to customers and support at a GA level. This commit
removes the pre-production / active development warnings from the
documentation.

Signed-off-by: Stephen Delano <stephen@chef.io>