### PR TITLE
Kill loading screen in ondestroy and add test associated

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
@@ -318,4 +318,14 @@ describe('ProfilesOverviewComponent', () => {
       expect(component.viewAvailableUpdatesList).toBe(false);
     });
   });
+
+  describe('onDestroy', () => {
+    it('removes the loader screen', () => {
+      component.layoutFacade.ShowPageLoading(true);
+      spyOn(component.layoutFacade, 'ShowPageLoading')
+
+      component.ngOnDestroy();
+      expect(component.layoutFacade.ShowPageLoading).toHaveBeenCalledWith(false);
+    });
+  });
 });

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
@@ -321,8 +321,7 @@ describe('ProfilesOverviewComponent', () => {
 
   describe('onDestroy', () => {
     it('removes the loader screen', () => {
-      component.layoutFacade.ShowPageLoading(true);
-      spyOn(component.layoutFacade, 'ShowPageLoading')
+      spyOn(component.layoutFacade, 'ShowPageLoading');
 
       component.ngOnDestroy();
       expect(component.layoutFacade.ShowPageLoading).toHaveBeenCalledWith(false);

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
@@ -282,6 +282,7 @@ export class ProfileOverviewComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.layoutFacade.ShowPageLoading(false);
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
   }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
A bug was discovered that if a user navigated away from the compliance/profiles screen prior to it being finished loading, the loader screen stayed present until the user did a hard refresh.

This branch kills the loading screen in the onDestroy, so that when a user navigates away from compliance/profiles while loading, the loader is removed as well. 

### :chains: Related Resources
fixes: https://github.com/chef/automate/issues/3342

### :+1: Definition of Done
The loading screen goes away when the user exits the page.

### :athletic_shoe: How to Build and Test the Change
build component/automate-ui-devproxy && start_all_services
make serve

navigate to compliance/compliance-profiles
navigate to another page in the top nav before it finishes loading
view the loading screen close upon navigation and the application is usable

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
