### PR TITLE
[ssl-tests] disable rating as it always fails due to hostname mismatch

### DIFF
--- a/integration/helpers/ssl_tests.sh
+++ b/integration/helpers/ssl_tests.sh
@@ -82,7 +82,7 @@ run_testssl() {
     mypath="$mypath:$(hab pkg path core/net-tools)/bin"
     mypath="$mypath:$(hab pkg path core/bind)/bin"
     mypath="$mypath:$PATH"
-    PATH="$mypath" ./testssl.sh --parallel --quiet -n none --color 0 --severity LOW --warnings off --jsonfile "$2" --fast --add-ca /hab/svc/deployment-service/data/root.crt --file "$1"
+    PATH="$mypath" ./testssl.sh --parallel --quiet -n none --color 0 --severity LOW --warnings off --disable-rating --jsonfile "$2" --fast --add-ca /hab/svc/deployment-service/data/root.crt --file "$1"
 }
 
 install_testssl_prereqs() {


### PR DESCRIPTION

Signed-off-by: Ryan Cragun <ryan@chef.io>