### PR TITLE
 [elasticsearch] remove post-run sentinel in the init hook

### DIFF
--- a/components/automate-elasticsearch/habitat/hooks/init
+++ b/components/automate-elasticsearch/habitat/hooks/init
@@ -1,16 +1,21 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
 # *** WARNING ***
-# Please put potentially long-running and/or complex operations in the init hook rather
-# than the run hook until the issue described in
+# Please put potentially long-running and/or complex operations in the run
+# hook rather than the run init until the issue described in
 #
 # https://github.com/habitat-sh/habitat/issues/1973
 #
 # has been resolved.
-# Currently, the Habitat `init` and `health_check` hooks run directly from the main loop
-# of the Habitat supervisor. If these hooks hang or take too long to run, they can block
+#
+# Currently, the Habitat `init` hook runs directly from the main loop of the
+# Habitat supervisor. If these hooks hang or take too long to run, they can block
 # execution of the supervisor.
 #
+
+# Make sure the old post-run sentinel file does not exist
+source {{pkg.svc_config_path}}/health_check
+[[ -f ${POST_RUN_SENTINEL} ]] && rm ${POST_RUN_SENTINEL}
 
 mkdir -p {{pkg.svc_var_path}}/logs
 mkdir -p {{pkg.svc_var_path}}/plugins

--- a/components/automate-elasticsearch/habitat/hooks/run
+++ b/components/automate-elasticsearch/habitat/hooks/run
@@ -23,9 +23,5 @@ export ES_PATH_CONF="{{pkg.svc_config_path}}"
 source {{pkg.svc_config_path}}/init_keystore
 source {{pkg.svc_config_path}}/init_ca
 
-# Make sure the old post-run sentinel file does not exist
-source {{pkg.svc_config_path}}/health_check
-[[ -f ${POST_RUN_SENTINEL} ]] && rm ${POST_RUN_SENTINEL}
-
 exec elasticsearch
 {{~/if}}


### PR DESCRIPTION
Remove the post-run sentinel file in init before the service is started.
This fixes a race where the post-run hook could touch the sentinel
before the run hook could delete it.

Fixes: https://buildkite.com/chef/chef-automate-master-nightly/builds/365#5c0180b9-8a97-4a14-8be9-77d304b7d248

Signed-off-by: Ryan Cragun <ryan@chef.io>