### PR TITLE
validate format of profile urls at scan job creation time

### DIFF
--- a/components/compliance-service/api/jobs/server/server_test.go
+++ b/components/compliance-service/api/jobs/server/server_test.go
@@ -2,9 +2,12 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/chef/automate/lib/grpc/auth_context"
 )
@@ -23,4 +26,18 @@ func TestGetUserValFromCtx(t *testing.T) {
 	subs = []string{"something_else", "not:right"}
 	ctx = auth_context.NewContext(ctx, subs, []string{}, "", "")
 	assert.Equal(t, "", getUserValFromCtx(ctx))
+}
+
+func TestValidateProfilesFormat(t *testing.T) {
+	err := validateProfilesFormat([]string{"compliance://admin/linux-baseline#2.2.2"})
+	assert.Equal(t, nil, err)
+
+	err = validateProfilesFormat([]string{"compliance://admin/linux-baseline"})
+	assert.Equal(t, status.Error(codes.InvalidArgument, fmt.Sprintf("Invalid job: profile version must be specified. Profile url provided: compliance://admin/linux-baseline")), err)
+
+	err = validateProfilesFormat([]string{"compliance://linux-baseline#2.2.2"})
+	assert.Equal(t, status.Error(codes.InvalidArgument, fmt.Sprintf("Invalid job: profile owner must be specified. Profile url provided: compliance://linux-baseline#2.2.2")), err)
+
+	err = validateProfilesFormat([]string{"compliance://admin/linux-baseline#2.2.2", "compliance://admin/linux-baseline", "https://github.com/dev-sec/linux-baseline/archive/master.tar.gz"})
+	assert.Equal(t, status.Error(codes.InvalidArgument, fmt.Sprintf("Invalid job: profile version must be specified. Profile url provided: compliance://admin/linux-baseline")), err)
 }


### PR DESCRIPTION
Signed-off-by: Victoria Jeffrey <vjeffrey@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

a customer recently had a problem with scan jobs

they were using the api, and they had specified the profile without including the version.
as a result of leaving out the version, we skipped the profile, and sent a report into compliance ingestion that just had no data, bc we couldnt find the profile

this pr adds validation to the api so that users dont create scan jobs with bad profile urls

### :+1: Definition of Done
profiles urls are validated before creating the job. 

### :athletic_shoe: How to Build and Test the Change
update compliance
try creating a scan job with a malformed profile url: 
```
{
"name": "scan",
"tags": [],
"type": "exec",
"nodes": ["node-id"],
"profiles": ["compliance://admin/linux-baseline"],
"retries": 1
}
```
### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

