### PR TITLE
Full Protobuf Rebuilds

### DIFF
--- a/.studio/common
+++ b/.studio/common
@@ -34,10 +34,10 @@ DOC
 function compile_go_protobuf_component() {
   [ "x$1" == "x" ] && error "Missing component name argument; try 'describe ${FUNCNAME[0]}'" && return 1
 
-  # FIXME: this comment is wrong
-  # Note: while we remove all pb-derived files before regenerating, we're
-  # actually cheating a bit: the protoc-gen-* executables built above do partly
-  # depend on them.
+  # NOTE: To (re)build the world from scratch, automate-grpc must first be
+  # bootstrapped so that our custom protoc-gen-* commands can be used in later
+  # build steps. See `bootstrap_proto_compilers` above.
+
   local path
   if [ "$1" == "api" ]; then
     path=api
@@ -54,11 +54,6 @@ function compile_go_protobuf_component() {
     fi
   fi
 
-  # FIXME: this comment is wrong
-  # prep policy generation (only automate-gateway needs that right now)
-  # Note: the actual generation is triggered by a call to protoc with the
-  # parameter '--policy_out=...'. Only if the service's methods has the proper
-  # annotations will the generated code not be a NO-OP.
   local proto_go_tools=(
     github.com/chef/automate/components/automate-grpc/protoc-gen-policy
     github.com/chef/automate/components/automate-grpc/protoc-gen-grpc-mock # generate mock grpc server implementations

--- a/.studio/common
+++ b/.studio/common
@@ -3,6 +3,28 @@
 # This file is the place we will put all the common functionality that
 # two or more components share/require (ex. install elasticsearch)
 
+document "clean_all_compiled_protos" <<DOC
+  Delete all the files with extensions matching '*pb*go' in the repo (except in vendor/)
+DOC
+function clean_all_compiled_protos() {
+  install_if_missing core/git git
+
+  find /src/{api,components,lib} -name '*pb*go' -exec rm '{}' \; 
+  git clean -fdx
+}
+
+document "bootstrap_proto_compilers" <<DOC
+  Builds everything you need to start recompiling protos from scratch (e.g.,
+  after running clean_all_compiled_protos). Our custom protoc-gen-* tools have
+  to be built in a certain order or else they will fail on circular dependencies.
+DOC
+function bootstrap_proto_compilers() {
+  compile_go_protobuf components/automate-grpc/scripts/bootstrap_protoc.sh
+  install_go_tool github.com/chef/automate/components/automate-grpc/protoc-gen-policy
+  install_go_tool github.com/chef/automate/components/automate-grpc/protoc-gen-grpc-mock
+  compile_go_protobuf components/automate-grpc/scripts/grpc.sh
+}
+
 # TODO (tc) Please take a pass @afiune and Infra Auto team to see if some of these other helpers
 # can be deleted in the new world.
 # Compile protobuf definitions

--- a/.studio/common
+++ b/.studio/common
@@ -34,6 +34,7 @@ DOC
 function compile_go_protobuf_component() {
   [ "x$1" == "x" ] && error "Missing component name argument; try 'describe ${FUNCNAME[0]}'" && return 1
 
+  # FIXME: this comment is wrong
   # Note: while we remove all pb-derived files before regenerating, we're
   # actually cheating a bit: the protoc-gen-* executables built above do partly
   # depend on them.
@@ -42,6 +43,8 @@ function compile_go_protobuf_component() {
     path=api
   elif [ "$1" == "config" ]; then
     path=api/config
+  elif [ "$1" == "license" ]; then
+    path=lib/license
   else
     path="components/$1"
     if [ ! -f "/src/$path/scripts/grpc.sh" ]; then
@@ -51,6 +54,7 @@ function compile_go_protobuf_component() {
     fi
   fi
 
+  # FIXME: this comment is wrong
   # prep policy generation (only automate-gateway needs that right now)
   # Note: the actual generation is triggered by a call to protoc with the
   # parameter '--policy_out=...'. Only if the service's methods has the proper

--- a/.studio/common
+++ b/.studio/common
@@ -7,10 +7,7 @@ document "clean_all_compiled_protos" <<DOC
   Delete all the files with extensions matching '*pb*go' in the repo (except in vendor/)
 DOC
 function clean_all_compiled_protos() {
-  install_if_missing core/git git
-
-  find /src/{api,components,lib} -name '*pb*go' -exec rm '{}' \; 
-  git clean -fdx
+  find /src/{api,components,lib} -name '*pb*go' -exec rm '{}' \;
 }
 
 document "bootstrap_proto_compilers" <<DOC

--- a/.studio/common
+++ b/.studio/common
@@ -144,7 +144,7 @@ function compile_all_protobuf_components() {
   install_if_missing core/git git
   # Note 2019/02/05 (sr): "api" doesn't fit in the folder structure, so it's
   # added to the list manually, same goes for "api/config".
-  components=($(git ls-files '*/scripts/grpc.sh' | awk -F/ '!/api/{print $2}') "api" "config")
+  components=($(git ls-files '*/scripts/grpc.sh' | awk -F/ '!/api/{print $2}') "config" "api")
   for component in "${components[@]}"; do
     log_line "Compiling protobuf files for ${YELLOW}'$component'${NC}"
     if ! compile_go_protobuf_component "$component"; then

--- a/.studio/common
+++ b/.studio/common
@@ -168,6 +168,8 @@ DOC
 function verify_all_protobuf_components() {
   install_if_missing core/git git
 
+  clean_all_compiled_protos || return $?
+  bootstrap_proto_compilers || return $?
   compile_all_protobuf_components || return $?
 
   git add .

--- a/components/automate-grpc/scripts/bootstrap_protoc.sh
+++ b/components/automate-grpc/scripts/bootstrap_protoc.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+###
+# ==BOOTSTRAP PROTOC==
+###
+# This script compiles enough protos for protoc-gen-policy and
+# protoc-gen-a2-configto be built, which enables us to subsequently compile all
+# the rest of the protocol buffers. This script needs to be able to run in a
+# completely clean checkout of the repo with all the compiled protos removed
+# (i.e., all files with '*pb*go' extensions deleted).
+
+
+printf 'GEN: %s\n' components/automate-grpc/protoc-gen-policy/api/*.proto
+protoc -I /src --go_out=logtostderr=true,paths=source_relative:/src \
+  components/automate-grpc/protoc-gen-policy/api/*.proto
+
+printf 'GEN: %s\n' components/automate-grpc/protoc-gen-policy/iam/*.proto
+protoc -I /src --go_out=logtostderr=true,paths=source_relative:/src \
+  components/automate-grpc/protoc-gen-policy/iam/*.proto
+

--- a/components/automate-grpc/scripts/grpc.sh
+++ b/components/automate-grpc/scripts/grpc.sh
@@ -2,13 +2,15 @@
 
 set -e
 
-printf 'GEN: %s\n' components/automate-grpc/protoc-gen-policy/api/*.proto
-protoc -I /src --go_out=logtostderr=true,paths=source_relative:/src \
-  components/automate-grpc/protoc-gen-policy/api/*.proto
+###
+# NOTE: grpc.sh vs. bootstrap_protoc.sh
+###
+# This script compiles all the protos. It is normally what you want. This
+# script is allowed to depend on tools in this repo (e.g.,
+# protoc-gen-a2-config, etc.)
 
-printf 'GEN: %s\n' components/automate-grpc/protoc-gen-policy/iam/*.proto
-protoc -I /src --go_out=logtostderr=true,paths=source_relative:/src \
-  components/automate-grpc/protoc-gen-policy/iam/*.proto
+# shellcheck disable=SC1090
+source "${BASH_SOURCE%/*}/bootstrap_protoc.sh"
 
 printf 'GEN: %s\n' lib/grpc/debug/debug_api/*.proto
 protoc -I /src --go_out=plugins=grpc,paths=source_relative:/src \

--- a/components/notifications-client/api/health.pb.go
+++ b/components/notifications-client/api/health.pb.go
@@ -5,9 +5,8 @@ package api
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/components/notifications-client/api/health.pb.go
+++ b/components/notifications-client/api/health.pb.go
@@ -95,7 +95,9 @@ func init() {
 	proto.RegisterType((*VersionResponse)(nil), "notifications.VersionResponse")
 }
 
-func init() { proto.RegisterFile("health.proto", fileDescriptor_fdbebe66dda7cb29) }
+func init() {
+	proto.RegisterFile("health.proto", fileDescriptor_fdbebe66dda7cb29)
+}
 
 var fileDescriptor_fdbebe66dda7cb29 = []byte{
 	// 111 bytes of a gzipped FileDescriptorProto

--- a/components/notifications-client/api/notifications.pb.go
+++ b/components/notifications-client/api/notifications.pb.go
@@ -5,10 +5,9 @@ package api
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	_ "github.com/golang/protobuf/ptypes/struct"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/components/notifications-client/api/notifications.pb.go
+++ b/components/notifications-client/api/notifications.pb.go
@@ -1429,7 +1429,9 @@ func init() {
 	proto.RegisterType((*Event)(nil), "notifications.Event")
 }
 
-func init() { proto.RegisterFile("notifications.proto", fileDescriptor_fbc3de4cce73c76f) }
+func init() {
+	proto.RegisterFile("notifications.proto", fileDescriptor_fbc3de4cce73c76f)
+}
 
 var fileDescriptor_fbc3de4cce73c76f = []byte{
 	// 1349 bytes of a gzipped FileDescriptorProto

--- a/components/notifications-client/api/rules.pb.go
+++ b/components/notifications-client/api/rules.pb.go
@@ -5,9 +5,8 @@ package api
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/components/notifications-client/api/rules.pb.go
+++ b/components/notifications-client/api/rules.pb.go
@@ -1082,7 +1082,9 @@ func init() {
 	proto.RegisterType((*RuleListResponse)(nil), "notifications.RuleListResponse")
 }
 
-func init() { proto.RegisterFile("rules.proto", fileDescriptor_8e722d3e922f0937) }
+func init() {
+	proto.RegisterFile("rules.proto", fileDescriptor_8e722d3e922f0937)
+}
 
 var fileDescriptor_8e722d3e922f0937 = []byte{
 	// 862 bytes of a gzipped FileDescriptorProto

--- a/components/notifications-client/api/server.pb.go
+++ b/components/notifications-client/api/server.pb.go
@@ -6,12 +6,11 @@ package api
 import (
 	context "context"
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -52,11 +51,11 @@ var fileDescriptor_ad098daeda4239f7 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // NotificationsClient is the client API for Notifications service.
 //
@@ -76,10 +75,10 @@ type NotificationsClient interface {
 }
 
 type notificationsClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewNotificationsClient(cc *grpc.ClientConn) NotificationsClient {
+func NewNotificationsClient(cc grpc.ClientConnInterface) NotificationsClient {
 	return &notificationsClient{cc}
 }
 

--- a/components/notifications-client/api/server.pb.go
+++ b/components/notifications-client/api/server.pb.go
@@ -24,7 +24,9 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
-func init() { proto.RegisterFile("server.proto", fileDescriptor_ad098daeda4239f7) }
+func init() {
+	proto.RegisterFile("server.proto", fileDescriptor_ad098daeda4239f7)
+}
 
 var fileDescriptor_ad098daeda4239f7 = []byte{
 	// 289 bytes of a gzipped FileDescriptorProto

--- a/components/notifications-client/scripts/grpc.sh
+++ b/components/notifications-client/scripts/grpc.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+pushd "${BASH_SOURCE%/*}/.."
+
+make proto
+
+popd
+

--- a/lib/license/license.pb.go
+++ b/lib/license/license.pb.go
@@ -5,10 +5,9 @@ package license
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/lib/license/license.pb.go
+++ b/lib/license/license.pb.go
@@ -208,7 +208,9 @@ func init() {
 	proto.RegisterType((*Entitlement)(nil), "license.Entitlement")
 }
 
-func init() { proto.RegisterFile("lib/license/license.proto", fileDescriptor_1d88e617a98a96bd) }
+func init() {
+	proto.RegisterFile("lib/license/license.proto", fileDescriptor_1d88e617a98a96bd)
+}
 
 var fileDescriptor_1d88e617a98a96bd = []byte{
 	// 381 bytes of a gzipped FileDescriptorProto

--- a/lib/license/scripts/grpc.sh
+++ b/lib/license/scripts/grpc.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+printf 'GEN: %s\n' lib/license/*.proto
+protoc -I /src --go_out=logtostderr=true,paths=source_relative:/src \
+  lib/license/*.proto
+


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Whilst dealing with some rebase woes recently, I found that I was unable to fully rebuild our compiled protobuf code and decided to fix it. So this PR does the following:
* Add studio function to delete all the compiled `*pb*go` files
* Add studio function to bootstrap the custom `protoc-gen-*` tools used in the main protobuf builds
* Add `scripts/grpc.sh` where it was missing, and adjust `compile_all_protobuf_components` accordingly for a "weird" one
* Rebuild all of the protobufs and update ones that have changed a bit
* Update the pipeline to do a full bootstrap rebuild when it tests the protos. The pipeline can now catch issues like a `.proto` file getting removed but the corresponding compiled file remaining, or protos getting added without being correctly integrated in our build tooling.

### :+1: Definition of Done

The protobuf code can be rebootstrapped

### :athletic_shoe: How to Build and Test the Change

In the studio:

* Delete all the things! `clean_all_compiled_protos` - check it out with `git status`
* `bootstrap_proto_compilers && compile_all_protobuf_components` - the repo should now be unchanged from before.
