### PR TITLE
adjusting active session language

### DIFF
--- a/components/automate-chef-io/content/docs/ldap.md
+++ b/components/automate-chef-io/content/docs/ldap.md
@@ -36,8 +36,7 @@ require you to adjust the [IAM]({{< relref "iam-v2-overview.md" >}}) policy memb
 
 {{< info >}}
 Users who sign in via SAML will have a session time of 24 hours before needing to sign in again.
-Local, MSAD, and LDAP users will have their Chef Automate sessions refreshed while they maintain an active
-browsing session of the Chef Automate UI or until they sign out directly.
+Local, MSAD, and LDAP users will have their Chef Automate sessions refreshed while their Chef Automate UI browser window remains open or until they sign out directly.
 {{< /info >}}
 
 ## Supported Identity Management Systems

--- a/components/automate-chef-io/content/docs/ldap.md
+++ b/components/automate-chef-io/content/docs/ldap.md
@@ -35,8 +35,7 @@ However, switching between either of those configurations and a SAML configurati
 require you to adjust the [IAM]({{< relref "iam-v2-overview.md" >}}) policy membership.
 
 {{< info >}}
-Users who sign in via SAML will have a session time of 24 hours before needing to sign in again.
-Local, MSAD, and LDAP users will have their Chef Automate sessions refreshed while their Chef Automate UI browser window remains open or until they sign out directly.
+Local, MSAD, and LDAP users will have their Chef Automate sessions refreshed while their Chef Automate browser window remains open or until they sign out directly.
 {{< /info >}}
 
 ## Supported Identity Management Systems

--- a/components/automate-chef-io/content/docs/saml.md
+++ b/components/automate-chef-io/content/docs/saml.md
@@ -38,8 +38,7 @@ your existing configuration by following these steps:
 
 {{< info >}}
 Users who sign in via SAML will have a session time of 24 hours before needing to sign in again.
-Local, MSAD, and LDAP users will have their Chef Automate sessions refreshed while they maintain an active
-browsing session of the Chef Automate UI or until they sign out directly.
+Local, MSAD, and LDAP users will have their Chef Automate sessions refreshed while their Chef Automate UI browser window remains open or until they sign out directly.
 {{< /info >}}
 
 ## Supported Identity Management Systems

--- a/components/automate-chef-io/content/docs/saml.md
+++ b/components/automate-chef-io/content/docs/saml.md
@@ -38,7 +38,6 @@ your existing configuration by following these steps:
 
 {{< info >}}
 Users who sign in via SAML will have a session time of 24 hours before needing to sign in again.
-Local, MSAD, and LDAP users will have their Chef Automate sessions refreshed while their Chef Automate UI browser window remains open or until they sign out directly.
 {{< /info >}}
 
 ## Supported Identity Management Systems

--- a/components/automate-chef-io/content/docs/users.md
+++ b/components/automate-chef-io/content/docs/users.md
@@ -15,7 +15,8 @@ toc = true
 
 Chef Automate supports three different types of users: local users, [LDAP users]({{< relref "ldap.md" >}}), and [SAML users]({{< relref "saml.md" >}}). Manage local users from the **Settings** tab.
 
-Local users can sign in and interact with the system independent of LDAP or SAML.
+Local users can sign in and interact with the system independent of LDAP or SAML. 
+Local users will have their Chef Automate sessions refreshed while their Chef Automate browser window remains open or until they sign out directly.
 
 Permission for the `iam:users` action is required to interact with users other than yourself. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

we often get questions about what it means to have an active session, this attempts to make it more clear

### :chains: Related Resources
none.

### :+1: Definition of Done
stuff is maybe more clear

### :athletic_shoe: How to Build and Test the Change
`make serve` from `components/automate-chef-io`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![session](https://user-images.githubusercontent.com/5489125/79368502-6045b800-7f04-11ea-9af1-9cdf4b781142.png)

