### PR TITLE
Automate 2544 2543 Control List Waived

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.html
@@ -49,7 +49,7 @@
               <div class="control-waiver-details" *ngFor="let waiver of control.waivers">
                 <div class="waiver-details">
                   <span class="label">Expires:</span>
-                  <span class="message">{{ waiver.expiration_date | datetime:'ddd, D MMMM YYYY HH:mm:ss [UTC]' }}</span>
+                  <span class="message">{{ waiver.expiration_date | datetime: Datetime.RFC2822 }}</span>
                 </div>
                 <div class="waiver-details">
                   <span class="label">Reason:</span>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.html
@@ -41,6 +41,39 @@
             <chef-icon>help</chef-icon>
             <span>{{ summary.skipped.total | number }}</span>
           </span>
+          <span *ngIf="summary.waived.total > 0" class="control-result" [ngClass]="{'waived': summary.waived.total > 0}">
+            <div [attr.id]="'waived-icon' + control.id" class="waived-icon"></div>
+            <chef-tooltip
+              [attr.for]="'waived-icon' + control.id"
+              position="left">
+              <div class="control-waiver-details" *ngFor="let waiver of control.waivers">
+                <div class="waiver-details">
+                  <span class="label">Expires:</span>
+                  <span class="message">{{ waiver.expiration_date | datetime:'ddd, D MMMM YYYY HH:mm:ss [UTC]' }}</span>
+                </div>
+                <div class="waiver-details">
+                  <span class="label">Reason:</span>
+                  <span class="message">{{ waiver.justification }}</span>
+                </div>
+                <div *ngIf="waiver.waived_str === 'yes_run'" class="waiver-details">
+                  <span class="label">Node Status:</span>
+                  <span class="status-details failed">
+                    <chef-icon>report_problem</chef-icon>
+                    <span>{{ waiver.waiver_summary.failed.total | number }}</span>
+                  </span>
+                  <span class="status-details passed">
+                    <chef-icon>check_circle</chef-icon>
+                    <span>{{ waiver.waiver_summary.passed.total | number }}</span>
+                  </span>
+                  <span class="status-details skipped">
+                    <chef-icon>help</chef-icon>
+                    <span>{{ waiver.waiver_summary.skipped.total | number }}</span>
+                  </span>
+                </div>
+              </div>
+            </chef-tooltip>
+            <span>{{ summary.waived.total | number }}</span>
+          </span>
         </chef-td>
         <chef-td class="actions-cell three-dot-column">
           <mat-select panelClass="chef-control-menu">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.scss
@@ -25,11 +25,15 @@
     align-items: center;
     color: $chef-grey;
 
+    .waived-icon:before {
+      color: $chef-white;
+    }
+
     &:last-child {
       margin-right: 0;
     }
 
-    chef-icon {
+    chef-icon, .waived-icon {
       margin-right: 5px;
     }
   }
@@ -49,6 +53,14 @@
       color: $chef-dark-grey;
     }
 
+    &.waived {
+      color: $chef-darkest;
+
+      .waived-icon:before {
+        color: inherit;
+      }
+    }
+
     &.critical {
       color: $chef-critical;
     }
@@ -66,4 +78,49 @@
 .item-count-warning {
   margin: 35px 0;
   text-align: center;
+}
+
+chef-tooltip {
+  width: 400px;
+}
+
+.control-waiver-details {
+  border-bottom: 1px solid $chef-grey;
+  font-size: 14px;
+  padding-bottom: 15px;
+
+  &:last-of-type {
+    border: none;
+    padding-top: 10px;
+  }
+
+  .waiver-details {
+    .label {
+      display: inline-block;
+      font-weight: bold;
+      line-height: 8px;
+      text-align: left;
+      width: 105px;
+    }
+
+    .status-details {
+      display: inline-flex;
+      margin-right: 1em;
+      align-items: center;
+
+      &.failed {
+        color: $chef-critical;
+      }
+
+      &.passed {
+        color: $chef-success;
+      }
+
+      &.skipped {
+        color: $chef-dark-grey;
+      }
+
+    }
+  }
+
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-controls/reporting-controls.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 import { ReportQueryService, ReportDataService, ReportQuery } from '../../shared/reporting';
 
@@ -12,6 +13,7 @@ import { ReportQueryService, ReportDataService, ReportQuery } from '../../shared
 })
 export class ReportingControlsComponent implements OnInit, OnDestroy {
 
+  public Datetime = DateTime;
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
   constructor(


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As an Automate User, I will use this work when I want to more details about the waived controls.

We need a way to show the Reason why a waiver was set, the (if applicable) the expiration date, and (if ran) the status of nodes that were waived.
Sometimes, there may be multiple waivers used with the same control and we need a way to reflect that.

### :chains: Related Resources
https://github.com/chef/automate/issues/2544
https://github.com/chef/automate/issues/2543

### :+1: Definition of Done
- We need a way to show the Reason why a waiver was set, the (if applicable) the expiration date, and (if ran) the status of nodes that were waived.
- Sometimes, there may be multiple waivers used with the same control and we need a way to reflect that.

A user can go to the Control List view, hover over the waived icon on any control that was waived and view the:
a. Expiration Date
b. Reason for being waived
c. [conditional] if it was ran, then show the nodes status in the hover dialogue, but do not show that control as passed or failed or skipped on the control row.

if a control, under "control_summary" has more than 0 waived nodes, show the waived icon with the count as shown above

### :athletic_shoe: How to Build and Test the Change
load data with load_compliance_reports

### :camera: Screenshots, if applicable
![Screen Shot 2020-03-25 at 1 32 01 PM](https://user-images.githubusercontent.com/4108100/77573602-eb500700-6e9e-11ea-966f-c40cf812ab26.png)
![Screen Shot 2020-03-25 at 1 32 14 PM](https://user-images.githubusercontent.com/4108100/77573604-ebe89d80-6e9e-11ea-9e2c-e62aa3b690e2.png)
