### PR TITLE
[infra-proxy-service] Auto populate terraform deployed chef servers.

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
+++ b/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
@@ -125,17 +125,17 @@ configure_retention() {
 }
 
 configure_automate_infra_views() {
-  if chef-automate dev grpcurl infra-proxy-service list | grep "chef.automate.domain.infra_proxy.service.InfraProxy" &> /dev/null; then
+  if chef-automate dev grpcurl automate-gateway list | grep "chef.automate.api.infra_proxy.InfraProxy" &> /dev/null; then
       chef_server_admin_key=$(cat "/hab/chef-server-admin-key.txt")
-      chef-automate dev grpcurl infra-proxy-service -- chef.automate.domain.infra_proxy.service.InfraProxy.CreateServer -d '{
+      chef-automate dev grpcurl automate-gateway -- chef.automate.api.infra_proxy.InfraProxy.CreateServer -d '{
         "id": "auto-deployed-chef-server",
         "name": "auto-deployed-chef-server",
         "fqdn": "localhost",
         "ip_address": "127.0.0.1",
       }'
 
-      chef-automate dev grpcurl infra-proxy-service -- chef.automate.domain.infra_proxy.service.InfraProxy.CreateOrg -d '{
-        "id": "auto-deployed-chef-server",
+      chef-automate dev grpcurl automate-gateway -- chef.automate.api.infra_proxy.InfraProxy.CreateOrg -d '{
+        "id": "auto-deployed-chef-org",
         "name": "${chef_server_org}",
         "admin_user": "${chef_server_admin_name}",
         "admin_key": "${chef_server_admin_key}",


### PR DESCRIPTION
 
### :nut_and_bolt: Description: What code changed, and why?
 - Add function configure_automate_infra_views.
 - if enable_chef_server is enabled the add entry in servers using infra-proxy-service.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
Fixes https://github.com/chef/automate/issues/3585

### :+1: Definition of Done
 - `dev` and `acceptance` environments have the pre-populated entry of terraform locally deployed chef servers.

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
