### PR TITLE
[infra-proxy-service] More specific foreign_key_violation  error messages.

### DIFF
--- a/components/infra-proxy-service/server/orgs.go
+++ b/components/infra-proxy-service/server/orgs.go
@@ -56,7 +56,7 @@ func (s *Server) CreateOrg(ctx context.Context, req *request.CreateOrg) (*respon
 
 	org, err := s.service.Storage.StoreOrg(ctx, req.Name, req.AdminUser, secretID.GetId(), req.ServerId, req.Projects)
 	if err != nil {
-		return nil, service.ParseStorageError(err, req.Name, "org")
+		return nil, service.ParseStorageError(err, req, "org")
 	}
 
 	return &response.CreateOrg{
@@ -76,7 +76,7 @@ func (s *Server) GetOrgs(ctx context.Context, req *request.GetOrgs) (*response.G
 
 	orgsList, err := s.service.Storage.GetOrgs(ctx, serverID)
 	if err != nil {
-		return nil, service.ParseStorageError(err, "", "org")
+		return nil, service.ParseStorageError(err, req, "org")
 	}
 
 	return &response.GetOrgs{
@@ -96,7 +96,7 @@ func (s *Server) GetOrg(ctx context.Context, req *request.GetOrg) (*response.Get
 
 	org, err := s.service.Storage.GetOrg(ctx, UUID)
 	if err != nil {
-		return nil, service.ParseStorageError(err, req.Id, "org")
+		return nil, service.ParseStorageError(err, req, "org")
 	}
 
 	secret, err := s.service.Secrets.Read(ctx, &secrets.Id{Id: org.AdminKey})
@@ -133,7 +133,7 @@ func (s *Server) GetOrgByName(ctx context.Context, req *request.GetOrgByName) (*
 
 	org, err := s.service.Storage.GetOrgByName(ctx, req.Name, serverID)
 	if err != nil {
-		return nil, service.ParseStorageError(err, req.Name, "org")
+		return nil, service.ParseStorageError(err, req, "org")
 	}
 
 	secret, err := s.service.Secrets.Read(ctx, &secrets.Id{Id: org.AdminKey})
@@ -164,7 +164,7 @@ func (s *Server) DeleteOrg(ctx context.Context, req *request.DeleteOrg) (*respon
 
 	org, err := s.service.Storage.DeleteOrg(ctx, UUID)
 	if err != nil {
-		return nil, service.ParseStorageError(err, req.Id, "org")
+		return nil, service.ParseStorageError(err, req, "org")
 	}
 
 	_, err = s.service.Secrets.Delete(ctx, &secrets.Id{Id: org.AdminKey})
@@ -210,7 +210,7 @@ func (s *Server) UpdateOrg(ctx context.Context, req *request.UpdateOrg) (*respon
 
 	oldOrg, err := s.service.Storage.GetOrg(ctx, id)
 	if err != nil {
-		return nil, service.ParseStorageError(err, req.Id, "org")
+		return nil, service.ParseStorageError(err, req, "org")
 	}
 
 	secret, err := s.service.Secrets.Read(ctx, &secrets.Id{Id: oldOrg.AdminKey})
@@ -246,7 +246,7 @@ func (s *Server) UpdateOrg(ctx context.Context, req *request.UpdateOrg) (*respon
 
 	org, err := s.service.Storage.EditOrg(ctx, orgStruct)
 	if err != nil {
-		return nil, service.ParseStorageError(err, id, "org")
+		return nil, service.ParseStorageError(err, req, "org")
 	}
 
 	return &response.UpdateOrg{

--- a/components/infra-proxy-service/server/orgs_test.go
+++ b/components/infra-proxy-service/server/orgs_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -199,16 +200,18 @@ func TestOrgs(t *testing.T) {
 			secretsMock.EXPECT().Create(gomock.Any(), &newSecret, gomock.Any()).Return(secretID, nil)
 			secretsMock.EXPECT().Read(gomock.Any(), secretID, gomock.Any()).Return(&secretWithID, nil)
 			secretsMock.EXPECT().Delete(gomock.Any(), secretID, gomock.Any())
-
+			serverID := "97e01ea1-976e-4626-88c8-43345c5d934f"
 			resp, err := cl.CreateOrg(ctx, &request.CreateOrg{
 				Name:      "infra-org",
 				AdminUser: "admin",
 				AdminKey:  "--KEY--",
-				ServerId:  "97e01ea1-976e-4626-88c8-43345c5d934f",
+				ServerId:  serverID,
 				Projects:  []string{},
 			})
 			require.Nil(t, resp)
+			require.Contains(t, err.Error(), fmt.Sprintf("no server found with ID \"%s\"", serverID))
 			grpctest.AssertCode(t, codes.NotFound, err)
+
 		})
 	})
 
@@ -522,11 +525,13 @@ func TestOrgs(t *testing.T) {
 
 		t.Run("when the org does not exists, return org not found", func(t *testing.T) {
 			ctx := context.Background()
+			orgID := "97e01ea1-976e-4626-88c8-43345c5d934f"
 			resp, err := cl.GetOrg(ctx, &request.GetOrg{
-				Id: "97e01ea1-976e-4626-88c8-43345c5d934f",
+				Id: orgID,
 			})
 
 			require.Nil(t, resp)
+			require.Contains(t, err.Error(), fmt.Sprintf("no org found with ID \"%s\"", orgID))
 			grpctest.AssertCode(t, codes.NotFound, err)
 		})
 

--- a/components/infra-proxy-service/server/servers.go
+++ b/components/infra-proxy-service/server/servers.go
@@ -42,7 +42,7 @@ func (s *Server) CreateServer(ctx context.Context, req *request.CreateServer) (*
 
 	server, err := s.service.Storage.StoreServer(ctx, req.Name, req.Description, req.Fqdn, req.IpAddress)
 	if err == storage.ErrConflict {
-		return nil, service.ParseStorageError(err, req.Name, "server")
+		return nil, service.ParseStorageError(err, req, "server")
 	}
 
 	return &response.CreateServer{
@@ -57,7 +57,7 @@ func (s *Server) GetServers(ctx context.Context, req *request.GetServers) (*resp
 
 	serversList, err := s.service.Storage.GetServers(ctx)
 	if err != nil {
-		return nil, service.ParseStorageError(err, "", "server")
+		return nil, service.ParseStorageError(err, req, "server")
 	}
 
 	return &response.GetServers{
@@ -77,7 +77,7 @@ func (s *Server) GetServer(ctx context.Context, req *request.GetServer) (*respon
 
 	server, err := s.service.Storage.GetServer(ctx, UUID)
 	if err != nil {
-		return nil, service.ParseStorageError(err, req.Id, "server")
+		return nil, service.ParseStorageError(err, req, "server")
 	}
 
 	return &response.GetServer{
@@ -97,7 +97,7 @@ func (s *Server) GetServerByName(ctx context.Context, req *request.GetServerByNa
 
 	server, err := s.service.Storage.GetServerByName(ctx, req.Name)
 	if err != nil {
-		return nil, service.ParseStorageError(err, req.Name, "server")
+		return nil, service.ParseStorageError(err, req, "server")
 	}
 
 	return &response.GetServer{
@@ -117,7 +117,7 @@ func (s *Server) DeleteServer(ctx context.Context, req *request.DeleteServer) (*
 
 	server, err := s.service.Storage.DeleteServer(ctx, UUID)
 	if err != nil {
-		return nil, service.ParseStorageError(err, req.Id, "server")
+		return nil, service.ParseStorageError(err, req, "server")
 	}
 
 	return &response.DeleteServer{
@@ -166,7 +166,7 @@ func (s *Server) UpdateServer(ctx context.Context, req *request.UpdateServer) (*
 
 	server, err := s.service.Storage.EditServer(ctx, serverStruct)
 	if err != nil {
-		return nil, service.ParseStorageError(err, id, "server")
+		return nil, service.ParseStorageError(err, req, "server")
 	}
 
 	return &response.UpdateServer{

--- a/components/infra-proxy-service/server/servers_test.go
+++ b/components/infra-proxy-service/server/servers_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -235,11 +236,13 @@ func TestServers(t *testing.T) {
 		})
 
 		t.Run("when the server does not exist, return server not found", func(t *testing.T) {
+			serverID := "97e01ea1-976e-4626-88c8-43345c5d934f"
 			resp, err := cl.GetServer(ctx, &request.GetServer{
-				Id: "97e01ea1-976e-4626-88c8-43345c5d934f",
+				Id: serverID,
 			})
 
 			require.Nil(t, resp)
+			require.Contains(t, err.Error(), fmt.Sprintf("no server found with ID \"%s\"", serverID))
 			grpctest.AssertCode(t, codes.NotFound, err)
 		})
 
@@ -366,6 +369,7 @@ func TestServers(t *testing.T) {
 			resp, err2 := cl.DeleteServer(ctx, &request.DeleteServer{Id: resp1.Server.Id})
 			require.Error(t, err2)
 			require.Nil(t, resp)
+			assert.Regexp(t, "cannot delete server.*still has organizations attached", err2.Error())
 			grpctest.AssertCode(t, codes.FailedPrecondition, err2)
 
 			serverListAfter, err3 := cl.GetServers(ctx, &request.GetServers{})

--- a/components/infra-proxy-service/storage/postgres/postgres.go
+++ b/components/infra-proxy-service/storage/postgres/postgres.go
@@ -3,7 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"strings"
+	"regexp"
 
 	"github.com/lib/pq" // adapter for database/sql
 	"github.com/pkg/errors"
@@ -64,7 +64,7 @@ func parsePQError(e *pq.Error) error {
 		// should be added to doesn't exist.
 		// The only way to distinguish this violation by comparing the server_id key in Error detail.
 		// DETAIL:  Key (server_id)=(2e831dec-f25c-4fde-aef6-8f68ea366251) is not present in table "servers".
-		if strings.Contains(e.Detail, "(server_id)") {
+		if regexp.MustCompile(`\(server_id\).*is not present.*table.*\"servers\"`).MatchString(e.Detail) {
 			return storage.ErrForeignKeyViolation
 		}
 		// Marking other foreign key violations as a record can not be deleted.

--- a/components/infra-proxy-service/storage/postgres/postgres.go
+++ b/components/infra-proxy-service/storage/postgres/postgres.go
@@ -64,7 +64,7 @@ func parsePQError(e *pq.Error) error {
 		// should be added to doesn't exist.
 		// The only way to distinguish this violation by comparing the server_id key in Error detail.
 		// DETAIL:  Key (server_id)=(2e831dec-f25c-4fde-aef6-8f68ea366251) is not present in table "servers".
-		if regexp.MustCompile(`.server_id.*is not present.*table.*servers.`).MatchString(e.Detail) {
+		if regexp.MustCompile(`\bserver_id\b.*is not present.*table "servers"`).MatchString(e.Detail) {
 			return storage.ErrForeignKeyViolation
 		}
 		// Marking other foreign key violations as a record can not be deleted.

--- a/components/infra-proxy-service/storage/postgres/postgres.go
+++ b/components/infra-proxy-service/storage/postgres/postgres.go
@@ -64,7 +64,7 @@ func parsePQError(e *pq.Error) error {
 		// should be added to doesn't exist.
 		// The only way to distinguish this violation by comparing the server_id key in Error detail.
 		// DETAIL:  Key (server_id)=(2e831dec-f25c-4fde-aef6-8f68ea366251) is not present in table "servers".
-		if regexp.MustCompile(`\(server_id\).*is not present.*table.*\"servers\"`).MatchString(e.Detail) {
+		if regexp.MustCompile(`.server_id.*is not present.*table.*servers.`).MatchString(e.Detail) {
 			return storage.ErrForeignKeyViolation
 		}
 		// Marking other foreign key violations as a record can not be deleted.

--- a/components/infra-proxy-service/storage/storage.go
+++ b/components/infra-proxy-service/storage/storage.go
@@ -66,4 +66,7 @@ var (
 
 	// ErrConflict is returned when a server there is a clash of server IDs
 	ErrConflict = errors.New("conflict")
+
+	// ErrForeignKeyViolation is returned when a server ID is not found
+	ErrForeignKeyViolation = errors.New("not found")
 )


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

 - Add ErrCannotDelete & ErrForeignKeyViolation custom errors.
 - In order to deal with foreign_key_violation error for invalid & delete cascade partial string match with error object detail.
 - Earlier only error code name was used to distinguish between errors but it was returning same for both the cases like invalid foreign key and delete parent record if child exists.

### :chains: Related Resources
 - https://github.com/chef/automate/issues/3297
 - https://github.com/chef/automate/issues/3294

### :+1: Definition of Done
 - If a user attempts to delete a chef server and if it has orgs now it raises the error:
```
"cannot delete server _<server-guid>_ because it still has organizations attached"
```
- If non-existed server ID is provided while creating the organization now it raises an error:

```
"no server found with ID _<server-guid>_"
```
### :athletic_shoe: How to Build and Test the Change

Steps to build:
- Check out this PR
- `rebuild components/infra-proxy-service`
- `rebuild components/automate-gateway`


Steps to test:
 - Load sample data `infra_service_load_sample_data` or Use the following curl command to add data.

 - Create a server:
```
$ curl -sSkH "api-token: $TOK" -X POST \
-d '{"name": "SERVER_NAME", "description": "DESCRIPTION", "fqdn": "example.com", "ip_address": "127.0.0.1"}' \
https://a2-dev.test/api/v0/infra/servers?pretty
{
  "server": {
    "id": "670e1cdf-55ab-4d78-9350-dcfe27f82ca4",
    "name": "SERVER_NAME",
    "description": "DESCRIPTION",
    "fqdn": "example.com",
    "ip_address": "127.0.0.1",
    "orgs_count": 0
  }
}
```
Add an organization consider `server_id` as from above created server:
```
$ curl -sSkH "api-token: $TOK" -X POST \
-d '{"name": "ORG_NAME", "admin_user": "ADMIN_USER", "admin_key": "KEY"}' \
https://a2-dev.test/api/v0/infra/servers/670e1cdf-55ab-4d78-9350-dcfe27f82ca4/orgs?pretty
{
  "org": {
    "id": "956c1773-d5ba-471b-8e0d-ceb37603e271",
    "name": "ORG_NAME",
    "admin_user": "ADMIN_USER",
    "admin_key": "e2ac8d74-b419-42b3-b96c-aa2f738e8f18",
    "server_id": "670e1cdf-55ab-4d78-9350-dcfe27f82ca4",
    "projects": [
    ]
  }
}
```
### Fixed: Attempt to delete the server:

```
$ curl -sSkH "api-token: $TOK" -X DELETE \
https://a2-dev.test/api/v0/infra/servers/670e1cdf-55ab-4d78-9350-dcfe27f82ca4?pretty
{
  "error": "cannot delete server \"670e1cdf-55ab-4d78-9350-dcfe27f82ca4\" because it still has organizations attached",
  "code": 9,
  "message": "cannot delete server \"670e1cdf-55ab-4d78-9350-dcfe27f82ca4\" because it still has organizations attached",
  "details": [
  ]
}
```

### Fixed: Attempt to add org with non-existed server-id
```
curl -sSkH "api-token: $TOK" -X POST \
  -d '{"name": "ORG_NAME", "admin_user": "ADMIN_USER", "admin_key": "KEY"}' \
  https://a2-dev.test/api/v0/infra/servers/1d0b8c0d-a40d-4e69-83db-a597e715c231/orgs?pretty
{
  "error": "no server found with ID \"1d0b8c0d-a40d-4e69-83db-a597e715c231\"",
  "code": 5,
  "message": "no server found with ID \"1d0b8c0d-a40d-4e69-83db-a597e715c231\"",
  "details": [
  ]
}
```

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>