### PR TITLE
add compliance service to the universal access policy

### DIFF
--- a/components/authz-service/server/v2/system.go
+++ b/components/authz-service/server/v2/system.go
@@ -12,10 +12,14 @@ func SystemPolicies() []*storage.Policy {
 		ID:   constants.UniversalAccessPolicyID,
 		Type: storage.System,
 		// used by automate-cli for API requests through the gateway
-		Name: "deployment-service universal access",
+		// used by compliance service for creating a token to give to ssm jobs
+		Name: "internal service universal access",
 		Members: []storage.Member{
 			{
 				Name: "tls:service:deployment-service:*",
+			},
+			{
+				Name: "tls:service:compliance-service:*",
 			},
 		},
 		Statements: []storage.Statement{{

--- a/components/compliance-service/inspec-agent/remote/remote.go
+++ b/components/compliance-service/inspec-agent/remote/remote.go
@@ -38,7 +38,7 @@ func RunSSMJob(ctx context.Context, ssmJob *types.InspecJob) *inspec.Error {
 		return translateToInspecErr(fmt.Errorf("unable to connect to auth client: aborting job run for job %+v", ssmJob))
 	}
 	tokenID := fmt.Sprintf("inspec-to-automate-scanjob-%s", ssmJob.JobID)
-	ctx = auth_context.NewOutgoingContext(auth_context.NewContext(ctx, []string{"tls:service:compliance-service:internal"}, []string{}, "", ""))
+	ctx = auth_context.NewOutgoingContext(auth_context.NewContext(ctx, []string{"tls:service:deployment-service:internal"}, []string{}, "", ""))
 	token, err := RemoteJobInfo.TokensMgmtClient.CreateToken(ctx, &authn.CreateTokenReq{
 		Id:     tokenID,
 		Name:   tokenID,

--- a/components/compliance-service/inspec-agent/remote/remote.go
+++ b/components/compliance-service/inspec-agent/remote/remote.go
@@ -38,7 +38,7 @@ func RunSSMJob(ctx context.Context, ssmJob *types.InspecJob) *inspec.Error {
 		return translateToInspecErr(fmt.Errorf("unable to connect to auth client: aborting job run for job %+v", ssmJob))
 	}
 	tokenID := fmt.Sprintf("inspec-to-automate-scanjob-%s", ssmJob.JobID)
-	ctx = auth_context.NewOutgoingContext(auth_context.NewContext(ctx, []string{"tls:service:deployment-service:internal"}, []string{}, "", ""))
+	ctx = auth_context.NewOutgoingContext(auth_context.NewContext(ctx, []string{"tls:service:compliance-service:internal"}, []string{}, "", ""))
 	token, err := RemoteJobInfo.TokensMgmtClient.CreateToken(ctx, &authn.CreateTokenReq{
 		Id:     tokenID,
 		Name:   tokenID,


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?

i had changed the value to compliance service based on some pr
feedback but it seems that it does not work when compliance is referenced:
```
["tls:service:compliance-service:internal"] subject is missing iam:projects:assign
on this project: ["(unassigned)"]
```

my bad, i should have retested after making the change; i didnt realize compliance would be unauthorized for this?

### :chains: Related Resources
https://github.com/chef/automate/pull/3421

