### PR TITLE
bugfix: ensure node name is correctly assigned when running ssm scan

### DIFF
--- a/components/compliance-service/inspec-agent/resolver/resolver.go
+++ b/components/compliance-service/inspec-agent/resolver/resolver.go
@@ -485,7 +485,7 @@ func (r *Resolver) handleAzureVmNodes(ctx context.Context, m *manager.NodeManage
 	return r.handleManagerNodes(ctx, m, nodeCollections, job)
 }
 
-func handleNodeInfo(node *manager.ManagerNode) nodeInfo {
+func nodeInfoFromManagerNode(node *manager.ManagerNode) nodeInfo {
 	var nodeDetails nodeInfo
 	if len(node.Name) == 0 {
 		nodeDetails.Name = node.Host
@@ -553,7 +553,7 @@ func (r *Resolver) handleManagerNodes(ctx context.Context, m *manager.NodeManage
 					backend = inspec.BackendWinRm
 				}
 				logrus.Debugf("inspec agent resolver handling node with backend: %s -- ssm ping status: %s", backend, node.Ssm)
-				nodeDetails := handleNodeInfo(node)
+				nodeDetails := nodeInfoFromManagerNode(node)
 				credsArr := r.handleInstanceCredentials(ctx, group.manager.InstanceCredentials, node)
 				ssmJob := false
 				// if the user has specified ssh/winrm secrets to be associated with the node

--- a/components/compliance-service/inspec-agent/resolver/resolver.go
+++ b/components/compliance-service/inspec-agent/resolver/resolver.go
@@ -485,17 +485,28 @@ func (r *Resolver) handleAzureVmNodes(ctx context.Context, m *manager.NodeManage
 	return r.handleManagerNodes(ctx, m, nodeCollections, job)
 }
 
-func (r *Resolver) handleInstanceCredentials(ctx context.Context, instanceCreds []*manager.CredentialsByTags, node *manager.ManagerNode) ([]*inspec.Secrets, nodeInfo) {
-	var nodeInfo nodeInfo
+func handleNodeInfo(node *manager.ManagerNode) nodeInfo {
+	var nodeDetails nodeInfo
+	if len(node.Name) == 0 {
+		nodeDetails.Name = node.Host
+	} else {
+		nodeDetails.Name = node.Name
+	}
+	for _, kv := range node.Tags {
+		if kv.Key == "Name" {
+			nodeDetails.Name = kv.Value
+		}
+		if kv.Key == "Environment" {
+			nodeDetails.Environment = kv.Value
+		}
+	}
+	return nodeDetails
+}
+
+func (r *Resolver) handleInstanceCredentials(ctx context.Context, instanceCreds []*manager.CredentialsByTags, node *manager.ManagerNode) []*inspec.Secrets {
 	credsArr := make([]*inspec.Secrets, 0)
 	for _, credTagGroup := range instanceCreds {
 		for _, kv := range node.Tags {
-			if kv.Key == "Name" {
-				nodeInfo.Name = kv.Value
-			}
-			if kv.Key == "Environment" {
-				nodeInfo.Environment = kv.Value
-			}
 			isMatch := utils.KvMatches(credTagGroup.TagKey, credTagGroup.TagValue, kv)
 			if isMatch {
 				for _, cred := range credTagGroup.CredentialIds {
@@ -514,7 +525,7 @@ func (r *Resolver) handleInstanceCredentials(ctx context.Context, instanceCreds 
 			}
 		}
 	}
-	return credsArr, nodeInfo
+	return credsArr
 }
 
 func (r *Resolver) handleManagerNodes(ctx context.Context, m *manager.NodeManager, nodeCollections map[string]managerNodes, job *jobs.Job) ([]*types.InspecJob, error) {
@@ -542,10 +553,8 @@ func (r *Resolver) handleManagerNodes(ctx context.Context, m *manager.NodeManage
 					backend = inspec.BackendWinRm
 				}
 				logrus.Debugf("inspec agent resolver handling node with backend: %s -- ssm ping status: %s", backend, node.Ssm)
-				credsArr, nodeDetails := r.handleInstanceCredentials(ctx, group.manager.InstanceCredentials, node)
-				if len(nodeDetails.Name) == 0 {
-					nodeDetails.Name = node.Host
-				}
+				nodeDetails := handleNodeInfo(node)
+				credsArr := r.handleInstanceCredentials(ctx, group.manager.InstanceCredentials, node)
 				ssmJob := false
 				// if the user has specified ssh/winrm secrets to be associated with the node
 				// then let's prioritize that -- otherwise try ssm

--- a/components/compliance-service/inspec-agent/resolver/resolver_test.go
+++ b/components/compliance-service/inspec-agent/resolver/resolver_test.go
@@ -139,22 +139,22 @@ func TestAssembleJob(t *testing.T) {
 	assert.NotZero(t, job.TargetConfig.SecretsArr)
 }
 
-func TestHandleNodeInfoCorrectlyAssignsName(t *testing.T) {
-	nodeDetails := handleNodeInfo(&manager.ManagerNode{
+func TestnodeInfoFromManagerNodeCorrectlyAssignsName(t *testing.T) {
+	nodeDetails := nodeInfoFromManagerNode(&manager.ManagerNode{
 		Name: "test-name",
 		Host: "localhost",
 	})
 	assert.Equal(t, "test-name", nodeDetails.Name)
 
-	nodeDetails = handleNodeInfo(&manager.ManagerNode{
+	nodeDetails = nodeInfoFromManagerNode(&manager.ManagerNode{
 		Name: "",
 		Host: "localhost",
 	})
 	assert.Equal(t, "localhost", nodeDetails.Name)
 }
 
-func TestHandleNodeInfoObservesTagValues(t *testing.T) {
-	nodeDetails := handleNodeInfo(&manager.ManagerNode{
+func TestnodeInfoFromManagerNodeObservesTagValues(t *testing.T) {
+	nodeDetails := nodeInfoFromManagerNode(&manager.ManagerNode{
 		Name: "test-name",
 		Host: "localhost",
 		Tags: []*common.Kv{
@@ -163,7 +163,7 @@ func TestHandleNodeInfoObservesTagValues(t *testing.T) {
 	})
 	assert.Equal(t, "tag-named-instance", nodeDetails.Name)
 
-	nodeDetails = handleNodeInfo(&manager.ManagerNode{
+	nodeDetails = nodeInfoFromManagerNode(&manager.ManagerNode{
 		Name: "test-name",
 		Host: "localhost",
 		Tags: []*common.Kv{

--- a/components/compliance-service/inspec-agent/resolver/resolver_test.go
+++ b/components/compliance-service/inspec-agent/resolver/resolver_test.go
@@ -138,3 +138,37 @@ func TestAssembleJob(t *testing.T) {
 	assert.Zero(t, job.TargetConfig.Secrets)
 	assert.NotZero(t, job.TargetConfig.SecretsArr)
 }
+
+func TestHandleNodeInfoCorrectlyAssignsName(t *testing.T) {
+	nodeDetails := handleNodeInfo(&manager.ManagerNode{
+		Name: "test-name",
+		Host: "localhost",
+	})
+	assert.Equal(t, "test-name", nodeDetails.Name)
+
+	nodeDetails = handleNodeInfo(&manager.ManagerNode{
+		Name: "",
+		Host: "localhost",
+	})
+	assert.Equal(t, "localhost", nodeDetails.Name)
+}
+
+func TestHandleNodeInfoObservesTagValues(t *testing.T) {
+	nodeDetails := handleNodeInfo(&manager.ManagerNode{
+		Name: "test-name",
+		Host: "localhost",
+		Tags: []*common.Kv{
+			{Key: "Name", Value: "tag-named-instance"},
+		},
+	})
+	assert.Equal(t, "tag-named-instance", nodeDetails.Name)
+
+	nodeDetails = handleNodeInfo(&manager.ManagerNode{
+		Name: "test-name",
+		Host: "localhost",
+		Tags: []*common.Kv{
+			{Key: "Environment", Value: "test-env"},
+		},
+	})
+	assert.Equal(t, "test-env", nodeDetails.Environment)
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
I noticed there was a bug with ssm jobs during some acceptance testing -- all nodes showed up nameless after an ssm scan.

Figured out we had some faulty logic in resolver.go -- we were looking for a key value to determine the name and completely ignoring the name of the instance as we had discovered it.
 
This code change fixes that!

### :chains: Related Resources
https://github.com/chef/automate/issues/2640

### :+1: Definition of Done
Cloud scans of ec2 result in nodes with names!

### :athletic_shoe: How to Build and Test the Change
rebuild compliance
run an ssm scan of the nodes (via aws or azure)
* this requires running the automate instance in aws, or having azure creds

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
