### PR TITLE
Run automate site on old Hugo theme

### DIFF
--- a/components/automate-chef-io/config.toml
+++ b/components/automate-chef-io/config.toml
@@ -5,9 +5,11 @@ description = "One platform with a unified workflow, end-to-end visibility, and 
 Paginate = 4
 theme = "chef"
 
-# To develop against a local copy of the chef hugo theme, uncomment this line
-# and set the value to the parent directory of where you have checked out the
-# chef-hugo-theme repository
+# To develop against a local copy of the chef hugo theme:
+# - clone the chef-hugo-theme repo with the "old_hugo_theme" branch
+# - checkout the "old_hugo_theme" branch
+# - uncomment this line below and set the value to the parent directory where
+#   you have checked out the chef-hugo-theme repository
 # themesDir = "../../../hugo-themes"
 
 [markup]

--- a/components/automate-chef-io/scripts/clone_hugo.sh
+++ b/components/automate-chef-io/scripts/clone_hugo.sh
@@ -5,4 +5,4 @@ if [[ -n "$GITHUB_TOKEN" ]];then
     clone_url="https://x-access-token:${GITHUB_TOKEN}@github.com/chef/chef-hugo-theme.git"
 fi
 
-git clone "$clone_url" themes/chef
+git clone -b old_hugo_theme "$clone_url" themes/chef


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

This will run automate.chef.io off the `old_hugo_theme` branch of the chef-hugo-theme repo. 

This will allow us to update the chef-hugo-theme repo with the new hugo theme that is currently on chef-web-docs, but still run the automate site with the older hugo theme.

### :chains: Related Resources

chef/release-engineering#983

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
