### PR TITLE
Add the new inspec truncation options

### DIFF
--- a/components/compliance-service/cmd/compliance-service/cmd/run.go
+++ b/components/compliance-service/cmd/compliance-service/cmd/run.go
@@ -26,12 +26,14 @@ var conf = config.Compliance{
 		MigrationsPath:   "dao/pgdb/migration/sql/",
 	},
 	InspecAgent: config.InspecAgent{
-		JobBufferSize: 1000,
-		JobWorkers:    10,
-		BackendCache:  "true",
-		AuthnTarget:   "0.0.0.0:10113",
-		AutomateFQDN:  "localhost",
-		TmpDir:        os.Getenv("TMPDIR"),
+		JobBufferSize:       1000,
+		JobWorkers:          10,
+		BackendCache:        "true",
+		AuthnTarget:         "0.0.0.0:10113",
+		AutomateFQDN:        "localhost",
+		TmpDir:              os.Getenv("TMPDIR"),
+		ResultMessageLimit:  10000,
+		ControlResultsLimit: 50,
 	},
 	ElasticSearch: config.ElasticSearch{},
 	ElasticSearchSidecar: config.ElasticSearchSidecar{
@@ -120,6 +122,8 @@ func init() {
 	runCmd.Flags().StringVar(&conf.InspecAgent.AutomateFQDN, "automate-fqdn", conf.InspecAgent.AutomateFQDN, "Target fqdn for inspec reporting to automate")
 	runCmd.Flags().StringVar(&conf.InspecAgent.TmpDir, "inspec-tmp-dir", conf.InspecAgent.TmpDir, "location of /tmp dir to be used by inspec for caching")
 	runCmd.Flags().StringVar(&conf.InspecAgent.RemoteInspecVersion, "remote-inspec-version", conf.InspecAgent.RemoteInspecVersion, "Option to specify the version of inspec to use for remote(e.g. AWS SSM) scan jobs")
+	runCmd.Flags().IntVar(&conf.InspecAgent.ResultMessageLimit, "result-message-limit", conf.InspecAgent.ResultMessageLimit, "A control result message that exceeds this character limit will be truncated")
+	runCmd.Flags().IntVar(&conf.InspecAgent.ControlResultsLimit, "control-results-limit", conf.InspecAgent.ControlResultsLimit, "The array of results per control will be truncated at this limit to avoid large reports that cannot be processed")
 
 	// Legacy Automate Headers/User Info
 	runCmd.Flags().StringVar(&conf.Delivery.Enterprise, "delivery-ent", conf.Delivery.Enterprise, "Automate Enterprise")

--- a/components/compliance-service/compliance.go
+++ b/components/compliance-service/compliance.go
@@ -119,6 +119,10 @@ func initBits(ctx context.Context, conf *config.Compliance) (db *pgdb.DB, connFa
 	} else {
 		inspec.BackendCache = backendCacheBool
 	}
+
+	inspec.ResultMessageLimit = conf.InspecAgent.ResultMessageLimit
+	runner.ControlResultsLimit = conf.InspecAgent.ControlResultsLimit
+
 	inspec.TmpDir = conf.InspecAgent.TmpDir
 	// Let's have something sensible if the temp dir is not specified
 	if inspec.TmpDir == "" {

--- a/components/compliance-service/config/types.go
+++ b/components/compliance-service/config/types.go
@@ -81,6 +81,8 @@ type InspecAgent struct {
 	AutomateFQDN        string
 	TmpDir              string
 	RemoteInspecVersion string
+	ResultMessageLimit  int
+	ControlResultsLimit int
 }
 
 // Postgres specific options

--- a/components/compliance-service/inspec-agent/runner/runner_test.go
+++ b/components/compliance-service/inspec-agent/runner/runner_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"testing"
 
+	ingest_inspec "github.com/chef/automate/api/interservice/compliance/ingest/events/inspec"
 	"github.com/chef/automate/components/compliance-service/inspec"
 	"github.com/chef/automate/components/compliance-service/inspec-agent/types"
 	"github.com/stretchr/testify/assert"
@@ -62,4 +63,137 @@ func TestPotentialTargetConfigs(t *testing.T) {
 			Password: "d",
 		},
 	}, targetConfigs[1])
+}
+
+func TestRemoveResults(t *testing.T) {
+	profiles := []*ingest_inspec.Profile{
+		{
+			Title: "Test Profile 1",
+			Controls: []*ingest_inspec.Control{
+				{
+					Id: "p1c1",
+					Results: []*ingest_inspec.Result{
+						{
+							Message: "Resource is as expected",
+							Status:  "passed",
+						},
+						{Status: "passed"},
+						{Status: "failed"},
+						{Status: "skipped"},
+						{Status: "failed"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "failed"},
+						{Status: "passed"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "failed"},
+						{Status: "passed"},
+						{Status: "failed"},
+						{Status: "skipped"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "skipped"},
+						{Status: "failed"},
+						{Status: "passed"},
+						{Status: "passed"},
+						{Status: "passed"},
+						{Status: "passed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+					},
+				},
+				{
+					Id: "p1c2",
+				},
+			},
+		},
+		{
+			Title: "Test Profile 2",
+		},
+	}
+
+	removeResults("test-report-id", profiles, 25)
+	assert.Equal(t, []*ingest_inspec.Profile{
+		{
+			Title: "Test Profile 1",
+			Controls: []*ingest_inspec.Control{
+				{
+					Id: "p1c1",
+					Results: []*ingest_inspec.Result{
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "skipped"},
+						{Status: "passed"},
+						{Status: "passed"},
+					},
+					RemovedResultsCounts: &ingest_inspec.RemovedResultsCounts{
+						Passed: 6,
+					},
+				},
+				{
+					Id: "p1c2",
+				},
+			},
+		},
+		{
+			Title: "Test Profile 2",
+		},
+	}, profiles)
+
+	removeResults("test-report-id", profiles, 4)
+	assert.Equal(t, []*ingest_inspec.Profile{
+		{
+			Title: "Test Profile 1",
+			Controls: []*ingest_inspec.Control{
+				{
+					Id: "p1c1",
+					Results: []*ingest_inspec.Result{
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+						{Status: "failed"},
+					},
+					RemovedResultsCounts: &ingest_inspec.RemovedResultsCounts{
+						Failed:  8,
+						Skipped: 11,
+						Passed:  2,
+					},
+				},
+				{
+					Id: "p1c2",
+				},
+			},
+		},
+		{
+			Title: "Test Profile 2",
+		},
+	}, profiles)
+
 }

--- a/components/compliance-service/inspec/types.go
+++ b/components/compliance-service/inspec/types.go
@@ -257,19 +257,20 @@ type Secrets struct {
 }
 
 type TargetBaseConfig struct {
-	Backend        string              `json:"backend,omitempty"`
-	Hostname       string              `json:"host,omitempty"`
-	Port           int                 `json:"port,omitempty"`
-	LoginPath      string              `json:"login_path,omitempty"` // winrm
-	Sudo           bool                `json:"sudo,omitempty"`
-	Format         string              `json:"format,omitempty"`
-	Reporter       map[string]Reporter `json:"reporter,omitempty"`
-	Ssl            bool                `json:"ssl,omitempty"`
-	SslSelfSigned  bool                `json:"self_signed,omitempty"`
-	BackendCache   bool                `json:"backend_cache,omitempty"`
-	Region         string              `json:"region,omitempty"`
-	SubscriptionId string              `json:"subscription_id,omitempty"`
-	AttributesJson *json.RawMessage    `json:"attributes,omitempty"`
+	Backend                string              `json:"backend,omitempty"`
+	Hostname               string              `json:"host,omitempty"`
+	Port                   int                 `json:"port,omitempty"`
+	LoginPath              string              `json:"login_path,omitempty"` // winrm
+	Sudo                   bool                `json:"sudo,omitempty"`
+	Reporter               map[string]Reporter `json:"reporter,omitempty"`
+	Ssl                    bool                `json:"ssl,omitempty"`
+	SslSelfSigned          bool                `json:"self_signed,omitempty"`
+	BackendCache           bool                `json:"backend_cache,omitempty"`
+	Region                 string              `json:"region,omitempty"`
+	SubscriptionId         string              `json:"subscription_id,omitempty"`
+	AttributesJson         *json.RawMessage    `json:"attributes,omitempty"`
+	ResultIncludeBacktrace bool                `json:"attributes,reporter_backtrace_inclusion"`
+	ResultMessageLimit     int                 `json:"attributes,reporter_message_truncation"`
 }
 
 // TargetConfig is inspec's JSON config options

--- a/components/compliance-service/scripts/grpcurl_it.sh
+++ b/components/compliance-service/scripts/grpcurl_it.sh
@@ -1,0 +1,64 @@
+#!/bin/bash -e
+
+which -s grpcurl || (echo "grpcurl is not installed, aborting..." && exit 1)
+which -s jq || (echo "js is not installed, aborting..." && exit 2)
+
+COMP_PORT=${PORT:-10121}
+MANAGER_PORT=${MANAGER_PORT:-10120}
+HOST=${HOST:-localhost}
+SSL_CERT="$(PWD)/../../../dev/certs/compliance-service.crt"
+SSL_KEY="$(PWD)/../../../dev/certs/compliance-service.key"
+CURL_COMP="--insecure -cert $SSL_CERT -key $SSL_KEY $HOST:$COMP_PORT"
+CURL_OPTS_COMP="--insecure -cert $SSL_CERT -key $SSL_KEY $HOST:$COMP_PORT chef.automate.domain.compliance"
+CURL_OPTS_MANAGER="--insecure -cert $SSL_CERT -key $SSL_KEY $HOST:$MANAGER_PORT chef.automate.domain.nodemanager"
+RAND_NR=$((RANDOM%100))
+
+# grpcurl $CURL_COMP list
+# grpcurl $CURL_COMP describe chef.automate.domain.compliance.jobs.JobsService
+# grpcurl $CURL_COMP describe chef.automate.domain.compliance.jobs.Job
+
+echo && echo "Compliance Service version:"
+grpcurl $CURL_OPTS_COMP.version.VersionService/Version
+
+NODE_NAME="curl_it docker node $RAND_NR"
+echo && echo "Adding docker node '$NODE_NAME'"
+NODE_ID=`grpcurl -d @ $CURL_OPTS_MANAGER.nodes.NodesService/Create <<EOM | jq -r .id
+{
+  "name": "$NODE_NAME",
+  "manager": "automate",
+  "target_config": {
+    "backend": "docker",
+    "host": "cc_pg",
+    "sudo": false
+  }
+}
+EOM
+`
+
+echo && echo "Adding a detect job for the new node '$NODE_NAME' with id '$NODE_ID'"
+grpcurl -d @ $CURL_OPTS_COMP.jobs.JobsService/Create <<EOM
+{
+  "name": "curl_it docker node detect job $RAND_NR",
+  "type": "detect",
+  "nodes": ["$NODE_ID"],
+  "retries": 1
+}
+EOM
+
+echo && echo "Adding an exec job for the new node '$NODE_NAME' with id '$NODE_ID'"
+grpcurl -d @ $CURL_OPTS_COMP.jobs.JobsService/Create <<EOM
+{
+  "name": "curl_it docker node exec job $RAND_NR",
+  "type": "exec",
+  "nodes": ["$NODE_ID"],
+  "profiles": ["https://github.com/dev-sec/apache-baseline/archive/master.tar.gz"],
+  "retries": 1
+}
+EOM
+
+
+# List all nodes
+# grpcurl $CURL_OPTS_MANAGER.nodes.NodesService/List
+
+# List all jobs
+# grpcurl $CURL_OPTS_COMP.jobs.JobsService/List


### PR DESCRIPTION
This PR makes use of the latest inspec `reporter_backtrace_inclusion` and `reporter_message_truncation` [options](https://github.com/inspec/inspec/pull/4994) when triggering Compliance scans from Automate.

It also truncates the controls to maximum 50 (default) results per control before sending the report through ingestion. This is to prevent reports that exceed 4MB which are not allowed through grpc.
^ To tests this, you have to trigger a scan with a control that has a loop inside and generates lots of describe blocks.