### PR TITLE
[automate-3385 followup] Simplify projects

### DIFF
--- a/components/automate-ui/src/app/entities/projects/project.model.ts
+++ b/components/automate-ui/src/app/entities/projects/project.model.ts
@@ -1,4 +1,3 @@
-import { xor } from 'lodash/fp';
 import { IAMType } from 'app/entities/policies/policy.model';
 import { ProjectStatus } from 'app/entities/rules/rule.model';
 
@@ -23,12 +22,4 @@ export class ProjectConstants {
   static readonly UNASSIGNED_PROJECT_LABEL = '(unassigned)';
   static readonly ALL_PROJECTS_LABEL = 'All projects';
   static readonly MULTIPLE_PROJECTS_LABEL = 'Multiple projects';
-}
-
-export function noProjectsUpdated(
-  previousProjects: string[], currentProjects: ProjectCheckedMap): boolean {
-  const projectsUpdated = xor(
-    previousProjects,
-    Object.keys(currentProjects).filter(id => currentProjects[id].checked));
-  return projectsUpdated.length === 0;
 }

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.html
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.html
@@ -52,13 +52,13 @@
         </div>
       </section>
       <section class="page-body" *ngIf="tabValue === 'details'">
-        <form [formGroup]="updateNameForm">
+        <form [formGroup]="updateForm">
           <chef-form-field>
             <label>Name <span aria-hidden="true">*</span></label>
             <input chefInput formControlName="name" type="text" [resetOrigin]="saveSuccessful" autocomplete="off"
               data-cy="team-details-name-input">
             <chef-error
-              *ngIf="(updateNameForm.get('name').hasError('required') || updateNameForm.get('name').hasError('pattern')) && updateNameForm.get('name').dirty">
+              *ngIf="(updateForm.get('name').hasError('required') || updateForm.get('name').hasError('pattern')) && updateForm.get('name').dirty">
               Name is required.
             </chef-error>
           </chef-form-field>
@@ -69,13 +69,13 @@
             </app-projects-dropdown>
           </chef-form-field>
         </form>
-        <chef-button [disabled]="isLoadingTeam || !updateNameForm.valid || !updateNameForm.dirty" primary inline
+        <chef-button [disabled]="isLoadingTeam || !updateForm.valid || !updateForm.dirty" primary inline
           (click)="saveTeam()" data-cy="team-details-submit-button">
           <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
           <span *ngIf="saveInProgress">Saving...</span>
           <span *ngIf="!saveInProgress">Save</span>
         </chef-button>
-        <span id="saved-note" *ngIf="saveSuccessful && !updateNameForm.dirty">All changes saved.</span>
+        <span id="saved-note" *ngIf="saveSuccessful && !updateForm.dirty">All changes saved.</span>
       </section>
     </main>
   </div>

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.spec.ts
@@ -14,10 +14,10 @@ import {
   defaultRouterState,
   defaultRouterRouterState
 } from 'app/ngrx.reducers';
+import { using } from 'app/testing/spec-helpers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { PolicyEntityInitialState } from 'app/entities/policies/policy.reducer';
-import { Project } from 'app/entities/projects/project.model';
-import { GetProjectsSuccess, GetProjects } from 'app/entities/projects/project.actions';
+import { GetProjects } from 'app/entities/projects/project.actions';
 import {
   GetTeamSuccess,
   GetTeamUsersSuccess,
@@ -151,34 +151,35 @@ describe('TeamDetailsComponent', () => {
     expect(store.dispatch).toHaveBeenCalledWith(new GetProjects());
   });
 
-  it('initializes dropdown with those included on the team checked', () => {
-    spyOn(store, 'dispatch').and.callThrough();
-    const teamProjects = ['b-proj', 'd-proj'];
-    const team: Team = { id: targetId, guid: 'any', name: 'any', projects: teamProjects };
-    store.dispatch(new GetTeamSuccess(team));
-    expect(store.dispatch).toHaveBeenCalledWith(new GetProjects());
+  using([
+    ['no projects', []],
+    ['one project', ['proj-one']],
+    ['multiple projects', ['p1', 'p2', 'p3', 'p4']]
+  ], function (description: string, projects: string[]) {
+    it(`initializes dropdown with those included on the team for ${description}`, () => {
+      const team: Team = { id: targetId, guid: 'any', name: 'any', projects };
+      store.dispatch(new GetTeamSuccess(team));
 
-    const projectList = [
-      genProject('a-proj'),
-      genProject('b-proj'),
-      genProject('c-proj'),
-      genProject('d-proj')
-    ];
-    store.dispatch(new GetProjectsSuccess({ projects: projectList }));
-
-    projectList.forEach(p => {
-      expect(component.projects[p.id].checked).toEqual(teamProjects.includes(p.id));
+      expect(component.team.projects).toEqual(projects);
     });
-   });
+  });
 
-  function genProject(id: string): Project {
-    return {
-      id,
-      status: 'NO_RULES', // unused
-      name: id, // unused
-      type: 'CUSTOM' // unused
-    };
-  }
+  using([
+    ['no projects', []],
+    ['one project', ['proj-one']],
+    ['multiple projects', ['p1', 'p2', 'p3', 'p4']]
+  ], function (description: string, projects: string[]) {
+    it(`transfers result from closing dropdown into form for ${description}`, () => {
+      const originalProjects = ['to-be-overwritten'];
+      const team: Team = { id: targetId, guid: 'any', name: 'any', projects: originalProjects };
+      store.dispatch(new GetTeamSuccess(team));
+      expect(component.team.projects).toEqual(originalProjects);
+
+      component.onProjectDropdownClosing(projects);
+
+      expect(component.updateNameForm.controls.projects.value).toEqual(projects);
+    });
+  });
 });
 
 export class GetRoute implements Action {

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.spec.ts
@@ -177,7 +177,7 @@ describe('TeamDetailsComponent', () => {
 
       component.onProjectDropdownClosing(projects);
 
-      expect(component.updateNameForm.controls.projects.value).toEqual(projects);
+      expect(component.updateForm.controls.projects.value).toEqual(projects);
     });
   });
 });

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, FormControl, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
-import { keyBy, at, isNil, identity } from 'lodash/fp';
+import { keyBy, at, identity, xor } from 'lodash/fp';
 import { combineLatest, Subject } from 'rxjs';
 import { filter, map, takeUntil, distinctUntilChanged } from 'rxjs/operators';
 
@@ -16,13 +16,7 @@ import { User } from 'app/entities/users/user.model';
 import { allUsers, getStatus as getAllUsersStatus } from 'app/entities/users/user.selectors';
 import { GetUsers } from 'app/entities/users/user.actions';
 import { GetProjects } from 'app/entities/projects/project.actions';
-import {
-  allProjects,
-  getAllStatus as getAllProjectStatus
-} from 'app/entities/projects/project.selectors';
-import {
-  ProjectConstants, ProjectCheckedMap, noProjectsUpdated
-} from 'app/entities/projects/project.model';
+import { ProjectConstants } from 'app/entities/projects/project.model';
 import {
   teamFromRoute,
   teamUsers,
@@ -65,7 +59,6 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   public removeText = 'Remove User';
 
   public teamId = '';
-  public projects: ProjectCheckedMap = {};
   public unassigned = ProjectConstants.UNASSIGNED_PROJECT_ID;
 
   constructor(
@@ -139,22 +132,6 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     });
 
     combineLatest([
-      this.store.select(allProjects),
-      this.store.select(getAllProjectStatus),
-      this.store.select(teamFromRoute)
-    ]).pipe(
-      takeUntil(this.isDestroyed),
-      filter(([_, pStatus, team]) => !pending(pStatus) && !isNil(team))
-    ).subscribe(([allowedProjects, _, team]) => {
-        this.projects = {};
-        allowedProjects
-          .forEach(p => {
-            this.projects[p.id] = { ...p, checked: team.projects.includes(p.id)
-            };
-          });
-      });
-
-    combineLatest([
       this.store.select(allUsers),
       this.store.select(getAllUsersStatus),
       this.store.select(teamUsers),
@@ -216,7 +193,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     this.saveInProgress = true;
     this.updateNameForm.controls['name'].disable();
     const name: string = this.updateNameForm.controls.name.value.trim();
-    const projects = Object.keys(this.projects).filter(id => this.projects[id].checked);
+    const projects: string[] = this.updateNameForm.controls.projects.value;
     this.store.dispatch(new UpdateTeam({ ...this.team, name, projects }));
   }
 
@@ -228,12 +205,11 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
 
   onProjectDropdownClosing(selectedProjects: string[]): void {
 
-    Object.keys(this.projects).forEach(id => this.projects[id].checked = false);
-    selectedProjects.forEach(id => this.projects[id].checked = true);
+    this.updateNameForm.controls.projects.setValue(selectedProjects);
 
     // since the app-projects-dropdown is not a true form input (select)
     // we have to manage the form reactions
-    if (noProjectsUpdated(this.team.projects, this.projects)) {
+    if (xor(this.team.projects, this.updateNameForm.controls.projects.value).length === 0) {
       this.updateNameForm.controls.projects.markAsPristine();
     } else {
       this.updateNameForm.controls.projects.markAsDirty();

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
@@ -114,9 +114,9 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
         (uStatus === EntityStatus.loading) ||
         (usersStatus === EntityStatus.loading);
       if (this.isLoadingTeam) {
-        this.updateForm.controls['name'].disable();
+        this.updateForm.controls.name.disable();
       } else {
-        this.updateForm.controls['name'].enable();
+        this.updateForm.controls.name.enable();
       }
     });
 
@@ -191,7 +191,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   saveTeam(): void {
     this.saveSuccessful = false;
     this.saveInProgress = true;
-    this.updateForm.controls['name'].disable();
+    this.updateForm.controls.name.disable();
     const name: string = this.updateForm.controls.name.value.trim();
     const projects: string[] = this.updateForm.controls.projects.value;
     this.store.dispatch(new UpdateTeam({ ...this.team, name, projects }));

--- a/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
+++ b/components/automate-ui/src/app/modules/team/team-details/team-details.component.ts
@@ -42,7 +42,7 @@ export type TeamTabName = 'users' | 'details';
   styleUrls: ['./team-details.component.scss']
 })
 export class TeamDetailsComponent implements OnInit, OnDestroy {
-  public updateNameForm: FormGroup;
+  public updateForm: FormGroup;
   // isLoadingTeam represents the initial team load as well as subsequent updates in progress.
   public isLoadingTeam = true;
   public saveInProgress = false;
@@ -67,7 +67,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     private router: Router,
     private layoutFacade: LayoutFacadeService
   ) {
-    this.updateNameForm = fb.group({
+    this.updateForm = fb.group({
       // Must stay in sync with error checks in team-details.component.html.
       // Also, initialize the form to disabled and enable after team load
       // to prevent people from typing before the team is fetched and have their
@@ -114,9 +114,9 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
         (uStatus === EntityStatus.loading) ||
         (usersStatus === EntityStatus.loading);
       if (this.isLoadingTeam) {
-        this.updateNameForm.controls['name'].disable();
+        this.updateForm.controls['name'].disable();
       } else {
-        this.updateNameForm.controls['name'].enable();
+        this.updateForm.controls['name'].enable();
       }
     });
 
@@ -126,7 +126,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
     ).subscribe((team) => {
       this.teamId = team.id;
       this.team = team;
-      this.updateNameForm.controls.name.setValue(this.team.name);
+      this.updateForm.controls.name.setValue(this.team.name);
       this.store.dispatch(new GetTeamUsers({ id: this.teamId }));
       this.store.dispatch(new GetProjects());
     });
@@ -159,7 +159,7 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
         this.saveInProgress = false;
         this.saveSuccessful = (state === EntityStatus.loadingSuccess);
         if (this.saveSuccessful) {
-          this.updateNameForm.markAsPristine();
+          this.updateForm.markAsPristine();
         }
       });
  }
@@ -191,9 +191,9 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
   saveTeam(): void {
     this.saveSuccessful = false;
     this.saveInProgress = true;
-    this.updateNameForm.controls['name'].disable();
-    const name: string = this.updateNameForm.controls.name.value.trim();
-    const projects: string[] = this.updateNameForm.controls.projects.value;
+    this.updateForm.controls['name'].disable();
+    const name: string = this.updateForm.controls.name.value.trim();
+    const projects: string[] = this.updateForm.controls.projects.value;
     this.store.dispatch(new UpdateTeam({ ...this.team, name, projects }));
   }
 
@@ -205,14 +205,14 @@ export class TeamDetailsComponent implements OnInit, OnDestroy {
 
   onProjectDropdownClosing(selectedProjects: string[]): void {
 
-    this.updateNameForm.controls.projects.setValue(selectedProjects);
+    this.updateForm.controls.projects.setValue(selectedProjects);
 
     // since the app-projects-dropdown is not a true form input (select)
     // we have to manage the form reactions
-    if (xor(this.team.projects, this.updateNameForm.controls.projects.value).length === 0) {
-      this.updateNameForm.controls.projects.markAsPristine();
+    if (xor(this.team.projects, this.updateForm.controls.projects.value).length === 0) {
+      this.updateForm.controls.projects.markAsPristine();
     } else {
-      this.updateNameForm.controls.projects.markAsDirty();
+      this.updateForm.controls.projects.markAsDirty();
     }
 
   }

--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.spec.ts
@@ -13,6 +13,7 @@ import {
   defaultRouterState,
   defaultRouterRouterState
 } from 'app/ngrx.reducers';
+import { using } from 'app/testing/spec-helpers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { Project } from 'app/entities/projects/project.model';
@@ -160,6 +161,34 @@ describe('ApiTokenDetailsComponent', () => {
     expect(component.updateForm.controls.projects.pristine).toEqual(false);
     component.onProjectDropdownClosing([ 'b-proj', 'd-proj']);
     expect(component.updateForm.controls.projects.pristine).toEqual(true);
+  });
+
+  using([
+    ['no projects', []],
+    ['one project', ['proj-one']],
+    ['multiple projects', ['p1', 'p2', 'p3', 'p4']]
+  ], function (description: string, projects: string[]) {
+    it(`initializes dropdown with those included on the team for ${description}`, () => {
+      store.dispatch(new GetTokenSuccess({ ...someToken, projects }));
+
+      expect(component.token.projects).toEqual(projects);
+    });
+  });
+
+  using([
+    ['no projects', []],
+    ['one project', ['proj-one']],
+    ['multiple projects', ['p1', 'p2', 'p3', 'p4']]
+  ], function (description: string, projects: string[]) {
+    it(`transfers result from closing dropdown into form for ${description}`, () => {
+      const originalProjects = ['to-be-overwritten'];
+      store.dispatch(new GetTokenSuccess({ ...someToken, projects: originalProjects }));
+      expect(component.token.projects).toEqual(originalProjects);
+
+      component.onProjectDropdownClosing(projects);
+
+      expect(component.updateForm.controls.projects.value).toEqual(projects);
+    });
   });
 
   function genProject(id: string): Project {

--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.spec.ts
@@ -117,20 +117,6 @@ describe('ApiTokenDetailsComponent', () => {
     expect(component.token).toEqual(token);
   });
 
-  it('initializes project dropdown with those checked on the token', () => {
-    spyOn(store, 'dispatch').and.callThrough();
-    const tokenProjects  = ['b-proj', 'd-proj'];
-    store.dispatch(new GetTokenSuccess({...someToken, projects: tokenProjects}));
-
-    expect(Object.keys(component.projects).length).toBe(0);
-    store.dispatch(new GetProjectsSuccess({ projects: projectList }));
-    expect(Object.keys(component.projects).length).toBe(projectList.length);
-
-    projectList.forEach(p => {
-      expect(component.projects[p.id].checked).toEqual(tokenProjects.includes(p.id));
-    });
-  });
-
   it('sets projects dirty when an unchecked project is checked', () => {
     store.dispatch(new GetTokenSuccess(
       { ...someToken, projects: ['b-proj', 'd-proj']}));


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Since working on #3385 (allow optional assign to policy on create token modal), I was mulling over the use of projects in team and token detail components, and realized a simplification was in order.

Also needed to add a couple tests for the new functionality in both team and token detail components, essentially using the same two sets of tests for both.

### :chains: Related Resources
PR #3385 

### :+1: Definition of Done
Simplicity.

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui.
Exercise updating teams and tokens on their respective detail pages.
1. You can add or remove projects and those are correctly reflected when you save the team/token.
2. This preserves the enable-save-iff-entity-changed paradigm: if you change projects and close the dropdown then <kbd>Save</kbd> becomes enabled, but if you then go back and change to the original set of projects and close the dropdown then <kbd>Save</kbd> becomes disabled again.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
