### PR TITLE
Add compliance:reports:export to both viewer roles

### DIFF
--- a/components/authz-service/storage/postgres/migration/sql/78_update_viewer_role_for_compliance.up.sql
+++ b/components/authz-service/storage/postgres/migration/sql/78_update_viewer_role_for_compliance.up.sql
@@ -1,0 +1,5 @@
+UPDATE iam_roles
+    SET actions = '{compliance:reports:export}' || actions
+    WHERE
+        (id='compliance-viewer' or id='viewer') AND
+        NOT actions @> '{compliance:reports:export}';

--- a/components/authz-service/storage/postgres/migration/sql/README.md
+++ b/components/authz-service/storage/postgres/migration/sql/README.md
@@ -77,3 +77,4 @@
 - [`75_update_roles_pols.up.sql`](75_update_roles_pols.up.sql)
 - [`76_compliance_roles_pols.up.sql`](76_compliance_roles_pols.up.sql)
 - [`77_update_infra_service_policies.up.sql`](77_update_infra_service_policies.up.sql)
+- [`78_update_viewer_role_for_compliance.up.sql`](78_update_viewer_role_for_compliance.up.sql)

--- a/components/automate-chef-io/content/docs/roles.md
+++ b/components/automate-chef-io/content/docs/roles.md
@@ -37,12 +37,12 @@ Name | ID| Actions
 Owner              | owner         | \*
 Project Owner      | project-owner | infra:nodes:\*, infra:nodeManagers:\*, compliance:\*, event:\*, ingest:\*, secrets:\*, iam:projects:list, iam:projects:get, iam:projects:assign, iam:policies:list, iam:policies:get, iam:policyMembers:\*, iam:teams:list, iam:teams:get, iam:teamUsers:\*, iam:users:get, iam:users:list, applications:\*
 Editor             | editor        | infra:infraServers:list, infra:infraServers:get, infra:nodes:\*, infra:nodeManagers:\*, compliance:\*, event:\*, ingest:\*, secrets:\*, iam:projects:list, iam:projects:get, iam:projects:assign, applications:\*
-Viewer             | viewer        | infra:infraServers:list, infra:infraServers:get, secrets:\*:get, secrets:\*:list, infra:nodes:get, infra:nodes:list, infra:nodeManagers:get, infra:nodeManagers:list, compliance:\*:get, compliance:\*:list, event:\*:get, event:\*:list, ingest:\*:get, ingest:\*:list, iam:projects:list, iam:projects:get, applications:\*:get, applications:\*:list
+Viewer             | viewer        | infra:infraServers:list, infra:infraServers:get, secrets:\*:get, secrets:\*:list, infra:nodes:get, infra:nodes:list, infra:nodeManagers:get, infra:nodeManagers:list, compliance:\*:get, compliance:\*:list, event:\*:get, event:\*:list, ingest:\*:get, ingest:\*:list, iam:projects:list, iam:projects:get, applications:\*:get, applications:\*:list, compliance:reports:export
 Ingest             | ingest        | infra:ingest:\*, compliance:profiles:get, compliance:profiles:list
 
 ### Custom Roles
 
-Custom roles are roles that any user with the permission for `iam:roles:update` can change. 
+Custom roles are roles that any user with the permission for `iam:roles:update` can change.
 In addition to the Chef-managed roles above, Chef Automate includes two custom roles by default.
 
 Role              | Description


### PR DESCRIPTION
```
     3 | viewer            | Viewer            | chef-managed | {compliance:reports:export,infra:infraServers:list,infra:infraServers:get,secrets:*:get,secrets:*:list,infra:nodes:get,infra:nodes:list,infra:nodeManagers:get,infra:nodeManagers:list,compliance:*:get,compliance:*:list,event:*:get,event:*:list,ingest:*:get,ingest:*:list,iam:projects:list,iam:projects:get,applications:*:get,applications:*:list}
     7 | compliance-viewer | Compliance Viewer | custom       | {compliance:reports:export,compliance:*:get,compliance:*:list}
```

