### PR TITLE
Only HTTPS on API

### DIFF
--- a/components/automate-chef-io/data/docs/api-static/00-meta.swagger.json
+++ b/components/automate-chef-io/data/docs/api-static/00-meta.swagger.json
@@ -20,7 +20,6 @@
   "host": "automate.chef.io",
   "basePath": "/api",
   "schemes": [
-    "http",
     "https"
   ],
   "consumes": [


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

Removes `http` from the schema.

<img width="393" alt="Screen Shot 2020-04-17 at 3 55 22 PM" src="https://user-images.githubusercontent.com/4400151/79620158-e0664c00-80c3-11ea-8acc-4f92e89b07e3.png">
