### PR TITLE
fix margin on chef automate logo in api docs

### DIFF
--- a/components/automate-chef-io/layouts/_default/data-api.html
+++ b/components/automate-chef-io/layouts/_default/data-api.html
@@ -15,6 +15,10 @@
         margin: 0;
         padding: 0;
       }
+      redoc[spec-url] a img[src^="/images/chef-automate-logo.svg"] {
+        width: 220px;
+        margin: 20px;
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
the lack of margin on the logo has literally been driving me wild
this fixes it
if you want me to fix it a different way just let me know, happy to adjust

### :chains: Related Resources
zero.

### :+1: Definition of Done
the logo has a margin
everything else is still the same

### :athletic_shoe: How to Build and Test the Change
`make serve` from `components/automate-chef-io`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
#### before
<img width="364" alt="before" src="https://user-images.githubusercontent.com/5489125/79662355-69838e80-8169-11ea-86cc-10c0f3fff4d0.png">

#### after
<img width="340" alt="after" src="https://user-images.githubusercontent.com/5489125/79662454-70120600-8169-11ea-8f25-40d2cdd35fa6.png">
