### PR TITLE
one node view skeleton

### DIFF
--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -272,6 +272,10 @@ const routes: Routes = [
       loadChildren: () => import('./modules/desktop/desktop.module').then(m => m.DesktopModule)
     },
     {
+      path: 'nodes',
+      loadChildren: () => import('./modules/nodes/nodes.module').then(m => m.NodesModule)
+    },
+    {
       path: 'profiles',
       redirectTo: '/compliance/compliance-profiles',
       pathMatch: 'full'

--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -71,6 +71,7 @@ import { ClientRunsRequests } from './entities/client-runs/client-runs.requests'
 import { CredentialRequests } from './entities/credentials/credential.requests';
 import { DesktopRequests } from './entities/desktop/desktop.requests';
 import { DestinationRequests } from './entities/destinations/destination.requests';
+import { NodesRequests } from './entities/nodes/nodes.requests';
 import { JobRequests } from './entities/jobs/job.requests';
 import { LicenseStatusRequests } from './entities/license/license.requests';
 import { ManagerRequests } from './entities/managers/manager.requests';
@@ -285,6 +286,7 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     CredentialRequests,
     DesktopRequests,
     DestinationRequests,
+    NodesRequests,
     EventFeedService,
     FeatureFlagsService,
     HistorySelection,

--- a/components/automate-ui/src/app/entities/nodes/nodes.actions.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.actions.ts
@@ -4,7 +4,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 export enum NodesActionTypes {
   LIST_NODES             = 'NODES::LIST_NODES',
   LIST_NODES_SUCCESS     = 'NODES::LIST_NODES::SUCCESS',
-  LIST_NODES_FAILURE     = 'NODES::LIST_NODES::FAILURE',
+  LIST_NODES_FAILURE     = 'NODES::LIST_NODES::FAILURE'
 }
 export interface NodesAction extends Action {
   payload?: any;

--- a/components/automate-ui/src/app/entities/nodes/nodes.actions.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.actions.ts
@@ -4,7 +4,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 export enum NodesActionTypes {
   LIST_NODES             = 'NODES::LIST_NODES',
   LIST_NODES_SUCCESS     = 'NODES::LIST_NODES::SUCCESS',
-  LIST_NODES_FAILURE     = 'NODES::LIST_NODES::FAILURE'
+  LIST_NODES_FAILURE     = 'NODES::LIST_NODES::FAILURE',
 }
 export interface NodesAction extends Action {
   payload?: any;
@@ -12,6 +12,14 @@ export interface NodesAction extends Action {
 
 export const GET_NODES = 'GET_NODES';
 export const getNodes = (payload): NodesAction => ({ type: NodesActionTypes.LIST_NODES, payload });
+
+export const DELETE_NODE = 'DELETE_NODE';
+export const deleteNode = (payload): NodesAction => ({ type: DELETE_NODE, payload });
+
+export const DELETE_NODE_SUCCESS = 'DELETE_NODE_SUCCESS';
+export const deleteNodeSuccess = (payload): NodesAction => {
+  return { type: DELETE_NODE_SUCCESS, payload };
+};
 
 export interface SearchNodesPayload {
   filters?: any[];

--- a/components/automate-ui/src/app/entities/nodes/nodes.actions.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.actions.ts
@@ -1,0 +1,49 @@
+import { Action } from '@ngrx/store';
+import { HttpErrorResponse } from '@angular/common/http';
+
+export enum NodesActionTypes {
+  LIST_NODES             = 'NODES::LIST_NODES',
+  LIST_NODES_SUCCESS     = 'NODES::LIST_NODES::SUCCESS',
+  LIST_NODES_FAILURE     = 'NODES::LIST_NODES::FAILURE'
+}
+export interface NodesAction extends Action {
+  payload?: any;
+}
+
+export const GET_NODES = 'GET_NODES';
+export const getNodes = (payload): NodesAction => ({ type: NodesActionTypes.LIST_NODES, payload });
+
+export interface SearchNodesPayload {
+  filters?: any[];
+  page?: number;
+  per_page?: number;
+  sort?: string;
+  order?: string;
+}
+
+export class ListNodes implements Action {
+  readonly type = NodesActionTypes.LIST_NODES;
+  constructor(public payload: SearchNodesPayload) {}
+}
+
+export interface ListNodesSuccessPayload {
+  nodes: any;
+  total: number;
+  total_reachable: number;
+  total_unreachable: number;
+  total_unknown: number;
+}
+export class ListNodesSuccess implements Action {
+  readonly type = NodesActionTypes.LIST_NODES_SUCCESS;
+  constructor(public payload: ListNodesSuccessPayload) {}
+}
+
+export class ListNodesFailure implements Action {
+  readonly type = NodesActionTypes.LIST_NODES_FAILURE;
+  constructor(public payload: HttpErrorResponse) {}
+}
+
+export type NodesActions =
+  | ListNodes
+  | ListNodesSuccess
+  | ListNodesFailure;

--- a/components/automate-ui/src/app/entities/nodes/nodes.effects.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.effects.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { HttpErrorResponse } from '@angular/common/http';
+import { catchError, mergeMap, map } from 'rxjs/operators';
+import { of } from 'rxjs';
+
+import { NodesActionTypes, ListNodes, ListNodesSuccess, ListNodesFailure} from './nodes.actions';
+import { RespNodes, NodesRequests } from './nodes.requests';
+import { CreateNotification } from '../notifications/notification.actions';
+import { Type } from '../notifications/notification.model';
+
+@Injectable()
+export class NodesEffects {
+  constructor(
+    private actions$: Actions,
+    private requests: NodesRequests,
+  ) { }
+
+
+  @Effect()
+  listNodes$ = this.actions$.pipe(
+    ofType(NodesActionTypes.LIST_NODES),
+    mergeMap((action: ListNodes) =>
+              this.requests.listNodes(action.payload).pipe(
+              map((resp: RespNodes) =>
+                   new ListNodesSuccess(resp)),
+              catchError((error: HttpErrorResponse) =>
+                     of(new ListNodesFailure(error))))));
+
+  @Effect()
+  listNodesFailure$ = this.actions$.pipe(
+      ofType(NodesActionTypes.LIST_NODES_FAILURE),
+      map(({ payload }: ListNodesFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not get nodes: ${msg || payload.error}`
+        });
+      }));
+}

--- a/components/automate-ui/src/app/entities/nodes/nodes.effects.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.effects.ts
@@ -4,7 +4,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { catchError, mergeMap, map } from 'rxjs/operators';
 import { of } from 'rxjs';
 
-import { NodesActionTypes, ListNodes, ListNodesSuccess, ListNodesFailure} from './nodes.actions';
+import { NodesActionTypes, ListNodes, ListNodesSuccess, ListNodesFailure } from './nodes.actions';
 import { RespNodes, NodesRequests } from './nodes.requests';
 import { CreateNotification } from '../notifications/notification.actions';
 import { Type } from '../notifications/notification.model';
@@ -13,7 +13,7 @@ import { Type } from '../notifications/notification.model';
 export class NodesEffects {
   constructor(
     private actions$: Actions,
-    private requests: NodesRequests,
+    private requests: NodesRequests
   ) { }
 
 

--- a/components/automate-ui/src/app/entities/nodes/nodes.model.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.model.ts
@@ -1,4 +1,4 @@
 export interface Node {
-  id: string,
-  name: string
+  id: string;
+  name: string;
 }

--- a/components/automate-ui/src/app/entities/nodes/nodes.model.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.model.ts
@@ -1,0 +1,4 @@
+export interface Node {
+  id: string,
+  name: string
+}

--- a/components/automate-ui/src/app/entities/nodes/nodes.reducer.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.reducer.ts
@@ -10,14 +10,14 @@ import { EntityStatus } from '../entities';
 export interface NodesEntityState extends EntityState<Node>{
   status: EntityStatus;
   nodesList: {
-    loading: boolean,
-    items: Node[],
-    total: number,
-    per_page: number,
-    page: number,
-    sort: string,
-    order: string,
-    filters: any[]
+    loading?: boolean,
+    items?: Node[],
+    total?: number,
+    per_page?: number,
+    page?: number,
+    sort?: string,
+    order?: string,
+    filters?: any[]
   };
   nodeTotals: {
     all: number,

--- a/components/automate-ui/src/app/entities/nodes/nodes.reducer.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.reducer.ts
@@ -7,7 +7,7 @@ import { Node } from './nodes.model';
 import { EntityStatus } from '../entities';
 
 
-export interface NodesEntityState extends EntityState<Node>{
+export interface NodesEntityState extends EntityState<Node> {
   status: EntityStatus;
   nodesList: {
     loading?: boolean,
@@ -57,7 +57,7 @@ export function nodesEntityReducer(state: NodesEntityState = NodesEntityInitialS
   switch (action.type) {
     case NodesActionTypes.LIST_NODES: {
       const {page, per_page, sort, order, filters} = action.payload;
-      set('status', EntityStatus.loading, state)      
+      set('status', EntityStatus.loading, state);
       const nodesList = assign({}, state.nodesList,
         {page, per_page, sort, order, filters});
       return assign({}, state, {nodesList});

--- a/components/automate-ui/src/app/entities/nodes/nodes.reducer.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.reducer.ts
@@ -1,0 +1,85 @@
+import { set, pipe } from 'lodash/fp';
+import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
+import { assign } from 'lodash';
+
+import { NodesActions, NodesActionTypes } from './nodes.actions';
+import { Node } from './nodes.model';
+import { EntityStatus } from '../entities';
+
+
+export interface NodesEntityState extends EntityState<Node>{
+  status: EntityStatus;
+  nodesList: {
+    loading: boolean,
+    items: Node[],
+    total: number,
+    per_page: number,
+    page: number,
+    sort: string,
+    order: string,
+    filters: any[]
+  };
+  nodeTotals: {
+    all: number,
+    unreachable: number,
+    reachable: number,
+    unknown: number
+  };
+  nodes: Node[];
+}
+
+export const nodesEntityAdapter: EntityAdapter<Node> = createEntityAdapter<Node>();
+
+export const NodesEntityInitialState: NodesEntityState = nodesEntityAdapter.getInitialState({
+  status: EntityStatus.notLoaded,
+  nodesList: {
+    loading: false,
+    items: [],
+    total: 0,
+    per_page: 100,
+    page: 1,
+    sort: 'name',
+    order: null,
+    filters: []
+  },
+  nodeTotals: {
+    all: 0,
+    unreachable: 0,
+    reachable: 0,
+    unknown: 0
+  },
+  nodes: []
+});
+
+export function nodesEntityReducer(state: NodesEntityState = NodesEntityInitialState,
+  action: NodesActions) {
+
+  switch (action.type) {
+    case NodesActionTypes.LIST_NODES: {
+      const {page, per_page, sort, order, filters} = action.payload;
+      set('status', EntityStatus.loading, state)      
+      const nodesList = assign({}, state.nodesList,
+        {page, per_page, sort, order, filters});
+      return assign({}, state, {nodesList});
+    }
+
+    case NodesActionTypes.LIST_NODES_SUCCESS: {
+      const { nodes, total, total_reachable, total_unreachable, total_unknown } = action.payload;
+      return pipe(
+        set('nodesList.loading', false),
+        set('nodesList.items', nodes || []),
+        set('nodesList.total', total || 0),
+        set('nodeTotals', {
+          all: total_reachable + total_unreachable + total_unknown,
+          reachable: total_reachable,
+          unreachable: total_unreachable,
+          unknown: total_unknown
+        })
+      )(state) as NodesEntityState;
+    }
+
+    default:
+      return state;
+
+  }
+}

--- a/components/automate-ui/src/app/entities/nodes/nodes.requests.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.requests.ts
@@ -14,8 +14,8 @@ export interface RespNodes {
 }
 
 export interface Node {
-  id: string,
-  name: string
+  id: string;
+  name: string;
 }
 
 @Injectable()
@@ -29,8 +29,6 @@ export class NodesRequests {
     const { page, per_page } = payload;
     const filters = [];
     const body = { filters, page, per_page };
-    console.log("called listNodes")
     return this.http.post(url, body);
-}
-  
+  }
 }

--- a/components/automate-ui/src/app/entities/nodes/nodes.requests.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.requests.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import * as actions from './nodes.actions';
+import { environment } from '../../../environments/environment';
+
+
+export interface RespNodes {
+  nodes: Node[];
+  total: number;
+  total_unreachable: number;
+  total_reachable: number;
+  total_unknown: number;
+}
+
+export interface Node {
+  id: string,
+  name: string
+}
+
+@Injectable()
+export class NodesRequests {
+
+  constructor(private http: HttpClient) { }
+
+  public listNodes(payload: actions.SearchNodesPayload):
+  Observable<any> {
+    const url = `${environment.nodes_url}/search`;
+    const { page, per_page } = payload;
+    const filters = [];
+    const body = { filters, page, per_page };
+    console.log("called listNodes")
+    return this.http.post(url, body);
+}
+  
+}

--- a/components/automate-ui/src/app/entities/nodes/nodes.selectors.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.selectors.ts
@@ -1,0 +1,18 @@
+import { createSelector } from '@ngrx/store';
+import { omit } from 'lodash';
+
+export interface Nodes {
+    nodes: Node[];
+}
+export const nodesState = state => state.nodes;
+
+export const nodesList = createSelector(nodesState, state => state.nodesList);
+
+export const nodesListItems = createSelector(nodesList, list => list.items);
+
+export const nodesStatus = createSelector(
+    nodesState,
+    (state) => state.status
+  );
+
+export const nodesListParams = createSelector(nodesList, list => omit(list, 'items', 'total'));

--- a/components/automate-ui/src/app/entities/nodes/nodes.selectors.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.selectors.ts
@@ -1,14 +1,17 @@
-import { createSelector } from '@ngrx/store';
+import { createSelector, createFeatureSelector } from '@ngrx/store';
 import { omit } from 'lodash';
 
 export interface Nodes {
-    nodes: Node[];
+  nodes: Node[];
 }
-export const nodesState = state => state.nodes;
+
+import { NodesEntityState } from './nodes.reducer';
+
+export const nodesState = createFeatureSelector<NodesEntityState>('nodes');
 
 export const nodesList = createSelector(nodesState, state => state.nodesList);
 
-export const nodesListItems = createSelector(nodesList, list => list.items);
+export const nodesListItems = createSelector(nodesState, state => state.nodesList.items);
 
 export const nodesStatus = createSelector(
     nodesState,

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.html
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.html
@@ -1,0 +1,81 @@
+<div class="content-container">
+    <div class="container">
+      <main>
+        <chef-table class="nodes-list-table" (sort-toggled)="onSortToggled($event)">
+          <chef-thead>
+            <chef-tr>
+              <chef-th>
+                Node
+                <chef-sort-toggle sort="name" [order]="orderFor('name')"></chef-sort-toggle>
+              </chef-th>
+              <chef-th>
+                Platform
+                <chef-sort-toggle sort="platform" [order]="orderFor('platform')"></chef-sort-toggle>
+              </chef-th>
+              <chef-th>
+                Manager
+                <chef-sort-toggle sort="manager" [order]="orderFor('manager')"></chef-sort-toggle>
+              </chef-th>
+              <chef-th>
+                Last Contact
+                <chef-sort-toggle sort="manager" [order]="orderFor('last_contact')"></chef-sort-toggle>
+              </chef-th>
+              <chef-th>
+                Last Scans
+              </chef-th>
+              <chef-th>
+                Last Runs
+              </chef-th>
+              <chef-th>
+                Last Known State
+                <chef-sort-toggle sort="manager" [order]="orderFor('state')"></chef-sort-toggle>
+              </chef-th>
+              <chef-th>
+                Tags
+              </chef-th>
+              <chef-th></chef-th>
+            </chef-tr>
+          </chef-thead>
+        
+          <chef-loading-spinner *ngIf="nodesList.loading" size="100"></chef-loading-spinner>
+        
+          <chef-tbody *ngIf="!nodesList.loading">
+            <chef-tr *ngFor="let node of nodesList.items; index as i; trackBy: trackBy;">
+              <chef-td>{{ node.name }}</chef-td>
+              <chef-td>{{ node.platform }} {{ node.platform_version }}</chef-td>
+              <chef-td>{{ node.manager }}</chef-td>
+              <chef-td>{{ node.last_contact }}</chef-td>
+              <chef-td>
+                <chef-icon class="status-icon" [ngClass]="node.scan_data.status">
+                  {{ statusIcon(node.scan_data.status) }}
+                </chef-icon>
+                <chef-icon class="status-icon" [ngClass]="node.scan_data.penultimate_status">
+                  {{ statusIcon(node.scan_data.penultimate_status) }}
+                </chef-icon>               
+              </chef-td>
+              <chef-td>
+                <chef-icon class="status-icon" [ngClass]="node.run_data.status">
+                  {{ statusIcon(node.run_data.status) }}
+                </chef-icon>
+                <chef-icon class="status-icon" [ngClass]="node.run_data.penultimate_status">
+                  {{ statusIcon(node.run_data.penultimate_status) }}
+                </chef-icon>               
+              </chef-td>    
+              <chef-td>{{ node.state }}</chef-td>
+              <chef-td>{{ displayNodeTags(node.tags) }}</chef-td>
+              <chef-td>
+                <chef-button label="edit" secondary
+                  [routerLink]="['/compliance', 'scan-jobs', 'nodes', node.id, 'edit']">
+                  <chef-icon>edit</chef-icon>
+                </chef-button>
+                <chef-button label="delete" secondary caution (click)="deleteNode(node)">
+                  <chef-icon>delete</chef-icon>
+                </chef-button>
+              </chef-td>
+            </chef-tr>
+          </chef-tbody>
+        </chef-table>
+      </main>
+    </div>
+  </div>
+  

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
@@ -1,25 +1,25 @@
 @import "~styles/variables";
 
 chef-td {
-    font-size: 80%;
+  font-size: 80%;
 }
 
 chef-tr {
-    height: 60px;
+  height: 60px;
 }
 
 chef-icon.FAILED {
-    color: $chef-critical;
+  color: $chef-critical;
 }
 
 chef-icon.PASSED {
-    color: $chef-success;
+  color: $chef-success;
 }
 
 chef-icon.UNKNOWN {
-    color: $chef-dark-grey;
+  color: $chef-dark-grey;
 }
 
 chef-icon.SKIPPED {
-    color: $chef-dark-grey;
+  color: $chef-dark-grey;
 }

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
@@ -1,0 +1,21 @@
+@import "~styles/variables";
+
+chef-td {
+    font-size: 80%;
+}
+
+chef-tr {
+    height: 60px;
+}
+
+chef-icon.FAILED {
+    color: $chef-critical;
+}
+
+chef-icon.PASSED {
+    color: $chef-success;
+}
+
+chef-icon.UNKNOWN {
+    color: $chef-dark-grey;
+}

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
@@ -19,3 +19,7 @@ chef-icon.PASSED {
 chef-icon.UNKNOWN {
     color: $chef-dark-grey;
 }
+
+chef-icon.SKIPPED {
+    color: $chef-dark-grey;
+}

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
@@ -1,17 +1,17 @@
 import { Component, OnInit } from '@angular/core';
-import { Router} from '@angular/router';
+import { Router } from '@angular/router';
 import { timer as observableTimer, Subject } from 'rxjs';
 import { takeUntil, withLatestFrom } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { DateTime } from 'app/helpers/datetime/datetime';
 
-import * as actions  from '../../../entities/nodes/nodes.actions';
-import * as selectors  from '../../../entities/nodes/nodes.selectors';
+import * as actions from '../../../entities/nodes/nodes.actions';
+import * as selectors from '../../../entities/nodes/nodes.selectors';
 import * as moment from 'moment';
 
 
-@Component({  
+@Component({
   selector: 'app-nodes-list',
   templateUrl: './nodes-list.component.html',
   styleUrls: ['./nodes-list.component.scss']
@@ -35,7 +35,6 @@ export class NodesListComponent implements OnInit {
       withLatestFrom(this.store.select(selectors.nodesListParams)),
       takeUntil(this.isDestroyed))
       .subscribe(([_i, params]) => {
-        params = {}
         this.store.dispatch(actions.getNodes(params));
       });
   }
@@ -83,12 +82,12 @@ export class NodesListComponent implements OnInit {
   }
 
   displayNodeTags(tags) {
-    let stringTags = "";
+    let stringTags = '';
     if (tags.length > 0) {
       tags.forEach((tag) => {
-        stringTags = stringTags + tag.key + ":" + tag.value + " ";
-      })
+        stringTags = stringTags + tag.key + ':' + tag.value + ' ';
+      });
     }
-    return stringTags
+    return stringTags;
   }
 }

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
@@ -1,0 +1,78 @@
+import { Component, OnInit } from '@angular/core';
+import { timer as observableTimer, Subject } from 'rxjs';
+import { takeUntil, withLatestFrom } from 'rxjs/operators';
+import { Store } from '@ngrx/store';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { DateTime } from 'app/helpers/datetime/datetime';
+
+// import * as actions  from '../../../entities/nodes/nodes.actions';
+// import * as selectors  from '../../../entities/nodes/nodes.selectors';
+import * as selectors from '../../../pages/+compliance/+scanner/state/scanner.selectors';
+import * as actions from '../../../pages/+compliance/+scanner/state/scanner.actions';
+import * as moment from 'moment';
+
+
+@Component({  
+  selector: 'app-nodes-list',
+  templateUrl: './nodes-list.component.html',
+  styleUrls: ['./nodes-list.component.scss']
+})
+
+export class NodesListComponent implements OnInit {
+  constructor(
+    private store: Store<NgrxStateAtom>
+  ) { }
+
+  nodesList;
+  private isDestroyed: Subject<boolean> = new Subject<boolean>();
+
+  ngOnInit(): void {
+    this.store.select(selectors.nodesList).pipe(
+      takeUntil(this.isDestroyed))
+      .subscribe(nodesList => this.nodesList = nodesList);
+
+    observableTimer(0, 100000).pipe(
+      withLatestFrom(this.store.select(selectors.nodesListParams)),
+      takeUntil(this.isDestroyed))
+      .subscribe(([_i, params]) => {
+        params = {}
+        this.store.dispatch(actions.getNodes(params));
+      });
+  }
+
+  orderFor(sortKey) {
+    const {sort, order} = this.nodesList;
+    if (sortKey === sort) {
+      return order;
+    }
+    return 'none';
+  }
+
+  deleteNode(node) {
+    this.store.dispatch(actions.deleteNode(node));
+  }
+
+  statusIcon(status) {
+    switch (status) {
+      case ('FAILED'): return 'report_problem';
+      case ('PASSED'): return 'check_circle';
+      case ('UNKNOWN'): return 'help';
+      case ('SKIPPED'): return 'help';
+      default: return '';
+    }
+  }
+
+  displayLastContact(time) {
+    return moment(time, DateTime.REPORT_DATE_TIME);
+  }
+
+  displayNodeTags(tags) {
+    let stringTags = "";
+    if (tags.length > 0) {
+      tags.forEach((tag) => {
+        stringTags = stringTags + tag.key + ":" + tag.value + " ";
+      })
+    }
+    return stringTags
+  }
+}

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
@@ -1,14 +1,15 @@
 import { Component, OnInit } from '@angular/core';
+import { Router} from '@angular/router';
 import { timer as observableTimer, Subject } from 'rxjs';
 import { takeUntil, withLatestFrom } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { DateTime } from 'app/helpers/datetime/datetime';
 
-// import * as actions  from '../../../entities/nodes/nodes.actions';
-// import * as selectors  from '../../../entities/nodes/nodes.selectors';
-import * as selectors from '../../../pages/+compliance/+scanner/state/scanner.selectors';
-import * as actions from '../../../pages/+compliance/+scanner/state/scanner.actions';
+import * as actions  from '../../../entities/nodes/nodes.actions';
+import * as selectors  from '../../../entities/nodes/nodes.selectors';
+// import * as selectors from '../../../pages/+compliance/+scanner/state/scanner.selectors';
+// import * as actions from '../../../pages/+compliance/+scanner/state/scanner.actions';
 import * as moment from 'moment';
 
 
@@ -20,7 +21,8 @@ import * as moment from 'moment';
 
 export class NodesListComponent implements OnInit {
   constructor(
-    private store: Store<NgrxStateAtom>
+    private store: Store<NgrxStateAtom>,
+    private router: Router
   ) { }
 
   nodesList;
@@ -41,11 +43,27 @@ export class NodesListComponent implements OnInit {
   }
 
   orderFor(sortKey) {
-    const {sort, order} = this.nodesList;
+    const {sort, order} = this.nodesList.items;
     if (sortKey === sort) {
       return order;
     }
     return 'none';
+  }
+
+  trackBy(node) {
+    return node;
+  }
+
+  onSortToggled(event) {
+    let {sort, order} = event.detail;
+    if (order === 'none') {
+      sort = undefined;
+      order = undefined;
+    }
+
+    const queryParams = {sort, order};
+
+    this.router.navigate([], {queryParams} );
   }
 
   deleteNode(node) {

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
@@ -8,8 +8,6 @@ import { DateTime } from 'app/helpers/datetime/datetime';
 
 import * as actions  from '../../../entities/nodes/nodes.actions';
 import * as selectors  from '../../../entities/nodes/nodes.selectors';
-// import * as selectors from '../../../pages/+compliance/+scanner/state/scanner.selectors';
-// import * as actions from '../../../pages/+compliance/+scanner/state/scanner.actions';
 import * as moment from 'moment';
 
 

--- a/components/automate-ui/src/app/modules/nodes/nodes-routing.module.ts
+++ b/components/automate-ui/src/app/modules/nodes/nodes-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { NodesListComponent } from './nodes-list/nodes-list.component';
+
+const nodesRoutes: Routes = [
+  {
+    path: '',
+    component: NodesListComponent
+  }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(nodesRoutes)
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class NodesRoutingModule { }

--- a/components/automate-ui/src/app/modules/nodes/nodes.module.ts
+++ b/components/automate-ui/src/app/modules/nodes/nodes.module.ts
@@ -1,0 +1,29 @@
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { ChefComponentsModule } from 'app/components/chef-components.module';
+import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
+
+import { NodesListComponent } from './nodes-list/nodes-list.component';
+
+import { NodesRoutingModule } from './nodes-routing.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    ChefComponentsModule,
+    NodesRoutingModule,
+    ChefPipesModule
+  ],
+  exports: [
+    NodesListComponent
+  ],
+  declarations: [
+    NodesListComponent
+  ],
+  schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+})
+export class NodesModule { }

--- a/components/automate-ui/src/app/ngrx.effects.ts
+++ b/components/automate-ui/src/app/ngrx.effects.ts
@@ -15,6 +15,7 @@ import { EventFeedEffects } from './services/event-feed/event-feed.effects';
 import { JobEffects } from './entities/jobs/job.effects';
 import { LicenseStatusEffects } from './entities/license/license.effects';
 import { ManagerEffects } from './entities/managers/manager.effects';
+import { NodesEffects } from './entities/nodes/nodes.effects';
 import { PolicyEffects } from './entities/policies/policy.effects';
 import { ProfileEffects } from './entities/profiles/profile.effects';
 import { ProjectEffects } from './entities/projects/project.effects';
@@ -45,6 +46,7 @@ import { UserPermEffects } from './entities/userperms/userperms.effects';
       JobEffects,
       LicenseStatusEffects,
       ManagerEffects,
+      NodesEffects,
       PolicyEffects,
       ProfileEffects,
       ProjectEffects,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -32,6 +32,7 @@ import * as ruleEntity from './entities/rules/rule.reducer';
 import * as serverEntity from './entities/servers/server.reducer';
 import * as orgEntity from './entities/orgs/org.reducer';
 import * as serviceGroups from './entities/service-groups/service-groups.reducer';
+import * as nodesEntity from './entities/nodes/nodes.reducer';
 import * as teamEntity from './entities/teams/team.reducer';
 import * as userEntity from './entities/users/user.reducer';
 import * as userSelfEntity from './entities/users/userself.reducer';
@@ -63,6 +64,7 @@ export interface NgrxStateAtom {
   jobs: jobEntity.JobEntityState;
   licenseStatus: license.LicenseStatusEntityState;
   managers: manager.ManagerEntityState;
+  nodes: nodesEntity.NodesEntityState;
   notifications: notificationEntity.NotificationEntityState;
   policies: policyEntity.PolicyEntityState;
   profiles: profileEntity.ProfileEntityState;
@@ -172,6 +174,7 @@ export const defaultInitialState = {
   jobs: jobEntity.JobEntityInitialState,
   licenseStatus: license.LicenseStatusEntityInitialState,
   managers: manager.ManagerEntityInitialState,
+  nodes: nodesEntity.NodesEntityInitialState,
   notifications: notificationEntity.InitialState,
   policies: policyEntity.PolicyEntityInitialState,
   profiles: profileEntity.ProfileEntityInitialState,
@@ -214,6 +217,7 @@ export const ngrxReducers = {
   destinations: destinationEntity.destinationEntityReducer,
   jobs: jobEntity.jobEntityReducer,
   managers: manager.managerEntityReducer,
+  nodes: nodesEntity.nodesEntityReducer,
   licenseStatus: license.licenseStatusEntityReducer,
   notifications: notificationEntity.notificationEntityReducer,
   policies: policyEntity.policyEntityReducer,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

lots of folks are chatting about the need for a "one node view" (again)
we've had a good bit of the api work to support that view ready for a while now, so this is a skeleton ui page we can use to see the gaps we have in the data, find holes, etc.
it's a hidden page (not accessible from anywhere in the ui, not being advertised in release notes or anything) - just for testing things out and letting ppl play with the data. the sorting isnt all wired up yet, nor is filtering. this is just for initial test and see the data kind of purposes.

thank you @tarablack01 for the help!!

### :+1: Definition of Done
hidden skeleton one node view page

### :athletic_shoe: How to Build and Test the Change
rebuild ui, go to dev-env/nodes
load_compliance_reports
chef_load_nodes

also see https://github.com/chef/automate/pull/3508

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [n/a] Tests added/updated?
- [n/a] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Screen Shot 2020-04-27 at 13 04 55](https://user-images.githubusercontent.com/10341541/80410401-bd882480-8887-11ea-84bc-a1f81f5ae941.png)
