### PR TITLE
[cli] Add --version flag to airgap bundle create

### DIFF
--- a/components/automate-chef-io/content/docs/airgapped-installation.md
+++ b/components/automate-chef-io/content/docs/airgapped-installation.md
@@ -36,10 +36,16 @@ curl https://packages.chef.io/files/current/latest/chef-automate-cli/chef-automa
 
 ### Prepare Airgap Installation Bundle
 
-To download and bundle the software included in a Chef Automate release, run:
+To download and bundle the software included in the most recent Chef Automate release, run:
 
 ```shell
 ./chef-automate airgap bundle create
+```
+
+To download and bundle the software included in a specific Chef Automate release, run
+
+```shell
+./chef-automate airgap bundle create --version VERSION
 ```
 
 A successful execution of this command produces an Airgap Installation Bundle named

--- a/components/automate-cli/cmd/chef-automate/airgap.go
+++ b/components/automate-cli/cmd/chef-automate/airgap.go
@@ -23,6 +23,7 @@ type airgapFlags struct {
 	channel        string
 	overrideOrigin string
 	hartifactsPath string
+	version        string
 	verbose        bool
 	hartsOnly      bool
 	retries        int
@@ -32,6 +33,14 @@ type airgapFlags struct {
 func (f airgapFlags) validateArgs() error {
 	if f.manifestPath != "" && f.channel != "" {
 		return status.New(status.AirgapCreateInstallBundleError, "You cannot provide both a manifest.json and a release channel")
+	}
+
+	if f.manifestPath != "" && f.version != "" {
+		return status.New(status.AirgapCreateInstallBundleError, "You cannot provide both a manifest.json and a version")
+	}
+
+	if f.channel != "" && f.version != "" {
+		return status.New(status.AirgapCreateInstallBundleError, "You cannot provide both a channel and a version")
 	}
 
 	if f.hartifactsPath != "" && f.overrideOrigin == "" {
@@ -104,6 +113,11 @@ func newAirgapCmd() *cobra.Command {
 	bundleCreateCmd.PersistentFlags().IntVar(
 		&airgapCmdFlags.retryDelay, "retry-delay", -1,
 		"Number of seconds to wait between retries (exponential backoff is used if not provided)",
+	)
+
+	bundleCreateCmd.PersistentFlags().StringVar(
+		&airgapCmdFlags.version, "version", "",
+		"Chef Automate version to create an airgap bundle for",
 	)
 
 	if !isDevMode() {
@@ -200,6 +214,13 @@ func runAirgapCreateInstallBundle(cmd *cobra.Command, args []string) error {
 		opts = append(
 			opts,
 			airgap.WithInstallBundleChannel(airgapCmdFlags.channel),
+		)
+	}
+
+	if airgapCmdFlags.version != "" {
+		opts = append(
+			opts,
+			airgap.WithInstallBundleVersion(airgapCmdFlags.version),
 		)
 	}
 

--- a/components/automate-deployment/pkg/airgap/bundle_creator.go
+++ b/components/automate-deployment/pkg/airgap/bundle_creator.go
@@ -150,6 +150,7 @@ var _ InstallBundleCreatorProgress = noopInstallBundleCreatorProgress{}
 type InstallBundleCreator struct {
 	manifestFile        string
 	channel             string
+	version             string
 	outputFile          string
 	workspacePath       string
 	depotClient         depot.Client
@@ -194,6 +195,13 @@ func WithInstallBundleManifestFile(path string) InstallBundleCreatorOpt {
 func WithInstallBundleChannel(channel string) InstallBundleCreatorOpt {
 	return func(c *InstallBundleCreator) {
 		c.channel = channel
+	}
+}
+
+// WithInstallBundleVersion sets the version whose manifest should be used.
+func WithInstallBundleVersion(version string) InstallBundleCreatorOpt {
+	return func(c *InstallBundleCreator) {
+		c.version = version
 	}
 }
 
@@ -368,6 +376,9 @@ func (creator *InstallBundleCreator) loadManifest() (*manifest.A2, error) {
 		manifestProvider = manifest.NewLocalHartManifestProvider(manifestProvider, creator.hartifactsPath, creator.overrideOrigin)
 	}
 
+	if creator.version != "" {
+		return manifestProvider.GetManifest(context.Background(), creator.version)
+	}
 	return manifestProvider.GetCurrentManifest(context.Background(), creator.channel)
 }
 


### PR DESCRIPTION
The `--version` flag allows the user to create an airgap bundle for a
specific version. Currently, an airgap bundle is the preferred way for
users to install a specific version of Chef Automate. The addition of
this flag makes it a bit easier to do so.

Signed-off-by: Steven Danna <steve@chef.io>