### PR TITLE
add a1 legacy token integration test

### DIFF
--- a/.expeditor/nightly.pipeline.yml
+++ b/.expeditor/nightly.pipeline.yml
@@ -96,6 +96,15 @@ steps:
           single-use: true
           privileged: true
 
+  - label: "[integration] a1 legacy token"
+    command:
+      - integration/run_test integration/tests/a1_legacy_token.sh
+    timeout_in_minutes: 20
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+
   # TODO(ssd) 2019-12-13: This test is broken given the current design
   # of config patch and backup/restore.  We are working on fixes for
   # the various problems that make this test incorrect.

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -771,6 +771,15 @@ steps:
         linux:
           privileged: true
 
+  - label: "a1 legacy token"
+    command:
+      - integration/run_test integration/tests/a1_legacy_token.sh
+    timeout_in_minutes: 20
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+
   - label: "security"
     command:
       - integration/run_test integration/tests/security.sh

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -771,15 +771,6 @@ steps:
         linux:
           privileged: true
 
-  - label: "a1 legacy token"
-    command:
-      - integration/run_test integration/tests/a1_legacy_token.sh
-    timeout_in_minutes: 20
-    expeditor:
-      executor:
-        linux:
-          privileged: true
-
   - label: "security"
     command:
       - integration/run_test integration/tests/security.sh

--- a/integration/tests/a1_legacy_token.sh
+++ b/integration/tests/a1_legacy_token.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+#shellcheck disable=SC2034
+test_name="a1_legacy_token"
+test_deploy_inspec_profiles=()
+test_skip_diagnostics=true
+token="myoldbutsupersecurea1token"
+
+do_setup() {
+    do_setup_default
+
+    # We are defaulting to a umask of 077 to test
+    # installations on systems that are super locked down.
+    # Briefly override that strict default so we can install
+    # packages that non-root users can use (like the hab user
+    # for health checks or this script).
+    local previous_umask
+    previous_umask=$(umask)
+    umask 022
+
+    hab pkg install core/curl
+
+    umask "$previous_umask"
+}
+
+hab_curl() {
+    hab pkg exec core/curl curl "$@"
+}
+
+do_create_config() {
+    do_create_config_default
+    #shellcheck disable=SC2154
+    cat <<EOF >> "$test_config_path"
+[auth_n.v1.sys.service]
+a1_data_collector_token = "$token"
+EOF
+}
+
+do_test_deploy() {
+    # we want to ensure that the token can be used to ingest data
+    local response_code
+    response_code=$(hab_curl -fsS -k -H "api-token: $token" "https://localhost/data-collector/v0" \
+      -d '{}' -o /dev/null -w '%{response_code}')
+    if ! grep -q 400 <<< "$response_code"; then
+      log_error "unexpected response code \"$response_code\" (expected 400)"
+      return 1
+    fi
+}

--- a/integration/tests/backup_repo_permissions.sh
+++ b/integration/tests/backup_repo_permissions.sh
@@ -48,7 +48,7 @@ EOF
   if out=$(chef-automate backup list "$root_backup_dir" 2>&1); then
     return 1
   else
-    grep "read/write/exec" <<< "$out"
+    grep "read/write/exec" <<< "$out" || return 1
   fi
 
   # Commands with hab dir succeed


### PR DESCRIPTION
Adding the test now since I've just been messing with this for acceptance testing.

- [x] see test pass correctly (the logs have a permission granted line, so the 400 is the ingestion handler)
- [x] move into nightlies 🌃 