### PR TITLE
Reset admin key

### DIFF
--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -65,6 +65,7 @@ import { SessionStorageService } from './services/storage/sessionstorage.service
 import { TelemetryService } from './services/telemetry/telemetry.service';
 
 // Requests
+import { AdminKeyRequests } from './entities/reset-admin-key/reset-admin-key.requests';
 import { ApiTokenRequests } from './entities/api-tokens/api-token.requests';
 import { AutomateSettingsRequests } from './entities/automate-settings/automate-settings.requests';
 import { CookbookRequests } from './entities/cookbooks/cookbook.requests';
@@ -287,6 +288,7 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     !environment.production ? StoreDevtoolsModule.instrument({ maxAge: 25 }) : []
   ],
   providers: [
+    AdminKeyRequests,
     ApiTokenRequests,
     AttributesService,
     AutomateSettingsRequests,

--- a/components/automate-ui/src/app/entities/orgs/org.model.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.model.ts
@@ -3,6 +3,5 @@ export interface Org {
   server_id: string;
   name: string;
   admin_user: string;
-  admin_key: string;
   projects?: string[];
 }

--- a/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.actions.ts
+++ b/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.actions.ts
@@ -9,14 +9,16 @@ export enum AdminKeyActionTypes {
   UPDATE_FAILURE = 'ADMINKEY::UPDATE::FAILURE'
 }
 
-export interface AdminKeySuccessPayload {
-  adminKey: AdminKey;
+export interface UpdateAdminKeyPayload {
+  server_id: string;
+  org_id: string;
+  admin_key: AdminKey;
 }
 
 export class UpdateAdminKey implements Action {
   readonly type = AdminKeyActionTypes.UPDATE;
 
-  constructor(public payload: {server_id: string, org_id: string, admin_Key: AdminKey} ) { }
+  constructor(public payload: UpdateAdminKeyPayload) { }
 }
 
 export class UpdateAdminKeySuccess implements Action {

--- a/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.actions.ts
+++ b/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.actions.ts
@@ -1,0 +1,37 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Action } from '@ngrx/store';
+
+import { AdminKey } from './reset-admin-key.model';
+
+export enum AdminKeyActionTypes {
+  UPDATE = 'ADMINKEY::UPDATE',
+  UPDATE_SUCCESS = 'ADMINKEY::UPDATE::SUCCESS',
+  UPDATE_FAILURE = 'ADMINKEY::UPDATE::FAILURE'
+}
+
+export interface AdminKeySuccessPayload {
+  adminKey: AdminKey;
+}
+
+export class UpdateAdminKey implements Action {
+  readonly type = AdminKeyActionTypes.UPDATE;
+
+  constructor(public payload: {server_id: string, org_id: string, admin_Key: AdminKey} ) { }
+}
+
+export class UpdateAdminKeySuccess implements Action {
+  readonly type = AdminKeyActionTypes.UPDATE_SUCCESS;
+
+  constructor(public payload) { }
+}
+
+export class UpdateAdminKeyFailure implements Action {
+  readonly type = AdminKeyActionTypes.UPDATE_FAILURE;
+
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export type AdminKeyActions =
+  | UpdateAdminKey
+  | UpdateAdminKeySuccess
+  | UpdateAdminKeyFailure;

--- a/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.effects.ts
+++ b/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.effects.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { of as observableOf } from 'rxjs';
+import { catchError, mergeMap, map } from 'rxjs/operators';
+
+import { CreateNotification } from 'app/entities/notifications/notification.actions';
+import { Type } from 'app/entities/notifications/notification.model';
+
+import {
+  UpdateAdminKey,
+  UpdateAdminKeyFailure,
+  UpdateAdminKeySuccess,
+  AdminKeyActionTypes
+} from './reset-admin-key.actions';
+
+import {
+  AdminKeyRequests
+} from './reset-admin-key.requests';
+
+@Injectable()
+export class AdminKeyEffects {
+  constructor(
+    private actions$: Actions,
+    private requests: AdminKeyRequests
+  ) { }
+
+  @Effect()
+  updateAdminKey$ = this.actions$.pipe(
+      ofType(AdminKeyActionTypes.UPDATE),
+      mergeMap(({ payload: {server_id, org_id, admin_Key} }: UpdateAdminKey) =>
+        this.requests.updateAdminKey(server_id, org_id, admin_Key).pipe(
+          map((resp) => new UpdateAdminKeySuccess(resp)),
+          catchError((error: HttpErrorResponse) =>
+            observableOf(new UpdateAdminKeyFailure(error))))));
+
+  @Effect()
+  updateAdminKeySuccess$ = this.actions$.pipe(
+      ofType(AdminKeyActionTypes.UPDATE_SUCCESS),
+      map(({ payload }: UpdateAdminKeySuccess) => new CreateNotification({
+      type: Type.info,
+      message: `Updated admin key ${payload.status}.`
+    })));
+
+  @Effect()
+  updateAdminKeyFailure$ = this.actions$.pipe(
+      ofType(AdminKeyActionTypes.UPDATE_FAILURE),
+      map(({ payload }: UpdateAdminKeyFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not update admin key: ${msg || payload.error}`
+        });
+      }));
+}
+

--- a/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.effects.ts
+++ b/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.effects.ts
@@ -28,8 +28,8 @@ export class AdminKeyEffects {
   @Effect()
   updateAdminKey$ = this.actions$.pipe(
       ofType(AdminKeyActionTypes.UPDATE),
-      mergeMap(({ payload: {server_id, org_id, admin_Key} }: UpdateAdminKey) =>
-        this.requests.updateAdminKey(server_id, org_id, admin_Key).pipe(
+      mergeMap(({ payload: {server_id, org_id, admin_key} }: UpdateAdminKey) =>
+        this.requests.updateAdminKey(server_id, org_id, admin_key).pipe(
           map((resp) => new UpdateAdminKeySuccess(resp)),
           catchError((error: HttpErrorResponse) =>
             observableOf(new UpdateAdminKeyFailure(error))))));
@@ -39,7 +39,7 @@ export class AdminKeyEffects {
       ofType(AdminKeyActionTypes.UPDATE_SUCCESS),
       map(({ payload }: UpdateAdminKeySuccess) => new CreateNotification({
       type: Type.info,
-      message: `Updated admin key ${payload.status}.`
+      message: `Reset admin key for organization ${payload.org.name}.`
     })));
 
   @Effect()
@@ -49,7 +49,7 @@ export class AdminKeyEffects {
         const msg = payload.error.error;
         return new CreateNotification({
           type: Type.error,
-          message: `Could not update admin key: ${msg || payload.error}`
+          message: `Could not update organization admin key: ${msg || payload.error}`
         });
       }));
 }

--- a/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.model.ts
+++ b/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.model.ts
@@ -1,0 +1,3 @@
+export interface AdminKey {
+  admin_key: string;
+}

--- a/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.reducer.ts
+++ b/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.reducer.ts
@@ -1,0 +1,42 @@
+import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
+import { set } from 'lodash/fp';
+
+import { EntityStatus } from 'app/entities/entities';
+import { AdminKeyActionTypes, AdminKeyActions } from './reset-admin-key.actions';
+import { AdminKey } from './reset-admin-key.model';
+
+export interface AdminKeyEntityState extends EntityState<AdminKey> {
+  updateStatus: EntityStatus;
+}
+
+const UPDATE_STATUS = 'updateStatus';
+
+export const adminKeyEntityAdapter: EntityAdapter<AdminKey> = createEntityAdapter<AdminKey>();
+
+export const AdminKeyEntityInitialState: AdminKeyEntityState =
+  adminKeyEntityAdapter.getInitialState(<AdminKeyEntityState>{
+    updateStatus: EntityStatus.notLoaded
+  });
+
+export function adminKeyEntityReducer(
+  state: AdminKeyEntityState = AdminKeyEntityInitialState,
+  action: AdminKeyActions): AdminKeyEntityState {
+
+  switch (action.type) {
+    case AdminKeyActionTypes.UPDATE:
+      return set(UPDATE_STATUS, EntityStatus.loading, state);
+
+    case AdminKeyActionTypes.UPDATE_SUCCESS:
+      return set(UPDATE_STATUS, EntityStatus.loadingSuccess,
+        adminKeyEntityAdapter.updateOne({
+          id: action.payload.status,
+          changes: action.payload
+        }, state));
+
+    case AdminKeyActionTypes.UPDATE_FAILURE:
+      return set(UPDATE_STATUS, EntityStatus.loadingFailure, state);
+
+    default:
+      return state;
+  }
+}

--- a/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.reducer.ts
+++ b/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.reducer.ts
@@ -29,7 +29,7 @@ export function adminKeyEntityReducer(
     case AdminKeyActionTypes.UPDATE_SUCCESS:
       return set(UPDATE_STATUS, EntityStatus.loadingSuccess,
         adminKeyEntityAdapter.updateOne({
-          id: action.payload.status,
+          id: action.payload.org.name,
           changes: action.payload
         }, state));
 

--- a/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.requests.ts
+++ b/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.requests.ts
@@ -4,10 +4,6 @@ import { Observable } from 'rxjs';
 import { environment as env } from 'environments/environment';
 import { AdminKey } from './reset-admin-key.model';
 
-// import {
-//   AdminKeySuccessPayload
-// } from './reset-admin-key.actions';
-
 export interface AdminKeyResponse {
   adminKey: AdminKey;
 }
@@ -17,9 +13,9 @@ export class AdminKeyRequests {
 
   constructor(private http: HttpClient) { }
 
-  public updateAdminKey(server_id: string, org_id: string, admin_Key: AdminKey):
+  public updateAdminKey(server_id: string, org_id: string, admin_key: AdminKey):
   Observable<AdminKeyResponse> {
     return this.http.put<AdminKeyResponse>(
-      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/reset-key`, admin_Key);
+      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/reset-key`, admin_key);
   }
 }

--- a/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.requests.ts
+++ b/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.requests.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment as env } from 'environments/environment';
+import { AdminKey } from './reset-admin-key.model';
+
+// import {
+//   AdminKeySuccessPayload
+// } from './reset-admin-key.actions';
+
+export interface AdminKeyResponse {
+  adminKey: AdminKey;
+}
+
+@Injectable()
+export class AdminKeyRequests {
+
+  constructor(private http: HttpClient) { }
+
+  public updateAdminKey(server_id: string, org_id: string, admin_Key: AdminKey):
+  Observable<AdminKeyResponse> {
+    return this.http.put<AdminKeyResponse>(
+      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/reset-key`, admin_Key);
+  }
+}

--- a/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.selectors.ts
+++ b/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.selectors.ts
@@ -5,7 +5,7 @@ import { AdminKeyEntityState, adminKeyEntityAdapter } from './reset-admin-key.re
 export const adminKeyState = createFeatureSelector<AdminKeyEntityState>('adminKey');
 
 export const {
-  selectAll: allAdminKey,
+  selectAll: allAdminKeys,
   selectEntities: adminKeyEntities
 } = adminKeyEntityAdapter.getSelectors(adminKeyState);
 

--- a/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.selectors.ts
+++ b/components/automate-ui/src/app/entities/reset-admin-key/reset-admin-key.selectors.ts
@@ -1,0 +1,15 @@
+import { createSelector, createFeatureSelector } from '@ngrx/store';
+
+import { AdminKeyEntityState, adminKeyEntityAdapter } from './reset-admin-key.reducer';
+
+export const adminKeyState = createFeatureSelector<AdminKeyEntityState>('adminKey');
+
+export const {
+  selectAll: allAdminKey,
+  selectEntities: adminKeyEntities
+} = adminKeyEntityAdapter.getSelectors(adminKeyState);
+
+export const updateStatus = createSelector(
+  adminKeyState,
+  (state) => state.updateStatus
+);

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.spec.ts
@@ -80,7 +80,6 @@ describe('ChefServerDetailsComponent', () => {
       id: '1',
       name: 'new org',
       admin_user: 'new org user',
-      admin_key: 'new admin key',
       server_id: '39cabe9d-996e-42cd-91d0-4335b2480aaf',
       projects: ['test_org_project']
     };
@@ -109,7 +108,6 @@ describe('ChefServerDetailsComponent', () => {
       component.orgForm.controls['id'].setValue(org.id);
       component.orgForm.controls['name'].setValue(org.name);
       component.orgForm.controls['admin_user'].setValue(org.admin_user);
-      component.orgForm.controls['admin_key'].setValue(org.admin_key);
       component.orgForm.controls.projects.setValue(org.projects[0]);
       component.createServerOrg();
 
@@ -128,7 +126,6 @@ describe('ChefServerDetailsComponent', () => {
       component.orgForm.controls['id'].setValue(org.id);
       component.orgForm.controls['name'].setValue(org.name);
       component.orgForm.controls['admin_user'].setValue(org.admin_user);
-      component.orgForm.controls['admin_key'].setValue(org.admin_key);
       component.orgForm.controls.projects.setValue(org.projects[0]);
       component.createServerOrg();
 
@@ -142,7 +139,6 @@ describe('ChefServerDetailsComponent', () => {
       component.orgForm.controls['id'].setValue(org.id);
       component.orgForm.controls['name'].setValue(org.name);
       component.orgForm.controls['admin_user'].setValue(org.admin_user);
-      component.orgForm.controls['admin_key'].setValue(org.admin_key);
       component.orgForm.controls.projects.setValue(org.projects[0]);
       component.createServerOrg();
 

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
@@ -21,6 +21,7 @@ import { JsonTreeTableComponent } from './json-tree-table/json-tree-table.compon
 import { OrgDetailsComponent } from './org-details/org-details.component';
 import { OrgEditComponent } from './org-edit/org-edit.component';
 import { PolicyFilesComponent } from './policy-files/policy-files.component';
+import { ResetAdminKeyComponent } from './reset-admin-key/reset-admin-key.component';
 import { TreeTableModule } from './tree-table/tree-table.module';
 
 @NgModule({
@@ -40,7 +41,8 @@ import { TreeTableModule } from './tree-table/tree-table.module';
     InfraRoleDetailsComponent,
     OrgDetailsComponent,
     OrgEditComponent,
-    PolicyFilesComponent
+    PolicyFilesComponent,
+    ResetAdminKeyComponent
   ],
   imports: [
     CommonModule,

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
@@ -53,7 +53,7 @@
             <app-org-edit *ngIf="details_tab.active" [serverId]="serverId" [orgId]="orgId"></app-org-edit> 
           </app-tab>
           <app-tab tabTitle="Reset Admin Key" #resetkey_tab [active]="resetKeyTab">
-            <app-reset-admin-key *ngIf="resetkey_tab.active" [serverId]="serverId" [orgId]="orgId"></app-reset-admin-key>	            <app-reset-admin-key *ngIf="resetkey_tab.active" [serverId]="serverId" [orgId]="orgId"></app-reset-admin-key>
+            <app-reset-admin-key *ngIf="resetkey_tab.active" [serverId]="serverId" [orgId]="orgId"></app-reset-admin-key>
           </app-tab>
         </app-tabs>
         <chef-scroll-top></chef-scroll-top>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
@@ -52,6 +52,9 @@
           <app-tab tabTitle="Details" #details_tab [active]="false">
             <app-org-edit *ngIf="details_tab.active" [serverId]="serverId" [orgId]="orgId"></app-org-edit> 
           </app-tab>
+          <app-tab tabTitle="Reset Admin Key" #resetkey_tab [active]="resetKeyTab">
+            <app-reset-admin-key *ngIf="resetkey_tab.active" [serverId]="serverId" [orgId]="orgId"></app-reset-admin-key>	            <app-reset-admin-key *ngIf="resetkey_tab.active" [serverId]="serverId" [orgId]="orgId"></app-reset-admin-key>
+          </app-tab>
         </app-tabs>
         <chef-scroll-top></chef-scroll-top>
       </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
@@ -29,6 +29,7 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
   public orgId: string;
   public cookbooksTab = true;
   public environmentsTab = false;
+  public resetKeyTab = false;
   public rolesTab = false;
   public dataBagsTab = false;
   public clientsTab = false;
@@ -65,6 +66,12 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
           this.rolesTab = false;
           this.environmentsTab = false;
           this.policyFilesTab = true;
+        }
+        if ( params.path.includes('resetkey') ) {
+          this.cookbooksTab = false;
+          this.rolesTab = false;
+          this.environmentsTab = false;
+          this.resetKeyTab = true;
         }
       });
     }
@@ -117,6 +124,9 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
         break;
       case 6:
         this.telemetryService.track('orgDetailsTab', 'orgEdit');
+        break;
+      case 7:
+        this.telemetryService.track('orgDetailsTab', 'resetkey');
         break;
     }
   }

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.html
@@ -30,13 +30,6 @@
       </chef-error>
     </chef-form-field>
     <chef-form-field>
-      <label>
-        <span class="label">Admin Key</span>
-        <textarea rows="27" cols="10" chefInput placeholder="-----BEGIN RSA PRIVATE KEY -----"
-          formControlName="admin_key" data-cy="update-org-admin-key"></textarea>
-      </label>
-    </chef-form-field>
-    <chef-form-field>
       <div id="button-bar">
         <chef-button [disabled]="isLoading || !updateOrgForm.valid || !updateOrgForm.dirty" primary
         inline (click)="saveOrg()">

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.ts
@@ -39,7 +39,6 @@ export class OrgEditComponent implements OnInit, OnDestroy {
       this.updateOrgForm = this.fb.group({
         name: new FormControl({value: ''}, [Validators.required]),
         admin_user: new FormControl({value: ''}, [Validators.required]),
-        admin_key: new FormControl({value: ''}),
         projects: [[]]
       });
    }
@@ -70,7 +69,6 @@ export class OrgEditComponent implements OnInit, OnDestroy {
       this.org = { ...orgState };
       this.updateOrgForm.controls['name'].setValue(this.org.name);
       this.updateOrgForm.controls['admin_user'].setValue(this.org.admin_user);
-      this.updateOrgForm.controls['admin_key'].setValue(this.org.admin_key);
       this.updateOrgForm.controls.projects.setValue(this.org.projects);
     });
 
@@ -91,9 +89,8 @@ export class OrgEditComponent implements OnInit, OnDestroy {
     this.saveInProgress = true;
     const name: string = this.updateOrgForm.controls.name.value.trim();
     const admin_user: string = this.updateOrgForm.controls.admin_user.value.trim();
-    const admin_key: string = this.updateOrgForm.controls.admin_key.value.trim();
     this.store.dispatch(new UpdateOrg({
-      org: {...this.org, name, admin_user, admin_key}
+      org: {...this.org, name, admin_user}
     }));
   }
 

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.html
@@ -1,0 +1,30 @@
+<chef-loading-spinner *ngIf="isLoading" size="50"></chef-loading-spinner>
+<section class="reset-admin-key">
+  <ng-container>
+      <form [formGroup]="resetKeyForm">
+        <chef-form-field>
+          <label>
+            <span class="label">New Admin Key<span aria-hidden="true">*</span></span>
+            <textarea rows="27" cols="10" chefInput placeholder="-----BEGIN RSA PRIVATE KEY -----"
+            formControlName="admin_key" data-cy="update-org-admin-key"></textarea> 
+          </label>
+          <chef-error
+            *ngIf="(resetKeyForm.get('admin_key').hasError('required') || resetKeyForm.get('admin_key').hasError('pattern')) && resetKeyForm.get('admin_key').dirty">
+            Admin key is required.
+          </chef-error>
+        </chef-form-field>
+        <chef-form-field>
+          <div id="button-bar">
+            <chef-button [disabled]="isLoading || !resetKeyForm.valid || !resetKeyForm.dirty" primary
+            inline (click)="saveNewKey()">
+              <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
+              <span *ngIf="saveInProgress">Saving...</span>
+              <span *ngIf="!saveInProgress">Reset Admin Key</span> 
+            </chef-button>
+            <span id="saved-note" *ngIf="saveSuccessful && !resetKeyForm.dirty">All changes
+            saved.</span>
+          </div>
+        </chef-form-field>
+      </form>
+  </ng-container>
+</section>

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.html
@@ -4,13 +4,13 @@
       <form [formGroup]="resetKeyForm">
         <chef-form-field>
           <label>
-            <span class="label">New Admin Key<span aria-hidden="true">*</span></span>
+            <span class="label">New Admin Key <span aria-hidden="true">*</span></span>
             <textarea rows="27" cols="10" chefInput placeholder="-----BEGIN RSA PRIVATE KEY -----"
             formControlName="admin_key" data-cy="update-org-admin-key"></textarea> 
           </label>
           <chef-error
             *ngIf="(resetKeyForm.get('admin_key').hasError('required') || resetKeyForm.get('admin_key').hasError('pattern')) && resetKeyForm.get('admin_key').dirty">
-            Admin key is required.
+            New admin key is required.
           </chef-error>
         </chef-form-field>
         <chef-form-field>
@@ -21,8 +21,6 @@
               <span *ngIf="saveInProgress">Saving...</span>
               <span *ngIf="!saveInProgress">Reset Admin Key</span> 
             </chef-button>
-            <span id="saved-note" *ngIf="saveSuccessful && !resetKeyForm.dirty">All changes
-            saved.</span>
           </div>
         </chef-form-field>
       </form>

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.scss
@@ -1,0 +1,65 @@
+@import "~styles/variables";
+
+chef-page-header {
+  padding-bottom: 0;
+}
+
+chef-toolbar {
+  display: block;
+  position: relative;
+  margin-bottom: 5px;
+
+  small {
+    bottom: 2px;
+    color: $chef-dark-grey;
+    position: absolute;
+    right: 0;
+  }
+}
+
+form {
+  chef-form-field {
+    width: 300px;
+    margin-bottom: 15px;
+  }
+
+  textarea {
+    height: 200px;
+  }
+
+  input[type="text"]:disabled {
+    opacity: 0.5;
+    background-color: $chef-grey;
+    border: none;
+  }
+
+  #changes-not-allowed {
+    font-size: 12px;
+  }
+
+  #button-bar {
+    margin-top: 15px;
+
+    span#saved-note {
+      display: inline-block;
+      margin-top: 5px;
+      font-size: 12px;
+    }
+
+    chef-button {
+      margin-top: 0;
+      margin-left: 0;
+    }
+  }
+}
+
+chef-loading-spinner {
+  z-index: 199;
+}
+
+chef-loading-spinner {
+  display: block;
+  margin: 100px auto;
+  width: 100px;
+  z-index: 199;
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.spec.ts
@@ -15,7 +15,9 @@ describe('ResetAdminKeyComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent({ selector: 'a', inputs: ['routerLink'] }),
+        MockComponent({ selector: 'chef-button', inputs: ['disabled'] }),
         MockComponent({ selector: 'chef-heading' }),
+        MockComponent({ selector: 'chef-form-field' }),
         MockComponent({ selector: 'chef-icon' }),
         MockComponent({ selector: 'chef-loading-spinner' }),
         MockComponent({ selector: 'chef-page-header' }),
@@ -43,7 +45,8 @@ describe('ResetAdminKeyComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('resets  admin_key to empty string', () => {
+    component.saveSuccessful = true;
+    expect(component.resetKeyForm.controls['admin_key'].value).toEqual('');
   });
 });

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.spec.ts
@@ -1,0 +1,49 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ResetAdminKeyComponent } from './reset-admin-key.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MockComponent } from 'ng2-mock-component';
+import { StoreModule } from '@ngrx/store';
+import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+
+describe('ResetAdminKeyComponent', () => {
+  let component: ResetAdminKeyComponent;
+  let fixture: ComponentFixture<ResetAdminKeyComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
+        MockComponent({ selector: 'chef-heading' }),
+        MockComponent({ selector: 'chef-icon' }),
+        MockComponent({ selector: 'chef-loading-spinner' }),
+        MockComponent({ selector: 'chef-page-header' }),
+        MockComponent({ selector: 'chef-subheading' }),
+        MockComponent({ selector: 'chef-toolbar' }),
+        MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
+        ResetAdminKeyComponent
+      ],
+      providers: [
+        FeatureFlagsService
+      ],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ResetAdminKeyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.ts
@@ -1,0 +1,74 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { FormGroup, Validators, FormBuilder } from '@angular/forms';
+import { Subject, combineLatest } from 'rxjs';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
+import { filter, takeUntil } from 'rxjs/operators';
+import { EntityStatus, pending } from 'app/entities/entities';
+import { AdminKey } from 'app/entities/reset-admin-key/reset-admin-key.model';
+import {
+   updateStatus
+} from 'app/entities/reset-admin-key/reset-admin-key.selectors';
+import { UpdateAdminKey } from 'app/entities/reset-admin-key/reset-admin-key.actions';
+
+@Component({
+  selector: 'app-reset-admin-key',
+  templateUrl: './reset-admin-key.component.html',
+  styleUrls: ['./reset-admin-key.component.scss']
+})
+
+export class ResetAdminKeyComponent implements OnInit {
+  @Input() serverId: string;
+  @Input() orgId: string;
+
+  public org: AdminKey;
+  public saveSuccessful = false;
+  public saveInProgress = false;
+  public isLoading = true;
+  public resetKeyForm: FormGroup;
+  private isDestroyed = new Subject<boolean>();
+
+  constructor(
+    private fb: FormBuilder,
+    private store: Store<NgrxStateAtom>,
+    private layoutFacade: LayoutFacadeService
+  ) {
+    this.resetKeyForm = this.fb.group({
+      admin_key: ['', [Validators.required]]
+    });
+  }
+
+  ngOnInit() {
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
+
+    combineLatest([
+      this.store.select(updateStatus)
+    ]).pipe(
+      takeUntil(this.isDestroyed)
+    ).subscribe(([updateSt]) => {
+      this.isLoading = updateSt === EntityStatus.loading;
+    });
+
+    this.store.select(updateStatus).pipe(
+      takeUntil(this.isDestroyed),
+      filter(state => this.saveInProgress && !pending(state)))
+      .subscribe((state) => {
+        this.saveInProgress = false;
+        this.saveSuccessful = (state === EntityStatus.loadingSuccess);
+        if (this.saveSuccessful) {
+          this.resetKeyForm.markAsPristine();
+          this.resetKeyForm.reset();
+        }
+      });
+  }
+
+  saveNewKey(): void {
+    this.saveSuccessful = false;
+    this.saveInProgress = true;
+    const admin_key: string = this.resetKeyForm.controls.admin_key.value.trim();
+    this.store.dispatch(new UpdateAdminKey({
+      server_id: this.serverId, org_id: this.orgId, admin_Key: {admin_key}
+    }));
+  }
+}

--- a/components/automate-ui/src/app/ngrx.effects.ts
+++ b/components/automate-ui/src/app/ngrx.effects.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
 
+import { AdminKeyEffects } from './entities/reset-admin-key/reset-admin-key.effects';
 import { ApiTokenEffects } from './entities/api-tokens/api-token.effects';
 import { AutomateSettingsEffects } from './entities/automate-settings/automate-settings.effects';
 import { ClientRunsEffects } from './entities/client-runs/client-runs.effects';
@@ -42,6 +43,7 @@ import { UserPermEffects } from './entities/userperms/userperms.effects';
 @NgModule({
   imports: [
     EffectsModule.forRoot([
+      AdminKeyEffects,
       ApiTokenEffects,
       AutomateSettingsEffects,
       ClientRunsEffects,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -6,6 +6,7 @@ import * as destinationEntity from './entities/destinations/destination.reducer'
 import * as scanner from './pages/+compliance/+scanner/state/scanner.state';
 import * as eventFeed from './services/event-feed/event-feed.reducer';
 import * as projectsFilter from './services/projects-filter/projects-filter.reducer';
+import * as adminKeyEntity from './entities/reset-admin-key/reset-admin-key.reducer';
 import * as apiToken from './entities/api-tokens/api-token.reducer';
 import * as automateSettings from './entities/automate-settings/automate-settings.reducer';
 import * as clientEntity from './entities/clients/client.reducer';
@@ -66,6 +67,7 @@ export interface NgrxStateAtom {
   job_list: jobList.JobListState;
 
   // Entities
+  adminKey: adminKeyEntity.AdminKeyEntityState;
   apiTokens: apiToken.ApiTokenEntityState;
   automateSettings: automateSettings.AutomateSettingsEntityState;
   clientRunsEntity: clientRuns.ClientRunsEntityState;
@@ -186,6 +188,7 @@ export const defaultInitialState = {
   job_list: jobList.JobListInitialState,
 
   // Entities
+  adminKey: adminKeyEntity.AdminKeyEntityInitialState,
   apiTokens: apiToken.ApiTokenEntityInitialState,
   automateSettings: automateSettings.AutomateSettingsEntityInitialState,
   clients: clientEntity.ClientEntityInitialState,
@@ -239,6 +242,7 @@ export const ngrxReducers = {
   integrations_edit: integrationsEdit.integrationsEditReducer,
 
   // Entities
+  adminKey: adminKeyEntity.adminKeyEntityReducer,
   apiTokens: apiToken.apiTokenEntityReducer,
   automateSettings: automateSettings.automateSettingsEntityReducer,
   clients: clientEntity.clientEntityReducer,

--- a/tools/credscan/credscan.go
+++ b/tools/credscan/credscan.go
@@ -79,7 +79,7 @@ var a2Config = config{
 		{regex: `components/automate-deployment/testdata/hab_responses/all_up.json`},
 		{regex: `components/automate-deployment/tools/upgrade-test-scaffold/upgrade-test-scaffold.go`},
 		{regex: `components/automate-ui/src/app/pages/\+compliance/\+credentials/components/credentials-form.html`},
-		{regex: `components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html`},
+		{regex: `components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.html`},
 		{regex: `components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html`},
 		{regex: `components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.html`},
 		{regex: `components/automate-minio/habitat/config/private.key`},


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Added Infra proxy Reset Admin Key tab on the org details page.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
fixes #3450 
### :+1: Definition of Done
Updated the ux consistency for reset admin key flow .
### :athletic_shoe: How to Build and Test the Change
1. git fetch origin Amol/reset_admin_key
2. build components/automate-ui
3. To add data https://github.com/chef/automate/blob/master/dev-docs/adding-data/adding_test_data.md#adding-data-to-infra-views
4. Go to Infrastructure tab >> Chef Servers it's under Chef-Server feature flag.
5. Click on `Server list` >> `Organisation list` >> `Reset Admin key ` Tab.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable

- When User clicks on the Reset Admin Key Tab in which it has form field to add a New Admin key.

![new-admin-key](https://user-images.githubusercontent.com/10369422/82987146-b3874c00-a014-11ea-9f0c-5fea2f1f2f5a.png)

- Added validators in the form field.

![showing-error](https://user-images.githubusercontent.com/10369422/82987410-17117980-a015-11ea-8f28-918690747d12.png)

- After the user clicks on the Reset admin key button, it saved successfully and it shows success notification.

![reset-admin-key-Success](https://user-images.githubusercontent.com/10369422/82987599-68ba0400-a015-11ea-87e0-8c62f7bae074.png)


