### PR TITLE
Add warning about running Manage with Server and A2

### DIFF
--- a/components/automate-chef-io/content/docs/infra-server.md
+++ b/components/automate-chef-io/content/docs/infra-server.md
@@ -14,10 +14,15 @@ toc = true
 
 {{% warning %}}
 
-Chef Automate will not deploy the following Chef Infra Server add-ons:
-- Chef Manage
-- Push Jobs Server
-- Supermarket
+Chef Automate will not deploy the Chef Infra Server add-ons Chef Manage
+and Push Jobs Server.
+
+{{% /warning %}}
+
+{{% warning %}}
+
+Supermarket cannot authenticate users on Chef Infra Server that is deployed
+with Chef Automate.
 
 {{% /warning %}}
 

--- a/components/automate-chef-io/content/docs/infra-server.md
+++ b/components/automate-chef-io/content/docs/infra-server.md
@@ -12,6 +12,12 @@ toc = true
     weight = 60
 +++
 
+{{% warning %}}
+
+We do not support using the Chef Automate 2 deployment service to deploy Chef Infra Server with Chef Manage.
+
+{{% /warning %}}
+
 Use Chef Automate to install Chef Infra Server either for a single-host installation that contains both Chef Infra Server and Chef Automate, or for a standalone Chef Infra Server instance.
 See the [Chef Infra Server documentation](https://docs.chef.io/server_overview/) for instructions and guidance on using and managing your Chef Infra Server.
 

--- a/components/automate-chef-io/content/docs/infra-server.md
+++ b/components/automate-chef-io/content/docs/infra-server.md
@@ -14,7 +14,10 @@ toc = true
 
 {{% warning %}}
 
-Chef Automate does not deploy Chef Manage alongside Chef Infra Server.
+Chef Automate will not deploy the following Chef Infra Server add-ons:
+- Chef Manage
+- Push Jobs Server
+- Supermarket
 
 {{% /warning %}}
 

--- a/components/automate-chef-io/content/docs/infra-server.md
+++ b/components/automate-chef-io/content/docs/infra-server.md
@@ -14,7 +14,7 @@ toc = true
 
 {{% warning %}}
 
-We do not support using the Chef Automate 2 deployment service to deploy Chef Infra Server with Chef Manage.
+Chef Automate does not deploy Chef Manage alongside Chef Infra Server.
 
 {{% /warning %}}
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

This adds a warning about deploying Infra Server with Chef Manage and A2.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [X] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
