### PR TITLE
adding back in iam v2 role content

### DIFF
--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -105,7 +105,7 @@ Default Chef-managed roles cannot change, like Chef-managed policies.
 
 Chef Automate includes five *Chef-managed* roles and two *Custom* roles by default.
 You can edit these Custom roles, *Compliance Viewer* and *Compliance Editor*.
-To see the actions comprising the roles, see [Chef-managed Roles]({{< relref "api/#tag/roles" >}}).
+To see the actions comprising the roles, see [IAM Actions]({{< relref "iam-actions.md" >}}).
 
 Role              |Type          |Description
 ------------------|--------------|------------------------------

--- a/components/automate-chef-io/content/docs/roles.md
+++ b/components/automate-chef-io/content/docs/roles.md
@@ -12,7 +12,7 @@ toc = true
 
 ## Overview
 
-Chef Automate Identity and Access Management roles are named groups of actions used to define [policies]({{< relref "policies.md" >}}). Actions describe what is allowed by users in Automate. [IAM Actions]({{< relref "iam-actions.md" >}}) describes how actions map to the UI.
+Chef Automate Identity and Access Management roles are named groups of actions used to define [policies]({{< relref "policies.md" >}}). Actions describe what is allowed by users in Automate. [IAM Actions]({{< relref "iam-actions.md" >}}) describes how actions map to pages in the browser.
 
 Users require permission for the `iam:roles` action to interact with roles. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
 
@@ -30,7 +30,7 @@ Owner         | **Do** everything in the system *including* IAM
 Project Owner | Editor + **view** and **assign** projects
 Ingest        | Ingest data into the system
 
-#### Actions for Chef-managed Roles
+#### Actions for Chef-Managed Roles
 
 Name | ID| Actions
 -----------------------|-----|--------
@@ -39,8 +39,6 @@ Project Owner      | project-owner | infra:nodes:\*, infra:nodeManagers:\*, comp
 Editor             | editor        | infra:infraServers:list, infra:infraServers:get, infra:nodes:\*, infra:nodeManagers:\*, compliance:\*, event:\*, ingest:\*, secrets:\*, iam:projects:list, iam:projects:get, iam:projects:assign, applications:\*
 Viewer             | viewer        | infra:infraServers:list, infra:infraServers:get, secrets:\*:get, secrets:\*:list, infra:nodes:get, infra:nodes:list, infra:nodeManagers:get, infra:nodeManagers:list, compliance:\*:get, compliance:\*:list, event:\*:get, event:\*:list, ingest:\*:get, ingest:\*:list, iam:projects:list, iam:projects:get, applications:\*:get, applications:\*:list
 Ingest             | ingest        | infra:ingest:\*, compliance:profiles:get, compliance:profiles:list
-
-
 
 ### Custom Roles
 

--- a/components/automate-chef-io/content/docs/roles.md
+++ b/components/automate-chef-io/content/docs/roles.md
@@ -30,6 +30,18 @@ Owner         | **Do** everything in the system *including* IAM
 Project Owner | Editor + **view** and **assign** projects
 Ingest        | Ingest data into the system
 
+#### Actions for Chef-managed Roles
+
+Name | ID| Actions
+-----------------------|-----|--------
+Owner              | owner         | \*
+Project Owner      | project-owner | infra:nodes:\*, infra:nodeManagers:\*, compliance:\*, event:\*, ingest:\*, secrets:\*, iam:projects:list, iam:projects:get, iam:projects:assign, iam:policies:list, iam:policies:get, iam:policyMembers:\*, iam:teams:list, iam:teams:get, iam:teamUsers:\*, iam:users:get, iam:users:list, applications:\*
+Editor             | editor        | infra:infraServers:list, infra:infraServers:get, infra:nodes:\*, infra:nodeManagers:\*, compliance:\*, event:\*, ingest:\*, secrets:\*, iam:projects:list, iam:projects:get, iam:projects:assign, applications:\*
+Viewer             | viewer        | infra:infraServers:list, infra:infraServers:get, secrets:\*:get, secrets:\*:list, infra:nodes:get, infra:nodes:list, infra:nodeManagers:get, infra:nodeManagers:list, compliance:\*:get, compliance:\*:list, event:\*:get, event:\*:list, ingest:\*:get, ingest:\*:list, iam:projects:list, iam:projects:get, applications:\*:get, applications:\*:list
+Ingest             | ingest        | infra:ingest:\*, compliance:profiles:get, compliance:profiles:list
+
+
+
 ### Custom Roles
 
 Custom roles are roles that any user with the permission for `iam:roles:update` can change. 
@@ -47,6 +59,25 @@ You can edit these custom roles like other user-created custom roles.
 ### Creating Roles
 
 _Custom_ roles can only be created using the [Roles API]({{< relref "api/#tag/roles" >}}).
+
+#### Example Custom Role
+
+```json
+{
+  "name": "Advocate",
+  "id": "advocate-role",
+  "actions": [
+    "infra:*",
+    "compliance:*",
+    "teams:*",
+    "users:*"
+  ],
+  "projects": [
+    "east-region",
+    "west-region"
+  ]
+}
+```
 
 ### Changing Role Details
 

--- a/components/automate-chef-io/content/docs/roles.md
+++ b/components/automate-chef-io/content/docs/roles.md
@@ -12,7 +12,7 @@ toc = true
 
 ## Overview
 
-Chef Automate Identity and Access Management roles are named groups of actions used to define [policies]({{< relref "policies.md" >}}). Actions describe what is allowed by users in Automate. [IAM Actions]({{< relref "iam-actions.md" >}}) describes how actions map to pages in the browser.
+Chef Automate Identity and Access Management roles are named groups of actions used to define [policies]({{< relref "policies.md" >}}). Actions describe what is allowed by users in Automate. [IAM Actions]({{< relref "iam-actions.md" >}}) describes how which action grants access to what page in the browser.
 
 Users require permission for the `iam:roles` action to interact with roles. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
 

--- a/components/automate-chef-io/content/docs/roles.md
+++ b/components/automate-chef-io/content/docs/roles.md
@@ -12,7 +12,7 @@ toc = true
 
 ## Overview
 
-Chef Automate Identity and Access Management roles are named groups of actions used to define [policies]({{< relref "policies.md" >}}). Actions describe what is allowed by users in Automate.
+Chef Automate Identity and Access Management roles are named groups of actions used to define [policies]({{< relref "policies.md" >}}). Actions describe what is allowed by users in Automate. [IAM Actions]({{< relref "iam-actions.md" >}}) describes how actions map to the UI.
 
 Users require permission for the `iam:roles` action to interact with roles. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
 

--- a/components/automate-chef-io/content/docs/roles.md
+++ b/components/automate-chef-io/content/docs/roles.md
@@ -12,7 +12,7 @@ toc = true
 
 ## Overview
 
-Chef Automate Identity and Access Management roles are named groups of actions used to define [policies]({{< relref "policies.md" >}}). Actions describe what is allowed by users in Automate. [IAM Actions]({{< relref "iam-actions.md" >}}) describes how which action grants access to what page in the browser.
+Chef Automate Identity and Access Management roles are named groups of actions used to define [policies]({{< relref "policies.md" >}}). Actions describe what is allowed by users in Automate. [IAM Actions]({{< relref "iam-actions.md" >}}) describes the associated action or actions required to access certain pages in the browser.
 
 Users require permission for the `iam:roles` action to interact with roles. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam-v2-guide.md#creating-custom-policies" >}}) can be created to assign this permission.
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
In the force upgrade this content was removed by way of the api reference, but never added into the api docs. Adding it back into the roles page.

### :chains: Related Resources
fixes #3572 

### :+1: Definition of Done
folks have more information

### :athletic_shoe: How to Build and Test the Change
`make serve` from `components/automate-chef-io`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Zero.