### PR TITLE
add docs for assigning policy on token creation

### DIFF
--- a/components/automate-chef-io/content/docs/api-tokens.md
+++ b/components/automate-chef-io/content/docs/api-tokens.md
@@ -20,9 +20,9 @@ Permission for the `iam:tokens` action is required to interact with tokens. Any 
 
 ### Creating API Tokens
 
-Navigate to _API Tokens_ in the **Settings** tab. Then use the **Create Token** button, which opens a dialog box for entering the token's _name_ and optionally assigning the API token to some _Projects_. A token ID automatically generates upon creation. If you would like to change the token ID, select the **Edit ID** button.
+Navigate to _API Tokens_ in the **Settings** tab. Then use the **Create Token** button, which opens a dialog box for entering the token's _name_ and optionally assigning the API token to some _Policies_ and some _Projects_. A token ID automatically generates upon creation. If you would like to change the token ID, select the **Edit ID** button.
 
-After a token is created from the UI, it will have no permissions. To assign the token permissions, navigate to _Policies_ in the **Settings** tab, locate the appropriate policy, and then add the token as a member of the policy using a [member expression]({{< relref "iam-v2-guide.md#member-expressions" >}}).
+If a policy is assigned to a token on creation it will have permissions, if no policy is selected it will have have no permissions. To assign the token permissions, navigate to _Policies_ in the **Settings** tab, locate the appropriate policy, and then add the token as a member of the policy using a [member expression]({{< relref "iam-v2-guide.md#member-expressions" >}}).
 
 ![API Tokens](/images/docs/admin-tab-API-tokens-list.png)
 

--- a/components/automate-chef-io/content/docs/api-tokens.md
+++ b/components/automate-chef-io/content/docs/api-tokens.md
@@ -20,9 +20,9 @@ Permission for the `iam:tokens` action is required to interact with tokens. Any 
 
 ### Creating API Tokens
 
-Navigate to _API Tokens_ in the **Settings** tab. Then use the **Create Token** button, which opens a dialog box for entering the token's _name_ and optionally assigning the API token to some _Policies_ and some _Projects_. A token ID automatically generates upon creation. If you would like to change the token ID, select the **Edit ID** button.
+Navigate to _API Tokens_ in the **Settings** tab. Then, use the **Create Token** button, which opens a dialog box for entering the API token's _name_ and optionally assigning the API token to one or more _Policies_ and to one or more _Projects_. A token ID automatically generates upon creation. If you would like to change the token ID, select the **Edit ID** button.
 
-If a policy is assigned to a token on creation it will have permissions; if no policy is selected it will have have no permissions. To assign the token permissions any time after creation, navigate to _Policies_ in the **Settings** tab, locate the appropriate policy, and then add the token as a member of the policy using a [member expression]({{< relref "iam-v2-guide.md#member-expressions" >}}).
+If a policy is assigned to an API token on creation, the API token will have permissions. If no policy is selected during its creation, the API token will have no permissions. To assign permissions to the API token any time after creation, navigate to _Policies_ in the **Settings** tab, locate the appropriate policy, and then add the API token as a member of the policy using a [member expression]({{< relref "iam-v2-guide.md#member-expressions" >}}).
 
 ![API Tokens](/images/docs/admin-tab-API-tokens-list.png)
 

--- a/components/automate-chef-io/content/docs/api-tokens.md
+++ b/components/automate-chef-io/content/docs/api-tokens.md
@@ -22,7 +22,7 @@ Permission for the `iam:tokens` action is required to interact with tokens. Any 
 
 Navigate to _API Tokens_ in the **Settings** tab. Then use the **Create Token** button, which opens a dialog box for entering the token's _name_ and optionally assigning the API token to some _Policies_ and some _Projects_. A token ID automatically generates upon creation. If you would like to change the token ID, select the **Edit ID** button.
 
-If a policy is assigned to a token on creation it will have permissions, if no policy is selected it will have have no permissions. To assign the token permissions, navigate to _Policies_ in the **Settings** tab, locate the appropriate policy, and then add the token as a member of the policy using a [member expression]({{< relref "iam-v2-guide.md#member-expressions" >}}).
+If a policy is assigned to a token on creation it will have permissions; if no policy is selected it will have have no permissions. To assign the token permissions any time after creation, navigate to _Policies_ in the **Settings** tab, locate the appropriate policy, and then add the token as a member of the policy using a [member expression]({{< relref "iam-v2-guide.md#member-expressions" >}}).
 
 ![API Tokens](/images/docs/admin-tab-API-tokens-list.png)
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
In #3511 we added ui functionality to assign policies to a token when they were created but we failed to add docs. This adds those docs.

### :chains: Related Resources
#3511
fixes #3570

### :+1: Definition of Done
docs have more information

### :athletic_shoe: How to Build and Test the Change
`make serve` from `components/automate-chef-io`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Zero.