### PR TITLE
Add admin-token back in as a hidden command and give deprecation error

### DIFF
--- a/components/automate-cli/cmd/chef-automate/deprecated.go
+++ b/components/automate-cli/cmd/chef-automate/deprecated.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// A place to put all of our deprecated commands
+
+func newAdminTokenCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:    "admin-token NAME",
+		Short:  "[deprecated] Chef Automate IAM v1 admin token create",
+		RunE:   runAdminTokenCmd,
+		Args:   cobra.ExactArgs(1),
+		Hidden: true,
+	}
+}
+
+func init() {
+	adminCommand := newAdminTokenCommand()
+	RootCmd.AddCommand(adminCommand)
+}
+
+func runAdminTokenCmd(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	writer.Failf("The admin-token command was an IAM V1 command and is now deprecated. "+
+		"To make an admin token in IAM V2, run:\n\nchef-automate iam token create %s --admin", name)
+	os.Exit(1)
+	return nil
+}

--- a/components/automate-cli/cmd/chef-automate/deprecated.go
+++ b/components/automate-cli/cmd/chef-automate/deprecated.go
@@ -13,7 +13,6 @@ func newAdminTokenCommand() *cobra.Command {
 		Use:    "admin-token NAME",
 		Short:  "[deprecated] Chef Automate IAM v1 admin token create",
 		RunE:   runAdminTokenCmd,
-		Args:   cobra.ExactArgs(1),
 		Hidden: true,
 	}
 }
@@ -23,11 +22,8 @@ func init() {
 	RootCmd.AddCommand(adminCommand)
 }
 
-func runAdminTokenCmd(cmd *cobra.Command, args []string) error {
-	name := args[0]
-
-	writer.Failf("The admin-token command is deprecated. "+
-		"Use, run:\n\nchef-automate iam token create %s --admin", name)
+func runAdminTokenCmd(cmd *cobra.Command, _ []string) error {
+	writer.Failf("The admin-token command is deprecated. Use:\n\nchef-automate iam token create NAME --admin")
 	os.Exit(1)
 	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/deprecated.go
+++ b/components/automate-cli/cmd/chef-automate/deprecated.go
@@ -26,7 +26,7 @@ func init() {
 func runAdminTokenCmd(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
-	writer.Failf("The admin-token command was an IAM V1 command and is now deprecated. "+
+	writer.Failf("The admin-token command is deprecated. "+
 		"To make an admin token in IAM V2, run:\n\nchef-automate iam token create %s --admin", name)
 	os.Exit(1)
 	return nil

--- a/components/automate-cli/cmd/chef-automate/deprecated.go
+++ b/components/automate-cli/cmd/chef-automate/deprecated.go
@@ -10,7 +10,7 @@ import (
 
 func newAdminTokenCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:    "admin-token NAME",
+		Use:    "admin-token",
 		Short:  "[deprecated] Chef Automate IAM v1 admin token create",
 		RunE:   runAdminTokenCmd,
 		Hidden: true,

--- a/components/automate-cli/cmd/chef-automate/deprecated.go
+++ b/components/automate-cli/cmd/chef-automate/deprecated.go
@@ -27,7 +27,7 @@ func runAdminTokenCmd(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
 	writer.Failf("The admin-token command is deprecated. "+
-		"To make an admin token in IAM V2, run:\n\nchef-automate iam token create %s --admin", name)
+		"Use, run:\n\nchef-automate iam token create %s --admin", name)
 	os.Exit(1)
 	return nil
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Add the command back in hidden with a message about how to create an admin token in IAM V2 so anyone who runs it out of habit or in a script knows how to fix for V2.

### :athletic_shoe: How to Build and Test the Change

```
# rebuild components/automate-cli
...
# chef-automate admin-token testname
Error: The admin-token command was an IAM V1 command and is now deprecated. To make an admin token in IAM V2, run:

chef-automate iam token create testname --admin
# echo $?
1
```

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
