### PR TITLE
Update date in Event Feed label to include UTC

### DIFF
--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -34,7 +34,7 @@ export class DateTime {
   public static readonly EVENT_TABLE_DAY_LABEL: string = 'dddd';
 
   // Format for date labels in event feed table
-  // 24 September
+  // 24 September UTC
   public static readonly EVENT_TABLE_DATE_LABEL: string = 'D MMMM [UTC]';
 
   // Format for navigating to compliance reports with an endtime set

--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -35,7 +35,7 @@ export class DateTime {
 
   // Format for date labels in event feed table
   // 24 September
-  public static readonly EVENT_TABLE_DATE_LABEL: string = 'D MMMM';
+  public static readonly EVENT_TABLE_DATE_LABEL: string = 'D MMMM [UTC]';
 
   // Format for navigating to compliance reports with an endtime set
   // 2019-09-24


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The Event feed date is UTC, but was not clear to users because there was no label.   This adds UTC to all of the event feed date labels on the side of the event feed list.

### :chains: Related Resources
Fixes: https://github.com/chef/automate/issues/3400

### :+1: Definition of Done
The event feed now has UTC in its time label

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
make serve

If you need data in your event feed, this should put one item in:
`cat components/ingest-service/examples/actions/policy_update.json | jq --arg date "$(date +%FT%TZ -d '1 day ago')" '.recorded_at = $date' | send_chef_data_raw lb`

navigate to: https://a2-dev.test/dashboards/event-feed
See `UTC` labeled alongside date as shown in Screenshot below

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
AFTER:
<img width="1298" alt="Screen Shot 2020-05-11 at 3 52 34 PM" src="https://user-images.githubusercontent.com/16737484/81619957-91989300-939f-11ea-8afa-cb7b1cd640cc.png">