### PR TITLE
[automate-3112] refactor team member APIs in storage layer

### DIFF
--- a/components/teams-service/server/v2/server.go
+++ b/components/teams-service/server/v2/server.go
@@ -142,27 +142,13 @@ func (s *Server) AddTeamMembers(ctx context.Context,
 		return nil, status.Error(codes.InvalidArgument, "missing user IDs")
 	}
 
-	// verify team exists and isn't filtered out by the project filter
-	_, err := s.service.Storage.GetTeam(ctx, req.Id)
-	if err != nil {
-		return nil, service.ParseStorageError(err, req.Id, "team")
-	}
-
-	_, err = s.service.Storage.AddUsers(ctx, req.Id, req.UserIds)
+	updatedUserIDs, err := s.service.Storage.AddUsers(ctx, req.Id, req.UserIds)
 	if err != nil && err != storage.ErrConflict {
 		return nil, service.ParseStorageError(err, req.Id, "user")
 	}
 
-	// TODO (tc): Get the updated set of user membership for the team since
-	// that is not what is returned from AddUsers for some reason
-	// (can refactor on V1 deprecation).
-	userIDs, err := s.service.Storage.GetUserIDsForTeam(ctx, req.Id)
-	if err != nil {
-		return nil, service.ParseStorageError(err, req.Id, "team")
-	}
-
 	return &teams.AddTeamMembersResp{
-		UserIds: userIDs,
+		UserIds: updatedUserIDs,
 	}, nil
 }
 
@@ -170,27 +156,13 @@ func (s *Server) AddTeamMembers(ctx context.Context,
 func (s *Server) RemoveTeamMembers(ctx context.Context,
 	req *teams.RemoveTeamMembersReq) (*teams.RemoveTeamMembersResp, error) {
 
-	// verify team exists and isn't filtered out by the project filter
-	_, err := s.service.Storage.GetTeam(ctx, req.Id)
-	if err != nil {
-		return nil, service.ParseStorageError(err, req.Id, "team")
-	}
-
-	_, err = s.service.Storage.RemoveUsers(ctx, req.Id, req.UserIds)
-	if err != nil {
-		return nil, service.ParseStorageError(err, req.Id, "team")
-	}
-
-	// TODO (tc): Get the updated set of user membership for the team since
-	// that is not what is returned from RemoveUsers for some reason
-	// (can refactor on V1 deprecation).
-	userIDs, err := s.service.Storage.GetUserIDsForTeam(ctx, req.Id)
+	updatedUserIDs, err := s.service.Storage.RemoveUsers(ctx, req.Id, req.UserIds)
 	if err != nil {
 		return nil, service.ParseStorageError(err, req.Id, "team")
 	}
 
 	return &teams.RemoveTeamMembersResp{
-		UserIds: userIDs,
+		UserIds: updatedUserIDs,
 	}, nil
 }
 

--- a/components/teams-service/server/v2/server_test.go
+++ b/components/teams-service/server/v2/server_test.go
@@ -1007,9 +1007,10 @@ func runAllServerTests(
 					resp, err := cl.CreateTeam(ctx, req)
 					require.NoError(t, err)
 
+					targetMemberID := "88f13b6b-b20b-4335-9fd6-2c09edf45cf9"
 					resp1, err := cl.AddTeamMembers(insertProjectsIntoNewContext([]string{constants.UnassignedProjectID}), &teams.AddTeamMembersReq{
 						Id:      req.Id,
-						UserIds: []string{"88f13b6b-b20b-4335-9fd6-2c09edf45cf9"},
+						UserIds: []string{targetMemberID},
 					})
 					require.NoError(t, err)
 					require.Equal(t, 1, len(resp1.UserIds))
@@ -1026,7 +1027,7 @@ func runAllServerTests(
 					require.NotNil(t, resp2)
 					assert.Equal(t, len(addReq.UserIds)+1, len(resp2.UserIds))
 
-					expectedUsers := append(addReq.UserIds, "88f13b6b-b20b-4335-9fd6-2c09edf45cf9")
+					expectedUsers := append(addReq.UserIds, targetMemberID)
 					assert.ElementsMatch(t, expectedUsers, resp2.UserIds)
 
 					cleanupTeam(t, cl, resp.Team.Id)

--- a/components/teams-service/server/v2/server_test.go
+++ b/components/teams-service/server/v2/server_test.go
@@ -983,7 +983,58 @@ func runAllServerTests(
 			}
 		})
 
-		t.Run("fails to add user with NotFound when a project filter that excludes the team", func(t *testing.T) {
+		t.Run("successfully adds user to team with existing users", func(t *testing.T) {
+			tests := []struct {
+				users []string
+				desc  string
+			}{
+				{[]string{"6ed95714-9466-463b-80da-0513ecb42a08"}, "single user"},
+				{[]string{
+					"299ea25b-62d4-4660-965a-e25870298792",
+					"d1f642c8-8907-4e8b-a9a0-b998a44dc4bf",
+				}, "multiple users"},
+			}
+			for _, test := range tests {
+				t.Run("when provided valid team and "+test.desc, func(t *testing.T) {
+					ctx := context.Background()
+
+					// arrange
+					req := &teams.CreateTeamReq{
+						Name:     "Gotta Catch Em All",
+						Id:       "corgis-inc",
+						Projects: []string{},
+					}
+					resp, err := cl.CreateTeam(ctx, req)
+					require.NoError(t, err)
+
+					resp1, err := cl.AddTeamMembers(insertProjectsIntoNewContext([]string{constants.UnassignedProjectID}), &teams.AddTeamMembersReq{
+						Id:      req.Id,
+						UserIds: []string{"88f13b6b-b20b-4335-9fd6-2c09edf45cf9"},
+					})
+					require.NoError(t, err)
+					require.Equal(t, 1, len(resp1.UserIds))
+
+					addReq := &teams.AddTeamMembersReq{
+						Id:      req.Id,
+						UserIds: test.users,
+					}
+					// act
+					resp2, err := cl.AddTeamMembers(insertProjectsIntoNewContext([]string{constants.UnassignedProjectID}), addReq)
+
+					// assert
+					require.NoError(t, err)
+					require.NotNil(t, resp2)
+					assert.Equal(t, len(addReq.UserIds)+1, len(resp2.UserIds))
+
+					expectedUsers := append(addReq.UserIds, "88f13b6b-b20b-4335-9fd6-2c09edf45cf9")
+					assert.ElementsMatch(t, expectedUsers, resp2.UserIds)
+
+					cleanupTeam(t, cl, resp.Team.Id)
+				})
+			}
+		})
+
+		t.Run("fails to adds user with NotFound when a project filter that excludes the team", func(t *testing.T) {
 			tests := []struct {
 				users []string
 				desc  string

--- a/components/teams-service/storage/conformance/conformance_test.go
+++ b/components/teams-service/storage/conformance/conformance_test.go
@@ -406,7 +406,7 @@ func testGetTeam(ctx context.Context, t *testing.T, s storage.Storage) {
 	assert.WithinDuration(t, team.CreatedAt, getTeam.CreatedAt, 50*time.Millisecond)
 	assert.Equal(t, team.Name, getTeam.Name)
 	assert.Equal(t, team.ID, getTeam.ID)
-	assert.ElementsMatch(t, userIDs, getTeamUserIDs)
+	assert.ElementsMatch(t, addUserIDs, getTeamUserIDs)
 }
 
 func testGetTeamNotFound(ctx context.Context, t *testing.T, s storage.Storage) {

--- a/components/teams-service/storage/conformance/conformance_test.go
+++ b/components/teams-service/storage/conformance/conformance_test.go
@@ -406,7 +406,7 @@ func testGetTeam(ctx context.Context, t *testing.T, s storage.Storage) {
 	assert.WithinDuration(t, team.CreatedAt, getTeam.CreatedAt, 50*time.Millisecond)
 	assert.Equal(t, team.Name, getTeam.Name)
 	assert.Equal(t, team.ID, getTeam.ID)
-	assert.Equal(t, addUserIDs, getTeamUserIDs)
+	assert.ElementsMatch(t, userIDs, getTeamUserIDs)
 }
 
 func testGetTeamNotFound(ctx context.Context, t *testing.T, s storage.Storage) {

--- a/components/teams-service/storage/conformance/conformance_test.go
+++ b/components/teams-service/storage/conformance/conformance_test.go
@@ -134,12 +134,11 @@ func testGetTeamByName(ctx context.Context, t *testing.T, s storage.Storage) {
 	team, err := s.StoreTeam(ctx, id, "team name", emptyProjectsList)
 	require.NoError(t, err, "setup: failed to store team")
 
-	users := []string{"one", "two", "three"}
-	team, err = s.AddUsers(ctx, id, users)
+	userIDs := []string{"one", "two", "three"}
+	updatedUserIDs, err := s.AddUsers(ctx, id, userIDs)
 	require.NoError(t, err, "setup: failed to add users to test team")
 
-	usersOnTeam, err := s.GetUserIDsForTeam(ctx, id)
-	require.Equal(t, len(users), len(usersOnTeam), "setup: user list size mismatch")
+	require.Equal(t, len(userIDs), len(updatedUserIDs), "setup: user list size mismatch")
 
 	getTeam, err := s.GetTeam(ctx, id)
 	require.NoError(t, err)
@@ -172,20 +171,19 @@ func testGetTeamsForUser(ctx context.Context, t *testing.T, s storage.Storage) {
 
 	initialUsers := []string{"user-for-team-fetch", "two", "three"}
 
-	team, err := s.AddUsers(ctx, id, initialUsers)
+	_, err = s.AddUsers(ctx, id, initialUsers)
 	require.NoError(t, err, "setup: failed to add users to team-1-with-user")
-	team2, err := s.AddUsers(ctx, id2, initialUsers)
+	_, err = s.AddUsers(ctx, id2, initialUsers)
 	require.NoError(t, err, "setup: failed to add users to team-2-with-user")
 	_, err = s.AddUsers(ctx, idWithout, []string{"two", "three"})
 	require.NoError(t, err, "setup: failed to add users to test team-without-user")
 
 	returnedTeams, err := s.GetTeamsForUser(ctx, "user-for-team-fetch")
 	require.NoError(t, err)
-	expectedFetchedTeams := []storage.Team{team, team2}
-	ids := []string{returnedTeams[0].ID, returnedTeams[1].ID}
-	expectedIDs := []string{expectedFetchedTeams[0].ID, expectedFetchedTeams[1].ID}
+	expectedFetchedTeamIDs := []string{id, id2}
+	returnedIDs := []string{returnedTeams[0].ID, returnedTeams[1].ID}
 
-	assert.ElementsMatch(t, ids, expectedIDs) // Comparing the objects wholly will fail due to updated_at :(
+	assert.ElementsMatch(t, expectedFetchedTeamIDs, returnedIDs)
 }
 
 func testPurgeUserMembership(ctx context.Context, t *testing.T, s storage.Storage) {
@@ -207,7 +205,7 @@ func testPurgeUserMembership(ctx context.Context, t *testing.T, s storage.Storag
 	require.NoError(t, err, "setup: failed to add users to team-1-with-user")
 	_, err = s.AddUsers(ctx, id2, initialUsers)
 	require.NoError(t, err, "setup: failed to add users to team-2-with-user")
-	teamWithout, err = s.AddUsers(ctx, idWithout, []string{"two", "three"})
+	_, err = s.AddUsers(ctx, idWithout, []string{"two", "three"})
 	require.NoError(t, err, "setup: failed to add users to test team-without-user")
 
 	updatedTeams, err := s.PurgeUserMembership(ctx, "user-id-to-purge")
@@ -322,16 +320,13 @@ func testAddUsers(ctx context.Context, t *testing.T, s storage.Storage) {
 	_, err := s.StoreTeam(ctx, id, id+" Name", emptyProjectsList)
 	require.NoError(t, err, "setup: failed to create test team")
 
-	users := []string{"one", "two", "three"}
-	team, err := s.AddUsers(ctx, id, users)
-	assert.NotNil(t, team)
+	userIDs := []string{"one", "two", "three"}
+	updatedUserIDs, err := s.AddUsers(ctx, id, userIDs)
+	assert.NotNil(t, updatedUserIDs)
 
-	userIDs, err := s.GetUserIDsForTeam(ctx, id)
-	require.NoError(t, err)
-
-	assert.Equal(t, len(users), len(userIDs), "number of users added does not match")
-	for _, user := range users {
-		assert.Contains(t, userIDs, user, "user %q not added", user)
+	assert.Equal(t, len(userIDs), len(updatedUserIDs), "number of users added does not match")
+	for _, id := range userIDs {
+		assert.Contains(t, updatedUserIDs, id, "user %q not added", id)
 	}
 
 	teams, err := s.GetTeams(ctx)
@@ -343,7 +338,7 @@ func testAddUsers(ctx context.Context, t *testing.T, s storage.Storage) {
 
 	userIDs, err = s.GetUserIDsForTeam(ctx, id)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, users, userIDs)
+	assert.ElementsMatch(t, userIDs, userIDs)
 }
 
 func testAddUsersNotFound(ctx context.Context, t *testing.T, s storage.Storage) {
@@ -395,14 +390,13 @@ func testRemoveUsersNotFound(ctx context.Context, t *testing.T, s storage.Storag
 
 func testGetTeam(ctx context.Context, t *testing.T, s storage.Storage) {
 	id := "id"
-	_, err := s.StoreTeam(ctx, id, "name", emptyProjectsList)
+	name := "name"
+	team, err := s.StoreTeam(ctx, id, name, emptyProjectsList)
 	require.NoError(t, err, "setup: failed to store team")
 	one, two, three := "one", "two", "three"
-	users := []string{one, two, three}
-	team, err := s.AddUsers(ctx, id, users)
+	addUserIDs := []string{one, two, three}
+	_, err = s.AddUsers(ctx, id, addUserIDs)
 	require.NoError(t, err, "setup: failed to add users to test team")
-	userIDs, err := s.GetUserIDsForTeam(ctx, id)
-	require.Equal(t, len(users), len(userIDs), "setup: user list size mismatch")
 
 	getTeam, err := s.GetTeam(ctx, id)
 	getTeamUserIDs, err := s.GetUserIDsForTeam(ctx, id)
@@ -412,7 +406,7 @@ func testGetTeam(ctx context.Context, t *testing.T, s storage.Storage) {
 	assert.WithinDuration(t, team.CreatedAt, getTeam.CreatedAt, 50*time.Millisecond)
 	assert.Equal(t, team.Name, getTeam.Name)
 	assert.Equal(t, team.ID, getTeam.ID)
-	assert.Equal(t, userIDs, getTeamUserIDs)
+	assert.Equal(t, addUserIDs, getTeamUserIDs)
 }
 
 func testGetTeamNotFound(ctx context.Context, t *testing.T, s storage.Storage) {
@@ -425,12 +419,10 @@ func testGetTeamImmutable(ctx context.Context, t *testing.T, s storage.Storage) 
 	_, err := s.StoreTeam(ctx, id, "name", emptyProjectsList)
 	require.NoError(t, err, "setup: failed to store team")
 	one, two, three := "one", "two", "three"
-	users := []string{one, two, three}
-	_, err = s.AddUsers(ctx, id, users)
+	userIDs := []string{one, two, three}
+	updatedUserIDs, err := s.AddUsers(ctx, id, userIDs)
 	require.NoError(t, err, "setup: failed to add users to test team")
-	userIDs, err := s.GetUserIDsForTeam(ctx, id)
-	require.NoError(t, err)
-	require.Equal(t, len(users), len(userIDs), "setup: user list size mismatch")
+	require.Equal(t, len(userIDs), len(updatedUserIDs), "setup: user list size mismatch")
 }
 
 func testGetTeams(ctx context.Context, t *testing.T, s storage.Storage) {

--- a/components/teams-service/storage/memstore/memstore.go
+++ b/components/teams-service/storage/memstore/memstore.go
@@ -126,18 +126,18 @@ func (m *memstore) EditTeam(ctx context.Context,
 }
 
 // AddUsers adds an array of user IDs to a team's map of user IDs
-func (m *memstore) AddUsers(ctx context.Context, id string, userIDs []string) (storage.Team, error) {
+func (m *memstore) AddUsers(ctx context.Context, id string, userIDs []string) ([]string, error) {
 	team, teamFound := m.teams[id]
 	if !teamFound {
-		return storage.Team{}, storage.ErrNotFound
+		return []string{}, storage.ErrNotFound
 	}
 	if !projectsIntersect(ctx, team) {
-		return storage.Team{}, storage.ErrNotFound
+		return []string{}, storage.ErrNotFound
 	}
 
 	teamUserIDs, usersFound := m.usersByTeam[id]
 	if !usersFound {
-		return storage.Team{}, storage.ErrNotFound
+		return []string{}, storage.ErrNotFound
 	}
 
 	for _, userID := range userIDs {
@@ -147,23 +147,26 @@ func (m *memstore) AddUsers(ctx context.Context, id string, userIDs []string) (s
 	}
 
 	m.usersByTeam[id] = teamUserIDs
-	return copyTeam(team), nil
+
+	updatedTeamUsers := m.usersByTeam[id]
+
+	return updatedTeamUsers, nil
 }
 
 // RemoveUsers updates team membership by removing all users from a team it can
 // find that are currently members.
-func (m *memstore) RemoveUsers(ctx context.Context, id string, userIDs []string) (storage.Team, error) {
+func (m *memstore) RemoveUsers(ctx context.Context, id string, userIDs []string) ([]string, error) {
 	team, ok := m.teams[id]
 	if !ok {
-		return storage.Team{}, storage.ErrNotFound
+		return []string{}, storage.ErrNotFound
 	}
 	if !projectsIntersect(ctx, team) {
-		return storage.Team{}, storage.ErrNotFound
+		return []string{}, storage.ErrNotFound
 	}
 
 	teamUserIDs, usersFound := m.usersByTeam[id]
 	if !usersFound {
-		return storage.Team{}, storage.ErrNotFound
+		return []string{}, storage.ErrNotFound
 	}
 
 	for _, userID := range userIDs {
@@ -171,7 +174,9 @@ func (m *memstore) RemoveUsers(ctx context.Context, id string, userIDs []string)
 	}
 
 	m.usersByTeam[id] = teamUserIDs
-	return copyTeam(team), nil
+	updatedTeamUsers := m.usersByTeam[id]
+
+	return updatedTeamUsers, nil
 }
 
 // PurgeUserMembership finds all teams the given user is a member of and

--- a/components/teams-service/storage/memstore/memstore.go
+++ b/components/teams-service/storage/memstore/memstore.go
@@ -125,7 +125,7 @@ func (m *memstore) EditTeam(ctx context.Context,
 	return copyTeam(team), nil
 }
 
-// AddUsers adds an array of user IDs to a team's map of user IDs
+// AddUsers updates team membership to include the given list of users.
 func (m *memstore) AddUsers(ctx context.Context, id string, userIDs []string) ([]string, error) {
 	team, teamFound := m.teams[id]
 	if !teamFound {

--- a/components/teams-service/storage/storage.go
+++ b/components/teams-service/storage/storage.go
@@ -12,10 +12,10 @@ import (
 type Storage interface {
 	GetTeams(context.Context) ([]Team, error)
 	StoreTeam(ctx context.Context, id string, name string, projects []string) (Team, error)
-	RemoveUsers(ctx context.Context, id string, userIDs []string) (Team, error)
+	RemoveUsers(ctx context.Context, id string, userIDs []string) ([]string, error)
 	GetTeam(ctx context.Context, id string) (Team, error)
 	PurgeUserMembership(ctx context.Context, userID string) (teamsUpdated []string, err error)
-	AddUsers(ctx context.Context, id string, userIDs []string) (Team, error)
+	AddUsers(ctx context.Context, id string, userIDs []string) ([]string, error)
 	GetTeamsForUser(ctx context.Context, userID string) ([]Team, error)
 	GetUserIDsForTeam(ctx context.Context, id string) ([]string, error)
 	DeleteTeam(ctx context.Context, id string) (Team, error)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

doin' this TODO:
```
// TODO (tc): Get the updated set of user membership for the team since	
// that is not what is returned from AddUsers for some reason	
// (can refactor on V1 deprecation).
```

### :chains: Related Resources
follows: https://github.com/chef/automate/pull/3361

### :+1: Definition of Done

- [x] AddUsers and RemoveUsers storage functions always return the final updated list of user IDs, instead of the Team object
- [x] AddUsers and RemoveUsers server functions only need to make one storage call instead of multiple

### :athletic_shoe: How to Build and Test the Change

- `rebuild components/teams-service`
- add and remove users from the API or UI. everything should work as usual

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).