### PR TITLE
[automate-platform-tools] drop dep on core/glibc

### DIFF
--- a/.studio/common
+++ b/.studio/common
@@ -239,7 +239,7 @@ function build() {
   if [ -z "$hab_build" ]; then
     exit_with "Hab build binary not found. Verify the 'build' wrapper inside the studio." 22
   else
-    HAB_FEAT_IGNORE_LOCAL=true HAB_BLDR_CHANNEL=dev $hab_build "$@"
+    HAB_FEAT_IGNORE_LOCAL=true HAB_BLDR_CHANNEL=${HAB_BLDR_CHANNEL:-dev} $hab_build "$@"
   fi
 }
 

--- a/components/automate-gateway/habitat/plan.sh
+++ b/components/automate-gateway/habitat/plan.sh
@@ -12,6 +12,7 @@ pkg_deps=(
   core/cacerts # communicate with license service over HTTPS
   core/curl
   core/jq-static
+  core/glibc # zoneinfo
   chef/mlsa
 )
 pkg_exports=(

--- a/components/automate-platform-tools/habitat/plan.sh
+++ b/components/automate-platform-tools/habitat/plan.sh
@@ -8,9 +8,6 @@ pkg_version="0.1.0"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=('Chef-MLSA')
 pkg_upstream_url="https://www.chef.io/automate"
-pkg_deps=(
-  core/glibc
-)
 pkg_bin_dirs=(bin)
 pkg_scaffolding="${local_scaffolding_origin:-chef}/automate-scaffolding-go"
 scaffolding_no_platform=true # Don't inject automate platform scaffolding

--- a/components/event-feed-service/habitat/plan.sh
+++ b/components/event-feed-service/habitat/plan.sh
@@ -10,6 +10,7 @@ pkg_license=('Chef-MLSA')
 pkg_upstream_url="http://github.com/chef/automate/components/event-feed-service"
 pkg_deps=(
   chef/mlsa
+  core/glibc # for zoneinfo
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
 )
 pkg_exports=(

--- a/components/event-feed-service/pkg/integration_test/feed_timeline_test.go
+++ b/components/event-feed-service/pkg/integration_test/feed_timeline_test.go
@@ -51,7 +51,7 @@ func TestEventStringsNormalRequest(t *testing.T) {
 
 	feedTimeline, err := testSuite.feedClient.GetFeedTimeline(ctx, request)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	printFeedTimeline(feedTimeline, request)
 
@@ -195,7 +195,7 @@ func TestEventStringsFilterEventType(t *testing.T) {
 		t.Run(fmt.Sprintf("with request '%v' it %s", test.request, test.description),
 			func(t *testing.T) {
 				res, err := testSuite.feedClient.GetFeedTimeline(ctx, &test.request)
-				if assert.Nil(t, err) {
+				if assert.NoError(t, err) {
 					for _, line := range res.ActionLines {
 						if line.Action == verb {
 
@@ -246,7 +246,7 @@ func TestEventStringsDayZoneActionsRequest(t *testing.T) {
 
 	feedTimeline, err := testSuite.feedClient.GetFeedTimeline(ctx, request)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	totalItems := 0
 	for _, line := range feedTimeline.ActionLines {
@@ -315,7 +315,7 @@ func TestEventStringsVaryingBucketsSizeRequest(t *testing.T) {
 
 		feedTimeline, err := testSuite.feedClient.GetFeedTimeline(ctx, request)
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		totalItems := 0
 		for _, line := range feedTimeline.ActionLines {
 			assert.Equal(t, numberOfBuckets, len(line.Slots), "with bucket size: %d", bucketSize)
@@ -354,7 +354,7 @@ func TestEventStringsVaryingBucketsSizeNoActionsRequest(t *testing.T) {
 
 		feedTimeline, err := testSuite.feedClient.GetFeedTimeline(ctx, request)
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		totalItems := 0
 		for _, line := range feedTimeline.ActionLines {
 			assert.Equal(t, numberOfBuckets, len(line.Slots), "with bucket size: %d", bucketSize)
@@ -466,7 +466,7 @@ func TestEventStringsThreeDayThreeActionsRequest(t *testing.T) {
 
 	feedTimeline, err := testSuite.feedClient.GetFeedTimeline(ctx, request)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	totalItems := 0
 	for _, line := range feedTimeline.ActionLines {
@@ -608,7 +608,7 @@ func TestEventStringsThreeDayThreeActionsInNewYorkRequest(t *testing.T) {
 
 	feedTimeline, err := testSuite.feedClient.GetFeedTimeline(ctx, request)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	totalItems := 0
 	for _, line := range feedTimeline.ActionLines {
@@ -684,7 +684,7 @@ func TestEventStringsDayOneActionsOutsideOfRequest(t *testing.T) {
 
 	feedTimeline, err := testSuite.feedClient.GetFeedTimeline(ctx, request)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	totalItems := 0
 	for _, line := range feedTimeline.ActionLines {
@@ -730,7 +730,7 @@ func TestEventStringsDayRequest(t *testing.T) {
 
 	feedTimeline, err := testSuite.feedClient.GetFeedTimeline(ctx, request)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	totalItems := 0
 	for _, line := range feedTimeline.ActionLines {
@@ -1228,7 +1228,7 @@ func TestEventStringsMultipleEventTypesAndCounts(t *testing.T) {
 
 	feedTimeline, err := testSuite.feedClient.GetFeedTimeline(ctx, request)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	totalItems := 0
 	for _, line := range feedTimeline.ActionLines {
 		assert.Equal(t, numberOfBuckets, len(line.Slots))


### PR DESCRIPTION
The platform tools are all statically compiled go binaries so we don't
need to depend on glibc.

* remove core/glibc dep in automate-platform-tools
* explicity add a dep on core/glibc in packages that were previously
  getting it transitively
* Normalize an event-feed-service test that was failing due to missing
  zoneinfo before the explicit dep was added
* Allow specifying the HAB_BLDR_CHANNEL in the studio

Signed-off-by: Ryan Cragun <ryan@chef.io>