### PR TITLE
Bug in UTC dateTime job scheduler

### DIFF
--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -268,11 +268,11 @@ export class JobAddComponent implements OnDestroy {
 
     if (end.include) {
       ruleOpts['until'] = new Date(Date.UTC(
-          parseInt(end.datetime.year, 10),
-          parseInt(end.datetime.month, 10),
-          parseInt(end.datetime.date, 10),
-          parseInt(end.datetime.hour, 10),
-          parseInt(end.datetime.minute, 10)
+        parseInt(end.datetime.year, 10),
+        parseInt(end.datetime.month, 10),
+        parseInt(end.datetime.date, 10),
+        parseInt(end.datetime.hour, 10),
+        parseInt(end.datetime.minute, 10)
       ));
     }
 

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -265,15 +265,17 @@ export class JobAddComponent implements OnDestroy {
       )
     };
 
+
     if (end.include) {
-      ruleOpts['until'] = new Date(
-        parseInt(end.datetime.year, 10),
-        parseInt(end.datetime.month, 10),
-        parseInt(end.datetime.date, 10),
-        parseInt(end.datetime.hour, 10),
-        parseInt(end.datetime.minute, 10)
+      ruleOpts['until'] = new Date (
+          parseInt(end.datetime.year, 10),
+          parseInt(end.datetime.month, 10),
+          parseInt(end.datetime.date, 10),
+          parseInt(end.datetime.hour, 10),
+          parseInt(end.datetime.minute, 10)
       );
     }
+
 
 
     if (repeat.include) {

--- a/components/automate-ui/src/app/pages/job-add/job-add.component.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.component.ts
@@ -256,24 +256,24 @@ export class JobAddComponent implements OnDestroy {
 
     const {start, end, repeat} = scheduleOpts;
     const ruleOpts = {
-      dtstart: new Date(
+      dtstart: new Date(Date.UTC(
         parseInt(start.datetime.year, 10),
         parseInt(start.datetime.month, 10),
         parseInt(start.datetime.date, 10),
         parseInt(start.datetime.hour, 10),
         parseInt(start.datetime.minute, 10)
-      )
+      ))
     };
 
 
     if (end.include) {
-      ruleOpts['until'] = new Date (
+      ruleOpts['until'] = new Date(Date.UTC(
           parseInt(end.datetime.year, 10),
           parseInt(end.datetime.month, 10),
           parseInt(end.datetime.date, 10),
           parseInt(end.datetime.hour, 10),
           parseInt(end.datetime.minute, 10)
-      );
+      ));
     }
 
 

--- a/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
+++ b/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
@@ -269,7 +269,7 @@ export class JobEditComponent implements OnDestroy {
           const rule = RRule.parseString(job.recurrence);
           const hasUntil = !!rule.until;
           const hasRepeat = !!rule.interval;
-          const start = moment.utc(rule.dtstart);
+          const start = moment(rule.dtstart);
 
           scheduleGroup.get('start.datetime').setValue({
             month: start.month(),
@@ -280,7 +280,7 @@ export class JobEditComponent implements OnDestroy {
           });
 
           if (hasUntil) {
-            const end = moment.utc(rule.until);
+            const end = moment(rule.until);
             scheduleGroup.get('end.include').setValue(hasUntil);
             scheduleGroup.get('end.datetime').setValue({
               month: end.month(),

--- a/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
+++ b/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
@@ -329,39 +329,44 @@ export class JobEditComponent implements OnDestroy {
       recurrence
     };
 
+    console.log(payload.recurrence);
+
     this.store.dispatch(new JobUpdate(payload));
   }
 
   public recurrenceFrom(schedule) {
+
     if (!schedule.include) {
       return '';
     }
 
     const {start, end, repeat} = schedule;
     const ruleOpts = {
-      dtstart: new Date(
+      dtstart: new Date(Date.UTC(
         parseInt(start.datetime.year, 10),
         parseInt(start.datetime.month, 10),
         parseInt(start.datetime.date, 10),
         parseInt(start.datetime.hour, 10),
         parseInt(start.datetime.minute, 10)
-      )
+      ))
     };
 
     if (end.include) {
-      ruleOpts['until'] = new Date(
+      ruleOpts['until'] = new Date(Date.UTC(
         parseInt(end.datetime.year, 10),
         parseInt(end.datetime.month, 10),
         parseInt(end.datetime.date, 10),
         parseInt(end.datetime.hour, 10),
         parseInt(end.datetime.minute, 10)
-      );
+      ));
     }
 
     if (repeat.include) {
       ruleOpts['freq'] = repeat.freq;
       ruleOpts['interval'] = repeat.interval;
     }
+
+    console.log(ruleOpts);
 
     return RRule.optionsToString(ruleOpts);
   }

--- a/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
+++ b/components/automate-ui/src/app/pages/job-edit/job-edit.component.ts
@@ -269,7 +269,7 @@ export class JobEditComponent implements OnDestroy {
           const rule = RRule.parseString(job.recurrence);
           const hasUntil = !!rule.until;
           const hasRepeat = !!rule.interval;
-          const start = moment(rule.dtstart);
+          const start = moment.utc(rule.dtstart);
 
           scheduleGroup.get('start.datetime').setValue({
             month: start.month(),
@@ -280,7 +280,7 @@ export class JobEditComponent implements OnDestroy {
           });
 
           if (hasUntil) {
-            const end = moment(rule.until);
+            const end = moment.utc(rule.until);
             scheduleGroup.get('end.include').setValue(hasUntil);
             scheduleGroup.get('end.datetime').setValue({
               month: end.month(),
@@ -329,8 +329,6 @@ export class JobEditComponent implements OnDestroy {
       recurrence
     };
 
-    console.log(payload.recurrence);
-
     this.store.dispatch(new JobUpdate(payload));
   }
 
@@ -365,8 +363,6 @@ export class JobEditComponent implements OnDestroy {
       ruleOpts['freq'] = repeat.freq;
       ruleOpts['interval'] = repeat.interval;
     }
-
-    console.log(ruleOpts);
 
     return RRule.optionsToString(ruleOpts);
   }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When editing a scan job schedule, the previously scheduled time was coming back different than prior.  This branch makes sure that the datetime is being populated as UTC before being sent as a request.

### :chains: Related Resources

### :+1: Definition of Done
After Creating a new scan job, when a user returns to edit, they should see the previously scheduled time.

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy
make serve

To Test
Navigate to https://a2-dev.test/compliance/scan-jobs/jobs
Create a New Scan Job, and add a schedule to it -> click save
Investigate the network tab, under then name `jobs` you can check the headers and check that the DateTime was formatted properly.

Return to https://a2-dev.test/compliance/scan-jobs/jobs
Click on the `edit` button to the scan job you just created.  The previously scheduled times should be the default display
Investigate the network tab, under then name column you will see a UID, here you can check the headers and check that the DateTime was formatted properly.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
