### PR TITLE
[Automate-3249] adjust clear selection in project filter

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.spec.ts
@@ -45,6 +45,7 @@ describe('ChefServerDetailsComponent', () => {
         MockComponent({ selector: 'chef-table-header-cell' }),
         MockComponent({ selector: 'chef-table-cell' }),
         MockComponent({ selector: 'a', inputs: ['routerLink'] }),
+        MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
         ChefServerDetailsComponent
       ],
       providers: [

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-list/cookbooks-list.component.spec.ts
@@ -35,6 +35,7 @@ describe('CookbooksListComponent', () => {
         MockComponent({ selector: 'chef-table-header-cell' }),
         MockComponent({ selector: 'chef-table-cell' }),
         MockComponent({ selector: 'a', inputs: ['routerLink'] }),
+        MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
         CookbooksListComponent
       ],
       providers: [

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -35,7 +35,7 @@
           <chef-button
           tertiary
           id="projects-filter-clear-selection"
-          (click)="handleClearSelection()">Clear Selection (99+)</chef-button>
+          (click)="handleClearSelection()">Clear Selection ({{filteredSelectedCount}})</chef-button>
         </div>
 
         <div id="drop-list" class="dropdown-content">

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -35,6 +35,8 @@
           <chef-button
           tertiary
           id="projects-filter-clear-selection"
+          class="pf-clear-selection"
+          [class.active]="filteredSelectedCount !== '0'" 
           (click)="handleClearSelection()">Clear Selection ({{filteredSelectedCount}})</chef-button>
         </div>
 

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -18,7 +18,7 @@
 
         <div class="dropdown-content">
           <!-- @TODO turn this into reusable Filter Input component -->
-          <input 
+          <input
             chefInput
             type="text"
             (keyup)="handleFilterKeyUp($event.target.value)"
@@ -35,7 +35,7 @@
           <chef-button
           tertiary
           id="projects-filter-clear-selection"
-          (click)="handleClearSelection()">Clear Selection</chef-button>
+          (click)="handleClearSelection()">Clear Selection (99+)</chef-button>
         </div>
 
         <div id="drop-list" class="dropdown-content">

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -99,7 +99,7 @@
 
     .button-container { // adjust for 8px global margin on buttons
       display: flex;
-      justify-content: space-between;
+      justify-content: flex-start;
       padding: calc(14px - 8px);
       padding-bottom: 0;
     }

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -161,10 +161,11 @@
 .pf-clear-selection {
   visibility: hidden;
   opacity: 0;
-  transition: .25s;
+  transition: .2s ease-in;
 
   &.active {
     visibility: visible;
-    opacity: 1
+    opacity: 1;
+    transition: .25s ease-out;
   }
 }

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -64,7 +64,7 @@
 }
 
 .dropdown {
-  width: 295px;
+  width: 326px;
   right: -10px;
   border: 1px solid $chef-grey;
   font-size: 14px;
@@ -99,6 +99,7 @@
 
     .button-container { // adjust for 8px global margin on buttons
       display: flex;
+      justify-content: space-between;
       padding: calc(14px - 8px);
       padding-bottom: 0;
     }

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -156,3 +156,15 @@
   max-height: 365px;
   overflow-x: scroll;
 }
+
+// animation
+.pf-clear-selection {
+  visibility: hidden;
+  opacity: 0;
+  transition: .25s;
+
+  &.active {
+    visibility: visible;
+    opacity: 1
+  }
+}

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -63,11 +63,9 @@ export class ProjectsFilterDropdownComponent {
   }
 
   handleOptionChange(event, label) {
-    this.editableOptions.find(option => {
-      if (option.label === label) {
-        option.checked = event.detail; // provides the new state of the checkbox
-      }
-    });
+    // sets the new state of the specific checkbox
+    this.editableOptions
+      .find(option => option.label === label).checked = event.detail;
     this.optionsEdited = true;
   }
 

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -43,6 +43,11 @@ export class ProjectsFilterDropdownComponent {
     }
   }
 
+  get filteredSelectedCount(): string {
+    const count = this.filteredOptions.filter(option => option.checked).length;
+    return count > 99 ? '99+' : count.toString();
+  }
+
   handleFilterKeyUp(filterValue: string): void {
     this.filteredOptions = this.editableOptions
       .filter(option => option.label.toLowerCase().indexOf(filterValue.toLowerCase()) > -1);

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -77,8 +77,9 @@ export class ProjectsFilterDropdownComponent {
   }
 
   handleClearSelection() {
-    // uncheck all the options
-    this.editableOptions.map(option => option.checked = false);
+    // TODO: Should ideally set to true only when some projects were selected upon opening
+    this.optionsEdited = true; // mark as edited
+    this.editableOptions.map(option => option.checked = false); // uncheck all the options
   }
 
   handleArrowUp(event: KeyboardEvent) {

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -84,7 +84,12 @@ export class ProjectsFilterDropdownComponent {
   handleClearSelection() {
     // TODO: Should ideally set to true only when some projects were selected upon opening
     this.optionsEdited = true; // mark as edited
-    this.editableOptions.map(option => option.checked = false); // uncheck all the options
+
+    // clear only entries visible by current filter
+    // TODO: Micro-optimization: use a hash to convert this O(n^2) to O(n).
+    this.editableOptions
+      .filter(option => this.filteredOptions.find(o => o.label === option.label))
+      .map(option => option.checked = false);
   }
 
   handleArrowUp(event: KeyboardEvent) {

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -44,12 +44,8 @@ export class ProjectsFilterDropdownComponent {
   }
 
   handleFilterKeyUp(filterValue: string): void {
-    this.filteredOptions = this.filterOptions(filterValue);
-  }
-
-  filterOptions(value: string): ProjectsFilterOption[] {
-    return this.editableOptions.filter(option =>
-      option.label.toLowerCase().indexOf(value.toLowerCase()) > -1);
+    this.filteredOptions = this.editableOptions
+      .filter(option => option.label.toLowerCase().indexOf(filterValue.toLowerCase()) > -1);
   }
 
   handleLabelClick() {

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -83,11 +83,8 @@ export class ProjectsFilterDropdownComponent {
   }
 
   handleClearSelection() {
-    this.dropdownActive = false;
-    this.optionsEdited = false;
-    // uncheck all the options and then save
+    // uncheck all the options
     this.editableOptions.map(option => option.checked = false);
-    this.onSelection.emit(this.editableOptions);
   }
 
   handleArrowUp(event: KeyboardEvent) {

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -317,7 +317,7 @@ describe('ProjectsFilterDropdownComponent', () => {
       spyOn(component.onSelection, 'emit');
       spyOn(component.onOptionChange, 'emit');
       component.dropdownActive = true;
-      component.optionsEdited = true;
+      component.optionsEdited = false;
       component.editableOptions = genOptions([false, true, true, false, true]);
       expect(component.editableOptions.some(o => o.checked)).toEqual(true);
       component.handleClearSelection();
@@ -329,7 +329,7 @@ describe('ProjectsFilterDropdownComponent', () => {
       expect(component.dropdownActive).toEqual(true);
     });
 
-    it('does not disable the "Apply Changes" button', () => {
+    it('enables the "Apply Changes" button', () => {
       expect(component.optionsEdited).toEqual(true);
     });
 

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -244,10 +244,11 @@ describe('ProjectsFilterDropdownComponent', () => {
     });
   });
 
-  describe('handleOptionChange()', () => {
+  describe('handleOptionChange() for single option', () => {
     beforeEach(() => {
       component.editableOptions = genOptions([false]);
       component.optionsEdited = false;
+      expect(component.editableOptions[0].checked).toEqual(false);
       component.handleOptionChange({ detail: true }, 'Project 1');
     });
 
@@ -256,6 +257,30 @@ describe('ProjectsFilterDropdownComponent', () => {
     });
 
     it('marks the list of options as edited', () => {
+      expect(component.optionsEdited).toEqual(true);
+    });
+  });
+
+  describe('handleOptionChange() for multiple options', () => {
+    beforeEach(() => {
+      component.editableOptions = genOptions([false, false, true, true, false]);
+      component.optionsEdited = false;
+    });
+
+    it('updates an unchecked value to the emitted value', () => {
+      expect(component.editableOptions[1].checked).toEqual(false);
+      component.handleOptionChange({ detail: true }, 'Project 2');
+      expect(component.editableOptions[1].checked).toEqual(true);
+    });
+
+     it('updates a checked value to the emitted value', () => {
+      expect(component.editableOptions[2].checked).toEqual(true);
+      component.handleOptionChange({ detail: false }, 'Project 3');
+      expect(component.editableOptions[2].checked).toEqual(false);
+    });
+
+    it('marks the list of options as edited', () => {
+      component.handleOptionChange({ detail: true }, 'Project 1');
       expect(component.optionsEdited).toEqual(true);
     });
   });

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -1,5 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+
+import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
 import { ProjectsFilterDropdownComponent } from './projects-filter-dropdown.component';
 
 describe('ProjectsFilterDropdownComponent', () => {
@@ -98,20 +100,7 @@ describe('ProjectsFilterDropdownComponent', () => {
   describe('dropdown', () => {
     beforeEach(() => {
       component.dropdownActive = true;
-      component.editableOptions = [
-        {
-          value: 'project-1',
-          label: 'Project 1',
-          type: 'CUSTOM',
-          checked: false
-        },
-        {
-          value: 'project-2',
-          label: 'Project 2',
-          type: 'CUSTOM',
-          checked: true
-        }
-      ];
+      component.editableOptions = genOptions([false, true]);
       // need filteredOptions in order for elements to be displayed in the UI
       component.filteredOptions = component.editableOptions;
       fixture.detectChanges();
@@ -187,20 +176,7 @@ describe('ProjectsFilterDropdownComponent', () => {
 
   describe('resetOptions()', () => {
     beforeEach(() => {
-      component.options = [
-        {
-          value: 'project-1',
-          label: 'Project 1',
-          type: 'CUSTOM',
-          checked: false
-        },
-        {
-          value: 'project-2',
-          label: 'Project 2',
-          type: 'CUSTOM',
-          checked: true
-        }
-      ];
+      component.options = genOptions([false, true]);
       component.editableOptions = [];
       component.optionsEdited = true;
 
@@ -220,20 +196,7 @@ describe('ProjectsFilterDropdownComponent', () => {
   describe('handleLabelClick()', () => {
     describe('when more than one option is available', () => {
       beforeEach(() => {
-        component.editableOptions = [
-          {
-            value: 'project-1',
-            label: 'Project 1',
-            type: 'CUSTOM',
-            checked: false
-          },
-          {
-            value: 'project-2',
-            label: 'Project 2',
-            type: 'CUSTOM',
-            checked: false
-          }
-        ];
+        component.editableOptions = genOptions([false, false]);
         component.dropdownActive = false;
         spyOn(component, 'resetOptions');
 
@@ -251,14 +214,7 @@ describe('ProjectsFilterDropdownComponent', () => {
 
     describe('when only one option is available', () => {
       beforeEach(() => {
-        component.editableOptions = [
-          {
-            value: 'project-1',
-            label: 'Project 1',
-            type: 'CUSTOM',
-            checked: false
-          }
-        ];
+        component.editableOptions = genOptions([false]);
         component.dropdownActive = false;
         spyOn(component, 'resetOptions');
 
@@ -290,14 +246,7 @@ describe('ProjectsFilterDropdownComponent', () => {
 
   describe('handleOptionChange()', () => {
     beforeEach(() => {
-      component.editableOptions = [
-        {
-          value: 'project-1',
-          label: 'Project 1',
-          type: 'CUSTOM',
-          checked: false
-        }
-      ];
+      component.editableOptions = genOptions([false]);
       component.optionsEdited = false;
       component.handleOptionChange({ detail: true }, 'Project 1');
     });
@@ -374,3 +323,17 @@ describe('ProjectsFilterDropdownComponent', () => {
     });
   });
 });
+
+function genOptions(checkedItems: boolean[]): ProjectsFilterOption[] {
+  const options: ProjectsFilterOption[] = [];
+  for (let i = 0; i < checkedItems.length; i++) {
+    options.push(
+      {
+        value: `project-${i + 1}`,
+        label: `Project ${i + 1}`,
+        type: 'CUSTOM',
+        checked: checkedItems[i]
+      });
+  }
+  return options;
+}

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -289,6 +289,7 @@ describe('ProjectsFilterDropdownComponent', () => {
   describe('handleApplySelection()', () => {
     beforeEach(() => {
       spyOn(component.onSelection, 'emit');
+      spyOn(component.onOptionChange, 'emit');
       component.dropdownActive = true;
       component.optionsEdited = true;
       component.handleApplySelection();
@@ -304,6 +305,44 @@ describe('ProjectsFilterDropdownComponent', () => {
 
     it('emits "onSelection" event with list of updated options', () => {
       expect(component.onSelection.emit).toHaveBeenCalledWith(component.editableOptions);
+    });
+
+    it('emits "onOptionChange" event with list of updated options', () => {
+      expect(component.onOptionChange.emit).toHaveBeenCalledWith(component.editableOptions);
+    });
+  });
+
+  describe('handleClearSelection()', () => {
+    beforeEach(() => {
+      spyOn(component.onSelection, 'emit');
+      spyOn(component.onOptionChange, 'emit');
+      component.dropdownActive = true;
+      component.optionsEdited = true;
+      component.editableOptions = genOptions([false, true, true, false, true]);
+      expect(component.editableOptions.some(o => o.checked)).toEqual(true);
+      component.handleClearSelection();
+    });
+
+    // Note: most of these would be phantom tests (see https://bit.ly/2UPrprX)
+    // except for the fact presence of the tests for handleApplySelection above.
+    it('does not hide the dropdown', () => {
+      expect(component.dropdownActive).toEqual(true);
+    });
+
+    it('does not disable the "Apply Changes" button', () => {
+      expect(component.optionsEdited).toEqual(true);
+    });
+
+    it('does not emit "onSelection" event', () => {
+      expect(component.onSelection.emit).not.toHaveBeenCalled();
+    });
+
+    it('does not emit "onOptionChange" event', () => {
+      expect(component.onOptionChange.emit).not.toHaveBeenCalled();
+    });
+
+    it('clears all checked options', () => {
+      expect(component.editableOptions.some(o => o.checked)).toEqual(false);
     });
   });
 

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -334,6 +334,18 @@ describe('ProjectsFilterDropdownComponent', () => {
       expect(component.optionsEdited).toEqual(true);
     });
 
+    it('hides the "Clear Selection" button', () => {
+      fixture.detectChanges();
+      let button: HTMLElement = fixture.nativeElement.querySelector('#projects-filter-clear-selection');
+      expect(button.classList.contains('active')).toEqual(true);
+
+      component.handleClearSelection();
+      fixture.detectChanges();
+
+      button = fixture.nativeElement.querySelector('#projects-filter-clear-selection');
+      expect(button.classList.contains('active')).toEqual(false);
+    });
+
     it('does not emit "onSelection" event', () => {
       component.handleClearSelection();
       expect(component.onSelection.emit).not.toHaveBeenCalled();
@@ -561,6 +573,88 @@ describe('ProjectsFilterDropdownComponent', () => {
     });
 
   });
+
+  describe('"Clear Selection" button', () => {
+    beforeEach(() => {
+      component.dropdownActive = true;
+    });
+    it('becomes visible after no projects checked and then checking one project', () => {
+      component.options = genOptionsWithId([
+        ['proj-one', false],
+        ['proj-two', false],
+        ['proj-three', false]
+      ]);
+      component.resetOptions();
+      fixture.detectChanges();
+      expect(hasClass('#projects-filter-clear-selection', 'active')).toEqual(false);
+
+      component.handleOptionChange({ detail: true }, 'proj-three');
+      fixture.detectChanges();
+
+      expect(hasClass('#projects-filter-clear-selection', 'active')).toEqual(true);
+    });
+
+    it('becomes hidden after unchecking the last checked project', () => {
+      component.options = genOptionsWithId([
+        ['proj-one', true],
+        ['proj-two', true],
+        ['proj-three', false]
+      ]);
+      component.resetOptions();
+      fixture.detectChanges();
+      expect(hasClass('#projects-filter-clear-selection', 'active')).toEqual(true);
+
+      component.handleOptionChange({ detail: false }, 'proj-one');
+      fixture.detectChanges();
+      expect(hasClass('#projects-filter-clear-selection', 'active')).toEqual(true);
+
+      component.handleOptionChange({ detail: false }, 'proj-two');
+      fixture.detectChanges();
+
+      expect(hasClass('#projects-filter-clear-selection', 'active')).toEqual(false);
+    });
+
+    it('becomes visible after loosening filter to reveal some checked projects', () => {
+      component.options = genOptionsWithId([
+        ['proj-one', true],
+        ['filtered-one', false],
+        ['proj-two', true],
+        ['filtered-two', false],
+        ['proj-three', false]
+      ]);
+      component.resetOptions();
+      component.handleFilterKeyUp('filtered');
+      fixture.detectChanges();
+      expect(hasClass('#projects-filter-clear-selection', 'active')).toEqual(false);
+
+      component.handleFilterKeyUp('');
+      fixture.detectChanges();
+      expect(hasClass('#projects-filter-clear-selection', 'active')).toEqual(true);
+    });
+
+    it('becomes hidden after tightening filter to hide all checked projects', () => {
+      component.options = genOptionsWithId([
+        ['proj-one', true],
+        ['filtered-one', false],
+        ['proj-two', true],
+        ['filtered-two', false],
+        ['proj-three', false]
+      ]);
+      component.resetOptions();
+      component.handleFilterKeyUp('proj');
+      fixture.detectChanges();
+      expect(hasClass('#projects-filter-clear-selection', 'active')).toEqual(true);
+
+      component.handleFilterKeyUp('filtered');
+      fixture.detectChanges();
+      expect(hasClass('#projects-filter-clear-selection', 'active')).toEqual(false);
+      });
+  });
+
+  function hasClass(selector: string, cssClass: string): boolean {
+    const element: HTMLElement = fixture.nativeElement.querySelector(selector);
+    return element.classList.contains(cssClass);
+  }
 
 });
 

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
+import { using } from 'app/testing/spec-helpers';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
 import { ProjectsFilterDropdownComponent } from './projects-filter-dropdown.component';
 
@@ -347,6 +348,42 @@ describe('ProjectsFilterDropdownComponent', () => {
       expect(nextElementSibling.focus).toHaveBeenCalled();
     });
   });
+
+  describe('filteredOptions', () => {
+    beforeEach(() => {
+      component.dropdownActive = true;
+      component.options = genOptionsWithId([
+        ['proj-one', true],
+        ['proj-three', false],
+        ['other-one', false],
+        ['other-two', true],
+        ['proj-two', false],
+        ['other-three', false],
+        ['proj-four', false]
+      ]);
+      component.resetOptions();
+    });
+
+    it('with no filter displays all options', () => {
+      expect(component.filteredOptions.length).toEqual(7);
+    });
+
+    using([
+      ['prefix', 'proj', 4],
+      ['mid-value', 'her', 3],
+      ['suffix', 'two', 2],
+      ['empty string', '', 7],
+      ['whitespace', ' ', 0],
+      ['exact match', 'proj-one', 1],
+      ['superset', 'proj-one-plus-one', 0],
+      ['everything', '-', 7]
+    ], function (description: string, filter: string, count: number) {
+      it(`with ${description} filter displays ${count} matching options`, () => {
+        component.handleFilterKeyUp(filter);
+        expect(component.filteredOptions.length).toEqual(count);
+      });
+    });
+  });
 });
 
 function genOptions(checkedItems: boolean[]): ProjectsFilterOption[] {
@@ -360,5 +397,18 @@ function genOptions(checkedItems: boolean[]): ProjectsFilterOption[] {
         checked: checkedItems[i]
       });
   }
+  return options;
+}
+
+function genOptionsWithId(checkedItems: [string, boolean][]): ProjectsFilterOption[] {
+  const options: ProjectsFilterOption[] = [];
+  checkedItems.forEach(([id, checked]) =>
+    options.push({
+        value: id,
+        label: id,
+        type: 'CUSTOM',
+        checked
+    })
+  );
   return options;
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

1. Previously "Clear Selection" would clear the list in the filter, close the filter, and apply those changes, perhaps inadvertantly wiping out a lot of work for a user. Now, it just clears the filter but leaves it open and does not apply the changes. Thus, if it was done accidentally, one need only close the filter then re-open it to get back the current list of checked projects. Bonus: clearing means clearing only from those visible, i.e. those rendered by the filter!

2. Add a count to the button, maxing out at "99+".

3. Hide the button if the count is zero.

Note: Browse by commit for easy digestion.

<img width="1027" alt="image" src="https://user-images.githubusercontent.com/6817500/78914557-6c7ed080-7a3f-11ea-892d-afefd6486a0c.png">


### :chains: Related Resources
NA

### :+1: Definition of Done
1. Selecting <kbd>Clear Changes</kbd> no longer auto-applies changes.
2. Button shows count of filtered and selected items.
3. Button auto-hides if no items in current filtered view or selected.

New tests that define what it does are highlighted: yellow shows testing new functionality; green shows new tests for previously existing functionality.

<img width="600" alt="image" src="https://user-images.githubusercontent.com/6817500/78912651-b619ec00-7a3c-11ea-8da8-661b2ae5079a.png">

### :athletic_shoe: How to Build and Test the Change
1. Rebuild automate-ui.
2. Generate a bunch of projects. From the command line `source ./scripts/auth_collections.sh`, then `authGen projects create 50 101` to create 50 projects.
3. Login in the browser.
4. Open the global projects filter and select some projects.
5. Select <kbd>Apply Changes</kbd>.
6. Re-open the global projects filter.
7. Select <kbd>Clear Changes</kbd>. Observe all changes are gone, but the underlying page does not change (assuming you had stuff assigned to projects).
8. Close the global projects filter. Observe the original projects are still indicated in the closed filter.
9. Re-open the global projects filter. Observe the original projects are still indicated in the open filter.

If you want to see the count go 97, 98, 99, 99+, you need a lot of projects.
Load the utility to do that with `source scripts/auth_collections.sh` then run e.g., `authGen projects create 200 101` to generate 200 projects.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
