### PR TITLE
Data Bags tab in infra view

### DIFF
--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -71,6 +71,7 @@ import { CookbookDetailsRequests } from './entities/cookbooks/cookbook-details.r
 import { CookbookVersionsRequests } from './entities/cookbooks/cookbook-versions.requests';
 import { ClientRunsRequests } from './entities/client-runs/client-runs.requests';
 import { CredentialRequests } from './entities/credentials/credential.requests';
+import { DataBagsRequests } from './entities/data-bags/data-bags.requests';
 import { DesktopRequests } from './entities/desktop/desktop.requests';
 import { DestinationRequests } from './entities/destinations/destination.requests';
 import { EnvironmentRequests } from './entities/environments/environment.requests';
@@ -292,6 +293,7 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     CookbookRequests,
     CookbookVersionsRequests,
     CredentialRequests,
+    DataBagsRequests,
     DesktopRequests,
     DestinationRequests,
     EnvironmentRequests,

--- a/components/automate-ui/src/app/entities/data-bags/data-bags.action.ts
+++ b/components/automate-ui/src/app/entities/data-bags/data-bags.action.ts
@@ -1,0 +1,33 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Action } from '@ngrx/store';
+import { DataBags } from './data-bags.model';
+
+export enum DataBagsActionTypes {
+  GET_ALL = 'DATA_BAGS::GET_ALL',
+  GET_ALL_SUCCESS = 'DATA_BAGS::GET_ALL::SUCCESS',
+  GET_ALL_FAILURE = 'DATA_BAGS::GET_ALL::FAILURE'
+}
+
+export interface DataBagsSuccessPayload {
+  data_bags: DataBags[];
+}
+
+export class GetDataBags implements Action {
+  readonly type = DataBagsActionTypes.GET_ALL;
+  constructor(public payload: { server_id: string, org_id: string }) { }
+}
+
+export class GetDataBagsSuccess implements Action {
+  readonly type = DataBagsActionTypes.GET_ALL_SUCCESS;
+  constructor(public payload: DataBagsSuccessPayload) { }
+}
+
+export class GetDataBagsFailure implements Action {
+  readonly type = DataBagsActionTypes.GET_ALL_FAILURE;
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export type DataBagsActions =
+  | GetDataBags
+  | GetDataBagsSuccess
+  | GetDataBagsFailure;

--- a/components/automate-ui/src/app/entities/data-bags/data-bags.effects.ts
+++ b/components/automate-ui/src/app/entities/data-bags/data-bags.effects.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { of as observableOf } from 'rxjs';
+import { catchError, mergeMap, map } from 'rxjs/operators';
+import { CreateNotification } from 'app/entities/notifications/notification.actions';
+import { Type } from 'app/entities/notifications/notification.model';
+
+import {
+  GetDataBags,
+  GetDataBagsSuccess,
+  GetDataBagsFailure,
+  DataBagsSuccessPayload,
+  DataBagsActionTypes
+} from './data-bags.action';
+
+import { DataBagsRequests } from './data-bags.requests';
+
+@Injectable()
+export class DataBagsEffects {
+  constructor(
+    private actions$: Actions,
+    private requests: DataBagsRequests
+  ) { }
+
+  @Effect()
+  getDataBags$ = this.actions$.pipe(
+      ofType(DataBagsActionTypes.GET_ALL),
+      mergeMap(({ payload: { server_id, org_id } }: GetDataBags) =>
+        this.requests.getDataBags(server_id, org_id).pipe(
+          map((resp: DataBagsSuccessPayload) => new GetDataBagsSuccess(resp)),
+          catchError((error: HttpErrorResponse) => observableOf(new GetDataBagsFailure(error))))));
+
+  @Effect()
+  getDataBagsFailure$ = this.actions$.pipe(
+      ofType(DataBagsActionTypes.GET_ALL_FAILURE),
+      map(({ payload }: GetDataBagsFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not get infra data bags: ${msg || payload.error}`
+        });
+      }));
+
+}

--- a/components/automate-ui/src/app/entities/data-bags/data-bags.model.ts
+++ b/components/automate-ui/src/app/entities/data-bags/data-bags.model.ts
@@ -1,0 +1,4 @@
+export interface DataBags {
+  name: string;
+}
+

--- a/components/automate-ui/src/app/entities/data-bags/data-bags.reducer.ts
+++ b/components/automate-ui/src/app/entities/data-bags/data-bags.reducer.ts
@@ -1,0 +1,44 @@
+import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
+import { set, pipe } from 'lodash/fp';
+import { EntityStatus } from 'app/entities/entities';
+import { DataBagsActionTypes, DataBagsActions } from './data-bags.action';
+import { DataBags } from './data-bags.model';
+
+export interface DataBagsEntityState extends EntityState<DataBags> {
+  getAllStatus: EntityStatus;
+}
+
+const GET_ALL_STATUS = 'getAllStatus';
+
+export const dataBagsEntityAdapter: EntityAdapter<DataBags> = createEntityAdapter<DataBags>({
+  selectId: (dataBags: DataBags) => dataBags.name
+});
+
+export const DataBagsEntityInitialState: DataBagsEntityState =
+dataBagsEntityAdapter.getInitialState(<DataBagsEntityState>{
+  getAllStatus: EntityStatus.notLoaded
+});
+
+export function dataBagsEntityReducer(
+  state: DataBagsEntityState = DataBagsEntityInitialState,
+  action: DataBagsActions): DataBagsEntityState {
+
+  switch (action.type) {
+    case DataBagsActionTypes.GET_ALL:
+      return set(GET_ALL_STATUS, EntityStatus.loading, dataBagsEntityAdapter.removeAll(state));
+
+    case DataBagsActionTypes.GET_ALL_SUCCESS:
+      return pipe(
+        set(GET_ALL_STATUS, EntityStatus.loadingSuccess))
+        (dataBagsEntityAdapter.setAll(action.payload.data_bags, state)) as DataBagsEntityState;
+
+    case DataBagsActionTypes.GET_ALL_FAILURE:
+      return set(GET_ALL_STATUS, EntityStatus.loadingFailure, state);
+
+    default:
+      return state;
+  }
+}
+
+export const getEntityById = (id: string) =>
+  (state: DataBagsEntityState) => state.entities[id];

--- a/components/automate-ui/src/app/entities/data-bags/data-bags.requests.ts
+++ b/components/automate-ui/src/app/entities/data-bags/data-bags.requests.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment as env } from 'environments/environment';
+import { DataBagsSuccessPayload } from './data-bags.action';
+
+@Injectable()
+export class DataBagsRequests {
+
+  constructor(private http: HttpClient) { }
+
+  public getDataBags(server_id: string, org_id: string): Observable<DataBagsSuccessPayload> {
+    return this.http.get<DataBagsSuccessPayload>(
+      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/data_bags`);
+  }
+}

--- a/components/automate-ui/src/app/entities/data-bags/data-bags.selectors.ts
+++ b/components/automate-ui/src/app/entities/data-bags/data-bags.selectors.ts
@@ -1,0 +1,21 @@
+import { createSelector, createFeatureSelector } from '@ngrx/store';
+import { DataBagsEntityState, dataBagsEntityAdapter } from './data-bags.reducer';
+import { routeParams } from 'app/route.selectors';
+import { find } from 'lodash/fp';
+
+export const dataBagsState = createFeatureSelector<DataBagsEntityState>('dataBags');
+export const {
+  selectAll: allDataBags,
+  selectEntities: dataBagsEntities
+} = dataBagsEntityAdapter.getSelectors(dataBagsState);
+
+export const getAllStatus = createSelector(
+  dataBagsState,
+  (state) => state.getAllStatus
+);
+
+export const dataBagsFromRoute = createSelector(
+  dataBagsState,
+  routeParams,
+  (state, { name }) => find({ name }, state)
+);

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.html
@@ -1,0 +1,17 @@
+<section class="databags">
+  <chef-loading-spinner *ngIf="dataBagsListLoading" size="50"></chef-loading-spinner>
+  <ng-container  *ngIf="!dataBagsListLoading">
+    <chef-table>
+      <chef-thead>
+        <chef-tr>
+          <chef-th>Name</chef-th>
+        </chef-tr>
+      </chef-thead>
+      <chef-tbody>
+        <chef-tr *ngFor="let dataBag of dataBags">
+          <chef-td>{{ dataBag.name }}</chef-td>
+        </chef-tr>
+      </chef-tbody>
+    </chef-table>
+  </ng-container>
+</section>

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.scss
@@ -1,0 +1,8 @@
+@import "~styles/variables";
+
+chef-loading-spinner {
+  display: block;
+  margin: 100px auto;
+  width: 100px;
+  z-index: 199;
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.spec.ts
@@ -1,0 +1,59 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { DataBagsListComponent } from './data-bags-list.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MockComponent } from 'ng2-mock-component';
+import { StoreModule } from '@ngrx/store';
+import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+
+describe('DataBagsListComponent', () => {
+  let component: DataBagsListComponent;
+  let fixture: ComponentFixture<DataBagsListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
+        MockComponent({ selector: 'chef-error' }),
+        MockComponent({ selector: 'chef-form-field' }),
+        MockComponent({ selector: 'chef-heading' }),
+        MockComponent({ selector: 'chef-icon' }),
+        MockComponent({ selector: 'chef-loading-spinner' }),
+        MockComponent({ selector: 'chef-page-header' }),
+        MockComponent({ selector: 'chef-subheading' }),
+        MockComponent({ selector: 'chef-toolbar' }),
+        MockComponent({ selector: 'chef-table' }),
+        MockComponent({ selector: 'chef-thead' }),
+        MockComponent({ selector: 'chef-tbody' }),
+        MockComponent({ selector: 'chef-tr' }),
+        MockComponent({ selector: 'chef-th' }),
+        MockComponent({ selector: 'chef-td' }),
+        MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
+        MockComponent({ selector: 'mat-select' }),
+        MockComponent({ selector: 'mat-option' }),
+        DataBagsListComponent
+      ],
+      providers: [
+        FeatureFlagsService
+      ],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DataBagsListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.spec.ts
@@ -1,11 +1,12 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { DataBagsListComponent } from './data-bags-list.component';
-import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MockComponent } from 'ng2-mock-component';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule } from '@ngrx/store';
+import { MockComponent } from 'ng2-mock-component';
+
 import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+import { DataBagsListComponent } from './data-bags-list.component';
 
 describe('DataBagsListComponent', () => {
   let component: DataBagsListComponent;

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.ts
@@ -1,0 +1,52 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { combineLatest } from 'rxjs';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
+import { filter } from 'rxjs/operators';
+import { isNil } from 'lodash/fp';
+import { EntityStatus } from 'app/entities/entities';
+import { GetDataBags } from 'app/entities/data-bags/data-bags.action';
+import { DataBags } from 'app/entities/data-bags/data-bags.model';
+import {
+  allDataBags,
+  getAllStatus as getAllDatabagsForOrgStatus
+} from 'app/entities/data-bags/data-bags.selectors';
+
+@Component({
+  selector: 'app-data-bags-list',
+  templateUrl: './data-bags-list.component.html',
+  styleUrls: ['./data-bags-list.component.scss']
+})
+
+export class DataBagsListComponent implements OnInit {
+  @Input() serverId: string;
+  @Input() orgId: string;
+
+  public dataBags: DataBags[];
+  public dataBagsListLoading = true;
+
+  constructor(
+    private store: Store<NgrxStateAtom>,
+    private layoutFacade: LayoutFacadeService
+  ) { }
+
+  ngOnInit() {
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
+
+    this.store.dispatch(new GetDataBags({
+      server_id: this.serverId, org_id: this.orgId
+    }));
+
+    combineLatest([
+      this.store.select(getAllDatabagsForOrgStatus),
+      this.store.select(allDataBags)
+    ]).pipe(
+      filter(([getDataBagsSt, allDataBagsState]) =>
+      getDataBagsSt === EntityStatus.loadingSuccess && !isNil(allDataBagsState))
+    ).subscribe(([ _getDataBagsSt, allDataBagsState]) => {
+      this.dataBags = allDataBagsState;
+      this.dataBagsListLoading = false;
+    });
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.ts
@@ -1,11 +1,12 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { combineLatest } from 'rxjs';
-import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { filter } from 'rxjs/operators';
 import { isNil } from 'lodash/fp';
+
+import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { EntityStatus } from 'app/entities/entities';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { GetDataBags } from 'app/entities/data-bags/data-bags.action';
 import { DataBags } from 'app/entities/data-bags/data-bags.model';
 import {

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
@@ -11,6 +11,7 @@ import { CookbooksComponent } from './cookbooks/cookbooks.component';
 import { CookbookDetailsComponent } from './cookbook-details/cookbook-details.component';
 import { CreateChefServerModalComponent } from './create-chef-server-modal/create-chef-server-modal.component';
 import { CreateOrgModalComponent } from './create-org-modal/create-org-modal.component';
+import { DataBagsListComponent } from './data-bags-list/data-bags-list.component';
 import { EnvironmentsComponent } from './environments/environments.component';
 import { InfraRolesComponent } from './infra-roles/infra-roles.component';
 import { InfraRoleDetailsComponent } from './infra-role-details/infra-role-details.component';
@@ -27,6 +28,7 @@ import { TreeTableModule } from './tree-table/tree-table.module';
     CookbookDetailsComponent,
     CreateChefServerModalComponent,
     CreateOrgModalComponent,
+    DataBagsListComponent,
     EnvironmentsComponent,
     JsonTreeTableComponent,
     InfraRolesComponent,

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
@@ -33,6 +33,9 @@
           </app-tab>
           <app-tab tabTitle="Environments" #environments_tab  [active]="environmentsTab">
             <app-environments *ngIf="environments_tab.active" [serverId]="serverId" [orgId]="orgId"></app-environments>
+          </app-tab>  
+          <app-tab tabTitle="Data Bags" #data_bags_tab  [active]="dataBagsTab">
+            <app-data-bags-list *ngIf="data_bags_tab.active" [serverId]="serverId" [orgId]="orgId"></app-data-bags-list>
           </app-tab>
           <app-tab tabTitle="Details" #details_tab [active]="false">
             <app-org-edit *ngIf="details_tab.active" [serverId]="serverId" [orgId]="orgId"></app-org-edit> 

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
@@ -29,6 +29,7 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
   public cookbooksTab = true;
   public environmentsTab = false;
   public rolesTab = false;
+  public dataBagsTab = false;
   private isDestroyed = new Subject<boolean>();
 
   previousRoute$: Observable<RouterState>;
@@ -45,6 +46,7 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
         if ( params.path.includes('roles') ) {
           this.cookbooksTab = false;
           this.environmentsTab = false;
+          this.dataBagsTab = false;
           this.rolesTab = true;
         }
 
@@ -94,6 +96,9 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
         this.telemetryService.track('orgDetailsTab', 'environments');
         break;
       case 3:
+        this.telemetryService.track('orgDetailsTab', 'dataBags');
+        break;
+      case 4:
         this.telemetryService.track('orgDetailsTab', 'org-edit');
         break;
     }

--- a/components/automate-ui/src/app/ngrx.effects.ts
+++ b/components/automate-ui/src/app/ngrx.effects.ts
@@ -11,6 +11,7 @@ import { CredentialsEffects } from './pages/+compliance/+credentials/credentials
 // CredentialEffect is for the credential entities. Don't confuse it with CredentialsEffects.
 // CredentialsEffects will be removed when the credentials page is refactored.
 import { CredentialEffects } from './entities/credentials/credential.effects';
+import { DataBagsEffects } from './entities/data-bags/data-bags.effects';
 import { DesktopEffects } from './entities/desktop/desktop.effects';
 import { DestinationEffects } from './entities/destinations/destination.effects';
 import { EnvironmentEffects } from './entities/environments/environment.effects';
@@ -46,6 +47,7 @@ import { UserPermEffects } from './entities/userperms/userperms.effects';
       CookbookVersionsEffects,
       CredentialsEffects,
       CredentialEffects,
+      DataBagsEffects,
       DesktopEffects,
       DestinationEffects,
       EnvironmentEffects,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -12,6 +12,7 @@ import * as clientRuns from './entities/client-runs/client-runs.reducer';
 import * as cookbookEntity from './entities/cookbooks/cookbook.reducer';
 import * as cookbookDetailsEntity from './entities/cookbooks/cookbook-details.reducer';
 import * as cookbookVersionsEntity from './entities/cookbooks/cookbook-versions.reducer';
+import * as dataBagsEntity from './entities/data-bags/data-bags.reducer';
 import * as desktopEntity from './entities/desktop/desktop.reducer';
 import * as environmentEntity from './entities/environments/environment.reducer';
 import * as infraRoleEntity from './entities/infra-roles/infra-role.reducer';
@@ -67,6 +68,7 @@ export interface NgrxStateAtom {
   cookbooks: cookbookEntity.CookbookEntityState;
   cookbookDetails: cookbookDetailsEntity.CookbookDetailsEntityState;
   cookbookVersions: cookbookVersionsEntity.CookbookVersionsEntityState;
+  dataBags: dataBagsEntity.DataBagsEntityState;
   destinations: destinationEntity.DestinationEntityState;
   environments: environmentEntity.EnvironmentEntityState;
   infraRoles: infraRoleEntity.InfraRoleEntityState;
@@ -182,6 +184,7 @@ export const defaultInitialState = {
   cookbooks: cookbookEntity.CookbookEntityInitialState,
   cookbookDetails: cookbookDetailsEntity.CookbookDetailsEntityInitialState,
   cookbookVersions: cookbookVersionsEntity.CookbookVersionsEntityInitialState,
+  dataBags: dataBagsEntity.DataBagsEntityInitialState,
   destinations: destinationEntity.DestinationEntityInitialState,
   environments: environmentEntity.EnvironmentEntityInitialState,
   infraRoles: infraRoleEntity.InfraRoleEntityInitialState,
@@ -231,6 +234,7 @@ export const ngrxReducers = {
   cookbookDetails: cookbookDetailsEntity.cookbookDetailsEntityReducer,
   cookbookVersions: cookbookVersionsEntity.cookbookVersionsEntityReducer,
   credentialEntity: credential.credentialReducer,
+  dataBags: dataBagsEntity.dataBagsEntityReducer,
   destinations: destinationEntity.destinationEntityReducer,
   environments: environmentEntity.environmentEntityReducer,
   infraRoles: infraRoleEntity.infraRoleEntityReducer,


### PR DESCRIPTION
Signed-off-by: sachin-msys <sbacchav@msystechnologies.com>

### :nut_and_bolt: Description: What code changed, and why?
Introduced Data Bags list view tab on the organisation details page.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
#3370 
### :+1: Definition of Done
Data Bags tab in organisation details page of infra view where we are display the data bags list.
### :athletic_shoe: How to Build and Test the Change

1. git fetch origin Sachin/infra-view-databags-list
2. build components/automate-ui
3. To add data https://github.com/chef/automate/blob/master/dev-docs/adding-data/adding_test_data.md#adding-data-to-infra-views
4. Go to Infrastructure tab >> Chef Servers its under Chef-Server feature flag.
5. Click on `Server list` >> `Organisation list` >> `Data Bags Tab`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![data bags list](https://user-images.githubusercontent.com/54940695/81871803-2c5ac280-9596-11ea-9418-508bb4512ba7.png)
