### PR TITLE
amend load_compliance_reports command: send in matching chef infra reports

### DIFF
--- a/.studio/compliance-service
+++ b/.studio/compliance-service
@@ -95,6 +95,16 @@ function load_compliance_reports() {
     pushd components/compliance-service/test_data/audit_reports &> /dev/null
     ./send_to_data_collector.sh https://a2-dev.test "$(get_admin_token)"
     popd &> /dev/null
+    generate_chef_run_example | jq '.entity_uuid = "34cbbb4c-c502-4971-b193-00e987b4678c"' | jq '.node_name = "debian(2)-zeta-linux(f)-apache(p)-failed"' | send_chef_data_raw
+    generate_chef_run_failure_example | jq '.entity_uuid = "9b9f4e51-b049-4b10-9555-10578916e149"' | jq '.node_name = "centos-beta"' | send_chef_data_raw
+    generate_chef_run_example | jq '.entity_uuid = "9b9f4e51-b049-4b10-9555-10578916e112"' | jq '.node_name = "redhat(2)-alpha-nginx(f)-apache(f)-failed"' | send_chef_data_raw
+    generate_chef_run_failure_example | jq '.entity_uuid = "9b9f4e51-b049-4b10-9555-10578916e111"' | jq '.node_name = "redhat(2)-alpha-nginx(f)-apache(s)-failed"' | send_chef_data_raw
+    generate_chef_run_example | jq '.entity_uuid = "9b9f4e51-b049-4b10-9555-10578916e222"' | jq '.node_name = "RedHat(2)-beta-nginx(f)-apache(s)-failed"' | send_chef_data_raw
+    generate_chef_run_failure_example | jq '.entity_uuid = "a0ddd774-cbbb-49be-8730-49c92f3fc2a0"' | jq '.node_name = "windows(1)-zeta-apache(s)-skipped"' | send_chef_data_raw
+    generate_chef_run_example | jq '.entity_uuid = "9b9f4e51-b049-4b10-9555-10578916e149"' | jq '.node_name = "centos-beta"' | send_chef_data_raw
+    generate_chef_run_failure_example | jq '.entity_uuid = "9b9f4e51-b049-4b10-9555-10578916e666"' | jq '.node_name = "ubuntu(1)-alpha-myprofile(s)-skipped"' | send_chef_data_raw
+    generate_chef_run_failure_example | jq '.entity_uuid = "34cbbb55-c502-4971-2222-999999999999"' | jq '.node_name = "osx(1)-omega-pro2(w)-waived"' | send_chef_data_raw
+    generate_chef_run_failure_example | jq '.entity_uuid = "34cbbb4c-c502-4971-1111-888888888888"' | jq '.node_name = "osx(2)-omega-pro1(f)-pro2(w)-failed"' | send_chef_data_raw
 }
 
 document "load_scan_jobs" <<DOC


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
this just adds some chef infra reports to the load_compliance_reports command.
helps with getting sample data for chef infra and compliance that has matching node id - just like it would if it was going through audit cookbook 

### :+1: Definition of Done
load_compliance_reports also sends node reports into chef infra with same name/id

### :athletic_shoe: How to Build and Test the Change
source .studio/compliance-service
load_compliance_reports
