### PR TITLE
Treat UI unit test warnings as errors

### DIFF
--- a/components/automate-ui/package.json
+++ b/components/automate-ui/package.json
@@ -15,7 +15,7 @@
     "copy-ui-lib:fonts": "cp -r ../chef-ui-library/dist/collection/assets/fonts/ src/assets/fonts",
     "build": "ng build",
     "build:prod": "npm run build -- --prod",
-    "test": "ng test --watch=false --code-coverage --source-map=false --configuration=no_auth",
+    "test": "/bin/bash -c 'exec 5>&1; t1=$(ng test --watch=false --code-coverage --source-map=false --configuration=no_auth | tee /dev/fd/5; exit ${PIPESTATUS[0]}); if [ $? -ne 0 ]; then exit 1; else echo $t1 | grep 'WARN:' >/dev/null; test $? -ne 0; fi'",
     "test:watch": "ng test --watch=true --browsers='Chrome' --source-map=true --configuration=no_auth",
     "e2e": "ng e2e --no-webdriver-update",
     "lint": "ng lint",

--- a/components/automate-ui/package.json
+++ b/components/automate-ui/package.json
@@ -15,7 +15,7 @@
     "copy-ui-lib:fonts": "cp -r ../chef-ui-library/dist/collection/assets/fonts/ src/assets/fonts",
     "build": "ng build",
     "build:prod": "npm run build -- --prod",
-    "test": "/bin/bash -c 'exec 5>&1; t1=$(ng test --watch=false --code-coverage --source-map=false --configuration=no_auth | tee /dev/fd/5; exit ${PIPESTATUS[0]}); if [ $? -ne 0 ]; then exit 1; else echo $t1 | grep 'WARN:' >/dev/null; test $? -ne 0; fi'",
+    "test": "scripts/unit-tests.sh",
     "test:watch": "ng test --watch=true --browsers='Chrome' --source-map=true --configuration=no_auth",
     "e2e": "ng e2e --no-webdriver-update",
     "lint": "ng lint",

--- a/components/automate-ui/scripts/unit-tests.sh
+++ b/components/automate-ui/scripts/unit-tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# The build machine is using sh; need to use bash to be able to use PIPESTATUS.
+
+# Setup an unused stream to redirect to stdout in the next command.
+exec 5>&1
+# We want to capture the `ng test` output to reuse it (rather than have to re-run the command),
+# so sending to an unused stream and redirecting that to stdout (stream 1) where it can be captured into the `out` variable.
+# In order to check the exit code of the `ng test` itself, need to use PIPESTATUS
+# to grab the exit code of the first pipe component rather than the final one.
+out=$(ng test --watch=false --code-coverage --source-map=false --configuration=no_auth | tee /dev/fd/5; exit "${PIPESTATUS[0]}")
+
+# If the unit test run reported non-zero--an actual unit test error--then exit with non-zero return code.
+# shellcheck disable=SC2181
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
+# If no errors, next check for any warnings.
+echo "$out" | grep 'WARN:' >/dev/null
+
+# Return a non-zero exit code if any warnings present.
+# $? will be 0 if warnings were found, so `test` inverts that result.
+test $? -ne 0


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

With unit test warnings not causing build failures, it is easy to either postpone fixing them indefinitely or possibly not even notice them in the first place. This somewhat complex machination adjusts the unit test run so that not only _errors_ but _warnings_ will now also generate a non-zero exit code.

Chances are there is a flag or switch somewhere to "treat warnings as errors" but I could not find it with angular or karma or jasmine... so I went with what I knew would work, because I have used it before.

### :chains: Related Resources
#3397 Fix unit test "failures"

### :+1: Definition of Done
Unit test warnings return a non-zero exit code, forcing a build failure.

### :athletic_shoe: How to Build and Test the Change

#### Prior to this PR

##### Case 1: No errors or warnings

Pay particular attention to the very last line of output:
```
0 ✓ (1m17s) 18:54:33 automate-ui (master) $ npm run test

> automate-ui@0.0.0 test2 /Users/msorens/code/go/src/github.com/chef/automate/components/automate-ui
> /bin/bash -c 'exec 5>&1; t1=$(ng test --watch=false --code-coverage --source-map=false --configuration=no_auth | tee /dev/fd/5; exit ${PIPESTATUS[0]}); if [ $? -ne 0 ]; then exit 1; else echo $t1 | grep 'WARN:' >/dev/null; test $? -ne 0; fi'

18 04 2020 18:58:38.425:INFO [karma-server]: Karma v4.4.1 server started at http://0.0.0.0:9876/
18 04 2020 18:58:38.427:INFO [launcher]: Launching browsers ChromeHeadless with concurrency unlimited
18 04 2020 18:58:38.607:INFO [launcher]: Starting browser ChromeHeadless
18 04 2020 18:59:03.838:INFO [HeadlessChrome 80.0.3987 (Mac OS X 10.14.6)]: Connected on socket ErbB527bDCQ59zrtAAAA with id 65774247
..............
HeadlessChrome 80.0.3987 (Mac OS X 10.14.6): Executed 14 of 1488 (skipped 1474) SUCCESS (2.774 secs / 0.482 secs)
TOTAL: 14 SUCCESS
TOTAL: 14 SUCCESS
18 04 2020 18:59:21.985:WARN [launcher]: ChromeHeadless was not killed in 2000 ms, sending SIGKILL.
0 ✓ (4m49s) 18:59:22 automate-ui (master) $ 
```
The last line above, because of my prompt configuration, shows the exit code from the just-finished command as the very first item on the line, followed by a checkmark, which is just duplicating the 0 in a more graphic format. You may, of course, not have your shell configured that way, so just do `echo $?` as the next command to confirm that the return code is, in fact, zero.

##### Case 2: Warnings present

Now let's generate a unit test warning. Here's one:
<img width="547" alt="image" src="https://user-images.githubusercontent.com/6817500/79677760-6c05d880-81a9-11ea-99e9-c7e85f8b6b42.png">

And here is what the run looks like:
```
0 ✓ (18.3s) 18:45:19 automate-ui (master) $ npm run test

> automate-ui@0.0.0 test /Users/msorens/code/go/src/github.com/chef/automate/components/automate-ui
> ng test --watch=false --code-coverage --source-map=false --configuration=no_auth
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'

. . .
< abbreviated output >
. . .

WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
.
HeadlessChrome 80.0.3987 (Mac OS X 10.14.6): Executed 14 of 1488 (skipped 1474) SUCCESS (2.826 secs / 0.573 secs)
TOTAL: 14 SUCCESS
TOTAL: 14 SUCCESS
18 04 2020 18:53:15.280:WARN [launcher]: ChromeHeadless was not killed in 2000 ms, sending SIGKILL.
0 ✓ (7m56s) 18:53:15 automate-ui (master) $
```
Again notice the zero return code, indicating success, even though there are warnings present.

#### With this PR

##### Case 1: No errors or warnings

Identical to above. Zero return code, as it should.

##### Case 2: Warnings present

Notice the last few lines now express an error condition and on the very last line, in front of the prompt, you see a non-zero return code (1) and a cross. Again echo $? will also show the 1 return code.

```
0 ✓ (18.3s) 18:45:19 automate-ui (master) $ npm run test

> automate-ui@0.0.0 test /Users/msorens/code/go/src/github.com/chef/automate/components/automate-ui
> ng test --watch=false --code-coverage --source-map=false --configuration=no_auth
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'

. . .
< abbreviated output >
. . .

WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
WARN: 'Can't bind to 'resetCheckboxEvent' since it isn't a known property of 'app-create-object-modal'.'
.
HeadlessChrome 80.0.3987 (Mac OS X 10.14.6): Executed 14 of 1488 (skipped 1474) SUCCESS (2.826 secs / 0.573 secs)
TOTAL: 14 SUCCESS
TOTAL: 14 SUCCESS
18 04 2020 18:53:15.280:WARN [launcher]: ChromeHeadless was not killed in 2000 ms, sending SIGKILL.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! automate-ui@0.0.0 test2: `/bin/bash -c 'exec 5>&1; t1=$(ng test --watch=false --code-coverage --source-map=false --configuration=no_auth | tee /dev/fd/5; exit ${PIPESTATUS[0]}); if [ $? -ne 0 ]; then exit 1; else echo $t1 | grep 'WARN:' >/dev/null; test $? -ne 0; fi'`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the automate-ui@0.0.0 test2 script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/msorens/.npm/_logs/2020-04-19T01_54_33_009Z-debug.log
1 ✗ (1m17s) 18:54:33 automate-ui (master) $ 
```

##### Case 3: No warnings present but actual error present

Let us also confirm that a failure is still a failure. Oh, here's one:

<img width="538" alt="image" src="https://user-images.githubusercontent.com/6817500/79795465-d1241000-8308-11ea-8045-26e9d9288c23.png">


The output looks like this, and reports a non-zero return code:
```
0 ✓ (4m49s) 18:59:22 automate-ui (master) $ npm run test

> automate-ui@0.0.0 test2 /Users/msorens/code/go/src/github.com/chef/automate/components/automate-ui
> /bin/bash -c 'exec 5>&1; t1=$(ng test --watch=false --code-coverage --source-map=false --configuration=no_auth | tee /dev/fd/5; exit ${PIPESTATUS[0]}); if [ $? -ne 0 ]; then exit 1; else echo $t1 | grep 'WARN:' >/dev/null; test $? -ne 0; fi'

.............
HeadlessChrome 80.0.3987 (Mac OS X 10.14.6) ProjectListComponent when there are no projects displays no projects FAILED
	Error: Expected 0 to be 1.
	    at <Jasmine>
	    at SafeSubscriber._next (http://localhost:9876/_karma_webpack_/main.js:268537:40)
	    at SafeSubscriber.__tryOrUnsub (http://localhost:9876/_karma_webpack_/vendor.js:328006:16)
	    at SafeSubscriber.next (http://localhost:9876/_karma_webpack_/vendor.js:327945:22)
HeadlessChrome 80.0.3987 (Mac OS X 10.14.6): Executed 14 of 1488 (1 FAILED) (skipped 1474) (2.632 secs / 0.476 secs)
TOTAL: 1 FAILED, 13 SUCCESS
TOTAL: 1 FAILED, 13 SUCCESS
18 04 2020 19:00:51.978:WARN [launcher]: ChromeHeadless was not killed in 2000 ms, sending SIGKILL.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! automate-ui@0.0.0 test2: `/bin/bash -c 'exec 5>&1; t1=$(ng test --watch=false --code-coverage --source-map=false --configuration=no_auth | tee /dev/fd/5; exit ${PIPESTATUS[0]}); if [ $? -ne 0 ]; then exit 1; else echo $t1 | grep 'WARN:' >/dev/null; test $? -ne 0; fi'`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the automate-ui@0.0.0 test2 script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/msorens/.npm/_logs/2020-04-19T02_00_52_113Z-debug.log
1 ✗ (1m29s) 19:00:52 automate-ui (master) $
```

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

