### PR TITLE
FormControlDirective fix

### DIFF
--- a/components/automate-ui/src/app/components/form-control/form-control.directive.spec.ts
+++ b/components/automate-ui/src/app/components/form-control/form-control.directive.spec.ts
@@ -9,16 +9,17 @@ const originalValue = 'originalValue';
 const newValue = 'newValue';
 
 @Component({
-  template: '<input [formControl]="control" />'
+  template: '<input [formControl]="control" [resetOrigin]="origin" />'
 })
 class InputFormControlHostComponent {
   control: FormControl = new FormControl(originalValue);
+  origin = false;
 }
 
 @Component({
   template: `
     <form [formGroup]="form">
-      <input formControlName="control" />
+      <input formControlName="control" [resetOrigin]="origin" />
     </form>
   `
 })
@@ -26,11 +27,12 @@ class InputFormControlNameHostComponent {
   form: FormGroup = new FormGroup({
     control: new FormControl(originalValue)
   });
+  origin = false;
 }
 
 @Component({
   template: `
-    <select [formControl]="control">
+    <select [formControl]="control" [resetOrigin]="origin">
       <option value="${originalValue}">${originalValue}</option>
       <option value="${newValue}">${newValue}</option>
     </select>
@@ -38,12 +40,13 @@ class InputFormControlNameHostComponent {
 })
 class SelectFormControlHostComponent {
   control: FormControl = new FormControl(originalValue);
+  origin = false;
 }
 
 @Component({
   template: `
     <form [formGroup]="form">
-      <select formControlName="control">
+      <select formControlName="control" [resetOrigin]="origin">
         <option value="${originalValue}">${originalValue}</option>
         <option value="${newValue}">${newValue}</option>
       </select>
@@ -54,6 +57,7 @@ class SelectFormControlNameHostComponent {
   form: FormGroup = new FormGroup({
     control: new FormControl(originalValue)
   });
+  origin = false;
 }
 
 type TestHostComponents =
@@ -63,9 +67,9 @@ type TestHostComponents =
   | SelectFormControlNameHostComponent;
 
 const scenarios = [
-  [InputFormControlHostComponent,      'input',                   'input' ],
-  [InputFormControlNameHostComponent,  'input[formcontrolname]',  'input' ],
-  [SelectFormControlHostComponent,     'select',                  'change'],
+  [InputFormControlHostComponent, 'input', 'input'],
+  [InputFormControlNameHostComponent, 'input[formcontrolname]', 'input'],
+  [SelectFormControlHostComponent, 'select', 'change'],
   [SelectFormControlNameHostComponent, 'select[formcontrolname]', 'change']
 ];
 
@@ -85,7 +89,7 @@ using(scenarios, (host, selector, eventName) => {
           FormControlDirective
         ]
       })
-      .compileComponents();
+        .compileComponents();
     }));
 
     beforeEach(fakeAsync(() => {
@@ -137,6 +141,27 @@ using(scenarios, (host, selector, eventName) => {
         expect(inputEl.classList.contains('ng-dirty')).toEqual(false);
         expect(inputEl.classList.contains('ng-pristine')).toEqual(true);
       }));
+
+      describe('when resetOrigin emits', () => {
+        it('is marked as pristine', fakeAsync(() => {
+          inputEl.value = newValue;
+          inputEl.dispatchEvent(new Event(eventName));
+          fixture.detectChanges();
+          tick();
+
+          expect(inputEl.value).toEqual(newValue);
+          expect(inputEl.classList.contains('ng-dirty')).toEqual(true);
+          expect(inputEl.classList.contains('ng-pristine')).toEqual(false);
+
+          input.componentInstance.origin = true;
+          fixture.detectChanges();
+          tick();
+
+          expect(inputEl.value).toEqual(newValue);
+          expect(inputEl.classList.contains('ng-dirty')).toEqual(false);
+          expect(inputEl.classList.contains('ng-pristine')).toEqual(true);
+        }));
+      });
     });
   });
 });

--- a/components/automate-ui/src/app/components/form-control/form-control.directive.ts
+++ b/components/automate-ui/src/app/components/form-control/form-control.directive.ts
@@ -5,6 +5,13 @@ import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
 // Getting the most from an Angular form
 // *************************************
+//
+// WHAT YOU GET BY JUST ADDING 'formControlName' TO YOUR CONTROL
+//
+// Instrument a control by adding the directive with the form field name. Example:
+//
+//     <input chefInput name="firstName" formControlName="firstName" type="text" autofocus>
+//
 // Out of the box, this directive automatically provides "memory" to your form
 // controls (typically <chef-input>, <chef-radio>, and <chef-select> elements)
 // when a focussed control is being edited.
@@ -17,6 +24,9 @@ import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 // If, upon a successful operation, the user is taken elsewhere
 // (e.g. the modal closes, or the page navigates to a summary, etc.)
 // nothing further is required.
+//
+// ADDITIONAL INSTRUMENTATION NEEDED IF YOU HAVE RELEVANT STATE CHANGES
+//
 // If, however, the form (or modal) remains open, you typically want
 // to have the "pristine state" of the control be updated
 // to the newly processed value. Here's how to make that happen:

--- a/components/automate-ui/src/app/components/form-control/form-control.directive.ts
+++ b/components/automate-ui/src/app/components/form-control/form-control.directive.ts
@@ -72,6 +72,13 @@ export class FormControlDirective implements OnInit, OnDestroy, OnChanges {
         distinctUntilChanged()
       )
       .subscribe(newValue => {
+        // If null, undefined, or empty string, we came in to early last time.
+        // So take this value as the originalValue.
+        if (!this.originalValue) {
+          this.originalValue = newValue;
+        }
+        // If the newValue has come around again to the original value,
+        // mark the control pristine.
         if (newValue === this.originalValue) {
           this.control.reset(this.originalValue);
         }

--- a/components/automate-ui/src/app/components/form-control/form-control.directive.ts
+++ b/components/automate-ui/src/app/components/form-control/form-control.directive.ts
@@ -95,6 +95,7 @@ export class FormControlDirective implements OnInit, OnDestroy, OnChanges {
       const resetRequested: boolean = changes.resetOrigin.currentValue;
       if (resetRequested) {
         this.setOriginalValue();
+        this.control.reset(this.originalValue);
       }
     }
   }

--- a/components/automate-ui/src/app/components/form-control/form-control.directive.ts
+++ b/components/automate-ui/src/app/components/form-control/form-control.directive.ts
@@ -72,7 +72,7 @@ export class FormControlDirective implements OnInit, OnDestroy, OnChanges {
         distinctUntilChanged()
       )
       .subscribe(newValue => {
-        // If null, undefined, or empty string, we came in to early last time.
+        // If null, undefined, or empty string, we came in too early last time.
         // So take this value as the originalValue.
         if (!this.originalValue) {
           this.originalValue = newValue;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The purpose of the `FormControlDirective` is to notice when a field's value matches its original value, thereby allowing a form to recognize that the value has not changed and take an appropriate action, typically contributing to disabling the <kbd>Save</kbd> button. 

I discovered a case where this was not working correctly. If one loads a page containing an `<input>` element governed by `FormControlDirective`,
the initial "original value" will be set to null. (In other words, the directive is being triggered too soon.) This PR allows capturing the slightly delayed "original value" so the control works more reasonably, recognizing as the "original value" the first non-empty value.

This worked fine if you were navigating within the app, which would be occurring most of the time. The fix here is only needed when refreshing the browser page.

### :chains: Related Resources

### :+1: Definition of Done
Original field value is recognized whether navigating within the app or refreshing a page.

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui.

#### Baseline Case
Navigate to some detail page within the auth pages, be it project details, team details, token details, etc, by way of Settings >> Projects >> `<project id>`.
Select the `Details` tab. Notice the <kbd>Save</kbd> button is disabled because there is nothing to save.
Say you had a project `proj1`. If you append a `2` so it now reads `proj12`, this will enable the <kbd>Save</kbd> button.
Now, press <kbd>Backspace</kbd> so it again reads `proj1`. Notice the <kbd>Save</kbd> button is disabled again. That is the previously working case.

#### New Case
Now refresh the details page.
You should again be at `proj1` with the <kbd>Save</kbd> button disabled.
Now repeat the exercise of changing the value then returning the value to `proj1` and you should see it enable then disable the <kbd>Save</kbd> button, respectively.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
