### PR TITLE
fix cypress in deploy pipeline

### DIFF
--- a/.expeditor/buildkite/cypress.sh
+++ b/.expeditor/buildkite/cypress.sh
@@ -16,6 +16,7 @@ do
   echo "--- Executing Cypress tests against $instance"
   export CYPRESS_BASE_URL="https://$instance"
   export CYPRESS_RECORD_KEY="$CYPRESS_RECORD_KEY"
+  export CYPRESS_RUN_FLAKY="no"
 
   npm install # get dependencies defined in e2e/package.json
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

fixes this failure: https://buildkite.com/chef/chef-automate-master-deploy-dev/builds/1462#42cdc38f-929b-4df6-9b3a-d29efee315a4

we weren't passing the `CYPRESS_RUN_FLAKY=no`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).