### PR TITLE
Rm/fix ipaddress pointer race condition

### DIFF
--- a/components/compliance-service/ingest/pipeline/processor/report.go
+++ b/components/compliance-service/ingest/pipeline/processor/report.go
@@ -46,11 +46,13 @@ func ComplianceReport(in <-chan message.Compliance) <-chan message.Compliance {
 				ChefTags:         msg.Report.ChefTags,
 				FQDN:             msg.Report.Fqdn,
 			}
+
+			copyOfIpAddress := msg.Report.Ipaddress
 			// Elastic won't accept empty string for a field of data type 'ip'
-			if msg.Report.Ipaddress == "" {
+			if copyOfIpAddress == "" {
 				msg.InspecReport.IPAddress = nil
 			} else {
-				*msg.InspecReport.IPAddress = msg.Report.Ipaddress
+				msg.InspecReport.IPAddress = &copyOfIpAddress
 			}
 			msg.InspecReport.Platform.Name = msg.Report.GetPlatform().GetName()
 			msg.InspecReport.Platform.Release = msg.Report.GetPlatform().GetRelease()

--- a/components/compliance-service/ingest/pipeline/processor/report.go
+++ b/components/compliance-service/ingest/pipeline/processor/report.go
@@ -44,12 +44,13 @@ func ComplianceReport(in <-chan message.Compliance) <-chan message.Compliance {
 				OrganizationName: msg.Report.OrganizationName,
 				SourceFQDN:       msg.Report.SourceFqdn,
 				ChefTags:         msg.Report.ChefTags,
-				IPAddress:        &msg.Report.Ipaddress,
 				FQDN:             msg.Report.Fqdn,
 			}
 			// Elastic won't accept empty string for a field of data type 'ip'
-			if *msg.InspecReport.IPAddress == "" {
+			if msg.Report.Ipaddress == "" {
 				msg.InspecReport.IPAddress = nil
+			} else {
+				*msg.InspecReport.IPAddress = msg.Report.Ipaddress
 			}
 			msg.InspecReport.Platform.Name = msg.Report.GetPlatform().GetName()
 			msg.InspecReport.Platform.Release = msg.Report.GetPlatform().GetRelease()


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This fixes a bug that was caused by setting a pointer to an attribute on an incoming inspec report.
By making a copy of the string from the incoming struct and then pointing to that instead, we avoid having the pointer get overwritten by subsequent messages in the channel.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
