### PR TITLE
Expand restore docs to cover questions raised by users

### DIFF
--- a/components/automate-chef-io/content/docs/backup.md
+++ b/components/automate-chef-io/content/docs/backup.md
@@ -10,16 +10,22 @@ toc = true
     parent = "get_started"
     weight = 70
 +++
-## Configuring Backups
 
 Backups are crucial for protecting your data from catastrophic loss and preparing a recovery procedure.
 Back up Chef Automate either to a filesystem or an S3 bucket
 
-### Backup to Filesystem
+## Backup Space Requirements
+
+This amount of space needed for a backup varies depending on your Chef Automate use. You need enough free space for:
+
+* Complete copies of each Chef Automate service PostgreSQL database.
+* Complete copies of your configuration files
+* Elasticsearch snapshots your Chef Automate configuration and data, such as converge, scan, and report data. You will need enough disk space for the each Elasticsearch snapshot and the delta--or the list of changes--for each successive snapshot.
+* Chef Habitat Builder artifacts
+
+## Backup to a Filesystem
 
 Backups can be stored in a configurable backup directory. The backup directory should be on network attached storage or synced periodically to a disk on another machine, to ensure that you can restore from your backup data during a hardware failure.
-
-We recommend that you configure a backup directory on a disk with sufficient free space.
 
 The default backup directory is `/var/opt/chef-automate/backups`. If it does not exist, the deployment process creates it.
 
@@ -40,7 +46,18 @@ To configure your Chef Automate installation's backup directory to another locat
 
     Once this command is applied, the `backup_config.toml` file is no longer necessary, and can be removed.
 
-### Backup to S3
+### Store a Filesystem Backup in a Single-file Archive
+
+Some users prefer to store backups offline in single-file archives. Such archives must
+include both the configuration data and the reporting data contained in the standard
+backup.
+
+The [configured]({{< ref "backup.md#backup-to-filesystem" >}}) backup directory contains both the timestamp-based directory for the configuration, and the reporting data stored in the `automate-elasticsearch-data` directory.
+You must archive both of these directory types in any single-file backups you create.
+
+A timestamp-based directory can be distinguished from the `automate-elasticsearch-data` directory by its file name format, such as `20180518010336`.
+
+## Backup to S3
 
 Backups can be stored in an existing S3 bucket.
 
@@ -78,9 +95,9 @@ The following settings are supported:
   -----END CERTIFICATE-----
 ```
 
-#### S3 Permissions
+### S3 Permissions
 
-The following IAM policy describes the minimum permissions Automate requires to successfully run backup and restore operations.
+The following IAM policy describes the lowest permissions Automate requires to run backup and restore operations.
 
 ```JSON
 {
@@ -129,17 +146,7 @@ The command shows the backup progress for each service. A successful backup disp
 Success: Created backup 20180518010336
 ```
 
-### Storing a Filesystem Backup in a Single-file Archive
-Some users prefer to store backups offline in single-file archives. Such archives must
-include both the configuration data and the reporting data contained in the standard
-backup.
-
-The [configured]({{< ref "backup.md#backup-to-filesystem" >}}) backup directory contains both the timestamp-based directory for the configuration, and the reporting data stored in the `automate-elasticsearch-data` directory.
-You must archive both of these directory types in any single-file backups you create.
-
-A timestamp-based directory can be distinguished from the `automate-elasticsearch-data` directory by its file name format, such as `20180518010336`.
-
-## Listing Backups
+## List Backups
 
 You can list existing backups with the `backup list` command:
 
@@ -177,59 +184,65 @@ chef-automate backup list s3://bucket_name/base_path
 
 where `bucket_name` is the name of the S3 bucket `base_path` an optional path within the bucket where the backups live.
 
-## Restoring Chef Automate
+## Restore Chef Automate
+
 Restore Chef Automate to an instance on which Automate is not already installed.
 
 ### Restore From a Filesystem Backup
 
 #### Prerequisites
-1. The `chef-automate` command line utility must be installed on the host on which you
-   plan to run the restore.
-1. Chef Automate must have access to a backup directory in the [configured location]({{< ref
+
+1. Install the `chef-automate` command line utility on the restore host.
+1. Ensure access for Chef Automate to a backup directory in the [configured location]({{< ref
 "backup.md#backup-to-filesystem" >}}):
-  1. If you used a network-attached filesystem backup, mount the shared backup directory to the same mount point that was configured when the backup was created.
-  1. If the backup directory is not a network-attached filesystem, copy the backup directory to the location that was [configured]({{< ref
-"backup.md#backup-to-filesystem" >}}) when the backup was created.
-  1. If you are restoring from a single-file backup archive, copy your archive to the machine on which you wish to restore and extract it to the [configured backup directory]({{< ref "backup.md#backup-to-filesystem" >}}).
+
+     1. To restore a network-attached filesystem backup, mount the shared backup directory to the same mount point configured at the time of the backup.
+     1. To restore a backup directory that is not a network-attached filesystem, copy the backup directory to the location that was [configured]({{< ref
+"backup.md#backup-to-filesystem" >}}) at the time of the backup.
+     1. For restoring a single-file backup archive, copy your archive to the restore host and extract it to the [configured backup directory]({{< ref "backup.md#backup-to-filesystem" >}}).
 
 #### Restore in an Internet-Connected Environment
-If you have [configured the backup directory]({{< ref "backup.md#backup-to-filesystem" >}}) to a directory that is not default (`/var/opt/chef-automate/backups`) you must supply the backup directory; if you do not provide a backup ID, Chef Automate uses the most recent backup in the backup directory.
 
-To restore on a fresh host:
+If you have [configured the backup directory]({{< ref "backup.md#backup-to-filesystem" >}}) to a directory other than the default directory (`/var/opt/chef-automate/backups`) you must supply the backup directory. Without a backup ID, Chef Automate uses the most recent backup in the backup directory.
+
+To restore on a new host:
 
 ```shell
 chef-automate backup restore </path/to/backups/>BACKUP_ID
 ```
 
-To restore on a host on which Automate has already been installed:
+To restore on an existing Chef Automate host:
 
 ```shell
 chef-automate backup restore </path/to/backups/>BACKUP_ID --skip-preflight
 ```
 
 #### Restore in an Airgapped Environment
-To restore a backup of an [airgapped installation]({{< relref "airgapped-installation.md" >}}), you must specify the [Airgap Installation Bundle]({{< relref "airgapped-installation.md#create-an-airgap-installation-bundle" >}}) used by the installation. If you have [configured the backup directory]({{< ref "backup.md#backup-to-filesystem" >}}) to a directory that is not default (`/var/opt/chef-automate/backups`) you must supply the backup directory; if you do not provide a backup ID, Chef Automate uses the most recent backup in the backup directory.
 
-To restore on a fresh host:
+To restore a backup of an [airgapped installation]({{< relref "airgapped-installation.md" >}}), you must specify the [Airgap Installation Bundle]({{< relref "airgapped-installation.md#create-an-airgap-installation-bundle" >}}) used by the installation.
+If you have [configured the backup directory]({{< ref "backup.md#backup-to-filesystem" >}}) to a directory that is not default (`/var/opt/chef-automate/backups`) you must supply the backup directory; if you do not provide a backup ID, Chef Automate uses the most recent backup in the backup directory.
+
+To restore on a new host:
 
 ```shell
 chef-automate backup restore --airgap-bundle </path/to/bundle> </path/to/backups/>BACKUP_ID
 ```
 
-To restore on a host on which Automate has already been installed:
+To restore on an existing Chef Automate host:
 
 ```shell
 chef-automate backup restore --airgap-bundle </path/to/bundle> </path/to/backups/>BACKUP_ID --skip-preflight
 ```
 
 ### Restore From an S3 Backup
-To restore on a fresh host:
+
+To restore on a new host:
 
 ```shell
 chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID
 ```
 
-To restore on a host on which Automate has already been installed:
+To restore on an existing Chef Automate host:
 
 ```shell
 chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID --skip-preflight
@@ -241,45 +254,7 @@ A successful restore shows the timestamp of the backup used at the end of the st
 Success: Restored backup 20180517223558
 ```
 
-### Update the FQDN
-Chef Automate's restore process expects to run on a host with the same FQDN as
-the host on which the backup was created. If the host on which the restore has run has a
-different FQDN, patch the FQDN and TLS certificate once the restore has completed:
-
-1. On the host on which you are restoring Chef Automate, run
-
-    ```shell
-    chef-automate init-config
-    ```
-to generate a configuration file for that host.
-1. Create a `patch.toml` file that contains the FQDN, TLS certificate, and TLS key entries from the
-   generated configuration:
-   ```toml
-    [global.v1]
-    fqdn = "<new-fqdn>"
-
-    [[global.v1.frontend_tls]]
-    # The TLS certificate for the load balancer frontend.
-    cert = """-----BEGIN CERTIFICATE-----
-    <certificate-for-new-fqdn>
-    -----END CERTIFICATE-----
-    """
-
-    # The TLS RSA key for the load balancer frontend.
-    key = """-----BEGIN RSA PRIVATE KEY-----
-    <key-for-new-fqdn>
-    -----END RSA PRIVATE KEY-----
-    """
-   ```
-1. Run
-   ```shell
-   chef-automate config patch </path/to/patch.toml>
-   ```
-   to patch the restored Automate
-   installation with the new FQDN, TLS certificate, and TLS key configuration entries.
-
-
-## Deleting Backups
+## Delete Backups
 
 To delete backups from a running instance of Chef Automate, first find the relevant backup ID with `chef-automate backup list` and then delete it using `chef automate backup delete ID`.
 
@@ -313,3 +288,42 @@ Are you sure you want to continue? (y/n)
 y
 Success: Backups deleted
 ```
+
+## Troubleshooting
+
+### Update the FQDN
+
+Chef Automate's restore process expects to run on a host with the same FQDN as the host FQDN at the time of the backup.
+If the restore runs on a host with a different FQDN, you will need to patch the FQDN and TLS certificate at the end of the restore process.
+
+1. On the restored host, generate a configuration file on the host:
+
+    ```shell
+    chef-automate init-config
+    ```
+
+2. Create a `patch.toml` file that contains the FQDN, TLS certificate, and TLS key entries from the generated configuration:
+
+   ```toml
+    [global.v1]
+    fqdn = "<new-fqdn>"
+
+    [[global.v1.frontend_tls]]
+    # The TLS certificate for the load balancer frontend.
+    cert = """-----BEGIN CERTIFICATE-----
+    <certificate-for-new-fqdn>
+    -----END CERTIFICATE-----
+    """
+
+    # The TLS RSA key for the load balancer frontend.
+    key = """-----BEGIN RSA PRIVATE KEY-----
+    <key-for-new-fqdn>
+    -----END RSA PRIVATE KEY-----
+    """
+   ```
+
+3. Patch the restored Chef Automate installation with the new FQDN, TLS certificate, and TLS key configuration entries:
+
+   ```shell
+   chef-automate config patch </path/to/patch.toml>
+   ```

--- a/components/automate-chef-io/content/docs/backup.md
+++ b/components/automate-chef-io/content/docs/backup.md
@@ -21,7 +21,7 @@ Backups can be stored in a configurable backup directory. The backup directory s
 
 We recommend that you configure a backup directory on a disk with sufficient free space.
 
-The the default backup directory is `/var/opt/chef-automate/backups`. If it does not exist it will be created during deployment.
+The default backup directory is `/var/opt/chef-automate/backups`. If it does not exist, the deployment process creates it.
 
 To configure your Chef Automate installation's backup directory to another location:
 
@@ -123,7 +123,7 @@ Make a backup with the following command:
 chef-automate backup create
 ```
 
-The command will show the backup progress for each service. If the backup is successful, you will see a success message and timestamp of the backup:
+The command shows the backup progress for each service. A successful backup displays a success message containing the timestamp of the backup:
 
 ```shell
 Success: Created backup 20180518010336
@@ -135,7 +135,7 @@ include both the configuration data and the reporting data contained in the stan
 backup.
 
 The [configured]({{< ref "backup.md#backup-to-filesystem" >}}) backup directory contains both the timestamp-based directory for the configuration, and the reporting data stored in the `automate-elasticsearch-data` directory.
-You will need to archive both of these directory types in any single-file backups you create.
+You must archive both of these directory types in any single-file backups you create.
 
 A timestamp-based directory can be distinguished from the `automate-elasticsearch-data` directory by its file name format, such as `20180518010336`.
 
@@ -147,7 +147,7 @@ You can list existing backups with the `backup list` command:
 chef-automate backup list
 ```
 
-The output will show each backup, and its age:
+The output shows each backup and its age:
 
 ```shell
         Backup        State  Age
@@ -193,7 +193,7 @@ Restore Chef Automate to an instance on which Automate is not already installed.
   1. If you are restoring from a single-file backup archive, copy your archive to the machine on which you wish to restore and extract it to the [configured backup directory]({{< ref "backup.md#backup-to-filesystem" >}}).
 
 #### Restore in an Internet-Connected Environment
-If you have [configured the backup directory]({{< ref "backup.md#backup-to-filesystem" >}}) to a directory that is not default (`/var/opt/chef-automate/backups`) you must supply the backup directory; if you do not provide a backup ID, Chef Automate will use the most recent backup in the backup directory.
+If you have [configured the backup directory]({{< ref "backup.md#backup-to-filesystem" >}}) to a directory that is not default (`/var/opt/chef-automate/backups`) you must supply the backup directory; if you do not provide a backup ID, Chef Automate uses the most recent backup in the backup directory.
 
 To restore on a fresh host:
 
@@ -208,7 +208,7 @@ chef-automate backup restore </path/to/backups/>BACKUP_ID --skip-preflight
 ```
 
 #### Restore in an Airgapped Environment
-To restore a backup of an [airgapped installation]({{< relref "airgapped-installation.md" >}}), you must specify the [Airgap Installation Bundle]({{< relref "airgapped-installation.md#create-an-airgap-installation-bundle" >}}) used by the installation. If you have [configured the backup directory]({{< ref "backup.md#backup-to-filesystem" >}}) to a directory that is not default (`/var/opt/chef-automate/backups`) you must supply the backup directory; if you do not provide a backup ID, Chef Automate will use the most recent backup in the backup directory.
+To restore a backup of an [airgapped installation]({{< relref "airgapped-installation.md" >}}), you must specify the [Airgap Installation Bundle]({{< relref "airgapped-installation.md#create-an-airgap-installation-bundle" >}}) used by the installation. If you have [configured the backup directory]({{< ref "backup.md#backup-to-filesystem" >}}) to a directory that is not default (`/var/opt/chef-automate/backups`) you must supply the backup directory; if you do not provide a backup ID, Chef Automate uses the most recent backup in the backup directory.
 
 To restore on a fresh host:
 
@@ -235,7 +235,7 @@ To restore on a host on which Automate has already been installed:
 chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID --skip-preflight
 ```
 
-If the restore is successful, you will see the following message at the end of the status output:
+A successful restore shows the timestamp of the backup used at the end of the status output:
 
 ```shell
 Success: Restored backup 20180517223558

--- a/tools/credscan/credscan.go
+++ b/tools/credscan/credscan.go
@@ -71,6 +71,7 @@ var a2Config = config{
 		// // TODO(ssd) 2019-01-22: The following files are files that need to be checked.
 		{regex: `components/automate-deployment/pkg/persistence/boltdb/internal/v1/testdata/boltdb-20180226095149.db`},
 		{regex: `components/automate-chef-io/content/docs/configuration.md`},
+		{regex: `components/automate-chef-io/content/docs/backup.md`},
 		{regex: `components/automate-deployment/cmd/chef-server-ctl/secrets.go`},
 		{regex: `components/automate-deployment/pkg/a1stub/test_harness.go`},
 		{regex: `components/automate-deployment/pkg/a1upgrade/a1commands_test.go`},


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Cover user questions raised around restoring Automate in several scenarios:
    
 1. Restore to a host on which Automate is already installed.
 2. Restore to a host with a different FQDN than the one on which the backup was taken.
 3. Restore in an airgapped environment.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
