### PR TITLE
Update chef-hugo-theme branch in makefile

### DIFF
--- a/components/automate-chef-io/Makefile
+++ b/components/automate-chef-io/Makefile
@@ -19,7 +19,7 @@ clean:
 	rm -rf public/
 
 sync: themes/chef
-	pushd themes/chef && git fetch && git reset --hard origin/master && popd
+	pushd themes/chef && git fetch origin old_hugo_theme && git reset --hard origin/old_hugo_theme && popd
 
 clean_swagger_files:
 	rm -rf ./$(SWAGGER_DIR)/*


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Specify `old-hugo-theme` branch in Makefile sync.

This should have been in #3131

### :chains: Related Resources

### :+1: Definition of Done

automate.chef.io builds using the `old_hugo_theme` branch from the **chef-hugo-theme** repo.

### :athletic_shoe: How to Build and Test the Change

`make sync` or `make serve`

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [X] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
