### PR TITLE
enforce non empty conditions on name and url for in destinations table

### DIFF
--- a/components/data-feed-service/dao/migration/sql/02_destinations.up.sql
+++ b/components/data-feed-service/dao/migration/sql/02_destinations.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE destinations ADD CONSTRAINT name_not_empty CHECK(name <> '');
+ALTER TABLE destinations ADD CONSTRAINT url_not_empty CHECK(url <> '');


### PR DESCRIPTION
Signed-off-by: Martin Scott <mscott@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Enforcing conditions on the data_feed_service database destinations table. Constraints added to name and url fields so they are not empty.

### :athletic_shoe: How to Build and Test the Change
Try creating or updating a destination through the UI or API with empty name, url fields. These should error. Otherwise destinations should be created and updated as normal.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated? Manually tested
- [ ] Docs added/updated? NA
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
