### PR TITLE
Global Projects Filter: Disable Apply Changes when No changes are present

### DIFF
--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -21,7 +21,8 @@
           <input
             chefInput
             type="text"
-            (keyup)="handleFilterKeyUp($event.target.value)"
+            #filter
+            (keyup)="handleFilterKeyUp(filter.value)"
             placeholder="Filter projects..." />
         </div>
 

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { cloneDeep } from 'lodash/fp';
+import { cloneDeep, isEqual } from 'lodash/fp';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
 import { ProjectConstants } from 'app/entities/projects/project.model';
 
@@ -32,8 +32,8 @@ export class ProjectsFilterDropdownComponent {
   // Filtered options is merely a copy of the editable options
   // so they can be filtered while maintaining the actual options.
   filteredOptions: ProjectsFilterOption[] = [];
-  // InitialFilters holds a copy of the initial state of filtered Options
-  initialFilters: ProjectsFilterOption[] = [];
+  // InitialFilters holds a boolean copy of the initial checked/unchecked state of filtered Options
+  initialFilters: boolean[] = [];
 
   optionsEdited = false;
 
@@ -44,7 +44,7 @@ export class ProjectsFilterDropdownComponent {
       this.filteredOptions = this.editableOptions = cloneDeep(this.options);
       // Keep a reference to the filteredOptions in initialFilters
       // to check deep equality when a user unchecks/checks same button
-      this.initialFilters = cloneDeep(this.filteredOptions);
+      this.initialFilters = this.filteredOptions.map(option => option.checked);
     }
   }
 
@@ -117,11 +117,13 @@ export class ProjectsFilterDropdownComponent {
     }
   }
 
-  checkInitialEquality(): void {
-    // Check for deep equality against new changes, disabling
+  checkInitialEquality() {
+    // Check for equality against new changes, disabling
     // apply button if changes are not new
-    JSON.stringify(this.initialFilters) === JSON.stringify(this.editableOptions)
-      ? this.optionsEdited = false
-      : this.optionsEdited = true;
+
+    // create a copy of checked/unchecked in most recently edited options
+    const currentEdits: boolean[] = this.editableOptions.map(option => option.checked);
+
+    this.optionsEdited = !isEqual(this.initialFilters, currentEdits);
   }
 }

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -79,9 +79,7 @@ export class ProjectsFilterDropdownComponent {
 
     // Check for deep equality against new changes, disabling
     // apply button if changes are not new
-    JSON.stringify(this.initialFilters) === JSON.stringify(this.editableOptions)
-      ? this.optionsEdited = false
-      : this.optionsEdited = true;
+    this.checkInitialEquality();
   }
 
   handleApplySelection() {
@@ -92,14 +90,13 @@ export class ProjectsFilterDropdownComponent {
   }
 
   handleClearSelection() {
-    // TODO: Should ideally set to true only when some projects were selected upon opening
-    this.optionsEdited = true; // mark as edited
-
     // clear only entries visible by current filter
     // TODO: Micro-optimization: use a hash to convert this O(n^2) to O(n).
     this.editableOptions
       .filter(option => this.filteredOptions.find(o => o.label === option.label))
       .map(option => option.checked = false);
+
+    this.checkInitialEquality();
   }
 
   handleArrowUp(event: KeyboardEvent) {
@@ -118,5 +115,13 @@ export class ProjectsFilterDropdownComponent {
     if (element) {
       (element as HTMLElement).focus();
     }
+  }
+
+  checkInitialEquality(): void {
+    // Check for deep equality against new changes, disabling
+    // apply button if changes are not new
+    JSON.stringify(this.initialFilters) === JSON.stringify(this.editableOptions)
+      ? this.optionsEdited = false
+      : this.optionsEdited = true;
   }
 }

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -28,11 +28,12 @@ export class ProjectsFilterDropdownComponent {
   @Output() onSelection = new EventEmitter<ProjectsFilterOption[]>();
   @Output() onOptionChange = new EventEmitter<ProjectsFilterOption[]>();
 
-  lastEdit: ProjectsFilterOption[] = [];
   editableOptions: ProjectsFilterOption[] = [];
   // Filtered options is merely a copy of the editable options
   // so they can be filtered while maintaining the actual options.
   filteredOptions: ProjectsFilterOption[] = [];
+  // InitialFilters holds a copy of the initial state of filtered Options
+  initialFilters: ProjectsFilterOption[] = [];
 
   optionsEdited = false;
 
@@ -41,9 +42,9 @@ export class ProjectsFilterDropdownComponent {
   resetOptions() {
     if (!this.optionsEdited) {
       this.filteredOptions = this.editableOptions = cloneDeep(this.options);
-      // Keep a reference to the initial filteredOptions
-      // in lastEdit to check deep equality when a user unchecks/checks same button
-      this.lastEdit = cloneDeep(this.filteredOptions);
+      // Keep a reference to the filteredOptions in initialFilters
+      // to check deep equality when a user unchecks/checks same button
+      this.initialFilters = cloneDeep(this.filteredOptions);
     }
   }
 
@@ -77,8 +78,8 @@ export class ProjectsFilterDropdownComponent {
       .find(option => option.label === label).checked = event.detail;
 
     // Check for deep equality against new changes, disabling
-    // applly button if changes are not new
-    JSON.stringify(this.lastEdit) === JSON.stringify(this.editableOptions)
+    // apply button if changes are not new
+    JSON.stringify(this.initialFilters) === JSON.stringify(this.editableOptions)
       ? this.optionsEdited = false
       : this.optionsEdited = true;
   }

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -28,6 +28,7 @@ export class ProjectsFilterDropdownComponent {
   @Output() onSelection = new EventEmitter<ProjectsFilterOption[]>();
   @Output() onOptionChange = new EventEmitter<ProjectsFilterOption[]>();
 
+  lastEdit: ProjectsFilterOption[] = [];
   editableOptions: ProjectsFilterOption[] = [];
   // Filtered options is merely a copy of the editable options
   // so they can be filtered while maintaining the actual options.
@@ -40,6 +41,9 @@ export class ProjectsFilterDropdownComponent {
   resetOptions() {
     if (!this.optionsEdited) {
       this.filteredOptions = this.editableOptions = cloneDeep(this.options);
+      // Keep a reference to the initial filteredOptions
+      // in lastEdit to check deep equality when a user unchecks/checks same button
+      this.lastEdit = cloneDeep(this.filteredOptions);
     }
   }
 
@@ -71,7 +75,12 @@ export class ProjectsFilterDropdownComponent {
     // sets the new state of the specific checkbox
     this.editableOptions
       .find(option => option.label === label).checked = event.detail;
-    this.optionsEdited = true;
+
+    // Check for deep equality against new changes, disabling
+    // applly button if changes are not new
+    JSON.stringify(this.lastEdit) === JSON.stringify(this.editableOptions)
+      ? this.optionsEdited = false
+      : this.optionsEdited = true;
   }
 
   handleApplySelection() {

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -174,6 +174,69 @@ describe('ProjectsFilterDropdownComponent', () => {
     });
   });
 
+  describe('The applyButton is enabled when', () => {
+    beforeEach(() => {
+      component.optionsEdited = false;
+      fixture.detectChanges();
+    });
+
+    describe('with no projects checked...', () => {
+      beforeEach(() => {
+        component.editableOptions = genOptions([false, false, false, false, false]);
+        component.filteredOptions = component.editableOptions;
+        component.initialFilters = component.filteredOptions.map(option => option.checked);
+      });
+
+      it('check one project', () => {
+        component.handleOptionChange({ detail: true }, 'Project 1');
+        expect(component.optionsEdited).toBe(true);
+      });
+
+      it('check multiple projects', () => {
+        component.handleOptionChange({ detail: true }, 'Project 1');
+        component.handleOptionChange({ detail: true }, 'Project 2');
+        component.handleOptionChange({ detail: true }, 'Project 4');
+
+        expect(component.optionsEdited).toBe(true);
+      });
+
+      it('check all projects', () => {
+        component.editableOptions.forEach(
+          (_o, index) => component.handleOptionChange({ detail: true }, `Project ${index + 1}`));
+
+        expect(component.optionsEdited).toBe(true);
+      });
+    });
+
+    describe('with some projects checked...', () => {
+      beforeEach(() => {
+        component.editableOptions = genOptions([false, true, true, false, false]);
+        component.filteredOptions = component.editableOptions;
+        component.initialFilters = component.filteredOptions.map(option => option.checked);
+      });
+
+      it('check one other project', () => {
+        component.handleOptionChange({ detail: true }, 'Project 1');
+        expect(component.optionsEdited).toBe(true);
+      });
+
+      it('check multiple other projects', () => {
+        component.handleOptionChange({ detail: true }, 'Project 1');
+        component.handleOptionChange({ detail: true }, 'Project 5');
+
+        expect(component.optionsEdited).toBe(true);
+      });
+
+      it('check all other projects', () => {
+        component.handleOptionChange({ detail: true }, 'Project 1');
+        component.handleOptionChange({ detail: true }, 'Project 4');
+        component.handleOptionChange({ detail: true }, 'Project 5');
+
+        expect(component.optionsEdited).toBe(true);
+      });
+    });
+  });
+
   describe('resetOptions()', () => {
     beforeEach(() => {
       component.options = genOptions([false, true]);

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -187,12 +187,12 @@ describe('ProjectsFilterDropdownComponent', () => {
         component.initialFilters = component.filteredOptions.map(option => option.checked);
       });
 
-      it('check one project', () => {
+      it('we check one project', () => {
         component.handleOptionChange({ detail: true }, 'Project 1');
         expect(component.optionsEdited).toBe(true);
       });
 
-      it('check multiple projects', () => {
+      it('we check multiple projects', () => {
         component.handleOptionChange({ detail: true }, 'Project 1');
         component.handleOptionChange({ detail: true }, 'Project 2');
         component.handleOptionChange({ detail: true }, 'Project 4');
@@ -200,7 +200,7 @@ describe('ProjectsFilterDropdownComponent', () => {
         expect(component.optionsEdited).toBe(true);
       });
 
-      it('check all projects', () => {
+      it('we check all projects', () => {
         component.editableOptions.forEach(
           (_o, index) => component.handleOptionChange({ detail: true }, `Project ${index + 1}`));
 
@@ -215,24 +215,188 @@ describe('ProjectsFilterDropdownComponent', () => {
         component.initialFilters = component.filteredOptions.map(option => option.checked);
       });
 
-      it('check one other project', () => {
+      it('we check one other project', () => {
         component.handleOptionChange({ detail: true }, 'Project 1');
         expect(component.optionsEdited).toBe(true);
       });
 
-      it('check multiple other projects', () => {
+      it('we check multiple other projects', () => {
         component.handleOptionChange({ detail: true }, 'Project 1');
         component.handleOptionChange({ detail: true }, 'Project 5');
 
         expect(component.optionsEdited).toBe(true);
       });
 
-      it('check all other projects', () => {
+      it('we check all other projects', () => {
         component.handleOptionChange({ detail: true }, 'Project 1');
         component.handleOptionChange({ detail: true }, 'Project 4');
         component.handleOptionChange({ detail: true }, 'Project 5');
 
         expect(component.optionsEdited).toBe(true);
+      });
+
+      it('we uncheck one other project', () => {
+        component.handleOptionChange({ detail: false }, 'Project 2');
+
+        expect(component.optionsEdited).toBe(true);
+      });
+
+      it('we uncheck all projects', () => {
+        component.editableOptions.forEach(
+          (_o, index) => component.handleOptionChange({ detail: false }, `Project ${index + 1}`));
+
+        expect(component.optionsEdited).toBe(true);
+      });
+    });
+
+    describe('with all projects checked...', () => {
+      beforeEach(() => {
+        component.editableOptions = genOptions([true, true, true, true, true]);
+        component.filteredOptions = component.editableOptions;
+        component.initialFilters = component.filteredOptions.map(option => option.checked);
+      });
+
+      it('we uncheck one project', () => {
+        component.handleOptionChange({ detail: false }, 'Project 1');
+        expect(component.optionsEdited).toBe(true);
+      });
+
+      it('we uncheck multiple projects', () => {
+        component.handleOptionChange({ detail: false }, 'Project 1');
+        component.handleOptionChange({ detail: false }, 'Project 2');
+        component.handleOptionChange({ detail: false }, 'Project 4');
+
+        expect(component.optionsEdited).toBe(true);
+      });
+
+      it('we uncheck all projects', () => {
+        component.editableOptions.forEach(
+          (_o, index) => component.handleOptionChange({ detail: false }, `Project ${index + 1}`));
+
+        expect(component.optionsEdited).toBe(true);
+      });
+    });
+  });
+
+  describe('The applyButton is disabled when', () => {
+    beforeEach(() => {
+      component.optionsEdited = false;
+      fixture.detectChanges();
+    });
+
+    describe('with no projects checked...', () => {
+      beforeEach(() => {
+        component.editableOptions = genOptions([false, false, false, false, false]);
+        component.filteredOptions = component.editableOptions;
+        component.initialFilters = component.filteredOptions.map(option => option.checked);
+      });
+
+      it('we check then uncheck one project', () => {
+        component.handleOptionChange({ detail: true }, 'Project 1');
+        expect(component.optionsEdited).toBe(true);
+
+        component.handleOptionChange({ detail: false }, 'Project 1');
+        expect(component.optionsEdited).toBe(false);
+      });
+
+      it('we check then uncheck multiple projects', () => {
+        component.handleOptionChange({ detail: true }, 'Project 1');
+        component.handleOptionChange({ detail: true }, 'Project 2');
+        component.handleOptionChange({ detail: true }, 'Project 4');
+        expect(component.optionsEdited).toBe(true);
+
+        component.handleOptionChange({ detail: false }, 'Project 1');
+        component.handleOptionChange({ detail: false }, 'Project 2');
+        component.handleOptionChange({ detail: false }, 'Project 4');
+        expect(component.optionsEdited).toBe(false);
+      });
+
+      it('we check then uncheck all projects', () => {
+        component.editableOptions.forEach(
+          (_o, index) => component.handleOptionChange({ detail: true }, `Project ${index + 1}`));
+        expect(component.optionsEdited).toBe(true);
+
+        component.editableOptions.forEach(
+          (_o, index) => component.handleOptionChange({ detail: false }, `Project ${index + 1}`));
+        expect(component.optionsEdited).toBe(false);
+      });
+    });
+
+    describe('with some projects checked...', () => {
+      beforeEach(() => {
+        component.editableOptions = genOptions([false, true, true, false, false]);
+        component.filteredOptions = component.editableOptions;
+        component.initialFilters = component.filteredOptions.map(option => option.checked);
+      });
+
+      it('we check then uncheck one other project', () => {
+        component.handleOptionChange({ detail: true }, 'Project 1');
+        expect(component.optionsEdited).toBe(true);
+
+        component.handleOptionChange({ detail: false }, 'Project 1');
+        expect(component.optionsEdited).toBe(false);
+      });
+
+      it('we check and uncheck, then recheck multiple other projects', () => {
+        component.handleOptionChange({ detail: true }, 'Project 1');
+        component.handleOptionChange({ detail: false }, 'Project 2');
+        component.handleOptionChange({ detail: false }, 'Project 3');
+        expect(component.optionsEdited).toBe(true);
+
+        component.handleOptionChange({ detail: false }, 'Project 1');
+        component.handleOptionChange({ detail: true }, 'Project 2');
+        component.handleOptionChange({ detail: true }, 'Project 3');
+        expect(component.optionsEdited).toBe(false);
+      });
+
+      it('check then uncheck all other projects', () => {
+        component.handleOptionChange({ detail: true }, 'Project 1');
+        component.handleOptionChange({ detail: true }, 'Project 4');
+        component.handleOptionChange({ detail: true }, 'Project 5');
+        expect(component.optionsEdited).toBe(true);
+
+        component.handleOptionChange({ detail: false }, 'Project 1');
+        component.handleOptionChange({ detail: false }, 'Project 4');
+        component.handleOptionChange({ detail: false }, 'Project 5');
+        expect(component.optionsEdited).toBe(false);
+      });
+    });
+
+    describe('with all projects checked...', () => {
+      beforeEach(() => {
+        component.editableOptions = genOptions([true, true, true, true, true]);
+        component.filteredOptions = component.editableOptions;
+        component.initialFilters = component.filteredOptions.map(option => option.checked);
+      });
+
+      it('we uncheck then check one project', () => {
+        component.handleOptionChange({ detail: false }, 'Project 1');
+        expect(component.optionsEdited).toBe(true);
+
+        component.handleOptionChange({ detail: true }, 'Project 1');
+        expect(component.optionsEdited).toBe(false);
+      });
+
+      it('we uncheck then check multiple projects', () => {
+        component.handleOptionChange({ detail: false }, 'Project 1');
+        component.handleOptionChange({ detail: false }, 'Project 4');
+        component.handleOptionChange({ detail: false }, 'Project 5');
+        expect(component.optionsEdited).toBe(true);
+
+        component.handleOptionChange({ detail: true }, 'Project 1');
+        component.handleOptionChange({ detail: true }, 'Project 4');
+        component.handleOptionChange({ detail: true }, 'Project 5');
+        expect(component.optionsEdited).toBe(false);
+      });
+
+      it('we uncheck then recheck all projects', () => {
+        component.editableOptions.forEach(
+          (_o, index) => component.handleOptionChange({ detail: false }, `Project ${index + 1}`));
+        expect(component.optionsEdited).toBe(true);
+
+        component.editableOptions.forEach(
+          (_o, index) => component.handleOptionChange({ detail: true }, `Project ${index + 1}`));
+        expect(component.optionsEdited).toBe(false);
       });
     });
   });

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -399,6 +399,50 @@ describe('ProjectsFilterDropdownComponent', () => {
         expect(component.optionsEdited).toBe(false);
       });
     });
+
+    describe('when options have filters applied', () => {
+      beforeEach(() => {
+        component.dropdownActive = true;
+        component.options = genOptionsWithId([
+          ['proj-one', true],
+          ['proj-three', false],
+          ['other-one', false],
+          ['other-two', true],
+          ['proj-two', false],
+          ['other-three', false],
+          ['proj-four', false]
+        ]);
+        component.filteredOptions = component.editableOptions;
+        component.initialFilters = component.filteredOptions.map(option => option.checked);
+        component.resetOptions();
+      });
+
+      it('apply button is active with no filters and no changes', () => {
+        expect(component.optionsEdited).toBe(false);
+      });
+
+      it('apply button is active with one new checked but filtered out option', () => {
+        component.handleOptionChange({ detail: true }, 'other-one');
+        component.handleFilterKeyUp('proj');
+        expect(component.optionsEdited).toBe(true);
+      });
+
+      it('apply button is disabled with a filter, then checked and unchecked option', () => {
+        component.handleFilterKeyUp('proj');
+        component.handleOptionChange({ detail: true }, 'proj-two');
+        expect(component.optionsEdited).toBe(true);
+
+        component.handleOptionChange({ detail: false }, 'proj-two');
+        expect(component.optionsEdited).toBe(false);
+      });
+
+      it('apply button enabled when selection is' +
+            ' cleared while filtered and there are changes', () => {
+          component.handleFilterKeyUp('proj'); // this leaves selected options hidden
+          component.handleClearSelection();
+          expect(component.optionsEdited).toBe(true);
+      });
+    });
   });
 
   describe('resetOptions()', () => {

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -417,7 +417,7 @@ describe('ProjectsFilterDropdownComponent', () => {
         component.resetOptions();
       });
 
-      it('apply button is active with no filters and no changes', () => {
+      it('apply button is disabled with no filters and no changes', () => {
         expect(component.optionsEdited).toBe(false);
       });
 

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.spec.ts
@@ -283,6 +283,12 @@ describe('ProjectsFilterDropdownComponent', () => {
       component.handleOptionChange({ detail: true }, 'Project 1');
       expect(component.optionsEdited).toEqual(true);
     });
+
+    it('checks for equality against the initial filters applied', () => {
+      spyOn(component, 'checkInitialEquality');
+      component.handleOptionChange({ detail: true }, 'Project 1');
+      expect(component.checkInitialEquality).toHaveBeenCalled();
+    });
   });
 
   describe('handleApplySelection()', () => {
@@ -359,6 +365,12 @@ describe('ProjectsFilterDropdownComponent', () => {
     it('clears all checked options with no filter applied', () => {
       component.handleClearSelection();
       expect(component.editableOptions.some(o => o.checked)).toEqual(false);
+    });
+
+    it('checks for equality against the initial filters applied', () => {
+      spyOn(component, 'checkInitialEquality');
+      component.handleClearSelection();
+      expect(component.checkInitialEquality).toHaveBeenCalled();
     });
 
     using([

--- a/components/automate-ui/tsconfig.json
+++ b/components/automate-ui/tsconfig.json
@@ -25,13 +25,13 @@
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,
-    "strictInputTypes": false,
+    "strictInputTypes": true,
     "strictNullInputTypes": true,
     "strictAttributeTypes": true,
     "strictSafeNavigationTypes": true,
-    "strictDomLocalRefTypes": false,
-    "strictOutputEventTypes": false,
-    "strictDomEventTypes": false,
+    "strictDomLocalRefTypes": true,
+    "strictOutputEventTypes": true,
+    "strictDomEventTypes": true,
     "strictContextGenerics": true,
     "strictLiteralTypes": true,
     "fullTemplateTypeCheck": true

--- a/components/automate-ui/tsconfig.json
+++ b/components/automate-ui/tsconfig.json
@@ -25,13 +25,13 @@
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,
-    "strictInputTypes": true,
+    "strictInputTypes": false,
     "strictNullInputTypes": true,
     "strictAttributeTypes": true,
     "strictSafeNavigationTypes": true,
-    "strictDomLocalRefTypes": true,
-    "strictOutputEventTypes": true,
-    "strictDomEventTypes": true,
+    "strictDomLocalRefTypes": false,
+    "strictOutputEventTypes": false,
+    "strictDomEventTypes": false,
     "strictContextGenerics": true,
     "strictLiteralTypes": true,
     "fullTemplateTypeCheck": true


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Currently when using the global projects filter, if a user makes selections, and then reverses those selections, they are still allowed to apply changes, even though no changes are present.

This branch disables the `apply changes` button when there are not "new" changes present.

### :chains: Related Resources
Fixes: https://github.com/chef/automate/issues/3413

### :+1: Definition of Done
Users see a disabled `apply changes` button until they have made true changes to the filter selections.

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
make serve

In the UI, create a handful of projects at https://a2-dev.test/settings/projects
in the top right of any page, click on the global projects dropdown
check some of the projects, see the `apply changes` button activate
uncheck those projects, see the `apply changes` button deactivate

check some of the projects, see the `apply changes` button activate
click `clear selection` button, see the `apply changes` button deactivate

Check some of the projects again and click to apply
After the selection has been applied
check some of the projects, see the `apply changes` button activate
uncheck those projects, see the `apply changes` button deactivate

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Project selection](https://user-images.githubusercontent.com/16737484/79811507-dbef9c80-832a-11ea-911c-6d319d1174bf.gif)
