### PR TITLE
api docs: fix examples to use correct quoting

### DIFF
--- a/components/automate-chef-io/data/docs/api-static/01-reporting-export.swagger.json
+++ b/components/automate-chef-io/data/docs/api-static/01-reporting-export.swagger.json
@@ -3,7 +3,7 @@
     "/compliance/reporting/export": {
       "post": {
         "summary": "Export reports",
-        "description": "Stream reports in JSON (default) or CSV format.\n\nSupports filtering, but not pagination or sorting.\n\nInclude the value `csv` for the `type` parameter in the request to receive CSV formatted data.\nIncluding more than one value for `profile_id`, or `profile_name` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\n\n Example: \n\n ```'{'type':'csv','filters':[{'type':'start_time','values':['2019-09-16T00:00:00Z']},{'type':'end_time','values':['2019-09-18T23:59:59Z']}, {'type':'environment','values':['_default']}]}'```",
+        "description": "Stream reports in JSON (default) or CSV format.\n\nSupports filtering, but not pagination or sorting.\n\nInclude the value `csv` for the `type` parameter in the request to receive CSV formatted data.\nIncluding more than one value for `profile_id`, or `profile_name` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\n\n Example: \n\n ```'{\"type\":\"csv\",\"filters\":[{\"type\":\"start_time\",\"values\":[\"2019-09-16T00:00:00Z\"]},{\"type\":\"end_time\",\"values\":[\"2019-09-18T23:59:59Z\"]}, {\"type\":\"environment\",\"values\":[\"_default\"]}]}'```",
         "tags": [
           "ReportingService"
         ],
@@ -35,7 +35,7 @@
     "/compliance/reporting/node/export": {
       "post": {
         "summary": "Export node reports",
-        "description": "Stream historical reports for a single node in JSON (default) or CSV format.\n\nSupports filtering, but not pagination or sorting.\nRequires one `node_id` filter.\n\nInclude the value `csv` for the `type` parameter in the request to receive CSV formatted data.\nIncluding more than one value for `profile_id`, `profile_name`, or `node_id` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\nLimited to 9999 results.\n\nExample: \n\n ```'{'type':'csv','filters':[{'type':'start_time','values':['2019-09-16T00:00:00Z']},{'type':'end_time','values':['2019-09-18T23:59:59Z']}, {'type':'node_id','values':['9b9f4e51-b049-4b10-9555-10578916e149']}]}'```",
+        "description": "Stream historical reports for a single node in JSON (default) or CSV format.\n\nSupports filtering, but not pagination or sorting.\nRequires one `node_id` filter.\n\nInclude the value `csv` for the `type` parameter in the request to receive CSV formatted data.\nIncluding more than one value for `profile_id`, `profile_name`, or `node_id` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\nLimited to 9999 results.\n\nExample: \n\n ```'{\"type\":\"csv\",\"filters\":[{\"type\":\"start_time\",\"values\":[\"2019-09-16T00:00:00Z\"]},{\"type\":\"end_time\",\"values\":[\"2019-09-18T23:59:59Z\"]}, {\"type\":\"node_id\",\"values\":[\"9b9f4e51-b049-4b10-9555-10578916e149\"]}]}'```",
         "tags": [
           "ReportingService"
         ],

--- a/components/automate-chef-io/data/docs/api-static/05-node-export.swagger.json
+++ b/components/automate-chef-io/data/docs/api-static/05-node-export.swagger.json
@@ -3,7 +3,7 @@
     "/cfgmgmt/nodes/export": {
       "post": {
         "summary": "NodeExport",
-        "description": "Stream nodes in JSON (default) or CSV format.\n\nSupports filtering and sorting, but not pagination.\n\nInclude the value `csv` for the `output_type` parameter in the request to receive CSV formatted data.\nInclude the value `json` for the `output_type` parameter in the request to receive JSON formatted data.\nInclude the value `0` to sort descending.\nInclude the value `1` to sort ascending.\n Example: \n\n ```'{'output_type':'csv','sorting':{'order': 1, 'field': 'name'},'filters':[{'status':'success','environment':'prod', 'organization:chef'}]}'```",
+        "description": "Stream nodes in JSON (default) or CSV format.\n\nSupports filtering and sorting, but not pagination.\n\nInclude the value `csv` for the `output_type` parameter in the request to receive CSV formatted data.\nInclude the value `json` for the `output_type` parameter in the request to receive JSON formatted data.\nInclude the value `0` to sort descending.\nInclude the value `1` to sort ascending.\n Example: \n\n ```'{\"output_type\":\"csv\",\"sorting\":{\"order\": 1, \"field\": \"name\"},\"filters\":[{\"status\":\"success\",\"environment\":\"prod\", \"organization:chef\"}]}'```",
         "tags": [
           "ConfigMgmt"
         ],
@@ -35,7 +35,7 @@
     "/cfgmgmt/reports/export": {
       "post": {
         "summary": "ReportExport",
-        "description": "Stream node run reports in JSON (default) or CSV format.\n\nSupports filtering, but not pagination or sorting.\n\nInclude the value `csv` for the `output_type` parameter in the request to receive CSV formatted data.\nInclude the value `json` for the `output_type` parameter in the request to receive JSON formatted data.\nInclude the node ID for the `node_id` for the reports to receive.\nInclude the number of seconds since the Unix Epoch for the `start` and `end` fields.\n Example: \n\n ```'{'output_type':'csv''node_id':'80e73cf5-32eb-3556-ac99-6597274a8522','start':{'seconds':1585336095},'end':{'seconds':1585337095},'filters':[{'status':'success'}]}'```",
+        "description": "Stream node run reports in JSON (default) or CSV format.\n\nSupports filtering, but not pagination or sorting.\n\nInclude the value `csv` for the `output_type` parameter in the request to receive CSV formatted data.\nInclude the value `json` for the `output_type` parameter in the request to receive JSON formatted data.\nInclude the node ID for the `node_id` for the reports to receive.\nInclude the number of seconds since the Unix Epoch for the `start` and `end` fields.\n Example: \n\n ```'{\"output_type\":\"csv\"node_id\":\"80e73cf5-32eb-3556-ac99-6597274a8522\",\"start\":{\"seconds\":1585336095},\"end\":{\"seconds\":1585337095},\"filters\":[{\"status\":\"success\"}]}'```",
         "tags": [
           "ConfigMgmt"
         ],


### PR DESCRIPTION
Signed-off-by: Victoria Jeffrey <vjeffrey@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
fix the quoting on the examples so that we use single quotes on outside and double inside

