### PR TITLE
automate-gateway: disallow unknown fields (with exceptions)

### DIFF
--- a/.studio/automate-gateway
+++ b/.studio/automate-gateway
@@ -141,7 +141,7 @@ function send_chef_action_example() {
   tmp_action_json="$(jq --arg event_task "$event_task" \
                         --arg rfc_time "$rfc_time" \
                         --arg event_type "$event_type" \
-                        --arg random_key "$(head -c 100 /dev/urandom | tr -cd 'a-zA-Z')" \
+                        --arg random_key "this_is_surely_not_a_known_key" \
                         '.task = $event_task |
                          .recorded_at = $rfc_time |
                          .entity_type = $event_type |
@@ -340,7 +340,7 @@ function uniqify_chef_run_report() {
      --arg run_uuid "$run_uuid" \
      --arg node_name "$node_name" \
      --arg node_uuid "$node_uuid" \
-     --arg random_key "$(head -c 100 /dev/urandom | tr -cd 'a-zA-Z')" \
+     --arg random_key "this_is_surely_not_a_known_field" \
      '.end_time = $rfc_time |
       .start_time = $rfc_time |
       .entity_uuid = $node_uuid |

--- a/.studio/automate-gateway
+++ b/.studio/automate-gateway
@@ -138,8 +138,14 @@ function send_chef_action_example() {
   rfc_time=$(date --rfc-3339=seconds  -d "$((RANDOM % 144)) hour ago" | sed 's/ /T/' | sed 's/\+.*/Z/')
 
   # Update the 'recorded_at' time from the ChefAction Example; and set entity_type and task
-  tmp_action_json="$(jq --arg event_task "$event_task" --arg rfc_time "$rfc_time" --arg event_type "$event_type" \
-    '.task = $event_task | .recorded_at = $rfc_time | .entity_type = $event_type' < $examples_path/chef_action.json)"
+  tmp_action_json="$(jq --arg event_task "$event_task" \
+                        --arg rfc_time "$rfc_time" \
+                        --arg event_type "$event_type" \
+                        --arg random_key "$(head -c 100 /dev/urandom | tr -cd 'a-zA-Z')" \
+                        '.task = $event_task |
+                         .recorded_at = $rfc_time |
+                         .entity_type = $event_type |
+                         .[$random_key] = "foo"' < $examples_path/chef_action.json)"
 
   # note: this needs to be fed in via stdin, as passing it in as --data "$tmp_action_json"
   # will exceed argmax
@@ -329,12 +335,19 @@ function uniqify_chef_run_report() {
 
   local examples_path="/src/components/ingest-service/examples"
 
-  # Update the IDs, names, and dates
+  # Update the IDs, names, and dates, and some random field
   jq --arg rfc_time "$rfc_time" \
      --arg run_uuid "$run_uuid" \
      --arg node_name "$node_name" \
      --arg node_uuid "$node_uuid" \
-     '.end_time = $rfc_time | .start_time = $rfc_time | .entity_uuid = $node_uuid | .id = $run_uuid | .run_id = $run_uuid | .node_name = $node_name'
+     --arg random_key "$(head -c 100 /dev/urandom | tr -cd 'a-zA-Z')" \
+     '.end_time = $rfc_time |
+      .start_time = $rfc_time |
+      .entity_uuid = $node_uuid |
+      .id = $run_uuid |
+      .run_id = $run_uuid |
+      .node_name = $node_name |
+      .[$random_key] = "foo"'
 }
 
 document "delete_multiple_nodes" <<DOC

--- a/.studiorc
+++ b/.studiorc
@@ -189,7 +189,7 @@ check_if_deployinate_started() {
   fi
 
   if ! chef-automate status > /dev/null 2>&1; then
-    error "The current status of your deploy is unhealthy."
+    error "The current status of your deployment is unhealthy."
     log_line "If you have yet to do so, run '${GREEN}chef-automate dev deployinate${NC}' to deploy Automate."
     log_line "If you have already deployed, there is an issue with your deploy."
     log_line "You can check the logs with '${YELLOW}sl${NC}' and the status with '${YELLOW}chef-automate status${NC}'."

--- a/components/automate-gateway/api/iam/v2/request/rules.pb.go
+++ b/components/automate-gateway/api/iam/v2/request/rules.pb.go
@@ -29,7 +29,7 @@ type CreateRuleReq struct {
 	ProjectId string `protobuf:"bytes,2,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
 	// Name for the project rule.
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
-	// Whether the rule is `STAGED` (not in effect) or `APPLIED` (in effect).
+	// Whether the rule affects nodes (`NODE`) or events (`EVENT`).
 	Type common.RuleType `protobuf:"varint,4,opt,name=type,proto3,enum=chef.automate.api.iam.v2.RuleType" json:"type,omitempty"`
 	// Conditions that ingested resources must match to belong to the project.
 	// Will contain one or more.
@@ -106,7 +106,7 @@ type UpdateRuleReq struct {
 	ProjectId string `protobuf:"bytes,2,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
 	// Name for the project rule.
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
-	// Whether the rule applies to ingested `NODE` or `EVENT resources.
+	// Whether the rule applies to ingested `NODE` or `EVENT` resources.
 	// Cannot be changed.
 	Type common.RuleType `protobuf:"varint,4,opt,name=type,proto3,enum=chef.automate.api.iam.v2.RuleType" json:"type,omitempty"`
 	// Conditions that ingested resources must match to belong to the project.

--- a/components/automate-gateway/api/iam/v2/request/rules.proto
+++ b/components/automate-gateway/api/iam/v2/request/rules.proto
@@ -20,7 +20,7 @@ message CreateRuleReq {
   string project_id = 2;
   // Name for the project rule.
   string name = 3;
-  // Whether the rule is `STAGED` (not in effect) or `APPLIED` (in effect).
+  // Whether the rule affects nodes (`NODE`) or events (`EVENT`).
   RuleType type = 4;
   // Conditions that ingested resources must match to belong to the project.
   // Will contain one or more.
@@ -40,7 +40,7 @@ message UpdateRuleReq {
   string project_id = 2;
   // Name for the project rule.
   string name = 3;
-  // Whether the rule applies to ingested `NODE` or `EVENT resources.
+  // Whether the rule applies to ingested `NODE` or `EVENT` resources.
   // Cannot be changed.
   RuleType type = 4;
   // Conditions that ingested resources must match to belong to the project.

--- a/components/automate-gateway/api/iam/v2/rules.swagger.json
+++ b/components/automate-gateway/api/iam/v2/rules.swagger.json
@@ -366,7 +366,7 @@
         },
         "type": {
           "$ref": "#/definitions/chef.automate.api.iam.v2.RuleType",
-          "description": "Whether the rule is `STAGED` (not in effect) or `APPLIED` (in effect)."
+          "description": "Whether the rule affects nodes (`NODE`) or events (`EVENT`)."
         },
         "conditions": {
           "type": "array",
@@ -580,7 +580,7 @@
         },
         "type": {
           "$ref": "#/definitions/chef.automate.api.iam.v2.RuleType",
-          "description": "Whether the rule applies to ingested `NODE` or `EVENT resources.\nCannot be changed."
+          "description": "Whether the rule applies to ingested `NODE` or `EVENT` resources.\nCannot be changed."
         },
         "conditions": {
           "type": "array",

--- a/components/automate-gateway/api/iam_v2_rules.pb.swagger.go
+++ b/components/automate-gateway/api/iam_v2_rules.pb.swagger.go
@@ -369,7 +369,7 @@ func init() {
         },
         "type": {
           "$ref": "#/definitions/chef.automate.api.iam.v2.RuleType",
-          "description": "Whether the rule is ` + "`" + `STAGED` + "`" + ` (not in effect) or ` + "`" + `APPLIED` + "`" + ` (in effect)."
+          "description": "Whether the rule affects nodes (` + "`" + `NODE` + "`" + `) or events (` + "`" + `EVENT` + "`" + `)."
         },
         "conditions": {
           "type": "array",
@@ -583,7 +583,7 @@ func init() {
         },
         "type": {
           "$ref": "#/definitions/chef.automate.api.iam.v2.RuleType",
-          "description": "Whether the rule applies to ingested ` + "`" + `NODE` + "`" + ` or ` + "`" + `EVENT resources.\nCannot be changed."
+          "description": "Whether the rule applies to ingested ` + "`" + `NODE` + "`" + ` or ` + "`" + `EVENT` + "`" + ` resources.\nCannot be changed."
         },
         "conditions": {
           "type": "array",

--- a/components/automate-gateway/gateway/services.go
+++ b/components/automate-gateway/gateway/services.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
@@ -366,10 +368,38 @@ func versionedRESTMux(grpcURI string, dopts []grpc.DialOption, toggles gwRouteFe
 	return muxFromRegisterMap(grpcURI, dopts, endpointMap)
 }
 
+type m struct {
+	*runtime.JSONPb
+	unmarshaler *jsonpb.Unmarshaler
+}
+
+type decoderWrapper struct {
+	*json.Decoder
+	*jsonpb.Unmarshaler
+}
+
+func (n *m) NewDecoder(r io.Reader) runtime.Decoder {
+	d := json.NewDecoder(r)
+	return &decoderWrapper{Decoder: d, Unmarshaler: n.unmarshaler}
+}
+
+func (d *decoderWrapper) Decode(v interface{}) error {
+	p, ok := v.(proto.Message)
+	if !ok { // if it's not decoding into a proto.Message, there's no notion of unknown fields
+		return d.Decoder.Decode(v)
+	}
+	return d.UnmarshalNext(d.Decoder, p) // uses m's jsonpb.Unmarshaler configuration
+}
+
 func muxFromRegisterMap(grpcURI string, dopts []grpc.DialOption, localEndpoints map[string]registerFunc) (*runtime.ServeMux, func(), error) {
 	opts := []runtime.ServeMuxOption{
 		runtime.WithIncomingHeaderMatcher(headerMatcher),
-		runtime.WithMarshalerOption("application/json+pretty", &runtime.JSONPb{OrigName: true, EmitDefaults: true, Indent: "  "}),
+		// Note(sr): pretty implies strict -- the assumption is that pretty is used by API usage from an
+		//           interactive console, so we'd want to tell them if they feed us garbage.
+		runtime.WithMarshalerOption("application/json+pretty",
+			&m{JSONPb: &runtime.JSONPb{OrigName: true, EmitDefaults: true, Indent: "  "}, unmarshaler: &jsonpb.Unmarshaler{AllowUnknownFields: false}}),
+		runtime.WithMarshalerOption("application/json+strict",
+			&m{JSONPb: &runtime.JSONPb{OrigName: true, EmitDefaults: true}, unmarshaler: &jsonpb.Unmarshaler{AllowUnknownFields: false}}),
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{OrigName: true, EmitDefaults: true}),
 		runtime.WithMetadata(middleware.CertificatePasser),
 	}

--- a/components/automate-gateway/gateway/services.go
+++ b/components/automate-gateway/gateway/services.go
@@ -398,9 +398,9 @@ func muxFromRegisterMap(grpcURI string, dopts []grpc.DialOption, localEndpoints 
 		//           interactive console, so we'd want to tell them if they feed us garbage.
 		runtime.WithMarshalerOption("application/json+pretty",
 			&m{JSONPb: &runtime.JSONPb{OrigName: true, EmitDefaults: true, Indent: "  "}, unmarshaler: &jsonpb.Unmarshaler{AllowUnknownFields: false}}),
-		runtime.WithMarshalerOption("application/json+strict",
+		runtime.WithMarshalerOption("application/json+lax", &runtime.JSONPb{OrigName: true, EmitDefaults: true}),
+		runtime.WithMarshalerOption(runtime.MIMEWildcard,
 			&m{JSONPb: &runtime.JSONPb{OrigName: true, EmitDefaults: true}, unmarshaler: &jsonpb.Unmarshaler{AllowUnknownFields: false}}),
-		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{OrigName: true, EmitDefaults: true}),
 		runtime.WithMetadata(middleware.CertificatePasser),
 	}
 	gwmux := runtime.NewServeMux(opts...)

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.spec.ts
@@ -35,6 +35,16 @@ describe('HttpClientAuthInterceptor', () => {
         .toEqual(`Bearer ${chefSession.id_token}`);
     });
 
+    it('sets the lax API header all requests', done => {
+      httpClient.get('/endpoint').subscribe(done);
+
+      const httpRequest = httpMock.expectOne('/endpoint');
+      httpRequest.flush('response');
+
+      expect(httpRequest.request.headers.get('Content-Type'))
+        .toEqual('application/json+lax');
+    });
+
     it('when a 401 response is intercepted logs out the session', done => {
       spyOn(chefSession, 'logout');
       httpClient.get('/endpoint').subscribe({ error: done });

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
@@ -35,6 +35,11 @@ export class HttpClientAuthInterceptor implements HttpInterceptor {
     //           Right now, we're throwing the ID token across the internet for telemetry,
     //           where it's not needed. It would be nice to _not_ do that.
     let headers = request.headers.set('Authorization', `Bearer ${this.chefSession.id_token}`);
+    // TODO(sr): Sadly, our UI code depends on the API ignoring unknown fields in the
+    //           request payloads in many places. We should not send any of those. But
+    //           Fixing that blows the scope of my little API validation adventure, so
+    //           we take a shortcut: ask the API not to be too strict on us.
+    headers = headers.set('Content-Type', 'application/json+lax');
     // Check and then remove `unfiltered` param; it is a piggybacked parameter
     // needed by this interceptor, not to be passed on.
     // It allows certain URLs to suppress sending the projects filter.

--- a/e2e/cypress/integration/api/iam/iam_integration.spec.ts
+++ b/e2e/cypress/integration/api/iam/iam_integration.spec.ts
@@ -133,7 +133,7 @@ describe('assigning projects', () => {
 
     it(`when creating ${iamResources}, successfully assigns an existing authorized project`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'POST',
         url: `/apis/iam/v2/${iamResources}`,
         body: {
@@ -150,7 +150,8 @@ describe('assigning projects', () => {
     it(`when creating ${iamResources} without projects is allowed, ` +
     `successfully creates unassigned ${iamResource}`,  () => {
       cy.request({
-        headers: { 'api-token': unassignedAndProjectAllowedTok },
+        headers: { 'api-token': unassignedAndProjectAllowedTok,
+          'content-type': 'application/json+lax' },
         method: 'POST',
         url: `/apis/iam/v2/${iamResources}`,
         failOnStatusCode: false,
@@ -167,7 +168,7 @@ describe('assigning projects', () => {
 
     it(`when updating ${iamResources}, successfully assigns an existing authorized project`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}`,
         body: {
@@ -185,7 +186,7 @@ describe('assigning projects', () => {
 
     it(`when creating ${iamResources}, fails to assign a non-existing project`, () => {
         cy.request({
-          headers: { 'api-token': twoAllowedProjectsTok },
+          headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
           method: 'POST',
           url: `/apis/iam/v2/${iamResources}`,
           failOnStatusCode: false,
@@ -201,7 +202,7 @@ describe('assigning projects', () => {
 
     it(`when updating ${iamResources}, fails to assign a non-existing project`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}`,
         failOnStatusCode: false,
@@ -217,7 +218,7 @@ describe('assigning projects', () => {
 
     it(`when creating ${iamResources}, fails to assign an unauthorized project`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'POST',
         url: `/apis/iam/v2/${iamResources}`,
         failOnStatusCode: false,
@@ -235,7 +236,7 @@ describe('assigning projects', () => {
     'project assignment permission is missing for (unassigned), ' +
     `fails to create unassigned ${iamResource}`,  () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'POST',
         url: `/apis/iam/v2/${iamResources}`,
         failOnStatusCode: false,
@@ -250,7 +251,7 @@ describe('assigning projects', () => {
 
     it(`when updating ${iamResources}, fails to assign an unauthorized project`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}`,
         failOnStatusCode: false,
@@ -266,7 +267,7 @@ describe('assigning projects', () => {
 
     it(`when updating ${iamResources}, succeeds updating without changing projects`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}`,
         body: {
@@ -286,7 +287,8 @@ describe('assigning projects', () => {
     it(`when assigning one project and (unassigned) is allowed,
       succeeds creating (unassigned) ${iamResource}`, () => {
       cy.request({
-        headers: { 'api-token': unassignedAndProjectAllowedTok },
+        headers: { 'api-token': unassignedAndProjectAllowedTok,
+          'content-type': 'application/json+lax' },
         method: 'POST',
         url: `/apis/iam/v2/${iamResources}`,
         body: {
@@ -306,7 +308,8 @@ describe('assigning projects', () => {
       succeeds updating ${iamResource} from (unassigned)
       to authorized project`, () => {
       cy.request({
-        headers: { 'api-token': unassignedAndProjectAllowedTok },
+        headers: { 'api-token': unassignedAndProjectAllowedTok,
+         'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}-2`,
         body: {
@@ -325,7 +328,8 @@ describe('assigning projects', () => {
     it(`when assigning one project and (unassigned) is allowed,
       succeeds updating ${iamResource} from authorized project to (unassigned)`, () => {
       cy.request({
-        headers: { 'api-token': unassignedAndProjectAllowedTok },
+        headers: { 'api-token': unassignedAndProjectAllowedTok,
+          'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}-2`,
         body: {
@@ -343,7 +347,8 @@ describe('assigning projects', () => {
     it(`when assigning one project and (unassigned) is allowed,
       fails to update ${iamResource} from unassigned to unauthorized project`, () => {
       cy.request({
-        headers: { 'api-token': unassignedAndProjectAllowedTok },
+        headers: { 'api-token': unassignedAndProjectAllowedTok,
+          'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}-2`,
         failOnStatusCode: false,
@@ -361,7 +366,7 @@ describe('assigning projects', () => {
     it(`when assigning only two projects is allowed,
       fails to update ${iamResource} from (unassigned) to authorized project`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}-2`,
         failOnStatusCode: false,
@@ -381,7 +386,7 @@ describe('assigning projects', () => {
     it(`when assigning only two projects is allowed,
       fails to create ${iamResource} with authorized and unauthorized projects`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'POST',
         url: `/apis/iam/v2/${iamResources}`,
         failOnStatusCode: false,
@@ -399,7 +404,8 @@ describe('assigning projects', () => {
     it(`when assigning one project and (unassigned) is allowed,
     succeeds updating ${iamResource} from authorized to (unassigned)`, () => {
         cy.request({
-          headers: { 'api-token': unassignedAndProjectAllowedTok },
+          headers: { 'api-token': unassignedAndProjectAllowedTok,
+            'content-type': 'application/json+lax' },
           method: 'POST',
           url: `/apis/iam/v2/${iamResources}`,
           body: {
@@ -410,7 +416,8 @@ describe('assigning projects', () => {
         });
 
       cy.request({
-        headers: { 'api-token': unassignedAndProjectAllowedTok},
+        headers: { 'api-token': unassignedAndProjectAllowedTok,
+          'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}-4a`,
         body: {
@@ -430,7 +437,7 @@ describe('assigning projects', () => {
     it(`when assigning only two projects is allowed and (unassigned) is not allowed,
       succeeds removing authorized project from ${iamResource} to make it (unassigned)`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'POST',
         url: `/apis/iam/v2/${iamResources}`,
         body: {
@@ -441,7 +448,7 @@ describe('assigning projects', () => {
       });
 
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}-4b`,
         body: {
@@ -459,7 +466,7 @@ describe('assigning projects', () => {
     it(`when assigning only two projects is allowed and (unassigned) is not allowed,
       fails to update ${iamResource} from authorized to unauthorized project`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'POST',
         url: `/apis/iam/v2/${iamResources}`,
         body: {
@@ -470,7 +477,7 @@ describe('assigning projects', () => {
       });
 
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}-5`,
         failOnStatusCode: false,
@@ -488,7 +495,7 @@ describe('assigning projects', () => {
     it(`when assigning only two projects is allowed and (unassigned) is not allowed,
       fails to update ${iamResource} from authorized to non-existent project`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}-5`,
         failOnStatusCode: false,
@@ -507,7 +514,7 @@ describe('assigning projects', () => {
       fails to update ${iamResource} from authorized project
       to a different authorized project and non-existent project`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}-5`,
         failOnStatusCode: false,
@@ -526,7 +533,7 @@ describe('assigning projects', () => {
       fails to update ${iamResource} from authorized project
       to an unauthorized project and non-existent project`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}-5`,
         failOnStatusCode: false,
@@ -545,7 +552,7 @@ describe('assigning projects', () => {
       fails to update ${iamResource} from authorized project
       to a different authorized project and unauthorized project`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}-5`,
         failOnStatusCode: false,
@@ -564,7 +571,7 @@ describe('assigning projects', () => {
     it(`when assigning only two projects is allowed and (unassigned) is not allowed,
       fails to create (unassigned) ${iamResource}`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'POST',
         url: `/apis/iam/v2/${iamResources}`,
         failOnStatusCode: false,
@@ -582,7 +589,7 @@ describe('assigning projects', () => {
     it(`when assigning only two projects is allowed,
     fails to update ${iamResource} to remove unauthorized project`, () => {
       cy.request({
-        headers: { 'api-token': twoAllowedProjectsTok },
+        headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
         method: 'POST',
         url: `/apis/iam/v2/${iamResources}`,
         body: {
@@ -593,7 +600,8 @@ describe('assigning projects', () => {
       });
 
       cy.request({
-        headers: { 'api-token': unassignedAndProjectAllowedTok },
+        headers: { 'api-token': unassignedAndProjectAllowedTok,
+          'content-type': 'application/json+lax' },
         method: 'PUT',
         url: `/apis/iam/v2/${iamResources}/${resource.id}-7`,
         failOnStatusCode: false,
@@ -645,7 +653,8 @@ describe('assigning projects', () => {
 
       it('succeeds updating without changing project assignment when there are no projects', () => {
         cy.request({
-          headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+          headers: { 'api-token': Cypress.env('ADMIN_TOKEN'),
+            'content-type': 'application/json+lax' },
           method: 'POST',
           url: `/apis/iam/v2/${iamResources}`,
           body: {
@@ -656,7 +665,7 @@ describe('assigning projects', () => {
         });
 
         cy.request({
-          headers: { 'api-token': twoAllowedProjectsTok },
+          headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
           method: 'PUT',
           url: `/apis/iam/v2/${iamResources}/${resource.id}-8`,
           body: {
@@ -676,7 +685,8 @@ describe('assigning projects', () => {
       it('succeeds updating without changing project assignment ' +
       'when there there are unauthorizerd projects', () => {
         cy.request({
-          headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+          headers: { 'api-token': Cypress.env('ADMIN_TOKEN'),
+            'content-type': 'application/json+lax' },
           method: 'POST',
           url: `/apis/iam/v2/${iamResources}`,
           body: {
@@ -687,7 +697,7 @@ describe('assigning projects', () => {
         });
 
         cy.request({
-          headers: { 'api-token': twoAllowedProjectsTok },
+          headers: { 'api-token': twoAllowedProjectsTok, 'content-type': 'application/json+lax' },
           method: 'PUT',
           url: `/apis/iam/v2/${iamResources}/${resource.id}-9`,
           body: {

--- a/inspec/a2-api-integration/controls/iam/iam_apis.rb
+++ b/inspec/a2-api-integration/controls/iam/iam_apis.rb
@@ -411,7 +411,6 @@ control 'iam-api-1' do
             request_body: {
               name: updatedName,
               password: "newpassword",
-              previous_password: "wrongagain"
             }.to_json
           )
           expect(resp.http_status).to eq 404

--- a/inspec/a2-api-integration/controls/iam/project_filtering.rb
+++ b/inspec/a2-api-integration/controls/iam/project_filtering.rb
@@ -18,22 +18,19 @@ control 'iam-project-filtering-1' do
           id: CUSTOM_ROLE_ID_1,
           name: "Test Role 1",
           actions: ["test:some:action", "test:other:action"],
-          projects: [CUSTOM_PROJECT_ID_1, CUSTOM_PROJECT_ID_2],
-          type: "CUSTOM"
+          projects: [CUSTOM_PROJECT_ID_1, CUSTOM_PROJECT_ID_2]
   }
   CUSTOM_ROLE_2 = {
           id: CUSTOM_ROLE_ID_2,
           name: "Test Role 2",
           actions: ["test:other:action"],
-          projects: [CUSTOM_PROJECT_ID_2],
-          type: "CUSTOM"
+          projects: [CUSTOM_PROJECT_ID_2]
   }
   CUSTOM_ROLE_3 = {
           id: CUSTOM_ROLE_ID_3,
           name: "Test Role 2",
           actions: ["test:other:action"],
-          projects: [],
-          type: "CUSTOM"
+          projects: []
   }
 
   CUSTOM_ROLES = [ CUSTOM_ROLE_1, CUSTOM_ROLE_2, CUSTOM_ROLE_3 ]
@@ -207,9 +204,10 @@ control 'iam-project-filtering-1' do
 
       describe 'ListRoles' do
 
-        it 'returns roles for allowed projects' do resp = automate_api_request(
+        it 'returns roles for allowed projects' do
+          resp = automate_api_request(
             "/apis/iam/v2/roles",
-            request_headers: { 'projects': CUSTOM_PROJECT_ID_2 },
+            request_headers: { projects: CUSTOM_PROJECT_ID_2 },
             )
           expect(resp.http_status).to eq 200
           expect(resp.parsed_response_body[:roles].length).to eq 2
@@ -218,12 +216,10 @@ control 'iam-project-filtering-1' do
         end
 
         it 'returns 403 due to explicitly denied project' do
-          puts "about to sleep"
           resp = automate_api_request(
             "/apis/iam/v2/roles",
-            request_headers: { 'projects': CUSTOM_PROJECT_ID_1 },
+            request_headers: { projects: CUSTOM_PROJECT_ID_1 },
             )
-          puts "request finished"
           expect(resp.http_status).to eq 403
         end
 

--- a/inspec/a2-iam-legacy-integration/controls/legacy_access.rb
+++ b/inspec/a2-iam-legacy-integration/controls/legacy_access.rb
@@ -3,7 +3,7 @@
 # license: All rights reserved
 
 # This test suite is meant to verify APIs return 403 or not, given legacy policy permissions.
-# Please don't test for API behavior beyond that; 
+# Please don't test for API behavior beyond that;
 # only for whether the invoker is authorized or not to make the call.
 
 require_relative '../../constants'
@@ -14,7 +14,7 @@ NON_ADMIN_USERNAME = 'inspec_test_non_admin'
 
 control 'iam-legacy-access-control-1' do
   title 'IAM access control with legacy policies'
-  desc 'Verify proper access for both admin and users who are not members of any policies. 
+  desc 'Verify proper access for both admin and users who are not members of any policies.
   V1 Legacy policies gave all users default permissions to most APIs, besides the IAM APIs.'
 
   describe 'IAM access control with migrated legacy policies' do
@@ -69,9 +69,9 @@ control 'iam-legacy-access-control-1' do
       legacy_policy_ids = legacy_policies.map { |p| p[:id] }
 
       expected_policies = [
-        "events-access-legacy", 
-        "ingest-access-legacy", 
-        "nodes-access-legacy", 
+        "events-access-legacy",
+        "ingest-access-legacy",
+        "nodes-access-legacy",
         "node-managers-access-legacy",
         "secrets-access-legacy",
         "compliance-profile-access-legacy",
@@ -177,6 +177,7 @@ control 'iam-legacy-access-control-1' do
                 http_method: 'PUT',
                 user: user,
                 request_body: test_object.to_json,
+                request_headers: { 'Content-Type': 'application/json+lax' } # we're messy with the payloads here
               ).http_status.to_s == url + ":PUT:403"
             ).to be(expect_403_response)
           end
@@ -203,9 +204,9 @@ control 'iam-legacy-access-control-1' do
         let(:failure_test_id) { 'does-not-exist' }
         let(:test_object) do
           {
-            'id': "inspec_test_team-#{TIMESTAMP}",
-            'name': 'This team was created by inspec tests. DELETE ME.',
-            'projects': []
+            id: "inspec_test_team-#{TIMESTAMP}",
+            name: 'This team was created by inspec tests. DELETE ME.',
+            projects: []
           }
         end
 
@@ -247,9 +248,9 @@ control 'iam-legacy-access-control-1' do
         let(:test_id) { "inspec_test_user-#{TIMESTAMP}" }
         let(:test_object) do
           {
-            'name': test_id,
-            'id': test_id,
-            'password': 'chefautomate',
+            name: test_id,
+            id: test_id,
+            password: 'chefautomate',
           }
         end
 
@@ -264,9 +265,9 @@ control 'iam-legacy-access-control-1' do
         let(:failure_test_id) { 'does-not-exist' }
         let(:test_object) do
           {
-            'id': "inspec_test_token_2-#{TIMESTAMP}",
-            'name': 'This token was created by inspec tests. DELETE ME.',
-            'projects': []
+            id: "inspec_test_token_2-#{TIMESTAMP}",
+            name: 'This token was created by inspec tests. DELETE ME.',
+            projects: []
           }
         end
 
@@ -281,17 +282,17 @@ control 'iam-legacy-access-control-1' do
         let(:failure_test_id) { 'does-not-exist' }
         let(:test_object) do
           {
-            'id': "inspec_test_policy-#{TIMESTAMP}",
-            'name': 'This policy was created by inspec tests. DELETE ME.',
-            "members": ["user:local:inspec", "team:local:inspec"],
-            "statements": [
+            id: "inspec_test_policy-#{TIMESTAMP}",
+            name: 'This policy was created by inspec tests. DELETE ME.',
+            members: ['user:local:inspec', 'team:local:inspec'],
+            statements: [
               {
-                "effect": "ALLOW",
-                "actions": ["do:some:thing"],
-                "projects": ["*"]
+                effect: 'ALLOW',
+                actions: ['do:some:thing'],
+                projects: ['*']
               }
             ],
-            'projects': []
+            projects: []
           }
         end
 
@@ -306,10 +307,10 @@ control 'iam-legacy-access-control-1' do
         let(:failure_test_id) { 'does-not-exist' }
         let(:test_object) do
           {
-            'id': "inspec_test_role-#{TIMESTAMP}",
-            'name': 'This role was created by inspec tests. DELETE ME.',
-            'actions': ['do:a:thing'],
-            'projects': []
+            id: "inspec_test_role-#{TIMESTAMP}",
+            name: 'This role was created by inspec tests. DELETE ME.',
+            actions: ['do:a:thing'],
+            projects: []
           }
         end
 
@@ -324,9 +325,9 @@ control 'iam-legacy-access-control-1' do
         let(:failure_test_id) { 'does-not-exist' }
         let(:test_object) do
           {
-            'id': "inspec_test_project-#{TIMESTAMP}",
-            'name': 'This project was created by inspec tests. DELETE ME.',
-            'skip_policies': true
+            id: "inspec_test_project-#{TIMESTAMP}",
+            name: 'This project was created by inspec tests. DELETE ME.',
+            skip_policies: true
           }
         end
 
@@ -341,11 +342,12 @@ control 'iam-legacy-access-control-1' do
         let(:http_verbs) { ["GET_ALL", "POST", "GET", "PUT", "DELETE"] }
         let(:failure_test_id) { 'does-not-exist' }
         let(:test_object) do
-          { "rule": {
-              "name": "test!!!",
-              "event": "CCRFailure",
-              "SlackAlert": {
-                "url": "http://testing"
+          {
+            rule: {
+              name: 'test!!!',
+              event: 'CCRFailure',
+              SlackAlert: {
+                url: 'http://testing'
                 }
               }
             }
@@ -415,7 +417,7 @@ control 'iam-legacy-access-control-1' do
             request_body: {}
           )
           # to save time on this test we don't post any data
-          # this results int a bad request 
+          # this results int a bad request
           # but we only care that it doesn't get a 403
           expect(node_request.http_status).to eq 400
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
It's a trap to accept unknown fields in an API. Users may send a request, everything looks great, but really half of what they had intended didn't work.

So this change enables strict validation of request payloads for grpc-gateway-provided endpoints, with the following exception:

**If the header `Content-Type: application/json+lax` is set**, the API will ignore unknown fields.

1. For `/api/v0/ingest/events/chef/*`, this header is automatically applied.
2. All requests made by automate-ui to the backend apply this header, too.

From what I understand, (1.) is required, and inherent to our mode of operation -- we don't know all the fields we may get.

(2.) is a shortcut. I don't think the UI should need this, but test-driving this change showed me that we depend on this "feature" in enough places to split off any refactorings related to this.

### :chains: Related Resources

None, sorry.

### :+1: Definition of Done

Everything works like before, except stricter.

### :athletic_shoe: How to Build and Test the Change

- `rebuild components/automate-gateway`
- `export TOK=$(chef-automate iam token create asdf --admin)`
- create a team with too many fields:
```
[123][default:/src:0]# curl -k -H "api-token: $TOK" "https://127.0.0.1/apis/iam/v2/teams?pretty" -d '{"id":"foo", "name":"foo", "projects": [],"foo":"bar"}'
{
  "error": "unknown field \"foo\" in request.CreateTeamReq",
  "code": 3,
  "message": "unknown field \"foo\" in request.CreateTeamReq",
  "details": [
  ]
}
```
Send the same payload with the lax header:
```
[125][default:/src:130]# curl -k -H "api-token: $TOK" "https://127.0.0.1/apis/iam/v2/teams?pretty" -d '{"id":"foo", "name":"foo", "projects": [],"foo":"bar"}'  -H "content-type: application/json+lax"
{
  "error": "team with ID \"foo\" already exists",
  "code": 6,
  "message": "team with ID \"foo\" already exists",
  "details": [
  ]
}
```

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
