### PR TITLE
Describe setting up `knife` for use with Automate-deployed Infra Server

### DIFF
--- a/components/automate-chef-io/content/docs/infra-server.md
+++ b/components/automate-chef-io/content/docs/infra-server.md
@@ -14,8 +14,7 @@ toc = true
 
 {{% warning %}}
 
-Chef Automate will not deploy the Chef Infra Server add-ons Chef Manage
-and Push Jobs Server.
+Chef Automate will not deploy the Chef Infra Server add-ons Chef Manage and Push Jobs Server.
 
 {{% /warning %}}
 
@@ -62,8 +61,7 @@ Install Chef Automate and Chef Infra Server on the same host with this command:
 sudo chef-automate deploy --product automate --product infra-server
 ```
 
-[Set up `knife`]({{< relref "infra-server.md#use-knife-with-chef-infra-server" >}}) to
-use with Chef Infra Server.
+Then, [set up `knife`]({{< relref "infra-server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
 
 ### Configuration File Install of Chef Automate and Infra Server
 
@@ -91,14 +89,13 @@ Installations require elevated privileges, so run the commands as the superuser 
       sudo chef-automate deploy config.toml
     ```
 
-1. [Set up `knife`]({{< relref "infra-server.md#use-knife-with-chef-infra-server" >}}) to
-use with Chef Infra Server.
+1. [Set up `knife`]({{< relref "infra-server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
 
 ## Install Standalone Chef Infra Server through Chef Automate
 
 Use either a command line interface or a configuration file to install Chef Infra Server through Chef Automate.
 
-Refer to the on Chef Infra Server [hardware requirements](https://docs.chef.io/install_server_pre/) for guidance on memory and number of CPUs.
+Refer to the Chef Infra Server [hardware requirements](https://docs.chef.io/install_server_pre/) for guidance on memory and number of CPUs.
 
 ### Command Line Install of Standalone Chef Infra Server
 
@@ -125,8 +122,7 @@ Installations require elevated privileges, so run the commands as the superuser 
        sudo chef-automate deploy --product infra-server <configuration_file>
     ```
 
-1. [Set up `knife`]({{< relref "infra-server.md#use-knife-with-chef-infra-server" >}}) to
-use with Chef Infra Server.
+1. [Set up `knife`]({{< relref "infra-server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
 
 ### Configuration File Install of Standalone Chef Infra Server
 
@@ -158,12 +154,11 @@ Installations require elevated privileges, so run the commands as the superuser 
       sudo chef-automate deploy config.toml
     ```
 
-1. [Set up `knife`]({{< relref "infra-server.md#use-knife-with-chef-infra-server" >}}) to
-use with Chef Infra Server.
+1. [Set up `knife`]({{< relref "infra-server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
 
 ## Use `knife` with Chef Infra Server
-The [`knife` command-line utility](https://docs.chef.io/workstation/knife/) provides an interface to interact with a Chef Infra
-Server from a workstation.
+
+The [`knife` command-line utility](https://docs.chef.io/workstation/knife/) provides an interface to interact with a Chef Infra Server from a workstation.
 
 On the Chef Infra Server host:
 
@@ -173,31 +168,41 @@ On the Chef Infra Server host:
       sudo chef-server-ctl user-create USER_NAME FIRST_NAME LAST_NAME EMAIL 'PASSWORD' --filename USER_NAME.pem
     ```
 
-    An RSA private key is generated automatically. This is the user's private key and should be saved to a safe location. The `--filename` option will save the RSA private key to the specified absolute path.
+    An RSA private key generates automatically and is the chef-validator key.
+    Save this RSA private key to a safe location.
+    The `--filename` option will save the RSA private key to the specified absolute path.
 
-1. Run the following command to create an organization, generate its validator key, and
-   assign the user created in the previous step as an administrator:
+1. Run the following command to create an organization, generate its validator key, and assign the user created in the previous step as an administrator:
 
     ```shell
-      sudo chef-server-ctl org-create short_name 'full_organization_name' --association_user user_name --filename ORGANIZATION-validator.pem
+      sudo chef-server-ctl org-create SHORT_NAME 'FULL_ORGANIZATION_NAME' --association_user USER_NAME --filename ORGANIZATION-validator.pem
     ```
 
-    The name must begin with a lower-case letter or digit, may only contain lower-case letters, digits, hyphens, and underscores, and must be between 1 and 255 characters. For example: 4thcoffee.
+    The short name must begin with a lower-case letter or digit, may contain only lower-case letters, digits, hyphens, and underscores, and must be between 1 and 255 characters. For example: `4thcoffee`.
 
-    The full name must begin with a non-white space character and must be between 1 and 1023 characters. For example: 'Fourth Coffee, Inc.'.
+    The full organization name must begin with a non-white space character and must be between 1 and 1023 characters. For example: `'Fourth Coffee, Inc.'`.
 
-    The `--association_user` option will associate the `user_name` with the `admins` security group on the Chef Infra Server.
+    The `--association_user` option will associate the `USER_NAME` with the `admins` security group on the Chef Infra Server.
 
-    An RSA private key is generated automatically. This is the chef-validator key and should be saved to a safe location. The `--filename` option will save the RSA private key to the specified absolute path.
+    An RSA private key generates automatically and is the chef-validator key.
+    Save this RSA private key to a safe location.
+    The `--filename` option will save the RSA private key to the specified absolute path.
 
 On the workstation:
 
-1. Install [Chef Workstation](https://docs.chef.io/workstation/install_workstation/)
+1. Install [Chef Workstation](https://docs.chef.io/workstation/install_workstation/).
 
-1. Run `chef generate repo chef-repo` to create a Chef repo.
+1. Create a Chef repository by using the `chef generate repo` subcommand.
+     For example, create a Chef repository named `chef-repo` by running: 
+     ```shell
+     chef generate repo chef-repo
+     ```
+     Replace `chef-repo` with your desired repository name.
 
-1. Within the Chef repo, make a `.chef` directory, e.g. `mkdir /chef-repo/.chef`
-
+1. Within your named Chef repository, create a `.chef` directory with the `mkdir` command. For example: 
+    ```shell
+      mkdir /chef-repo/.chef
+    ```
 1. Copy `ORGANIZATION-validator.pem` and `USER_NAME.pem` to the `.chef` directory.
 
 1. In the `.chef` directory, create a `config.rb` file that contains:
@@ -219,7 +224,6 @@ On the workstation:
     template](https://docs.chef.io/install_chef_air_gap/#create-a-bootstrap-template) and
     [add it](https://docs.chef.io/install_chef_air_gap/#configure-knife) to your `config.rb`.
 
-1. Run `knife ssl fetch` to get the SSL certificates from Chef Infra Server and make them
-   available to `knife`.
+1. Run `knife ssl fetch` to get the SSL certificates from Chef Infra Server and make them available to `knife`.
 
-For more on setting up the workstation, see [the Chef Workstation documentation](https://docs.chef.io/workstation/getting_started/).
+For more information on how to set up the workstation, see [the Chef Workstation documentation](https://docs.chef.io/workstation/getting_started/).


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Describe how to set up `knife` for use with the Automate-deployed Infra Server. Users coming to the Automate-deployed Infra Server from using Automate + Infra Server on Opsworks or Infra Server with Manage (deprecated) are used to a different setup model.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
