### PR TITLE
docs build requires a github token

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -58,7 +58,7 @@ steps:
       HAB_NONINTERACTIVE: true
     expeditor:
       secrets:
-        HAB_STUDIO_SECRET_GITHUB_TOKEN:
+        GITHUB_TOKEN:
           account: github
           field: token
       executor:

--- a/components/automate-chef-io/scripts/clone_hugo.sh
+++ b/components/automate-chef-io/scripts/clone_hugo.sh
@@ -2,7 +2,7 @@
 
 clone_url="https://github.com/chef/chef-hugo-theme.git"
 if [[ -n "$GITHUB_TOKEN" ]];then
-    clone_url="https://x-access-token:${GITHUB_TOKEN}@github.com/chef/chef-hugo-theme.git"
+	clone_url="https://x-access-token:${GITHUB_TOKEN}@github.com/chef/chef-hugo-theme.git"
 fi
 
 git clone "$clone_url" themes/chef

--- a/scripts/verify_build.sh
+++ b/scripts/verify_build.sh
@@ -69,6 +69,7 @@ if [[ "$build_commands" != "" ]]; then
     # We override HAB_CACHE_KEY_PATH to ensure we only see the key we
     # generated in this build
     export HAB_DOCKER_OPTS="--label buildkitejob=$BUILDKITE_JOB_ID"
+    export HAB_STUDIO_SECRET_GITHUB_TOKEN="$GITHUB_TOKEN"
     HAB_ORIGIN=chef HAB_CACHE_KEY_PATH=$RESOLVED_RESULTS_DIR DO_CHECK=true hab studio run -D "source .studiorc; set -e; $build_commands"
 fi
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Workaround to get the docs build working. There is an issue in ci-studio-common such that setting HAB_STUDIO_SECRET_GITHUB_TOKEN does not result in GITHUB_TOKEN being set in the habitat studio. 
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
