### PR TITLE
ssm jobs: use  node id instead of job id for token creation

### DIFF
--- a/components/compliance-service/inspec-agent/remote/remote.go
+++ b/components/compliance-service/inspec-agent/remote/remote.go
@@ -37,7 +37,7 @@ func RunSSMJob(ctx context.Context, ssmJob *types.InspecJob) *inspec.Error {
 		logrus.Error("unable to create auth token")
 		return translateToInspecErr(fmt.Errorf("unable to connect to auth client: aborting job run for job %+v", ssmJob))
 	}
-	tokenID := fmt.Sprintf("inspec-to-automate-scanjob-%s", ssmJob.JobID)
+	tokenID := fmt.Sprintf("inspec-to-automate-scanjob-%s", ssmJob.NodeID)
 	ctx = auth_context.NewOutgoingContext(auth_context.NewContext(ctx, []string{"tls:service:compliance-service:internal"}, []string{}, "", ""))
 	token, err := RemoteJobInfo.TokensMgmtClient.CreateToken(ctx, &authn.CreateTokenReq{
 		Id:     tokenID,


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?
using job id creates a token conflict since many nodes can be assigned
to a single job. using node id resolves that!

i hadnt realized this bc i was testing against a single ssm instance 🤦‍♀️ 

### :chains: Related Resources
https://github.com/chef/automate/pull/3421

### :+1: Definition of Done
can scan more than one ssm instance per scan job

### :athletic_shoe: How to Build and Test the Change
see 3421
