### PR TITLE
[automate-3031] Show pending edits bar promptly upon login

### DIFF
--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.spec.ts
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.spec.ts
@@ -5,18 +5,15 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule, Store } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { using } from 'app/testing/spec-helpers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
-import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
 import { GetIamVersionSuccess } from 'app/entities/policies/policy.actions';
-import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
 import { Project } from 'app/entities/projects/project.model';
 import { ProjectStatus } from 'app/entities/rules/rule.model';
 import { ProjectService } from 'app/entities/projects/project.service';
-import { projectEntityReducer, ApplyRulesStatusState } from 'app/entities/projects/project.reducer';
+import { ApplyRulesStatusState } from 'app/entities/projects/project.reducer';
 import {
   GetProjectsSuccess,
   GetApplyRulesStatusSuccess,
@@ -79,13 +76,7 @@ describe('PendingEditsBarComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         ChefPipesModule,
-        StoreModule.forRoot(
-          {
-          policies: policyEntityReducer,
-          projects: projectEntityReducer,
-          notifications: notificationEntityReducer, // not used here but needed to suppress warnings
-          clientRunsEntity: clientRunsEntityReducer // not used here but needed to suppress warnings
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       providers: [
         FeatureFlagsService,

--- a/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.spec.ts
+++ b/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.spec.ts
@@ -4,17 +4,14 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule, Store } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { customMatchers } from 'app/testing/custom-matchers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
-import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
 import { GetIamVersionSuccess } from 'app/entities/policies/policy.actions';
-import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
 import { ProjectService } from 'app/entities/projects/project.service';
 import { ProcessProgressBarComponent } from './process-progress-bar.component';
-import { projectEntityReducer, ApplyRulesStatusState } from 'app/entities/projects/project.reducer';
+import { ApplyRulesStatusState } from 'app/entities/projects/project.reducer';
 import {
   GetApplyRulesStatusSuccessPayload,
   GetApplyRulesStatusSuccess
@@ -74,13 +71,7 @@ describe('ProcessProgressBarComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         ChefPipesModule,
-        StoreModule.forRoot(
-          {
-          policies: policyEntityReducer,
-          projects: projectEntityReducer,
-          notifications: notificationEntityReducer, // not used here but needed to suppress warnings
-          clientRunsEntity: clientRunsEntityReducer // not used here but needed to suppress warnings
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       providers: [
         FeatureFlagsService,

--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, OnInit, OnDestroy } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { Subject, Observable, BehaviorSubject } from 'rxjs';
+import { Observable, BehaviorSubject } from 'rxjs';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { isProductDeployed } from 'app/staticConfig';
@@ -15,13 +15,12 @@ import { MenuItemGroup } from 'app/entities/layout/layout.model';
 @Injectable({
     providedIn: 'root'
 })
-export class LayoutSidebarService implements OnInit, OnDestroy {
+export class LayoutSidebarService {
     public chefInfraServerViewsFeatureFlagOn: boolean;
     public isIAMv2$: Observable<boolean>;
     public ServiceNowFeatureFlagOn: boolean;
     private activeSidebar: string;
     private workflowEnabled$: Observable<boolean>;
-    private isDestroyed = new Subject<boolean>();
     private sidebars: Sidebars;
 
     constructor(
@@ -33,6 +32,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
         this.chefInfraServerViewsFeatureFlagOn = this.featureFlagsService.getFeatureStatus('chefInfraServerViews');
         this.isIAMv2$ = this.store.select(isIAMv2);
         this.workflowEnabled$ = this.clientRunsStore.select(clientRunsWorkflowEnabled);
+        this.updateSidebars();
     }
 
     populateSidebar() {
@@ -241,15 +241,6 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
         }]
       };
       this.sidebars = this.updateVisibleValues(sidebars);
-    }
-
-    ngOnInit() {
-      this.updateSidebars();
-    }
-
-    ngOnDestroy() {
-      this.isDestroyed.next(true);
-      this.isDestroyed.complete();
     }
 
     private updateVisibleValues(sidebars: Sidebars): Sidebars {

--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -1,6 +1,6 @@
-import { Injectable, OnDestroy, OnInit } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { Observable, Subject } from 'rxjs';
+import { Observable } from 'rxjs';
 import { first, filter } from 'rxjs/operators';
 import { identity } from 'lodash/fp';
 
@@ -33,7 +33,7 @@ export enum Sidebar {
 @Injectable({
   providedIn: 'root'
 })
-export class LayoutFacadeService implements OnInit, OnDestroy {
+export class LayoutFacadeService {
   public layout = {
     license: {
       display: true
@@ -56,7 +56,6 @@ export class LayoutFacadeService implements OnInit, OnDestroy {
   public contentHeight = `calc(100% - ${Height.Navigation}px)`;
   public sidebar$: Observable<MenuItemGroup[]>;
   public showPageLoading$: Observable<boolean>;
-  private isDestroyed = new Subject<boolean>();
 
   constructor(
     private store: Store<fromLayout.LayoutEntityState>,
@@ -65,9 +64,6 @@ export class LayoutFacadeService implements OnInit, OnDestroy {
     this.sidebar$ = store.select(sidebar);
     this.showPageLoading$ = store.select(showPageLoading);
     this.updateDisplay();
-  }
-
-  ngOnInit(): void {
     this.store.select(isIAMv2)
       .pipe(filter(identity), first())
       .subscribe(isV2 => {
@@ -75,11 +71,6 @@ export class LayoutFacadeService implements OnInit, OnDestroy {
           this.store.dispatch(new GetProjects());
         }
       });
-  }
-
-  ngOnDestroy(): void {
-    this.isDestroyed.next(true);
-    this.isDestroyed.complete();
   }
 
   getContentStyle(): any {

--- a/components/automate-ui/src/app/entities/policies/policy.selectors.ts
+++ b/components/automate-ui/src/app/entities/policies/policy.selectors.ts
@@ -16,9 +16,10 @@ export const iamMajorVersion = createSelector(
   (state) => state.iamMajorVersion
 );
 
+// This is used early enough that we have to guard against undefined (at least for unit tests)
 export const isIAMv2 = createSelector(
   policyState,
-  (state) => (state.iamMajorVersion === 'v2')
+  (state) => (state && state.iamMajorVersion === 'v2')
 );
 
 export const getAllStatus = createSelector(

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.spec.ts
@@ -4,15 +4,10 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
-import { runtimeChecks } from 'app/ngrx.reducers';
+import { runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { apiTokenEntityReducer } from 'app/entities/api-tokens/api-token.reducer';
-import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
-import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
 import { ApiTokenListComponent } from './api-token-list.component';
-import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
-import { projectsFilterReducer } from 'app/services/projects-filter/projects-filter.reducer';
 
 describe('ApiTokenListComponent', () => {
   let component: ApiTokenListComponent;
@@ -25,13 +20,7 @@ describe('ApiTokenListComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         ChefPipesModule,
-        StoreModule.forRoot({
-          apiTokens: apiTokenEntityReducer,
-          policies: policyEntityReducer,
-          projectsFilter: projectsFilterReducer,
-          notifications: notificationEntityReducer, // not used here but needed to suppress warnings
-          clientRunsEntity: clientRunsEntityReducer // not used here but needed to suppress warnings
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       providers: [
         FeatureFlagsService

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-details/profile-details.component.spec.ts
@@ -2,16 +2,13 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Store, StoreModule } from '@ngrx/store';
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { ProfileDetailsComponent } from './profile-details.component';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { Observable, throwError, of as observableOf } from 'rxjs';
 import { ProfilesService } from 'app/services/profiles/profiles.service';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
-import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
-import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
-import * as fromLayout from 'app/entities/layout/layout.reducer';
 
 class MockProfilesService {
   getProfile(_owner: string, _name: string): Observable<Object> {
@@ -35,11 +32,7 @@ describe('ProfileDetailsComponent', () => {
       imports: [
         RouterTestingModule,
         HttpClientTestingModule,
-        StoreModule.forRoot({
-          clientRunsEntity: clientRunsEntityReducer, // not used but needed to suppress warnings
-          notifications: notificationEntityReducer, // not used but needed to suppress warnings
-          layout: fromLayout.layoutEntityReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       declarations: [
         ProfileDetailsComponent

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
@@ -1,5 +1,5 @@
 import { Store, StoreModule } from '@ngrx/store';
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { By } from '@angular/platform-browser';
@@ -11,9 +11,6 @@ import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.se
 import { ProfilesService } from 'app/services/profiles/profiles.service';
 import { UploadService } from 'app/services/profiles/upload.service';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
-import * as fromClientRuns from 'app/entities/client-runs/client-runs.reducer';
-import * as fromNotifications from 'app/entities/notifications/notification.reducer';
-import * as fromLayout from 'app/entities/layout/layout.reducer';
 
 class MockProfilesService {
   getAllProfiles(): Observable<Array<Object>> {
@@ -43,11 +40,7 @@ describe('ProfilesOverviewComponent', () => {
       imports: [
         RouterTestingModule,
         HttpClientTestingModule,
-        StoreModule.forRoot({
-          clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
-          notifications: fromNotifications.notificationEntityReducer,
-          layout: fromLayout.layoutEntityReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       declarations: [
         ProfileOverviewComponent

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.spec.ts
@@ -3,7 +3,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Store, StoreModule } from '@ngrx/store';
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { CookieModule } from 'ngx-cookie';
 import { ReportingNodeComponent } from './reporting-node.component';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
@@ -11,9 +11,6 @@ import { of as observableOf } from 'rxjs';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { StatsService, ReportQueryService, ScanResultsService } from '../../shared/reporting';
 import { DatetimePipe } from 'app/pipes/datetime.pipe';
-import * as fromClientRuns from 'app/entities/client-runs/client-runs.reducer';
-import * as fromNotifications from 'app/entities/notifications/notification.reducer';
-import * as fromLayout from 'app/entities/layout/layout.reducer';
 
 describe('ReportingNodeComponent', () => {
   let store: Store<NgrxStateAtom>;
@@ -28,11 +25,7 @@ describe('ReportingNodeComponent', () => {
         RouterTestingModule,
         CookieModule.forRoot(),
         HttpClientTestingModule,
-        StoreModule.forRoot({
-          clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
-          notifications: fromNotifications.notificationEntityReducer,
-          layout: fromLayout.layoutEntityReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       declarations: [
         ReportingNodeComponent,

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Store, StoreModule } from '@ngrx/store';
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ReportingProfileComponent } from '../+reporting-profile/reporting-profile.component';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
@@ -13,9 +13,6 @@ import { StatsService, ReportQueryService,
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { of as observableOf } from 'rxjs';
 import * as moment from 'moment';
-import * as fromClientRuns from 'app/entities/client-runs/client-runs.reducer';
-import * as fromNotifications from 'app/entities/notifications/notification.reducer';
-import * as fromLayout from 'app/entities/layout/layout.reducer';
 
 describe('ReportingProfileComponent', () => {
   let store: Store<NgrxStateAtom>;
@@ -27,11 +24,7 @@ describe('ReportingProfileComponent', () => {
         RouterTestingModule,
         CookieModule.forRoot(),
         HttpClientTestingModule,
-        StoreModule.forRoot({
-          clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
-          notifications: fromNotifications.notificationEntityReducer,
-          layout: fromLayout.layoutEntityReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       declarations: [
         ReportingProfileComponent

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -8,7 +8,7 @@ import { CookieModule } from 'ngx-cookie';
 import { Observable, of as observableOf } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { Store, StoreModule } from '@ngrx/store';
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { ReportingComponent } from '../+reporting/reporting.component';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
 import {
@@ -23,9 +23,6 @@ import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.se
 import * as moment from 'moment';
 import { DatetimePipe } from 'app/pipes/datetime.pipe';
 import { using } from 'app/testing/spec-helpers';
-import * as fromClientRuns from 'app/entities/client-runs/client-runs.reducer';
-import * as fromNotifications from 'app/entities/notifications/notification.reducer';
-import * as fromLayout from 'app/entities/layout/layout.reducer';
 
 class MockTelemetryService {
   track() { }
@@ -47,11 +44,7 @@ describe('ReportingComponent', () => {
         RouterTestingModule,
         CookieModule.forRoot(),
         HttpClientTestingModule,
-        StoreModule.forRoot({
-          clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
-          notifications: fromNotifications.notificationEntityReducer,
-          layout: fromLayout.layoutEntityReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       declarations: [
         ReportingComponent,

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-add/nodes-add.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-add/nodes-add.component.spec.ts
@@ -3,16 +3,13 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Store, StoreModule } from '@ngrx/store';
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CookieModule } from 'ngx-cookie';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
 import { MockChefSessionService } from 'app/testing/mock-chef-session.service';
 import { NodesAddComponent } from './nodes-add.component';
-import * as fromClientRuns from 'app/entities/client-runs/client-runs.reducer';
-import * as fromNotifications from 'app/entities/notifications/notification.reducer';
-import * as fromLayout from 'app/entities/layout/layout.reducer';
 
 describe('NodesAddComponent', () => {
   let store: Store<NgrxStateAtom>;
@@ -27,11 +24,7 @@ describe('NodesAddComponent', () => {
         ReactiveFormsModule,
         CookieModule.forRoot(),
         HttpClientTestingModule,
-        StoreModule.forRoot({
-          clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
-          notifications: fromNotifications.notificationEntityReducer,
-          layout: fromLayout.layoutEntityReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       declarations: [
         NodesAddComponent

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.spec.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.spec.ts
@@ -6,12 +6,9 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
-import { runtimeChecks } from 'app/ngrx.reducers';
+import { runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { EntityStatus } from '../../entities/entities';
-import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
-import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
 import { UpdateNodeFilters } from '../../entities/client-runs/client-runs.actions';
-import * as sidebar from '../../services/sidebar/sidebar.reducer';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { ClientRunsComponent } from './client-runs.component';
@@ -48,11 +45,7 @@ describe('ClientRunsComponent', () => {
       imports: [
         RouterTestingModule,
         HttpClientTestingModule,
-        StoreModule.forRoot({
-          sidebar: sidebar.sidebarReducer,
-          notifications: notificationEntityReducer, // not used here but needed to suppress warnings
-          clientRunsEntity: clientRunsEntityReducer // not used here but needed to suppress warnings
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     });

--- a/components/automate-ui/src/app/pages/data-feed-form/data-feed-form.component.spec.ts
+++ b/components/automate-ui/src/app/pages/data-feed-form/data-feed-form.component.spec.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { Observable, of as observableOf } from 'rxjs';
 import { MockComponent } from 'ng2-mock-component';
 import { Store, StoreModule } from '@ngrx/store';
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 
 import { Destination } from 'app/pages/data-feed/destination';
 import { DatafeedFormComponent } from './data-feed-form.component';
@@ -11,9 +11,6 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { FeatureFlagsService } from '../../services/feature-flags/feature-flags.service';
 import { DatafeedService } from '../../services/data-feed/data-feed.service';
-import * as fromClientRuns from 'app/entities/client-runs/client-runs.reducer';
-import * as fromNotifications from 'app/entities/notifications/notification.reducer';
-import * as fromLayout from 'app/entities/layout/layout.reducer';
 
 describe('DatafeedFormComponent', () => {
   let store: Store<NgrxStateAtom>;
@@ -53,11 +50,7 @@ describe('DatafeedFormComponent', () => {
       ],
       imports: [
         FormsModule,
-        StoreModule.forRoot({
-          clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
-          notifications: fromNotifications.notificationEntityReducer,
-          layout: fromLayout.layoutEntityReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     }).compileComponents();

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.spec.ts
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.spec.ts
@@ -4,7 +4,7 @@ import { MatDialog, MatSnackBar } from '@angular/material';
 import { By } from '@angular/platform-browser';
 import { Observable, of as observableOf } from 'rxjs';
 import { Store, StoreModule } from '@ngrx/store';
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 
 import { Destination } from './destination';
 import { DatafeedService } from '../../services/data-feed/data-feed.service';
@@ -12,9 +12,6 @@ import { TelemetryService } from '../../services/telemetry/telemetry.service';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { DatafeedComponent } from './data-feed.component';
 import { RouterTestingModule } from '@angular/router/testing';
-import * as fromClientRuns from 'app/entities/client-runs/client-runs.reducer';
-import * as fromNotifications from 'app/entities/notifications/notification.reducer';
-import * as fromLayout from 'app/entities/layout/layout.reducer';
 
 describe('DatafeedComponent', () => {
   let store: Store<NgrxStateAtom>;
@@ -65,11 +62,7 @@ describe('DatafeedComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
-        StoreModule.forRoot({
-          clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
-          notifications: fromNotifications.notificationEntityReducer,
-          layout: fromLayout.layoutEntityReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       declarations: [
         DatafeedComponent

--- a/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/integrations/list/integrations-list.component.spec.ts
@@ -3,10 +3,7 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule } from '@ngrx/store';
 
-import { runtimeChecks } from 'app/ngrx.reducers';
-import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
-import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
-import { managerEntityReducer } from '../../../entities/managers/manager.reducer';
+import { runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { ChefPipesModule } from '../../../pipes/chef-pipes.module';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { IntegrationsListComponent } from './integrations-list.component';
@@ -21,6 +18,7 @@ describe('IntegrationsListComponent', () => {
         RouterTestingModule,
         ChefPipesModule,
         StoreModule.forRoot({
+          ...ngrxReducers,
           router: () => ({
             state: {
               url: '/',
@@ -31,10 +29,7 @@ describe('IntegrationsListComponent', () => {
             },
             previousRoute: {},
             navigationId: 0
-          }),
-          managers: managerEntityReducer,
-          notifications: notificationEntityReducer, // not used here but needed to suppress warnings
-          clientRunsEntity: clientRunsEntityReducer // not used here but needed to suppress warnings
+          })
         }, { runtimeChecks })
       ],
       declarations: [

--- a/components/automate-ui/src/app/pages/node-details/node-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/node-details/node-details.component.spec.ts
@@ -7,14 +7,12 @@ import { StoreModule } from '@ngrx/store';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { MockComponent } from 'ng2-mock-component';
 
-import { runtimeChecks } from 'app/ngrx.reducers';
+import { runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { NodeRun } from 'app/types/types';
 import { NodeDetailsService } from 'app/services/node-details/node-details.service';
 import { AttributesService } from 'app/services/attributes/attributes.service';
 import { TelemetryService } from 'app/services/telemetry/telemetry.service';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
-import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
 import { NodeDetailsComponent  } from './node-details.component';
 
 class MockTelemetryService {
@@ -84,8 +82,7 @@ function createTestFixture(
       FormsModule,
       RouterTestingModule,
       StoreModule.forRoot({
-        notifications: notificationEntityReducer, // not used here but needed to suppress warnings
-        clientRunsEntity: clientRunsEntityReducer, // not used here but needed to suppress warnings
+        ...ngrxReducers,
         router: () => ({
           state: {
             url: '/',

--- a/components/automate-ui/src/app/pages/notification-form/notification-form.component.spec.ts
+++ b/components/automate-ui/src/app/pages/notification-form/notification-form.component.spec.ts
@@ -4,7 +4,7 @@ import { By } from '@angular/platform-browser';
 import { Observable, of as observableOf } from 'rxjs';
 import { MockComponent } from 'ng2-mock-component';
 import { Store, StoreModule } from '@ngrx/store';
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 
 import { using } from 'app/testing/spec-helpers';
 import { RulesService } from 'app/services/rules/rules.service';
@@ -14,9 +14,6 @@ import { NotificationFormComponent } from './notification-form.component';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { FeatureFlagsService } from '../../services/feature-flags/feature-flags.service';
-import * as fromClientRuns from 'app/entities/client-runs/client-runs.reducer';
-import * as fromNotifications from 'app/entities/notifications/notification.reducer';
-import * as fromLayout from 'app/entities/layout/layout.reducer';
 
 describe('NotificationFormComponent', () => {
   let store: Store<NgrxStateAtom>;
@@ -56,11 +53,7 @@ describe('NotificationFormComponent', () => {
       ],
       imports: [
         FormsModule,
-        StoreModule.forRoot({
-          clientRunsEntity: fromClientRuns.clientRunsEntityReducer,
-          notifications: fromNotifications.notificationEntityReducer,
-          layout: fromLayout.layoutEntityReducer
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     }).compileComponents();

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.spec.ts
@@ -5,17 +5,13 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule, Store } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
-import { runtimeChecks } from 'app/ngrx.reducers';
+import { runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
-import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
 import { GetProjectSuccess } from 'app/entities/projects/project.actions';
-import { projectEntityReducer } from 'app/entities/projects/project.reducer';
 import { Project } from 'app/entities/projects/project.model';
 import { Rule } from 'app/entities/rules/rule.model';
-import { ruleEntityReducer } from 'app/entities/rules/rule.reducer';
 import { GetRulesSuccess } from 'app/entities/rules/rule.actions';
 import { ProjectDetailsComponent } from './project-details.component';
 
@@ -105,6 +101,7 @@ describe('ProjectDetailsComponent', () => {
         RouterTestingModule,
         ChefPipesModule,
         StoreModule.forRoot({
+          ...ngrxReducers,
           router: () => ({
             state: {
               url: '/settings/projects/uuid-1',
@@ -115,12 +112,8 @@ describe('ProjectDetailsComponent', () => {
             },
             previousRoute: {},
             navigationId: 0
-          }),
-          projects: projectEntityReducer,
-          rules: ruleEntityReducer,
-          notifications: notificationEntityReducer, // not used here but needed to suppress warnings
-          clientRunsEntity: clientRunsEntityReducer // not used here but needed to suppress warnings
-        }, { runtimeChecks })
+          })
+         }, { runtimeChecks })
       ],
       providers: [
         FeatureFlagsService

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
@@ -5,21 +5,17 @@ import { StoreModule, Store } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
 import { using } from 'app/testing/spec-helpers';
-import { NgrxStateAtom, runtimeChecks } from 'app/ngrx.reducers';
+import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { customMatchers } from 'app/testing/custom-matchers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { ProjectStatus } from 'app/entities/rules/rule.model';
-import { notificationEntityReducer } from 'app/entities/notifications/notification.reducer';
-import { clientRunsEntityReducer } from 'app/entities/client-runs/client-runs.reducer';
 import { GetIamVersionSuccess } from 'app/entities/policies/policy.actions';
-import { policyEntityReducer } from 'app/entities/policies/policy.reducer';
 import { ProjectService } from 'app/entities/projects/project.service';
 import {
   GetProjectsSuccess
 } from 'app/entities/projects/project.actions';
 import { Project } from 'app/entities/projects/project.model';
-import { projectEntityReducer } from 'app/entities/projects/project.reducer';
 import { ProjectListComponent } from './project-list.component';
 import { ChefKeyboardEvent } from 'app/types/material-types';
 
@@ -94,13 +90,7 @@ describe('ProjectListComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         ChefPipesModule,
-        StoreModule.forRoot(
-          {
-          policies: policyEntityReducer,
-          projects: projectEntityReducer,
-          notifications: notificationEntityReducer, // not used here but needed to suppress warnings
-          clientRunsEntity: clientRunsEntityReducer // not used here but needed to suppress warnings
-        }, { runtimeChecks })
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
       providers: [
         FeatureFlagsService,

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -7,10 +7,8 @@ import { MockComponent } from 'ng2-mock-component';
 import { using } from 'app/testing/spec-helpers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { runtimeChecks } from 'app/ngrx.reducers';
-import { projectEntityReducer } from 'app/entities/projects/project.reducer';
+import { runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { Rule, Condition, ConditionOperator, RuleType } from 'app/entities/rules/rule.model';
-import { ruleEntityReducer } from 'app/entities/rules/rule.reducer';
 import { Project } from 'app/entities/projects/project.model';
 import { ProjectRulesComponent } from './project-rules.component';
 import { of as observableOf } from 'rxjs';
@@ -82,6 +80,7 @@ describe('ProjectRulesComponent', () => {
         RouterTestingModule,
         ChefPipesModule,
         StoreModule.forRoot({
+          ...ngrxReducers,
           router: () => ({
             state: {
               url: '/projects/uuid-1/rules',
@@ -92,9 +91,7 @@ describe('ProjectRulesComponent', () => {
             },
             previousRoute: {},
             navigationId: 0
-          }),
-          projects: projectEntityReducer,
-          rules: ruleEntityReducer
+          })
         }, { runtimeChecks })
       ],
       providers: [


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
We need the pending edits bar to be present promptly upon page refresh or upon login. Before this fix, it would only start appearing upon visiting selected pages (e.g. project list page), which is any page that did a `GetProjects` call. There was seemingly a call to `GetProjects` in the LayoutFacadeService but therein lies the problem! That call was in an `ngOnInit` function but that `ngOnInit` hook was never being called! That is because LayoutFacadeService is neither a Component nor a Directive (reference: Reference: https://angular.io/guide/lifecycle-hooks). Moving that to the constructor made the code actually run, resolving the issue.
The `noOnDestroy` hook code was never used either, for the same reason, so that is removed here as well.

Finally, the very same things were true of the LayoutSidebarService, so changes for that as well.

### :chains: Related Resources
#3103 (Fixes from auditing Angular lifecycle hooks)

### :+1: Definition of Done
Pending edits bar now appears immediately upon login or page refresh,
and remains present throughout a session.

### :athletic_shoe: How to Build and Test the Change

Setup: rebuild automate-ui, login, and create a project and a rule. Observe the pending edits bar appears, as it did previously. 
Now go to a non-auth page, e.g. events feed or compliance. Then logout and log back in. You should see the pending edits bar immediately.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
