### PR TITLE
[infra-proxy-service] Limit adding/removing Infra Servers and organizations to Editors

### DIFF
--- a/components/authz-service/storage/postgres/migration/sql/77_update_infra_servers_editor_role_pols.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/77_update_infra_servers_editor_role_pols.up.sql
@@ -1,0 +1,8 @@
+-- append "infra:infraServers:*" with "infra:nodes:*" and "infra:nodeManagers:*"
+-- for the editor role
+
+UPDATE iam_roles
+    SET actions = '{infra:infraServers:*}' || actions
+    WHERE
+        id = 'editor' AND
+        NOT actions @> '{infra:infraServers:*}';

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -76,3 +76,4 @@
 - [`74_pre_force_upgrade.up.sql`](74_pre_force_upgrade.up.sql)
 - [`75_update_roles_pols.up.sql`](75_update_roles_pols.up.sql)
 - [`76_compliance_roles_pols.up.sql`](76_compliance_roles_pols.up.sql)
+- [`77_update_infra_servers_editor_role_pols.up.sql`](77_update_infra_servers_editor_role_pols.up.sql)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
At present this PR only added a migration to append the `infra:infraServers:*` to the editor role.

I am not aware of the consequence of implied the policy to particular role need guidance to follow the path?

### :chains: Related Resources
https://github.com/chef/automate/issues/3519

### :+1: Definition of Done
- Limit adding/removing Infra Servers and organizations to Editors

### :athletic_shoe: How to Build and Test the Change

Steps to build:
 - `rebuild components/authz-service`

Steps to test:

- After rebuilding login with editor user.
- Go to Dashboard >> Infrastructure >> Chef servers (shown) earlier it was hidden.

- Perform any actions on servers or orgs will work accordingly.


### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
