### PR TITLE
fix weird focus outline on chef modals

### DIFF
--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
@@ -118,7 +118,9 @@ export class ChefModal {
       // when Angular detects the modal is open
       // sets the focus on the close button for unlocked modals,
       // or the div for locked modals
-      const focusElement = (this.locked ? this.el.getElementsByClassName('modal').item(0) : this.el.getElementsByClassName('close').item(0).firstElementChild) as HTMLElement
+      const focusElement =
+        (this.locked ? this.el.getElementsByClassName('modal').item(0) :
+        this.el.getElementsByClassName('close').item(0).firstElementChild) as HTMLElement;
 
       const focusElementInterval = setInterval(() => {
         focusElement.focus();

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
@@ -115,12 +115,15 @@ export class ChefModal {
     if (visible) {
       this.prevFocusedElement = document.activeElement as HTMLElement;
 
-      // sets the focus on the close button once Angular has detected modal is open
-      const focusCloseButton = setInterval(() => {
-        const close = this.el.getElementsByClassName('close').item(0).firstElementChild as HTMLElement;
-        close.focus();
-        if (close === document.activeElement) {
-          clearInterval(focusCloseButton);
+      // when Angular detects the modal is open
+      // sets the focus on the close button for unlocked modals,
+      // or the div for locked modals
+      const focusElement = (this.locked ? this.el.getElementsByClassName('modal').item(0) : this.el.getElementsByClassName('close').item(0).firstElementChild) as HTMLElement
+
+      const focusElementInterval = setInterval(() => {
+        focusElement.focus();
+        if (focusElement === document.activeElement) {
+          clearInterval(focusElementInterval);
         }
       }, 1);
     }
@@ -137,7 +140,8 @@ export class ChefModal {
           class="modal"
           aria-modal="true"
           role="dialog"
-          aria-labelledby={this.label}>
+          aria-labelledby={this.label}
+          tabindex="0">
           <chef-trap-focus>
             {
               this.renderButton()

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
@@ -115,13 +115,12 @@ export class ChefModal {
     if (visible) {
       this.prevFocusedElement = document.activeElement as HTMLElement;
 
-      // sets the focus on the modal once Angular has detected modal is open
-      const focusModal = setInterval(() => {
-        const modal = this.el.getElementsByClassName('modal').item(0) as HTMLElement;
-        modal.focus();
-
-        if (modal === document.activeElement) {
-          clearInterval(focusModal);
+      // sets the focus on the close button once Angular has detected modal is open
+      const focusCloseButton = setInterval(() => {
+        const close = this.el.getElementsByClassName('close').item(0).firstElementChild as HTMLElement;
+        close.focus();
+        if (close === document.activeElement) {
+          clearInterval(focusCloseButton);
         }
       }, 1);
     }
@@ -138,8 +137,7 @@ export class ChefModal {
           class="modal"
           aria-modal="true"
           role="dialog"
-          aria-labelledby={this.label}
-          tabindex="0">
+          aria-labelledby={this.label}>
           <chef-trap-focus>
             {
               this.renderButton()


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
in chrome the focus of our chef modals was displaying super weird
i also noticed that we were putting focus on a non-interactive element (div)
this changes the focus to be on the first interactive element (close button)
which also resolves the weird focus outline issue

... and i forgot about the locked modals
so added a case for that, if anyone has a better way to do that please let me know

### :chains: Related Resources
fixes #2371

### :+1: Definition of Done
no more weird focus outline
everything still works

### :athletic_shoe: How to Build and Test the Change
`make update-ui-lib` from `components/automate-ui`
`rebuild components/automate-ui-devproxy`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
this is just one example, it was happening on all the chef modals

#### before
<img width="1004" alt="before" src="https://user-images.githubusercontent.com/5489125/77838974-c2917100-712d-11ea-8791-273068750396.png">

#### after
<img width="716" alt="after" src="https://user-images.githubusercontent.com/5489125/77838975-c624f800-712d-11ea-83a2-b939692d57ef.png">
