### PR TITLE
Ensure content within info columns wrap w/ the column width

### DIFF
--- a/components/automate-ui/src/app/page-components/run-summary/run-summary.component.scss
+++ b/components/automate-ui/src/app/page-components/run-summary/run-summary.component.scss
@@ -59,6 +59,11 @@
       font-size: 14px;
       padding: 2px 10px 2px 0;
     }
+
+    td {
+      overflow-wrap: break-word;
+      word-break: break-all;
+    }
   }
 
   &.failure {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
@@ -60,6 +60,11 @@ chef-loading-spinner {
       font-size: 14px;
       padding: 2px 10px 2px 0;
     }
+
+    td {
+      overflow-wrap: break-word;
+      word-break: break-all;
+    }
   }
 
   &.failed {


### PR DESCRIPTION
Text content with long continuous characters like guids and such were causing columns to grow wider than intended by the flex layout settings.

Before
![Screen Shot 2020-03-03 at 4 52 12 PM](https://user-images.githubusercontent.com/479121/75831491-da651780-5d70-11ea-8b6e-c4bcdf180d19.png)

After
![Screen Shot 2020-03-03 at 4 52 22 PM](https://user-images.githubusercontent.com/479121/75831503-df29cb80-5d70-11ea-84d5-030200705a14.png)
