### PR TITLE
Make sure passwords with percent work

### DIFF
--- a/integration/services/ha_backend/init.sh
+++ b/integration/services/ha_backend/init.sh
@@ -10,6 +10,7 @@ ha_backend_container2=$(service_container_name "ha_backend_2")
 
 ha_backend_private=$(service_config_path "ha_backend_private")
 ha_backend_config=$(service_config_path "ha_backend.toml")
+ha_admin_pg_password='thisisapassword%u'
 
 ha_backend_setup() {
     mkdir -p "$ha_backend_private"
@@ -84,10 +85,10 @@ ha_backend_setup() {
     for try in {1..60}; do
         echo "Trying to create dbuser (attempt #${try})"
         errcode="0"
-        output="$(docker exec --env PGPASSWORD="thisisapassword" --env HAB_LICENSE=accept-no-persist "$ha_backend_container1" \
+        output="$(docker exec --env PGPASSWORD="$ha_admin_pg_password" --env HAB_LICENSE=accept-no-persist "$ha_backend_container1" \
 	hab pkg exec core/postgresql11 psql \
             -h 127.0.0.1 -p 7432 -U admin -d postgres -c \
-            "CREATE USER dbuser WITH PASSWORD 'thisisapassword'")" || errcode="$?"
+            "CREATE USER dbuser WITH PASSWORD '$ha_admin_pg_password'")" || errcode="$?"
         if [ "$errcode" -eq "0" ]; then
             break
         else
@@ -138,10 +139,10 @@ scheme = "password"
 
 [global.v1.external.postgresql.auth.password.superuser]
 username = "admin"
-password = "thisisapassword"
+password = "$ha_admin_pg_password"
 [global.v1.external.postgresql.auth.password.dbuser]
 username = "dbuser"
-password = "thisisapassword"
+password = "$ha_admin_pg_password"
 
 [global.v1.external.postgresql.backup]
 enable = true

--- a/integration/services/ha_backend/setup.sh
+++ b/integration/services/ha_backend/setup.sh
@@ -148,7 +148,7 @@ EOF
 mkdir -p "/hab/user/${PG_PKG_NAME}/config/"
 cat > "/hab/user/${PG_PKG_NAME}/config/user.toml" <<EOF
 [superuser]
-password = 'thisisapassword'
+password = 'thisisapassword%u'
 [ssl]
 enable = true
 ssl_cert    = """$(cat /certificates/postgresql.pem)"""

--- a/lib/platform/config/config.go
+++ b/lib/platform/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -165,9 +166,10 @@ func (c *PGConnInfo) String() string {
 }
 
 func externalConnURIRenderer(ip string, port int, user string, password string, opts []string) (pgConnURIRenderer, string) {
-	fmtStr := "postgresql://%s:%s@%s:%d/%s?%s"
+	fmtStr := "postgresql://%s@%s:%d/%s?%s"
+	userInfo := url.UserPassword(user, password)
 	return func(dbname string) string {
-		return fmt.Sprintf(fmtStr, user, password, ip, port, dbname, strings.Join(opts, "&"))
+		return fmt.Sprintf(fmtStr, userInfo.String(), ip, port, dbname, strings.Join(opts, "&"))
 	}, fmt.Sprintf(fmtStr, user, "<readacted>", ip, port, "<database>", strings.Join(opts, "&"))
 }
 


### PR DESCRIPTION
The existing code that we have to parse the platform config and generate postgresql connection strings contains a bug that results in unparseable URL strings when the password contains a `%` character.

The cause of this is that we generate the bulk of the URL connection string (user, password, ip, port, options) and then run `fmt.Sprintf()` on THAT string to insert the database name later on.

This change uses a function pointer to make the `fmt.Sprintf` call only once with all of the data.