### PR TITLE
fix focus outline on global project filter checkboxes

### DIFF
--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -131,7 +131,7 @@
       font-weight: 400;
 
       & + chef-checkbox {
-        padding-top: 14px;
+        margin-top: 14px;
       }
 
       ::ng-deep .label-wrap {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

in acceptance testing we noticed a weird focus outline, this fixes it.

### :chains: Related Resources
zero.

### :+1: Definition of Done
everything still works.
focus outline isn't weird anymore.

### :athletic_shoe: How to Build and Test the Change
`rebuild components/automate-ui-devproxy`

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
#### before
![before](https://user-images.githubusercontent.com/5489125/79597214-b9455580-8096-11ea-8d23-e308c93fcd71.png)

#### after
![after](https://user-images.githubusercontent.com/5489125/79597216-bc404600-8096-11ea-9b3d-02e38ff2e2fc.png)
