### PR TITLE
Add `v0` to API path

### DIFF
--- a/components/automate-chef-io/data/docs/api-static/00-meta.swagger.json
+++ b/components/automate-chef-io/data/docs/api-static/00-meta.swagger.json
@@ -18,7 +18,7 @@
     }
   },
   "host": "automate.chef.io",
-  "basePath": "/api",
+  "basePath": "/api/v0",
   "schemes": [
     "http",
     "https"


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

This is the quick-fix, until we sort out API versioning in the front-end.

<img width="351" alt="Screen Shot 2020-04-17 at 4 25 43 PM" src="https://user-images.githubusercontent.com/4400151/79621488-756b4400-80c8-11ea-912a-898070edf418.png">
