### PR TITLE
Don't fail project update if ES doesn't give back a response

### DIFF
--- a/components/compliance-service/ingest/ingestic/project_update.go
+++ b/components/compliance-service/ingest/ingestic/project_update.go
@@ -102,8 +102,8 @@ func (backend *ESClient) MonitorProjectUpdateTask(ctx context.Context,
 	if res.Completed {
 		projectUpdateStatus.PercentageComplete = 1
 		if res.Response == nil {
-			projectUpdateStatus.State = project_update_lib.SerializedProjectUpdateTaskFailed
-			projectUpdateStatus.Error = "response missing from completed task"
+			projectUpdateStatus.State = project_update_lib.SerializedProjectUpdateTaskSuccess
+			logrus.Warnf("response missing from completed task for task %s", id)
 		} else if len(res.Response.Failures) > 0 {
 			projectUpdateStatus.State = project_update_lib.SerializedProjectUpdateTaskFailed
 			projectUpdateStatus.Error = res.Response.Failures[0]

--- a/components/ingest-service/backend/elastic/project_update.go
+++ b/components/ingest-service/backend/elastic/project_update.go
@@ -99,8 +99,8 @@ func (backend *Backend) MonitorProjectUpdateTask(ctx context.Context,
 	if res.Completed {
 		projectUpdateStatus.PercentageComplete = 1
 		if res.Response == nil {
-			projectUpdateStatus.State = project_update_lib.SerializedProjectUpdateTaskFailed
-			projectUpdateStatus.Error = "response missing from completed task"
+			projectUpdateStatus.State = project_update_lib.SerializedProjectUpdateTaskSuccess
+			logrus.Warnf("response missing from completed task for task %s", id)
 		} else if len(res.Response.Failures) > 0 {
 			projectUpdateStatus.State = project_update_lib.SerializedProjectUpdateTaskFailed
 			projectUpdateStatus.Error = res.Response.Failures[0]


### PR DESCRIPTION
We ran into this case after it was running for days. It seems ES can
tell you a task is complete but not have the result.