### PR TITLE
dev env: add command for creating scan jobs: load_scan_jobs

### DIFF
--- a/.studio/compliance-service
+++ b/.studio/compliance-service
@@ -101,11 +101,11 @@ document "load_scan_jobs" <<DOC
   Loads scan jobs.
 DOC
 function load_scan_jobs() {
-  # shellcheck disable=SC1091
   FILE=./dev/secrets-env.sh
   if [ ! -e "$FILE" ]; then
     echo "secrets file not found; pls run the get_secrets script"
   else
+    # shellcheck disable=SC1091
     source dev/secrets-env.sh
     pushd dev-docs/adding-data &> /dev/null
     go run add_scanjobs.go

--- a/.studio/compliance-service
+++ b/.studio/compliance-service
@@ -108,6 +108,7 @@ function load_scan_jobs() {
     # shellcheck disable=SC1091
     source dev/secrets-env.sh
     pushd dev-docs/adding-data &> /dev/null
+    install_if_missing core/go go
     go run add_scanjobs.go
     popd &> /dev/null
   fi

--- a/.studio/compliance-service
+++ b/.studio/compliance-service
@@ -101,8 +101,13 @@ document "load_scan_jobs" <<DOC
   Loads scan jobs.
 DOC
 function load_scan_jobs() {
-  source dev/secrets-env.sh
-  pushd dev-docs/adding-data &> /dev/null
-  go run add_scanjobs.go
-  popd &> /dev/null
+  FILE=./dev/secrets-env.sh
+  if [ ! -e "$FILE" ]; then
+    echo "secrets file not found; pls run the get_secrets script"
+  else
+    source dev/secrets-env.sh
+    pushd dev-docs/adding-data &> /dev/null
+    go run add_scanjobs.go
+    popd &> /dev/null
+  fi
 }

--- a/.studio/compliance-service
+++ b/.studio/compliance-service
@@ -101,6 +101,7 @@ document "load_scan_jobs" <<DOC
   Loads scan jobs.
 DOC
 function load_scan_jobs() {
+  # shellcheck disable=SC1091
   FILE=./dev/secrets-env.sh
   if [ ! -e "$FILE" ]; then
     echo "secrets file not found; pls run the get_secrets script"

--- a/.studio/compliance-service
+++ b/.studio/compliance-service
@@ -96,3 +96,13 @@ function load_compliance_reports() {
     ./send_to_data_collector.sh https://a2-dev.test "$(get_admin_token)"
     popd &> /dev/null
 }
+
+document "load_scan_jobs" <<DOC
+  Loads scan jobs.
+DOC
+function load_scan_jobs() {
+  source dev/secrets-env.sh
+  pushd dev-docs/adding-data &> /dev/null
+  go run add_scanjobs.go
+  popd &> /dev/null
+}

--- a/dev-docs/adding-data/add_scanjobs.go
+++ b/dev-docs/adding-data/add_scanjobs.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/chef/automate/api/external/common/query"
+	gwnodes "github.com/chef/automate/api/external/nodes"
+	"github.com/chef/automate/api/external/secrets"
+	"github.com/chef/automate/api/interservice/compliance/jobs"
+	"github.com/chef/automate/components/automate-gateway/gateway"
+	"github.com/chef/automate/components/compliance-service/examples/helpers"
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+)
+
+const (
+	gatewayBindAddress = "127.0.0.1:2001"
+)
+
+type GatewayTestSuite struct {
+	ctx     context.Context
+	clients gateway.ClientsFactory
+	gwConn  *grpc.ClientConn
+}
+
+type acceptanceTarget struct {
+	Key   string
+	Host  string
+	Host2 string
+	User  string
+}
+
+func getAcceptanceTargetFromEnvironment() *acceptanceTarget {
+	return &acceptanceTarget{
+		Key:  acceptanceTargetKey(),
+		Host: os.Getenv("AUTOMATE_ACCEPTANCE_TARGET_HOST"),
+		User: os.Getenv("AUTOMATE_ACCEPTANCE_TARGET_USER"),
+	}
+}
+
+func acceptanceTargetKey() string {
+	defaultKey := "default_key"
+
+	if encoded := os.Getenv("AUTOMATE_ACCEPTANCE_TARGET_KEY"); encoded != "" {
+		key, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return defaultKey
+		}
+
+		return string(key)
+	}
+
+	return defaultKey
+}
+
+func NewGatewaySuite(ctx context.Context) (*GatewayTestSuite, error) {
+	connFactory := helpers.SecureConnFactoryHabWithDeploymentServiceCerts()
+	viper.SetConfigFile("/hab/svc/automate-gateway/config/config.toml")
+	err := viper.ReadInConfig()
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := gateway.ConfigFromViper()
+	clients, err := gateway.NewClientsFactory(cfg.GrpcClients, connFactory)
+	if err != nil {
+		return nil, err
+	}
+	gwConn, err := connFactory.Dial("automate-gateway", gatewayBindAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GatewayTestSuite{
+		ctx:     ctx,
+		clients: clients,
+		gwConn:  gwConn,
+	}, nil
+}
+
+func main() {
+	fmt.Println("setting up clients")
+
+	targets := getAcceptanceTargetFromEnvironment()
+
+	if len(targets.Host) == 0 {
+		log.Fatal("\n\nsecrets are missing. pls check the contents of dev/secrets-env.sh and run the get_secrets script if this is empty\n")
+	}
+
+	suite, err := NewGatewaySuite(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("\n\n!!!!!!!!!!!!!!!!!!!!!!\nNOTE: YOU MUST BE ON VPN TO GET WORKING SCAN JOBS\n!!!!!!!!!!!!!!!!!!!!!!\n\n")
+
+	// get the gateway nodes client
+	gatewayNodesClient := gwnodes.NewNodesServiceClient(suite.gwConn)
+
+	// setup secrets service for secret creation
+	secretsClient, err := suite.clients.SecretClient()
+
+	// setup compliance-service clients for job creation
+	jobsClient, err := suite.clients.ComplianceJobsServiceClient()
+
+	fmt.Println("creating two secrets for the nodes")
+
+	ec2SecretID, err := secretsClient.Create(suite.ctx, &secrets.Secret{
+		Name: "ecw secret",
+		Type: "ssh",
+		Data: []*query.Kv{
+			{Key: "username", Value: targets.User},
+			{Key: "key", Value: targets.Key},
+		},
+	})
+	vagrantSecretID, err := secretsClient.Create(suite.ctx, &secrets.Secret{
+		Name: "vagrant secret",
+		Type: "ssh",
+		Data: []*query.Kv{
+			{Key: "username", Value: "vagrant"},
+			{Key: "password", Value: "vagrant"},
+		},
+	})
+
+	fmt.Println("creating three nodes")
+
+	ec2NodeID, err := gatewayNodesClient.Create(suite.ctx, &gwnodes.Node{
+		Name: targets.Host,
+		Tags: []*query.Kv{},
+		TargetConfig: &gwnodes.TargetConfig{
+			Backend: "ssh",
+			Host:    targets.Host,
+			Port:    22,
+			Secrets: []string{ec2SecretID.GetId()},
+		},
+	})
+	ec2NodeID2, err := gatewayNodesClient.Create(suite.ctx, &gwnodes.Node{
+		Name: "inspec-target-rhel7-acceptance.cd.chef.co",
+		Tags: []*query.Kv{},
+		TargetConfig: &gwnodes.TargetConfig{
+			Backend: "ssh",
+			Host:    "inspec-target-rhel7-acceptance.cd.chef.co",
+			Port:    22,
+			Secrets: []string{ec2SecretID.GetId()},
+		},
+	})
+	vagrantNodeID, err := gatewayNodesClient.Create(suite.ctx, &gwnodes.Node{
+		Name: "vagrant node - localhost",
+		Tags: []*query.Kv{},
+		TargetConfig: &gwnodes.TargetConfig{
+			Backend: "ssh",
+			Host:    "localhost",
+			Port:    22,
+			Secrets: []string{vagrantSecretID.GetId()},
+		},
+	})
+
+	fmt.Println("creating three scan jobs")
+
+	jobsClient.Create(suite.ctx, &jobs.Job{
+		Name:     "ec2 node job - inspec-target-rhel7-dev.cd.chef.co",
+		Type:     "exec",
+		Nodes:    []string{ec2NodeID.GetId()},
+		Profiles: []string{"https://github.com/dev-sec/ssh-baseline/archive/master.tar.gz"},
+	})
+
+	jobsClient.Create(suite.ctx, &jobs.Job{
+		Name:     "ec2 node job - inspec-target-rhel7-acceptance.cd.chef.co",
+		Type:     "exec",
+		Nodes:    []string{ec2NodeID2.GetId()},
+		Profiles: []string{"https://github.com/dev-sec/ssh-baseline/archive/master.tar.gz"},
+	})
+
+	jobsClient.Create(suite.ctx, &jobs.Job{
+		Name:     "vagrant node job",
+		Type:     "exec",
+		Nodes:    []string{vagrantNodeID.GetId()},
+		Profiles: []string{"https://github.com/dev-sec/ssh-baseline/archive/master.tar.gz"},
+	})
+
+}

--- a/dev-docs/adding-data/adding_test_data.md
+++ b/dev-docs/adding-data/adding_test_data.md
@@ -32,22 +32,9 @@ if you need to add reports to a non-dev-env instance, you can use the following 
 
 # Adding nodes to populate the nodes and scan jobs pages
 
-option 1:
-if you don't care if the nodes are reachable and scan jobs are successful, do the following:
-- create an ssh or winrm credential in your Automate GUI at `a2-url/settings/node-credentials` with fake data
-- create a node in your Automate GUI at `a2-url/compliance/scan-jobs/nodes/add` with host `fake-localhost` and attach your fake credential 
-- ensure you've installed a profile or two in your Automate GUI under `a2-url/compliance/compliance-profiles`
-- create a scan job at `a2-url/jobs/add` using the profile and node 
+from hab studio:
 
-option 2:
-this should give you some reachable nodes and successful scan jobs, and some unreachable nodes/unsuccessful jobs:
-ensure you have `jq` installed locally (`brew install jq`)
-get a token for the api call: `get_admin_token` from within the studio is the quickest way
-get the secrets: run `cat dev/secrets-env.sh` - if there's nothing there, run `CHEF_USERNAME=username scripts/get_secrets.sh`
-
-_note: this should be run on your local system, not from within the studio. you will need to be on the vpn_
-`source dev/secrets-env.sh`
-`A2_URL='https://a2-dev.test' A2_TOKEN='token_val' components/compliance-service/scripts/create-pg-data.sh`
+run `load_scan_jobs`
 
 # Adding profiles
 


### PR DESCRIPTION
Signed-off-by: Victoria Jeffrey <vjeffrey@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
adding an easy way to create scan jobs in dev env

```
[246][default:/src:0]# load_scan_jobs
setting up clients
INFO[0000] certs dir is /hab/svc/deployment-service/data
INFO[0000] Dialing                                       metrics=false secure=true service=deployment-service target="10.0.2.15:10160"
INFO[0000] Dialing                                       metrics=false secure=true service=notifications-service target="10.0.2.15:10125"
INFO[0000] Dialing                                       metrics=false secure=true service=infra-proxy-service target="10.0.2.15:10153"
INFO[0000] Dialing                                       metrics=true secure=true service=ingest-service target="10.0.2.15:10122"
INFO[0000] Dialing                                       metrics=false secure=true service=config-mgmt-service target="10.0.2.15:10119"
INFO[0000] Dialing                                       metrics=false secure=true service=license-control-service target="10.0.2.15:10124"
INFO[0000] Dialing                                       metrics=true secure=true service=authz-service target="10.0.2.15:10130"
INFO[0000] Dialing                                       metrics=false secure=true service=nodemanager-service target="10.0.2.15:10120"
INFO[0000] Dialing                                       metrics=false secure=true service=teams-service target="10.0.2.15:10128"
INFO[0000] Dialing                                       metrics=false secure=true service=applications-service target="10.0.2.15:10133"
INFO[0000] Dialing                                       metrics=false secure=true service=compliance-service target="10.0.2.15:10121"
INFO[0000] Dialing                                       metrics=false secure=true service=secrets-service target="10.0.2.15:10131"
INFO[0000] Dialing                                       metrics=false secure=true service=event-feed-service target="10.0.2.15:10134"
INFO[0000] Dialing                                       metrics=false secure=true service=local-user-service target="10.0.2.15:10127"
INFO[0000] Dialing                                       metrics=true secure=true service=authn-service target="10.0.2.15:10113"
INFO[0000] Dialing                                       metrics=false secure=true service=data-feed-service target="10.0.2.15:14001"


!!!!!!!!!!!!!!!!!!!!!!
NOTE: YOU MUST BE ON VPN TO GET WORKING SCAN JOBS
!!!!!!!!!!!!!!!!!!!!!!


creating two secrets for the nodes
creating three nodes
creating three scan jobs
```