### PR TITLE
Display Menus over notifications and table cell wrapping cleanup

### DIFF
--- a/components/automate-ui/src/app/components/table/table-cell/table-cell.component.scss
+++ b/components/automate-ui/src/app/components/table/table-cell/table-cell.component.scss
@@ -10,6 +10,7 @@
   border-bottom: 1px solid $chef-grey;
   border-top: 1px solid $chef-grey;
   overflow: hidden;
+  word-break: break-word;
 
   &.text-right {
     text-align: right;

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.scss
@@ -13,7 +13,7 @@
   align-items: center;
   justify-content: flex-end;
   position: relative;
-  z-index: 2;
+  z-index: 99;
   padding: 10px 0;
   margin-left: auto;
   cursor: pointer;
@@ -81,7 +81,7 @@
   right: -10px;
   border: 1px solid $chef-grey;
   font-size: 14px;
-  z-index: 3;
+  z-index: 100;
 
   &::before {
     display: block;

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -25,7 +25,7 @@
 .sticky-notifications {
   position: sticky;
   top: 0;
-  z-index: 199;
+  z-index: 95;
 
   // An inner container of sticky-inner ensures the notification content will overlay
   // page content and not push it down.


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
After the recent notification cleanup, the notifications were sitting over the global dropdowns when displayed.  This branch raises the z-index on the global dropdowns and bumps the notifications down.

Small update to the table cell while I was in here so that long, no spaced words are broken to fit in the column as requested by UX.

### :chains: Related Resources
Fixes: https://github.com/chef/automate/issues/3677

### :+1: Definition of Done
Notifications are now beneath the global dropdown when displaying at the same time.

### :athletic_shoe: How to Build and Test the Change
in hab studio: build components/automate-ui-devproxy && start_all_services
in terminal: cd into components/automate-ui and run `make serve`

Navigate to any page that displays a notification ribbon as a result of an activity.  (i.e. settings -> api tokens, create team, create users, etc.) Complete the action and while the notification is exposed, see that it still lays over all other content, but dropdowns display over the notifications.

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![dropdowns over notification](https://user-images.githubusercontent.com/16737484/81996661-6d88bc00-9602-11ea-94e5-dc9451a8df8c.gif)
