### PR TITLE
removed admin token section of restore admin docs and other iam cleanup

### DIFF
--- a/components/automate-chef-io/content/docs/iam-v1-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v1-overview.md
@@ -16,7 +16,7 @@ toc = true
 +++
 
 {{< warning >}}
-This documentation and the feature it covers, IAM v1, are deprecated. This documentation will be removed soon. Most Chef Automate installations upgraded automatically to the current IAM implementation. The [Airgap Installation documentation {{< relref "airgapped-installation.md/#upgrades" >}} covers the manual upgrade process for systems without internet connectivity.
+This documentation and the feature it covers, IAM v1, are deprecated. This documentation will be removed soon. Most Chef Automate installations upgraded automatically to the current IAM implementation. The [Airgap Installation documentation]({{< relref "airgapped-installation#upgrades" >}}) covers the manual upgrade process for systems without internet connectivity.
 The current IAM documentation pages are: the [IAM Overview]({{< relref "iam-v2-overview" >}}), the [IAM Guide]({{< relref "iam-v2-guide" >}}) and the [Chef Automate API](https://automate.chef.io/docs/api/).
 {{< /warning >}}
 

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -49,7 +49,7 @@ Note that you could also add users directly to policies without the intermediate
 
 #### Create Users
 
-Follow the instructions on [Creating Users]({{< relref "users.md#manage-local-users-from-the-ui" >}}) to:
+Follow the instructions on [Creating Users]({{< relref "users.md#creating-local-users" >}}) to:
 
 * Create a local user with the username `test_viewer`.
 * Create a local user with the username `test_editor`.
@@ -59,7 +59,7 @@ Follow the instructions on [Creating Users]({{< relref "users.md#manage-local-us
 Select `Teams` from the left navigation of the **Settings** tab.
 Three teams are provided by default: `admins`, `viewers`, and `editors`.
 
-Follow the instructions for [Adding Users to a Team]({{< relref "teams.md#adding-users-to-a-team" >}}) to:
+Follow the instructions for [Adding Users to a Team]({{< relref "teams.md#adding-local-users-to-teams" >}}) to:
 
 * Add the user `test_viewer` to the Chef-managed `viewers` team.
 * Add the user `test_editor` to the Chef-managed `editors` team.
@@ -162,7 +162,7 @@ In this case, we only need a single statement providing access to the _get_, _li
 }
 ```
 
-Save your JSON file and refer to the [IAM Policies API reference](https://automate.chef.io/docs/api/#tag/Policies) to send that policy data to Chef Automate.
+Save your JSON file and refer to the [IAM Policies API reference](https://automate.chef.io/docs/api/#tag/policies) to send that policy data to Chef Automate.
 
 ### Policy Membership
 
@@ -267,7 +267,7 @@ If you would like to delegate ownership of a project to another user so that the
 While Automate's local teams and tokens can be directly assigned to a project, ingested resources must be assigned to projects using ingest rules.
 
 Project ingest rules are used to associate ingested resources with projects within Automate. An ingest rule contains conditions that determine if an ingested resource should be moved into the rule's project.
-Each condition contains an attribute, operator, and value. See [IAM Project Rules API reference](https://automate.chef.io/docs/api/#tag/Project_rules) for details on how to manage project rules.
+Each condition contains an attribute, operator, and value. See [IAM Project Rules API reference](https://automate.chef.io/docs/api/#tag/rules) for details on how to manage project rules.
 
 In this example, after [creating a project]({{< relref "iam-v2-guide.md#creating-a-project" >}}) with the ID `project-devops`, you will add an ingest rule to this new project.
 You will update projects to apply this new project rule, causing all matching ingested resources to be associated with `project-devops`.

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -406,9 +406,3 @@ This command resets the local `admin` user's password and ensures that the user 
 ```bash
   chef-automate iam admin-access restore <your new password here>
 ```
-
-Generate a new token and add that token as a new member of the Chef-managed `Administrator` policy.
-
-```bash
-  chef-automate iam token create <your token name here> --admin
-```

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -115,7 +115,7 @@ The statement allows us to specify the `actions` a user is permitted to take upo
 The `projects` field on a statement is an array that may contain more than one existing project, a wildcard `*` to indicate permission to resources in _any project_, or `(unassigned)` to indicate permission to resources that have not been assigned to a project.
 
 Note that the `projects` property in statements designates permission for the resources within the statement (here, that is `iam:users` and `iam:teams`), _not_ for the policy itself, and _cannot_ be left empty.
-For more about projects, see [Projects in the IAM Guide]({{< relref "iam-v2-guide.md#projects" >}} documentation.
+For more about projects, see [Projects in the IAM Guide]({{< relref "iam-v2-guide.md#projects" >}}) documentation.
 
 In this case, we only need a single statement providing access to the _get_, _list_, and _update_ actions for _users_ and _teams_ that have been assigned to the project `project-devops`.
 

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -87,7 +87,7 @@ See the end of this section for a [complete JSON policy example]({{< relref "iam
 ```
 
 The `name` field is for human consumption. When you want to refer to the policy in commands, you will need to know the policy's ID.
-So let us give this policy the ID value: `team-managers-devops`.
+Let us give this policy the ID value: `team-managers-devops`.
 
 ```json
   "id": "team-managers-devops",

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -248,17 +248,15 @@ Policy Name                      | Policy ID                        | Associated
 
 These policies are discussed in more detail in [Project Policies]({{< relref "iam-v2-guide.md#project-policies" >}}).
 
-#### Assigning Resources to Projects
+#### Assigning Teams and Tokens to Projects
 
-Projects can be assigned to Automate-created resources on creation or update.
+Projects can be assigned to Automate-created teams or tokens on creation or update.
 
 To assign a team to projects, select a team from the _Teams_ list, then select **Details**.
 Likewise, to assign a token to projects, select a token from the API tokens list, then select **Details**.
 In either case, you can select projects from the projects dropdown to assign.
 
 You may also assign teams and tokens to projects on creation. In the creation modal, select any projects to which the new resource should belong.
-
-Presently, policies and roles can only be assigned to projects using the command line, not the browser. Users cannot be assigned to projects from the browser or the command line.
 
 If you would like to delegate ownership of a project to another user so that they may assign resources, you will want to make that user a [Project Owner]({{< relref "iam-v2-guide.md#project-owners" >}}) of that project.
 

--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -211,5 +211,5 @@ Property               | Description
 -----------------------|------------
 Event Attribute        | Chef Organization or Chef Server
 Node Attribute         | Chef Organization, Chef Server, Environment, Chef Role, Chef Tag, Chef Policy Name, or Chef Policy Group
-Operator               | equals of member of
+Operator               | equals or member of
 Values                 | list of one or more values to match on the specified attribute

--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -14,7 +14,7 @@ toc = true
 This documentation covers Chef Automate's IAM feature in release 20200326170928 and later.
 {{< /info >}}
 
-Chef Automate's Identity and Access Managment (IAM) allows direct management of policy members from Chef Automate in the browser.
+Chef Automate's Identity and Access Management (IAM) allows direct management of policy members from Chef Automate in the browser.
 IAM supports the projects feature, which allow for filtering and segregation of your data amongst your user base.
 IAM policies allow you to use multiple permissions, distinguish policy membership from policy definition for fine-grained control, and include roles for role-based access control.
 
@@ -138,7 +138,7 @@ Set up IAM projects using the following steps:
 2. Create or edit IAM policy statements to restrict permissions to specific projects as needed.
    *Every* statement must either name specific projects, specify the wildcard (`*`), which denotes all projects, or specify as `(unassigned)`, which provides permissions on objects without projects.
    By default, any pre-upgrade previous policies are automatically set up with that wildcard, so they apply to all projects.
-3. [Assign resources to projects]({{< relref "iam-v2-overview.md#assigning-resources-to-projects" >}}).
+3. [Assign teams or tokens to projects]({{< relref "iam-v2-guide.md#assigning-teams-and-tokens-to-projects" >}}).
 4. Select the projects to filter in the UI.
    After creating projects, use the **global project filter** in the top navigation to select one or more projects for viewing.
    No selection displays all resources for which you have permission.

--- a/components/automate-chef-io/content/docs/projects.md
+++ b/components/automate-chef-io/content/docs/projects.md
@@ -61,7 +61,7 @@ To change the name of a project, navigate to _Projects_ in the **Settings** tab 
 
 The _Project List_ page displays the status of project ingest rules (*No rules*, *Edits pending*, or *Applied*).
 
-If a project has pending edits from changes to ingest rules, then all projects must be updated for those pending edits to take effect. The update background process can take up to 12 hours if there is a lot of historical data. 
+If a project has pending edits from changes to ingest rules, then all projects must be updated for those pending edits to take effect. Updating projects will apply all pending edits and move ingested resources into the correct projects. This background process can take a few minutes for systems with a limited number of nodes, and **several days** for systems with a large number of nodes. 
 
 All changes will be applied together when you update projects. To update projects navigate to _Projects_ in the **Settings** tab and use the **Update Projects** button.
 


### PR DESCRIPTION
## Overview
Recently, in [internal slack](https://chefio.slack.com/archives/C08K8CD9Q/p1585691037001500?thread_ts=1585690965.000800&cid=C08K8CD9Q), someone asked if their tokens became invalidated after restoring admin access and reviewing the docs i noticed that we included a weird reference to admin tokens which is where i think the confusion came from. so i removed that section, its already documented on the tokens docs page, and in the api token docs.

also fixed a bunch of broken links and few other incorrect things.

## definition of done
things are less broken and less confusing

## to test
`make serve` from `components/automate-chef-io`