### PR TITLE
Top desktop errors on skeleton UI

### DIFF
--- a/components/automate-ui/src/app/entities/desktop/desktop.actions.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.actions.ts
@@ -1,13 +1,16 @@
 import { Action } from '@ngrx/store';
 import { HttpErrorResponse } from '@angular/common/http';
 
-import { DailyCheckInCountCollection } from './desktop.model';
+import { DailyCheckInCountCollection, TopErrorsCollection } from './desktop.model';
 
 export enum DesktopActionTypes {
   GET_DAILY_CHECK_IN_TIME_SERIES         = 'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES',
   GET_DAILY_CHECK_IN_TIME_SERIES_SUCCESS = 'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES::SUCCESS',
   GET_DAILY_CHECK_IN_TIME_SERIES_FAILURE = 'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES::FAILURE',
-  SET_DAYS_AGO_SELECTED                  = 'DESKTOP::SET::DAYS_AGO_SELECTED'
+  SET_DAYS_AGO_SELECTED                  = 'DESKTOP::SET::DAYS_AGO_SELECTED',
+  GET_TOP_ERRORS_COLLECTION              = 'DESKTOP::GET::TOP_ERRORS_COLLECTION',
+  GET_TOP_ERRORS_COLLECTION_SUCCESS      = 'DESKTOP::GET::TOP_ERRORS_COLLECTION::SUCCESS',
+  GET_TOP_ERRORS_COLLECTION_FAILURE      = 'DESKTOP::GET::TOP_ERRORS_COLLECTION::FAILURE'
 }
 
 export class SetDaysAgoSelected implements Action {
@@ -29,8 +32,25 @@ export class GetDailyCheckInTimeSeriesFailure implements Action {
   constructor(public payload: HttpErrorResponse) { }
 }
 
+export class GetTopErrorsCollection implements Action {
+  readonly type = DesktopActionTypes.GET_TOP_ERRORS_COLLECTION;
+}
+
+export class GetTopErrorsCollectionSuccess implements Action {
+  readonly type = DesktopActionTypes.GET_TOP_ERRORS_COLLECTION_SUCCESS;
+  constructor(public payload: TopErrorsCollection) { }
+}
+
+export class GetTopErrorsCollectionFailure implements Action {
+  readonly type = DesktopActionTypes.GET_TOP_ERRORS_COLLECTION_FAILURE;
+  constructor(public payload: HttpErrorResponse) { }
+}
+
 export type DesktopActions =
   | SetDaysAgoSelected
   | GetDailyCheckInTimeSeries
   | GetDailyCheckInTimeSeriesSuccess
-  | GetDailyCheckInTimeSeriesFailure;
+  | GetDailyCheckInTimeSeriesFailure
+  | GetTopErrorsCollection
+  | GetTopErrorsCollectionSuccess
+  | GetTopErrorsCollectionFailure;

--- a/components/automate-ui/src/app/entities/desktop/desktop.effects.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.effects.ts
@@ -9,7 +9,10 @@ import {
   GetDailyCheckInTimeSeries,
   GetDailyCheckInTimeSeriesSuccess,
   GetDailyCheckInTimeSeriesFailure,
-  DesktopActionTypes
+  DesktopActionTypes,
+  GetTopErrorsCollection,
+  GetTopErrorsCollectionSuccess,
+  GetTopErrorsCollectionFailure
 } from './desktop.actions';
 import { DesktopRequests } from './desktop.requests';
 import { CreateNotification } from 'app/entities/notifications/notification.actions';
@@ -51,6 +54,28 @@ export class DesktopEffects {
       return new CreateNotification({
         type: Type.error,
         message: `Could not get time series: ${msg || error}`
+      });
+    }));
+
+  @Effect()
+  getTopErrorCollection$ =
+    this.actions$.pipe(ofType<GetTopErrorsCollection>(
+      DesktopActionTypes.GET_TOP_ERRORS_COLLECTION),
+      mergeMap((_action) =>
+        this.requests.getTopErrorsCollection().pipe(
+          map(topErrorsCollection =>
+        new GetTopErrorsCollectionSuccess(topErrorsCollection)),
+        catchError((error) => of(new GetTopErrorsCollectionFailure(error)))))
+    );
+
+  @Effect()
+  getTopErrorCollectionFailure$ = this.actions$.pipe(
+    ofType(DesktopActionTypes.GET_TOP_ERRORS_COLLECTION_FAILURE),
+    map(({ payload: { error } }: GetTopErrorsCollectionFailure) => {
+      const msg = error.error;
+      return new CreateNotification({
+        type: Type.error,
+        message: `Could not get top errors: ${msg || error}`
       });
     }));
 }

--- a/components/automate-ui/src/app/entities/desktop/desktop.model.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.model.ts
@@ -13,3 +13,13 @@ export interface DayPercentage {
   daysAgo: number;
   percentage: number;
 }
+
+export interface TopErrorsCollection {
+  items: TopErrorsItem[];
+}
+
+export interface TopErrorsItem {
+  count: number;
+  type: string;
+  message: string;
+}

--- a/components/automate-ui/src/app/entities/desktop/desktop.reducer.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.reducer.ts
@@ -2,18 +2,22 @@ import { set, pipe } from 'lodash/fp';
 
 import { EntityStatus } from '../entities';
 import { DesktopActionTypes, DesktopActions } from './desktop.actions';
-import { DailyCheckInCountCollection } from './desktop.model';
+import { DailyCheckInCountCollection, TopErrorsCollection } from './desktop.model';
 
 export interface DesktopEntityState {
   dailyCheckInCountCollection: DailyCheckInCountCollection;
   getDailyCheckInTimeSeriesStatus: EntityStatus;
   selectedDaysAgo: number;
+  topErrorCollection: TopErrorsCollection;
+  getTopErrorCollectionStatus: EntityStatus;
 }
 
 export const desktopEntityInitialState: DesktopEntityState = {
   dailyCheckInCountCollection: { buckets: []},
   getDailyCheckInTimeSeriesStatus: EntityStatus.notLoaded,
-  selectedDaysAgo: 3
+  selectedDaysAgo: 3,
+  topErrorCollection: {items: []},
+  getTopErrorCollectionStatus: EntityStatus.notLoaded
 };
 
 export function userEntityReducer(state: DesktopEntityState = desktopEntityInitialState,
@@ -33,6 +37,17 @@ export function userEntityReducer(state: DesktopEntityState = desktopEntityIniti
 
     case DesktopActionTypes.GET_DAILY_CHECK_IN_TIME_SERIES_FAILURE:
       return set('getDailyCheckInTimeSeriesStatus', EntityStatus.loadingFailure, state);
+
+    case DesktopActionTypes.GET_TOP_ERRORS_COLLECTION:
+      return set('getTopErrorCollectionStatus', EntityStatus.loading, state);
+
+    case DesktopActionTypes.GET_TOP_ERRORS_COLLECTION_SUCCESS:
+      return pipe(
+        set('getTopErrorCollectionStatus', EntityStatus.loadingSuccess),
+        set('topErrorCollection', action.payload))(state);
+
+    case DesktopActionTypes.GET_TOP_ERRORS_COLLECTION_FAILURE:
+      return set('getTopErrorCollectionStatus', EntityStatus.loadingFailure, state);
 
     default:
       return state;

--- a/components/automate-ui/src/app/entities/desktop/desktop.requests.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.requests.ts
@@ -2,7 +2,8 @@ import { map } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
-import { DailyCheckInCountCollection, DailyCheckInCount } from './desktop.model';
+import { DailyCheckInCountCollection, DailyCheckInCount,
+  TopErrorsCollection, TopErrorsItem } from './desktop.model';
 
 import { environment } from '../../../environments/environment';
 const CONFIG_MGMT_URL = environment.config_mgmt_url;
@@ -19,6 +20,16 @@ interface RespDailyCheckInCount {
   total: number;
 }
 
+interface RespTopNodeErrors {
+  errors: RespErrorItem[];
+}
+
+interface RespErrorItem {
+  count: number;
+  type: string;
+  error_message: string;
+}
+
 @Injectable()
 export class DesktopRequests {
 
@@ -29,6 +40,26 @@ export class DesktopRequests {
       `${CONFIG_MGMT_URL}/stats/checkin_counts_timeseries?days_ago=${daysAgo}`)
       .pipe(map(respDailyCheckInCountCollection =>
         this.createDailyCheckInCountCollection(respDailyCheckInCountCollection)));
+  }
+
+  public getTopErrorsCollection(): Observable<TopErrorsCollection> {
+    return this.http.get<RespTopNodeErrors>(`${CONFIG_MGMT_URL}/errors`)
+    .pipe(map(respTopNodeErrors =>
+      this.createTopErrorCollection(respTopNodeErrors)));
+  }
+
+  private createTopErrorCollection(respTopNodeErrors: RespTopNodeErrors): TopErrorsCollection {
+    return {
+      items: respTopNodeErrors.errors.map(respItem => this.createErrorItem(respItem))
+    };
+  }
+
+  private createErrorItem(item: RespErrorItem): TopErrorsItem {
+    return {
+      count: item.count,
+      type: item.type,
+      message: item.error_message
+    };
   }
 
   private createDailyCheckInCountCollection(

--- a/components/automate-ui/src/app/entities/desktop/desktop.selectors.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.selectors.ts
@@ -18,3 +18,8 @@ export const getSelectedDaysAgo = createSelector(
   desktopState,
   (state) => state.selectedDaysAgo
 );
+
+export const topErrorsCollection = createSelector(
+  desktopState,
+  (state) => state.topErrorCollection
+);

--- a/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.html
+++ b/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.html
@@ -16,13 +16,13 @@
         <thead>
           <tr >
             <th>Days Ago</th>
-            <th>Percentage Of Total</th>
+            <th>Percentage of Total</th>
           </tr>
         </thead>
         <tbody>
           <tr *ngFor="let day of days">
             <td>{{ day.daysAgo }}</td>
-            <td>{{ day.percentage }}%</td>
+            <td>{{ day.percentage | number:'1.0-0' }}%</td>
             <td></td>
           </tr>
         </tbody>

--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
@@ -6,11 +6,11 @@
       <div>
         <div class="item">
           <div class="title">Unknown %</div>
-          <div class="total">{{ unknownPercentage }}%</div>
+          <div class="total">{{ unknownPercentage | number:'1.0-0' }}%</div>
         </div>
         <div class="item">
           <div class="title">Checked-in %</div>
-          <div class="total">{{ checkedInPercentage }}%</div>
+          <div class="total">{{ checkedInPercentage | number:'1.0-0' }}%</div>
         </div>
         <div class="item">
           <div class="title">Checked-in Count</div>

--- a/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.html
+++ b/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.html
@@ -13,6 +13,8 @@
         [selectedDaysAgo] = "selectedDaysAgo$ | async"
         (daysAgoChanged)="handleDaysAgoChange($event)">
       </app-check-in-time-series>
+      <app-top-errors
+        [topErrorsItems] = "topErrorsItems$ | async"></app-top-errors>
     </main>
   </div>
 </div>

--- a/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.ts
@@ -7,16 +7,18 @@ import { last, reverse } from 'lodash/fp';
 
 import {
   GetDailyCheckInTimeSeries,
-  SetDaysAgoSelected
+  SetDaysAgoSelected,
+  GetTopErrorsCollection
 } from 'app/entities/desktop/desktop.actions';
 
 import {
   dailyCheckInCountCollection,
-  getSelectedDaysAgo
+  getSelectedDaysAgo,
+  topErrorsCollection
 } from 'app/entities/desktop/desktop.selectors';
 
 import {
-  DailyCheckInCount, DailyCheckInCountCollection, DayPercentage
+  DailyCheckInCount, DailyCheckInCountCollection, DayPercentage, TopErrorsItem
 } from 'app/entities/desktop/desktop.model';
 
 @Component({
@@ -35,6 +37,7 @@ export class DashboardComponent implements OnInit {
   public checkedInCount$: Observable<number>;
   public days$: Observable<DayPercentage[]>;
   public selectedDaysAgo$: Observable<number>;
+  public topErrorsItems$: Observable<TopErrorsItem[]>;
 
   constructor(
     private store: Store<NgrxStateAtom>
@@ -42,6 +45,7 @@ export class DashboardComponent implements OnInit {
 
   ngOnInit() {
     this.store.dispatch(new GetDailyCheckInTimeSeries());
+    this.store.dispatch(new GetTopErrorsCollection());
 
     this.selectedDaysAgo$ = this.store.select(getSelectedDaysAgo);
 
@@ -91,6 +95,10 @@ export class DashboardComponent implements OnInit {
 
     this.unknownCount$ = this.last24HourCheckInCount$.pipe(
       map(count => count.total - count.checkInCount)
+    );
+
+    this.topErrorsItems$ = this.store.select(topErrorsCollection).pipe(
+      map(collection => collection.items)
     );
   }
 

--- a/components/automate-ui/src/app/modules/desktop/desktop.module.ts
+++ b/components/automate-ui/src/app/modules/desktop/desktop.module.ts
@@ -7,6 +7,7 @@ import { ChefComponentsModule } from 'app/components/chef-components.module';
 import { DailyCheckInComponent } from './daily-check-in/daily-check-in.component';
 import { CheckInTimeSeriesComponent } from './check-in-time-series/check-in-time-series.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
+import { TopErrorsComponent } from './top-errors/top-errors.component';
 
 import { DesktopRoutingModule } from './desktop-routing.module';
 
@@ -21,12 +22,14 @@ import { DesktopRoutingModule } from './desktop-routing.module';
   exports: [
     DailyCheckInComponent,
     DashboardComponent,
-    CheckInTimeSeriesComponent
+    CheckInTimeSeriesComponent,
+    TopErrorsComponent
   ],
   declarations: [
     DailyCheckInComponent,
     DashboardComponent,
-    CheckInTimeSeriesComponent
+    CheckInTimeSeriesComponent,
+    TopErrorsComponent
   ],
   schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
 })

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.html
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.html
@@ -1,0 +1,24 @@
+<div class="content-container">
+  <div class="container">
+    <main>
+      <div class="page-title">Top 10 Errors</div>
+
+      <table>
+        <thead>
+          <tr >
+            <th>Error Message</th>
+            <th>Number of Desktops</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let topErrorsItem of topErrorsItems">
+            <td>{{topErrorsItem.type}}: {{ topErrorsItem.message }}</td>
+            <td>{{ topErrorsItem.count }}</td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
+
+    </main>
+  </div>
+</div>

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.scss
@@ -1,0 +1,21 @@
+@import "~styles/variables";
+
+.page-title {
+  color: var(--chef-primary-dark);
+  margin-top: 0;
+  margin-bottom: 12px;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 18px;
+}
+
+.content-container {
+  margin: 10px;
+  padding: 10px;
+  font-family: Muli;
+  font-size: 13px;
+  font-weight: 100;
+  background-color: $chef-med-grey;
+  border: 1px solid $chef-blue-medium;
+  border-radius: 4px;
+}

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input } from '@angular/core';
+
+import {
+  TopErrorsItem
+} from 'app/entities/desktop/desktop.model';
+
+@Component({
+  selector: 'app-top-errors',
+  templateUrl: './top-errors.component.html',
+  styleUrls: ['./top-errors.component.scss']
+})
+export class TopErrorsComponent {
+
+  @Input() topErrorsItems: TopErrorsItem[];
+
+  constructor() { }
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Adding the top desktop errors to the skeleton UI page. 

### :chains: Related Resources

https://github.com/chef/automate/issues/3107

### :athletic_shoe: How to Build and Test the Change
1. Start up the automate-ui locally with build component/automate-ui or the dev way with https://github.com/chef/automate/blob/master/dev-docs/ui-development.md. 
1. Go to https://a2-dev.test/dashboards/desktop

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![image](https://user-images.githubusercontent.com/1679247/77809716-2b092100-704e-11ea-9e66-ab7eb73cec34.png)
