### PR TITLE
Tweak navbar and sidebar styles to handle smaller viewports

### DIFF
--- a/components/automate-ui/.sass-lint.yml
+++ b/components/automate-ui/.sass-lint.yml
@@ -15,13 +15,6 @@ rules:
   extends-before-mixins: 2
   extends-before-declarations: 2
 
-  # Mixinss
-  mixins-before-declarations:
-    - 2
-    - exclude:
-        - breakpoint
-        - mq
-
   # Line Spacing
   one-declaration-per-line: 2
   empty-line-between-blocks: 2

--- a/components/automate-ui/src/app/components/sidebar-entry/sidebar-entry.component.html
+++ b/components/automate-ui/src/app/components/sidebar-entry/sidebar-entry.component.html
@@ -12,7 +12,7 @@
 <ng-template #sidebarEntryTemplate>
   <chef-icon class="sidebar-icon" *ngIf="icon"
     [style.transform]="'rotate(' + (iconRotation ? iconRotation : 0) + 'deg)'">{{icon}}</chef-icon>
-  <ng-content></ng-content>
+  <span class="text"><ng-content></ng-content></span>
   <chef-icon *ngIf="!openInNewPage" class="arrow">play_arrow</chef-icon>
   <chef-icon *ngIf="openInNewPage" class="open-in-new sidebar-icon">launch</chef-icon>
 </ng-template>

--- a/components/automate-ui/src/app/components/sidebar-entry/sidebar-entry.component.scss
+++ b/components/automate-ui/src/app/components/sidebar-entry/sidebar-entry.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/components/automate-ui/src/app/components/sidebar-entry/sidebar-entry.component.ts
+++ b/components/automate-ui/src/app/components/sidebar-entry/sidebar-entry.component.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core';
 @Component({
   selector: 'chef-sidebar-entry',
   templateUrl: './sidebar-entry.component.html',
-  styleUrls: []
+  styleUrls: ['./sidebar-entry.component.scss']
 })
 export class SidebarEntryComponent {
   @Input() icon: string;

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.html
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.html
@@ -4,36 +4,44 @@
   </div>
   <nav role="navigation" class="sidebar-nav">
     <div class="nav-items">
-      <span *ngFor="let menuGroup of menuGroups$ | async">
+      <ng-container *ngFor="let menuGroup of menuGroups$ | async; index as groupIndex">
         <div
           [hidden]="!((menuGroup.visible$ | async) && menuGroup.hasVisibleMenuItems)"
-          class="menu-item-groups"
-        >
+          class="menu-item-groups">
           <div class="group">{{ menuGroup.name }}</div>
-          <span *ngFor="let menuItem of menuGroup.items">
-            <span *ngIf="!menuItem.authorized && (menuItem.visible$ | async)">
+          <div class="group-item" *ngFor="let menuItem of menuGroup.items; index as itemIndex">
+            <ng-container *ngIf="!menuItem.authorized && (menuItem.visible$ | async)">
               <chef-sidebar-entry
+                [id]="'entry' + groupIndex + '-' + itemIndex"
                 [route]="menuItem.route"
                 [icon]="menuItem.icon"
                 [openInNewPage]="menuItem.openInNewPage"
               >{{ menuItem.name }}</chef-sidebar-entry>
-            </span>
-            <span *ngIf="menuItem.authorized && (menuItem.visible$ | async)">
-                <app-authorized
-                  [anyOf]="menuItem.authorized.anyOf"
-                  [allOf]="menuItem.authorized.allOf"
-                  (isAuthorized)="isAuthorized($event, menuItem, menuGroup)"
-                >
-                  <chef-sidebar-entry
-                    [route]="menuItem.route"
-                    [icon]="menuItem.icon"
-                    [openInNewPage]="menuItem.openInNewPage"
-                  >{{ menuItem.name }}</chef-sidebar-entry>
-                </app-authorized>
-              </span>
-          </span>
+              <chef-tooltip
+              [attr.for]="'entry' + groupIndex + '-' + itemIndex"
+              position="right"
+              delay="0">{{ menuItem.name }}</chef-tooltip>
+            </ng-container>
+            <ng-container *ngIf="menuItem.authorized && (menuItem.visible$ | async)">
+              <app-authorized
+                [anyOf]="menuItem.authorized.anyOf"
+                [allOf]="menuItem.authorized.allOf"
+                (isAuthorized)="isAuthorized($event, menuItem, menuGroup)">
+                <chef-sidebar-entry
+                  [id]="'entry' + groupIndex + '-' + itemIndex"
+                  [route]="menuItem.route"
+                  [icon]="menuItem.icon"
+                  [openInNewPage]="menuItem.openInNewPage"
+                >{{ menuItem.name }}</chef-sidebar-entry>
+                <chef-tooltip
+                  [attr.for]="'entry' + groupIndex + '-' + itemIndex"
+                  position="right"
+                  delay="0">{{ menuItem.name }}</chef-tooltip>
+              </app-authorized>
+            </ng-container>
+          </div>
         </div>
-      </span>
+      </ng-container>
     </div>
 
     <ng-content select=".nav-items"></ng-content>

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.scss
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.scss
@@ -1,4 +1,5 @@
 @import "~styles/variables";
+@import "@carbon/layout/scss/layout";
 
 .sidebar {
   display: block;
@@ -8,7 +9,20 @@
   width: $sidebar-width;
   height: 100%;
   background-color: $chef-white;
-  border-right: 1px solid #DFE3E5;
+  border-right: 1px solid $chef-grey;
+
+  @include carbon--breakpoint-down(lg) {
+    width: $sidebar-small-width;
+  }
+
+  chef-tooltip {
+    display: none;
+    transition-duration: 0.1s;
+
+    @include carbon--breakpoint-down(lg) {
+      display: block;
+    }
+  }
 
   .sidebar-selector {
 
@@ -73,6 +87,7 @@
         text-decoration: none;
         font-size: 16px;
         overflow: hidden;
+        white-space: nowrap;
 
         // yields required 16px gap between elements
         padding-top: 8px;
@@ -87,6 +102,7 @@
 
           .arrow {
             display: inline;
+            margin-right: -3px;
           }
         }
       }
@@ -97,7 +113,8 @@
         vertical-align: -2px;
       }
 
-      .arrow {
+      .arrow,
+      .open-in-new {
         display: none;
         margin-top: 4px;
         float: right;
@@ -105,8 +122,8 @@
       }
 
       .open-in-new {
-        font-size: 14px;
-        padding-left: 4px;
+        display: inline;
+        margin-right: -3px;
       }
 
       .group {
@@ -116,30 +133,15 @@
         font-size: 12px;
         color: #6F7878;
       }
-    }
-  }
-}
 
-@media screen and (max-width: 769px) {
-  .sidebar {
-    width: $sidebar-small-width;
+      @include carbon--breakpoint-down(lg) {
+        .menu-item-groups:not(:last-child) {
+          border-bottom: 1px solid $chef-grey;
+        }
 
-    .text {
-      display: none;
-    }
-
-    ul {
-      li {
-        padding: 0;
-      }
-    }
-
-    .sidebar-nav {
-      ul {
-        li {
-          a {
-            padding: 30px 7px 30px 7px;
-          }
+        .group,
+        .text {
+          display: none;
         }
       }
     }

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -1,55 +1,53 @@
 <header role="banner">
   <nav role="navigation" class="navigation-wrapper">
-    <div class="left-nav"  role="menubar">
-      <div role="menuitem" class="logo-wrapper">
-        <a tabindex="0" routerLink="/" class="logo" title="logo link to homepage"></a>
-      </div>
-      <div class="navigation-menu">
-        <app-authorized [allOf]="[
-            ['/api/v0/eventfeed', 'get'],
-            ['/api/v0/eventstrings', 'get'],
-            ['/api/v0/event_type_counts', 'get'],
-            ['/api/v0/event_task_counts', 'get']]">
-          <div role="menuitem" class="nav-link"><a routerLink="/dashboards/event-feed" routerLinkActive="active" tabindex="0">Dashboards</a></div>
-        </app-authorized>
+    <div role="menuitem" class="logo-wrapper">
+      <a tabindex="0" routerLink="/" class="logo" title="logo link to homepage"></a>
+    </div>
+    <div class="navigation-menu">
+      <app-authorized [allOf]="[
+          ['/api/v0/eventfeed', 'get'],
+          ['/api/v0/eventstrings', 'get'],
+          ['/api/v0/event_type_counts', 'get'],
+          ['/api/v0/event_task_counts', 'get']]">
+        <div role="menuitem" class="nav-link"><a routerLink="/dashboards/event-feed" routerLinkActive="active" tabindex="0">Dashboards</a></div>
+      </app-authorized>
 
-        <app-authorized [allOf]="[
-            ['/api/v0/applications/services', 'get'],
-            ['/api/v0/applications/service-groups', 'get']]">
-          <div role="menuitem" class="nav-link"><a routerLink="/applications/service-groups" routerLinkActive="active" tabindex="0">Applications</a></div>
-        </app-authorized>
+      <app-authorized [allOf]="[
+          ['/api/v0/applications/services', 'get'],
+          ['/api/v0/applications/service-groups', 'get']]">
+        <div role="menuitem" class="nav-link"><a routerLink="/applications/service-groups" routerLinkActive="active" tabindex="0">Applications</a></div>
+      </app-authorized>
 
-        <app-authorized [allOf]="[
-            ['/api/v0/cfgmgmt/nodes', 'get'],
-            ['/api/v0/cfgmgmt/stats/node_counts', 'get']]">
-          <div role="menuitem" class="nav-link"><a routerLink="/infrastructure" routerLinkActive="active" tabindex="0">Infrastructure</a></div>
-        </app-authorized>
+      <app-authorized [allOf]="[
+          ['/api/v0/cfgmgmt/nodes', 'get'],
+          ['/api/v0/cfgmgmt/stats/node_counts', 'get']]">
+        <div role="menuitem" class="nav-link"><a routerLink="/infrastructure" routerLinkActive="active" tabindex="0">Infrastructure</a></div>
+      </app-authorized>
 
-        <app-authorized [anyOf]="[
-              ['/api/v0/compliance/reporting/stats/summary', 'post'],
-              ['/api/v0/compliance/reporting/stats/failures', 'post'],
-              ['/api/v0/compliance/reporting/stats/trend', 'post'],
-              ['/api/v0/compliance/scanner/jobs', 'post'],
-              ['/api/v0/compliance/scanner/jobs/search', 'post'],
-              ['/api/v0/compliance/profiles/search', 'post']]">
-          <div role="menuitem" class="nav-link"><a routerLink="/compliance" routerLinkActive="active" tabindex="0">Compliance</a></div>
-        </app-authorized>
+      <app-authorized [anyOf]="[
+            ['/api/v0/compliance/reporting/stats/summary', 'post'],
+            ['/api/v0/compliance/reporting/stats/failures', 'post'],
+            ['/api/v0/compliance/reporting/stats/trend', 'post'],
+            ['/api/v0/compliance/scanner/jobs', 'post'],
+            ['/api/v0/compliance/scanner/jobs/search', 'post'],
+            ['/api/v0/compliance/profiles/search', 'post']]">
+        <div role="menuitem" class="nav-link"><a routerLink="/compliance" routerLinkActive="active" tabindex="0">Compliance</a></div>
+      </app-authorized>
 
-        <app-authorized [anyOf]="[
-              ['/api/v0/datafeed/destinations', 'post'],
-              ['/api/v0/notifications/rules', 'get'],
-              ['/api/v0/secrets/search', 'post'],
-              ['/api/v0/nodemanagers/search', 'post'],
-              ['/api/v0/retention/nodes/status', 'get'],
-              ['/apis/iam/v2/users', 'get'],
-              ['/apis/iam/v2/teams', 'get'],
-              ['/apis/iam/v2/tokens', 'get'],
-              ['/apis/iam/v2/policies', 'get'],
-              ['/apis/iam/v2/roles', 'get'],
-              ['/apis/iam/v2/projects', 'get']] ">
-          <div role="menuitem" class="nav-link"><a routerLink="/settings" routerLinkActive="active" tabindex="0">Settings</a></div>
-        </app-authorized>
-      </div>
+      <app-authorized [anyOf]="[
+            ['/api/v0/datafeed/destinations', 'post'],
+            ['/api/v0/notifications/rules', 'get'],
+            ['/api/v0/secrets/search', 'post'],
+            ['/api/v0/nodemanagers/search', 'post'],
+            ['/api/v0/retention/nodes/status', 'get'],
+            ['/apis/iam/v2/users', 'get'],
+            ['/apis/iam/v2/teams', 'get'],
+            ['/apis/iam/v2/tokens', 'get'],
+            ['/apis/iam/v2/policies', 'get'],
+            ['/apis/iam/v2/roles', 'get'],
+            ['/apis/iam/v2/projects', 'get']] ">
+        <div role="menuitem" class="nav-link"><a routerLink="/settings" routerLinkActive="active" tabindex="0">Settings</a></div>
+      </app-authorized>
     </div>
     <div class="right-nav" role="menubar">
       <app-projects-filter></app-projects-filter>

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.scss
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.scss
@@ -1,77 +1,72 @@
 @import "~styles/variables";
+@import "@carbon/layout/scss/layout";
+
+:host {
+  display: block;
+  background-color: $white;
+  height: $navigation-height;
+  border-bottom: 1px solid $chef-grey;
+}
 
 header {
   position: relative;
+}
 
-  .cl-link {
-    display: flex;
-    position: fixed;
-    align-items: center;
-    color: $white;
-    bottom: 0;
-    right: 0;
-    background-color: $chef-primary;
-    padding: 0.25em 1em 0.25em 0.5em;
-    border-radius: $global-radius 0 0 0;
-    opacity: 0.5;
-    font-weight: bold;
-    text-decoration: none;
+.navigation-wrapper {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
 
-    &:hover {
-      opacity: 1;
-    }
+  @include carbon--breakpoint-down(lg) {
+    flex-flow: row wrap;
+  }
 
-    span {
-      padding-left: 0.5em;
+  .logo-wrapper {
+    margin-left: 16px;
+
+    a.logo {
+      display: block;
+      background: $default-logo transparent no-repeat center;
+      width: 160px;
+      height: $navigation-height;
+
+      @include carbon--breakpoint-down(lg) {
+        height: $navigation-height / 2;
+      }
     }
   }
 
-  .navigation-wrapper {
+  .navigation-menu {
     display: flex;
-    justify-content: space-between;
-    padding-top: 2px 36px 0 0;
-    background-color: $white;
-    box-sizing: padding-box;
-    z-index: 200;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: $navigation-height;
-    border-bottom: 1px solid #DFE3E5;
+    align-items: center;
 
-    .left-nav {
-      display: flex;
+    @include carbon--breakpoint-down(lg) {
+      order: 3;
+      width: 100%;
+      height: ($navigation-height / 2) - 2px;
+      line-height: ($navigation-height / 2) - 2px;
+      border-top: 1px solid $chef-grey;
+      overflow-x: auto;
     }
 
-    .right-nav {
-      display: flex;
-      align-items: center;
-      padding-right: 16px;
-    }
-
-    .logo-wrapper {
-      margin: 0 21px 0 20px;
-
-      a.logo {
-        display: block;
-        background: $default-logo transparent no-repeat center;
-        width: 160px;
-        height: $navigation-height;
-      }
-    }
-
-    .navigation-menu {
-      display: flex;
-      align-items: center;
+    app-authorized {
+      display: block;
     }
 
     .nav-link {
       padding-left: 35px;
 
+      @include carbon--breakpoint-down(lg) {
+        padding-left: 16px;
+      }
+
       a {
         color: $chef-primary-dark;
         text-decoration: none;
+
+        @include carbon--breakpoint-down(lg) {
+          font-size: 14px;
+        }
       }
 
       a:hover, a.active {
@@ -80,35 +75,10 @@ header {
     }
   }
 
-  .nav-icon-link {
-    display: inline-block;
-    margin: 0 0 0 16px;
-    padding: 0.36em 0;
-    text-align: center;
-    color: $chef-primary-bright;
-    font-size: 18px;
-    height: 32px;
-    width: 32px;
-    border: 1px solid $chef-primary-bright;
-    border-radius: 50%;
-
-    &.active {
-      background-color: $chef-primary-bright;
-      color: $chef-white;
-    }
-
-    &.key-icon {
-      padding: 0.42em 0;
-      font-size: 16px;
-    }
+  .right-nav {
+    display: flex;
+    margin-left: auto;
+    align-items: center;
+    padding-right: 16px;
   }
-}
-
-chef-tooltip {
-  font-size: 14px;
-}
-
-.rotated-icon {
-  transform: rotate(90deg) scaleX(1);
-  -webkit-transform: rotate(90deg) scaleX(1);
 }

--- a/components/automate-ui/src/app/page-components/profile/profile.component.scss
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.scss
@@ -1,7 +1,14 @@
 @import "~styles/variables";
 @import "~styles/mixins";
+@import "@carbon/layout/scss/layout";
 
 $dropdown-width: 196px;
+
+:host {
+  display: block;
+  margin-left: 6px;
+  margin-right: -4px;
+}
 
 button {
   -webkit-appearance: none;
@@ -38,16 +45,19 @@ a, button:not(.dropdown-toggle) {
 }
 
 .dropdown-toggle {
-  margin-left: 35px;
+  display: flex;
+  align-items: center;
   padding: 10px 0;
 }
 
 .dropdown-toggle-user-icon {
   position: relative;
-  top: 6px;
-  margin-right: -5px;
   font-size: 30px;
   line-height: 10px;
+
+  @include carbon--breakpoint-down(lg) {
+    font-size: 20px;
+  }
 }
 
 .dropdown {
@@ -55,7 +65,7 @@ a, button:not(.dropdown-toggle) {
   right: 16px;
   width: $dropdown-width;
   border: 1px solid $chef-grey;
-  z-index: 1;
+  z-index: 191;
 
   &::before {
     display: block;

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -1,5 +1,6 @@
 @import "~styles/variables";
 @import "~styles/mixins";
+@import "@carbon/layout/scss/layout";
 
 :host {
   display: block;
@@ -20,6 +21,10 @@
   background: transparent;
   font-weight: 600;
 
+  @include carbon--breakpoint-down(lg) {
+    padding: 8px 0;
+  }
+
   &:disabled {
     color: $chef-primary-dark;
     cursor: default; // no pointer when there's only one element
@@ -33,7 +38,7 @@
   > chef-icon {
     font-size: 16px;
     color: $chef-primary-dark;
-    margin-left: 8px;
+    margin-left: 5px;
   }
 
   .selection-label {
@@ -43,6 +48,10 @@
     overflow: hidden;
     text-overflow: ellipsis;
     line-height: normal; // solves descender clipping due to overflow: hidden
+
+    @include carbon--breakpoint-down(lg) {
+      font-size: 14px;
+    }
   }
 
   .selection-count {
@@ -55,6 +64,10 @@
     border-radius: 50%;
     margin-left: 10px;
     background: $chef-grey;
+
+    @include carbon--breakpoint-down(lg) {
+      font-size: 12px;
+    }
 
     &.active {
       background: $chef-primary-bright;

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -55,12 +55,6 @@
   }
 }
 
-@media screen and (max-width: 769px) {
-  .container {
-    margin-left: $sidebar-small-width;
-  }
-}
-
 html, body {
   margin: 0;
   padding: 0;

--- a/components/automate-ui/src/styles/_variables.scss
+++ b/components/automate-ui/src/styles/_variables.scss
@@ -61,7 +61,7 @@ $header-max-height: 110px;
 $modal-z-index: 99;
 $sidebar-width: 200px;
 $sidebar-top: 70px; // required space to accommodate header
-$sidebar-small-width: 80px;
+$sidebar-small-width: 70px;
 $global-radius: 4px;
 // width used for run-history sidebar
 $sidebar-right-width: 200px;


### PR DESCRIPTION
Until a more permanent solution is implemented, this commit retrofits the main navbar and sidebar styles to better handle smaller viewport sizes. The bulk of this diff is tweaks to paddings and font-sizes within Carbon grid breakpoints. The largest visual change is the main navbar collapsing to two rows within smaller viewports.

<details>
  <summary>Before</summary>
  <img src="https://user-images.githubusercontent.com/479121/81750814-73986480-946b-11ea-8241-331fae853201.gif" />
</details>

<details>
  <summary>After</summary>
  <img src="https://user-images.githubusercontent.com/479121/81750821-78f5af00-946b-11ea-95ed-09c61a5bbe95.gif" />
</details>
