### PR TITLE
make send raw chef run configurable

### DIFF
--- a/.studio/automate-gateway
+++ b/.studio/automate-gateway
@@ -89,7 +89,7 @@ document "gateway_get" <<DOC
 
   Example: Send a GET Request to $GATEWAY_URL/version using a specific token
   --------------------------------------------------------------------------
-  # gateway_get "/version" "$TOKEN"
+  # gateway_get "/version" "$token"
 DOC
 function gateway_get() {
   install_if_missing core/curl curl >/dev/null 2>&1

--- a/.studio/automate-gateway
+++ b/.studio/automate-gateway
@@ -286,6 +286,7 @@ function send_chef_data_raw() {
   install_if_missing core/curl curl
 
   local endpoint=$1
+  local token=$2
   if [[ "$1" == "legacy" ]]; then
     endpoint="${GATEWAY_URL}/events/data-collector"
   elif [[ "$1" == "lb" ]]; then
@@ -293,10 +294,16 @@ function send_chef_data_raw() {
   elif [[ "$1x" == "x" ]]; then
     endpoint="${GATEWAY_URL}/ingest/events/chef/run"
   else
-    endpoint="${GATEWAY_URL}$1"
+    endpoint="$1"
   fi
 
-  curl -f --insecure -H "api-token: $(get_api_token)" \
+  if [[ "$2x" == "x" ]]; then
+    token=$(get_api_token)
+  else
+    token=$2
+  fi
+
+  curl -f --insecure -H "api-token: ${token}" \
   --data "@-" "${endpoint}"
 }
 


### PR DESCRIPTION
Signed-off-by: Victoria Jeffrey <vjeffrey@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
making the command dan added last week for loading a bunch of chef-client reports with custom data configurable for non-dev-env url and token

### :chains: Related Resources
https://github.com/chef/automate/pull/3213

### :+1: Definition of Done
can use the command to load data in dev env or another env

### :athletic_shoe: How to Build and Test the Change
```
source .studio/automate-gateway

local dev env:
for _ in {1..500} ; do   m=$((RANDOM % 4));   n=$((RANDOM % 25));   generate_chef_run_failure_example |     jq --arg msg "Error $n occurred" --arg type "Chef::ExampleError$m" '.error.message = $msg | .error.class = $type' |     send_chef_data_raw; done

other env:
for _ in {1..500} ; do   m=$((RANDOM % 4));   n=$((RANDOM % 25));   generate_chef_run_failure_example |     jq --arg msg "Error $n occurred" --arg type "Chef::ExampleError$m" '.error.message = $msg | .error.class = $type' |     send_chef_data_raw https://a2-local-inplace-upgrade-dev.cd.chef.co/data-collector/v0 token-val; done
```
