### PR TITLE
Be less specific about the conn error being expected

### DIFF
--- a/components/compliance-service/api/tests/30_jobs_docker_spec.rb
+++ b/components/compliance-service/api/tests/30_jobs_docker_spec.rb
@@ -427,7 +427,11 @@ describe File.basename(__FILE__) do
       assert_equal(true, TimeStuff.checkTimestampAndAdjustIfNeeded(test_start_time, n, 'last_contact'))
       n.scan_data.end_time = Google::Protobuf::Timestamp.new()
       n.scan_data.id = "some-id"
+      if n.connection_error.is_a?(String) && n.connection_error.include?("No such container: cc_pggggggggg (Docker::Error::NotFoundError)")
+        n.connection_error = "No such container: cc_pggggggggg. (TRUNCATED IN TESTS)"
+      end
     }
+
     expected_nodes = {
       "nodes": [
         {
@@ -491,7 +495,7 @@ describe File.basename(__FILE__) do
           "managerIds": [
             "e69dc612-7e67-43f2-9b19-256afd385820"
           ],
-          "connectionError": "unknown error\n\nUnknown inspec error for cc_pggggggggg: exit status 1\n\nSTDERR: /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/docker-api-1.34.2/lib/docker/connection.rb:46:in `rescue in request': No such container: cc_pggggggggg (Docker::Error::NotFoundError)\n\tfrom /hab/pkgs/chef/inspec/4.18.51/2019121122093 [truncated for length]",
+          "connectionError": "No such container: cc_pggggggggg. (TRUNCATED IN TESTS)",
           "runData": {},
           "scanData": {
             "id": "some-id",


### PR DESCRIPTION
Avoids [this](https://buildkite.com/chef-oss/chef-automate-master-verify/builds/10717#beb6af87-6c2d-4892-b485-428ac06ae488) sort of test failure: 

```
expected
actual
@@ -8,9 +8,9 @@
 " +
      "
 " +
-     "STDERR: /hab/pkgs/chef/inspec/4.18.51/20191211220937/lib/gems/docker-api-1.34.2/lib/docker/connection.rb:46:in `rescue in request': No such container: cc_pggggggggg (Docker::Error::NotFoundError)
+     "STDERR: /hab/pkgs/core/ruby26/2.6.5/20191007205438/lib/ruby/gems/2.6.0/gems/docker-api-1.34.2/lib/docker/connection.rb:46:in `rescue in request': No such container: cc_pggggggggg (Docker::Error::NotFoundError)
 " +
-     "\tfrom /hab/pkgs/chef/inspec/4.18.51/2019121122093 [truncated for length]",
+     "\tfrom /hab/pkgs/core/ruby26/2.6.5/2 [truncated for length]",
     "id"=>"8a7d5ff0-f589-4f37-ac41-7732f986262f",
     "lastJob"=>
      {"jobId"=>"941a6b05-4e5a-4e5c-87e2-a0d685c0acb4",
 
7 runs, 55 assertions, 1 failures, 0 errors, 0 skips
```