### PR TITLE
Turn on strict Angular checks that pass

### DIFF
--- a/components/automate-ui/tsconfig.json
+++ b/components/automate-ui/tsconfig.json
@@ -24,6 +24,16 @@
     "noUnusedParameters": true
   },
   "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputTypes": false,
+    "strictNullInputTypes": true,
+    "strictAttributeTypes": true,
+    "strictSafeNavigationTypes": true,
+    "strictDomLocalRefTypes": false,
+    "strictOutputEventTypes": false,
+    "strictDomEventTypes": false,
+    "strictContextGenerics": true,
+    "strictLiteralTypes": true,
     "fullTemplateTypeCheck": true
   },
   "exclude": [


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

We recently activated what I refer to as "level one" type checking via `fullTemplateTypeCheck` (see PR #3230). This PR starts to address "level two", which would include the single check `strictInjectionParameters` (not clear why this one is separate 🤷‍♂ ) and `strictTemplates`, which comprises a group of checks. We are not yet ready for `strictTemplates` because it reports quite a lot of issues to address, so instead I have itemized its components in the config file and this PR turns on all the ones that are already clean in the code base, requiring no code fixes.

### :chains: Related Resources

- [fullTemplateTypeCheck](https://angular.io/guide/angular-compiler-options#fulltemplatetypecheck)
- [strictInjectionParameters](https://angular.io/guide/angular-compiler-options#strictinjectionparameters)
- [all other check options](https://angular.io/guide/angular-compiler-options#fulltemplatetypecheck)

### :+1: Definition of Done
Buildkite passes

### :athletic_shoe: How to Build and Test the Change
Run `ng build` -- should present no errors.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
