### PR TITLE
Fix UI + doc branding: "Chef Client" -> "Chef Infra Client"

### DIFF
--- a/api/external/cfgmgmt/cfgmgmt.pb.go
+++ b/api/external/cfgmgmt/cfgmgmt.pb.go
@@ -288,7 +288,7 @@ type ConfigMgmtClient interface {
 	//
 	//GetErrors
 	//
-	//Returns a list of the most common errors reported for infra nodes' most recent Chef Client runs.
+	//Returns a list of the most common errors reported for infra nodes' most recent Chef Infra Client runs.
 	//
 	//Authorization Action:
 	//```
@@ -659,7 +659,7 @@ type ConfigMgmtServer interface {
 	//
 	//GetErrors
 	//
-	//Returns a list of the most common errors reported for infra nodes' most recent Chef Client runs.
+	//Returns a list of the most common errors reported for infra nodes' most recent Chef Infra Client runs.
 	//
 	//Authorization Action:
 	//```

--- a/api/external/cfgmgmt/cfgmgmt.proto
+++ b/api/external/cfgmgmt/cfgmgmt.proto
@@ -300,7 +300,7 @@ service ConfigMgmt {
   /*
   GetErrors
 
-  Returns a list of the most common errors reported for infra nodes' most recent Chef Client runs.
+  Returns a list of the most common errors reported for infra nodes' most recent Chef Infra Client runs.
 
   Authorization Action:
   ```

--- a/api/external/cfgmgmt/cfgmgmt.swagger.json
+++ b/api/external/cfgmgmt/cfgmgmt.swagger.json
@@ -14,7 +14,7 @@
     "/cfgmgmt/errors": {
       "get": {
         "summary": "GetErrors",
-        "description": "Returns a list of the most common errors reported for infra nodes' most recent Chef Client runs.\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "description": "Returns a list of the most common errors reported for infra nodes' most recent Chef Infra Client runs.\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
         "operationId": "GetErrors",
         "responses": {
           "200": {

--- a/components/automate-chef-io/content/docs/client-runs.md
+++ b/components/automate-chef-io/content/docs/client-runs.md
@@ -1,6 +1,6 @@
 +++
 title = "Client Runs"
-description = "Chef Client Run Status"
+description = "Chef Infra Client Runs"
 date = 2018-03-26T16:01:58-07:00
 draft = false
 bref = ""
@@ -10,11 +10,11 @@ toc = true
 ## Overview
 
 The _Client Runs_ page shows all nodes connected to Chef Automate, either directly or via a Chef Infra Server proxy. 
-Nodes appear in this view after a Chef Client run has executed.
+Nodes appear in this view after a Chef Infra Client run has executed.
 
-## Chef Client Run Status Overview
+## Chef Infra Client Run Status Overview
 
-The Chef Client Run Status chart displays a summary of node statuses: failed, successful, or missing, as well as the total node count.
+The Chef Infra Client Run Status chart displays a summary of node statuses: failed, successful, or missing, as well as the total node count.
 The chart changes as you select filters.
 
 ![Client Runs Overview](/images/docs/client-runs.png)
@@ -22,9 +22,9 @@ The chart changes as you select filters.
 ## Node List Table
 
 The node list table shows all nodes connected to Chef Automate. 
-Filter the node list table by selecting any of the status tabs below the **Chef Client Run Status** box.
+Filter the node list table by selecting any of the status tabs below the **Chef Infra Client Run Status** box.
 Sort the nodes listed on the table by selecting the arrows to the right of the column headers: _Node Name_, _Check-In_, _Uptime_, _Platform_, _Environment_ or _Policy Group_.
-Selecting an entry in this table will take you to a _Node details_ page with more information about the Chef Client runs associated with this node.
+Selecting an entry in this table will take you to a _Node details_ page with more information about the Chef Infra Client runs associated with this node.
 
 A node may be present in this table without any associated run history.
 This situation happens when data retention settings erase the most recent run history for such a node.
@@ -50,7 +50,7 @@ Use the search bar to discover the node attributes by attribute name, key name, 
 The search results show by highlighting matching attributes. Use the _default_, _normal_, _override_, and _automatic_ buttons beneath the search bar to filter attributes by to these categories.
 Learn more about [attributes](https://docs.chef.io/attributes/).
 
-When looking at a failed Chef Client run, select **View Error Log** at the top of the page to open a window showing the error message and backtrace. 
+When looking at a failed Chef Infra Client run, select **View Error Log** at the top of the page to open a window showing the error message and backtrace. 
 Use the downloaded button to save the error message.
 
 Selecting a node from the node list table opens the _Node details_ page with the most recent information about that node.
@@ -58,7 +58,7 @@ Selecting a node from the node list table opens the _Node details_ page with the
 To look at past run data, select **Run History** on the upper right of the page, which opens a side panel containing historical run data. 
 You can filter this data by using the Run Status icons and Date Range selections.
 
-Node history data supports up to three months of Chef Client run information.
+Node history data supports up to three months of Chef Infra Client run information.
 Scroll through the node history using the pagination buttons at the bottom of the side panel. 
 Use the **X** button at the top of the panel to close the side panel.
 
@@ -122,7 +122,7 @@ Configure the timing for labeling nodes as missing and then deleting them from [
 
 ### Deleting Missing Nodes
 
-Admins and users with the relevant permissions defined in access policies can delete missing nodes from the Chef Client Runs page.
+Admins and users with the relevant permissions defined in access policies can delete missing nodes from the Chef Infra Client Runs page.
 You cannot delete active nodes.
 
 To delete one or more missing nodes, tick the checkbox to the left of the node name, and then select the red **Delete** button above the table header.

--- a/components/automate-chef-io/content/docs/data-collection.md
+++ b/components/automate-chef-io/content/docs/data-collection.md
@@ -34,7 +34,11 @@ There are two steps to getting data collection running in Chef Automate:
 
 ### Porting the Existing Chef Automate 1 Data Collector Token to Chef Automate 2
 
+<<<<<<< HEAD
 If you are migrating from Chef Automate 1, you probably have already deployed a data collector token on either your Chef Infra Servers or your Chef Infra Clients.
+=======
+If you are migrating from Chef Automate 1, you probably have already deployed a data collector token on either your Chef Servers or your Chef Infra Clients.
+>>>>>>> updated static docs
 To re-use your existing data collector token from your Chef Automate 1 installation, you need to perform the configuration change outlined here.
 
 For this process, you need the existing token (let's call it `A1_DC_TOKEN`), and access to the machine running the `chef-automate` CLI client.
@@ -64,8 +68,13 @@ When logged in with admin permissions, you will also find your added token in
 > Legacy data collector token ported from A1
 
 Now that you have a valid API token, you'll need to
+<<<<<<< HEAD
 [update your Chef Infra Server data collector configuration]({{< relref "#configure-your-chef-server-to-send-data-to-chef-automate" >}})
 if you are using a Chef Infra Server. Otherwise, you must
+=======
+[update your Chef Server data collector configuration]({{< relref "#configure-your-chef-server-to-send-data-to-chef-automate" >}})
+if you are using a Chef Server. Otherwise, you must
+>>>>>>> updated static docs
 [configure your Chef Infra Clients to send data directly to Chef Automate]({{< relref "#configure-your-chef-client-to-send-data-to-chef-automate-without-chef-server" >}}).
 
 ## Configure your Chef Infra Server to Send Data to Chef Automate
@@ -74,7 +83,11 @@ if you are using a Chef Infra Server. Otherwise, you must
 
 In addition to forwarding Chef run data to Chef Automate, Chef Infra Server will send messages to Chef Automate whenever an action is taken on a Chef Infra Server object, such as when a cookbook is uploaded to the Chef Infra Server or when a user edits a role.
 
+<<<<<<< HEAD
 In order to have Chef Infra Server send run data from connected Chef Infra Clients, set the data collection proxy attribute to `true`.
+=======
+In order to have Chef Server send run data from connected Chef Infra Clients, set the data collection proxy attribute to `true`.
+>>>>>>> updated static docs
 
 ### Setting Up Data Collection on Chef Infra Server Versions 12.14 and Higher
 
@@ -92,7 +105,7 @@ Next, configure the Chef Infra Server for data collection forwarding by adding t
 
 ```ruby
 data_collector['root_url'] = 'https://{{< example_fqdn "automate" >}}/data-collector/v0/'
-# Add for chef client run forwarding
+# Add for Chef Infra Client run forwarding
 data_collector['proxy'] = true
 # Add for compliance scanning
 profiles['root_url'] = 'https://{{< example_fqdn "automate" >}}'
@@ -113,7 +126,7 @@ For Chef Infra Server versions between 12.11 and 12.13, simply add the `root_url
 ```ruby
 data_collector['root_url'] = 'https://{{< example_fqdn "automate" >}}/data-collector/v0/'
 data_collector['token'] = '<API_TOKEN_FROM_STEP_1>'
-# Add for chef client run forwarding
+# Add for Chef Infra Client run forwarding
 data_collector['proxy']= true
 # Add for compliance scanning
 profiles['root_url'] = 'https://{{< example_fqdn "automate" >}}'
@@ -126,9 +139,15 @@ To apply the changes, run:
 chef-server-ctl reconfigure
 ```
 
+<<<<<<< HEAD
 ### Setting Up Chef Infra Client to Send Compliance Scan Data Through the Chef Infra Server to Chef Automate
 
 Now that the Chef Infra Server is configured for data collection, you can also enable Compliance Scanning
+=======
+### Setting Up Chef Infra Client to Send Compliance Scan Data Through the Chef Server to Chef Automate
+
+Now that the Chef Server is configured for data collection, you can also enable Compliance Scanning
+>>>>>>> updated static docs
 on your Chef Infra Clients via the [Audit Cookbook](https://github.com/chef-cookbooks/audit).
 
 * Set the following attributes for the audit cookbook:
@@ -204,9 +223,15 @@ When this attribute is unspecified, the default behavior is as follows:
 
 When this attribute is specified, the supplied string will be sent as the ``Host`` header on all requests. This may be required for some third-party Elasticsearch offerings. -->
 
+<<<<<<< HEAD
 ## Configure your Chef Infra Client to Send Data to Chef Automate without Chef Infra Server
 
 If you do not use a Chef Infra Server in your environment (if you only use `chef-solo`, for example), you
+=======
+## Configure your Chef Infra Client to Send Data to Chef Automate without Chef Server
+
+If you do not use a Chef Server in your environment (if you only use `chef-solo`, for example), you
+>>>>>>> updated static docs
 can configure your Chef Infra Clients to send their run data to Chef Automate directly by performing the following:
 
 1. Add Chef Automate SSL certificate to `trusted_certs` directory.
@@ -238,7 +263,11 @@ server.
 
 The data collector functionality is used by the Chef Infra Client to send node
 and converge data to Chef Automate. This feature works for Chef Infra Client, as well as both the default
+<<<<<<< HEAD
 and legacy modes of `chef-solo`.
+=======
+and legacy modes of Chef solo.
+>>>>>>> updated static docs
 
 To send node, converge, and compliance data to Chef Automate, modify
 your Chef config (that is `client.rb`, `solo.rb`, or add an additional
@@ -279,13 +308,17 @@ Chef Automate. Please see the audit cookbook for an
 
 | Configuration                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Options                        | Default |
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ------- |
-| `data_collector.mode`             | The mode in which the data collector is allowed to operate. This can be used to run data collector only when running as Chef solo but not when using Chef client.                                                                                                                                                                                                                                                                                                                                         | `:solo`, `:client`, or `:both` | `:both` |
+| `data_collector.mode`             | The mode in which the data collector is allowed to operate. This can be used to run data collector only when running as Chef solo but not when using Chef Infra Client.                                                                                                                                                                                                                                                                                                                                         | `:solo`, `:client`, or `:both` | `:both` |
 | `data_collector.raise_on_failure` | When the data collector cannot send the "starting a run" message to the data collector server, the data collector will be disabled for that run. In some situations, such as highly-regulated environments, it may be more reasonable to Prevents data collection when the data collector cannot send the "starting a run" message to the data collector server. In these situations, setting this value to `true` will cause the Chef run to raise an exception before starting any converge activities. | `true`, `false`                | `false` |
 | `data_collector.organization`     | A user-supplied organization string that can be sent in payloads generated by the data collector when Chef is run in Solo mode. This allows users to associate their Solo nodes with faux organizations without the nodes being connected to an actual Chef Infra Server.                                                                                                                                                                                                                                       | `string`                       | `none`  |
 
 ## Troubleshooting: My Data Does Not Show Up in the User Interface
 
 Organizations without associated nodes will not show up on the Chef Automate _Nodes_ page. A node
+<<<<<<< HEAD
 is not associated with automate until a Chef Infra Client run has completed. This is also true for roles,
+=======
+is not associated with automate until a Chef Infra Client Run has completed. This is also true for roles,
+>>>>>>> updated static docs
 cookbooks, recipes, attributes, resources, node names, and environments but does not highlight them
 in the UI. This is designed to keep the UI focused on the nodes in your cluster.

--- a/components/automate-chef-io/content/docs/data-collection.md
+++ b/components/automate-chef-io/content/docs/data-collection.md
@@ -35,7 +35,6 @@ There are two steps to getting data collection running in Chef Automate:
 ### Porting the Existing Chef Automate 1 Data Collector Token to Chef Automate 2
 
 If you are migrating from Chef Automate 1, you probably have already deployed a data collector token on either your Chef Infra Servers or your Chef Infra Clients.
-
 To re-use your existing data collector token from your Chef Automate 1 installation, you need to perform the configuration change outlined here.
 
 For this process, you need the existing token (let's call it `A1_DC_TOKEN`), and access to the machine running the `chef-automate` CLI client.
@@ -67,7 +66,6 @@ When logged in with admin permissions, you will also find your added token in
 Now that you have a valid API token, you'll need to
 [update your Chef Infra Server data collector configuration]({{< relref "#configure-your-chef-server-to-send-data-to-chef-automate" >}})
 if you are using a Chef Infra Server. Otherwise, you must
-
 [configure your Chef Infra Clients to send data directly to Chef Automate]({{< relref "#configure-your-chef-client-to-send-data-to-chef-automate-without-chef-server" >}}).
 
 ## Configure your Chef Infra Server to Send Data to Chef Automate

--- a/components/automate-chef-io/content/docs/data-collection.md
+++ b/components/automate-chef-io/content/docs/data-collection.md
@@ -34,11 +34,8 @@ There are two steps to getting data collection running in Chef Automate:
 
 ### Porting the Existing Chef Automate 1 Data Collector Token to Chef Automate 2
 
-<<<<<<< HEAD
 If you are migrating from Chef Automate 1, you probably have already deployed a data collector token on either your Chef Infra Servers or your Chef Infra Clients.
-=======
-If you are migrating from Chef Automate 1, you probably have already deployed a data collector token on either your Chef Servers or your Chef Infra Clients.
->>>>>>> updated static docs
+
 To re-use your existing data collector token from your Chef Automate 1 installation, you need to perform the configuration change outlined here.
 
 For this process, you need the existing token (let's call it `A1_DC_TOKEN`), and access to the machine running the `chef-automate` CLI client.
@@ -68,13 +65,9 @@ When logged in with admin permissions, you will also find your added token in
 > Legacy data collector token ported from A1
 
 Now that you have a valid API token, you'll need to
-<<<<<<< HEAD
 [update your Chef Infra Server data collector configuration]({{< relref "#configure-your-chef-server-to-send-data-to-chef-automate" >}})
 if you are using a Chef Infra Server. Otherwise, you must
-=======
-[update your Chef Server data collector configuration]({{< relref "#configure-your-chef-server-to-send-data-to-chef-automate" >}})
-if you are using a Chef Server. Otherwise, you must
->>>>>>> updated static docs
+
 [configure your Chef Infra Clients to send data directly to Chef Automate]({{< relref "#configure-your-chef-client-to-send-data-to-chef-automate-without-chef-server" >}}).
 
 ## Configure your Chef Infra Server to Send Data to Chef Automate
@@ -83,11 +76,7 @@ if you are using a Chef Server. Otherwise, you must
 
 In addition to forwarding Chef run data to Chef Automate, Chef Infra Server will send messages to Chef Automate whenever an action is taken on a Chef Infra Server object, such as when a cookbook is uploaded to the Chef Infra Server or when a user edits a role.
 
-<<<<<<< HEAD
 In order to have Chef Infra Server send run data from connected Chef Infra Clients, set the data collection proxy attribute to `true`.
-=======
-In order to have Chef Server send run data from connected Chef Infra Clients, set the data collection proxy attribute to `true`.
->>>>>>> updated static docs
 
 ### Setting Up Data Collection on Chef Infra Server Versions 12.14 and Higher
 
@@ -139,15 +128,10 @@ To apply the changes, run:
 chef-server-ctl reconfigure
 ```
 
-<<<<<<< HEAD
 ### Setting Up Chef Infra Client to Send Compliance Scan Data Through the Chef Infra Server to Chef Automate
 
 Now that the Chef Infra Server is configured for data collection, you can also enable Compliance Scanning
-=======
-### Setting Up Chef Infra Client to Send Compliance Scan Data Through the Chef Server to Chef Automate
 
-Now that the Chef Server is configured for data collection, you can also enable Compliance Scanning
->>>>>>> updated static docs
 on your Chef Infra Clients via the [Audit Cookbook](https://github.com/chef-cookbooks/audit).
 
 * Set the following attributes for the audit cookbook:
@@ -223,15 +207,10 @@ When this attribute is unspecified, the default behavior is as follows:
 
 When this attribute is specified, the supplied string will be sent as the ``Host`` header on all requests. This may be required for some third-party Elasticsearch offerings. -->
 
-<<<<<<< HEAD
 ## Configure your Chef Infra Client to Send Data to Chef Automate without Chef Infra Server
 
 If you do not use a Chef Infra Server in your environment (if you only use `chef-solo`, for example), you
-=======
-## Configure your Chef Infra Client to Send Data to Chef Automate without Chef Server
 
-If you do not use a Chef Server in your environment (if you only use `chef-solo`, for example), you
->>>>>>> updated static docs
 can configure your Chef Infra Clients to send their run data to Chef Automate directly by performing the following:
 
 1. Add Chef Automate SSL certificate to `trusted_certs` directory.
@@ -263,11 +242,7 @@ server.
 
 The data collector functionality is used by the Chef Infra Client to send node
 and converge data to Chef Automate. This feature works for Chef Infra Client, as well as both the default
-<<<<<<< HEAD
 and legacy modes of `chef-solo`.
-=======
-and legacy modes of Chef solo.
->>>>>>> updated static docs
 
 To send node, converge, and compliance data to Chef Automate, modify
 your Chef config (that is `client.rb`, `solo.rb`, or add an additional
@@ -315,10 +290,6 @@ Chef Automate. Please see the audit cookbook for an
 ## Troubleshooting: My Data Does Not Show Up in the User Interface
 
 Organizations without associated nodes will not show up on the Chef Automate _Nodes_ page. A node
-<<<<<<< HEAD
 is not associated with automate until a Chef Infra Client run has completed. This is also true for roles,
-=======
-is not associated with automate until a Chef Infra Client Run has completed. This is also true for roles,
->>>>>>> updated static docs
 cookbooks, recipes, attributes, resources, node names, and environments but does not highlight them
 in the UI. This is designed to keep the UI focused on the nodes in your cluster.

--- a/components/automate-chef-io/content/docs/data-lifecycle.md
+++ b/components/automate-chef-io/content/docs/data-lifecycle.md
@@ -13,7 +13,7 @@ toc = true
     weight = 20
 +++
 
-Data Lifecycle manages the retention of events, service groups, Chef Client runs, compliance reports and scans in Chef Automate.
+Data Lifecycle manages the retention of events, service groups, Chef Infra Client runs, compliance reports and scans in Chef Automate.
 Chef Automate stores data from the ingest-service,event-feed-service, compliance-service and applications-service in Elasticsearch or PostgreSQL.
 Over time, you may wish to remove that data from Chef Automate by using the data lifecycle settings.
 
@@ -47,7 +47,7 @@ The default is to label health check reports as disconnected after 5 minutes, an
 
 The Client Runs data lifecycle settings allow you to remove data after a set amount of days.
 They also allow you to label nodes as missing and automatically remove them after a set amount of days.
-The default is to remove Chef Client run data after 1 day, to label nodes as missing after 30 days, and to remove nodes labeled as missing after 30 days.
+The default is to remove Chef Infra Client run data after 1 day, to label nodes as missing after 30 days, and to remove nodes labeled as missing after 30 days.
 
 ### Compliance
 
@@ -60,7 +60,7 @@ Chef Automate stores data from the `ingest-service`, `event-feed-service`, `comp
 
 The `data-lifecycle` API allows configuring and running lifecycle jobs by data type:
 
-* `infra` - Chef Infra Server actions and Chef Client converge data
+* `infra` - Chef Infra Server actions and Chef Infra Client converge data
 * `compliance` - Chef InSpec reports and Chef Compliance scans
 * `event-feed` - Event metadata that powers the operational visibility and query language
 

--- a/components/automate-chef-io/content/docs/delivery_build_cookbook.md
+++ b/components/automate-chef-io/content/docs/delivery_build_cookbook.md
@@ -16,7 +16,7 @@ Workflow is a legacy feature for Chef Automate, which was designed for managing 
 Workflow is available in Chef Automate for existing users. If you are not already using Workflow, but are interested in the solution it offers, please contact your sales or success representative for support with continuous integration pipelines.
 {{< /warning >}}
 
-Chef Automate uses the Chef Client to run recipes for each phase in a
+Chef Automate uses the Chef Infra Client to run recipes for each phase in a
 build pipeline. The phases are grouped into different stages.
 
 The following illustration shows the phases of each pipeline stage.
@@ -36,9 +36,9 @@ a project. A **build-cookbook** should be initially configured to use the
 may be modified as necessary. The **build-cookbook** is effectively a
 wrapper cookbook for the **delivery-truck** cookbook.
 
-A build node is configured through two isolated Chef Client runs: First, the
-**default.rb** recipe is run by the Chef Client as the root user, after
-which the phase-specific recipe is run by the Chef Client as the build
+A build node is configured through two isolated Chef Infra Client runs: First, the
+**default.rb** recipe is run by the Chef Infra Client as the root user, after
+which the phase-specific recipe is run by the Chef Infra Client as the build
 user (`dbuild`). For example, during the unit phase the first run is the
 **default.rb** file, and then the second is the **unit.rb** file.
 
@@ -46,7 +46,7 @@ The following recipes should be configured to include the corresponding
 **delivery-truck** recipe as a dependency:
 
 default.rb
-: Use the **default.rb** recipe to configure a project on a build node. This recipe is run by the Chef Client as the root user and is a standard default recipe. The Chef Client may use this recipe to configure this project on any node, whether or not it's part of a Chef Automate pipeline.
+: Use the **default.rb** recipe to configure a project on a build node. This recipe is run by the Chef Infra Client as the root user and is a standard default recipe. The Chef Infra Client may use this recipe to configure this project on any node, whether or not it's part of a Chef Automate pipeline.
 
 deploy.rb
 : Use the **deploy.rb** recipe to define how artifacts are published to one (or more) nodes after they are built successfully. The contents of this recipe are project-specific.

--- a/components/automate-chef-io/content/docs/delivery_truck.md
+++ b/components/automate-chef-io/content/docs/delivery_truck.md
@@ -25,7 +25,7 @@ The following recipes are available by default in the **delivery-truck**
 cookbook:
 
 default.rb
-: Use the **default.rb** recipe to configure a project on a build node. This recipe is run by the Chef Client as the root user and is a standard default recipe. The Chef Client may use this recipe to configure this project on any node, whether or not it's part of a Chef Automate pipeline.
+: Use the **default.rb** recipe to configure a project on a build node. This recipe is run by the Chef Infra Client as the root user and is a standard default recipe. The Chef Infra Client may use this recipe to configure this project on any node, whether or not it's part of a Chef Automate pipeline.
 
 deploy.rb
 : Use the **deploy.rb** recipe to define how artifacts are published to one (or more) nodes after they are built successfully. The contents of this recipe are project-specific.
@@ -133,12 +133,12 @@ this **build-cookbook**.
 A project cookbook is a cookbook that is located within a project and is used to deploy that project's software onto one (or more) nodes in the Chef Automate pipeline.
 These cookbooks are located in the `/cookbooks` directory, which should exist at the root of the project (similar to the `.delivery` directory).
 
-The **default.rb** recipe in a project cookbook is executed by the Chef Client on infrastructure nodes as the project moves through the Chef Automate pipeline.
+The **default.rb** recipe in a project cookbook is executed by the Chef Infra Client on infrastructure nodes as the project moves through the Chef Automate pipeline.
 The **provision.rb** recipe discovers all **metadata.rb** and/or **metadata.json** files in the project, including those under the `/cookbooks` directory.
 
 ### Single Cookbook
 
-A project may use a single cookbook to tell the Chef Client how to configure nodes in the Chef Automate pipeline.
+A project may use a single cookbook to tell the Chef Infra Client how to configure nodes in the Chef Automate pipeline.
 
 ### Add Project Cookbook
 
@@ -172,7 +172,7 @@ Create a project cookbook. From the project's root directory, do the following:
 
 ### Configure default.rb
 
-In the **default.rb** recipe, define how this project is to be deployed. This is a normal Chef recipe that is executed by the Chef Client, so do the same in this recipe as you would do in any other.
+In the **default.rb** recipe, define how this project is to be deployed. This is a normal Chef recipe that is executed by the Chef Infra Client, so do the same in this recipe as you would do in any other.
 
 ### Promote the Project
 
@@ -251,7 +251,7 @@ Some projects need more than one project cookbook. Put as many cookbooks as nece
 Each cookbook under the `/cookbooks` directory must have a valid cookbook structure. If the cookbook does not have a **metadata.rb** or **metadata.json** file, it will not be discovered by the **provision.rb** recipe.
 Consequently, that cookbook will not be used to configure nodes in the Chef Automate pipeline.
 
-The **default.rb** recipes in all project cookbooks are executed by the Chef Client on infrastructure nodes as the project moves through the Chef Automate pipeline.
+The **default.rb** recipes in all project cookbooks are executed by the Chef Infra Client on infrastructure nodes as the project moves through the Chef Automate pipeline.
 The **default.rb** recipe in the **build-cookbook** is run first, and then each **default.rb** recipe in each cookbook under `/cookbooks` is run (in alphabetical order, by cookbook name).
 
 ## Project Applications

--- a/components/automate-chef-io/content/docs/migrate.md
+++ b/components/automate-chef-io/content/docs/migrate.md
@@ -103,7 +103,7 @@ While we've taken care to make the migration process as smooth as possible, this
 
 The Chef Automate 2 migration process puts your Chef Automate 1 installation into maintenance mode, shuts it down, and starts Chef Automate 2. During the downtime, the migration process takes a backup of your Chef Automate 1 data and exports some of its data to a local snapshot, which is imported into Chef Automate 2.
 
-To minimize this downtime, we recommended that you create an online backup of Chef Automate 1 just prior to the upgrade. Historical information such as Chef Client run data and compliance scan data is backed up incrementally, which means that the upgrade only needs to transfer data that has been added since the last backup.
+To minimize this downtime, we recommended that you create an online backup of Chef Automate 1 just prior to the upgrade. Historical information such as Chef Infra Client run data and compliance scan data is backed up incrementally, which means that the upgrade only needs to transfer data that has been added since the last backup.
 
 By default, the Chef Automate 2 upgrade process will not proceed if your Chef Automate 1 installation does not have backups configured. Invoke the migration using the `--skip-backup-check` flag to avoid this check.
 

--- a/components/automate-chef-io/content/docs/notifications.md
+++ b/components/automate-chef-io/content/docs/notifications.md
@@ -1,6 +1,6 @@
 +++
 title = "Notifications"
-description = "Notifications for Inspec compliance scans and Chef client runs."
+description = "Notifications for Inspec compliance scans and Chef Infra Client runs."
 date = 2018-05-18T13:19:02-07:00
 draft = false
 bref = ""
@@ -33,7 +33,7 @@ To add a Slack notification for Chef Automate:
 1. Select **Create Notification**.
 1. Select **Slack**.
 1. Enter a unique notification name.
-1. Select the failure type to be notified on from the drop-down menu. Current options are chef client run or InSpec scan
+1. Select the failure type to be notified on from the drop-down menu. Current options are Chef Infra Client run or InSpec scan
 1. Get your Slack webhook address by using the **What's this?** link, which opens an external Slack site.
 1. On the Slack page, select a channel or user for the notification. Slack will create the new webhook and then provide a webhook URL for you to copy. After entering a recipient, use the **Add Incoming WebHooks Integration** button.
 1. Copy the URL, return to the Chef Automate page, paste the URL into the _Notifications_ form.
@@ -67,7 +67,7 @@ To add a webhook notification for Chef Automate:
 1. Select **Create Notification**.
 1. Select **Webhooks**.
 1. Enter a unique notification name.
-1. Select the failure type to be notified on from the drop-down menu. Current options are chef client run or InSpec scan
+1. Select the failure type to be notified on from the drop-down menu. Current options are Chef Infra Client run or InSpec scan
 1. Enter the webhook URL the notification should be sent to.
 1. Use the **Send Test** button to try out your webhook notification.
 1. Use the **Save Notification** button to create the webhook notification.

--- a/components/automate-chef-io/content/docs/runners.md
+++ b/components/automate-chef-io/content/docs/runners.md
@@ -20,7 +20,7 @@ Chef Automate's workflow engine automatically creates phase jobs as project code
 
 ## Prerequisites
 
-* Workflow runners for Chef Automate 2 require the latest version of [ChefDK](https://downloads.chef.io/chefdk/3.7.23), which includes Chef Client 14.10. The runners will not function unless upgraded.
+* Workflow runners for Chef Automate 2 require the latest version of [ChefDK](https://downloads.chef.io/chefdk/3.7.23), which includes Chef Infra Client 14.10. The runners will not function unless upgraded.
 * Cookbooks used with Workflow for Chef Automate must be upgraded to work with Chef 14.10 or newer.
 * Chef Automate requires either the latest version of [ChefDK](https://downloads.chef.io/chefdk/3.7.23), which includes the `delivery-cli` that supports Workflow.
 

--- a/components/automate-chef-io/content/docs/servicenow-integration-install.md
+++ b/components/automate-chef-io/content/docs/servicenow-integration-install.md
@@ -109,7 +109,7 @@ Setting the value to `cookbook` creates an incident for the failed cookbook. All
 
 ![CCR Failed Cookbook Description](/images/docs/SNOW_Failed_Cookbook.png)
 
-The associated client runs are shown on the 'Chef Client runs' tab of the incident.
+The associated client runs are shown on the 'Chef Infra Client runs' tab of the incident.
 
 Setting the value to `node` creates an incident for each failed node. All failing Chef Infra Client runs for a node are associated with the corresponding incident. The short description of the incident will indicate the failed node:
 

--- a/components/automate-gateway/api/cfgmgmt.pb.swagger.go
+++ b/components/automate-gateway/api/cfgmgmt.pb.swagger.go
@@ -17,7 +17,7 @@ func init() {
     "/cfgmgmt/errors": {
       "get": {
         "summary": "GetErrors",
-        "description": "Returns a list of the most common errors reported for infra nodes' most recent Chef Client runs.\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\ninfra:nodes:list\n` + "`" + `` + "`" + `` + "`" + `",
+        "description": "Returns a list of the most common errors reported for infra nodes' most recent Chef Infra Client runs.\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\ninfra:nodes:list\n` + "`" + `` + "`" + `` + "`" + `",
         "operationId": "GetErrors",
         "responses": {
           "200": {

--- a/components/automate-ui/src/app/page-components/converge-radial-graph/converge-radial-graph.component.html
+++ b/components/automate-ui/src/app/page-components/converge-radial-graph/converge-radial-graph.component.html
@@ -7,7 +7,7 @@ after the async onInit function runs -->
 </chef-alert>
 <div class="chart-container"  *ngIf="count !== undefined">
   <div class="label">
-    <h2 class="display3">Chef Client Run Status</h2>
+    <h2 class="display3">Chef Infra Client Run Status</h2>
 
     <div class="chart-legend">
       <div class="display5">

--- a/components/automate-ui/src/app/page-components/run-summary/run-summary.component.html
+++ b/components/automate-ui/src/app/page-components/run-summary/run-summary.component.html
@@ -45,7 +45,7 @@
         <h4 class="metadata-group-heading">Node Information</h4>
         <table>
           <tr *ngIf="nodeRun.chefVersion?.length">
-            <th>Chef Client Version</th>
+            <th>Chef Infra Client Version</th>
             <td>{{ nodeRun.chefVersion }}</td>
           </tr>
           <tr *ngIf="nodeRun.fqdn?.length">

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
@@ -11,7 +11,7 @@
 
       <chef-page-header>
         <chef-heading>Data Lifecycle</chef-heading>
-        <chef-subheading>Manage the retention of events, service groups, Chef Client runs, compliance reports and scans in Chef Automate.</chef-subheading>
+        <chef-subheading>Manage the retention of events, service groups, Chef Infra Client runs, compliance reports and scans in Chef Automate.</chef-subheading>
       </chef-page-header>
 
       <div class="page-body">
@@ -119,7 +119,7 @@
               (change)="handleFormActivation(clientRunsRemoveData, $event.detail)">
               </chef-checkbox>
             </div>
-            <p>Remove data for Chef Client runs after
+            <p>Remove data for Chef Infra Client runs after
               <input chefInput type="number" min="0" formControlName="threshold"
                 (keydown)="preventNegatives($event.key)" />days
             </p>
@@ -133,7 +133,7 @@
               </chef-checkbox>
             </div>
           
-            <p>When no Chef Client run data has been received from a node in
+            <p>When no Chef Infra Client run data has been received from a node in
               <input chefInput 
                 type="number" 
                 min="0" 

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
@@ -17,7 +17,7 @@
       <div class="node-list-container">
         <chef-page-header>
           <chef-heading>Client Runs</chef-heading>
-          <chef-subheading>Nodes connected to Chef Automate by way of chef-client.</chef-subheading>
+          <chef-subheading>Nodes connected to Chef Automate by way of Chef Infra Client.</chef-subheading>
 
           <app-search-bar
             [numberOfFilters]="numberOfSearchBarFilters$ | async"

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -70,7 +70,7 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
     },
     {
       type: 'chef_version',
-      text: 'Chef Client Version',
+      text: 'Chef Infra Client Version',
       allowWildcards: true
     },
     {

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.html
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.html
@@ -7,7 +7,7 @@
     <main>
       <chef-page-header>
         <chef-heading>Notifications</chef-heading>
-        <chef-subheading>Notifications for Inspec compliance scans and Chef client runs.</chef-subheading>
+        <chef-subheading>Notifications for Inspec compliance scans and Chef Infra Client runs.</chef-subheading>
       </chef-page-header>
 
       <div class="page-body">

--- a/components/automate-ui/src/app/pages/notifications/rule.ts
+++ b/components/automate-ui/src/app/pages/notifications/rule.ts
@@ -19,7 +19,7 @@ export interface RuleInterface {
 export class Rule implements RuleInterface {
 
   AlertTypeLabels = {
-    CCRFailure: 'Chef client run failures',
+    CCRFailure: 'Chef Infra Client run failures',
     ComplianceFailure: 'InSpec scan failures'
   };
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Automate is behind on the branding for Chef Infra Client, we need to update all labels to reflect current branding.

## Design Details
Fix it in all these places...
### ui
- [x] Radial graph heading on client runs
- [x] Node detail label
- [x] data lifecycle settings
- [x] subheading on client runs page
- [x] subheading on notifications
- [x] Dropdown on notifications

### docs
- [x] Static docs
- [x] api docs

### :chains: Related Resources
fixes #3346 

### :+1: Definition of Done
everything still works but the branding is updated

### :athletic_shoe: How to Build and Test the Change
`rebuild components/automate-ui-devproxy`
`make serve` from components/automate-chef-io

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
