### PR TITLE
automate-cli/Makefile: attempt to fix CLI docs issue around removed commands

### DIFF
--- a/components/automate-cli/Makefile
+++ b/components/automate-cli/Makefile
@@ -36,12 +36,16 @@ echo-build-data:
 ${BIN_DIR}:
 	mkdir -p ${BIN_DIR}
 
-docs: ${BINS} ${GOOS}
+docs: clean ${BINS} ${GOOS}
 	mkdir -p ${DOCS_PATH}
-	bin/${GOOS}/chef-automate dev generate-docs --docs-dir ${DOCS_PATH} --format yaml
+	# In the studio, CHEF_DEV_ENVIRONMENT is set to true. This has the
+	# effect that further dev-only commands appear in the output of
+	# chef-automate --help etc. Since it unhides commands, that'll also
+	# have an effect on the documentation data generated.
+	CHEF_DEV_ENVIRONMENT=false bin/${GOOS}/chef-automate dev generate-docs --docs-dir ${DOCS_PATH} --format yaml
 
 clean:
-	rm -rf bin/*
+	rm -rf bin/* "${DOCS_PATH}"
 
 EXE = chef-automate
 linux: EXTRA_OPTS = CGO_ENABLED=0


### PR DESCRIPTION
This should fix stale CLI docs of removed commands sticking around.

The removed yamls aren't included in this PR, merging it should show us
if it works, or if there's state somewhere else that needs to be reset.

Running this in the dev env with `env CHEF_DEV_ENVIRONMENT=false make docs`
yields the following deleted files:

    deleted:    components/automate-chef-io/data/docs/cli_chef_automate/chef-automate_uninstall.yaml
    deleted:    components/automate-chef-io/data/docs/cli_chef_automate/commands/chef-automate_airgap_bundle_unpack.yaml
    deleted:    components/automate-chef-io/data/docs/cli_chef_automate/commands/chef-automate_debug.yaml
    deleted:    components/automate-chef-io/data/docs/cli_chef_automate/commands/chef-automate_debug_get-version.yaml
    deleted:    components/automate-chef-io/data/docs/cli_chef_automate/commands/chef-automate_debug_profile.yaml
    deleted:    components/automate-chef-io/data/docs/cli_chef_automate/commands/chef-automate_debug_set-log-level.yaml
    deleted:    components/automate-chef-io/data/docs/cli_chef_automate/commands/chef-automate_debug_trace.yaml
    deleted:    components/automate-chef-io/data/docs/cli_chef_automate/commands/chef-automate_diagnostics.yaml
    deleted:    components/automate-chef-io/data/docs/cli_chef_automate/commands/chef-automate_iam_reset-to-v1.yaml
    deleted:    components/automate-chef-io/data/docs/cli_chef_automate/commands/chef-automate_iam_upgrade-to-v2.yaml
    deleted:    components/automate-chef-io/data/docs/cli_chef_automate/commands/chef-automate_node-inventory.yaml

