### PR TITLE
Automate-2545 Profile List Waivers

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.html
@@ -7,6 +7,42 @@
 </div>
 
 <ng-container *ngIf="!reportData.profilesListEmpty">
+  <chef-phat-radio
+    class="profiles-list-status-filters"
+    [value]="profileFilterStatus"
+    (change)="filterProfileStatus($event, $event.target.value)">
+    <chef-option class="filter all" value='all'>
+      <span class="filter-label">Total Profiles</span>
+      <span class="filter-total">
+        <chef-icon class="filter-icon">storage</chef-icon> {{ reportData.profilesList.total | number}}
+      </span>
+    </chef-option>
+    <chef-option class="filter critical" value='failed'>
+      <span class="filter-label">Failed Profiles</span>
+      <span class="filter-total">
+        <chef-icon class="filter-icon">report_problem</chef-icon> {{ reportData.profilesList.failed | number}}
+      </span>
+    </chef-option>
+    <chef-option class="filter passed" value='passed'>
+      <span class="filter-label">Passed Profiles</span>
+      <span class="filter-total">
+        <chef-icon class="filter-icon">check_circle</chef-icon> {{ reportData.profilesList.passed | number}}
+      </span>
+    </chef-option>
+    <chef-option class="filter skipped" value='skipped'>
+      <span class="filter-label">Skipped Profiles</span>
+      <span class="filter-total">
+        <chef-icon class="filter-icon">help</chef-icon> {{ reportData.profilesList.skipped | number}}
+      </span>
+    </chef-option>
+    <chef-option class="filter waived" value='waived'>
+      <span class="filter-label">Waived Profiles</span>
+      <span class="filter-total">
+        <div class="filter-icon waived-icon"></div> {{ reportData.profilesList.waived | number}}
+      </span>
+    </chef-option>
+  </chef-phat-radio>
+
   <chef-table class="reporting-profiles-table" (sort-toggled)="onProfilesListSortToggled($event)">
     <chef-thead>
       <chef-tr>
@@ -20,7 +56,7 @@
       </chef-tr>
     </chef-thead>
     <chef-tbody *ngIf="!reportData.profilesListLoading">
-      <chef-tr *ngFor="let profile of reportData.profilesList.items">
+      <chef-tr *ngFor="let profile of filteredProfiles(reportData.profilesList.items)">
         <chef-td class="title-cell">
           <!-- Material Icon Font -->
           <chef-icon *ngIf="profile.status !== 'waived'" class="status-icon" [ngClass]="profile.status">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.scss
@@ -1,5 +1,87 @@
 @import "~styles/variables";
 
+.profiles-list-status-filters {
+  display: flex;
+  margin: 35px;
+  align-items: center;
+
+  ::ng-deep .filter {
+    font-size: 14px;
+    height: auto;
+
+    &::before {
+      display: none;
+    }
+
+    .option-content {
+      display: flex;
+      padding: 0;
+      flex-direction: column;
+    }
+
+    .filter-total {
+      display: flex;
+      align-items: center;
+
+      .filter-icon {
+        margin: -2px 0.5em 0 0;
+      }
+    }
+
+    &.selected {
+      background: blue;
+
+      .filter-label,
+      .filter-total,
+      .filter-total chef-icon {
+        color: $chef-white;
+      }
+
+      &.all  {
+        background: $chef-primary-bright;
+      }
+
+      &.critical  {
+        background: $chef-critical;
+      }
+
+      &.skipped  {
+        background: $chef-dark-grey;
+      }
+
+      &.passed  {
+        background: $chef-success;
+      }
+
+      &.waived  {
+        background: $chef-dark-grey;
+      }
+    }
+
+    &:not(.selected) {
+      &.all .filter-total  {
+        color: $chef-primary-bright;
+      }
+
+      &.critical .filter-total  {
+        color: $chef-critical;
+      }
+
+      &.skipped .filter-total  {
+        color: $chef-dark-grey;
+      }
+
+      &.passed .filter-total  {
+        color: $chef-success;
+      }
+
+      &.waived .filter-total  {
+        color: $chef-dark-grey;
+      }
+    }
+  }
+}
+
 .reporting-profiles-table {
   margin: 2em 35px 0;
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profiles/reporting-profiles.component.ts
@@ -23,6 +23,7 @@ export class ReportingProfilesComponent implements OnInit, OnDestroy {
   layerOneData: any = {};
   layerTwoData: any = {};
   control: any = {};
+  profileFilterStatus = 'all';
 
   scanResultsPane = 0;
   openControls = {};
@@ -48,6 +49,20 @@ export class ReportingProfilesComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
+  }
+
+  filterProfileStatus(_event, status) {
+    this.profileFilterStatus = status;
+  }
+
+  isProfileStatusSelected(status): boolean {
+    return this.profileFilterStatus === status;
+  }
+
+  filteredProfiles(profiles) {
+    return this.profileFilterStatus === 'all'
+      ? profiles
+      : profiles.filter((profile) => profile.status === this.profileFilterStatus);
   }
 
   onProfilesListPageChanged(event) {

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
@@ -42,7 +42,11 @@ export class ReportDataService {
   profilesListEmpty = false;
   profilesList: any = {
     items: [],
-    total: 0
+    total: 0,
+    failed: 0,
+    passed: 0,
+    skipped: 0,
+    waived: 0
   };
 
   controlsListLoading = true;

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
@@ -90,12 +90,32 @@ describe('StatsService', () => {
       const listParams = {perPage: 10, page: 1};
 
       const expectedUrl = `${COMPLIANCE_URL}/reporting/profiles`;
-      const expectedTotal = 20;
+      const expectedTotal = 21;
+      const expectedFailed = 3;
+      const expectedPassed = 10;
+      const expectedSkipped = 7;
+      const expectedWaived = 1;
       const expectedItems = [{}, {}];
-      const mockResp = { profiles: expectedItems, counts: { total: expectedTotal }};
+      const mockResp = {
+        profiles: expectedItems,
+        counts: {
+          total: expectedTotal,
+          failed: expectedFailed,
+          passed: expectedPassed,
+          skipped: expectedSkipped,
+          waived: expectedWaived
+        }
+      };
 
       service.getProfiles(reportQuery, listParams).subscribe(data => {
-        expect(data).toEqual({total: expectedTotal, items: expectedItems});
+        expect(data).toEqual({
+          total: expectedTotal,
+          failed: expectedFailed,
+          passed: expectedPassed,
+          skipped: expectedSkipped,
+          waived: expectedWaived,
+          items: expectedItems
+        });
       });
 
       const req = httpTestingController.expectOne(expectedUrl);

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -134,7 +134,8 @@ export class StatsService {
     }
 
     return this.httpClient.post<any>(url, body).pipe(
-      map(({ profiles, counts: { total }}) => ({total, items: profiles})));
+      map(({ profiles, counts: { total, failed, passed, skipped, waived } }) =>
+        ({ total, failed, passed, skipped, waived, items: profiles })));
   }
 
   getControls(reportQuery: ReportQuery) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As an Automate User, I will use this work when I want to see which profiles have been waived.

In the rare case, if a profile has all waived controls within it, we need to show that the profile itself has been waived.

### :chains: Related Resources
https://github.com/chef/automate/issues/2545

### :+1: Definition of Done
1. A user can see if a Profile is waived based on the new status that the API returns for a profile
2. A user can filter by status of Waived

### :athletic_shoe: How to Build and Test the Change
load data by using the `load_compliance_reports` command from your studio dev env

### :camera: Screenshots, if applicable
![Screen Shot 2020-03-25 at 10 02 30 AM](https://user-images.githubusercontent.com/4108100/77551011-c8fac100-6e7f-11ea-9930-2f492a44d0b5.png)
![Screen Shot 2020-03-25 at 10 02 37 AM](https://user-images.githubusercontent.com/4108100/77551013-cac48480-6e7f-11ea-8465-ba76c8063950.png)
