### PR TITLE
Add `waived` status to reporting nodes list and node detail

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -132,22 +132,10 @@
               <chef-icon class="filter-icon">storage</chef-icon> {{activeReport.controls.total | number}}
             </span>
           </chef-option>
-          <chef-option class="filter critical" value='critical'>
-            <span class="filter-label">Critical Controls</span>
+          <chef-option class="filter failed" value='failed'>
+            <span class="filter-label">Failed Controls</span>
             <span class="filter-total">
-              <chef-icon class="filter-icon">report_problem</chef-icon> {{activeReport.controls.failed.critical | number}}
-            </span>
-          </chef-option>
-          <chef-option class="filter major" value='major'>
-            <span class="filter-label">Major Controls</span>
-            <span class="filter-total">
-              <chef-icon class="filter-icon">report_problem</chef-icon> {{activeReport.controls.failed.major | number}}
-            </span>
-          </chef-option>
-          <chef-option class="filter minor" value='minor'>
-            <span class="filter-label">Minor Controls</span>
-            <span class="filter-total">
-              <chef-icon class="filter-icon">report_problem</chef-icon> {{activeReport.controls.failed.minor | number}}
+              <chef-icon class="filter-icon">report_problem</chef-icon> {{activeReport.controls.failed.total | number}}
             </span>
           </chef-option>
           <chef-option class="filter passed" value='passed'>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -129,37 +129,43 @@
           <chef-option class="filter all" value='all'>
             <span class="filter-label">Total Controls</span>
             <span class="filter-total">
-              <chef-icon>storage</chef-icon> {{activeReport.controls.total | number}}
+              <chef-icon class="filter-icon">storage</chef-icon> {{activeReport.controls.total | number}}
             </span>
           </chef-option>
           <chef-option class="filter critical" value='critical'>
             <span class="filter-label">Critical Controls</span>
             <span class="filter-total">
-              <chef-icon>report_problem</chef-icon> {{activeReport.controls.failed.critical | number}}
+              <chef-icon class="filter-icon">report_problem</chef-icon> {{activeReport.controls.failed.critical | number}}
             </span>
           </chef-option>
           <chef-option class="filter major" value='major'>
             <span class="filter-label">Major Controls</span>
             <span class="filter-total">
-              <chef-icon>check_circle</chef-icon> {{activeReport.controls.failed.major | number}}
+              <chef-icon class="filter-icon">report_problem</chef-icon> {{activeReport.controls.failed.major | number}}
             </span>
           </chef-option>
           <chef-option class="filter minor" value='minor'>
             <span class="filter-label">Minor Controls</span>
             <span class="filter-total">
-              <chef-icon>help</chef-icon> {{activeReport.controls.failed.minor | number}}
-            </span>
-          </chef-option>
-          <chef-option class="filter skipped" value='skipped'>
-            <span class="filter-label">Skipped Controls</span>
-            <span class="filter-total">
-              <chef-icon>help</chef-icon> {{activeReport.controls.skipped.total | number}}
+              <chef-icon class="filter-icon">report_problem</chef-icon> {{activeReport.controls.failed.minor | number}}
             </span>
           </chef-option>
           <chef-option class="filter passed" value='passed'>
             <span class="filter-label">Passed Controls</span>
             <span class="filter-total">
-              <chef-icon>help</chef-icon> {{activeReport.controls.passed.total | number}}
+              <chef-icon class="filter-icon">check_circle</chef-icon> {{activeReport.controls.passed.total | number}}
+            </span>
+          </chef-option>
+          <chef-option class="filter skipped" value='skipped'>
+            <span class="filter-label">Skipped Controls</span>
+            <span class="filter-total">
+              <chef-icon class="filter-icon">help</chef-icon> {{activeReport.controls.skipped.total | number}}
+            </span>
+          </chef-option>
+          <chef-option class="filter waived" value='waived'>
+            <span class="filter-label">Waived Controls</span>
+            <span class="filter-total">
+              <div class="filter-icon waived-icon"></div> {{activeReport.controls.waived.total | number}}
             </span>
           </chef-option>
         </chef-phat-radio>
@@ -179,9 +185,10 @@
               <ng-container *ngFor="let control of filteredControls(profile.controls, activeStatusFilter)">
                 <chef-tr>
                   <chef-td>
-                    <chef-icon class="status-icon" [ngClass]="control.status">
+                    <chef-icon *ngIf="control.status !== 'waived'" class="status-icon" [ngClass]="control.status">
                       {{ statusIcon(control.status) }}
                     </chef-icon>
+                    <div *ngIf="control.status === 'waived'" class="status-icon waived-icon"></div>
                     <span><strong>{{ control.id }}:</strong> {{ control.title }}</span>
                   </chef-td>
                   <chef-td class="impact-status" [ngClass]="impactStatus(control)">
@@ -206,16 +213,25 @@
                   </chef-toggle>
                   <ng-container [ngSwitch]="openControlPane(control)">
                     <div *ngSwitchCase="'results'">
-                      <div class="result-item" *ngFor="let result of control.results">
-                        <div class="result-item-header">
-                          <chef-icon class="status-icon" [ngClass]="result.status">{{ statusIcon(result.status) }}</chef-icon>
-                          <p>{{ result.code_desc }}</p>
+                      <ng-container *ngIf="control.status !== 'waived'">
+                        <div class="result-item" *ngFor="let result of control.results">
+                          <div class="result-item-header">
+                            <chef-icon class="status-icon" [ngClass]="result.status">{{ statusIcon(result.status) }}</chef-icon>
+                            <p>{{ result.code_desc }}</p>
+                          </div>
+                          <div class="result-item-body" *ngIf="result.message.length || result.skip_message.length">
+                            <chef-snippet [code]="result.message + result.skip_message"></chef-snippet>
+                          </div>
                         </div>
-                        <div
-                          class="result-item-body"
-                          *ngIf="result.message.length || result.skip_message.length">
-                          <chef-snippet [code]="result.message + result.skip_message"></chef-snippet>
-                        </div>
+                      </ng-container>
+                      <div *ngIf="control.status === 'waived'">
+                        <p>This control was waived.</p>
+                        <dl class="waiver-details">
+                          <dt>Expires:</dt>
+                          <dd>{{ control.waiver_data.expiration_date | datetime: RFC2822 }}</dd>
+                          <dt>Reason:</dt>
+                          <dd>{{ control.waiver_data.justification }}</dd>
+                        </dl>
                       </div>
                     </div>
                     <chef-snippet

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
@@ -167,7 +167,7 @@ chef-tooltip[for='skipped-count'] {
       display: flex;
       align-items: center;
 
-      chef-icon {
+      .filter-icon {
         margin: -2px 0.5em 0 0;
       }
     }
@@ -203,6 +203,10 @@ chef-tooltip[for='skipped-count'] {
 
       &.passed  {
         background: $chef-success;
+      }
+
+      &.waived  {
+        background: $chef-dark-grey;
       }
     }
 
@@ -243,7 +247,7 @@ chef-tooltip[for='skipped-count'] {
       flex-grow: 5;
       word-break: break-all;
 
-      chef-icon {
+      .status-icon {
         margin-right: 1em;
       }
 
@@ -539,5 +543,25 @@ chef-tooltip[for='skipped-count'] {
         }
       }
     }
+  }
+}
+
+dl.waiver-details {
+  display: flex;
+  flex-flow: row wrap;
+
+  dt, dd {
+    font-size: 14px;
+    margin: 5px 0;
+  }
+
+  dt {
+    flex-basis: 15%;
+    font-weight: bold;
+  }
+
+  dd {
+    flex-basis: 85%;
+    flex-grow: 1;
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
@@ -539,8 +539,8 @@ dl.waiver-details {
   flex-flow: row wrap;
 
   dt, dd {
-    font-size: 14px;
     margin: 5px 0;
+    font-size: 14px;
   }
 
   dt {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
@@ -185,16 +185,8 @@ chef-tooltip[for='skipped-count'] {
         background: $chef-primary-bright;
       }
 
-      &.critical  {
+      &.failed  {
         background: $chef-critical;
-      }
-
-      &.major  {
-        background: $chef-major;
-      }
-
-      &.minor  {
-        background: $chef-minor;
       }
 
       &.skipped  {
@@ -215,16 +207,8 @@ chef-tooltip[for='skipped-count'] {
         color: $chef-primary-bright;
       }
 
-      &.critical .filter-total  {
+      &.failed .filter-total  {
         color: $chef-critical;
-      }
-
-      &.major .filter-total  {
-        color: $chef-major;
-      }
-
-      &.minor .filter-total  {
-        color: $chef-minor;
       }
 
       &.skipped .filter-total  {
@@ -233,6 +217,10 @@ chef-tooltip[for='skipped-count'] {
 
       &.passed .filter-total  {
         color: $chef-success;
+      }
+
+      &.waived .filter-total  {
+        color: $chef-dark-grey;
       }
     }
   }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.spec.ts
@@ -82,7 +82,8 @@ describe('ReportingNodeComponent', () => {
       {id: 3, controls: [ {status: 'failed', impact: 0.7} ]},
       {id: 4, controls: [ {status: 'failed', impact: 0.3} ]},
       {id: 5, controls: [ {status: 'passed', impact: 0.5} ]},
-      {id: 6, controls: [ {status: 'failed', impact: 0.5} ]}
+      {id: 6, controls: [ {status: 'failed', impact: 0.5} ]},
+      {id: 7, controls: [ {status: 'waived', impact: 0.5} ]}
     ];
 
     it('returns controls with a matching passed status', () => {
@@ -118,6 +119,13 @@ describe('ReportingNodeComponent', () => {
       expect(component.filteredProfiles(profiles, 'minor')).toEqual(
         [
           {id: 4, controls: [ {status: 'failed', impact: 0.3} ]}
+        ]);
+    });
+
+    it('returns controls with a matching waived status', () => {
+      expect(component.filteredProfiles(profiles, 'waived')).toEqual(
+        [
+          { id: 7, controls: [{ status: 'waived', impact: 0.5 }] }
         ]);
     });
   });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.spec.ts
@@ -101,24 +101,12 @@ describe('ReportingNodeComponent', () => {
         ]);
     });
 
-    it('returns controls with a matching critical status', () => {
-      expect(component.filteredProfiles(profiles, 'critical')).toEqual(
+    it('returns controls with a matching failed status', () => {
+      expect(component.filteredProfiles(profiles, 'failed')).toEqual(
         [
-          {id: 3, controls: [ {status: 'failed', impact: 0.7} ]}
-        ]);
-    });
-
-    it('returns controls with a matching major status', () => {
-      expect(component.filteredProfiles(profiles, 'major')).toEqual(
-        [
+          {id: 3, controls: [ {status: 'failed', impact: 0.7} ]},
+          {id: 4, controls: [ {status: 'failed', impact: 0.3} ]},
           {id: 6, controls: [ {status: 'failed', impact: 0.5} ]}
-        ]);
-    });
-
-    it('returns controls with a matching minor status', () => {
-      expect(component.filteredProfiles(profiles, 'minor')).toEqual(
-        [
-          {id: 4, controls: [ {status: 'failed', impact: 0.3} ]}
         ]);
     });
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -115,7 +115,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
       if (status === 'all') {
         return true;
       }
-      if (status === 'passed' || status === 'skipped') {
+      if (status === 'passed' || status === 'skipped' || status === 'waived') {
         return c.status === status;
       }
       if (status === 'critical') {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -111,23 +111,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
   }
 
   filteredControls(controls, status) {
-    return controls.filter(c => {
-      if (status === 'all') {
-        return true;
-      }
-      if (status === 'passed' || status === 'skipped' || status === 'waived') {
-        return c.status === status;
-      }
-      if (status === 'critical') {
-        return c.status === 'failed' && c.impact >= 0.7;
-      }
-      if (status === 'major') {
-        return c.status === 'failed' && c.impact >= 0.4 && c.impact < 0.7;
-      }
-      if (status === 'minor') {
-        return c.status === 'failed' && c.impact < 0.4;
-      }
-    });
+    return controls.filter(c => status === 'all' || c.status === status);
   }
 
   profilesByStatus(profiles, status) {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
@@ -7,32 +7,38 @@
 </div>
 
 <ng-container *ngIf="!reportData.nodesListEmpty">
-    <chef-phat-radio
+  <chef-phat-radio
     class="nodes-list-status-filters"
     [value]="nodeFilterStatus"
     (change)="filterNodeStatus($event, $event.target.value)">
     <chef-option class="filter all" value='all'>
       <span class="filter-label">Total Nodes</span>
       <span class="filter-total">
-        <chef-icon>storage</chef-icon> {{ reportData.nodesList.total | number}}
+        <chef-icon class="filter-icon">storage</chef-icon> {{ reportData.nodesList.total | number}}
       </span>
     </chef-option>
     <chef-option class="filter critical" value='failed'>
       <span class="filter-label">Failed Nodes</span>
       <span class="filter-total">
-        <chef-icon>report_problem</chef-icon> {{ reportData.nodesList.total_failed | number}}
+        <chef-icon class="filter-icon">report_problem</chef-icon> {{ reportData.nodesList.total_failed | number}}
       </span>
     </chef-option>
     <chef-option class="filter passed" value='passed'>
       <span class="filter-label">Passed Nodes</span>
       <span class="filter-total">
-        <chef-icon>check_circle</chef-icon> {{ reportData.nodesList.total_passed | number}}
+        <chef-icon class="filter-icon">check_circle</chef-icon> {{ reportData.nodesList.total_passed | number}}
       </span>
     </chef-option>
     <chef-option class="filter skipped" value='skipped'>
       <span class="filter-label">Skipped Nodes</span>
       <span class="filter-total">
-        <chef-icon>help</chef-icon> {{ reportData.nodesList.total_skipped | number}}
+        <chef-icon class="filter-icon">help</chef-icon> {{ reportData.nodesList.total_skipped | number}}
+      </span>
+    </chef-option>
+    <chef-option class="filter waived" value='waived'>
+      <span class="filter-label">Waived Nodes</span>
+      <span class="filter-total">
+        <div class="filter-icon waived-icon"></div> {{ reportData.nodesList.total_waived | number}}
       </span>
     </chef-option>
   </chef-phat-radio>
@@ -81,9 +87,10 @@
     <chef-tbody *ngIf="!reportData.nodesListLoading">
       <chef-tr *ngFor="let node of filteredNodes(reportData.nodesList.items)">
         <chef-td>
-          <chef-icon class="status-icon" [ngClass]="node.latest_report.status">
+          <chef-icon *ngIf="node.latest_report.status !== 'waived'" class="status-icon" [ngClass]="node.latest_report.status">
             {{ statusIcon(node.latest_report.status) }}
           </chef-icon>
+          <div *ngIf="node.latest_report.status === 'waived'" class="status-icon waived-icon"></div>
           <a [routerLink]="['/compliance/reports/nodes', node.id]">{{ node.name }}</a>
         </chef-td>
         <chef-td>{{ node.platform.name }} {{ node.platform.release }}</chef-td>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.scss
@@ -23,7 +23,7 @@
       display: flex;
       align-items: center;
 
-      chef-icon {
+      .filter-icon {
         margin: -2px 0.5em 0 0;
       }
     }
@@ -51,6 +51,10 @@
 
       &.passed  {
         background: $chef-success;
+      }
+
+      &.waived  {
+        background: $chef-dark-grey;
       }
     }
 
@@ -86,7 +90,7 @@
     &:first-child {
       flex-grow: 2;
 
-      chef-icon {
+      .status-icon {
         margin-right: 1em;
       }
     }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.scss
@@ -74,6 +74,10 @@
       &.passed .filter-total  {
         color: $chef-success;
       }
+
+      &.waived .filter-total  {
+        color: $chef-dark-grey;
+      }
     }
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
@@ -24,7 +24,8 @@ export class ReportDataService {
     total: 0,
     total_failed: 0,
     total_passed: 0,
-    total_skipped: 0
+    total_skipped: 0,
+    total_waived: 0
   };
   nodesListParams: any = {
     perPage: 100,

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
@@ -44,17 +44,19 @@ describe('StatsService', () => {
       const listParams = {perPage: 10, page: 1};
 
       const expectedUrl = `${COMPLIANCE_URL}/reporting/nodes/search`;
-      const expectedTotal = 20;
+      const expectedTotal = 21;
       const expectedTotalFailed = 1;
       const expectedTotalPassed = 18;
       const expectedTotalSkipped = 2;
+      const expectedTotalWaived = 1;
       const expectedItems = [{}, {}];
       const mockResp = {
         nodes: expectedItems,
         total: expectedTotal,
         total_failed: expectedTotalFailed,
         total_passed: expectedTotalPassed,
-        total_skipped: expectedTotalSkipped
+        total_skipped: expectedTotalSkipped,
+        total_waived: expectedTotalWaived
       };
 
       service.getNodes(reportQuery, listParams).subscribe(data => {
@@ -63,7 +65,8 @@ describe('StatsService', () => {
           items: expectedItems,
           total_failed: expectedTotalFailed,
           total_passed: expectedTotalPassed,
-          total_skipped: expectedTotalSkipped
+          total_skipped: expectedTotalSkipped,
+          total_waived: expectedTotalWaived
         });
       });
 

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -113,8 +113,8 @@ export class StatsService {
     }
 
     return this.httpClient.post<any>(url, body).pipe(
-      map(({ nodes, total, total_failed, total_passed, total_skipped }) =>
-        ({total, total_failed, total_passed, total_skipped, items: nodes})));
+      map(({ nodes, total, total_failed, total_passed, total_skipped, total_waived }) =>
+        ({ total, total_failed, total_passed, total_skipped, total_waived, items: nodes })));
   }
 
   getProfiles(reportQuery: ReportQuery, listParams: any): Observable<any> {
@@ -216,6 +216,8 @@ export class StatsService {
      them private? */
   getControlStatus(control): string {
     const statuses = control.results.map(r => r.status);
+    const waived = control.waiver_data && control.waiver_data.skipped_due_to_waiver;
+    if (waived) { return 'waived'; }
     if (statuses.every(s => s === 'passed')) { return 'passed'; }
     if (statuses.every(s => s === 'skipped')) { return 'skipped'; }
     return 'failed';


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

- Adds `waived` status filter to reporting nodes list view
![Screen Shot 2020-03-17 at 3 39 08 PM](https://user-images.githubusercontent.com/479121/76905075-d8b64c00-6866-11ea-9988-14dbfc78c587.png)

- Adds `waived` status filter to reporting node detail view
![Screen Shot 2020-03-17 at 3 41 16 PM](https://user-images.githubusercontent.com/479121/76905093-e10e8700-6866-11ea-9d06-c8c292befe86.png)
![Screen Shot 2020-03-17 at 3 42 28 PM](https://user-images.githubusercontent.com/479121/76905096-e1a71d80-6866-11ea-88d8-fb139840a71a.png)


<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://github.com/chef/automate/issues/2574
https://github.com/chef/automate/issues/2557