### PR TITLE
[Automate-3537] Sequence addPolicyMembers from createToken

### DIFF
--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.ts
@@ -87,6 +87,7 @@ export class ApiTokenListComponent implements OnInit, OnDestroy {
       .subscribe(state => {
         this.creatingToken = false;
         if (state === EntityStatus.loadingSuccess) {
+          this.assignPolicies();
           this.closeCreateModal();
         }
       });
@@ -132,22 +133,20 @@ export class ApiTokenListComponent implements OnInit, OnDestroy {
   public createToken(): void {
     this.creatingToken = true;
     const tok = {
-      id: this.createTokenForm.controls['id'].value,
-      name: this.createTokenForm.controls['name'].value.trim(),
+      id: this.createTokenForm.controls.id.value,
+      name: this.createTokenForm.controls.name.value.trim(),
       projects: this.createTokenForm.controls.projects.value
     };
     this.store.dispatch(new CreateToken(tok));
+  }
 
-    const member = stringToMember(`token:${tok.id}`);
-    const policies: string[] = this.createTokenForm.controls.policies.value;
-    if (policies) {
-      policies.forEach(id =>
-        this.store.dispatch(new AddPolicyMembers(<PolicyMembersMgmtPayload>{
-          id,
-          members: [member]
-        }))
-      );
-    }
+  private assignPolicies(): void {
+    const member = stringToMember(`token:${this.createTokenForm.controls.id.value}`);
+    const policies: string[] = this.createTokenForm.controls.policies.value || [];
+    policies.forEach(id => this.store.dispatch(new AddPolicyMembers(<PolicyMembersMgmtPayload>{
+      id,
+      members: [member]
+    })));
   }
 
   public toggleActive($event: ChefKeyboardEvent, token: ApiToken): void {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The initial pass introducing adding a token to policies during token creation made the two actions concurrent: creating the token and adding it to policies. That strategy only works well, though, if the token creation succeeds. If it fails due to an id conflict--a token of the same name already exists--then it is inappropriate for the policy assignment to still be done.

This PR sequences those so that the policy assignment is initiated iff the token creation is successful.

Let us also consider the flip side--what if token creation succeeds but the policy assignment fails? Should the two operations be done transactionally so that both must succeed otherwise neither does? I would suggest no, it is OK to create the token regardless, and if the policy assignments failed they could be retried through other routes. (Partly because that seems reasonable to me and partly because the implementation of this is straightforward; hence, this PR. 😁 )

### :chains: Related Resources
PR #3511 (Introduce policy dropdown for tokens)

### :+1: Definition of Done
Policy assignments are not attempted if token creation fails for any reason.

### :athletic_shoe: How to Build and Test the Change
1. Rebuild automate-ui.
2. Navigate to Settings >> Tokens
3. Use <kbd>Create Token</kbd> to create an initial token, t1; neither projects nor policies matters.
4. Again open up the token creation modal with Use <kbd>Create Token</kbd>. Enter the same id for the token and this time be sure to select one or more policies from the dropdown.
5. Upon pressing <kbd>Create</kbd> you should see an in-modal error notification and on the underlying page **_no_** notification for policies.
6. Change the id to something unique so the token creation will succeed. This time observe that the modal closes, the first notification indicates token created, and then there is an additional success notification for each policy you specified.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
