### PR TITLE
fix IAM v2 migration of policies with single-term resource

### DIFF
--- a/components/authz-service/storage/postgres/migration/legacy/iam.go
+++ b/components/authz-service/storage/postgres/migration/legacy/iam.go
@@ -434,12 +434,7 @@ func convertV1Resource(resource string) (string, error) {
 		return "*", nil
 	}
 
-	// these are the single-term resources that match an endpoint's v1 policy annotation
-	// (i.e. the node APIs in api/external/nodes/nodes.proto use the resource "nodes")
-	// all other single-term resources are not actually enforcing any permissions on v1
-	// and therefore can be skipped
-	singleTermsToMigrate := []string{"nodes", "events", "license", "nodemanagers", "service_groups"}
-	if len(terms) == 1 && !includes(singleTermsToMigrate, terms[0]) {
+	if len(terms) == 1 && !singleTermToMigrate(terms[0]) {
 		return "", nil
 	}
 
@@ -654,8 +649,14 @@ func convertV1Action(action string, resource string) ([]string, error) {
 	}
 }
 
-func includes(terms []string, termToCheck string) bool {
-	for _, term := range terms {
+func singleTermToMigrate(termToCheck string) bool {
+	// these are the single-term resources that match an endpoint's v1 policy annotation
+	// (i.e. the node APIs in api/external/nodes/nodes.proto use the resource "nodes")
+	// all other single-term resources are not actually enforcing any permissions on v1
+	// and therefore can be skipped
+	singleTermsToMigrate := []string{"nodes", "events", "license", "nodemanagers", "service_groups"}
+
+	for _, term := range singleTermsToMigrate {
 		if term == termToCheck {
 			return true
 		}

--- a/components/authz-service/storage/postgres/migration/legacy/iam.go
+++ b/components/authz-service/storage/postgres/migration/legacy/iam.go
@@ -434,6 +434,10 @@ func convertV1Resource(resource string) (string, error) {
 		return "*", nil
 	}
 
+	// these are the single-term resources that match an endpoint's v1 policy annotation
+	// (i.e. the node APIs in api/external/nodes/nodes.proto use the resource "nodes")
+	// all other single-term resources are not actually enforcing any permissions on v1
+	// and therefore can be skipped
 	singleTermsToMigrate := []string{"nodes", "events", "license", "nodemanagers", "service_groups"}
 	if len(terms) == 1 && !includes(singleTermsToMigrate, terms[0]) {
 		return "", nil
@@ -512,11 +516,6 @@ func convertV1Resource(resource string) (string, error) {
 }
 
 func convertV1Cfgmgmt(terms []string) (string, error) {
-	if len(terms) == 1 {
-		// skip?
-		return "", nil
-	}
-
 	if terms[1] == "stats" {
 		return "infra:nodes", nil
 	}

--- a/components/authz-service/storage/postgres/migration/legacy/iam_migration_test.go
+++ b/components/authz-service/storage/postgres/migration/legacy/iam_migration_test.go
@@ -243,6 +243,7 @@ func TestMigrateToV2(t *testing.T) {
 				"secrets",
 				"telemetry",
 				"notifications",
+				"not_real_resource",
 			}
 
 			policyIDs := make([]string, len(singleTermResources))


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

A customer ran into an issue that broke authz-service when they tried to migrate a policy with the resource `cfgmgmt` to v2. This PR fixes that bug and ensures we skip migrating any v1 policies with single term resources that don't directly correspond to an existing API's policy annotations. Those policies were not enforcing any permissions in v1 anyway.

The exceptions to this skip-single-term-resource rule are:
- [nodes](https://github.com/chef/automate/blob/master/api/external/nodes/nodes.proto#L53)
- [events](https://github.com/chef/automate/blob/master/components/automate-gateway/api/event_feed/event_feed.proto#L21)
- [license](https://github.com/chef/automate/blob/master/components/automate-gateway/api/license/license.proto#L18)
- [nodemanagers](https://github.com/chef/automate/blob/master/api/external/nodes/manager/manager.proto#L38)
- [service_groups](https://github.com/chef/automate/blob/master/api/external/applications/applications.proto#L39)

The resources above match an existing v1 policy annotation API, so they do enforce permissions on v1 and should continue to do so on v2.

### :+1: Definition of Done

- [x] IAM v1->v2 migration does not fail on migrating v1 policies with single-term resources

### :athletic_shoe: How to Build and Test the Change

TODO

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).