### PR TITLE
Updated Infra server and org modal UI to construct human readable Id

### DIFF
--- a/components/automate-ui/src/app/entities/orgs/org.actions.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.actions.ts
@@ -66,6 +66,7 @@ export class GetOrgFailure implements Action {
 }
 
 export interface CreateOrgPayload {
+  id: string;
   server_id: string;
   name: string;
   admin_user: string;

--- a/components/automate-ui/src/app/entities/orgs/org.effects.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.effects.ts
@@ -84,7 +84,7 @@ export class OrgEffects {
       mergeMap(({ payload }: CreateOrg) =>
       this.requests.createOrg( payload ).pipe(
         map((resp: OrgSuccessPayload) => new CreateOrgSuccess(resp)),
-        catchError((error: HttpErrorResponse) => observableOf(new GetOrgFailure(error))))));
+        catchError((error: HttpErrorResponse) => observableOf(new CreateOrgFailure(error))))));
 
   @Effect()
   createOrgSuccess$ = this.actions$.pipe(

--- a/components/automate-ui/src/app/entities/servers/server.actions.ts
+++ b/components/automate-ui/src/app/entities/servers/server.actions.ts
@@ -64,8 +64,8 @@ export class GetServerFailure implements Action {
 }
 
 export interface CreateServerPayload {
+  id: string;
   name: string;
-  description: string;
   fqdn: string;
   ip_address: string;
 }

--- a/components/automate-ui/src/app/entities/servers/server.model.ts
+++ b/components/automate-ui/src/app/entities/servers/server.model.ts
@@ -1,7 +1,6 @@
 export interface Server {
   id: string;
   name: string;
-  description: string;
   fqdn: string;
   ip_address: string;
   orgs_count?: number;

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -55,17 +55,6 @@
               Name is required.
             </chef-error>
           </chef-form-field>
-          <chef-form-field id="update-description">
-            <label>
-              <span class="label">Description <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="description" type="text" [resetOrigin]="saveSuccessful" autocomplete="off"
-                data-cy="update-chefServer-description">
-            </label>
-            <chef-error
-              *ngIf="(updateServerForm.get('description').hasError('required') || updateServerForm.get('description').hasError('pattern')) && updateServerForm.get('description').dirty">
-              Description is required.
-            </chef-error>
-          </chef-form-field>
           <chef-form-field id="update-fqdn">
             <label>
               <span class="label">FQDN <span aria-hidden="true">*</span></span>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.spec.ts
@@ -92,6 +92,7 @@ describe('ChefServerDetailsComponent', () => {
 
     it('opening create modal resets name, admin_user and admin_key to empty string', () => {
       component.openCreateModal('create');
+      expect(component.orgForm.controls['id'].value).toEqual('');
       expect(component.orgForm.controls['name'].value).toEqual('');
       expect(component.orgForm.controls['admin_user'].value).toEqual('');
       expect(component.orgForm.controls['admin_key'].value).toEqual('');
@@ -100,6 +101,7 @@ describe('ChefServerDetailsComponent', () => {
     it('on conflict error, modal remains open and displays conflict error', () => {
       spyOn(component.conflictErrorEvent, 'emit');
       component.openCreateModal('create');
+      component.orgForm.controls['id'].setValue(org.id);
       component.orgForm.controls['name'].setValue(org.name);
       component.orgForm.controls['admin_user'].setValue(org.admin_user);
       component.orgForm.controls['admin_key'].setValue(org.admin_key);
@@ -117,6 +119,7 @@ describe('ChefServerDetailsComponent', () => {
     it('on success, closes modal and adds new server', () => {
       spyOn(component.conflictErrorEvent, 'emit');
       component.openCreateModal('create');
+      component.orgForm.controls['id'].setValue(org.id);
       component.orgForm.controls['name'].setValue(org.name);
       component.orgForm.controls['admin_user'].setValue(org.admin_user);
       component.orgForm.controls['admin_key'].setValue(org.admin_key);
@@ -129,6 +132,7 @@ describe('ChefServerDetailsComponent', () => {
     it('on create error, modal is closed (because error is handled by failure banner)', () => {
       spyOn(component.conflictErrorEvent, 'emit');
       component.openCreateModal('create');
+      component.orgForm.controls['id'].setValue(org.id);
       component.orgForm.controls['name'].setValue(org.name);
       component.orgForm.controls['admin_user'].setValue(org.admin_user);
       component.orgForm.controls['admin_key'].setValue(org.admin_key);
@@ -141,7 +145,7 @@ describe('ChefServerDetailsComponent', () => {
 
       store.dispatch(new CreateOrgFailure(error));
 
-      expect(component.createModalVisible).toBe(true);
+      expect(component.createModalVisible).toBe(false);
     });
   });
 });

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
@@ -82,7 +82,6 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
 
     this.updateServerForm = this.fb.group({
       name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
-      description: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       fqdn: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       ip_address: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
@@ -123,7 +122,6 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
       this.server = { ...ServerState };
       this.orgs = allOrgsState;
       this.updateServerForm.controls['name'].setValue(this.server.name);
-      this.updateServerForm.controls['description'].setValue(this.server.description);
       this.updateServerForm.controls['fqdn'].setValue(this.server.fqdn);
       this.updateServerForm.controls['ip_address'].setValue(this.server.ip_address);
       this.creatingServerOrg = false;
@@ -209,7 +207,6 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
     const updatedServer = {
       id: this.server.id,
       name: this.updateServerForm.controls.name.value.trim(),
-      description: this.updateServerForm.controls.description.value.trim(),
       fqdn: this.updateServerForm.controls.fqdn.value.trim(),
       ip_address: this.updateServerForm.controls.ip_address.value.trim()
     };

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
@@ -46,9 +46,9 @@
               <chef-td>
                 <a [routerLink]="['/infrastructure/chef-servers', server.id]">{{ server.name }}</a>
               </chef-td>
-              <chef-td  >{{ server.fqdn }}</chef-td>
-              <chef-td  >{{ server.ip_address }}</chef-td>
-              <chef-td  >{{ server.orgs_count }}</chef-td>
+              <chef-td>{{ server.fqdn }}</chef-td>
+              <chef-td>{{ server.ip_address }}</chef-td>
+              <chef-td>{{ server.orgs_count }}</chef-td>
               <chef-td class="three-dot-column">
                 <mat-select panelClass="chef-control-menu" id="menu-{{server.id}}">
                   <mat-option (onSelectionChange)="startServerDelete($event, server)" data-cy="remove-server">Remove

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
@@ -37,7 +37,6 @@
               <chef-th>Name</chef-th>
               <chef-th>FQDN</chef-th>
               <chef-th>IP Address</chef-th>
-              <chef-th>Description</chef-th>
               <chef-th>No Of Orgs</chef-th>
               <chef-th class="three-dot-column"></chef-th>
             </chef-tr>
@@ -47,10 +46,9 @@
               <chef-td>
                 <a [routerLink]="['/infrastructure/chef-servers', server.id]">{{ server.name }}</a>
               </chef-td>
-              <chef-td>{{ server.fqdn }}</chef-td>
-              <chef-td>{{ server.ip_address }}</chef-td>
-              <chef-td>{{ server.description }}</chef-td>
-              <chef-td>{{ server.orgs_count }}</chef-td>
+              <chef-td  >{{ server.fqdn }}</chef-td>
+              <chef-td  >{{ server.ip_address }}</chef-td>
+              <chef-td  >{{ server.orgs_count }}</chef-td>
               <chef-td class="three-dot-column">
                 <mat-select panelClass="chef-control-menu" id="menu-{{server.id}}">
                   <mat-option (onSelectionChange)="startServerDelete($event, server)" data-cy="remove-server">Remove

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.spec.ts
@@ -83,7 +83,6 @@ describe('ChefServersListComponent', () => {
     const server = <Server>{
       id: '1',
       name: 'new server',
-      description: 'new server description',
       fqdn: 'xyz.com',
       ip_address: '1.1.1.1'
     };
@@ -98,21 +97,21 @@ describe('ChefServersListComponent', () => {
       expect(component.createModalVisible).toBe(true);
     });
 
-    it('opening create modal resets name, description, fqdn and ip_address to empty string', () => {
+    it('opening create modal resets id, name, fqdn and ip_address to empty string', () => {
+      component.createChefServerForm.controls['id'].setValue('any');
       component.createChefServerForm.controls['name'].setValue('any');
-      component.createChefServerForm.controls['description'].setValue('any');
       component.createChefServerForm.controls['fqdn'].setValue('any');
       component.createChefServerForm.controls['ip_address'].setValue('any');
       component.openCreateModal();
+      expect(component.createChefServerForm.controls['id'].value).toBe(null);
       expect(component.createChefServerForm.controls['name'].value).toBe(null);
-      expect(component.createChefServerForm.controls['description'].value).toBe(null);
       expect(component.createChefServerForm.controls['fqdn'].value).toBe(null);
       expect(component.createChefServerForm.controls['ip_address'].value).toBe(null);
     });
 
     it('on success, closes modal and adds new server', () => {
+      component.createChefServerForm.controls['id'].setValue(server.id);
       component.createChefServerForm.controls['name'].setValue(server.name);
-      component.createChefServerForm.controls['description'].setValue(server.description);
       component.createChefServerForm.controls['fqdn'].setValue(server.fqdn);
       component.createChefServerForm.controls['ip_address'].setValue(server.ip_address);
       component.createChefServer();
@@ -127,8 +126,8 @@ describe('ChefServersListComponent', () => {
     it('on conflict error, modal is open with conflict error', () => {
       spyOn(component.conflictErrorEvent, 'emit');
       component.openCreateModal();
+      component.createChefServerForm.controls['id'].setValue(server.id);
       component.createChefServerForm.controls['name'].setValue(server.name);
-      component.createChefServerForm.controls['description'].setValue(server.description);
       component.createChefServerForm.controls['fqdn'].setValue(server.fqdn);
       component.createChefServerForm.controls['ip_address'].setValue(server.ip_address);
       component.createChefServer();
@@ -146,8 +145,8 @@ describe('ChefServersListComponent', () => {
     it('on create error, modal is closed with failure banner', () => {
       spyOn(component.conflictErrorEvent, 'emit');
       component.openCreateModal();
+      component.createChefServerForm.controls['id'].setValue(server.id);
       component.createChefServerForm.controls['name'].setValue(server.name);
-      component.createChefServerForm.controls['description'].setValue(server.description);
       component.createChefServerForm.controls['fqdn'].setValue(server.fqdn);
       component.createChefServerForm.controls['ip_address'].setValue(server.ip_address);
       component.createChefServer();
@@ -261,7 +260,6 @@ describe('ChefServersListComponent', () => {
       id,
       orgs_count,
       name: 'Demo Server',
-      description: 'Demo Description',
       fqdn: 'http://demo.com/',
       ip_address: '192.168.2.1'
     };

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
@@ -47,8 +47,9 @@ export class ChefServersListComponent implements OnInit, OnDestroy {
 
     this.createChefServerForm = this.fb.group({
       // Must stay in sync with error checks in create-chef-server-modal.component.html
+      id: ['',
+        [Validators.required, Validators.pattern(Regex.patterns.ID), Validators.maxLength(64)]],
       name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
-      description: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       fqdn: ['', [Validators.required,
         Validators.pattern(Regex.patterns.NON_BLANK),
         Validators.pattern(Regex.patterns.VALID_FQDN)
@@ -109,8 +110,8 @@ export class ChefServersListComponent implements OnInit, OnDestroy {
   public createChefServer(): void {
     this.creatingChefServer = true;
     const server = {
+      id: this.createChefServerForm.controls['id'].value,
       name: this.createChefServerForm.controls['name'].value.trim(),
-      description: this.createChefServerForm.controls['description'].value.trim(),
       fqdn: this.createChefServerForm.controls['fqdn'].value.trim(),
       ip_address: this.createChefServerForm.controls['ip_address'].value.trim()
     };

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.html
@@ -6,25 +6,44 @@
           <chef-form-field>
             <label>
               <span class="label">Name <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="name" type="text" id="name-input" (keyup)="handleInput($event)" autocomplete="off"/>
+              <input chefInput formControlName="name" type="text" id="name-input" (keyup)="handleNameInput($event)" autocomplete="off"/>
             </label>
             <chef-error
             *ngIf="(createForm.get('name').hasError('required') || createForm.get('name').hasError('pattern')) && createForm.get('name').dirty">
             Display Name is required.
           </chef-error>
           </chef-form-field>
+          <span class="detail light">Don't worry, {{ objectNoun }} names can be changed later.</span>
         </div>
-        <div class="input-margin">
+        <div *ngIf="modifyID" class="id-margin">
           <chef-form-field>
             <label>
-              <span class="label">Description<span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="description" type="text" id="description-input" (keyup)="handleInput($event)" autocomplete="off"/>
+              <span class="label">ID <span aria-hidden="true">*</span></span>
+              <input chefInput formControlName="id" type="text" (keyup)="handleInput($event)" id="id-input" data-cy="create-id" autocomplete="off"/>
             </label>
-            <chef-error
-            *ngIf="(createForm.get('description').hasError('required') || createForm.get('description').hasError('pattern')) && createForm.get('description').dirty">
-            Description is required.
-          </chef-error>
+            <chef-error *ngIf="createForm.get('id').hasError('maxlength') && createForm.get('id').dirty">
+              ID must be 64 characters or less.
+            </chef-error>
+            <chef-error *ngIf="createForm.get('id').hasError('required') && createForm.get('id').dirty">
+              ID is required.
+            </chef-error>
+            <chef-error *ngIf="createForm.get('id').hasError('pattern') && createForm.get('id').dirty">
+              Only lowercase letters, numbers, hyphens, and underscores are allowed.
+            </chef-error>
+            <chef-error *ngIf="conflictError">
+              {{ objectNoun | titlecase }} ID "{{createForm.get('id').value}}" already exists.
+            </chef-error>
           </chef-form-field>
+          <span class="detail light">{{ objectNoun | titlecase }} IDs are unique, permanent, and cannot be changed later.</span>
+        </div>
+        <div *ngIf="!modifyID" class="id-margin">
+          <div id="id-fields">
+            <span class="key-label">ID:&nbsp;</span>
+            <span data-cy="id-label">{{ this.createForm?.value.id }}</span>
+          </div>
+          <chef-toolbar>
+            <chef-button tertiary (click)="modifyID = true" id="edit-button-object-modal" data-cy="edit-button">Edit ID</chef-button>
+          </chef-toolbar>
         </div>
         <div class="input-margin">
           <chef-form-field>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.scss
@@ -28,6 +28,11 @@ chef-modal {
         padding-bottom: 0;
       }
 
+      .detail {
+        color: $chef-primary-dark;
+        font-size: 12px;
+      }
+
       #id-fields {
         font-size: 0.75em;
 

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.scss
@@ -27,6 +27,14 @@ chef-modal {
       label {
         padding-bottom: 0;
       }
+
+      #id-fields {
+        font-size: 0.75em;
+
+        .key-label {
+          font-weight: bold;
+        }
+      }
     }
 
     #button-bar {

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.ts
@@ -34,6 +34,7 @@ export class CreateChefServerModalComponent implements OnInit {
         IdMapper.transform(this.createForm.controls.name.value.trim()));
     }
   }
+
   public handleInput(event: KeyboardEvent): void {
     if (this.isNavigationKey(event)) {
       return;

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+import { IdMapper } from 'app/helpers/auth/id-mapper';
 import { FormGroup } from '@angular/forms';
 
 @Component({
@@ -13,15 +14,26 @@ export class CreateChefServerModalComponent implements OnInit {
   @Output() close = new EventEmitter();
   @Output() createClicked = new EventEmitter();
   @Input() createForm: FormGroup;
+  @Input() objectNoun: string;
+  public modifyID = false; // Whether the edit ID form is open or not.
 
   public conflictError = false;
 
   ngOnInit() {
     this.conflictErrorEvent.subscribe((isConflict: boolean) => {
       this.conflictError = isConflict;
+      // Open the ID input on conflict so user can resolve it.
+      this.modifyID = isConflict;
     });
   }
 
+  handleNameInput(event: KeyboardEvent): void {
+    if (!this.modifyID && !this.isNavigationKey(event)) {
+      this.conflictError = false;
+      this.createForm.controls.id.setValue(
+        IdMapper.transform(this.createForm.controls.name.value.trim()));
+    }
+  }
   public handleInput(event: KeyboardEvent): void {
     if (this.isNavigationKey(event)) {
       return;
@@ -30,6 +42,7 @@ export class CreateChefServerModalComponent implements OnInit {
   }
 
   closeEvent(): void {
+    this.modifyID = false;
     this.close.emit();
   }
 

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
@@ -2,20 +2,53 @@
   <h2 slot="title">Add Chef Org</h2>
   <div class="flex-container">
     <form [formGroup]="createForm">
-      <div class="name-margin"> 
+      <div class="input-margin">
         <chef-form-field>
           <label>
-            Org Name <span aria-hidden="true">*</span>
-            <input chefInput name="name" formControlName="name" type="text" data-cy="org-name" autocomplete="off">
+            <span class="label">Org Name <span aria-hidden="true">*</span></span>
+            <input chefInput name="name" formControlName="name" type="text" (keyup)="handleNameInput($event)" data-cy="org-name" autocomplete="off">
           </label>
           <chef-error
             *ngIf="(createForm.get('name').hasError('required') || createForm.get('name').hasError('pattern')) && createForm.get('name').dirty">
             Display Name is required.
           </chef-error>
         </chef-form-field>
+        <span class="detail light">Don't worry, {{ objectNoun }} names can be changed later.</span>
+      </div>
+      <div *ngIf="modifyID" class="id-margin">
         <chef-form-field>
           <label>
-            Admin User <span aria-hidden="true">*</span>
+            <span class="label">ID <span aria-hidden="true">*</span></span>
+            <input chefInput formControlName="id" type="text" (keyup)="handleInput($event)" id="id-input" data-cy="create-id" autocomplete="off"/>
+          </label>
+          <chef-error *ngIf="createForm.get('id').hasError('maxlength') && createForm.get('id').dirty">
+            ID must be 64 characters or less.
+          </chef-error>
+          <chef-error *ngIf="createForm.get('id').hasError('required') && createForm.get('id').dirty">
+            ID is required.
+          </chef-error>
+          <chef-error *ngIf="createForm.get('id').hasError('pattern') && createForm.get('id').dirty">
+            Only lowercase letters, numbers, hyphens, and underscores are allowed.
+          </chef-error>
+          <chef-error *ngIf="conflictError">
+            {{ objectNoun | titlecase }} ID "{{createForm.get('id').value}}" already exists.
+          </chef-error>
+        </chef-form-field>
+        <span class="detail light">{{ objectNoun | titlecase }} IDs are unique, permanent, and cannot be changed later.</span>
+      </div>
+      <div *ngIf="!modifyID" class="id-margin">
+        <div id="id-fields">
+          <span class="key-label">ID:&nbsp;</span>
+          <span data-cy="id-label">{{ this.createForm?.value.id }}</span>
+        </div>
+        <chef-toolbar>
+          <chef-button tertiary (click)="modifyID = true" id="edit-button-object-modal" data-cy="edit-button">Edit ID</chef-button>
+        </chef-toolbar>
+      </div>
+      <div class="input-margin">
+        <chef-form-field>
+          <label>
+            <span class="label">Admin User <span aria-hidden="true">*</span></span>
             <input chefInput name="admin_user" formControlName="admin_user" type="text" id="admin-input" data-cy="admin-user" autocomplete="off">
           </label>
           <chef-error
@@ -23,9 +56,11 @@
             Admin user is required.
           </chef-error>
         </chef-form-field>
+      </div>
+      <div class="input-margin">
         <chef-form-field>
           <label>
-            Admin Key <span aria-hidden="true">*</span>
+            <span class="label">Admin Key <span aria-hidden="true">*</span></span>
             <textarea chefInput name="admin_key" id="admin_key" formControlName="admin_key" cols="54" rows="10" autofocus></textarea>
           </label>
           <chef-error

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
@@ -74,6 +74,7 @@
         <span *ngIf="!creating">Add Org</span>
         <span *ngIf="creating">Adding Org...</span>
       </chef-button>
+      <chef-button tertiary (click)="closeEvent()">Cancel</chef-button>
     </form>
   </div>
 </chef-modal>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
@@ -69,12 +69,14 @@
           </chef-error>
         </chef-form-field>
       </div>
-      <chef-button [disabled]="!createForm?.valid || creating || conflictError"  primary id="create-org-modal-btn" (click)="createServerOrg()">
-        <chef-loading-spinner *ngIf="creating"></chef-loading-spinner>
-        <span *ngIf="!creating">Add Org</span>
-        <span *ngIf="creating">Adding Org...</span>
-      </chef-button>
-      <chef-button tertiary (click)="closeEvent()">Cancel</chef-button>
+      <div id="button-org">
+        <chef-button [disabled]="!createForm?.valid || creating || conflictError"  primary id="create-org-modal-btn" (click)="createServerOrg()">
+          <chef-loading-spinner *ngIf="creating"></chef-loading-spinner>
+          <span *ngIf="!creating">Add Org</span>
+          <span *ngIf="creating">Adding Org...</span>
+        </chef-button>
+        <chef-button tertiary (click)="closeEvent()">Cancel</chef-button>
+      </div>
     </form>
   </div>
 </chef-modal>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
@@ -61,7 +61,7 @@
         <chef-form-field>
           <label>
             <span class="label">Admin Key <span aria-hidden="true">*</span></span>
-            <textarea chefInput name="admin_key" id="admin_key" formControlName="admin_key" cols="54" rows="10" autofocus></textarea>
+            <textarea chefInput name="admin_key" id="admin_key" formControlName="admin_key" cols="54" rows="10" placeholder="-----BEGIN RSA PRIVATE KEY -----" autofocus></textarea>
           </label>
           <chef-error
             *ngIf="(createForm.get('admin_key').hasError('required') || createForm.get('admin_key').hasError('pattern')) && createForm.get('admin_key').dirty">

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
@@ -14,7 +14,7 @@ chef-modal {
     justify-content: center;
 
     .input-margin {
-      margin-bottom: 30px;
+      margin-bottom: 5px;
     }
 
     form {
@@ -53,7 +53,7 @@ chef-modal {
     }
 
     #admin_key {
-      height: 200px;
+      height: 140px;
     }
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
@@ -42,7 +42,7 @@ chef-modal {
       }
     }
 
-    #button-bar {
+    #button-org {
       text-align: center;
 
       chef-loading-spinner {

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
@@ -13,7 +13,7 @@ chef-modal {
     display: flex;
     justify-content: center;
 
-    .margin {
+    .input-margin {
       margin-bottom: 30px;
     }
 
@@ -26,6 +26,19 @@ chef-modal {
 
       label {
         padding-bottom: 0;
+      }
+
+      .detail {
+        color: $chef-primary-dark;
+        font-size: 12px;
+      }
+
+      #id-fields {
+        font-size: 0.75em;
+
+        .key-label {
+          font-weight: bold;
+        }
       }
     }
 

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
+import { IdMapper } from 'app/helpers/auth/id-mapper';
 
 @Component({
   selector: 'app-create-org-modal',
@@ -13,20 +14,44 @@ export class CreateOrgModalComponent implements OnInit {
   @Output() close = new EventEmitter();
   @Output() createClicked = new EventEmitter();
   @Input() createForm: FormGroup;
+  @Input() objectNoun: string;
 
   public conflictError = false;
+  public modifyID = false; // Whether the edit ID form is open or not.
 
   ngOnInit() {
     this.conflictErrorEvent.subscribe((isConflict: boolean) => {
       this.conflictError = isConflict;
+      // Open the ID input on conflict so user can resolve it.
+      this.modifyID = isConflict;
     });
   }
 
+  handleNameInput(event: KeyboardEvent): void {
+    if (!this.modifyID && !this.isNavigationKey(event)) {
+      this.conflictError = false;
+      this.createForm.controls.id.setValue(
+        IdMapper.transform(this.createForm.controls.name.value.trim()));
+    }
+  }
+
+  public handleInput(event: KeyboardEvent): void {
+    if (this.isNavigationKey(event)) {
+      return;
+    }
+    this.conflictError = false;
+  }
+
   closeEvent(): void {
+    this.modifyID = false;
     this.close.emit();
   }
 
   createServerOrg(): void {
     this.createClicked.emit();
+  }
+
+  private isNavigationKey(event: KeyboardEvent): boolean {
+    return event.key === 'Shift' || event.key === 'Tab';
   }
 }

--- a/tools/credscan/credscan.go
+++ b/tools/credscan/credscan.go
@@ -80,6 +80,7 @@ var a2Config = config{
 		{regex: `components/automate-deployment/tools/upgrade-test-scaffold/upgrade-test-scaffold.go`},
 		{regex: `components/automate-ui/src/app/pages/\+compliance/\+credentials/components/credentials-form.html`},
 		{regex: `components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html`},
+		{regex: `components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html`},
 		{regex: `components/automate-minio/habitat/config/private.key`},
 		{regex: `components/backup-gateway/habitat/config/private.key`},
 		{regex: `components/compliance-service/api/tests/containers/key.pem`},


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Previously Chef Server & Orgs model doesn't have an editable ID field so we have added for both models.

Scope of works:
**Chef Infra Servers**
Update the servers modal so that the user can construct the human-readable ids.
servers table has a name(unique) and description columns. consider Name as Id and description as Name similar to team services.
**Chef organizations**
Update the org modal so that the user can construct the human-readable ids.
### :chains: Related Resources
https://github.com/chef/automate/issues/3240
### :+1: Definition of Done
I have added changes for the model popup to add an editable ID and some UI changes 
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots
![Editable](https://user-images.githubusercontent.com/12297653/81280955-dc9c6880-9076-11ea-962c-c97c5fbc0b0e.png)
![id](https://user-images.githubusercontent.com/12297653/81280959-de662c00-9076-11ea-96a1-3aaf397eb94e.png)
![iderror](https://user-images.githubusercontent.com/12297653/81280961-df975900-9076-11ea-9ba0-f8cef7636a4a.png)



