### PR TITLE
Fixes from auditing Angular lifecycle hooks

### DIFF
--- a/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.ts
+++ b/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation, OnDestroy } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -12,7 +12,7 @@ import { ProjectService } from 'app/entities/projects/project.service';
   styleUrls: ['./process-progress-bar.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
-export class ProcessProgressBarComponent implements OnInit {
+export class ProcessProgressBarComponent implements OnInit, OnDestroy {
   public confirmApplyStopModalVisible = false;
   public cancelRulesInProgress = false;
   public mode = 'determinate';
@@ -43,6 +43,11 @@ export class ProcessProgressBarComponent implements OnInit {
         this.layoutFacade.layout.userNotifications.updatesProcessing = this.applyRulesInProgress;
         this.layoutFacade.updateDisplay();
       });
+  }
+
+  ngOnDestroy() {
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
   }
 
   public openConfirmUpdateStopModal(): void {

--- a/components/automate-ui/src/app/modules/roles/list/roles-list.component.ts
+++ b/components/automate-ui/src/app/modules/roles/list/roles-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable, Subject } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, takeUntil } from 'rxjs/operators';
 
 import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { ChefSorters } from 'app/helpers/auth/sorter';
@@ -30,8 +30,11 @@ export class RolesListComponent implements OnInit, OnDestroy {
     private store: Store<NgrxStateAtom>,
     private layoutFacade: LayoutFacadeService
   ) {
-    store.select(getAllStatus).pipe(map(loading)).subscribe((isloading) =>
-      this.layoutFacade.ShowPageLoading(isloading));
+    store.select(getAllStatus).pipe(
+      map(loading),
+      takeUntil(this.isDestroyed)
+    ).subscribe(isLoading =>
+      this.layoutFacade.ShowPageLoading(isLoading));
 
     this.sortedRoles$ = store.select(allRoles).pipe(
       map((roles: Role[]) => ChefSorters.naturalSort(roles, 'name')));

--- a/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.ts
@@ -1,7 +1,6 @@
 import {
   Component,
   OnInit,
-  OnDestroy,
   OnChanges,
   ElementRef,
   HostListener,
@@ -11,17 +10,16 @@ import {
   SimpleChanges,
   ViewChild
 } from '@angular/core';
+import * as moment from 'moment';
+import { reduce } from 'lodash/fp';
+import * as d3 from 'd3';
 import { GuitarString,
   GuitarStringCollection,
   GuitarStringItem,
   DateRange
 } from '../../types/types';
-import * as moment from 'moment';
-import { initialState } from '../../services/event-feed/event-feed.reducer';
-import { Subject } from 'rxjs';
-import { reduce } from 'lodash/fp';
-import * as d3 from 'd3';
 import { DateTime } from 'app/helpers/datetime/datetime';
+import { initialState } from '../../services/event-feed/event-feed.reducer';
 
 export class GuitarStringDataContainer {
   dynamicallyBucketedGuitarStrings: GuitarString[] = [];
@@ -266,8 +264,7 @@ export class GraphicProportions {
   templateUrl: './event-feed-guitar-strings.component.html',
   styleUrls: ['./event-feed-guitar-strings.component.scss']
 })
-export class EventFeedGuitarStringsComponent implements OnInit, OnDestroy, OnChanges {
-  private isDestroyed: Subject<boolean> = new Subject<boolean>();
+export class EventFeedGuitarStringsComponent implements OnInit, OnChanges {
   @Output() newDateRange: EventEmitter<DateRange> = new EventEmitter();
   @Input() guitarStringCollection: GuitarStringCollection = initialState.guitarStringCollection;
 
@@ -323,11 +320,6 @@ export class EventFeedGuitarStringsComponent implements OnInit, OnDestroy, OnCha
   }
 
   itemSelected(_item: GuitarStringItem): void {}
-
-  ngOnDestroy(): void {
-    this.isDestroyed.next(true);
-    this.isDestroyed.complete();
-  }
 
   @HostListener('window:resize', ['$event.target'])
   onResize() {

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, ViewChild, ElementRef, OnDestroy, OnInit } from '@angular/core';
 import { capitalize, getOr, endsWith, replace, concat } from 'lodash/fp';
 import { Subject, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, takeUntil } from 'rxjs/operators';
 import { ChefEvent, ChefEventCollection, EventFeedFilter, Chicklet } from '../../types/types';
 import { EventFeedService } from '../../services/event-feed/event-feed.service';
 import * as moment from 'moment';
@@ -52,7 +52,9 @@ export class EventFeedTableComponent implements OnDestroy, OnInit {
     this.sidepanel.nativeElement.focus();
     this.groupedEventsButton = document.getElementById(clickEvent.target.id);
 
-    this.getGroupedEvents(event).subscribe((events: ChefEvent[]) => {
+    this.getGroupedEvents(event)
+      .pipe(takeUntil(this.isDestroyed))
+      .subscribe((events: ChefEvent[]) => {
       this.groupedEvents = events;
     });
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -6,6 +6,7 @@ import { ReportQueryService } from '../../shared/reporting/report-query.service'
 import * as moment from 'moment';
 import { DateTime } from 'app/helpers/datetime/datetime';
 import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-reporting-node',
@@ -43,10 +44,12 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     reportQuery.filters = reportQuery.filters.concat([{type: {name: 'node_id'}, value: {id}}]);
 
     this.statsService.getReports(reportQuery, {sort: 'latest_report.end_time', order: 'DESC'})
+      .pipe(takeUntil(this.isDestroyed))
       .subscribe(reports => {
         this.reports = reports;
         const queryForReport = this.reportQuery.getReportQueryForReport(reports[0]);
         this.statsService.getSingleReport(reports[0].id, queryForReport)
+          .pipe(takeUntil(this.isDestroyed))
           .subscribe(data => {
             this.reportLoading = false;
             this.layoutFacade.ShowPageLoading(false);
@@ -65,6 +68,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     this.layoutFacade.ShowPageLoading(true);
     const reportQuery = this.reportQuery.getReportQueryForReport(report);
     this.statsService.getSingleReport(report.id, reportQuery)
+      .pipe(takeUntil(this.isDestroyed))
       .subscribe(data => {
         this.reportLoading = false;
         this.layoutFacade.ShowPageLoading(false);

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -54,7 +54,7 @@ export class JobAddComponent implements OnDestroy {
   managers$: Observable<Manager[]>;
   profiles$: Observable<Profile[]>;
 
-  isDestroyed: Subject<boolean> = new Subject<boolean>();
+  private isDestroyed = new Subject<boolean>();
 
   constructor(
     private store: Store<NgrxStateAtom>,

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -86,6 +86,7 @@ export class JobAddComponent implements OnDestroy {
 
   public ngOnDestroy() {
     this.isDestroyed.next(true);
+    this.isDestroyed.complete();
   }
 
   public setupForm() {

--- a/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
+++ b/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
@@ -99,6 +99,7 @@ export class JobEditComponent implements OnDestroy {
 
   public ngOnDestroy() {
     this.isDestroyed.next(true);
+    this.isDestroyed.complete();
   }
 
   public setupForm() {
@@ -156,8 +157,8 @@ export class JobEditComponent implements OnDestroy {
         this.profiles$,
         this.job$
       ]).pipe(
-      takeUntil(this.isDestroyed),
-      debounceTime(250))
+        takeUntil(this.isDestroyed),
+        debounceTime(250))
       .subscribe(([managers, profiles, job]: any) => {
         form.get('id').setValue(job.id);
 
@@ -191,8 +192,10 @@ export class JobEditComponent implements OnDestroy {
                 values: this.fb.array(ns['values']),
                 include: !ns['exclude']
               });
-              tagGroup.get('key').valueChanges.pipe(
-                startWith(tagGroup.get('key').value))
+              tagGroup.get('key').valueChanges
+                .pipe(
+                  startWith(tagGroup.get('key').value),
+                  takeUntil(this.isDestroyed))
                 .subscribe(key => {
                   const field = `tags:${key}`;
                   this.store.dispatch(new ManagerSearchFields({managerId, field}));

--- a/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
+++ b/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
@@ -57,7 +57,7 @@ export class JobEditComponent implements OnDestroy {
   profiles$: Observable<Profile[]>;
   job$: Observable<Job>;
 
-  isDestroyed: Subject<boolean> = new Subject<boolean>();
+  private isDestroyed = new Subject<boolean>();
 
   constructor(
     private store: Store<NgrxStateAtom>,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
In another issue, I was diagnosing why the pending edits bar was not showing up promptly upon login; rather, it required visiting any among a group of select pages (like project-list) then it would remain persistent.
The root cause turned out to be incorrectly applied lifecycle hooks on a class that did not pay attention to them. That got me thinking about other classes of violations, which led to this PR.

`wwo` (pronounced "wa-wo" and meaning _with-and-with-out_) is the workhorse that finds files containing the first argument but not containing the second argument:
```

wwo() {
  rg --files-without-match "$2" $(rg --files-with-matches "$1") 
}
```

The `rg` tool in there is a `grep` alternative that @stevendanna put me on to that really proved its worth here (install on mac with `brew install ripgrep`). With `rg` the following shell script takes just a couple seconds; with `grep`, well, I just aborted it after a while. 

```
checkSubs() {
  printf "=== Files with ngOnInit hook that are not Components or Directives\n"
  wwo ngOnInit '@Component|@Directive' | grep -v spec.ts

  printf "\n=== Files with ngOnDestroy hook that are not Components or Directives\n"
  wwo ngOnDestroy '@Component|@Directive' | grep -v spec.ts

  printf "\n=== Files implementing onDestroy but not using it with takeUntil\n"
  wwo 'isDestroyed\$?.next' 'takeUntil\(this.isDestroyed'

  printf "\n=== Files seemingly using takeUntil but never triggering it\n"
  wwo 'takeUntil\(this.isDestroyed' 'isDestroyed\$?.next' 

  printf "\n=== Files with ngOnDestroy that are not extending the class with OnDestroy\n"
  wwo '^\s*ngOnDestroy' '\bOnDestroy' 

  printf "\n=== Files where isDestroyed is not private\n"
  wwo isDestroyed 'private isDestroyed'

  printf "\n=== Files missing 'next' in ngOnDestroy\n"
  wwo 'isDestroyed\$?.complete' 'isDestroyed\$?.next'

  printf "\n=== Files missing 'complete' in ngOnDestroy\n"
  wwo 'isDestroyed\$?.next' 'isDestroyed\$?.complete'

  printf "\n=== Things above should be fixed ASAP! Things below, eventually. ===\n"

  printf "\n=== Files not using best practice for ngOnDestroy\n"
  wwo ngOnDestroy 'isDestroyed\$?.next'

  printf "\n=== Files not applying takeUntil to subscriptions\n=== (OK for components that are always present like license-apply.component.ts, etc.)\n"
  wwo subscribe takeUntil | grep -v spec.ts
}
```

### :chains: Related Resources
#3031 (Fix for pending edits bar not displaying promptly)

### :+1: Definition of Done
No visible changes, but there are a few less subscription leaks.
When auditing the code, we have gone from this...
```
=== Files implementing onDestroy but not using it with takeUntil
src/app/page-components/event-feed-table/event-feed-table.component.ts
src/app/entities/layout/layout-sidebar.service.ts
src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.ts
src/app/entities/layout/layout.facade.ts
src/app/modules/roles/list/roles-list.component.ts
src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts

=== Files seemingly using takeUntil but never triggering it
src/app/components/process-progress-bar/process-progress-bar.component.ts

=== Files with ngOnDestroy that are not extending the class with OnDestroy

=== Files where isDestroyed is not private
src/app/pages/job-edit/job-edit.component.ts
src/app/pages/job-add/job-add.component.ts
src/app/pages/+compliance/+reporting/reporting.component.spec.ts

=== Files missing 'next' in ngOnDestroy

=== Files missing 'complete' in ngOnDestroy
src/app/pages/job-edit/job-edit.component.ts
src/app/pages/job-add/job-add.component.ts
```
to this...
(The two layout*.ts files are fixed in #3031 and the spec file is a false positive)
```
$ checkSubs 
=== Files with ngOnInit hook that are not Components or Directives
src/app/entities/layout/layout.facade.ts
src/app/entities/layout/layout-sidebar.service.ts

=== Files with ngOnDestroy hook that are not Components or Directives
src/app/entities/layout/layout.facade.ts
src/app/entities/layout/layout-sidebar.service.ts

=== Files implementing onDestroy but not using it with takeUntil
src/app/entities/layout/layout-sidebar.service.ts
src/app/entities/layout/layout.facade.ts

=== Files seemingly using takeUntil but never triggering it

=== Files with ngOnDestroy that are not extending the class with OnDestroy

=== Files where isDestroyed is not private
src/app/pages/+compliance/+reporting/reporting.component.spec.ts

=== Files missing 'next' in ngOnDestroy

=== Files missing 'complete' in ngOnDestroy
```

If you review by commit, you will see each of those fixes in separate commits.

Just one more thing:
I truncated the output above because this PR does not address the last two checks, so both before and after still report these final items:
```
=== Things above should be fixed ASAP! Things below, eventually. ===

=== Files not using best practice for ngOnDestroy
src/app/pages/node-details/node-details.component.ts
src/app/page-components/run-history/run-history.component.ts
src/app/page-components/telemetry-checkbox/telemetry-checkbox.component.ts
src/app/page-components/profile/profile.component.spec.ts
src/app/pages/+compliance/+reporting/reporting.component.spec.ts
src/app/pages/integrations/edit/integrations-edit.component.ts
src/app/pages/integrations/add/integrations-add.component.ts
src/app/pages/+compliance/+reporting/+reporting-overview/overview-failures/overview-failures.component.ts
src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts

=== Files not applying takeUntil to subscriptions
=== (OK for components that are always present like license-apply.component.ts, etc.)
src/app/ui.component.ts
src/app/components/sidebar/sidebar.component.ts
src/app/components/landing/landing.component.ts
src/app/pages/notification-form/notification-form.component.ts
src/app/pages/node-noruns-details/node-noruns-details.component.ts
src/app/pages/job-list/job-list.component.ts
src/app/components/form-field/form-field.component.ts
src/app/components/projects-dropdown/projects-dropdown.component.ts
src/app/pages/node-details/node-details.component.ts
src/app/pages/signin/signin.component.ts
src/app/pages/data-feed/data-feed.component.ts
src/app/pages/data-feed-form/data-feed-form.component.ts
src/app/pages/notifications/notifications.component.ts
src/app/pages/automate-settings/automate-settings.component.ts
src/app/components/notifications/notifications.component.ts
src/app/entities/layout/layout-sidebar.service.ts
src/app/entities/layout/layout.facade.ts
src/app/page-components/run-history/run-history.component.ts
src/app/services/http/http-client-auth.interceptor.ts
src/app/page-components/create-v1-team-modal/create-v1-team-modal.component.ts
src/app/page-components/search-bar/search-bar.component.ts
src/app/page-components/telemetry-checkbox/telemetry-checkbox.component.ts
src/app/services/telemetry/telemetry.service.ts
src/app/page-components/sidebar-select-list/sidebar-select-list.component.ts
src/app/page-components/job-nodes-form/job-nodes-form.component.ts
src/app/modules/license/license-apply/license-apply.component.ts
src/app/modules/license/license-lockout/license-lockout.component.ts
src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.ts
src/app/pages/integrations/edit/integrations-edit.component.ts
src/app/pages/integrations/list/integrations-list.component.ts
src/app/pages/integrations/add/integrations-add.component.ts
src/app/pages/+compliance/+credentials/containers/credentials-add-edit-screen.ts
src/app/page-components/welcome-modal/welcome-modal.component.ts
src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
src/app/pages/+compliance/shared/reporting/report-data.service.ts
src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.ts
src/app/pages/+compliance/+scanner/containers/nodes-add/nodes-add.component.ts
src/app/pages/component-library/demos/component-library-screen/component-library-screen.component.ts
src/app/pages/+compliance/+scanner/containers/nodes-edit/nodes-edit.component.ts
```

### :athletic_shoe: How to Build and Test the Change
```
cd components/automate-ui
checkSubs
```

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
