### PR TITLE
Move desktop dashboard to top-level route

### DIFF
--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -272,7 +272,7 @@ const routes: Routes = [
       ]
     },
     {
-      path: 'dashboards/desktop',
+      path: 'desktop',
       loadChildren: () => import('./modules/desktop/desktop.module').then(m => m.DesktopModule)
     },
     {

--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -123,4 +123,8 @@ export class LayoutFacadeService {
   showSidebar(sidebarName: string) {
     this.layoutSidebarService.updateSidebars(sidebarName);
   }
+
+  hideSidebar() {
+    this.layout.sidebar.display = false;
+  }
 }

--- a/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.ts
@@ -4,6 +4,7 @@ import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { map, filter } from 'rxjs/operators';
 import { last, reverse } from 'lodash/fp';
+import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 
 import {
   GetDailyCheckInTimeSeries,
@@ -62,7 +63,8 @@ export class DashboardComponent implements OnInit {
   public insightVisible = false;
 
   constructor(
-    private store: Store<NgrxStateAtom>
+    private store: Store<NgrxStateAtom>,
+    private layoutFacade: LayoutFacadeService
   ) { }
 
   ngOnInit() {
@@ -151,6 +153,8 @@ export class DashboardComponent implements OnInit {
       this.store.select(unknownDesktopDurationCounts).pipe(
       map(counts => counts.updated)
     );
+
+    setTimeout(() => this.layoutFacade.hideSidebar());
   }
 
   handleDaysAgoChange(daysAgo: number) {


### PR DESCRIPTION
- Moved `/dashboards/desktop` to `/desktop`. Desktop dashboard will be a top-level route with its own link in the top-level navbar.
- Removed the sidebar in desktop dashboard view. Desktop dashboard will be a full-width view.

Before
<img width="1060" alt="Screen Shot 2020-04-20 at 12 22 50 PM" src="https://user-images.githubusercontent.com/479121/79786602-f7df4800-8302-11ea-87e7-e7eaeb61fa81.png">

After
<img width="1060" alt="Screen Shot 2020-04-20 at 12 21 32 PM" src="https://user-images.githubusercontent.com/479121/79786629-ff065600-8302-11ea-990f-0f1a3f5680e1.png">
