### PR TITLE
[terraform] don't forward journald to syslog

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/main.tf
+++ b/terraform/test-environments/modules/chef_automate_install/main.tf
@@ -114,6 +114,7 @@ SystemMaxUse=${var.journald_system_max_use}
 SystemMaxFileSize=1G
 RateLimitBurst=0
 RateLimitInterval=0
+ForwardToSyslog=no
 EOF
   }
 


### PR DESCRIPTION
Several integration instances were recently rebooted to update them to more economical and recent instance sizes. After the reboot, journald started logging to syslog, which doesn't have a max file limit configured so we ran out of disk space before logrotate could purge the old syslog file. There's no reason to forward journald to syslog so we'll disable it.

Signed-off-by: Ryan Cragun <ryan@chef.io>