### PR TITLE
Hab studio chef load updating url path

### DIFF
--- a/components/ingest-service/chef-load-data/chef-load.toml
+++ b/components/ingest-service/chef-load-data/chef-load.toml
@@ -1,4 +1,4 @@
-data_collector_url = "https://localhost:2000/events/data-collector"
+data_collector_url = "https://localhost:2000/api/v0/events/data-collector"
 data_collector_token = "REPLACE_ME_VIA_HAB"
 converge_status_json_file = "./components/ingest-service/examples/converge-success-report.json"
 ohai_json_file = "./components/ingest-service/chef-load-data/ohai-data.json"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Fixing the hab studio hab studio chef load commands like the `chef_load_nodes 10`. The problem was that the URL was updated in the PR #3474, but it was not update for chef load in the studio. 

### :chains: Related Resources

https://github.com/chef/automate/pull/3474

### :+1: Definition of Done

Be able to run `chef_load_nodes 10`. 

### :athletic_shoe: How to Build and Test the Change

1. run start_all_services then `chef_load_nodes 10`.
1. got to https://a2-dev.test/infrastructure/client-runs
1. Ensure you see some nodes. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
