### PR TITLE
[automate-3030] Enhance edits pending bar to show failure

### DIFF
--- a/components/authz-service/server/v2/project.go
+++ b/components/authz-service/server/v2/project.go
@@ -258,11 +258,16 @@ func (s *ProjectState) ApplyRulesStatus(
 		s.log.Errorf("Could not convert EstimatedTimeComplete to protobuf Timestamp %v", err)
 		time = &tspb.Timestamp{}
 	}
+	// When cancelling failed gets triggered, too, so let's suppress that
+	// to make cancel unambiguous.
+	// (Leaving FailureMessage as that just reports "Canceled".)
+	failed := status.Failed() && !status.Cancelled()
+
 	return &api.ApplyRulesStatusResp{
 		State:                 string(status.State()),
 		PercentageComplete:    float32(status.PercentageComplete()),
 		EstimatedTimeComplete: time,
-		Failed:                status.Failed(),
+		Failed:                failed,
 		FailureMessage:        status.FailureMessage(),
 		Cancelled:             status.Cancelled(),
 	}, nil

--- a/components/authz-service/server/v2/project_update_manager_test.go
+++ b/components/authz-service/server/v2/project_update_manager_test.go
@@ -41,38 +41,30 @@ func loadWorkflowFromDisk(t *testing.T, name string) *workflowInstance {
 	}
 
 	payloadFname := fmt.Sprintf("testdata/%s/payload.json", name)
-	fPayload, err := os.Open(payloadFname)
+
+	tmpl, err := template.ParseFiles(payloadFname)
 	if err != nil {
-		if !os.IsNotExist(err) {
-			t.Fatalf("could not open %s", payloadFname)
-		}
-	} else {
-		defer fPayload.Close()
-		payload := patterns.ChainWorkflowPayload{}
-
-		tmpl, err := template.ParseFiles(payloadFname)
-		if err != nil {
-			t.Fatalf("could not parse file: %s", err)
-		}
-
-		b := bytes.NewBuffer(nil)
-		err = tmpl.Execute(b, struct {
-			StartTime   string
-			LastUpdated string
-		}{
-			StartTime:   time.Now().Format(time.RFC3339),
-			LastUpdated: time.Now().Add(time.Minute).Format(time.RFC3339),
-		})
-		if err != nil {
-			t.Fatalf("could not update time fields in template: %s", err)
-		}
-
-		if err := json.Unmarshal(b.Bytes(), &payload); err != nil {
-			t.Fatalf("failed to decode %s", payloadFname)
-		}
-		w.WithPayload(&payload)
-		loaded = true
+		t.Fatalf("could not parse file: %s", err)
 	}
+
+	b := bytes.NewBuffer(nil)
+	err = tmpl.Execute(b, struct {
+		StartTime   string
+		LastUpdated string
+	}{
+		StartTime:   time.Now().Format(time.RFC3339),
+		LastUpdated: time.Now().Add(time.Minute).Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("could not update time fields in template: %s", err)
+	}
+
+	payload := patterns.ChainWorkflowPayload{}
+	if err := json.Unmarshal(b.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode %s", payloadFname)
+	}
+	w.WithPayload(&payload)
+	loaded = true
 
 	if !loaded {
 		t.Fatalf("no workflow data found for %s", name)

--- a/components/authz-service/server/v2/testdata/running_workflow_01/payload.json
+++ b/components/authz-service/server/v2/testdata/running_workflow_01/payload.json
@@ -2856,8 +2856,8 @@
                 ],
                 "CompletedTasks": 0,
                 "TotalTasks": 186,
-                "StartTime": "2020-03-09T18:01:53.19500762Z",
-                "LastUpdated": "2020-03-09T18:21:47.387265641Z"
+                "StartTime": "{{ .StartTime }}",
+                "LastUpdated": "{{ .LastUpdated }}"
               },
               "MonitorFailures": 0
             },

--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.html
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.html
@@ -1,8 +1,15 @@
 <div id="pending-edits-bar" [hidden]="isBarHidden">
-  <span class="info">Project edits pending, update <a [routerLink]="['/settings/projects']">projects</a> to apply changes.</span>
-  <app-authorized [allOf]="['/iam/v2/apply-rules', 'post']">
-    <button mat-button (click)="openConfirmUpdateStartModal()">Update Projects</button>
-  </app-authorized>
+  <div [className]="updateProjectsFailed ? 'failure-container' : 'normal-container'">
+    <span *ngIf="!updateProjectsFailed" class="info">
+      Project edits pending, update <a [routerLink]="['/settings/projects']">projects</a> to apply changes.
+    </span>
+    <span *ngIf="updateProjectsFailed" class="info">
+      Project update failed. Review system status from the command line with <pre>chef-automate status</pre> and try again.
+    </span>
+    <app-authorized [allOf]="['/iam/v2/apply-rules', 'post']">
+      <button mat-button (click)="openConfirmUpdateStartModal()">Update Projects</button>
+    </app-authorized>
+  </div>
 </div>
 
 <app-confirm-apply-start-modal

--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.scss
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.scss
@@ -3,8 +3,16 @@
 #pending-edits-bar {
   background-color: $chef-primary-bright;
   color: $chef-white;
-  padding: 16px 10px;
   position: relative;
+
+  .normal-container {
+    padding: 16px 10px;
+  }
+
+  .failure-container {
+    padding: 16px 10px;
+    background-color: $chef-critical;
+  }
 
   .info {
     font-size: 16px;
@@ -12,6 +20,11 @@
 
     a {
       color: inherit;
+    }
+
+    pre {
+      display: inline;
+      padding: 0;
     }
   }
 
@@ -23,8 +36,13 @@
     top: 0;
   }
 
-  button:hover,
-  button:focus {
+  .failure-container button:hover,
+  .failure-container button:focus {
+    background-color: $chef-critical-hover;
+  }
+
+  .normal-container button:hover,
+  .normal-container button:focus {
     background-color: $chef-primary-hover;
   }
 }

--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.spec.ts
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule, Store } from '@ngrx/store';
@@ -6,7 +7,7 @@ import { MockComponent } from 'ng2-mock-component';
 
 import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
-import { customMatchers } from 'app/testing/custom-matchers';
+import { using } from 'app/testing/spec-helpers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
 import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
@@ -16,16 +17,17 @@ import { Project } from 'app/entities/projects/project.model';
 import { ProjectStatus } from 'app/entities/rules/rule.model';
 import { ProjectService } from 'app/entities/projects/project.service';
 import { projectEntityReducer, ApplyRulesStatusState } from 'app/entities/projects/project.reducer';
-import { PendingEditsBarComponent } from './pending-edits-bar.component';
 import {
   GetProjectsSuccess,
   GetApplyRulesStatusSuccess,
   GetApplyRulesStatusSuccessPayload
 } from 'app/entities/projects/project.actions';
+import { PendingEditsBarComponent } from './pending-edits-bar.component';
 
 describe('PendingEditsBarComponent', () => {
   let component: PendingEditsBarComponent;
   let fixture: ComponentFixture<PendingEditsBarComponent>;
+  let element: HTMLElement;
   let projectService: ProjectService;
   let store: Store<NgrxStateAtom>;
 
@@ -93,10 +95,10 @@ describe('PendingEditsBarComponent', () => {
   }));
 
   beforeEach(() => {
-    jasmine.addMatchers(customMatchers);
     projectService = TestBed.get(ProjectService);
     fixture = TestBed.createComponent(PendingEditsBarComponent);
     component = fixture.componentInstance;
+    element = fixture.debugElement.query(By.css('#pending-edits-bar')).nativeElement;
     store = TestBed.get(Store);
 
     store.dispatch(new GetIamVersionSuccess({ version: { major: 'v2' } }));
@@ -107,31 +109,35 @@ describe('PendingEditsBarComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('when update-start-confirmation modal emits a cancellation', () => {
-    it('hides the modal', () => {
-      component.openConfirmUpdateStartModal();
-      component.cancelApplyStart();
-      expect(component.confirmApplyStartModalVisible).toEqual(false);
-    });
-  });
+  describe('update-start-confirmation modal', () => {
 
-  describe('when update-start-confirmation modal emits a confirmation', () => {
-    beforeEach(() => {
-      spyOn(projectService, 'applyRulesStart');
-      component.openConfirmUpdateStartModal();
-      component.confirmApplyStart();
+    describe('when it emits a cancellation', () => {
+      it('it hides the modal', () => {
+        component.openConfirmUpdateStartModal();
+        component.cancelApplyStart();
+        expect(component.confirmApplyStartModalVisible).toEqual(false);
+      });
     });
 
-    it('hides the modal', () => {
-      expect(component.confirmApplyStartModalVisible).toEqual(false);
-    });
+    describe('when it emits a confirmation', () => {
+      beforeEach(() => {
+        spyOn(projectService, 'applyRulesStart');
+        component.openConfirmUpdateStartModal();
+        component.confirmApplyStart();
+      });
 
-    it('has the projectService start the rule updates', () => {
-      expect(projectService.applyRulesStart).toHaveBeenCalled();
+      it('it hides the modal', () => {
+        expect(component.confirmApplyStartModalVisible).toEqual(false);
+      });
+
+      it('the projectService starts the rule updates', () => {
+        expect(projectService.applyRulesStart).toHaveBeenCalled();
+      });
     });
   });
 
   describe('pending edits bar', () => {
+
     it('is hidden if no project has changes', () => {
       const uneditedProject1 = genProject('uuid-111', 'RULES_APPLIED');
       const uneditedProject2 = genProject('uuid-112', 'RULES_APPLIED');
@@ -191,7 +197,7 @@ describe('PendingEditsBarComponent', () => {
       expect(component.isBarHidden).toEqual(false);
     });
 
-    it('is displayed if update is cancelled but update is still running', () => {
+    it('is visible if update is cancelled but update is still running', () => {
       store.dispatch(
         new GetProjectsSuccess({ projects: [genProject('uuid-99', 'RULES_APPLIED')] }));
       component.confirmApplyStart();
@@ -200,8 +206,29 @@ describe('PendingEditsBarComponent', () => {
       component.updateDisplay();
       expect(component.isBarHidden).toEqual(false);
     });
-  });
 
+    it('displays edits pending message before update is applied', () => {
+      store.dispatch(
+        new GetProjectsSuccess({ projects: [genProject('uuid-99', 'EDITS_PENDING')] }));
+      fixture.detectChanges();
+      expect(element.textContent).toContain('Project edits pending');
+    });
+
+    using([
+      ['is cancelled', false, true, 'edits pending'],
+      ['fails', true, false, 'update failed'],
+      // if it could happen, failure takes precedence:
+      ['both fails and is cancelled', true, true, 'update failed']
+    ], function (description: string, failed: boolean, cancelled: boolean, message: string) {
+      it(`displays "${message}" message when update ${description}`, () => {
+        store.dispatch(new GetApplyRulesStatusSuccess(
+          genState(ApplyRulesStatusState.NotRunning, failed, cancelled)));
+        fixture.detectChanges();
+        expect(element.textContent).toContain(`Project ${message}`);
+      });
+    });
+
+  });
 });
 
 function genProject(id: string, status: ProjectStatus): Project {

--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.ts
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.ts
@@ -20,7 +20,7 @@ export class PendingEditsBarComponent implements OnDestroy {
   public confirmApplyStartModalVisible = false;
   private isDestroyed = new Subject<boolean>();
   private projectsHaveStagedChanges = false;
-  private updateProjectsFailed = false;
+  public updateProjectsFailed = false;
   private updateProjectsCancelled = false;
 
   constructor(

--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.ts
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.ts
@@ -43,6 +43,11 @@ export class PendingEditsBarComponent implements OnDestroy {
         this.updateProjectsCancelled = cancelled;
         this.updateDisplay();
       });
+    observableInterval(5000)
+      .subscribe(() => {
+        this.projects.getApplyRulesStatus();
+      });
+
     }
 
   ngOnDestroy(): void {

--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.ts
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.ts
@@ -43,11 +43,6 @@ export class PendingEditsBarComponent implements OnDestroy {
         this.updateProjectsCancelled = cancelled;
         this.updateDisplay();
       });
-    observableInterval(5000)
-      .subscribe(() => {
-        this.projects.getApplyRulesStatus();
-      });
-
     }
 
   ngOnDestroy(): void {

--- a/components/automate-ui/src/app/entities/projects/project.reducer.ts
+++ b/components/automate-ui/src/app/entities/projects/project.reducer.ts
@@ -3,7 +3,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { set, pipe, unset, mapKeys, camelCase } from 'lodash/fp';
 
 import { EntityStatus } from 'app/entities/entities';
-import { ProjectActionTypes, ProjectActions } from './project.actions';
+import { ProjectActionTypes, ProjectActions, GetApplyRulesStatusSuccessPayload } from './project.actions';
 import { Project } from './project.model';
 
 export enum ApplyRulesStatusState {
@@ -126,14 +126,11 @@ export function projectEntityReducer(
       return set(UPDATE_STATUS, EntityStatus.loadingFailure, state);
 
     case ProjectActionTypes.GET_APPLY_RULES_STATUS_SUCCESS:
-      return set(
-        APPLY_RULES_STATUS,
-        mapKeys(key => camelCase(key),
-          {
-            ...action.payload,
-            percentage_complete: action.payload.percentage_complete * 100
-          }),
-        state);
+      const payload: GetApplyRulesStatusSuccessPayload = {
+        ...action.payload,
+        percentage_complete: action.payload.percentage_complete * 100
+      };
+      return set(APPLY_RULES_STATUS, mapKeys(key => camelCase(key), payload), state);
 
     default:
       return state;

--- a/components/automate-ui/src/app/entities/projects/project.reducer.ts
+++ b/components/automate-ui/src/app/entities/projects/project.reducer.ts
@@ -128,6 +128,7 @@ export function projectEntityReducer(
     case ProjectActionTypes.GET_APPLY_RULES_STATUS_SUCCESS:
       const payload: GetApplyRulesStatusSuccessPayload = {
         ...action.payload,
+        failed: Math.random() > 0.5,
         percentage_complete: action.payload.percentage_complete * 100
       };
       return set(APPLY_RULES_STATUS, mapKeys(key => camelCase(key), payload), state);

--- a/components/automate-ui/src/app/entities/projects/project.reducer.ts
+++ b/components/automate-ui/src/app/entities/projects/project.reducer.ts
@@ -128,7 +128,6 @@ export function projectEntityReducer(
     case ProjectActionTypes.GET_APPLY_RULES_STATUS_SUCCESS:
       const payload: GetApplyRulesStatusSuccessPayload = {
         ...action.payload,
-        failed: Math.random() > 0.5,
         percentage_complete: action.payload.percentage_complete * 100
       };
       return set(APPLY_RULES_STATUS, mapKeys(key => camelCase(key), payload), state);

--- a/components/automate-ui/src/styles/_colors.scss
+++ b/components/automate-ui/src/styles/_colors.scss
@@ -19,7 +19,7 @@ $science-blue: #0075DB;
 $fuchsia: #A424B4;
 $fuchsia-light: #FADAFA;
 $fuchsia-dark: #440F4B;
-$burgundy: #BA1E6A;
+$maroon: #BA1E6A;
 // greyscale
 $sirocco: #6F7878;
 $iron: #DFE3E5;

--- a/components/automate-ui/src/styles/_colors.scss
+++ b/components/automate-ui/src/styles/_colors.scss
@@ -19,6 +19,7 @@ $science-blue: #0075DB;
 $fuchsia: #A424B4;
 $fuchsia-light: #FADAFA;
 $fuchsia-dark: #440F4B;
+$burgundy: #BA1E6A;
 // greyscale
 $sirocco: #6F7878;
 $iron: #DFE3E5;

--- a/components/automate-ui/src/styles/_variables.scss
+++ b/components/automate-ui/src/styles/_variables.scss
@@ -8,7 +8,7 @@ $chef-primary-dark: $ebony-clay;
 $chef-primary-bright: $royal-blue;
 $chef-primary-light: $malibu;
 $chef-primary-hover: $blue;
-$chef-critical-hover: $burgundy;
+$chef-critical-hover: $maroon;
 //secondary
 $chef-critical: $pink;
 $chef-warning: $atomic-tangerine;

--- a/components/automate-ui/src/styles/_variables.scss
+++ b/components/automate-ui/src/styles/_variables.scss
@@ -8,6 +8,7 @@ $chef-primary-dark: $ebony-clay;
 $chef-primary-bright: $royal-blue;
 $chef-primary-light: $malibu;
 $chef-primary-hover: $blue;
+$chef-critical-hover: $burgundy;
 //secondary
 $chef-critical: $pink;
 $chef-warning: $atomic-tangerine;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When a project update fails, we want to make that much more apparent to the user.
This replaces the standard "edits pending" message with an error message (and coloring) that makes it evident to the user.

The illustration shows the two possible states of the pending edits bar, showing both wording and color change, along with the subtle color change of the button itself when hovering or focusing it.

![image](https://user-images.githubusercontent.com/6817500/76629727-fcdafb80-64fb-11ea-97ff-04fc7035f0bb.png)

### :chains: Related Resources
NA

### :+1: Definition of Done
Here is the contract as defined by unit tests. Most of these were already in place. The new tests are after the `-----` divider.
```
 update-start-confirmation modal...
   when it emits a cancellation, hides the modal
   when it emits a confirmation, hides the modal
   when it emits a confirmation, the projectService starts the rule updates
 pending edits bar...
   is hidden if no project has changes
   is visible if some project has changes
   is visible if some project has changes... UNLESS progress bar is active
   is visible if rules are not being applied
   is visible if update fails
   is visible if update is cancelled
   is visible if update is cancelled but update is still running
----
   displays edits pending message before update is applied
   displays edits pending message if an update is cancelled
   displays failed message if an update fails
   displays failed message if both an update fails and was cancelled
```

### :athletic_shoe: How to Build and Test the Change

In hab studio: `rebuild components/authz-service`

Remove the last commit to expose a testing harness:
```
git revert -n 3df50d5
```
Then rebuild automate-ui per your preferred method.
Create a project and a rule in the browser.
Navigate to the projects page to expose the edits pending bar in its nominal condition (due to another issue, the edits pending bar will not start appearing until you visit that particular page).
Now just watch: every 5 seconds a random failure--or not--will occur. You should see the blue (normal) or pink (failure) bars both appear over time.

That shows the "normal" edits pending state--before an update is applied,
and the result of a failed update. To see the result of a cancelled update, first you have to reset the code--pull down a fresh copy of the branch so it no longer has that revert mentioned above. Then just proceed normally: start an update and cancel it. You will see the normal edits pending bar.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

