### PR TITLE
[hab] update pins for core plan refresh

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -92,6 +92,7 @@ steps:
 
   - label: "[unit] OPA"
     command:
+      - scripts/install_hab_pkg.sh core/glibc # opa depends implicitly glibc
       - scripts/install_hab_pkg.sh core/opa
       - cd components/authz-service/engine/opa/policy
       - make static unit

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -612,7 +612,7 @@ steps:
       - sudo scripts/install_golang.sh
       - sudo scripts/install_grpcurl.sh
       - cd components/compliance-service
-      - sudo -E  PATH=\$(hab pkg path core/ruby26)/bin:\$PATH make test-integration-scanner
+      - sudo -E  PATH=\$(hab pkg path core/ruby)/bin:\$PATH make test-integration-scanner
       - cd ../.. && sudo git clean -fxd
     artifact_paths:
       - /tmp/secrets-service.log

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -143,7 +143,7 @@ steps:
 
   # The nodemanager tests require access to AWS and Azure accounts as
   # they test against the actual API endpoints of those services.
-  - label: "nodemanager-integration-tests"
+  - label: "nodemanager-integration"
     command:
       - . scripts/verify_setup.sh
       - |
@@ -184,7 +184,7 @@ steps:
 
   # The license_usage_nodes_test appears to require AWS access. We
   # might consider splitting this into two different tests.
-  - label: "gateway-integration-tests"
+  - label: "gateway-integration"
     command:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh && start_all_services && go_test ./components/automate-gateway/integration/..."
@@ -500,7 +500,7 @@ steps:
   - label: "airgap a1migration"
     command:
       - integration/run_test integration/tests/airgap_a1migration.sh
-    timeout_in_minutes: 20
+    timeout_in_minutes: 25
     expeditor:
       executor:
         linux:
@@ -530,7 +530,7 @@ steps:
   - label: "product airgap"
     command:
       - integration/run_test integration/tests/airgap_product.sh
-    timeout_in_minutes: 20
+    timeout_in_minutes: 25
     expeditor:
       executor:
         linux:
@@ -564,7 +564,7 @@ steps:
   - label: "airgap backup"
     command:
       - integration/run_test integration/tests/airgap_backup.sh
-    timeout_in_minutes: 25
+    timeout_in_minutes: 30
     expeditor:
       executor:
         linux:
@@ -610,7 +610,7 @@ steps:
   - label: "backup to s3"
     command:
       - integration/run_test integration/tests/backup_s3.sh
-    timeout_in_minutes: 30
+    timeout_in_minutes: 35
     expeditor:
       accounts:
         - aws/chef-cd
@@ -819,7 +819,7 @@ steps:
           single-use: true
           privileged: true
 
-  - label: "builder smoke tests"
+  - label: "builder smoke"
     command:
       - integration/run_test integration/tests/bldr_smoke.sh
     timeout_in_minutes: 25

--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -271,6 +271,10 @@ exceptions:
       reason: Exception made by Chef Legal
     - name: core/nss-myhostname
       reason: Exception made by Chef Legal
+    - name: core/binutils
+      reason: (rc) dep of core/bundler. Exception made by Stephen Delano, 4/23/20
+    - name: core/perl
+      reason: (rc) dep of core/git, used by Workflow and sqitch. Exception made by Stephen Delano, 4/23/20
 
   ruby:
     - name: highline

--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -275,6 +275,8 @@ exceptions:
       reason: (rc) dep of core/bundler. Exception made by Stephen Delano, 4/23/20
     - name: core/perl
       reason: (rc) dep of core/git, used by Workflow and sqitch. Exception made by Stephen Delano, 4/23/20
+    - name: core/procps-ng
+      reason: Exception made by Chef Legal
 
   ruby:
     - name: highline

--- a/components/automate-builder-api-proxy/habitat/plan.sh
+++ b/components/automate-builder-api-proxy/habitat/plan.sh
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # We need to pin here to get a build from unstable
-  "habitat/builder-api-proxy/8796/20200309134228"
+  "habitat/builder-api-proxy/8865/20200421224604"
 )
 
 pkg_build_deps=(

--- a/components/automate-builder-api/habitat/plan.sh
+++ b/components/automate-builder-api/habitat/plan.sh
@@ -14,7 +14,7 @@ pkg_deps=(
   core/bash
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # We need to pin here to get a build from unstable
-  "habitat/builder-api/8850/20200330144923"
+  "habitat/builder-api/8850/20200421223841"
 )
 
 pkg_binds=(

--- a/components/automate-cs-bookshelf/habitat/plan.sh
+++ b/components/automate-cs-bookshelf/habitat/plan.sh
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/bookshelf/13.0.47/20191009112037"
+  "${vendor_origin}/bookshelf/13.0.47/20200421211738"
 )
 
 pkg_binds=(

--- a/components/automate-cs-nginx/habitat/plan.sh
+++ b/components/automate-cs-nginx/habitat/plan.sh
@@ -10,15 +10,12 @@ pkg_license=('Chef-MLSA')
 pkg_version="13.0.47"
 pkg_deps=(
   chef/mlsa
-  # TODO: REMOVE PINS
-  # The following pins match those in the chef-server-* packages below
-  # and can be removed once we unblock upgrades of chef-server.
-  core/curl/7.65.3/20190826035620
-  core/bundler/1.17.3/20191007210608
-  core/ruby/2.5.7/20191007205439
+  core/curl
+  core/bundler
+  core/ruby
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/chef-server-nginx/13.0.47/20191009112851"
-  "${vendor_origin}/chef-server-ctl/13.0.47/20191009112038"
+  "${vendor_origin}/chef-server-nginx/13.0.47/20200421235836"
+  "${vendor_origin}/chef-server-ctl/13.0.47/20200421235903"
 )
 
 pkg_bin_dirs=(bin)

--- a/components/automate-cs-oc-bifrost/habitat/plan.sh
+++ b/components/automate-cs-oc-bifrost/habitat/plan.sh
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/oc_bifrost/13.0.47/20191009112044"
+  "${vendor_origin}/oc_bifrost/13.0.47/20200421235620"
 )
 
 pkg_binds=(

--- a/components/automate-cs-oc-erchef/habitat/plan.sh
+++ b/components/automate-cs-oc-erchef/habitat/plan.sh
@@ -16,7 +16,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/oc_erchef/13.0.47/20191009112044"
+  "${vendor_origin}/oc_erchef/13.0.47/20200421235032"
 )
 
 pkg_build_deps=(

--- a/components/automate-workflow-nginx/habitat/plan.sh
+++ b/components/automate-workflow-nginx/habitat/plan.sh
@@ -1,3 +1,6 @@
+#shellcheck disable=SC2034
+#shellcheck disable=SC2154
+
 pkg_name=automate-workflow-nginx
 pkg_origin=chef
 pkg_version=2.8.61
@@ -6,14 +9,14 @@ pkg_license=('Chef-MLSA')
 vendor_origin=${vendor_origin:-"chef"}
 
 pkg_deps=(
-  core/libossp-uuid
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/openresty-noroot/1.13.6.2/20191009112038"
+  "${vendor_origin}/openresty-noroot/1.13.6.2/20200421183321"
+  "${vendor_origin}/automate-workflow-web"
   chef/mlsa
   core/bash
   core/curl
   core/coreutils
-  "${vendor_origin}/automate-workflow-web"
+  core/libossp-uuid
 )
 
 pkg_exposes=(port ssl-port)
@@ -38,7 +41,7 @@ do_build() {
 
 do_install() {
     mkdir -pv "$pkg_prefix/www/workflow" "$pkg_prefix/www/loading"
-    cp -Rv "$(pkg_path_for ${vendor_origin}/automate-workflow-web)"/dist/* "$pkg_prefix/www/workflow"
+    cp -Rv "$(pkg_path_for "${vendor_origin}/automate-workflow-web")"/dist/* "${pkg_prefix}/www/workflow"
     cp -v "$SRC_PATH/loading.html" "$pkg_prefix/www/loading/index.html"
 }
 

--- a/components/automate-workflow-web/habitat/plan.sh
+++ b/components/automate-workflow-web/habitat/plan.sh
@@ -1,3 +1,6 @@
+#shellcheck disable=SC2034
+#shellcheck disable=SC2154
+
 pkg_name=automate-workflow-web
 pkg_origin=chef
 pkg_version="1.0.0"

--- a/components/compliance-service/api/tests/11_wonky_profiles_spec.rb
+++ b/components/compliance-service/api/tests/11_wonky_profiles_spec.rb
@@ -53,6 +53,8 @@ describe File.basename(__FILE__) do
     assert_equal(Profiles::CheckResult, res.class)
 
     assert_equal(true, res['summary']['valid'])
-    assert_equal([Profiles::CheckMessage.new(file: "controls/files_spec.rb", line: 9, control_id: "apache-08", msg: "Control apache-08 has no tests defined")], res['warnings'])
+    assert_equal(true, res['warnings'].include?(
+      Profiles::CheckMessage.new(file: "controls/files_spec.rb", line: 9, control_id: "apache-08", msg: "Control apache-08 has no tests defined")
+    ))
   end
 end

--- a/components/compliance-service/habitat/plan.sh
+++ b/components/compliance-service/habitat/plan.sh
@@ -29,17 +29,14 @@ pkg_binds_optional=(
   [authn-service]="port"
   [notifications-service]="port"
 )
-inspec_release="chef/inspec/4.18.108/20200424204949"
+inspec_release="chef/inspec/4.18.104/20200421173550"
 pkg_deps=(
-  core/bash
-  core/grpcurl              # Used in habitat/hooks/health_check
-  core/jq-static            # Used in habitat/hooks/health_check
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
-  # WARNING: Update with care. The chef/inspec is managed with Expeditor.
-
-  # See .expeditor/update-inspec-version.sh for details
   "${inspec_release}"
   chef/mlsa
+  core/grpcurl              # Used in habitat/hooks/health_check
+  core/jq-static            # Used in habitat/hooks/health_check
+  core/bash
 )
 
 if [[ -n "$AUTOMATE_OSS_BUILD" ]]; then

--- a/scripts/install_grpcurl.sh
+++ b/scripts/install_grpcurl.sh
@@ -6,6 +6,8 @@ export HAB_NOCOLORING=true
 export HAB_LICENSE="accept-no-persist"
 
 install_grpcurl() {
+  #grpcurl implicity depends on latest glibc
+  hab pkg install core/glibc
   hab pkg install core/grpcurl -b -f
 }
 

--- a/scripts/install_grpcurl.sh
+++ b/scripts/install_grpcurl.sh
@@ -7,7 +7,7 @@ export HAB_LICENSE="accept-no-persist"
 
 install_grpcurl() {
   #grpcurl implicity depends on latest glibc
-  hab pkg install core/glibc
+  hab pkg install core/glibc/2.27/20190115002733
   hab pkg install core/grpcurl -b -f
 }
 

--- a/scripts/install_inspec_master.sh
+++ b/scripts/install_inspec_master.sh
@@ -7,7 +7,7 @@ export HAB_LICENSE="accept-no-persist"
 
 install_inspec() {
   hab pkg install core/gcc --binlink --force
-  hab pkg install core/ruby26 --binlink --force
+  hab pkg install core/ruby --binlink --force
 
   tmp_dir=$(mktemp -d)
   git clone --depth=1 https://github.com/inspec/inspec "$tmp_dir"


### PR DESCRIPTION
:warning: DO NOT MERGE until the refresh-2020q1-008 hab channel has been promoted to stable :warning: 

This change updates the hardcoded pins in Chef Automate to use versions in the refresh-2020q1-008 core plan refresh channel. It has been tested against refresh-2020q1-008 channel:
* https://buildkite.com/chef-oss/chef-automate-master-verify/builds/11382
* https://buildkite.com/chef/chef-automate-master-verify-private/builds/11761

## How to rebuild the universe
* [x] refresh-2020q1-008 has been promoted to the stable channel
* [ ] Rebuild and merge this PR (or force merge if you have godmode)
* [ ] Create a new master automate build job and use the master branch. https://buildkite.com/chef/chef-automate-master-habitat-build
  We use expeditors `smart_build` option so we'll need to trigger a build job manually to rebuild all the things. If we don't rebuild everything our airgap bundles will include multiple universes of packages.
* [ ] After the manual habitat/build job has completed and the artifacts have been promoted to the dev channel, create a new PR that updates the `automate-elasticsearch` and `automate-postgresql` pins in `.expeditor/create-manifest.rb` to the packages built in the manual habitat build.
* [ ] Merge the new PR
* [ ] :beers: 

Signed-off-by: Ryan Cragun <ryan@chef.io>