### PR TITLE
Vanished teams on force-upgrade

### DIFF
--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -181,7 +181,7 @@ export class LayoutSidebarService implements OnInit, OnDestroy {
                 icon: 'people',
                 route: '/settings/teams',
                 authorized: {
-                  allOf: ['/auth/teams', 'get']
+                  allOf: ['/iam/v2/teams', 'get']
                 }
               },
               {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The teams entry in the left navigation panel had vanished on the `forceUpgrade` branch.

![image](https://user-images.githubusercontent.com/6817500/76705497-a60d2780-669d-11ea-9c6b-92d76e052896.png)


### :chains: Related Resources
NA

### :+1: Definition of Done
"Teams" is back.

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui.
Log in as admin and navigate to Settings.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
