### PR TITLE
Squelch browser error regarding undefined pipe

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -47,13 +47,15 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
     });
 
     // the addPolicies checkbox should always be checked by default when the modal opens
-    this.resetCheckboxEvent.pipe(takeUntil(this.isDestroyed))
-      .subscribe(() => {
-        // the checkbox needs to use this component variable
-        // but we must ensure the createForm.addPolicies value stays in sync
-        this.addPolicies = true;
-        this.createForm.controls.addPolicies.setValue(this.addPolicies);
-      });
+    if (this.resetCheckboxEvent) {
+      this.resetCheckboxEvent.pipe(takeUntil(this.isDestroyed))
+        .subscribe(() => {
+          // the checkbox needs to use this component variable
+          // but we must ensure the createForm.addPolicies value stays in sync
+          this.addPolicies = true;
+          this.createForm.controls.addPolicies.setValue(this.addPolicies);
+        });
+    }
   }
 
   ngOnDestroy() {

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -21,9 +21,9 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
   @Input() visible = false;
   @Input() creating = false;
   @Input() objectNoun: string;
+  @Input() createProjectModal = false;
   @Input() assignableProjects: Project[] = [];
   @Input() createForm: FormGroup; // NB: The form must contain 'name' and 'id' fields
-  @Input() resetPoliciesCheckboxEvent: EventEmitter<null>;
   @Input() conflictErrorEvent: EventEmitter<boolean>; // TC: This element assumes 'id' is the
                                                       // only create field that can conflict.
   @Output() close = new EventEmitter();
@@ -34,7 +34,6 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
   public conflictError = false;
   public addPolicies = true;
   public projectsUpdatedEvent = new EventEmitter();
-  public createProjectModal = false;
 
   private isDestroyed = new Subject<boolean>();
 
@@ -45,18 +44,6 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
       // Open the ID input on conflict so user can resolve it.
       this.modifyID = isConflict;
     });
-
-    // the addPolicies checkbox should always be checked by default when the modal opens
-    if (this.resetPoliciesCheckboxEvent) {
-      this.createProjectModal = true;
-      this.resetPoliciesCheckboxEvent.pipe(takeUntil(this.isDestroyed))
-        .subscribe(() => {
-          // the checkbox needs to use this component variable
-          // but we must ensure the createForm.addPolicies value stays in sync
-          this.addPolicies = true;
-          this.createForm.controls.addPolicies.setValue(this.addPolicies);
-        });
-    }
   }
 
   ngOnDestroy() {
@@ -75,6 +62,9 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
     if (changes.visible && (changes.visible.currentValue as boolean)) {
       Object.values(this.projects).forEach(p => p.checked = false);
       this.projectsUpdatedEvent.emit();
+      if (this.createProjectModal) {
+        this.updatePolicyCheckbox(true); // always set to checked upon opening
+      }
     }
   }
 

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -21,7 +21,6 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
   @Input() visible = false;
   @Input() creating = false;
   @Input() objectNoun: string;
-  @Input() createProjectModal = false;
   @Input() assignableProjects: Project[] = [];
   @Input() createForm: FormGroup; // NB: The form must contain 'name' and 'id' fields
   @Input() resetCheckboxEvent: EventEmitter<null>;
@@ -35,6 +34,7 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
   public conflictError = false;
   public addPolicies = true;
   public projectsUpdatedEvent = new EventEmitter();
+  public createProjectModal = false;
 
   private isDestroyed = new Subject<boolean>();
 
@@ -48,6 +48,7 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
 
     // the addPolicies checkbox should always be checked by default when the modal opens
     if (this.resetCheckboxEvent) {
+      this.createProjectModal = true;
       this.resetCheckboxEvent.pipe(takeUntil(this.isDestroyed))
         .subscribe(() => {
           // the checkbox needs to use this component variable

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -23,7 +23,7 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
   @Input() objectNoun: string;
   @Input() assignableProjects: Project[] = [];
   @Input() createForm: FormGroup; // NB: The form must contain 'name' and 'id' fields
-  @Input() resetCheckboxEvent: EventEmitter<null>;
+  @Input() resetPoliciesCheckboxEvent: EventEmitter<null>;
   @Input() conflictErrorEvent: EventEmitter<boolean>; // TC: This element assumes 'id' is the
                                                       // only create field that can conflict.
   @Output() close = new EventEmitter();
@@ -47,9 +47,9 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
     });
 
     // the addPolicies checkbox should always be checked by default when the modal opens
-    if (this.resetCheckboxEvent) {
+    if (this.resetPoliciesCheckboxEvent) {
       this.createProjectModal = true;
-      this.resetCheckboxEvent.pipe(takeUntil(this.isDestroyed))
+      this.resetPoliciesCheckboxEvent.pipe(takeUntil(this.isDestroyed))
         .subscribe(() => {
           // the checkbox needs to use this component variable
           // but we must ensure the createForm.addPolicies value stays in sync

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.html
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.html
@@ -68,7 +68,7 @@
         [visible]="createModalVisible"
         [creating]="creatingProject"
         [conflictErrorEvent]="conflictErrorEvent"
-        [resetCheckboxEvent]="resetCheckboxEvent"
+        [resetPoliciesCheckboxEvent]="resetCheckboxEvent"
         objectNoun="project"
         [createForm]="createProjectForm"
         (close)="closeCreateModal()"

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.html
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.html
@@ -66,9 +66,9 @@
 
       <app-create-object-modal
         [visible]="createModalVisible"
+        [createProjectModal]="true"
         [creating]="creatingProject"
         [conflictErrorEvent]="conflictErrorEvent"
-        [resetPoliciesCheckboxEvent]="resetCheckboxEvent"
         objectNoun="project"
         [createForm]="createProjectForm"
         (close)="closeCreateModal()"

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.html
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.html
@@ -66,7 +66,6 @@
 
       <app-create-object-modal
         [visible]="createModalVisible"
-        [createProjectModal]="true"
         [creating]="creatingProject"
         [conflictErrorEvent]="conflictErrorEvent"
         [resetCheckboxEvent]="resetCheckboxEvent"

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.spec.ts
@@ -63,7 +63,7 @@ describe('ProjectListComponent', () => {
         MockComponent({
           selector: 'app-create-object-modal',
           inputs: ['creating', 'createForm', 'visible', 'objectNoun',
-            'conflictErrorEvent', 'createProjectModal', 'resetCheckboxEvent'],
+            'conflictErrorEvent', 'createProjectModal', 'resetPoliciesCheckboxEvent'],
           outputs: ['close', 'deleteClicked']
         }),
         MockComponent({

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -35,7 +35,6 @@ export class ProjectListComponent implements OnInit, OnDestroy {
   public createProjectForm: FormGroup;
   public creatingProject = false;
   public conflictErrorEvent = new EventEmitter<boolean>();
-  public resetCheckboxEvent = new EventEmitter();
   private isDestroyed = new Subject<boolean>();
 
   public statusLabel: Record<ProjectStatus, string> = {
@@ -165,7 +164,6 @@ export class ProjectListComponent implements OnInit, OnDestroy {
   resetCreateModal(): void {
     this.creatingProject = false;
     this.createProjectForm.reset();
-    this.resetCheckboxEvent.emit();
     this.conflictErrorEvent.emit(false);
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

PR #3314 recently introduced an optional `resetCheckboxEvent` parameter to `CreateObjectModalComponent`, but assumed it was always defined. That was true on the projects list page but not on the teams or tokens list pages (the other consumers of CreateObjectModalComponent). Thus, these browser errors occurred whenever visiting those pages:

<img width="476" alt="image" src="https://user-images.githubusercontent.com/6817500/79924597-0570fc80-83ed-11ea-8dd4-f1af34d5cc54.png">

Commits show the play-by-play.

### :chains: Related Resources
PR #3314 Allow skipping policy creation on project creation

### :+1: Definition of Done
Browser errors are gone.

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui
Visit teams or tokens pages and observe no error.
Visit projects page and create projects with and without the policies checkbox checked, to confirm that it still works.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
