### PR TITLE
Robust Deprecation of IAM v1

### DIFF
--- a/components/automate-chef-io/config.toml
+++ b/components/automate-chef-io/config.toml
@@ -124,13 +124,11 @@ url = "/docs/client-runs"
 name = "Compliance"
 weight = 60
 identifier = "compliance"
-url = "/docs/compliance"
 
 [[menu.docs]]
 name = "Settings"
 weight = 90
 identifier = "settings"
-url = "/docs/settings"
 
 [[menu.docs]]
 name = "Authorization"

--- a/components/automate-chef-io/content/docs/api-tokens.md
+++ b/components/automate-chef-io/content/docs/api-tokens.md
@@ -14,7 +14,7 @@ toc = true
 
 API Tokens are used to access the Chef Automate API. They are the only way to authenticate against the Chef Automate API. Tokens can be added as members of policies in order to grant them permissions.
 
-Permission for the `iam:tokens` action is required to interact with tokens. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM v2 custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
+Permission for the `iam:tokens` action is required to interact with tokens. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
 
 ## Managing API Tokens
 
@@ -32,7 +32,7 @@ After creating an API Token, you can obtain the token's value by opening the men
 
 #### Admin Tokens
 
-Admin tokens are tokens that are automatically added to the Administrator policy, which grants full access to Chef Automate. 
+Admin tokens are tokens that are automatically added to the Administrator policy, which grants full access to Chef Automate.
 Admin tokens can only be created using the `chef-automate` command line.
 
 ```

--- a/components/automate-chef-io/content/docs/iam-v1-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v1-overview.md
@@ -16,7 +16,7 @@ toc = true
 +++
 
 {{< warning >}}
-This documentation and the feature it covers, IAM v1, are deprecated. This documentation will be removed soon. Most Chef Automate installations upgraded automatically to the current IAM implementation. Contact your customer service representative for help upgrading airgapped installations.
+This documentation and the feature it covers, IAM v1, are deprecated. This documentation will be removed soon. Most Chef Automate installations upgraded automatically to the current IAM implementation. The [Airgap Installation documentation {{< relref "airgapped-installation.md/#upgrades" >}} covers the manual upgrade process for systems without internet connectivity.
 The current IAM documentation pages are: the [IAM Overview]({{< relref "iam-v2-overview" >}}), the [IAM Guide]({{< relref "iam-v2-guide" >}}) and the [Chef Automate API]({{< relref "docs/api/#tag/teams" >}}).
 {{< /warning >}}
 
@@ -48,7 +48,7 @@ Policies can contain wildcards to match a range of values.
 
 ## Structure
 
-A policy has three essential components: the **subjects**, which is
+A policy has three components: the **subjects**, which is
 a list of users and teams, the **action** that those users/team members are allowed to perform,
 and the **resource** on which they perform actions. Resources can be very granular,
 but for most instances, restricting at the uppermost namespace will suffice.

--- a/components/automate-chef-io/content/docs/iam-v1-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v1-overview.md
@@ -5,7 +5,7 @@ aliases = [
     "/docs/default-policies/",
     "/docs/iam-v1-policies/"
 ]
-description = "IAM v1 Overview"
+description = "IAM v1 Overview (Deprecated)"
 draft = false
 bref = ""
 toc = true
@@ -16,10 +16,11 @@ toc = true
 +++
 
 {{< warning >}}
-IAM v1 is deprecated and we recommend updating to the latest version of Automate to make use of [IAM v2]({{< relref "iam-v2-overview" >}}).
+This documentation and the feature it covers, IAM v1, are deprecated. This documentation will be removed soon. Most Chef Automate installations upgraded automatically to the current IAM implementation. Contact your customer service representative for help upgrading airgapped installations.
+The current IAM documentation pages are: the [IAM Overview]({{< relref "iam-v2-overview" >}}), the [IAM Guide]({{< relref "iam-v2-guide" >}}) and the [Chef Automate API]({{< relref "docs/api/#tag/teams" >}}).
 {{< /warning >}}
 
-This guide helps you understand and use Chef Automate's IAM v1 authorization system. 
+This guide helps you understand and use Chef Automate's IAM v1 authorization system.
 
 ## Overview
 
@@ -47,7 +48,7 @@ Policies can contain wildcards to match a range of values.
 
 ## Structure
 
-A policy is made up of three essential components: the **subjects**, which is
+A policy has three essential components: the **subjects**, which is
 a list of users and teams, the **action** that those users/team members are allowed to perform,
 and the **resource** on which they perform actions. Resources can be very granular,
 but for most instances, restricting at the uppermost namespace will suffice.
@@ -97,7 +98,7 @@ A wildcard can replace any term of the subject; however, no terms can follow the
 Each user or team must specify its _provider_: _local_, _ldap_, or _saml_.
 
 IAM v1 supports LDAP, SAML,
-and local users or teams. 
+and local users or teams.
 
 ### Resource
 
@@ -156,9 +157,9 @@ This may be a policy that gives permissions directly to a user, but more likely 
 
 Use the ID of the policy to delete it:
 
-    ```bash
-    curl -s -X DELETE -H "api-token: $TOKEN" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/policies/{id}?pretty
-    ```
+```bash
+curl -s -X DELETE -H "api-token: $TOKEN" -H "Content-Type: application/json" https://{{< example_fqdn "automate" >}}/api/v0/auth/policies/{id}?pretty
+```
 
 ### Open Permissions on All Resources
 
@@ -174,6 +175,7 @@ curl -s -H "api-token: $TOKEN" -H "Content-Type: application/json" -d '{"subject
 ```
 
 ### Permission for an API Client on Compliance Resources
+
 To create a token that gives a client permission to read any Compliance resource.
 
 1. Create an API token.
@@ -393,6 +395,7 @@ UsersMgmt | UpdateUser | /auth/users/{username} | PUT | auth:users:{username} | 
 {{% /responsive-table %}}
 
 #### Teams
+
 Admins that are member of the admins team can perform any action on any resource including Authorization and Notifications resources, which are inaccessible to non-admins.
 
 {{% responsive-table %}}
@@ -435,4 +438,3 @@ Authorization | IntrospectAll | /auth/introspect | GET | auth_introspection:intr
 Authorization | IntrospectSome | /auth/introspect_some | POST | auth_introspection:introspect_some | read
 Authorization | Introspect | /auth/introspect | POST | auth_introspection:introspect | read
 {{% /responsive-table %}}
-

--- a/components/automate-chef-io/content/docs/iam-v1-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v1-overview.md
@@ -1,5 +1,5 @@
 +++
-title = "IAM v1 Overview"
+title = "IAM v1 Overview (Deprecated)"
 aliases = [
     "/docs/authorization-overview/",
     "/docs/default-policies/",

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -1,6 +1,6 @@
 +++
-title = "IAM v2 Users Guide"
-description = "IAM v2 Users Guide"
+title = "IAM Users Guide"
+description = "IAM Users Guide"
 draft = false
 bref = ""
 toc = true
@@ -360,7 +360,7 @@ Setting the project rule `Resource Type` determines what condition attributes ar
 
 Rules of type `Node` can have conditions with attributes `Chef Organization`, `Chef Server`, `Environment`, `Chef Role`, `Chef Tag`, `Chef Policy Name`, `Chef Policy Group`.
 
-Select the `Update Projects` button from the bottom banner. 
+Select the `Update Projects` button from the bottom banner.
 Upon completion of the update, you should be able to filter by `project-devops` across Automate's dashboards and see only the ingested data that you expect.
 
 #### Effortless Infra Project
@@ -369,9 +369,9 @@ To create a project that contains all Effortless Infra nodes, create a ingest ru
 
 ![](/images/docs/effortless-project-rule.png)
 
-The above rule matches on a node's Chef Server field, which is set to `localhost`. This rule works because all Effortless Infra nodes list the `Chef Server` attribute as `localhost`. 
+The above rule matches on a node's Chef Server field, which is set to `localhost`. This rule works because all Effortless Infra nodes list the `Chef Server` attribute as `localhost`.
 
-If desired, create subgroups of Effortless Infra nodes by adding a second condition that matches a specific `Chef Policy Name`. 
+If desired, create subgroups of Effortless Infra nodes by adding a second condition that matches a specific `Chef Policy Name`.
 
 #### Project Policies
 

--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -1,6 +1,6 @@
 +++
-title = "IAM Overview"
-description = "IAM Overview"
+title = "IAM v2 Overview"
+description = "IAM v2 Overview"
 draft = false
 bref = ""
 toc = true
@@ -10,7 +10,7 @@ toc = true
     weight = 10
 +++
 
-## Features of IAM
+## Features in IAM v2
 
 IAM v2 policies allow multiple permissions, separating out policy membership from policy definition for fine-grained control, and includes roles for role-based access control.
 Additionally, IAM v2 allows policy members to be managed directly from the Automate UI.

--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -1,6 +1,6 @@
 +++
-title = "IAM v2 Overview"
-description = "IAM v2 Overview"
+title = "IAM Overview"
+description = "IAM Overview"
 draft = false
 bref = ""
 toc = true
@@ -10,7 +10,7 @@ toc = true
     weight = 10
 +++
 
-## Features in IAM v2
+## Features of IAM
 
 IAM v2 policies allow multiple permissions, separating out policy membership from policy definition for fine-grained control, and includes roles for role-based access control.
 Additionally, IAM v2 allows policy members to be managed directly from the Automate UI.

--- a/components/automate-chef-io/content/docs/ldap.md
+++ b/components/automate-chef-io/content/docs/ldap.md
@@ -32,7 +32,7 @@ Chef Automate does not support using _two_ SAML IdPs or _two_ LDAP services simu
 Switching between a Microsoft AD configuration and generic LDAP configuration will
 not affect your policies, as they are both LDAP configurations.
 However, switching between either of those configurations and a SAML configuration will
-require you to adjust the [IAM v2]({{< relref "iam-v2-overview.md" >}}) policy membership.
+require you to adjust the [IAM]({{< relref "iam-v2-overview.md" >}}) policy membership.
 
 {{< info >}}
 Users who sign in via SAML will have a session time of 24 hours before needing to sign in again.
@@ -269,7 +269,7 @@ Once the user has provided a username and password at the sign in screen, Chef A
 
 #### Authorization with LDAP
 
-Chef Automate supports defining permissions for LDAP users and their groups. See [IAM v2 members and policies]({{< ref "iam-v2-overview.md#members-and-policies" >}}).
+Chef Automate supports defining permissions for LDAP users and their groups. See [IAM members and policies]({{< ref "iam-v2-overview.md#members-and-policies" >}}).
 
 #### Connect
 

--- a/components/automate-chef-io/content/docs/on-prem-builder.md
+++ b/components/automate-chef-io/content/docs/on-prem-builder.md
@@ -345,4 +345,4 @@ MIIDfDCCAmSgAcaSldKaf...
 If you are using a certificate signed by a trusted certificate authority instead of the default certificate,
 you can provide Builder with the root certificate authority for the signed certificate.
 
-For more information, check out this further explanation on how to [configure Builder to authenticate via Chef Automate]((https://github.com/habitat-sh/on-prem-builder).
+For more information, check out this further explanation on how to [configure Builder to authenticate via Chef Automate](https://github.com/habitat-sh/on-prem-builder).

--- a/components/automate-chef-io/content/docs/policies.md
+++ b/components/automate-chef-io/content/docs/policies.md
@@ -12,9 +12,9 @@ toc = true
 
 ## Overview
 
-Identity and Access Management policies manage the resources and actions used by identities. Policies are composed of statements that specify permissions. 
+Identity and Access Management policies manage the resources and actions used by identities. Policies are composed of statements that specify permissions.
 
-Permission for the `iam:policies` action is required to interact with policies. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM v2 custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
+Permission for the `iam:policies` action is required to interact with policies. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
 
 ![](/images/docs/settings-policies.png)
 

--- a/components/automate-chef-io/content/docs/roles.md
+++ b/components/automate-chef-io/content/docs/roles.md
@@ -14,7 +14,7 @@ toc = true
 
 Chef Automate Identity and Access Management roles are named groups of actions used to define [policies]({{< relref "policies.md" >}}). Actions describe what is allowed by users in Automate.
 
-Permission for the `iam:roles` action is required to interact with roles. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM v2 custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
+Permission for the `iam:roles` action is required to interact with roles. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
 
 ![](/images/docs/settings-roles.png)
 
@@ -32,7 +32,7 @@ Ingest        | Ingest data into the system
 
 ### Custom Roles
 
-Custom roles are roles that can be changed by anyone with the permission for `iam:roles:update`. 
+Custom roles are roles that can be changed by anyone with the permission for `iam:roles:update`.
 
 ## Managing Roles
 

--- a/components/automate-chef-io/content/docs/saml.md
+++ b/components/automate-chef-io/content/docs/saml.md
@@ -84,7 +84,7 @@ The `groups_attr` setting is optional. However, if it is not provided,
 users authenticating via SAML will not be members of any teams.
 {{% /warning %}}
 
-Chef Automate supports using SAML to authenticate users and apply permissions to SAML groups. See [IAM v2 Overview]({{< relref "iam-v2-overview.md" >}}).
+Chef Automate supports using SAML to authenticate users and apply permissions to SAML groups. See [IAM Overview]({{< relref "iam-v2-overview.md" >}}).
 
 ```toml
 [dex.v1.sys.connectors.saml]

--- a/components/automate-chef-io/content/docs/teams.md
+++ b/components/automate-chef-io/content/docs/teams.md
@@ -15,7 +15,7 @@ toc = true
 
 A Chef Automate team is an assigned grouping of users. You can import existing teams into Chef Automate with [Microsoft AD (LDAP)]({{< ref "ldap.md#microsoft-active-directory" >}}), [generic LDAP]({{< ref "ldap.md" >}}), or [SAML]({{< ref "saml.md" >}}). You can also create local Chef Automate teams that are independent of LDAP or SAML.
 
-Permission for the `iam:teams` action is required to interact with teams. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM v2 custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
+Permission for the `iam:teams` action is required to interact with teams. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
 
 ## Managing Local Teams
 

--- a/components/automate-chef-io/content/docs/users.md
+++ b/components/automate-chef-io/content/docs/users.md
@@ -17,7 +17,7 @@ Chef Automate supports three different types of users: local users, [LDAP users]
 
 Local users can sign in and interact with the system independent of LDAP or SAML.
 
-Permission for the `iam:users` action is required to interact with users other than yourself. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM v2 custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
+Permission for the `iam:users` action is required to interact with users other than yourself. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
 
 ## Managing Local Users
 


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

This PR makes the IAM v1 deprecation more robust. The intention is two-fold: To guide users to the correct IAM documentation with ease, and to reduce future docs work. 

* Strengthens deprecation notices
* Adds (Deprecated) to the v1 title
* Renames "IAM v2 Overview" to  "IAM Overview" 
* Renames "IAM v2 Guide" to "IAM Guide"
* Fix references to these pages 
* Fixes a few broken links that I discovered along the way

The pages are retitled, but the urls are unchanged.

