### PR TITLE
[automate-3510 amendment] Correct leaky subscription

### DIFF
--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { timer as observableTimer, Subject } from 'rxjs';
 import { takeUntil, withLatestFrom } from 'rxjs/operators';
@@ -17,7 +17,7 @@ import * as moment from 'moment';
   styleUrls: ['./nodes-list.component.scss']
 })
 
-export class NodesListComponent implements OnInit {
+export class NodesListComponent implements OnInit, OnDestroy {
   constructor(
     private store: Store<NgrxStateAtom>,
     private router: Router
@@ -37,6 +37,11 @@ export class NodesListComponent implements OnInit {
       .subscribe(([_i, params]) => {
         this.store.dispatch(actions.getNodes(params));
       });
+  }
+
+  ngOnDestroy(): void {
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
   }
 
   orderFor(sortKey) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Recent PR #3510 (one node skeleton view) did not quite set up the subscription management to prevent leaks. Inserting standard code to do that.

### :chains: Related Resources
#3510 

### :+1: Definition of Done
Subscription completes when the component is destroyed.

### :athletic_shoe: How to Build and Test the Change
NA

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
