### PR TITLE
Automate-2561 Waivers

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-status/overview-status.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-status/overview-status.component.html
@@ -1,6 +1,6 @@
 <chef-radial-chart class="chart">
   <span slot="innerText">
-    {{ data.failed + data.passed + data.skipped | number }} Total {{ type | titlecase }}
+    {{ data.failed + data.passed + data.skipped + data.waived | number }} Total {{ type | titlecase }}
   </span>
 
   <chef-data-point [value]="data.failed" class="failed">
@@ -11,6 +11,9 @@
   </chef-data-point>
   <chef-data-point [value]="data.skipped" class="skipped">
     {{ data.skipped | number }} Skipped {{ type | titlecase }}
+  </chef-data-point>
+  <chef-data-point [value]="data.waived" class="waived">
+    {{ data.waived | number }} Wavied {{ type | titlecase }}
   </chef-data-point>
 
   <chef-data-point [value]="data.critical" secondary class="critical">
@@ -41,5 +44,10 @@
   <dd class="legend-item-label">
     <span class="legend-item-status skipped"></span>
     <span>Skipped {{ type | titlecase }}</span>
+  </dd>
+  <dt class="legend-item-total">{{ data.waived | number }}</dt>
+  <dd class="legend-item-label">
+    <span class="legend-item-status skipped"></span>
+    <span>Waived {{ type | titlecase }}</span>
   </dd>
 </dl>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-status/overview-status.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-status/overview-status.component.scss
@@ -29,6 +29,10 @@
       color: $chef-grey;
     }
 
+    .waived {
+      color: $chef-med-grey;
+    }
+
     .critical {
       color: $chef-critical;
     }
@@ -98,6 +102,10 @@
 
       &.skipped {
         background: $chef-grey;
+      }
+
+      &.waived {
+        background: $chef-med-grey;
       }
     }
   }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
@@ -185,6 +185,7 @@ describe('ReportingOverviewComponent', () => {
           'noncompliant': 4,
           'compliant': 10,
           'skipped': 6,
+          'waived': 1,
           'high_risk': 4,
           'medium_risk': 2,
           'low_risk': 8
@@ -255,7 +256,7 @@ describe('ReportingOverviewComponent', () => {
           'failures': 9,
           'passed': 1,
           'skipped': 0,
-          'wavied': 1,
+          'waived': 1,
           'criticals': 2,
           'majors': 2,
           'minors': 5

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
@@ -197,6 +197,7 @@ describe('ReportingOverviewComponent', () => {
           'failed': 4,
           'passed': 10,
           'skipped': 6,
+          'waived': 1,
           'critical': 4,
           'major': 2,
           'minor': 8
@@ -254,6 +255,7 @@ describe('ReportingOverviewComponent', () => {
           'failures': 9,
           'passed': 1,
           'skipped': 0,
+          'wavied': 1,
           'criticals': 2,
           'majors': 2,
           'minors': 5
@@ -266,6 +268,7 @@ describe('ReportingOverviewComponent', () => {
           'failed': 9,
           'passed': 1,
           'skipped': 0,
+          'waived': 1,
           'critical': 2,
           'major': 2,
           'minor': 5

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.ts
@@ -245,6 +245,7 @@ export class ReportingOverviewComponent implements OnInit, OnDestroy {
       passed: data.compliant,
       skipped: data.skipped,
       failed: data.noncompliant,
+      waived: data.waived,
       critical: data.high_risk,
       major: data.medium_risk,
       minor: data.low_risk
@@ -255,6 +256,7 @@ export class ReportingOverviewComponent implements OnInit, OnDestroy {
     return {
       passed: data.passed,
       skipped: data.skipped,
+      waived: data.waived,
       failed: data.failures,
       critical: data.criticals,
       major: data.majors,

--- a/components/automate-ui/src/styles/_colors.scss
+++ b/components/automate-ui/src/styles/_colors.scss
@@ -21,7 +21,7 @@ $fuchsia-light: #FADAFA;
 $fuchsia-dark: #440F4B;
 // greyscale
 $sirocco: #6F7878;
-$darksea: #819ba9;
+$darksea: #819BA9;
 $iron: #DFE3E5;
 $mystic: #E6EBEE;
 $haze: #F3F6F8;

--- a/components/automate-ui/src/styles/_colors.scss
+++ b/components/automate-ui/src/styles/_colors.scss
@@ -21,6 +21,7 @@ $fuchsia-light: #FADAFA;
 $fuchsia-dark: #440F4B;
 // greyscale
 $sirocco: #6F7878;
+$darksea: #819ba9;
 $iron: #DFE3E5;
 $mystic: #E6EBEE;
 $haze: #F3F6F8;

--- a/components/automate-ui/src/styles/_variables.scss
+++ b/components/automate-ui/src/styles/_variables.scss
@@ -19,6 +19,7 @@ $chef-info-alert-light: $fuchsia-light;
 $chef-info-alert-dark: $fuchsia-dark;
 //greyscale
 $chef-dark-grey: $sirocco;
+$chef-med-grey: $darksea;
 $chef-grey: $iron;
 $chef-light-grey: $mystic;
 $chef-lightest-grey: $haze;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As an Automate User, I will use this work when I want to easily identify any waived nodes or controls in a summary view.

### :chains: Related Resources
https://github.com/chef/automate/issues/2561

### :+1: Definition of Done
In the compliance reporting overview tab:
A user can see the node count of waived nodes
A user can see the history of nodes that have been waived
A user can see the count of controls that have been waived
A user can see the history of controls that have been waived

### :athletic_shoe: How to Build and Test the Change
load data by using the load_compliance_reports command from your studio dev env

### :camera: Screenshots, if applicable
![Screen Shot 2020-03-13 at 12 39 56 PM](https://user-images.githubusercontent.com/4108100/76645869-d92daa80-6527-11ea-8c1e-f10430d1b69f.png)
![Screen Shot 2020-03-13 at 12 40 11 PM](https://user-images.githubusercontent.com/4108100/76645870-d9c64100-6527-11ea-984d-3d8e971f4458.png)
