### PR TITLE
[automate-3165] verify force upgrade in backup restore scenarios

### DIFF
--- a/integration/tests/airgap_ow_upgrade.sh
+++ b/integration/tests/airgap_ow_upgrade.sh
@@ -43,6 +43,10 @@ do_deploy() {
         --airgap-bundle bundle.aib \
         --admin-password chefautomate \
         --accept-terms-and-mlsa
+
+    # one by-product of these tests is a custom v1 policy
+    # it should be preserved by the force-uprade
+    run_inspec_tests "${A2_ROOT_DIR}" "a2-iam-v1-integration"
 }
 
 do_prepare_upgrade() {
@@ -56,4 +60,9 @@ do_upgrade() {
         --airgap-bundle update.aib \
         --no-check-version \
         "$test_backup_id"
+
+    # verifies IAM force-upgrade was applied,
+    # v1 default and custom policies were migrated,
+    # and the upgraded system demonstrates expected behavior around IAM permissions
+    run_inspec_tests "${A2_ROOT_DIR}" "a2-iam-legacy-integration"
 }

--- a/integration/tests/backup.sh
+++ b/integration/tests/backup.sh
@@ -75,4 +75,8 @@ do_test_restore() {
     delete_backup_and_assert_idempotent
     test_delete_broken_backups
     test_can_regenerate_cert_after_restore
+
+    # verifies IAM force-upgrade was applied
+    # and the restored system demonstrates expected behavior around IAM permissions
+    run_inspec_tests "${A2_ROOT_DIR}" "a2-iam-no-legacy-integration"
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Adds some IAM inspec testing to our test scenario that backs up Automate on an old version then upgrades/restores the same instance.

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).