### PR TITLE
Handle languages unrecognized by chef-snippet

### DIFF
--- a/components/chef-ui-library/src/atoms/chef-snippet/chef-snippet.e2e.tsx
+++ b/components/chef-ui-library/src/atoms/chef-snippet/chef-snippet.e2e.tsx
@@ -1,35 +1,72 @@
 import { newE2EPage } from '@stencil/core/testing';
 
 describe('chef-snippet', () => {
-  const code = '<h1>Example markup</h1>';
-  const lang = 'html';
-  const html = `<chef-snippet code='${code}' lang='${lang}'></chef-snippet>`;
-
   it('renders', async () => {
-    const page = await newE2EPage();
+    const code = '# hello world';
+    const lang = 'md';
+    const html = genSnippet(code, lang);
 
+    const page = await newE2EPage();
     await page.setContent(html);
+
     const element = await page.find('chef-snippet');
     expect(element).toHaveClass('hydrated');
   });
 
   it('displays highlighted code', async () => {
-    const page = await newE2EPage();
+    const code = '<h1>Example markup</h1>';
+    const lang = 'html';
+    const html = genSnippet(code, lang);
 
+    const page = await newE2EPage();
     await page.setContent(html);
+
     const element = await page.find('chef-snippet');
-    expect(element.textContent).toEqual('<h1>Example markup</h1>');
+    expect(element.textContent).toEqual(code);
   });
 
   describe('when `code` prop is empty', () => {
     it('displays nothing', async () => {
-      const page = await newE2EPage();
-      const snippet = `<chef-snippet code='' lang='${lang}'></chef-snippet>`;
+      const code = '';
+      const lang = 'html';
+      const html = genSnippet(code, lang);
 
-      await page.setContent(snippet);
+      const page = await newE2EPage();
+      await page.setContent(html);
 
       const content = await page.find('pre');
       expect(content).toBeFalsy();
     });
   });
+
+  describe('when grammar rules for provided `lang` are unavailable', () => {
+    it('displays provided `code` as plain text', async () => {
+      const code = '#>>some code%%';
+      const lang = 'unrecognized lang!';
+      const html = genSnippet(code, lang);
+
+      const page = await newE2EPage();
+      await page.setContent(html);
+
+      const content = await page.find('pre');
+      expect(content.textContent).toEqual(code);
+    });
+
+    it('does not log error to the console', async () => {
+      const code = '#>>some code%%';
+      const lang = 'unrecognized lang!';
+      const html = genSnippet(code, lang);
+
+      const page = await newE2EPage();
+      const consoleSpy = jasmine.createSpy();
+      page.on('console', consoleSpy);
+      await page.setContent(html);
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+  });
 });
+
+function genSnippet(code: string, lang: string): string {
+  return `<chef-snippet code='${code}' lang='${lang}'></chef-snippet>`;
+}

--- a/components/chef-ui-library/src/atoms/chef-snippet/chef-snippet.tsx
+++ b/components/chef-ui-library/src/atoms/chef-snippet/chef-snippet.tsx
@@ -60,6 +60,15 @@ export class ChefSnippet {
   }
 
   private highlight(code: string, lang = 'html'): string {
-    return Prism.highlight(code, Prism.languages[lang]);
+    let grammar = Prism.languages[lang];
+
+    // If the grammar rules for the specified language are unavailable then
+    // default to 'none' (no color highlighting, formatted plain text only)
+    if (!grammar) {
+      grammar = {};
+      lang = 'none';
+    }
+
+    return Prism.highlight(code, grammar, lang);
   }
 }


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?

Currently, `chef-snippet` will log an error if the syntax grammar rules for the language it's asked to render are unavailable.

<img width="490" alt="Screen Shot 2020-04-23 at 12 48 27 AM" src="https://user-images.githubusercontent.com/479121/80069277-51f82d00-84fe-11ea-8632-97999a8c94b0.png">

Instead, this commit modifies the code highlighter to silently render code blocks as uncolored plain text in this scenario. This makes downstream usage easier for consumers like `chef-markdown`.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://github.com/PrismJS/prism/issues/344#issuecomment-53880549

Fixes https://github.com/chef/automate/issues/3462

### :+1: Definition of Done

`chef-snippet` doesn't throw error if asked to render an unsupported language.

### :athletic_shoe: How to Build and Test the Change

Render a `chef-snippet` element with any `lang` value specified, see rendered snippet with no errors in console.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable

<img width="639" src="https://user-images.githubusercontent.com/479121/80070972-19a61e00-8501-11ea-833d-336ad975dd59.png">


