### PR TITLE
Refetch rules when project becomes applied

### DIFF
--- a/components/automate-ui/src/app/pages/project/details/project-details.component.ts
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.ts
@@ -3,7 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Subject, combineLatest } from 'rxjs';
-import { filter, pluck, map, takeUntil, distinctUntilChanged } from 'rxjs/operators';
+import { filter, pluck, takeUntil, distinctUntilChanged } from 'rxjs/operators';
 import { identity, isNil } from 'lodash/fp';
 
 import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
@@ -11,9 +11,7 @@ import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeParams, routeURL } from 'app/route.selectors';
 import { Regex } from 'app/helpers/auth/regex';
 import { EntityStatus, allLoaded, pending } from 'app/entities/entities';
-import {
-  getStatus, updateStatus, projectFromRoute, allProjects
-} from 'app/entities/projects/project.selectors';
+import { getStatus, updateStatus, projectFromRoute } from 'app/entities/projects/project.selectors';
 import { Project } from 'app/entities/projects/project.model';
 import { GetProject, UpdateProject } from 'app/entities/projects/project.actions';
 import { GetRulesForProject, DeleteRule } from 'app/entities/rules/rule.actions';
@@ -134,13 +132,12 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
       });
 
     // when project becomes applied need to also mark rules applied
-    this.store.select(allProjects).pipe(
-      map((projects: Project[]) => projects.find(p => p.id === this.id)),
+    this.store.select(projectFromRoute).pipe(
       distinctUntilChanged(),
       filter(project => project && project.status === 'RULES_APPLIED'),
       takeUntil(this.isDestroyed))
-      .subscribe(() => {
-        this.store.dispatch(new GetRulesForProject({ project_id: this.id }));
+      .subscribe(project => {
+        this.store.dispatch(new GetRulesForProject({ project_id: project.id }));
       });
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

If you are on the Projects List page and invoke a Project Update, the projects marked "pending" get promptly updated to "applied" because we re-fetch the projects in a timely fashion. The same thing should happen if you happen to be on the Ingest Rules tab of a project details page at the time you invoke a Project Update. Prior to thi PR, you had to do either a page refresh or re-navigate to the rules page to instigate that update. 

### :chains: Related Resources
NA

### :+1: Definition of Done
Upon invoking "Update Projects" when displaying an edited list of project rules, the status promptly changes from "pending" to "applied".

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui
Create a project.
Create a rule.
Upon creating the rule you should be sitting back on the list of rules page for the project.
Invoke "Update Projects".
Observe that the page updates the status of the edited rule(s).

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).