### PR TITLE
ensure region is always set for aws api integration

### DIFF
--- a/components/compliance-service/inspec-agent/resolver/resolver.go
+++ b/components/compliance-service/inspec-agent/resolver/resolver.go
@@ -343,7 +343,7 @@ func (r *Resolver) handleAwsApiNodesSingleNode(ctx context.Context, m *manager.N
 		UUID:           node.Id,
 		CloudID:        m.AccountId,
 		Name:           node.Name,
-		Environment:    "gcp-api",
+		Environment:    "aws-api",
 		ManagerID:      m.Id,
 		CloudAccountID: m.AccountId,
 	}
@@ -351,6 +351,7 @@ func (r *Resolver) handleAwsApiNodesSingleNode(ctx context.Context, m *manager.N
 		Backend: "aws",
 		Region:  awsCreds.Region,
 	}
+	logrus.Infof("region being used for aws scan: %s", awsCreds.Region)
 	secrets := inspec.Secrets{
 		AwsUser:         awsCreds.AccessKeyId,
 		AwsPassword:     awsCreds.SecretAccessKey,

--- a/components/nodemanager-service/managers/managers.go
+++ b/components/nodemanager-service/managers/managers.go
@@ -42,6 +42,9 @@ func GetAWSCreds(secret *secrets.Secret) awsec2.AwsCreds {
 			logrus.Errorf("GetAwsCreds insufficient creds available; len(accessKeyID) %d len(secretKey) %d", len(accessKeyID), len(secretKey))
 		}
 	}
+	if len(region) == 0 {
+		region = awsec2.DefaultRegion
+	}
 	return awsec2.AwsCreds{
 		AccessKeyId:     accessKeyID,
 		SecretAccessKey: secretKey,

--- a/components/nodemanager-service/managers/managers_test.go
+++ b/components/nodemanager-service/managers/managers_test.go
@@ -1,0 +1,41 @@
+package managers
+
+import (
+	"testing"
+
+	"github.com/chef/automate/api/external/common/query"
+	"github.com/chef/automate/api/external/secrets"
+	"github.com/chef/automate/components/nodemanager-service/managers/awsec2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAWSCredsSetsDefaultRegionWhenNone(t *testing.T) {
+	secret := &secrets.Secret{
+		Data: []*query.Kv{
+			{Key: "AWS_ACCESS_KEY_ID", Value: "fake-1"},
+			{Key: "AWS_SECRET_ACCESS_KEY", Value: "fake-2"},
+		},
+	}
+	creds := GetAWSCreds(secret)
+	assert.Equal(t, awsec2.AwsCreds{
+		AccessKeyId:     "fake-1",
+		SecretAccessKey: "fake-2",
+		Region:          "us-east-1",
+	}, creds)
+}
+
+func TestGetAWSCredsSetsRegionWhenProvided(t *testing.T) {
+	secret := &secrets.Secret{
+		Data: []*query.Kv{
+			{Key: "AWS_ACCESS_KEY_ID", Value: "fake-1"},
+			{Key: "AWS_SECRET_ACCESS_KEY", Value: "fake-2"},
+			{Key: "AWS_REGION", Value: "user-provided-region"},
+		},
+	}
+	creds := GetAWSCreds(secret)
+	assert.Equal(t, awsec2.AwsCreds{
+		AccessKeyId:     "fake-1",
+		SecretAccessKey: "fake-2",
+		Region:          "user-provided-region",
+	}, creds)
+}

--- a/components/nodemanager-service/tests/scanjob_aws_api_integration_test.go
+++ b/components/nodemanager-service/tests/scanjob_aws_api_integration_test.go
@@ -116,6 +116,7 @@ func TestAWSAPIScanJob(t *testing.T) {
 	}
 	// ensure the job
 	require.Equal(t, "completed", status)
+	t.Logf("job status: %s", status)
 
 	// check reporting nodes. if job completed we should have an extra node in reporting nodes
 	reportingNodes, err := reportingClient.ListNodes(ctx, &reporting.Query{})
@@ -144,6 +145,7 @@ func TestAWSAPIScanJob(t *testing.T) {
 		require.NoError(t, err)
 		if endtime.After(now) && listNode.GetEnvironment() == "aws-api" {
 			awsApiNodeFound = true
+			t.Log("aws api node found")
 			t.Logf("Beginning test time: %s", now)
 			t.Logf("Found node %s, end time: %s", listNode, endtime)
 			// check `/nodes` endpoint to ensure node marked as reachable

--- a/components/nodemanager-service/tests/scanjob_aws_api_integration_test.go
+++ b/components/nodemanager-service/tests/scanjob_aws_api_integration_test.go
@@ -138,10 +138,12 @@ func TestAWSAPIScanJob(t *testing.T) {
 		"expected reportingNodes.Total (%d) > originalReportingNodes.Total (%d)",
 		reportingNodes.GetTotal(), originalReportingNodes.GetTotal())
 
+	awsApiNodeFound := false
 	for _, listNode := range reportingNodes.GetNodes() {
 		endtime, err := ptypes.Timestamp(listNode.GetLatestReport().GetEndTime())
 		require.NoError(t, err)
 		if endtime.After(now) && listNode.GetEnvironment() == "aws-api" {
+			awsApiNodeFound = true
 			t.Logf("Beginning test time: %s", now)
 			t.Logf("Found node %s, end time: %s", listNode, endtime)
 			// check `/nodes` endpoint to ensure node marked as reachable
@@ -150,4 +152,5 @@ func TestAWSAPIScanJob(t *testing.T) {
 			require.Equal(t, "reachable", foundNode.GetStatus())
 		}
 	}
+	require.Equal(t, true, awsApiNodeFound)
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
this issue was reported in slack

a user found that all controls for the aws profile had results like "region value is not set/missing". they also noticed the env value was being set to gcp-api

this change fixes the env region to be the correct "aws-api" and ensures that the region gets set when calling the awscreds function

### :+1: Definition of Done
aws api scans working

### :athletic_shoe: How to Build and Test the Change
add a node integration for aws (https://github.com/chef/automate/blob/master/components/compliance-service/scripts/create-pg-data.sh#L144)
run a scan job on it, see the error about missing region
rebuild compliance and nodemanager
run scan again, no region error, just normal results

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [n/a] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
<img width="1220" alt="Screen Shot 2020-03-24 at 13 57 20" src="https://user-images.githubusercontent.com/10341541/77471152-6d74f880-6dd7-11ea-84bc-5da59c4bf1f0.png">
