### PR TITLE
Add clarification to lifecycle docs

### DIFF
--- a/components/automate-chef-io/content/docs/data-lifecycle.md
+++ b/components/automate-chef-io/content/docs/data-lifecycle.md
@@ -171,7 +171,10 @@ Configure the data lifecycle job settings by creating a JSON file with the desir
 }
 ```
 
-Configure the jobs by sending the JSON payload to the `configure` endpoint.
+Configure the jobs by sending the JSON payload to the `config` endpoint.
+Note that the data you send to this input is **not** the same as the data returned from the `status` endpoint.
+That is, you cannot just read the data on the `status` endpoint, change some values, and feed it back on the `config` endpoint.
+
 Save the JSON file as `config.json` in the current working directory:
 
 ```bash

--- a/components/automate-chef-io/content/docs/data-lifecycle.md
+++ b/components/automate-chef-io/content/docs/data-lifecycle.md
@@ -172,8 +172,11 @@ Configure the data lifecycle job settings by creating a JSON file with the desir
 ```
 
 Configure the jobs by sending the JSON payload to the `config` endpoint.
-Note that the data you send to this input is **not** the same as the data returned from the `status` endpoint.
-That is, you cannot just read the data on the `status` endpoint, change some values, and feed it back on the `config` endpoint.
+
+{{% info %}}
+The data sent to the `config` endpoint intentionally follows a different format than the data returned from the `status` endpoint.
+You cannot read the data on the `status` endpoint, change some values, and feed it back on the `config` endpoint.
+{{% /info %}}
 
 Save the JSON file as `config.json` in the current working directory:
 

--- a/components/automate-chef-io/content/docs/data-lifecycle.md
+++ b/components/automate-chef-io/content/docs/data-lifecycle.md
@@ -175,7 +175,7 @@ Configure the jobs by sending the JSON payload to the `config` endpoint.
 
 {{% info %}}
 The data sent to the `config` endpoint intentionally follows a different format than the data returned from the `status` endpoint.
-You cannot read the data on the `status` endpoint, change some values, and feed it back on the `config` endpoint.
+You cannot read the data on the `status` endpoint, change some values, and feed the modified data back on the `config` endpoint.
 {{% /info %}}
 
 Save the JSON file as `config.json` in the current working directory:


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?

Try to help users who will reasonably try to feed the lifecycle settings output (`status` endpoint) back into the system to change settings on the `config` endpoint. Unfortunately, those two formats are not quite compatible. We need to fix this, certainly, but in the meantime, this at least cautions folks about it.

### :chains: Related Resources

### :+1: Definition of Done
Docs update

### :athletic_shoe: How to Build and Test the Change
NA

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
