### PR TITLE
ensure the region is set for credentialless node integrations

### DIFF
--- a/components/compliance-service/inspec-agent/resolver/resolver.go
+++ b/components/compliance-service/inspec-agent/resolver/resolver.go
@@ -356,10 +356,18 @@ func assembleAwsApiNodeInfo(node *nodes.Node, m *manager.NodeManager, awsCreds a
 		ManagerID:      m.Id,
 		CloudAccountID: m.AccountId,
 	}
+	// we want to prioritize using the region as it was saved
+	// in the credential for the nodemanager
 	region := awsCreds.Region
-	if len(awsCreds.Region) == 0 {
+	if len(region) == 0 && node.TargetConfig != nil {
+		// set region to the value saved on the node's target config
+		region = node.TargetConfig.Region
+	}
+	if len(region) == 0 {
+		// no other values found, set to default
 		region = awsec2.DefaultRegion
 	}
+
 	tc := inspec.TargetBaseConfig{
 		Backend: "aws",
 		Region:  region,

--- a/components/compliance-service/inspec-agent/resolver/resolver_test.go
+++ b/components/compliance-service/inspec-agent/resolver/resolver_test.go
@@ -8,11 +8,57 @@ import (
 	"github.com/chef/automate/api/interservice/compliance/common"
 	"github.com/chef/automate/api/interservice/compliance/jobs"
 	"github.com/chef/automate/api/interservice/nodemanager/manager"
+	"github.com/chef/automate/api/interservice/nodemanager/nodes"
 	"github.com/chef/automate/components/compliance-service/inspec"
+	"github.com/chef/automate/components/nodemanager-service/managers/awsec2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func TestAssembleAwsApiNodeInfo(t *testing.T) {
+	node := &nodes.Node{
+		Id:   "123",
+		Name: "test-node-name",
+	}
+	m := &manager.NodeManager{
+		Id:        "12300",
+		Name:      "test-name",
+		AccountId: "1234",
+	}
+	awsCreds := awsec2.AwsCreds{
+		AccessKeyId:     "456",
+		SecretAccessKey: "789",
+		Region:          "test-region",
+	}
+	nodeDetails, tc, secrets := assembleAwsApiNodeInfo(node, m, awsCreds)
+
+	assert.Equal(t, nodeInfo{
+		UUID:           "123",
+		CloudID:        "1234",
+		Name:           "test-node-name",
+		Environment:    "aws-api",
+		ManagerID:      "12300",
+		CloudAccountID: "1234",
+	}, nodeDetails)
+
+	assert.Equal(t, inspec.TargetBaseConfig{
+		Backend: "aws",
+		Region:  "test-region",
+	}, tc)
+
+	assert.Equal(t, inspec.Secrets{
+		AwsUser:     "456",
+		AwsPassword: "789",
+	}, secrets)
+
+	// test the case when no creds were provided
+	awsCreds = awsec2.AwsCreds{}
+	nodeDetails, tc, secrets = assembleAwsApiNodeInfo(node, m, awsCreds)
+	assert.Equal(t, inspec.TargetBaseConfig{
+		Backend: "aws",
+		Region:  "us-east-1",
+	}, tc)
+}
 func TestHandleSSMNodes(t *testing.T) {
 	ssmJob, skip := false, false
 	node := &manager.ManagerNode{

--- a/components/compliance-service/inspec-agent/resolver/resolver_test.go
+++ b/components/compliance-service/inspec-agent/resolver/resolver_test.go
@@ -58,6 +58,16 @@ func TestAssembleAwsApiNodeInfo(t *testing.T) {
 		Backend: "aws",
 		Region:  "us-east-1",
 	}, tc)
+
+	node.TargetConfig = &nodes.TargetConfig{
+		Region: "node-set-region",
+	}
+	nodeDetails, tc, secrets = assembleAwsApiNodeInfo(node, m, awsCreds)
+	assert.Equal(t, inspec.TargetBaseConfig{
+		Backend: "aws",
+		Region:  "node-set-region",
+	}, tc)
+
 }
 func TestHandleSSMNodes(t *testing.T) {
 	ssmJob, skip := false, false

--- a/components/nodemanager-service/pgdb/node-managers-cloud.go
+++ b/components/nodemanager-service/pgdb/node-managers-cloud.go
@@ -98,7 +98,7 @@ func (db *DB) AddManagerSubscriptionsToDB(subs []*manager.ManagerNode, managerId
 	return nodeIds
 }
 
-func (db *DB) AddManagerNodeToDB(managerId string, managerAcctId string, credential string, acctAlias string) ([]string, error) {
+func (db *DB) AddManagerNodeToDB(managerId string, managerAcctId string, credential string, acctAlias string, region string) ([]string, error) {
 	nodeIds := make([]string, 0)
 	var name string
 	uuid := uuid.Must(uuid.NewV4()).String()
@@ -109,7 +109,7 @@ func (db *DB) AddManagerNodeToDB(managerId string, managerAcctId string, credent
 	}
 	tc := nodes.TargetConfig{
 		Backend: "aws",
-		Region:  "us-east-1",
+		Region:  region,
 	}
 	jsonTc, err := json.Marshal(tc)
 	if err != nil {

--- a/components/nodemanager-service/pgdb/node_managers_cloud_integration_test.go
+++ b/components/nodemanager-service/pgdb/node_managers_cloud_integration_test.go
@@ -211,7 +211,7 @@ func (suite *NodeManagersAndNodesDBSuite) TestAddManagerNodeToDBAddsANodeWithCor
 		suite.FailNow(err.Error())
 	}
 
-	nodeIds, err := suite.Database.AddManagerNodeToDB(mgrId, "242403433", secretId, "account alias")
+	nodeIds, err := suite.Database.AddManagerNodeToDB(mgrId, "242403433", secretId, "account alias", "us-east-1")
 	if err != nil {
 		suite.FailNow(err.Error())
 	}
@@ -587,7 +587,7 @@ func (suite *NodeManagersAndNodesDBSuite) TestAddManagerNodeToDBResetsManagerFie
 		suite.FailNow(err.Error())
 	}
 
-	nodeIds, err := suite.Database.AddManagerNodeToDB(mgrId, "242403433", secretId, "account alias")
+	nodeIds, err := suite.Database.AddManagerNodeToDB(mgrId, "242403433", secretId, "account alias", "us-west-1")
 	if err != nil {
 		suite.FailNow(err.Error())
 	}
@@ -615,7 +615,7 @@ func (suite *NodeManagersAndNodesDBSuite) TestAddManagerNodeToDBResetsManagerFie
 		suite.FailNow(err.Error())
 	}
 
-	nodeIds, err = suite.Database.AddManagerNodeToDB(mgrId, "242403433", secretId, "account alias")
+	nodeIds, err = suite.Database.AddManagerNodeToDB(mgrId, "242403433", secretId, "account alias", "us-east-2")
 	if err != nil {
 		suite.FailNow(err.Error())
 	}
@@ -636,7 +636,7 @@ func (suite *NodeManagersAndNodesDBSuite) TestAddManagerNodeToDBName() {
 		suite.FailNow(err.Error())
 	}
 
-	nodeIds, err := suite.Database.AddManagerNodeToDB(mgrId, "242403433", secretId, "")
+	nodeIds, err := suite.Database.AddManagerNodeToDB(mgrId, "242403433", secretId, "", "us-east-1")
 	if err != nil {
 		suite.FailNow(err.Error())
 	}
@@ -649,7 +649,7 @@ func (suite *NodeManagersAndNodesDBSuite) TestAddManagerNodeToDBName() {
 
 	suite.Equal("aws-account-242403433", n.Name)
 
-	nodeIds, err = suite.Database.AddManagerNodeToDB(mgrId, "242403433", secretId, "a cool alias")
+	nodeIds, err = suite.Database.AddManagerNodeToDB(mgrId, "242403433", secretId, "a cool alias", "us-west-2")
 	if err != nil {
 		suite.FailNow(err.Error())
 	}
@@ -661,6 +661,7 @@ func (suite *NodeManagersAndNodesDBSuite) TestAddManagerNodeToDBName() {
 	}
 
 	suite.Equal("aws-account-a cool alias", n.Name)
+	suite.Equal("us-west-2", n.TargetConfig.Region)
 
 }
 func (suite *NodeManagersAndNodesDBSuite) TestRemoveStaleNodeAssociationsUpdatesOrphanNodes() {

--- a/components/nodemanager-service/server/manager/server.go
+++ b/components/nodemanager-service/server/manager/server.go
@@ -659,7 +659,7 @@ func (srv *Server) addNodeForAccount(ctx context.Context, managerId string, mana
 		// the user may have never set an alias for their account, and that's ok, but we should log it out
 		logrus.Warnf("addNodeForAccount; no account aliases found for manager: %s", managerName)
 	}
-	nodeIds, err := srv.DB.AddManagerNodeToDB(managerId, managerAcctId, credential, acctAlias)
+	nodeIds, err := srv.DB.AddManagerNodeToDB(managerId, managerAcctId, credential, acctAlias, myaws.Region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Victoria Jeffrey <vjeffrey@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
follow up to https://github.com/chef/automate/pull/3194

that one fixed the case for aws api integrations that use credentials.
it unfortunately missed the case for when we read creds from cloud env
