### PR TITLE
automate-chef-io: trigger rebuild of automate-cli docs

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -111,6 +111,7 @@ subscriptions:
           only_if_modified:
             - components/automate-cli/cmd/*
             - components/automate-cli/pkg/status/error_codes.go
+            - components/automate-cli/Makefile
             - .expeditor/generate-automate-cli-docs.sh
       - bash:.expeditor/generate-automate-api-docs.sh:
           post_commit: false

--- a/components/automate-cli/Makefile
+++ b/components/automate-cli/Makefile
@@ -38,8 +38,8 @@ ${BIN_DIR}:
 
 docs: clean ${BINS} ${GOOS}
 	mkdir -p ${DOCS_PATH}
-	# In the studio, CHEF_DEV_ENVIRONMENT is set to true. This has the
-	# effect that further dev-only commands appear in the output of
+	# In the dev studio, CHEF_DEV_ENVIRONMENT is set to true. This has
+	# the effect that further dev-only commands appear in the output of
 	# chef-automate --help etc. Since it unhides commands, that'll also
 	# have an effect on the documentation data generated.
 	CHEF_DEV_ENVIRONMENT=false bin/${GOOS}/chef-automate dev generate-docs --docs-dir ${DOCS_PATH} --format yaml


### PR DESCRIPTION
The make target is used in the script that's watched. So it makes sense
to include it in the watched files.

I would have done that in #3403 had I not forgotten about it. The change
to the Makefile in this PR is silly.
