### PR TITLE
fix usability of return to docs button for api docs

### DIFF
--- a/components/automate-chef-io/layouts/_default/data-api.html
+++ b/components/automate-chef-io/layouts/_default/data-api.html
@@ -26,16 +26,16 @@
           background: #EF9600;
           display: block;
           text-align: center;
-          width: 228px;
-          margin: 1rem 0 1.5rem 16px;
+          width: 260px;
           padding: 8px 0;
           color: white;
           text-decoration: none;
           font-family: montserrat;
           font-size: 14px;
+          position: fixed;
+          z-index: 1;
         " href='/docs'>Return to Docs</a>
-    <ReDoc spec-url="/api-docs/all-apis.swagger.json"></ReDoc>
+    <ReDoc spec-url="/api-docs/all-apis.swagger.json" scroll-y-offset="34"></ReDoc>
     <script src="/redoc.standalone.js"></script>
   </body>
 </html>
-


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Previously, there were a few usability concerns with the return to docs button. (1) the left-nav would not scroll all the way to the bottom until you forced it, which hid content (2) you could only ever access the button when you were at the very top of the page.

This pr attempts to address both of those issues. The solution uses the `scroll-y-offset` option provided by redoc to offset the left nav, fixes the button to the page, and also improves the visual style of the button.

I am open to feedback if anyone has concerns, my motivations are to improve the usability.

### :chains: Related Resources
None.

### :+1: Definition of Done
The user experience of the return to docs button on the api docs is improved.

### :athletic_shoe: How to Build and Test the Change
_Note: The logo is fixed in #3422 so what you see prolly wont match the screenshot until that merges._ 
`make serve` from `components/automate-chef-io`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
<img width="518" alt="return-to-docs-button" src="https://user-images.githubusercontent.com/5489125/79671692-31884580-8181-11ea-82c9-84bd734ed51c.png">
