### PR TITLE
[automate-2912] Add labels for 0 and 100 percent to project upgrade

### DIFF
--- a/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.spec.ts
+++ b/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.spec.ts
@@ -49,12 +49,12 @@ describe('ConfirmApplyStopModalComponent', () => {
 
   describe('progress bar', () => {
     using([
-      [0,     '0% complete'],
-      [0.75,  '0% complete'],
+      [0,    'Preparing...'],
+      [0.75, 'Preparing...'],
       [10,   '10% complete'],
       [91.9, '91% complete'],
       [92,   '92% complete'],
-      [100, '100% complete']
+      [100,  'Finishing Up...']
     ], (percentageComplete, progressPrefixText) => {
       it('displays correct percentage', () => {
         component.updateProgress({ ...component.applyRulesStatus, percentageComplete });
@@ -70,19 +70,25 @@ describe('ConfirmApplyStopModalComponent', () => {
     const NOW = '2019-01-01T00:00:00Z';
 
     using([
-      ['0001-01-01T00:00:00Z', '00:00:00 until finished'],
-      ['1970-01-01T00:00:00Z', '00:00:00 until finished'],
-      ['2019-01-01T00:00:00Z', '00:00:00 until finished'],
-      ['2019-01-01T00:15:00Z', '00:15:00 until finished'],
-      ['2019-01-01T12:30:45Z', '12:30:45 until finished'],
-      ['2019-01-02T06:45:15Z', '30:45:15 until finished']
-    ], (estimatedTimeComplete, progressSuffixText) => {
+      // floor(0) percent and ceil(100) percent don't have time estimates
+      [0, '0001-01-01T00:00:00Z', ''],
+      [0, '1970-01-01T00:00:00Z', ''],
+      [0.5, '2019-01-01T00:00:00Z', ''],
+      [10, '2019-01-01T00:15:00Z', '00:15:00 until finished'],
+      [50, '2019-01-01T12:30:45Z', '12:30:45 until finished'],
+      [99.9, '2019-01-02T06:45:15Z', '']
+    ], (percentageComplete, estimatedTimeComplete, progressSuffixText) => {
       beforeEach(() => jasmine.clock().mockDate(new Date(NOW)));
 
       afterEach(() => jasmine.clock().uninstall());
 
       it('displays correct suffix text', () => {
-        component.updateProgress({ ...component.applyRulesStatus, estimatedTimeComplete });
+        component.updateProgress({
+          ...component.applyRulesStatus,
+          percentageComplete,
+          estimatedTimeComplete
+        });
+        expect(component.progressValue).toEqual(percentageComplete);
         expect(component.progressSuffixText).toEqual(progressSuffixText);
       });
     });
@@ -100,18 +106,19 @@ describe('ConfirmApplyStopModalComponent', () => {
     });
 
     it('does not update time once update is cancelled', () => {
+      const percentageComplete = 30;
       jasmine.clock().mockDate(new Date(NOW));
       component.updateProgress(
-        { ...component.applyRulesStatus, estimatedTimeComplete: '2019-01-01T12:30:45Z' });
+        { ...component.applyRulesStatus, percentageComplete, estimatedTimeComplete: '2019-01-01T12:30:45Z' });
       expect(component.progressSuffixText).toContain('12:30:45');
       component.updateProgress(
-        { ...component.applyRulesStatus, estimatedTimeComplete: '2019-01-01T11:30:45Z' });
+        { ...component.applyRulesStatus, percentageComplete, estimatedTimeComplete: '2019-01-01T11:30:45Z' });
       expect(component.progressSuffixText).toContain('11:30:45');
 
       component.stopRulesInProgress = true;
 
       component.updateProgress(
-        { ...component.applyRulesStatus, estimatedTimeComplete: '2019-01-01T09:30:45Z' });
+        { ...component.applyRulesStatus, percentageComplete, estimatedTimeComplete: '2019-01-01T09:30:45Z' });
       expect(component.progressSuffixText).toContain('11:30:45');
     });
   });

--- a/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.ts
+++ b/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.ts
@@ -46,7 +46,15 @@ export class ConfirmApplyStopModalComponent implements OnChanges {
     const durCountdown = etc.diff(now) < 0 ? '00:00:00' : `${durHours}:${durMins}:${durSecs}`;
 
     this.progressValue = percentageComplete;
-    this.progressPrefixText = `${Math.floor(percentageComplete)}% complete`;
+
+    if (Math.floor(percentageComplete) === 0) {
+      this.progressPrefixText = 'Preparing...';
+    } else if (Math.ceil(percentageComplete) === 100) {
+      this.progressPrefixText = 'Finishing Up...';
+    } else {
+      this.progressPrefixText = `${Math.floor(percentageComplete)}% complete`;
+    }
+
     this.progressSuffixText = `${durCountdown} until finished`;
   }
 }

--- a/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.ts
+++ b/components/automate-ui/src/app/components/confirm-apply-stop-modal/confirm-apply-stop-modal.component.ts
@@ -49,12 +49,13 @@ export class ConfirmApplyStopModalComponent implements OnChanges {
 
     if (Math.floor(percentageComplete) === 0) {
       this.progressPrefixText = 'Preparing...';
+      this.progressSuffixText = '';
     } else if (Math.ceil(percentageComplete) === 100) {
       this.progressPrefixText = 'Finishing Up...';
+      this.progressSuffixText = '';
     } else {
       this.progressPrefixText = `${Math.floor(percentageComplete)}% complete`;
+      this.progressSuffixText = `${durCountdown} until finished`;
     }
-
-    this.progressSuffixText = `${durCountdown} until finished`;
   }
 }

--- a/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.html
+++ b/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.html
@@ -1,5 +1,5 @@
 <div id="process-progress-bar" [hidden]="!layoutFacade.layout.userNotifications.updatesProcessing">
-  <span class="info">Updating resources across all projects ({{ percentageComplete }}%)</span>
+  <span class="info">Updating resources across all projects ({{ displayPercent() }})</span>
   <app-authorized [allOf]="['/iam/v2/apply-rules', 'delete']">
     <button mat-button (click)="openConfirmUpdateStopModal()">Stop Project Update</button>
   </app-authorized>

--- a/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.ts
+++ b/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.ts
@@ -68,9 +68,9 @@ export class ProcessProgressBarComponent implements OnInit, OnDestroy {
   }
 
   public displayPercent(): string {
-    if (this.percentageComplete === 0) {
+    if (Math.floor(this.percentageComplete) === 0) {
       return 'Preparing...';
-    } else if (this.percentageComplete === 100) {
+    } else if (Math.ceil(this.percentageComplete) === 100) {
       return 'Finishing Up...';
     }
     return `${this.percentageComplete.toString()}%`;

--- a/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.ts
+++ b/components/automate-ui/src/app/components/process-progress-bar/process-progress-bar.component.ts
@@ -66,4 +66,13 @@ export class ProcessProgressBarComponent implements OnInit, OnDestroy {
   public cancelApplyStop(): void {
     this.closeConfirmApplyStopModal();
   }
+
+  public displayPercent(): string {
+    if (this.percentageComplete === 0) {
+      return 'Preparing...';
+    } else if (this.percentageComplete === 100) {
+      return 'Finishing Up...';
+    }
+    return `${this.percentageComplete.toString()}%`;
+  }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Added labels for the 0 and 100 cases.

### :athletic_shoe: How to Build and Test the Change

```  
chef_load_nodes 500
```

Add a rule and update projects to see new labels.

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
