### PR TITLE
Include now-required name field for toggle token

### DIFF
--- a/components/automate-ui/src/app/entities/api-tokens/api-token.effects.ts
+++ b/components/automate-ui/src/app/entities/api-tokens/api-token.effects.ts
@@ -115,8 +115,8 @@ export class ApiTokenEffects {
 
   @Effect()
   toggleToken$ = this.actions$.pipe(ofType<ToggleTokenActive>(ApiTokenActionTypes.TOGGLE),
-    mergeMap(({ payload: { id, active } }: ToggleTokenActive) =>
-      this.requests.toggleActive(id, active).pipe(
+    mergeMap(({ payload: { id, name, active } }: ToggleTokenActive) =>
+      this.requests.toggleActive(id, name, active).pipe(
         map(resp => new ToggleTokenActiveSuccess(resp.token)),
         catchError((error: HttpErrorResponse) => of(new ToggleTokenActiveFailure(error))))
     ));

--- a/components/automate-ui/src/app/entities/api-tokens/api-token.requests.ts
+++ b/components/automate-ui/src/app/entities/api-tokens/api-token.requests.ts
@@ -39,9 +39,9 @@ export class ApiTokenRequests {
 
   // Note: toggleActive takes the EXISTING value in `active`, and will take care
   // of flipping it.
-  public toggleActive(id: string, active: boolean): Observable<TokenPayloadResponse> {
+  public toggleActive(id: string, name: string, active: boolean): Observable<TokenPayloadResponse> {
     return this.http.put<TokenPayloadResponse>(`${env.iam_url}/tokens/${id}`,
-      { active: !active });
+      { name, active: !active });
   }
 
   public delete(id: string): Observable<Object> {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Recent PR tightening up API parameters caused a break in the toggleToken call.

![image](https://user-images.githubusercontent.com/6817500/79508848-2c938c80-7fef-11ea-9c1e-bc1f2622eb58.png)


### :chains: Related Resources
PR #3197 Add missing "required" field constraints

### :+1: Definition of Done
Toggling token status inactive/active works

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui
Create a token
From the control menu, select <kbd>Toggle Token</kbd>.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
