### PR TITLE
[automate-2697] stabilize project mgmt tests

### DIFF
--- a/e2e/cypress/integration/ui/settings/project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/project_mgmt.spec.ts
@@ -11,8 +11,6 @@ describe('project management', () => {
   const projectID = `${cypressPrefix}-project1-${now}`;
   const projectName = `${cypressPrefix} project1 ${now}`;
   const customProjectID = `${cypressPrefix}-custom-${now}`;
-  const ruleID = `${cypressPrefix}-rule-${now}`;
-  const ruleName = `${cypressPrefix} rule ${now}`;
 
   before(() => {
     cy.adminLogin('/settings/projects').then(() => {
@@ -134,97 +132,6 @@ describe('project management', () => {
     cy.url().should('include', `/settings/projects/${projectID}`);
   });
 
-  it('can create a rule for the new project', () => {
-    cy.get('app-pending-edits-bar').should('not.be.visible');
-    cy.get('app-project-details app-authorized button').contains('Create Rule').click();
-
-    cy.url().should('include', `/settings/projects/${projectID}/rules`);
-    cy.get('app-project-rules chef-page').should('be.visible');
-
-    cy.get('#create-name input').focus().type(ruleName, { delay: typeDelay })
-      .should('have.value', ruleName);
-    cy.get('[data-cy=edit-id]').click();
-
-    cy.get('#create-id input').should('have.value', ruleID);
-
-    // Verify correct attributes/operators are selectable for each resource
-    cy.get('#create-type-dropdown').select('Event');
-    cy.get('[data-cy=attribute-dropdown]').select('Chef Organization');
-    cy.get('[data-cy=attribute-dropdown]').select('Chef Infra Server');
-    cy.get('[data-cy=operator-dropdown]').select('equals');
-    cy.get('[data-cy=operator-dropdown]').select('member of');
-
-    cy.get('#create-type-dropdown').select('Node');
-    const nodeAttributes = ['Chef Organization', 'Chef Infra Server', 'Environment',
-      'Chef Role', 'Chef Tag', 'Chef Policy Name', 'Chef Policy Group'];
-
-    nodeAttributes.forEach((att: string) => {
-      cy.get('[data-cy=attribute-dropdown]').select(att);
-    });
-
-    cy.get('[data-cy=operator-dropdown]').select('member of');
-    cy.get('[data-cy=operator-dropdown]').select('equals');
-    cy.get('[data-cy=rule-value]').type('Chef Policy Group Foo');
-
-    cy.get('app-project-rules #right-buttons button').contains('Save Rule').click();
-    cy.get('app-project-rules chef-page').should('not.be.visible');
-
-    cy.url().should('include', `/settings/projects/${projectID}`);
-    cy.get('app-project-details chef-td').contains(ruleID);
-    cy.get('app-pending-edits-bar').contains('Project edits pending');
-  });
-
-  it('displays a list of rules for a project', () => {
-    ['Name', 'ID', 'Resource Type', 'Conditions', 'Edits'].forEach((header) => {
-      cy.get('app-project-details chef-th').contains(header);
-    });
-
-    cy.get('app-project-details chef-td').contains(ruleID);
-    cy.get('app-project-details chef-td').contains(ruleName);
-    cy.get('app-project-details chef-td').contains('Node');
-    cy.get('app-project-details chef-td').contains('1 condition');
-    cy.get('app-project-details chef-td').contains('Edits pending');
-  });
-
-  it('can update a project rule', () => {
-    cy.get('app-pending-edits-bar').contains('Project edits pending');
-    const updatedRuleName = `updated ${ruleName}`;
-    cy.get('app-project-details a').contains(ruleName).click();
-
-    cy.url().should('include', `/settings/projects/${projectID}/rules/${ruleID}`);
-    cy.get('app-project-rules chef-page').should('be.visible');
-
-    cy.get('#create-name input').focus().clear().type(updatedRuleName, { delay: typeDelay })
-      .should('have.value', updatedRuleName);
-
-    cy.get('#create-id input').should('have.value', ruleID);
-    cy.get('#create-id input').should('be.disabled');
-
-    cy.get('#create-type-dropdown option:first').should('have.value', 'NODE');
-    cy.get('#create-type-dropdown option:first').should('be.selected');
-    cy.get('#create-type-dropdown').should('be.disabled');
-
-    cy.get('app-project-rules chef-button').contains('Add Condition').click();
-    cy.get('app-project-rules .end-row-items span').contains('AND').should('be.visible');
-
-    cy.get('[data-cy=attribute-dropdown]:last')
-      .select('Environment');
-
-    cy.get('[data-cy=operator-dropdown]:last')
-      .select('member of');
-
-    cy.get('[data-cy=rule-value]:last')
-      .type('Dev, Prod, Test');
-
-    cy.get('app-project-rules #right-buttons button').contains('Save Rule').click();
-    cy.get('app-project-rules chef-page').should('not.be.visible');
-
-    cy.url().should('include', '/settings/projects');
-    cy.get('app-project-details chef-td').contains(updatedRuleName);
-    cy.get('app-project-details chef-td').contains('2 conditions');
-    cy.get('app-pending-edits-bar').contains('Project edits pending');
-  });
-
   it('can update a project name', () => {
     const updatedProjectName = `updated ${projectName}`;
     cy.route('GET', `/apis/iam/v2/projects/${projectID}`).as('getProject');
@@ -238,32 +145,6 @@ describe('project management', () => {
     cy.get('app-project-details chef-button').contains('Save').click();
 
     cy.get('app-project-details h1.page-title').contains(updatedProjectName);
-  });
-
-  it('can delete a project rule', () => {
-    cy.get('app-pending-edits-bar').contains('Project edits pending');
-    cy.get('[data-cy=rules-tab]').click();
-
-    cy.get('app-project-details chef-td').contains(ruleID).parent()
-      .find('.mat-select-trigger').as('controlMenu');
-
-    // we throw in a `should` so cypress retries until introspection allows menu to be shown
-    cy.get('@controlMenu').should('be.visible')
-      .click();
-    cy.get('[data-cy=delete-rule]').should('be.visible')
-      .click();
-
-    // accept dialog
-    cy.get('app-project-details chef-button').contains('Delete Rule').click();
-
-    // since this is a cypress custom project, we know this is the only rule.
-    // the empty UI should show up so entire table will be missing.
-    cy.get('app-project-details chef-tbody').should('not.exist');
-    cy.get('app-pending-edits-bar').contains('Project edits pending').should('not.be.visible');
-
-    // verify success notification and then dismiss it
-    cy.get('app-notification.info').contains(`Deleted rule ${ruleID}`);
-    cy.get('app-notification.info chef-icon').click();
   });
 
   it('can delete a project', () => {

--- a/e2e/cypress/integration/ui/settings/project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/project_mgmt.spec.ts
@@ -79,8 +79,11 @@ describe('project management', () => {
 
     cy.get('[data-cy=save-button]').click();
     cy.get('app-project-list chef-modal').should('not.be.visible');
-    cy.get('#main-content-wrapper').scrollTo('top');
-    cy.get('app-notification.info').should('be.visible');
+
+    // verify success notification and then dismiss it
+    cy.get('app-notification.info').contains(`Created project ${projectID}`);
+    cy.get('app-notification.info chef-icon').click();
+
     cy.contains(projectName).should('exist');
     cy.contains(projectID).should('exist');
 
@@ -106,8 +109,11 @@ describe('project management', () => {
 
     cy.get('[data-cy=save-button]').click();
     cy.get('app-project-list chef-modal').should('not.be.visible');
-    cy.get('#main-content-wrapper').scrollTo('top');
-    cy.get('chef-notification.info').should('be.visible');
+
+    // verify success notification and then dismiss it
+    cy.get('app-notification.info').contains(`Created project ${customProjectID}`);
+    cy.get('app-notification.info chef-icon').click();
+
     cy.contains(projectName).should('exist');
     cy.contains(customProjectID).should('exist');
 
@@ -254,10 +260,10 @@ describe('project management', () => {
     // the empty UI should show up so entire table will be missing.
     cy.get('app-project-details chef-tbody').should('not.exist');
     cy.get('app-pending-edits-bar').contains('Project edits pending').should('not.be.visible');
-    cy.get('chef-notification.info').contains(`Deleted rule ${ruleID}`);
 
-    // dismiss notification
-    cy.get('chef-notification.info chef-icon').click();
+    // verify success notification and then dismiss it
+    cy.get('app-notification.info').contains(`Deleted rule ${ruleID}`);
+    cy.get('app-notification.info chef-icon').click();
   });
 
   it('can delete a project', () => {
@@ -266,7 +272,7 @@ describe('project management', () => {
 
     cy.wait('@getProjects');
 
-    cy.get('app-project-list chef-td').contains(projectID).parent()
+    cy.get('app-project-list chef-td').contains(customProjectID).parent()
       .find('.mat-select-trigger').as('controlMenu');
 
     // we throw in a `should` so cypress retries until introspection allows menu to be shown
@@ -278,10 +284,12 @@ describe('project management', () => {
     // accept dialog
     cy.get('app-project-list chef-button').contains('Delete Project').click();
 
+    // verify success notification and then dismiss it
+    cy.get('app-notification.info').contains(`Deleted project ${customProjectID}`);
+    cy.get('app-notification.info chef-icon').click();
+
     // Once we get this notification we know the network call to delete succeeded,
     // so now we can check if there are other projects or not.
-    cy.get('#main-content-wrapper').scrollTo('top');
-    cy.get('app-notification.info').contains(`Deleted project ${projectID}`);
     cy.request({
       auth: { bearer: adminIdToken },
       method: 'GET',
@@ -294,7 +302,7 @@ describe('project management', () => {
         // otherwise, check that the projectID is no longer in the table
       } else {
         cy.get('app-project-list chef-tbody chef-td')
-          .contains(projectID).should('not.exist');
+          .contains(customProjectID).should('not.exist');
       }
     });
   });

--- a/e2e/cypress/integration/ui/settings/project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/project_mgmt.spec.ts
@@ -1,9 +1,4 @@
-import { itFlaky } from '../../../support/constants';
-interface Project {
-  id: string;
-  name: string;
-  type: string;
-}
+import { Project } from '../../../support/types';
 
 describe('project management', () => {
   // we increase the default delay to mimic the average human's typing speed
@@ -98,7 +93,7 @@ describe('project management', () => {
   });
 
   // something is occasionally resetting the projects filter to (unassigned)
-  itFlaky('can create a rule for the new project', () => {
+  it('can create a rule for the new project', () => {
     cy.get('app-project-details').contains('Edits are pending').should('not.exist');
     cy.get('app-project-details app-authorized button').contains('Create Rule').click();
 
@@ -140,7 +135,7 @@ describe('project management', () => {
     cy.get('app-project-details').contains('Edits are pending');
   });
 
-  itFlaky('displays a list of rules for a project', () => {
+  it('displays a list of rules for a project', () => {
     ['Name', 'ID', 'Resource Type', 'Conditions', 'Edits'].forEach((header) => {
       cy.get('app-project-details chef-th').contains(header);
     });
@@ -152,7 +147,7 @@ describe('project management', () => {
     cy.get('app-project-details chef-td').contains('Edits pending');
   });
 
-  itFlaky('can update a project rule', () => {
+  it('can update a project rule', () => {
     cy.get('app-project-details').contains('Edits are pending');
     const updatedRuleName = `updated ${ruleName}`;
     cy.get('app-project-details a').contains(ruleName).click();
@@ -191,7 +186,7 @@ describe('project management', () => {
     cy.get('app-project-details').contains('Edits are pending');
   });
 
-  itFlaky('can update a project name', () => {
+  it('can update a project name', () => {
     const updatedProjectName = `updated ${projectName}`;
     cy.route('GET', `/apis/iam/v2/projects/${projectID}`).as('getProject');
 
@@ -206,7 +201,7 @@ describe('project management', () => {
     cy.get('app-project-details h1.page-title').contains(updatedProjectName);
   });
 
-  itFlaky('can delete a project rule', () => {
+  it('can delete a project rule', () => {
     cy.get('app-project-details').contains('Edits are pending');
     cy.get('[data-cy=rules-tab]').click();
 
@@ -226,7 +221,7 @@ describe('project management', () => {
   });
 
   // sometimes the deleted successfully notification isn't showing up
-  itFlaky('can delete a project', () => {
+  it('can delete a project', () => {
     cy.get('.breadcrumb').click();
 
     cy.get('app-project-list chef-td').contains(projectID).parent()
@@ -258,7 +253,7 @@ describe('project management', () => {
   });
 
   // these tests are currently interdependent so mark as flaky until the above isn't
-  itFlaky('can create a project with a custom ID', () => {
+  it('can create a project with a custom ID', () => {
     cy.cleanupIAMObjectsByIDPrefixes(cypressPrefix, ['projects', 'policies']);
 
     cy.get('[data-cy=create-project]').contains('Create Project').click();

--- a/e2e/cypress/integration/ui/settings/project_rule_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/project_rule_mgmt.spec.ts
@@ -1,0 +1,159 @@
+import { Project } from '../../../support/types';
+
+describe('project rule management', () => {
+  const now = Cypress.moment().format('MMDDYYhhmm');
+  const cypressPrefix = 'project-rules';
+  const project: Project = {
+    id: `${cypressPrefix}-proj-${now}`,
+    name: 'project rules test proj',
+    skip_policies: true
+  };
+  const ruleID = `${cypressPrefix}-rule-${now}`;
+  const ruleName = `${cypressPrefix} rule ${now}`;
+
+  before(() => {
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'POST',
+      url: '/apis/iam/v2/projects',
+      body: project
+    }).then((resp) => {
+      expect(resp.status).to.equal(200);
+    });
+
+    cy.adminLogin(`/settings/projects/${project.id}`);
+  });
+
+  beforeEach(() => {
+    cy.restoreStorage();
+  });
+
+  afterEach(() => {
+    cy.saveStorage();
+  });
+
+  after(() => {
+    cy.cleanupIAMObjectsByIDPrefixes(cypressPrefix, ['projects', 'policies']);
+  });
+
+  it('can create a rule for the new project', () => {
+    cy.get('app-project-details app-authorized button').contains('Create Rule').click();
+
+    cy.url().should('include', `/settings/projects/${project.id}/rules`);
+    cy.get('app-project-rules chef-page').should('be.visible');
+
+    cy.get('#create-name input').focus().type(ruleName)
+      .should('have.value', ruleName);
+    cy.get('[data-cy=edit-id]').click();
+
+    cy.get('#create-id input').should('have.value', ruleID);
+
+    // Verify correct attributes/operators are selectable for each resource
+    cy.get('#create-type-dropdown').select('Event');
+    cy.get('[data-cy=attribute-dropdown]').select('Chef Organization');
+    cy.get('[data-cy=attribute-dropdown]').select('Chef Infra Server');
+    cy.get('[data-cy=operator-dropdown]').select('equals');
+    cy.get('[data-cy=operator-dropdown]').select('member of');
+
+    cy.get('#create-type-dropdown').select('Node');
+    const nodeAttributes = ['Chef Organization', 'Chef Infra Server', 'Environment',
+      'Chef Role', 'Chef Tag', 'Chef Policy Name', 'Chef Policy Group'];
+
+    nodeAttributes.forEach((att: string) => {
+      cy.get('[data-cy=attribute-dropdown]').select(att);
+    });
+
+    cy.get('[data-cy=operator-dropdown]').select('member of');
+    cy.get('[data-cy=operator-dropdown]').select('equals');
+    cy.get('[data-cy=rule-value]').type('Chef Policy Group Foo');
+
+    cy.get('app-project-rules #right-buttons button').contains('Save Rule').click();
+    cy.get('app-project-rules chef-page').should('not.be.visible');
+
+    cy.url().should('include', `/settings/projects/${project.id}`);
+    cy.get('app-project-details chef-td').contains(ruleID);
+    cy.get('app-pending-edits-bar').contains('Project edits pending');
+
+    // verify success notification and then dismiss it
+    cy.get('app-notification.info').contains(`Created rule ${ruleID}`);
+    cy.get('app-notification.info chef-icon').click();
+  });
+
+  it('displays a list of rules for a project', () => {
+    ['Name', 'ID', 'Resource Type', 'Conditions', 'Edits'].forEach((header) => {
+      cy.get('app-project-details chef-th').contains(header);
+    });
+
+    cy.get('app-project-details chef-td').contains(ruleID);
+    cy.get('app-project-details chef-td').contains(ruleName);
+    cy.get('app-project-details chef-td').contains('Node');
+    cy.get('app-project-details chef-td').contains('1 condition');
+    cy.get('app-project-details chef-td').contains('Edits pending');
+  });
+
+  it('can update a project rule', () => {
+    cy.get('app-pending-edits-bar').contains('Project edits pending');
+    const updatedRuleName = `updated ${ruleName}`;
+    cy.get('app-project-details a').contains(ruleName).click();
+
+    cy.url().should('include', `/settings/projects/${project.id}/rules/${ruleID}`);
+    cy.get('app-project-rules chef-page').should('be.visible');
+
+    cy.get('#create-name input').focus().clear().type(updatedRuleName)
+      .should('have.value', updatedRuleName);
+
+    cy.get('#create-id input').should('have.value', ruleID);
+    cy.get('#create-id input').should('be.disabled');
+
+    cy.get('#create-type-dropdown option:first').should('have.value', 'NODE');
+    cy.get('#create-type-dropdown option:first').should('be.selected');
+    cy.get('#create-type-dropdown').should('be.disabled');
+
+    cy.get('app-project-rules chef-button').contains('Add Condition').click();
+    cy.get('app-project-rules .end-row-items span').contains('AND').should('be.visible');
+
+    cy.get('[data-cy=attribute-dropdown]:last')
+      .select('Environment');
+
+    cy.get('[data-cy=operator-dropdown]:last')
+      .select('member of');
+
+    cy.get('[data-cy=rule-value]:last')
+      .type('Dev, Prod, Test');
+
+    cy.get('app-project-rules #right-buttons button').contains('Save Rule').click();
+    cy.get('app-project-rules chef-page').should('not.be.visible');
+
+    cy.url().should('include', '/settings/projects');
+    cy.get('app-project-details chef-td').contains(updatedRuleName);
+    cy.get('app-project-details chef-td').contains('2 conditions');
+    cy.get('app-pending-edits-bar').contains('Project edits pending');
+  });
+
+  it('can delete a project rule', () => {
+    cy.get('app-pending-edits-bar').contains('Project edits pending');
+    cy.get('[data-cy=rules-tab]').click();
+
+    cy.get('app-project-details chef-td').contains(ruleID).parent()
+      .find('.mat-select-trigger').as('controlMenu');
+
+    // we throw in a `should` so cypress retries until introspection allows menu to be shown
+    cy.get('@controlMenu').should('be.visible')
+      .click();
+    cy.get('[data-cy=delete-rule]').should('be.visible')
+      .click();
+
+    // accept dialog
+    cy.get('app-project-details chef-button').contains('Delete Rule').click();
+
+    // since this is a cypress custom project, we know this is the only rule.
+    // the empty UI should show up so entire table will be missing.
+    cy.get('app-project-details chef-tbody').should('not.exist');
+    cy.get('app-pending-edits-bar').contains('Project edits pending').should('not.be.visible');
+
+    // verify success notification and then dismiss it
+    cy.get('app-notification.info').contains(`Deleted rule ${ruleID}`);
+    cy.get('app-notification.info chef-icon').click();
+  });
+});
+


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Stabilized existing tests and marked them unflaky.
Also broke up `project_mgmt` into `project_mgmt`, testing just Projects CRUD, and `project_rule_mgmt`, testing just Rules CRUD.

This we have Cypress coverage for the [Projects GUI section  and most of the Project Rules flow](https://docs.google.com/spreadsheets/d/1mV8dAARhBFxxMZR6gEm1yDXnPqHb9U2mPhZ-zhHLajw/edit#gid=218075547).

What's missing is testing the project update in the UI. I'd like to make that it's own test, since it will involve a lot of moving parts: adding some resources to projects, loading some nodes that we'll write rules for, granting a new user project permissions and then having them log in to verify permissions. I've created a [new tech debt card](https://github.com/chef/automate/issues/3594) for that work.

To run them locally, follow the [e2e Readme](https://github.com/chef/automate/tree/master/e2e#running-cypress-locally)

### :+1: Definition of Done
- [x] `project mgmt` and `project rule mgmt` pass buildkite consistently

### :white_check_mark: Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
