### PR TITLE
[Automate-2971] fill project filter before backend calls

### DIFF
--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.actions.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.actions.ts
@@ -3,11 +3,22 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { ProjectsFilterOption, ProjectsFilterOptionTuple } from './projects-filter.reducer';
 
 export enum ProjectsFilterActionTypes {
+  INIT_OPTIONS           = 'PROJECTS_FILTER::INIT_OPTIONS',
+  INIT_OPTIONS_SUCCESS   = 'PROJECTS_FILTER::INIT_OPTIONS::SUCCESS',
   LOAD_OPTIONS           = 'PROJECTS_FILTER::LOAD_OPTIONS',
   LOAD_OPTIONS_SUCCESS   = 'PROJECTS_FILTER::LOAD_OPTIONS::SUCCESS',
   LOAD_OPTIONS_FAILURE   = 'PROJECTS_FILTER::LOAD_OPTIONS::FAILURE',
   SAVE_OPTIONS           = 'PROJECTS_FILTER::SAVE_OPTIONS',
   UPDATE_SELECTION_COUNT = 'PROJECTS_FILTER::UPDATE_SELECTION_COUNT'
+}
+
+export class InitOptions implements Action {
+  readonly type = ProjectsFilterActionTypes.INIT_OPTIONS;
+}
+
+export class InitOptionsSuccess implements Action {
+  readonly type = ProjectsFilterActionTypes.INIT_OPTIONS_SUCCESS;
+  constructor(public payload: ProjectsFilterOptionTuple) { }
 }
 
 export class LoadOptions implements Action {
@@ -35,6 +46,8 @@ export class UpdateSelectionCount implements Action {
 }
 
 export type ProjectsFilterActions =
+  | InitOptions
+  | InitOptionsSuccess
   | LoadOptions
   | LoadOptionsSuccess
   | LoadOptionsFailure

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
@@ -11,6 +11,7 @@ import { ProjectsFilterRequests, AuthorizedProjectsResponse } from './projects-f
 import {
   ProjectsFilterActionTypes,
   ProjectsFilterActions,
+  InitOptionsSuccess,
   LoadOptions,
   LoadOptionsSuccess,
   LoadOptionsFailure,
@@ -30,6 +31,18 @@ export class ProjectsFilterEffects {
   @Effect()
   latestOptions$ = observableInterval(1000 * this.POLLING_INTERVAL_IN_SECONDS).pipe(
     mergeMap(this.loadOptionsAction$()));
+
+  // Fast-initialize project filter just from local storage
+  @Effect()
+  initOptions$ = this.actions$.pipe(
+    ofType<LoadOptions>(ProjectsFilterActionTypes.INIT_OPTIONS),
+    map(() => {
+      return new InitOptionsSuccess({
+        fetched: [],
+        restored: this.projectsFilter.restoreOptions() || []
+      });
+    })
+  );
 
   @Effect()
   loadOptions$ = this.actions$.pipe(

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.reducer.ts
@@ -58,19 +58,15 @@ export function projectsFilterReducer(
       return set('optionsLoadingStatus', EntityStatus.loading, state);
     }
 
+    case ProjectsFilterActionTypes.INIT_OPTIONS_SUCCESS: {
+      const sortedOptions = sortOptions(action.payload.restored);
+      return setDropdownProperties(sortedOptions, state);
+    }
+
     case ProjectsFilterActionTypes.LOAD_OPTIONS_SUCCESS: {
       const mergedOptions = mergeOptions(action.payload.fetched, action.payload.restored);
       const sortedOptions = sortOptions(mergedOptions);
-      return pipe(
-        set('options', sortedOptions),
-        set('optionsLoadingStatus', EntityStatus.loadingSuccess),
-        set('selectionLabel', selectionLabel(sortedOptions)),
-        set('selectionCount', selectionCount(sortedOptions)),
-        set('selectionCountVisible', selectionCountVisible(sortedOptions)),
-        set('selectionCountActive', selectionCountActive(sortedOptions)),
-        set('dropdownCaretVisible', dropdownCaretVisible(sortedOptions)),
-        set('filterVisible', filterVisible(sortedOptions))
-      )(state) as ProjectsFilterState;
+      return setDropdownProperties(sortedOptions, state);
     }
 
     case ProjectsFilterActionTypes.LOAD_OPTIONS_FAILURE: {
@@ -105,6 +101,20 @@ export function projectsFilterReducer(
   }
 
   return state;
+}
+
+function setDropdownProperties(
+  sortedOptions: ProjectsFilterOption[], state: ProjectsFilterState): ProjectsFilterState {
+  return pipe(
+    set('options', sortedOptions),
+    set('optionsLoadingStatus', EntityStatus.loadingSuccess),
+    set('selectionLabel', selectionLabel(sortedOptions)),
+    set('selectionCount', selectionCount(sortedOptions)),
+    set('selectionCountVisible', selectionCountVisible(sortedOptions)),
+    set('selectionCountActive', selectionCountActive(sortedOptions)),
+    set('dropdownCaretVisible', dropdownCaretVisible(sortedOptions)),
+    set('filterVisible', filterVisible(sortedOptions)
+    ))(state) as ProjectsFilterState;
 }
 
 function selectionLabel(options: ProjectsFilterOption[]): string {
@@ -187,11 +197,11 @@ function filterVisible(options: ProjectsFilterOption[]): boolean {
   return hasSomePermissions && !hasOnlyUnassignedPermission;
 }
 
+// Grab previously saved options from localstorage (restored) and,
+// if any has the same value as one of the newly fetched options (fetched),
+// merge its current checked status with the fetched option
+// to create the final list of available options.
 function mergeOptions(
-  // Grab previously saved options from localstorage (restored) and,
-  // if any has the same value as one of the newly fetched options (fetched),
-  // merge its current checked status with the fetched option
-  // to create the final list of available options.
   fetched: ProjectsFilterOption[], restored: ProjectsFilterOption[]): ProjectsFilterOption[] {
   return fetched.map(fetchedOpt => {
     const restoredOpt = find(['value', fetchedOpt.value], restored);

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { ProjectsFilterOption } from './projects-filter.reducer';
 import * as selectors from './projects-filter.selectors';
-import { LoadOptions, SaveOptions, UpdateSelectionCount } from './projects-filter.actions';
+import { InitOptions, LoadOptions, SaveOptions, UpdateSelectionCount } from './projects-filter.actions';
 
 const STORE_OPTIONS_KEY = 'projectsFilter.options';
 
@@ -29,6 +29,9 @@ export class ProjectsFilterService {
   constructor(private store: Store<NgrxStateAtom>, private router: Router) { }
 
   loadOptions() {
+    // fast load of project selection just from local storage
+    this.store.dispatch(new InitOptions());
+    // leisurely load of updated projects from back-end refining above
     this.store.dispatch(new LoadOptions());
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The original issue scenario is shown in the console trace below:
"Create a project. Tag a single team with the project (leave others unassigned). Select the project from the projects filter. A single team will correctly show up. Hit refresh. ~All the teams will show up.~ _Just the correct team will show up._"

<img width="599" alt="image" src="https://user-images.githubusercontent.com/6817500/78052530-1ec5e200-7334-11ea-94f2-f2e0ab9b322e.png">

1. The interceptor (the conduit for all back-end requests) early on gets notified of... no projects.
2. Thus, very early requests at this point have no projects in the header.
3. As components are instantiated, the layout facade is starting to build. That kicks off a back-end request for projects.
4. But we already have the project selections in local storage, so we just activate those immediately while waiting for the latest projects list updates, if any, to return from the back-end.
5. The page continues to be constructed. We are on the teams page, so we have now gotten to that component, which kicks off a request to the back-end, now complete with the necessary project header!
6. Sometime later, the initial back-end request for projects is satisfied, so the project dropdown now gets updated, if needed, to reflect any project changes in the system.
7. Just to show other things working, I navigated to tokens and teams again without page refresh, showing they still correctly show the project header.

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/6817500/78054231-94cb4880-7336-11ea-9f85-ae4cca349785.png">

### :chains: Related Resources
NA

### :+1: Definition of Done
On page refreshes, the global project filter settings are honored.

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui.
Follow steps noted above.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
