### PR TITLE
studio: add other factors for adjusting GOBIN

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -55,7 +55,12 @@ export GO111MODULE=on
 # Specify where to put 'go installed' binaries
 setup_gobin() {
     local vendor_hash
-    vendor_hash=$(sha256sum /src/vendor/modules.txt | cut -c1-16)
+    vendor_hash=$(cat \
+      /src/vendor/modules.txt \
+      /src/components/automate-grpc/protoc-gen-policy/policy/policy.go \
+      /src/components/automate-grpc/protoc-gen-policy/api/policy.proto \
+      /src/components/automate-grpc/protoc-gen-policy/iam/policy.proto \
+    | sha256sum | cut -c1-16)
     export GOBIN_BASE="/src/bin"
     GOBIN="${GOBIN_BASE}/${vendor_hash}"
     export GOBIN


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

A recent PR made the `bin` directory in hab studio sensitive to changes in the vendored files that would affect the tools there, but it would also help to include files that are in our interface to some of those tools, specifically the `protoc-gen-policy` component.

### :chains: Related Resources
PR #2911 studio: use vendor-state specific directory for GOBIN

### :+1: Definition of Done
You get a new subdir of `bin` with changes to the `protoc-gen-policy` component.

### :athletic_shoe: How to Build and Test the Change
If you have not refreshed your studio lately:
```
# First observe your initial bin dir:
[27][default:/src:0]# ls bin
8291598b482a8f2e
[27][default:/src:0]# source .studiorc
. . .
# Now observe your bin dir, and you will see a new entry:
[27][default:/src:0]# ls bin
0e6386b8aa91af26  8291598b482a8f2e
```
If you have a new studio up, just make any edit to one of the newly referenced files in this PR, then run `source .studiorc` (or `setup_gobin`) to see a similar result.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
