### PR TITLE
Added RunTimeLimit option and runner code to strip profiles metadata

### DIFF
--- a/components/compliance-service/cmd/compliance-service/cmd/run.go
+++ b/components/compliance-service/cmd/compliance-service/cmd/run.go
@@ -34,7 +34,7 @@ var conf = config.Compliance{
 		TmpDir:              os.Getenv("TMPDIR"),
 		ResultMessageLimit:  10000,
 		ControlResultsLimit: 50,
-		RunTimeLimit:        1.0,
+		RunTimeLimit:        1.0, // Value in seconds
 	},
 	ElasticSearch: config.ElasticSearch{},
 	ElasticSearchSidecar: config.ElasticSearchSidecar{
@@ -125,7 +125,7 @@ func init() {
 	runCmd.Flags().StringVar(&conf.InspecAgent.RemoteInspecVersion, "remote-inspec-version", conf.InspecAgent.RemoteInspecVersion, "Option to specify the version of inspec to use for remote(e.g. AWS SSM) scan jobs")
 	runCmd.Flags().IntVar(&conf.InspecAgent.ResultMessageLimit, "result-message-limit", conf.InspecAgent.ResultMessageLimit, "A control result message that exceeds this character limit will be truncated")
 	runCmd.Flags().IntVar(&conf.InspecAgent.ControlResultsLimit, "control-results-limit", conf.InspecAgent.ControlResultsLimit, "The array of results per control will be truncated at this limit to avoid large reports that cannot be processed")
-	runCmd.Flags().Float32Var(&conf.InspecAgent.RunTimeLimit, "run-time-limit", conf.InspecAgent.RunTimeLimit, "Control results that have a `run_time` below this limit will be stripped of the `start_time` and `run_time` fields")
+	runCmd.Flags().Float32Var(&conf.InspecAgent.RunTimeLimit, "run-time-limit", conf.InspecAgent.RunTimeLimit, "Control results that have a `run_time` (in seconds) below this limit will be stripped of the `start_time` and `run_time` fields")
 
 	// Legacy Automate Headers/User Info
 	runCmd.Flags().StringVar(&conf.Delivery.Enterprise, "delivery-ent", conf.Delivery.Enterprise, "Automate Enterprise")

--- a/components/compliance-service/cmd/compliance-service/cmd/run.go
+++ b/components/compliance-service/cmd/compliance-service/cmd/run.go
@@ -34,6 +34,7 @@ var conf = config.Compliance{
 		TmpDir:              os.Getenv("TMPDIR"),
 		ResultMessageLimit:  10000,
 		ControlResultsLimit: 50,
+		RunTimeLimit:        1.0,
 	},
 	ElasticSearch: config.ElasticSearch{},
 	ElasticSearchSidecar: config.ElasticSearchSidecar{
@@ -124,6 +125,7 @@ func init() {
 	runCmd.Flags().StringVar(&conf.InspecAgent.RemoteInspecVersion, "remote-inspec-version", conf.InspecAgent.RemoteInspecVersion, "Option to specify the version of inspec to use for remote(e.g. AWS SSM) scan jobs")
 	runCmd.Flags().IntVar(&conf.InspecAgent.ResultMessageLimit, "result-message-limit", conf.InspecAgent.ResultMessageLimit, "A control result message that exceeds this character limit will be truncated")
 	runCmd.Flags().IntVar(&conf.InspecAgent.ControlResultsLimit, "control-results-limit", conf.InspecAgent.ControlResultsLimit, "The array of results per control will be truncated at this limit to avoid large reports that cannot be processed")
+	runCmd.Flags().Float32Var(&conf.InspecAgent.RunTimeLimit, "run-time-limit", conf.InspecAgent.RunTimeLimit, "Control results that have a `run_time` below this limit will be stripped of the `start_time` and `run_time` fields")
 
 	// Legacy Automate Headers/User Info
 	runCmd.Flags().StringVar(&conf.Delivery.Enterprise, "delivery-ent", conf.Delivery.Enterprise, "Automate Enterprise")

--- a/components/compliance-service/compliance.go
+++ b/components/compliance-service/compliance.go
@@ -122,6 +122,7 @@ func initBits(ctx context.Context, conf *config.Compliance) (db *pgdb.DB, connFa
 
 	inspec.ResultMessageLimit = conf.InspecAgent.ResultMessageLimit
 	runner.ControlResultsLimit = conf.InspecAgent.ControlResultsLimit
+	runner.RunTimeLimit = conf.InspecAgent.RunTimeLimit
 
 	inspec.TmpDir = conf.InspecAgent.TmpDir
 	// Let's have something sensible if the temp dir is not specified
@@ -172,6 +173,7 @@ func serveGrpc(ctx context.Context, db *pgdb.DB, connFactory *secureconn.Factory
 	nodeManagerServiceClient := getManagerConnection(connFactory, conf.Manager.Endpoint)
 	ingesticESClient := ingestic.NewESClient(esClient)
 	ingesticESClient.InitializeStore(context.Background())
+	runner.ESClient = ingesticESClient
 
 	s := connFactory.NewServer(tracing.GlobalServerInterceptor())
 

--- a/components/compliance-service/config/types.go
+++ b/components/compliance-service/config/types.go
@@ -83,6 +83,7 @@ type InspecAgent struct {
 	RemoteInspecVersion string
 	ResultMessageLimit  int
 	ControlResultsLimit int
+	RunTimeLimit        float32
 }
 
 // Postgres specific options

--- a/components/compliance-service/inspec-agent/runner/runner_test.go
+++ b/components/compliance-service/inspec-agent/runner/runner_test.go
@@ -3,9 +3,11 @@ package runner
 import (
 	"testing"
 
+	ingest_events_compliance_api "github.com/chef/automate/api/interservice/compliance/ingest/events/compliance"
 	ingest_inspec "github.com/chef/automate/api/interservice/compliance/ingest/events/inspec"
 	"github.com/chef/automate/components/compliance-service/inspec"
 	"github.com/chef/automate/components/compliance-service/inspec-agent/types"
+	"github.com/golang/protobuf/ptypes/struct"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -196,4 +198,216 @@ func TestRemoveResults(t *testing.T) {
 		},
 	}, profiles)
 
+}
+
+func TestStripProfilesMetadata(t *testing.T) {
+	report := ingest_events_compliance_api.Report{
+		ReportUuid: "test1",
+		Profiles: []*ingest_inspec.Profile{
+			{
+				Name:           "test-profile-1",
+				Sha256:         "test-profile-1-sha256-id",
+				Version:        "4.5.6",
+				Maintainer:     "Testus",
+				Copyright:      "Testus Biz",
+				CopyrightEmail: "Testus Biz",
+				Title:          "Test Profile 1",
+				Depends: []*ingest_inspec.Dependency{
+					{
+						Name: "test",
+					},
+				},
+				Supports: []*ingest_inspec.Support{
+					{
+						Inspec: "2.3.4",
+					},
+				},
+				Controls: []*ingest_inspec.Control{
+					{
+						Id:     "p1c1",
+						Title:  "p1c1 title",
+						Impact: 1,
+						Code:   "some code",
+						Desc:   "some desc",
+						SourceLocation: &ingest_inspec.SourceLocation{
+							Ref:  "123",
+							Line: 456,
+						},
+						Refs: []*structpb.Struct{},
+						Tags: &structpb.Struct{},
+						Results: []*ingest_inspec.Result{
+							{
+								Message:   "Resource is as expected",
+								Status:    "passed",
+								RunTime:   0.12345,
+								StartTime: "2020-05-15T18:37:19+01:00",
+							},
+							{
+								Message:   "Resource is as expected",
+								Status:    "passed",
+								RunTime:   1.12345,
+								StartTime: "2020-05-15T18:37:20+01:00",
+							},
+						},
+					},
+					{
+						Id:     "p1c2",
+						Title:  "p1c2 title",
+						Impact: 1,
+						Code:   "some code",
+						Desc:   "some desc",
+						Results: []*ingest_inspec.Result{
+							{
+								Message:   "Resource is as expected",
+								Status:    "skipped",
+								RunTime:   0.42345,
+								StartTime: "2020-05-15T18:37:21+01:00",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:           "test-profile-2",
+				Sha256:         "test-profile-2-sha256-id",
+				Version:        "4.5.6",
+				Maintainer:     "Testus2",
+				Copyright:      "Testus Biz2",
+				CopyrightEmail: "Testus Biz2",
+				Title:          "Test Profile 2",
+				Depends: []*ingest_inspec.Dependency{
+					{
+						Name: "test2",
+					},
+				},
+				Supports: []*ingest_inspec.Support{
+					{
+						Inspec: "2.3.5",
+					},
+				},
+				Controls: []*ingest_inspec.Control{
+					{
+						Id:     "p2c1",
+						Title:  "p2c1 title",
+						Impact: 0.6,
+						Code:   "some code",
+						Desc:   "some desc",
+						SourceLocation: &ingest_inspec.SourceLocation{
+							Ref:  "12",
+							Line: 45,
+						},
+						Refs: []*structpb.Struct{},
+						Tags: &structpb.Struct{},
+						Results: []*ingest_inspec.Result{
+							{
+								Message:   "Resource is as expected",
+								Status:    "passed",
+								RunTime:   0.12345,
+								StartTime: "2020-05-15T18:37:19+01:00",
+							},
+							{
+								Message:   "Resource is as expected",
+								Status:    "passed",
+								RunTime:   1.12345,
+								StartTime: "2020-05-15T18:37:20+01:00",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	var missingProfilesMap = map[string]struct{}{
+		"test-profile-2-sha256-id": {},
+	}
+
+	stripProfilesMetadata(&report, missingProfilesMap, 1.1)
+
+	expectedReport := ingest_events_compliance_api.Report{
+		ReportUuid: "test1",
+		Profiles: []*ingest_inspec.Profile{
+			{
+				Sha256:  "test-profile-1-sha256-id",
+				Version: "4.5.6",
+				Title:   "Test Profile 1",
+				Controls: []*ingest_inspec.Control{
+					{
+						Id: "p1c1",
+						Results: []*ingest_inspec.Result{
+							{
+								Message: "Resource is as expected",
+								Status:  "passed",
+							},
+							{
+								Message:   "Resource is as expected",
+								Status:    "passed",
+								RunTime:   1.12345,
+								StartTime: "2020-05-15T18:37:20+01:00",
+							},
+						},
+					},
+					{
+						Id: "p1c2",
+						Results: []*ingest_inspec.Result{
+							{
+								Message: "Resource is as expected",
+								Status:  "skipped",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:           "test-profile-2",
+				Sha256:         "test-profile-2-sha256-id",
+				Version:        "4.5.6",
+				Maintainer:     "Testus2",
+				Copyright:      "Testus Biz2",
+				CopyrightEmail: "Testus Biz2",
+				Title:          "Test Profile 2",
+				Depends: []*ingest_inspec.Dependency{
+					{
+						Name: "test2",
+					},
+				},
+				Supports: []*ingest_inspec.Support{
+					{
+						Inspec: "2.3.5",
+					},
+				},
+				Controls: []*ingest_inspec.Control{
+					{
+						Id:     "p2c1",
+						Title:  "p2c1 title",
+						Impact: 0.6,
+						Code:   "some code",
+						Desc:   "some desc",
+						SourceLocation: &ingest_inspec.SourceLocation{
+							Ref:  "12",
+							Line: 45,
+						},
+						Refs: []*structpb.Struct{},
+						Tags: &structpb.Struct{},
+						Results: []*ingest_inspec.Result{
+							{
+								Message:   "Resource is as expected",
+								Status:    "passed",
+								RunTime:   0.12345,
+								StartTime: "2020-05-15T18:37:19+01:00",
+							},
+							{
+								Message:   "Resource is as expected",
+								Status:    "passed",
+								RunTime:   1.12345,
+								StartTime: "2020-05-15T18:37:20+01:00",
+							},
+						},
+					},
+				},
+			},
+		},
+		RunTimeLimit: 1.1,
+	}
+
+	assert.Equal(t, expectedReport, report)
 }


### PR DESCRIPTION
This is the Automate equivalent change for this audit cookbook report reducing approach: https://github.com/chef-cookbooks/audit/pull/418

It will strip profile metadata from reports when the compliance-profile index already has the metadata.