### PR TITLE
return more verbose error msgs for detect and exec scans

### DIFF
--- a/components/automate-gateway/integration/nodes_test.go
+++ b/components/automate-gateway/integration/nodes_test.go
@@ -168,7 +168,7 @@ func (suite *GatewayTestSuite) TestGatewayNodesClient() {
 	node.LastJob = nil
 	node.TargetConfig = nil
 	suite.Equal(&nodes.Node{
-		ConnectionError: "authentication failed",
+		ConnectionError: "authentication failed\n\nAuthentication failed for inspec-target-rhel7-dev.cd.chef.co\n\nNet::SSH::AuthenticationFailed",
 		Id:              nodeID.Id,
 		Name:            "test node",
 		Manager:         "automate",

--- a/components/compliance-service/api/tests/30_jobs_docker_spec.rb
+++ b/components/compliance-service/api/tests/30_jobs_docker_spec.rb
@@ -491,7 +491,7 @@ describe File.basename(__FILE__) do
           "managerIds": [
             "e69dc612-7e67-43f2-9b19-256afd385820"
           ],
-          "connectionError": "unknown error\n\nUnknown inspec error for cc_pggggggggg: exit status 1\n\nSTDERR: /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/docker-api-1.34.2/lib/docker/connection.rb:46:in `rescue in request': No such container: cc_pggggggggg (Docker::Error::NotFoundError)\n\tfrom /hab/pkgs/chef/inspec/4.18.51/2019121122093",
+          "connectionError": "unknown error\n\nUnknown inspec error for cc_pggggggggg: exit status 1\n\nSTDERR: /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/docker-api-1.34.2/lib/docker/connection.rb:46:in `rescue in request': No such container: cc_pggggggggg (Docker::Error::NotFoundError)\n\tfrom /hab/pkgs/chef/inspec/4.18.51/2019121122093 [truncated for length]",
           "runData": {},
           "scanData": {
             "id": "some-id",

--- a/components/compliance-service/api/tests/30_jobs_docker_spec.rb
+++ b/components/compliance-service/api/tests/30_jobs_docker_spec.rb
@@ -491,7 +491,7 @@ describe File.basename(__FILE__) do
           "managerIds": [
             "e69dc612-7e67-43f2-9b19-256afd385820"
           ],
-          "connectionError": "unknown error",
+          "connectionError": "unknown error\n\nUnknown inspec error for cc_pggggggggg: exit status 1\n\nSTDERR: /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/docker-api-1.34.2/lib/docker/connection.rb:46:in `rescue in request': No such container: cc_pggggggggg (Docker::Error::NotFoundError)\n\tfrom /hab/pkgs/chef/inspec/4.18.51/2019121122093",
           "runData": {},
           "scanData": {
             "id": "some-id",

--- a/components/compliance-service/inspec/cli.go
+++ b/components/compliance-service/inspec/cli.go
@@ -242,56 +242,60 @@ func Archive(profilePath string, outputPath string) error {
 }
 
 func getInspecError(stdOut string, stdErr string, err error, target *TargetConfig, timeout time.Duration) *Error {
-	connErr := "Errno::ECONNREFUSED"
 	for _, serr := range []string{stdOut, stdErr} {
+		connErr := "Errno::ECONNREFUSED"
 		if strings.Index(serr, connErr) >= 0 {
 			return NewInspecError(CONN_REFUSED,
-				"Failed to connect to "+target.Hostname+", connection refused.")
+				"Failed to connect to "+target.Hostname+", connection refused."+"\n\n"+connErr)
 		}
 		noTTYErr := "Errno::ENOTTY"
 		if strings.Index(serr, noTTYErr) >= 0 {
 			return NewInspecError(AUTH_FAILED,
-				"Authentication failed for "+target.Hostname)
+				"Authentication failed for "+target.Hostname+"\n\n"+noTTYErr)
 		}
 		hostDownErr := "Errno::EHOSTDOWN"
 		if strings.Index(serr, hostDownErr) >= 0 {
 			return NewInspecError(UNREACHABLE_HOST,
-				"Failed to connect to "+target.Hostname+", host is unreachable.")
+				"Failed to connect to "+target.Hostname+", host is unreachable."+"\n\n"+hostDownErr)
 		}
 		connTimeoutErr := "Net::SSH::ConnectionTimeout"
 		if strings.Index(serr, connTimeoutErr) >= 0 {
 			return NewInspecError(CONN_TIMEOUT,
-				"Failed to connect to "+target.Hostname+", connection timeout.")
+				"Failed to connect to "+target.Hostname+", connection timeout."+"\n\n"+connTimeoutErr)
 		}
 		authErr := "Net::SSH::AuthenticationFailed"
-		winRmAuthErr := "WinRM::WinRMAuthorizationError"
-		if strings.Index(serr, authErr) >= 0 || strings.Index(serr, winRmAuthErr) >= 0 {
+		if strings.Index(serr, authErr) >= 0 {
 			return NewInspecError(AUTH_FAILED,
-				"Authentication failed for "+target.Hostname)
+				"Authentication failed for "+target.Hostname+"\n\n"+authErr)
+		}
+		winRmAuthErr := "WinRM::WinRMAuthorizationError"
+		if strings.Index(serr, winRmAuthErr) >= 0 {
+			return NewInspecError(AUTH_FAILED,
+				"Authentication failed for "+target.Hostname+"\n\n"+winRmAuthErr)
 		}
 		sudoErr := "Sudo requires a password"
 		if strings.Index(serr, sudoErr) >= 0 {
 			return NewInspecError(SUDO_PW_REQUIRED,
 				"Failed to run commands on "+target.Hostname+
-					": The node is configured to use sudo, but sudo requires a password to run commands.")
+					": The node is configured to use sudo, but sudo requires a password to run commands."+"\n\n"+sudoErr)
 		}
 		pwErr := "Wrong sudo password"
 		if strings.Index(serr, pwErr) >= 0 {
 			return NewInspecError(WRONG_SUDO_PW,
 				"Failed to run commands on "+target.Hostname+
-					": Sudo password is incorrect.")
+					": Sudo password is incorrect."+"\n\n"+pwErr)
 		}
 		nosudoErr := "Can't find sudo command"
 		if strings.Index(serr, nosudoErr) >= 0 {
 			return NewInspecError(NO_SUDO,
 				"Failed to run commands on "+target.Hostname+
-					": Cannot use sudo, please deactivate it or configure sudo for this user.")
+					": Cannot use sudo, please deactivate it or configure sudo for this user."+"\n\n"+nosudoErr)
 		}
 		notInSudoersErr := "is not in the sudoers file"
 		if strings.Index(serr, notInSudoersErr) >= 0 {
 			return NewInspecError(NO_SUDO,
 				"Failed to run commands on "+target.Hostname+
-					": User is not in sudoers file.")
+					": User is not in sudoers file."+"\n\n"+notInSudoersErr)
 		}
 	}
 

--- a/components/compliance-service/inspec/cli.go
+++ b/components/compliance-service/inspec/cli.go
@@ -264,7 +264,8 @@ func getInspecError(stdOut string, stdErr string, err error, target *TargetConfi
 				"Failed to connect to "+target.Hostname+", connection timeout.")
 		}
 		authErr := "Net::SSH::AuthenticationFailed"
-		if strings.Index(serr, authErr) >= 0 {
+		winRmAuthErr := "WinRM::WinRMAuthorizationError"
+		if strings.Index(serr, authErr) >= 0 || strings.Index(serr, winRmAuthErr) >= 0 {
 			return NewInspecError(AUTH_FAILED,
 				"Authentication failed for "+target.Hostname)
 		}

--- a/components/compliance-service/inspec/cli_test.go
+++ b/components/compliance-service/inspec/cli_test.go
@@ -1,0 +1,36 @@
+package inspec
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInspecErrReturnsCorrectErr(t *testing.T) {
+	target := &TargetConfig{
+		TargetBaseConfig: TargetBaseConfig{Hostname: "test"},
+	}
+	blankErr := errors.New("")
+
+	// winrm auth error
+	stdErr := "/hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/winrm-2.3.3/lib/winrm/http/response_handler.rb:59:in raise_if_auth_error': WinRM::WinRMAuthorizationError (WinRM::WinRMAuthorizationError)\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/winrm-2.3.3/lib/winrm/http/response_handler.rb:51:in raise_if_error'\n\tfrom /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/winrm-2.3.3/lib/winrm/http/response_handler.rb:34:in parse_to_xml'\n\tfrom /hab/pkgs/chef/inspec/4.18.51"
+	err := getInspecError("", stdErr, blankErr, target, time.Duration(90))
+	assert.Equal(t, &Error{Type: "authentication failed", Message: "Authentication failed for test\n\nWinRM::WinRMAuthorizationError"}, err)
+
+	// some random error
+	stdErr = "some random error from inspec that we haven't checked for"
+	err = getInspecError("", stdErr, blankErr, target, time.Duration(90))
+	assert.Equal(t, &Error{Type: "unknown error", Message: "Unknown inspec error for test: \n\nSTDERR: some random error from inspec that we haven't checked for"}, err)
+
+	// conn refused error
+	stdErr = "some thing will be here and then Errno::ECONNREFUSED and then more words"
+	err = getInspecError("", stdErr, blankErr, target, time.Duration(90))
+	assert.Equal(t, &Error{Type: "connection refused", Message: "Failed to connect to test, connection refused.\n\nErrno::ECONNREFUSED"}, err)
+
+	stdErr = "/hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/ more words here Net::SSH::AuthenticationFailed other details"
+	err = getInspecError("", stdErr, blankErr, target, time.Duration(90))
+	assert.Equal(t, &Error{Type: "authentication failed", Message: "Authentication failed for test\n\nNet::SSH::AuthenticationFailed"}, err)
+
+}

--- a/components/compliance-service/inspec/cli_test.go
+++ b/components/compliance-service/inspec/cli_test.go
@@ -29,6 +29,7 @@ func TestInspecErrReturnsCorrectErr(t *testing.T) {
 	err = getInspecError("", stdErr, blankErr, target, time.Duration(90))
 	assert.Equal(t, &Error{Type: "connection refused", Message: "Failed to connect to test, connection refused.\n\nErrno::ECONNREFUSED"}, err)
 
+	// ssh auth error
 	stdErr = "/hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/ more words here Net::SSH::AuthenticationFailed other details"
 	err = getInspecError("", stdErr, blankErr, target, time.Duration(90))
 	assert.Equal(t, &Error{Type: "authentication failed", Message: "Authentication failed for test\n\nNet::SSH::AuthenticationFailed"}, err)

--- a/components/compliance-service/scanner/db.go
+++ b/components/compliance-service/scanner/db.go
@@ -219,11 +219,14 @@ func (s *Scanner) UpdateResult(ctx context.Context, job *types.InspecJob, output
 		} else {
 			result.Result = fmt.Sprintf("unable to complete scan on node. please check the logs for more information. node id ref: %s", job.NodeID)
 		}
-		connectionErr := ""
+		var connectionErr, errMsg string
 		if inspecErr != nil {
 			if len(inspecErr.Message) > 300 {
-				connectionErr = fmt.Sprintf("%s\n\n%s", inspecErr.Type, inspecErr.Message[0:300])
+				errMsg = inspecErr.Message[0:300]
+			} else {
+				errMsg = inspecErr.Message
 			}
+			connectionErr = fmt.Sprintf("%s\n\n%s", inspecErr.Type, errMsg)
 		}
 		if connectionErr != "" {
 			_, err := s.nodesClient.UpdateNodeConnectionError(ctx, &nodes.NodeError{

--- a/components/compliance-service/scanner/db.go
+++ b/components/compliance-service/scanner/db.go
@@ -221,7 +221,9 @@ func (s *Scanner) UpdateResult(ctx context.Context, job *types.InspecJob, output
 		}
 		connectionErr := ""
 		if inspecErr != nil {
-			connectionErr = fmt.Sprintf("%s:\n\n%s", inspecErr.Type, inspecErr.Message)
+			if len(inspecErr.Message) > 300 {
+				connectionErr = fmt.Sprintf("%s\n\n%s", inspecErr.Type, inspecErr.Message[0:300])
+			}
 		}
 		if connectionErr != "" {
 			_, err := s.nodesClient.UpdateNodeConnectionError(ctx, &nodes.NodeError{

--- a/components/compliance-service/scanner/db.go
+++ b/components/compliance-service/scanner/db.go
@@ -222,7 +222,7 @@ func (s *Scanner) UpdateResult(ctx context.Context, job *types.InspecJob, output
 		var connectionErr, errMsg string
 		if inspecErr != nil {
 			if len(inspecErr.Message) > 300 {
-				errMsg = inspecErr.Message[0:300]
+				errMsg = fmt.Sprintf("%s [truncated for length]", inspecErr.Message[0:300])
 			} else {
 				errMsg = inspecErr.Message
 			}

--- a/components/compliance-service/scanner/db.go
+++ b/components/compliance-service/scanner/db.go
@@ -221,7 +221,7 @@ func (s *Scanner) UpdateResult(ctx context.Context, job *types.InspecJob, output
 		}
 		connectionErr := ""
 		if inspecErr != nil {
-			connectionErr = inspecErr.Type
+			connectionErr = fmt.Sprintf("%s:\n\n%s", inspecErr.Type, inspecErr.Message)
 		}
 		if connectionErr != "" {
 			_, err := s.nodesClient.UpdateNodeConnectionError(ctx, &nodes.NodeError{


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
- added error msg to error saved as "connection error" on node object
- added winrm auth error to inspec errors list
- added original err msg to returned inspec error on scans

### :chains: Related Resources
https://github.com/chef/automate/issues/3149

### :+1: Definition of Done
inspec errors returned are more verbose

### :athletic_shoe: How to Build and Test the Change
get a box to test against
add node with incorrect credential
note error msg after adding node
rebuild compliance
press rerun on node
see better error msg

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
before:
<img width="468" alt="Screen Shot 2020-03-18 at 21 56 20" src="https://user-images.githubusercontent.com/10341541/77031962-bf95c400-6968-11ea-88ff-29c4555dcb03.png">

after:
<img width="555" alt="Screen Shot 2020-03-18 at 22 30 54" src="https://user-images.githubusercontent.com/10341541/77031978-c58ba500-6968-11ea-9469-13c8f17aefd7.png">
