### PR TITLE
Deleting chef server message modal window

### DIFF
--- a/components/automate-ui/src/app/entities/servers/server.model.ts
+++ b/components/automate-ui/src/app/entities/servers/server.model.ts
@@ -4,5 +4,5 @@ export interface Server {
   description: string;
   fqdn: string;
   ip_address: string;
-  orgs_count?: string;
+  orgs_count?: number;
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
@@ -25,7 +25,7 @@
         [title]="'Could Not Delete Server'" 
         [visible]="messageModalVisible"
         (close)="closeMessageModal()">
-        Before you can delete this server, delete all orgnisations attached to this server.
+        Before you can delete this server, delete all organizations attached to it.
       </app-message-modal>
       <div class="page-body">
         <chef-toolbar>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
@@ -5,14 +5,25 @@
         <chef-heading>Chef Servers</chef-heading>
         <chef-subheading>Manage Chef Servers with Chef Automate.</chef-subheading>
       </chef-page-header>
-      <app-create-chef-server-modal [visible]="createModalVisible" [creating]="creatingChefServer"
-        [createForm]="createChefServerForm" (close)="closeCreateModal()" [conflictErrorEvent]="conflictErrorEvent"
+      <app-create-chef-server-modal 
+        [visible]="createModalVisible" 
+        [creating]="creatingChefServer"
+        [createForm]="createChefServerForm" 
+        (close)="closeCreateModal()" 
+        [conflictErrorEvent]="conflictErrorEvent"
         (createClicked)="createChefServer()">
       </app-create-chef-server-modal>
-      <app-delete-object-modal [visible]="deleteModalVisible" objectNoun="server" [objectName]="serverToDelete?.name"
-        (close)="closeDeleteModal()" (deleteClicked)="deleteServer()" objectAction="Delete">
+      <app-delete-object-modal 
+        [visible]="deleteModalVisible" 
+        objectNoun="server" 
+        [objectName]="serverToDelete?.name"
+        (close)="closeDeleteModal()" 
+        (deleteClicked)="deleteServer()" 
+        objectAction="Delete">
       </app-delete-object-modal>
-      <app-message-modal [title]="'Could Not Delete Server'" [visible]="messageModalVisible"
+      <app-message-modal 
+        [title]="'Could Not Delete Server'" 
+        [visible]="messageModalVisible"
         (close)="closeMessageModal()">
         Before you can delete this server, delete all orgnisations attached to this server.
       </app-message-modal>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
@@ -5,22 +5,17 @@
         <chef-heading>Chef Servers</chef-heading>
         <chef-subheading>Manage Chef Servers with Chef Automate.</chef-subheading>
       </chef-page-header>
-      <app-create-chef-server-modal
-        [visible]="createModalVisible"
-        [creating]="creatingChefServer"
-        [createForm]="createChefServerForm"
-        (close)="closeCreateModal()"
-        [conflictErrorEvent]="conflictErrorEvent"
+      <app-create-chef-server-modal [visible]="createModalVisible" [creating]="creatingChefServer"
+        [createForm]="createChefServerForm" (close)="closeCreateModal()" [conflictErrorEvent]="conflictErrorEvent"
         (createClicked)="createChefServer()">
       </app-create-chef-server-modal>
-      <app-delete-object-modal
-        [visible]="deleteModalVisible"
-        objectNoun="server"
-        [objectName]="serverToDelete?.name"
-        (close)="closeDeleteModal()"
-        (deleteClicked)="deleteServer()"
-        objectAction="Delete">
+      <app-delete-object-modal [visible]="deleteModalVisible" objectNoun="server" [objectName]="serverToDelete?.name"
+        (close)="closeDeleteModal()" (deleteClicked)="deleteServer()" objectAction="Delete">
       </app-delete-object-modal>
+      <app-message-modal [title]="'Could Not Delete Server'" [visible]="messageModalVisible"
+        (close)="closeMessageModal()">
+        Before you can delete this server, delete all orgnisations attached to this server.
+      </app-message-modal>
       <div class="page-body">
         <chef-toolbar>
           <chef-button primary (click)="openCreateModal()">Add Chef Server</chef-button>
@@ -37,17 +32,18 @@
             </chef-tr>
           </chef-thead>
           <chef-tbody>
-            <chef-tr *ngFor= "let server of sortedChefServers$ | async">
-              <chef-td >
+            <chef-tr *ngFor="let server of sortedChefServers$ | async">
+              <chef-td>
                 <a [routerLink]="['/infrastructure/chef-servers', server.id]">{{ server.name }}</a>
               </chef-td>
-              <chef-td  >{{ server.fqdn }}</chef-td>
-              <chef-td  >{{ server.ip_address }}</chef-td>
-              <chef-td  >{{ server.description }}</chef-td>
-              <chef-td  >{{ server.orgs_count }}</chef-td>
+              <chef-td>{{ server.fqdn }}</chef-td>
+              <chef-td>{{ server.ip_address }}</chef-td>
+              <chef-td>{{ server.description }}</chef-td>
+              <chef-td>{{ server.orgs_count }}</chef-td>
               <chef-td class="three-dot-column">
                 <mat-select panelClass="chef-control-menu" id="menu-{{server.id}}">
-                  <mat-option (onSelectionChange)="startServerDelete($event, server)" data-cy="remove-server">Remove Chef Server</mat-option>
+                  <mat-option (onSelectionChange)="startServerDelete($event, server)" data-cy="remove-server">Remove
+                    Chef Server</mat-option>
                 </mat-select>
               </chef-td>
             </chef-tr>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.spec.ts
@@ -12,6 +12,7 @@ import { CreateServerSuccess, CreateServerFailure } from 'app/entities/servers/s
 import { NgrxStateAtom, ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { HttpStatus } from 'app/types/types';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+import { ChefKeyboardEvent } from 'app/types/material-types';
 
 describe('ChefServersListComponent', () => {
   let component: ChefServersListComponent;
@@ -21,15 +22,19 @@ describe('ChefServersListComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent({
-        selector: 'app-create-chef-server-modal',
-        inputs: ['visible', 'creating', 'conflictErrorEvent', 'createForm'],
-        outputs: ['close', 'createClicked']
+          selector: 'app-create-chef-server-modal',
+          inputs: ['visible', 'creating', 'conflictErrorEvent', 'createForm'],
+          outputs: ['close', 'createClicked']
         }),
-        MockComponent({ selector: 'app-delete-object-modal',
-        inputs: ['default', 'visible', 'objectNoun', 'objectName'],
-        outputs: ['close', 'deleteClicked'] }),
-        MockComponent({ selector: 'chef-button',
-                inputs: ['disabled', 'routerLink'] }),
+        MockComponent({
+          selector: 'app-delete-object-modal',
+          inputs: ['default', 'visible', 'objectNoun', 'objectName'],
+          outputs: ['close', 'deleteClicked']
+        }),
+        MockComponent({
+          selector: 'chef-button',
+          inputs: ['disabled', 'routerLink']
+        }),
         MockComponent({ selector: 'chef-error' }),
         MockComponent({ selector: 'chef-form-field' }),
         MockComponent({ selector: 'chef-heading' }),
@@ -58,9 +63,9 @@ describe('ChefServersListComponent', () => {
         RouterTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
@@ -75,13 +80,13 @@ describe('ChefServersListComponent', () => {
 
   describe('create server', () => {
     let store: Store<NgrxStateAtom>;
-    const server = <Server> {
-        id: '1',
-        name: 'new server',
-        description: 'new server description',
-        fqdn: 'xyz.com',
-        ip_address: '1.1.1.1'
-      };
+    const server = <Server>{
+      id: '1',
+      name: 'new server',
+      description: 'new server description',
+      fqdn: 'xyz.com',
+      ip_address: '1.1.1.1'
+    };
 
     beforeEach(() => {
       store = TestBed.inject(Store);
@@ -112,7 +117,7 @@ describe('ChefServersListComponent', () => {
       component.createChefServerForm.controls['ip_address'].setValue(server.ip_address);
       component.createChefServer();
 
-      store.dispatch(new CreateServerSuccess({'server': server}));
+      store.dispatch(new CreateServerSuccess({ 'server': server }));
 
       component.sortedChefServers$.subscribe(servers => {
         expect(servers).toContain(server);
@@ -208,5 +213,56 @@ describe('ChefServersListComponent', () => {
 
     });
   });
+
+  describe('delete modal', () => {
+    const mockChefKeyEvent = new KeyboardEvent('keypress') as ChefKeyboardEvent;
+    mockChefKeyEvent.isUserInput = true;
+
+    it('upon selecting delete from control menu, opens with org count 0', () => {
+      expect(component.deleteModalVisible).toBe(false);
+      component.startServerDelete(mockChefKeyEvent, genServer('uuid-111', 0));
+      expect(component.deleteModalVisible).toBe(true);
+    });
+
+    it('closes upon sending request to back-end', () => {
+      component.startServerDelete(mockChefKeyEvent, genServer('uuid-111', 0));
+       expect(component.deleteModalVisible).toBe(true);
+       component.deleteServer();
+       expect(component.deleteModalVisible).toBe(false);
+     });
+
+  });
+
+  describe('message modal', () => {
+    const mockChefKeyEvent = new KeyboardEvent('keypress') as ChefKeyboardEvent;
+    mockChefKeyEvent.isUserInput = true;
+
+
+    it('upon selecting delete from control menu, opens with org count 1', () => {
+      expect(component.messageModalVisible).toBe(false);
+      component.startServerDelete(mockChefKeyEvent, genServer('uuid-111', 1));
+      expect(component.messageModalVisible).toBe(true);
+    });
+
+    it('closes upon request', () => {
+      component.startServerDelete(mockChefKeyEvent, genServer('uuid-111', 1));
+      expect(component.messageModalVisible).toBe(true);
+      component.closeMessageModal();
+      expect(component.messageModalVisible).toBe(false);
+    });
+
+  });
+
+  function genServer(id: string, orgs_count: number): Server {
+    return {
+      id,
+      orgs_count,
+      name: 'Demo Server',
+      description: 'Demo Description',
+      fqdn: 'http://demo.com/',
+      ip_address: '192.168.2.1'
+    };
+  }
+
 });
 

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.spec.ts
@@ -3,6 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatOptionSelectionChange } from '@angular/material/core/option';
 import { MockComponent } from 'ng2-mock-component';
 import { StoreModule, Store } from '@ngrx/store';
 
@@ -12,7 +13,6 @@ import { CreateServerSuccess, CreateServerFailure } from 'app/entities/servers/s
 import { NgrxStateAtom, ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { HttpStatus } from 'app/types/types';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
-import { ChefKeyboardEvent } from 'app/types/material-types';
 
 describe('ChefServersListComponent', () => {
   let component: ChefServersListComponent;
@@ -215,37 +215,40 @@ describe('ChefServersListComponent', () => {
   });
 
   describe('delete modal', () => {
-    const mockChefKeyEvent = new KeyboardEvent('keypress') as ChefKeyboardEvent;
-    mockChefKeyEvent.isUserInput = true;
+    const mockEvent = { isUserInput: true } as MatOptionSelectionChange;
 
-    it('upon selecting delete from control menu, opens with org count 0', () => {
+    it('With no orgs, selecting delete from control menu opens the delete modal', () => {
       expect(component.deleteModalVisible).toBe(false);
-      component.startServerDelete(mockChefKeyEvent, genServer('uuid-111', 0));
+      component.startServerDelete(mockEvent, genServer('uuid-111', 0));
       expect(component.deleteModalVisible).toBe(true);
     });
 
     it('closes upon sending request to back-end', () => {
-      component.startServerDelete(mockChefKeyEvent, genServer('uuid-111', 0));
-       expect(component.deleteModalVisible).toBe(true);
-       component.deleteServer();
-       expect(component.deleteModalVisible).toBe(false);
-     });
+      component.startServerDelete(mockEvent, genServer('uuid-111', 0));
+      expect(component.deleteModalVisible).toBe(true);
+      component.deleteServer();
+      expect(component.deleteModalVisible).toBe(false);
+    });
 
   });
 
   describe('message modal', () => {
-    const mockChefKeyEvent = new KeyboardEvent('keypress') as ChefKeyboardEvent;
-    mockChefKeyEvent.isUserInput = true;
+    const mockEvent = { isUserInput: true } as MatOptionSelectionChange;
 
-
-    it('upon selecting delete from control menu, opens with org count 1', () => {
+    it('With one org, selecting delete from control menu opens the message modal', () => {
       expect(component.messageModalVisible).toBe(false);
-      component.startServerDelete(mockChefKeyEvent, genServer('uuid-111', 1));
+      component.startServerDelete(mockEvent, genServer('uuid-111', 1));
+      expect(component.messageModalVisible).toBe(true);
+    });
+
+    it('With multiple orgs, selecting delete from control menu opens the message modal', () => {
+      expect(component.messageModalVisible).toBe(false);
+      component.startServerDelete(mockEvent, genServer('uuid-111', 1));
       expect(component.messageModalVisible).toBe(true);
     });
 
     it('closes upon request', () => {
-      component.startServerDelete(mockChefKeyEvent, genServer('uuid-111', 1));
+      component.startServerDelete(mockEvent, genServer('uuid-111', 4));
       expect(component.messageModalVisible).toBe(true);
       component.closeMessageModal();
       expect(component.messageModalVisible).toBe(false);

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnInit, OnDestroy, EventEmitter } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatOptionSelectionChange } from '@angular/material/core/option';
 import { Store, select } from '@ngrx/store';
 import { filter, takeUntil, map } from 'rxjs/operators';
 import { Regex } from 'app/helpers/auth/regex';
 import { Observable, Subject, combineLatest } from 'rxjs';
 import { isNil } from 'lodash/fp';
+
 import { HttpStatus } from 'app/types/types';
-import { ChefKeyboardEvent } from 'app/types/material-types';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { loading, EntityStatus, pending } from 'app/entities/entities';
@@ -121,7 +122,7 @@ export class ChefServersListComponent implements OnInit, OnDestroy {
     this.conflictErrorEvent.emit(false);
   }
 
-  public startServerDelete($event: ChefKeyboardEvent, server: Server): void {
+  public startServerDelete($event: MatOptionSelectionChange, server: Server): void {
     if ($event.isUserInput) {
       if (server.orgs_count > 0) {
         this.messageModalVisible = true;

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
@@ -30,6 +30,7 @@ export class ChefServersListComponent implements OnInit, OnDestroy {
   private isDestroyed = new Subject<boolean>();
   public serverToDelete: Server;
   public deleteModalVisible = false;
+  public messageModalVisible = false;
 
   constructor(
     private store: Store<NgrxStateAtom>,
@@ -122,8 +123,12 @@ export class ChefServersListComponent implements OnInit, OnDestroy {
 
   public startServerDelete($event: ChefKeyboardEvent, server: Server): void {
     if ($event.isUserInput) {
-      this.serverToDelete = server;
-      this.deleteModalVisible = true;
+      if (server.orgs_count > 0) {
+        this.messageModalVisible = true;
+      } else {
+        this.serverToDelete = server;
+        this.deleteModalVisible = true;
+      }
     }
   }
 
@@ -134,5 +139,9 @@ export class ChefServersListComponent implements OnInit, OnDestroy {
 
   public closeDeleteModal(): void {
     this.deleteModalVisible = false;
+  }
+
+  public closeMessageModal(): void {
+    this.messageModalVisible = false;
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
User should NOT be allowed to delete a chef server if it has orgs, so added message window for the same.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
### :chains: Related Resources
#3294 
### :+1: Definition of Done
- Added message window on delete a chef server if it has and organisation attached to it 
### :athletic_shoe: How to Build and Test the Change
1. `git fetch origin Sachin/infra-cookbook-details`
2. `build components/automate-ui` 
3. Go to `Chef Servers` option which is under `Infrastructure` tab and its under `Chef-Server` feature flag.
4. Add chef server and one organisation under it.
5. Add one more just chef server with no organisation. 
6. Now try to delete both chef server one by one you will able to see the delete and message window as shown in attached screen shots


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests updated
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![server-with-org](https://user-images.githubusercontent.com/54940695/80123176-2895da80-85ac-11ea-95f6-1df9b9d1c409.png)
![server-without-org](https://user-images.githubusercontent.com/54940695/80123191-2f245200-85ac-11ea-9882-bf4274e9606c.png)
