### PR TITLE
Add new function for checking if waived.

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -15,6 +15,8 @@ export interface DateRange {
   end: Date | moment.Moment;
 }
 
+export type ControlStatus = 'passed' | 'failed' | 'waived' | 'skipped';
+
 @Injectable()
 export class StatsService {
   constructor(
@@ -215,14 +217,19 @@ export class StatsService {
   /* TODO Auth team: Helper functions that are only not private because
      they have unit testing. Should we delete their tests and make
      them private? */
-  getControlStatus(control): string {
+  getControlStatus(control): ControlStatus {
     const statuses = control.results.map(r => r.status);
-    const waived = control.waiver_data && control.waiver_data.skipped_due_to_waiver;
+    const waived = this.checkIfWaived(control.waived_str);
     if (waived) { return 'waived'; }
     if (statuses.every(s => s === 'passed')) { return 'passed'; }
     if (statuses.every(s => s === 'skipped')) { return 'skipped'; }
     return 'failed';
   }
+
+  private checkIfWaived(waivedStatus: string): boolean {
+    return waivedStatus === 'yes_run' || waivedStatus === 'yes';
+  }
+
 
   addDateRange(filters, dateRange) {
     if (filters) {

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -218,9 +218,15 @@ export class StatsService {
      they have unit testing. Should we delete their tests and make
      them private? */
   getControlStatus(control): ControlStatus {
-    const statuses = control.results.map(r => r.status);
+    // In some cases, nodes don't have results data.  In these
+    // cases we want to display those nodes as skipped
+    const hasResults = control.results.length > 0;
+    if (!hasResults) { return 'skipped'; }
+
     const waived = this.checkIfWaived(control.waived_str);
     if (waived) { return 'waived'; }
+
+    const statuses = control.results.map(r => r.status);
     if (statuses.every(s => s === 'passed')) { return 'passed'; }
     if (statuses.every(s => s === 'skipped')) { return 'skipped'; }
     return 'failed';

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -218,18 +218,16 @@ export class StatsService {
      they have unit testing. Should we delete their tests and make
      them private? */
   getControlStatus(control): ControlStatus {
-    // In some cases, nodes don't have results data.  In these
-    // cases we want to display those nodes as passed
-    const hasResults = control.results.length > 0;
-    if (!hasResults) { return 'passed'; }
-
     const waived = this.checkIfWaived(control.waived_str);
     if (waived) { return 'waived'; }
 
     const statuses = control.results.map(r => r.status);
     if (statuses.every(s => s === 'passed')) { return 'passed'; }
+    if (statuses.every(s => s === 'failed')) { return 'failed'; }
     if (statuses.every(s => s === 'skipped')) { return 'skipped'; }
-    return 'failed';
+    // In some cases, nodes don't have results data.  In these
+    // cases we want to display those nodes as passed
+    return 'passed';
   }
 
   private checkIfWaived(waivedStatus: string): boolean {

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -225,8 +225,8 @@ export class StatsService {
     if (statuses.every(s => s === 'passed')) { return 'passed'; }
     if (statuses.every(s => s === 'failed')) { return 'failed'; }
     if (statuses.every(s => s === 'skipped')) { return 'skipped'; }
-    // In some cases, nodes don't have results data.  In these
-    // cases we want to display those nodes as passed
+    // In some cases, controls don't have results data.  In these
+    // cases we want to display those controls as passed
     return 'passed';
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -222,8 +222,10 @@ export class StatsService {
     if (waived) { return 'waived'; }
 
     const statuses = control.results.map(r => r.status);
+    // If any of the results come back as failed, the control has failed
+    if (statuses.find(s => s === 'failed')) { return 'failed'; }
+
     if (statuses.every(s => s === 'passed')) { return 'passed'; }
-    if (statuses.every(s => s === 'failed')) { return 'failed'; }
     if (statuses.every(s => s === 'skipped')) { return 'skipped'; }
     // In some cases, controls don't have results data.  In these
     // cases we want to display those controls as passed

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -219,9 +219,9 @@ export class StatsService {
      them private? */
   getControlStatus(control): ControlStatus {
     // In some cases, nodes don't have results data.  In these
-    // cases we want to display those nodes as skipped
+    // cases we want to display those nodes as passed
     const hasResults = control.results.length > 0;
-    if (!hasResults) { return 'skipped'; }
+    if (!hasResults) { return 'passed'; }
 
     const waived = this.checkIfWaived(control.waived_str);
     if (waived) { return 'waived'; }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The filters for compliance scans were incorrectly checking for waived values.  With guidance from Superteam, this branch corrects the check for waived values, so that the number matches the amount of reports displayed in all column.

### :chains: Related Resources
fixes https://github.com/chef/automate/issues/3277

### :+1: Definition of Done
Counts on the top of each of the compliance reports columns matches the number or reports shown.

### :athletic_shoe: How to Build and Test the Change
build component/automate-ui-devproxy && start_all_services
make serve

run `load_compliance_reports` in hab studio
navigate to https://a2-dev.test/compliance/reports/nodes
click on one of the nodes that has a lot of runs to see the detail view
filter by waived controls
the number on the top of waived controls column should match how many are in the filtered display

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Screen Shot 2020-04-28 at 9 37 34 AM](https://user-images.githubusercontent.com/16737484/80513452-ec5bd480-8933-11ea-9185-38cd9d7a9550.png)