### PR TITLE
ensure waived profiles get the waived icon on nodes list scan results

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
@@ -142,12 +142,13 @@
           <p>Tap on a profile to view detailed scan results</p>
         </div>
         <ul class="results-nodes-list">
-          <ng-container *ngFor="let status of ['failed', 'passed', 'skipped']">
+          <ng-container *ngFor="let status of ['failed', 'passed', 'waived', 'skipped']">
             <li
               *ngFor="let profile of layerOneData[status]"
               class="results-nodes-list-item">
               <div class="list-item-summary">
-                <chef-icon class="list-item-icon" [ngClass]="profile.status">{{ statusIcon(status) }}</chef-icon>
+                <chef-icon *ngIf="profile.status !== 'waived'" class="list-item-icon" [ngClass]="profile.status">{{ statusIcon(status) }}</chef-icon>
+                <div *ngIf="profile.status === 'waived'" class="status-icon waived-icon"></div>
                 <div class="list-item-text">
                   <p class="node-name">
                     <strong>{{ profile.name }}</strong>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.spec.ts
@@ -44,14 +44,20 @@ describe('ReportingNodesComponent', () => {
   describe('addProfileStatus', () => {
     describe('if there are any failures', () => {
       const data = {items: [
-        { failures: 23, passed: 29, skipped: 3, name: 'linux-baseline' },
-        { failures: 1, passed: 20, skipped: 3, name: 'ssh-baseline' },
-        { failures: 3, passed: 0, skipped: 24, name: 'apache-baseline' }
+        { failures: 23, passed: 29, skipped: 3, waived: 1,
+          name: 'linux-baseline' },
+        { failures: 1, passed: 20, skipped: 3, waived: 1,
+          name: 'ssh-baseline' },
+        { failures: 3, passed: 0, skipped: 24, waived: 1,
+          name: 'apache-baseline' }
       ]};
       const expected = [
-        { failures: 23, passed: 29, skipped: 3, name: 'linux-baseline', status: 'failed' },
-        { failures: 1, passed: 20, skipped: 3, name: 'ssh-baseline', status: 'failed' },
-        { failures: 3, passed: 0, skipped: 24, name: 'apache-baseline', status: 'failed' }
+        { failures: 23, passed: 29, skipped: 3, waived: 1,
+          name: 'linux-baseline', status: 'failed' },
+        { failures: 1, passed: 20, skipped: 3, waived: 1,
+          name: 'ssh-baseline', status: 'failed' },
+        { failures: 3, passed: 0, skipped: 24, waived: 1,
+          name: 'apache-baseline', status: 'failed' }
       ];
 
       it('sets the status for the profile to failed', () => {
@@ -61,10 +67,12 @@ describe('ReportingNodesComponent', () => {
 
     describe('if all are skipped', () => {
       const data = {items: [
-        { failures: 0, passed: 0, skipped: 30, waived: 0, name: 'linux-baseline' }
+        { failures: 0, passed: 0, skipped: 30, waived: 0,
+          name: 'linux-baseline' }
       ]};
       const expected = [
-        { failures: 0, passed: 0, skipped: 30, waived: 0, name: 'linux-baseline', status: 'skipped' }
+        { failures: 0, passed: 0, skipped: 30, waived: 0,
+          name: 'linux-baseline', status: 'skipped' }
       ];
       it('sets the status for the profile to skipped', () => {
         expect(component.addProfileStatus(data)).toEqual(expected);
@@ -73,10 +81,12 @@ describe('ReportingNodesComponent', () => {
 
     describe('if all are waived', () => {
       const data = {items: [
-        { failures: 0, passed: 0, skipped: 0, waived: 1, name: 'linux-baseline' }
+        { failures: 0, passed: 0, skipped: 0, waived: 1,
+          name: 'linux-baseline' }
       ]};
       const expected = [
-        { failures: 0, passed: 0, skipped: 0, waived: 1, name: 'linux-baseline', status: 'waived' }
+        { failures: 0, passed: 0, skipped: 0, waived: 1,
+          name: 'linux-baseline', status: 'waived' }
       ];
       it('sets the status for the profile to skipped', () => {
         expect(component.addProfileStatus(data)).toEqual(expected);
@@ -85,12 +95,16 @@ describe('ReportingNodesComponent', () => {
 
     describe('if there are no failures and one or more passed', () => {
       const data = {items: [
-        { failures: 0, passed: 29, skipped: 0, name: 'linux-baseline' },
-        { failures: 0, passed: 20, skipped: 3, name: 'ssh-baseline' }
+        { failures: 0, passed: 29, skipped: 0, waived: 1,
+          name: 'linux-baseline' },
+        { failures: 0, passed: 20, skipped: 3, waived: 1,
+          name: 'ssh-baseline' }
       ]};
       const expected = [
-        { failures: 0, passed: 29, skipped: 0, name: 'linux-baseline', status: 'passed' },
-        { failures: 0, passed: 20, skipped: 3, name: 'ssh-baseline', status: 'passed' }
+        { failures: 0, passed: 29, skipped: 0, waived: 1,
+          name: 'linux-baseline', status: 'passed' },
+        { failures: 0, passed: 20, skipped: 3, waived: 1,
+          name: 'ssh-baseline', status: 'passed' }
       ];
       it('sets the status for the profile to passed', () => {
         expect(component.addProfileStatus(data)).toEqual(expected);

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.spec.ts
@@ -61,10 +61,22 @@ describe('ReportingNodesComponent', () => {
 
     describe('if all are skipped', () => {
       const data = {items: [
-        { failures: 0, passed: 0, skipped: 30, name: 'linux-baseline' }
+        { failures: 0, passed: 0, skipped: 30, waived: 0, name: 'linux-baseline' }
       ]};
       const expected = [
-        { failures: 0, passed: 0, skipped: 30, name: 'linux-baseline', status: 'skipped' }
+        { failures: 0, passed: 0, skipped: 30, waived: 0, name: 'linux-baseline', status: 'skipped' }
+      ];
+      it('sets the status for the profile to skipped', () => {
+        expect(component.addProfileStatus(data)).toEqual(expected);
+      });
+    });
+
+    describe('if all are waived', () => {
+      const data = {items: [
+        { failures: 0, passed: 0, skipped: 0, waived: 1, name: 'linux-baseline' }
+      ]};
+      const expected = [
+        { failures: 0, passed: 0, skipped: 0, waived: 1, name: 'linux-baseline', status: 'waived' }
       ];
       it('sets the status for the profile to skipped', () => {
         expect(component.addProfileStatus(data)).toEqual(expected);

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.ts
@@ -170,15 +170,15 @@ export class ReportingNodesComponent implements OnInit, OnDestroy {
 
   addProfileStatus(data) {
     return data.items.map(profile => {
-      if (profile.failures === 0) {
-        if (profile.passed > 0) {
-          profile.status = 'passed';
-        } else {
-          profile.status = 'skipped';
-        }
-      } else {
+      if (profile.failures > 0) {
         profile.status = 'failed';
-      }
+      } else if (profile.passed > 0) {
+          profile.status = 'passed';
+      } else if (profile.waived > 0) {
+          profile.status = 'waived';
+      } else {
+          profile.status = 'skipped';
+      }    
       return profile;
     });
   }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.ts
@@ -178,7 +178,7 @@ export class ReportingNodesComponent implements OnInit, OnDestroy {
           profile.status = 'waived';
       } else {
           profile.status = 'skipped';
-      }    
+      }
       return profile;
     });
   }


### PR DESCRIPTION
Signed-off-by: Victoria Jeffrey <vjeffrey@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
i noticed the waived profiles were showing up as skipped when viewing scan results from nodes list -- i think i missed making a card for that at some point so i just fixed it real quick.

before:
<img width="1264" alt="Screen Shot 2020-03-29 at 17 23 42" src="https://user-images.githubusercontent.com/10341541/77927104-274ee780-7264-11ea-912e-02b2d8aa2dc8.png">

after:
<img width="1251" alt="Screen Shot 2020-03-29 at 17 42 09" src="https://user-images.githubusercontent.com/10341541/77927121-2d44c880-7264-11ea-8d07-2b43592f9a80.png">

### :+1: Definition of Done
waived profiles have waived icon on nodes list scan results

### :athletic_shoe: How to Build and Test the Change
rebuild ui
load_compliance_reports
go to nodes list
select waived node scan results
see profile is waived

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [n/a] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
