### PR TITLE
Make pending edits apply to multi-user environment

### DIFF
--- a/components/automate-ui/src/app/entities/projects/project.effects.ts
+++ b/components/automate-ui/src/app/entities/projects/project.effects.ts
@@ -49,7 +49,7 @@ import { applyRulesStatus } from './project.selectors';
 import { ApplyRulesStatusState } from './project.reducer';
 
 const ACTIVE_RULE_STATUS_INTERVAL = 5; // seconds between checks while update is in progress
-const DORMANT_RULE_STATUS_INTERVAL = 60; // seconds between checks while update is dormant
+const DORMANT_RULE_STATUS_INTERVAL = 120; // seconds between checks while update is dormant
 
 @Injectable()
 export class ProjectEffects {
@@ -219,7 +219,11 @@ export class ProjectEffects {
     filter(([[_, isV2], { state }]) =>
       isV2 && state === ApplyRulesStatusState.NotRunning
     ),
-    switchMap(this.getRulesStatus$()));
+    switchMap(() => [
+      new GetProjects(),
+      new GetApplyRulesStatus()
+    ]),
+    catchError((error: HttpErrorResponse) => observableOf(new GetApplyRulesStatusFailure(error))));
 
   private getRulesStatus$(): () => Observable<ProjectActions> {
     return () => this.requests.getApplyRulesStatus().pipe(


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The prior fix (#3100) made "pending edits" status appear promptly for a newly logged-in user, but neglected to handle if edits _become_ pending while a user is logged in.

This modifies the rules status polling to also include a project fetch, which is used to determine whether edits are pending.
Also changing the interval from 1 to 2 minutes just to keep overhead to a minimum.

### :chains: Related Resources
PR #3100 Show pending edits bar promptly on login.

### :+1: Definition of Done
If rules are modified by another user, either in the UI or command line,
all other users are notified within 2 minutes.

### :athletic_shoe: How to Build and Test the Change
1. rebuild automate-ui
2. login and create a project. Let's call this browser A. Just to show there's nothing up the sleeve, navigate to some innocuous page (e.g. Compliance) that has nothing to do with projects or rules per se.
3. make sure no edits are pending; if so, apply updates so the <kbd>edits pending</kbd> bar goes away.
4. Keeping that session open, go to either the command line or another browser window.

**In a browser:**
5. Login to a new browser window as a different user; let's call this browser B. Add or update a rule so that the rule is marked <kbd>edits pending</kbd>. Also, the <kbd>edits pending</kbd> bar should appear immediately for this user in browser B. Check back in browser A. The <kbd>edits pending</kbd> should appear spontaneously within 2 minutes--regardless of which page was currently visible in the browser.

**From the command-line:**
6. Add or update a rule from the command-line. Check back in browser A. The <kbd>edits pending</kbd> should appear spontaneously within 2 minutes --regardless of which page was currently visible in the browser.
Here is an example command-line request to create a rule, assuming `project-p1` exists:
```
curl -sSkH "api-token: $TOK" $TARGET_HOST/apis/iam/v2/projects/project-p1/rules?pretty -d \
"$(jq -n '{ id: "rule-1", name: "rule 1",  type: "NODE",  conditions: [{ operator: "MEMBER_OF", attribute: "CHEF_SERVER", values: ["prod", "staging"]}]}')"
```

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/6817500/77479850-cd6e9d80-6ddd-11ea-9f55-9dba28ffb828.png">

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
