### PR TITLE
[Automate-1044] Permission-based routing for top nav bar

### DIFF
--- a/components/automate-chef-io/content/docs/event-feed.md
+++ b/components/automate-chef-io/content/docs/event-feed.md
@@ -12,6 +12,8 @@ toc = true
 Use the event feed for actionable insights and operational visibility.
 The guitar strings and improved query language help you drill into infrastructure & compliance automation events quickly to isolate errors.
 
+Permission for the `event:*` action is required to interact with the **Event Feed** page. In order to search on this page the `infra:nodes:list` action is also required.
+
 ## Event Guitar Strings
 
 ![Guitar Strings](/images/docs/guitar-strings.png)
@@ -36,7 +38,7 @@ In the event feed, events of the same type by the same user are grouped. The eve
 
 ## Filtering events
 
-To filter the event feed and event timeline by event type, Chef Infra Server, or Chef Organization, use the search bar. Available event type filters are clients, cookbooks, data bags, environments, nodes, policyfiles, profiles, roles, and scan jobs.
+To filter the event feed and event timeline by event type, Chef Infra Server, or Chef Organization, use the search bar. The search bar is only shown to folks who also have permission on the `infra:nodes:list` action. Available event type filters are clients, cookbooks, data bags, environments, nodes, policyfiles, profiles, roles, and scan jobs.
 To filter, select Event Type, Chef Infra Server or Chef Organization in the search bar and start typing the name. You cannot filter compliance events -- profiles and scan jobs -- by organization or Chef Infra Server. Compliance events are not visible when either of these filters are applied.
 
 ![Event feed filters by server](/images/docs/event-feed-filters-servers.png)

--- a/components/automate-chef-io/content/docs/event-feed.md
+++ b/components/automate-chef-io/content/docs/event-feed.md
@@ -12,7 +12,7 @@ toc = true
 Use the event feed for actionable insights and operational visibility.
 The guitar strings and improved query language help you drill into infrastructure & compliance automation events quickly to isolate errors.
 
-Permission for the `event:*` action is required to interact with the **Event Feed** page. In order to search on this page the `infra:nodes:list` action is also required.
+Users require permission for the `event:*` action to view and interact with *Event Feed*. Filter and search ability in *Event Feed* requires user permission for the `infra:nodes:list` action.
 
 ## Event Guitar Strings
 
@@ -38,7 +38,8 @@ In the event feed, events of the same type by the same user are grouped. The eve
 
 ## Filtering events
 
-To filter the event feed and event timeline by event type, Chef Infra Server, or Chef Organization, use the search bar. The search bar is only shown to folks who also have permission on the `infra:nodes:list` action. Available event type filters are clients, cookbooks, data bags, environments, nodes, policyfiles, profiles, roles, and scan jobs.
+To filter the event feed and event timeline by Event Type, Chef Infra Server, or Chef Organization, use the search bar. The search bar appears to users with permission for the `infra:nodes:list` action. Available event type filters are clients, cookbooks, data bags, environments, nodes, policyfiles, profiles, roles, and scan jobs.
+
 To filter, select Event Type, Chef Infra Server or Chef Organization in the search bar and start typing the name. You cannot filter compliance events -- profiles and scan jobs -- by organization or Chef Infra Server. Compliance events are not visible when either of these filters are applied.
 
 ![Event feed filters by server](/images/docs/event-feed-filters-servers.png)

--- a/components/automate-chef-io/content/docs/iam-actions.md
+++ b/components/automate-chef-io/content/docs/iam-actions.md
@@ -20,6 +20,7 @@ Specify the action to restrict user access to the specific action.
 |  Task           | Browser Tab     | IAM Action       | API endpoint  | URL       |
 | --------------- | --------------- | ---------------- | ------------- | --------- |
 | View Events | Dashboards | event:* | /event_feed | https://{{< example_fqdn "automate" >}}/dashboards/event-feed |
+| View and Search Events | Dashboards | [event:*, infra:nodes:list] | /event_feed | https://{{< example_fqdn "automate" >}}/dashboards/event-feed |
 | View Service Group Data | Applications | applications:*  | /applications/service-groups | https://{{< example_fqdn "automate" >}}/applications/service-groups |
 | View Client Runs | Infrastructure | infra:nodes:*   | /cfgmgmt/nodes | https://{{< example_fqdn "automate" >}}/infrastructure/client-runs |
 | View Chef Servers | Infrastructure | infra:infraServers:* | /infra/servers | https://{{< example_fqdn "automate" >}}/infrastructure/chef-servers |

--- a/components/automate-ui/Makefile
+++ b/components/automate-ui/Makefile
@@ -1,3 +1,5 @@
+PAGE_DIR := pages
+PAGE_FLAGS := --module app
 PAGE_COMPONENT_DIR := page-components
 PAGE_COMPONENT_FLAGS := --module app
 COMPONENT_PREFIX := chef
@@ -60,11 +62,24 @@ license_scout:
 	cd /tmp/license_scout && bundle install --without=development --quiet && echo "license_scout version" && git rev-parse HEAD
 	/tmp/license_scout/bin/license_scout
 
+# These are shortcuts for generating new components in various subdirs.
+# Example:
+#    $ make page/TopNavLanding
+#    ng "generate" "component" "pages/TopNavLanding" "--module" "app"
+#    CREATE src/app/pages/top-nav-landing/top-nav-landing.component.scss (0 bytes)
+#    CREATE src/app/pages/top-nav-landing/top-nav-landing.component.html (30 bytes)
+#    CREATE src/app/pages/top-nav-landing/top-nav-landing.component.spec.ts (679 bytes)
+#    CREATE src/app/pages/top-nav-landing/top-nav-landing.component.ts (310 bytes)
+#    UPDATE src/app/app.module.ts (14252 bytes)
+
 demo/%:
 	$(NG_CMD) generate component $(DEMO_DIR)/demo-$(@F) $(DEMO_FLAGS)
 
 component/%:
 	$(NG_CMD) generate component $(COMPONENT_DIR)/$(@F) $(COMPONENT_FLAGS)
+
+page/%:
+	$(NG_CMD) generate component $(PAGE_DIR)/$(@F) $(PAGE_FLAGS)
 
 page-component/%:
 	$(NG_CMD) generate component $(PAGE_COMPONENT_DIR)/$(@F) $(PAGE_COMPONENT_FLAGS)

--- a/components/automate-ui/e2e/app.e2e-spec.ts
+++ b/components/automate-ui/e2e/app.e2e-spec.ts
@@ -7,7 +7,7 @@ describe('App', () => {
     browser.waitForAngularEnabled(false);
     browser.get('/');
 
-    expect(browser.getCurrentUrl()).toMatch(/http:\/\/localhost:\d+\//);
+    expect(browser.getCurrentUrl()).toMatch(/http:\/\/localhost:\d+\/$/);
   });
 });
 

--- a/components/automate-ui/e2e/app.e2e-spec.ts
+++ b/components/automate-ui/e2e/app.e2e-spec.ts
@@ -3,11 +3,11 @@ import { fakeServer } from './helpers/fake_server';
 import { enableWelcomeModal, disableWelcomeModal } from './helpers/welcome_modal';
 
 describe('App', () => {
-  it('lands on the event feed page', () => {
+  it('starts on the top-level domain (before permission-based routing occurs)', () => {
     browser.waitForAngularEnabled(false);
     browser.get('/');
 
-    expect(browser.getCurrentUrl()).toMatch(/\/event-feed$/);
+    expect(browser.getCurrentUrl()).toMatch(/http:\/\/localhost:\d+\//);
   });
 });
 
@@ -74,7 +74,8 @@ xdescribe('Welcome Modal', () => {
   });
 });
 
-describe('Main Navigation', () => {
+// TODO: all unavailable due to authz introspection guards
+xdescribe('Main Navigation', () => {
   beforeAll(disableWelcomeModal);
 
   xit('redirects to Client Runs', () => {
@@ -83,14 +84,12 @@ describe('Main Navigation', () => {
     expect(browser.getCurrentUrl()).toMatch(/infrastructure\/client-runs/);
   });
 
-  it('redirects to Event Feed', () => {
+  xit('redirects to Event Feed', () => {
     browser.waitForAngularEnabled(false);
     element(by.linkText('Dashboards')).click();
     expect(browser.getCurrentUrl()).toMatch(/dashboards\/event-feed/);
   });
 
-  // TODO: this now depends on authz introspection -- it's hidden in the e2e
-  // situation, it seems
   xit('redirects to Admin', () => {
     browser.waitForAngularEnabled(false);
     element(by.linkText('Admin')).click();

--- a/components/automate-ui/e2e/signin.e2e-spec.ts
+++ b/components/automate-ui/e2e/signin.e2e-spec.ts
@@ -29,7 +29,7 @@ describe('Signin Process', () => {
   describe('when the user logs in', () => {
     it('redirects to / when nothing else is passed in state', () => {
       browser.get(validSigninPathWithState());
-      expect(browser.getCurrentUrl()).toMatch(/\/event-feed$/);
+      expect(browser.getCurrentUrl()).toMatch(/http:\/\/localhost:\d+\//);
     });
 
     it('redirects to /settings when passed in state', () => {

--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -55,6 +55,7 @@ import {
 
 // Other
 import { SettingsLandingComponent } from './pages/settings-landing/settings-landing.component';
+import { TopNavLandingComponent } from './pages/top-nav-landing/top-nav-landing.component';
 
 const routes: Routes = [
   {
@@ -63,8 +64,8 @@ const routes: Routes = [
     canActivate: [ChefSessionService],
     children: [{
       path: '',
-      redirectTo: 'dashboards/event-feed',
-      pathMatch: 'full'
+      pathMatch: 'full',
+      component: TopNavLandingComponent
     },
     {
       path: 'settings',

--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -374,7 +374,7 @@ const routes: Routes = [
   // END Deprecated routes.
   {
     path: '**',
-    redirectTo: 'dashboards/event-feed'
+    redirectTo: ''
   }
 ];
 

--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -185,6 +185,7 @@ import {
 import {
   TelemetryCheckboxComponent
 } from './page-components/telemetry-checkbox/telemetry-checkbox.component';
+import { TopNavLandingComponent } from './pages/top-nav-landing/top-nav-landing.component';
 import { UIComponent } from 'app/ui.component';
 
 import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-modal.component';
@@ -244,6 +245,7 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     SettingsLandingComponent,
     SigninComponent,
     TelemetryCheckboxComponent,
+    TopNavLandingComponent,
     UIComponent,
     WelcomeModalComponent
   ],

--- a/components/automate-ui/src/app/components/authorized/authorized.component.ts
+++ b/components/automate-ui/src/app/components/authorized/authorized.component.ts
@@ -15,7 +15,7 @@ import { allPerms } from 'app/entities/userperms/userperms.selectors';
 // Each input datum is converted to a CheckObj upon arrival.
 // Internally, this allows for more robust handling of the data.
 // (So properties must be in sync with `CheckObj`!)
-export type Check = [string, string, string | string[]];
+export type Check = [string, string] | [string, string, string | string[]];
 
 @Component({
   selector: 'app-authorized',

--- a/components/automate-ui/src/app/components/landing/landing.component.spec.ts
+++ b/components/automate-ui/src/app/components/landing/landing.component.spec.ts
@@ -19,12 +19,12 @@ describe('LandingComponent', () => {
   const targetRoute = '/settings/teams';
   const routePerms: RoutePerms[] = [
     {
-      allOfCheck: [['/apis/iam/v2/teams', 'get', '']],
-      anyOfCheck: [['/apis/iam/v2/something-else', 'get', '']],
+      allOfCheck: [['/apis/iam/v2/teams', 'get']],
+      anyOfCheck: [['/apis/iam/v2/something-else', 'get']],
       route: '/settings/teams'
     },
-    { anyOfCheck: [['/apis/iam/v2/tokens', 'get', '']], route: '/settings/tokens' },
-    { allOfCheck: [['/apis/iam/v2/users', 'get', '']], route: '/settings/users' }
+    { anyOfCheck: [['/apis/iam/v2/tokens', 'get']], route: '/settings/tokens' },
+    { allOfCheck: [['/apis/iam/v2/users', 'get']], route: '/settings/users' }
   ];
 
 
@@ -103,9 +103,9 @@ describe('LandingComponent', () => {
   describe('with second page allowed and all others denied', () => {
     const targetIndex = 1;
     const newRoutePerms: RoutePerms[] = [
-      { allOfCheck: [['/apis/iam/v2/teams', 'get', '']], route: '/settings/teams' },
-      { anyOfCheck: [['/apis/iam/v2/tokens', 'get', '']], route: '/settings/tokens' },
-      { allOfCheck: [['/apis/iam/v2/users', 'get', '']], route: '/settings/users' }
+      { allOfCheck: [['/apis/iam/v2/teams', 'get']], route: '/settings/teams' },
+      { anyOfCheck: [['/apis/iam/v2/tokens', 'get']], route: '/settings/tokens' },
+      { allOfCheck: [['/apis/iam/v2/users', 'get']], route: '/settings/users' }
     ];
 
     beforeEach(async(() => {

--- a/components/automate-ui/src/app/components/landing/landing.component.ts
+++ b/components/automate-ui/src/app/components/landing/landing.component.ts
@@ -35,6 +35,10 @@ export interface RoutePerms {
 })
 export class LandingComponent implements OnInit {
 
+  public authorizedChecker: AuthorizedChecker;
+  private authComponent: AuthorizedComponent;
+  private index = 0;
+
   /**
    * The single input to this class is this list that corresponds
    * to the items in your sidebar component.
@@ -44,9 +48,14 @@ export class LandingComponent implements OnInit {
    */
   @Input() routePerms: RoutePerms[] = [];
 
-  public authorizedChecker: AuthorizedChecker;
-  private authComponent: AuthorizedComponent;
-  private index = 0;
+  /**
+   * A callback function to perform some actions in the event that no landing page was found.
+   * If no callback is provided, the caller guarantees one will always be found.
+   * (That should be the case for sidebars because we will never attempt to
+   * materialize a sidebar unless at least one item is permissible.)
+   * Thus, this defaults to a no-op function.
+   */
+  @Input() onNotFound: () => void = () => { };
 
   constructor(
     cdr: ChangeDetectorRef,
@@ -69,6 +78,8 @@ export class LandingComponent implements OnInit {
       this.router.navigate(this.routeToSegmentList(this.route), { replaceUrl: true });
     } else if (++this.index < this.routePerms.length) {
       this.setPerms();
+    } else {
+        this.onNotFound();
     }
   }
 

--- a/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
+++ b/components/automate-ui/src/app/entities/layout/layout-sidebar.service.ts
@@ -8,7 +8,7 @@ import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.se
 import { clientRunsWorkflowEnabled } from 'app/entities/client-runs/client-runs.selectors';
 import * as fromClientRuns from 'app/entities/client-runs/client-runs.reducer';
 import { UpdateSidebars } from './layout.actions';
-import { Sidebars } from './layout.model';
+import { Sidebars, MenuItem } from './layout.model';
 import { MenuItemGroup } from 'app/entities/layout/layout.model';
 
 @Injectable({
@@ -254,17 +254,15 @@ export class LayoutSidebarService {
               this.setVisibleValuesToObservables(menuItem);
             });
           }
-          menuGroup.visible$ = menuGroup.visible$ ? menuGroup.visible$ : new BehaviorSubject(true);
+          menuGroup.visible$ = menuGroup.visible$ || new BehaviorSubject(true);
         });
       });
       return sidebars;
     }
 
-    private setVisibleValuesToObservables(item: any): void {
+    private setVisibleValuesToObservables(item: MenuItem | MenuItemGroup): void {
       if (item.visible$ === undefined) {
         item.visible$ = new BehaviorSubject(true);
-      } else if (!item.visible$.subscribe) {
-        item.visible$ = new BehaviorSubject(item.visible$);
       }
     }
 

--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -113,6 +113,13 @@ export class LayoutFacadeService {
     this.layout.userNotifications.display = false;
   }
 
+  showFullPagePlusTopBar(): void {
+    this.contentHeight = '100vh';
+    this.layout.header.display = true;
+    this.layout.sidebar.display = false;
+    this.layout.userNotifications.display = false;
+  }
+
   hideFullPage(): void {
     this.updateDisplay();
     this.layout.header.display = true;

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -9,8 +9,7 @@
             ['/api/v0/eventfeed', 'get'],
             ['/api/v0/eventstrings', 'get'],
             ['/api/v0/event_type_counts', 'get'],
-            ['/api/v0/event_task_counts', 'get'],
-            ['/api/v0/cfgmgmt/suggestions', 'get']]">
+            ['/api/v0/event_task_counts', 'get']]">
           <div role="menuitem" class="nav-link"><a routerLink="/dashboards/event-feed" routerLinkActive="active" tabindex="0">Dashboards</a></div>
         </app-authorized>
 

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -7,26 +7,40 @@
       <div class="navigation-menu">
         <div role="menuitem" class="nav-link"><a routerLink="/dashboards/event-feed" routerLinkActive="active" tabindex="0">Dashboards</a></div>
 
-        <app-authorized [allOf]="[['/api/v0/applications/services', 'get'], ['/api/v0/applications/service-groups', 'get']]">
+        <app-authorized [allOf]="[
+            ['/api/v0/applications/services', 'get'],
+            ['/api/v0/applications/service-groups', 'get']]">
           <div role="menuitem" class="nav-link"><a routerLink="/applications/service-groups" routerLinkActive="active" tabindex="0">Applications</a></div>
         </app-authorized>
 
-        <app-authorized [allOf]="[['/api/v0/cfgmgmt/nodes', 'get'], ['/api/v0/cfgmgmt/stats/node_counts', 'get']]">
+        <app-authorized [allOf]="[
+            ['/api/v0/cfgmgmt/nodes', 'get'],
+            ['/api/v0/cfgmgmt/stats/node_counts', 'get']]">
           <div role="menuitem" class="nav-link"><a routerLink="/infrastructure" routerLinkActive="active" tabindex="0">Infrastructure</a></div>
         </app-authorized>
 
-        <app-authorized
-          [anyOf]="[['/api/v0/compliance/reporting/stats/summary', 'post'], ['/api/v0/compliance/reporting/stats/failures', 'post'],
-            ['/api/v0/compliance/reporting/stats/trend', 'post'], ['/api/v0/compliance/scanner/jobs', 'post'],
-            ['/api/v0/compliance/scanner/jobs/search', 'post'], ['/api/v0/compliance/profiles/search', 'post']]">
+        <app-authorized [anyOf]="[
+              ['/api/v0/compliance/reporting/stats/summary', 'post'],
+              ['/api/v0/compliance/reporting/stats/failures', 'post'],
+              ['/api/v0/compliance/reporting/stats/trend', 'post'],
+              ['/api/v0/compliance/scanner/jobs', 'post'],
+              ['/api/v0/compliance/scanner/jobs/search', 'post'],
+              ['/api/v0/compliance/profiles/search', 'post']]">
           <div role="menuitem" class="nav-link"><a routerLink="/compliance" routerLinkActive="active" tabindex="0">Compliance</a></div>
         </app-authorized>
 
-        <app-authorized
-          [anyOf]="[['/api/v0/datafeed/destinations', 'post'], ['/api/v0/notifications/rules', 'get'], ['/api/v0/secrets/search', 'post'],
-            ['/api/v0/nodemanagers/search', 'post'], ['/api/v0/retention/nodes/status', 'get'],
-            ['/apis/iam/v2/users', 'get'], ['/apis/iam/v2/teams', 'get'], ['/apis/iam/v2/tokens', 'get'],
-            ['/apis/iam/v2/policies', 'get'], ['/apis/iam/v2/roles', 'get'], ['/apis/iam/v2/projects', 'get']] ">
+        <app-authorized [anyOf]="[
+              ['/api/v0/datafeed/destinations', 'post'],
+              ['/api/v0/notifications/rules', 'get'],
+              ['/api/v0/secrets/search', 'post'],
+              ['/api/v0/nodemanagers/search', 'post'],
+              ['/api/v0/retention/nodes/status', 'get'],
+              ['/apis/iam/v2/users', 'get'],
+              ['/apis/iam/v2/teams', 'get'],
+              ['/apis/iam/v2/tokens', 'get'],
+              ['/apis/iam/v2/policies', 'get'],
+              ['/apis/iam/v2/roles', 'get'],
+              ['/apis/iam/v2/projects', 'get']] ">
           <div role="menuitem" class="nav-link"><a routerLink="/settings" routerLinkActive="active" tabindex="0">Settings</a></div>
         </app-authorized>
       </div>

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -5,7 +5,14 @@
         <a tabindex="0" routerLink="/" class="logo" title="logo link to homepage"></a>
       </div>
       <div class="navigation-menu">
-        <div role="menuitem" class="nav-link"><a routerLink="/dashboards/event-feed" routerLinkActive="active" tabindex="0">Dashboards</a></div>
+        <app-authorized [allOf]="[
+            ['/api/v0/eventfeed', 'get'],
+            ['/api/v0/eventstrings', 'get'],
+            ['/api/v0/event_type_counts', 'get'],
+            ['/api/v0/event_task_counts', 'get'],
+            ['/api/v0/cfgmgmt/suggestions', 'get']]">
+          <div role="menuitem" class="nav-link"><a routerLink="/dashboards/event-feed" routerLinkActive="active" tabindex="0">Dashboards</a></div>
+        </app-authorized>
 
         <app-authorized [allOf]="[
             ['/api/v0/applications/services', 'get'],

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
@@ -1,11 +1,11 @@
 <div class="content-container">
   <div *ngIf="permissionDenied$ | async" class="permission-denied-banner">
-    <p>You do not currently have permission to view this page.</p>
-    <p>Please contact your administrator for permission.</p>
+    <p>You do not currently have permission to view this page.
+    Please contact your administrator for permission.</p>
   </div>
 
   <div class="container">
-    
+
     <div class="sticky-notifications">
       <div class="sticky-inner">
         <app-notification

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
@@ -1,9 +1,4 @@
 <div class="content-container">
-  <div *ngIf="permissionDenied$ | async" class="permission-denied-banner">
-    <p>You do not currently have permission to view this page.
-    Please contact your administrator for permission.</p>
-  </div>
-
   <div class="container">
 
     <div class="sticky-notifications">

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -164,7 +164,7 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
   nodeCounts$: Observable<NodeCount>;
 
   // Does the request have the correct permissions
-  permissionDenied$: Observable<boolean>;
+  permissionDenied$: Observable<boolean>; // not currently used
 
   // Is the Error banner visible
   notificationVisible = false;

--- a/components/automate-ui/src/app/pages/compliance-landing/compliance-landing.component.ts
+++ b/components/automate-ui/src/app/pages/compliance-landing/compliance-landing.component.ts
@@ -11,18 +11,18 @@ export class ComplianceLandingComponent {
   // order determined by LayoutSidebarService and vetted by SidebarComponent unit tests
   public routeList: RoutePerms[] = [
     {
-      allOfCheck: [['/api/v0/compliance/reporting/stats/summary', 'post', ''],
-        ['/api/v0/compliance/reporting/stats/failures', 'post', ''],
-        ['/api/v0/compliance/reporting/stats/trend', 'post', '']],
+      allOfCheck: [['/api/v0/compliance/reporting/stats/summary', 'post'],
+        ['/api/v0/compliance/reporting/stats/failures', 'post'],
+        ['/api/v0/compliance/reporting/stats/trend', 'post']],
       route: '/compliance/reports'
     },
     {
-      allOfCheck: [['/api/v0/compliance/scanner/jobs', 'post', ''],
-      ['/compliance/scanner/jobs/search', 'post', '']],
+      allOfCheck: [['/api/v0/compliance/scanner/jobs', 'post'],
+      ['/compliance/scanner/jobs/search', 'post']],
       route: '/compliance/scan-jobs'
     },
     {
-      allOfCheck: [['/api/v0/compliance/profiles/search', 'post', '']],
+      allOfCheck: [['/api/v0/compliance/profiles/search', 'post']],
       route: '/compliance/compliance-profiles'
     }
   ];

--- a/components/automate-ui/src/app/pages/event-feed/event-feed.component.html
+++ b/components/automate-ui/src/app/pages/event-feed/event-feed.component.html
@@ -6,19 +6,21 @@
           <chef-page-header>
             <chef-heading>Event Feed</chef-heading>
             <chef-subheading>Displays events for the past week. Use <em>SHIFT+R</em>  to reset the time scale.</chef-subheading>
-            <app-search-bar
-            [numberOfFilters]="numberOfSearchBarFilters$ | async"
-            [categories]="categoryTypes"
-            [dynamicSuggestions]="suggestions$ | async"
-            (suggestValues)="onSuggestValues($event)"
-            (itemSelected)="onFilterAdded($event)"
-            (filtersButtonClick)="toggleFilters()">
-            </app-search-bar>
-            <app-search-bar-filter-bar *ngIf="filtersVisible"
-              [filters]="searchBarFilters$ | async"
-              (filtersCleared)="onFiltersClear($event)"
-              (filterRemoved)="onFilterRemoved($event)">
-            </app-search-bar-filter-bar>
+            <app-authorized [allOf]="['/api/v0/cfgmgmt/suggestions', 'get']">
+              <app-search-bar
+                [numberOfFilters]="numberOfSearchBarFilters$ | async"
+                [categories]="categoryTypes"
+                [dynamicSuggestions]="suggestions$ | async"
+                (suggestValues)="onSuggestValues($event)"
+                (itemSelected)="onFilterAdded($event)"
+                (filtersButtonClick)="toggleFilters()">
+              </app-search-bar>
+              <app-search-bar-filter-bar *ngIf="filtersVisible"
+                [filters]="searchBarFilters$ | async"
+                (filtersCleared)="onFiltersClear($event)"
+                (filterRemoved)="onFilterRemoved($event)">
+              </app-search-bar-filter-bar>
+            </app-authorized>
           </chef-page-header>
         </div>
         <div class="page-body">

--- a/components/automate-ui/src/app/pages/event-feed/event-feed.component.html
+++ b/components/automate-ui/src/app/pages/event-feed/event-feed.component.html
@@ -1,9 +1,4 @@
 <div class="content-container">
-  <div *ngIf="permissionDenied" class="permission-denied-banner">
-    <p>It looks like you don't have permission to access this page.
-    If this is a mistake, then reach out to your administrator.</p>
-  </div>
-
   <div class="container">
     <main>
       <div class="event-feed-container">

--- a/components/automate-ui/src/app/pages/event-feed/event-feed.component.html
+++ b/components/automate-ui/src/app/pages/event-feed/event-feed.component.html
@@ -1,7 +1,7 @@
 <div class="content-container">
   <div *ngIf="permissionDenied" class="permission-denied-banner">
-    <p>It looks like you don't have permission to access this page.</p>
-    <p>If this is a mistake, then reach out to your administrator.</p>
+    <p>It looks like you don't have permission to access this page.
+    If this is a mistake, then reach out to your administrator.</p>
   </div>
 
   <div class="container">

--- a/components/automate-ui/src/app/pages/event-feed/event-feed.component.ts
+++ b/components/automate-ui/src/app/pages/event-feed/event-feed.component.ts
@@ -47,7 +47,7 @@ export class EventFeedComponent implements OnInit, OnDestroy {
   eventsLoading = false;
   errorLoadingEvents = false;
   loadedEmptySetOfEvents = false;
-  permissionDenied = false;
+  permissionDenied = false; // not currently used
   guitarStringCollection: GuitarStringCollection = initialState.guitarStringCollection;
   @ViewChild('guitarStrings', { static: true }) guitarStrings;
   resetTimescaleDisabled = true;

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.html
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.html
@@ -1,9 +1,5 @@
 <div class="content-container">
-  <div *ngIf="permissionDenied" class="permission-denied-banner">
-    <p>You do not have permission to view everything on this page.
-    Please contact an administrator for permission.</p>
-  </div>
-  <div class="container">
+ <div class="container">
     <main>
       <chef-page-header>
         <chef-heading>Notifications</chef-heading>

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.html
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.html
@@ -1,7 +1,7 @@
 <div class="content-container">
   <div *ngIf="permissionDenied" class="permission-denied-banner">
-    <p>You do not have permission to view everything on this page.</p>
-    <p>Please contact an administrator for permission.</p>
+    <p>You do not have permission to view everything on this page.
+    Please contact an administrator for permission.</p>
   </div>
   <div class="container">
     <main>

--- a/components/automate-ui/src/app/pages/notifications/notifications.component.ts
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.ts
@@ -31,7 +31,7 @@ export class NotificationsComponent implements OnInit {
   pageSize = 10;
   sortField: string;
   sortDir: FieldDirection;
-  permissionDenied = false;
+  permissionDenied = false; // not currently used
   // This is exposed here to allow the component HTML access to ServiceActionType
   serviceActionType = ServiceActionType;
 

--- a/components/automate-ui/src/app/pages/settings-landing/settings-landing.component.ts
+++ b/components/automate-ui/src/app/pages/settings-landing/settings-landing.component.ts
@@ -10,18 +10,18 @@ export class SettingsLandingComponent {
 
   // order determined by LayoutSidebarService and vetted by SidebarComponent unit tests
   public routeList: RoutePerms[] = [
-    { anyOfCheck: [['/api/v0/notifications/rules', 'get', '']], route: '/settings/notifications' },
-    { anyOfCheck: [['/api/v0/datafeed/destinations', 'post', '']], route: '/settings/data-feeds' },
-    { anyOfCheck: [['/api/v0/retention/nodes/status', 'get', '']],
+    { anyOfCheck: [['/api/v0/notifications/rules', 'get']], route: '/settings/notifications' },
+    { anyOfCheck: [['/api/v0/datafeed/destinations', 'post']], route: '/settings/data-feeds' },
+    { anyOfCheck: [['/api/v0/retention/nodes/status', 'get']],
       route: '/settings/data-lifecycle' },
-    { anyOfCheck: [['/api/v0/nodemanagers/search', 'post', '']], route: '/settings/node-integrations' },
-    { anyOfCheck: [['/api/v0/secrets/search', 'post', '']], route: '/settings/node-credentials' },
-    { allOfCheck: [['/apis/iam/v2/users', 'get', '']], route: '/settings/users' },
-    { allOfCheck: [['/apis/iam/v2/teams', 'get', '']], route: '/settings/teams' },
-    { allOfCheck: [['/apis/iam/v2/tokens', 'get', '']], route: '/settings/tokens' },
-    { allOfCheck: [['/apis/iam/v2/policies', 'get', '']], route: '/settings/policies' },
-    { allOfCheck: [['/apis/iam/v2/roles', 'get', '']], route: '/settings/roles' },
-    { allOfCheck: [['/apis/iam/v2/projects', 'get', '']], route: '/settings/projects' }
+    { anyOfCheck: [['/api/v0/nodemanagers/search', 'post']], route: '/settings/node-integrations' },
+    { anyOfCheck: [['/api/v0/secrets/search', 'post']], route: '/settings/node-credentials' },
+    { allOfCheck: [['/apis/iam/v2/users', 'get']], route: '/settings/users' },
+    { allOfCheck: [['/apis/iam/v2/teams', 'get']], route: '/settings/teams' },
+    { allOfCheck: [['/apis/iam/v2/tokens', 'get']], route: '/settings/tokens' },
+    { allOfCheck: [['/apis/iam/v2/policies', 'get']], route: '/settings/policies' },
+    { allOfCheck: [['/apis/iam/v2/roles', 'get']], route: '/settings/roles' },
+    { allOfCheck: [['/apis/iam/v2/projects', 'get']], route: '/settings/projects' }
   ];
 
 }

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.html
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.html
@@ -1,6 +1,6 @@
 <app-landing [routePerms]="routeList" [onNotFound]="SetPageCoverage"></app-landing>
 
-<div>
+<div class="permission-denied-banner">
   <p>
     It looks like you do not have permission to access any data in Automate.
     <br/>

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.html
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.html
@@ -1,0 +1,1 @@
+<p>top-nav-landing works!</p>

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.html
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.html
@@ -1,1 +1,14 @@
-<p>top-nav-landing works!</p>
+<app-landing [routePerms]="routeList" [onNotFound]="SetPageCoverage"></app-landing>
+
+<div>
+  <p>
+    It looks like you do not have permission to access any data in Automate.
+    <br/>
+    Reach out to your administrator or
+    contact <a href="https://www.chef.io/support/" target="_blank" class="error-msg">Chef support</a> for help.
+  </p>
+  <p>
+    In the meantime, feel free to explore the
+    <a href="https://automate.chef.io/docs/" target="_blank" class="error-msg">Automate documentation</a>.
+  </p>
+</div>

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.html
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.html
@@ -1,6 +1,6 @@
 <app-landing [routePerms]="routeList" [onNotFound]="SetPageCoverage"></app-landing>
 
-<div class="permission-denied-banner">
+<div class="no-permissions">
   <p>
     It looks like you do not have permission to access any data in Automate.
     <br/>

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.scss
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.scss
@@ -10,7 +10,7 @@
   z-index: 190;
   padding-top: 77px;
   text-align: center;
-  font-weight: bold;
+  font-weight: normal;
 
   & > p {
     font-size: 18px;

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.scss
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.scss
@@ -1,0 +1,20 @@
+@import "~styles/variables";
+
+.no-permissions {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba($chef-white, 0.85);
+  z-index: 190;
+  padding-top: 77px;
+  text-align: center;
+  font-weight: bold;
+
+  & > p {
+    font-size: 18px;
+    line-height: 1.6;
+    color: $chef-primary-dark;
+  }
+}

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.spec.ts
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.spec.ts
@@ -1,0 +1,29 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockComponent } from 'ng2-mock-component';
+
+import { TopNavLandingComponent } from './top-nav-landing.component';
+
+describe('TopNavLandingComponent', () => {
+  let component: TopNavLandingComponent;
+  let fixture: ComponentFixture<TopNavLandingComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        TopNavLandingComponent,
+        MockComponent({ selector: 'app-landing', inputs: ['routePerms'] })
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TopNavLandingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.spec.ts
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.spec.ts
@@ -1,6 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
 
+import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { TopNavLandingComponent } from './top-nav-landing.component';
 
 describe('TopNavLandingComponent', () => {
@@ -9,9 +12,15 @@ describe('TopNavLandingComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [
+      imports: [
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+      ],
+      providers: [
+        FeatureFlagsService
+      ],
+       declarations: [
         TopNavLandingComponent,
-        MockComponent({ selector: 'app-landing', inputs: ['routePerms'] })
+        MockComponent({ selector: 'app-landing', inputs: ['routePerms', 'onNotFound'] })
       ]
     })
     .compileComponents();

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { RoutePerms } from 'app/components/landing/landing.component';
+import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 
 @Component({
   selector: 'app-top-nav-landing',
-  template: '<app-landing [routePerms]="routeList"></app-landing>',
+  templateUrl: './top-nav-landing.component.html',
   styleUrls: []
 })
 export class TopNavLandingComponent {
@@ -57,4 +58,8 @@ export class TopNavLandingComponent {
       ], route: '/settings'
     }
   ];
+
+  constructor(public layoutFacade: LayoutFacadeService) { }
+
+  SetPageCoverage = () => this.layoutFacade.showFullPagePlusTopBar();
 }

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { RoutePerms } from 'app/components/landing/landing.component';
+
+@Component({
+  selector: 'app-top-nav-landing',
+  template: '<app-landing [routePerms]="routeList"></app-landing>',
+  styleUrls: []
+})
+export class TopNavLandingComponent {
+
+  public routeList: RoutePerms[] = [
+  ];
+}

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
@@ -16,8 +16,7 @@ export class TopNavLandingComponent {
         ['/api/v0/eventfeed', 'get', ''],
         ['/api/v0/eventstrings', 'get', ''],
         ['/api/v0/event_type_counts', 'get', ''],
-        ['/api/v0/event_task_counts', 'get', ''],
-        ['/api/v0/cfgmgmt/suggestions', 'get', '']
+        ['/api/v0/event_task_counts', 'get', '']
       ], route: '/dashboards/event-feed'
     },
     {

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
@@ -8,6 +8,53 @@ import { RoutePerms } from 'app/components/landing/landing.component';
 })
 export class TopNavLandingComponent {
 
+  // order must match layout in navbar.component.html
   public routeList: RoutePerms[] = [
+    {
+      allOfCheck: [
+        ['/api/v0/eventfeed', 'get', ''],
+        ['/api/v0/eventstrings', 'get', ''],
+        ['/api/v0/event_type_counts', 'get', ''],
+        ['/api/v0/event_task_counts', 'get', ''],
+        ['/api/v0/cfgmgmt/suggestions', 'get', '']
+      ], route: '/dashboards/event-feed'
+    },
+    {
+      anyOfCheck: [
+        ['/api/v0/applications/services', 'get', ''],
+        ['/api/v0/applications/service-groups', 'get', '']
+      ], route: '/applications/service-groups'
+    },
+    {
+      allOfCheck: [
+        ['/api/v0/cfgmgmt/nodes', 'get', ''],
+        ['/api/v0/cfgmgmt/stats/node_counts', 'get', '']
+      ], route: '/infrastructure'
+    },
+    {
+      anyOfCheck: [
+        ['/api/v0/compliance/reporting/stats/summary', 'post', ''],
+        ['/api/v0/compliance/reporting/stats/failures', 'post', ''],
+        ['/api/v0/compliance/reporting/stats/trend', 'post', ''],
+        ['/api/v0/compliance/scanner/jobs', 'post', ''],
+        ['/api/v0/compliance/scanner/jobs/search', 'post', ''],
+        ['/api/v0/compliance/profiles/search', 'post', '']
+      ], route: '/compliance'
+    },
+    {
+      anyOfCheck: [
+        ['/api/v0/datafeed/destinations', 'post', ''],
+        ['/api/v0/notifications/rules', 'get', ''],
+        ['/api/v0/secrets/search', 'post', ''],
+        ['/api/v0/nodemanagers/search', 'post', ''],
+        ['/api/v0/retention/nodes/status', 'get', ''],
+        ['/apis/iam/v2/users', 'get', ''],
+        ['/apis/iam/v2/teams', 'get', ''],
+        ['/apis/iam/v2/tokens', 'get', ''],
+        ['/apis/iam/v2/policies', 'get', ''],
+        ['/apis/iam/v2/roles', 'get', ''],
+        ['/apis/iam/v2/projects', 'get', '']
+      ], route: '/settings'
+    }
   ];
 }

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
@@ -5,7 +5,7 @@ import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 @Component({
   selector: 'app-top-nav-landing',
   templateUrl: './top-nav-landing.component.html',
-  styleUrls: []
+  styleUrls: ['./top-nav-landing.component.scss']
 })
 export class TopNavLandingComponent {
 

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
@@ -13,47 +13,47 @@ export class TopNavLandingComponent {
   public routeList: RoutePerms[] = [
     {
       allOfCheck: [
-        ['/api/v0/eventfeed', 'get', ''],
-        ['/api/v0/eventstrings', 'get', ''],
-        ['/api/v0/event_type_counts', 'get', ''],
-        ['/api/v0/event_task_counts', 'get', '']
+        ['/api/v0/eventfeed', 'get'],
+        ['/api/v0/eventstrings', 'get'],
+        ['/api/v0/event_type_counts', 'get'],
+        ['/api/v0/event_task_counts', 'get']
       ], route: '/dashboards/event-feed'
     },
     {
       anyOfCheck: [
-        ['/api/v0/applications/services', 'get', ''],
-        ['/api/v0/applications/service-groups', 'get', '']
+        ['/api/v0/applications/services', 'get'],
+        ['/api/v0/applications/service-groups', 'get']
       ], route: '/applications/service-groups'
     },
     {
       allOfCheck: [
-        ['/api/v0/cfgmgmt/nodes', 'get', ''],
-        ['/api/v0/cfgmgmt/stats/node_counts', 'get', '']
+        ['/api/v0/cfgmgmt/nodes', 'get'],
+        ['/api/v0/cfgmgmt/stats/node_counts', 'get']
       ], route: '/infrastructure'
     },
     {
       anyOfCheck: [
-        ['/api/v0/compliance/reporting/stats/summary', 'post', ''],
-        ['/api/v0/compliance/reporting/stats/failures', 'post', ''],
-        ['/api/v0/compliance/reporting/stats/trend', 'post', ''],
-        ['/api/v0/compliance/scanner/jobs', 'post', ''],
-        ['/api/v0/compliance/scanner/jobs/search', 'post', ''],
-        ['/api/v0/compliance/profiles/search', 'post', '']
+        ['/api/v0/compliance/reporting/stats/summary', 'post'],
+        ['/api/v0/compliance/reporting/stats/failures', 'post'],
+        ['/api/v0/compliance/reporting/stats/trend', 'post'],
+        ['/api/v0/compliance/scanner/jobs', 'post'],
+        ['/api/v0/compliance/scanner/jobs/search', 'post'],
+        ['/api/v0/compliance/profiles/search', 'post']
       ], route: '/compliance'
     },
     {
       anyOfCheck: [
-        ['/api/v0/datafeed/destinations', 'post', ''],
-        ['/api/v0/notifications/rules', 'get', ''],
-        ['/api/v0/secrets/search', 'post', ''],
-        ['/api/v0/nodemanagers/search', 'post', ''],
-        ['/api/v0/retention/nodes/status', 'get', ''],
-        ['/apis/iam/v2/users', 'get', ''],
-        ['/apis/iam/v2/teams', 'get', ''],
-        ['/apis/iam/v2/tokens', 'get', ''],
-        ['/apis/iam/v2/policies', 'get', ''],
-        ['/apis/iam/v2/roles', 'get', ''],
-        ['/apis/iam/v2/projects', 'get', '']
+        ['/api/v0/datafeed/destinations', 'post'],
+        ['/api/v0/notifications/rules', 'get'],
+        ['/api/v0/secrets/search', 'post'],
+        ['/api/v0/nodemanagers/search', 'post'],
+        ['/api/v0/retention/nodes/status', 'get'],
+        ['/apis/iam/v2/users', 'get'],
+        ['/apis/iam/v2/teams', 'get'],
+        ['/apis/iam/v2/tokens', 'get'],
+        ['/apis/iam/v2/policies', 'get'],
+        ['/apis/iam/v2/roles', 'get'],
+        ['/apis/iam/v2/projects', 'get']
       ], route: '/settings'
     }
   ];

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -54,25 +54,6 @@
   }
 }
 
-.permission-denied-banner {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba($chef-white, 0.85);
-  z-index: 190;
-  padding-top: 77px;
-  text-align: center;
-  font-weight: bold;
-
-  & > p {
-    font-size: 18px;
-    line-height: 1.6;
-    color: $chef-primary-dark;
-  }
-}
-
 @media screen and (max-width: 769px) {
   .container {
     margin-left: $sidebar-small-width;

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -335,7 +335,7 @@ input {
       background-color: var(--chef-white);
 
       &:after {
-        color: #212334;
+        color: $chef-primary-dark;
       }
     }
   }

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -18,8 +18,8 @@
 }
 
 
-// These are used to wrap a collection of notifications
-// An outer container of sticky-notifications causes the notifications to to stick to the 
+// These are used to wrap a collection of notifications.
+// An outer container of sticky-notifications causes the notifications to stick to the
 // upper scrollable window the user scrolls.
 .sticky-notifications {
   position: sticky;
@@ -67,7 +67,6 @@
   font-weight: bold;
 
   & > p {
-    margin: 0;
     line-height: 1.6;
     color: $chef-dark-grey;
   }

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -62,13 +62,14 @@
   bottom: 0;
   background: rgba($chef-white, 0.85);
   z-index: 190;
-  padding-top: 38vh;
+  padding-top: 77px;
   text-align: center;
   font-weight: bold;
 
   & > p {
+    font-size: 18px;
     line-height: 1.6;
-    color: $chef-dark-grey;
+    color: $chef-primary-dark;
   }
 }
 

--- a/components/chef-ui-library/src/molecules/chef-status-filter-group/chef-status-filter-group.scss
+++ b/components/chef-ui-library/src/molecules/chef-status-filter-group/chef-status-filter-group.scss
@@ -44,7 +44,7 @@ chef-status-filter-group {
 
     &.general {
       chef-icon {
-        color: #212334;
+        color: var(--chef-primary-dark);
       }
     }
 
@@ -91,7 +91,7 @@ chef-status-filter-group {
       .filter-label,
       .lean-filter-label,
       .filter-total {
-        color: #212334;
+        color: var(--chef-primary-dark);
       }
 
       &.general {

--- a/components/release-mgmt-dashboard/src/styles.css
+++ b/components/release-mgmt-dashboard/src/styles.css
@@ -1,7 +1,7 @@
 /* You can add global styles to this file, and also import other style files */
 @import url('https://fonts.googleapis.com/css?family=Muli:400,600');
 
-html, 
+html,
 body {
   margin: 0;
   padding: 0;
@@ -9,7 +9,7 @@ body {
   height: 100%;
   background-color: #F3F6F8;
 
-  color: #212334;
+  color: #222435;
   font-family: Muli, Helvetica, sans-serif;
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This PR applies the permission-based routing scheme (previously in use just for the sidebar navigation panel) to the top navigation bar.

1. Adds an introspection guard to the one unguarded element, `Dashboards`. Now, each of the top navigation choices will appear only when the user has permission to access it.
2. Changes from static routing to dynamic (permission-based routing): upon navigating to the root level URL (e.g. `https://a2-dev.test/` or `https://a2-local-inplace-upgrade-acceptance.cd.chef.co/`), previously one landed just on the first listed element, `Dashboards` -- whether or not having had permission to access it. Now, the set of top-level navigation choices are examined in turn; the user lands on the first one that they have permission to access, and the URL in the browser bar auto-adjusts to that route.
3. Should the user have **_no_** permission for any of the top-level navigation choices, they are presented a new, "no permission" screen and the URL remains at the root level URL.

OK, but what is really cool about this pull request?
This is almost a "no-code" implementation. There is one new component, a `TopNavLandingComponent` that subclasses the `LandingComponent` by providing one variable (a set of routes and permissions) and a one-line function (`SetPageCoverage`) that tells the parent to hide the sidebar when there are no permissions. This was possible because of the recently redesigned sidebar and landing component architectures (thanks @tarablack01 for the sidebar!).

Note that permission-based routing **_only_** occurs when navigating to the root level URL (e.g. `https://a2-dev.test/`); it does not occur if you happen to know a sub-URL under there and you enter that directly (e.g., `https://a2-dev.test/dashboards/event-feed`). Thus, it is still useful for individual pages to be able to show a page-level "no permissions here", which several pages do:
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/6817500/81323729-a77a2100-904a-11ea-8a2e-7c468c92b6b3.png">

### :chains: Related Resources
* [Convert SettingsLandingComponent to reusable landing component](https://github.com/chef/a2/pull/5039)
* [Settings landing page for permission-based routing](https://github.com/chef/a2/pull/4642)

### :+1: Definition of Done
See next section.

### :athletic_shoe: How to Build and Test the Change

Rebuild automate-ui.
Create a new user, e.g. `bob`.
Login as `bob` and observe that the URL shows the top-level domain in the address bar (e.g. `https://a2-dev.test/`) and the new "no permissions" page.
(Note that the same styles used on the pre-existing page shown above were applied to this page for consistency.)
<img width="1033" alt="image" src="https://user-images.githubusercontent.com/6817500/81323888-fa53d880-904a-11ea-85c6-de36b4b75da7.png">

Next, create a policy granting `bob` selective permissions to see tokens (under `Settings`) and nodes (under `Infrastructure`):
```
curl -sSkH "api-token: $TOK" -X POST \
-d '{ "name": "perm routing test", "id": "perm-routing-test", "members": [ "user:local:bob" ], "statements": [ { "effect": "ALLOW", "actions": [ "iam:tokens:*","infra:nodes:list" ], "projects": [ "*" ] } ], "projects": [] }' \
$TARGET_HOST/apis/iam/v2/policies?pretty
```
Refresh bob's browser page. You will now see just those two choices available on the top navigation bar, and you will land on the first one, with the address bar reflecting the newly-routed page (`https://a2-dev.test/infrastructure/client-runs`).
<img width="1036" alt="image" src="https://user-images.githubusercontent.com/6817500/81323210-e360b680-9049-11ea-96fb-538ad0d8791a.png">

Next, open up bob's permissions further, by, e.g. adding to a project owner policy and you will see all available top nav bar choices (or you could just log in as an admin to see the same):
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/6817500/81324342-ab5a7300-904b-11ea-8ece-ba9d88edff9d.png">


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
