### PR TITLE
[Automate-3327] fix delete user from team

### DIFF
--- a/components/automate-ui/src/app/entities/teams/team.reducer.ts
+++ b/components/automate-ui/src/app/entities/teams/team.reducer.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
-import { difference, get, pipe, set } from 'lodash/fp';
+import { pipe, set } from 'lodash/fp';
 
 import { EntityStatus } from '../entities';
 import { TeamActionTypes, TeamActions } from './team.actions';
@@ -171,10 +171,10 @@ export function teamEntityReducer(state: TeamEntityState = TeamEntityInitialStat
     }
 
     case TeamActionTypes.REMOVE_USERS_SUCCESS: {
-      // get the current list and filter the newly removed user ids
+      // returns the full list sans the removed users
       return pipe(
         set('removeUsersStatus', EntityStatus.loadingSuccess),
-        set('userIDs', difference(get('userIDs', state), action.payload.membership_ids))
+        set('userIDs', action.payload.membership_ids)
       )(state) as TeamEntityState;
     }
 

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
@@ -8,13 +8,23 @@ import { filter, map, takeUntil, distinctUntilChanged } from 'rxjs/operators';
 
 import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { ChefSorters } from 'app/helpers/auth/sorter';
+import { Regex } from 'app/helpers/auth/regex';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { routeURL, routeState } from 'app/route.selectors';
 import { EntityStatus, pending } from 'app/entities/entities';
 import { User } from 'app/entities/users/user.model';
-import { Regex } from 'app/helpers/auth/regex';
 import { allUsers, getStatus as getAllUsersStatus } from 'app/entities/users/user.selectors';
 import { GetUsers } from 'app/entities/users/user.actions';
+import {
+  ProjectChecked,
+  ProjectCheckedMap
+} from 'app/components/projects-dropdown/projects-dropdown.component';
+import { GetProjects } from 'app/entities/projects/project.actions';
+import {
+  allProjects,
+  getAllStatus as getAllProjectStatus
+} from 'app/entities/projects/project.selectors';
+import { ProjectConstants } from 'app/entities/projects/project.model';
 import {
   teamFromRoute,
   teamUsers,
@@ -26,21 +36,9 @@ import { Team } from 'app/entities/teams/team.model';
 import {
   GetTeam,
   GetTeamUsers,
-  TeamUserMgmtPayload,
   RemoveTeamUsers,
   UpdateTeam
 } from 'app/entities/teams/team.actions';
-import {
-  ProjectChecked,
-  ProjectCheckedMap
-} from 'app/components/projects-dropdown/projects-dropdown.component';
-
-import { GetProjects } from 'app/entities/projects/project.actions';
-import {
-  allProjects,
-  getAllStatus as getAllProjectStatus
-} from 'app/entities/projects/project.selectors';
-import { ProjectConstants } from 'app/entities/projects/project.model';
 
 const TEAM_DETAILS_ROUTE = /^\/settings\/teams/;
 
@@ -209,7 +207,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   }
 
   removeUser(user: User): void {
-    this.store.dispatch(new RemoveTeamUsers(<TeamUserMgmtPayload>{
+    this.store.dispatch(new RemoveTeamUsers({
       id: this.teamId,
       membership_ids: [user.membership_id]
     }));


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When removing a user from a team in the UI, the user is correctly deleted on the back-end, but on-screen it completes by replacing the list of users with the single deleted user, rather than the list of users sans the deleted one.
Note that it is a mirage; if you navigate away then back, or just refresh the page, you see the correct team membership.

This peculiar behavior was only affecting team user management. Every other resource list in the system returns the single deleted resource from the back-end so on the front-end that single user returned in the payload is just removed from the ngrx store. For deleting users from teams, however, the payload returns the entire, correct membership list of the team, so can just replace the ngrx store contents.

### :chains: Related Resources
NA

### :+1: Definition of Done
Deleting a user in the UI results immediately in showing the now reduced by one team membership.

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui.

1. Create a team (or pick an existing one).
2. Create a few users (or you can use system-provided ones).
3. Go to that team's users page and add a few users to the team. Observe that the team's users list contains all those that you have added.
4. Remove a user from the team. Observe that the single user you chose has been deleted from the team.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
