### PR TITLE
[automate-cs-nginx] Pin shared habitat dependencies

### DIFF
--- a/components/automate-cs-nginx/habitat/plan.sh
+++ b/components/automate-cs-nginx/habitat/plan.sh
@@ -10,9 +10,24 @@ pkg_license=('Chef-MLSA')
 pkg_version="13.0.47"
 pkg_deps=(
   chef/mlsa
-  core/curl
-  core/bundler
-  core/ruby
+  # TODO 2020-05-12: PIN PIN PIN
+  #
+  # All dependencies that are shared between this package and the
+  # chef-server-* packages are pinned to the versions required by the
+  # chef-server-* packages.
+  #
+  # Currently, the chef-server-* packages we are pinned to were
+  # hand-built and any update to any of these three packages will
+  # require them to be re-built.
+  #
+  # We cannot follow the latest chef-server-* packages until the
+  # following issue is resolved:
+  #
+  # https://github.com/chef/automate/pull/2002#issuecomment-600343881
+  #
+  core/bundler/1.17.3/20200404130802
+  core/curl/7.68.0/20200319191535
+  core/ruby/2.5.7/20200404130135
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
   "${vendor_origin}/chef-server-nginx/13.0.47/20200421235836"
   "${vendor_origin}/chef-server-ctl/13.0.47/20200421235903"


### PR DESCRIPTION
This PR pins All dependencies shared between this package and the
chef-server-* packages to the versions required by the chef-server-*
packages.

Currently, the chef-server-* packages we are pinned to were hand-built
and any update to any of these three dependencies will require them to
be re-built.

We cannot follow the latest chef-server-* packages until the
following issue is resolved:

https://github.com/chef/automate/pull/2002#issuecomment-600343881

Signed-off-by: Steven Danna <steve@chef.io>