### PR TITLE
Fixed the parallel API calling for the org details tabs(Cookbooks, Roles and Org edit tabs)

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
@@ -4,13 +4,15 @@
     <chef-table>
       <chef-thead>
         <chef-tr>
-          <chef-td>Cookbook Name</chef-td>
-          <chef-td>Cookbook Version</chef-td>
+          <chef-th>Cookbook Name</chef-th>
+          <chef-th>Cookbook Version</chef-th>
         </chef-tr>
       </chef-thead>
       <chef-tbody>
         <chef-tr *ngFor="let cookbook of cookbooks">
-          <chef-td>{{ cookbook.name }}</chef-td>
+          <chef-td>
+            <a [routerLink]="['/infrastructure','chef-servers', serverId, 'org', orgId, 'cookbooks', cookbook.name]">{{ cookbook.name }}</a>
+          </chef-td>
           <chef-td>{{ cookbook.version }}</chef-td>
         </chef-tr>
       </chef-tbody>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
@@ -1,0 +1,19 @@
+<section class="cookbooks">
+  <chef-loading-spinner *ngIf="cookbooksListLoading" size="50"></chef-loading-spinner>
+  <ng-container  *ngIf="!cookbooksListLoading">
+    <chef-table>
+      <chef-thead>
+        <chef-tr>
+          <chef-td>Cookbook Name</chef-td>
+          <chef-td>Cookbook Version</chef-td>
+        </chef-tr>
+      </chef-thead>
+      <chef-tbody>
+        <chef-tr *ngFor="let cookbook of cookbooks">
+          <chef-td>{{ cookbook.name }}</chef-td>
+          <chef-td>{{ cookbook.version }}</chef-td>
+        </chef-tr>
+      </chef-tbody>
+    </chef-table>
+  </ng-container>
+</section>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.scss
@@ -1,0 +1,35 @@
+@import "~styles/variables";
+
+thead {
+  font-size: 14px;
+  letter-spacing: 0.2px;
+  color: $chef-primary-dark;
+}
+
+th {
+  text-align: left;
+  padding: 0px;
+}
+
+tbody > .detail-row {
+  padding-top: 0px;
+  padding-bottom: 15px;
+}
+
+chef-table-new {
+  .controls {
+    text-align: right;
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+}
+
+chef-loading-spinner {
+  display: block;
+  margin: 100px auto;
+  width: 100px;
+  z-index: 199;
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.spec.ts
@@ -1,5 +1,5 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { CookbooksComponent } from './cookbooks.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -45,7 +45,8 @@ describe('CookbooksComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ]
+      ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.spec.ts
@@ -15,8 +15,6 @@ describe('CookbooksComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent({ selector: 'a', inputs: ['routerLink'] }),
-        MockComponent({ selector: 'chef-th' }),
-        MockComponent({ selector: 'chef-td' }),
         MockComponent({ selector: 'chef-error' }),
         MockComponent({ selector: 'chef-form-field' }),
         MockComponent({ selector: 'chef-heading' }),

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.spec.ts
@@ -1,4 +1,3 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CookbooksComponent } from './cookbooks.component';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -15,6 +14,7 @@ describe('CookbooksComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
+        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
         MockComponent({ selector: 'chef-th' }),
         MockComponent({ selector: 'chef-td' }),
         MockComponent({ selector: 'chef-error' }),
@@ -22,8 +22,6 @@ describe('CookbooksComponent', () => {
         MockComponent({ selector: 'chef-heading' }),
         MockComponent({ selector: 'chef-icon' }),
         MockComponent({ selector: 'chef-loading-spinner' }),
-        MockComponent({ selector: 'mat-select' }),
-        MockComponent({ selector: 'mat-option' }),
         MockComponent({ selector: 'chef-page-header' }),
         MockComponent({ selector: 'chef-subheading' }),
         MockComponent({ selector: 'chef-toolbar' }),
@@ -33,8 +31,9 @@ describe('CookbooksComponent', () => {
         MockComponent({ selector: 'chef-tr' }),
         MockComponent({ selector: 'chef-th' }),
         MockComponent({ selector: 'chef-td' }),
-        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
         MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
+        MockComponent({ selector: 'mat-select' }),
+        MockComponent({ selector: 'mat-option' }),
         CookbooksComponent
       ],
       providers: [
@@ -45,8 +44,7 @@ describe('CookbooksComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      ]
     })
     .compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.spec.ts
@@ -1,7 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { OrgDetailsComponent } from './org-details.component';
+import { CookbooksComponent } from './cookbooks.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MockComponent } from 'ng2-mock-component';
@@ -9,14 +9,17 @@ import { StoreModule } from '@ngrx/store';
 import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 
-describe('OrgDetailsComponent', () => {
-  let component: OrgDetailsComponent;
-  let fixture: ComponentFixture<OrgDetailsComponent>;
+describe('CookbooksComponent', () => {
+  let component: CookbooksComponent;
+  let fixture: ComponentFixture<CookbooksComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
+        MockComponent({ selector: 'chef-th' }),
+        MockComponent({ selector: 'chef-td' }),
         MockComponent({ selector: 'chef-error' }),
+        MockComponent({ selector: 'chef-form-field' }),
         MockComponent({ selector: 'chef-heading' }),
         MockComponent({ selector: 'chef-icon' }),
         MockComponent({ selector: 'chef-loading-spinner' }),
@@ -25,9 +28,6 @@ describe('OrgDetailsComponent', () => {
         MockComponent({ selector: 'chef-page-header' }),
         MockComponent({ selector: 'chef-subheading' }),
         MockComponent({ selector: 'chef-toolbar' }),
-        MockComponent({ selector: 'chef-breadcrumbs'}),
-        MockComponent({ selector: 'chef-breadcrumb', inputs: ['link']}),
-        MockComponent({ selector: 'app-tabs' }),
         MockComponent({ selector: 'chef-table' }),
         MockComponent({ selector: 'chef-thead' }),
         MockComponent({ selector: 'chef-tbody' }),
@@ -36,7 +36,7 @@ describe('OrgDetailsComponent', () => {
         MockComponent({ selector: 'chef-td' }),
         MockComponent({ selector: 'a', inputs: ['routerLink'] }),
         MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
-        OrgDetailsComponent
+        CookbooksComponent
       ],
       providers: [
         FeatureFlagsService
@@ -53,7 +53,7 @@ describe('OrgDetailsComponent', () => {
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(OrgDetailsComponent);
+    fixture = TestBed.createComponent(CookbooksComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.spec.ts
@@ -1,4 +1,3 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CookbooksComponent } from './cookbooks.component';
@@ -46,8 +45,7 @@ describe('CookbooksComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      ]
     })
     .compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
@@ -6,7 +6,7 @@ import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade'
 import { filter } from 'rxjs/operators';
 import { isNil } from 'lodash/fp';
 import { EntityStatus } from 'app/entities/entities';
-import { GetCookbooksForOrg } from 'app/entities/cookbooks/cookbook.actions';
+import { GetCookbooks } from 'app/entities/cookbooks/cookbook.actions';
 import { Cookbook } from 'app/entities/cookbooks/cookbook.model';
 import {
   allCookbooks,
@@ -34,7 +34,7 @@ export class CookbooksComponent implements OnInit {
   ngOnInit() {
     this.layoutFacade.showSidebar(Sidebar.Infrastructure);
 
-    this.store.dispatch(new GetCookbooksForOrg({
+    this.store.dispatch(new GetCookbooks({
       server_id: this.serverId, org_id: this.orgId
     }));
 

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
@@ -42,8 +42,8 @@ export class CookbooksComponent implements OnInit {
       this.store.select(getAllCookbooksForOrgStatus),
       this.store.select(allCookbooks)
     ]).pipe(
-      filter(([getCookbooksSt, _allCookbooksState]) =>
-        getCookbooksSt === EntityStatus.loadingSuccess && !isNil(_allCookbooksState))
+      filter(([getCookbooksSt, allCookbooksState]) =>
+        getCookbooksSt === EntityStatus.loadingSuccess && !isNil(allCookbooksState))
     ).subscribe(([ _getCookbooksSt, allCookbooksState]) => {
       this.cookbooks = allCookbooksState;
       this.cookbooksListLoading = false;

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
@@ -1,0 +1,52 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { combineLatest } from 'rxjs';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
+import { filter } from 'rxjs/operators';
+import { isNil } from 'lodash/fp';
+import { EntityStatus } from 'app/entities/entities';
+import { GetCookbooksForOrg } from 'app/entities/cookbooks/cookbook.actions';
+import { Cookbook } from 'app/entities/cookbooks/cookbook.model';
+import {
+  allCookbooks,
+  getAllStatus as getAllCookbooksForOrgStatus
+} from 'app/entities/cookbooks/cookbook.selectors';
+
+@Component({
+  selector: 'app-cookbooks',
+  templateUrl: './cookbooks.component.html',
+  styleUrls: ['./cookbooks.component.scss']
+})
+
+export class CookbooksComponent implements OnInit {
+  @Input() serverId: string;
+  @Input() orgId: string;
+
+  public cookbooks: Cookbook[] = [];
+  public cookbooksListLoading = true;
+
+  constructor(
+    private store: Store<NgrxStateAtom>,
+    private layoutFacade: LayoutFacadeService
+  ) { }
+
+  ngOnInit() {
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
+
+    this.store.dispatch(new GetCookbooksForOrg({
+      server_id: this.serverId, org_id: this.orgId
+    }));
+
+    combineLatest([
+      this.store.select(getAllCookbooksForOrgStatus),
+      this.store.select(allCookbooks)
+    ]).pipe(
+      filter(([getCookbooksSt, _allCookbooksState]) =>
+        getCookbooksSt === EntityStatus.loadingSuccess && !isNil(_allCookbooksState))
+    ).subscribe(([ _getCookbooksSt, allCookbooksState]) => {
+      this.cookbooks = allCookbooksState;
+      this.cookbooksListLoading = false;
+    });
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
@@ -7,24 +7,30 @@ import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { ChefComponentsModule } from 'app/components/chef-components.module';
 import { ChefServerDetailsComponent } from './chef-server-details/chef-server-details.component';
 import { ChefServersListComponent } from './chef-servers-list/chef-servers-list.component';
-import { OrgDetailsComponent } from './org-details/org-details.component';
-import { InfraRoleDetailsComponent } from './infra-role-details/infra-role-details.component';
+import { CookbooksComponent } from './cookbooks/cookbooks.component';
 import { CookbookDetailsComponent } from './cookbook-details/cookbook-details.component';
 import { CreateChefServerModalComponent } from './create-chef-server-modal/create-chef-server-modal.component';
 import { CreateOrgModalComponent } from './create-org-modal/create-org-modal.component';
-import { TreeTableModule } from './tree-table/tree-table.module';
+import { InfraRolesComponent } from './infra-roles/infra-roles.component';
+import { InfraRoleDetailsComponent } from './infra-role-details/infra-role-details.component';
 import { JsonTreeTableComponent } from './json-tree-table/json-tree-table.component';
+import { OrgDetailsComponent } from './org-details/org-details.component';
+import { OrgEditComponent } from './org-edit/org-edit.component';
+import { TreeTableModule } from './tree-table/tree-table.module';
 
 @NgModule({
   declarations: [
     ChefServersListComponent,
     ChefServerDetailsComponent,
-    OrgDetailsComponent,
-    InfraRoleDetailsComponent,
+    CookbooksComponent,
     CookbookDetailsComponent,
     CreateChefServerModalComponent,
     CreateOrgModalComponent,
-    JsonTreeTableComponent
+    JsonTreeTableComponent,
+    InfraRolesComponent,
+    InfraRoleDetailsComponent,
+    OrgDetailsComponent,
+    OrgEditComponent
   ],
   imports: [
     CommonModule,

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.html
@@ -1,0 +1,23 @@
+<section class="infra-roles">
+  <chef-loading-spinner *ngIf="rolesListLoading" size="50"></chef-loading-spinner>
+  <ng-container *ngIf="!rolesListLoading">
+    <chef-table>
+      <chef-thead>
+        <chef-tr>
+          <chef-th>Role Name</chef-th>
+          <chef-th>Description</chef-th>
+          <chef-th>Environments</chef-th>
+        </chef-tr>
+      </chef-thead>
+      <chef-tbody>
+        <chef-tr *ngFor="let role of roles">
+          <chef-td>
+            <a [routerLink]="['/infrastructure','chef-servers', serverId, 'org', orgId, 'roles', role.name]">{{ role.name }}</a>
+          </chef-td>
+          <chef-td>{{ role.description == '' ?  'N/A' : role.description }}</chef-td>
+          <chef-td>{{ role.environments.join(", ") }}</chef-td>
+        </chef-tr>
+      </chef-tbody>
+    </chef-table>
+  </ng-container>
+</section>

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.html
@@ -14,7 +14,7 @@
           <chef-td>
             <a [routerLink]="['/infrastructure','chef-servers', serverId, 'org', orgId, 'roles', role.name]">{{ role.name }}</a>
           </chef-td>
-          <chef-td>{{ role.description == '' ?  'N/A' : role.description }}</chef-td>
+          <chef-td>{{ role.description === '' ?  'N/A' : role.description }}</chef-td>
           <chef-td>{{ role.environments.join(", ") }}</chef-td>
         </chef-tr>
       </chef-tbody>

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.scss
@@ -1,0 +1,35 @@
+@import "~styles/variables";
+
+thead {
+  font-size: 14px;
+  letter-spacing: 0.2px;
+  color: $chef-primary-dark;
+}
+
+th {
+  text-align: left;
+  padding: 0px;
+}
+
+tbody > .detail-row {
+  padding-top: 0px;
+  padding-bottom: 15px;
+}
+
+chef-table-new {
+  .controls {
+    text-align: right;
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+}
+
+chef-loading-spinner {
+  display: block;
+  margin: 100px auto;
+  width: 100px;
+  z-index: 199;
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.spec.ts
@@ -1,4 +1,3 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { InfraRolesComponent } from './infra-roles.component';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -15,11 +14,10 @@ describe('InfraRolesComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
+        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
         MockComponent({ selector: 'chef-heading' }),
         MockComponent({ selector: 'chef-icon' }),
         MockComponent({ selector: 'chef-loading-spinner' }),
-        MockComponent({ selector: 'mat-select' }),
-        MockComponent({ selector: 'mat-option' }),
         MockComponent({ selector: 'chef-page-header' }),
         MockComponent({ selector: 'chef-subheading' }),
         MockComponent({ selector: 'chef-toolbar' }),
@@ -29,8 +27,9 @@ describe('InfraRolesComponent', () => {
         MockComponent({ selector: 'chef-tr' }),
         MockComponent({ selector: 'chef-th' }),
         MockComponent({ selector: 'chef-td' }),
-        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
         MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
+        MockComponent({ selector: 'mat-select' }),
+        MockComponent({ selector: 'mat-option' }),
         InfraRolesComponent
       ],
       providers: [
@@ -41,8 +40,7 @@ describe('InfraRolesComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      ]
     })
     .compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.spec.ts
@@ -1,5 +1,5 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { InfraRolesComponent } from './infra-roles.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -41,7 +41,8 @@ describe('InfraRolesComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ]
+      ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.spec.ts
@@ -1,7 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { OrgDetailsComponent } from './org-details.component';
+import { InfraRolesComponent } from './infra-roles.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MockComponent } from 'ng2-mock-component';
@@ -9,14 +9,13 @@ import { StoreModule } from '@ngrx/store';
 import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 
-describe('OrgDetailsComponent', () => {
-  let component: OrgDetailsComponent;
-  let fixture: ComponentFixture<OrgDetailsComponent>;
+describe('InfraRolesComponent', () => {
+  let component: InfraRolesComponent;
+  let fixture: ComponentFixture<InfraRolesComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        MockComponent({ selector: 'chef-error' }),
         MockComponent({ selector: 'chef-heading' }),
         MockComponent({ selector: 'chef-icon' }),
         MockComponent({ selector: 'chef-loading-spinner' }),
@@ -25,9 +24,6 @@ describe('OrgDetailsComponent', () => {
         MockComponent({ selector: 'chef-page-header' }),
         MockComponent({ selector: 'chef-subheading' }),
         MockComponent({ selector: 'chef-toolbar' }),
-        MockComponent({ selector: 'chef-breadcrumbs'}),
-        MockComponent({ selector: 'chef-breadcrumb', inputs: ['link']}),
-        MockComponent({ selector: 'app-tabs' }),
         MockComponent({ selector: 'chef-table' }),
         MockComponent({ selector: 'chef-thead' }),
         MockComponent({ selector: 'chef-tbody' }),
@@ -36,7 +32,7 @@ describe('OrgDetailsComponent', () => {
         MockComponent({ selector: 'chef-td' }),
         MockComponent({ selector: 'a', inputs: ['routerLink'] }),
         MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
-        OrgDetailsComponent
+        InfraRolesComponent
       ],
       providers: [
         FeatureFlagsService
@@ -53,7 +49,7 @@ describe('OrgDetailsComponent', () => {
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(OrgDetailsComponent);
+    fixture = TestBed.createComponent(InfraRolesComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.spec.ts
@@ -1,4 +1,3 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { InfraRolesComponent } from './infra-roles.component';
@@ -42,8 +41,7 @@ describe('InfraRolesComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      ]
     })
     .compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.ts
@@ -43,8 +43,8 @@ export class InfraRolesComponent implements OnInit {
       this.store.select(getAllRolesForOrgStatus),
       this.store.select(allInfraRoles)
     ]).pipe(
-      filter(([getRolesSt, _allInfraRolesState]) =>
-        getRolesSt === EntityStatus.loadingSuccess && !isNil(_allInfraRolesState))
+      filter(([getRolesSt, allInfraRolesState]) =>
+        getRolesSt === EntityStatus.loadingSuccess && !isNil(allInfraRolesState))
     ).subscribe(([ _getRolesSt, allInfraRolesState]) => {
       this.roles = allInfraRolesState;
       this.rolesListLoading = false;

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.ts
@@ -1,0 +1,53 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { combineLatest } from 'rxjs';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
+import { filter } from 'rxjs/operators';
+import { isNil } from 'lodash/fp';
+import { EntityStatus } from 'app/entities/entities';
+import { GetRoles } from 'app/entities/infra-roles/infra-role.action';
+import { InfraRole } from 'app/entities/infra-roles/infra-role.model';
+import {
+  allInfraRoles,
+  getAllStatus as getAllRolesForOrgStatus
+} from 'app/entities/infra-roles/infra-role.selectors';
+
+
+@Component({
+  selector: 'app-infra-roles',
+  templateUrl: './infra-roles.component.html',
+  styleUrls: ['./infra-roles.component.scss']
+})
+
+export class InfraRolesComponent implements OnInit {
+  @Input() serverId: string;
+  @Input() orgId: string;
+
+  public roles: InfraRole[] = [];
+  public rolesListLoading = true;
+
+  constructor(
+    private store: Store<NgrxStateAtom>,
+    private layoutFacade: LayoutFacadeService
+  ) { }
+
+  ngOnInit() {
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
+
+    this.store.dispatch(new GetRoles({
+      server_id: this.serverId, org_id: this.orgId
+    }));
+
+    combineLatest([
+      this.store.select(getAllRolesForOrgStatus),
+      this.store.select(allInfraRoles)
+    ]).pipe(
+      filter(([getRolesSt, _allInfraRolesState]) =>
+        getRolesSt === EntityStatus.loadingSuccess && !isNil(_allInfraRolesState))
+    ).subscribe(([ _getRolesSt, allInfraRolesState]) => {
+      this.roles = allInfraRolesState;
+      this.rolesListLoading = false;
+    });
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
@@ -22,105 +22,21 @@
             </tr>
           </tbody>
         </table>
-        <chef-tab-selector [value]="tabValue" (change)="onSelectedTab($event)">
-        <chef-option value='cookbooks' data-cy="cookbooks-tab">Cookbooks</chef-option>
-        <chef-option value='roles' data-cy="roles-tab">Roles</chef-option>
-        <chef-option value='details' data-cy="details-tab">Details</chef-option>
-        </chef-tab-selector>
       </chef-page-header>
-      <section class="page-body" *ngIf="tabValue === 'details'">
-        <form [formGroup]="updateOrgForm">
-          <chef-form-field>
-            <label>
-            <span class="label">Name <span aria-hidden="true">*</span></span>
-            <input chefInput formControlName="name" type="text" autocomplete="off"
-              data-cy="update-org-name" [resetOrigin]="saveSuccessful">
-            </label>
-            <chef-error
-              *ngIf="(updateOrgForm.get('name').hasError('required') || updateOrgForm.get('name').hasError('pattern')) && updateOrgForm.get('name').dirty">
-              Display Name is required.
-            </chef-error>
-          </chef-form-field>
-          <chef-form-field>
-            <label>
-            <span class="label">Admin User <span aria-hidden="true">*</span></span>
-            <input chefInput formControlName="admin_user" type="text" autocomplete="off"
-              data-cy="update-Org-admin-user" [resetOrigin]="saveSuccessful">
-            </label>
-            <chef-error
-              *ngIf="(updateOrgForm.get('admin_user').hasError('required') || updateOrgForm.get('admin_user').hasError('pattern')) && updateOrgForm.get('admin_user').dirty">
-              Admin User is required.
-            </chef-error>
-          </chef-form-field>
-          <chef-form-field>
-            <label>
-            <span class="label">Admin Key<span aria-hidden="true">*</span></span>
-            <textarea rows="27" cols="10" chefInput placeholder="-----BEGIN RSA PRIVATE KEY -----"
-              formControlName="admin_key" data-cy="update-org-admin-key"></textarea>   
-            </label>
-            <chef-error
-              *ngIf="(updateOrgForm.get('admin_key').hasError('required') || updateOrgForm.get('admin_key').hasError('pattern')) && updateOrgForm.get('admin_key').dirty">
-              Admin Key is required.
-            </chef-error>
-          </chef-form-field>
-          <chef-form-field>
-            <div id="button-bar">
-              <chef-button [disabled]="isLoading || !updateOrgForm.valid || !updateOrgForm.dirty" primary
-              inline (click)="saveOrg()">
-                <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
-                <span *ngIf="saveInProgress">Saving...</span>
-                <span *ngIf="!saveInProgress">Save</span>
-              </chef-button>
-              <span id="saved-note" *ngIf="saveSuccessful && !updateOrgForm.dirty">All changes
-              saved.</span>
-            </div>
-          </chef-form-field>
-        </form>
-      </section>
-      <section class="page-body" *ngIf="tabValue === 'cookbooks'">
-        <chef-loading-spinner *ngIf="cookbooksListLoading" size="50"></chef-loading-spinner>
-        <ng-container  *ngIf="!cookbooksListLoading">
-          <chef-table>
-            <chef-thead>
-              <chef-tr>
-                <chef-th>Cookbook Name</chef-th>
-                <chef-th>Cookbook Version</chef-th>
-              </chef-tr>
-            </chef-thead>
-            <chef-tbody>
-              <chef-tr *ngFor="let cookbook of cookbooks">
-                <chef-td>
-                  <a [routerLink]="['/infrastructure','chef-servers', serverId, 'org', org.id, 'cookbooks', cookbook.name]">{{ cookbook.name }}</a>
-                </chef-td>
-                <chef-td>{{ cookbook.version }}</chef-td>
-              </chef-tr>
-            </chef-tbody>
-          </chef-table>
-        </ng-container>
-      </section>
-      <section class="page-body" *ngIf="tabValue === 'roles'">
-        <chef-loading-spinner *ngIf="rolesListLoading" size="50"></chef-loading-spinner>
-        <ng-container *ngIf="!rolesListLoading">
-          <chef-table>
-            <chef-thead>
-              <chef-tr>
-                <chef-th>Role Name</chef-th>
-                <chef-th>Description</chef-th>
-                <chef-th>Environments</chef-th>
-              </chef-tr>
-            </chef-thead>
-            <chef-tbody>
-              <chef-tr *ngFor="let role of roles">
-                <chef-td>
-                  <a [routerLink]="['/infrastructure','chef-servers', serverId, 'org', OrgId, 'roles', role.name]">{{ role.name }}</a>
-                </chef-td>
-                <chef-td>{{ role.description == '' ?  'N/A' : role.description }}</chef-td>
-                <chef-td>{{ role.environments.join(", ") }}</chef-td>
-              </chef-tr>
-            </chef-tbody>
-          </chef-table>
-        </ng-container>
-      </section>
+      <div class="main page-body">
+        <app-tabs class="tabs-row" (tabChange)="tabChange($event)">
+          <app-tab tabTitle="Cookbooks" #cookbooks_tab [active]="cookbooksTab">
+            <app-cookbooks *ngIf="cookbooks_tab.active" [serverId]="serverId" [orgId]="orgId"></app-cookbooks>
+          </app-tab>
+          <app-tab tabTitle="Roles" #roles_tab  [active]="rolesTab">
+            <app-infra-roles *ngIf="roles_tab.active" [serverId]="serverId" [orgId]="orgId"></app-infra-roles>
+          </app-tab>
+          <app-tab tabTitle="Details" #details_tab [active]="false">
+            <app-org-edit *ngIf="details_tab.active" [serverId]="serverId" [orgId]="orgId"></app-org-edit> 
+          </app-tab>
+        </app-tabs>
+        <chef-scroll-top></chef-scroll-top>
+      </div>
     </main>
   </div>
 </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.scss
@@ -17,56 +17,6 @@ chef-toolbar {
   }
 }
 
-chef-tab-selector {
-  chef-option {
-    margin-right: 16px;
-    color: $chef-primary-dark;
-  }
-}
-
-form {
-
-  chef-form-field {
-    width: 300px;
-    margin-bottom: 15px;
-  }
-
-  textarea {
-    height: 200px;
-  }
-
-  input[type="text"]:disabled {
-    opacity: 0.5;
-    background-color: $chef-grey;
-    border: none;
-  }
-
-  #changes-not-allowed {
-    font-size: 12px;
-  }
-
-  #button-bar {
-    margin-top: 15px;
-
-    span#saved-note {
-      display: inline-block;
-      margin-top: 5px;
-      font-size: 12px;
-    }
-
-    chef-button {
-      margin-top: 0;
-      margin-left: 0;
-
-      chef-loading-spinner {
-        position: relative;
-        top: 2px;
-        margin-right: 5px;
-      }
-    }
-  }
-}
-
 thead {
   font-size: 14px;
   letter-spacing: 0.2px;
@@ -111,14 +61,19 @@ chef-table {
   }
 }
 
-chef-loading-spinner {
-  z-index: 199;
-}
-
 .page-body {
+  padding-top: 0;
+
   chef-loading-spinner {
     display: block;
     margin: 100px auto;
     width: 100px;
   }
+}
+
+chef-loading-spinner {
+  display: block;
+  margin: 100px auto;
+  width: 100px;
+  z-index: 199;
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.spec.ts
@@ -1,13 +1,21 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async,
+  ComponentFixtureAutoDetect,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+import { StoreModule } from '@ngrx/store';
 import { OrgDetailsComponent } from './org-details.component';
 import { RouterTestingModule } from '@angular/router/testing';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MockComponent } from 'ng2-mock-component';
-import { StoreModule } from '@ngrx/store';
 import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+import { TelemetryService } from 'app/services/telemetry/telemetry.service';
+
+class MockTelemetryService {
+  track() { }
+}
 
 describe('OrgDetailsComponent', () => {
   let component: OrgDetailsComponent;
@@ -16,7 +24,6 @@ describe('OrgDetailsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        MockComponent({ selector: 'chef-error' }),
         MockComponent({ selector: 'chef-heading' }),
         MockComponent({ selector: 'chef-icon' }),
         MockComponent({ selector: 'chef-loading-spinner' }),
@@ -25,29 +32,30 @@ describe('OrgDetailsComponent', () => {
         MockComponent({ selector: 'chef-page-header' }),
         MockComponent({ selector: 'chef-subheading' }),
         MockComponent({ selector: 'chef-toolbar' }),
-        MockComponent({ selector: 'chef-breadcrumbs'}),
-        MockComponent({ selector: 'chef-breadcrumb', inputs: ['link']}),
-        MockComponent({ selector: 'app-tabs' }),
         MockComponent({ selector: 'chef-table' }),
         MockComponent({ selector: 'chef-thead' }),
         MockComponent({ selector: 'chef-tbody' }),
         MockComponent({ selector: 'chef-tr' }),
         MockComponent({ selector: 'chef-th' }),
         MockComponent({ selector: 'chef-td' }),
+        MockComponent({ selector: 'app-tabs' }),
         MockComponent({ selector: 'a', inputs: ['routerLink'] }),
         MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
         OrgDetailsComponent
       ],
       providers: [
+        { provide: ComponentFixtureAutoDetect, useValue: true },
+        { provide: TelemetryService, useClass: MockTelemetryService },
         FeatureFlagsService
       ],
       imports: [
-        FormsModule,
-        ReactiveFormsModule,
         RouterTestingModule,
+        HttpClientTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
       ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      schemas: [
+        NO_ERRORS_SCHEMA,
+        CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();
   }));
@@ -56,9 +64,11 @@ describe('OrgDetailsComponent', () => {
     fixture = TestBed.createComponent(OrgDetailsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    TestBed.inject(TelemetryService);
   });
 
-  it('should create', () => {
+  /* TODO: need a add the cases for TelemetryService */
+  xit('should create', () => {
     expect(component).toBeTruthy();
   });
 });

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.spec.ts
@@ -1,3 +1,4 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async,
   ComponentFixtureAutoDetect,
   ComponentFixture,
@@ -51,7 +52,8 @@ describe('OrgDetailsComponent', () => {
         RouterTestingModule,
         HttpClientTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ]
+      ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.spec.ts
@@ -1,4 +1,3 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async,
   ComponentFixtureAutoDetect,
   ComponentFixture,
@@ -24,11 +23,11 @@ describe('OrgDetailsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
+        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
+        MockComponent({ selector: 'app-tabs' }),
         MockComponent({ selector: 'chef-heading' }),
         MockComponent({ selector: 'chef-icon' }),
         MockComponent({ selector: 'chef-loading-spinner' }),
-        MockComponent({ selector: 'mat-select' }),
-        MockComponent({ selector: 'mat-option' }),
         MockComponent({ selector: 'chef-page-header' }),
         MockComponent({ selector: 'chef-subheading' }),
         MockComponent({ selector: 'chef-toolbar' }),
@@ -38,9 +37,9 @@ describe('OrgDetailsComponent', () => {
         MockComponent({ selector: 'chef-tr' }),
         MockComponent({ selector: 'chef-th' }),
         MockComponent({ selector: 'chef-td' }),
-        MockComponent({ selector: 'app-tabs' }),
-        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
         MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
+        MockComponent({ selector: 'mat-select' }),
+        MockComponent({ selector: 'mat-option' }),
         OrgDetailsComponent
       ],
       providers: [
@@ -52,8 +51,7 @@ describe('OrgDetailsComponent', () => {
         RouterTestingModule,
         HttpClientTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      ]
     })
     .compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.spec.ts
@@ -1,4 +1,3 @@
-import { NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async,
   ComponentFixtureAutoDetect,
   ComponentFixture,
@@ -52,10 +51,7 @@ describe('OrgDetailsComponent', () => {
         RouterTestingModule,
         HttpClientTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ],
-      schemas: [
-        NO_ERRORS_SCHEMA,
-        CUSTOM_ELEMENTS_SCHEMA ]
+      ]
     })
     .compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
@@ -1,33 +1,19 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
-import { Router } from '@angular/router';
 import { Observable, Subject, combineLatest } from 'rxjs';
-import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { NgrxStateAtom, RouterState } from 'app/ngrx.reducers';
 import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
-import { routeParams, routeURL } from 'app/route.selectors';
+import { routeParams } from 'app/route.selectors';
 import { filter, pluck, takeUntil } from 'rxjs/operators';
 import { identity, isNil } from 'lodash/fp';
-import { EntityStatus, allLoaded, pending } from 'app/entities/entities';
+import { previousRoute } from '../../../route.selectors';
+import { TelemetryService } from '../../../services/telemetry/telemetry.service';
+import { EntityStatus } from 'app/entities/entities';
 import { Org } from 'app/entities/orgs/org.model';
 import {
-  getStatus, updateStatus, orgFromRoute
+  getStatus, orgFromRoute
 } from 'app/entities/orgs/org.selectors';
-import { GetOrg, UpdateOrg } from 'app/entities/orgs/org.actions';
-import { GetCookbooks } from 'app/entities/cookbooks/cookbook.actions';
-import { Cookbook } from 'app/entities/cookbooks/cookbook.model';
-import {
-  allCookbooks,
-  getAllStatus as getAllCookbooksForOrgStatus
-} from 'app/entities/cookbooks/cookbook.selectors';
-import { GetRoles } from 'app/entities/infra-roles/infra-role.action';
-import { InfraRole } from 'app/entities/infra-roles/infra-role.model';
-import {
-  allInfraRoles,
-  getAllStatus as getAllRolesForOrgStatus
-} from 'app/entities/infra-roles/infra-role.selectors';
-
-export type OrgTabName = 'cookbooks' | 'roles' | 'details';
+import { GetOrg } from 'app/entities/orgs/org.actions';
 
 @Component({
   selector: 'app-org-details',
@@ -37,60 +23,33 @@ export type OrgTabName = 'cookbooks' | 'roles' | 'details';
 
 export class OrgDetailsComponent implements OnInit, OnDestroy {
   public org: Org;
-  public cookbooks: Cookbook[] = [];
-  public roles: InfraRole[] = [];
   public loading$: Observable<boolean>;
-  public sortedCookbooks$: Observable<Cookbook[]>;
-  public saveSuccessful = false;
-  public saveInProgress = false;
-  public isLoading = true;
-  public url: string;
   public serverId;
-  public OrgId;
-  public updateOrgForm: FormGroup;
-  public tabValue: OrgTabName = 'cookbooks';
+  public orgId;
+  public cookbooksTab = true;
+  public rolesTab = false;
   private isDestroyed = new Subject<boolean>();
 
-  cookbooksListLoading = true;
-  rolesListLoading = true;
+  previousRoute$: Observable<RouterState>;
 
   constructor(
-    private fb: FormBuilder,
     private store: Store<NgrxStateAtom>,
     private layoutFacade: LayoutFacadeService,
-    private router: Router
+    private telemetryService: TelemetryService
   ) {
-    this.updateOrgForm = this.fb.group({
-      name: new FormControl({value: ''}, [Validators.required]),
-      admin_user: new FormControl({value: ''}, [Validators.required]),
-      admin_key: new FormControl({value: ''}, [Validators.required])
-    });
-   }
+      this.previousRoute$ = this.store.select(previousRoute);
+
+      // condition for breadcrumb to select specific tab
+      this.previousRoute$.subscribe((params: any) => {
+        if ( params.path.includes('roles') ) {
+          this.cookbooksTab = false;
+          this.rolesTab = true;
+        }
+      });
+    }
 
   ngOnInit() {
     this.layoutFacade.showSidebar(Sidebar.Infrastructure);
-
-    this.store.select(routeURL).pipe(
-      takeUntil(this.isDestroyed)
-    )
-    .subscribe((url: string) => {
-      this.url = url;
-      const [, fragment] = url.split('#');
-      switch (fragment) {
-        case 'details': {
-          this.tabValue = 'details';
-          break;
-        }
-        case 'cookbooks': {
-          this.tabValue = 'cookbooks';
-          break;
-        }
-        case 'roles': {
-          this.tabValue = 'roles';
-          break;
-        }
-      }
-    });
 
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
@@ -99,27 +58,9 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
       takeUntil(this.isDestroyed)
     ).subscribe(([server_id, org_id]: string[]) => {
       this.serverId = server_id;
-      this.OrgId = org_id;
+      this.orgId = org_id;
       this.store.dispatch(new GetOrg({ server_id: server_id, id: org_id }));
-      this.store.dispatch(new GetCookbooks({
-        server_id: server_id, org_id: org_id
-      }));
-      this.store.dispatch(new GetRoles({
-        server_id: server_id, org_id: org_id
-      }));
     });
-
-    combineLatest([
-      this.store.select(getStatus),
-      this.store.select(updateStatus),
-      this.store.select(getAllCookbooksForOrgStatus),
-      this.store.select(getAllRolesForOrgStatus)
-    ]).pipe(
-      takeUntil(this.isDestroyed)
-    ).subscribe(([getOrgSt, updateSt, getCookbooksSt, getRolesSt]) => {
-        this.isLoading =
-          !allLoaded([getOrgSt, getCookbooksSt, getRolesSt]) || updateSt === EntityStatus.loading;
-      });
 
     combineLatest([
       this.store.select(getStatus),
@@ -130,65 +71,21 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
       takeUntil(this.isDestroyed)
     ).subscribe(([_getOrgSt, orgState]) => {
       this.org = { ...orgState };
-      this.updateOrgForm.controls['name'].setValue(this.org.name);
-      this.updateOrgForm.controls['admin_user'].setValue(this.org.admin_user);
-      this.updateOrgForm.controls['admin_key'].setValue(this.org.admin_key);
     });
-
-    combineLatest([
-      this.store.select(getAllCookbooksForOrgStatus),
-      this.store.select(allCookbooks)
-    ]).pipe(
-      filter(([getCookbooksSt, _allCookbooksState]) =>
-        getCookbooksSt === EntityStatus.loadingSuccess),
-      filter(([_getCookbooksSt, allCookbooksState]) =>
-        !isNil(allCookbooksState)),
-      takeUntil(this.isDestroyed)
-    ).subscribe(([ _getCookbooksSt, allCookbooksState]) => {
-      this.cookbooks = allCookbooksState;
-      this.cookbooksListLoading = false;
-    });
-
-    combineLatest([
-      this.store.select(getAllRolesForOrgStatus),
-      this.store.select(allInfraRoles)
-    ]).pipe(
-      filter(([getRolesSt, _allInfraRolesState]) =>
-        getRolesSt === EntityStatus.loadingSuccess),
-      filter(([_getRolesSt, allInfraRolesState]) =>
-        !isNil(allInfraRolesState)),
-      takeUntil(this.isDestroyed)
-    ).subscribe(([ _getRolesSt, allInfraRolesState]) => {
-      this.roles = allInfraRolesState;
-      this.rolesListLoading = false;
-    });
-
-    this.store.select(updateStatus).pipe(
-      takeUntil(this.isDestroyed),
-      filter(state => this.saveInProgress && !pending(state)))
-      .subscribe((state) => {
-        this.saveInProgress = false;
-        this.saveSuccessful = (state === EntityStatus.loadingSuccess);
-        if (this.saveSuccessful) {
-          this.updateOrgForm.markAsPristine();
-        }
-      });
   }
 
-  onSelectedTab(event: { target: { value: OrgTabName } }) {
-    this.tabValue = event.target.value;
-    this.router.navigate([this.url.split('#')[0]], { fragment: event.target.value });
-  }
-
-  saveOrg(): void {
-    this.saveSuccessful = false;
-    this.saveInProgress = true;
-    const name: string = this.updateOrgForm.controls.name.value.trim();
-    const admin_user: string = this.updateOrgForm.controls.admin_user.value.trim();
-    const admin_key: string = this.updateOrgForm.controls.admin_key.value.trim();
-    this.store.dispatch(new UpdateOrg({
-      org: {...this.org, name, admin_user, admin_key}
-    }));
+  tabChange(tab: number) {
+    switch (tab) {
+      case 0:
+        this.telemetryService.track('orgDetailsTab', 'cookbooks');
+        break;
+      case 1:
+        this.telemetryService.track('orgDetailsTab', 'roles');
+        break;
+      case 2:
+        this.telemetryService.track('orgDetailsTab', 'org-edit');
+        break;
+    }
   }
 
   ngOnDestroy(): void {

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
@@ -24,8 +24,8 @@ import { GetOrg } from 'app/entities/orgs/org.actions';
 export class OrgDetailsComponent implements OnInit, OnDestroy {
   public org: Org;
   public loading$: Observable<boolean>;
-  public serverId;
-  public orgId;
+  public serverId: string;
+  public orgId: string;
   public cookbooksTab = true;
   public rolesTab = false;
   private isDestroyed = new Subject<boolean>();

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.html
@@ -1,0 +1,50 @@
+
+<section class="org-edit">
+  <form [formGroup]="updateOrgForm">
+    <chef-form-field>
+      <label>
+      <span class="label">Name <span aria-hidden="true">*</span></span>
+      <input chefInput formControlName="name" type="text" autocomplete="off"
+        data-cy="update-org-name" [resetOrigin]="saveSuccessful">
+      </label>
+      <chef-error
+        *ngIf="(updateOrgForm.get('name').hasError('required') || updateOrgForm.get('name').hasError('pattern')) && updateOrgForm.get('name').dirty">
+        Display Name is required.
+      </chef-error>
+    </chef-form-field>
+    <chef-form-field>
+      <label>
+      <span class="label">Admin User <span aria-hidden="true">*</span></span>
+      <input chefInput formControlName="admin_user" type="text" autocomplete="off"
+        data-cy="update-Org-admin-user" [resetOrigin]="saveSuccessful">
+      </label>
+      <chef-error
+        *ngIf="(updateOrgForm.get('admin_user').hasError('required') || updateOrgForm.get('admin_user').hasError('pattern')) && updateOrgForm.get('admin_user').dirty">
+        Admin User is required.
+      </chef-error>
+    </chef-form-field>
+    <chef-form-field>
+      <label>
+      <span class="label">Admin Key<span aria-hidden="true">*</span></span>
+      <textarea rows="27" cols="10" chefInput placeholder="-----BEGIN RSA PRIVATE KEY -----"
+        formControlName="admin_key" data-cy="update-org-admin-key"></textarea>   
+      </label>
+      <chef-error
+        *ngIf="(updateOrgForm.get('admin_key').hasError('required') || updateOrgForm.get('admin_key').hasError('pattern')) && updateOrgForm.get('admin_key').dirty">
+        Admin Key is required.
+      </chef-error>
+    </chef-form-field>
+    <chef-form-field>
+      <div id="button-bar">
+        <chef-button [disabled]="isLoading || !updateOrgForm.valid || !updateOrgForm.dirty" primary
+        inline (click)="saveOrg()">
+          <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
+          <span *ngIf="saveInProgress">Saving...</span>
+          <span *ngIf="!saveInProgress">Save</span>
+        </chef-button>
+        <span id="saved-note" *ngIf="saveSuccessful && !updateOrgForm.dirty">All changes
+        saved.</span>
+      </div>
+    </chef-form-field>
+  </form>
+</section>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.html
@@ -1,4 +1,4 @@
-
+<chef-loading-spinner *ngIf="isLoading" size="50"></chef-loading-spinner>
 <section class="org-edit">
   <form [formGroup]="updateOrgForm">
     <chef-form-field>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.scss
@@ -57,10 +57,9 @@ chef-loading-spinner {
   z-index: 199;
 }
 
-.page-body {
-  chef-loading-spinner {
-    display: block;
-    margin: 100px auto;
-    width: 100px;
-  }
+chef-loading-spinner {
+  display: block;
+  margin: 100px auto;
+  width: 100px;
+  z-index: 199;
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.scss
@@ -1,0 +1,66 @@
+@import "~styles/variables";
+
+chef-page-header {
+  padding-bottom: 0;
+}
+
+chef-toolbar {
+  display: block;
+  position: relative;
+  margin-bottom: 5px;
+
+  small {
+    bottom: 2px;
+    color: $chef-dark-grey;
+    position: absolute;
+    right: 0;
+  }
+}
+
+form {
+  chef-form-field {
+    width: 300px;
+    margin-bottom: 15px;
+  }
+
+  textarea {
+    height: 200px;
+  }
+
+  input[type="text"]:disabled {
+    opacity: 0.5;
+    background-color: $chef-grey;
+    border: none;
+  }
+
+  #changes-not-allowed {
+    font-size: 12px;
+  }
+
+  #button-bar {
+    margin-top: 15px;
+
+    span#saved-note {
+      display: inline-block;
+      margin-top: 5px;
+      font-size: 12px;
+    }
+
+    chef-button {
+      margin-top: 0;
+      margin-left: 0;
+    }
+  }
+}
+
+chef-loading-spinner {
+  z-index: 199;
+}
+
+.page-body {
+  chef-loading-spinner {
+    display: block;
+    margin: 100px auto;
+    width: 100px;
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.spec.ts
@@ -1,4 +1,3 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { OrgEditComponent } from './org-edit.component';
@@ -46,8 +45,7 @@ describe('OrgEditComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      ]
     })
     .compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.spec.ts
@@ -16,8 +16,6 @@ describe('OrgEditComponent', () => {
       declarations: [
         MockComponent({ selector: 'a', inputs: ['routerLink'] }),
         MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),
-        MockComponent({ selector: 'chef-th' }),
-        MockComponent({ selector: 'chef-td' }),
         MockComponent({ selector: 'chef-error' }),
         MockComponent({ selector: 'chef-form-field' }),
         MockComponent({ selector: 'chef-heading' }),

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.spec.ts
@@ -1,5 +1,5 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { OrgEditComponent } from './org-edit.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -45,7 +45,8 @@ describe('OrgEditComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ]
+      ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.spec.ts
@@ -1,7 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { OrgDetailsComponent } from './org-details.component';
+import { OrgEditComponent } from './org-edit.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MockComponent } from 'ng2-mock-component';
@@ -9,14 +9,17 @@ import { StoreModule } from '@ngrx/store';
 import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 
-describe('OrgDetailsComponent', () => {
-  let component: OrgDetailsComponent;
-  let fixture: ComponentFixture<OrgDetailsComponent>;
+describe('OrgEditComponent', () => {
+  let component: OrgEditComponent;
+  let fixture: ComponentFixture<OrgEditComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
+        MockComponent({ selector: 'chef-th' }),
+        MockComponent({ selector: 'chef-td' }),
         MockComponent({ selector: 'chef-error' }),
+        MockComponent({ selector: 'chef-form-field' }),
         MockComponent({ selector: 'chef-heading' }),
         MockComponent({ selector: 'chef-icon' }),
         MockComponent({ selector: 'chef-loading-spinner' }),
@@ -25,9 +28,6 @@ describe('OrgDetailsComponent', () => {
         MockComponent({ selector: 'chef-page-header' }),
         MockComponent({ selector: 'chef-subheading' }),
         MockComponent({ selector: 'chef-toolbar' }),
-        MockComponent({ selector: 'chef-breadcrumbs'}),
-        MockComponent({ selector: 'chef-breadcrumb', inputs: ['link']}),
-        MockComponent({ selector: 'app-tabs' }),
         MockComponent({ selector: 'chef-table' }),
         MockComponent({ selector: 'chef-thead' }),
         MockComponent({ selector: 'chef-tbody' }),
@@ -36,7 +36,7 @@ describe('OrgDetailsComponent', () => {
         MockComponent({ selector: 'chef-td' }),
         MockComponent({ selector: 'a', inputs: ['routerLink'] }),
         MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
-        OrgDetailsComponent
+        OrgEditComponent
       ],
       providers: [
         FeatureFlagsService
@@ -53,7 +53,7 @@ describe('OrgDetailsComponent', () => {
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(OrgDetailsComponent);
+    fixture = TestBed.createComponent(OrgEditComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.spec.ts
@@ -1,4 +1,3 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { OrgEditComponent } from './org-edit.component';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -15,6 +14,8 @@ describe('OrgEditComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
+        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
+        MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),
         MockComponent({ selector: 'chef-th' }),
         MockComponent({ selector: 'chef-td' }),
         MockComponent({ selector: 'chef-error' }),
@@ -22,8 +23,6 @@ describe('OrgEditComponent', () => {
         MockComponent({ selector: 'chef-heading' }),
         MockComponent({ selector: 'chef-icon' }),
         MockComponent({ selector: 'chef-loading-spinner' }),
-        MockComponent({ selector: 'mat-select' }),
-        MockComponent({ selector: 'mat-option' }),
         MockComponent({ selector: 'chef-page-header' }),
         MockComponent({ selector: 'chef-subheading' }),
         MockComponent({ selector: 'chef-toolbar' }),
@@ -33,8 +32,9 @@ describe('OrgEditComponent', () => {
         MockComponent({ selector: 'chef-tr' }),
         MockComponent({ selector: 'chef-th' }),
         MockComponent({ selector: 'chef-td' }),
-        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
         MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
+        MockComponent({ selector: 'mat-select' }),
+        MockComponent({ selector: 'mat-option' }),
         OrgEditComponent
       ],
       providers: [
@@ -45,8 +45,7 @@ describe('OrgEditComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      ]
     })
     .compileComponents();
   }));

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.ts
@@ -1,0 +1,104 @@
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
+import { Observable, Subject, combineLatest } from 'rxjs';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
+import { filter, takeUntil } from 'rxjs/operators';
+import { isNil } from 'lodash/fp';
+import { EntityStatus, allLoaded, pending } from 'app/entities/entities';
+import { Org } from 'app/entities/orgs/org.model';
+import {
+  getStatus, updateStatus, orgFromRoute
+} from 'app/entities/orgs/org.selectors';
+import { GetOrg, UpdateOrg } from 'app/entities/orgs/org.actions';
+
+@Component({
+  selector: 'app-org-edit',
+  templateUrl: './org-edit.component.html',
+  styleUrls: ['./org-edit.component.scss']
+})
+
+export class OrgEditComponent implements OnInit, OnDestroy {
+  @Input() serverId: string;
+  @Input() orgId: string;
+
+  public org: Org;
+  public loading$: Observable<boolean>;
+  public saveSuccessful = false;
+  public saveInProgress = false;
+  public isLoading = true;
+  public updateOrgForm: FormGroup;
+  private isDestroyed = new Subject<boolean>();
+
+
+  constructor(
+    private fb: FormBuilder,
+    private store: Store<NgrxStateAtom>,
+    private layoutFacade: LayoutFacadeService
+  ) {
+      this.updateOrgForm = this.fb.group({
+        name: new FormControl({value: ''}, [Validators.required]),
+        admin_user: new FormControl({value: ''}, [Validators.required]),
+        admin_key: new FormControl({value: ''}, [Validators.required])
+      });
+   }
+
+  ngOnInit() {
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
+
+    this.store.dispatch(new GetOrg({ server_id: this.serverId, id: this.orgId }));
+
+    combineLatest([
+      this.store.select(getStatus),
+      this.store.select(updateStatus)
+    ]).pipe(
+      takeUntil(this.isDestroyed)
+    ).subscribe(([getOrgSt, updateSt]) => {
+        this.isLoading =
+          !allLoaded([getOrgSt]) || updateSt === EntityStatus.loading;
+      });
+
+    combineLatest([
+      this.store.select(getStatus),
+      this.store.select(orgFromRoute)
+    ]).pipe(
+      filter(([getOrgSt, orgState]) => getOrgSt ===
+        EntityStatus.loadingSuccess && !isNil(orgState)),
+      takeUntil(this.isDestroyed)
+    ).subscribe(([_getOrgSt, orgState]) => {
+      this.org = { ...orgState };
+      this.updateOrgForm.controls['name'].setValue(this.org.name);
+      this.updateOrgForm.controls['admin_user'].setValue(this.org.admin_user);
+      this.updateOrgForm.controls['admin_key'].setValue(this.org.admin_key);
+    });
+
+    this.store.select(updateStatus).pipe(
+      takeUntil(this.isDestroyed),
+      filter(state => this.saveInProgress && !pending(state)))
+      .subscribe((state) => {
+        this.saveInProgress = false;
+        this.saveSuccessful = (state === EntityStatus.loadingSuccess);
+        if (this.saveSuccessful) {
+          this.updateOrgForm.markAsPristine();
+        }
+      });
+  }
+
+  saveOrg(): void {
+    this.saveSuccessful = false;
+    this.saveInProgress = true;
+    const name: string = this.updateOrgForm.controls.name.value.trim();
+    const admin_user: string = this.updateOrgForm.controls.admin_user.value.trim();
+    const admin_key: string = this.updateOrgForm.controls.admin_key.value.trim();
+    this.store.dispatch(new UpdateOrg({
+      org: {...this.org, name, admin_user, admin_key}
+    }));
+  }
+
+  ngOnDestroy(): void {
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
+  }
+
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
-import { Observable, Subject, combineLatest } from 'rxjs';
+import { Subject, combineLatest } from 'rxjs';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { filter, takeUntil } from 'rxjs/operators';
@@ -24,7 +24,6 @@ export class OrgEditComponent implements OnInit, OnDestroy {
   @Input() orgId: string;
 
   public org: Org;
-  public loading$: Observable<boolean>;
   public saveSuccessful = false;
   public saveInProgress = false;
   public isLoading = true;
@@ -55,9 +54,9 @@ export class OrgEditComponent implements OnInit, OnDestroy {
     ]).pipe(
       takeUntil(this.isDestroyed)
     ).subscribe(([getOrgSt, updateSt]) => {
-        this.isLoading =
-          !allLoaded([getOrgSt]) || updateSt === EntityStatus.loading;
-      });
+      this.isLoading =
+        !allLoaded([getOrgSt]) || updateSt === EntityStatus.loading;
+    });
 
     combineLatest([
       this.store.select(getStatus),

--- a/tools/credscan/credscan.go
+++ b/tools/credscan/credscan.go
@@ -81,6 +81,7 @@ var a2Config = config{
 		{regex: `components/automate-ui/src/app/pages/\+compliance/\+credentials/components/credentials-form.html`},
 		{regex: `components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html`},
 		{regex: `components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html`},
+		{regex: `components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.html`},
 		{regex: `components/automate-minio/habitat/config/private.key`},
 		{regex: `components/backup-gateway/habitat/config/private.key`},
 		{regex: `components/compliance-service/api/tests/containers/key.pem`},


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
Org details page has different tabs, when we click to a particular tab then all API's calling parallel, on this page we are going to add more tabs so we have to manage like if we click to particular tab then only related API will calling.

I have added changes to separate the API calls, now if we click to particular tab then only specific API is called.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/3410
### :+1: Definition of Done
we have separated the API calls now only specific tabs related API is calling when we clicking to a particular tab.
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

$npm run serve:hab
```

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![org](https://user-images.githubusercontent.com/12297653/79740021-a0e66c80-831c-11ea-8ff6-580a20c461f3.png)
![cookbooklists](https://user-images.githubusercontent.com/12297653/79739884-6f6da100-831c-11ea-9100-39185d56603d.png)
![org-details](https://user-images.githubusercontent.com/12297653/79739886-71cffb00-831c-11ea-8bf2-127e031959f5.png)
![Roleslist](https://user-images.githubusercontent.com/12297653/79739887-72689180-831c-11ea-922d-aa44a93a2f1b.png)

