### PR TITLE
 fix ssm jobs

### DIFF
--- a/components/compliance-service/compliance.go
+++ b/components/compliance-service/compliance.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/chef/automate/api/external/secrets"
-	auth "github.com/chef/automate/api/interservice/authn"
+	authn "github.com/chef/automate/api/interservice/authn"
 	iam_v2 "github.com/chef/automate/api/interservice/authz/v2"
 	"github.com/chef/automate/api/interservice/compliance/ingest/ingest"
 	"github.com/chef/automate/api/interservice/compliance/jobs"
@@ -474,7 +474,7 @@ func setupDataLifecyclePurgeInterface(ctx context.Context, connFactory *secureco
 func setup(ctx context.Context, connFactory *secureconn.Factory, conf config.Compliance,
 	esr relaxting.ES2Backend, db *pgdb.DB, cerealManager *cereal.Manager) error {
 	var err error
-	var conn, mgrConn, secretsConn, authConn *grpc.ClientConn
+	var conn, mgrConn, secretsConn, authnConn, authzConn *grpc.ClientConn
 	timeoutCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
@@ -554,22 +554,36 @@ func setup(ctx context.Context, connFactory *secureconn.Factory, conf config.Com
 	} else {
 		// get the authn-service connection
 		logrus.Debugf("compliance setup, dialing authn-service(%s)", conf.InspecAgent.AuthnTarget)
-		authConn, err = connFactory.DialContext(timeoutCtx, "authn-service", conf.InspecAgent.AuthnTarget,
+		authnConn, err = connFactory.DialContext(timeoutCtx, "authn-service", conf.InspecAgent.AuthnTarget,
 			grpc.WithBlock())
-		if err != nil || authConn == nil {
+		if err != nil || authnConn == nil {
 			err = errors.New("compliance setup, error grpc dialing to authn aborting...")
 			return err
 		}
 		// get the authn client
-		authClient := auth.NewTokensMgmtClient(authConn)
-		if authClient == nil {
+		authnClient := authn.NewTokensMgmtClient(authnConn)
+		if authnClient == nil {
 			logrus.Errorf("serveGrpc got nil for NewTokensMgmtClient: %s", err)
+			return err
+		}
+		// get authz connection
+		authzConn, err = connFactory.DialContext(timeoutCtx, "authz-service", fmt.Sprintf("%s:%d", conf.Authz.HostBind, conf.Authz.Port),
+			grpc.WithBlock())
+		if err != nil || authzConn == nil {
+			err = errors.New("compliance setup, error grpc dialing to authz aborting...")
+			return err
+		}
+		// get the authz client
+		authzClient := iam_v2.NewPoliciesClient(authzConn)
+		if authzClient == nil {
+			logrus.Errorf("serveGrpc got nil for NewPoliciesClient: %s", err)
 			return err
 		}
 		// in order to execute scan jobs remotely (i.e. on a different server, reporting back out
 		// to automate), we need access to the auth client for a token and the automate fqdn for reporting
 		remote.RemoteJobInfo = remote.RemoteJob{
-			TokensMgmtClient: authClient,
+			PoliciesClient:   authzClient,
+			TokensMgmtClient: authnClient,
 			AutomateFQDN:     conf.InspecAgent.AutomateFQDN,
 		}
 	}

--- a/components/compliance-service/inspec-agent/remote/remote.go
+++ b/components/compliance-service/inspec-agent/remote/remote.go
@@ -38,7 +38,7 @@ func RunSSMJob(ctx context.Context, ssmJob *types.InspecJob) *inspec.Error {
 		return translateToInspecErr(fmt.Errorf("unable to connect to auth client: aborting job run for job %+v", ssmJob))
 	}
 	tokenID := fmt.Sprintf("inspec-to-automate-scanjob-%s", ssmJob.JobID)
-	ctx = auth_context.NewOutgoingContext(auth_context.NewContext(ctx, []string{"tls:service:deployment-service:internal"}, []string{}, "", ""))
+	ctx = auth_context.NewOutgoingContext(auth_context.NewContext(ctx, []string{"tls:service:compliance-service:internal"}, []string{}, "", ""))
 	token, err := RemoteJobInfo.TokensMgmtClient.CreateToken(ctx, &authn.CreateTokenReq{
 		Id:     tokenID,
 		Name:   tokenID,

--- a/components/compliance-service/inspec-agent/remote/remote.go
+++ b/components/compliance-service/inspec-agent/remote/remote.go
@@ -13,13 +13,17 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/chef/automate/api/interservice/authn"
+	"github.com/chef/automate/api/interservice/authz/v2"
+	"github.com/chef/automate/components/authz-service/constants"
 	"github.com/chef/automate/components/compliance-service/inspec"
 	"github.com/chef/automate/components/compliance-service/inspec-agent/types"
 	"github.com/chef/automate/components/nodemanager-service/managers"
+	"github.com/chef/automate/lib/grpc/auth_context"
 )
 
 type RemoteJob struct {
 	TokensMgmtClient authn.TokensMgmtClient
+	PoliciesClient   v2.PoliciesClient
 	AutomateFQDN     string
 }
 
@@ -29,16 +33,28 @@ func RunSSMJob(ctx context.Context, ssmJob *types.InspecJob) *inspec.Error {
 	logrus.Debugf("Running ssm job: %+v", ssmJob)
 	// 1. CREATE TOKEN
 	// this is needed to hand over to inspec so it can report to automate
-	if RemoteJobInfo.TokensMgmtClient == nil {
+	if RemoteJobInfo.TokensMgmtClient == nil || RemoteJobInfo.PoliciesClient == nil {
 		logrus.Error("unable to create auth token")
 		return translateToInspecErr(fmt.Errorf("unable to connect to auth client: aborting job run for job %+v", ssmJob))
 	}
+	tokenID := fmt.Sprintf("inspec-to-automate-scanjob-%s", ssmJob.JobID)
+	ctx = auth_context.NewOutgoingContext(auth_context.NewContext(ctx, []string{"tls:service:deployment-service:internal"}, []string{}, "", ""))
 	token, err := RemoteJobInfo.TokensMgmtClient.CreateToken(ctx, &authn.CreateTokenReq{
-		Name:   "token for inspec to report to automate",
+		Id:     tokenID,
+		Name:   tokenID,
 		Active: true,
 	})
 	if err != nil {
-		logrus.Errorf("unable to create auth token for reporting to automate: %s", err.Error())
+		logrus.Errorf("unable to create auth token for reporting to automate; aborting job %s: %s", ssmJob.JobName, err.Error())
+		return translateToInspecErr(err)
+	}
+	// add token to ingest policy
+	_, err = RemoteJobInfo.PoliciesClient.AddPolicyMembers(ctx, &v2.AddPolicyMembersReq{
+		Id:      constants.IngestPolicyID,
+		Members: []string{fmt.Sprintf("token:%s", tokenID)},
+	})
+	if err != nil {
+		logrus.Errorf("unable to add token to ingest policy for reporting to automate; aborting job %s: %s", ssmJob.JobName, err.Error())
 		return translateToInspecErr(err)
 	}
 	ssmJob.Reporter.Token = token.GetValue()


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
we now have to add a token to an ingest policy after creation for that token to be a valid ingest token; this change makes that happen

### :chains: Related Resources
https://github.com/chef/automate/issues/3394

### :+1: Definition of Done
tokens created for ssm jobs work

### :athletic_shoe: How to Build and Test the Change
to truly test this, you need to bring up the dev env in aws and create an ec2 node integration, then try scanning some ssm nodes

the other way to test locally is to call the runssmjob function from the regular scan job path, log the token, and then ensure the token works for sending in a report and fetching a profile

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
