### PR TITLE
Add change origin to assist form control directive

### DIFF
--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
@@ -51,7 +51,7 @@
               </chef-checkbox>
             </div>
             <p>Remove Chef Server actions after
-              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
+              <input chefInput formControlName="threshold" [resetOrigin]="shouldResetValues" type="number" min="0"
                 (keydown)="preventNegatives($event.key)"/>days
             </p>
           </div>
@@ -74,7 +74,7 @@
             </div>
 
             <p>When no health check reports have been received for a service in
-              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
+              <input chefInput formControlName="threshold" [resetOrigin]="shouldResetValues" type="number" min="0"
                 (keydown)="preventNegatives($event.key)" />
               <mat-form-field appearance="none">
                 <mat-select panelClass="chef-dropdown" formControlName="unit" [resetOrigin]="shouldResetValues">
@@ -101,7 +101,7 @@
               </span>
             </div>
             <p>Remove services labeled as disconnected after
-              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
+              <input chefInput formControlName="threshold" [resetOrigin]="shouldResetValues" type="number" min="0"
                 (keydown)="preventNegatives($event.key)" />
               <mat-form-field appearance="none">
                 <mat-select panelClass="chef-dropdown" formControlName="unit" [resetOrigin]="shouldResetValues">
@@ -124,7 +124,7 @@
               </chef-checkbox>
             </div>
             <p>Remove data for Chef Infra Client runs after
-              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
+              <input chefInput formControlName="threshold" [resetOrigin]="shouldResetValues" type="number" min="0"
                 (keydown)="preventNegatives($event.key)" />days
             </p>
           </div>
@@ -139,11 +139,8 @@
             </div>
           
             <p>When no Chef Infra Client run data has been received from a node in
-              <input chefInput 
-                type="number" 
-                min="0" 
-                formControlName="threshold" [resetOrigin]="shouldResetValues"
-                (keydown)="preventNegatives($event.key)" />
+              <input chefInput formControlName="threshold" [resetOrigin]="shouldResetValues"
+                type="number" min="0" (keydown)="preventNegatives($event.key)" />
               <mat-form-field appearance="none">
                 <mat-select panelClass="chef-dropdown" formControlName="unit" [resetOrigin]="shouldResetValues">
                   <mat-option value="m">minutes</mat-option>
@@ -164,7 +161,7 @@
               </chef-checkbox>
             </div>
             <p>Remove nodes labeled as missing after
-              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
+              <input chefInput formControlName="threshold" [resetOrigin]="shouldResetValues" type="number" min="0"
                 (keydown)="preventNegatives($event.key)" />days
             </p>
           </div>
@@ -180,7 +177,7 @@
               </chef-checkbox>
             </div>
             <p>Remove compliance reports after
-              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
+              <input chefInput formControlName="threshold" [resetOrigin]="shouldResetValues" type="number" min="0"
                 (keydown)="preventNegatives($event.key)" />days
             </p>
           </div>
@@ -193,7 +190,7 @@
               </chef-checkbox>
             </div>
             <p>Remove compliance scans after
-              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
+              <input chefInput formControlName="threshold" [resetOrigin]="shouldResetValues" type="number" min="0"
                 (keydown)="preventNegatives($event.key)" />days
             </p>
           </div>

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
@@ -38,7 +38,7 @@
               </chef-checkbox>
             </div>
             <p>Remove event feed data after
-              <input chefInput formControlName="threshold" type="number" min="0" 
+              <input chefInput formControlName="threshold" [resetOrigin]="shouldResetValues" type="number" min="0" 
                 (keydown)="preventNegatives($event.key)"/>days
             </p>
           </div>
@@ -51,7 +51,7 @@
               </chef-checkbox>
             </div>
             <p>Remove Chef Server actions after
-              <input chefInput type="number" min="0" formControlName="threshold" 
+              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
                 (keydown)="preventNegatives($event.key)"/>days
             </p>
           </div>
@@ -74,10 +74,10 @@
             </div>
 
             <p>When no health check reports have been received for a service in
-              <input chefInput type="number" min="0" formControlName="threshold" 
+              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
                 (keydown)="preventNegatives($event.key)" />
               <mat-form-field appearance="none">
-                <mat-select panelClass="chef-dropdown" formControlName="unit">
+                <mat-select panelClass="chef-dropdown" formControlName="unit" [resetOrigin]="shouldResetValues">
                   <mat-option value="m">minutes</mat-option>
                   <mat-option value="h">hours</mat-option>
                   <mat-option value="d">days</mat-option>
@@ -101,10 +101,10 @@
               </span>
             </div>
             <p>Remove services labeled as disconnected after
-              <input chefInput type="number" min="0" formControlName="threshold"
+              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
                 (keydown)="preventNegatives($event.key)" />
               <mat-form-field appearance="none">
-                <mat-select panelClass="chef-dropdown" formControlName="unit">
+                <mat-select panelClass="chef-dropdown" formControlName="unit" [resetOrigin]="shouldResetValues">
                   <mat-option value="m">minutes</mat-option>
                   <mat-option value="h">hours</mat-option>
                   <mat-option value="d">days</mat-option>
@@ -124,7 +124,7 @@
               </chef-checkbox>
             </div>
             <p>Remove data for Chef Infra Client runs after
-              <input chefInput type="number" min="0" formControlName="threshold"
+              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
                 (keydown)="preventNegatives($event.key)" />days
             </p>
           </div>
@@ -142,10 +142,10 @@
               <input chefInput 
                 type="number" 
                 min="0" 
-                formControlName="threshold" 
+                formControlName="threshold" [resetOrigin]="shouldResetValues"
                 (keydown)="preventNegatives($event.key)" />
               <mat-form-field appearance="none">
-                <mat-select panelClass="chef-dropdown" formControlName="unit">
+                <mat-select panelClass="chef-dropdown" formControlName="unit" [resetOrigin]="shouldResetValues">
                   <mat-option value="m">minutes</mat-option>
                   <mat-option value="h">hours</mat-option>
                   <mat-option value="d">days</mat-option>
@@ -164,7 +164,7 @@
               </chef-checkbox>
             </div>
             <p>Remove nodes labeled as missing after
-              <input chefInput type="number" min="0" formControlName="threshold" 
+              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
                 (keydown)="preventNegatives($event.key)" />days
             </p>
           </div>
@@ -180,7 +180,7 @@
               </chef-checkbox>
             </div>
             <p>Remove compliance reports after
-              <input chefInput type="number" min="0" formControlName="threshold" 
+              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
                 (keydown)="preventNegatives($event.key)" />days
             </p>
           </div>
@@ -193,7 +193,7 @@
               </chef-checkbox>
             </div>
             <p>Remove compliance scans after
-              <input chefInput type="number" min="0" formControlName="threshold" 
+              <input chefInput type="number" min="0" formControlName="threshold" [resetOrigin]="shouldResetValues"
                 (keydown)="preventNegatives($event.key)" />days
             </p>
           </div>

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
@@ -6,6 +6,7 @@ import { FormGroup, FormBuilder, FormsModule, ReactiveFormsModule } from '@angul
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MockComponent } from 'ng2-mock-component';
 
 import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import {
@@ -75,7 +76,8 @@ describe('AutomateSettingsComponent', () => {
           StoreModule.forRoot(ngrxReducers, { runtimeChecks })
         ],
         declarations: [
-          AutomateSettingsComponent
+          AutomateSettingsComponent,
+          MockComponent({ selector: 'input', inputs: ['resetOrigin'] })
         ],
         providers: [
           FormBuilder,

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
@@ -131,7 +131,8 @@ describe('AutomateSettingsComponent', () => {
           StoreModule.forRoot(ngrxReducers, { runtimeChecks })
         ],
         declarations: [
-          AutomateSettingsComponent
+          AutomateSettingsComponent,
+          MockComponent({ selector: 'input', inputs: ['resetOrigin'] })
         ],
         providers: [
           FormBuilder,

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
@@ -155,8 +155,8 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
           } else if (changeConfigurationSelector.status === 'loadingSuccess') {
             this.showSuccessNotification();
             this.saving = false;
-            // After a successful Save, we flip shouldResetValues to true
-            // to update the resetOrigin values
+            // After a successful save, trigger a notification to FormControlDirective
+            // to consider the newly updated values as the new "original" values
             this.shouldResetValues = true;
             this.automateSettingsForm.markAsPristine();
           }
@@ -316,7 +316,8 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
           break;
       }
     });
-    // AfterInit, we need to apply this for resetOrigin to reset the values of formcontrolDirective
+    // After a successful load of initial values, trigger a notification
+    // to FormControlDirective to treat them as the "original" values.
     this.shouldResetValues = true;
     this.automateSettingsForm.markAsPristine();
   }

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
@@ -59,6 +59,9 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
   // Are settings currently saving
   saving = false;
 
+  // Change origin boolean for formControl directive
+  shouldResetValues = false;
+
   // Notification bits
   notificationVisible = false;
   notificationType = 'info';
@@ -151,8 +154,11 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
             this.saving = false;
           } else if (changeConfigurationSelector.status === 'loadingSuccess') {
             this.showSuccessNotification();
-            this.automateSettingsForm.markAsPristine();
             this.saving = false;
+            // After a successful Save, we flip shouldResetValues to true
+            // to update the resetOrigin values
+            this.shouldResetValues = true;
+            this.automateSettingsForm.markAsPristine();
           }
         });
   }
@@ -200,6 +206,7 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
   // Apply the changes that the user updated in the forms
   public applyChanges() {
     this.saving = true;
+    this.shouldResetValues = false;
     // Note: Services are currently not enabled through the form
     const jobs: IngestJob[] = [
       // Event Feed
@@ -287,7 +294,6 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
 
   // Update forms until we get the job scheduler status
   public updateForm(jobSchedulerStatus: JobSchedulerStatus) {
-
     if (jobSchedulerStatus === null) {
       return;
     }
@@ -310,6 +316,9 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
           break;
       }
     });
+    // AfterInit, we need to apply this for resetOrigin to reset the values of formcontrolDirective
+    this.shouldResetValues = true;
+    this.automateSettingsForm.markAsPristine();
   }
 
   // Splits a packed threshold into a number and a unit, where unit is a single character


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
On the data lifecycle page, users were prevented from selecting "days" as an option in Client Runs : label node as missing, if they hadn't already altered something on the page.

This branch adds the `resetOrigin` property to the formControl inputs, as well as updates them on save, so that the user can save as many times as they want and the formControl will remember their last known value.

### :chains: Related Resources
Fixes part 2 of: https://github.com/chef/automate/issues/3651

### :+1: Definition of Done
Users can change the values to whatever they like.  If the value is different than before, the 'Save Changes' button will activate.  If the value is the changed back to its previous value prior to saving changes, the 'Save Changes' button will deactivate.

### :athletic_shoe: How to Build and Test the Change
in hab studio `build components/automate-ui-devproxy && start_all_services`
cd into components/automate-ui and run `make serve`

navigate to https://a2-dev.test/settings/data-lifecycle
unless disabled user should be able to change all values as desired and 'Save Changes' button is activated when values are different than previously set.  If they move back to the previous value prior to saving. Save Changes button is disabled again.

One thing to note, I've found that with the Number inputs, if user uses the mouse or arrow keys to alter the numbers, the formControl Directive values are not respected.  This does not prevent the user from sending any values, but we wont see the full value of the form control directive.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
After:
![Chef Automate (5)](https://user-images.githubusercontent.com/16737484/81877165-42866580-9539-11ea-9272-b0171df5c223.gif)
