### PR TITLE
when fleet status is waived; show compliant overall status

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.scss
@@ -171,6 +171,10 @@ chef-subheading {
     background: $chef-success;
   }
 
+  .waived .summary-toggle {
+    background: $chef-success;
+  }
+
   .skipped .summary-toggle {
     background: $chef-dark-grey;
   }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -415,6 +415,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
     switch (status) {
       case 'failed': return 'report_problem';
       case 'passed': return 'check_circle';
+      case 'waived': return 'check_circle';
       case 'skipped': return 'help';
       case 'unknown': return 'help';
     }
@@ -424,6 +425,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
     switch (status) {
       case 'failed': return 'Not Compliant';
       case 'passed': return 'Compliant';
+      case 'waived': return 'Compliant';
       case 'skipped': return 'Skipped';
       case 'unknown': return 'Unknown';
     }


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?

I was reviewing some waivers work when i noticed that we hadn't yet made a card for overall status.
I spoke with @jonong1972 -- he brought up that when a fleet's entire status is waived, that is equivalent to compliant/passing. So this is a small code change to make that happen

### :+1: Definition of Done
waived overall status == compliant

### :athletic_shoe: How to Build and Test the Change
rebuild ui
send in reports with `load_compliance_reports`
apply a filter on a waived profile

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
