### PR TITLE
Supply oldest date tag in `channel_contains_commit` output

### DIFF
--- a/.studio/tooling
+++ b/.studio/tooling
@@ -105,6 +105,11 @@ function channel_contains_commit() {
     else
         echo -e '   current: \033[0;91m✗\033[0m'
     fi
+
+    oldest_tag=$(git tag --contains "$commit" | grep -P '\d{14}' | head -1)
+    if [ "$oldest_tag" != "" ]; then
+        echo "Oldest tag containing commit: $oldest_tag"
+    fi
 }
 
 document "get_release_diff_url" <<DOC


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Add the oldest date tag that contains a commit to the output of `channel_contains_commit. The output is (see last line)

```
[68][default:/src:0]# channel_contains_commit 57577936c94209bb787d8e6e7012b76ec108c79b
fatal: Not a valid commit name 277666461ff0e196bee3f81dad31b858309c06b5
       dev: ✗
acceptance: ✓
   current: ✓
Oldest tag containing commit: 20200408145843
```
If no tag contains the commit, we don't print the last line.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
1. checkout this branch
1. either start a new hab studio or run `source /src/.studio/tooling` in an existing one
1. run `channel_contains_commit` against a commit that is included in a tag and note that the output contains the tag in the last line, e.g.

```
[68][default:/src:0]# channel_contains_commit 57577936c94209bb787d8e6e7012b76ec108c79b
fatal: Not a valid commit name 277666461ff0e196bee3f81dad31b858309c06b5
       dev: ✗
acceptance: ✓
   current: ✓
Oldest tag containing commit: 20200408145843 
```
### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
