### PR TITLE
On project list fetch, remove any projects that no longer exist

### DIFF
--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
@@ -63,13 +63,13 @@ export class ProjectsFilterEffects {
         const fetched = this.convertResponse(resp.projects);
         let restored = this.projectsFilter.restoreOptions() || [];
 
-        // throw out any localstoreage keys that no longer exist.
-        // intersectionBy choses results from the first array so
+        // throw out any LocalStorage keys that no longer exist.
+        // intersectionBy chooses results from the first array so
         // restored's checked results are preserved.
         restored = intersectionBy('value', restored, fetched);
 
         // don't reload the page, but persist to localstorage
-        this.projectsFilter.updateLocalstorage(restored);
+        this.projectsFilter.updateLocalStorage(restored);
 
         return new LoadOptionsSuccess({
           fetched,

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.effects.ts
@@ -3,6 +3,8 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { interval as observableInterval, of as observableOf, Observable } from 'rxjs';
 import { catchError, mergeMap, map, tap } from 'rxjs/operators';
+import { intersectionBy } from 'lodash/fp';
+
 
 import { Project } from 'app/entities/projects/project.model';
 import { ProjectsFilterOption } from './projects-filter.reducer';
@@ -57,11 +59,20 @@ export class ProjectsFilterEffects {
 
   private loadOptionsAction$(): () => Observable<ProjectsFilterActions> {
     return () => this.requests.fetchOptions().pipe(
-      map((fetched: AuthorizedProjectsResponse) => {
-        const converted = this.convertResponse(fetched.projects);
-        const restored = this.projectsFilter.restoreOptions() || [];
+      map((resp: AuthorizedProjectsResponse) => {
+        const fetched = this.convertResponse(resp.projects);
+        let restored = this.projectsFilter.restoreOptions() || [];
+
+        // throw out any localstoreage keys that no longer exist.
+        // intersectionBy choses results from the first array so
+        // restored's checked results are preserved.
+        restored = intersectionBy('value', restored, fetched);
+
+        // don't reload the page, but persist to localstorage
+        this.projectsFilter.updateLocalstorage(restored);
+
         return new LoadOptionsSuccess({
-          fetched: converted,
+          fetched,
           restored
         });
       }),

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -43,8 +43,12 @@ export class ProjectsFilterService {
     this.store.dispatch(new UpdateSelectionCount(options));
   }
 
-  storeOptions(options: ProjectsFilterOption[]) {
+  updateLocalstorage(options: ProjectsFilterOption[]) {
     localStorage.setItem(STORE_OPTIONS_KEY, JSON.stringify(options));
+  }
+
+  storeOptions(options: ProjectsFilterOption[]) {
+    this.updateLocalstorage(options);
 
     // To get back to where we are
     const currentUrl = location.pathname + location.search;

--- a/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
+++ b/components/automate-ui/src/app/services/projects-filter/projects-filter.service.ts
@@ -43,12 +43,12 @@ export class ProjectsFilterService {
     this.store.dispatch(new UpdateSelectionCount(options));
   }
 
-  updateLocalstorage(options: ProjectsFilterOption[]) {
+  updateLocalStorage(options: ProjectsFilterOption[]) {
     localStorage.setItem(STORE_OPTIONS_KEY, JSON.stringify(options));
   }
 
   storeOptions(options: ProjectsFilterOption[]) {
-    this.updateLocalstorage(options);
+    this.updateLocalStorage(options);
 
     // To get back to where we are
     const currentUrl = location.pathname + location.search;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

If a project got deleted by someone besides the active UI user, they could persist in localstorage. Now when we fetch the project list on app start, intersect localstorage with that list so there are no zombies 👻.

### :athletic_shoe: How to Build and Test the Change

* Create project `test` in the UI.
* Check it in projects dropdown.
* See that it shows up in local storage.
* Delete the project via the API:
```curl -H "api-token: $TOK" -XDELETE  https://localhost/apis/iam/v2/projects/test --insecure```
* Refresh the app and see that it no longer exists in localstorage and that the dropdown goes away since now there is only the default project.


### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

