### PR TITLE
[infra-proxy-service] Add secrets-service credential type `chef-server`

### DIFF
--- a/api/external/secrets/secrets.go
+++ b/api/external/secrets/secrets.go
@@ -24,6 +24,7 @@ const (
 	requiredAzureClientSecretError         = "Invalid data content for secret type 'azure'. AZURE_CLIENT_SECRET not provided"
 	requiredAzureTenantIDError             = "Invalid data content for secret type 'azure'. AZURE_TENANT_ID not provided"
 	requiredGcpCredentialsJsonError        = "Invalid data content for secret type 'gcp'. GOOGLE_CREDENTIALS_JSON not provided"
+	requiredChefServerOrganizationKeyError = "Invalid data content for secret type 'chef-server'. A 'key' field is required"
 )
 
 type GcpCredential struct {
@@ -77,6 +78,8 @@ func (s *Secret) Validate() error {
 	case "service_now":
 		errors = requiredField(kvMap["username"], requiredServiceNowUsernameError, errors)
 		errors = requiredField(kvMap["password"], requiredServiceNowPasswordError, errors)
+	case "chef-server":
+		errors = requiredField(kvMap["key"], requiredChefServerOrganizationKeyError, errors)
 	}
 
 	// Eventually I'd like to switch our error handling to be handle an aggregation of errors

--- a/api/external/secrets/secrets_test.go
+++ b/api/external/secrets/secrets_test.go
@@ -115,6 +115,11 @@ var exampleValidationFailures = []struct {
 		Data: appendKvs(&query.Kv{Key: "AZURE_CLIENT_SECRET", Value: "AZURE_CLIENT_SECRET"}, &query.Kv{Key: "AZURE_TENANT_ID", Value: "AZURE_TENANT_ID"})},
 		"Invalid data content for secret type 'azure'. AZURE_CLIENT_ID not provided",
 	},
+	//chef-server
+	{Secret{
+		Name: "name",
+		Type: "chef-server",
+	}, "Invalid data content for secret type 'chef-server'. A 'key' field is required"},
 }
 
 var exampleValidationSuccesses = []struct {
@@ -163,6 +168,11 @@ var exampleValidationSuccesses = []struct {
 		Data: appendKvs(&query.Kv{Key: "AZURE_CLIENT_ID", Value: "AZURE_CLIENT_ID"},
 			&query.Kv{Key: "AZURE_CLIENT_SECRET", Value: "AZURE_CLIENT_SECRET"},
 			&query.Kv{Key: "AZURE_TENANT_ID", Value: "AZURE_TENANT_ID"})}},
+	//chef-server
+	{Secret{
+		Name: "name",
+		Type: "chef-server",
+		Data: appendKvs(&query.Kv{Key: "key", Value: "--KEY--"})}},
 }
 
 func appendKvs(kvs ...*query.Kv) []*query.Kv {

--- a/components/infra-proxy-service/server/orgs.go
+++ b/components/infra-proxy-service/server/orgs.go
@@ -42,9 +42,8 @@ func (s *Server) CreateOrg(ctx context.Context, req *request.CreateOrg) (*respon
 
 	newSecret := &secrets.Secret{
 		Name: "infra-proxy-service-admin-key",
-		Type: "ssh",
+		Type: "chef-server",
 		Data: []*query.Kv{
-			{Key: "username", Value: req.AdminUser},
 			{Key: "key", Value: req.AdminKey},
 		},
 	}
@@ -195,9 +194,8 @@ func (s *Server) UpdateOrg(ctx context.Context, req *request.UpdateOrg) (*respon
 		newSecret := &secrets.Secret{
 			Id:   secret.GetId(),
 			Name: "infra-proxy-service-admin-key",
-			Type: "ssh",
+			Type: "chef-server",
 			Data: []*query.Kv{
-				{Key: "username", Value: req.AdminUser},
 				{Key: "key", Value: req.AdminKey},
 			},
 		}

--- a/components/infra-proxy-service/server/orgs_test.go
+++ b/components/infra-proxy-service/server/orgs_test.go
@@ -53,9 +53,8 @@ func TestOrgs(t *testing.T) {
 	}
 	newSecret := secrets.Secret{
 		Name: "infra-proxy-service-admin-key",
-		Type: "ssh",
+		Type: "chef-server",
 		Data: []*query.Kv{
-			{Key: "username", Value: "admin"},
 			{Key: "key", Value: "--KEY--"},
 		},
 	}

--- a/components/infra-proxy-service/server/servers_test.go
+++ b/components/infra-proxy-service/server/servers_test.go
@@ -40,9 +40,8 @@ func TestServers(t *testing.T) {
 	}
 	newSecret := secrets.Secret{
 		Name: "infra-proxy-service-admin-key",
-		Type: "ssh",
+		Type: "chef-server",
 		Data: []*query.Kv{
-			{Key: "username", Value: "admin"},
 			{Key: "key", Value: "--KEY--"},
 		},
 	}


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

Earlier admin key added in `secrets-service` with type `ssh` but seems it getting populated on `node-credentials` setting page. In order to prevent this, it required to add a new secret type `chef-server`.


### :chains: Related Resources

https://github.com/chef/automate/issues/3309

### :+1: Definition of Done
- Added secret type `chef-server` to `secrets-service` to store the chef organization admin key.

### :athletic_shoe: How to Build and Test the Change
Steps to build:
 - `rebuild components/automate-gateway`
 - `rebuild components/infra-proxy-service`
 - `rebuild components/secrets-service`

Steps to test:

1. Valid request
```

chef-automate dev grpcurl secrets-service chef.automate.api.secrets.SecretsService.Create -- -d '{"name": "test-key", "type": "chef-server", "data": [{"key": "key", "value": "--KEY--"}]}'

Response:
{
  "id": "f970da44-5ec7-4085-82d4-65586edd71d0"
}
```

2. Invalid request
```
chef-automate dev grpcurl secrets-service chef.automate.api.secrets.SecretsService.Create -- -d '{"name": "test-key", "type": "chef-server"}'

Response:
ERROR:
  Code: InvalidArgument
  Message: Invalid data content for secret type 'chef-server'. A 'key' field is required

```

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
