### PR TITLE
Support the infra server's `/version` endpoint in the automate-deployed infra server

### DIFF
--- a/components/automate-load-balancer/habitat/config/automate-cs-nginx-location.conf
+++ b/components/automate-load-balancer/habitat/config/automate-cs-nginx-location.conf
@@ -4,7 +4,7 @@
 
 #
 # Bookshelf requests are handled specially so that we can cache
-# cookbook data at the edge fo the system.
+# cookbook data at the edge of the system.
 #
 location ~ "^/bookshelf/organization-.+" {
   set $destination @bookshelf_cached;
@@ -49,7 +49,7 @@ location @bookshelf_uncached {
   proxy_set_header Connection "";
 }
 
-location ~ ^/(_status|compliance/organizations|organizations|users|authenticate_user|system_recovery|license|server_api_version|_stats)/?(.*) {
+location ~ ^/(_status|compliance/organizations|organizations|users|authenticate_user|system_recovery|license|server_api_version|_stats|version)/?(.*) {
   proxy_set_header Host $http_host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/components/automate-load-balancer/habitat/config/automate-cs-nginx-location.conf
+++ b/components/automate-load-balancer/habitat/config/automate-cs-nginx-location.conf
@@ -49,7 +49,7 @@ location @bookshelf_uncached {
   proxy_set_header Connection "";
 }
 
-location ~ ^/(_status|compliance/organizations|organizations|users|authenticate_user|system_recovery|license|server_api_version|_stats|version)/?(.*) {
+location ~ ^/(_status|compliance/organizations|organizations|users|authenticate_user|system_recovery|license|server_api_version|_stats|version|universe)/?(.*) {
   proxy_set_header Host $http_host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Supporting the infra server's `/version` endpoint enables using `knife ec backup` to backup the data from an infra server installed from an omnibus package and using `knife ec restore` to restore the data to an automate-deployed infra server.

Fixes #3301 

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
#### Deploy an infra server and take a backup
1. In `automate/components/automate-deployment`, run `vagrant up` to bring up a minimal vagrant box. Use `vagrant ssh` to login, and go to the `/a2/ directory. 
1. Install a [standalone infra server](https://docs.chef.io/install_server/).
1. As root, install chefdk (`dpkg -i chefdk_4.7.113-1_amd64.deb`) and the knife-ec-backup plugin (`apt-get install ruby-dev g++ libpq-dev; chef gem install knife-ec-backup`).
1. As root, run `knife fetch ssl` to make the infra server's SSL certs available to knife.
1. As root, backup the infra server: `mkdir ./tmp; knife ec backup --server-url https://automate-deployment.test --key <admin-key> ./tmp`. The backup will land in `automate/components/automate-deployment/tmp`.
1. Exit the vagrant box and run `vagrant destroy -f` to stop and remove it.

#### Deploy the infra server using Automate and restore the data from the first infra serveer
1. Checkout the branch yzl/3301 from the automate repo, bring up the studio dev environment, and run `build components/automate-load-balancer`.
1. In `automate/components/automate-deployment`, run `vagrant up` to bring up a minimal vagrant environment.
1. Go to the `/a2` directory and, as root, install automate and infra server using the package built in the first step, e.g. `./components/automate-deployment/bin/linux/chef-automate deploy --product automate --product chef-server --hartifacts ./results --override-origin <your-origin>`
1. As root, install chefdk (`dpkg -i chefdk_4.7.113-1_amd64.deb`) and the knife-ec-backup plugin (`apt-get install ruby-dev g++ libpq-dev; chef gem install knife-ec-backup`).
1. As root, run `knife ssl fetch` to make Automate's SSL certs available to knife.
1. As root, go to `components/automate-deployment/tmp`, which contains the infra server backup, and restore the data to the infra server:
```
knife ec restore . -u pivotal --webui-key /hab/svc/automate-cs-oc-erchef/data/webui_priv.pem --skip-version-check -s https://`hostname -f`
```
### :white_check_mark: Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
