### PR TITLE
automate-ui: don't fetch projects on iamv1

### DIFF
--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -59,7 +59,6 @@ export class LayoutFacadeService implements OnInit, OnDestroy {
     private store: Store<fromLayout.LayoutEntityState>,
     private layoutSidebarService: LayoutSidebarService
   ) {
-    this.store.dispatch(new GetProjects());
     this.sidebar$ = store.select(sidebar);
     this.showPageLoading$ = store.select(showPageLoading);
     this.updateDisplay();


### PR DESCRIPTION
The line removed in this change was fetching the projects for a user
before checking if the install was on IAMv1 or v2. Projects are not
a concept in IAMv1 and we were displaying an error if you logged in as
a non-admin user.

To test: sign in as a *non* admin user.

Fixes: #3004

Signed-off-by: Stephen Delano <stephen@chef.io>
