### PR TITLE
Report estimated completion time sooner for project update

### DIFF
--- a/components/authz-service/server/v2/project_update_manager.go
+++ b/components/authz-service/server/v2/project_update_manager.go
@@ -514,9 +514,12 @@ func (w *workflowInstance) collectRunningJobStatuses() []project_update_tags.Job
 					logrus.WithError(err).Errorf("failed to get payload for %q", d)
 					continue
 				}
-				if state.Running.CompletedTasks > 0 && state.Running.TotalTasks > 0 &&
+				if state.Running.TotalTasks > 0 &&
 					!state.Running.StartTime.IsZero() && !state.Running.LastUpdated.IsZero() {
 					percentComplete := (float64(state.Running.CompletedTasks) + float64(state.Running.RunningTask.LastStatus.PercentageComplete)) / float64(state.Running.TotalTasks)
+					if percentComplete == 0 {
+						continue
+					}
 					elapsed := state.Running.LastUpdated.Sub(state.Running.StartTime)
 					expectedDuration := time.Duration(float64(elapsed) / percentComplete)
 					jobStatuses = append(jobStatuses, project_update_tags.JobStatus{

--- a/components/authz-service/server/v2/project_update_manager_test.go
+++ b/components/authz-service/server/v2/project_update_manager_test.go
@@ -1,0 +1,63 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/chef/automate/lib/cereal/patterns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunningWorkflow01EstimatedTime(t *testing.T) {
+	w := loadWorkflowFromDisk(t, "running_workflow_01")
+	require.NotZero(t, w.EstimatedTimeComplete())
+}
+
+func loadWorkflowFromDisk(t *testing.T, name string) *workflowInstance {
+	t.Helper()
+
+	loaded := false
+	w := &patterns.ChainWorkflowInstance{}
+
+	paramsFname := fmt.Sprintf("testdata/%s/params.json", name)
+	fParams, err := os.Open(paramsFname)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			t.Fatalf("could not open %s", paramsFname)
+		}
+	} else {
+		defer fParams.Close()
+		params := patterns.ChainWorkflowParams{}
+		if err := json.NewDecoder(fParams).Decode(&params); err != nil {
+			t.Fatalf("failed to decode %s", paramsFname)
+		}
+		w.WithParams(&params)
+		loaded = true
+	}
+
+	payloadFname := fmt.Sprintf("testdata/%s/payload.json", name)
+	fPayload, err := os.Open(payloadFname)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			t.Fatalf("could not open %s", payloadFname)
+		}
+	} else {
+		defer fPayload.Close()
+		payload := patterns.ChainWorkflowPayload{}
+		if err := json.NewDecoder(fPayload).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode %s", payloadFname)
+		}
+		w.WithPayload(&payload)
+		loaded = true
+	}
+
+	if !loaded {
+		t.Fatalf("no workflow data found for %s", name)
+	}
+
+	return &workflowInstance{
+		chain: w,
+	}
+}

--- a/components/authz-service/server/v2/testdata/running_workflow_01/params.json
+++ b/components/authz-service/server/v2/testdata/running_workflow_01/params.json
@@ -1,0 +1,23 @@
+{
+	"WorkflowParams": [
+	  {},
+	  {
+		"SubworkflowKeys": [
+		  "serialized",
+		  "nodemanager"
+		],
+		"WorkflowParams": {
+		  "nodemanager": {
+			"ProjectUpdateID": "4c07acd7-0a30-48b3-900a-e3bdbdae4277"
+		  },
+		  "serialized": {
+			"ProjectUpdateID": "4c07acd7-0a30-48b3-900a-e3bdbdae4277",
+			"DomainServices": [
+			  "compliance",
+			  "ingest"
+			]
+		  }
+		}
+	  }
+	]
+}

--- a/components/authz-service/server/v2/testdata/running_workflow_01/payload.json
+++ b/components/authz-service/server/v2/testdata/running_workflow_01/payload.json
@@ -1,0 +1,2879 @@
+{
+  "Cancelled": false,
+  "State": [
+    {
+      "Payload": null,
+      "Result": {},
+      "Err": "",
+      "EnqueuedTasks": 1,
+      "CompletedTasks": 1,
+      "IsFinished": true
+    },
+    {
+      "Payload": {
+        "State": {
+          "nodemanager": {
+            "Payload": {
+              "ProjectUpdateID": "4c07acd7-0a30-48b3-900a-e3bdbdae4277",
+              "JobIDs": [
+                "67db9fdf-2f36-4cd6-8743-b1d655f1227b"
+              ],
+              "ConsecutiveJobCheckFailures": 0,
+              "MergedJobStatus": {
+                "Completed": false,
+                "PercentageComplete": 0.19017354,
+                "EstimatedEndTimeInSec": 0
+              },
+              "Canceled": false
+            },
+            "Result": null,
+            "Err": "",
+            "EnqueuedTasks": 65,
+            "CompletedTasks": 64,
+            "IsFinished": false
+          },
+          "serialized": {
+            "Payload": {
+              "ProjectUpdateID": "4c07acd7-0a30-48b3-900a-e3bdbdae4277",
+              "DomainServices": [
+                "compliance",
+                "ingest"
+              ],
+              "Phase": "running",
+              "Starting": {
+                "ListTasksResults": {
+                  "compliance": {
+                    "Tasks": [
+                      {
+                        "Priority": 1579392000,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.19"
+                        }
+                      },
+                      {
+                        "Priority": 1583193600,
+                        "Params": {
+                          "n": "comp-7-s-2020.03.03"
+                        }
+                      },
+                      {
+                        "Priority": 1579910400,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.25"
+                        }
+                      },
+                      {
+                        "Priority": 1578614400,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.10"
+                        }
+                      },
+                      {
+                        "Priority": 1582675200,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.26"
+                        }
+                      },
+                      {
+                        "Priority": 1578700800,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.11"
+                        }
+                      },
+                      {
+                        "Priority": 1582934400,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.29"
+                        }
+                      },
+                      {
+                        "Priority": 1581811200,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.16"
+                        }
+                      },
+                      {
+                        "Priority": 1579219200,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.17"
+                        }
+                      },
+                      {
+                        "Priority": 1580774400,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.04"
+                        }
+                      },
+                      {
+                        "Priority": 1583625600,
+                        "Params": {
+                          "n": "comp-7-r-2020.03.08"
+                        }
+                      },
+                      {
+                        "Priority": 1580169600,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.28"
+                        }
+                      },
+                      {
+                        "Priority": 1583452800,
+                        "Params": {
+                          "n": "comp-7-s-2020.03.06"
+                        }
+                      },
+                      {
+                        "Priority": 1583452800,
+                        "Params": {
+                          "n": "comp-7-r-2020.03.06"
+                        }
+                      },
+                      {
+                        "Priority": 1580601600,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.02"
+                        }
+                      },
+                      {
+                        "Priority": 1581897600,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.17"
+                        }
+                      },
+                      {
+                        "Priority": 1581724800,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.15"
+                        }
+                      },
+                      {
+                        "Priority": 1581984000,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.18"
+                        }
+                      },
+                      {
+                        "Priority": 1583280000,
+                        "Params": {
+                          "n": "comp-7-r-2020.03.04"
+                        }
+                      },
+                      {
+                        "Priority": 1581033600,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.07"
+                        }
+                      },
+                      {
+                        "Priority": 1581465600,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.12"
+                        }
+                      },
+                      {
+                        "Priority": 1579392000,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.19"
+                        }
+                      },
+                      {
+                        "Priority": 1580428800,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.31"
+                        }
+                      },
+                      {
+                        "Priority": 1580515200,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.01"
+                        }
+                      },
+                      {
+                        "Priority": 1579824000,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.24"
+                        }
+                      },
+                      {
+                        "Priority": 1580428800,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.31"
+                        }
+                      },
+                      {
+                        "Priority": 1578441600,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.08"
+                        }
+                      },
+                      {
+                        "Priority": 1580688000,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.03"
+                        }
+                      },
+                      {
+                        "Priority": 1580601600,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.02"
+                        }
+                      },
+                      {
+                        "Priority": 1579996800,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.26"
+                        }
+                      },
+                      {
+                        "Priority": 1579737600,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.23"
+                        }
+                      },
+                      {
+                        "Priority": 1581292800,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.10"
+                        }
+                      },
+                      {
+                        "Priority": 1581206400,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.09"
+                        }
+                      },
+                      {
+                        "Priority": 1582416000,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.23"
+                        }
+                      },
+                      {
+                        "Priority": 1583712000,
+                        "Params": {
+                          "n": "comp-7-s-2020.03.09"
+                        }
+                      },
+                      {
+                        "Priority": 1580083200,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.27"
+                        }
+                      },
+                      {
+                        "Priority": 1578614400,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.10"
+                        }
+                      },
+                      {
+                        "Priority": 1580083200,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.27"
+                        }
+                      },
+                      {
+                        "Priority": 1582761600,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.27"
+                        }
+                      },
+                      {
+                        "Priority": 1583625600,
+                        "Params": {
+                          "n": "comp-7-s-2020.03.08"
+                        }
+                      },
+                      {
+                        "Priority": 1579046400,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.15"
+                        }
+                      },
+                      {
+                        "Priority": 1578441600,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.08"
+                        }
+                      },
+                      {
+                        "Priority": 1579046400,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.15"
+                        }
+                      },
+                      {
+                        "Priority": 1579219200,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.17"
+                        }
+                      },
+                      {
+                        "Priority": 1582588800,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.25"
+                        }
+                      },
+                      {
+                        "Priority": 1579305600,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.18"
+                        }
+                      },
+                      {
+                        "Priority": 1580256000,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.29"
+                        }
+                      },
+                      {
+                        "Priority": 1582243200,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.21"
+                        }
+                      },
+                      {
+                        "Priority": 1583539200,
+                        "Params": {
+                          "n": "comp-7-s-2020.03.07"
+                        }
+                      },
+                      {
+                        "Priority": 1580947200,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.06"
+                        }
+                      },
+                      {
+                        "Priority": 1583539200,
+                        "Params": {
+                          "n": "comp-7-r-2020.03.07"
+                        }
+                      },
+                      {
+                        "Priority": 1583193600,
+                        "Params": {
+                          "n": "comp-7-r-2020.03.03"
+                        }
+                      },
+                      {
+                        "Priority": 1578787200,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.12"
+                        }
+                      },
+                      {
+                        "Priority": 1582156800,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.20"
+                        }
+                      },
+                      {
+                        "Priority": 1583366400,
+                        "Params": {
+                          "n": "comp-7-r-2020.03.05"
+                        }
+                      },
+                      {
+                        "Priority": 1582502400,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.24"
+                        }
+                      },
+                      {
+                        "Priority": 1582848000,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.28"
+                        }
+                      },
+                      {
+                        "Priority": 1580688000,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.03"
+                        }
+                      },
+                      {
+                        "Priority": 1579651200,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.22"
+                        }
+                      },
+                      {
+                        "Priority": 1581292800,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.10"
+                        }
+                      },
+                      {
+                        "Priority": 1582070400,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.19"
+                        }
+                      },
+                      {
+                        "Priority": 1581120000,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.08"
+                        }
+                      },
+                      {
+                        "Priority": 1579564800,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.21"
+                        }
+                      },
+                      {
+                        "Priority": 1579478400,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.20"
+                        }
+                      },
+                      {
+                        "Priority": 1578873600,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.13"
+                        }
+                      },
+                      {
+                        "Priority": 1583280000,
+                        "Params": {
+                          "n": "comp-7-s-2020.03.04"
+                        }
+                      },
+                      {
+                        "Priority": 1579651200,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.22"
+                        }
+                      },
+                      {
+                        "Priority": 1578528000,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.09"
+                        }
+                      },
+                      {
+                        "Priority": 1582156800,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.20"
+                        }
+                      },
+                      {
+                        "Priority": 1582243200,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.21"
+                        }
+                      },
+                      {
+                        "Priority": 1583020800,
+                        "Params": {
+                          "n": "comp-7-r-2020.03.01"
+                        }
+                      },
+                      {
+                        "Priority": 1582502400,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.24"
+                        }
+                      },
+                      {
+                        "Priority": 1578960000,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.14"
+                        }
+                      },
+                      {
+                        "Priority": 1579132800,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.16"
+                        }
+                      },
+                      {
+                        "Priority": 1581811200,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.16"
+                        }
+                      },
+                      {
+                        "Priority": 1583712000,
+                        "Params": {
+                          "n": "comp-7-r-2020.03.09"
+                        }
+                      },
+                      {
+                        "Priority": 1582761600,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.27"
+                        }
+                      },
+                      {
+                        "Priority": 1582416000,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.23"
+                        }
+                      },
+                      {
+                        "Priority": 1579824000,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.24"
+                        }
+                      },
+                      {
+                        "Priority": 1582675200,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.26"
+                        }
+                      },
+                      {
+                        "Priority": 1580860800,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.05"
+                        }
+                      },
+                      {
+                        "Priority": 1583107200,
+                        "Params": {
+                          "n": "comp-7-r-2020.03.02"
+                        }
+                      },
+                      {
+                        "Priority": 1581638400,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.14"
+                        }
+                      },
+                      {
+                        "Priority": 1581724800,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.15"
+                        }
+                      },
+                      {
+                        "Priority": 1579132800,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.16"
+                        }
+                      },
+                      {
+                        "Priority": 1579996800,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.26"
+                        }
+                      },
+                      {
+                        "Priority": 1579305600,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.18"
+                        }
+                      },
+                      {
+                        "Priority": 1581552000,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.13"
+                        }
+                      },
+                      {
+                        "Priority": 1578787200,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.12"
+                        }
+                      },
+                      {
+                        "Priority": 1582934400,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.29"
+                        }
+                      },
+                      {
+                        "Priority": 1581379200,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.11"
+                        }
+                      },
+                      {
+                        "Priority": 1583366400,
+                        "Params": {
+                          "n": "comp-7-s-2020.03.05"
+                        }
+                      },
+                      {
+                        "Priority": 1582588800,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.25"
+                        }
+                      },
+                      {
+                        "Priority": 1581033600,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.07"
+                        }
+                      },
+                      {
+                        "Priority": 1581120000,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.08"
+                        }
+                      },
+                      {
+                        "Priority": 1580515200,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.01"
+                        }
+                      },
+                      {
+                        "Priority": 1579910400,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.25"
+                        }
+                      },
+                      {
+                        "Priority": 1581379200,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.11"
+                        }
+                      },
+                      {
+                        "Priority": 1583107200,
+                        "Params": {
+                          "n": "comp-7-s-2020.03.02"
+                        }
+                      },
+                      {
+                        "Priority": 1578528000,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.09"
+                        }
+                      },
+                      {
+                        "Priority": 1581984000,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.18"
+                        }
+                      },
+                      {
+                        "Priority": 1581897600,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.17"
+                        }
+                      },
+                      {
+                        "Priority": 1578700800,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.11"
+                        }
+                      },
+                      {
+                        "Priority": 1579564800,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.21"
+                        }
+                      },
+                      {
+                        "Priority": 1578873600,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.13"
+                        }
+                      },
+                      {
+                        "Priority": 1582329600,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.22"
+                        }
+                      },
+                      {
+                        "Priority": 1581638400,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.14"
+                        }
+                      },
+                      {
+                        "Priority": 1580774400,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.04"
+                        }
+                      },
+                      {
+                        "Priority": 1580947200,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.06"
+                        }
+                      },
+                      {
+                        "Priority": 1580860800,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.05"
+                        }
+                      },
+                      {
+                        "Priority": 1580256000,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.29"
+                        }
+                      },
+                      {
+                        "Priority": 1579737600,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.23"
+                        }
+                      },
+                      {
+                        "Priority": 1581206400,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.09"
+                        }
+                      },
+                      {
+                        "Priority": 1583020800,
+                        "Params": {
+                          "n": "comp-7-s-2020.03.01"
+                        }
+                      },
+                      {
+                        "Priority": 1580342400,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.30"
+                        }
+                      },
+                      {
+                        "Priority": 1582848000,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.28"
+                        }
+                      },
+                      {
+                        "Priority": 1582070400,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.19"
+                        }
+                      },
+                      {
+                        "Priority": 1581552000,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.13"
+                        }
+                      },
+                      {
+                        "Priority": 1580342400,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.30"
+                        }
+                      },
+                      {
+                        "Priority": 1578960000,
+                        "Params": {
+                          "n": "comp-7-r-2020.01.14"
+                        }
+                      },
+                      {
+                        "Priority": 1580169600,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.28"
+                        }
+                      },
+                      {
+                        "Priority": 1582329600,
+                        "Params": {
+                          "n": "comp-7-r-2020.02.22"
+                        }
+                      },
+                      {
+                        "Priority": 1581465600,
+                        "Params": {
+                          "n": "comp-7-s-2020.02.12"
+                        }
+                      },
+                      {
+                        "Priority": 1579478400,
+                        "Params": {
+                          "n": "comp-7-s-2020.01.20"
+                        }
+                      }
+                    ]
+                  },
+                  "ingest": {
+                    "Tasks": [
+                      {
+                        "Priority": 1582070400,
+                        "Params": {
+                          "n": "actions-2020.02.19"
+                        }
+                      },
+                      {
+                        "Priority": 1582761600,
+                        "Params": {
+                          "n": "actions-2020.02.27"
+                        }
+                      },
+                      {
+                        "Priority": 1580860800,
+                        "Params": {
+                          "n": "actions-2020.02.05"
+                        }
+                      },
+                      {
+                        "Priority": 1583452800,
+                        "Params": {
+                          "n": "actions-2020.03.06"
+                        }
+                      },
+                      {
+                        "Priority": 1582502400,
+                        "Params": {
+                          "n": "actions-2020.02.24"
+                        }
+                      },
+                      {
+                        "Priority": 1583020800,
+                        "Params": {
+                          "n": "actions-2020.03.01"
+                        }
+                      },
+                      {
+                        "Priority": 1580601600,
+                        "Params": {
+                          "n": "actions-2020.02.02"
+                        }
+                      },
+                      {
+                        "Priority": 1581897600,
+                        "Params": {
+                          "n": "actions-2020.02.17"
+                        }
+                      },
+                      {
+                        "Priority": 1581292800,
+                        "Params": {
+                          "n": "actions-2020.02.10"
+                        }
+                      },
+                      {
+                        "Priority": 1581724800,
+                        "Params": {
+                          "n": "actions-2020.02.15"
+                        }
+                      },
+                      {
+                        "Priority": 1582588800,
+                        "Params": {
+                          "n": "actions-2020.02.25"
+                        }
+                      },
+                      {
+                        "Priority": 1580688000,
+                        "Params": {
+                          "n": "actions-2020.02.03"
+                        }
+                      },
+                      {
+                        "Priority": 1581811200,
+                        "Params": {
+                          "n": "actions-2020.02.16"
+                        }
+                      },
+                      {
+                        "Priority": 1579737600,
+                        "Params": {
+                          "n": "actions-2020.01.23"
+                        }
+                      },
+                      {
+                        "Priority": 1583107200,
+                        "Params": {
+                          "n": "actions-2020.03.02"
+                        }
+                      },
+                      {
+                        "Priority": 1582934400,
+                        "Params": {
+                          "n": "actions-2020.02.29"
+                        }
+                      },
+                      {
+                        "Priority": 1581984000,
+                        "Params": {
+                          "n": "actions-2020.02.18"
+                        }
+                      },
+                      {
+                        "Priority": 1583625600,
+                        "Params": {
+                          "n": "actions-2020.03.08"
+                        }
+                      },
+                      {
+                        "Priority": 1580342400,
+                        "Params": {
+                          "n": "actions-2020.01.30"
+                        }
+                      },
+                      {
+                        "Priority": 1578614400,
+                        "Params": {
+                          "n": "actions-2020.01.10"
+                        }
+                      },
+                      {
+                        "Priority": 1579219200,
+                        "Params": {
+                          "n": "actions-2020.01.17"
+                        }
+                      },
+                      {
+                        "Priority": 1580169600,
+                        "Params": {
+                          "n": "actions-2020.01.28"
+                        }
+                      },
+                      {
+                        "Priority": 1579910400,
+                        "Params": {
+                          "n": "actions-2020.01.25"
+                        }
+                      },
+                      {
+                        "Priority": 1578873600,
+                        "Params": {
+                          "n": "actions-2020.01.13"
+                        }
+                      },
+                      {
+                        "Priority": 1583539200,
+                        "Params": {
+                          "n": "actions-2020.03.07"
+                        }
+                      },
+                      {
+                        "Priority": 1580256000,
+                        "Params": {
+                          "n": "actions-2020.01.29"
+                        }
+                      },
+                      {
+                        "Priority": 1579564800,
+                        "Params": {
+                          "n": "actions-2020.01.21"
+                        }
+                      },
+                      {
+                        "Priority": 1579132800,
+                        "Params": {
+                          "n": "actions-2020.01.16"
+                        }
+                      },
+                      {
+                        "Priority": 1580083200,
+                        "Params": {
+                          "n": "actions-2020.01.27"
+                        }
+                      },
+                      {
+                        "Priority": 1579824000,
+                        "Params": {
+                          "n": "actions-2020.01.24"
+                        }
+                      },
+                      {
+                        "Priority": 1583280000,
+                        "Params": {
+                          "n": "actions-2020.03.04"
+                        }
+                      },
+                      {
+                        "Priority": 1579478400,
+                        "Params": {
+                          "n": "actions-2020.01.20"
+                        }
+                      },
+                      {
+                        "Priority": 1582243200,
+                        "Params": {
+                          "n": "actions-2020.02.21"
+                        }
+                      },
+                      {
+                        "Priority": 1582675200,
+                        "Params": {
+                          "n": "actions-2020.02.26"
+                        }
+                      },
+                      {
+                        "Priority": 1578960000,
+                        "Params": {
+                          "n": "actions-2020.01.14"
+                        }
+                      },
+                      {
+                        "Priority": 1578528000,
+                        "Params": {
+                          "n": "actions-2020.01.09"
+                        }
+                      },
+                      {
+                        "Priority": 1581033600,
+                        "Params": {
+                          "n": "actions-2020.02.07"
+                        }
+                      },
+                      {
+                        "Priority": 1582848000,
+                        "Params": {
+                          "n": "actions-2020.02.28"
+                        }
+                      },
+                      {
+                        "Priority": 1582416000,
+                        "Params": {
+                          "n": "actions-2020.02.23"
+                        }
+                      },
+                      {
+                        "Priority": 1578700800,
+                        "Params": {
+                          "n": "actions-2020.01.11"
+                        }
+                      },
+                      {
+                        "Priority": 1581638400,
+                        "Params": {
+                          "n": "actions-2020.02.14"
+                        }
+                      },
+                      {
+                        "Priority": 1581206400,
+                        "Params": {
+                          "n": "actions-2020.02.09"
+                        }
+                      },
+                      {
+                        "Priority": 1580947200,
+                        "Params": {
+                          "n": "actions-2020.02.06"
+                        }
+                      },
+                      {
+                        "Priority": 1581552000,
+                        "Params": {
+                          "n": "actions-2020.02.13"
+                        }
+                      },
+                      {
+                        "Priority": 1579046400,
+                        "Params": {
+                          "n": "actions-2020.01.15"
+                        }
+                      },
+                      {
+                        "Priority": 1582156800,
+                        "Params": {
+                          "n": "actions-2020.02.20"
+                        }
+                      },
+                      {
+                        "Priority": 1579651200,
+                        "Params": {
+                          "n": "actions-2020.01.22"
+                        }
+                      },
+                      {
+                        "Priority": 1580428800,
+                        "Params": {
+                          "n": "actions-2020.01.31"
+                        }
+                      },
+                      {
+                        "Priority": 1582329600,
+                        "Params": {
+                          "n": "actions-2020.02.22"
+                        }
+                      },
+                      {
+                        "Priority": 1580515200,
+                        "Params": {
+                          "n": "actions-2020.02.01"
+                        }
+                      },
+                      {
+                        "Priority": 1583193600,
+                        "Params": {
+                          "n": "actions-2020.03.03"
+                        }
+                      },
+                      {
+                        "Priority": 1583366400,
+                        "Params": {
+                          "n": "actions-2020.03.05"
+                        }
+                      },
+                      {
+                        "Priority": 1580774400,
+                        "Params": {
+                          "n": "actions-2020.02.04"
+                        }
+                      },
+                      {
+                        "Priority": 1581465600,
+                        "Params": {
+                          "n": "actions-2020.02.12"
+                        }
+                      },
+                      {
+                        "Priority": 1578787200,
+                        "Params": {
+                          "n": "actions-2020.01.12"
+                        }
+                      },
+                      {
+                        "Priority": 1583712000,
+                        "Params": {
+                          "n": "actions-2020.03.09"
+                        }
+                      },
+                      {
+                        "Priority": 1579392000,
+                        "Params": {
+                          "n": "actions-2020.01.19"
+                        }
+                      },
+                      {
+                        "Priority": 1579996800,
+                        "Params": {
+                          "n": "actions-2020.01.26"
+                        }
+                      },
+                      {
+                        "Priority": 1581379200,
+                        "Params": {
+                          "n": "actions-2020.02.11"
+                        }
+                      },
+                      {
+                        "Priority": 1581120000,
+                        "Params": {
+                          "n": "actions-2020.02.08"
+                        }
+                      },
+                      {
+                        "Priority": 1579305600,
+                        "Params": {
+                          "n": "actions-2020.01.18"
+                        }
+                      },
+                      {
+                        "Priority": 1583776911,
+                        "Params": {
+                          "n": "node-state-7"
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "Running": {
+                "RunningTask": {
+                  "ID": "8FHoLNxOT1e5ys-sQV_ymQ:1082109",
+                  "Task": {
+                    "t": {
+                      "Priority": 1583776911,
+                      "Params": {
+                        "n": "node-state-7"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  "LastStatus": {
+                    "State": "running",
+                    "PercentageComplete": 0.6483871,
+                    "Metadata": null,
+                    "Error": ""
+                  }
+                },
+                "RemainingTasks": [
+                  {
+                    "t": {
+                      "Priority": 1583712000,
+                      "Params": {
+                        "n": "comp-7-r-2020.03.09"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583712000,
+                      "Params": {
+                        "n": "actions-2020.03.09"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583712000,
+                      "Params": {
+                        "n": "comp-7-s-2020.03.09"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583625600,
+                      "Params": {
+                        "n": "comp-7-s-2020.03.08"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583625600,
+                      "Params": {
+                        "n": "comp-7-r-2020.03.08"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583625600,
+                      "Params": {
+                        "n": "actions-2020.03.08"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583539200,
+                      "Params": {
+                        "n": "comp-7-r-2020.03.07"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583539200,
+                      "Params": {
+                        "n": "actions-2020.03.07"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583539200,
+                      "Params": {
+                        "n": "comp-7-s-2020.03.07"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583452800,
+                      "Params": {
+                        "n": "comp-7-s-2020.03.06"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583452800,
+                      "Params": {
+                        "n": "comp-7-r-2020.03.06"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583452800,
+                      "Params": {
+                        "n": "actions-2020.03.06"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583366400,
+                      "Params": {
+                        "n": "actions-2020.03.05"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583366400,
+                      "Params": {
+                        "n": "comp-7-s-2020.03.05"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583366400,
+                      "Params": {
+                        "n": "comp-7-r-2020.03.05"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583280000,
+                      "Params": {
+                        "n": "comp-7-s-2020.03.04"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583280000,
+                      "Params": {
+                        "n": "actions-2020.03.04"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583280000,
+                      "Params": {
+                        "n": "comp-7-r-2020.03.04"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583193600,
+                      "Params": {
+                        "n": "comp-7-r-2020.03.03"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583193600,
+                      "Params": {
+                        "n": "comp-7-s-2020.03.03"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583193600,
+                      "Params": {
+                        "n": "actions-2020.03.03"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583107200,
+                      "Params": {
+                        "n": "comp-7-s-2020.03.02"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583107200,
+                      "Params": {
+                        "n": "actions-2020.03.02"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583107200,
+                      "Params": {
+                        "n": "comp-7-r-2020.03.02"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583020800,
+                      "Params": {
+                        "n": "comp-7-s-2020.03.01"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583020800,
+                      "Params": {
+                        "n": "actions-2020.03.01"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1583020800,
+                      "Params": {
+                        "n": "comp-7-r-2020.03.01"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582934400,
+                      "Params": {
+                        "n": "actions-2020.02.29"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582934400,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.29"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582934400,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.29"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582848000,
+                      "Params": {
+                        "n": "actions-2020.02.28"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582848000,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.28"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582848000,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.28"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582761600,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.27"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582761600,
+                      "Params": {
+                        "n": "actions-2020.02.27"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582761600,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.27"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582675200,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.26"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582675200,
+                      "Params": {
+                        "n": "actions-2020.02.26"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582675200,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.26"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582588800,
+                      "Params": {
+                        "n": "actions-2020.02.25"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582588800,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.25"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582588800,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.25"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582502400,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.24"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582502400,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.24"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582502400,
+                      "Params": {
+                        "n": "actions-2020.02.24"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582416000,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.23"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582416000,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.23"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582416000,
+                      "Params": {
+                        "n": "actions-2020.02.23"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582329600,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.22"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582329600,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.22"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582329600,
+                      "Params": {
+                        "n": "actions-2020.02.22"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582243200,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.21"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582243200,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.21"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582243200,
+                      "Params": {
+                        "n": "actions-2020.02.21"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582156800,
+                      "Params": {
+                        "n": "actions-2020.02.20"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582156800,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.20"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582156800,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.20"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582070400,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.19"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582070400,
+                      "Params": {
+                        "n": "actions-2020.02.19"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1582070400,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.19"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581984000,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.18"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581984000,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.18"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581984000,
+                      "Params": {
+                        "n": "actions-2020.02.18"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581897600,
+                      "Params": {
+                        "n": "actions-2020.02.17"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581897600,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.17"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581897600,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.17"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581811200,
+                      "Params": {
+                        "n": "actions-2020.02.16"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581811200,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.16"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581811200,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.16"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581724800,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.15"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581724800,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.15"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581724800,
+                      "Params": {
+                        "n": "actions-2020.02.15"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581638400,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.14"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581638400,
+                      "Params": {
+                        "n": "actions-2020.02.14"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581638400,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.14"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581552000,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.13"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581552000,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.13"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581552000,
+                      "Params": {
+                        "n": "actions-2020.02.13"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581465600,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.12"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581465600,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.12"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581465600,
+                      "Params": {
+                        "n": "actions-2020.02.12"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581379200,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.11"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581379200,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.11"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581379200,
+                      "Params": {
+                        "n": "actions-2020.02.11"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581292800,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.10"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581292800,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.10"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581292800,
+                      "Params": {
+                        "n": "actions-2020.02.10"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581206400,
+                      "Params": {
+                        "n": "actions-2020.02.09"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581206400,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.09"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581206400,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.09"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581120000,
+                      "Params": {
+                        "n": "actions-2020.02.08"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581120000,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.08"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581120000,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.08"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581033600,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.07"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581033600,
+                      "Params": {
+                        "n": "actions-2020.02.07"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1581033600,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.07"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580947200,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.06"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580947200,
+                      "Params": {
+                        "n": "actions-2020.02.06"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580947200,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.06"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580860800,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.05"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580860800,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.05"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580860800,
+                      "Params": {
+                        "n": "actions-2020.02.05"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580774400,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.04"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580774400,
+                      "Params": {
+                        "n": "actions-2020.02.04"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580774400,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.04"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580688000,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.03"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580688000,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.03"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580688000,
+                      "Params": {
+                        "n": "actions-2020.02.03"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580601600,
+                      "Params": {
+                        "n": "actions-2020.02.02"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580601600,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.02"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580601600,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.02"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580515200,
+                      "Params": {
+                        "n": "comp-7-s-2020.02.01"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580515200,
+                      "Params": {
+                        "n": "comp-7-r-2020.02.01"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580515200,
+                      "Params": {
+                        "n": "actions-2020.02.01"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580428800,
+                      "Params": {
+                        "n": "actions-2020.01.31"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580428800,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.31"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580428800,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.31"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580342400,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.30"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580342400,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.30"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580342400,
+                      "Params": {
+                        "n": "actions-2020.01.30"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580256000,
+                      "Params": {
+                        "n": "actions-2020.01.29"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580256000,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.29"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580256000,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.29"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580169600,
+                      "Params": {
+                        "n": "actions-2020.01.28"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580169600,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.28"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580169600,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.28"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580083200,
+                      "Params": {
+                        "n": "actions-2020.01.27"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580083200,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.27"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1580083200,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.27"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579996800,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.26"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579996800,
+                      "Params": {
+                        "n": "actions-2020.01.26"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579996800,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.26"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579910400,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.25"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579910400,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.25"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579910400,
+                      "Params": {
+                        "n": "actions-2020.01.25"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579824000,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.24"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579824000,
+                      "Params": {
+                        "n": "actions-2020.01.24"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579824000,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.24"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579737600,
+                      "Params": {
+                        "n": "actions-2020.01.23"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579737600,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.23"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579737600,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.23"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579651200,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.22"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579651200,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.22"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579651200,
+                      "Params": {
+                        "n": "actions-2020.01.22"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579564800,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.21"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579564800,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.21"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579564800,
+                      "Params": {
+                        "n": "actions-2020.01.21"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579478400,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.20"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579478400,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.20"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579478400,
+                      "Params": {
+                        "n": "actions-2020.01.20"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579392000,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.19"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579392000,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.19"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579392000,
+                      "Params": {
+                        "n": "actions-2020.01.19"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579305600,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.18"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579305600,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.18"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579305600,
+                      "Params": {
+                        "n": "actions-2020.01.18"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579219200,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.17"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579219200,
+                      "Params": {
+                        "n": "actions-2020.01.17"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579219200,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.17"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579132800,
+                      "Params": {
+                        "n": "actions-2020.01.16"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579132800,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.16"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579132800,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.16"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579046400,
+                      "Params": {
+                        "n": "actions-2020.01.15"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579046400,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.15"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1579046400,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.15"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578960000,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.14"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578960000,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.14"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578960000,
+                      "Params": {
+                        "n": "actions-2020.01.14"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578873600,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.13"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578873600,
+                      "Params": {
+                        "n": "actions-2020.01.13"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578873600,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.13"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578787200,
+                      "Params": {
+                        "n": "actions-2020.01.12"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578787200,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.12"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578787200,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.12"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578700800,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.11"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578700800,
+                      "Params": {
+                        "n": "actions-2020.01.11"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578700800,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.11"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578614400,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.10"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578614400,
+                      "Params": {
+                        "n": "actions-2020.01.10"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578614400,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.10"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578528000,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.09"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578528000,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.09"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578528000,
+                      "Params": {
+                        "n": "actions-2020.01.09"
+                      }
+                    },
+                    "svc": "ingest"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578441600,
+                      "Params": {
+                        "n": "comp-7-r-2020.01.08"
+                      }
+                    },
+                    "svc": "compliance"
+                  },
+                  {
+                    "t": {
+                      "Priority": 1578441600,
+                      "Params": {
+                        "n": "comp-7-s-2020.01.08"
+                      }
+                    },
+                    "svc": "compliance"
+                  }
+                ],
+                "CompletedTasks": 0,
+                "TotalTasks": 186,
+                "StartTime": "2020-03-09T18:01:53.19500762Z",
+                "LastUpdated": "2020-03-09T18:21:47.387265641Z"
+              },
+              "MonitorFailures": 0
+            },
+            "Result": null,
+            "Err": "",
+            "EnqueuedTasks": 129,
+            "CompletedTasks": 128,
+            "IsFinished": false
+          }
+        }
+      },
+      "Result": null,
+      "Err": "",
+      "EnqueuedTasks": 194,
+      "CompletedTasks": 192,
+      "IsFinished": false
+    }
+  ]
+}

--- a/lib/cereal/patterns/chain.go
+++ b/lib/cereal/patterns/chain.go
@@ -139,6 +139,20 @@ type ChainWorkflowInstance struct {
 	err       error
 }
 
+func (instance *ChainWorkflowInstance) WithPayload(payload *ChainWorkflowPayload) {
+	instance.isRunning = true
+	instance.payload = payload
+}
+
+func (instance *ChainWorkflowInstance) WithParams(params *ChainWorkflowParams) {
+	instance.params = params
+}
+
+func (instance *ChainWorkflowInstance) WithResult(result *ChainWorkflowPayload) {
+	instance.isRunning = false
+	instance.result = result
+}
+
 func (instance *ChainWorkflowInstance) GetSubWorkflow(idx int) (cereal.ImmutableWorkflowInstance, error) {
 	if instance.err != nil {
 		return nil, instance.err


### PR DESCRIPTION
nodemanager doesn't report an estimated completion, and the ES bits were
waiting until an entire index had been updated. This should now report
as soon as ES has processed at least 1 document.
