### PR TITLE
Fix unit test "failures"

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
@@ -18,7 +18,7 @@ describe('CreateObjectModalComponent', () => {
         MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),
         MockComponent({ selector: 'chef-loading-spinner' }),
         MockComponent({ selector: 'chef-form-field' }),
-        MockComponent({ selector: 'chef-checkbox' }),
+        MockComponent({ selector: 'chef-checkbox', inputs: ['checked'] }),
         MockComponent({ selector: 'chef-error' }),
         MockComponent({ selector: 'chef-toolbar' }),
         MockComponent({ selector: 'chef-modal', inputs: ['visible'] }),

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
@@ -62,7 +62,8 @@ describe('ProjectListComponent', () => {
         }),
         MockComponent({
           selector: 'app-create-object-modal',
-          inputs: ['creating', 'createForm', 'visible', 'objectNoun', 'conflictErrorEvent', 'createProjectModal'],
+          inputs: ['creating', 'createForm', 'visible', 'objectNoun',
+            'conflictErrorEvent', 'createProjectModal', 'resetCheckboxEvent'],
           outputs: ['close', 'deleteClicked']
         }),
         MockComponent({


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Actually all unit tests were passing. But both the regular test runner and Wallaby test runner reported "console" errors. (Wallaby actually told me the tests where the errors emanated from.)

Output from `make unit` before the fix:

```
16 04 2020 14:34:38.763:INFO [launcher]: Launching browsers ChromeHeadless with concurrency unlimited
16 04 2020 14:34:38.925:INFO [launcher]: Starting browser ChromeHeadless
16 04 2020 14:35:10.202:INFO [HeadlessChrome 80.0.3987 (Mac OS X 10.14.6)]: Connected on socket gDVUDuz1Fz_zVJoTAAAA with id 32456407
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
.................................
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
.
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
.
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
.
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
.
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
. . .
```


### :chains: Related Resources
Unit test noise crept in from here:
PR #3275 allow folks to uncheck policy creation checkbox

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
