### PR TITLE
[core-plan-refresh-2020q1-008] update pins

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -56,6 +56,7 @@ steps:
       ALLOW_LOCAL_PACKAGES: true
       HAB_STUDIO_SUP: false
       HAB_NONINTERACTIVE: true
+      HAB_BLDR_CHANNEL: refresh-2020q1-008
     expeditor:
       secrets:
         HAB_STUDIO_SECRET_GITHUB_TOKEN:
@@ -143,7 +144,7 @@ steps:
 
   # The nodemanager tests require access to AWS and Azure accounts as
   # they test against the actual API endpoints of those services.
-  - label: "nodemanager-integration-tests"
+  - label: "nodemanager-integration"
     command:
       - . scripts/verify_setup.sh
       - |
@@ -184,7 +185,7 @@ steps:
 
   # The license_usage_nodes_test appears to require AWS access. We
   # might consider splitting this into two different tests.
-  - label: "gateway-integration-tests"
+  - label: "gateway-integration"
     command:
       - . scripts/verify_setup.sh
       - hab studio run "source scripts/verify_studio_init.sh && start_all_services && go_test ./components/automate-gateway/integration/..."
@@ -500,7 +501,7 @@ steps:
   - label: "airgap a1migration"
     command:
       - integration/run_test integration/tests/airgap_a1migration.sh
-    timeout_in_minutes: 20
+    timeout_in_minutes: 25
     expeditor:
       executor:
         linux:
@@ -530,7 +531,7 @@ steps:
   - label: "product airgap"
     command:
       - integration/run_test integration/tests/airgap_product.sh
-    timeout_in_minutes: 20
+    timeout_in_minutes: 25
     expeditor:
       executor:
         linux:
@@ -564,7 +565,7 @@ steps:
   - label: "airgap backup"
     command:
       - integration/run_test integration/tests/airgap_backup.sh
-    timeout_in_minutes: 25
+    timeout_in_minutes: 30
     expeditor:
       executor:
         linux:
@@ -610,7 +611,7 @@ steps:
   - label: "backup to s3"
     command:
       - integration/run_test integration/tests/backup_s3.sh
-    timeout_in_minutes: 30
+    timeout_in_minutes: 35
     expeditor:
       accounts:
         - aws/chef-cd
@@ -819,7 +820,7 @@ steps:
           single-use: true
           privileged: true
 
-  - label: "builder smoke tests"
+  - label: "builder smoke"
     command:
       - integration/run_test integration/tests/bldr_smoke.sh
     timeout_in_minutes: 25

--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -271,6 +271,10 @@ exceptions:
       reason: Exception made by Chef Legal
     - name: core/nss-myhostname
       reason: Exception made by Chef Legal
+    - name: core/binutils
+      reason: (rc) dep of core/bundler. Exception made by Stephen Delano, 4/23/20
+    - name: core/perl
+      reason: (rc) dep of core/git, used by Workflow and sqitch. Exception made by Stephen Delano, 4/23/20
 
   ruby:
     - name: highline

--- a/components/automate-builder-api-proxy/habitat/plan.sh
+++ b/components/automate-builder-api-proxy/habitat/plan.sh
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # We need to pin here to get a build from unstable
-  "habitat/builder-api-proxy/8796/20200309134228"
+  "habitat/builder-api-proxy/8865/20200421224604"
 )
 
 pkg_build_deps=(

--- a/components/automate-builder-api/habitat/plan.sh
+++ b/components/automate-builder-api/habitat/plan.sh
@@ -14,7 +14,7 @@ pkg_deps=(
   core/bash
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # We need to pin here to get a build from unstable
-  "habitat/builder-api/8850/20200330144923"
+  "habitat/builder-api/8850/20200421223841"
 )
 
 pkg_binds=(

--- a/components/automate-cs-bookshelf/habitat/plan.sh
+++ b/components/automate-cs-bookshelf/habitat/plan.sh
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/bookshelf/13.0.47/20191009112037"
+  "${vendor_origin}/bookshelf/13.0.47/20200421211738"
 )
 
 pkg_binds=(

--- a/components/automate-cs-nginx/habitat/plan.sh
+++ b/components/automate-cs-nginx/habitat/plan.sh
@@ -10,15 +10,12 @@ pkg_license=('Chef-MLSA')
 pkg_version="13.0.47"
 pkg_deps=(
   chef/mlsa
-  # TODO: REMOVE PINS
-  # The following pins match those in the chef-server-* packages below
-  # and can be removed once we unblock upgrades of chef-server.
-  core/curl/7.65.3/20190826035620
-  core/bundler/1.17.3/20191007210608
-  core/ruby/2.5.7/20191007205439
+  core/curl
+  core/bundler
+  core/ruby
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/chef-server-nginx/13.0.47/20191009112851"
-  "${vendor_origin}/chef-server-ctl/13.0.47/20191009112038"
+  "${vendor_origin}/chef-server-nginx/13.0.47/20200421235836"
+  "${vendor_origin}/chef-server-ctl/13.0.47/20200421235903"
 )
 
 pkg_bin_dirs=(bin)

--- a/components/automate-cs-oc-bifrost/habitat/plan.sh
+++ b/components/automate-cs-oc-bifrost/habitat/plan.sh
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/oc_bifrost/13.0.47/20191009112044"
+  "${vendor_origin}/oc_bifrost/13.0.47/20200421235620"
 )
 
 pkg_binds=(

--- a/components/automate-cs-oc-erchef/habitat/plan.sh
+++ b/components/automate-cs-oc-erchef/habitat/plan.sh
@@ -16,7 +16,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/oc_erchef/13.0.47/20191009112044"
+  "${vendor_origin}/oc_erchef/13.0.47/20200421235032"
 )
 
 pkg_build_deps=(

--- a/components/automate-workflow-nginx/habitat/plan.sh
+++ b/components/automate-workflow-nginx/habitat/plan.sh
@@ -1,3 +1,6 @@
+#shellcheck disable=SC2034
+#shellcheck disable=SC2154
+
 pkg_name=automate-workflow-nginx
 pkg_origin=chef
 pkg_version=2.8.61
@@ -6,14 +9,14 @@ pkg_license=('Chef-MLSA')
 vendor_origin=${vendor_origin:-"chef"}
 
 pkg_deps=(
-  core/libossp-uuid
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/openresty-noroot/1.13.6.2/20191009112038"
+  "${vendor_origin}/openresty-noroot/1.13.6.2/20200421183321"
+  "${vendor_origin}/automate-workflow-web"
   chef/mlsa
   core/bash
   core/curl
   core/coreutils
-  "${vendor_origin}/automate-workflow-web"
+  core/libossp-uuid
 )
 
 pkg_exposes=(port ssl-port)
@@ -38,7 +41,7 @@ do_build() {
 
 do_install() {
     mkdir -pv "$pkg_prefix/www/workflow" "$pkg_prefix/www/loading"
-    cp -Rv "$(pkg_path_for ${vendor_origin}/automate-workflow-web)"/dist/* "$pkg_prefix/www/workflow"
+    cp -Rv "$(pkg_path_for "${vendor_origin}/automate-workflow-web")"/dist/* "${pkg_prefix}/www/workflow"
     cp -v "$SRC_PATH/loading.html" "$pkg_prefix/www/loading/index.html"
 }
 

--- a/components/automate-workflow-web/habitat/plan.sh
+++ b/components/automate-workflow-web/habitat/plan.sh
@@ -1,3 +1,6 @@
+#shellcheck disable=SC2034
+#shellcheck disable=SC2154
+
 pkg_name=automate-workflow-web
 pkg_origin=chef
 pkg_version="1.0.0"

--- a/components/compliance-service/habitat/plan.sh
+++ b/components/compliance-service/habitat/plan.sh
@@ -29,17 +29,14 @@ pkg_binds_optional=(
   [authn-service]="port"
   [notifications-service]="port"
 )
-inspec_release="chef/inspec/4.18.104/20200407121143"
+inspec_release="chef/inspec/4.18.104/20200421173550"
 pkg_deps=(
-  core/bash
-  core/grpcurl              # Used in habitat/hooks/health_check
-  core/jq-static            # Used in habitat/hooks/health_check
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
-  # WARNING: Update with care. The chef/inspec is managed with Expeditor.
-
-  # See .expeditor/update-inspec-version.sh for details
   "${inspec_release}"
   chef/mlsa
+  core/grpcurl              # Used in habitat/hooks/health_check
+  core/jq-static            # Used in habitat/hooks/health_check
+  core/bash
 )
 
 if [[ -n "$AUTOMATE_OSS_BUILD" ]]; then


### PR DESCRIPTION
:warning: DO NOT MERGE until the refresh-2020q1-008 hab channel has been promoted to stable :warning: 

This change updates the hardcoded pins in Chef Automate to use versions in the refresh-2020q1-008 core plan refresh channel. It has been tested against refresh-2020q1-008 channel:
* https://buildkite.com/chef-oss/chef-automate-master-verify/builds/11382
* https://buildkite.com/chef/chef-automate-master-verify-private/builds/11761

This change supersedes the work done previous here https://github.com/chef/automate/pull/3311

## How to rebuild the universe
* [ ] refresh-2020q1-008 has bee promoted to stable
* [ ] Rebuild this PR
* [ ] Merge the change
* [ ] Create a new master automate build job and use the master branch. We use expeditors `smart_build` option so we'll need to trigger a build job manually to rebuild all the things. If we don't rebuild everything our airgap bundles will include multiple universes of packages. https://buildkite.com/chef/chef-automate-master-habitat-build
* [ ] After the manual habitat/build job has completed and the artifacts have been promoted to the dev channel, create and merge a new PR that updates the `automate-elasticsearch` and `automate-postgresql` pins in `.expeditor/create-manifest.rb` to the packages built in the manual habitat build.
* [ ] :beers: 