### PR TITLE
Fixing InSpec e2e flaky test

### DIFF
--- a/inspec/a2-api-integration/files/fixtures/converge/converge-failure-report_with_ignored_failure_run_converge.json
+++ b/inspec/a2-api-integration/files/fixtures/converge/converge-failure-report_with_ignored_failure_run_converge.json
@@ -3457,7 +3457,7 @@
         "cookbook_version":"0.1.1"
      }
   ],
-  "run_id":"ba6acb91-1eaa-4c84-8d68-f19ee641e606",
+  "run_id":"e2779003-228c-43d2-812b-2b060ed9e81d",
   "run_list":[
      "recipe[insights-ignored::default, insights-real::default]"
   ],


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Two of the e2e InSpec tests were ingesting runs with the same UUID. This data is not deleted after the test, therefore the second test was failing when it requested data from that run.

### :chains: Related Resources

One example of the test failing
https://buildkite.com/chef/chef-automate-master-verify-private/builds/11816#6cbb0244-bf01-49b8-8bb5-26d900bd3d37/498-1169

### :+1: Definition of Done

The test is not flaky anymore. 

### :athletic_shoe: How to Build and Test the Change

Check buildkite.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
