### PR TITLE
#3331: remove '*' from non legacy policies' resources in ui

### DIFF
--- a/components/automate-ui/e2e/admin.e2e-spec.ts
+++ b/components/automate-ui/e2e/admin.e2e-spec.ts
@@ -121,13 +121,21 @@ describe('Admin pages', () => {
                 id: 'some-policy-id',
                 name: 'Some policy whose name does not start with A',
                 members: [],
-                type: 'CUSTOM'
+                type: 'CUSTOM',
+                statements: [
+                  { effect: 'ALLOW', role: 'some-role', resources: ['*'], projects: [] }
+                ],
+                projects: []
               },
               {
                 id: 'chef-managed-administrator',
                 name: 'Administrator All Access',
                 members: ['team:local:admins'],
-                type: 'CHEF_MANAGED'
+                statements: [
+                  { effect: 'ALLOW', actions: ['*'], resources: ['*'], projects: [] }
+                ],
+                type: 'CHEF_MANAGED',
+                projects: []
               }
             ]
           }
@@ -258,7 +266,11 @@ describe('Admin pages', () => {
               id: 'some-test-policy',
               name: 'All access policy',
               members: ['team:local:admins'],
-              type: 'CHEF_MANAGED'
+              type: 'CHEF_MANAGED',
+              statements: [
+                { effect: 'ALLOW', role: 'some-role', resources: ['*'], projects: [] }
+              ],
+              projects: []
             }
           }
         ));

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
@@ -89,9 +89,10 @@ describe('CreateObjectModalComponent', () => {
 
   it('upon opening, checked status of all policies is set to false', () => {
     component.policies = [
-        { id: 'proj1', name: 'proj1', type: 'CHEF_MANAGED', members: [], checked: true },
-        { id: 'proj3', name: 'proj3', type: 'CUSTOM', members: [], checked: false },
-        { id: 'proj2', name: 'proj2', type: 'CUSTOM', members: [], checked: true }
+        { id: 'proj1', name: 'proj1', type: 'CHEF_MANAGED', members: [], projects: [],
+          checked: true },
+        { id: 'proj3', name: 'proj3', type: 'CUSTOM', members: [], projects: [], checked: false },
+        { id: 'proj2', name: 'proj2', type: 'CUSTOM', members: [], projects: [], checked: true }
     ];
 
     component.ngOnChanges(

--- a/components/automate-ui/src/app/entities/policies/policy.model.spec.ts
+++ b/components/automate-ui/src/app/entities/policies/policy.model.spec.ts
@@ -306,9 +306,11 @@ describe('policy model', () => {
           {
             effect: 'ALLOW',
             actions: ['*'],
-            role: ''
+            role: '',
+            projects: []
           }
-        ]
+        ],
+        projects: []
       };
       const actual = policyFromPayload(policy);
       expect(actual.statements[0].role).toBeUndefined();
@@ -325,9 +327,11 @@ describe('policy model', () => {
           {
             effect: 'ALLOW',
             actions: [],
-            role: 'viewer'
+            role: 'viewer',
+            projects: []
           }
-        ]
+        ],
+        projects: []
       };
       const actual = policyFromPayload(policy);
       expect(actual.statements[0].actions).toBeUndefined();

--- a/components/automate-ui/src/app/entities/policies/policy.model.ts
+++ b/components/automate-ui/src/app/entities/policies/policy.model.ts
@@ -5,6 +5,7 @@ export interface Policy {
   type: IAMType;
   members: string[];
   statements?: Statement[];
+  projects: string[];
 }
 
 export interface Statement {
@@ -12,6 +13,7 @@ export interface Statement {
   role?: string;
   actions?: string[];
   resources?: string[];
+  projects: string[];
 }
 
 export interface PolicyChecked extends Policy {

--- a/components/automate-ui/src/app/modules/policy/details/policy-details.component.ts
+++ b/components/automate-ui/src/app/modules/policy/details/policy-details.component.ts
@@ -111,7 +111,7 @@ export class PolicyDetailsComponent implements OnInit, OnDestroy {
   }
 
   private policyToString(policy: Policy): string {
-    return JSON.stringify(policy);
+    return JSON.stringify(policy, null, '  ');
   }
 
   removeMember($event: ChefKeyboardEvent, member: Member): void {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

* omit `["*"]` from display when that's the only resources (see #3331 )
* attempt to fix the ordering of the JSON properties of a policy
* use the same ordering and the same spacing for the "Copy Definition" functionality

So far, this seems to work, but I'm uncertain about the approach -- I'm not sure the object construction ordering is guaranteed, I believe it might *not* be.

👉 Some random person says it's safe! 🎊 https://www.stefanjudis.com/today-i-learned/property-order-is-predictable-in-javascript-objects-since-es2015/ (@chef/ui-team you would know, wouldn't you? 😃)

### :chains: Related Resources

#3331.

### :+1: Definition of Done

See above. Resources that are not `"*"` are displayed, empty resources arrays (including those with only one, removed, `"*"` element) are not.

### :athletic_shoe: How to Build and Test the Change

UI-only change.

- Use your favorite way to spin up the UI,
- go to https://a2-dev.test/settings/policies/administrator-access
- look at the JSON displayed: there's one statement with a resource (`iam:policies:administrator-access`) and one without one displayed (`"role":"owner"`)
- click "copy definition" examine the clipboard contents

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [X] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable

![Screenshot 2020-04-30 at 15 32 30](https://user-images.githubusercontent.com/870638/80718392-5d4ce900-8afa-11ea-99f9-74d9b2efc874.png)

Copied definition:
```
{
  "name": "Administrator",
  "id": "administrator-access",
  "type": "CHEF_MANAGED",
  "projects": [],
  "members": [
    "team:local:admins"
  ],
  "statements": [
    {
      "effect": "DENY",
      "actions": [
        "iam:policies:delete",
        "iam:policies:update"
      ],
      "resources": [
        "iam:policies:administrator-access"
      ],
      "projects": [
        "*"
      ]
    },
    {
      "effect": "ALLOW",
      "role": "owner",
      "projects": [
        "*"
      ]
    }
  ]
}
```
Note that the copied def includes members.