### PR TITLE
remove frontend validation for data feed urls

### DIFF
--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -24,7 +24,6 @@ export class Regex {
 
     // Allows valid FQDN only
     VALID_FQDN: /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-zA-Z0-9_]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,5}(:[0-9]{1,5})?(\/.*)?$/,
-    VALID_DATA_FEED_URL: /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-zA-Z0-9_]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,5}(:[0-9]{1,5})?(\/.*)?$/,
     // Allows valid IP Address only (ipv4)
     VALID_IP_ADDRESS: '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
   };

--- a/components/automate-ui/src/app/pages/create-data-feed-modal/create-data-feed-modal.component.html
+++ b/components/automate-ui/src/app/pages/create-data-feed-modal/create-data-feed-modal.component.html
@@ -25,7 +25,7 @@
               <input chefInput formControlName="url" type="text" id="url-input" (keyup)="handleInput($event)" autocomplete="off"/>
             </label>
             <chef-error
-            *ngIf="createForm.get('url').hasError('required') && createForm.get('url').dirty">
+            *ngIf="(createForm.get('url').hasError('required') || createForm.get('url').hasError('pattern')) && createForm.get('url').dirty">
             Data Feed URL is required.
             </chef-error>
           </chef-form-field>
@@ -65,7 +65,7 @@
             <chef-icon class="url-failed-icon">warning</chef-icon>
             <span>Unable to connect, check URL, username and password.</span>
           </div>
-          
+
           <div class="url-success" *ngIf="hookStatus === urlState.Success">
             <chef-icon class="url-success-icon">done</chef-icon>
             <span class="status-heading">Data feed test connected successfully!</span>

--- a/components/automate-ui/src/app/pages/create-data-feed-modal/create-data-feed-modal.component.html
+++ b/components/automate-ui/src/app/pages/create-data-feed-modal/create-data-feed-modal.component.html
@@ -28,9 +28,6 @@
             *ngIf="createForm.get('url').hasError('required') && createForm.get('url').dirty">
             Data Feed URL is required.
             </chef-error>
-            <chef-error *ngIf="createForm.get('url').hasError('pattern')">
-              Data Feed URL is invalid.
-            </chef-error>
           </chef-form-field>
         </div>
         <div class="margin">

--- a/components/automate-ui/src/app/pages/create-data-feed-modal/create-data-feed-modal.component.html
+++ b/components/automate-ui/src/app/pages/create-data-feed-modal/create-data-feed-modal.component.html
@@ -21,7 +21,7 @@
         <div class="margin">
           <chef-form-field>
             <label>
-              <span class="label">Data Feed URL<span aria-hidden="true">*</span></span>
+              <span class="label">Data Feed URL <span aria-hidden="true">*</span></span>
               <input chefInput formControlName="url" type="text" id="url-input" (keyup)="handleInput($event)" autocomplete="off"/>
             </label>
             <chef-error

--- a/components/automate-ui/src/app/pages/data-feed-details/data-feed-details.component.html
+++ b/components/automate-ui/src/app/pages/data-feed-details/data-feed-details.component.html
@@ -35,11 +35,8 @@
           <chef-form-field>
             <label>Data Feed URL <span aria-hidden="true">*</span></label>
             <input chefInput formControlName="url" type="text" [resetOrigin]="saveSuccessful" autocomplete="off" data-cy="url-input"/>
-            <chef-error *ngIf="urlCtrl.hasError('required')">
+            <chef-error *ngIf="(urlCtrl.hasError('required') || urlCtrl.hasError('pattern')) && urlCtrl.dirty">
               Data Feed URL is required.
-            </chef-error>
-            <chef-error *ngIf="urlCtrl.hasError('pattern')">
-              Data Feed URL is invalid.
             </chef-error>
           </chef-form-field>
         </form>

--- a/components/automate-ui/src/app/pages/data-feed-details/data-feed-details.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed-details/data-feed-details.component.ts
@@ -72,10 +72,8 @@ export class DataFeedDetailsComponent implements OnInit, OnDestroy {
     this.updateForm = this.fb.group({
       // Must stay in sync with error checks in data-feed-details.component.html
       name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
-      url: ['', [Validators.required,
-        Validators.pattern(Regex.patterns.NON_BLANK),
-        Validators.pattern(Regex.patterns.VALID_FQDN)
-      ]]
+      // Note that URL here may be FQDN -or- IP!
+      url: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
 
     this.store.pipe(

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.spec.ts
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.spec.ts
@@ -177,40 +177,20 @@ describe('DataFeedComponent', () => {
       errors = url.errors || {};
       expect(errors['required']).toBeTruthy();
 
+      url.setValue('');
+      errors = url.errors || {};
+      expect(errors['required']).toBeTruthy();
+
       // Set url to invalid inputs
-      url.setValue('http://foo.bar-.-.');
+      url.setValue('  ');
       errors = url.errors || {};
       expect(errors['pattern']).toBeTruthy();
-
-      url.setValue('http://foo.bar..com/');
-      errors = url.errors || {};
-      expect(errors['pattern']).toBeTruthy();
-
-      url.setValue('http://...foo.bar.com/');
-      errors = url.errors || {};
-      expect(errors['pattern']).toBeTruthy();
-
-      url.setValue('http://...foo.bar com/');
-      errors = url.errors || {};
-      expect(errors['pattern']).toBeTruthy();
+      expect(errors['required']).toBeFalsy();
 
       // Set url to valid inputs
-      url.setValue('http://fo_o.bar/');
+      url.setValue('any');
       errors = url.errors || {};
       expect(errors['pattern']).toBeFalsy();
-
-      url.setValue('https://bit.ly/2OWGwiL');
-      errors = url.errors || {};
-      expect(errors['pattern']).toBeFalsy();
-
-      url.setValue('http://demo.com/');
-      errors = url.errors || {};
-      expect(errors['pattern']).toBeFalsy();
-
-      url.setValue('https://example_test.co.in/2OWGwiL');
-      errors = url.errors || {};
-      expect(errors['pattern']).toBeFalsy();
-
     });
   });
 });

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.ts
@@ -66,14 +66,10 @@ export class DataFeedComponent implements OnInit, OnDestroy {
     this.createDataFeedForm = this.fb.group({
       // Must stay in sync with error checks in create-data-feed-modal.component.html
       name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
-      url: ['', [Validators.required,
-        Validators.pattern(Regex.patterns.NON_BLANK),
-        Validators.pattern(Regex.patterns.VALID_FQDN)
-      ]],
+      // Note that URL here may be FQDN -or- IP!
+      url: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       username: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
-      password: ['', [Validators.required,
-        Validators.pattern(Regex.patterns.NON_BLANK)
-      ]]
+      password: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
folks need to be able to provide items other than standard urls

### :chains: Related Resources
fixes #3691 

### :+1: Definition of Done
customers are able to create data feeds again

### :athletic_shoe: How to Build and Test the Change
1. `rebuild components/automate-ui-devproxy`
1. navigate to settings > data feeds
1. use the create data feed button
1. provide an IP for the url, make sure it allows you to create it
1. also confirm that entering all whitespace is still disallowed, as is an empty field
1. Editing a data feed URL has the same changes

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
