### PR TITLE
Dan/refactor studio infra data gen

### DIFF
--- a/.studio/automate-gateway
+++ b/.studio/automate-gateway
@@ -51,6 +51,13 @@ function gateway_integration() {
   set +o pipefail # reset
 }
 
+document "get_service_versions" <<DOC
+  Get all the service versions running in automate
+DOC
+function get_service_versions() {
+  curl -f --insecure -H "api-token: $(get_api_token)" "${GATEWAY_URL}/deployment/service_versions"
+}
+
 document "gateway_version" <<DOC
   Display the automate-gateway service version.
 
@@ -133,6 +140,24 @@ function send_chef_action_example() {
     --data "@-" "${GATEWAY_URL}${endpoint}" <<< "$tmp_action_json"
 }
 
+document "generate_chef_run_example" <<DOC
+  Generates a unique Chef run report by updating the example document with new
+  UUIDS.
+
+  Example: Generate the document and pretty print:
+  ------------------------------------------------
+  generate_chef_run_example | jq .
+
+  Example: Generate the document and send to automate:
+  ----------------------------------------------------
+  generate_chef_run_example | send_chef_data_raw
+DOC
+function generate_chef_run_example() {
+  local node_name="insights.success.$((RANDOM % 100))"
+  local examples_json_path=${JSON_FILE:-/src/components/ingest-service/examples/converge-success-report.json}
+  uniqify_chef_run_report "$node_name" < "$examples_json_path"
+}
+
 document "send_chef_run_example" <<DOC
   Send the example chef run message to the chef run rest endpoint.
 
@@ -157,27 +182,14 @@ document "send_chef_run_example" <<DOC
 DOC
 # shellcheck disable=SC2120
 function send_chef_run_example() {
-  install_if_missing core/curl curl
+  generate_chef_run_example | send_chef_data_raw "$1"
+}
 
-  local examples_json_path=${JSON_FILE:-/src/components/ingest-service/examples/converge-success-report.json}
-
-  if [[ "$1" == "legacy" ]]; then
-    endpoint=${GATEWAY_URL}"/events/data-collector"
-  elif [[ "$1" == "lb" ]]; then
-    endpoint="https://localhost/data-collector/v0"
-  else
-    endpoint=${GATEWAY_URL}"/ingest/events/chef/run"
-  fi
-
-  uuid=$(uuidgen)
-  entity_uuid=$(uuidgen)
-
-  tmp_ccr_json="$(jq --arg id "$uuid" '.id = $id' <"$examples_json_path")"
-  tmp_ccr_json="$(echo "$tmp_ccr_json" | jq --arg id "$entity_uuid" '.entity_uuid = $id')"
-
-  echo "$tmp_ccr_json" \
-       | curl -f --insecure -H "api-token: $(get_admin_token)" \
-       --data "@-" "${endpoint}"
+document "generate_chef_run_start_example" <<DOC
+  Returns a chef run start document from the examples.
+DOC
+function generate_chef_run_start_example() {
+  cat /src/components/ingest-service/examples/chef_client_run_start.json
 }
 
 document "send_chef_run_start_example" <<DOC
@@ -196,26 +208,32 @@ document "send_chef_run_start_example" <<DOC
   # send_chef_run_start_example lb
 DOC
 function send_chef_run_start_example() {
-  install_if_missing core/curl curl
-
-  local examples_path="/src/components/ingest-service/examples"
-  if [[ "$1" == "legacy" ]]; then
-    endpoint=${GATEWAY_URL}"/events/data-collector"
-  elif [[ "$1" == "lb" ]]; then
-    endpoint="https://localhost/data-collector/v0"
-  else
-    endpoint=${GATEWAY_URL}"/ingest/events/chef/run"
-  fi
-
-  curl -f --insecure -H "api-token: $(get_api_token)" \
-       --data @$examples_path/chef_client_run_start.json "${endpoint}"
+  generate_chef_run_start_example | send_chef_data_raw "$1"
 }
 
-document "get_service_versions" <<DOC
-  Get all the service versions running in automate
+# shellcheck disable=SC2154
+document "generate_chef_run_failure_example" <<DOC
+  Generate a unique chef run failure report by updating the example with new
+  UUIDs and times/dates. You can send it automate directly or modify it as you
+  wish.
+
+  Example: Send a Chef Run example to the new ingest endpoint:
+  --------------------------------------------------------
+  # generate_chef_run_failure_example | send_chef_data_raw
+
+  Example: Generate run data and modify it
+  --------------------------------------------------------
+  # generate_chef_run_failure_example | jq --arg error_message "example error1" '.error.message = $error_message'
+
+  Example: Generate run data, modify it, and send it to ingest
+  --------------------------------------------------------
+  generate_chef_run_failure_example | jq --arg error_message "example error1" '.error.message = $error_message' | send_chef_data_raw
 DOC
-function get_service_versions() {
-  curl -f --insecure -H "api-token: $(get_api_token)" "${GATEWAY_URL}/deployment/service_versions"
+# shellcheck disable=SC2120
+function generate_chef_run_failure_example() {
+  local node_name="node_failed_$((RANDOM % 100))"
+  local examples_path="/src/components/ingest-service/examples"
+  uniqify_chef_run_report "$node_name" < $examples_path/converge-failure-report.json
 }
 
 document "send_chef_run_failure_example" <<DOC
@@ -226,27 +244,14 @@ document "send_chef_run_failure_example" <<DOC
   # send_chef_run_failure_example legacy
 DOC
 function send_chef_run_failure_example() {
-  install_if_missing core/curl curl
-  install_if_missing core/jq-static jq
+  generate_chef_run_failure_example| send_chef_data_raw "$1"
+}
 
-  local run_uuid
-  run_uuid=$(uuidgen)
-  local node_uuid
-  node_uuid=$(uuidgen)
-
-  local node_name="node_failed_$((RANDOM % 100))"
-  local rfc_time
-  rfc_time=$(date +%FT%TZ -d "$((RANDOM % 144)) hour ago")
-
-  local examples_path="/src/components/ingest-service/examples"
-  [[ "$1" == "legacy" ]] && endpoint="/events/data-collector" || endpoint="/ingest/events/chef/run"
-
-  # Update the IDs, names, and dates
-  tmp_ccr_json="$(jq --arg rfc_time "$rfc_time" --arg run_uuid "$run_uuid" --arg node_name "$node_name" --arg node_uuid "$node_uuid" '.end_time = $rfc_time | .start_time = $rfc_time | .entity_uuid = $node_uuid | .id = $run_uuid | .run_id = $run_uuid | .node_name = $node_name' <$examples_path/converge-failure-report.json)"
-
-  echo "$tmp_ccr_json" \
-       | curl -f --insecure -H "api-token: $(get_api_token)" \
-       --data "@-" "${GATEWAY_URL}${endpoint}"
+document "generate_chef_liveness_example" <<DOC
+  Prints the example chef liveness message to stdout
+DOC
+function generate_chef_liveness_example() {
+  cat "/src/components/ingest-service/examples/liveness_ping.json"
 }
 
 document "send_chef_liveness_example" <<DOC
@@ -257,13 +262,65 @@ document "send_chef_liveness_example" <<DOC
   # send_chef_liveness_example legacy
 DOC
 function send_chef_liveness_example() {
+  generate_chef_liveness_example | send_chef_data_raw "$1"
+}
+
+document "send_chef_data_raw" <<DOC
+  Send data from stdin to the given endpoint.
+
+  One optional argument can be given to send the data via different paths:
+  * 'send_chef_data_raw legacy': send to automate-gateway's events/data-collector endpoint
+  * 'send_chef_data_raw lb': send to automate-load-balancer (nginx) data-collector/v0 endpoint
+  * 'send_chef_data_raw SOME/PATH': send to automate-gateway at the given path
+  * 'send_chef_data_raw' (default): send to new ingest/events/chef/run endpoint
+
+  Example: Send a Chef Run failure example to the new ingest endpoint:
+  --------------------------------------------------------
+  # generate_chef_run_failure_example | send_chef_data_raw
+
+  Example: Same but via the load balancer
+  --------------------------------------------------------
+  # generate_chef_run_failure_example | send_chef_data_raw lb
+DOC
+function send_chef_data_raw() {
   install_if_missing core/curl curl
 
-  local examples_path="/src/components/ingest-service/examples"
-  [[ "$1" == "legacy" ]] && endpoint="/events/data-collector" || endpoint="/ingest/events/chef/liveness"
+  local endpoint=$1
+  if [[ "$1" == "legacy" ]]; then
+    endpoint="${GATEWAY_URL}/events/data-collector"
+  elif [[ "$1" == "lb" ]]; then
+    endpoint="https://localhost/data-collector/v0"
+  elif [[ "$1x" == "x" ]]; then
+    endpoint="${GATEWAY_URL}/ingest/events/chef/run"
+  else
+    endpoint="${GATEWAY_URL}$1"
+  fi
 
   curl -f --insecure -H "api-token: $(get_api_token)" \
-       --data @$examples_path/liveness_ping.json "${GATEWAY_URL}${endpoint}"
+  --data "@-" "${endpoint}"
+}
+
+function uniqify_chef_run_report() {
+  install_if_missing core/jq-static jq
+
+  local node_name="$1"
+
+  local run_uuid
+  run_uuid=$(uuidgen)
+  local node_uuid
+  node_uuid=$(uuidgen)
+
+  local rfc_time
+  rfc_time=$(date +%FT%TZ -d "$((RANDOM % 144)) hour ago")
+
+  local examples_path="/src/components/ingest-service/examples"
+
+  # Update the IDs, names, and dates
+  jq --arg rfc_time "$rfc_time" \
+     --arg run_uuid "$run_uuid" \
+     --arg node_name "$node_name" \
+     --arg node_uuid "$node_uuid" \
+     '.end_time = $rfc_time | .start_time = $rfc_time | .entity_uuid = $node_uuid | .id = $run_uuid | .run_id = $run_uuid | .node_name = $node_name'
 }
 
 document "delete_multiple_nodes" <<DOC

--- a/.studio/automate-gateway
+++ b/.studio/automate-gateway
@@ -21,7 +21,7 @@ function gateway_integration() {
   # The main tests here is to send a ChefRun Message and a
   # Inspec Message through the legacy endpoint, so we need
   # the relevant services up and running:
-  wait_or_fail_for_port_to_listen $GATEWAY_PORT
+  wait_or_fail_for_port_to_listen "$GATEWAY_PORT"
   # Make sure that the gateway is accepting requests
   wait_for_success gateway_get /gateway/version || return 1
   log_line "The automate-gateway version"
@@ -31,12 +31,14 @@ function gateway_integration() {
   viewer_token="$(get_api_token_with_policy viewer-access)"
 
   log_line "Sending 30 Chef Action Messages"
-  for i in {1..30}; do
+  for _ in {1..30}; do
+    # shellcheck disable=SC2119
     send_chef_action_example || return 1
   done
   log_line "List Cfgmgmt Nodes (Empty)"
   gateway_get /cfgmgmt/nodes "$viewer_token" | jq || return 1
   log_line "Sending a Chef Run Message"
+  # shellcheck disable=SC2119
   send_chef_run_example || return 1
   log_line "Sending an Inspec Message through the Legacy endpoint"
   send_inspec_example legacy || return 1
@@ -86,7 +88,7 @@ function gateway_get() {
   install_if_missing core/curl curl >/dev/null 2>&1
   # use admin token only if not provided as second argument
   local api_token="${2:-$(get_admin_token)}"
-  curl -fsS --insecure -H "api-token: ${api_token}" ${GATEWAY_URL}${1}
+  curl -fsS --insecure -H "api-token: ${api_token}" "${GATEWAY_URL}${1}"
 }
 
 document "send_chef_action_example" <<DOC
@@ -100,6 +102,7 @@ document "send_chef_action_example" <<DOC
   --------------------------------------------------------
   # send_chef_action_example cookbook create
 DOC
+# shellcheck disable=SC2120
 function send_chef_action_example() {
   install_if_missing core/curl curl
   install_if_missing core/jq-static jq
@@ -127,7 +130,7 @@ function send_chef_action_example() {
   # note: this needs to be fed in via stdin, as passing it in as --data "$tmp_action_json"
   # will exceed argmax
   curl -f --insecure -H "api-token: $(get_api_token)" \
-    --data "@-" ${GATEWAY_URL}${endpoint} <<< "$tmp_action_json"
+    --data "@-" "${GATEWAY_URL}${endpoint}" <<< "$tmp_action_json"
 }
 
 document "send_chef_run_example" <<DOC
@@ -152,6 +155,7 @@ document "send_chef_run_example" <<DOC
   --------------------------------------------------------
   # send_chef_run_example lb
 DOC
+# shellcheck disable=SC2120
 function send_chef_run_example() {
   install_if_missing core/curl curl
 
@@ -168,12 +172,12 @@ function send_chef_run_example() {
   uuid=$(uuidgen)
   entity_uuid=$(uuidgen)
 
-  tmp_ccr_json="$(jq --arg id "$uuid" '.id = $id' <$examples_json_path)"
-  tmp_ccr_json="$(echo $tmp_ccr_json | jq --arg id "$entity_uuid" '.entity_uuid = $id')"
+  tmp_ccr_json="$(jq --arg id "$uuid" '.id = $id' <"$examples_json_path")"
+  tmp_ccr_json="$(echo "$tmp_ccr_json" | jq --arg id "$entity_uuid" '.entity_uuid = $id')"
 
   echo "$tmp_ccr_json" \
        | curl -f --insecure -H "api-token: $(get_admin_token)" \
-       --data "@-" ${endpoint}
+       --data "@-" "${endpoint}"
 }
 
 document "send_chef_run_start_example" <<DOC
@@ -204,14 +208,14 @@ function send_chef_run_start_example() {
   fi
 
   curl -f --insecure -H "api-token: $(get_api_token)" \
-       --data @$examples_path/chef_client_run_start.json ${endpoint}
+       --data @$examples_path/chef_client_run_start.json "${endpoint}"
 }
 
 document "get_service_versions" <<DOC
   Get all the service versions running in automate
 DOC
 function get_service_versions() {
-  curl -f --insecure -H "api-token: $(get_api_token)" ${GATEWAY_URL}"/deployment/service_versions"
+  curl -f --insecure -H "api-token: $(get_api_token)" "${GATEWAY_URL}/deployment/service_versions"
 }
 
 document "send_chef_run_failure_example" <<DOC
@@ -275,7 +279,7 @@ function delete_multiple_nodes() {
 
   endpoint="/ingest/events/chef/node-multiple-deletes"
 
-  jo node_ids=$(jo -a "$@") \
+  jo "node_ids=$(jo -a "$@")" \
     | curl -X POST -f --insecure -H "api-token: $(get_api_token)" \
     --data "@-" "${GATEWAY_URL}${endpoint}"
 }
@@ -296,7 +300,7 @@ function send_inspec_example() {
   report_uuid=$(uuidgen)
   rfc_time=$(date +%FT%TZ -d "$((RANDOM % 144)) hour ago")
 
-  tmp_inspec_json="$(jq --arg id "$uuid" --arg report_uuid "$report_uuid" --arg rfc_time "$rfc_time" '.node_uuid = $id | .report_uuid = $report_uuid | .end_time = $rfc_time' <$examples_json_path)"
+  tmp_inspec_json="$(jq --arg id "$uuid" --arg report_uuid "$report_uuid" --arg rfc_time "$rfc_time" '.node_uuid = $id | .report_uuid = $report_uuid | .end_time = $rfc_time' <"$examples_json_path")"
 
   echo "$tmp_inspec_json" | curl -f --insecure -H "api-token: $(get_admin_token)" \
        --data "@-" "${GATEWAY_URL}${endpoint}"
@@ -354,6 +358,7 @@ function gateway_create_secret() {
 
   endpoint="/secrets"
 
+  # shellcheck disable=SC2086
   echo '{"name": "bob", "type": "service_now", "data": [{"key": "username", "value": "'$username'"}, {"key": "password", "value": "'$password'"}] }' |\
     curl -X POST -f --insecure -H "api-token: $(get_admin_token)" \
     --data "@-" "${GATEWAY_URL}${endpoint}" | jq
@@ -372,6 +377,7 @@ function gateway_delete_secret() {
 
   endpoint="/secrets/id/$id"
 
+  # shellcheck disable=SC2086
   echo '{"id": "'$id'"}' |\
     curl -X DELETE -f --insecure -H "api-token: $(get_admin_token)" \
     --data "@-" "${GATEWAY_URL}${endpoint}"
@@ -391,6 +397,7 @@ function gateway_read_secret() {
 
   endpoint="/secrets/id/$id"
 
+  # shellcheck disable=SC2086
   echo '{"id": "'$id'"}' |\
     curl -X GET -f --insecure -H "api-token: $(get_admin_token)" \
     --data "@-" "${GATEWAY_URL}${endpoint}" | jq
@@ -411,6 +418,7 @@ function gateway_update_secret() {
 
   endpoint="/secrets/id/$id"
 
+  # shellcheck disable=SC2086
   echo '{"id": "'$id'", "name": "bob", "type": "service_now", "data": [{"key": "username", "value": "'$username'"}, {"key": "password", "value": "'$password'"}] }' |\
     curl -X PATCH -f --insecure -H "api-token: $(get_admin_token)" \
     --data "@-" ${GATEWAY_URL}${endpoint} | jq
@@ -430,6 +438,7 @@ function gateway_delete_notification_rule() {
 
   endpoint="/notifications/rules/$id"
 
+  # shellcheck disable=SC2086
   echo '{"id": "'$id'"}' |\
     curl -X DELETE -f --insecure -H "api-token: $(get_admin_token)" \
     --data "@-" ${GATEWAY_URL}${endpoint} | jq
@@ -444,9 +453,10 @@ function gateway_create_notification_rule() {
 
   endpoint="/notifications/rules"
 
+  # shellcheck disable=SC2154,SC2086
   echo '{"rule": { "name": "'$name'", "event": "CCRFailure", "SlackAlert": { "url": "http://localhost:55565"} }}' |\
     curl -X POST -f --insecure -H "api-token: $(get_admin_token)" \
-    --data "@-" ${GATEWAY_URL}${endpoint} | jq
+    --data "@-" "${GATEWAY_URL}${endpoint}" | jq
 }
 
 document "gateway_get_notification_rule" <<DOC
@@ -463,9 +473,10 @@ function gateway_get_notification_rule() {
 
   endpoint="/notifications/rules/$id"
 
+  # shellcheck disable=SC2086
   echo '{"id": "'$id'"}' |\
     curl -X GET -f --insecure -H "api-token: $(get_admin_token)" \
-    --data "@-" ${GATEWAY_URL}${endpoint} | jq
+    --data "@-" "${GATEWAY_URL}${endpoint}" | jq
 }
 
 
@@ -533,6 +544,7 @@ function get_api_token() {
     cat /tmp/api_token
   else
     date +%s | xargs -I % chef-automate iam token create admin-token-% --admin >/tmp/api_token
+    # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
       get_api_token_with_policy ingest-access >/tmp/api_token || return 1
     fi


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

1. Make the automate-gateway studio functions spellcheck clean. I have shellcheck turned on in my editor for shell files, it has a fair number of false positives but IMO is worth it.
2. Make the functions that populate the database with Chef Infra data more composable. Mostly I need this so I can create more variation in certain properties in the data without editing the sample data files 1000 times. In the process I factored out a lot of duplication.

With this change, you can now create a lot of variation in the generated data with a little bit of shell, like this:

```
for _ in {1..500} ; do
  m=$((RANDOM % 4))
  n=$((RANDOM % 25))
  generate_chef_run_failure_example | \
    jq --arg msg "Error $n occurred" --arg type "Chef::ExampleError$m" '.error.message = $msg | .error.class = $type' | \
    send_chef_data_raw
done
```
