### PR TITLE
Clean up Infra Server and Org update subscriptions

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -47,7 +47,7 @@
           <chef-form-field id="update-name">
             <label>
                 <span class="label">Name <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="name" type="text" autocomplete="off"
+              <input chefInput formControlName="name" type="text" [resetOrigin]="saveSuccessful" autocomplete="off"
                 data-cy="update-chefServer-name">
             </label>
             <chef-error
@@ -58,7 +58,7 @@
           <chef-form-field id="update-description">
             <label>
               <span class="label">Description <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="description" type="text" autocomplete="off"
+              <input chefInput formControlName="description" type="text" [resetOrigin]="saveSuccessful" autocomplete="off"
                 data-cy="update-chefServer-description">
             </label>
             <chef-error
@@ -69,7 +69,7 @@
           <chef-form-field id="update-fqdn">
             <label>
               <span class="label">FQDN <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="fqdn" type="text" autocomplete="off"
+              <input chefInput formControlName="fqdn" type="text" [resetOrigin]="saveSuccessful" autocomplete="off"
                 data-cy="update-chefServer-fqdn">
             </label>
             <chef-error
@@ -80,7 +80,7 @@
           <chef-form-field id="update-ip_address">    
             <label>
               <span class="label">IP Address <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="ip_address" type="text" autocomplete="off"
+              <input chefInput formControlName="ip_address" type="text" [resetOrigin]="saveSuccessful" autocomplete="off"
                 data-cy="update-chefServer-ip_address">
             </label>
             <chef-error

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -91,9 +91,9 @@
           <div id="button-bar">
             <chef-button [disabled]="isLoading || !updateServerForm.valid || !updateServerForm.dirty"
               primary inline (click)="saveServer()">                
-            <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
-            <span *ngIf="saving">Saving...</span>
-            <span *ngIf="!saving">Save</span></chef-button>
+            <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
+            <span *ngIf="saveInProgress">Saving...</span>
+            <span *ngIf="!saveInProgress">Save</span></chef-button>
             <span id="saved-note" *ngIf="saveSuccessful && !updateServerForm.dirty">All changes saved.</span>
           </div>
         </form>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
@@ -51,10 +51,9 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
   public modalType: string;
   private id: string;
   public saveSuccessful = false;
-
+  public saveInProgress = false;
   // isLoading represents the initial load as well as subsequent updates in progress.
   public isLoading = true;
-  public saving = false;
   private isDestroyed = new Subject<boolean>();
 
   constructor(
@@ -139,6 +138,17 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
         this.store.dispatch(new GetServer({ id: this.id })
       );
     });
+
+    this.store.pipe(select(updateStatus),
+    takeUntil(this.isDestroyed),
+    filter(state => this.saveInProgress && !pending(state)))
+    .subscribe((state) => {
+      this.saveInProgress = false;
+      this.saveSuccessful = (state === EntityStatus.loadingSuccess);
+      if (this.saveSuccessful) {
+        this.updateServerForm.markAsPristine();
+      }
+    });
   }
 
   ngOnDestroy(): void {
@@ -196,7 +206,7 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
 
   saveServer(): void {
     this.saveSuccessful = false;
-    this.saving = true;
+    this.saveInProgress = true;
     const updatedServer = {
       id: this.server.id,
       name: this.updateServerForm.controls.name.value.trim(),
@@ -205,16 +215,6 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
       ip_address: this.updateServerForm.controls.ip_address.value.trim()
     };
     this.store.dispatch(new UpdateServer({server: updatedServer}));
-    this.store.pipe(select(updateStatus),
-      takeUntil(this.isDestroyed),
-      filter(state => this.saving && !pending(state)))
-      .subscribe((state) => {
-        this.saving = false;
-        this.saveSuccessful = (state === EntityStatus.loadingSuccess);
-        if (this.saveSuccessful) {
-          this.updateServerForm.markAsPristine();
-        }
-      });
   }
 
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, EventEmitter } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
-import { Store, select } from '@ngrx/store';
+import { Store } from '@ngrx/store';
 import { Subject, combineLatest } from 'rxjs';
 import { filter, pluck, takeUntil } from 'rxjs/operators';
 import { identity, isNil } from 'lodash/fp';
@@ -139,9 +139,9 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
       );
     });
 
-    this.store.pipe(select(updateStatus),
-    takeUntil(this.isDestroyed),
-    filter(state => this.saveInProgress && !pending(state)))
+    this.store.select(updateStatus).pipe(
+      takeUntil(this.isDestroyed),
+      filter(state => this.saveInProgress && !pending(state)))
     .subscribe((state) => {
       this.saveInProgress = false;
       this.saveSuccessful = (state === EntityStatus.loadingSuccess);

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.html
@@ -32,7 +32,7 @@
                     <chef-form-field>
                         <label>
                             <span class="label">Name <span aria-hidden="true">*</span></span>
-                            <input chefInput formControlName="name" type="text" autocomplete="off"
+                            <input chefInput formControlName="name" type="text" [resetOrigin]="saveSuccessful" autocomplete="off"
                                 data-cy="update-org-name">
                         </label>
                         <chef-error
@@ -43,7 +43,7 @@
                     <chef-form-field>
                         <label>
                             <span class="label">Admin User <span aria-hidden="true">*</span></span>
-                            <input chefInput formControlName="admin_user" type="text" autocomplete="off"
+                            <input chefInput formControlName="admin_user" type="text" [resetOrigin]="saveSuccessful" autocomplete="off"
                                 data-cy="update-Org-admin-user">
                         </label>
                         <chef-error

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.html
@@ -66,9 +66,9 @@
                         <div id="button-bar">
                             <chef-button [disabled]="isLoading || !updateOrgForm.valid || !updateOrgForm.dirty" primary
                                 inline (click)="saveOrg()">
-                                <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
-                                <span *ngIf="saving">Saving...</span>
-                                <span *ngIf="!saving">Save</span>
+                                <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
+                                <span *ngIf="saveInProgress">Saving...</span>
+                                <span *ngIf="!saveInProgress">Save</span>
                             </chef-button>
                             <span id="saved-note" *ngIf="saveSuccessful && !updateOrgForm.dirty">All changes
                                 saved.</span>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Store, select } from '@ngrx/store';
+import { Store } from '@ngrx/store';
 import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Observable, Subject, combineLatest } from 'rxjs';

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
@@ -46,7 +46,7 @@ export class CookbooksListComponent implements OnInit, OnDestroy {
     private store: Store<NgrxStateAtom>,
     private layoutFacade: LayoutFacadeService,
     private router: Router
-  ) { 
+  ) {
     this.updateOrgForm = this.fb.group({
       name: new FormControl({value: ''}, [Validators.required]),
       admin_user: new FormControl({value: ''}, [Validators.required]),

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
@@ -118,8 +118,7 @@ export class CookbooksListComponent implements OnInit, OnDestroy {
         this.cookbooks = allCookbooksState;
       });
 
-      this.store.pipe(
-        select(updateStatus),
+      this.store.select(updateStatus).pipe(
         takeUntil(this.isDestroyed),
         filter(state => this.saveInProgress && !pending(state)))
         .subscribe((state) => {

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Store } from '@ngrx/store';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Store, select } from '@ngrx/store';
+import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Observable, Subject, combineLatest } from 'rxjs';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
@@ -8,7 +8,7 @@ import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade'
 import { routeParams, routeURL } from 'app/route.selectors';
 import { filter, pluck, takeUntil } from 'rxjs/operators';
 import { identity, isNil } from 'lodash/fp';
-import { EntityStatus, loading, allLoaded } from 'app/entities/entities';
+import { EntityStatus, allLoaded, pending } from 'app/entities/entities';
 import { Org } from 'app/entities/orgs/org.model';
 import {
   getStatus, updateStatus, orgFromRoute
@@ -34,7 +34,7 @@ export class CookbooksListComponent implements OnInit, OnDestroy {
   public sortedCookbooks$: Observable<Cookbook[]>;
   private isDestroyed = new Subject<boolean>();
   public saveSuccessful = false;
-  public saving = false;
+  public saveInProgress = false;
   public isLoading = true;
   public url: string;
   public serverId;
@@ -46,7 +46,13 @@ export class CookbooksListComponent implements OnInit, OnDestroy {
     private store: Store<NgrxStateAtom>,
     private layoutFacade: LayoutFacadeService,
     private router: Router
-  ) { }
+  ) { 
+    this.updateOrgForm = this.fb.group({
+      name: new FormControl({value: ''}, [Validators.required]),
+      admin_user: new FormControl({value: ''}, [Validators.required]),
+      admin_key: new FormControl({value: ''}, [Validators.required])
+    });
+   }
 
   ngOnInit() {
     this.layoutFacade.showSidebar(Sidebar.Infrastructure);
@@ -56,12 +62,6 @@ export class CookbooksListComponent implements OnInit, OnDestroy {
       this.url = url;
       const [, fragment] = url.split('#');
       this.tabValue = (fragment === 'details') ? 'details' : 'cookbooks';
-    });
-
-    this.updateOrgForm = this.fb.group({
-      name: ['', [Validators.required]],
-      admin_user: ['', [Validators.required]],
-      admin_key: ['', [Validators.required]]
     });
 
     combineLatest([
@@ -117,6 +117,19 @@ export class CookbooksListComponent implements OnInit, OnDestroy {
       ).subscribe(([ _getCookbooksSt, allCookbooksState]) => {
         this.cookbooks = allCookbooksState;
       });
+
+      this.store.pipe(
+        select(updateStatus),
+        takeUntil(this.isDestroyed),
+        filter(state => this.saveInProgress && !pending(state)))
+        .subscribe((state) => {
+          this.saveInProgress = false;
+          this.saveSuccessful = (state === EntityStatus.loadingSuccess);
+          if (this.saveSuccessful) {
+            this.updateOrgForm.markAsPristine();
+          }
+        });  
+
   }
 
   onSelectedTab(event: { target: { value: OrgTabName } }) {
@@ -126,36 +139,13 @@ export class CookbooksListComponent implements OnInit, OnDestroy {
 
   saveOrg(): void {
     this.saveSuccessful = false;
-    this.saving = true;
-    const updatedOrg = {
-      id: this.org.id,
-      server_id: this.org.server_id,
-      name: this.updateOrgForm.controls.name.value.trim(),
-      admin_user: this.updateOrgForm.controls.admin_user.value.trim(),
-      admin_key: this.updateOrgForm.controls.admin_key.value
-    };
+    this.saveInProgress = true;
+    const name: string = this.updateOrgForm.controls.name.value.trim();
+    const admin_user: string = this.updateOrgForm.controls.admin_user.value.trim();
+    const admin_key: string = this.updateOrgForm.controls.admin_key.value.trim();
     this.store.dispatch(new UpdateOrg({
-      org: updatedOrg
+      org: {...this.org, name, admin_user, admin_key}
     }));
-
-    const pendingSave = new Subject<boolean>();
-    this.store.select(updateStatus).pipe(
-      filter(identity),
-      takeUntil(pendingSave))
-      .subscribe((state) => {
-        if (!loading(state)) {
-          pendingSave.next(true);
-          pendingSave.complete();
-          this.saving = false;
-          this.saveSuccessful = (state === EntityStatus.loadingSuccess);
-          if (this.saveSuccessful) {
-            this.updateOrgForm.markAsPristine();
-          }
-          this.updateOrgForm.controls['name'].setValue(this.org.name);
-          this.updateOrgForm.controls['admin_user'].setValue(this.org.admin_user);
-          this.updateOrgForm.controls['admin_key'].setValue(this.org.admin_key);
-        }
-      });
   }
 
   ngOnDestroy(): void {

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.ts
@@ -128,7 +128,7 @@ export class CookbooksListComponent implements OnInit, OnDestroy {
           if (this.saveSuccessful) {
             this.updateOrgForm.markAsPristine();
           }
-        });  
+        });
 
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

 this PR cleans up subscriptions for server and org update subscription in infra module :
-- removes Leaking subscriptions

### :chains: Related Resources
#3270 
### :+1: Definition of Done
Updating Server and Org details successfully as before 

### :athletic_shoe: How to Build and Test the Change

- start the UI and navigate to https://a2-dev.test/infrastructure/chef-servers
- Create a server and org with chef manage credentials or with mock data 
- Click on server from the list >>> Click on details tab and update server details and click on save
- Click on org >>> click on details tab and update org details and click on save (Note : Feature is still in progress).

### :white_check_mark: Checklist

- [x] Tests added/updated?
- [ ] Docs added/updated?
