### PR TITLE
Improved errors for data-feed-service API

### DIFF
--- a/components/data-feed-service/dao/destination.go
+++ b/components/data-feed-service/dao/destination.go
@@ -28,7 +28,7 @@ func addToDBDestination(inDestination *datafeed.AddDestinationRequest) *Destinat
 
 func updateToDBDestination(inDestination *datafeed.UpdateDestinationRequest) *Destination {
 	newDestination := Destination{}
-	newDestination.ID, _ = strconv.ParseInt(inDestination.Id, 10 , 64)
+	newDestination.ID, _ = strconv.ParseInt(inDestination.Id, 10, 64)
 	newDestination.Name = inDestination.Name
 	newDestination.URL = inDestination.Url
 	newDestination.Secret = inDestination.Secret
@@ -90,7 +90,7 @@ func (db *DB) UpdateDestination(destination *datafeed.UpdateDestinationRequest) 
 			return errors.Wrap(err, "UpdateDestination: unable to update destination")
 		}
 		if count == 0 {
-			return errorutils.ProcessSQLNotFound(sql.ErrNoRows, strconv.FormatInt(destination.Id, 10), "UpdateDestination")
+			return errorutils.ProcessSQLNotFound(sql.ErrNoRows, destination.Id, "UpdateDestination")
 		}
 		return nil
 	})


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Failed API calls to the data-feed-service were returning 500 in all error cases, I have updated the API to return 404 for update, get, delete operations with an id that doesn't correspond to a datafeed destination record

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated? tested in service now dev env and with curl
- [ ] Docs added/updated? docs TBD 
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).


### :camera: Screenshots, if applicable
