### PR TITLE
Part of #3332: fix diagnostics left overs -- projects and rules

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -726,6 +726,7 @@ paths = [
   "lib/stringutils/*",
   "lib/tls/*",
   "lib/tracing/*",
+  "lib/uuid4/*",
   "lib/version/*",
   "vendor/github.com/apache/thrift/*",
   "vendor/github.com/aws/aws-sdk-go/*",

--- a/components/automate-cli/pkg/diagnostics/context.go
+++ b/components/automate-cli/pkg/diagnostics/context.go
@@ -199,7 +199,7 @@ func (c *testContext) DoLBRequest(path string, opts ...lbrequest.Opts) (*http.Re
 			continue
 		}
 		if resp.StatusCode >= 500 || resp.StatusCode == 403 {
-			lastErr = errors.Errorf("Got 5xx. %d %s: %s", resp.StatusCode, resp.Status, path)
+			lastErr = errors.Errorf("Got status: %d %s: %s", resp.StatusCode, resp.Status, path)
 			resp.Body.Close() // nolint: errcheck
 			continue
 		}

--- a/components/automate-cli/pkg/diagnostics/integration/helpers.go
+++ b/components/automate-cli/pkg/diagnostics/integration/helpers.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	uuid "github.com/gofrs/uuid"
+	uuid "github.com/chef/automate/lib/uuid4"
 	"github.com/pkg/errors"
 )
 

--- a/components/automate-cli/pkg/diagnostics/integration/iam_projects.go
+++ b/components/automate-cli/pkg/diagnostics/integration/iam_projects.go
@@ -189,7 +189,7 @@ func CreateIAMProjectsDiagnostic() diagnostics.Diagnostic {
 			loaded := generatedProjectData{}
 			err = tstCtx.GetValue("iam-projects", &loaded)
 			if err != nil {
-				return errors.Errorf(err.Error(), "could not find generated context")
+				return errors.Wrap(err, "could not find generated context")
 			}
 
 			tstCtx.SetValue("iam-projects", &generatedProjectData{

--- a/components/automate-cli/pkg/diagnostics/integration/iam_projects.go
+++ b/components/automate-cli/pkg/diagnostics/integration/iam_projects.go
@@ -130,16 +130,19 @@ func GetProject(tstCtx diagnostics.TestContext, id string) (*ProjectInfo, error)
 	return &projectInfo, nil
 }
 
-// DeleteProject deletes the project with the given id
-func DeleteProject(tstCtx diagnostics.TestContext, id string) error {
-	// any associated rules are cascade-deleted with the project
-	err := MustJSONDecodeSuccess(
-		tstCtx.DoLBRequest(
-			fmt.Sprintf("/apis/iam/v2/projects/%s", id),
-			lbrequest.WithMethod("DELETE"),
-		)).Error()
+// DeleteProjectWithRule deletes the project with the given id and its associated rule
+func DeleteProjectWithRule(tstCtx diagnostics.TestContext, projectID, ruleID string) error {
+	if err := MustJSONDecodeSuccess(tstCtx.DoLBRequest(
+		fmt.Sprintf("/apis/iam/v2/projects/%s/rules/%s", projectID, ruleID),
+		lbrequest.WithMethod("DELETE"),
+	)).WithValue(&struct{}{}); err != nil {
+		return errors.Wrap(err, "Could not delete rule")
+	}
 
-	if err != nil {
+	if err := MustJSONDecodeSuccess(tstCtx.DoLBRequest(
+		fmt.Sprintf("/apis/iam/v2/projects/%s", projectID),
+		lbrequest.WithMethod("DELETE"),
+	)).WithValue(&struct{}{}); err != nil {
 		return errors.Wrap(err, "Could not delete project")
 	}
 	return nil
@@ -228,7 +231,7 @@ func CreateIAMProjectsDiagnostic() diagnostics.Diagnostic {
 				return errors.Wrap(err, "Could not find generated context")
 			}
 
-			return DeleteProject(tstCtx, loaded.ID)
+			return DeleteProjectWithRule(tstCtx, loaded.ID, loaded.RuleID)
 		},
 	}
 }

--- a/components/automate-cli/pkg/diagnostics/integration/iam_roles.go
+++ b/components/automate-cli/pkg/diagnostics/integration/iam_roles.go
@@ -73,13 +73,11 @@ func GetRole(tstCtx diagnostics.TestContext, id string) (*RoleInfo, error) {
 
 // DeleteRole deletes the role with the given id
 func DeleteRole(tstCtx diagnostics.TestContext, id string) error {
-	err := MustJSONDecodeSuccess(
+	if err := MustJSONDecodeSuccess(
 		tstCtx.DoLBRequest(
 			fmt.Sprintf("/apis/iam/v2/roles/%s", id),
 			lbrequest.WithMethod("DELETE"),
-		)).Error()
-
-	if err != nil {
+		)).WithValue(&struct{}{}); err != nil {
 		return errors.Wrap(err, "Could not delete role")
 	}
 	return nil
@@ -126,7 +124,7 @@ func CreateIAMRolesDiagnostic() diagnostics.Diagnostic {
 			loaded := generatedRoleData{}
 			err = tstCtx.GetValue("iam-roles", &loaded)
 			if err != nil {
-				return errors.Errorf(err.Error(), "could not find generated context")
+				return errors.Wrap(err, "could not find generated context")
 			}
 
 			tstCtx.SetValue("iam-roles", &generatedRoleData{

--- a/components/automate-cli/pkg/diagnostics/integration/iam_teams.go
+++ b/components/automate-cli/pkg/diagnostics/integration/iam_teams.go
@@ -123,13 +123,11 @@ func DeleteTeam(tstCtx diagnostics.TestContext, id string) error {
 		reqPath = fmt.Sprintf("/api/v0/auth/teams/%s", id)
 	}
 
-	err = MustJSONDecodeSuccess(
+	if err := MustJSONDecodeSuccess(
 		tstCtx.DoLBRequest(
 			reqPath,
 			lbrequest.WithMethod("DELETE"),
-		)).Error()
-
-	if err != nil {
+		)).WithValue(&struct{}{}); err != nil {
 		return errors.Wrap(err, "Could not delete team")
 	}
 	return nil

--- a/components/automate-cli/pkg/diagnostics/integration/iam_tokens.go
+++ b/components/automate-cli/pkg/diagnostics/integration/iam_tokens.go
@@ -126,13 +126,11 @@ func DeleteToken(tstCtx diagnostics.TestContext, id string) error {
 		reqPath = fmt.Sprintf("/api/v0/auth/tokens/%s", id)
 	}
 
-	err = MustJSONDecodeSuccess(
+	if err := MustJSONDecodeSuccess(
 		tstCtx.DoLBRequest(
 			reqPath,
 			lbrequest.WithMethod("DELETE"),
-		)).Error()
-
-	if err != nil {
+		)).WithValue(&struct{}{}); err != nil {
 		return errors.Wrap(err, "Could not delete token")
 	}
 	return nil

--- a/components/automate-cli/pkg/diagnostics/integration/iam_users.go
+++ b/components/automate-cli/pkg/diagnostics/integration/iam_users.go
@@ -134,13 +134,11 @@ func DeleteUser(tstCtx diagnostics.TestContext, username string) error {
 		reqPath = fmt.Sprintf("/api/v0/auth/users/%s", username)
 	}
 
-	err = MustJSONDecodeSuccess(
+	if err := MustJSONDecodeSuccess(
 		tstCtx.DoLBRequest(
 			reqPath,
 			lbrequest.WithMethod("DELETE"),
-		)).Error()
-
-	if err != nil {
+		)).WithValue(&struct{}{}); err != nil {
 		return errors.Wrap(err, "Could not delete user")
 	}
 	return nil

--- a/components/automate-cli/pkg/diagnostics/integration/iam_v1_policies.go
+++ b/components/automate-cli/pkg/diagnostics/integration/iam_v1_policies.go
@@ -69,13 +69,11 @@ func DeletePolicy(tstCtx diagnostics.TestContext, id string) error {
 		reqPath = fmt.Sprintf("/api/v0/auth/policies/%s", id)
 	}
 
-	err = MustJSONDecodeSuccess(
+	if err := MustJSONDecodeSuccess(
 		tstCtx.DoLBRequest(
 			reqPath,
 			lbrequest.WithMethod("DELETE"),
-		)).Error()
-
-	if err != nil {
+		)).WithValue(&struct{}{}); err != nil {
 		return errors.Wrap(err, "Could not delete policy")
 	}
 	return nil
@@ -121,7 +119,7 @@ func CreateIAMV1PoliciesDiagnostic() diagnostics.Diagnostic {
 				tstCtx.DoLBRequest(
 					"/api/v0/gateway/version",
 					lbrequest.WithAuthToken(loaded.TokenValue),
-				)).Error()
+				)).WithValue(&struct{}{})
 			require.NoError(tstCtx, err, "Expected to be able to read gateway version")
 		},
 		Cleanup: func(tstCtx diagnostics.TestContext) error {

--- a/components/automate-cli/pkg/diagnostics/integration/iam_v2_policies.go
+++ b/components/automate-cli/pkg/diagnostics/integration/iam_v2_policies.go
@@ -16,8 +16,8 @@ const createV2PolicyTemplateStr = `
 	"id": "{{ .ID }}",
 	"name": "{{ .ID }} test policy",
 	"members": [
-		"token:{{ .TokenID }}", 
-		"user:local:{{ .UserID }}", 
+		"token:{{ .TokenID }}",
+		"user:local:{{ .UserID }}",
 		"team:local:{{ .TeamID }}"
 	],
 	"statements": [
@@ -42,6 +42,7 @@ type PolicyParameters struct {
 	UserID    string
 	RoleID    string
 	ProjectID string
+	RuleID    string
 }
 
 type generatedV2PolicyData struct {
@@ -52,6 +53,7 @@ type generatedV2PolicyData struct {
 	UserID     string `json:"user_id"`
 	RoleID     string `json:"role_id"`
 	ProjectID  string `json:"project_id"`
+	RuleID     string `json:"rule_id"`
 	Skipped    bool   `json:"skipped"`
 }
 
@@ -118,6 +120,7 @@ func CreateIAMV2PoliciesDiagnostic() diagnostics.Diagnostic {
 					UserID:     loaded.UserID,
 					RoleID:     loaded.RoleID,
 					ProjectID:  loaded.ProjectID,
+					RuleID:     loaded.RuleID,
 					Skipped:    loaded.Skipped,
 				})
 			}
@@ -157,6 +160,7 @@ func CreateIAMV2PoliciesDiagnostic() diagnostics.Diagnostic {
 				UserID:    userInfo.ID,
 				RoleID:    roleInfo.Role.ID,
 				ProjectID: projectInfo.Project.ID,
+				RuleID:    projectInfo.Project.Rule.ID,
 			}
 
 			policyInfo, err := CreateV2Policy(tstCtx, pol)
@@ -178,6 +182,7 @@ func CreateIAMV2PoliciesDiagnostic() diagnostics.Diagnostic {
 				UserID:     pol.UserID,
 				RoleID:     pol.RoleID,
 				ProjectID:  pol.ProjectID,
+				RuleID:     projectInfo.Project.Rule.ID,
 				Skipped:    loaded.Skipped,
 			})
 			return nil
@@ -271,7 +276,7 @@ func CreateIAMV2PoliciesDiagnostic() diagnostics.Diagnostic {
 				DeleteTeam(tstCtx, loaded.TeamID),
 				DeleteUser(tstCtx, loaded.UserID),
 				DeleteRole(tstCtx, loaded.RoleID),
-				DeleteProject(tstCtx, loaded.ProjectID),
+				DeleteProjectWithRule(tstCtx, loaded.ProjectID, loaded.RuleID),
 			)
 		},
 	}

--- a/components/automate-cli/pkg/diagnostics/integration/iam_v2_policies.go
+++ b/components/automate-cli/pkg/diagnostics/integration/iam_v2_policies.go
@@ -171,7 +171,7 @@ func CreateIAMV2PoliciesDiagnostic() diagnostics.Diagnostic {
 			loaded := generatedV2PolicyData{}
 			err = tstCtx.GetValue("iam-policies-v2", &loaded)
 			if err != nil {
-				return errors.Errorf(err.Error(), "could not find generated context")
+				return errors.Wrap(err, "could not find generated context")
 			}
 
 			tstCtx.SetValue("iam-policies-v2", generatedV2PolicyData{
@@ -198,14 +198,14 @@ func CreateIAMV2PoliciesDiagnostic() diagnostics.Diagnostic {
 				err = MustJSONDecodeSuccess(
 					tstCtx.DoLBRequest(
 						fmt.Sprintf("/apis/iam/v2/policies/%s", v1loaded.PolicyID),
-					)).Error()
+					)).WithValue(&struct{}{})
 				require.NoError(tstCtx, err, "Expected to be able to read gateway version")
 
 				err = MustJSONDecodeSuccess(
 					tstCtx.DoLBRequest(
 						"/api/v0/gateway/version",
 						lbrequest.WithAuthToken(v1loaded.TokenValue),
-					)).Error()
+					)).WithValue(&struct{}{})
 				require.NoError(tstCtx, err, "Expected to be able to read gateway version")
 			}
 
@@ -226,7 +226,7 @@ func CreateIAMV2PoliciesDiagnostic() diagnostics.Diagnostic {
 				tstCtx.DoLBRequest(
 					"/api/v0/gateway/version",
 					lbrequest.WithAuthToken(v2loaded.TokenValue),
-				)).Error()
+				)).WithValue(&struct{}{})
 			require.NoError(tstCtx, err, "Expected to be able to read gateway version")
 
 			type Statement struct {

--- a/components/automate-cli/pkg/diagnostics/lbrequest/lbrequest.go
+++ b/components/automate-cli/pkg/diagnostics/lbrequest/lbrequest.go
@@ -99,7 +99,7 @@ func WithFormFile(filename string, data []byte) Opts {
 	}
 }
 
-// WithHost sets the host the request should be made to.
+// WithURL sets the URL the request should be made to.
 func WithURL(url url.URL) Opts {
 	return func(opts *requestOpts) {
 		opts.target = url


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

We had a bug or two in our diagnostics code that caused projects and rules to stick around after a successful run. Please see the first commit for the fix. The rest of the PR is fixing other occurrences, and minor issues.

⚠️ This doesn't fix these left-overs:
- Token `This token was generated by the chef-automate diagnostic tool. It has admin level access on the entire Automate API.`
- Policy `admin policy for token 1735392e-b4cf-42eb-bf58-611b17e28241`

They are created using a different code-flow and hence their removal can be tackled separately.

### :chains: Related Resources

- #3332 
- Fixes #3445 

### :+1: Definition of Done

Run diagnostics, see the project **not** left over.

### :athletic_shoe: How to Build and Test the Change

- `rebuild components/automate-cli`
- `chef-automate diagnostics run iam`
- observe existing projects

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
