### PR TITLE
Add a new credential error message fixed

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+credentials/containers/credentials-add-edit-screen.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/containers/credentials-add-edit-screen.ts
@@ -62,9 +62,9 @@ export class CredentialsAddEditScreenComponent implements OnInit {
       this.httpClient.post<Credential>(`${SECRETS_URL}`, credential);
 
     saveReq.pipe(
-      catchError(error => {
+      catchError(response => {
         this.saveErrorOccurred = true;
-        this.saveErrorMessage = error._body || '';
+        this.saveErrorMessage = response.error.message || '';
         this.ref.markForCheck();
 
         return observableThrowError(this.saveErrorMessage);


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
"Add a new credential" has confusing required fields for type "SSH"

### :chains: Related Resources
https://app.zenhub.com/workspaces/ui-team-5cba23a3b14fdc05970c8f87/issues/chef/automate/3432

### :+1: Definition of Done
Display the error message that is returned from the api.

### :athletic_shoe: How to Build and Test the Change
When a user adds a credential, and adds values into both the SSH password and RSA key you'll see a generic error message that doesn't convey the problem.

### :white_check_mark: Checklist
- [X ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ X] Tests added/updated?
- [ ] Docs added/updated?
- [ X] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Screen Shot 2020-04-30 at 11 52 29 AM](https://user-images.githubusercontent.com/4108100/80737813-ac365680-8ad9-11ea-8c95-7492f9dea681.png)
