### PR TITLE
Automate 2546 Waiver

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
@@ -22,9 +22,10 @@
     <chef-tbody *ngIf="!reportData.profilesListLoading">
       <chef-tr *ngFor="let profile of reportData.profilesList.items">
         <chef-td class="title-cell">
-          <chef-icon class="status-icon" [ngClass]="profile.status">
+          <chef-icon *ngIf="profile.status !== 'waived'" class="status-icon" [ngClass]="profile.status">
             {{ statusIcon(profile.status) }}
           </chef-icon>
+          <div *ngIf="profile.status === 'waived'" class="waived-icon"></div>
           <a [routerLink]="['/compliance/reports/profiles', profile.id]">{{ profile.title }}</a>
         </chef-td>
         <chef-td class="version-cell">{{ profile.version }}</chef-td>
@@ -70,12 +71,13 @@
           <p>Tap on a node to view detailed scan results</p>
         </div>
         <ul class="results-profiles-list">
-          <ng-container *ngFor="let status of ['failed', 'passed', 'skipped']">
+          <ng-container *ngFor="let status of ['failed', 'passed', 'skipped', 'waived']">
             <li
               *ngFor="let node of layerOneData[status]"
               class="results-profiles-list-item">
               <div class="list-item-summary">
-                <chef-icon class="list-item-icon" [ngClass]="node.status">{{ statusIcon(status) }}</chef-icon>
+                <chef-icon *ngIf="node.status !== 'waived'" class="list-item-icon" [ngClass]="node.status">{{ statusIcon(status) }}</chef-icon>
+                <div *ngIf="node.status === 'waived'" class="waived-icon"></div>
                 <div class="list-item-text">
                   <p class="node-name">
                     <strong>{{ node.name }}</strong>
@@ -98,12 +100,13 @@
           <p>{{ layerTwoData?.id }}</p>
         </div>
         <ul class="results-profiles-list">
-          <ng-container *ngFor="let status of ['failed', 'passed', 'skipped']">
+          <ng-container *ngFor="let status of ['failed', 'passed', 'skipped', 'waived']">
             <li
               *ngFor="let control of layerTwoData[status]"
               class="results-profiles-list-item">
               <div class="list-item-summary">
-                <chef-icon class="list-item-icon" [ngClass]="status">{{ statusIcon(status) }}</chef-icon>
+                <chef-icon *ngIf="status !== 'waived'" class="list-item-icon" [ngClass]="status">{{ statusIcon(status) }}</chef-icon>
+                <div *ngIf="status === 'waived'" class="waived-icon"></div>
                 <div class="list-item-text">
                   <p class="node-name">
                     <strong>{{ control.title }}</strong>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
@@ -22,9 +22,11 @@
     <chef-tbody *ngIf="!reportData.profilesListLoading">
       <chef-tr *ngFor="let profile of reportData.profilesList.items">
         <chef-td class="title-cell">
+          <!-- Material Icon Font -->
           <chef-icon *ngIf="profile.status !== 'waived'" class="status-icon" [ngClass]="profile.status">
             {{ statusIcon(profile.status) }}
           </chef-icon>
+          <!-- Custom Waived Icon -->
           <div *ngIf="profile.status === 'waived'" class="waived-icon"></div>
           <a [routerLink]="['/compliance/reports/profiles', profile.id]">{{ profile.title }}</a>
         </chef-td>
@@ -105,7 +107,9 @@
               *ngFor="let control of layerTwoData[status]"
               class="results-profiles-list-item">
               <div class="list-item-summary">
+                <!-- Material Icon Font -->
                 <chef-icon *ngIf="status !== 'waived'" class="list-item-icon" [ngClass]="status">{{ statusIcon(status) }}</chef-icon>
+                <!-- Custom Waived Icon -->
                 <div *ngIf="status === 'waived'" class="waived-icon"></div>
                 <div class="list-item-text">
                   <p class="node-name">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.scss
@@ -12,7 +12,7 @@
     &.title-cell {
       flex-basis: 40%;
 
-      chef-icon {
+      chef-icon, .waived-icon {
         margin-right: 1em;
       }
     }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.spec.ts
@@ -64,26 +64,4 @@ describe('ReportingProfilesComponent', () => {
       expect(component.getData).toHaveBeenCalledWith(reportQuery);
     });
   });
-
-  describe('addControlStatus()', () => {
-    const data = {profiles: [
-      {
-        controls: [
-          { results: [ {status: 'skipped'}, {status: 'passed'} ] },
-          { results: [ {status: 'passed'}, {status: 'passed'} ] },
-          { results: [ {status: 'failed'}, {status: 'passed'} ] },
-          { results: [ {status: 'skipped'}, {status: 'skipped'} ] }
-        ]
-      }
-    ]};
-    const expected = [
-      { results: [ { status: 'skipped' }, { status: 'passed' } ], status: 'passed' },
-      { results: [ { status: 'passed' }, { status: 'passed' } ], status: 'passed' },
-      { results: [ { status: 'failed' }, { status: 'passed' } ], status: 'failed' },
-      { results: [ { status: 'skipped'}, {status: 'skipped'} ], status: 'skipped' }
-    ];
-    it('sets the status for the control according to results', () => {
-      expect(component.addControlStatus(data)).toEqual(expected);
-    });
-  });
 });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.ts
@@ -177,27 +177,10 @@ export class ReportingProfilesComponent implements OnInit, OnDestroy {
     this.statsService.getSingleReport(reportID, filters).pipe(
       takeUntil(this.isDestroyed))
       .subscribe(data => {
-        const controls = this.addControlStatus(data);
+        const controls = data.profiles[0].controls;
         this.layerTwoData = Object.assign({'id': item.name }, groupBy(controls, 'status'));
         this.scanResultsPane = 1;
       });
-  }
-
-  addControlStatus(data) {
-    return data.profiles[0].controls.map(control => {
-      if (control.results) {
-        const isSkipped = control.results.every(r => r.status === 'skipped');
-        const isFailed = control.results.some(r => r.status === 'failed');
-        if (isSkipped) {
-          control.status = 'skipped';
-        } else if (isFailed) {
-          control.status = 'failed';
-        } else {
-          control.status = 'passed';
-        }
-      }
-      return control;
-    });
   }
 
   setControl(item) {

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -330,6 +330,7 @@ input {
 }
 
 .waived-icon {
+  border-radius: 2px;
   height: 16px;
   width: 16px;
   background-color: #CDD7DD;

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -328,3 +328,21 @@ input {
     display: none;
   }
 }
+
+.waived-icon {
+  height: 16px;
+  width: 16px;
+  background-color: #CDD7DD;
+  position: relative;
+}
+
+.waived-icon:before {
+  color: #26293A;
+  content: 'W';
+  font-size: 9px;
+  font-weight: bolder;
+  position: absolute;
+  right: 3px;
+  text-align: center;
+  top: -2px;
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As an Automate User, I will use this work when I want to drill down to the control and see which control was waived.

### :chains: Related Resources
https://github.com/chef/automate/issues/2561

### :+1: Definition of Done
A user can click on "Scan Results" on the Profile list page, and then choose a node - which will then show controls that have been waived.
Waived control will be displayed at the bottom of the control list.

### :athletic_shoe: How to Build and Test the Change
load data by using the load_compliance_reports command from your studio dev env

### :camera: Screenshots, if applicable
![Screen Shot 2020-03-12 at 5 25 48 PM](https://user-images.githubusercontent.com/4108100/76571859-9071e500-6486-11ea-8e53-e40401c03167.png)
![Screen Shot 2020-03-12 at 5 25 56 PM](https://user-images.githubusercontent.com/4108100/76571860-91a31200-6486-11ea-86ac-649d5e7de22b.png)

![Screen Shot 2020-03-12 at 4 19 13 PM](https://user-images.githubusercontent.com/4108100/76571829-7cc67e80-6486-11ea-884d-956771293fa1.png)
