### PR TITLE
Add CIDR filtering to restrict data-feed to certain nodes

### DIFF
--- a/components/data-feed-service/config/config.go
+++ b/components/data-feed-service/config/config.go
@@ -12,11 +12,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-//const (
-//	FEED_KEY = "feed"
-//	CFG_KEY  = "cfgingest"
-//)
-
 // Configuration for the Data Feed Service
 type DataFeedConfig struct {
 	ServiceConfig    ServiceConfig    `mapstructure:"service"`
@@ -36,13 +31,15 @@ type LogConfig struct {
 }
 
 type ServiceConfig struct {
-	Host             string        `mapstructure:"host"`
-	Port             uint16        `mapstructure:"port"`
-	FeedInterval     time.Duration `mapstructure:"feed_interval"`
-	AssetPageSize    int32         `mapstructure:"asset_page_size"`
-	ReportsPageSize  int32         `mapstructure:"reports_page_size"`
-	NodeBatchSize    int           `mapstructure:"node_batch_size"`
-	UpdatedNodesOnly bool          `mapstructure:"updated_nodes_only"`
+	Host              string        `mapstructure:"host"`
+	Port              uint16        `mapstructure:"port"`
+	FeedInterval      time.Duration `mapstructure:"feed_interval"`
+	AssetPageSize     int32         `mapstructure:"asset_page_size"`
+	ReportsPageSize   int32         `mapstructure:"reports_page_size"`
+	NodeBatchSize     int           `mapstructure:"node_batch_size"`
+	UpdatedNodesOnly  bool          `mapstructure:"updated_nodes_only"`
+	DisableCIDRFilter bool          `mapstructure:"disable_cidr_filter"`
+	CIDRFilter        string        `mapstructure:"cidr_filter"`
 }
 
 type PostgresConfig struct {

--- a/components/data-feed-service/habitat/config/config.toml
+++ b/components/data-feed-service/habitat/config/config.toml
@@ -11,7 +11,7 @@ reports_page_size = {{cfg.service.reports_page_size}}
 node_batch_size = {{cfg.service.node_batch_size}}
 updated_nodes_only = {{cfg.service.updated_nodes_only}}
 disable_cidr_filter = {{cfg.service.disable_cidr_filter}}
-cidr_filter = {{cfg.service.cidr_filter}}
+cidr_filter = "{{cfg.service.cidr_filter}}"
 
 [postgres]
 database = "{{cfg.storage.database}}"

--- a/components/data-feed-service/habitat/config/config.toml
+++ b/components/data-feed-service/habitat/config/config.toml
@@ -10,6 +10,8 @@ asset_page_size = {{cfg.service.asset_page_size}}
 reports_page_size = {{cfg.service.reports_page_size}}
 node_batch_size = {{cfg.service.node_batch_size}}
 updated_nodes_only = {{cfg.service.updated_nodes_only}}
+disable_cidr_filter = {{cfg.service.disable_cidr_filter}}
+cidr_filter = {{cfg.service.cidr_filter}}
 
 [postgres]
 database = "{{cfg.storage.database}}"

--- a/components/data-feed-service/habitat/default.toml
+++ b/components/data-feed-service/habitat/default.toml
@@ -21,7 +21,7 @@ accept = false
 
 [log]
 format = "text"
-level = "debug"
+level = "info"
 
 [storage]
 database = "data_feed_service"

--- a/components/data-feed-service/habitat/default.toml
+++ b/components/data-feed-service/habitat/default.toml
@@ -6,10 +6,8 @@ asset_page_size = 100
 reports_page_size = 1000
 node_batch_size = 100
 updated_nodes_only = true
-#disable_cidr_filter = true
-#cidr_filter = "0.0.0.0/0"
-disable_cidr_filter = false
-cidr_filter = "172.18.2.120/29,172.18.2.128/29,172.18.2.140/30,172.18.2.144/30,172.18.2.148/31,172.18.2.150/32"
+disable_cidr_filter = true
+cidr_filter = "0.0.0.0/0"
 
 [tls]
 key_contents =""

--- a/components/data-feed-service/habitat/default.toml
+++ b/components/data-feed-service/habitat/default.toml
@@ -6,6 +6,10 @@ asset_page_size = 100
 reports_page_size = 1000
 node_batch_size = 100
 updated_nodes_only = true
+#disable_cidr_filter = true
+#cidr_filter = "0.0.0.0/0"
+disable_cidr_filter = false
+cidr_filter = "172.18.2.120/29,172.18.2.128/29,172.18.2.140/30,172.18.2.144/30,172.18.2.148/31,172.18.2.150/32"
 
 [tls]
 key_contents =""
@@ -17,7 +21,7 @@ accept = false
 
 [log]
 format = "text"
-level = "info"
+level = "debug"
 
 [storage]
 database = "data_feed_service"

--- a/components/data-feed-service/service/data-feed-poll-task_test.go
+++ b/components/data-feed-service/service/data-feed-poll-task_test.go
@@ -1,0 +1,133 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chef/automate/components/data-feed-service/config"
+)
+
+func TestEmptyFilters(t *testing.T) {
+	serviceConfig := config.ServiceConfig{DisableCIDRFilter: false, CIDRFilter: ""}
+	config := &config.DataFeedConfig{ServiceConfig: serviceConfig}
+	ipNets, err := parseCIDRFilters(config)
+	if err == nil {
+		t.Error("expected error but got nil")
+	}
+	if ipNets != nil {
+		t.Errorf("Expected nil got %s", ipNets)
+	}
+	t.Log("TestEmptyFilters OK")
+}
+
+func TestBadFilter(t *testing.T) {
+	serviceConfig := config.ServiceConfig{DisableCIDRFilter: false, CIDRFilter: "bad filter"}
+	config := &config.DataFeedConfig{ServiceConfig: serviceConfig}
+	ipNets, err := parseCIDRFilters(config)
+	if err == nil {
+		t.Error("expected error but got nil")
+	}
+	if ipNets != nil {
+		t.Errorf("Expected nil got %s", ipNets)
+	}
+	t.Log("TestBadFilter OK")
+}
+
+func TestBadFilters(t *testing.T) {
+	serviceConfig := config.ServiceConfig{DisableCIDRFilter: false, CIDRFilter: "10.0.0.0,bad filter,another"}
+	config := &config.DataFeedConfig{ServiceConfig: serviceConfig}
+	ipNets, err := parseCIDRFilters(config)
+	if err == nil {
+		t.Error("expected error but got nil")
+	}
+	if ipNets != nil {
+		t.Errorf("Expected nil got %s", ipNets)
+	}
+	t.Log("TestBadFilters OK")
+}
+
+func TestDefaultFilter(t *testing.T) {
+	serviceConfig := config.ServiceConfig{DisableCIDRFilter: false, CIDRFilter: "0.0.0.0/0"}
+	config := &config.DataFeedConfig{ServiceConfig: serviceConfig}
+	ipNets, err := parseCIDRFilters(config)
+	if err != nil {
+		t.Errorf("expected nil but got %s", err)
+	}
+	if ipNets == nil {
+		t.Error("Expected ipnet got nil")
+	} else if _, ok := ipNets["0.0.0.0/0"]; !ok {
+		t.Error("Expected 0.0.0.0/0 to be in the ipNets")
+	}
+	t.Log("TestDefaultFilter OK")
+}
+
+func TestInvalidFilter(t *testing.T) {
+	serviceConfig := config.ServiceConfig{DisableCIDRFilter: false, CIDRFilter: "10.0.0.0/50"}
+	config := &config.DataFeedConfig{ServiceConfig: serviceConfig}
+	ipNets, err := parseCIDRFilters(config)
+	if err == nil {
+		t.Error("expected error but got nil")
+	}
+	if ipNets != nil {
+		t.Errorf("Expected nil got %s", ipNets)
+	}
+	t.Log("TestInvalidFilter OK")
+}
+
+func TestValidFilter(t *testing.T) {
+	serviceConfig := config.ServiceConfig{DisableCIDRFilter: false, CIDRFilter: "10.0.0.0/10"}
+	config := &config.DataFeedConfig{ServiceConfig: serviceConfig}
+	ipNets, err := parseCIDRFilters(config)
+	if err != nil {
+		t.Errorf("expected nil but got %s", err)
+	}
+	if ipNets == nil {
+		t.Error("Expected ipnet got nil")
+	} else if _, ok := ipNets["10.0.0.0/10"]; !ok {
+		t.Error("Expected 10.0.0.0/10 to be in the ipNets")
+	}
+	t.Log("TestValidFilter OK")
+}
+
+func TestValidAndInvalidFilters(t *testing.T) {
+	serviceConfig := config.ServiceConfig{DisableCIDRFilter: false, CIDRFilter: "10.0.0.0/10,10.0.0.0/50"}
+	config := &config.DataFeedConfig{ServiceConfig: serviceConfig}
+	ipNets, err := parseCIDRFilters(config)
+	if err == nil {
+		t.Error("expected error but got nil")
+	}
+	if ipNets != nil {
+		t.Errorf("Expected nil got %s", ipNets)
+	}
+	t.Log("TestValidAndInvalidFilters OK")
+}
+
+func TestValidFilters(t *testing.T) {
+	filters := "10.0.0.0/10,192.168.0.0/24,172.18.2.0/32"
+	filterArray := strings.Split(filters, ",")
+	serviceConfig := config.ServiceConfig{DisableCIDRFilter: false, CIDRFilter: filters}
+	config := &config.DataFeedConfig{ServiceConfig: serviceConfig}
+	ipNets, err := parseCIDRFilters(config)
+	if err != nil {
+		t.Errorf("expected nil but got %s", err)
+	}
+	if ipNets == nil {
+		t.Error("Expected ipnet got nil")
+	} else {
+		for filter := range filterArray {
+			if value, ok := ipNets[filterArray[filter]]; !ok {
+				t.Errorf("Expected %s to be in the ipNets", value)
+			}
+		}
+	}
+	t.Log("TestValidFilters OK")
+}
+
+func TestIncludeIPAddressWhenDisableTrue(t *testing.T) {
+	pollTask := &DataFeedPollTask{disableCIDRFilter: true}
+	included := pollTask.includeNode("anything")
+	if !included {
+		t.Error("Expected true")
+	}
+	t.Log("TestIncludeIPAddressWhenDisableTrue OK")
+}

--- a/components/data-feed-service/service/data-feed-service.go
+++ b/components/data-feed-service/service/data-feed-service.go
@@ -77,7 +77,11 @@ func Start(dataFeedConfig *config.DataFeedConfig, connFactory *secureconn.Factor
 		return errors.Wrap(err, "could not connect to secrets-service")
 	}
 
-	dataFeedPollTask := NewDataFeedPollTask(dataFeedConfig, cfgMgmtConn, complianceConn, db, manager)
+	dataFeedPollTask, err := NewDataFeedPollTask(dataFeedConfig, cfgMgmtConn, complianceConn, db, manager)
+	if err != nil {
+		return errors.Wrap(err, "could not create data feed poll task")
+	}
+
 	dataFeedAggregateTask := NewDataFeedAggregateTask(dataFeedConfig, cfgMgmtConn, complianceConn, secretsConn, db)
 
 	err = manager.RegisterWorkflowExecutor(dataFeedWorkflowName, &DataFeedWorkflowExecutor{workflowName: dataFeedWorkflowName, dataFeedConfig: dataFeedConfig, manager: manager})


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Two new configuration options with defaults

disable_cidr_filter = true
cidr_filter = "0.0.0.0/0"

disable_cidr_filter: true/false
cidr_filter: string of csv CIDRS e.g: "172.18.2.120/29,172.18.2.128/29,172.18.2.140/30,172.18.2.144/30,172.18.2.148/31,172.18.2.150/32"

Thus Allowing a user to configure the data-feed-service for a restricted number of nodes using a CIDR block or a number of CIDR blocks.  

The poll task will only include nodes whose ip address is in the defined CIDR ranges, thus only those nodes will be reported in the data feed

### :athletic_shoe: How to Build and Test the Change
Update the config manually and restart the service to test CIDR ranges

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated? NA no docs yet
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
