### PR TITLE
Optimize time range when fetching a node's compliance report

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -45,7 +45,8 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     this.statsService.getReports(reportQuery, {sort: 'latest_report.end_time', order: 'DESC'})
       .subscribe(reports => {
         this.reports = reports;
-        this.statsService.getSingleReport(reports[0].id, reportQuery)
+        const queryForReport = this.reportQuery.getReportQueryForReport(reports[0]);
+        this.statsService.getSingleReport(reports[0].id, queryForReport)
           .subscribe(data => {
             this.reportLoading = false;
             this.layoutFacade.ShowPageLoading(false);
@@ -62,7 +63,8 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
   onReportItemClick(_event, report) {
     this.reportLoading = true;
     this.layoutFacade.ShowPageLoading(true);
-    this.statsService.getSingleReport(report.id, this.reportQuery.getReportQuery())
+    const reportQuery = this.reportQuery.getReportQueryForReport(report);
+    this.statsService.getSingleReport(report.id, reportQuery)
       .subscribe(data => {
         this.reportLoading = false;
         this.layoutFacade.ShowPageLoading(false);

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-query.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-query.service.ts
@@ -15,6 +15,10 @@ interface TimeIntervals {
   findStartDate: (endDate: moment.Moment) => moment.Moment;
 }
 
+interface ReportSummary {
+  end_time: string;
+}
+
 @Injectable()
 export class ReportQueryService {
 
@@ -51,6 +55,23 @@ export class ReportQueryService {
       interval: reportQuery.interval,
       filters: [...reportQuery.filters]
     };
+  }
+
+  // getReportQueryForReport provides the same functionality as getReportQuery,
+  // but uses the additional information in the given report summary to make
+  // the query more efficient for the backend server.
+  getReportQueryForReport(report: ReportSummary): ReportQuery {
+    // Reports are stored separately (per-day) according to their `end_time` on
+    // the server; therefore, the API to fetch a report is much faster/uses
+    // fewer resources when we limit the date/time range of our query to the
+    // minimum possible. We use the `end_time` we already have from the report
+    // to restrict our query to a very narrow time range. The StatsService will
+    // take care of setting the start and end dates to the beginning and end of
+    // the given day as needed.
+    const query = this.getReportQuery();
+    query.startDate = moment(report.end_time);
+    query.endDate = moment(report.end_time);
+    return query;
   }
 
   setState(newState: ReportQuery) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Currently, when you navigate to a compliance report by clicking on a node's name in the table, the UI specifies a date range limit based on what you selected in the trend graph drop-down. The performance of the query to fetch the report is inversely related to to how wide the date range is, because the report is stored in a date-named index in elasticsearch. Using the date range from the trend graph drop down is silly because we already got a list of compliance reports with dates to populate the "scan history" popover.

This change uses the known timestamp of the report we are fetching to hint the API to the index it should use to fetch the report.

### :chains: Related Resources

https://github.com/chef/automate/pull/3037

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

* build automate-ui, start all services
* create sample data going back in time, I used: `chef_load_compliance_scans -D 100 -M 100 -T 100000`
* go to the compliance tab and select "last 3 months" in the trend graph drop down
* open the browser dev tools so you can inspect the requests
* navigate to the nodes tab and click your node. Find the request for the node's compliance report (a URL like `https://a2-dev.test/api/v0/compliance/reporting/reports/id/d6103814-900a-44b9-bb13-676f39285f04` but the id will be different). Check the request data, you should have the start time and end time be the beginning and end of one single day, like this:
```
{"type":"start_time","values":["2020-03-11T00:00:00Z"]},
{"type":"end_time","values":["2020-03-11T23:59:59Z"]}
```
* Click through the scan history. For reports further in the past, the requests should also have a single day for the start time/end time range.

