### PR TITLE
[Automate-2960] Adjust scan jobs permissions

### DIFF
--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -104,8 +104,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
               icon: 'wifi_tethering',
               route: '/compliance/scan-jobs',
               authorized: {
-                allOf: [['/compliance/scanner/jobs', 'post'],
-                ['/compliance/scanner/jobs/search', 'post']]
+                allOf: ['/compliance/scanner/jobs/search', 'post']
               }
             },
             {

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
@@ -23,12 +23,14 @@
   <chef-loading-spinner *ngIf="jobsList.loading" size="100"></chef-loading-spinner>
 
   <chef-tbody *ngIf="!jobsList.loading">
-    <chef-tr class="empty new-row">
-      <span class="cta">Create a new scan job with nodes and profiles</span>
-      <span class="action">
-        <chef-button primary [routerLink]="['/jobs/add']">Create new job</chef-button>
-      </span>
-    </chef-tr>
+    <app-authorized [allOf]="['/compliance/scanner/jobs', 'post']">
+      <chef-tr class="empty new-row">
+        <span class="cta">Create a new scan job with nodes and profiles</span>
+        <span class="action">
+          <chef-button primary [routerLink]="['/jobs/add']">Create new job</chef-button>
+        </span>
+      </chef-tr>
+    </app-authorized>
     <chef-tr *ngFor="let job of jobsList.items; trackBy: trackBy;">
       <chef-td *ngIf="isJobReport(job)">
         {{ job.name }}

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
@@ -27,7 +27,7 @@
       <chef-tr class="empty new-row">
         <span class="cta">Create a new scan job with nodes and profiles</span>
         <span class="action">
-          <chef-button primary [routerLink]="['/jobs/add']">Create new job</chef-button>
+          <chef-button primary [routerLink]="['/jobs/add']">Create Scan Job</chef-button>
         </span>
       </chef-tr>
     </app-authorized>

--- a/components/automate-ui/src/app/pages/job-list/job-list.component.html
+++ b/components/automate-ui/src/app/pages/job-list/job-list.component.html
@@ -31,7 +31,7 @@
         <chef-tr class="empty new-row">
           <span class="cta">Create a new scan job with nodes and profiles</span>
           <span class="action">
-            <chef-button primary [routerLink]="['/jobs/add']">Create new job</chef-button>
+            <chef-button primary [routerLink]="['/jobs/add']">Create Scan Job</chef-button>
           </span>
         </chef-tr>
       </app-authorized>

--- a/components/automate-ui/src/app/pages/job-list/job-list.component.html
+++ b/components/automate-ui/src/app/pages/job-list/job-list.component.html
@@ -27,12 +27,14 @@
     <chef-loading-spinner *ngIf="loading(jobStatus$ | async)" size='50'></chef-loading-spinner>
 
     <chef-tbody>
-      <chef-tr class="empty new-row">
-        <span class="cta">Create a new scan job with nodes and profiles</span>
-        <span class="action">
-          <chef-button primary [routerLink]="['/jobs/add']">Create new job</chef-button>
-        </span>
-      </chef-tr>
+      <app-authorized [allOf]="['/compliance/scanner/jobs', 'post']">
+        <chef-tr class="empty new-row">
+          <span class="cta">Create a new scan job with nodes and profiles</span>
+          <span class="action">
+            <chef-button primary [routerLink]="['/jobs/add']">Create new job</chef-button>
+          </span>
+        </chef-tr>
+      </app-authorized>
       <chef-tr *ngFor="let job of jobs$ | async">
         <chef-td>{{ job.name }}</chef-td>
         <chef-td>{{ job.node_count }}</chef-td>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

A user having the Viewer role should be able to access the scan jobs page.
Previously, an admin user would see the screen below, specifically both the "Scan Jobs" entry in the left navigation bar, and the <kbd>Create new Job</kbd> button.

<img width="1056" alt="image" src="https://user-images.githubusercontent.com/6817500/75826560-99630800-5d5c-11ea-82e8-657fd86e0012.png">

But if you logged in as the default `viewer` the left navigation entry was not showing due to an incorrect authorization guard around that entry, fixed in this PR. That authorization guard has not been removed though; it has been tightened up, so it is now around the <kbd>Create new Job</kbd> button itself, yielding this for the `viewer` user (observe the left nav entry is present but the row with the button is gone):

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/6817500/75827157-e1365f00-5d5d-11ea-8cd5-a5f71b35fb1a.png">

Behind the scenes, though, here is the proof that the guard is in place. Using the Web Developer Tools in Chrome, notice that when I select the object on the page--the box containing the text and the button--its hierarchy is revealed at the bottom of the window. I am pointing out where the `<app-authorized>` has been added.

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/6817500/75827400-6ae62c80-5d5e-11ea-81bf-ebb7f86e90d5.png">


### :chains: Related Resources
NA

### :+1: Definition of Done
Left nav entry is present for `viewer` and above.
<kbd>Create new Job</kbd> is present for `editor` and above.

### :athletic_shoe: How to Build and Test the Change
rebuild automate UI
Login as `admin`--observe left nav entry and button are present.
Login as `viewer`--observe left nav entry is present but not the button.
Login as `editor`--observe left nav entry and button are present.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
