### PR TITLE
getFeatureStatus for server

### DIFF
--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -30,6 +30,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
         private featureFlagsService: FeatureFlagsService
     ) {
         this.ServiceNowFeatureFlagOn = this.featureFlagsService.getFeatureStatus('servicenow_cmdb');
+        this.chefInfraServerViewsFeatureFlagOn = this.featureFlagsService.getFeatureStatus('chefInfraServerViews');
         this.isIAMv2$ = this.store.select(isIAMv2);
         this.workflowEnabled$ = this.clientRunsStore.select(clientRunsWorkflowEnabled);
     }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
chef servers is missing from left nav of infrastructure.

### :chains: Related Resources
https://github.com/chef/automate/issues/3021

### :+1: Definition of Done
chef servers is showing from left nav of infrastructure.

### :athletic_shoe: How to Build and Test the Change
sign in with admin/chefautomate
navigate to infrastructure
turn on feature flag for chef servers by typing feat
refresh page
notice that there is no chef servers left nav item

### :camera: Screenshots, if applicable
![Screen Shot 2020-03-03 at 1 41 38 PM](https://user-images.githubusercontent.com/4108100/75812948-bd225000-5d54-11ea-9d58-3308ebd13820.png)
