### PR TITLE
adjust project update modal text 

### DIFF
--- a/components/automate-ui/src/app/components/confirm-apply-start-modal/confirm-apply-start-modal.component.html
+++ b/components/automate-ui/src/app/components/confirm-apply-start-modal/confirm-apply-start-modal.component.html
@@ -1,7 +1,7 @@
 <chef-modal id="confirm-apply-start-modal" [visible]="visible" (closeModal)="cancel.emit()">
   <h2 id="title" slot="title">Update Projects?</h2>
   <div class="modal-content">
-    <p>Updating projects will apply all pending edits and move ingested resources into the correct projects. This background process can take a few minutes for systems with a limited number of nodes, and up to <strong>6 days</strong> for systems with a large number of nodes.</p>
+    <p>Updating projects will apply all pending edits and move ingested resources into the correct projects. This background process can take a few minutes for systems with a limited number of nodes, and <strong>several days</strong> for systems with a large number of nodes.</p>
     <div class="options">
       <chef-button id="confirm-button" primary (click)="confirm.emit()">
         Update Projects

--- a/components/automate-ui/src/app/components/confirm-apply-start-modal/confirm-apply-start-modal.component.html
+++ b/components/automate-ui/src/app/components/confirm-apply-start-modal/confirm-apply-start-modal.component.html
@@ -1,7 +1,7 @@
 <chef-modal id="confirm-apply-start-modal" [visible]="visible" (closeModal)="cancel.emit()">
   <h2 id="title" slot="title">Update Projects?</h2>
   <div class="modal-content">
-    <p>Updating projects will apply all pending edits and move ingested resources into the correct projects. This background process can take up to <strong>12 hours</strong> to complete.</p>
+    <p>Updating projects will apply all pending edits and move ingested resources into the correct projects. This background process can take a few minutes for systems with a limited number of nodes, and up to <strong>6 days</strong> for systems with a large number of nodes.</p>
     <div class="options">
       <chef-button id="confirm-button" primary (click)="confirm.emit()">
         Update Projects


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
We did some testing in our perf acceptance environment and a project update took approximately 6 days, this updates the modal text to better communicate that.

#### new text
```
Updating projects will apply all pending edits and move ingested resources into the correct projects. This background process can take a few minutes for systems with a limited number of nodes, and <strong>several days</strong> for systems with a large number of nodes.
```

### :+1: Definition of Done
everything still works
text is different

### :athletic_shoe: How to Build and Test the Change
`rebuild components/automate-ui-devproxy`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
#### before
![update-projects-before](https://user-images.githubusercontent.com/5489125/77260061-daa35500-6c42-11ea-8467-c7391fadd625.png)

#### after
![new-project-update-modal](https://user-images.githubusercontent.com/5489125/77323563-b2fbcd80-6cd2-11ea-9f3a-a46989f3a18d.png)

