### PR TITLE
Patch for policies value and added test

### DIFF
--- a/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.spec.ts
@@ -106,7 +106,7 @@ describe('EventFeedGuitarStringsComponent', () => {
     const text = component.getTooltipText(item, item.isMultiple(), guitarString);
 
     expect(text).toBe('<strong>5 nodes</strong>, <strong>9 cookbooks</strong>,' +
-      ' and <strong>7 roles</strong> were created.');
+      ' <strong>7 roles</strong>, and <strong>3 policies</strong> were created.');
   });
 
   describe('GuitarStringDataContainer', () => {
@@ -393,7 +393,8 @@ describe('EventFeedGuitarStringsComponent', () => {
       types = [
         {'name': 'node', 'count': 5},
         {'name': 'cookbook', 'count': 9},
-        {'name': 'role', 'count': 7}
+        {'name': 'role', 'count': 7},
+        {'name': 'policy', 'count': 3}
       ];
     } else {
       types = [

--- a/components/automate-ui/src/app/types/types.ts
+++ b/components/automate-ui/src/app/types/types.ts
@@ -1,4 +1,4 @@
-import { merge, endsWith, replace } from 'lodash';
+import { merge } from 'lodash';
 import * as moment from 'moment';
 
 export type Status = 'success' | 'failure' | 'missing' | 'skipped';

--- a/components/automate-ui/src/app/types/types.ts
+++ b/components/automate-ui/src/app/types/types.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import { merge, endsWith, replace } from 'lodash';
 import * as moment from 'moment';
 
 export type Status = 'success' | 'failure' | 'missing' | 'skipped';
@@ -628,10 +628,15 @@ export class GuitarStringItem {
         label = name;
     }
 
-    label = count > 1 ? label + 's' : label;
+    // Pluralize the event label type if necessary
+    if (count > 1) {
+      label = label === 'policy' ? 'policies' : label + 's';
+    }
+
     return label;
   }
 }
+
 
 export class GuitarStringCollection {
   strings: GuitarString[];


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
In the event feed guitar strings on the event feed dashboard, the word 'policy' was getting pluralized to 'policys' - this corrects pluralization to 'policies'

### :chains: Related Resources
fixes https://github.com/chef/automate/issues/2892

### :+1: Definition of Done
Tooltips no longer show the work "policys" when they are plural, and now reflect the correct. "policies"

### :athletic_shoe: How to Build and Test the Change
build component/automate-ui-devproxy && start_all_services
make serve

in hab studio run the following a few times:
`cat components/ingest-service/examples/actions/policy_update.json | jq --arg date "$(date +%FT%TZ -d '1 day ago')" '.recorded_at = $date' | send_chef_data_raw lb`

navigate to https://a2-dev.test/dashboards/event-feed
Hover over the guitar string icons in the following photo until you see the tooltip pop up.
<img width="644" alt="Screen Shot 2020-04-16 at 12 07 59 PM" src="https://user-images.githubusercontent.com/16737484/79501088-56928200-7fe2-11ea-8307-f6e5db52cda4.png">

Wherever there has been an update to a policy, we should the name reflected as `policy` if singular and `policies` if plural.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
after:
<img width="436" alt="Screen Shot 2020-04-16 at 12 04 24 PM" src="https://user-images.githubusercontent.com/16737484/79501104-5d20f980-7fe2-11ea-9175-f3a637b0202b.png">
<img width="415" alt="Screen Shot 2020-04-16 at 12 04 31 PM" src="https://user-images.githubusercontent.com/16737484/79501108-5eeabd00-7fe2-11ea-8612-4dd79266622b.png">

