### PR TITLE
Fix logic error that prevented multi-select dropdowns from closing properly

### DIFF
--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -74,11 +74,10 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     if (!this.active) { // opening
       this.filterValue = '';
       this.filteredResources = this.resourcesInOrder;
+      this.active = true;
     } else { // closing
       this.closeDropdown();
     }
-
-    this.active = !this.active;
   }
 
   resourceChecked(checked: boolean, resource: ResourceChecked): void {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

`toggleDropdown` was calling `closeDropdown`, which set `active` to false, but then `toggleDropdown` flipped the value of `active `for both the open and close case, incorrectly setting `active` back to true after `closeDropdown` was called.

### :athletic_shoe: How to Build and Test the Change

Create a project then go to a multi-select dropdown (say in teams create modal).

Click on the dropdown and it will open.

Now, do any of the following and it should close properly:

* click outside the dropdown.
* click the dropdown header again.
* press enter.

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
