### PR TITLE
Only dispatch for policies during token creation if some specified

### DIFF
--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.spec.ts
@@ -1,10 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { StoreModule } from '@ngrx/store';
+import { StoreModule, Store } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
-import { runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
+import { runtimeChecks, ngrxReducers, NgrxStateAtom } from 'app/ngrx.reducers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { ApiTokenListComponent } from './api-token-list.component';
@@ -13,6 +13,7 @@ describe('ApiTokenListComponent', () => {
   let component: ApiTokenListComponent;
   let fixture: ComponentFixture<ApiTokenListComponent>;
   let element: HTMLElement;
+  let store: Store<NgrxStateAtom>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -65,6 +66,7 @@ describe('ApiTokenListComponent', () => {
     fixture = TestBed.createComponent(ApiTokenListComponent);
     component = fixture.componentInstance;
     element = fixture.debugElement.nativeElement;
+    store = TestBed.inject(Store);
     fixture.detectChanges();
   });
 
@@ -85,6 +87,21 @@ describe('ApiTokenListComponent', () => {
       expect(component.createTokenForm.controls.name.value).toBe(null);
       expect(component.createTokenForm.controls.id.value).toBe(null);
       expect(component.createTokenForm.controls.projects.value).toBe(null);
+    });
+
+    it('create token with no policies dispatches action just to create token', () => {
+      spyOn(store, 'dispatch').and.callThrough();
+      component.createTokenForm.controls.policies.setValue(null);
+      component.createToken();
+      expect(store.dispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('create token with 2 policies dispatches actions to create token plus each policy', () => {
+      const policies = ['p1', 'p2'];
+      spyOn(store, 'dispatch').and.callThrough();
+      component.createTokenForm.controls.policies.setValue(policies);
+      component.createToken();
+      expect(store.dispatch).toHaveBeenCalledTimes(1 + policies.length);
     });
   });
 });

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
@@ -139,13 +139,15 @@ export class ApiTokenListComponent implements OnInit, OnDestroy {
     this.store.dispatch(new CreateToken(tok));
 
     const member = stringToMember(`token:${tok.id}`);
-    (this.createTokenForm.controls.policies.value as string[])
-      .forEach(id =>
+    const policies: string[] = this.createTokenForm.controls.policies.value;
+    if (policies) {
+      policies.forEach(id =>
         this.store.dispatch(new AddPolicyMembers(<PolicyMembersMgmtPayload>{
           id,
           members: [member]
         }))
       );
+    }
   }
 
   public toggleActive($event: ChefKeyboardEvent, token: ApiToken): void {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This fixes a browser console error "cannot read property 'forEach' of null" if no policies are selected when creating a token.

### :chains: Related Resources
NA

### :+1: Definition of Done
No browser console error

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui
Go to Settings >> Tokens >> Create Token
Attempt to create a token without specifying any policies to attach to.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
