### PR TITLE
Use bigint for services table

### DIFF
--- a/components/applications-service/pkg/storage/postgres/schema/sql/16_service_full_bigint_id.up.sql
+++ b/components/applications-service/pkg/storage/postgres/schema/sql/16_service_full_bigint_id.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE service_full ALTER COLUMN id type bigint;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

A customer recently had an outage after exhausting all the 2 billion integers for the service IDs. This should only happen if creating and deleting services at a high rate, since the steady state total is usually in the 10s of thousands of services range, but since we do know it happens we might as well use a bigint to give ourselves some more room.

