### PR TITLE
automate-ui/telemetry: don't send projects header

### DIFF
--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
@@ -151,7 +151,7 @@ describe('HttpClientAuthInterceptor', () => {
           const options = { params: { unfiltered: String(setting) } };
           httpClient.get('/endpoint', options).subscribe(done);
 
-          const httpRequest = httpMock.expectOne(`/endpoint?unfiltered=${setting}`);
+          const httpRequest = httpMock.expectOne('/endpoint');
           httpRequest.flush('response');
 
           const headerKeys = httpRequest.request.headers.keys();
@@ -162,18 +162,17 @@ describe('HttpClientAuthInterceptor', () => {
           }
         });
 
-        // Uncomment test after https://github.com/angular/angular/issues/18812 is fixed.
-        // it('strips unfiltered param when set to ' + setting, done => {
-        //   const options = { params: { unfiltered: String(setting), dummy: 'foobar' } };
-        //   httpClient.get('/endpoint', options).subscribe(done);
+        it('strips unfiltered param when set to ' + setting, done => {
+          const options = { params: { unfiltered: String(setting), dummy: 'foobar' } };
+          httpClient.get('/endpoint', options).subscribe(done);
 
-        //   const httpRequest = httpMock.expectOne('/endpoint?dummy=foobar');
-        //   httpRequest.flush('response');
+          const httpRequest = httpMock.expectOne('/endpoint?dummy=foobar');
+          httpRequest.flush('response');
 
-        //   // This assertion is completely redundant with the expectOne above,
-        //   // but having it adds to clarity.
-        //   expect(httpRequest.request.params.get('unfiltered')).toBeFalsy();
-        // });
+          // This assertion is completely redundant with the expectOne above,
+          // but having it adds to clarity.
+          expect(httpRequest.request.params.get('unfiltered')).toBeFalsy();
+        });
       });
     });
   });

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
@@ -31,17 +31,17 @@ export class HttpClientAuthInterceptor implements HttpInterceptor {
   }
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    // TODO(sr): Can we check if the request is sent to some external API?
+    //           Right now, we're throwing the ID token across the internet for telemetry,
+    //           where it's not needed. It would be nice to _not_ do that.
     let headers = request.headers.set('Authorization', `Bearer ${this.chefSession.id_token}`);
     const filtered = request.params.get('unfiltered') !== 'true';
-    // Uncomment here and after to clone() arg list
-    // after we've upgraded to angular 7.2+ (for this issue:
-    // https://github.com/angular/angular/issues/18812).
-    // const params = request.params.delete('unfiltered');
+    const params = request.params.delete('unfiltered');
     if (this.projects && filtered) {
       headers = headers.set('projects', this.projects);
     }
     return next
-      .handle(request.clone({ headers })).pipe(
+      .handle(request.clone({ headers, params })).pipe(
         catchError((error: HttpErrorResponse) => {
           if (error.status === 401) {
             this.chefSession.logout();

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
@@ -35,8 +35,12 @@ export class HttpClientAuthInterceptor implements HttpInterceptor {
     //           Right now, we're throwing the ID token across the internet for telemetry,
     //           where it's not needed. It would be nice to _not_ do that.
     let headers = request.headers.set('Authorization', `Bearer ${this.chefSession.id_token}`);
+    // Check and then remove `unfiltered` param; it is a piggybacked parameter
+    // needed by this interceptor, not to be passed on.
+    // It allows certain URLs to suppress sending the projects filter.
     const filtered = request.params.get('unfiltered') !== 'true';
     const params = request.params.delete('unfiltered');
+
     if (this.projects && filtered) {
       headers = headers.set('projects', this.projects);
     }

--- a/components/automate-ui/src/app/services/telemetry/telemetry.service.ts
+++ b/components/automate-ui/src/app/services/telemetry/telemetry.service.ts
@@ -253,7 +253,7 @@ export class TelemetryService {
       "timestamp": "${this.getCurrentDateTime()}",
       "payload": ${JSON.stringify(payload)}
     }`;
-    this.httpClient.post(this.telemetryUrl + '/events', json, { headers: headers })
+    this.httpClient.post(this.telemetryUrl + '/events', json, { headers, params: { unfiltered: 'true' } })
       .subscribe(
          _response => {
            // WooHoo! we successfully submitted our telemetry event to the pipeline!
@@ -265,7 +265,8 @@ export class TelemetryService {
   }
 
   private retrieveSegmentWriteKey() {
-    return this.httpClient.get(this.telemetryUrl + '/segment/api_keys');
+    return this.httpClient.get(this.telemetryUrl + '/segment/api_keys',
+     { params: { unfiltered: 'true' }}); // don't pass 'projects' header
   }
 
   // ISO 8601 formatted date time


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Now, we don't have a bunch of exceptions related to that header and CORS
in the browser console, and the requests flow again:

![image](https://user-images.githubusercontent.com/870638/80578259-76756d00-8a08-11ea-85d7-7f862bf0a43b.png)


However, it gets us a new warning:

![image](https://user-images.githubusercontent.com/870638/80578289-82f9c580-8a08-11ea-92b7-8b0add914a8b.png)

This is less bad. So let's iterate from here 😉 

### :chains: Related Resources

- Fixes #3130 

### :+1: Definition of Done

✅ No console exception
✅ Telemetry stuff is fired way

### :athletic_shoe: How to Build and Test the Change

- Rebuild UI, open browser with console open. Notice `api_keys`, `events`, and `t` requests succeeding.

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
