### PR TITLE
Fix external ES docs

### DIFF
--- a/components/automate-chef-io/content/docs/install.md
+++ b/components/automate-chef-io/content/docs/install.md
@@ -150,7 +150,7 @@ Add the following to your config.toml:
 # Uncomment and fill out if using external elasticsearch with SSL and/or basic auth
 # [global.v1.external.elasticsearch.auth]
 #   scheme = "basic_auth"
-# [global.v1.external.elasticsearch.basic_auth]
+# [global.v1.external.elasticsearch.auth.basic_auth]
 #   username = "<admin username>"
 #   password = "<admin password>"
 # [global.v1.external.elasticsearch.ssl]


### PR DESCRIPTION
The configuration in the docs is wrong. `basic_auth` needs to be under `auth`
ref: [success slack question](https://chef-success.slack.com/archives/C071VQUP5/p1586353834046000)