### PR TITLE
Automate infra views roles UI changes

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
@@ -5,7 +5,7 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Server</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Orgs</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'org', orgId]">Cookbooks</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Cookbooks</chef-breadcrumb>
         {{ cookbookName }}
       </chef-breadcrumbs>
       <chef-page-header>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
@@ -11,7 +11,7 @@
       <chef-tbody>
         <chef-tr *ngFor="let cookbook of cookbooks">
           <chef-td>
-            <a [routerLink]="['/infrastructure','chef-servers', serverId, 'org', orgId, 'cookbooks', cookbook.name]">{{ cookbook.name }}</a>
+            <a [routerLink]="['/infrastructure','chef-servers', serverId, 'organizations', orgId, 'cookbooks', cookbook.name]">{{ cookbook.name }}</a>
           </chef-td>
           <chef-td>{{ cookbook.version }}</chef-td>
         </chef-tr>

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.html
@@ -4,7 +4,7 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Server</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Orgs</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'org', orgId]">Roles</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Roles</chef-breadcrumb>
          {{role?.name}}
       </chef-breadcrumbs>
       <chef-page-header>

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.html
@@ -12,9 +12,9 @@
       <chef-tbody>
         <chef-tr *ngFor="let role of roles">
           <chef-td>
-            <a [routerLink]="['/infrastructure','chef-servers', serverId, 'org', orgId, 'roles', role.name]">{{ role.name }}</a>
+            <a [routerLink]="['/infrastructure','chef-servers', serverId, 'organizations', orgId, 'roles', role.name]">{{ role.name }}</a>
           </chef-td>
-          <chef-td>{{ role.description === '' ?  'N/A' : role.description }}</chef-td>
+          <chef-td>{{ role.description === '' ?  '...' : role.description }}</chef-td>
           <chef-td>{{ role.environments.join(", ") }}</chef-td>
         </chef-tr>
       </chef-tbody>

--- a/components/automate-ui/src/app/modules/infra-proxy/tree-table/component/tree-table.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/tree-table/component/tree-table.component.html
@@ -2,13 +2,15 @@
   <div *ngFor="let column of displayedColumns; first as isFirst;">
     <ng-container matColumnDef="{{column}}">
       <th mat-header-cell *matHeaderCellDef [ngClass]="{'vertical-separator': options.verticalSeparator}">
-        {{options.capitalisedHeader ? (column | titlecase) : column}}
+        <p *ngIf="column !== 'name'">
+          {{options.capitalisedHeader ? (column | titlecase) : column}}
+        </p>
       </th>
       <td mat-cell *matCellDef="let element" [ngClass]="{'vertical-separator': options.verticalSeparator}">
         <div *ngIf="isFirst">
           <div class="value-cell">
             <div [class]="'child-step-'+(element.depth)"></div>
-            <mat-icon [ngStyle]="{'visibility': element.children.length ? 'visible' : 'hidden'}" (click)="onNodeClick(element)">
+            <mat-icon [ngStyle]="{'visibility': element.children.length ? 'visible' : 'hidden'}" (click)="onNodeClick(element, $event)">
               {{element.isExpanded ? 'remove' : 'add'}}
             </mat-icon>
             <div [ngClass]="{'hasChildren': element.children.length}">{{element.value[column]}}</div>

--- a/components/automate-ui/src/app/modules/infra-proxy/tree-table/component/tree-table.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/tree-table/component/tree-table.component.html
@@ -10,7 +10,7 @@
         <div *ngIf="isFirst">
           <div class="value-cell">
             <div [class]="'child-step-'+(element.depth)"></div>
-            <mat-icon [ngStyle]="{'visibility': element.children.length ? 'visible' : 'hidden'}" (click)="onNodeClick(element, $event)">
+            <mat-icon [ngStyle]="{'visibility': element.children.length ? 'visible' : 'hidden'}" (click)="onNodeClick(element)">
               {{element.isExpanded ? 'remove' : 'add'}}
             </mat-icon>
             <div [ngClass]="{'hasChildren': element.children.length}">{{element.value[column]}}</div>

--- a/components/automate-ui/src/app/modules/infra-proxy/tree-table/component/tree-table.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/tree-table/component/tree-table.component.scss
@@ -54,10 +54,6 @@ th.mat-header-cell {
   color: #222435;
 }
 
-th:first-child {
-  color: #FFFFFF;
-}
-
 .mat-elevation-z5 {
   box-shadow: none;
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/tree-table/component/tree-table.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/tree-table/component/tree-table.component.ts
@@ -52,6 +52,7 @@ export class TreeTableComponent<T> implements OnInit, OnChanges {
     this.searchableTree = this.tree.map(t => this.converterService.toSearchableTree(t));
     const treeTableTree = this.searchableTree.map(st => this.converterService.toTreeTableTree(st));
     this.treeTable = flatMap(treeTableTree, this.treeService.flatten);
+    this.treeCollepsed();
     this.dataSource = this.generateDataSource();
   }
 
@@ -63,6 +64,7 @@ export class TreeTableComponent<T> implements OnInit, OnChanges {
     this.searchableTree = this.tree.map(t => this.converterService.toSearchableTree(t));
     const treeTableTree = this.searchableTree.map(st => this.converterService.toTreeTableTree(st));
     this.treeTable = flatMap(treeTableTree, this.treeService.flatten);
+    this.treeCollepsed();
     this.dataSource = this.generateDataSource();
   }
 
@@ -75,7 +77,8 @@ export class TreeTableComponent<T> implements OnInit, OnChanges {
   }
 
   // A given element `el` is marked visible if every node between it and the root is expanded.
-  onNodeClick(clickedNode: TreeTableNode<T>): void {
+  onNodeClick(clickedNode: TreeTableNode<T>, $event: Event): void {
+    $event.stopPropagation();
     clickedNode.isExpanded = !clickedNode.isExpanded;
     this.treeTable.forEach(el => {
       el.isVisible = this.searchableTree.every(st => {
@@ -86,6 +89,15 @@ export class TreeTableComponent<T> implements OnInit, OnChanges {
     });
     this.dataSource = this.generateDataSource();
     this.nodeClicked.next(clickedNode);
+  }
+
+  treeCollepsed() {
+    this.treeTable.forEach((item, index) => {
+      item.isExpanded = false;
+      if (item.depth > 0 && index > 0) {
+        item.isVisible = false;
+      }
+    });
   }
 
   // Overrides default options with those specified by the user

--- a/components/automate-ui/src/app/modules/infra-proxy/tree-table/component/tree-table.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/tree-table/component/tree-table.component.ts
@@ -52,7 +52,7 @@ export class TreeTableComponent<T> implements OnInit, OnChanges {
     this.searchableTree = this.tree.map(t => this.converterService.toSearchableTree(t));
     const treeTableTree = this.searchableTree.map(st => this.converterService.toTreeTableTree(st));
     this.treeTable = flatMap(treeTableTree, this.treeService.flatten);
-    this.treeCollepsed();
+    this.treeCollapsed();
     this.dataSource = this.generateDataSource();
   }
 
@@ -64,7 +64,7 @@ export class TreeTableComponent<T> implements OnInit, OnChanges {
     this.searchableTree = this.tree.map(t => this.converterService.toSearchableTree(t));
     const treeTableTree = this.searchableTree.map(st => this.converterService.toTreeTableTree(st));
     this.treeTable = flatMap(treeTableTree, this.treeService.flatten);
-    this.treeCollepsed();
+    this.treeCollapsed();
     this.dataSource = this.generateDataSource();
   }
 
@@ -90,7 +90,7 @@ export class TreeTableComponent<T> implements OnInit, OnChanges {
     this.nodeClicked.next(clickedNode);
   }
 
-  treeCollepsed() {
+  treeCollapsed() {
     this.treeTable.forEach((item, index) => {
       item.isExpanded = false;
       if (item.depth > 0 && index > 0) {

--- a/components/automate-ui/src/app/modules/infra-proxy/tree-table/component/tree-table.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/tree-table/component/tree-table.component.ts
@@ -77,8 +77,7 @@ export class TreeTableComponent<T> implements OnInit, OnChanges {
   }
 
   // A given element `el` is marked visible if every node between it and the root is expanded.
-  onNodeClick(clickedNode: TreeTableNode<T>, $event: Event): void {
-    $event.stopPropagation();
+  onNodeClick(clickedNode: TreeTableNode<T>): void {
     clickedNode.isExpanded = !clickedNode.isExpanded;
     this.treeTable.forEach(el => {
       el.isVisible = this.searchableTree.every(st => {


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
I have added some UI changes for the roles list and role details page. 
### :chains: Related Resources
https://github.com/chef/automate/issues/3646
### :+1: Definition of Done

- Fixed hiding Name attribute on role's run-list page detail. Need better UX.
- Fixed default run list in expanded state bit should be in collapse state.
- Fixed On Role's detail page "Roles" breadcrumb directed to cookbooks tab it should be on the respective tab ie.(Roles).
- Fixed blank role's description "NA" should be represented using "...".

### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots
![colleps](https://user-images.githubusercontent.com/12297653/81825038-bd5c7a00-9553-11ea-857d-f22de7c089e0.png)
