### PR TITLE
bugfix: use job id and end time to navigate to compliance reporting from job scans

### DIFF
--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -36,4 +36,9 @@ export class DateTime {
   // Format for date labels in event feed table
   // 24 September
   public static readonly EVENT_TABLE_DATE_LABEL: string = 'D MMMM';
+
+  // Format for navigating to compliance reports with an endtime set
+  // 2019-09-24
+  public static readonly REPORT_DATE: string = 'YYYY-MM-DD';
+
 }

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/job-scans-list/job-scans-list.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/job-scans-list/job-scans-list.component.html
@@ -44,7 +44,7 @@
               <chef-td>
                 <chef-button secondary
                   *ngIf="job.status === 'completed'"
-                  (click)="viewReport(job.id)">
+                  (click)="viewReport(job.id, job.end_time)">
                   Report
                 </chef-button>
                 <chef-button secondary caution

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/job-scans-list/job-scans-list.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/job-scans-list/job-scans-list.component.ts
@@ -8,6 +8,7 @@ import * as moment from 'moment';
 import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import * as selectors from '../../state/scanner.selectors';
 import * as actions from '../../state/scanner.actions';
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 @Component({
   templateUrl: './job-scans-list.component.html',
@@ -139,7 +140,7 @@ export class JobScansListComponent implements OnInit, OnDestroy {
       this.router.navigate(['/compliance', 'reports', 'overview'],
         {queryParams: {job_id: jobID}});
     } else {
-      const endDateString = moment.utc(endDate).format('YYYY-MM-DD');
+      const endDateString = moment.utc(endDate).format(DateTime.REPORT_DATE);
 
       this.router.navigate(['/compliance', 'reports', 'overview'],
         {queryParams: {job_id: jobID, end_time: endDateString}});

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/job-scans-list/job-scans-list.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/job-scans-list/job-scans-list.component.ts
@@ -133,9 +133,17 @@ export class JobScansListComponent implements OnInit, OnDestroy {
     return moment(time).fromNow();
   }
 
-  viewReport(jobID) {
-    const filters = 'job_id:' + jobID;
-    this.router.navigate(['/compliance', 'reports', 'overview'], {queryParams: {filters}});
+  viewReport(jobID: string, endDate) {
+    // `null` dates from API are currently sent as "beginning of time"
+    if (!endDate || moment.utc(endDate).isBefore('2000-01-01T00:00:00.000Z')) {
+      this.router.navigate(['/compliance', 'reports', 'overview'],
+        {queryParams: {job_id: jobID}});
+    } else {
+      const endDateString = moment.utc(endDate).format('YYYY-MM-DD');
+
+      this.router.navigate(['/compliance', 'reports', 'overview'],
+        {queryParams: {job_id: jobID, end_time: endDateString}});
+    }
   }
 
   promptDeleteJob(job) {

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.ts
@@ -8,6 +8,7 @@ import { NgrxStateAtom } from '../../../../../ngrx.reducers';
 import * as moment from 'moment';
 import * as selectors from '../../state/scanner.selectors';
 import * as actions from '../../state/scanner.actions';
+import { DateTime } from 'app/helpers/datetime/datetime';
 
 @Component({
   templateUrl: './jobs-list.component.html',
@@ -118,7 +119,7 @@ export class JobsListComponent implements OnInit, OnDestroy {
       this.router.navigate(['/compliance', 'reports', 'overview'],
         {queryParams: {job_id: jobID}});
     } else {
-      const endDateString = moment.utc(endDate).format('YYYY-MM-DD');
+      const endDateString = moment.utc(endDate).format(DateTime.REPORT_DATE);
 
       this.router.navigate(['/compliance', 'reports', 'overview'],
         {queryParams: {job_id: jobID, end_time: endDateString}});


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

Navigating to compliance reporting page with job id filter set was broken from the job scans list (scans from a scheduled job).
I stole the function we use on the jobs list and make the job scans list use it.
I just copied it bc i didn't know where i should put it for sharing - pls advise!

### :chains: Related Resources
https://github.com/chef/automate/issues/3210

### :+1: Definition of Done
can navigate to compliance reporting from the scans list of a recurring job

### :athletic_shoe: How to Build and Test the Change
rebuild automate ui
create a recurring scan job
try to click the report button on one of the scans

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

