### PR TITLE
ignore status for chicklets

### DIFF
--- a/components/compliance-service/api/tests/02_nodes_spec.rb
+++ b/components/compliance-service/api/tests/02_nodes_spec.rb
@@ -653,6 +653,7 @@ describe File.basename(__FILE__) do
             }
         ],
         "total" => 1,
+        "totalFailed" => 1,
         "totalPassed" => 1
     }.to_json
     assert_equal_json_sorted(expected_nodes, actual_nodes.to_json)
@@ -716,7 +717,9 @@ describe File.basename(__FILE__) do
             }
         ],
         "total" => 1,
-        "totalPassed" => 1
+        "totalFailed" => 3,
+        "totalPassed" => 1,
+        "totalSkipped" => 1
     }.to_json
     assert_equal_json_sorted(expected_nodes, actual_nodes.to_json)
 

--- a/components/compliance-service/api/tests/02_nodes_spec.rb
+++ b/components/compliance-service/api/tests/02_nodes_spec.rb
@@ -652,7 +652,7 @@ describe File.basename(__FILE__) do
                 ]
             }
         ],
-        "total" => 1,
+        "total" => 2,
         "totalFailed" => 1,
         "totalPassed" => 1
     }.to_json
@@ -716,7 +716,7 @@ describe File.basename(__FILE__) do
                 ]
             }
         ],
-        "total" => 1,
+        "total" => 5,
         "totalFailed" => 3,
         "totalPassed" => 1,
         "totalSkipped" => 1

--- a/components/compliance-service/api/tests/08_deep_search_profiles_spec.rb
+++ b/components/compliance-service/api/tests/08_deep_search_profiles_spec.rb
@@ -373,7 +373,7 @@ describe File.basename(__FILE__) do
         ],
         page: 1, per_page: 2)
     expected_data = {
-      "counts" => { "waived" => 1 },
+      "counts" => { "total" => 1, "waived" => 1 },
       "profiles" => [
           {
             "id" => "447542ecfb8a8800ed0146039da3af8fed047f575f6037cfba75f3b664a97ea5",

--- a/components/compliance-service/api/tests/08_search_profiles_spec.rb
+++ b/components/compliance-service/api/tests/08_search_profiles_spec.rb
@@ -205,7 +205,8 @@ describe File.basename(__FILE__) do
             }
         ],
         "counts" => {
-            "total" => 2,
+            "total" => 3,
+            "failed" => 1,
             "skipped" => 2
         }
     }

--- a/components/compliance-service/reporting/relaxting/nodes.go
+++ b/components/compliance-service/reporting/relaxting/nodes.go
@@ -175,6 +175,8 @@ func (backend *ES2Backend) GetNodes(from int32, size int32, filters map[string][
 			}
 
 		}
+		//take status out of filters similar to why we remove them from suggestions.. we want to always see what's available in this context
+		delete(filters, "status")
 		// get node counts of passed/failed/skipped/waived nodes to append to totals response
 		nodeSummary, err := backend.GetStatsSummaryNodes(filters)
 		if err != nil {

--- a/components/compliance-service/reporting/relaxting/nodes.go
+++ b/components/compliance-service/reporting/relaxting/nodes.go
@@ -182,7 +182,15 @@ func (backend *ES2Backend) GetNodes(from int32, size int32, filters map[string][
 		if err != nil {
 			return nil, emptyTotals, errors.Wrapf(err, "%s error retrieving node count totals: ", myName)
 		}
-		return nodes, TotalNodeCounts{Total: int32(searchResult.TotalHits()), Passed: nodeSummary.Compliant, Failed: nodeSummary.Noncompliant, Skipped: nodeSummary.Skipped, Waived: nodeSummary.Waived}, nil
+
+		total := nodeSummary.Compliant + nodeSummary.Noncompliant + nodeSummary.Skipped + nodeSummary.Waived
+		return nodes, TotalNodeCounts{
+			Total:   total,
+			Passed:  nodeSummary.Compliant,
+			Failed:  nodeSummary.Noncompliant,
+			Skipped: nodeSummary.Skipped,
+			Waived:  nodeSummary.Waived,
+		}, nil
 	}
 
 	logrus.Debugf("%s Found no nodes\n", myName)

--- a/components/compliance-service/reporting/relaxting/profiles_control_level.go
+++ b/components/compliance-service/reporting/relaxting/profiles_control_level.go
@@ -57,6 +57,7 @@ func (depth *ControlDepth) getProfileMinsFromNodesResults(
 
 	profileMins := make(map[string]reporting.ProfileMin)
 	var counts *reportingapi.ProfileCounts
+	statusMap := make(map[string]int, 4)
 
 	if aggRoot, found := depth.unwrap(&searchResult.Aggregations); found {
 		if impactBuckets, found := aggRoot.Aggregations.Terms("impact"); found && len(impactBuckets.Buckets) > 0 {
@@ -109,12 +110,15 @@ func (depth *ControlDepth) getProfileMinsFromNodesResults(
 				Status: profileStatus,
 			}
 			profileMins[summary.Id] = summaryRep
+
+			//let's keep track of the counts even if they're not in the filter so that we may know that they're there for UI chicklets
+			statusMap[profileStatus]++
 			counts = &reportingapi.ProfileCounts{
-				Total:   summary.Failures + summary.Passed + summary.Skipped + summary.Waived,
-				Failed:  summary.Failures,
-				Passed:  summary.Passed,
-				Skipped: summary.Skipped,
-				Waived:  summary.Waived,
+				Total:   int32(statusMap["failed"] + statusMap["passed"] + statusMap["skipped"]),
+				Failed:  int32(statusMap["failed"]),
+				Passed:  int32(statusMap["passed"]),
+				Skipped: int32(statusMap["skipped"]),
+				Waived:  int32(statusMap["waived"]),
 			}
 		}
 	}

--- a/components/compliance-service/reporting/relaxting/profiles_control_level.go
+++ b/components/compliance-service/reporting/relaxting/profiles_control_level.go
@@ -114,7 +114,7 @@ func (depth *ControlDepth) getProfileMinsFromNodesResults(
 			//let's keep track of the counts even if they're not in the filter so that we may know that they're there for UI chicklets
 			statusMap[profileStatus]++
 			counts = &reportingapi.ProfileCounts{
-				Total:   int32(statusMap["failed"] + statusMap["passed"] + statusMap["skipped"]),
+				Total:   int32(statusMap["failed"] + statusMap["passed"] + statusMap["skipped"] + statusMap["waived"]),
 				Failed:  int32(statusMap["failed"]),
 				Passed:  int32(statusMap["passed"]),
 				Skipped: int32(statusMap["skipped"]),

--- a/components/compliance-service/reporting/relaxting/profiles_profile_level.go
+++ b/components/compliance-service/reporting/relaxting/profiles_profile_level.go
@@ -80,11 +80,12 @@ func (depth *ProfileDepth) getProfileMinsFromNodesResults(
 						int32(*sumSkipped.Value), int32(*sumWaived.Value))
 				}
 
+				//let's keep track of the counts even if they're not in the filter so that we may know that they're there for UI chicklets
+				statusMap[profileStatus]++
+
 				if len(statusFilters) > 0 && !stringutils.SliceContains(statusFilters, profileStatus) {
 					continue
 				}
-
-				statusMap[profileStatus]++
 
 				summary := reporting.ProfileMin{
 					Name:   profileName,

--- a/components/compliance-service/reporting/relaxting/profiles_profile_level.go
+++ b/components/compliance-service/reporting/relaxting/profiles_profile_level.go
@@ -99,7 +99,7 @@ func (depth *ProfileDepth) getProfileMinsFromNodesResults(
 	logrus.Debugf("%s Done with statusMap=%+v", myName, statusMap)
 	logrus.Debugf("%s Done with statusMap['something']=%+v", myName, statusMap["passed"])
 	counts := &reportingapi.ProfileCounts{
-		Total:   int32(statusMap["failed"] + statusMap["passed"] + statusMap["skipped"]),
+		Total:   int32(statusMap["failed"] + statusMap["passed"] + statusMap["skipped"] + statusMap["waived"]),
 		Failed:  int32(statusMap["failed"]),
 		Passed:  int32(statusMap["passed"]),
 		Skipped: int32(statusMap["skipped"]),

--- a/components/compliance-service/reporting/relaxting/profiles_report_level.go
+++ b/components/compliance-service/reporting/relaxting/profiles_report_level.go
@@ -96,7 +96,7 @@ func (depth *ReportDepth) getProfileMinsFromNodesResults(
 	logrus.Debugf("Done with statusMap=%+v", statusMap)
 	logrus.Debugf("Done with statusMap['something']=%+v", statusMap["passed"])
 	counts := &reportingapi.ProfileCounts{
-		Total:   int32(statusMap["failed"]+statusMap["passed"]+statusMap["skipped"]) + int32(statusMap["waived"]),
+		Total:   int32(statusMap["failed"] + statusMap["passed"] + statusMap["skipped"] + statusMap["waived"]),
 		Failed:  int32(statusMap["failed"]),
 		Passed:  int32(statusMap["passed"]),
 		Skipped: int32(statusMap["skipped"]),

--- a/components/compliance-service/reporting/relaxting/profiles_report_level.go
+++ b/components/compliance-service/reporting/relaxting/profiles_report_level.go
@@ -77,11 +77,12 @@ func (depth *ReportDepth) getProfileMinsFromNodesResults(
 					logrus.Debugf("getProfileMinsFromNodesResults profile_name=%s, status=%s (sumFailures=%d, sumPassed=%d, sumSkipped=%d, sumWaived=%d)", profileName, profileStatus, int32(*sumFailures.Value), int32(*sumPassed.Value), int32(*sumSkipped.Value), int32(*sumWaived.Value))
 				}
 
+				//let's keep track of the counts even if they're not in the filter so that we may know that they're there for UI chicklets
+				statusMap[profileStatus]++
+
 				if len(statusFilters) > 0 && !stringutils.SliceContains(statusFilters, profileStatus) {
 					continue
 				}
-
-				statusMap[profileStatus]++
 
 				summary := reporting.ProfileMin{
 					Name:   profileName,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When we send it status as a filter for nodes or profiles lists, do not apply the status filter to the actual summary counts.  If we apply the status filter to the counts then we won't be able to subsequently choose them in the UI

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
