### PR TITLE
fix failing project update test

### DIFF
--- a/components/authz-service/server/v2/project_update_manager_test.go
+++ b/components/authz-service/server/v2/project_update_manager_test.go
@@ -41,38 +41,30 @@ func loadWorkflowFromDisk(t *testing.T, name string) *workflowInstance {
 	}
 
 	payloadFname := fmt.Sprintf("testdata/%s/payload.json", name)
-	fPayload, err := os.Open(payloadFname)
+
+	tmpl, err := template.ParseFiles(payloadFname)
 	if err != nil {
-		if !os.IsNotExist(err) {
-			t.Fatalf("could not open %s", payloadFname)
-		}
-	} else {
-		defer fPayload.Close()
-		payload := patterns.ChainWorkflowPayload{}
-
-		tmpl, err := template.ParseFiles(payloadFname)
-		if err != nil {
-			t.Fatalf("could not parse file: %s", err)
-		}
-
-		b := bytes.NewBuffer(nil)
-		err = tmpl.Execute(b, struct {
-			StartTime   string
-			LastUpdated string
-		}{
-			StartTime:   time.Now().Format(time.RFC3339),
-			LastUpdated: time.Now().Add(time.Minute).Format(time.RFC3339),
-		})
-		if err != nil {
-			t.Fatalf("could not update time fields in template: %s", err)
-		}
-
-		if err := json.Unmarshal(b.Bytes(), &payload); err != nil {
-			t.Fatalf("failed to decode %s", payloadFname)
-		}
-		w.WithPayload(&payload)
-		loaded = true
+		t.Fatalf("could not parse file: %s", err)
 	}
+
+	b := bytes.NewBuffer(nil)
+	err = tmpl.Execute(b, struct {
+		StartTime   string
+		LastUpdated string
+	}{
+		StartTime:   time.Now().Format(time.RFC3339),
+		LastUpdated: time.Now().Add(time.Minute).Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("could not update time fields in template: %s", err)
+	}
+
+	payload := patterns.ChainWorkflowPayload{}
+	if err := json.Unmarshal(b.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode %s", payloadFname)
+	}
+	w.WithPayload(&payload)
+	loaded = true
 
 	if !loaded {
 		t.Fatalf("no workflow data found for %s", name)

--- a/components/authz-service/server/v2/testdata/running_workflow_01/payload.json
+++ b/components/authz-service/server/v2/testdata/running_workflow_01/payload.json
@@ -2856,8 +2856,8 @@
                 ],
                 "CompletedTasks": 0,
                 "TotalTasks": 186,
-                "StartTime": "2020-03-09T18:01:53.19500762Z",
-                "LastUpdated": "2020-03-09T18:21:47.387265641Z"
+                "StartTime": "{{ .StartTime }}",
+                "LastUpdated": "{{ .LastUpdated }}"
               },
               "MonitorFailures": 0
             },


### PR DESCRIPTION
The `StartTime` and `LastUpdated` in `payload.json` times were just some hard-coded dates grabbed from the perf env. Once those dates passed, the project_update helper `FindSlowestJobStatus` started returning null time and failing the test. 

This fixes the issue by turning `payload.json` into a template and setting `StartTime` and `LastUpdated`, respectively, to the current time and current time + 1 min.