### PR TITLE
automate-{gateway,load-balancer} integration: add test for /api/v0/status

### DIFF
--- a/.studio/automate-gateway
+++ b/.studio/automate-gateway
@@ -14,6 +14,8 @@ document "gateway_integration" <<DOC
   Runs the integration tests for automate-gateway
 DOC
 function gateway_integration() {
+  install_if_missing core/curl curl
+
   set -o pipefail # don't let the jq-pipe ruin the return 1
   install_if_missing core/jq-static jq
 
@@ -26,6 +28,11 @@ function gateway_integration() {
   wait_for_success gateway_get /api/v0/gateway/version || return 1
   log_line "The automate-gateway version"
   gateway_version || return 1
+
+  log_line "/api/v0/status responds correctly"
+  local status
+  status="$(gateway_get /api/v0/status)"
+  jq -ne --argjson status "$status" '$status.ok' || return 1
 
   local viewer_token
   viewer_token="$(get_api_token_with_policy viewer-access)"

--- a/.studio/automate-load-balancer
+++ b/.studio/automate-load-balancer
@@ -9,12 +9,18 @@ automate_load_balancer_integration() {
 
   install_if_missing core/curl curl
   if ! output=$(curl --http2 -vk "$target" 2>&1); then
-    echo "non-zero exit code from curl: ${output}"
+    log_error "non-zero exit code from curl: ${output}"
     return 1
   fi
   if ! grep -q "ALPN, server accepted to use h2" <<< "${output}"; then
-    echo "server did NOT accept to use HTTP/2"
+    log_error "server did NOT accept to use HTTP/2"
     return 1
   fi
+
+  log_line "/api/v0/status responds correctly"
+  local status api_token
+  api_token="$(get_admin_token)"
+  status="$(curl -fsS --insecure -H "api-token: ${api_token}" "${target}/api/v0/status")"
+  jq -ne --argjson status "$status" '$status.ok' || return 1
 }
 


### PR DESCRIPTION
Left-over from #3606 (broken in #3474): add integration test coverage for the status endpoint

There are so many places where these could be put -- I've chosen the Bash place.