### PR TITLE
Add license_scout exceptions

### DIFF
--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -271,6 +271,12 @@ exceptions:
       reason: Exception made by Chef Legal
     - name: core/nss-myhostname
       reason: Exception made by Chef Legal
+    - name: core/binutils
+      reason: Exception made by Chef Legal
+    - name: core/perl
+      reason: Exception made by Chef Legal
+    - name: core/procps-ng
+      reason: Exception made by Chef Legal
 
   ruby:
     - name: highline


### PR DESCRIPTION
These were not being enforced before because the plans were
not using standard license string formats. The plans were
updated in the recent core plans refresh
