### PR TITLE
[Automate-2843] introspect get projects to improve UX

### DIFF
--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.spec.ts
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.spec.ts
@@ -9,8 +9,11 @@ import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { using } from 'app/testing/spec-helpers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { Project } from 'app/entities/projects/project.model';
+import { IndexedEntities } from 'app/entities/entities';
+import { UserPermEntity } from 'app/entities/userperms/userperms.entity';
+import { PermEntityState, Status } from 'app/entities/userperms/userperms.reducer';
 import { ProjectStatus } from 'app/entities/rules/rule.model';
+import { Project } from 'app/entities/projects/project.model';
 import { ProjectService } from 'app/entities/projects/project.service';
 import { ApplyRulesStatusState } from 'app/entities/projects/project.reducer';
 import {
@@ -28,60 +31,9 @@ describe('PendingEditsBarComponent', () => {
   let store: Store<NgrxStateAtom>;
 
   beforeEach(async(() => {
-
-    TestBed.configureTestingModule({
-      declarations: [
-        MockComponent({
-          selector: 'chef-toolbar',
-          template: '<ng-content></ng-content>'
-        }),
-         MockComponent({
-          selector: 'app-authorized',
-          inputs: ['allOf', 'not'],
-          template: '<ng-content></ng-content>'
-        }),
-        MockComponent({
-          selector: 'app-message-modal',
-          inputs: ['visible' ],
-          outputs: ['close' ]
-        }),
-         MockComponent({
-          selector: 'app-confirm-apply-start-modal',
-          inputs: ['visible'],
-          outputs: ['confirm', 'cancel']
-        }),
-        MockComponent({
-          selector: 'app-confirm-apply-stop-modal',
-          inputs: ['visible', 'applyRulesStatus', 'stopRulesInProgress'],
-          outputs: ['confirm', 'cancel']
-        }),
-        MockComponent({ selector: 'mat-progress-bar', inputs: ['mode', 'value', 'bufferValue'] }),
-        MockComponent({ selector: 'mat-select' }),
-        MockComponent({ selector: 'mat-option' }),
-        MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),
-        MockComponent({ selector: 'chef-heading' }),
-        MockComponent({ selector: 'chef-loading-spinner' }),
-        MockComponent({ selector: 'chef-page-header' }),
-        MockComponent({ selector: 'chef-subheading' }),
-        MockComponent({ selector: 'chef-table-new' }),
-        MockComponent({ selector: 'chef-table-header' }),
-        MockComponent({ selector: 'chef-table-body' }),
-        MockComponent({ selector: 'chef-table-row' }),
-        MockComponent({ selector: 'chef-table-header-cell' }),
-        MockComponent({ selector: 'chef-table-cell' }),
-        PendingEditsBarComponent
-      ],
-      imports: [
-        ReactiveFormsModule,
-        RouterTestingModule,
-        ChefPipesModule,
-        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ],
-      providers: [
-        FeatureFlagsService,
-        ProjectService
-      ]
-    }).compileComponents();
+      configureWith({
+        '/iam/v2/projects': genPerm('/iam/v2/projects', true)
+      });
   }));
 
   beforeEach(() => {
@@ -218,6 +170,156 @@ describe('PendingEditsBarComponent', () => {
 
   });
 });
+
+describe('PendingEditsBarComponent--unauthorized', () => {
+  let component: PendingEditsBarComponent;
+  let fixture: ComponentFixture<PendingEditsBarComponent>;
+  let store: Store<NgrxStateAtom>;
+
+  beforeEach(async(() => {
+    configureWith({
+      '/iam/v2/projects': genPerm('/iam/v2/projects', false)
+    });
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PendingEditsBarComponent);
+    component = fixture.componentInstance;
+    store = TestBed.inject(Store);
+    fixture.detectChanges();
+  });
+
+  // This section contains a copy of the relevant tests from above that are affected
+  // when the user is NOT authorized, i.e. all the tests where the bar was previously visible.
+  describe('pending edits bar', () => {
+
+    it('is hidden if no project has changes', () => {
+      const uneditedProject1 = genProject('uuid-111', 'RULES_APPLIED');
+      const uneditedProject2 = genProject('uuid-112', 'RULES_APPLIED');
+      store.dispatch(new GetProjectsSuccess({ projects: [uneditedProject1, uneditedProject2] }));
+      component.updateDisplay();
+      expect(component.isBarHidden).toEqual(true);
+    });
+
+    it('is hidden if some project has changes', () => {
+      const editedProject = genProject('uuid-99', 'EDITS_PENDING');
+      const uneditedProject = genProject('uuid-111', 'RULES_APPLIED');
+      store.dispatch(new GetProjectsSuccess({ projects: [uneditedProject, editedProject] }));
+      component.updateDisplay();
+      expect(component.isBarHidden).toEqual(true);
+    });
+
+    it('is hidden if rules are not being applied', () => {
+      // isolate rules being applied because bar would be visible with just this
+      store.dispatch(
+        new GetProjectsSuccess({ projects: [genProject('uuid-99', 'EDITS_PENDING')] }));
+
+      component.confirmApplyStart();  // update running
+      store.dispatch(new GetApplyRulesStatusSuccess( // update finished
+          genState(ApplyRulesStatusState.NotRunning)));
+      component.updateDisplay();
+      expect(component.isBarHidden).toEqual(true);
+    });
+
+    it('is hidden if update fails', () => {
+      store.dispatch(
+        new GetProjectsSuccess({ projects: [genProject('uuid-99', 'RULES_APPLIED')] }));
+      component.confirmApplyStart();
+      store.dispatch(new GetApplyRulesStatusSuccess(
+        genState(ApplyRulesStatusState.NotRunning, true, false)));
+      component.updateDisplay();
+      expect(component.isBarHidden).toEqual(true);
+    });
+
+    it('is hidden if update is cancelled', () => {
+      store.dispatch(
+        new GetProjectsSuccess({ projects: [genProject('uuid-99', 'RULES_APPLIED')] }));
+      component.confirmApplyStart();
+      store.dispatch(new GetApplyRulesStatusSuccess(
+        genState(ApplyRulesStatusState.NotRunning, false, true)));
+      component.updateDisplay();
+      expect(component.isBarHidden).toEqual(true);
+    });
+
+    it('is hidden if update is cancelled but update is still running', () => {
+      store.dispatch(
+        new GetProjectsSuccess({ projects: [genProject('uuid-99', 'RULES_APPLIED')] }));
+      component.confirmApplyStart();
+      store.dispatch(new GetApplyRulesStatusSuccess(
+        genState(ApplyRulesStatusState.Running, false, true)));
+      component.updateDisplay();
+      expect(component.isBarHidden).toEqual(true);
+    });
+  });
+});
+
+
+function configureWith(perms: IndexedEntities<UserPermEntity>): void {
+  TestBed.configureTestingModule({
+    declarations: [
+      MockComponent({
+        selector: 'chef-toolbar',
+        template: '<ng-content></ng-content>'
+      }),
+      MockComponent({
+        selector: 'app-authorized',
+        inputs: ['allOf', 'not'],
+        template: '<ng-content></ng-content>'
+      }),
+      MockComponent({
+        selector: 'app-message-modal',
+        inputs: ['visible'],
+        outputs: ['close']
+      }),
+      MockComponent({
+        selector: 'app-confirm-apply-start-modal',
+        inputs: ['visible'],
+        outputs: ['confirm', 'cancel']
+      }),
+      MockComponent({
+        selector: 'app-confirm-apply-stop-modal',
+        inputs: ['visible', 'applyRulesStatus', 'stopRulesInProgress'],
+        outputs: ['confirm', 'cancel']
+      }),
+      MockComponent({ selector: 'mat-progress-bar', inputs: ['mode', 'value', 'bufferValue'] }),
+      MockComponent({ selector: 'mat-select' }),
+      MockComponent({ selector: 'mat-option' }),
+      MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),
+      MockComponent({ selector: 'chef-heading' }),
+      MockComponent({ selector: 'chef-loading-spinner' }),
+      MockComponent({ selector: 'chef-page-header' }),
+      MockComponent({ selector: 'chef-subheading' }),
+      MockComponent({ selector: 'chef-table-new' }),
+      MockComponent({ selector: 'chef-table-header' }),
+      MockComponent({ selector: 'chef-table-body' }),
+      MockComponent({ selector: 'chef-table-row' }),
+      MockComponent({ selector: 'chef-table-header-cell' }),
+      MockComponent({ selector: 'chef-table-cell' }),
+      PendingEditsBarComponent
+    ],
+    imports: [
+      ReactiveFormsModule,
+      RouterTestingModule,
+      ChefPipesModule,
+      StoreModule.forRoot({
+        ...ngrxReducers,
+          userperms: () => <PermEntityState>{
+            status: Status.loadingSuccess,
+            byId: perms
+          }
+      }, { runtimeChecks })
+    ],
+    providers: [
+      FeatureFlagsService,
+      ProjectService
+    ]
+  }).compileComponents();
+}
+
+function genPerm(name: string, state: boolean): UserPermEntity {
+  return new UserPermEntity(
+    { get: state, put: state, post: state, delete: state, patch: state }, name);
+}
 
 function genProject(id: string, status: ProjectStatus): Project {
   return {

--- a/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.ts
+++ b/components/automate-ui/src/app/components/pending-edits-bar/pending-edits-bar.component.ts
@@ -62,9 +62,10 @@ export class PendingEditsBarComponent implements OnDestroy {
 
   public updateDisplay() {
     this.layoutFacade.layout.userNotifications.pendingEdits =
-      this.projectsHaveStagedChanges
-      || this.updateProjectsCancelled
-      || this.updateProjectsFailed;
+      this.isAuthorized &&
+      (this.projectsHaveStagedChanges
+        || this.updateProjectsCancelled
+        || this.updateProjectsFailed);
     this.layoutFacade.updateDisplay();
   }
 
@@ -96,8 +97,11 @@ export class PendingEditsBarComponent implements OnDestroy {
   }
 
   get isBarHidden() {
-    return !this.isAuthorized
-      || !this.layoutFacade.layout.userNotifications.pendingEdits
+    // NB: All visibility factors must be embedded in these two properties
+    // so the layoutFacade can correctly compensate for the bar's presence/absence.
+    // That is why, for example, introspection is done in this code-behind
+    // instead of just using an <app-authorized> in the template.
+    return !this.layoutFacade.layout.userNotifications.pendingEdits
       || this.layoutFacade.layout.userNotifications.updatesProcessing;
   }
 }

--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -68,8 +68,9 @@ export class LayoutFacadeService {
 
     this.authorizedChecker = new AuthorizedChecker(fullStore);
     this.authorizedChecker.setPermissions([{ endpoint: '/iam/v2/projects', verb: 'get' }], []);
-    this.authorizedChecker.isAuthorized$.subscribe((isAuthorized) => {
+    const authSub = this.authorizedChecker.isAuthorized$.subscribe((isAuthorized) => {
       if (isAuthorized) {
+        authSub.unsubscribe();
         this.store.dispatch(new GetProjects());
       }
     });

--- a/components/automate-ui/src/app/entities/projects/project.effects.ts
+++ b/components/automate-ui/src/app/entities/projects/project.effects.ts
@@ -4,11 +4,13 @@ import { Store } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { interval as observableInterval, of as observableOf, Observable } from 'rxjs';
 import { catchError, mergeMap, map, filter, switchMap, withLatestFrom } from 'rxjs/operators';
+import { get } from 'lodash/fp';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { HttpStatus } from 'app/types/types';
 import { CreateNotification } from 'app/entities/notifications/notification.actions';
 import { Type } from 'app/entities/notifications/notification.model';
+import { allPerms } from 'app/entities/userperms/userperms.selectors';
 import { ProjectRequests } from './project.requests';
 
 import {
@@ -212,14 +214,16 @@ export class ProjectEffects {
 
   @Effect()
   getDormantApplyRulesStatus$ = observableInterval(1000 * DORMANT_RULE_STATUS_INTERVAL).pipe(
+    withLatestFrom(this.store.select(allPerms)),
     withLatestFrom(this.store.select(applyRulesStatus)),
-    filter(([_, { state }]) =>
+    filter(([[_interval, _allPerms], { state }]) =>
       state === ApplyRulesStatusState.NotRunning
     ),
-    switchMap(() => [
-      new GetProjects(),
-      new GetApplyRulesStatus()
-    ]),
+    switchMap(([[_interval, list], _status]) => {
+      return get(['/iam/v2/projects', 'get'], list) ?
+        [new GetProjects(), new GetApplyRulesStatus()] :
+        [new GetApplyRulesStatus()];
+    }),
     catchError((error: HttpErrorResponse) => observableOf(new GetApplyRulesStatusFailure(error))));
 
   private getRulesStatus$(): () => Observable<ProjectActions> {

--- a/components/automate-ui/src/app/helpers/auth/authorized.ts
+++ b/components/automate-ui/src/app/helpers/auth/authorized.ts
@@ -22,7 +22,7 @@ import { allPerms } from 'app/entities/userperms/userperms.selectors';
 export interface CheckObj {
   endpoint: string;
   verb: string;
-  paramList: string | string[];
+  paramList?: string | string[];
 }
 
 export class AuthorizedChecker {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

We want to improve the user experience for the case of creating a brand new user that has not yet been placed into any teams or policies. Previously, you would immediately see one error bar like that shown, and at times, they could cascade down the page.
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/6817500/78405425-52fc0580-75b5-11ea-8b36-fefa0c02baca.png">

So we are applying introspection to determine if we can make the GetProjects call at all.

Points addressed:
1. **Initial login or page refresh.** The page is constructed and, during initialization, it makes a call to GetProjects to be able to determine whether there are any edits pending and thus whether the <kbd>edits pending</kbd> bar should be displayed.
2. **Periodically to keep up-to-date.** As Automate is a multi-user application, actions of one user may affect what other users do. Specifically, if one user edits a project or rule, that needs to reflect in the  <kbd>edits pending</kbd> bar not just for that user, but for all users. So every two minutes each connected browser polls with a GetProjects call.
3. **Rendering the <kbd>edits pending</kbd> bar itself.** The bar displays in varying forms for any of 3 reasons: rules have been edited, a project update has been cancelled by a user, or a project update has failed. While the second and third are still knowable for a user with no permissions, the first relies on GetProjects, so is not knowable. We decided to therefore suppress the <kbd>edits pending</kbd> bar entirely as the most reasonable UX. 
4. Display the <kbd>update in progress</kbd> bar in all cases. This does not rely on GetProjects, so is safe (and useful) to display.

### :chains: Related Resources
NA

### :+1: Definition of Done
If the user does not have permission to call `GetProjects`, then `GetProjects` is not called (a) upon login, (b) upon page refresh, or (c) periodically (as described above). Should one navigate directly to team details, token details, or project list (which issue explicit GetProject calls), the usual error will still appear, and rightly so.

### :athletic_shoe: How to Build and Test the Change

(Note should test on pages OTHER THAN team details, token details, or project list--those pages fetch the project list explicitly)

Login as admin.
```
* GET /iam/v2/projects occurs during page construction on any page. 
* Every two minutes another GET /iam/v2/projects occurs to refresh projects. 
* "Edits pending" bar appears when rules are edited, when update fails, or when update is canceled.
* "Update in progress" bar appears when project update is in progress.
```

Create a new user with no permissions. Login as this user.
```
* GET /iam/v2/projects DOES NOT occur during page construction on any page.
* Every two minutes -- nothing happens. 
* "Edits pending" bar DOES NOT appear when rules are edited, when update fails, or when update is cancelled.
* "Update in progress" bar APPEARS when project update is in progress.
```

As an admin, add that new user to the viewers team, then refresh the user's browser.
```
* GET /iam/v2/projects occurs during page construction on any page.
* Every two minutes another GET /iam/v2/projects occurs to refresh projects. 
* "Edits pending" bar appears when rules are edited, when update fails, or when update is cancelled.
* "Update in progress" bar appears when project update is in progress.
```

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).