### PR TITLE
automate infra proxy cookbook list UI

### DIFF
--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -27,6 +27,7 @@ import { SigninComponent } from './pages/signin/signin.component';
 import { AutomateSettingsComponent } from './pages/automate-settings/automate-settings.component';
 import { ChefServersListComponent } from './modules/infra-proxy/chef-servers-list/chef-servers-list.component';
 import { ChefServerDetailsComponent } from './modules/infra-proxy/chef-server-details/chef-server-details.component';
+import { CookbooksListComponent } from './modules/infra-proxy/cookbook-list/cookbooks-list.component';
 import { NodeDetailsComponent } from './pages/node-details/node-details.component';
 import {
   NodeNoRunsDetailsComponent
@@ -243,6 +244,10 @@ const routes: Routes = [
             {
               path: ':id',
               component: ChefServerDetailsComponent
+            },
+            {
+              path: ':id/org/:orgid/cookbooks',
+              component: CookbooksListComponent
             }
           ]
         }

--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -68,6 +68,7 @@ import { TelemetryService } from './services/telemetry/telemetry.service';
 // Requests
 import { ApiTokenRequests } from './entities/api-tokens/api-token.requests';
 import { AutomateSettingsRequests } from './entities/automate-settings/automate-settings.requests';
+import { CookbookRequests } from './entities/cookbooks/cookbook.requests';
 import { ClientRunsRequests } from './entities/client-runs/client-runs.requests';
 import { CredentialRequests } from './entities/credentials/credential.requests';
 import { JobRequests } from './entities/jobs/job.requests';
@@ -291,6 +292,7 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     ChefSessionService,
     ConfigService,
     ClientRunsRequests,
+    CookbookRequests,
     CredentialRequests,
     DatafeedService,
     EventFeedService,

--- a/components/automate-ui/src/app/entities/cookbooks/cookbook.actions.ts
+++ b/components/automate-ui/src/app/entities/cookbooks/cookbook.actions.ts
@@ -1,0 +1,41 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Action } from '@ngrx/store';
+
+import { Cookbook } from './cookbook.model';
+
+export enum CookbookActionTypes {
+  GET_ALL = 'COOKBOOKS::GET_ALL',
+  GET_ALL_SUCCESS = 'COOKBOOKS::GET_ALL::SUCCESS',
+  GET_ALL_FAILURE = 'COOKBOOKS::GET_ALL::FAILURE'
+}
+
+export interface CookbookSuccessPayload {
+  cookbook: Cookbook;
+}
+
+export class GetCookbooksForOrg implements Action {
+  readonly type = CookbookActionTypes.GET_ALL;
+
+  constructor(public payload: { server_id: string, org_id: string }) { }
+}
+
+export interface CookbooksSuccessPayload {
+  cookbooks: Cookbook[];
+}
+
+export class GetCookbooksSuccess implements Action {
+  readonly type = CookbookActionTypes.GET_ALL_SUCCESS;
+
+  constructor(public payload: CookbooksSuccessPayload) { }
+}
+
+export class GetCookbooksFailure implements Action {
+  readonly type = CookbookActionTypes.GET_ALL_FAILURE;
+
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export type CookbookActions =
+  | GetCookbooksForOrg
+  | GetCookbooksSuccess
+  | GetCookbooksFailure;

--- a/components/automate-ui/src/app/entities/cookbooks/cookbook.effects.ts
+++ b/components/automate-ui/src/app/entities/cookbooks/cookbook.effects.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { of as observableOf } from 'rxjs';
+import { catchError, mergeMap, map } from 'rxjs/operators';
+
+import { CreateNotification } from 'app/entities/notifications/notification.actions';
+import { Type } from 'app/entities/notifications/notification.model';
+
+import {
+  GetCookbooksForOrg,
+  GetCookbooksSuccess,
+  CookbooksSuccessPayload,
+  GetCookbooksFailure,
+  CookbookActionTypes
+} from './cookbook.actions';
+
+import {
+  CookbookRequests
+} from './cookbook.requests';
+
+@Injectable()
+export class CookbookEffects {
+  constructor(
+    private actions$: Actions,
+    private requests: CookbookRequests
+  ) { }
+
+  @Effect()
+  getCookbooksForOrgs$ = this.actions$.pipe(
+      ofType(CookbookActionTypes.GET_ALL),
+      mergeMap(({ payload: { server_id, org_id } }: GetCookbooksForOrg) =>
+        this.requests.getCookbooksForOrgs(server_id, org_id).pipe(
+          map((resp: CookbooksSuccessPayload) => new GetCookbooksSuccess(resp)),
+          catchError((error: HttpErrorResponse) => observableOf(new GetCookbooksFailure(error))))));
+
+  @Effect()
+  getCookbooksFailure$ = this.actions$.pipe(
+      ofType(CookbookActionTypes.GET_ALL_FAILURE),
+      map(({ payload }: GetCookbooksFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not get cookbooks: ${msg || payload.error}`
+        });
+      }));
+
+}

--- a/components/automate-ui/src/app/entities/cookbooks/cookbook.model.ts
+++ b/components/automate-ui/src/app/entities/cookbooks/cookbook.model.ts
@@ -1,0 +1,4 @@
+export interface Cookbook {
+    name: string;
+    version: string;
+}

--- a/components/automate-ui/src/app/entities/cookbooks/cookbook.reducer.ts
+++ b/components/automate-ui/src/app/entities/cookbooks/cookbook.reducer.ts
@@ -1,0 +1,46 @@
+import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
+import { set, pipe } from 'lodash/fp';
+
+import { EntityStatus } from 'app/entities/entities';
+import { CookbookActionTypes, CookbookActions } from './cookbook.actions';
+import { Cookbook } from './cookbook.model';
+
+export interface CookbookEntityState extends EntityState<Cookbook> {
+  getAllStatus: EntityStatus;
+  getStatus: EntityStatus;
+}
+
+const GET_ALL_STATUS = 'getAllStatus';
+
+export const cookbookEntityAdapter: EntityAdapter<Cookbook> = createEntityAdapter<Cookbook>({
+  selectId: (cookbook: Cookbook) => cookbook.name
+});
+
+export const CookbookEntityInitialState: CookbookEntityState =
+  cookbookEntityAdapter.getInitialState(<CookbookEntityState>{
+    getAllStatus: EntityStatus.notLoaded,
+    getStatus: EntityStatus.notLoaded
+  });
+
+export function cookbookEntityReducer(
+  state: CookbookEntityState = CookbookEntityInitialState,
+  action: CookbookActions): CookbookEntityState {
+
+  switch (action.type) {
+    case CookbookActionTypes.GET_ALL:
+      return set(GET_ALL_STATUS, EntityStatus.loading, cookbookEntityAdapter.removeAll(state));
+
+    case CookbookActionTypes.GET_ALL_SUCCESS:
+      return pipe(
+        set(GET_ALL_STATUS, EntityStatus.loadingSuccess))
+        (cookbookEntityAdapter.addAll(action.payload.cookbooks, state)) as CookbookEntityState;
+
+    case CookbookActionTypes.GET_ALL_FAILURE:
+      return set(GET_ALL_STATUS, EntityStatus.loadingFailure, state);
+
+    default:
+      return state;
+  }
+}
+
+export const getEntityById = (name: string) => (state: CookbookEntityState) => state.entities[name];

--- a/components/automate-ui/src/app/entities/cookbooks/cookbook.requests.ts
+++ b/components/automate-ui/src/app/entities/cookbooks/cookbook.requests.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment as env } from 'environments/environment';
+
+import {
+  CookbooksSuccessPayload
+} from './cookbook.actions';
+
+@Injectable()
+export class CookbookRequests {
+
+  constructor(private http: HttpClient) { }
+
+  // tslint:disable-next-line: max-line-length
+  public getCookbooksForOrgs(server_id: string, org_id: string): Observable<CookbooksSuccessPayload> {
+    return this.http.get<CookbooksSuccessPayload>(
+      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/cookbooks`);
+  }
+
+}

--- a/components/automate-ui/src/app/entities/cookbooks/cookbook.selectors.ts
+++ b/components/automate-ui/src/app/entities/cookbooks/cookbook.selectors.ts
@@ -1,0 +1,19 @@
+import { createSelector, createFeatureSelector } from '@ngrx/store';
+import { CookbookEntityState, cookbookEntityAdapter } from './cookbook.reducer';
+
+export const cookbookState = createFeatureSelector<CookbookEntityState>('cookbooks');
+
+export const {
+  selectAll: allCookbooks,
+  selectEntities: cookbookEntities
+} = cookbookEntityAdapter.getSelectors(cookbookState);
+
+export const getAllStatus = createSelector(
+  cookbookState,
+  (state) => state.getAllStatus
+);
+
+export const getStatus = createSelector(
+  cookbookState,
+  (state) => state.getStatus
+);

--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -76,6 +76,9 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
               name: 'Chef Servers',
               icon: 'storage',
               route: '/infrastructure/chef-servers',
+              authorized: {
+                anyOf: [['/infra/servers', 'get']]
+              },
               visible$: new BehaviorSubject(this.chefInfraServerViewsFeatureFlagOn)
             },
             {

--- a/components/automate-ui/src/app/entities/orgs/org.selectors.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.selectors.ts
@@ -43,5 +43,5 @@ export const deleteStatus = createSelector(
 export const orgFromRoute = createSelector(
   orgEntities,
   routeParams,
-  (state, { orgId }) => state[orgId]
+  (state, { orgid }) => state[orgid]
 );

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -114,7 +114,7 @@
             <chef-table-body>
               <chef-table-row *ngFor="let org of orgs">
                 <chef-table-cell>
-                  <a [routerLink]="['/infrastructure','chef-servers', server?.id, 'orgs', org.id, 'cookbooks']">{{ org.name }}</a>
+                  <a [routerLink]="['/infrastructure','chef-servers', server?.id, 'org', org.id, 'cookbooks']">{{ org.name }}</a>
                 </chef-table-cell>
                 <chef-table-cell>{{ org.admin_user }}</chef-table-cell>
                 <chef-table-cell class="three-dot-column">

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -2,7 +2,7 @@
   <div class="container">
     <main>
       <chef-breadcrumbs>
-        <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Server</chef-breadcrumb>
+        <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Servers</chef-breadcrumb>
         {{ server?.name }}
       </chef-breadcrumbs>
       <chef-page-header>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -46,7 +46,7 @@
         <form [formGroup]="updateServerForm">
           <chef-form-field id="update-name">
             <label>
-                <span class="label">Chef Server Name <span aria-hidden="true">*</span></span>
+                <span class="label">Name <span aria-hidden="true">*</span></span>
               <input chefInput formControlName="name" type="text" autocomplete="off"
                 data-cy="update-chefServer-name">
             </label>
@@ -101,7 +101,7 @@
       <section class="page-body" *ngIf="tabValue === 'orgs'">
         <ng-container>
           <chef-toolbar>
-            <chef-button id="create-button" primary (click)="openCreateModal('create')">Create Org</chef-button>
+            <chef-button id="create-button" primary (click)="openCreateModal('create')">Add Org</chef-button>
           </chef-toolbar>
           <chef-table-new>
             <chef-table-header>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -118,7 +118,7 @@
                 </chef-table-cell>
                 <chef-table-cell>{{ org.admin_user }}</chef-table-cell>
                 <chef-table-cell class="three-dot-column">
-                  <mat-select>
+                  <mat-select panelClass="chef-control-menu" id="menu-{{org.id}}">
                     <mat-option data-cy="delete" (onSelectionChange)="startOrgDelete($event, org)">Delete Org</mat-option>
                   </mat-select>
                 </chef-table-cell>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
@@ -111,17 +111,3 @@ chef-table-new {
   }
 }
 
-.empty-case-container {
-  margin-top: 42px;
-  justify-content: center;
-  text-align: center;
-
-  .empty-case-entry {
-    margin-top: 18px;
-    margin-bottom: 0;
-  }
-
-  p {
-    font-size: 18px;
-  }
-}

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.scss
@@ -1,0 +1,5 @@
+@import "~styles/variables";
+
+chef-table-cell {
+    overflow: hidden;
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.scss
@@ -1,5 +1,0 @@
-@import "~styles/variables";
-
-chef-table-cell {
-    overflow: hidden;
-}

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
@@ -18,7 +18,8 @@ import { ChefSorters } from 'app/helpers/auth/sorter';
 
 @Component({
   selector: 'app-chef-servers-list',
-  templateUrl: './chef-servers-list.component.html'
+  templateUrl: './chef-servers-list.component.html',
+  styleUrls: ['./chef-servers-list.component.scss']
 })
 export class ChefServersListComponent implements OnInit, OnDestroy {
   public loading$: Observable<boolean>;

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
@@ -18,8 +18,7 @@ import { ChefSorters } from 'app/helpers/auth/sorter';
 
 @Component({
   selector: 'app-chef-servers-list',
-  templateUrl: './chef-servers-list.component.html',
-  styleUrls: ['./chef-servers-list.component.scss']
+  templateUrl: './chef-servers-list.component.html'
 })
 export class ChefServersListComponent implements OnInit, OnDestroy {
   public loading$: Observable<boolean>;

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.html
@@ -1,0 +1,98 @@
+<div class="content-container">
+    <div class="container">
+        <main>
+            <chef-breadcrumbs>
+                <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Orgs</chef-breadcrumb>
+                {{ org?.name }}
+            </chef-breadcrumbs>
+            <chef-page-header>
+                <chef-heading>{{ org?.name }}</chef-heading>
+                <table>
+                    <thead>
+                        <tr class="detail-row">
+                            <th class="id-column">Name</th>
+                            <th class="id-column">Admin User</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr class="detail-row">
+                            <td class="id-column">{{ org?.name }}</td>
+                            <td class="id-column">{{ org?.admin_user }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <chef-tab-selector [value]="tabValue" (change)="onSelectedTab($event)">
+                    <chef-option value='cookbooks' data-cy="cookbooks-tab">Cookbooks</chef-option>
+                    <chef-option value='details' data-cy="details-tab">Details</chef-option>
+                </chef-tab-selector>
+            </chef-page-header>
+            <section class="page-body" *ngIf="tabValue === 'details'">
+                <form [formGroup]="updateOrgForm">
+                    <chef-form-field>
+                        <label>
+                            <span class="label">Name <span aria-hidden="true">*</span></span>
+                            <input chefInput formControlName="name" type="text" autocomplete="off"
+                                data-cy="update-org-name">
+                        </label>
+                        <chef-error
+                            *ngIf="(updateOrgForm.get('name').hasError('required') || updateOrgForm.get('name').hasError('pattern')) && updateOrgForm.get('name').dirty">
+                            Display Name is required.
+                        </chef-error>
+                    </chef-form-field>
+                    <chef-form-field>
+                        <label>
+                            <span class="label">Admin User <span aria-hidden="true">*</span></span>
+                            <input chefInput formControlName="admin_user" type="text" autocomplete="off"
+                                data-cy="update-Org-admin-user">
+                        </label>
+                        <chef-error
+                            *ngIf="(updateOrgForm.get('admin_user').hasError('required') || updateOrgForm.get('admin_user').hasError('pattern')) && updateOrgForm.get('admin_user').dirty">
+                            Admin User is required.
+                        </chef-error>
+                    </chef-form-field>
+                    <chef-form-field>
+                        <label>
+                            <span class="label">Admin Key<span aria-hidden="true">*</span></span>
+                            <textarea rows="27" cols="54" chefInput placeholder="-----BEGIN RSA PRIVATE KEY -----"
+                                formControlName="admin_key" data-cy="update-org-admin-key"></textarea>
+                        </label>
+                        <chef-error
+                            *ngIf="(updateOrgForm.get('admin_key').hasError('required') || updateOrgForm.get('admin_key').hasError('pattern')) && updateOrgForm.get('admin_key').dirty">
+                            Admin Key is required.
+                        </chef-error>
+                    </chef-form-field>
+                    <chef-form-field>
+                        <div id="button-bar">
+                            <chef-button [disabled]="isLoading || !updateOrgForm.valid || !updateOrgForm.dirty" primary
+                                inline (click)="saveOrg()">
+                                <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
+                                <span *ngIf="saving">Saving...</span>
+                                <span *ngIf="!saving">Save</span>
+                            </chef-button>
+                            <span id="saved-note" *ngIf="saveSuccessful && !updateOrgForm.dirty">All changes
+                                saved.</span>
+                        </div>
+                    </chef-form-field>
+                </form>
+            </section>
+            <section class="page-body" *ngIf="tabValue === 'cookbooks'">
+                <ng-container>
+                    <chef-table-new>
+                        <chef-table-header>
+                            <chef-table-row>
+                                <chef-table-header-cell>Cookbook Name</chef-table-header-cell>
+                                <chef-table-header-cell>Cookbook Version</chef-table-header-cell>
+                            </chef-table-row>
+                        </chef-table-header>
+                        <chef-table-body>
+                            <!-- <chef-table-row *ngFor="let cookbook of cookbooks">
+                                <chef-table-cell>{{ cookbook.name }}</chef-table-cell>
+                                <chef-table-cell>{{ cookbook.version }}</chef-table-cell>
+                            </chef-table-row> -->
+                        </chef-table-body>
+                    </chef-table-new>
+                </ng-container>
+            </section>
+        </main>
+    </div>
+</div>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.html
@@ -2,7 +2,8 @@
     <div class="container">
         <main>
             <chef-breadcrumbs>
-                <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Orgs</chef-breadcrumb>
+                <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Servers</chef-breadcrumb>
+                <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', org?.server_id]">Orgs</chef-breadcrumb>
                 {{ org?.name }}
             </chef-breadcrumbs>
             <chef-page-header>
@@ -53,8 +54,8 @@
                     <chef-form-field>
                         <label>
                             <span class="label">Admin Key<span aria-hidden="true">*</span></span>
-                            <textarea rows="27" cols="54" chefInput placeholder="-----BEGIN RSA PRIVATE KEY -----"
-                                formControlName="admin_key" data-cy="update-org-admin-key"></textarea>
+                            <textarea rows="27" cols="10" chefInput placeholder="-----BEGIN RSA PRIVATE KEY -----"
+                                formControlName="admin_key" data-cy="update-org-admin-key"></textarea>   
                         </label>
                         <chef-error
                             *ngIf="(updateOrgForm.get('admin_key').hasError('required') || updateOrgForm.get('admin_key').hasError('pattern')) && updateOrgForm.get('admin_key').dirty">

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.html
@@ -85,10 +85,10 @@
                             </chef-table-row>
                         </chef-table-header>
                         <chef-table-body>
-                            <!-- <chef-table-row *ngFor="let cookbook of cookbooks">
+                            <chef-table-row *ngFor="let cookbook of cookbooks">
                                 <chef-table-cell>{{ cookbook.name }}</chef-table-cell>
                                 <chef-table-cell>{{ cookbook.version }}</chef-table-cell>
-                            </chef-table-row> -->
+                            </chef-table-row>
                         </chef-table-body>
                     </chef-table-new>
                 </ng-container>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.scss
@@ -1,0 +1,135 @@
+@import "~styles/variables";
+
+chef-page-header {
+  padding-bottom: 0;
+}
+
+chef-toolbar {
+  display: block;
+  position: relative;
+  margin-bottom: 5px;
+
+  small {
+    bottom: 2px;
+    color: $chef-dark-grey;
+    position: absolute;
+    right: 0;
+  }
+}
+
+chef-tab-selector {
+  chef-option {
+    margin-right: 16px;
+    color: $chef-primary-dark;
+  }
+}
+
+form {
+  input {
+    font-size: 1.02em;
+    width: 520px;
+    margin-bottom: -6px;
+  }
+
+  textarea {
+    font-size: 1.02em;
+    width: 520px;
+  }
+
+  .errors {
+    width: 520px;
+    margin-top: -6px;
+  }
+
+  input[type="text"]:disabled {
+    opacity: 0.5;
+    background-color: $chef-grey;
+    border: none;
+  }
+
+  #changes-not-allowed {
+    font-size: 12px;
+  }
+
+  #button-bar {
+    margin-top: 15px;
+
+    span#saved-note {
+      display: inline-block;
+      margin-top: 5px;
+      font-size: 12px;
+    }
+
+    chef-button {
+      margin-top: 0;
+      margin-left: 0;
+
+      chef-loading-spinner {
+        position: relative;
+        top: 2px;
+        margin-right: 5px;
+      }
+    }
+  }
+}
+
+thead {
+  font-size: 14px;
+  letter-spacing: 0.2px;
+  color: $chef-primary-dark;
+}
+
+th {
+  text-align: left;
+  padding: 0px;
+}
+
+tbody > .detail-row {
+  padding-top: 0px;
+  padding-bottom: 15px;
+}
+
+.detail-row {
+  display: flex;
+  color: $chef-primary-dark;
+}
+
+.id-column {
+  width: 33%;
+  padding-top: 0px;
+  padding-left: 0px;
+}
+
+.type-column {
+  width: 66%;
+  padding-top: 0px;
+  padding-left: 0px;
+}
+
+chef-table-new {
+  .controls {
+    text-align: right;
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+}
+
+.empty-case-container {
+  margin-top: 42px;
+  //display: flex;
+  justify-content: center;
+  //flex-direction: column;
+  text-align: center;
+
+  .empty-case-entry {
+    margin-top: 18px;
+    margin-bottom: 0;
+  }
+
+  p {
+    font-size: 18px;
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.scss
@@ -25,20 +25,14 @@ chef-tab-selector {
 }
 
 form {
-  input {
-    font-size: 1.02em;
-    width: 520px;
-    margin-bottom: -6px;
+
+  chef-form-field {
+    width: 300px;
+    margin-bottom: 15px;
   }
 
   textarea {
-    font-size: 1.02em;
-    width: 520px;
-  }
-
-  .errors {
-    width: 520px;
-    margin-top: -6px;
+    height: 200px;
   }
 
   input[type="text"]:disabled {

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.scss
@@ -111,19 +111,3 @@ chef-table-new {
   }
 }
 
-.empty-case-container {
-  margin-top: 42px;
-  //display: flex;
-  justify-content: center;
-  //flex-direction: column;
-  text-align: center;
-
-  .empty-case-entry {
-    margin-top: 18px;
-    margin-bottom: 0;
-  }
-
-  p {
-    font-size: 18px;
-  }
-}

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.spec.ts
@@ -1,0 +1,27 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CookbooksListComponent } from './cookbooks-list.component';
+
+xdescribe('CookbooksListComponent', () => {
+  let component: CookbooksListComponent;
+  let fixture: ComponentFixture<CookbooksListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CookbooksListComponent ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CookbooksListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.spec.ts
@@ -2,33 +2,20 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CookbooksListComponent } from './cookbooks-list.component';
-// import { HttpErrorResponse } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MockComponent } from 'ng2-mock-component';
 import { StoreModule } from '@ngrx/store';
-// import { Cookbook } from 'app/entities/cookbooks/cookbook.model';
 import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
-// import { HttpStatus } from 'app/types/types';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 
-xdescribe('CookbooksListComponent', () => {
+describe('CookbooksListComponent', () => {
   let component: CookbooksListComponent;
   let fixture: ComponentFixture<CookbooksListComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ CookbooksListComponent ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
       declarations: [
-        MockComponent({ selector: 'chef-button',
-                inputs: ['disabled', 'routerLink'] }),
         MockComponent({ selector: 'chef-th' }),
         MockComponent({ selector: 'chef-td' }),
         MockComponent({ selector: 'chef-error' }),

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.spec.ts
@@ -2,6 +2,15 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CookbooksListComponent } from './cookbooks-list.component';
+// import { HttpErrorResponse } from '@angular/common/http';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MockComponent } from 'ng2-mock-component';
+import { StoreModule } from '@ngrx/store';
+// import { Cookbook } from 'app/entities/cookbooks/cookbook.model';
+import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
+// import { HttpStatus } from 'app/types/types';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 
 xdescribe('CookbooksListComponent', () => {
   let component: CookbooksListComponent;
@@ -10,6 +19,46 @@ xdescribe('CookbooksListComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ CookbooksListComponent ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        MockComponent({ selector: 'chef-button',
+                inputs: ['disabled', 'routerLink'] }),
+        MockComponent({ selector: 'chef-th' }),
+        MockComponent({ selector: 'chef-td' }),
+        MockComponent({ selector: 'chef-error' }),
+        MockComponent({ selector: 'chef-form-field' }),
+        MockComponent({ selector: 'chef-heading' }),
+        MockComponent({ selector: 'chef-icon' }),
+        MockComponent({ selector: 'chef-loading-spinner' }),
+        MockComponent({ selector: 'mat-select' }),
+        MockComponent({ selector: 'mat-option' }),
+        MockComponent({ selector: 'chef-page-header' }),
+        MockComponent({ selector: 'chef-subheading' }),
+        MockComponent({ selector: 'chef-toolbar' }),
+        MockComponent({ selector: 'chef-table-new' }),
+        MockComponent({ selector: 'chef-table-header' }),
+        MockComponent({ selector: 'chef-table-body' }),
+        MockComponent({ selector: 'chef-table-row' }),
+        MockComponent({ selector: 'chef-table-header-cell' }),
+        MockComponent({ selector: 'chef-table-cell' }),
+        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
+        CookbooksListComponent
+      ],
+      providers: [
+        FeatureFlagsService
+      ],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+      ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
@@ -1,0 +1,150 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { Observable, Subject, combineLatest } from 'rxjs';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { routeParams, routeURL } from 'app/route.selectors';
+import { filter, pluck, takeUntil } from 'rxjs/operators';
+import { identity, isNil } from 'lodash/fp';
+import { EntityStatus, loading, allLoaded } from 'app/entities/entities';
+import { Org } from 'app/entities/orgs/org.model';
+import {
+  getStatus, updateStatus, orgFromRoute
+} from 'app/entities/orgs/org.selectors';
+import { GetOrg, UpdateOrg } from 'app/entities/orgs/org.actions';
+import { GetCookbooksForOrg } from 'app/entities/cookbooks/cookbook.actions';
+import { Cookbook } from 'app/entities/cookbooks/cookbook.model';
+import {
+  allCookbooks,
+  getAllStatus as getAllCookbooksForOrgStatus
+} from 'app/entities/cookbooks/cookbook.selectors';
+
+export type OrgTabName = 'cookbooks' | 'details';
+@Component({
+  selector: 'app-cookbooks-list',
+  templateUrl: './cookbooks-list.component.html',
+  styleUrls: ['./cookbooks-list.component.scss']
+})
+export class CookbooksListComponent implements OnInit, OnDestroy {
+  public org: Org;
+  public cookbooks: Cookbook[] = [];
+  public loading$: Observable<boolean>;
+  public sortedCookbooks$: Observable<Cookbook[]>;
+  private isDestroyed = new Subject<boolean>();
+  public saveSuccessful = false;
+  public saving = false;
+  public isLoading = true;
+  public url: string;
+  public serverId;
+  public OrgId;
+  public updateOrgForm: FormGroup;
+  public tabValue: OrgTabName = 'cookbooks';
+  constructor(
+    private fb: FormBuilder,
+    private store: Store<NgrxStateAtom>,
+    private layoutFacade: LayoutFacadeService,
+    private router: Router
+  ) { }
+
+  ngOnInit() {
+    this.layoutFacade.showInfrastructureSidebar();
+
+    this.store.select(routeURL).pipe()
+    .subscribe((url: string) => {
+      this.url = url;
+      const [, fragment] = url.split('#');
+      this.tabValue = (fragment === 'details') ? 'details' : 'cookbooks';
+    });
+
+    this.updateOrgForm = this.fb.group({
+      name: ['', [Validators.required]],
+      admin_user: ['', [Validators.required]],
+      admin_key: ['', [Validators.required]]
+    });
+
+    combineLatest([
+      this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
+      this.store.select(routeParams).pipe(pluck('orgid'), filter(identity))
+    ]).pipe(
+      takeUntil(this.isDestroyed)
+    ).subscribe(([server_id, org_id]: string[]) => {
+      this.serverId = server_id;
+      this.OrgId = org_id;
+      this.store.dispatch(new GetOrg({ server_id: server_id, id: org_id }));
+      this.store.dispatch(new GetCookbooksForOrg({
+        server_id: server_id, org_id: org_id
+      }));
+    });
+
+    combineLatest([
+      this.store.select(getStatus),
+      this.store.select(updateStatus),
+      this.store.select(getAllCookbooksForOrgStatus)
+    ]).pipe(
+      takeUntil(this.isDestroyed)
+    ).subscribe(([getOrgSt, updateSt, getCookbooksSt]) => {
+        this.isLoading =
+          !allLoaded([getOrgSt, getCookbooksSt]) || updateSt === EntityStatus.loading;
+      });
+
+    combineLatest([
+      this.store.select(getStatus),
+      this.store.select(getAllCookbooksForOrgStatus),
+      this.store.select(orgFromRoute),
+      this.store.select(allCookbooks)
+    ]).pipe(
+        filter(([getOrgSt, getCookbooksSt, _orgState, _allCookbooksState]) =>
+          getOrgSt === EntityStatus.loadingSuccess &&
+          getCookbooksSt === EntityStatus.loadingSuccess),
+        filter(([_getOrgSt, _getCookbooksSt, orgState, allCookbooksState]) =>
+          !isNil(orgState) && !isNil(allCookbooksState)),
+        takeUntil(this.isDestroyed)
+      ).subscribe(([_getOrgSt, _getCookbooksSt, orgState, allCookbooksState]) => {
+        this.org = { ...orgState };
+        this.cookbooks = allCookbooksState;
+        this.updateOrgForm.controls['name'].setValue(this.org.name);
+        this.updateOrgForm.controls['admin_user'].setValue(this.org.admin_user);
+        this.updateOrgForm.controls['admin_key'].setValue(this.org.admin_key);
+      });
+  }
+
+  onSelectedTab(event: { target: { value: OrgTabName } }) {
+    this.tabValue = event.target.value;
+    this.router.navigate([this.url.split('#')[0]], { fragment: event.target.value });
+  }
+
+  saveOrg(): void {
+    this.saveSuccessful = false;
+    this.saving = true;
+    this.store.dispatch(new UpdateOrg({
+      org: this.org
+    }));
+
+    const pendingSave = new Subject<boolean>();
+    this.store.select(updateStatus).pipe(
+      filter(identity),
+      takeUntil(pendingSave))
+      .subscribe((state) => {
+        if (!loading(state)) {
+          pendingSave.next(true);
+          pendingSave.complete();
+          this.saving = false;
+          this.saveSuccessful = (state === EntityStatus.loadingSuccess);
+          if (this.saveSuccessful) {
+            this.updateOrgForm.markAsPristine();
+          }
+          this.updateOrgForm.controls['name'].setValue(this.org.name);
+          this.updateOrgForm.controls['admin_user'].setValue(this.org.admin_user);
+          this.updateOrgForm.controls['admin_key'].setValue(this.org.admin_key);
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
+  }
+
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
@@ -4,7 +4,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Observable, Subject, combineLatest } from 'rxjs';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { routeParams, routeURL } from 'app/route.selectors';
 import { filter, pluck, takeUntil } from 'rxjs/operators';
 import { identity, isNil } from 'lodash/fp';
@@ -49,7 +49,7 @@ export class CookbooksListComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit() {
-    this.layoutFacade.showInfrastructureSidebar();
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
 
     this.store.select(routeURL).pipe()
     .subscribe((url: string) => {

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.html
@@ -2,7 +2,7 @@
   <h2 slot="title">Add Chef Server </h2>
     <div class="flex-container">
       <form [formGroup]="createForm">
-        <div class="margin">
+        <div class="input-margin">
           <chef-form-field>
             <label>
               <span class="label">Name <span aria-hidden="true">*</span></span>
@@ -14,7 +14,7 @@
           </chef-error>
           </chef-form-field>
         </div>
-        <div class="margin">
+        <div class="input-margin">
           <chef-form-field>
             <label>
               <span class="label">Description<span aria-hidden="true">*</span></span>
@@ -26,7 +26,7 @@
           </chef-error>
           </chef-form-field>
         </div>
-        <div class="margin">
+        <div class="input-margin">
           <chef-form-field>
             <label>
               <span class="label">FQDN <span aria-hidden="true">*</span></span>
@@ -42,7 +42,7 @@
             </chef-error>
           </chef-form-field>
         </div>
-        <div class="margin">
+        <div class="input-margin">
           <chef-form-field>
             <label>
               <span class="label">IP Address <span aria-hidden="true">*</span></span>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.scss
@@ -13,7 +13,7 @@ chef-modal {
     display: flex;
     justify-content: center;
 
-    .margin {
+    .input-margin {
       margin-bottom: 30px;
     }
 

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
@@ -1,5 +1,5 @@
 <chef-modal [visible]="visible" (closeModal)="closeEvent()">
-  <h2 slot="title">Create New Org</h2>
+  <h2 slot="title">Add Chef Org</h2>
   <div class="flex-container">
     <form [formGroup]="createForm">
       <div class="name-margin"> 
@@ -36,8 +36,8 @@
       </div>
       <chef-button [disabled]="!createForm?.valid || creating || conflictError"  primary id="create-org-modal-btn" (click)="createServerOrg()">
         <chef-loading-spinner *ngIf="creating"></chef-loading-spinner>
-        <span *ngIf="!creating">Create Org</span>
-        <span *ngIf="creating">Creating Org...</span>
+        <span *ngIf="!creating">Add Org</span>
+        <span *ngIf="creating">Adding Org...</span>
       </chef-button>
     </form>
   </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
@@ -5,16 +5,19 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AppRoutingModule } from 'app/app-routing.module';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { ChefComponentsModule } from 'app/components/chef-components.module';
-import { ChefServersListComponent } from './chef-servers-list/chef-servers-list.component';
-import { CreateChefServerModalComponent } from './create-chef-server-modal/create-chef-server-modal.component';
 import { ChefServerDetailsComponent } from './chef-server-details/chef-server-details.component';
+import { ChefServersListComponent } from './chef-servers-list/chef-servers-list.component';
+import { CookbooksListComponent } from './cookbook-list/cookbooks-list.component';
+import { CreateChefServerModalComponent } from './create-chef-server-modal/create-chef-server-modal.component';
 import { CreateOrgModalComponent } from './create-org-modal/create-org-modal.component';
+
 
 @NgModule({
   declarations: [
     ChefServersListComponent,
-    CreateChefServerModalComponent,
     ChefServerDetailsComponent,
+    CookbooksListComponent,
+    CreateChefServerModalComponent,
     CreateOrgModalComponent
   ],
   imports: [

--- a/components/automate-ui/src/app/ngrx.effects.ts
+++ b/components/automate-ui/src/app/ngrx.effects.ts
@@ -4,6 +4,7 @@ import { EffectsModule } from '@ngrx/effects';
 import { ApiTokenEffects } from './entities/api-tokens/api-token.effects';
 import { AutomateSettingsEffects } from './entities/automate-settings/automate-settings.effects';
 import { ClientRunsEffects } from './entities/client-runs/client-runs.effects';
+import { CookbookEffects } from './entities/cookbooks/cookbook.effects';
 import { CredentialsEffects } from './pages/+compliance/+credentials/credentials.state';
 // CredentialEffect is for the credential entities. Don't confuse it with CredentialsEffects.
 // CredentialsEffects will be removed when the credentials page is refactored.
@@ -34,6 +35,7 @@ import { UserPermEffects } from './entities/userperms/userperms.effects';
       ApiTokenEffects,
       AutomateSettingsEffects,
       ClientRunsEffects,
+      CookbookEffects,
       CredentialsEffects,
       CredentialEffects,
       EventFeedEffects,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -9,6 +9,7 @@ import * as projectsFilter from './services/projects-filter/projects-filter.redu
 import * as apiToken from './entities/api-tokens/api-token.reducer';
 import * as automateSettings from './entities/automate-settings/automate-settings.reducer';
 import * as clientRuns from './entities/client-runs/client-runs.reducer';
+import * as cookbookEntity from './entities/cookbooks/cookbook.reducer';
 import * as integrationsAdd from './pages/integrations/add/integration-add.reducer';
 import * as integrationsDetail from './pages/integrations/detail/integrations-detail.reducer';
 import * as integrationsEdit from './pages/integrations/edit/integrations-edit.reducer';
@@ -57,6 +58,7 @@ export interface NgrxStateAtom {
   apiTokens: apiToken.ApiTokenEntityState;
   automateSettings: automateSettings.AutomateSettingsEntityState;
   clientRunsEntity: clientRuns.ClientRunsEntityState;
+  cookbooks: cookbookEntity.CookbookEntityState;
   jobs: jobEntity.JobEntityState;
   licenseStatus: license.LicenseStatusEntityState;
   managers: manager.ManagerEntityState;
@@ -164,6 +166,7 @@ export const defaultInitialState = {
   apiTokens: apiToken.ApiTokenEntityInitialState,
   automateSettings: automateSettings.AutomateSettingsEntityInitialState,
   clientRunsEntity: clientRuns.ClientRunsEntityInitialState,
+  cookbooks: cookbookEntity.CookbookEntityInitialState,
   jobs: jobEntity.JobEntityInitialState,
   licenseStatus: license.LicenseStatusEntityInitialState,
   managers: manager.ManagerEntityInitialState,
@@ -204,6 +207,7 @@ export const ngrxReducers = {
   apiTokens: apiToken.apiTokenEntityReducer,
   automateSettings: automateSettings.automateSettingsEntityReducer,
   clientRunsEntity: clientRuns.clientRunsEntityReducer,
+  cookbooks: cookbookEntity.cookbookEntityReducer,
   credentialEntity: credential.credentialReducer,
   jobs: jobEntity.jobEntityReducer,
   managers: manager.managerEntityReducer,

--- a/tools/credscan/credscan.go
+++ b/tools/credscan/credscan.go
@@ -78,6 +78,7 @@ var a2Config = config{
 		{regex: `components/automate-deployment/testdata/hab_responses/all_up.json`},
 		{regex: `components/automate-deployment/tools/upgrade-test-scaffold/upgrade-test-scaffold.go`},
 		{regex: `components/automate-ui/src/app/pages/\+compliance/\+credentials/components/credentials-form.html`},
+		{regex: `components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.html`},
 		{regex: `components/automate-minio/habitat/config/private.key`},
 		{regex: `components/backup-gateway/habitat/config/private.key`},
 		{regex: `components/compliance-service/api/tests/containers/key.pem`},


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Code changes for the introduction of infra proxy cookbook list component in infra proxy module to make automate-ui a single source of truth for chef infra cookbook data here

In this PR following points we have covered:

1. Created cookbook-list component in infra-proxy module to show cookbook list of specific Org
Designed infra proxy cookbook-list UI flows and used Infra-proxy-service
2. Fixed chef-sever left side navbar option issue for non accessible policy 
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
Refered Wireframes: https://chef.invisionapp.com/share/3JVLVFMASDZ#/screens/401258847 
For feature description refer: #1544
### :+1: Definition of Done
1. Added cookbook-list component in infra proxy module 
2.  Fixed chef-sever left side navbar option issue for non accessible policy 
### :athletic_shoe: How to Build and Test the Change
build components/automate-ui
1. Unable chef server side nav option under Infrastructure using feature flag 
2. add sever and org credentials of chef-sever/chef manage
3. click on specific org to check cookbook list 
### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![infra-cookbooklist](https://user-images.githubusercontent.com/54940695/75785381-a0543f80-5d89-11ea-8f4c-5554e3a5cfc1.png)
