### PR TITLE
ci: use fully qualified account names

### DIFF
--- a/.expeditor/build.habitat.yml
+++ b/.expeditor/build.habitat.yml
@@ -3,5 +3,5 @@ origin: chef
 smart_build: true
 studio_secrets:
   GITHUB_TOKEN:
-    account: github
+    account: github/chef
     field: token

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -40,7 +40,7 @@ steps:
     expeditor:
       secrets:
         GITHUB_TOKEN:
-          account: github
+          account: github/chef
           field: token
       executor:
         docker:
@@ -59,7 +59,7 @@ steps:
     expeditor:
       secrets:
         HAB_STUDIO_SECRET_GITHUB_TOKEN:
-          account: github
+          account: github/chef
           field: token
       executor:
         linux:


### PR DESCRIPTION
Previous `accounts: github` worked because of a configuration file
that was on disk in our CI environment. This configuration file was
removed, leading to the following error when our CI tooling attempts
to place the requested secret in the environment:

```
panic: no account name provided, and no default account set for github

goroutine 1 [running]:
github.com/chef/ci-studio-common/lib.Check(...)
	/Users/tom/code/chef/ci-studio-common/lib/utils.go:11
github.com/chef/ci-studio-common/vault-util/cmd.fetchSecret(0xc000136510, 0xc0001364e0, 0xc00012fd00)
	/Users/tom/code/chef/ci-studio-common/vault-util/cmd/fetch-secret-env.go:87 +0x3c2
github.com/chef/ci-studio-common/vault-util/cmd.printSecrets(0xdaf460, 0xdd5700, 0x0, 0x0)
	/Users/tom/code/chef/ci-studio-common/vault-util/cmd/fetch-secret-env.go:51 +0x177
github.com/spf13/cobra.(*Command).execute(0xdaf460, 0xdd5700, 0x0, 0x0, 0xdaf460, 0xdd5700)
	/Users/tom/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x2aa
github.com/spf13/cobra.(*Command).ExecuteC(0xdaef60, 0x0, 0x0, 0x0)
	/Users/tom/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/tom/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
github.com/chef/ci-studio-common/vault-util/cmd.Execute()
	/Users/tom/code/chef/ci-studio-common/vault-util/cmd/root.go:27 +0x2d
main.main()
	/Users/tom/code/chef/ci-studio-common/vault-util/main.go:8 +0x20
```

The `default account` is what was previously set by the configuration
file.

Rather than depend on this configuration file, we can fully specify
the GitHub account we want access to.

Signed-off-by: Steven Danna <steve@chef.io>