### PR TITLE
nodemanager nodes: fix platform and tags info, add state to possible sort options

### DIFF
--- a/components/compliance-service/api/tests/25_nodes_spec.rb
+++ b/components/compliance-service/api/tests/25_nodes_spec.rb
@@ -45,7 +45,7 @@ describe File.basename(__FILE__) do
       MANAGER_GRPC nodes, :read, Nodes::Id.new(id: 'missing')
     end
 
-    assert_grpc_error("Invalid sort field, valid ones are: [last_contact manager name platform platform_version status]", 3) do
+    assert_grpc_error("Invalid sort field, valid ones are: [last_contact manager name platform platform_version state status]", 3) do
       MANAGER_GRPC nodes, :list, Nodes::Query.new(sort: "wrong")
     end
 

--- a/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher.go
+++ b/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher.go
@@ -87,7 +87,7 @@ func gatherInfoForNode(in message.Compliance) (*manager.NodeMetadata, error) {
 		})
 	}
 	if in.Report.GetEnvironment() != "" {
-		tags = append(tags, &common.Kv{Key: "Environment", Value: in.Report.GetEnvironment()})
+		tags = append(tags, &common.Kv{Key: "environment", Value: in.Report.GetEnvironment()})
 	}
 
 	return &manager.NodeMetadata{

--- a/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher.go
+++ b/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/chef/automate/api/interservice/compliance/common"
 	"github.com/chef/automate/api/interservice/compliance/ingest/events/compliance"
 	"github.com/chef/automate/api/interservice/nodemanager/manager"
 	"github.com/chef/automate/api/interservice/nodemanager/nodes"
@@ -77,6 +78,18 @@ func gatherInfoForNode(in message.Compliance) (*manager.NodeMetadata, error) {
 		status = nodes.LastContactData_SKIPPED
 	}
 
+	// translate tags
+	tags := in.Report.GetTags()
+	for _, tag := range in.Report.GetChefTags() {
+		tags = append(tags, &common.Kv{
+			Key:   "chef-tag",
+			Value: tag,
+		})
+	}
+	if in.Report.GetEnvironment() != "" {
+		tags = append(tags, &common.Kv{Key: "Environment", Value: in.Report.GetEnvironment()})
+	}
+
 	return &manager.NodeMetadata{
 		Uuid:            in.Report.GetNodeUuid(),
 		Name:            in.Report.GetNodeName(),
@@ -87,7 +100,7 @@ func gatherInfoForNode(in message.Compliance) (*manager.NodeMetadata, error) {
 		SourceId:        in.Report.GetSourceId(),
 		SourceRegion:    in.Report.GetSourceRegion(),
 		SourceAccountId: in.Report.GetSourceAccountId(),
-		Tags:            in.Report.GetTags(),
+		Tags:            tags,
 		ProjectsData:    gatherProjectsData(&in.Report),
 		Projects:        in.InspecReport.Projects,
 		ScanData: &nodes.LastContactData{

--- a/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher_test.go
+++ b/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher_test.go
@@ -76,7 +76,7 @@ func TestGatherInfoForNode(t *testing.T) {
 		Tags: []*common.Kv{
 			{Key: "chef-tag", Value: "application"},
 			{Key: "chef-tag", Value: "database"},
-			{Key: "Environment", Value: "test-env"},
+			{Key: "environment", Value: "test-env"},
 		},
 	}, nodeMetadata)
 }

--- a/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher_test.go
+++ b/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher_test.go
@@ -128,6 +128,10 @@ func TestGatherInfoForNodeDoesNotCollectProjectsDataIfScanJob(t *testing.T) {
 		Projects:     []string{"tomato", "cucumber"},
 		JobUuid:      "12335892329454",
 		ProjectsData: []*nodes.ProjectsData{},
+		Tags: []*common.Kv{
+			{Key: "chef-tag", Value: "application"},
+			{Key: "chef-tag", Value: "database"},
+		},
 	}, nodeMetadata)
 }
 

--- a/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher_test.go
+++ b/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/chef/automate/api/interservice/compliance/common"
 	inspec "github.com/chef/automate/api/interservice/compliance/ingest/events/inspec"
 
 	"github.com/chef/automate/api/interservice/compliance/ingest/events/compliance"
@@ -40,6 +41,7 @@ func TestGatherInfoForNode(t *testing.T) {
 			SourceRegion:      "us-west-2a",
 			ReportUuid:        "123353254545425",
 			AutomateManagerId: "12345",
+			Environment:       "test-env",
 		},
 		InspecReport: &relaxting.ESInSpecReport{
 			Projects: []string{"tomato", "cucumber"},
@@ -64,12 +66,18 @@ func TestGatherInfoForNode(t *testing.T) {
 		},
 		Projects: []string{"tomato", "cucumber"},
 		ProjectsData: []*nodes.ProjectsData{
+			{Key: "environment", Values: []string{"test-env"}},
 			{Key: "roles", Values: []string{"my-cool-role"}},
 			{Key: "organization_name", Values: []string{"test-org"}},
 			{Key: "chef_tags", Values: []string{"application", "database"}},
 			{Key: "chef_server", Values: []string{"chef-server-2"}},
 		},
 		ManagerId: "12345",
+		Tags: []*common.Kv{
+			{Key: "chef-tag", Value: "application"},
+			{Key: "chef-tag", Value: "database"},
+			{Key: "Environment", Value: "test-env"},
+		},
 	}, nodeMetadata)
 }
 

--- a/components/ingest-service/backend/chef_client_run.go
+++ b/components/ingest-service/backend/chef_client_run.go
@@ -250,7 +250,7 @@ func (ccr *ChefClientRun) initializeNodeInfo() (sharedNodeInfo NodeInfo, err err
 		UptimeSeconds:         int64(uptimeSeconds),
 		OrganizationName:      ccr.OrganizationName,
 		Environment:           ccr.NodePayload.ChefEnvironment,
-		Platform:              getPlatformWithVersion(ccr.NodePayload),
+		Platform:              ccr.PlatformWithVersion(),
 		PlatformFamily:        EmptyStringIfNil(ccr.NodePayload.Automatic["platform_family"]),
 		PlatformVersion:       EmptyStringIfNil(ccr.NodePayload.Automatic["platform_version"]),
 		Source:                ccr.Source,
@@ -353,6 +353,10 @@ func (ccr *ChefClientRun) CloudProvider() string {
 	cloud := extractMapOrEmpty(ccr.NodePayload.Automatic, "cloud")
 
 	return EmptyStringIfNil(cloud["provider"])
+}
+
+func (ccr *ChefClientRun) Platform() string {
+	return EmptyStringIfNil(ccr.NodePayload.Automatic["platform"])
 }
 
 // ChefVersion Returns a chef version string retrieved from automatic attributes or an empty string if it is not present
@@ -561,9 +565,9 @@ func countNumberOfValueObject(object interface{}) int {
 	return count
 }
 
-func getPlatformWithVersion(nodePayload NodePayload) string {
-	platform := EmptyStringIfNil(nodePayload.Automatic["platform"])
-	platformVersion := EmptyStringIfNil(nodePayload.Automatic["platform_version"])
+func (ccr *ChefClientRun) PlatformWithVersion() string {
+	platform := ccr.Platform()
+	platformVersion := EmptyStringIfNil(ccr.NodePayload.Automatic["platform_version"])
 
 	platformAndVersion := ""
 

--- a/components/ingest-service/pipeline/message/chef_run.go
+++ b/components/ingest-service/pipeline/message/chef_run.go
@@ -30,6 +30,7 @@ type ChefRun struct {
 	NodeRun          backend.Run
 	NodeAttribute    backend.NodeAttribute
 	BulkableRequests []elastic.BulkableRequest
+	Platform         string
 	Ctx              context.Context
 	errc             chan<- error
 }
@@ -43,6 +44,7 @@ func NewChefRun(ctx context.Context, run *chef.Run, err chan<- error) ChefRun {
 		backend.Run{},
 		backend.NodeAttribute{},
 		[]elastic.BulkableRequest{},
+		"",
 		ctx,
 		err,
 	}

--- a/components/ingest-service/pipeline/processor/transmogrify_run.go
+++ b/components/ingest-service/pipeline/processor/transmogrify_run.go
@@ -80,6 +80,9 @@ func ChefRunTransmogrify(in <-chan message.ChefRun, out chan<- message.ChefRun, 
 				continue
 			}
 
+			// Needed for the nodemanager because the platform field is combined with the version.
+			msg.Platform = ccr.Platform()
+
 			message.PropagateChefRun(out, &msg)
 		}
 		close(out)

--- a/components/ingest-service/pipeline/publisher/node_manager_publisher.go
+++ b/components/ingest-service/pipeline/publisher/node_manager_publisher.go
@@ -79,7 +79,7 @@ func gatherInfoForNode(node backend.Node) (*manager.NodeMetadata, error) {
 	return &manager.NodeMetadata{
 		Uuid:            node.EntityUuid,
 		Name:            node.NodeName,
-		PlatformName:    node.Platform,
+		PlatformName:    node.PlatformFamily,
 		PlatformRelease: node.PlatformVersion,
 		LastContact:     timestamp,
 		SourceId:        node.CloudID,

--- a/components/ingest-service/pipeline/publisher/node_manager_publisher.go
+++ b/components/ingest-service/pipeline/publisher/node_manager_publisher.go
@@ -32,7 +32,7 @@ func nodeManagerPublisher(in <-chan message.ChefRun, nodeManagerClient manager.N
 				continue
 			}
 
-			nodeMetadata, err := gatherInfoForNode(msg.Node)
+			nodeMetadata, err := gatherInfoForNode(msg)
 			if err != nil {
 				log.Errorf("unable parse node data to be send to manager. aborting attempt to send info to mgr for node %s -- %v", msg.Node.NodeName, err)
 				out <- msg
@@ -51,7 +51,9 @@ func nodeManagerPublisher(in <-chan message.ChefRun, nodeManagerClient manager.N
 	return out
 }
 
-func gatherInfoForNode(node backend.Node) (*manager.NodeMetadata, error) {
+func gatherInfoForNode(msg message.ChefRun) (*manager.NodeMetadata, error) {
+	node := msg.Node
+
 	// convert node check in time to proto timestamp
 	timestamp, err := ptypes.TimestampProto(node.Checkin)
 	if err != nil {
@@ -82,7 +84,7 @@ func gatherInfoForNode(node backend.Node) (*manager.NodeMetadata, error) {
 	return &manager.NodeMetadata{
 		Uuid:            node.EntityUuid,
 		Name:            node.NodeName,
-		PlatformName:    node.PlatformFamily,
+		PlatformName:    msg.Platform,
 		PlatformRelease: node.PlatformVersion,
 		LastContact:     timestamp,
 		SourceId:        node.CloudID,

--- a/components/ingest-service/pipeline/publisher/node_manager_publisher.go
+++ b/components/ingest-service/pipeline/publisher/node_manager_publisher.go
@@ -76,7 +76,7 @@ func gatherInfoForNode(node backend.Node) (*manager.NodeMetadata, error) {
 		}
 	}
 	if node.Environment != "" {
-		tags = append(tags, &common.Kv{Key: "Environment", Value: node.Environment})
+		tags = append(tags, &common.Kv{Key: "environment", Value: node.Environment})
 	}
 
 	return &manager.NodeMetadata{

--- a/components/ingest-service/pipeline/publisher/node_manager_publisher.go
+++ b/components/ingest-service/pipeline/publisher/node_manager_publisher.go
@@ -75,6 +75,9 @@ func gatherInfoForNode(node backend.Node) (*manager.NodeMetadata, error) {
 			Value: tag,
 		}
 	}
+	if node.Environment != "" {
+		tags = append(tags, &common.Kv{Key: "Environment", Value: node.Environment})
+	}
 
 	return &manager.NodeMetadata{
 		Uuid:            node.EntityUuid,

--- a/components/ingest-service/pipeline/publisher/node_manager_publisher_test.go
+++ b/components/ingest-service/pipeline/publisher/node_manager_publisher_test.go
@@ -52,7 +52,7 @@ func TestGatherInfoForNode(t *testing.T) {
 		Tags: []*common.Kv{
 			{Key: "chef-tag", Value: "application"},
 			{Key: "chef-tag", Value: "database"},
-			{Key: "Environment", Value: "test-env"},
+			{Key: "environment", Value: "test-env"},
 		},
 		LastContact:     timestampNow,
 		SourceId:        "i-0aee75f0b4b0d9f22",

--- a/components/ingest-service/pipeline/publisher/node_manager_publisher_test.go
+++ b/components/ingest-service/pipeline/publisher/node_manager_publisher_test.go
@@ -21,34 +21,37 @@ func TestGatherInfoForNode(t *testing.T) {
 	timestampNow, err := ptypes.TimestampProto(nowTime)
 	assert.NoError(t, err)
 
-	backendNode := backend.Node{
-		NodeInfo: backend.NodeInfo{
-			EntityUuid:       "8dcca219-a730-3985-907b-e6b22f9f848d",
-			NodeName:         "chef-load-44",
-			PlatformFamily:   "ubuntu",
-			PlatformVersion:  "16.04",
-			ChefTags:         []string{"application", "database"},
-			Status:           "success",
-			OrganizationName: "test-org",
-			SourceFqdn:       "chef-server-2",
-			Roles:            []string{"my-cool-role"},
-			Environment:      "test-env",
+	run := message.ChefRun{
+		Platform: "redhat",
+		Node: backend.Node{
+			NodeInfo: backend.NodeInfo{
+				EntityUuid:       "8dcca219-a730-3985-907b-e6b22f9f848d",
+				NodeName:         "chef-load-44",
+				PlatformFamily:   "rhel",
+				PlatformVersion:  "8.9",
+				ChefTags:         []string{"application", "database"},
+				Status:           "success",
+				OrganizationName: "test-org",
+				SourceFqdn:       "chef-server-2",
+				Roles:            []string{"my-cool-role"},
+				Environment:      "test-env",
+			},
+			Checkin:        nowTime,
+			LatestRunID:    "123353254545425",
+			Projects:       []string{"tomato", "cucumber"},
+			CloudID:        "i-0aee75f0b4b0d9f22",
+			CloudAccountID: "123456789",
+			CloudRegion:    "us-west-2",
 		},
-		Checkin:        nowTime,
-		LatestRunID:    "123353254545425",
-		Projects:       []string{"tomato", "cucumber"},
-		CloudID:        "i-0aee75f0b4b0d9f22",
-		CloudAccountID: "123456789",
-		CloudRegion:    "us-west-2",
 	}
 
-	nodeMetadata, err := gatherInfoForNode(backendNode)
+	nodeMetadata, err := gatherInfoForNode(run)
 	assert.NoError(t, err)
 	assert.Equal(t, &manager.NodeMetadata{
 		Uuid:            "8dcca219-a730-3985-907b-e6b22f9f848d",
 		Name:            "chef-load-44",
-		PlatformName:    "ubuntu",
-		PlatformRelease: "16.04",
+		PlatformName:    "redhat",
+		PlatformRelease: "8.9",
 		Tags: []*common.Kv{
 			{Key: "chef-tag", Value: "application"},
 			{Key: "chef-tag", Value: "database"},

--- a/components/ingest-service/pipeline/publisher/node_manager_publisher_test.go
+++ b/components/ingest-service/pipeline/publisher/node_manager_publisher_test.go
@@ -25,13 +25,14 @@ func TestGatherInfoForNode(t *testing.T) {
 		NodeInfo: backend.NodeInfo{
 			EntityUuid:       "8dcca219-a730-3985-907b-e6b22f9f848d",
 			NodeName:         "chef-load-44",
-			Platform:         "ubuntu",
+			PlatformFamily:   "ubuntu",
 			PlatformVersion:  "16.04",
 			ChefTags:         []string{"application", "database"},
 			Status:           "success",
 			OrganizationName: "test-org",
 			SourceFqdn:       "chef-server-2",
 			Roles:            []string{"my-cool-role"},
+			Environment:      "test-env",
 		},
 		Checkin:        nowTime,
 		LatestRunID:    "123353254545425",
@@ -51,6 +52,7 @@ func TestGatherInfoForNode(t *testing.T) {
 		Tags: []*common.Kv{
 			{Key: "chef-tag", Value: "application"},
 			{Key: "chef-tag", Value: "database"},
+			{Key: "Environment", Value: "test-env"},
 		},
 		LastContact:     timestampNow,
 		SourceId:        "i-0aee75f0b4b0d9f22",
@@ -63,6 +65,7 @@ func TestGatherInfoForNode(t *testing.T) {
 		},
 		Projects: []string{"tomato", "cucumber"},
 		ProjectsData: []*nodes.ProjectsData{
+			{Key: "environment", Values: []string{"test-env"}},
 			{Key: "roles", Values: []string{"my-cool-role"}},
 			{Key: "organization_name", Values: []string{"test-org"}},
 			{Key: "chef_tags", Values: []string{"application", "database"}},

--- a/components/nodemanager-service/pgdb/nodes.go
+++ b/components/nodemanager-service/pgdb/nodes.go
@@ -166,6 +166,7 @@ var nodesSortFields = map[string]string{
 	"status":           "LOWER(n.status)",
 	"manager":          "LOWER(n.manager)",
 	"last_contact":     "n.last_contact",
+	"state":            "n.source_state",
 }
 
 type dbNode struct {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
a few issues:
- platform version was showing up twice in the nodemanager nodes: this is bc we were mistakenly sending the full platform field + the version, instead of either just sending the full field or jsut sending the family and version. i switched to used family for now, for consistency with the compliance side of things, but we may want to come back and just have everything send the full field? not sure yet. should discuss how customers would want to filter that data.
- tags: added environment value as a tag to the node, and also modified the compliance bits to include chef tags in the tags information sent to nodemanager
- state: we did not previously allow sorting by state; we should!

### :chains: Related Resources
https://github.com/chef/automate/issues/3515

### :+1: Definition of Done
platform information doesn't double up. tags are all sent over, including env. can filter by state.

### :athletic_shoe: How to Build and Test the Change
go_update_component compliance-service
same for ingest-service
and nodemanager-service
send in some reports, e.g. load_compliance_reports
check the data returned by `api/v0/nodes`, accessible at automate-url/nodes in the ui

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [n/a] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
