### PR TITLE
[automate-2648] add compliance policies

### DIFF
--- a/components/authz-service/storage/postgres/migration/sql/76_compliance_roles_pols.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/76_compliance_roles_pols.up.sql
@@ -1,0 +1,25 @@
+DO $$
+BEGIN
+    IF
+        (NOT EXISTS(SELECT id FROM iam_policies WHERE id IN ('compliance-access', 'compliance-editor-access')))
+        AND (NOT EXISTS(SELECT id FROM iam_roles WHERE id IN ('compliance-viewer', 'compliance-editor')))
+    THEN
+        INSERT INTO iam_roles (id, name, type, actions)
+            VALUES ('compliance-viewer', 'Compliance Viewer', 'custom', '{compliance:*:get, compliance:*:list}');
+
+        INSERT INTO iam_roles (id, name, type, actions)
+            VALUES ('compliance-editor', 'Compliance Editor', 'custom', '{compliance:*}');
+
+        INSERT INTO iam_policies (id, name, type)
+            VALUES ('compliance-access', 'Compliance Viewers', 'custom');
+
+        INSERT INTO iam_policies (id, name, type)
+            VALUES ('compliance-editor-access', 'Compliance Editors', 'custom');
+
+        PERFORM insert_iam_statement_into_policy('compliance-access', 'allow', '{}', '{*}', 'compliance-viewer', '{~~ALL-PROJECTS~~}');
+
+        PERFORM insert_iam_statement_into_policy('compliance-editor-access', 'allow', '{}', '{*}', 'compliance-editor', '{~~ALL-PROJECTS~~}');
+    END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/components/authz-service/storage/postgres/migration/sql/76_compliance_roles_pols.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/76_compliance_roles_pols.up.sql
@@ -1,7 +1,7 @@
 DO $$
 BEGIN
     IF
-        (NOT EXISTS(SELECT id FROM iam_policies WHERE id IN ('compliance-access', 'compliance-editor-access')))
+        (NOT EXISTS(SELECT id FROM iam_policies WHERE id IN ('compliance-viewer-access', 'compliance-editor-access')))
         AND (NOT EXISTS(SELECT id FROM iam_roles WHERE id IN ('compliance-viewer', 'compliance-editor')))
     THEN
         INSERT INTO iam_roles (id, name, type, actions)
@@ -11,12 +11,12 @@ BEGIN
             VALUES ('compliance-editor', 'Compliance Editor', 'custom', '{compliance:*}');
 
         INSERT INTO iam_policies (id, name, type)
-            VALUES ('compliance-access', 'Compliance Viewers', 'custom');
+            VALUES ('compliance-viewer-access', 'Compliance Viewers', 'custom');
 
         INSERT INTO iam_policies (id, name, type)
             VALUES ('compliance-editor-access', 'Compliance Editors', 'custom');
 
-        PERFORM insert_iam_statement_into_policy('compliance-access', 'allow', '{}', '{*}', 'compliance-viewer', '{~~ALL-PROJECTS~~}');
+        PERFORM insert_iam_statement_into_policy('compliance-viewer-access', 'allow', '{}', '{*}', 'compliance-viewer', '{~~ALL-PROJECTS~~}');
 
         PERFORM insert_iam_statement_into_policy('compliance-editor-access', 'allow', '{}', '{*}', 'compliance-editor', '{~~ALL-PROJECTS~~}');
     END IF;

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -75,3 +75,4 @@
 - [`73_add_constraint_iam_role_projects.up.sql`](73_add_constraint_iam_role_projects.up.sql)
 - [`74_pre_force_upgrade.up.sql`](74_pre_force_upgrade.up.sql)
 - [`75_update_roles_pols.up.sql`](75_update_roles_pols.up.sql)
+- [`76_compliance_roles_pols.up.sql`](76_compliance_roles_pols.up.sql)

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -71,7 +71,7 @@ Once this step is done, the `test_viewer` and `test_editor` users may log in wit
 
 ### Creating Custom Policies
 
-The Chef-managed policies give you a starting-point for permissions.
+The Chef-managed policies give you a starting point for permissions.
 You may want to write more fine-grained policies, tailored to the demands of your organization.
 Defining your own policies must be done from the command line.
 

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -71,7 +71,7 @@ Once this step is done, the `test_viewer` and `test_editor` users may log in wit
 
 ### Creating Custom Policies
 
-The Chef-managed default policies give you a starting-point for permissions.
+The Chef-managed policies give you a starting-point for permissions.
 You may want to write more fine-grained policies, tailored to the demands of your organization.
 Defining your own policies must be done from the command line.
 

--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -100,24 +100,28 @@ This list provides the benefit of *encapsulation*.
 A policy statement only needs the role's name, and the policy is not burdened by all the details.
 Also, the list offers *reusability* as you can apply the role to any statement that needs it.
 
-Chef Automate has five default roles.
-To see the actions comprising the roles, see [Chef-managed Roles]({{< relref "api/#tag/roles" >}}).
-
-Role          | Description
---------------|------------
-Viewer        | **View** everything in the system *except* IAM
-Editor        | **Do** everything in the system *except* IAM and license application
-Owner         | **Do** everything in the system *including* IAM
-Project Owner | Editor + **view** and **assign** projects
-Ingest        | Ingest data into the system
-
 Just like policies, roles are either *Chef-managed* or *Custom* types.
 Default Chef-managed roles cannot change, like Chef-managed policies.
-You can use these default Chef-managed roles in your policies, or create your custom roles for more customized permissions.
+
+Chef Automate has five *Chef-managed* roles and two *Custom* roles
+that you might find helpful. Unlike the others, those roles, *Compliance Viewer* and *Compliance Editor*, can be modified.
+To see the actions comprising the roles, see [Chef-managed Roles]({{< relref "api/#tag/roles" >}}).
+
+Role              |Type          |Description
+------------------|--------------|------------------------------
+Viewer            |Chef-managed  |**View** everything in the system *except* IAM
+Editor            |Chef-managed  |**Do** everything in the system *except* IAM and license application
+Owner             |Chef-managed  |**Do** everything in the system *including* IAM
+Project Owner     |Chef-managed  |Editor + **view** and **assign** projects
+Ingest            |Chef-managed  |Ingest data into the system
+Compliance Viewer |Custom        |Viewer for compliance resources
+Compliance Editor |Custom        |Editor for compliance resources
+
+You can use these default Chef-created roles in your policies, or create your custom roles for more customized permissions.
 You can later edit any roles you create.
 
-Chef Automate also ships with default policies that leverage these default roles.
-The default policies are Viewers, Editors, Administrator, and Ingest.
+Chef Automate also ships with policies that leverage these roles.
+Those Chef-managed policies are Viewers, Editors, Administrator, and Ingest. The custom ones are Compliance Viewers and Compliance Editors.
 
 ## Working with Projects
 

--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -97,14 +97,14 @@ Both types of policies allow for membership modification.
 
 A role is a named list of actions.
 This list provides the benefit of *encapsulation*.
-A policy statement only needs the role's name, and the policy is not burdened by all the details.
+A policy statement needs only the role's name, and the policy is not burdened by all the details.
 Also, the list offers *reusability* as you can apply the role to any statement that needs it.
 
 Just like policies, roles are either *Chef-managed* or *Custom* types.
 Default Chef-managed roles cannot change, like Chef-managed policies.
 
-Chef Automate has five *Chef-managed* roles and two *Custom* roles
-that you might find helpful. Unlike the others, those roles, *Compliance Viewer* and *Compliance Editor*, can be modified.
+Chef Automate includes five *Chef-managed* roles and two *Custom* roles by default.
+You can edit these Custom roles, *Compliance Viewer* and *Compliance Editor*.
 To see the actions comprising the roles, see [Chef-managed Roles]({{< relref "api/#tag/roles" >}}).
 
 Role              |Type          |Description
@@ -117,11 +117,12 @@ Ingest            |Chef-managed  |Ingest data into the system
 Compliance Viewer |Custom        |Viewer for compliance resources
 Compliance Editor |Custom        |Editor for compliance resources
 
-You can use these default Chef-created roles in your policies, or create your custom roles for more customized permissions.
+You can use these default Chef-created roles in your policies, or create more custom roles for further customized permissions.
 You can later edit any roles you create.
 
 Chef Automate also ships with policies that leverage these roles.
-Those Chef-managed policies are Viewers, Editors, Administrator, and Ingest. The custom ones are Compliance Viewers and Compliance Editors.
+Those Chef-managed policies are Viewers, Editors, Administrator, and Ingest.
+The custom policies are Compliance Viewers and Compliance Editors.
 
 ## Working with Projects
 

--- a/components/automate-chef-io/content/docs/policies.md
+++ b/components/automate-chef-io/content/docs/policies.md
@@ -24,7 +24,7 @@ Permission for the `iam:policies` action is required to interact with policies. 
 
 ### Custom Policies
 
-*Custom* policies are policies that you create for your own needs. You can add, edit, and delete policy statements in your custom policies.
+*Custom* policies are policies that you create for your own needs. You can add, edit, and delete policy statements in your custom policies. Chef Automate ships with two additional custom policies users find helpful, Compliance Viewers and Compliance Editors, that can be modified like other custom policies.
 
 ## Managing Policies
 

--- a/components/automate-chef-io/content/docs/policies.md
+++ b/components/automate-chef-io/content/docs/policies.md
@@ -12,9 +12,12 @@ toc = true
 
 ## Overview
 
-Identity and Access Management policies manage the resources and actions used by identities. Policies are composed of statements that specify permissions.
+Identity and Access Management policies manage the resources and actions used by identities.
+Policies are composed of statements that specify permissions.
 
-Permission for the `iam:policies` action is required to interact with policies. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
+Permission for the `iam:policies` action is required to interact with policies.
+Any user that is part of the `admins` team or the `Administrator` policy will have this permission.
+Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
 
 ![](/images/docs/settings-policies.png)
 
@@ -24,7 +27,9 @@ Permission for the `iam:policies` action is required to interact with policies. 
 
 ### Custom Policies
 
-*Custom* policies are policies that you create for your own needs. You can add, edit, and delete policy statements in your custom policies. Chef Automate ships with two additional custom policies users find helpful, Compliance Viewers and Compliance Editors, that can be modified like other custom policies.
+*Custom* policies are policies that you create for your own needs.
+You can add, edit, and delete policy statements in your custom policies.
+Chef Automate ships with two custom policies, Compliance Viewers and Compliance Editors, which you can edit like other custom policies.
 
 ## Managing Policies
 
@@ -34,20 +39,26 @@ _Custom_ policies can only be created using the [Policies API]({{< relref "api/#
 
 ### Deleting Policies
 
-Navigate to _Policies_ in the **Settings** tab. Then open the menu at the end of the table row and select **Delete Policy**.
+Navigate to _Policies_ in the **Settings** tab.
+Then open the menu at the end of the table row and select **Delete Policy**.
 
 ### Policy Membership
 
-The policy membership can be changed for both _Chef-Managed_ and _Custom_ policies. The only exception is that the _admins_ team cannot be removed from the _Administrator_ policy.
+The policy membership can be changed for both _Chef-Managed_ and _Custom_ policies.
+The only exception is that the _admins_ team cannot be removed from the _Administrator_ policy.
 
 #### Adding Members to Policies
 
-To add members to a policy, navigate to _Policies_ in the **Settings** tab and locate the policy. Navigate to the policy's detail page and use the **Add Members** button. Select local users or teams from the list, or use the **Add Member Expression** button to add API Tokens, and SAML or LDAP users or groups.
+To add members to a policy, navigate to _Policies_ in the **Settings** tab and locate the policy.
+Navigate to the policy's detail page and use the **Add Members** button.
+Select local users or teams from the list, or use the **Add Member Expression** button to add API Tokens, and SAML or LDAP users or groups.
 
 #### Removing Members from Policies
 
-To remove members from a policy, navigate to _Policies_ in the **Settings** tab and locate the policy. Navigate to the policy's detail page and select the **Members** tab. Then locate the member to remove and use the menu at the end of the table row to remove the user.
+To remove members from a policy, navigate to _Policies_ in the **Settings** tab and locate the policy.
+Navigate to the policy's detail page and select the **Members** tab.
+Then locate the member to remove and use the menu at the end of the table row to remove the user.
 
 ### Changing Policy Details
 
-For _custom_ policies, the policy name, statements, and projects can only be changed using the [Policies API]({{< relref "api/#tag/policies" >}}).
+For _custom_ policies, use the [Policies API]({{< relref "api/#tag/policies" >}}) to change the policy name, statements, and projects.

--- a/components/automate-chef-io/content/docs/roles.md
+++ b/components/automate-chef-io/content/docs/roles.md
@@ -32,7 +32,15 @@ Ingest        | Ingest data into the system
 
 ### Custom Roles
 
-Custom roles are roles that can be changed by anyone with the permission for `iam:roles:update`.
+Custom roles are roles that can be changed by anyone with the permission for `iam:roles:update`. In
+addition to the Chef-managed roles above, Chef Automate includes two custom roles.
+
+Role              | Description
+------------------|------------
+Compliance Viewer |Viewer for compliance resources
+Compliance Editor |Editor for compliance resources
+
+Like other custom roles, these can be modified.
 
 ## Managing Roles
 

--- a/components/automate-chef-io/content/docs/roles.md
+++ b/components/automate-chef-io/content/docs/roles.md
@@ -14,7 +14,7 @@ toc = true
 
 Chef Automate Identity and Access Management roles are named groups of actions used to define [policies]({{< relref "policies.md" >}}). Actions describe what is allowed by users in Automate.
 
-Permission for the `iam:roles` action is required to interact with roles. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
+Users require permission for the `iam:roles` action to interact with roles. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
 
 ![](/images/docs/settings-roles.png)
 
@@ -32,15 +32,15 @@ Ingest        | Ingest data into the system
 
 ### Custom Roles
 
-Custom roles are roles that can be changed by anyone with the permission for `iam:roles:update`. In
-addition to the Chef-managed roles above, Chef Automate includes two custom roles.
+Custom roles are roles that any user with the permission for `iam:roles:update` can change. 
+In addition to the Chef-managed roles above, Chef Automate includes two custom roles by default.
 
 Role              | Description
 ------------------|------------
 Compliance Viewer |Viewer for compliance resources
 Compliance Editor |Editor for compliance resources
 
-Like other custom roles, these can be modified.
+You can edit these custom roles like other user-created custom roles.
 
 ## Managing Roles
 
@@ -50,7 +50,7 @@ _Custom_ roles can only be created using the [Roles API]({{< relref "api/#tag/ro
 
 ### Changing Role Details
 
-For _custom_ roles, the role name, actions list, and projects can only be changed using the [Roles API]({{< relref "api/#tag/roles" >}}).
+For _custom_ roles, use the [Roles API]({{< relref "api/#tag/roles" >}} to change the role name, actions list, and projects.
 
 ### Deleting Roles
 

--- a/e2e/cypress/integration/api/iam/policies_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/policies_api.spec.ts
@@ -31,6 +31,7 @@ const chefCustomPolicyIDs = [
   'compliance-editor-access'
 ];
 
+// All policyIDs must stay in sync with what is in the authz DB (check migration files).
 const totalChefCreatedPolicyCount = chefManagedPolicyIDs.length + chefCustomPolicyIDs.length;
 
 describe('policies API', () => {

--- a/e2e/cypress/integration/api/iam/policies_api.spec.ts
+++ b/e2e/cypress/integration/api/iam/policies_api.spec.ts
@@ -26,6 +26,13 @@ const chefManagedPolicyIDs = [
   'ingest-access'
 ];
 
+const chefCustomPolicyIDs = [
+  'compliance-access',
+  'compliance-editor-access'
+];
+
+const totalChefCreatedPolicyCount = chefManagedPolicyIDs.length + chefCustomPolicyIDs.length;
+
 describe('policies API', () => {
 
   before(() => {
@@ -118,7 +125,7 @@ describe('policies API', () => {
           url: '/apis/iam/v2/policies'
         }).then((response) => {
           expect(response.status).to.equal(200);
-          expect(response.body.policies.length).to.equal(chefManagedPolicyIDs.length + 1);
+          expect(response.body.policies.length).to.equal(totalChefCreatedPolicyCount + 1);
 
           const policyIDs = response.body.policies.map((pol: Policy) => pol.id);
 


### PR DESCRIPTION
Signed-off-by: Blake Johnson <bstier@chef.io>

### :nut_and_bolt: Description: What code changed, and why?


This PR adds several "helper" roles/policies for IAMv2 users who want to restrict/allow use of compliance resources. Unlike other policies/roles we define, these can be deleted.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :athletic_shoe: How to Build and Test the Change

Enter studio, rebuild authz.

You should now have 

## Roles
### Compliance Editor

```
{
	"name": "Compliance Editor",
  	"id": "compliance-editor",
	"actions": [
                "compliance:*"
	],
  	"projects": []
}
```

### Compliance Viewer

```
{
	"name": "Compliance Viewer",
  	"id": "compliance-viewer",
	"actions": [
                "compliance:*:get",
		"compliance:*:list"
	],
  	"projects": []
}
```


## Policies
### Compliance Editor
```
{
  "name": "Compliance Editors",
  "id": "compliance-editor-access",
  "projects": [],
  "members": [],
  "statements": [
    {
      "effect": "ALLOW",
      "role": "compliance-editor",
      "projects": ["*"]
    }
  ]
}
```

### Compliance Viewer

```
{
  "name": "Compliance Viewers",
  "id": "compliance-viewers",
  "projects": [],
  "members": [],
  "statements": [
    {
      "effect": "ALLOW",
      "role": "compliance-viewer",
      "projects": ["*"]
    }
  ]
}
```

If you add a user to either of those roles, that user should have the related permissions.

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

