### PR TITLE
Require packages using pg-helper to have package.meta

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -30,7 +30,7 @@ steps:
   #
   - label: repo health
     command:
-      - hab studio run "source .studiorc && scripts/repo_health.sh"
+      - hab studio run "source .studiorc && scripts/repo_health.sh && run_studio_repo_health_checks"
     timeout_in_minutes: 10
     retry:
       automatic:

--- a/.studio/common
+++ b/.studio/common
@@ -3,6 +3,15 @@
 # This file is the place we will put all the common functionality that
 # two or more components share/require (ex. install elasticsearch)
 
+document "run_studio_repo_health_checks" <<DOC
+  Run repo health checks that are implemented in the .studio helpers
+DOC
+
+function run_studio_repo_health_checks() {
+  echo "Checking for packages missing required metadata"
+  verify_components_have_platform_config || return 1
+}
+
 document "clean_all_compiled_protos" <<DOC
   Delete all the files with extensions matching '*pb*go' in the repo (except in vendor/)
 DOC
@@ -193,6 +202,56 @@ function link_component_bin() {
 
 function desired_golang_ident() {
     echo "core/go/$(cat /src/GOLANG_VERSION)"
+}
+
+function verify_components_have_platform_config() {
+  for component in components/*; do
+    verify_component_has_platform_config "$component" || return 1
+  done
+}
+
+function verify_component_has_platform_config() {
+  if [[ -z $1 ]]; then
+      error "Missing component name argument to ${FUNCNAME[0]}"
+      return 1
+  fi
+
+  install_if_missing core/jq-static jq
+
+  local component_dir=$1
+  local component_name; component_name="\"$(basename "$component_dir")\""
+
+  local hab_hooks; hab_hooks="$component_dir/habitat/hooks"
+
+  if [[ ! -d "$hab_hooks" ]]; then
+    echo "SKIP: $component_name has no hab hooks, platform config not needed"
+    return 0
+  fi
+
+  if ! grep -q pg-helper "$hab_hooks"/*; then
+    echo "SKIP: $component_name doesn't use pg-helper, platform config not needed"
+    return 0
+  fi
+
+
+  local package_meta; package_meta="$component_dir"/package.meta
+
+  if [[ ! -f "$package_meta" ]]; then
+    error "$component_name uses \`pg-helper\`, but doesn't have a package metadata file"
+    error "Create the $package_meta file and rebuild the generated files in automate-deployment"
+    error "for more information, consult the ProductMetadata documentation: https://godoc.org/github.com/chef/automate/lib/product"
+    return 1
+  fi
+
+  if jq '.uses_platform_scaffolding | type' "$package_meta" | grep -q null; then
+    error "$component_name uses \`pg-helper\` in habitat hooks but doesn't specify \`uses_platform_scaffolding\` in package.meta"
+    error "Set \"uses_platform_scaffolding\" to \`true\` or \`false\` in $package_meta"
+    error "for more information, consult the ProductMetadata documentation: https://godoc.org/github.com/chef/automate/lib/product"
+    return 1
+  fi
+
+  echo "OK:   $component_name platform config integration looks correct"
+  return 0
 }
 
 function start_sup() {

--- a/components/automate-workflow-server/package.meta
+++ b/components/automate-workflow-server/package.meta
@@ -1,4 +1,5 @@
 {
   "name": "chef/automate-workflow-server",
+  "uses_platform_scaffolding": false,
   "binlinks": ["workflow-ctl"]
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

If you don't know about package.meta, it takes a long time to learn the hard way. Anything using postgres will fail to work correctly in HA without it.

### How to Build and Test

This Ci build did not have the second commit that fixes the package.meta for automate-workflow-server, and it failed the repo health job: You can see that the checker works in this build: https://buildkite.com/chef-oss/chef-automate-master-verify/builds/11874

To run locally, enter the studio and `source .studio/common` if necessary. Then:
- `run_studio_repo_health_checks` should print some output and exit 0 with a clean repo
- edit `components/config-mgmt-service/package.meta` by removing `"uses_platform_scaffolding": true` from it. Now `run_studio_repo_health_checks` should fail
- delete `components/config-mgmt-service/package.meta` entirely. `run_studio_repo_health_checks` should fail
- edit `components/config-mgmt-service/habitat/hooks/run`, delete all the lines with `pg-helper`. Now `run_studio_repo_health_checks` should pass and the output should say it skipped config-mgmt-service