### PR TITLE
Add carbon grid system

### DIFF
--- a/components/automate-ui/package-lock.json
+++ b/components/automate-ui/package-lock.json
@@ -1861,6 +1861,25 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@carbon/grid": {
+      "version": "10.10.2",
+      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-10.10.2.tgz",
+      "integrity": "sha512-H6rq2QmarZdhW7g5LJADdVNd1k0xGe74mbgqatRpyVkom/XHlDXJ2cimzXz9L8q0QFrgm78MFI5YVvXBDhPQtQ==",
+      "requires": {
+        "@carbon/import-once": "^10.3.0",
+        "@carbon/layout": "^10.9.2"
+      }
+    },
+    "@carbon/import-once": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@carbon/import-once/-/import-once-10.3.0.tgz",
+      "integrity": "sha512-PFk3FhMe3psihYtCg3JsyPHismqglnbUqIpz1DCG5Gn/kt0HdVKhGvHdEq7E305rGoBUCKzMn/4xoY9v9mcmlg=="
+    },
+    "@carbon/layout": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-10.9.2.tgz",
+      "integrity": "sha512-/dthurRdaMyc1rAWq8TZmBkBHds+pgbb0+NcPUqC7W9rytRZqu8qY+vaQdXPuso1BPgYN6LBJU7mXHwEEkM84Q=="
+    },
     "@istanbuljs/schema": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",

--- a/components/automate-ui/package.json
+++ b/components/automate-ui/package.json
@@ -35,6 +35,7 @@
     "@angular/platform-browser-dynamic": "^9.1.4",
     "@angular/platform-server": "^9.1.4",
     "@angular/router": "^9.1.4",
+    "@carbon/grid": "^10.10.2",
     "@ngrx/effects": "^9.1.0",
     "@ngrx/entity": "^9.1.0",
     "@ngrx/router-store": "^9.1.0",

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -1,4 +1,5 @@
 /* You can add global styles to this file, and also import other style files */
+@import "@carbon/grid/scss/grid";
 @import "assets/chef-ui-library/chef/chef.css";
 @import "assets/chef-ui-library/collection/assets/fonts/material-icons/material-icons.css";
 @import "assets/chef-ui-library/collection/styles/variables.example.css";


### PR DESCRIPTION
This commit adds the [carbon grid](https://www.carbondesignsystem.com/guidelines/2x-grid/implementation/) scss package to the project. The grid classNames (`.bx--row`, `.bx--col`, etc) are globally available across the app's templates. Components that need access to the grid system variables and mixins need to import them from where they are stored in `@carbon/layout`:

```scss
@import "@carbon/layout/scss/layout";

:host {
  margin: $carbon--grid-gutter;

  @include carbon--breakpoint(lg) {
    margin: 0;
  }
}
```

