### PR TITLE
Remove v1/v2 vestiges in ui

### DIFF
--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.html
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.html
@@ -56,7 +56,6 @@
                       <ng-container *ngIf="team.projects.length > 1">{{ team.projects.length }} projects</ng-container>
                     </chef-table-cell>
                     <chef-table-cell class="three-dot-column">
-                      <!-- TODO: Need to account for v1 / v2 in the app-authorized path -->
                       <!-- <app-authorized [allOf]="['/iam/v2/teams/{id}', 'delete', team.id]"> -->
                       <mat-select panelClass="chef-control-menu">
                         <mat-option (onSelectionChange)="startTeamDelete($event, team)">Delete Team</mat-option>

--- a/components/automate-ui/src/app/modules/team/team-management/team-management.component.spec.ts
+++ b/components/automate-ui/src/app/modules/team/team-management/team-management.component.spec.ts
@@ -81,7 +81,7 @@ describe('TeamManagementComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('create v2 team', () => {
+  describe('create team', () => {
     let store: Store<NgrxStateAtom>;
     const team: Team = {
       guid: 'uuid-1',
@@ -94,7 +94,7 @@ describe('TeamManagementComponent', () => {
       store = TestBed.inject(Store);
     });
 
-    it('openCreateModal on v2 opens v2 modal', () => {
+    it('openCreateModal opens modal', () => {
       expect(component.createModalVisible).toBe(false);
       component.openCreateModal();
       expect(component.createModalVisible).toBe(true);

--- a/components/automate-ui/src/app/modules/user/user-table/user-table.component.html
+++ b/components/automate-ui/src/app/modules/user/user-table/user-table.component.html
@@ -30,7 +30,6 @@
             {{ user.id }}
           </chef-table-cell>
           <chef-table-cell class="three-dot-column">
-            <!-- TODO: Need to account for v1 / v2 in the app-authorized path -->
             <!-- <app-authorized [allOf]="['/iam/v2/users/{id}', 'delete', user.id]"> -->
             <mat-select panelClass="chef-control-menu" data-cy="select">
               <mat-option data-cy="delete" (onSelectionChange)="deleteUser($event, user)">{{ removeText }}</mat-option>

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
@@ -130,12 +130,7 @@ describe('ProjectListComponent', () => {
       });
     });
 
-    it('does not display project data for v1', () => {
-      store.dispatch(new GetProjectsSuccess({ projects: projectList }));
-      expect(element).not.toContainPath('chef-table-new');
-    });
-
-    describe('create modal', () => {
+   describe('create modal', () => {
       it('opens upon clicking create button', () => {
         store.dispatch(new GetProjectsSuccess({ projects: projectList }));
         fixture.detectChanges();

--- a/e2e/cypress/integration/ui/common/global_filter.spec.ts
+++ b/e2e/cypress/integration/ui/common/global_filter.spec.ts
@@ -40,21 +40,6 @@ describe('global projects filter', () => {
     });
     cy.logout();
   });
-
-  // TODO can uncomment when we have a flag to remove legacy policies,
-  // which are currently allowing full project access to all users.
-  // it('shows allowed projects for non-admin', () => {
-  //   cy.login('/settings', nonAdminUsername);
-  //   // hide modal unrelated to test flow
-  //   cy.get('app-welcome-modal').invoke('hide');
-  //   cy.get('chef-sidebar');
-  //   const allowedProjects = [proj1.name, proj2.name];
-  //   cy.get('.dropdown-label').click();
-  //   allowedProjects.forEach(project => {
-  //     cy.get('#projects-filter-dropdown').contains(project);
-  //   });
-  //   cy.logout();
-  // });
 });
 
 function cleanupProjects(id_token: string): void {

--- a/e2e/cypress/integration/ui/common/global_filter.spec.ts
+++ b/e2e/cypress/integration/ui/common/global_filter.spec.ts
@@ -31,39 +31,30 @@ describe('global projects filter', () => {
   it('shows all projects for admin', () => {
     cy.adminLogin('/settings');
     cy.get('chef-sidebar');
-      const allowedProjects = [proj1.name, proj2.name, proj3.name, '(unassigned)'];
-      // we don't check that projects in dropdown match *exactly* as
-      // we can't control creation of other projects in the test env
+    const allowedProjects = [proj1.name, proj2.name, proj3.name, '(unassigned)'];
+    // we don't check that projects in dropdown match *exactly* as
+    // we can't control creation of other projects in the test env
     cy.get('.dropdown-label').click();
-      allowedProjects.forEach(project => {
-        cy.get('#projects-filter-dropdown').contains(project);
-      });
+    allowedProjects.forEach(project => {
+      cy.get('#projects-filter-dropdown').contains(project);
+    });
     cy.logout();
   });
 
   // TODO can uncomment when we have a flag to remove legacy policies,
   // which are currently allowing full project access to all users.
   // it('shows allowed projects for non-admin', () => {
-  //   cy.login('/settings', nonAdminUsername)
+  //   cy.login('/settings', nonAdminUsername);
   //   // hide modal unrelated to test flow
-  //   cy.get('app-welcome-modal').invoke('hide')
-
-  //   cy.get('chef-sidebar')
-  //     .should('have.attr', 'minor-version')
-  //     .then((version) => {
-  //       if (version === 'v1') {
-  //         cy.get('[data-cy=projects-filter-button]').click()
-
-  //         const allowedProjects = [proj1, proj2];
-  //         cy.get('[data-cy=projects-filter-dropdown] chef-checkbox')
-  //           .should(($elements) => { expect($elements).to.have.length(allowedProjects.length) })
-  //         allowedProjects.forEach(project => {
-  //           cy.get('[data-cy=projects-filter-dropdown]').contains(project)
-  //         })
-  //       }
-  //     })
-  //   cy.logout()
-  // })
+  //   cy.get('app-welcome-modal').invoke('hide');
+  //   cy.get('chef-sidebar');
+  //   const allowedProjects = [proj1.name, proj2.name];
+  //   cy.get('.dropdown-label').click();
+  //   allowedProjects.forEach(project => {
+  //     cy.get('#projects-filter-dropdown').contains(project);
+  //   });
+  //   cy.logout();
+  // });
 });
 
 function cleanupProjects(id_token: string): void {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Follow-up to #2722, removes the last vestiges of v1 and v2 in the UI.
Review by following the commits for specifics.

### :chains: Related Resources
#2722 

### :+1: Definition of Done
No more v1 and v2 in the UI. Really.

### :athletic_shoe: How to Build and Test the Change
No changes in functionality.
Also no changes in tests really; just one test deleted.
So the only way to test the change is to grep v1 and v2... and then sort through the barrage of output.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
