### PR TITLE
Automate 2558

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-status/overview-status.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-status/overview-status.component.scss
@@ -30,7 +30,7 @@
     }
 
     .waived {
-      color: $chef-med-grey;
+      color: $chef-darker;
     }
 
     .critical {
@@ -105,7 +105,7 @@
       }
 
       &.waived {
-        background: $chef-med-grey;
+        background: $chef-darker;
       }
     }
   }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
@@ -76,6 +76,10 @@
                   <chef-icon>help</chef-icon>
                   <span>{{ control.skipped | number }}</span>
                 </span>
+                <span class="control-result" [ngClass]="{'waived': control.waived > 0}">
+                  <div class="waived-icon"></div>
+                  <span>{{ control.waived | number }}</span>
+                </span>
               </chef-td>
               <chef-td>
                 <chef-button secondary (click)="onControlClick(control.control)">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.scss
@@ -96,10 +96,10 @@
     }
 
     &.waived {
-      color: $chef-darker;
+      color: $chef-darkest;
 
       .waived-icon:before {
-        color: $chef-darkest;
+        color: inherit;
       }
     }
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.scss
@@ -67,11 +67,15 @@
     align-items: center;
     color: $chef-grey;
 
+    .waived-icon:before {
+      color: $chef-white;
+    }
+
     &:last-child {
       margin-right: 0;
     }
 
-    chef-icon {
+    chef-icon, .waived-icon {
       margin-right: 5px;
     }
   }
@@ -89,6 +93,14 @@
 
     &.skipped {
       color: $chef-dark-grey;
+    }
+
+    &.waived {
+      color: $chef-darker;
+
+      .waived-icon:before {
+        color: $chef-darkest;
+      }
     }
 
     &.critical {

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -333,12 +333,12 @@ input {
   border-radius: 2px;
   height: 16px;
   width: 16px;
-  background-color: #CDD7DD;
+  background-color: $chef-med-grey;
   position: relative;
 }
 
 .waived-icon:before {
-  color: #26293A;
+  color: $chef-darkest;
   content: 'W';
   font-size: 9px;
   font-weight: bolder;

--- a/components/automate-ui/src/styles/_colors.scss
+++ b/components/automate-ui/src/styles/_colors.scss
@@ -21,8 +21,10 @@ $fuchsia-light: #FADAFA;
 $fuchsia-dark: #440F4B;
 $maroon: #BA1E6A;
 // greyscale
+$charcoal: #26293A;
 $sirocco: #6F7878;
 $darksea: #819BA9;
+$steel: #CDD7DD;
 $iron: #DFE3E5;
 $mystic: #E6EBEE;
 $haze: #F3F6F8;

--- a/components/automate-ui/src/styles/_variables.scss
+++ b/components/automate-ui/src/styles/_variables.scss
@@ -19,8 +19,11 @@ $chef-info-alert: $fuchsia;
 $chef-info-alert-light: $fuchsia-light;
 $chef-info-alert-dark: $fuchsia-dark;
 //greyscale
+
 $chef-dark-grey: $sirocco;
-$chef-med-grey: $darksea;
+$chef-darker: $darksea;
+$chef-darkest: $charcoal;
+$chef-med-grey: $steel;
 $chef-grey: $iron;
 $chef-light-grey: $mystic;
 $chef-lightest-grey: $haze;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As an Automate User, I will use this work when I want to look at the waived controls of a profile.

### :chains: Related Resources
https://github.com/chef/automate/issues/2558

### :+1: Definition of Done
- A user can go to a Reports Profile detail page and see which controls where waived
- A user can see on the report profile detail page how many nodes where affected by a waived control
- A user can filter by Waived controls

### :athletic_shoe: How to Build and Test the Change
load data with load_compliance_reports

### :camera: Screenshots, if applicable
![Screen Shot 2020-03-19 at 11 23 15 AM](https://user-images.githubusercontent.com/4108100/77089628-0f5da500-69d4-11ea-9d58-036c89bf20cb.png)
