### PR TITLE
[automate-ui] Reinstate some meta-unit tests

### DIFF
--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.spec.ts
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.spec.ts
@@ -5,37 +5,79 @@ import { NgrxStateAtom, ngrxReducers, defaultInitialState, runtimeChecks } from 
 
 import { SidebarComponent } from './sidebar.component';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
+import { SettingsLandingComponent } from 'app/pages/settings-landing/settings-landing.component';
+import { using } from 'app/testing/spec-helpers';
+import { ComplianceLandingComponent } from 'app/pages/compliance-landing/compliance-landing.component';
 
 describe('SidebarComponent', () => {
   let store: Store<NgrxStateAtom>;
   let component: SidebarComponent;
   let fixture: ComponentFixture<SidebarComponent>;
+  let element: HTMLElement;
+  let layoutFacade: LayoutFacadeService;
+  let featureFlags: FeatureFlagsService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SidebarComponent ],
+      declarations: [SidebarComponent],
       schemas: [
         NO_ERRORS_SCHEMA,
         CUSTOM_ELEMENTS_SCHEMA
       ],
       providers: [
-        FeatureFlagsService
+        FeatureFlagsService,
+        LayoutFacadeService
       ],
       imports: [
         StoreModule.forRoot(ngrxReducers, { initialState: defaultInitialState, runtimeChecks })
       ]
     }).compileComponents();
     store = TestBed.inject(Store);
+    layoutFacade = TestBed.inject(LayoutFacadeService);
+    featureFlags = TestBed.inject(FeatureFlagsService);
     spyOn(store, 'dispatch').and.callThrough();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SidebarComponent);
     component = fixture.componentInstance;
+    element = fixture.debugElement.nativeElement;
+
+    // enable all feature flags, if any, for testing
+    featureFlags.setFeature('servicenow_cmdb', true);
+
     fixture.detectChanges();
   });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  using([
+    [new SettingsLandingComponent(), Sidebar.Settings, 'Settings Landing Component'],
+    [new ComplianceLandingComponent(), Sidebar.Compliance, 'Compliance Landing Component']
+
+  ], function (landingComponent: any, sidebar: Sidebar,  description: string) {
+    describe(`${description} route list`, () => {
+
+      beforeEach(() => {
+        layoutFacade.showSidebar(sidebar);
+        fixture.detectChanges();
+      });
+
+      it('has length consistent with sidebar', () => {
+        const links = element.querySelectorAll('div.nav-items chef-sidebar-entry');
+        expect(links.length).toBe(landingComponent.routeList.length);
+      });
+
+      it('has route order consistent with sidebar', () => {
+        const links = element.querySelectorAll('div.nav-items chef-sidebar-entry');
+        for (let i = 0; i < links.length; i++) {
+          const link: any = links[i];
+          expect(link.route).toBe(landingComponent.routeList[i].route);
+        }
+      });
+    });
   });
 });

--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -32,7 +32,7 @@ export class LayoutSidebarService {
         this.updateSidebars();
     }
 
-    populateSidebar() {
+    private populateSidebar() {
       const sidebars: Sidebars = {
         active: '',
         dashboards: [{

--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -120,7 +120,7 @@ export class LayoutFacadeService {
     this.layout.userNotifications.display = true;
   }
 
-  showSidebar(sidebarName: string) {
+  showSidebar(sidebarName: Sidebar) {
     this.layoutSidebarService.updateSidebars(sidebarName);
   }
 

--- a/components/automate-ui/src/app/pages/compliance-landing/compliance-landing.component.ts
+++ b/components/automate-ui/src/app/pages/compliance-landing/compliance-landing.component.ts
@@ -8,8 +8,7 @@ import { RoutePerms } from 'app/components/landing/landing.component';
 })
 export class ComplianceLandingComponent {
 
-  // order determined by compliance-reporting-sidebar
-  // template and is vetted by compliance-reporting-sidebar unit tests
+  // order determined by LayoutSidebarService and vetted by SidebarComponent unit tests
   public routeList: RoutePerms[] = [
     {
       allOfCheck: [['/api/v0/compliance/reporting/stats/summary', 'post', ''],

--- a/components/automate-ui/src/app/pages/settings-landing/settings-landing.component.ts
+++ b/components/automate-ui/src/app/pages/settings-landing/settings-landing.component.ts
@@ -8,14 +8,14 @@ import { RoutePerms } from 'app/components/landing/landing.component';
 })
 export class SettingsLandingComponent {
 
-  // order determined by settings-sidebar template and is vetted by settings-sidebar unit tests
+  // order determined by LayoutSidebarService and vetted by SidebarComponent unit tests
   public routeList: RoutePerms[] = [
     { anyOfCheck: [['/api/v0/notifications/rules', 'get', '']], route: '/settings/notifications' },
     { anyOfCheck: [['/api/v0/datafeed/destinations', 'post', '']], route: '/settings/data-feeds' },
-    { anyOfCheck: [['/api/v0/nodemanagers/search', 'post', '']], route: '/settings/node-integrations' },
-    { anyOfCheck: [['/api/v0/secrets/search', 'post', '']], route: '/settings/node-credentials' },
     { anyOfCheck: [['/api/v0/retention/nodes/status', 'get', '']],
       route: '/settings/data-lifecycle' },
+    { anyOfCheck: [['/api/v0/nodemanagers/search', 'post', '']], route: '/settings/node-integrations' },
+    { anyOfCheck: [['/api/v0/secrets/search', 'post', '']], route: '/settings/node-credentials' },
     { allOfCheck: [['/apis/iam/v2/users', 'get', '']], route: '/settings/users' },
     { allOfCheck: [['/apis/iam/v2/teams', 'get', '']], route: '/settings/teams' },
     { allOfCheck: [['/apis/iam/v2/tokens', 'get', '']], route: '/settings/tokens' },


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The sidebar architecture was changed recently (#2467) and there was a follow-up PR to remove all the old, no longer used bits (#3341). What I missed in that first cleanup, though, is included in this PR: the meta-unit tests that ensure consistency between *LandingComponents and the actual sidebar contents.

Those tests are important, because, once I re-activated them, they confirmed a bug that I had found, to wit: the SettingsLandingComponent data order differed from the actual sidebar order.

#### Magnitude of the user problem
very small

#### Manifestation to the user
the order in SettingsLandingComponent is the order pages are checked for permission, and the user will land on the first page that they have permission for. Since those were out of order, someone with very specific permissions would land on a different page than the sidebar order would suggest.

#### Note
This is a quick fix to ensure things are kept in sync; when time permits will DRY it up so *LandingComponents just use the data from the LayoutSidebarService directly.

### :chains: Related Resources
PR #2467 
PR #3341 

### :+1: Definition of Done
Settings sidebar elements are in the correct order.

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).