### PR TITLE
Update links to docs.chef.io

### DIFF
--- a/components/automate-chef-io/content/docs/client-runs.md
+++ b/components/automate-chef-io/content/docs/client-runs.md
@@ -39,7 +39,7 @@ _Resources_ displays the status of the most recent resources are failed, success
 Selecting the tabs with these names will filter the list to show only those resources.
 _Run List_ shows cookbooks, roles and recipes. For a node using policyfiles, you will be able to see the policy ID's for each cookbook listed.
 _Attributes_ shows an expandable list of node properties. Use the search bar to discover the node attributes by attribute name, key name, or value. The search results show by highlighting matching attributes. Use the _default_, _normal_, _override_, and _automatic_ buttons beneath the search bar to filter attributes by to these categories.
-Learn more about [attributes](https://docs.chef.io/attributes.html)
+Learn more about [attributes](https://docs.chef.io/attributes/)
 
 When looking at a failed Chef client run, selecting "view error log" button at the top of the page opens a window showing the error message and backtrace. Use the downloaded button to save the error message.
 
@@ -58,46 +58,46 @@ To save a search, select the share button to the right of the search bar, and co
 
 #### Node Filters
 
-[Attribute](https://docs.chef.io/attributes.html)
+[Attribute](https://docs.chef.io/attributes/)
 : Search for an attribute key, this will not search across attribute values.
 
-[Chef Organization](https://docs.chef.io/server_orgs.html)
+[Chef Organization](https://docs.chef.io/server_orgs/)
 : A Chef Server organization name.
 
-[Chef Server](https://docs.chef.io/server_components.html)
+[Chef Server](https://docs.chef.io/server_overview/)
 : A Chef Server URL.
 
-[Cookbook](https://docs.chef.io/cookbooks.html)
+[Cookbook](https://docs.chef.io/cookbooks/)
 : A cookbook name.
 
-[Environment](https://docs.chef.io/environments.html)
+[Environment](https://docs.chef.io/environments/)
 : Nodes can have one environment.
 
-[Node Name](https://docs.chef.io/nodes.html#about-node-names)
+[Node Name](https://docs.chef.io/nodes/#about-node-names)
 : Name of the node.
 
-[Platform](https://docs.chef.io/platforms.html#chef-automate-server)
+[Platform](https://docs.chef.io/platforms/#chef-automate-server)
 : OS Platform of a node.
 
-[Policy Group](https://docs.chef.io/policyfile.html#settings)
+[Policy Group](https://docs.chef.io/policyfile/#settings)
 : Policy group name, only nodes using policyfiles will be shown.
 
-[Policy Name](https://docs.chef.io/policyfile.html#settings)
+[Policy Name](https://docs.chef.io/policyfile/#settings)
 : Name of the policy as set in policyfile.rb, only nodes using policyfiles will be shown.
 
-[Policy Revision](https://docs.chef.io/release_notes_server.html#policies-name-revisions)
+[Policy Revision](https://docs.chef.io/release_notes_server/#policiesnamerevisions)
 : The policy revision ID, only nodes using policyfiles will be shown.
 
-[Recipe](https://docs.chef.io/recipes.html)
+[Recipe](https://docs.chef.io/recipes/)
 : A recipe within a cookbook.
 
-[Resource Name](https://docs.chef.io/resource_reference.html)
+[Resource Name](https://docs.chef.io/resources/)
 : A resource within a cookbook.
 
-[Role](https://docs.chef.io/roles.html)
+[Role](https://docs.chef.io/roles/)
 : Search by nodes assigned to a role. Nodes can have zero or many roles.
 
-See more about [policyfiles](https://docs.chef.io/policyfile.html).
+See more about [policyfiles](https://docs.chef.io/policyfile/).
 
 ## Managing Node Data
 
@@ -167,7 +167,7 @@ Configuring the UUID on the client side keeps the node associated with the same 
 In the node's `client.rb`, set `chef_guid` to the _desired UUID_.
 If the node already exists, check that it uses the correct UUID, otherwise it will appear as a new node the next time it is recreated.
 
-See the `client.rb` documentation for more information about [configuring your client nodes](https://docs.chef.io/config_rb_client.html).
+See the `client.rb` documentation for more information about [configuring your client nodes](https://docs.chef.io/config_rb_client/).
 
 The following are the configuration parameters available:
 

--- a/components/automate-chef-io/content/docs/data-collection.md
+++ b/components/automate-chef-io/content/docs/data-collection.md
@@ -169,7 +169,7 @@ via the Chef Server. Please see the audit cookbook for an
 Chef Automate uses Elasticsearch to store its data, and the default Chef Automate install includes a single Elasticsearch service.
 This is sufficient to run production workloads; however, for greater data retention, we recommend using a multi-node Elasticsearch cluster with replication and sharding to store and protect your data.
 
-As of Chef Automate 1.7.114, the compliance service uses a ``compliance-latest`` Elasticsearch index to improves the performance of the reporting APIs at scale. Chef Automate creates this index automatically as part of the upgrade to Chef Automate 1.7.114. The index is updated with each new compliance report. If the ``compliance-latest`` Elasticsearch index becomes out of sync with the time-series data, it can be regenerated using the ``workflow-ctl migrate-compliance`` subcommand. For more information, see [migrate-compliance ](https://docs.chef.io/ctl_automate_server.html#migrate-compliance).
+As of Chef Automate 1.7.114, the compliance service uses a ``compliance-latest`` Elasticsearch index to improves the performance of the reporting APIs at scale. Chef Automate creates this index automatically as part of the upgrade to Chef Automate 1.7.114. The index is updated with each new compliance report. If the ``compliance-latest`` Elasticsearch index becomes out of sync with the time-series data, it can be regenerated using the ``workflow-ctl migrate-compliance`` subcommand. For more information, see [migrate-compliance ](https://docs.chef.io/ctl_automate_server/#migrate-compliance).
 
 ### Prerequisites
 

--- a/components/automate-chef-io/content/docs/migrate.md
+++ b/components/automate-chef-io/content/docs/migrate.md
@@ -107,7 +107,7 @@ To minimize this downtime, we recommended that you create an online backup of Ch
 
 By default, the Chef Automate 2 upgrade process will not proceed if your Chef Automate 1 installation does not have backups configured. Invoke the migration using the `--skip-backup-check` flag to avoid this check.
 
-To configure Chef Automate 1 backups, see the [Chef Automate 1 Documentation](https://docs.chef.io/delivery_server_backup.html).
+To configure Chef Automate 1 backups, see the [Chef Automate 1 Documentation](https://docs.chef.io/delivery_server_backup/).
 
 ### Unsupported Features and Topologies
 
@@ -154,7 +154,7 @@ To use Workflow with Chef Automate 2 specify the `--enable-workflow` option to e
 Login to Chef Automate to start a trial. The trial provides you with a 60-day license.
 Requesting a trial license requires internet connectivity in your Chef Automate 2 instance (only at the time of the license request).
 
-If you are migrating an [airgapped Chef Automate installation](https://docs.chef.io/install_chef_air_gap.html#chef-automate),
+If you are migrating an [airgapped Chef Automate installation](https://docs.chef.io/install_chef_air_gap/#chef-automate),
 contact your Chef account representative for a Chef Automate 2 license.
 
 ## Migrate

--- a/components/automate-chef-io/content/docs/runners.md
+++ b/components/automate-chef-io/content/docs/runners.md
@@ -40,7 +40,7 @@ You can add a new runner via `workflow-ctl` from your Chef Automate server. Log 
 
 After the [install-runner](/ctl_automate_server.html#install-runner) command succeeds, the new runner will appear in the **Manage Runners** tab in the **Workflow** area on the _Client Runs_ page. Selecting  the `Test` button verifies that you can dispatch jobs to the runner by opening a ssh connection to it. If the test fails and the runner is unreachable, an error should appear in the UI.
 
-Supported runner platforms are listed [here](https://docs.chef.io/platforms.html#runners).
+Supported runner platforms are listed [here](https://docs.chef.io/platforms/#chef-automate-job-runners).
 
 ### Removing a Runner
 

--- a/components/automate-chef-io/content/docs/servicenow-integration-install.md
+++ b/components/automate-chef-io/content/docs/servicenow-integration-install.md
@@ -28,7 +28,7 @@ The Chef Automate Incident Creation application is a ServiceNow certified scoped
 #### Prerequisites
 
 * The ServiceNow instance must be publicly reachable on https port 443
-* [Chef automate server installation](https://docs.chef.io/chef_automate.html)
+* [Chef automate server installation](/docs/install/)
 * ServiceNow package - System Import Sets com.glide.system_import_set, min version 1.0.0
 
 ## Configuration

--- a/components/automate-chef-io/content/docs/workflow_install.md
+++ b/components/automate-chef-io/content/docs/workflow_install.md
@@ -7,7 +7,7 @@ toc = true
 [menu]
   [menu.docs]
     parent = "workflow"
-    weight = 20 
+    weight = 20
 +++
 
 Workflow is a legacy feature for Chef Automate, which was designed for managing changes to both infrastructure and application code.
@@ -60,7 +60,7 @@ Migration of Workflow data must happen during your upgrade to Chef Automate 2.
 
 ### Build a Standalone Chef Server
 
-Create a standalone Chef server following the [standalone server installation](https://docs.chef.io/install_server.html#standalone).
+Create a standalone Chef server following the [standalone server installation](https://docs.chef.io/install_server/#standalone).
 
 Then, on the Chef server:
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Fix links to docs.chef.io:
- pages now have pretty urls, so no `.html` suffix
- resource pages are now in the `resources` subdirectory
- replaced one circular link that linked to docs.chef.io and redirected back to automate.chef.io/docs/
- fix a couple links to headings that don't exist

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
