### PR TITLE
Fix for bug #3301 where `knife ec restore` cannot reach the `/version` context path

### DIFF
--- a/components/automate-load-balancer/habitat/config/automate-cs-nginx-location.conf
+++ b/components/automate-load-balancer/habitat/config/automate-cs-nginx-location.conf
@@ -49,7 +49,7 @@ location @bookshelf_uncached {
   proxy_set_header Connection "";
 }
 
-location ~ ^/(_status|compliance/organizations|organizations|users|authenticate_user|system_recovery|license|server_api_version|_stats)/?(.*) {
+location ~ ^/(_status|compliance/organizations|organizations|users|authenticate_user|system_recovery|license|version|server_api_version|_stats)/?(.*) {
   proxy_set_header Host $http_host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Update automate-cs-nginx-location.conf file to have a version location endpoint so that the automate-load-balancer will send requests to the `/version` context path to the automate-cs-nginx service.  This fixes bug #3301 where `knife ec restore` fails to start the restore process because the version check fails.

Signed-off-by: Davin Taddeo <davin@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
File changed:
`components/automate-load-balancer/habitat/config/automate-cs-nginx-location.conf`

[Line 52](https://github.com/chef/automate/blob/2dc9ccc2074506797028984ccd8165d52957b4d0/components/automate-load-balancer/habitat/config/automate-cs-nginx-location.conf#L52) has a regex array of locations that get forwarded to the automate-cs-nginx service for processing.  The automate-cs-nginx has configurations in place to process the `/version` context path location, but automate load balancer wasn't forwarding to it.  This corrects that by adding `|version|` into the list of location context paths.

### :chains: Related Resources
This will forward traffic to the `automate-cs-nginx` service when a client tries to reach out to `https://automate-server-url.com/version`.  This is handled via the config file in `components/automate-cs-nginx/habitat/config/chef_https.conf` on [lines 60-64](https://github.com/chef/automate/blob/2dc9ccc2074506797028984ccd8165d52957b4d0/components/automate-cs-nginx/habitat/config/chef_https.conf#L60)

### :+1: Definition of Done
This is a pretty small change, and fixes the bug #3301 and should be done with this merge request.

### :athletic_shoe: How to Build and Test the Change
build the automate server with the Chef Infra Server components enabled, and hit the `/version` context path on your endpoint to ensure you get a proper response, and not a 404 or 502.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
