### PR TITLE
Map outgoing and incoming data to opposite inputs in client runs

### DIFF
--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
@@ -247,7 +247,7 @@ describe('AutomateSettingsComponent', () => {
       // ['serviceGroupRemoveServices'],
 
       // Client Runs
-      ['clientRunsRemoveNodes', 'converge-history',
+      ['clientRunsRemoveData', 'converge-history',
           genNestedIngestJob('infra', 'periodic_purge_timeseries', 'converge-history', 7, false)],
 
         // Compliance
@@ -271,7 +271,7 @@ describe('AutomateSettingsComponent', () => {
 
     using([
       // Client Runs
-      ['clientRunsRemoveData', genInjestJob('infra', 'missing_nodes_for_deletion', '5m', false)],
+      ['clientRunsRemoveNodes', genInjestJob('infra', 'missing_nodes_for_deletion', '5m', false)],
       ['clientRunsLabelMissing', genInjestJob('infra', 'missing_nodes', '6h', false)]
     ], function (formName: string, job: IngestJob) {
       it(`when updating ${formName} form,
@@ -303,7 +303,7 @@ describe('AutomateSettingsComponent', () => {
       // ['serviceGroupRemoveServices'],
 
       // Client Runs
-      ['clientRunsRemoveNodes', 'converge-history',
+      ['clientRunsRemoveData', 'converge-history',
         genNestedIngestJob('infra', 'periodic_purge_timeseries', 'converge-history', 7, true)],
 
       // Compliance
@@ -327,7 +327,7 @@ describe('AutomateSettingsComponent', () => {
 
     using([
       // Client Runs
-      ['clientRunsRemoveData', genInjestJob('infra', 'missing_nodes_for_deletion', '5m', true)],
+      ['clientRunsRemoveNodes', genInjestJob('infra', 'missing_nodes_for_deletion', '5m', true)],
       ['clientRunsLabelMissing', genInjestJob('infra', 'missing_nodes', '6h', true)]
     ], function (formName: string, job: IngestJob) {
       it(`when ${formName} form is saved as disabled, unit and threshold are undefined

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
@@ -66,22 +66,22 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
     },
     clientRunsRemoveData: {
       category: JobCategories.Infra,
-      name: 'missing_nodes',
+      name: 'periodic_purge_timeseries',
+      nested_name: NestedJobName.ConvergeHistory,
       unit: { value: 'd', disabled: false },
       threshold: [{ value: '30', disabled: false }, Validators.required],
       disabled: false
     },
     clientRunsLabelMissing: {
       category: JobCategories.Infra,
-      name: 'missing_nodes_for_deletion',
+      name: 'missing_nodes',
       unit: { value: 'd', disabled: false },
       threshold: [{ value: '30', disabled: false }, Validators.required],
       disabled: false
     },
     clientRunsRemoveNodes: {
       category: JobCategories.Infra,
-      name: 'periodic_purge_timeseries',
-      nested_name: NestedJobName.ConvergeHistory,
+      name: 'missing_nodes_for_deletion',
       unit: { value: 'd', disabled: false },
       threshold: [{ value: '30', disabled: false }, Validators.required],
       disabled: false
@@ -391,9 +391,9 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
 
     switch (job.name) {
       case InfraJobName.MissingNodesForDeletion: {
-        this.handleDisable(this.clientRunsRemoveData, job.disabled);
+        this.handleDisable(this.clientRunsRemoveNodes, job.disabled);
         [formThreshold, formUnit] = this.splitThreshold(job.threshold);
-        this.clientRunsRemoveData.patchValue({
+        this.clientRunsRemoveNodes.patchValue({
           unit: formUnit,
           threshold: formThreshold,
           disabled: job.disabled
@@ -462,8 +462,8 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
         break;
 
         case NestedJobName.ConvergeHistory: {
-          this.handleDisable(this.clientRunsRemoveNodes, _job.disabled);
-          this.clientRunsRemoveNodes.patchValue(form);
+          this.handleDisable(this.clientRunsRemoveData, _job.disabled);
+          this.clientRunsRemoveData.patchValue(form);
         }
           break;
 


### PR DESCRIPTION
#### :nut_and_bolt: Description: What code changed, and why?

The data going out for converge history and missing_nodes_for_deletion
was swapped, which sent the wrong data to the wrong areas in the api
while looking correct.

This branch alters the mapping so that the correct data is placed.

### :chains: Related Resources
This is part 1 of https://github.com/chef/automate/issues/3651.  It does not yet handle the non-activation of save button when nodes labeled as missing input is switched to days.

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
in hab studio: `build components/automate-ui-devproxy && start_all_services`
cd into components/automate-ui and run `make serve`

navigate to https://a2-dev.test/settings/data-lifecycle
change data in all of the client runs section and save
check that the data is the same after a refresh

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
