### PR TITLE
Fixing flaky config-mgmt-service test

### DIFF
--- a/components/config-mgmt-service/integration_test/count_missing_node_durations_test.go
+++ b/components/config-mgmt-service/integration_test/count_missing_node_durations_test.go
@@ -160,7 +160,7 @@ func TestMissingNodeRangeCounts(t *testing.T) {
 			description: "months: no nodes are missing after 2 months",
 			nodes: []iBackend.Node{
 				{
-					Checkin: time.Now().AddDate(0, -2, 0).Add(time.Hour * 2),
+					Checkin: time.Now().AddDate(0, -2, 3),
 				},
 			},
 			durations: []string{"2M"},
@@ -175,7 +175,7 @@ func TestMissingNodeRangeCounts(t *testing.T) {
 			description: "months: one node is missing after 2 months",
 			nodes: []iBackend.Node{
 				{
-					Checkin: time.Now().AddDate(0, -2, 0).Add(time.Hour * -2),
+					Checkin: time.Now().AddDate(0, -2, -3),
 				},
 			},
 			durations: []string{"2M"},


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Setting the month two back in go with `AddDate(0, -2, 0)` is not the same as elasticsearch "is it greater than 2 months" with "2M" https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/date-math-expressions.html

### :chains: Related Resources
Below is an example of the test failing
https://buildkite.com/chef/chef-automate-master-verify-private/builds/11948#7b326a6c-f32a-4026-aa77-ff3cf5dd62cd

### :athletic_shoe: How to Build and Test the Change
Ensure the private config-mgmt-service buildkite is passing. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
