### PR TITLE
Config mgmt Adding Error Message filter to GetNodes request. 

### DIFF
--- a/components/config-mgmt-service/backend/parameters.go
+++ b/components/config-mgmt-service/backend/parameters.go
@@ -39,6 +39,7 @@ var (
 	ChefTags           string = "chef_tags"
 	Project            string = "projects"
 	ErrorMessage       string = "error_message"
+	ErrorType          string = "error_type"
 	ChefServer         string = NodeFieldToJson("SourceFqdn")
 	EntityTypeName     string = "entity_type"
 	RunEndTime         string = "end_time"

--- a/components/config-mgmt-service/params/parameters.go
+++ b/components/config-mgmt-service/params/parameters.go
@@ -90,6 +90,8 @@ func ConvertParamToNodeStateBackendLowerFilter(parameter string) string {
 		return backend.ChefTags + ".lower"
 	case "error", backend.ErrorMessage:
 		return backend.ErrorMessage + ".lower"
+	case "error_type", backend.ErrorType:
+		return backend.ErrorType + ".lower"
 	case "chef_server", "source_fqdn", backend.ChefServer:
 		return backend.ChefServer + ".lower"
 	case "environment", backend.Environment:


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This change is adding the "error_type" as a filter for the GetNodes request. 

### :chains: Related Resources
#3219 

### :athletic_shoe: How to Build and Test the Change
1. Build and start the change with `build components/config-mgmt-service && start_all_services`
1. Add some failed nodes with error messages and error types with the below
```
for _ in {1..100} ; do
  m=$((RANDOM % 4))
  n=$((RANDOM % 4))
  generate_chef_run_failure_example | \
    jq --arg msg "Error $n occurred" --arg type "Chef::ExampleError$m" '.error.message = $msg | .error.class = $type' | \
    send_chef_data_raw
done
```
1. Open the Desktop UI page https://a2-dev.test/dashboards/desktop
1. Click on one of the error message names in the "Top 10 Errors" control.
1. The Insights control should appear. 
1. Click on the "error_message" filter to remove it. Ensure note the total number of desktops
1. Click on the "error_type" filter to remove it. Ensure the total number of desktops increases. 
1. To test from the command line run `curl -s -f --insecure -H "api-token: $(get_api_token)"  "https://localhost/api/v0/cfgmgmt/nodes?filter=error_type:Chef%253A%253AExampleError0&pagination.size=1000" | jq .[].name | wc -l` with the filter
1. Compare with `curl -s -f --insecure -H "api-token: $(get_api_token)"  "https://localhost/api/v0/cfgmgmt/nodes?pagination.size=1000" | jq .[].name | wc -l`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
