### PR TITLE
[infra-proxy-service] Add test resetter implementation

### DIFF
--- a/components/infra-proxy-service/Makefile
+++ b/components/infra-proxy-service/Makefile
@@ -26,7 +26,9 @@ build:
 	go build -mod=vendor -o bin/infra-proxy-service ./cmd/infra-proxy-service
 
 test:
+	@docker ps | grep infra-proxy-postgres || (echo "Docker postgres not up. Run make setup_docker_pg and try this command again."; exit 1)
 	@PG_URL=$(PG_URL) go test $(verbose) -cover -count=1 -parallel=1 -p 1 $(packages)
+	@echo "Docker containers still up, run 'make kill_docker_pg' to bring them down or test again with make test."
 
 setup_docker_pg:
 	docker run --name infra-proxy-postgres -e POSTGRES_USER=postgres -e POSTGRES_DB=infra_proxy_test -e POSTGRES_PASSWORD=docker -p 5432:5432 -d postgres:9
@@ -37,9 +39,6 @@ setup_docker_pg:
 
 kill_docker_pg:
 	docker rm -f infra-proxy-postgres || true
-
-truncate_servers:
-	docker exec -it infra-proxy-postgres psql -U postgres -d infra_proxy_test -c "TRUNCATE table servers CASCADE;"
 
 # this command lists all the changes since master, and looks for modifications
 # to the migration files -- if there's any of (M)odify, (R)ename, or (D)elete,

--- a/components/infra-proxy-service/Makefile
+++ b/components/infra-proxy-service/Makefile
@@ -26,9 +26,7 @@ build:
 	go build -mod=vendor -o bin/infra-proxy-service ./cmd/infra-proxy-service
 
 test:
-	@docker ps | grep infra-proxy-postgres || (echo "Docker postgres not up. Run make setup_docker_pg and try this command again."; exit 1)
 	@PG_URL=$(PG_URL) go test $(verbose) -cover -count=1 -parallel=1 -p 1 $(packages)
-	@echo "Docker containers still up, run 'make kill_docker_pg' to bring them down or test again with make test."
 
 setup_docker_pg:
 	docker run --name infra-proxy-postgres -e POSTGRES_USER=postgres -e POSTGRES_DB=infra_proxy_test -e POSTGRES_PASSWORD=docker -p 5432:5432 -d postgres:9

--- a/components/infra-proxy-service/server/root_test.go
+++ b/components/infra-proxy-service/server/root_test.go
@@ -8,26 +8,15 @@ import (
 
 	"github.com/chef/automate/api/external/common/version"
 	infra_proxy "github.com/chef/automate/api/interservice/infra_proxy/service"
-	"github.com/chef/automate/lib/logger"
 
 	"github.com/chef/automate/components/infra-proxy-service/test"
 )
 
 func TestVersion(t *testing.T) {
 	ctx := context.Background()
-
-	l, err := logger.NewLogger("text", "debug")
-	require.NoError(t, err, "could not init logger", err)
-
-	migrationConfig, err := test.MigrationConfigIfPGTestsToBeRun(l, "../storage/postgres/migration/sql")
-	require.NoError(t, err)
-
-	_, _, conn, close, _ := test.SetupInfraProxyService(ctx, t, l, *migrationConfig)
-	defer close()
-
+	_, _, conn, close, _, _ := test.SetupInfraProxyService(ctx, t)
 	cl := infra_proxy.NewInfraProxyClient(conn)
 
-	t.Helper()
 	defer close()
 
 	t.Run("GetVersion", func(t *testing.T) {

--- a/components/infra-proxy-service/server/server_test.go
+++ b/components/infra-proxy-service/server/server_test.go
@@ -7,24 +7,15 @@ import (
 	"github.com/stretchr/testify/require"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
-	"github.com/chef/automate/lib/logger"
-
 	"github.com/chef/automate/components/infra-proxy-service/test"
 )
 
 func TestHealthGRPC(t *testing.T) {
 	ctx := context.Background()
-
-	l, err := logger.NewLogger("text", "debug")
-	require.NoError(t, err, "could not init logger", err)
-
-	migrationConfig, err := test.MigrationConfigIfPGTestsToBeRun(l, "../storage/postgres/migration/sql")
-	require.NoError(t, err)
-
-	_, _, conn, close, _ := test.SetupInfraProxyService(ctx, t, l, *migrationConfig)
-	defer close()
-
+	_, _, conn, close, _, _ := test.SetupInfraProxyService(ctx, t)
 	cl := healthpb.NewHealthClient(conn)
+
+	defer close()
 
 	t.Run("Check", func(t *testing.T) {
 		actual, err := cl.Check(ctx, &healthpb.HealthCheckRequest{})

--- a/components/infra-proxy-service/server/servers_test.go
+++ b/components/infra-proxy-service/server/servers_test.go
@@ -16,23 +16,13 @@ import (
 	infra_proxy "github.com/chef/automate/api/interservice/infra_proxy/service"
 	"github.com/chef/automate/components/infra-proxy-service/test"
 	"github.com/chef/automate/lib/grpc/grpctest"
-	"github.com/chef/automate/lib/logger"
 )
 
 func TestServers(t *testing.T) {
 	ctx := context.Background()
-
-	l, err := logger.NewLogger("text", "debug")
-	require.NoError(t, err, "could not init logger", err)
-
-	migrationConfig, err := test.MigrationConfigIfPGTestsToBeRun(l, "../storage/postgres/migration/sql")
-	require.NoError(t, err)
-
-	_, serviceRef, conn, close, _ := test.SetupInfraProxyService(ctx, t, l, *migrationConfig)
-	secretsMock := serviceRef.Secrets.(*secrets.MockSecretsServiceClient)
+	_, serviceRef, conn, close, _, secretsMock := test.SetupInfraProxyService(ctx, t)
 	cl := infra_proxy.NewInfraProxyClient(conn)
 
-	t.Helper()
 	defer close()
 
 	secretID := &secrets.Id{

--- a/components/infra-proxy-service/storage/postgres/resetter.go
+++ b/components/infra-proxy-service/storage/postgres/resetter.go
@@ -1,0 +1,12 @@
+// +build !prod
+
+package postgres
+
+import (
+	"context"
+)
+
+func (p *postgres) Reset(ctx context.Context) error {
+	_, err := p.db.ExecContext(ctx, "TRUNCATE table servers CASCADE;")
+	return err
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

- Observed minor refactoring while setting up an infra server for the test environment.

- if any failures occur in test cases, the next run raises error due to existed records.

- Left with test DB resetter interface implementation. 



### :chains: Related Resources
NA
### :+1: Definition of Done
 - DRY some of the test helpers code.
 - Added test DB resetter.

### :athletic_shoe: How to Build and Test the Change
 - Navigate to `cd components/infra-proxy-service`
 - `make setup_docker_pg`
 - `make test`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>