### PR TITLE
[automate-2699] deflake team add users

### DIFF
--- a/e2e/cypress/integration/ui/settings/team_add_users.spec.ts
+++ b/e2e/cypress/integration/ui/settings/team_add_users.spec.ts
@@ -52,6 +52,7 @@ describe('team add users', () => {
     // the whole app has to reload, slowing down the test and causing timeouts
     cy.visit(`/settings/teams/${teamID}/add-users`);
     cy.wait(['@getTeam', '@getTeamUsers', '@getUsers']);
+    cy.get('app-welcome-modal').invoke('hide');
   });
 
   afterEach(() => {

--- a/e2e/cypress/integration/ui/settings/team_add_users.spec.ts
+++ b/e2e/cypress/integration/ui/settings/team_add_users.spec.ts
@@ -1,5 +1,3 @@
-import { itFlaky } from '../../../support/constants';
-
 describe('team add users', () => {
   const now = Cypress.moment().format('MMDDYYhhmm');
   const cypressPrefix = 'test-add-users';
@@ -63,17 +61,17 @@ describe('team add users', () => {
     cy.cleanupIAMObjectsByIDPrefixes(cypressPrefix, ['users', 'teams']);
   });
 
-  itFlaky('when the x is clicked, it returns to the team details page', () => {
+  it('when the x is clicked, it returns to the team details page', () => {
     cy.get('chef-page chef-button.close-button').click();
     cy.url().should('eq', `${Cypress.config().baseUrl}/settings/teams/${teamID}`);
   });
 
-  itFlaky('when the cancel button is clicked, it returns to the team details page', () => {
+  it('when the cancel button is clicked, it returns to the team details page', () => {
     cy.get('#page-footer #right-buttons chef-button').last().click();
     cy.url().should('eq', `${Cypress.config().baseUrl}/settings/teams/${teamID}`);
   });
 
-  itFlaky('navigates to the team users add page', () => {
+  it('navigates to the team users add page', () => {
     cy.get('chef-page-header h1').contains(`Add Users to ${teamName}`);
 
     cy.get('chef-tbody chef-tr').contains(userID);
@@ -85,7 +83,7 @@ describe('team add users', () => {
     cy.get('#page-footer #right-buttons chef-button ng-container').first().contains('Add User');
   });
 
-  itFlaky('adds a single user', () => {
+  it('adds a single user', () => {
     cy.get('chef-tbody').contains('chef-tr', userID)
       .find('chef-checkbox').click();
     cy.get('#users-selected').contains('1 user selected');
@@ -115,7 +113,7 @@ describe('team add users', () => {
     });
   });
 
-  itFlaky('adds all users then sees empty message on attempting to add more users', () => {
+  it('adds all users then sees empty message on attempting to add more users', () => {
     // Note: we add one user, and there always is an admin user. So,
     // we don't need to care for singular texts here ("Add 1 user" etc).
     cy.get('chef-tbody').find('chef-tr').then(rows => {

--- a/e2e/cypress/integration/ui/settings/team_add_users.spec.ts
+++ b/e2e/cypress/integration/ui/settings/team_add_users.spec.ts
@@ -105,10 +105,10 @@ describe('team add users', () => {
     }).then((resp) => {
       cy.request({
         auth: { bearer: adminIdToken },
-        method: 'PUT',
-        url: `/apis/iam/v2/teams/${teamID}/users`,
+        method: 'POST',
+        url: `/apis/iam/v2/teams/${teamID}/users:remove`,
         body: {
-          membership_ids: [resp.body.id]
+          membership_ids: [resp.body.user.membership_id]
         }
       });
     });
@@ -132,7 +132,7 @@ describe('team add users', () => {
     cy.get('chef-tbody chef-td a').contains('Local Administrator');
 
     // navigate back to add users and see empty page and message
-    cy.get('chef-toolbar chef-button').contains('Add User').click();
+    cy.get('chef-toolbar chef-button').contains('Add Users').click();
     cy.url().should('eq',
     `${Cypress.config().baseUrl}/settings/teams/${teamID}/add-users`);
     cy.get('chef-table').should('not.exist');


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Deflaking some teams add users tests.

Refreshing the store is causing the modal to continue to pop up, so hiding the modal "fixed" the flakiness. Seems like there should be another way to ensure that all the things are present without the storage changes, but none were obvious to me. 

We were also passing a malformed request to delete the users after the fact.

These tests passed CI on 4 separate builds . . . is that enough?

### :athletic_shoe: How to Build and Test the Change

Run the tests?
