### PR TITLE
Changes for scan jobs consistency fixes

### DIFF
--- a/components/automate-ui/src/app/entities/nodes/nodes.model.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.model.ts
@@ -2,3 +2,10 @@ export interface Node {
   id: string;
   name: string;
 }
+
+export interface NodeTotals {
+  all: number;
+  unreachable: number;
+  reachable: number;
+  unknown: number;
+}

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
@@ -1,4 +1,15 @@
-<chef-table class="jobs-list-table" (sort-toggled)="onSortToggled($event)">
+<chef-toolbar>
+  <app-authorized [allOf]="['/api/v0/compliance/scanner/jobs', 'post']">
+    <div *ngIf="jobsList.items.length === 0" class="empty-state">
+      <p>Create the first scan job to get started!</p>
+    </div>
+    <div [ngClass]="jobsList.items.length === 0 ? 'empty-state' : ''">
+      <chef-button primary [routerLink]="['/jobs/add']">Create Scan Job</chef-button>
+    </div>
+  </app-authorized>
+</chef-toolbar>
+
+<chef-table *ngIf="jobsList.items.length > 0" class="jobs-list-table" (sort-toggled)="onSortToggled($event)">
   <chef-thead>
     <chef-tr>
       <chef-th>
@@ -22,15 +33,7 @@
 
   <chef-loading-spinner *ngIf="jobsList.loading" size="100"></chef-loading-spinner>
 
-  <chef-tbody *ngIf="!jobsList.loading">
-    <app-authorized [allOf]="['/api/v0/compliance/scanner/jobs', 'post']">
-      <chef-tr class="empty new-row">
-        <span class="cta">Create a new scan job with nodes and profiles</span>
-        <span class="action">
-          <chef-button primary [routerLink]="['/jobs/add']">Create Scan Job</chef-button>
-        </span>
-      </chef-tr>
-    </app-authorized>
+  <chef-tbody *ngIf="!jobsList.loading"> 
     <chef-tr *ngFor="let job of jobsList.items; trackBy: trackBy;">
       <chef-td  *ngIf="isJobReport(job)">
         {{ job.name }}

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.scss
@@ -143,3 +143,13 @@
     margin-top: 30px;
   }
 }
+
+.empty-state {
+  text-align: center;
+
+  p {
+    font-size: 18px;
+    font-weight: 400;
+    margin-top: 80px;
+  }
+}

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.html
@@ -1,96 +1,102 @@
-<chef-phat-radio
-  class="nodes-list-status-filters"
-  (change)="onStatusFilterChanged($event)"
-  [value]="statusFilter$ | async">
-  <chef-option class="filter all" value='all'>
-    <span class="filter-label">All</span>
-    <span class="filter-total">
-      <chef-icon>storage</chef-icon> {{ (nodeTotals$ | async)?.all | number }}
-    </span>
-  </chef-option>
-  <chef-option class="filter unreachable" value='unreachable'>
-    <span class="filter-label">Unreachable</span>
-    <span class="filter-total">
-      <chef-icon>report_problem</chef-icon> {{ (nodeTotals$ | async)?.unreachable | number }}
-    </span>
-  </chef-option>
-  <chef-option class="filter reachable" value='reachable'>
-    <span class="filter-label">Reachable</span>
-    <span class="filter-total">
-      <chef-icon>check_circle</chef-icon> {{ (nodeTotals$ | async)?.reachable | number }}
-    </span>
-  </chef-option>
-  <chef-option class="filter unknown" value='unknown'>
-    <span class="filter-label">Unknown</span>
-    <span class="filter-total">
-      <chef-icon>help</chef-icon> {{ (nodeTotals$ | async)?.unknown | number }}
-    </span>
-  </chef-option>
-</chef-phat-radio>
-
-<chef-table class="nodes-list-table" (sort-toggled)="onSortToggled($event)">
-  <chef-thead>
-    <chef-tr>
-      <chef-th>
-        Node
-        <chef-sort-toggle sort="name" [order]="orderFor('name')"></chef-sort-toggle>
-      </chef-th>
-      <chef-th>
-        Platform
-        <chef-sort-toggle sort="platform" [order]="orderFor('platform')"></chef-sort-toggle>
-      </chef-th>
-      <chef-th>
-        Status
-        <chef-sort-toggle sort="status" [order]="orderFor('status')"></chef-sort-toggle>
-      </chef-th>
-      <chef-th>
-        Manager
-        <chef-sort-toggle sort="manager" [order]="orderFor('manager')"></chef-sort-toggle>
-      </chef-th>
-      <chef-th></chef-th>
-    </chef-tr>
-  </chef-thead>
-
-  <chef-loading-spinner *ngIf="nodesList.loading" size="100"></chef-loading-spinner>
-
-  <chef-tbody *ngIf="!nodesList.loading">
-    <chef-tr class="empty new-row">
-      <span class="cta">Add new nodes to scan</span>
-      <span class="action">
-        <chef-button primary
-          [routerLink]="['/compliance/scan-jobs/nodes/add']">
-          Add Nodes
-        </chef-button>
+<div *ngIf="(nodeTotals$ | async)?.all > 0">
+  <chef-phat-radio
+    class="nodes-list-status-filters"
+    (change)="onStatusFilterChanged($event)"
+    [value]="statusFilter$ | async">
+    <chef-option class="filter all" value='all'>
+      <span class="filter-label">All</span>
+      <span class="filter-total">
+        <chef-icon>storage</chef-icon> {{ (nodeTotals$ | async)?.all | number }}
       </span>
-    </chef-tr>
-    <chef-tr *ngFor="let node of nodesList.items; index as i; trackBy: trackBy;">
-      <chef-td>{{ node.name }}</chef-td>
-      <chef-td>{{ node.platform }} {{ node.platform_version }}</chef-td>
-      <chef-td>
-        <chef-button [attr.id]="'rerun'+i" class="rerun-btn" tertiary (click)="rerunNode(node)">
-          <chef-icon>cached</chef-icon>
-        </chef-button>
-        <chef-tooltip [attr.for]="'rerun'+i">Check connection</chef-tooltip>
-        {{ node.status }}
-      </chef-td>
-      <chef-td>{{ node.manager }}</chef-td>
-      <chef-td>
-        <chef-button secondary caution
-          *ngIf="node.status === 'unreachable'"
-          (click)="onNodeResultsShow(node.id)">
-          Error
-        </chef-button>
-        <chef-button label="edit" secondary
-          [routerLink]="['/compliance', 'scan-jobs', 'nodes', node.id, 'edit']">
-          <chef-icon>edit</chef-icon>
-        </chef-button>
-        <chef-button label="delete" secondary caution (click)="deleteNode(node)">
-          <chef-icon>delete</chef-icon>
-        </chef-button>
-      </chef-td>
-    </chef-tr>
-  </chef-tbody>
-</chef-table>
+    </chef-option>
+    <chef-option class="filter unreachable" value='unreachable'>
+      <span class="filter-label">Unreachable</span>
+      <span class="filter-total">
+        <chef-icon>report_problem</chef-icon> {{ (nodeTotals$ | async)?.unreachable | number }}
+      </span>
+    </chef-option>
+    <chef-option class="filter reachable" value='reachable'>
+      <span class="filter-label">Reachable</span>
+      <span class="filter-total">
+        <chef-icon>check_circle</chef-icon> {{ (nodeTotals$ | async)?.reachable | number }}
+      </span>
+    </chef-option>
+    <chef-option class="filter unknown" value='unknown'>
+      <span class="filter-label">Unknown</span>
+      <span class="filter-total">
+        <chef-icon>help</chef-icon> {{ (nodeTotals$ | async)?.unknown | number }}
+      </span>
+    </chef-option>
+  </chef-phat-radio>
+</div>
+
+<chef-toolbar>
+  <app-authorized [allOf]="['/api/v0/compliance/scanner/jobs', 'post']">
+    <div *ngIf="(nodeTotals$ | async)?.all === 0" class="empty-state">
+      <p>Add the first nodes to get started!</p>
+    </div>
+    <div [ngClass]="(nodeTotals$ | async)?.all === 0 ? 'empty-state' : ''">
+      <chef-button primary [routerLink]="['/compliance/scan-jobs/nodes/add']">Add Nodes</chef-button>
+    </div>
+  </app-authorized>
+</chef-toolbar>
+
+<div *ngIf="(nodeTotals$ | async)?.all > 0">
+  <chef-table class="nodes-list-table" (sort-toggled)="onSortToggled($event)">
+    <chef-thead>
+      <chef-tr>
+        <chef-th>
+          Node
+          <chef-sort-toggle sort="name" [order]="orderFor('name')"></chef-sort-toggle>
+        </chef-th>
+        <chef-th>
+          Platform
+          <chef-sort-toggle sort="platform" [order]="orderFor('platform')"></chef-sort-toggle>
+        </chef-th>
+        <chef-th>
+          Status
+          <chef-sort-toggle sort="status" [order]="orderFor('status')"></chef-sort-toggle>
+        </chef-th>
+        <chef-th>
+          Manager
+          <chef-sort-toggle sort="manager" [order]="orderFor('manager')"></chef-sort-toggle>
+        </chef-th>
+        <chef-th></chef-th>
+      </chef-tr>
+    </chef-thead>
+
+    <chef-loading-spinner *ngIf="nodesList.loading" size="100"></chef-loading-spinner>
+
+    <chef-tbody *ngIf="!nodesList.loading">
+      <chef-tr *ngFor="let node of nodesList.items; index as i; trackBy: trackBy;">
+        <chef-td>{{ node.name }}</chef-td>
+        <chef-td>{{ node.platform }} {{ node.platform_version }}</chef-td>
+        <chef-td>
+          <chef-button [attr.id]="'rerun'+i" class="rerun-btn" tertiary (click)="rerunNode(node)">
+            <chef-icon>cached</chef-icon>
+          </chef-button>
+          <chef-tooltip [attr.for]="'rerun'+i">Check connection</chef-tooltip>
+          {{ node.status }}
+        </chef-td>
+        <chef-td>{{ node.manager }}</chef-td>
+        <chef-td>
+          <chef-button secondary caution
+            *ngIf="node.status === 'unreachable'"
+            (click)="onNodeResultsShow(node.id)">
+            Error
+          </chef-button>
+          <chef-button label="edit" secondary
+            [routerLink]="['/compliance', 'scan-jobs', 'nodes', node.id, 'edit']">
+            <chef-icon>edit</chef-icon>
+          </chef-button>
+          <chef-button label="delete" secondary caution (click)="deleteNode(node)">
+            <chef-icon>delete</chef-icon>
+          </chef-button>
+        </chef-td>
+      </chef-tr>
+    </chef-tbody>
+  </chef-table>
+</div>
 
 <app-page-picker
   class="nodes-list-paging"

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.scss
@@ -160,3 +160,13 @@
     }
   }
 }
+
+.empty-state {
+  text-align: center;
+
+  p {
+    font-size: 18px;
+    font-weight: 400;
+    margin-top: 80px;
+  }
+}

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-list/nodes-list.component.ts
@@ -7,6 +7,7 @@ import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from '../../../../../ngrx.reducers';
 import * as selectors from '../../state/scanner.selectors';
 import * as actions from '../../state/scanner.actions';
+import { NodeTotals } from 'app/entities/nodes/nodes.model';
 
 @Component({
   templateUrl: './nodes-list.component.html',
@@ -23,7 +24,7 @@ export class NodesListComponent implements OnInit, OnDestroy {
 
   nodeDetail$: Observable<any>;
 
-  nodeTotals$: Observable<any>;
+  nodeTotals$: Observable<NodeTotals>;
 
   statusFilter$: Observable<string>;
 

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/scanner/scanner.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/scanner/scanner.component.html
@@ -8,10 +8,10 @@
 
       <ul class="nav-tabs">
         <li class="nav-tab" routerLink="/compliance/scan-jobs/jobs" routerLinkActive="active">
-          <span *ngIf="jobsCountLoaded">{{jobsCount$ | async | number}}</span> Scan jobs 
+          <span *ngIf="jobsCountLoaded">{{(jobsCount$ | async | number) === '0' ? '' : (jobsCount$ | async | number)}}</span> Scan Jobs 
         </li>
         <li class="nav-tab" routerLink="/compliance/scan-jobs/nodes" routerLinkActive="active">
-          <span *ngIf="nodesCountLoaded">{{nodesCount$ | async | number}}</span> Nodes added
+          <span *ngIf="nodesCountLoaded">{{(nodesCount$ | async | number) === '0' ? '' : (nodesCount$ | async | number)}}</span> Nodes Added
         </li>
       </ul>
 

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/scanner/scanner.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/scanner/scanner.component.html
@@ -8,10 +8,10 @@
 
       <ul class="nav-tabs">
         <li class="nav-tab" routerLink="/compliance/scan-jobs/jobs" routerLinkActive="active">
-          <span *ngIf="jobsCountLoaded">{{(jobsCount$ | async | number) === '0' ? '' : (jobsCount$ | async | number)}}</span> Scan Jobs 
+          <span *ngIf="jobsCountLoaded">{{(jobsCount$ | async) === 0 ? '' : (jobsCount$ | async | number)}}</span> Scan Jobs 
         </li>
         <li class="nav-tab" routerLink="/compliance/scan-jobs/nodes" routerLinkActive="active">
-          <span *ngIf="nodesCountLoaded">{{(nodesCount$ | async | number) === '0' ? '' : (nodesCount$ | async | number)}}</span> Nodes Added
+          <span *ngIf="nodesCountLoaded">{{(nodesCount$ | async) === 0 ? '' : (nodesCount$ | async | number)}}</span> Nodes Added
         </li>
       </ul>
 


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
I have added some changes for compliance/scan-jobs page so it aligns with the rest of the design patterns in Automate.

### :chains: Related Resources
fixes #2437
### :+1: Definition of Done
I have added some UI changes for the scan job and nodes tab.
**compliance/scan-jobs tabs**
- change the tab labels to hide the count when it is 0
- change Scan jobs to Scan Jobs
- change Nodes added to Nodes Added

Empty State
- hide the table when there are no scan jobs
- add the empty state pattern
- message: Create the first scan job to get started!
- primary button: Create Scan Job

**compliance/scan-jobs/nodes**
- remove the table row with a message and the primary button
- move the primary button to the top of the table
- change the label to Add Nodes

Empty State
- hide the table when there are no nodes added
- add the empty state pattern
- message: Add the first nodes to get started!
- primary button: Add Nodes

### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```

`load_scan_jobs` will load some scan jobs, you need to be on vpn for them to work correclty
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots
![s4](https://user-images.githubusercontent.com/12297653/81690389-cdebf200-9478-11ea-8658-6a39159e95e6.png)
![s3](https://user-images.githubusercontent.com/12297653/81690397-cf1d1f00-9478-11ea-87bc-a42f07e1b5d0.png)
![s1](https://user-images.githubusercontent.com/12297653/81690426-dba17780-9478-11ea-8cc6-cb802036c101.png)
![s2](https://user-images.githubusercontent.com/12297653/81690435-dcd2a480-9478-11ea-9fcb-9f08a9c58a5b.png)
