### PR TITLE
Swapping mark missing and delete runs controls

### DIFF
--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
@@ -271,8 +271,8 @@ describe('AutomateSettingsComponent', () => {
 
     using([
       // Client Runs
-      ['clientRunsRemoveData', genInjestJob('infra', 'missing_nodes', '5m', false)],
-      ['clientRunsLabelMissing', genInjestJob('infra', 'missing_nodes_for_deletion', '6h', false)]
+      ['clientRunsRemoveData', genInjestJob('infra', 'missing_nodes_for_deletion', '5m', false)],
+      ['clientRunsLabelMissing', genInjestJob('infra', 'missing_nodes', '6h', false)]
     ], function (formName: string, job: IngestJob) {
       it(`when updating ${formName} form,
             the form data is extracted from the non-nested form`, () => {
@@ -327,8 +327,8 @@ describe('AutomateSettingsComponent', () => {
 
     using([
       // Client Runs
-      ['clientRunsRemoveData', genInjestJob('infra', 'missing_nodes', '5m', true)],
-      ['clientRunsLabelMissing', genInjestJob('infra', 'missing_nodes_for_deletion', '6h', true)]
+      ['clientRunsRemoveData', genInjestJob('infra', 'missing_nodes_for_deletion', '5m', true)],
+      ['clientRunsLabelMissing', genInjestJob('infra', 'missing_nodes', '6h', true)]
     ], function (formName: string, job: IngestJob) {
       it(`when ${formName} form is saved as disabled, unit and threshold are undefined
             because they are not present in the non-nested form anymore`, () => {

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
@@ -390,7 +390,7 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
     let formThreshold, formUnit;
 
     switch (job.name) {
-      case InfraJobName.MissingNodes: {
+      case InfraJobName.MissingNodesForDeletion: {
         this.handleDisable(this.clientRunsRemoveData, job.disabled);
         [formThreshold, formUnit] = this.splitThreshold(job.threshold);
         this.clientRunsRemoveData.patchValue({
@@ -401,7 +401,7 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
       }
       break;
 
-      case InfraJobName.MissingNodesForDeletion: {
+      case InfraJobName.MissingNodes: {
         this.handleDisable(this.clientRunsLabelMissing, job.disabled);
         [formThreshold, formUnit] = this.splitThreshold(job.threshold);
         this.clientRunsLabelMissing.patchValue({


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The mark nodes are missing and delete runs after x amount of days fields were switched. 

![image](https://user-images.githubusercontent.com/1679247/78615225-c441ef80-7825-11ea-9d80-7650fc7901c9.png)

### :athletic_shoe: How to Build and Test the Change
1. Start the UI with the code from this PR. 
1. Open data lifecycle page https://a2-dev.test/settings/data-lifecycle
1. Ensure that the default value for the "Remove data for Chef Client runs after" control is 30 days. Ensure the default value for the "When no Chef Client run data has been received from a node in" field is 1 day. 
1. This can also be tested by updating the disabling control for the mark missing and saving. Then check the parameters to ensure the "missing_nodes" "disabled" is true. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![image](https://user-images.githubusercontent.com/1679247/78615496-88f3f080-7826-11ea-95ea-32a66fb7f39c.png)
